### PR TITLE
feat: add model validate command with validate-all support

### DIFF
--- a/integration/model_validate_test.ts
+++ b/integration/model_validate_test.ts
@@ -1,0 +1,492 @@
+/**
+ * Integration tests for the model validate command.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { ModelInput } from "../src/domain/models/model_input.ts";
+import { ModelResource } from "../src/domain/models/model_resource.ts";
+import { YamlInputRepository } from "../src/infrastructure/persistence/yaml_input_repository.ts";
+import { YamlResourceRepository } from "../src/infrastructure/persistence/yaml_resource_repository.ts";
+import { ECHO_MODEL_TYPE } from "../src/domain/models/echo/echo_model.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-validate-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+async function runCliCommand(
+  args: string[],
+  cwd: string,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["task", "dev", ...args],
+    stdout: "piped",
+    stderr: "piped",
+    cwd,
+  });
+
+  const { code, stdout, stderr } = await command.output();
+  return {
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+    code,
+  };
+}
+
+Deno.test("CLI: model validate passes for valid echo model input", async () => {
+  await withTempDir(async (repoDir) => {
+    const inputRepo = new YamlInputRepository(repoDir);
+    const modelType = ECHO_MODEL_TYPE;
+
+    // Create a valid echo model input
+    const input = ModelInput.create({
+      name: "valid-echo-input",
+      attributes: { message: "Hello, world!" },
+    });
+    await inputRepo.save(modelType, input);
+
+    // Run the validate command
+    const result = await runCliCommand(
+      [
+        "model",
+        "validate",
+        "valid-echo-input",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Command should succeed. stderr: ${result.stderr}`,
+    );
+
+    // Parse and verify JSON output
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.modelName, "valid-echo-input");
+    assertEquals(output.type, "swamp/echo");
+    assertEquals(output.passed, true);
+    assertEquals(output.validations.length, 2); // Input schema + Input attributes
+    assertEquals(
+      output.validations.every((v: { passed: boolean }) => v.passed),
+      true,
+    );
+  });
+});
+
+Deno.test("CLI: model validate passes for valid echo model with resource", async () => {
+  await withTempDir(async (repoDir) => {
+    const inputRepo = new YamlInputRepository(repoDir);
+    const resourceRepo = new YamlResourceRepository(repoDir);
+    const modelType = ECHO_MODEL_TYPE;
+
+    // Create a valid echo model input
+    const input = ModelInput.create({
+      name: "echo-with-resource",
+      attributes: { message: "Hello, world!" },
+    });
+    await inputRepo.save(modelType, input);
+
+    // Create a valid resource
+    const resource = ModelResource.create({
+      inputId: input.id,
+      attributes: {
+        message: "Hello, world!",
+        timestamp: new Date().toISOString(),
+      },
+    });
+    await resourceRepo.save(modelType, resource);
+
+    // Run the validate command
+    const result = await runCliCommand(
+      [
+        "model",
+        "validate",
+        "echo-with-resource",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Command should succeed. stderr: ${result.stderr}`,
+    );
+
+    // Parse and verify JSON output
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.passed, true);
+    assertEquals(output.validations.length, 4); // Input + Resource validations
+  });
+});
+
+Deno.test("CLI: model validate fails for invalid input attributes", async () => {
+  await withTempDir(async (repoDir) => {
+    const inputRepo = new YamlInputRepository(repoDir);
+    const modelType = ECHO_MODEL_TYPE;
+
+    // Create an echo model input with invalid attributes (missing message)
+    const input = ModelInput.create({
+      name: "invalid-echo-input",
+      attributes: { wrongField: "oops" },
+    });
+    await inputRepo.save(modelType, input);
+
+    // Run the validate command
+    const result = await runCliCommand(
+      [
+        "model",
+        "validate",
+        "invalid-echo-input",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      1,
+      `Command should fail with exit code 1`,
+    );
+
+    // Parse and verify JSON output
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.passed, false);
+
+    // Find the failing validation
+    const failedValidation = output.validations.find(
+      (v: { passed: boolean }) => !v.passed,
+    );
+    assertEquals(failedValidation.name, "Input attributes");
+    assertEquals(typeof failedValidation.error, "string");
+  });
+});
+
+Deno.test("CLI: model validate fails for invalid resource attributes", async () => {
+  await withTempDir(async (repoDir) => {
+    const inputRepo = new YamlInputRepository(repoDir);
+    const resourceRepo = new YamlResourceRepository(repoDir);
+    const modelType = ECHO_MODEL_TYPE;
+
+    // Create a valid echo model input
+    const input = ModelInput.create({
+      name: "echo-invalid-resource",
+      attributes: { message: "Hello" },
+    });
+    await inputRepo.save(modelType, input);
+
+    // Create an invalid resource (missing timestamp)
+    const resource = ModelResource.create({
+      inputId: input.id,
+      attributes: {
+        message: "Hello",
+        // Missing required timestamp
+      },
+    });
+    await resourceRepo.save(modelType, resource);
+
+    // Run the validate command
+    const result = await runCliCommand(
+      [
+        "model",
+        "validate",
+        "echo-invalid-resource",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      1,
+      `Command should fail with exit code 1`,
+    );
+
+    // Parse and verify JSON output
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.passed, false);
+
+    // Find the failing resource validation
+    const failedValidation = output.validations.find(
+      (v: { name: string; passed: boolean }) =>
+        v.name === "Resource attributes" && !v.passed,
+    );
+    assertEquals(failedValidation !== undefined, true);
+  });
+});
+
+Deno.test("CLI: model validate can look up by UUID", async () => {
+  await withTempDir(async (repoDir) => {
+    const inputRepo = new YamlInputRepository(repoDir);
+    const modelType = ECHO_MODEL_TYPE;
+
+    // Create a valid echo model input
+    const input = ModelInput.create({
+      name: "uuid-lookup-test",
+      attributes: { message: "Hello" },
+    });
+    await inputRepo.save(modelType, input);
+
+    // Run the validate command using the UUID
+    const result = await runCliCommand(
+      [
+        "model",
+        "validate",
+        input.id,
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Command should succeed. stderr: ${result.stderr}`,
+    );
+
+    // Verify it found the right model
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.modelId, input.id);
+    assertEquals(output.modelName, "uuid-lookup-test");
+  });
+});
+
+Deno.test("CLI: model validate errors for non-existent model", async () => {
+  await withTempDir(async (repoDir) => {
+    // Run the validate command for a model that doesn't exist
+    const result = await runCliCommand(
+      [
+        "model",
+        "validate",
+        "non-existent-model",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code !== 0,
+      true,
+      `Command should fail`,
+    );
+    assertStringIncludes(result.stderr, "Model not found");
+  });
+});
+
+Deno.test("CLI: model validate interactive output shows checkmarks and summary", async () => {
+  await withTempDir(async (repoDir) => {
+    const inputRepo = new YamlInputRepository(repoDir);
+    const modelType = ECHO_MODEL_TYPE;
+
+    // Create a valid echo model input
+    const input = ModelInput.create({
+      name: "interactive-test",
+      attributes: { message: "Hello" },
+    });
+    await inputRepo.save(modelType, input);
+
+    // Run without --json to get interactive output
+    const result = await runCliCommand(
+      [
+        "model",
+        "validate",
+        "interactive-test",
+        "--repo-dir",
+        repoDir,
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Command should succeed. stderr: ${result.stderr}`,
+    );
+
+    // Verify interactive output contains expected elements
+    assertStringIncludes(result.stdout, "interactive-test");
+    assertStringIncludes(result.stdout, "swamp/echo");
+    assertStringIncludes(result.stdout, "PASSED");
+  });
+});
+
+// Validate-all tests (no argument)
+
+Deno.test("CLI: model validate with no args validates all models", async () => {
+  await withTempDir(async (repoDir) => {
+    const inputRepo = new YamlInputRepository(repoDir);
+    const modelType = ECHO_MODEL_TYPE;
+
+    // Create multiple valid echo model inputs
+    const input1 = ModelInput.create({
+      name: "all-test-1",
+      attributes: { message: "Hello 1" },
+    });
+    const input2 = ModelInput.create({
+      name: "all-test-2",
+      attributes: { message: "Hello 2" },
+    });
+    await inputRepo.save(modelType, input1);
+    await inputRepo.save(modelType, input2);
+
+    // Run the validate command without specifying a model
+    const result = await runCliCommand(
+      [
+        "model",
+        "validate",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Command should succeed. stderr: ${result.stderr}`,
+    );
+
+    // Parse and verify JSON output
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.models.length, 2);
+    assertEquals(output.totalPassed, 2);
+    assertEquals(output.totalFailed, 0);
+    assertEquals(output.passed, true);
+
+    // Verify both models are included
+    const modelNames = output.models.map((m: { modelName: string }) =>
+      m.modelName
+    );
+    assertEquals(modelNames.includes("all-test-1"), true);
+    assertEquals(modelNames.includes("all-test-2"), true);
+  });
+});
+
+Deno.test("CLI: model validate with no args exits 1 when any model fails", async () => {
+  await withTempDir(async (repoDir) => {
+    const inputRepo = new YamlInputRepository(repoDir);
+    const modelType = ECHO_MODEL_TYPE;
+
+    // Create one valid and one invalid model
+    const validInput = ModelInput.create({
+      name: "valid-model",
+      attributes: { message: "Hello" },
+    });
+    const invalidInput = ModelInput.create({
+      name: "invalid-model",
+      attributes: { wrongField: "oops" },
+    });
+    await inputRepo.save(modelType, validInput);
+    await inputRepo.save(modelType, invalidInput);
+
+    // Run the validate command without specifying a model
+    const result = await runCliCommand(
+      [
+        "model",
+        "validate",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      1,
+      `Command should fail with exit code 1`,
+    );
+
+    // Parse and verify JSON output
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.models.length, 2);
+    assertEquals(output.totalPassed, 1);
+    assertEquals(output.totalFailed, 1);
+    assertEquals(output.passed, false);
+  });
+});
+
+Deno.test("CLI: model validate with no args errors when no models found", async () => {
+  await withTempDir(async (repoDir) => {
+    // Run the validate command on an empty repo
+    const result = await runCliCommand(
+      [
+        "model",
+        "validate",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code !== 0,
+      true,
+      `Command should fail`,
+    );
+    assertStringIncludes(result.stderr, "No models found");
+  });
+});
+
+Deno.test("CLI: model validate with no args interactive output shows all models", async () => {
+  await withTempDir(async (repoDir) => {
+    const inputRepo = new YamlInputRepository(repoDir);
+    const modelType = ECHO_MODEL_TYPE;
+
+    // Create multiple valid echo model inputs
+    const input1 = ModelInput.create({
+      name: "interactive-all-1",
+      attributes: { message: "Hello 1" },
+    });
+    const input2 = ModelInput.create({
+      name: "interactive-all-2",
+      attributes: { message: "Hello 2" },
+    });
+    await inputRepo.save(modelType, input1);
+    await inputRepo.save(modelType, input2);
+
+    // Run without --json to get interactive output
+    const result = await runCliCommand(
+      [
+        "model",
+        "validate",
+        "--repo-dir",
+        repoDir,
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Command should succeed. stderr: ${result.stderr}`,
+    );
+
+    // Verify interactive output contains expected elements
+    assertStringIncludes(result.stdout, "Validating all models...");
+    assertStringIncludes(result.stdout, "interactive-all-1");
+    assertStringIncludes(result.stdout, "interactive-all-2");
+    assertStringIncludes(result.stdout, "2/2 models passed");
+    assertStringIncludes(result.stdout, "PASSED");
+  });
+});

--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -8,10 +8,7 @@ import { ModelType } from "../../domain/models/model_type.ts";
 import { ModelInput } from "../../domain/models/model_input.ts";
 import { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
-import { echoModel } from "../../domain/models/echo/echo_model.ts";
-
-// Register the echo model
-modelRegistry.register(echoModel);
+import { modelValidateCommand } from "./model_validate.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -74,4 +71,5 @@ export const modelCommand = new Command()
   .action(function () {
     this.showHelp();
   })
-  .command("create", modelCreateCommand);
+  .command("create", modelCreateCommand)
+  .command("validate", modelValidateCommand);

--- a/src/cli/commands/model_create_test.ts
+++ b/src/cli/commands/model_create_test.ts
@@ -18,3 +18,10 @@ Deno.test("modelCreateCommand is registered as subcommand", async () => {
   const createCmd = commands.find((c) => c.getName() === "create");
   assertEquals(createCmd !== undefined, true);
 });
+
+Deno.test("modelValidateCommand is registered as subcommand", async () => {
+  const { modelCommand } = await import("./model_create.ts");
+  const commands = modelCommand.getCommands();
+  const validateCmd = commands.find((c) => c.getName() === "validate");
+  assertEquals(validateCmd !== undefined, true);
+});

--- a/src/cli/commands/model_validate.ts
+++ b/src/cli/commands/model_validate.ts
@@ -1,0 +1,193 @@
+import { Command } from "@cliffy/command";
+import {
+  type ModelValidateData,
+  renderModelValidate,
+  renderModelValidateAll,
+  type ValidationItemData,
+} from "../../presentation/output/model_validate_output.tsx";
+import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createModelInputId,
+  type ModelInput,
+} from "../../domain/models/model_input.ts";
+import type { ModelType } from "../../domain/models/model_type.ts";
+import { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
+import { YamlResourceRepository } from "../../infrastructure/persistence/yaml_resource_repository.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
+import {
+  DefaultModelValidationService,
+  type ValidationResult,
+} from "../../domain/models/validation_service.ts";
+
+/**
+ * UUID v4 regex pattern for detecting if an argument is a UUID.
+ */
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Checks if a string looks like a UUID.
+ */
+function isUuid(value: string): boolean {
+  return UUID_PATTERN.test(value);
+}
+
+/**
+ * Finds an input by ID, searching across all registered model types.
+ */
+async function findInputByIdGlobal(
+  inputRepo: YamlInputRepository,
+  id: string,
+): Promise<{ input: ModelInput; type: ModelType } | null> {
+  const inputId = createModelInputId(id);
+
+  for (const type of modelRegistry.types()) {
+    const input = await inputRepo.findById(type, inputId);
+    if (input) {
+      return { input, type };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Converts ValidationResult array to ValidationItemData array for presentation.
+ */
+function toValidationItemData(
+  results: ValidationResult[],
+): ValidationItemData[] {
+  return results.map((r) => ({
+    name: r.name,
+    passed: r.passed,
+    error: r.error,
+  }));
+}
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const modelValidateCommand = new Command()
+  .name("validate")
+  .description("Validate a model input against its schema")
+  .arguments("[model_id_or_name:string]")
+  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .action(
+    async function (options: AnyOptions, modelIdOrName?: string) {
+      const ctx = createContext(options as GlobalOptions, "model-validate");
+      const repoDir = options.repoDir ?? ".";
+      const inputRepo = new YamlInputRepository(repoDir);
+      const resourceRepo = new YamlResourceRepository(repoDir);
+      const validationService = new DefaultModelValidationService();
+
+      // If no argument provided, validate all models
+      if (!modelIdOrName) {
+        ctx.logger.debug`Validating all models`;
+        const allInputs = await inputRepo.findAllGlobal();
+
+        if (allInputs.length === 0) {
+          throw new Error("No models found");
+        }
+
+        const results: ModelValidateData[] = [];
+        for (const { input, type } of allInputs) {
+          const definition = modelRegistry.get(type);
+          if (!definition) {
+            continue;
+          }
+
+          const resource = await resourceRepo.findByInputId(type, input.id);
+          const validationResults = await validationService.validateModel(
+            input,
+            definition,
+            resource,
+          );
+
+          const validations = toValidationItemData(validationResults);
+          const allPassed = validationResults.every((r) => r.passed);
+
+          results.push({
+            modelId: input.id,
+            modelName: input.name,
+            type: type.normalized,
+            validations,
+            passed: allPassed,
+          });
+        }
+
+        renderModelValidateAll(results, ctx.outputMode);
+
+        const anyFailed = results.some((r) => !r.passed);
+        ctx.logger.debug`Validation completed, anyFailed=${anyFailed}`;
+
+        if (anyFailed) {
+          Deno.exit(1);
+        }
+        return;
+      }
+
+      // Single model validation (existing behavior)
+      ctx.logger.debug`Validating model: ${modelIdOrName}`;
+
+      // Look up the model input
+      let input: ModelInput;
+      let modelType: ModelType;
+
+      if (isUuid(modelIdOrName)) {
+        ctx.logger.debug`Looking up by ID: ${modelIdOrName}`;
+        const result = await findInputByIdGlobal(inputRepo, modelIdOrName);
+        if (!result) {
+          throw new Error(`Model not found: ${modelIdOrName}`);
+        }
+        input = result.input;
+        modelType = result.type;
+      } else {
+        ctx.logger.debug`Looking up by name: ${modelIdOrName}`;
+        const result = await inputRepo.findByNameGlobal(modelIdOrName);
+        if (!result) {
+          throw new Error(`Model not found: ${modelIdOrName}`);
+        }
+        input = result.input;
+        modelType = result.type;
+      }
+
+      ctx.logger
+        .debug`Found model: id=${input.id}, type=${modelType.normalized}`;
+
+      // Get the model definition
+      const definition = modelRegistry.get(modelType);
+      if (!definition) {
+        throw new Error(`Unknown model type: ${modelType.normalized}`);
+      }
+
+      // Load the resource if it exists
+      const resource = await resourceRepo.findByInputId(modelType, input.id);
+      ctx.logger.debug`Resource exists: ${resource !== null}`;
+
+      // Run validations
+      const results = await validationService.validateModel(
+        input,
+        definition,
+        resource,
+      );
+
+      const validations = toValidationItemData(results);
+      const allPassed = results.every((r) => r.passed);
+
+      const data: ModelValidateData = {
+        modelId: input.id,
+        modelName: input.name,
+        type: modelType.normalized,
+        validations,
+        passed: allPassed,
+      };
+
+      renderModelValidate(data, ctx.outputMode);
+      ctx.logger.debug`Validation completed, passed=${allPassed}`;
+
+      // Exit with code 1 if any validation failed
+      if (!allPassed) {
+        Deno.exit(1);
+      }
+    },
+  );

--- a/src/cli/commands/model_validate_test.ts
+++ b/src/cli/commands/model_validate_test.ts
@@ -1,0 +1,21 @@
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Initialize logging for tests
+await initializeLogging({ debugLogs: false });
+
+// Note: Full CLI integration tests are in integration/model_validate_test.ts
+// These tests verify the command module loads correctly
+
+Deno.test("modelValidateCommand module loads", async () => {
+  const { modelValidateCommand } = await import("./model_validate.ts");
+  assertEquals(modelValidateCommand.getName(), "validate");
+});
+
+Deno.test("modelValidateCommand has correct description", async () => {
+  const { modelValidateCommand } = await import("./model_validate.ts");
+  assertEquals(
+    modelValidateCommand.getDescription(),
+    "Validate a model input against its schema",
+  );
+});

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -4,6 +4,9 @@ import { VERSION, versionCommand } from "./commands/version.ts";
 import { modelCommand } from "./commands/model_create.ts";
 import type { GlobalOptions } from "./context.ts";
 
+// Initialize model registry at startup
+import "../domain/models/registry_init.ts";
+
 export async function runCli(args: string[]): Promise<void> {
   const cli = new Command()
     .name("swamp")

--- a/src/domain/models/registry_init.ts
+++ b/src/domain/models/registry_init.ts
@@ -1,0 +1,21 @@
+/**
+ * Initializes the model registry with all known model types.
+ *
+ * This module should be imported at application startup to ensure
+ * all models are registered before any commands run.
+ */
+import { modelRegistry } from "./model.ts";
+import { echoModel } from "./echo/echo_model.ts";
+
+/**
+ * Registers all model definitions with the global registry.
+ * Safe to call multiple times - will not re-register existing models.
+ */
+export function initializeModelRegistry(): void {
+  if (!modelRegistry.has(echoModel.type)) {
+    modelRegistry.register(echoModel);
+  }
+}
+
+// Auto-register on import
+initializeModelRegistry();

--- a/src/domain/models/validation_service.ts
+++ b/src/domain/models/validation_service.ts
@@ -1,0 +1,160 @@
+import type { z } from "zod";
+import type { ModelDefinition } from "./model.ts";
+import type { ModelInput } from "./model_input.ts";
+import { ModelInputSchema } from "./model_input.ts";
+import type { ModelResource } from "./model_resource.ts";
+import { ModelResourceSchema } from "./model_resource.ts";
+
+/**
+ * Value object representing the result of a single validation.
+ *
+ * Immutable with equality based on value (name + passed + error).
+ */
+export class ValidationResult {
+  private constructor(
+    readonly name: string,
+    readonly passed: boolean,
+    readonly error?: string,
+  ) {}
+
+  /**
+   * Creates a passing validation result.
+   */
+  static pass(name: string): ValidationResult {
+    return new ValidationResult(name, true);
+  }
+
+  /**
+   * Creates a failing validation result with an error message.
+   */
+  static fail(name: string, error: string): ValidationResult {
+    return new ValidationResult(name, false, error);
+  }
+
+  /**
+   * Value equality comparison.
+   */
+  equals(other: ValidationResult): boolean {
+    return (
+      this.name === other.name &&
+      this.passed === other.passed &&
+      this.error === other.error
+    );
+  }
+}
+
+/**
+ * Formats a Zod error into a human-readable string.
+ */
+function formatZodError(error: z.ZodError): string {
+  if (error.issues.length === 1) {
+    const issue = error.issues[0];
+    const path = issue.path.length > 0 ? ` at "${issue.path.join(".")}"` : "";
+    return `${issue.message}${path}`;
+  }
+  return error.issues
+    .map((issue) => {
+      const path = issue.path.length > 0 ? ` at "${issue.path.join(".")}"` : "";
+      return `${issue.message}${path}`;
+    })
+    .join("; ");
+}
+
+/**
+ * Domain service interface for model validation.
+ */
+export interface ModelValidationService {
+  /**
+   * Validates a model input and optionally its resource against the model definition.
+   *
+   * Runs all validations in parallel.
+   *
+   * @param input - The model input to validate
+   * @param definition - The model definition containing schemas
+   * @param resource - The model resource if one exists, or null
+   * @returns Array of validation results
+   */
+  validateModel(
+    input: ModelInput,
+    definition: ModelDefinition,
+    resource: ModelResource | null,
+  ): Promise<ValidationResult[]>;
+}
+
+/**
+ * Default implementation of the model validation service.
+ */
+export class DefaultModelValidationService implements ModelValidationService {
+  validateModel(
+    input: ModelInput,
+    definition: ModelDefinition,
+    resource: ModelResource | null,
+  ): Promise<ValidationResult[]> {
+    const validations: Promise<ValidationResult>[] = [
+      this.validateInputSchema(input),
+      this.validateInputAttributes(input, definition),
+    ];
+
+    if (resource) {
+      validations.push(
+        this.validateResourceSchema(resource),
+        this.validateResourceAttributes(resource, definition),
+      );
+    }
+
+    return Promise.all(validations);
+  }
+
+  private validateInputSchema(input: ModelInput): Promise<ValidationResult> {
+    const result = ModelInputSchema.safeParse(input.toData());
+    if (result.success) {
+      return Promise.resolve(ValidationResult.pass("Input schema"));
+    }
+    return Promise.resolve(
+      ValidationResult.fail("Input schema", formatZodError(result.error)),
+    );
+  }
+
+  private validateInputAttributes(
+    input: ModelInput,
+    definition: ModelDefinition,
+  ): Promise<ValidationResult> {
+    const result = definition.inputAttributesSchema.safeParse(input.attributes);
+    if (result.success) {
+      return Promise.resolve(ValidationResult.pass("Input attributes"));
+    }
+    return Promise.resolve(
+      ValidationResult.fail("Input attributes", formatZodError(result.error)),
+    );
+  }
+
+  private validateResourceSchema(
+    resource: ModelResource,
+  ): Promise<ValidationResult> {
+    const result = ModelResourceSchema.safeParse(resource.toData());
+    if (result.success) {
+      return Promise.resolve(ValidationResult.pass("Resource schema"));
+    }
+    return Promise.resolve(
+      ValidationResult.fail("Resource schema", formatZodError(result.error)),
+    );
+  }
+
+  private validateResourceAttributes(
+    resource: ModelResource,
+    definition: ModelDefinition,
+  ): Promise<ValidationResult> {
+    const result = definition.resourceAttributesSchema.safeParse(
+      resource.attributes,
+    );
+    if (result.success) {
+      return Promise.resolve(ValidationResult.pass("Resource attributes"));
+    }
+    return Promise.resolve(
+      ValidationResult.fail(
+        "Resource attributes",
+        formatZodError(result.error),
+      ),
+    );
+  }
+}

--- a/src/domain/models/validation_service_test.ts
+++ b/src/domain/models/validation_service_test.ts
@@ -1,0 +1,208 @@
+import { assertEquals } from "@std/assert";
+import {
+  DefaultModelValidationService,
+  ValidationResult,
+} from "./validation_service.ts";
+import { ModelInput } from "./model_input.ts";
+import { ModelResource } from "./model_resource.ts";
+import { echoModel } from "./echo/echo_model.ts";
+
+// ValidationResult value object tests
+
+Deno.test("ValidationResult.pass creates passing result", () => {
+  const result = ValidationResult.pass("Test validation");
+  assertEquals(result.name, "Test validation");
+  assertEquals(result.passed, true);
+  assertEquals(result.error, undefined);
+});
+
+Deno.test("ValidationResult.fail creates failing result with error", () => {
+  const result = ValidationResult.fail(
+    "Test validation",
+    "Something went wrong",
+  );
+  assertEquals(result.name, "Test validation");
+  assertEquals(result.passed, false);
+  assertEquals(result.error, "Something went wrong");
+});
+
+Deno.test("ValidationResult.equals returns true for identical results", () => {
+  const result1 = ValidationResult.pass("Test");
+  const result2 = ValidationResult.pass("Test");
+  assertEquals(result1.equals(result2), true);
+});
+
+Deno.test("ValidationResult.equals returns true for identical failing results", () => {
+  const result1 = ValidationResult.fail("Test", "error");
+  const result2 = ValidationResult.fail("Test", "error");
+  assertEquals(result1.equals(result2), true);
+});
+
+Deno.test("ValidationResult.equals returns false for different names", () => {
+  const result1 = ValidationResult.pass("Test1");
+  const result2 = ValidationResult.pass("Test2");
+  assertEquals(result1.equals(result2), false);
+});
+
+Deno.test("ValidationResult.equals returns false for different passed status", () => {
+  const result1 = ValidationResult.pass("Test");
+  const result2 = ValidationResult.fail("Test", "error");
+  assertEquals(result1.equals(result2), false);
+});
+
+Deno.test("ValidationResult.equals returns false for different errors", () => {
+  const result1 = ValidationResult.fail("Test", "error1");
+  const result2 = ValidationResult.fail("Test", "error2");
+  assertEquals(result1.equals(result2), false);
+});
+
+// DefaultModelValidationService tests
+
+Deno.test("validateModel with valid input and no resource returns 2 passing results", async () => {
+  const service = new DefaultModelValidationService();
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: { message: "hello" },
+  });
+
+  const results = await service.validateModel(input, echoModel, null);
+
+  assertEquals(results.length, 2);
+  assertEquals(results[0].name, "Input schema");
+  assertEquals(results[0].passed, true);
+  assertEquals(results[1].name, "Input attributes");
+  assertEquals(results[1].passed, true);
+});
+
+Deno.test("validateModel with valid input and valid resource returns 4 passing results", async () => {
+  const service = new DefaultModelValidationService();
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: { message: "hello" },
+  });
+  const resource = ModelResource.create({
+    inputId: input.id,
+    attributes: {
+      message: "hello",
+      timestamp: new Date().toISOString(),
+    },
+  });
+
+  const results = await service.validateModel(input, echoModel, resource);
+
+  assertEquals(results.length, 4);
+  assertEquals(results[0].name, "Input schema");
+  assertEquals(results[0].passed, true);
+  assertEquals(results[1].name, "Input attributes");
+  assertEquals(results[1].passed, true);
+  assertEquals(results[2].name, "Resource schema");
+  assertEquals(results[2].passed, true);
+  assertEquals(results[3].name, "Resource attributes");
+  assertEquals(results[3].passed, true);
+});
+
+Deno.test("validateModel with invalid input attributes returns failing result", async () => {
+  const service = new DefaultModelValidationService();
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: { wrongAttribute: "hello" }, // Missing required 'message'
+  });
+
+  const results = await service.validateModel(input, echoModel, null);
+
+  assertEquals(results.length, 2);
+  assertEquals(results[0].name, "Input schema");
+  assertEquals(results[0].passed, true);
+  assertEquals(results[1].name, "Input attributes");
+  assertEquals(results[1].passed, false);
+  assertEquals(typeof results[1].error, "string");
+});
+
+Deno.test("validateModel with empty message returns failing result", async () => {
+  const service = new DefaultModelValidationService();
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: { message: "" }, // Empty message fails min(1) validation
+  });
+
+  const results = await service.validateModel(input, echoModel, null);
+
+  assertEquals(results.length, 2);
+  assertEquals(results[0].passed, true);
+  assertEquals(results[1].passed, false);
+  assertEquals(results[1].error !== undefined, true);
+});
+
+Deno.test("validateModel with invalid resource attributes returns failing result", async () => {
+  const service = new DefaultModelValidationService();
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: { message: "hello" },
+  });
+  const resource = ModelResource.create({
+    inputId: input.id,
+    attributes: {
+      message: 123, // Should be string
+      timestamp: new Date().toISOString(),
+    },
+  });
+
+  const results = await service.validateModel(input, echoModel, resource);
+
+  assertEquals(results.length, 4);
+  assertEquals(results[0].passed, true); // Input schema
+  assertEquals(results[1].passed, true); // Input attributes
+  assertEquals(results[2].passed, true); // Resource schema
+  assertEquals(results[3].name, "Resource attributes");
+  assertEquals(results[3].passed, false);
+  assertEquals(typeof results[3].error, "string");
+});
+
+Deno.test("validateModel with missing resource timestamp returns failing result", async () => {
+  const service = new DefaultModelValidationService();
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: { message: "hello" },
+  });
+  const resource = ModelResource.create({
+    inputId: input.id,
+    attributes: {
+      message: "hello",
+      // Missing timestamp
+    },
+  });
+
+  const results = await service.validateModel(input, echoModel, resource);
+
+  assertEquals(results.length, 4);
+  assertEquals(results[3].name, "Resource attributes");
+  assertEquals(results[3].passed, false);
+});
+
+Deno.test("validateModel runs validations in parallel", async () => {
+  const service = new DefaultModelValidationService();
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: { message: "hello" },
+  });
+  const resource = ModelResource.create({
+    inputId: input.id,
+    attributes: {
+      message: "hello",
+      timestamp: new Date().toISOString(),
+    },
+  });
+
+  // Run multiple times to verify parallel execution doesn't cause issues
+  const promises = Array.from(
+    { length: 10 },
+    () => service.validateModel(input, echoModel, resource),
+  );
+
+  const allResults = await Promise.all(promises);
+
+  for (const results of allResults) {
+    assertEquals(results.length, 4);
+    assertEquals(results.every((r) => r.passed), true);
+  }
+});

--- a/src/infrastructure/persistence/yaml_input_repository.ts
+++ b/src/infrastructure/persistence/yaml_input_repository.ts
@@ -108,6 +108,50 @@ export class YamlInputRepository implements InputRepository {
     return null;
   }
 
+  /**
+   * Finds all inputs across all model types in the repository.
+   */
+  async findAllGlobal(): Promise<{ input: ModelInput; type: ModelType }[]> {
+    const inputsDir = join(this.repoDir, "inputs");
+    const results: { input: ModelInput; type: ModelType }[] = [];
+
+    try {
+      // Iterate through all type directories
+      for await (const vendorEntry of Deno.readDir(inputsDir)) {
+        if (!vendorEntry.isDirectory) continue;
+
+        const vendorDir = join(inputsDir, vendorEntry.name);
+        for await (const typeEntry of Deno.readDir(vendorDir)) {
+          if (!typeEntry.isDirectory) continue;
+
+          const typeDir = join(vendorDir, typeEntry.name);
+          // Read all inputs in this type directory
+          for await (const fileEntry of Deno.readDir(typeDir)) {
+            if (!fileEntry.isFile || !fileEntry.name.endsWith(".yaml")) {
+              continue;
+            }
+
+            const path = join(typeDir, fileEntry.name);
+            const content = await Deno.readTextFile(path);
+            const data = parseYaml(content) as ModelInputData;
+            const input = ModelInput.fromData(data);
+
+            // Reconstruct the model type from the directory path
+            const typeStr = `${vendorEntry.name}/${typeEntry.name}`;
+            results.push({ input, type: ModelType.create(typeStr) });
+          }
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+
+    return results;
+  }
+
   async save(type: ModelType, input: ModelInput): Promise<void> {
     const dir = this.getTypeDir(type);
     await ensureDir(dir);

--- a/src/presentation/output/model_validate_output.tsx
+++ b/src/presentation/output/model_validate_output.tsx
@@ -1,0 +1,231 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { Box, render, Text } from "ink";
+import type { OutputMode } from "./output.tsx";
+
+export interface ValidationItemData {
+  name: string;
+  passed: boolean;
+  error?: string;
+}
+
+export interface ModelValidateData {
+  modelId: string;
+  modelName: string;
+  type: string;
+  validations: ValidationItemData[];
+  passed: boolean;
+}
+
+export interface ModelValidateAllData {
+  models: ModelValidateData[];
+  totalPassed: number;
+  totalFailed: number;
+  passed: boolean;
+}
+
+export function renderModelValidate(
+  data: ModelValidateData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    renderInteractiveModelValidate(data);
+  }
+}
+
+function renderInteractiveModelValidate(data: ModelValidateData): void {
+  const { unmount } = render(<ModelValidateDisplay {...data} />);
+  unmount();
+}
+
+interface ValidationItemDisplayProps {
+  name: string;
+  passed: boolean;
+  error?: string;
+}
+
+function ValidationItemDisplay(
+  props: ValidationItemDisplayProps,
+): React.ReactElement {
+  const checkmark = "\u2713";
+  const cross = "\u2717";
+  const arrow = "\u2192";
+  const icon = props.passed
+    ? <Text color="green">{checkmark}</Text>
+    : <Text color="red">{cross}</Text>;
+
+  return (
+    <Box flexDirection="column">
+      <Text>
+        <Text></Text>
+        {icon}
+        <Text>{props.name}</Text>
+      </Text>
+      {props.error && (
+        <Text>
+          <Text></Text>
+          <Text color="red">{arrow} {props.error}</Text>
+        </Text>
+      )}
+    </Box>
+  );
+}
+
+interface ModelValidateDisplayProps {
+  modelId: string;
+  modelName: string;
+  type: string;
+  validations: ValidationItemData[];
+  passed: boolean;
+}
+
+export function ModelValidateDisplay(
+  props: ModelValidateDisplayProps,
+): React.ReactElement {
+  const passedCount = props.validations.filter((v) => v.passed).length;
+  const totalCount = props.validations.length;
+
+  return (
+    <Box flexDirection="column">
+      <Text>
+        Validating model: <Text bold>{props.modelName}</Text> (
+        <Text dimColor>{props.type}</Text>)
+      </Text>
+      <Text />
+      {props.validations.map((v, i) => (
+        <ValidationItemDisplay
+          key={i}
+          {...v}
+        />
+      ))}
+      <Text />
+      <Text>
+        Summary: {passedCount}/{totalCount} validations passed
+      </Text>
+      <Text>
+        Result: {props.passed
+          ? (
+            <Text color="green" bold>
+              PASSED
+            </Text>
+          )
+          : (
+            <Text color="red" bold>
+              FAILED
+            </Text>
+          )}
+      </Text>
+    </Box>
+  );
+}
+
+export function renderModelValidateAll(
+  models: ModelValidateData[],
+  mode: OutputMode,
+): void {
+  const totalPassed = models.filter((m) => m.passed).length;
+  const totalFailed = models.length - totalPassed;
+  const passed = totalFailed === 0;
+
+  const data: ModelValidateAllData = {
+    models,
+    totalPassed,
+    totalFailed,
+    passed,
+  };
+
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    renderInteractiveModelValidateAll(data);
+  }
+}
+
+function renderInteractiveModelValidateAll(data: ModelValidateAllData): void {
+  const { unmount } = render(<ModelValidateAllDisplay {...data} />);
+  unmount();
+}
+
+interface ModelSummaryDisplayProps {
+  modelName: string;
+  type: string;
+  validations: ValidationItemData[];
+  passed: boolean;
+}
+
+function ModelSummaryDisplay(
+  props: ModelSummaryDisplayProps,
+): React.ReactElement {
+  return (
+    <Box flexDirection="column">
+      <Text>
+        <Text bold>{props.modelName}</Text> (<Text dimColor>{props.type}</Text>)
+      </Text>
+      {props.validations.map((v, i) => (
+        <ValidationItemDisplay
+          key={i}
+          {...v}
+        />
+      ))}
+      <Text>
+        Result: {props.passed
+          ? (
+            <Text color="green" bold>
+              PASSED
+            </Text>
+          )
+          : (
+            <Text color="red" bold>
+              FAILED
+            </Text>
+          )}
+      </Text>
+    </Box>
+  );
+}
+
+interface ModelValidateAllDisplayProps {
+  models: ModelValidateData[];
+  totalPassed: number;
+  totalFailed: number;
+  passed: boolean;
+}
+
+export function ModelValidateAllDisplay(
+  props: ModelValidateAllDisplayProps,
+): React.ReactElement {
+  return (
+    <Box flexDirection="column">
+      <Text>Validating all models...</Text>
+      <Text />
+      {props.models.map((model, i) => (
+        <Box key={i} flexDirection="column" marginBottom={1}>
+          <ModelSummaryDisplay
+            modelName={model.modelName}
+            type={model.type}
+            validations={model.validations}
+            passed={model.passed}
+          />
+        </Box>
+      ))}
+      <Text>
+        Summary: {props.totalPassed}/{props.models.length} models passed
+      </Text>
+      <Text>
+        Overall: {props.passed
+          ? (
+            <Text color="green" bold>
+              PASSED
+            </Text>
+          )
+          : (
+            <Text color="red" bold>
+              FAILED
+            </Text>
+          )}
+      </Text>
+    </Box>
+  );
+}

--- a/src/presentation/output/model_validate_output_test.tsx
+++ b/src/presentation/output/model_validate_output_test.tsx
@@ -1,0 +1,422 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { render } from "ink-testing-library";
+import {
+  ModelValidateAllDisplay,
+  type ModelValidateData,
+  ModelValidateDisplay,
+  renderModelValidate,
+  renderModelValidateAll,
+} from "./model_validate_output.tsx";
+
+const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
+
+const allPassingData: ModelValidateData = {
+  modelId: "550e8400-e29b-41d4-a716-446655440000",
+  modelName: "test-model",
+  type: "swamp/echo",
+  validations: [
+    { name: "Input schema", passed: true },
+    { name: "Input attributes", passed: true },
+    { name: "Resource schema", passed: true },
+    { name: "Resource attributes", passed: true },
+  ],
+  passed: true,
+};
+
+const mixedResultsData: ModelValidateData = {
+  modelId: "550e8400-e29b-41d4-a716-446655440000",
+  modelName: "test-model",
+  type: "swamp/echo",
+  validations: [
+    { name: "Input schema", passed: true },
+    { name: "Input attributes", passed: true },
+    { name: "Resource schema", passed: true },
+    {
+      name: "Resource attributes",
+      passed: false,
+      error: 'Expected string, received number at "message"',
+    },
+  ],
+  passed: false,
+};
+
+const inputOnlyData: ModelValidateData = {
+  modelId: "550e8400-e29b-41d4-a716-446655440000",
+  modelName: "test-model",
+  type: "swamp/echo",
+  validations: [
+    { name: "Input schema", passed: true },
+    { name: "Input attributes", passed: true },
+  ],
+  passed: true,
+};
+
+Deno.test({
+  name: "ModelValidateDisplay renders model name and type",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<ModelValidateDisplay {...allPassingData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "test-model");
+    assertStringIncludes(output, "swamp/echo");
+  },
+});
+
+Deno.test({
+  name: "ModelValidateDisplay renders checkmarks for passing validations",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<ModelValidateDisplay {...allPassingData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "\u2713");
+    assertStringIncludes(output, "Input schema");
+    assertStringIncludes(output, "Input attributes");
+  },
+});
+
+Deno.test({
+  name: "ModelValidateDisplay renders X for failing validations",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelValidateDisplay {...mixedResultsData} />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "\u2717");
+    assertStringIncludes(output, "Resource attributes");
+  },
+});
+
+Deno.test({
+  name: "ModelValidateDisplay shows error message for failed validation",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelValidateDisplay {...mixedResultsData} />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Expected string, received number");
+    assertStringIncludes(output, "\u2192");
+  },
+});
+
+Deno.test({
+  name: "ModelValidateDisplay shows summary count",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelValidateDisplay {...mixedResultsData} />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "3/4 validations passed");
+  },
+});
+
+Deno.test({
+  name: "ModelValidateDisplay shows PASSED for all passing",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<ModelValidateDisplay {...allPassingData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "PASSED");
+  },
+});
+
+Deno.test({
+  name: "ModelValidateDisplay shows FAILED when any validation fails",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelValidateDisplay {...mixedResultsData} />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "FAILED");
+  },
+});
+
+Deno.test({
+  name: "ModelValidateDisplay works with input-only validations",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<ModelValidateDisplay {...inputOnlyData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "2/2 validations passed");
+    assertStringIncludes(output, "PASSED");
+  },
+});
+
+Deno.test("renderModelValidate with json mode outputs valid JSON", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelValidate(allPassingData, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.modelId, allPassingData.modelId);
+    assertEquals(parsed.modelName, allPassingData.modelName);
+    assertEquals(parsed.type, allPassingData.type);
+    assertEquals(parsed.validations.length, 4);
+    assertEquals(parsed.passed, true);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderModelValidate JSON includes error messages", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelValidate(mixedResultsData, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.passed, false);
+
+    const failedValidation = parsed.validations.find(
+      (v: { passed: boolean }) => !v.passed,
+    );
+    assertEquals(failedValidation.name, "Resource attributes");
+    assertEquals(
+      failedValidation.error,
+      'Expected string, received number at "message"',
+    );
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+// Multi-model output tests
+
+const multiModelData: ModelValidateData[] = [
+  {
+    modelId: "550e8400-e29b-41d4-a716-446655440001",
+    modelName: "model-1",
+    type: "swamp/echo",
+    validations: [
+      { name: "Input schema", passed: true },
+      { name: "Input attributes", passed: true },
+    ],
+    passed: true,
+  },
+  {
+    modelId: "550e8400-e29b-41d4-a716-446655440002",
+    modelName: "model-2",
+    type: "swamp/echo",
+    validations: [
+      { name: "Input schema", passed: true },
+      {
+        name: "Input attributes",
+        passed: false,
+        error: 'Required at "message"',
+      },
+    ],
+    passed: false,
+  },
+];
+
+const allPassingMultiModelData: ModelValidateData[] = [
+  {
+    modelId: "550e8400-e29b-41d4-a716-446655440001",
+    modelName: "model-1",
+    type: "swamp/echo",
+    validations: [
+      { name: "Input schema", passed: true },
+      { name: "Input attributes", passed: true },
+    ],
+    passed: true,
+  },
+  {
+    modelId: "550e8400-e29b-41d4-a716-446655440002",
+    modelName: "model-2",
+    type: "swamp/echo",
+    validations: [
+      { name: "Input schema", passed: true },
+      { name: "Input attributes", passed: true },
+    ],
+    passed: true,
+  },
+];
+
+Deno.test({
+  name: "ModelValidateAllDisplay renders all model names",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelValidateAllDisplay
+        models={multiModelData}
+        totalPassed={1}
+        totalFailed={1}
+        passed={false}
+      />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "model-1");
+    assertStringIncludes(output, "model-2");
+  },
+});
+
+Deno.test({
+  name: "ModelValidateAllDisplay shows validating all models header",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelValidateAllDisplay
+        models={multiModelData}
+        totalPassed={1}
+        totalFailed={1}
+        passed={false}
+      />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Validating all models...");
+  },
+});
+
+Deno.test({
+  name: "ModelValidateAllDisplay shows model summary count",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelValidateAllDisplay
+        models={multiModelData}
+        totalPassed={1}
+        totalFailed={1}
+        passed={false}
+      />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "1/2 models passed");
+  },
+});
+
+Deno.test({
+  name: "ModelValidateAllDisplay shows Overall FAILED when any model fails",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelValidateAllDisplay
+        models={multiModelData}
+        totalPassed={1}
+        totalFailed={1}
+        passed={false}
+      />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Overall:");
+    assertStringIncludes(output, "FAILED");
+  },
+});
+
+Deno.test({
+  name: "ModelValidateAllDisplay shows Overall PASSED when all models pass",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelValidateAllDisplay
+        models={allPassingMultiModelData}
+        totalPassed={2}
+        totalFailed={0}
+        passed
+      />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "2/2 models passed");
+    assertStringIncludes(output, "Overall:");
+    assertStringIncludes(output, "PASSED");
+  },
+});
+
+Deno.test({
+  name: "ModelValidateAllDisplay shows error messages for failing validations",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelValidateAllDisplay
+        models={multiModelData}
+        totalPassed={1}
+        totalFailed={1}
+        passed={false}
+      />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, 'Required at "message"');
+  },
+});
+
+Deno.test("renderModelValidateAll with json mode outputs valid JSON", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelValidateAll(multiModelData, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.models.length, 2);
+    assertEquals(parsed.totalPassed, 1);
+    assertEquals(parsed.totalFailed, 1);
+    assertEquals(parsed.passed, false);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderModelValidateAll JSON includes all model data", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelValidateAll(multiModelData, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+
+    assertEquals(parsed.models[0].modelName, "model-1");
+    assertEquals(parsed.models[0].passed, true);
+    assertEquals(parsed.models[1].modelName, "model-2");
+    assertEquals(parsed.models[1].passed, false);
+
+    const failedValidation = parsed.models[1].validations.find(
+      (v: { passed: boolean }) => !v.passed,
+    );
+    assertEquals(failedValidation.error, 'Required at "message"');
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderModelValidateAll JSON shows passed true when all pass", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelValidateAll(allPassingMultiModelData, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.totalPassed, 2);
+    assertEquals(parsed.totalFailed, 0);
+    assertEquals(parsed.passed, true);
+  } finally {
+    console.log = originalLog;
+  }
+});


### PR DESCRIPTION
## Summary

- Add `model validate` command to validate model inputs and resources against their Zod schemas
- Support single-model validation: `model validate <model_id_or_name>`
- Support batch validation: `model validate` (no args) validates all models in repository
- Add `findAllGlobal()` method to `YamlInputRepository` for centralized batch operations
- Add `ValidationService` with parallel validation execution
- Interactive and JSON output modes with appropriate exit codes

## Test plan

- [x] Unit tests for ValidationService and output components
- [x] Integration tests for single-model and batch validation
- [x] `deno task test` passes (192 tests)
- [x] `deno check main.ts` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] Manual testing with `model validate --repo-dir /tmp/test`

🤖 Generated with [Claude Code](https://claude.ai/code)