### PR TITLE
chore: gitignore inputs/swamp/echo directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dev-logs/*
 swamp
+inputs/swamp/echo/*

--- a/inputs/swamp/echo/4062501b-7b72-475e-8235-9d780fec4e18.yaml
+++ b/inputs/swamp/echo/4062501b-7b72-475e-8235-9d780fec4e18.yaml
@@ -1,5 +1,0 @@
-id: 4062501b-7b72-475e-8235-9d780fec4e18
-name: test-name
-version: 1
-tags: {}
-attributes: {}


### PR DESCRIPTION
## Summary
- Remove existing echo input files
- Add `inputs/swamp/echo/*` to `.gitignore` to prevent committing test input artifacts

## Test plan
- [x] Verify files are removed
- [x] Verify directory is gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)