### PR TITLE
feat: add type describe command and fix terminal output issues

### DIFF
--- a/design/models.md
+++ b/design/models.md
@@ -71,6 +71,14 @@ The valid shape of a resource is specified with a Zod 4 schema.
 
 ## CLI Commands
 
+### type describe <type>
+
+This command describes the model as a markdown document, will all of its
+details, using code blocks as neccessary. it should syntax highlight the
+markdown.
+
+when specifying json, it should have the same content.
+
 ### model create <type> <name>
 
 Creates a new instance of a type with the given unqiue name. Type should accept

--- a/src/cli/commands/type_describe.ts
+++ b/src/cli/commands/type_describe.ts
@@ -1,0 +1,98 @@
+import { Command } from "@cliffy/command";
+import { z } from "zod";
+import {
+  type MethodDescribeData,
+  renderTypeDescribe,
+  type TypeDescribeData,
+} from "../../presentation/output/type_describe_output.tsx";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
+import {
+  type MethodDefinition,
+  modelRegistry,
+} from "../../domain/models/model.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+/**
+ * Converts a Zod schema to JSON Schema format.
+ */
+function zodToJsonSchema(schema: z.ZodTypeAny): object {
+  return z.toJSONSchema(schema);
+}
+
+/**
+ * Converts a MethodDefinition to MethodDescribeData for presentation.
+ */
+function toMethodDescribeData(
+  name: string,
+  method: MethodDefinition,
+): MethodDescribeData {
+  return {
+    name,
+    description: method.description,
+    inputAttributesSchema: zodToJsonSchema(method.inputAttributesSchema),
+  };
+}
+
+export const typeDescribeCommand = new Command()
+  .description("Describe a model type with schema details")
+  .arguments("<type:string>")
+  .action(function (options: AnyOptions, typeArg: string) {
+    const ctx = createContext(options as GlobalOptions, "type-describe");
+    ctx.logger.debug`Describing type: ${typeArg}`;
+
+    // Parse and validate the model type
+    const modelType = ModelType.create(typeArg);
+    ctx.logger.debug`Normalized type: ${modelType.normalized}`;
+
+    // Look up the model definition
+    const definition = modelRegistry.get(modelType);
+    if (!definition) {
+      const availableTypes = modelRegistry.types().map((t) => t.normalized)
+        .join(", ");
+      throw new Error(
+        `Unknown model type: ${typeArg}. Available types: ${
+          availableTypes || "none"
+        }`,
+      );
+    }
+
+    // Convert Zod schemas to JSON Schema
+    const inputAttributesSchema = zodToJsonSchema(
+      definition.inputAttributesSchema,
+    );
+    const resourceAttributesSchema = zodToJsonSchema(
+      definition.resourceAttributesSchema,
+    );
+
+    // Build method descriptions
+    const methods: MethodDescribeData[] = Object.entries(definition.methods)
+      .map(
+        ([name, method]) => toMethodDescribeData(name, method),
+      );
+
+    // Build the output data
+    const data: TypeDescribeData = {
+      type: {
+        raw: modelType.raw,
+        normalized: modelType.normalized,
+      },
+      version: definition.version,
+      inputAttributesSchema,
+      resourceAttributesSchema,
+      methods,
+    };
+
+    renderTypeDescribe(data, ctx.outputMode);
+    ctx.logger.debug("Type describe command completed");
+  });
+
+export const typeCommand = new Command()
+  .name("type")
+  .description("Inspect model types")
+  .action(function () {
+    this.showHelp();
+  })
+  .command("describe", typeDescribeCommand);

--- a/src/cli/commands/type_describe_test.ts
+++ b/src/cli/commands/type_describe_test.ts
@@ -1,0 +1,28 @@
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Initialize logging for tests
+await initializeLogging({ debugLogs: false });
+
+// Initialize model registry
+import "../../domain/models/registry_init.ts";
+
+Deno.test("typeCommand module loads", async () => {
+  const { typeCommand } = await import("./type_describe.ts");
+  assertEquals(typeCommand.getName(), "type");
+});
+
+Deno.test("typeDescribeCommand is registered as subcommand", async () => {
+  const { typeCommand } = await import("./type_describe.ts");
+  const commands = typeCommand.getCommands();
+  const describeCmd = commands.find((c) => c.getName() === "describe");
+  assertEquals(describeCmd !== undefined, true);
+});
+
+Deno.test("typeDescribeCommand has correct description", async () => {
+  const { typeDescribeCommand } = await import("./type_describe.ts");
+  assertEquals(
+    typeDescribeCommand.getDescription(),
+    "Describe a model type with schema details",
+  );
+});

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -2,6 +2,7 @@ import { Command } from "@cliffy/command";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
 import { VERSION, versionCommand } from "./commands/version.ts";
 import { modelCommand } from "./commands/model_create.ts";
+import { typeCommand } from "./commands/type_describe.ts";
 import type { GlobalOptions } from "./context.ts";
 
 // Initialize model registry at startup
@@ -25,7 +26,8 @@ export async function runCli(args: string[]): Promise<void> {
       this.showHelp();
     })
     .command("version", versionCommand)
-    .command("model", modelCommand);
+    .command("model", modelCommand)
+    .command("type", typeCommand);
 
   await cli.parse(args);
 }

--- a/src/presentation/output/error_output.tsx
+++ b/src/presentation/output/error_output.tsx
@@ -1,6 +1,7 @@
 // deno-lint-ignore verbatim-module-syntax
 import React from "react";
-import { Box, render, Text } from "ink";
+import { Box, Text } from "ink";
+import { render } from "ink-testing-library";
 import type { OutputMode } from "./output.tsx";
 
 export interface ErrorData {
@@ -42,8 +43,10 @@ export function renderError(error: unknown, mode: OutputMode): void {
 }
 
 function renderInteractiveError(message: string, stack?: string): void {
-  const { unmount } = render(<ErrorDisplay message={message} stack={stack} />);
-  unmount();
+  const { lastFrame } = render(
+    <ErrorDisplay message={message} stack={stack} />,
+  );
+  console.log(lastFrame());
 }
 
 interface ErrorDisplayProps {

--- a/src/presentation/output/model_create_output.tsx
+++ b/src/presentation/output/model_create_output.tsx
@@ -1,6 +1,7 @@
 // deno-lint-ignore verbatim-module-syntax
 import React from "react";
-import { Box, render, Text } from "ink";
+import { Box, Text } from "ink";
+import { render } from "ink-testing-library";
 import type { OutputMode } from "./output.tsx";
 
 export interface ModelCreateData {
@@ -22,8 +23,8 @@ export function renderModelCreate(
 }
 
 function renderInteractiveModelCreate(data: ModelCreateData): void {
-  const { unmount } = render(<ModelCreateDisplay {...data} />);
-  unmount();
+  const { lastFrame } = render(<ModelCreateDisplay {...data} />);
+  console.log(lastFrame());
 }
 
 interface ModelCreateDisplayProps {

--- a/src/presentation/output/model_method_run_output.tsx
+++ b/src/presentation/output/model_method_run_output.tsx
@@ -1,6 +1,7 @@
 // deno-lint-ignore verbatim-module-syntax
 import React from "react";
-import { Box, render, Text } from "ink";
+import { Box, Text } from "ink";
+import { render } from "ink-testing-library";
 import type { OutputMode } from "./output.tsx";
 
 export interface ModelMethodRunData {
@@ -25,8 +26,8 @@ export function renderModelMethodRun(
 }
 
 function renderInteractiveModelMethodRun(data: ModelMethodRunData): void {
-  const { unmount } = render(<ModelMethodRunDisplay {...data} />);
-  unmount();
+  const { lastFrame } = render(<ModelMethodRunDisplay {...data} />);
+  console.log(lastFrame());
 }
 
 interface AttributeItemProps {

--- a/src/presentation/output/model_validate_output.tsx
+++ b/src/presentation/output/model_validate_output.tsx
@@ -1,6 +1,7 @@
 // deno-lint-ignore verbatim-module-syntax
 import React from "react";
-import { Box, render, Text } from "ink";
+import { Box, Text } from "ink";
+import { render } from "ink-testing-library";
 import type { OutputMode } from "./output.tsx";
 
 export interface ValidationItemData {
@@ -36,8 +37,8 @@ export function renderModelValidate(
 }
 
 function renderInteractiveModelValidate(data: ModelValidateData): void {
-  const { unmount } = render(<ModelValidateDisplay {...data} />);
-  unmount();
+  const { lastFrame } = render(<ModelValidateDisplay {...data} />);
+  console.log(lastFrame());
 }
 
 interface ValidationItemDisplayProps {
@@ -144,8 +145,8 @@ export function renderModelValidateAll(
 }
 
 function renderInteractiveModelValidateAll(data: ModelValidateAllData): void {
-  const { unmount } = render(<ModelValidateAllDisplay {...data} />);
-  unmount();
+  const { lastFrame } = render(<ModelValidateAllDisplay {...data} />);
+  console.log(lastFrame());
 }
 
 interface ModelSummaryDisplayProps {

--- a/src/presentation/output/output.tsx
+++ b/src/presentation/output/output.tsx
@@ -1,6 +1,6 @@
 // deno-lint-ignore verbatim-module-syntax
 import React from "react";
-import { render } from "ink";
+import { render } from "ink-testing-library";
 import { VersionDisplay } from "./components/VersionDisplay.tsx";
 
 export type OutputMode = "interactive" | "json";
@@ -19,8 +19,8 @@ export function renderVersion(data: VersionData, mode: OutputMode): void {
 }
 
 function renderInteractiveVersion(data: VersionData): void {
-  const { unmount } = render(
+  const { lastFrame } = render(
     <VersionDisplay version={data.version} haiku={data.haiku} />,
   );
-  unmount();
+  console.log(lastFrame());
 }

--- a/src/presentation/output/type_describe_output.tsx
+++ b/src/presentation/output/type_describe_output.tsx
@@ -1,0 +1,156 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { Box, Text } from "ink";
+import { render } from "ink-testing-library";
+import type { OutputMode } from "./output.tsx";
+
+/**
+ * Data structure for a method's description.
+ */
+export interface MethodDescribeData {
+  name: string;
+  description: string;
+  inputAttributesSchema: object;
+}
+
+/**
+ * Data structure for the type describe output.
+ */
+export interface TypeDescribeData {
+  type: {
+    raw: string;
+    normalized: string;
+  };
+  version: number;
+  inputAttributesSchema: object;
+  resourceAttributesSchema: object;
+  methods: MethodDescribeData[];
+}
+
+/**
+ * Renders the type description in either interactive or JSON mode.
+ */
+export function renderTypeDescribe(
+  data: TypeDescribeData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    renderInteractiveTypeDescribe(data);
+  }
+}
+
+function renderInteractiveTypeDescribe(data: TypeDescribeData): void {
+  const { lastFrame } = render(<TypeDescribeDisplay data={data} />);
+  console.log(lastFrame());
+}
+
+interface TypeDescribeDisplayProps {
+  data: TypeDescribeData;
+}
+
+/**
+ * Formats a JSON schema object as a string with indentation.
+ */
+function formatSchema(schema: object): string {
+  return JSON.stringify(schema, null, 2);
+}
+
+/**
+ * Component to display a schema section with a header.
+ */
+function SchemaSection({
+  title,
+  schema,
+}: {
+  title: string;
+  schema: object;
+}): React.ReactElement {
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text color="cyan" bold>
+        ## {title}
+      </Text>
+      <Box marginTop={1}>
+        <Text dimColor>{formatSchema(schema)}</Text>
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * Component to display a single method.
+ */
+function MethodDisplay({
+  method,
+}: {
+  method: MethodDescribeData;
+}): React.ReactElement {
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text color="yellow" bold>
+        ### {method.name}
+      </Text>
+      <Box marginLeft={2}>
+        <Text>{method.description}</Text>
+      </Box>
+      <Box marginTop={1} marginLeft={2} flexDirection="column">
+        <Text color="cyan">Input Schema:</Text>
+        <Text dimColor>{formatSchema(method.inputAttributesSchema)}</Text>
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * Interactive display component for type description.
+ */
+export function TypeDescribeDisplay(
+  props: TypeDescribeDisplayProps,
+): React.ReactElement {
+  const { data } = props;
+
+  return (
+    <Box flexDirection="column">
+      {/* Header */}
+      <Text color="green" bold>
+        # {data.type.normalized}
+      </Text>
+
+      {/* Metadata */}
+      <Box marginTop={1} flexDirection="column">
+        <Text>
+          <Text color="cyan">Normalized:</Text>
+          <Text>{data.type.normalized}</Text>
+        </Text>
+        <Text>
+          <Text color="cyan">Version:</Text>
+          <Text>{data.version}</Text>
+        </Text>
+      </Box>
+
+      {/* Input Attributes Schema */}
+      <SchemaSection
+        title="Input Attributes Schema"
+        schema={data.inputAttributesSchema}
+      />
+
+      {/* Resource Attributes Schema */}
+      <SchemaSection
+        title="Resource Attributes Schema"
+        schema={data.resourceAttributesSchema}
+      />
+
+      {/* Methods */}
+      <Box flexDirection="column" marginTop={1}>
+        <Text color="cyan" bold>
+          ## Methods
+        </Text>
+        {data.methods.map((method) => (
+          <MethodDisplay key={method.name} method={method} />
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/src/presentation/output/type_describe_output_test.tsx
+++ b/src/presentation/output/type_describe_output_test.tsx
@@ -1,0 +1,117 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { render } from "ink-testing-library";
+import {
+  renderTypeDescribe,
+  type TypeDescribeData,
+  TypeDescribeDisplay,
+} from "./type_describe_output.tsx";
+
+const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
+
+const testData: TypeDescribeData = {
+  type: {
+    raw: "swamp/echo",
+    normalized: "swamp/echo",
+  },
+  version: 1,
+  inputAttributesSchema: {
+    type: "object",
+    properties: {
+      message: { type: "string", minLength: 1 },
+    },
+    required: ["message"],
+  },
+  resourceAttributesSchema: {
+    type: "object",
+    properties: {
+      message: { type: "string" },
+      timestamp: { type: "string", format: "date-time" },
+    },
+    required: ["message", "timestamp"],
+  },
+  methods: [
+    {
+      name: "write",
+      description: "Write the input message to a resource with a timestamp",
+      inputAttributesSchema: {
+        type: "object",
+        properties: {
+          message: { type: "string", minLength: 1 },
+        },
+        required: ["message"],
+      },
+    },
+  ],
+};
+
+Deno.test({
+  name: "TypeDescribeDisplay renders type name",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<TypeDescribeDisplay data={testData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "swamp/echo");
+  },
+});
+
+Deno.test({
+  name: "TypeDescribeDisplay renders version",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<TypeDescribeDisplay data={testData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Version:");
+    assertStringIncludes(output, "1");
+  },
+});
+
+Deno.test({
+  name: "TypeDescribeDisplay renders schema sections",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<TypeDescribeDisplay data={testData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Input Attributes Schema");
+    assertStringIncludes(output, "Resource Attributes Schema");
+  },
+});
+
+Deno.test({
+  name: "TypeDescribeDisplay renders methods",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<TypeDescribeDisplay data={testData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Methods");
+    assertStringIncludes(output, "write");
+    assertStringIncludes(
+      output,
+      "Write the input message to a resource with a timestamp",
+    );
+  },
+});
+
+Deno.test("renderTypeDescribe with json mode outputs valid JSON", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderTypeDescribe(testData, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.type.raw, testData.type.raw);
+    assertEquals(parsed.type.normalized, testData.type.normalized);
+    assertEquals(parsed.version, testData.version);
+    assertEquals(parsed.methods.length, 1);
+    assertEquals(parsed.methods[0].name, "write");
+  } finally {
+    console.log = originalLog;
+  }
+});


### PR DESCRIPTION
## Summary

- Add `type describe <type>` command that displays model type details including schemas and methods
- Fix terminal output issues that were causing scrollback destruction and missing trailing newlines

## Changes

### New `type describe` command
- Displays type name, version, input/resource attribute schemas, and method definitions
- Supports both interactive (colored markdown-style) and JSON output modes
- Converts Zod schemas to JSON Schema format for display

### Terminal output fixes
- Use `ink-testing-library`'s render to capture output as string instead of writing directly to stdout
- Print via `console.log()` to ensure trailing newline (prevents zsh `%` marker)
- Avoids Ink's `clearTerminal` code path which was destroying scrollback history

## Test plan

- [x] `deno run dev type describe swamp/echo` - displays type info
- [x] `deno run dev type describe swamp/echo --json` - outputs JSON
- [x] `deno run dev version` - no duplicate output, proper newline
- [x] All 224 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)