### PR TITLE
feat: implement model domain layer with Echo reference model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,12 +34,14 @@ Use `deno run` to get a complete list of custom tasks.
 - Uses LogTape for logging
 - Uses JSON for non-interactive output
 - Every command _must_ support both interactive and non-interactive output
+- You can read the files in `design/*.md` to understand elements of the design
 
 ## Testing
 
 - Unit tests live next to source files: `foo.ts` → `foo_test.ts`
 - Integration tests live in `integration/` directory (sibling to `src/`)
-- Use `@std/assert` for assertions (`assertEquals`, `assertStringIncludes`, etc.)
+- Use `@std/assert` for assertions (`assertEquals`, `assertStringIncludes`,
+  etc.)
 - Use `ink-testing-library` for testing Ink components
 - Test private functions indirectly through public APIs
 - Run tests with `deno task test`

--- a/deno.json
+++ b/deno.json
@@ -13,6 +13,8 @@
     "@std/assert": "jsr:@std/assert@1",
     "@std/fs": "jsr:@std/fs@1",
     "@std/path": "jsr:@std/path@1",
+    "@std/yaml": "jsr:@std/yaml@1",
+    "zod": "npm:zod@3",
     "@cliffy/command": "jsr:@cliffy/command@1.0.0-rc.8",
     "@logtape/logtape": "jsr:@logtape/logtape@0.8",
     "ink": "npm:ink@5",

--- a/deno.lock
+++ b/deno.lock
@@ -10,12 +10,15 @@
     "jsr:@std/fmt@~1.0.2": "1.0.8",
     "jsr:@std/fs@1": "1.0.22",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@std/text@~1.0.7": "1.0.16",
+    "jsr:@std/yaml@1": "1.0.10",
     "npm:@types/react@18": "18.3.27",
     "npm:ink-testing-library@4": "4.0.0_@types+react@18.3.27",
     "npm:ink@5": "5.2.1_@types+react@18.3.27_react@18.3.1",
-    "npm:react@18": "18.3.1"
+    "npm:react@18": "18.3.1",
+    "npm:zod@3": "3.25.76"
   },
   "jsr": {
     "@cliffy/command@1.0.0-rc.8": {
@@ -59,7 +62,7 @@
       "integrity": "de0f277a58a867147a8a01bc1b181d0dfa80bfddba8c9cf2bacd6747bcec9308",
       "dependencies": [
         "jsr:@std/internal",
-        "jsr:@std/path"
+        "jsr:@std/path@^1.1.4"
       ]
     },
     "@std/internal@1.0.12": {
@@ -73,6 +76,9 @@
     },
     "@std/text@1.0.16": {
       "integrity": "ddb9853b75119a2473857d691cf1ec02ad90793a2e8b4a4ac49d7354281a0cf8"
+    },
+    "@std/yaml@1.0.10": {
+      "integrity": "245706ea3511cc50c8c6d00339c23ea2ffa27bd2c7ea5445338f8feff31fa58e"
     }
   },
   "npm": {
@@ -321,6 +327,9 @@
     },
     "yoga-layout@3.2.1": {
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="
+    },
+    "zod@3.25.76": {
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
     }
   },
   "workspace": {
@@ -330,10 +339,12 @@
       "jsr:@std/assert@1",
       "jsr:@std/fs@1",
       "jsr:@std/path@1",
+      "jsr:@std/yaml@1",
       "npm:@types/react@18",
       "npm:ink-testing-library@4",
       "npm:ink@5",
-      "npm:react@18"
+      "npm:react@18",
+      "npm:zod@3"
     ]
   }
 }

--- a/design/high-level.md
+++ b/design/high-level.md
@@ -1,0 +1,25 @@
+# Swamp
+
+## Purpose
+
+Swamp is an AI Native Automation tool. It has 1:1 models of external APIs or CLI
+tools (for example, AWS or Azure cloud resources, or the GitHub CLI), which it
+can then validate are correct. Each model has a Type, which specifies some
+metadata about the model, input data that is specified, methods that take the
+input data and produce outputs of either more model inputs or resources (which
+are specified by each model as well.) Model inputs and resources are stored as
+separate YAML files in a 'inputs' or 'resources' directory. Model inputs have a
+simple expression language (like github actions) for inserting data.
+
+Swamp also has workflows, which allow for executing workflow steps in parallel
+groups. A workflow step can be a method on a model, or an external script.
+
+Swamp allows for organizing model inputs and resources into applications and
+environments, which can be used to compare resources and inputs to detect
+configuration drift.
+
+All this is stored in a 'swamp repo', which is a git repository.
+
+## Models
+
+See [./models.md].

--- a/design/models.md
+++ b/design/models.md
@@ -1,0 +1,90 @@
+# Models
+
+A model in swamp specifies _inputs_, that are passed to _methods_, that produce
+_outputs_, which may be _model inputs_ or _resources_.
+
+## Type
+
+All models in swamp are of a unique _type_. Types are defined by the thing that
+they model - for example, a swamp model to manage AWS VPCs using the Cloud
+Control API would be named 'AWS::EC2::VPC', because that is what the cloud
+control api calls it. They should map semantically to the domain.
+
+They _must_ include a domain identifier at the start of the type. For example:
+
+AWS: AWS::EC2::VPC, AWS::Budget::Budgets Docker CLI: docker run, docker pull
+Azure: Microsoft.Resources/resourceGroup
+
+Each type also has a normalized representation, where special characters are
+mapped into directory structures like 'aws/ec2/vpc' or 'docker/run' or
+'microsoft/resources/resourceGroup'.
+
+## ID
+
+Each instance of a model has a unique ID that is a uuidv4.
+
+## Version
+
+Each model has a version number, starting with 1. Models must support data
+written by all earlier versions, but not later versions.
+
+For example, a model '4' can read data from version 1-4, but not '5'.
+
+## Migration
+
+A model can migrate its inputs and resources from one version to the next.
+
+## Inputs
+
+Inputs are specified as YAML files that live in the /inputs directory of a
+repository, underneath the normalized type as a directory. The file name is
+'${id}.yaml'. For example,
+'aws/ec2/vpc/input-fc7fd41e-ae16-4b31-b57a-86de716e3ece.yaml'.
+
+The valid shape of an input is specified with a Zod 4 schema.
+
+Each input has the following core properties:
+
+- id: the models unqiue id
+- resourceId: an optional resource id, if one exists
+- name: a unique human readable name
+- tags: string based key value pairs
+- attributes: domain specific data for the input (for example, the model of a
+  VPC from above).
+
+## Methods
+
+Are named functions that take the model as an input, and produce other model
+inputs or resources as outputs.
+
+The method should use a MethodInput zod schema to validate that any specific
+inputs it needs are present in the input model.
+
+## Resources
+
+Resources are specified as YAML files that live in the /resources directory of a
+repository, underneath the normalized type as a directory. The file name is
+'${id}.yaml'. For example,
+'aws/ec2/vpc/resource-fc7fd41e-ae16-4b31-b57a-86de716e3ece.yaml'.
+
+The valid shape of a resource is specified with a Zod 4 schema.
+
+## CLI Commands
+
+### model create <type> <name>
+
+Creates a new instance of a type with the given unqiue name. Type should accept
+either the domain specific type or the normalized type. It should return the id
+and path to the model that is created.
+
+### model get <model_id_or_name>
+
+Shows the models input, schema, resource, methods, etc.
+
+### model validate <model_id_or_name>
+
+Runs the models zod validations for the models inputs and resources. Run them in parallel and print the output as it comes.
+
+### model method run <model_id_or_name> <method_name>
+
+Runs a method for the given model.

--- a/inputs/swamp/echo/4062501b-7b72-475e-8235-9d780fec4e18.yaml
+++ b/inputs/swamp/echo/4062501b-7b72-475e-8235-9d780fec4e18.yaml
@@ -1,0 +1,5 @@
+id: 4062501b-7b72-475e-8235-9d780fec4e18
+name: test-name
+version: 1
+tags: {}
+attributes: {}

--- a/integration/echo_model_test.ts
+++ b/integration/echo_model_test.ts
@@ -1,0 +1,284 @@
+/**
+ * Integration tests for the Echo model.
+ *
+ * Tests the full flow:
+ * 1. Create an echo model input
+ * 2. Execute the write method
+ * 3. Verify the resource is created with correct content
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { existsSync } from "@std/fs";
+import { parse as parseYaml } from "@std/yaml";
+import { ModelInput } from "../src/domain/models/model_input.ts";
+import { YamlInputRepository } from "../src/infrastructure/persistence/yaml_input_repository.ts";
+import { YamlResourceRepository } from "../src/infrastructure/persistence/yaml_resource_repository.ts";
+import {
+  ECHO_MODEL_TYPE,
+  echoModel,
+} from "../src/domain/models/echo/echo_model.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-integration-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("Echo model: full flow - create input, execute write, verify resource", async () => {
+  await withTempDir(async (repoDir) => {
+    // Setup repositories
+    const inputRepo = new YamlInputRepository(repoDir);
+    const resourceRepo = new YamlResourceRepository(repoDir);
+    const modelType = ECHO_MODEL_TYPE;
+
+    // Create and save an input
+    const testMessage = "Hello, Swamp!";
+    const input = ModelInput.create({
+      name: "test-echo-input",
+      attributes: { message: testMessage },
+    });
+    await inputRepo.save(modelType, input);
+
+    // Verify input file was created
+    const inputPath = inputRepo.getPath(modelType, input.id);
+    assertEquals(existsSync(inputPath), true, "Input file should exist");
+
+    // Read and verify input file contents
+    const inputContent = await Deno.readTextFile(inputPath);
+    const inputData = parseYaml(inputContent) as Record<string, unknown>;
+    assertEquals(inputData.name, "test-echo-input");
+    assertEquals(
+      (inputData.attributes as Record<string, unknown>).message,
+      testMessage,
+    );
+
+    // Execute the write method
+    const result = await echoModel.methods.write.execute(input, { repoDir });
+
+    // Save the resource
+    await resourceRepo.save(modelType, result.resource);
+
+    // Verify resource file was created
+    const resourcePath = resourceRepo.getPath(modelType, result.resource.id);
+    assertEquals(existsSync(resourcePath), true, "Resource file should exist");
+
+    // Read and verify resource file contents
+    const resourceContent = await Deno.readTextFile(resourcePath);
+    const resourceData = parseYaml(resourceContent) as Record<string, unknown>;
+    assertEquals(
+      resourceData.inputId,
+      input.id,
+      "Resource should reference the input",
+    );
+
+    const resourceAttrs = resourceData.attributes as Record<string, unknown>;
+    assertEquals(
+      resourceAttrs.message,
+      testMessage,
+      "Resource should contain the message",
+    );
+    assertEquals(
+      typeof resourceAttrs.timestamp,
+      "string",
+      "Resource should have a timestamp",
+    );
+
+    // Verify timestamp is a valid ISO date
+    const timestamp = new Date(resourceAttrs.timestamp as string);
+    assertEquals(
+      isNaN(timestamp.getTime()),
+      false,
+      "Timestamp should be valid",
+    );
+  });
+});
+
+Deno.test("Echo model: directory structure is correct", async () => {
+  await withTempDir(async (repoDir) => {
+    const inputRepo = new YamlInputRepository(repoDir);
+    const resourceRepo = new YamlResourceRepository(repoDir);
+    const modelType = ECHO_MODEL_TYPE;
+
+    const input = ModelInput.create({
+      name: "test-structure",
+      attributes: { message: "test" },
+    });
+    await inputRepo.save(modelType, input);
+
+    const result = await echoModel.methods.write.execute(input, { repoDir });
+    await resourceRepo.save(modelType, result.resource);
+
+    // Verify directory structure
+    const inputDir = join(repoDir, "inputs", "swamp/echo");
+    const resourceDir = join(repoDir, "resources", "swamp/echo");
+
+    assertEquals(existsSync(inputDir), true, "Input directory should exist");
+    assertEquals(
+      existsSync(resourceDir),
+      true,
+      "Resource directory should exist",
+    );
+  });
+});
+
+Deno.test("Echo model: multiple inputs and resources", async () => {
+  await withTempDir(async (repoDir) => {
+    const inputRepo = new YamlInputRepository(repoDir);
+    const resourceRepo = new YamlResourceRepository(repoDir);
+    const modelType = ECHO_MODEL_TYPE;
+
+    // Create multiple inputs
+    const messages = ["First message", "Second message", "Third message"];
+    const inputs: ModelInput[] = [];
+
+    for (let i = 0; i < messages.length; i++) {
+      const input = ModelInput.create({
+        name: `test-input-${i}`,
+        attributes: { message: messages[i] },
+      });
+      await inputRepo.save(modelType, input);
+      inputs.push(input);
+    }
+
+    // Verify all inputs exist
+    const allInputs = await inputRepo.findAll(modelType);
+    assertEquals(allInputs.length, 3, "Should have 3 inputs");
+
+    // Execute write for each input
+    for (const input of inputs) {
+      const result = await echoModel.methods.write.execute(input, { repoDir });
+      await resourceRepo.save(modelType, result.resource);
+    }
+
+    // Verify all resources exist
+    const allResources = await resourceRepo.findAll(modelType);
+    assertEquals(allResources.length, 3, "Should have 3 resources");
+
+    // Verify each resource has correct message
+    for (const input of inputs) {
+      const resource = await resourceRepo.findByInputId(modelType, input.id);
+      assertEquals(
+        resource !== null,
+        true,
+        `Resource should exist for input ${input.name}`,
+      );
+      assertEquals(
+        resource?.attributes.message,
+        input.attributes.message,
+        "Resource message should match input",
+      );
+    }
+  });
+});
+
+// CLI integration test
+async function runCliCommand(
+  args: string[],
+  cwd: string,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["task", "dev", ...args],
+    stdout: "piped",
+    stderr: "piped",
+    cwd,
+  });
+
+  const { code, stdout, stderr } = await command.output();
+  return {
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+    code,
+  };
+}
+
+Deno.test("CLI: model create command creates input file", async () => {
+  await withTempDir(async (repoDir) => {
+    // Run the CLI command
+    const result = await runCliCommand(
+      [
+        "model",
+        "create",
+        "swamp/echo",
+        "cli-test-input",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Command should succeed. stderr: ${result.stderr}`,
+    );
+
+    // Parse the JSON output
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.type, "swamp/echo");
+    assertEquals(output.name, "cli-test-input");
+    assertEquals(typeof output.id, "string");
+    assertStringIncludes(output.path, "swamp/echo");
+
+    // Verify the file was created
+    assertEquals(existsSync(output.path), true, "Input file should exist");
+  });
+});
+
+Deno.test("CLI: model create command rejects duplicate names", async () => {
+  await withTempDir(async (repoDir) => {
+    // Create first input
+    const result1 = await runCliCommand(
+      [
+        "model",
+        "create",
+        "swamp/echo",
+        "duplicate-test",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+    assertEquals(result1.code, 0);
+
+    // Try to create another with the same name
+    const result2 = await runCliCommand(
+      [
+        "model",
+        "create",
+        "swamp/echo",
+        "duplicate-test",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+    assertEquals(result2.code !== 0, true, "Should fail for duplicate name");
+    assertStringIncludes(result2.stderr, "already exists");
+  });
+});
+
+Deno.test("CLI: model create command rejects unknown model type", async () => {
+  await withTempDir(async (repoDir) => {
+    const result = await runCliCommand(
+      [
+        "model",
+        "create",
+        "unknown/type",
+        "test-input",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+    assertEquals(result.code !== 0, true, "Should fail for unknown type");
+    assertStringIncludes(result.stderr, "Unknown model type");
+  });
+});

--- a/main.ts
+++ b/main.ts
@@ -1,5 +1,12 @@
 import { runCli } from "./src/cli/mod.ts";
+import { getOutputModeFromArgs } from "./src/cli/context.ts";
+import { renderError } from "./src/presentation/output/error_output.tsx";
 
 if (import.meta.main) {
-  await runCli(Deno.args);
+  try {
+    await runCli(Deno.args);
+  } catch (error) {
+    renderError(error, getOutputModeFromArgs(Deno.args));
+    Deno.exit(1);
+  }
 }

--- a/sample-repo/inputs/swamp/echo/ac341b73-64b1-4838-bb59-58b5306c6765.yaml
+++ b/sample-repo/inputs/swamp/echo/ac341b73-64b1-4838-bb59-58b5306c6765.yaml
@@ -1,0 +1,5 @@
+id: ac341b73-64b1-4838-bb59-58b5306c6765
+name: my-input
+version: 1
+tags: {}
+attributes: {}

--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -1,0 +1,77 @@
+import { Command } from "@cliffy/command";
+import {
+  type ModelCreateData,
+  renderModelCreate,
+} from "../../presentation/output/model_create_output.tsx";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
+import { ModelInput } from "../../domain/models/model_input.ts";
+import { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
+import { echoModel } from "../../domain/models/echo/echo_model.ts";
+
+// Register the echo model
+modelRegistry.register(echoModel);
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const modelCreateCommand = new Command()
+  .description("Create a new model input")
+  .arguments("<type:string> <name:string>")
+  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .action(async function (options: AnyOptions, typeArg: string, name: string) {
+    const ctx = createContext(options as GlobalOptions, "model-create");
+    ctx.logger.debug`Creating model input: type=${typeArg}, name=${name}`;
+
+    // Validate the model type
+    const modelType = ModelType.create(typeArg);
+    ctx.logger.debug`Normalized type: ${modelType.normalized}`;
+
+    // Check if model type is registered
+    if (!modelRegistry.has(modelType)) {
+      const availableTypes = modelRegistry.types().map((t) => t.normalized)
+        .join(", ");
+      throw new Error(
+        `Unknown model type: ${typeArg}. Available types: ${
+          availableTypes || "none"
+        }`,
+      );
+    }
+
+    // Create the repository and input
+    const repoDir = options.repoDir ?? ".";
+    const inputRepo = new YamlInputRepository(repoDir);
+
+    // Check if name already exists (globally unique across all types)
+    const existing = await inputRepo.findByNameGlobal(name);
+    if (existing) {
+      throw new Error(
+        `Model input with name '${name}' already exists (type: '${existing.type.normalized}')`,
+      );
+    }
+
+    // Create and save the input
+    const input = ModelInput.create({ name });
+    await inputRepo.save(modelType, input);
+
+    ctx.logger.debug`Created input with ID: ${input.id}`;
+
+    const data: ModelCreateData = {
+      id: input.id,
+      type: modelType.normalized,
+      name: input.name,
+      path: inputRepo.getPath(modelType, input.id),
+    };
+
+    renderModelCreate(data, ctx.outputMode);
+    ctx.logger.debug("Model create command completed");
+  });
+
+export const modelCommand = new Command()
+  .name("model")
+  .description("Manage models")
+  .action(function () {
+    this.showHelp();
+  })
+  .command("create", modelCreateCommand);

--- a/src/cli/commands/model_create_test.ts
+++ b/src/cli/commands/model_create_test.ts
@@ -1,0 +1,20 @@
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Initialize logging for tests
+await initializeLogging({ debugLogs: false });
+
+// Note: Full CLI integration tests are in integration/echo_model_test.ts
+// These tests verify the command module loads correctly
+
+Deno.test("modelCommand module loads", async () => {
+  const { modelCommand } = await import("./model_create.ts");
+  assertEquals(modelCommand.getName(), "model");
+});
+
+Deno.test("modelCreateCommand is registered as subcommand", async () => {
+  const { modelCommand } = await import("./model_create.ts");
+  const commands = modelCommand.getCommands();
+  const createCmd = commands.find((c) => c.getName() === "create");
+  assertEquals(createCmd !== undefined, true);
+});

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -33,3 +33,11 @@ export function createContext(
     logger: getSwampLogger(loggerName),
   };
 }
+
+/**
+ * Determines the output mode from raw CLI arguments.
+ * Used for error handling before the CLI has fully parsed options.
+ */
+export function getOutputModeFromArgs(args: string[]): OutputMode {
+  return args.includes("--json") ? "json" : "interactive";
+}

--- a/src/cli/context_test.ts
+++ b/src/cli/context_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals } from "@std/assert";
-import { createContext, type GlobalOptions } from "./context.ts";
+import {
+  createContext,
+  getOutputModeFromArgs,
+  type GlobalOptions,
+} from "./context.ts";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
 
 // Initialize logging once before tests run
@@ -54,4 +58,15 @@ Deno.test("createContext uses custom logger name when provided", () => {
   // Logger is created - we can verify it exists and has expected methods
   assertEquals(typeof context.logger.debug, "function");
   assertEquals(typeof context.logger.error, "function");
+});
+
+Deno.test("getOutputModeFromArgs returns interactive by default", () => {
+  assertEquals(getOutputModeFromArgs([]), "interactive");
+  assertEquals(getOutputModeFromArgs(["model", "create"]), "interactive");
+});
+
+Deno.test("getOutputModeFromArgs returns json when --json is present", () => {
+  assertEquals(getOutputModeFromArgs(["--json"]), "json");
+  assertEquals(getOutputModeFromArgs(["model", "create", "--json"]), "json");
+  assertEquals(getOutputModeFromArgs(["--json", "model", "create"]), "json");
 });

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1,6 +1,7 @@
 import { Command } from "@cliffy/command";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
 import { VERSION, versionCommand } from "./commands/version.ts";
+import { modelCommand } from "./commands/model_create.ts";
 import type { GlobalOptions } from "./context.ts";
 
 export async function runCli(args: string[]): Promise<void> {
@@ -20,7 +21,8 @@ export async function runCli(args: string[]): Promise<void> {
     .action(function () {
       this.showHelp();
     })
-    .command("version", versionCommand);
+    .command("version", versionCommand)
+    .command("model", modelCommand);
 
   await cli.parse(args);
 }

--- a/src/domain/models/echo/echo_model.ts
+++ b/src/domain/models/echo/echo_model.ts
@@ -1,0 +1,85 @@
+import { z } from "zod";
+import { ModelType } from "../model_type.ts";
+import { ModelResource } from "../model_resource.ts";
+import type { MethodContext, MethodResult, ModelDefinition } from "../model.ts";
+import type { ModelInput } from "../model_input.ts";
+
+/**
+ * Schema for echo model input attributes.
+ */
+export const EchoInputAttributesSchema = z.object({
+  message: z.string().min(1),
+});
+
+/**
+ * Type for echo model input attributes.
+ */
+export type EchoInputAttributes = z.infer<typeof EchoInputAttributesSchema>;
+
+/**
+ * Schema for echo model resource attributes.
+ */
+export const EchoResourceAttributesSchema = z.object({
+  message: z.string(),
+  timestamp: z.string().datetime(),
+});
+
+/**
+ * Type for echo model resource attributes.
+ */
+export type EchoResourceAttributes = z.infer<
+  typeof EchoResourceAttributesSchema
+>;
+
+/**
+ * The echo model type identifier.
+ */
+export const ECHO_MODEL_TYPE = ModelType.create("swamp/echo");
+
+/**
+ * Executes the "write" method for the echo model.
+ *
+ * Takes the message from the input and writes it to a resource
+ * along with a timestamp.
+ */
+function executeWrite(
+  input: ModelInput,
+  _context: MethodContext,
+): Promise<MethodResult> {
+  // Validate input attributes
+  const attrs = EchoInputAttributesSchema.parse(input.attributes);
+
+  // Create the resource with message and timestamp
+  const resource = ModelResource.create({
+    inputId: input.id,
+    attributes: {
+      message: attrs.message,
+      timestamp: new Date().toISOString(),
+    },
+  });
+
+  return Promise.resolve({ resource });
+}
+
+/**
+ * The echo model definition.
+ *
+ * A simple model that takes a string message input and writes it
+ * to a resource with a timestamp.
+ */
+export const echoModel: ModelDefinition<
+  typeof EchoInputAttributesSchema,
+  typeof EchoResourceAttributesSchema
+> = {
+  type: ECHO_MODEL_TYPE,
+  version: 1,
+  inputAttributesSchema: EchoInputAttributesSchema,
+  resourceAttributesSchema: EchoResourceAttributesSchema,
+  methods: {
+    write: {
+      description: "Write the input message to a resource with a timestamp",
+      inputAttributesSchema: EchoInputAttributesSchema,
+      execute: executeWrite,
+    },
+  },
+};

--- a/src/domain/models/echo/echo_model_test.ts
+++ b/src/domain/models/echo/echo_model_test.ts
@@ -1,0 +1,113 @@
+import { assertEquals } from "@std/assert";
+import { ModelInput } from "../model_input.ts";
+import {
+  ECHO_MODEL_TYPE,
+  EchoInputAttributesSchema,
+  echoModel,
+  EchoResourceAttributesSchema,
+} from "./echo_model.ts";
+
+Deno.test("ECHO_MODEL_TYPE has correct normalized type", () => {
+  assertEquals(ECHO_MODEL_TYPE.normalized, "swamp/echo");
+});
+
+Deno.test("echoModel has correct version", () => {
+  assertEquals(echoModel.version, 1);
+});
+
+Deno.test("echoModel.type equals ECHO_MODEL_TYPE", () => {
+  assertEquals(echoModel.type.equals(ECHO_MODEL_TYPE), true);
+});
+
+Deno.test("EchoInputAttributesSchema validates message", () => {
+  const result = EchoInputAttributesSchema.safeParse({ message: "hello" });
+  assertEquals(result.success, true);
+  if (result.success) {
+    assertEquals(result.data.message, "hello");
+  }
+});
+
+Deno.test("EchoInputAttributesSchema rejects empty message", () => {
+  const result = EchoInputAttributesSchema.safeParse({ message: "" });
+  assertEquals(result.success, false);
+});
+
+Deno.test("EchoInputAttributesSchema rejects missing message", () => {
+  const result = EchoInputAttributesSchema.safeParse({});
+  assertEquals(result.success, false);
+});
+
+Deno.test("EchoResourceAttributesSchema validates correct data", () => {
+  const result = EchoResourceAttributesSchema.safeParse({
+    message: "hello",
+    timestamp: "2024-01-15T10:30:00.000Z",
+  });
+  assertEquals(result.success, true);
+});
+
+Deno.test("EchoResourceAttributesSchema rejects invalid timestamp", () => {
+  const result = EchoResourceAttributesSchema.safeParse({
+    message: "hello",
+    timestamp: "not-a-date",
+  });
+  assertEquals(result.success, false);
+});
+
+Deno.test("echoModel has write method", () => {
+  assertEquals("write" in echoModel.methods, true);
+  assertEquals(
+    echoModel.methods.write.description,
+    "Write the input message to a resource with a timestamp",
+  );
+});
+
+Deno.test("echoModel.methods.write executes correctly", async () => {
+  const input = ModelInput.create({
+    name: "test-echo",
+    attributes: { message: "hello world" },
+  });
+
+  const result = await echoModel.methods.write.execute(input, {
+    repoDir: "/tmp",
+  });
+
+  assertEquals(result.resource.inputId, input.id);
+  assertEquals(result.resource.attributes.message, "hello world");
+  assertEquals(typeof result.resource.attributes.timestamp, "string");
+
+  // Verify timestamp is valid ISO date
+  const timestamp = new Date(result.resource.attributes.timestamp as string);
+  assertEquals(isNaN(timestamp.getTime()), false);
+});
+
+Deno.test("echoModel.methods.write validates input attributes", async () => {
+  const input = ModelInput.create({
+    name: "test-echo",
+    attributes: { notAMessage: "value" },
+  });
+
+  let error: Error | null = null;
+  try {
+    await echoModel.methods.write.execute(input, { repoDir: "/tmp" });
+  } catch (e) {
+    error = e as Error;
+  }
+
+  assertEquals(error !== null, true);
+});
+
+Deno.test("echoModel.methods.write rejects empty message", async () => {
+  const input = ModelInput.create({
+    name: "test-echo",
+    attributes: { message: "" },
+  });
+
+  let error: Error | null = null;
+  try {
+    await echoModel.methods.write.execute(input, { repoDir: "/tmp" });
+  } catch (e) {
+    error = e as Error;
+  }
+
+  assertEquals(error !== null, true);
+});

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -1,0 +1,145 @@
+import type { z } from "zod";
+import { ModelType } from "./model_type.ts";
+import type { ModelInput } from "./model_input.ts";
+import type { ModelResource } from "./model_resource.ts";
+
+/**
+ * Context provided to method execution.
+ */
+export interface MethodContext {
+  /**
+   * The base directory for the repository (where inputs/resources are stored).
+   */
+  repoDir: string;
+}
+
+/**
+ * Result of a method execution.
+ */
+export interface MethodResult {
+  /**
+   * The resource created by the method.
+   */
+  resource: ModelResource;
+}
+
+/**
+ * Definition of a model method.
+ */
+export interface MethodDefinition<
+  TInputAttrs extends z.ZodTypeAny = z.ZodTypeAny,
+> {
+  /**
+   * Human-readable description of what the method does.
+   */
+  description: string;
+
+  /**
+   * Zod schema for validating the input attributes required by this method.
+   * The method will only execute if the input's attributes match this schema.
+   */
+  inputAttributesSchema: TInputAttrs;
+
+  /**
+   * Executes the method with the given input and context.
+   *
+   * @param input - The model input
+   * @param context - Execution context
+   * @returns The method result containing the created resource
+   */
+  execute(input: ModelInput, context: MethodContext): Promise<MethodResult>;
+}
+
+/**
+ * Definition of a model type (the aggregate root).
+ *
+ * A model defines:
+ * - Its type identifier
+ * - Current version
+ * - Schema for input attributes
+ * - Schema for resource attributes
+ * - Available methods
+ */
+export interface ModelDefinition<
+  TInputAttrs extends z.ZodTypeAny = z.ZodTypeAny,
+  TResourceAttrs extends z.ZodTypeAny = z.ZodTypeAny,
+> {
+  /**
+   * The model type.
+   */
+  type: ModelType;
+
+  /**
+   * Current version of this model definition.
+   */
+  version: number;
+
+  /**
+   * Zod schema for validating input attributes.
+   */
+  inputAttributesSchema: TInputAttrs;
+
+  /**
+   * Zod schema for validating resource attributes.
+   */
+  resourceAttributesSchema: TResourceAttrs;
+
+  /**
+   * Available methods on this model.
+   */
+  methods: Record<string, MethodDefinition>;
+}
+
+/**
+ * Registry of all known model definitions.
+ */
+export class ModelRegistry {
+  private models = new Map<string, ModelDefinition>();
+
+  /**
+   * Registers a model definition.
+   *
+   * @param model - The model definition to register
+   */
+  register(model: ModelDefinition): void {
+    const key = model.type.normalized;
+    if (this.models.has(key)) {
+      throw new Error(`Model type already registered: ${key}`);
+    }
+    this.models.set(key, model);
+  }
+
+  /**
+   * Gets a model definition by type.
+   *
+   * @param type - The model type (raw or normalized)
+   * @returns The model definition, or undefined if not found
+   */
+  get(type: string | ModelType): ModelDefinition | undefined {
+    const modelType = typeof type === "string" ? ModelType.create(type) : type;
+    return this.models.get(modelType.normalized);
+  }
+
+  /**
+   * Checks if a model type is registered.
+   *
+   * @param type - The model type (raw or normalized)
+   * @returns true if registered, false otherwise
+   */
+  has(type: string | ModelType): boolean {
+    const modelType = typeof type === "string" ? ModelType.create(type) : type;
+    return this.models.has(modelType.normalized);
+  }
+
+  /**
+   * Returns all registered model types.
+   */
+  types(): ModelType[] {
+    return Array.from(this.models.values()).map((m) => m.type);
+  }
+}
+
+/**
+ * Global model registry instance.
+ */
+export const modelRegistry = new ModelRegistry();

--- a/src/domain/models/model_input.ts
+++ b/src/domain/models/model_input.ts
@@ -1,0 +1,169 @@
+import { z } from "zod";
+
+/**
+ * Branded type for ModelInput IDs.
+ */
+export type ModelInputId = string & { readonly _brand: unique symbol };
+
+/**
+ * Creates a ModelInputId from a string.
+ */
+export function createModelInputId(id: string): ModelInputId {
+  return id as ModelInputId;
+}
+
+/**
+ * Zod schema for the core properties of a ModelInput.
+ */
+export const ModelInputSchema = z.object({
+  id: z.string().uuid(),
+  resourceId: z.string().uuid().optional(),
+  name: z.string().min(1),
+  version: z.number().int().positive(),
+  tags: z.record(z.string(), z.string()).default({}),
+  attributes: z.record(z.string(), z.unknown()).default({}),
+});
+
+/**
+ * Type representing the data stored in a ModelInput.
+ */
+export type ModelInputData = z.infer<typeof ModelInputSchema>;
+
+/**
+ * Properties required to create a new ModelInput.
+ */
+export interface CreateModelInputProps {
+  id?: string;
+  name: string;
+  version?: number;
+  resourceId?: string;
+  tags?: Record<string, string>;
+  attributes?: Record<string, unknown>;
+}
+
+/**
+ * ModelInput is an entity representing the input configuration for a model instance.
+ *
+ * Each input has a unique ID (UUID), a human-readable name, version, optional tags,
+ * and domain-specific attributes.
+ */
+export class ModelInput {
+  private constructor(
+    readonly id: ModelInputId,
+    private _resourceId: string | undefined,
+    readonly name: string,
+    readonly version: number,
+    private _tags: Record<string, string>,
+    private _attributes: Record<string, unknown>,
+  ) {}
+
+  /**
+   * Creates a new ModelInput instance.
+   *
+   * @param props - Properties for the new input
+   * @returns A new ModelInput instance
+   */
+  static create(props: CreateModelInputProps): ModelInput {
+    const id = props.id ?? crypto.randomUUID();
+    const version = props.version ?? 1;
+
+    const validated = ModelInputSchema.parse({
+      id,
+      resourceId: props.resourceId,
+      name: props.name,
+      version,
+      tags: props.tags ?? {},
+      attributes: props.attributes ?? {},
+    });
+
+    return new ModelInput(
+      createModelInputId(validated.id),
+      validated.resourceId,
+      validated.name,
+      validated.version,
+      validated.tags,
+      validated.attributes,
+    );
+  }
+
+  /**
+   * Reconstructs a ModelInput from persisted data.
+   *
+   * @param data - The persisted data
+   * @returns A ModelInput instance
+   */
+  static fromData(data: ModelInputData): ModelInput {
+    const validated = ModelInputSchema.parse(data);
+    return new ModelInput(
+      createModelInputId(validated.id),
+      validated.resourceId,
+      validated.name,
+      validated.version,
+      validated.tags,
+      validated.attributes,
+    );
+  }
+
+  /**
+   * Returns the resource ID if one has been assigned.
+   */
+  get resourceId(): string | undefined {
+    return this._resourceId;
+  }
+
+  /**
+   * Returns a copy of the tags.
+   */
+  get tags(): Record<string, string> {
+    return { ...this._tags };
+  }
+
+  /**
+   * Returns a copy of the attributes.
+   */
+  get attributes(): Record<string, unknown> {
+    return { ...this._attributes };
+  }
+
+  /**
+   * Sets the resource ID for this input.
+   */
+  setResourceId(resourceId: string): void {
+    this._resourceId = resourceId;
+  }
+
+  /**
+   * Sets a tag value.
+   */
+  setTag(key: string, value: string): void {
+    this._tags[key] = value;
+  }
+
+  /**
+   * Removes a tag.
+   */
+  removeTag(key: string): void {
+    delete this._tags[key];
+  }
+
+  /**
+   * Sets an attribute value.
+   */
+  setAttribute(key: string, value: unknown): void {
+    this._attributes[key] = value;
+  }
+
+  /**
+   * Converts the input to a plain data object for persistence.
+   */
+  toData(): ModelInputData {
+    return {
+      id: this.id,
+      resourceId: this._resourceId,
+      name: this.name,
+      version: this.version,
+      tags: { ...this._tags },
+      attributes: { ...this._attributes },
+    };
+  }
+}

--- a/src/domain/models/model_input_test.ts
+++ b/src/domain/models/model_input_test.ts
@@ -1,0 +1,155 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { createModelInputId, ModelInput } from "./model_input.ts";
+
+Deno.test("ModelInput.create generates UUID if not provided", () => {
+  const input = ModelInput.create({ name: "test-input" });
+  assertEquals(typeof input.id, "string");
+  assertEquals(input.id.length, 36); // UUID length
+});
+
+Deno.test("ModelInput.create uses provided ID", () => {
+  const id = "550e8400-e29b-41d4-a716-446655440000";
+  const input = ModelInput.create({ id, name: "test-input" });
+  assertEquals(input.id, id);
+});
+
+Deno.test("ModelInput.create sets default version to 1", () => {
+  const input = ModelInput.create({ name: "test-input" });
+  assertEquals(input.version, 1);
+});
+
+Deno.test("ModelInput.create uses provided version", () => {
+  const input = ModelInput.create({ name: "test-input", version: 3 });
+  assertEquals(input.version, 3);
+});
+
+Deno.test("ModelInput.create sets empty tags by default", () => {
+  const input = ModelInput.create({ name: "test-input" });
+  assertEquals(input.tags, {});
+});
+
+Deno.test("ModelInput.create uses provided tags", () => {
+  const tags = { env: "production", team: "platform" };
+  const input = ModelInput.create({ name: "test-input", tags });
+  assertEquals(input.tags, tags);
+});
+
+Deno.test("ModelInput.create sets empty attributes by default", () => {
+  const input = ModelInput.create({ name: "test-input" });
+  assertEquals(input.attributes, {});
+});
+
+Deno.test("ModelInput.create uses provided attributes", () => {
+  const attributes = { message: "hello", count: 42 };
+  const input = ModelInput.create({ name: "test-input", attributes });
+  assertEquals(input.attributes, attributes);
+});
+
+Deno.test("ModelInput.create throws on empty name", () => {
+  assertThrows(
+    () => ModelInput.create({ name: "" }),
+    Error,
+  );
+});
+
+Deno.test("ModelInput.create throws on invalid version", () => {
+  assertThrows(
+    () => ModelInput.create({ name: "test", version: 0 }),
+    Error,
+  );
+});
+
+Deno.test("ModelInput.setResourceId updates resourceId", () => {
+  const input = ModelInput.create({ name: "test-input" });
+  assertEquals(input.resourceId, undefined);
+
+  const resourceId = "550e8400-e29b-41d4-a716-446655440001";
+  input.setResourceId(resourceId);
+  assertEquals(input.resourceId, resourceId);
+});
+
+Deno.test("ModelInput.setTag adds/updates tags", () => {
+  const input = ModelInput.create({ name: "test-input" });
+  input.setTag("env", "production");
+  assertEquals(input.tags.env, "production");
+
+  input.setTag("env", "staging");
+  assertEquals(input.tags.env, "staging");
+});
+
+Deno.test("ModelInput.removeTag removes tags", () => {
+  const input = ModelInput.create({
+    name: "test-input",
+    tags: { env: "prod" },
+  });
+  assertEquals(input.tags.env, "prod");
+
+  input.removeTag("env");
+  assertEquals(input.tags.env, undefined);
+});
+
+Deno.test("ModelInput.setAttribute adds/updates attributes", () => {
+  const input = ModelInput.create({ name: "test-input" });
+  input.setAttribute("message", "hello");
+  assertEquals(input.attributes.message, "hello");
+});
+
+Deno.test("ModelInput.toData returns correct structure", () => {
+  const input = ModelInput.create({
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "test-input",
+    version: 2,
+    tags: { env: "prod" },
+    attributes: { message: "hello" },
+  });
+  input.setResourceId("550e8400-e29b-41d4-a716-446655440001");
+
+  const data = input.toData();
+  assertEquals(data, {
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    resourceId: "550e8400-e29b-41d4-a716-446655440001",
+    name: "test-input",
+    version: 2,
+    tags: { env: "prod" },
+    attributes: { message: "hello" },
+  });
+});
+
+Deno.test("ModelInput.fromData reconstructs input correctly", () => {
+  const data = {
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    resourceId: "550e8400-e29b-41d4-a716-446655440001",
+    name: "test-input",
+    version: 2,
+    tags: { env: "prod" },
+    attributes: { message: "hello" },
+  };
+
+  const input = ModelInput.fromData(data);
+  assertEquals(input.id, data.id);
+  assertEquals(input.resourceId, data.resourceId);
+  assertEquals(input.name, data.name);
+  assertEquals(input.version, data.version);
+  assertEquals(input.tags, data.tags);
+  assertEquals(input.attributes, data.attributes);
+});
+
+Deno.test("ModelInput.tags returns a copy, not the original", () => {
+  const input = ModelInput.create({ name: "test-input", tags: { a: "1" } });
+  const tags = input.tags;
+  tags.b = "2";
+  assertEquals(input.tags.b, undefined);
+});
+
+Deno.test("ModelInput.attributes returns a copy, not the original", () => {
+  const input = ModelInput.create({ name: "test-input", attributes: { a: 1 } });
+  const attrs = input.attributes;
+  attrs.b = 2;
+  assertEquals(input.attributes.b, undefined);
+});
+
+Deno.test("createModelInputId creates branded type", () => {
+  const id = createModelInputId("550e8400-e29b-41d4-a716-446655440000");
+  assertEquals(typeof id, "string");
+  assertEquals(id, "550e8400-e29b-41d4-a716-446655440000");
+});

--- a/src/domain/models/model_resource.ts
+++ b/src/domain/models/model_resource.ts
@@ -1,0 +1,128 @@
+import { z } from "zod";
+
+/**
+ * Branded type for ModelResource IDs.
+ */
+export type ModelResourceId = string & { readonly _brand: unique symbol };
+
+/**
+ * Creates a ModelResourceId from a string.
+ */
+export function createModelResourceId(id: string): ModelResourceId {
+  return id as ModelResourceId;
+}
+
+/**
+ * Zod schema for the core properties of a ModelResource.
+ */
+export const ModelResourceSchema = z.object({
+  id: z.string().uuid(),
+  inputId: z.string().uuid(),
+  version: z.number().int().positive(),
+  createdAt: z.string().datetime(),
+  attributes: z.record(z.string(), z.unknown()).default({}),
+});
+
+/**
+ * Type representing the data stored in a ModelResource.
+ */
+export type ModelResourceData = z.infer<typeof ModelResourceSchema>;
+
+/**
+ * Properties required to create a new ModelResource.
+ */
+export interface CreateModelResourceProps {
+  id?: string;
+  inputId: string;
+  version?: number;
+  createdAt?: Date;
+  attributes?: Record<string, unknown>;
+}
+
+/**
+ * ModelResource is an entity representing the output/result of a model method execution.
+ *
+ * Each resource has a unique ID (UUID), a reference to its input, creation timestamp,
+ * version, and domain-specific attributes.
+ */
+export class ModelResource {
+  private constructor(
+    readonly id: ModelResourceId,
+    readonly inputId: string,
+    readonly version: number,
+    readonly createdAt: Date,
+    private _attributes: Record<string, unknown>,
+  ) {}
+
+  /**
+   * Creates a new ModelResource instance.
+   *
+   * @param props - Properties for the new resource
+   * @returns A new ModelResource instance
+   */
+  static create(props: CreateModelResourceProps): ModelResource {
+    const id = props.id ?? crypto.randomUUID();
+    const version = props.version ?? 1;
+    const createdAt = props.createdAt ?? new Date();
+
+    const validated = ModelResourceSchema.parse({
+      id,
+      inputId: props.inputId,
+      version,
+      createdAt: createdAt.toISOString(),
+      attributes: props.attributes ?? {},
+    });
+
+    return new ModelResource(
+      createModelResourceId(validated.id),
+      validated.inputId,
+      validated.version,
+      new Date(validated.createdAt),
+      validated.attributes,
+    );
+  }
+
+  /**
+   * Reconstructs a ModelResource from persisted data.
+   *
+   * @param data - The persisted data
+   * @returns A ModelResource instance
+   */
+  static fromData(data: ModelResourceData): ModelResource {
+    const validated = ModelResourceSchema.parse(data);
+    return new ModelResource(
+      createModelResourceId(validated.id),
+      validated.inputId,
+      validated.version,
+      new Date(validated.createdAt),
+      validated.attributes,
+    );
+  }
+
+  /**
+   * Returns a copy of the attributes.
+   */
+  get attributes(): Record<string, unknown> {
+    return { ...this._attributes };
+  }
+
+  /**
+   * Sets an attribute value.
+   */
+  setAttribute(key: string, value: unknown): void {
+    this._attributes[key] = value;
+  }
+
+  /**
+   * Converts the resource to a plain data object for persistence.
+   */
+  toData(): ModelResourceData {
+    return {
+      id: this.id,
+      inputId: this.inputId,
+      version: this.version,
+      createdAt: this.createdAt.toISOString(),
+      attributes: { ...this._attributes },
+    };
+  }
+}

--- a/src/domain/models/model_resource_test.ts
+++ b/src/domain/models/model_resource_test.ts
@@ -1,0 +1,133 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { createModelResourceId, ModelResource } from "./model_resource.ts";
+
+const TEST_INPUT_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+Deno.test("ModelResource.create generates UUID if not provided", () => {
+  const resource = ModelResource.create({ inputId: TEST_INPUT_ID });
+  assertEquals(typeof resource.id, "string");
+  assertEquals(resource.id.length, 36);
+});
+
+Deno.test("ModelResource.create uses provided ID", () => {
+  const id = "550e8400-e29b-41d4-a716-446655440001";
+  const resource = ModelResource.create({ id, inputId: TEST_INPUT_ID });
+  assertEquals(resource.id, id);
+});
+
+Deno.test("ModelResource.create sets inputId", () => {
+  const resource = ModelResource.create({ inputId: TEST_INPUT_ID });
+  assertEquals(resource.inputId, TEST_INPUT_ID);
+});
+
+Deno.test("ModelResource.create sets default version to 1", () => {
+  const resource = ModelResource.create({ inputId: TEST_INPUT_ID });
+  assertEquals(resource.version, 1);
+});
+
+Deno.test("ModelResource.create uses provided version", () => {
+  const resource = ModelResource.create({ inputId: TEST_INPUT_ID, version: 3 });
+  assertEquals(resource.version, 3);
+});
+
+Deno.test("ModelResource.create sets createdAt to now if not provided", () => {
+  const before = new Date();
+  const resource = ModelResource.create({ inputId: TEST_INPUT_ID });
+  const after = new Date();
+
+  assertEquals(resource.createdAt >= before, true);
+  assertEquals(resource.createdAt <= after, true);
+});
+
+Deno.test("ModelResource.create uses provided createdAt", () => {
+  const createdAt = new Date("2024-01-15T10:30:00Z");
+  const resource = ModelResource.create({ inputId: TEST_INPUT_ID, createdAt });
+  assertEquals(resource.createdAt.toISOString(), createdAt.toISOString());
+});
+
+Deno.test("ModelResource.create sets empty attributes by default", () => {
+  const resource = ModelResource.create({ inputId: TEST_INPUT_ID });
+  assertEquals(resource.attributes, {});
+});
+
+Deno.test("ModelResource.create uses provided attributes", () => {
+  const attributes = { message: "hello", timestamp: "2024-01-15" };
+  const resource = ModelResource.create({ inputId: TEST_INPUT_ID, attributes });
+  assertEquals(resource.attributes, attributes);
+});
+
+Deno.test("ModelResource.create throws on invalid inputId", () => {
+  assertThrows(
+    () => ModelResource.create({ inputId: "not-a-uuid" }),
+    Error,
+  );
+});
+
+Deno.test("ModelResource.create throws on invalid version", () => {
+  assertThrows(
+    () => ModelResource.create({ inputId: TEST_INPUT_ID, version: 0 }),
+    Error,
+  );
+});
+
+Deno.test("ModelResource.setAttribute adds/updates attributes", () => {
+  const resource = ModelResource.create({ inputId: TEST_INPUT_ID });
+  resource.setAttribute("message", "hello");
+  assertEquals(resource.attributes.message, "hello");
+
+  resource.setAttribute("message", "world");
+  assertEquals(resource.attributes.message, "world");
+});
+
+Deno.test("ModelResource.toData returns correct structure", () => {
+  const createdAt = new Date("2024-01-15T10:30:00.000Z");
+  const resource = ModelResource.create({
+    id: "550e8400-e29b-41d4-a716-446655440001",
+    inputId: TEST_INPUT_ID,
+    version: 2,
+    createdAt,
+    attributes: { message: "hello" },
+  });
+
+  const data = resource.toData();
+  assertEquals(data, {
+    id: "550e8400-e29b-41d4-a716-446655440001",
+    inputId: TEST_INPUT_ID,
+    version: 2,
+    createdAt: "2024-01-15T10:30:00.000Z",
+    attributes: { message: "hello" },
+  });
+});
+
+Deno.test("ModelResource.fromData reconstructs resource correctly", () => {
+  const data = {
+    id: "550e8400-e29b-41d4-a716-446655440001",
+    inputId: TEST_INPUT_ID,
+    version: 2,
+    createdAt: "2024-01-15T10:30:00.000Z",
+    attributes: { message: "hello" },
+  };
+
+  const resource = ModelResource.fromData(data);
+  assertEquals(resource.id, data.id);
+  assertEquals(resource.inputId, data.inputId);
+  assertEquals(resource.version, data.version);
+  assertEquals(resource.createdAt.toISOString(), data.createdAt);
+  assertEquals(resource.attributes, data.attributes);
+});
+
+Deno.test("ModelResource.attributes returns a copy, not the original", () => {
+  const resource = ModelResource.create({
+    inputId: TEST_INPUT_ID,
+    attributes: { a: 1 },
+  });
+  const attrs = resource.attributes;
+  attrs.b = 2;
+  assertEquals(resource.attributes.b, undefined);
+});
+
+Deno.test("createModelResourceId creates branded type", () => {
+  const id = createModelResourceId("550e8400-e29b-41d4-a716-446655440001");
+  assertEquals(typeof id, "string");
+  assertEquals(id, "550e8400-e29b-41d4-a716-446655440001");
+});

--- a/src/domain/models/model_test.ts
+++ b/src/domain/models/model_test.ts
@@ -1,0 +1,143 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { z } from "zod";
+import { type ModelDefinition, ModelRegistry } from "./model.ts";
+import { ModelType } from "./model_type.ts";
+import { ModelInput } from "./model_input.ts";
+import { ModelResource } from "./model_resource.ts";
+
+function createTestModel(typeString: string): ModelDefinition {
+  return {
+    type: ModelType.create(typeString),
+    version: 1,
+    inputAttributesSchema: z.object({ message: z.string() }),
+    resourceAttributesSchema: z.object({
+      message: z.string(),
+      timestamp: z.string(),
+    }),
+    methods: {
+      write: {
+        description: "Write message to resource",
+        inputAttributesSchema: z.object({ message: z.string() }),
+        execute: (input: ModelInput) => {
+          const resource = ModelResource.create({
+            inputId: input.id,
+            attributes: {
+              message: input.attributes.message,
+              timestamp: new Date().toISOString(),
+            },
+          });
+          return Promise.resolve({ resource });
+        },
+      },
+    },
+  };
+}
+
+Deno.test("ModelRegistry.register adds model to registry", () => {
+  const registry = new ModelRegistry();
+  const model = createTestModel("swamp/echo");
+
+  registry.register(model);
+  assertEquals(registry.has("swamp/echo"), true);
+});
+
+Deno.test("ModelRegistry.register throws on duplicate type", () => {
+  const registry = new ModelRegistry();
+  const model1 = createTestModel("swamp/echo");
+  const model2 = createTestModel("swamp/echo");
+
+  registry.register(model1);
+  assertThrows(
+    () => registry.register(model2),
+    Error,
+    "Model type already registered: swamp/echo",
+  );
+});
+
+Deno.test("ModelRegistry.get returns registered model", () => {
+  const registry = new ModelRegistry();
+  const model = createTestModel("swamp/echo");
+  registry.register(model);
+
+  const retrieved = registry.get("swamp/echo");
+  assertEquals(retrieved?.type.normalized, "swamp/echo");
+  assertEquals(retrieved?.version, 1);
+});
+
+Deno.test("ModelRegistry.get accepts ModelType", () => {
+  const registry = new ModelRegistry();
+  const model = createTestModel("swamp/echo");
+  registry.register(model);
+
+  const type = ModelType.create("swamp/echo");
+  const retrieved = registry.get(type);
+  assertEquals(retrieved?.type.normalized, "swamp/echo");
+});
+
+Deno.test("ModelRegistry.get returns undefined for unknown type", () => {
+  const registry = new ModelRegistry();
+  const retrieved = registry.get("unknown/type");
+  assertEquals(retrieved, undefined);
+});
+
+Deno.test("ModelRegistry.get normalizes type strings", () => {
+  const registry = new ModelRegistry();
+  const model = createTestModel("AWS::EC2::VPC");
+  registry.register(model);
+
+  const retrieved = registry.get("aws/ec2/vpc");
+  assertEquals(retrieved?.type.raw, "AWS::EC2::VPC");
+});
+
+Deno.test("ModelRegistry.has returns true for registered types", () => {
+  const registry = new ModelRegistry();
+  const model = createTestModel("swamp/echo");
+  registry.register(model);
+
+  assertEquals(registry.has("swamp/echo"), true);
+});
+
+Deno.test("ModelRegistry.has returns false for unregistered types", () => {
+  const registry = new ModelRegistry();
+  assertEquals(registry.has("swamp/echo"), false);
+});
+
+Deno.test("ModelRegistry.has normalizes type strings", () => {
+  const registry = new ModelRegistry();
+  const model = createTestModel("AWS::EC2::VPC");
+  registry.register(model);
+
+  assertEquals(registry.has("aws/ec2/vpc"), true);
+  assertEquals(registry.has("AWS::EC2::VPC"), true);
+});
+
+Deno.test("ModelRegistry.types returns all registered types", () => {
+  const registry = new ModelRegistry();
+  registry.register(createTestModel("swamp/echo"));
+  registry.register(createTestModel("swamp/other"));
+
+  const types = registry.types();
+  assertEquals(types.length, 2);
+  assertEquals(types.map((t) => t.normalized).sort(), [
+    "swamp/echo",
+    "swamp/other",
+  ]);
+});
+
+Deno.test("ModelRegistry.types returns empty array when no models", () => {
+  const registry = new ModelRegistry();
+  assertEquals(registry.types(), []);
+});
+
+Deno.test("ModelDefinition method can execute", async () => {
+  const model = createTestModel("swamp/echo");
+  const input = ModelInput.create({
+    name: "test",
+    attributes: { message: "hello world" },
+  });
+
+  const result = await model.methods.write.execute(input, { repoDir: "/tmp" });
+  assertEquals(result.resource.inputId, input.id);
+  assertEquals(result.resource.attributes.message, "hello world");
+  assertEquals(typeof result.resource.attributes.timestamp, "string");
+});

--- a/src/domain/models/model_type.ts
+++ b/src/domain/models/model_type.ts
@@ -1,0 +1,91 @@
+/**
+ * ModelType is a value object representing the type of a model.
+ *
+ * Types can be specified in various formats (e.g., AWS::EC2::VPC, docker run, swamp/echo)
+ * and are normalized to a path-safe format (e.g., aws/ec2/vpc, docker/run, swamp/echo).
+ */
+export class ModelType {
+  private constructor(
+    readonly raw: string,
+    readonly normalized: string,
+  ) {}
+
+  /**
+   * Creates a ModelType from a raw type string.
+   * Normalizes the type to a path-safe format.
+   *
+   * @param rawType - The raw type string (e.g., "AWS::EC2::VPC", "docker run", "swamp/echo")
+   * @returns A new ModelType instance
+   * @throws Error if the raw type is empty or invalid
+   */
+  static create(rawType: string): ModelType {
+    const trimmed = rawType.trim();
+    if (trimmed.length === 0) {
+      throw new Error("Model type cannot be empty");
+    }
+
+    const normalized = ModelType.normalize(trimmed);
+    if (normalized.length === 0) {
+      throw new Error("Model type normalization resulted in empty string");
+    }
+
+    return new ModelType(trimmed, normalized);
+  }
+
+  /**
+   * Normalizes a raw type string to a path-safe format.
+   *
+   * Conversion rules:
+   * - Convert to lowercase
+   * - Replace "::" with "/"
+   * - Replace spaces with "/"
+   * - Replace "." with "/"
+   * - Remove consecutive slashes
+   * - Remove leading/trailing slashes
+   *
+   * Examples:
+   * - "AWS::EC2::VPC" -> "aws/ec2/vpc"
+   * - "docker run" -> "docker/run"
+   * - "Microsoft.Resources/resourceGroup" -> "microsoft/resources/resourcegroup"
+   * - "swamp/echo" -> "swamp/echo"
+   */
+  private static normalize(raw: string): string {
+    return raw
+      .toLowerCase()
+      .replace(/::/g, "/")
+      .replace(/\s+/g, "/")
+      .replace(/\./g, "/")
+      .replace(/\/+/g, "/")
+      .replace(/^\/|\/$/g, "");
+  }
+
+  /**
+   * Returns the normalized type string (path-safe format).
+   */
+  toNormalized(): string {
+    return this.normalized;
+  }
+
+  /**
+   * Returns the directory path for storing files of this type.
+   * Same as normalized, but explicitly named for clarity.
+   */
+  toDirectoryPath(): string {
+    return this.normalized;
+  }
+
+  /**
+   * Checks equality with another ModelType.
+   * Two ModelTypes are equal if their normalized forms are equal.
+   */
+  equals(other: ModelType): boolean {
+    return this.normalized === other.normalized;
+  }
+
+  /**
+   * Returns the raw type string representation.
+   */
+  toString(): string {
+    return this.raw;
+  }
+}

--- a/src/domain/models/model_type_test.ts
+++ b/src/domain/models/model_type_test.ts
@@ -1,0 +1,76 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { ModelType } from "./model_type.ts";
+
+Deno.test("ModelType.create normalizes AWS-style types", () => {
+  const type = ModelType.create("AWS::EC2::VPC");
+  assertEquals(type.raw, "AWS::EC2::VPC");
+  assertEquals(type.normalized, "aws/ec2/vpc");
+  assertEquals(type.toNormalized(), "aws/ec2/vpc");
+});
+
+Deno.test("ModelType.create normalizes space-separated types", () => {
+  const type = ModelType.create("docker run");
+  assertEquals(type.raw, "docker run");
+  assertEquals(type.normalized, "docker/run");
+});
+
+Deno.test("ModelType.create normalizes dot-separated types", () => {
+  const type = ModelType.create("Microsoft.Resources.resourceGroup");
+  assertEquals(type.raw, "Microsoft.Resources.resourceGroup");
+  assertEquals(type.normalized, "microsoft/resources/resourcegroup");
+});
+
+Deno.test("ModelType.create preserves already-normalized types", () => {
+  const type = ModelType.create("swamp/echo");
+  assertEquals(type.raw, "swamp/echo");
+  assertEquals(type.normalized, "swamp/echo");
+});
+
+Deno.test("ModelType.create handles mixed separators", () => {
+  const type = ModelType.create("Microsoft.Resources/resourceGroup");
+  assertEquals(type.normalized, "microsoft/resources/resourcegroup");
+});
+
+Deno.test("ModelType.create trims whitespace", () => {
+  const type = ModelType.create("  swamp/echo  ");
+  assertEquals(type.raw, "swamp/echo");
+  assertEquals(type.normalized, "swamp/echo");
+});
+
+Deno.test("ModelType.create throws on empty string", () => {
+  assertThrows(
+    () => ModelType.create(""),
+    Error,
+    "Model type cannot be empty",
+  );
+});
+
+Deno.test("ModelType.create throws on whitespace-only string", () => {
+  assertThrows(
+    () => ModelType.create("   "),
+    Error,
+    "Model type cannot be empty",
+  );
+});
+
+Deno.test("ModelType.equals returns true for same normalized types", () => {
+  const type1 = ModelType.create("AWS::EC2::VPC");
+  const type2 = ModelType.create("aws/ec2/vpc");
+  assertEquals(type1.equals(type2), true);
+});
+
+Deno.test("ModelType.equals returns false for different types", () => {
+  const type1 = ModelType.create("AWS::EC2::VPC");
+  const type2 = ModelType.create("swamp/echo");
+  assertEquals(type1.equals(type2), false);
+});
+
+Deno.test("ModelType.toDirectoryPath returns normalized path", () => {
+  const type = ModelType.create("AWS::EC2::VPC");
+  assertEquals(type.toDirectoryPath(), "aws/ec2/vpc");
+});
+
+Deno.test("ModelType.toString returns raw type", () => {
+  const type = ModelType.create("AWS::EC2::VPC");
+  assertEquals(type.toString(), "AWS::EC2::VPC");
+});

--- a/src/domain/models/repositories.ts
+++ b/src/domain/models/repositories.ts
@@ -1,0 +1,139 @@
+import type { ModelType } from "./model_type.ts";
+import type { ModelInput, ModelInputId } from "./model_input.ts";
+import type { ModelResource, ModelResourceId } from "./model_resource.ts";
+
+/**
+ * Repository interface for persisting and retrieving ModelInputs.
+ */
+export interface InputRepository {
+  /**
+   * Finds an input by its ID.
+   *
+   * @param type - The model type
+   * @param id - The input ID
+   * @returns The input if found, or null
+   */
+  findById(type: ModelType, id: ModelInputId): Promise<ModelInput | null>;
+
+  /**
+   * Finds all inputs of a given type.
+   *
+   * @param type - The model type
+   * @returns Array of inputs
+   */
+  findAll(type: ModelType): Promise<ModelInput[]>;
+
+  /**
+   * Finds an input by its name within a specific type.
+   *
+   * @param type - The model type
+   * @param name - The input name
+   * @returns The input if found, or null
+   */
+  findByName(type: ModelType, name: string): Promise<ModelInput | null>;
+
+  /**
+   * Finds an input by its name across all model types.
+   * Used to enforce global name uniqueness.
+   *
+   * @param name - The input name
+   * @returns The input and its type if found, or null
+   */
+  findByNameGlobal(
+    name: string,
+  ): Promise<{ input: ModelInput; type: ModelType } | null>;
+
+  /**
+   * Saves an input.
+   *
+   * @param type - The model type
+   * @param input - The input to save
+   */
+  save(type: ModelType, input: ModelInput): Promise<void>;
+
+  /**
+   * Deletes an input.
+   *
+   * @param type - The model type
+   * @param id - The input ID
+   */
+  delete(type: ModelType, id: ModelInputId): Promise<void>;
+
+  /**
+   * Generates a new unique ID.
+   */
+  nextId(): ModelInputId;
+
+  /**
+   * Returns the file path for an input.
+   *
+   * @param type - The model type
+   * @param id - The input ID
+   * @returns The file path
+   */
+  getPath(type: ModelType, id: ModelInputId): string;
+}
+
+/**
+ * Repository interface for persisting and retrieving ModelResources.
+ */
+export interface ResourceRepository {
+  /**
+   * Finds a resource by its ID.
+   *
+   * @param type - The model type
+   * @param id - The resource ID
+   * @returns The resource if found, or null
+   */
+  findById(type: ModelType, id: ModelResourceId): Promise<ModelResource | null>;
+
+  /**
+   * Finds all resources of a given type.
+   *
+   * @param type - The model type
+   * @returns Array of resources
+   */
+  findAll(type: ModelType): Promise<ModelResource[]>;
+
+  /**
+   * Finds a resource by its input ID.
+   *
+   * @param type - The model type
+   * @param inputId - The input ID
+   * @returns The resource if found, or null
+   */
+  findByInputId(
+    type: ModelType,
+    inputId: ModelInputId,
+  ): Promise<ModelResource | null>;
+
+  /**
+   * Saves a resource.
+   *
+   * @param type - The model type
+   * @param resource - The resource to save
+   */
+  save(type: ModelType, resource: ModelResource): Promise<void>;
+
+  /**
+   * Deletes a resource.
+   *
+   * @param type - The model type
+   * @param id - The resource ID
+   */
+  delete(type: ModelType, id: ModelResourceId): Promise<void>;
+
+  /**
+   * Generates a new unique ID.
+   */
+  nextId(): ModelResourceId;
+
+  /**
+   * Returns the file path for a resource.
+   *
+   * @param type - The model type
+   * @param id - The resource ID
+   * @returns The file path
+   */
+  getPath(type: ModelType, id: ModelResourceId): string;
+}

--- a/src/infrastructure/persistence/yaml_input_repository.ts
+++ b/src/infrastructure/persistence/yaml_input_repository.ts
@@ -1,0 +1,143 @@
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import type { InputRepository } from "../../domain/models/repositories.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
+import {
+  createModelInputId,
+  ModelInput,
+  type ModelInputData,
+  type ModelInputId,
+} from "../../domain/models/model_input.ts";
+
+/**
+ * YAML-based implementation of InputRepository.
+ *
+ * Stores inputs as YAML files in the directory structure:
+ * {repoDir}/inputs/{normalized-type}/{id}.yaml
+ */
+export class YamlInputRepository implements InputRepository {
+  constructor(private readonly repoDir: string) {}
+
+  async findById(
+    type: ModelType,
+    id: ModelInputId,
+  ): Promise<ModelInput | null> {
+    const path = this.getPath(type, id);
+    try {
+      const content = await Deno.readTextFile(path);
+      const data = parseYaml(content) as ModelInputData;
+      return ModelInput.fromData(data);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async findAll(type: ModelType): Promise<ModelInput[]> {
+    const dir = this.getTypeDir(type);
+    const inputs: ModelInput[] = [];
+
+    try {
+      for await (const entry of Deno.readDir(dir)) {
+        if (entry.isFile && entry.name.endsWith(".yaml")) {
+          const path = join(dir, entry.name);
+          const content = await Deno.readTextFile(path);
+          const data = parseYaml(content) as ModelInputData;
+          inputs.push(ModelInput.fromData(data));
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+
+    return inputs;
+  }
+
+  async findByName(type: ModelType, name: string): Promise<ModelInput | null> {
+    const inputs = await this.findAll(type);
+    return inputs.find((input) => input.name === name) ?? null;
+  }
+
+  async findByNameGlobal(
+    name: string,
+  ): Promise<{ input: ModelInput; type: ModelType } | null> {
+    const inputsDir = join(this.repoDir, "inputs");
+
+    try {
+      // Iterate through all type directories
+      for await (const vendorEntry of Deno.readDir(inputsDir)) {
+        if (!vendorEntry.isDirectory) continue;
+
+        const vendorDir = join(inputsDir, vendorEntry.name);
+        for await (const typeEntry of Deno.readDir(vendorDir)) {
+          if (!typeEntry.isDirectory) continue;
+
+          const typeDir = join(vendorDir, typeEntry.name);
+          // Read all inputs in this type directory
+          for await (const fileEntry of Deno.readDir(typeDir)) {
+            if (!fileEntry.isFile || !fileEntry.name.endsWith(".yaml")) continue;
+
+            const path = join(typeDir, fileEntry.name);
+            const content = await Deno.readTextFile(path);
+            const data = parseYaml(content) as ModelInputData;
+            const input = ModelInput.fromData(data);
+
+            if (input.name === name) {
+              // Reconstruct the model type from the directory path
+              const typeStr = `${vendorEntry.name}/${typeEntry.name}`;
+              return { input, type: ModelType.create(typeStr) };
+            }
+          }
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+
+    return null;
+  }
+
+  async save(type: ModelType, input: ModelInput): Promise<void> {
+    const dir = this.getTypeDir(type);
+    await ensureDir(dir);
+
+    const path = this.getPath(type, input.id);
+    const data = input.toData();
+    // Remove undefined values since YAML can't stringify them
+    const cleanData = JSON.parse(JSON.stringify(data));
+    const content = stringifyYaml(cleanData as Record<string, unknown>);
+    await Deno.writeTextFile(path, content);
+  }
+
+  async delete(type: ModelType, id: ModelInputId): Promise<void> {
+    const path = this.getPath(type, id);
+    try {
+      await Deno.remove(path);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+  }
+
+  nextId(): ModelInputId {
+    return createModelInputId(crypto.randomUUID());
+  }
+
+  getPath(type: ModelType, id: ModelInputId): string {
+    return join(this.getTypeDir(type), `${id}.yaml`);
+  }
+
+  private getTypeDir(type: ModelType): string {
+    return join(this.repoDir, "inputs", type.toDirectoryPath());
+  }
+}

--- a/src/infrastructure/persistence/yaml_input_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_input_repository_test.ts
@@ -1,0 +1,234 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { ModelType } from "../../domain/models/model_type.ts";
+import {
+  createModelInputId,
+  ModelInput,
+} from "../../domain/models/model_input.ts";
+import { YamlInputRepository } from "./yaml_input_repository.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("YamlInputRepository.save creates directory structure", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlInputRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const input = ModelInput.create({ name: "test-input" });
+
+    await repo.save(type, input);
+
+    const expectedDir = join(dir, "inputs", "swamp/echo");
+    const stat = await Deno.stat(expectedDir);
+    assertEquals(stat.isDirectory, true);
+  });
+});
+
+Deno.test("YamlInputRepository.save creates yaml file", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlInputRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const input = ModelInput.create({
+      name: "test-input",
+      attributes: { message: "hello" },
+    });
+
+    await repo.save(type, input);
+
+    const path = repo.getPath(type, input.id);
+    const content = await Deno.readTextFile(path);
+    assertStringIncludes(content, "name: test-input");
+    assertStringIncludes(content, "message: hello");
+  });
+});
+
+Deno.test("YamlInputRepository.findById returns saved input", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlInputRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const input = ModelInput.create({
+      name: "test-input",
+      tags: { env: "prod" },
+      attributes: { message: "hello" },
+    });
+
+    await repo.save(type, input);
+    const found = await repo.findById(type, input.id);
+
+    assertEquals(found?.id, input.id);
+    assertEquals(found?.name, "test-input");
+    assertEquals(found?.tags, { env: "prod" });
+    assertEquals(found?.attributes, { message: "hello" });
+  });
+});
+
+Deno.test("YamlInputRepository.findById returns null for non-existent", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlInputRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const id = createModelInputId("550e8400-e29b-41d4-a716-446655440000");
+
+    const found = await repo.findById(type, id);
+    assertEquals(found, null);
+  });
+});
+
+Deno.test("YamlInputRepository.findAll returns all inputs of type", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlInputRepository(dir);
+    const type = ModelType.create("swamp/echo");
+
+    const input1 = ModelInput.create({ name: "input-1" });
+    const input2 = ModelInput.create({ name: "input-2" });
+    await repo.save(type, input1);
+    await repo.save(type, input2);
+
+    const all = await repo.findAll(type);
+    assertEquals(all.length, 2);
+    assertEquals(all.map((i) => i.name).sort(), ["input-1", "input-2"]);
+  });
+});
+
+Deno.test("YamlInputRepository.findAll returns empty array when no inputs", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlInputRepository(dir);
+    const type = ModelType.create("swamp/echo");
+
+    const all = await repo.findAll(type);
+    assertEquals(all, []);
+  });
+});
+
+Deno.test("YamlInputRepository.findByName finds input by name", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlInputRepository(dir);
+    const type = ModelType.create("swamp/echo");
+
+    const input = ModelInput.create({ name: "my-input" });
+    await repo.save(type, input);
+
+    const found = await repo.findByName(type, "my-input");
+    assertEquals(found?.id, input.id);
+    assertEquals(found?.name, "my-input");
+  });
+});
+
+Deno.test("YamlInputRepository.findByName returns null when not found", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlInputRepository(dir);
+    const type = ModelType.create("swamp/echo");
+
+    const found = await repo.findByName(type, "nonexistent");
+    assertEquals(found, null);
+  });
+});
+
+Deno.test("YamlInputRepository.delete removes input file", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlInputRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const input = ModelInput.create({ name: "test-input" });
+
+    await repo.save(type, input);
+    assertEquals(await repo.findById(type, input.id) !== null, true);
+
+    await repo.delete(type, input.id);
+    assertEquals(await repo.findById(type, input.id), null);
+  });
+});
+
+Deno.test("YamlInputRepository.delete is idempotent", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlInputRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const id = createModelInputId("550e8400-e29b-41d4-a716-446655440000");
+
+    // Should not throw even if file doesn't exist
+    await repo.delete(type, id);
+  });
+});
+
+Deno.test("YamlInputRepository.nextId generates valid UUID", () => {
+  const repo = new YamlInputRepository("/tmp");
+  const id = repo.nextId();
+  assertEquals(typeof id, "string");
+  assertEquals(id.length, 36);
+});
+
+Deno.test("YamlInputRepository.getPath returns correct path", () => {
+  const repo = new YamlInputRepository("/repo");
+  const type = ModelType.create("swamp/echo");
+  const id = createModelInputId("550e8400-e29b-41d4-a716-446655440000");
+
+  const path = repo.getPath(type, id);
+  assertEquals(
+    path,
+    "/repo/inputs/swamp/echo/550e8400-e29b-41d4-a716-446655440000.yaml",
+  );
+});
+
+Deno.test("YamlInputRepository handles nested type paths", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlInputRepository(dir);
+    const type = ModelType.create("AWS::EC2::VPC");
+    const input = ModelInput.create({ name: "my-vpc" });
+
+    await repo.save(type, input);
+
+    const path = repo.getPath(type, input.id);
+    assertStringIncludes(path, "aws/ec2/vpc");
+
+    const found = await repo.findById(type, input.id);
+    assertEquals(found?.name, "my-vpc");
+  });
+});
+
+Deno.test("YamlInputRepository.findByNameGlobal finds input across all types", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlInputRepository(dir);
+    const echoType = ModelType.create("swamp/echo");
+    const otherType = ModelType.create("swamp/other");
+
+    const echoInput = ModelInput.create({ name: "echo-input" });
+    const otherInput = ModelInput.create({ name: "other-input" });
+    await repo.save(echoType, echoInput);
+    await repo.save(otherType, otherInput);
+
+    // Should find input from echo type
+    const foundEcho = await repo.findByNameGlobal("echo-input");
+    assertEquals(foundEcho?.input.id, echoInput.id);
+    assertEquals(foundEcho?.type.normalized, "swamp/echo");
+
+    // Should find input from other type
+    const foundOther = await repo.findByNameGlobal("other-input");
+    assertEquals(foundOther?.input.id, otherInput.id);
+    assertEquals(foundOther?.type.normalized, "swamp/other");
+  });
+});
+
+Deno.test("YamlInputRepository.findByNameGlobal returns null when not found", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlInputRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const input = ModelInput.create({ name: "my-input" });
+    await repo.save(type, input);
+
+    const found = await repo.findByNameGlobal("nonexistent");
+    assertEquals(found, null);
+  });
+});
+
+Deno.test("YamlInputRepository.findByNameGlobal returns null when no inputs exist", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlInputRepository(dir);
+
+    const found = await repo.findByNameGlobal("nonexistent");
+    assertEquals(found, null);
+  });
+});

--- a/src/infrastructure/persistence/yaml_resource_repository.ts
+++ b/src/infrastructure/persistence/yaml_resource_repository.ts
@@ -1,0 +1,105 @@
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import type { ResourceRepository } from "../../domain/models/repositories.ts";
+import type { ModelType } from "../../domain/models/model_type.ts";
+import type { ModelInputId } from "../../domain/models/model_input.ts";
+import {
+  createModelResourceId,
+  ModelResource,
+  type ModelResourceData,
+  type ModelResourceId,
+} from "../../domain/models/model_resource.ts";
+
+/**
+ * YAML-based implementation of ResourceRepository.
+ *
+ * Stores resources as YAML files in the directory structure:
+ * {repoDir}/resources/{normalized-type}/{id}.yaml
+ */
+export class YamlResourceRepository implements ResourceRepository {
+  constructor(private readonly repoDir: string) {}
+
+  async findById(
+    type: ModelType,
+    id: ModelResourceId,
+  ): Promise<ModelResource | null> {
+    const path = this.getPath(type, id);
+    try {
+      const content = await Deno.readTextFile(path);
+      const data = parseYaml(content) as ModelResourceData;
+      return ModelResource.fromData(data);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async findAll(type: ModelType): Promise<ModelResource[]> {
+    const dir = this.getTypeDir(type);
+    const resources: ModelResource[] = [];
+
+    try {
+      for await (const entry of Deno.readDir(dir)) {
+        if (entry.isFile && entry.name.endsWith(".yaml")) {
+          const path = join(dir, entry.name);
+          const content = await Deno.readTextFile(path);
+          const data = parseYaml(content) as ModelResourceData;
+          resources.push(ModelResource.fromData(data));
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+
+    return resources;
+  }
+
+  async findByInputId(
+    type: ModelType,
+    inputId: ModelInputId,
+  ): Promise<ModelResource | null> {
+    const resources = await this.findAll(type);
+    return resources.find((resource) => resource.inputId === inputId) ?? null;
+  }
+
+  async save(type: ModelType, resource: ModelResource): Promise<void> {
+    const dir = this.getTypeDir(type);
+    await ensureDir(dir);
+
+    const path = this.getPath(type, resource.id);
+    const data = resource.toData();
+    // Remove undefined values since YAML can't stringify them
+    const cleanData = JSON.parse(JSON.stringify(data));
+    const content = stringifyYaml(cleanData as Record<string, unknown>);
+    await Deno.writeTextFile(path, content);
+  }
+
+  async delete(type: ModelType, id: ModelResourceId): Promise<void> {
+    const path = this.getPath(type, id);
+    try {
+      await Deno.remove(path);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+  }
+
+  nextId(): ModelResourceId {
+    return createModelResourceId(crypto.randomUUID());
+  }
+
+  getPath(type: ModelType, id: ModelResourceId): string {
+    return join(this.getTypeDir(type), `${id}.yaml`);
+  }
+
+  private getTypeDir(type: ModelType): string {
+    return join(this.repoDir, "resources", type.toDirectoryPath());
+  }
+}

--- a/src/infrastructure/persistence/yaml_resource_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_resource_repository_test.ts
@@ -1,0 +1,182 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { ModelType } from "../../domain/models/model_type.ts";
+import { createModelInputId } from "../../domain/models/model_input.ts";
+import {
+  createModelResourceId,
+  ModelResource,
+} from "../../domain/models/model_resource.ts";
+import { YamlResourceRepository } from "./yaml_resource_repository.ts";
+
+const TEST_INPUT_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("YamlResourceRepository.save creates directory structure", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlResourceRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const resource = ModelResource.create({ inputId: TEST_INPUT_ID });
+
+    await repo.save(type, resource);
+
+    const expectedDir = join(dir, "resources", "swamp/echo");
+    const stat = await Deno.stat(expectedDir);
+    assertEquals(stat.isDirectory, true);
+  });
+});
+
+Deno.test("YamlResourceRepository.save creates yaml file", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlResourceRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const resource = ModelResource.create({
+      inputId: TEST_INPUT_ID,
+      attributes: { message: "hello", timestamp: "2024-01-15" },
+    });
+
+    await repo.save(type, resource);
+
+    const path = repo.getPath(type, resource.id);
+    const content = await Deno.readTextFile(path);
+    assertStringIncludes(content, "message: hello");
+    assertStringIncludes(content, "timestamp:");
+  });
+});
+
+Deno.test("YamlResourceRepository.findById returns saved resource", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlResourceRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const resource = ModelResource.create({
+      inputId: TEST_INPUT_ID,
+      attributes: { message: "hello" },
+    });
+
+    await repo.save(type, resource);
+    const found = await repo.findById(type, resource.id);
+
+    assertEquals(found?.id, resource.id);
+    assertEquals(found?.inputId, TEST_INPUT_ID);
+    assertEquals(found?.attributes, { message: "hello" });
+  });
+});
+
+Deno.test("YamlResourceRepository.findById returns null for non-existent", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlResourceRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const id = createModelResourceId("550e8400-e29b-41d4-a716-446655440001");
+
+    const found = await repo.findById(type, id);
+    assertEquals(found, null);
+  });
+});
+
+Deno.test("YamlResourceRepository.findAll returns all resources of type", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlResourceRepository(dir);
+    const type = ModelType.create("swamp/echo");
+
+    const resource1 = ModelResource.create({
+      inputId: TEST_INPUT_ID,
+      attributes: { n: 1 },
+    });
+    const resource2 = ModelResource.create({
+      inputId: TEST_INPUT_ID,
+      attributes: { n: 2 },
+    });
+    await repo.save(type, resource1);
+    await repo.save(type, resource2);
+
+    const all = await repo.findAll(type);
+    assertEquals(all.length, 2);
+  });
+});
+
+Deno.test("YamlResourceRepository.findAll returns empty array when no resources", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlResourceRepository(dir);
+    const type = ModelType.create("swamp/echo");
+
+    const all = await repo.findAll(type);
+    assertEquals(all, []);
+  });
+});
+
+Deno.test("YamlResourceRepository.findByInputId finds resource by input ID", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlResourceRepository(dir);
+    const type = ModelType.create("swamp/echo");
+
+    const resource = ModelResource.create({ inputId: TEST_INPUT_ID });
+    await repo.save(type, resource);
+
+    const inputId = createModelInputId(TEST_INPUT_ID);
+    const found = await repo.findByInputId(type, inputId);
+    assertEquals(found?.id, resource.id);
+    assertEquals(found?.inputId, TEST_INPUT_ID);
+  });
+});
+
+Deno.test("YamlResourceRepository.findByInputId returns null when not found", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlResourceRepository(dir);
+    const type = ModelType.create("swamp/echo");
+
+    const inputId = createModelInputId("550e8400-e29b-41d4-a716-446655440099");
+    const found = await repo.findByInputId(type, inputId);
+    assertEquals(found, null);
+  });
+});
+
+Deno.test("YamlResourceRepository.delete removes resource file", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlResourceRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const resource = ModelResource.create({ inputId: TEST_INPUT_ID });
+
+    await repo.save(type, resource);
+    assertEquals(await repo.findById(type, resource.id) !== null, true);
+
+    await repo.delete(type, resource.id);
+    assertEquals(await repo.findById(type, resource.id), null);
+  });
+});
+
+Deno.test("YamlResourceRepository.delete is idempotent", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlResourceRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const id = createModelResourceId("550e8400-e29b-41d4-a716-446655440001");
+
+    // Should not throw even if file doesn't exist
+    await repo.delete(type, id);
+  });
+});
+
+Deno.test("YamlResourceRepository.nextId generates valid UUID", () => {
+  const repo = new YamlResourceRepository("/tmp");
+  const id = repo.nextId();
+  assertEquals(typeof id, "string");
+  assertEquals(id.length, 36);
+});
+
+Deno.test("YamlResourceRepository.getPath returns correct path", () => {
+  const repo = new YamlResourceRepository("/repo");
+  const type = ModelType.create("swamp/echo");
+  const id = createModelResourceId("550e8400-e29b-41d4-a716-446655440001");
+
+  const path = repo.getPath(type, id);
+  assertEquals(
+    path,
+    "/repo/resources/swamp/echo/550e8400-e29b-41d4-a716-446655440001.yaml",
+  );
+});

--- a/src/presentation/output/error_output.tsx
+++ b/src/presentation/output/error_output.tsx
@@ -1,0 +1,65 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { Box, render, Text } from "ink";
+import type { OutputMode } from "./output.tsx";
+
+export interface ErrorData {
+  error: string;
+  stack?: string;
+}
+
+/**
+ * Extracts just the stack trace lines from an error stack.
+ * Removes the error message line and any source code snippets.
+ */
+function extractStackLines(stack: string | undefined): string | undefined {
+  if (!stack) return undefined;
+
+  const lines = stack.split("\n");
+  // Find lines that start with "at " (stack frames)
+  const stackLines = lines.filter((line) => line.trim().startsWith("at "));
+  return stackLines.length > 0 ? stackLines.join("\n") : undefined;
+}
+
+/**
+ * Renders an error to the console based on output mode.
+ */
+export function renderError(error: unknown, mode: OutputMode): void {
+  const err = error instanceof Error ? error : new Error(String(error));
+  const stackLines = extractStackLines(err.stack);
+
+  if (mode === "json") {
+    const data: ErrorData = {
+      error: err.message,
+    };
+    if (stackLines) {
+      data.stack = stackLines;
+    }
+    console.error(JSON.stringify(data, null, 2));
+  } else {
+    renderInteractiveError(err.message, stackLines);
+  }
+}
+
+function renderInteractiveError(message: string, stack?: string): void {
+  const { unmount } = render(<ErrorDisplay message={message} stack={stack} />);
+  unmount();
+}
+
+interface ErrorDisplayProps {
+  message: string;
+  stack?: string;
+}
+
+export function ErrorDisplay(props: ErrorDisplayProps): React.ReactElement {
+  return (
+    <Box flexDirection="column">
+      <Text color="red">Error: {props.message}</Text>
+      {props.stack && (
+        <Box marginTop={1}>
+          <Text dimColor>{props.stack}</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/presentation/output/error_output_test.tsx
+++ b/src/presentation/output/error_output_test.tsx
@@ -1,0 +1,105 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { render } from "ink-testing-library";
+import { ErrorDisplay, renderError } from "./error_output.tsx";
+
+const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
+
+Deno.test({
+  name: "ErrorDisplay renders error message in red",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ErrorDisplay message="Something went wrong" />,
+    );
+    const output = lastFrame() ?? "";
+    assertStringIncludes(output, "Error: Something went wrong");
+  },
+});
+
+Deno.test({
+  name: "ErrorDisplay renders stack trace when provided",
+  ...inkTestOptions,
+  fn: () => {
+    const stack = "    at foo (file.ts:10:5)\n    at bar (file.ts:20:3)";
+    const { lastFrame } = render(
+      <ErrorDisplay message="Test error" stack={stack} />,
+    );
+    const output = lastFrame() ?? "";
+    assertStringIncludes(output, "at foo");
+    assertStringIncludes(output, "at bar");
+  },
+});
+
+Deno.test({
+  name: "ErrorDisplay omits stack section when not provided",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<ErrorDisplay message="Test error" />);
+    const output = lastFrame() ?? "";
+    assertStringIncludes(output, "Error: Test error");
+    // Should not have extra content
+    assertEquals(output.includes("at "), false);
+  },
+});
+
+Deno.test("renderError with json mode outputs valid JSON", () => {
+  const logs: string[] = [];
+  const originalError = console.error;
+  console.error = (msg: string) => logs.push(msg);
+
+  try {
+    const error = new Error("Test error message");
+    error.stack = "Error: Test error message\n    at test (file.ts:1:1)";
+    renderError(error, "json");
+
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.error, "Test error message");
+    assertStringIncludes(parsed.stack, "at test");
+  } finally {
+    console.error = originalError;
+  }
+});
+
+Deno.test("renderError extracts only stack lines", () => {
+  const logs: string[] = [];
+  const originalError = console.error;
+  console.error = (msg: string) => logs.push(msg);
+
+  try {
+    const error = new Error("Test error");
+    // Simulate a real stack with error message line
+    error.stack = `Error: Test error
+    at functionOne (file:///path/to/file.ts:10:5)
+    at functionTwo (file:///path/to/other.ts:20:10)`;
+
+    renderError(error, "json");
+
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.error, "Test error");
+    // Stack should only contain "at" lines, not the error message
+    assertEquals(parsed.stack.includes("Error: Test error"), false);
+    assertStringIncludes(parsed.stack, "at functionOne");
+    assertStringIncludes(parsed.stack, "at functionTwo");
+  } finally {
+    console.error = originalError;
+  }
+});
+
+Deno.test("renderError handles non-Error objects", () => {
+  const logs: string[] = [];
+  const originalError = console.error;
+  console.error = (msg: string) => logs.push(msg);
+
+  try {
+    renderError("plain string error", "json");
+
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.error, "plain string error");
+  } finally {
+    console.error = originalError;
+  }
+});

--- a/src/presentation/output/model_create_output.tsx
+++ b/src/presentation/output/model_create_output.tsx
@@ -1,0 +1,62 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { Box, render, Text } from "ink";
+import type { OutputMode } from "./output.tsx";
+
+export interface ModelCreateData {
+  id: string;
+  type: string;
+  name: string;
+  path: string;
+}
+
+export function renderModelCreate(
+  data: ModelCreateData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    renderInteractiveModelCreate(data);
+  }
+}
+
+function renderInteractiveModelCreate(data: ModelCreateData): void {
+  const { unmount } = render(<ModelCreateDisplay {...data} />);
+  unmount();
+}
+
+interface ModelCreateDisplayProps {
+  id: string;
+  type: string;
+  name: string;
+  path: string;
+}
+
+export function ModelCreateDisplay(
+  props: ModelCreateDisplayProps,
+): React.ReactElement {
+  return (
+    <Box flexDirection="column">
+      <Text color="green">Created model input:</Text>
+      <Box marginLeft={2} flexDirection="column">
+        <Text>
+          <Text color="cyan">Type:</Text>
+          <Text>{props.type}</Text>
+        </Text>
+        <Text>
+          <Text color="cyan">Name:</Text>
+          <Text>{props.name}</Text>
+        </Text>
+        <Text>
+          <Text color="cyan">ID:</Text>
+          <Text dimColor>{props.id}</Text>
+        </Text>
+        <Text>
+          <Text color="cyan">Path:</Text>
+          <Text dimColor>{props.path}</Text>
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/presentation/output/model_create_output_test.tsx
+++ b/src/presentation/output/model_create_output_test.tsx
@@ -1,0 +1,60 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { render } from "ink-testing-library";
+import {
+  type ModelCreateData,
+  ModelCreateDisplay,
+  renderModelCreate,
+} from "./model_create_output.tsx";
+
+const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
+
+const testData: ModelCreateData = {
+  id: "550e8400-e29b-41d4-a716-446655440000",
+  type: "swamp/echo",
+  name: "test-echo",
+  path: "inputs/swamp/echo/550e8400-e29b-41d4-a716-446655440000.yaml",
+};
+
+Deno.test({
+  name: "ModelCreateDisplay renders all fields",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<ModelCreateDisplay {...testData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "swamp/echo");
+    assertStringIncludes(output, "test-echo");
+    assertStringIncludes(output, "550e8400-e29b-41d4-a716-446655440000");
+  },
+});
+
+Deno.test({
+  name: "ModelCreateDisplay shows 'Created model input' message",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<ModelCreateDisplay {...testData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Created model input");
+  },
+});
+
+Deno.test("renderModelCreate with json mode outputs valid JSON", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelCreate(testData, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.id, testData.id);
+    assertEquals(parsed.type, testData.type);
+    assertEquals(parsed.name, testData.name);
+    assertEquals(parsed.path, testData.path);
+  } finally {
+    console.log = originalLog;
+  }
+});


### PR DESCRIPTION
## Summary

- Add foundational model system implementing domain-driven design principles
- Create domain layer with ModelType, ModelInput, ModelResource entities and model registry
- Implement Echo model as a reference implementation for testing
- Add YAML-based persistence with YamlInputRepository and YamlResourceRepository
- Implement `model create <type> <name>` CLI command with interactive and JSON output modes
- Add design documentation for high-level architecture and model specification

## Test plan

- [ ] Run `deno task test` to verify all unit and integration tests pass
- [ ] Run `deno check` to verify type checking passes
- [ ] Run `deno lint` to verify linting passes
- [ ] Test `model create swamp/echo test-model` creates input file correctly
- [ ] Test `model create swamp/echo test-model --output json` returns JSON output

🤖 Generated with [Claude Code](https://claude.com/claude-code)