### PR TITLE
Upgrade Zod from v3 to v4

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -14,7 +14,7 @@
     "@std/fs": "jsr:@std/fs@1",
     "@std/path": "jsr:@std/path@1",
     "@std/yaml": "jsr:@std/yaml@1",
-    "zod": "npm:zod@3",
+    "zod": "npm:zod@4",
     "@cliffy/command": "jsr:@cliffy/command@1.0.0-rc.8",
     "@logtape/logtape": "jsr:@logtape/logtape@0.8",
     "ink": "npm:ink@5",

--- a/deno.lock
+++ b/deno.lock
@@ -18,7 +18,7 @@
     "npm:ink-testing-library@4": "4.0.0_@types+react@18.3.27",
     "npm:ink@5": "5.2.1_@types+react@18.3.27_react@18.3.1",
     "npm:react@18": "18.3.1",
-    "npm:zod@3": "3.25.76"
+    "npm:zod@4": "4.3.6"
   },
   "jsr": {
     "@cliffy/command@1.0.0-rc.8": {
@@ -328,8 +328,8 @@
     "yoga-layout@3.2.1": {
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="
     },
-    "zod@3.25.76": {
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
+    "zod@4.3.6": {
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="
     }
   },
   "workspace": {
@@ -344,7 +344,7 @@
       "npm:ink-testing-library@4",
       "npm:ink@5",
       "npm:react@18",
-      "npm:zod@3"
+      "npm:zod@4"
     ]
   }
 }


### PR DESCRIPTION
Upgrades the Zod validation library from version 3 to version 4.3.6.

### Changes

- Updated deno.json to specify zod@4 instead of zod@3
- Updated deno.lock with Zod 4.3.6 dependency resolution

### Compatibility

All existing Zod usage in the codebase is fully compatible with v4:
- Schema definitions (model input/resource schemas)
- Type inference with z.infer
- Validation methods (parse, safeParse)
- Schema composition and chaining

### Testing

- ✅ Type checking passes (deno check)
- ✅ All Zod-related tests pass (59 tests across model domain layer)
- ✅ Integration tests pass
- ✅ 145/146 tests pass (1 unrelated pre-existing failure in logger tests)

### Migration Notes

No code changes required. Zod v4 maintains API compatibility with v3 for the features used in this codebase.