### PR TITLE
feat: implement type search command

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -17,6 +17,7 @@
     "zod": "npm:zod@4",
     "@cliffy/command": "jsr:@cliffy/command@1.0.0-rc.8",
     "@logtape/logtape": "jsr:@logtape/logtape@0.8",
+    "fzf": "npm:fzf@0.5.2",
     "ink": "npm:ink@5",
     "ink-testing-library": "npm:ink-testing-library@4",
     "react": "npm:react@18",

--- a/deno.lock
+++ b/deno.lock
@@ -15,6 +15,7 @@
     "jsr:@std/text@~1.0.7": "1.0.16",
     "jsr:@std/yaml@1": "1.0.10",
     "npm:@types/react@18": "18.3.27",
+    "npm:fzf@0.5.2": "0.5.2",
     "npm:ink-testing-library@4": "4.0.0_@types+react@18.3.27",
     "npm:ink@5": "5.2.1_@types+react@18.3.27_react@18.3.1",
     "npm:react@18": "18.3.1",
@@ -156,6 +157,9 @@
     },
     "escape-string-regexp@2.0.0": {
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+    },
+    "fzf@0.5.2": {
+      "integrity": "sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q=="
     },
     "get-east-asian-width@1.4.0": {
       "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="
@@ -341,6 +345,7 @@
       "jsr:@std/path@1",
       "jsr:@std/yaml@1",
       "npm:@types/react@18",
+      "npm:fzf@0.5.2",
       "npm:ink-testing-library@4",
       "npm:ink@5",
       "npm:react@18",

--- a/design/agent.md
+++ b/design/agent.md
@@ -1,0 +1,30 @@
+# AI Agent
+
+The primary method for working with swamp is through an AI agent. Each
+repository will have skills dedicated to working with swamp, through the cli,
+writing files, etc.
+
+## Model Skill
+
+This skill understands how to work with models. It will be able to:
+
+### Search for model types
+
+Use the `swamp type search --json` command, and select the correct type.
+
+### Describe specific model types
+
+Learn the shape and validations for inputs, resources, and callable methods for
+a model with `swamp type describe --json`.
+
+### Create model inputs
+
+Use `swamp model create --json` command to create a new model input, according
+to the type description from `swamp type describe`.
+
+Then edit the resulting file and set any attributes or metadata that is
+neccessary.
+
+### Run individual methods
+
+Use `swamp model method run`.

--- a/design/models.md
+++ b/design/models.md
@@ -79,6 +79,16 @@ markdown.
 
 when specifying json, it should have the same content.
 
+### type search <string>
+
+When run interactively, it should show a text box that says "type to search",
+and then use the npm:fzf package to search the list of available types (by
+either normalized type or actual type name). Then the user can use the arrow
+keys to select the type they want, and the result will be the same as type
+describe.
+
+When run non-interactively, it should produce a json output that has the list.
+
 ### model create <type> <name>
 
 Creates a new instance of a type with the given unqiue name. Type should accept

--- a/src/cli/commands/type_describe.ts
+++ b/src/cli/commands/type_describe.ts
@@ -11,6 +11,7 @@ import {
   type MethodDefinition,
   modelRegistry,
 } from "../../domain/models/model.ts";
+import { typeSearchCommand } from "./type_search.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -95,4 +96,5 @@ export const typeCommand = new Command()
   .action(function () {
     this.showHelp();
   })
-  .command("describe", typeDescribeCommand);
+  .command("describe", typeDescribeCommand)
+  .command("search", typeSearchCommand);

--- a/src/cli/commands/type_search.ts
+++ b/src/cli/commands/type_search.ts
@@ -1,0 +1,125 @@
+import { Command } from "@cliffy/command";
+import {
+  renderTypeSearch,
+  type TypeSearchData,
+  type TypeSearchItem,
+} from "../../presentation/output/type_search_output.tsx";
+import { renderTypeDescribe } from "../../presentation/output/type_describe_output.tsx";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
+import { z } from "zod";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+/**
+ * Converts a Zod schema to JSON Schema format.
+ */
+function zodToJsonSchema(schema: z.ZodTypeAny): object {
+  return z.toJSONSchema(schema);
+}
+
+/**
+ * Gets all registered types as TypeSearchItem array.
+ */
+function getAllTypes(): TypeSearchItem[] {
+  return modelRegistry.types().map((t) => ({
+    raw: t.raw,
+    normalized: t.normalized,
+  }));
+}
+
+/**
+ * Filters types by a query string (case-insensitive match on raw or normalized).
+ */
+function filterTypes(types: TypeSearchItem[], query: string): TypeSearchItem[] {
+  if (!query) {
+    return types;
+  }
+  const lowerQuery = query.toLowerCase();
+  return types.filter(
+    (t) =>
+      t.raw.toLowerCase().includes(lowerQuery) ||
+      t.normalized.toLowerCase().includes(lowerQuery),
+  );
+}
+
+/**
+ * Displays the type describe output for a selected type.
+ */
+function displayTypeDescribe(item: TypeSearchItem, options: AnyOptions): void {
+  const ctx = createContext(options as GlobalOptions, "type-search");
+  const modelType = ModelType.create(item.normalized);
+  const definition = modelRegistry.get(modelType);
+
+  if (!definition) {
+    throw new Error(`Type not found: ${item.normalized}`);
+  }
+
+  const inputAttributesSchema = zodToJsonSchema(
+    definition.inputAttributesSchema,
+  );
+  const resourceAttributesSchema = zodToJsonSchema(
+    definition.resourceAttributesSchema,
+  );
+
+  const methods = Object.entries(definition.methods).map(([name, method]) => ({
+    name,
+    description: method.description,
+    inputAttributesSchema: zodToJsonSchema(method.inputAttributesSchema),
+  }));
+
+  renderTypeDescribe(
+    {
+      type: {
+        raw: modelType.raw,
+        normalized: modelType.normalized,
+      },
+      version: definition.version,
+      inputAttributesSchema,
+      resourceAttributesSchema,
+      methods,
+    },
+    ctx.outputMode,
+  );
+}
+
+export const typeSearchCommand = new Command()
+  .name("search")
+  .description("Search for model types")
+  .arguments("[query:string]")
+  .action(async function (options: AnyOptions, query?: string) {
+    const ctx = createContext(options as GlobalOptions, "type-search");
+    ctx.logger.debug`Searching types with query: ${query ?? "(none)"}`;
+
+    const allTypes = getAllTypes();
+
+    if (ctx.outputMode === "json") {
+      // Non-interactive: filter and output JSON
+      const filteredTypes = filterTypes(allTypes, query ?? "");
+      const data: TypeSearchData = {
+        query: query ?? "",
+        results: filteredTypes,
+      };
+      await renderTypeSearch(data, ctx.outputMode);
+    } else {
+      // Interactive: show fuzzy search UI
+      const data: TypeSearchData = {
+        query: query ?? "",
+        results: allTypes,
+      };
+
+      const selected = await renderTypeSearch(data, ctx.outputMode);
+
+      if (selected) {
+        ctx.logger.debug`Selected type: ${selected.normalized}`;
+        // Display the type description
+        displayTypeDescribe(selected, options);
+      } else {
+        ctx.logger.debug`Search cancelled`;
+      }
+    }
+
+    ctx.logger.debug("Type search command completed");
+  });

--- a/src/cli/commands/type_search_test.ts
+++ b/src/cli/commands/type_search_test.ts
@@ -1,0 +1,28 @@
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Initialize logging for tests
+await initializeLogging({ debugLogs: false });
+
+// Initialize model registry
+import "../../domain/models/registry_init.ts";
+
+Deno.test("typeSearchCommand module loads", async () => {
+  const { typeSearchCommand } = await import("./type_search.ts");
+  assertEquals(typeSearchCommand.getName(), "search");
+});
+
+Deno.test("typeSearchCommand has correct description", async () => {
+  const { typeSearchCommand } = await import("./type_search.ts");
+  assertEquals(
+    typeSearchCommand.getDescription(),
+    "Search for model types",
+  );
+});
+
+Deno.test("typeSearchCommand is registered as subcommand of typeCommand", async () => {
+  const { typeCommand } = await import("./type_describe.ts");
+  const commands = typeCommand.getCommands();
+  const searchCmd = commands.find((c) => c.getName() === "search");
+  assertEquals(searchCmd !== undefined, true);
+});

--- a/src/presentation/output/type_search_output.tsx
+++ b/src/presentation/output/type_search_output.tsx
@@ -1,0 +1,217 @@
+// deno-lint-ignore verbatim-module-syntax
+import React, { useCallback, useEffect, useState } from "react";
+import { Box, render, Text, useApp, useInput } from "ink";
+import type { OutputMode } from "./output.tsx";
+import { Fzf, type FzfResultItem } from "fzf";
+
+/**
+ * Represents a single type search result item.
+ */
+export interface TypeSearchItem {
+  raw: string;
+  normalized: string;
+}
+
+/**
+ * Data structure for type search results.
+ */
+export interface TypeSearchData {
+  query: string;
+  results: TypeSearchItem[];
+}
+
+/**
+ * Renders type search results in either interactive or JSON mode.
+ *
+ * @param data - The search data to render
+ * @param mode - The output mode (interactive or json)
+ * @returns A promise that resolves with the selected type in interactive mode, or undefined in JSON mode
+ */
+export async function renderTypeSearch(
+  data: TypeSearchData,
+  mode: OutputMode,
+): Promise<TypeSearchItem | undefined> {
+  if (mode === "json") {
+    renderJsonTypeSearch(data);
+    return undefined;
+  } else {
+    return await renderInteractiveTypeSearch(data);
+  }
+}
+
+/**
+ * Renders type search results as JSON.
+ */
+function renderJsonTypeSearch(data: TypeSearchData): void {
+  console.log(JSON.stringify(data, null, 2));
+}
+
+/**
+ * Renders an interactive type search UI.
+ *
+ * @param data - The initial search data (types to search and optional initial query)
+ * @returns A promise that resolves with the selected type, or undefined if cancelled
+ */
+export function renderInteractiveTypeSearch(
+  data: TypeSearchData,
+): Promise<TypeSearchItem | undefined> {
+  return new Promise<TypeSearchItem | undefined>((resolve) => {
+    const { waitUntilExit } = render(
+      <TypeSearchUI
+        types={data.results}
+        initialQuery={data.query}
+        onSelect={(item) => resolve(item)}
+        onCancel={() => resolve(undefined)}
+      />,
+    );
+    waitUntilExit();
+  });
+}
+
+interface TypeSearchUIProps {
+  types: TypeSearchItem[];
+  initialQuery: string;
+  onSelect: (item: TypeSearchItem) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Interactive type search component using fzf for fuzzy matching.
+ */
+export function TypeSearchUI(
+  props: TypeSearchUIProps,
+): React.ReactElement {
+  const { types, initialQuery, onSelect, onCancel } = props;
+  const { exit } = useApp();
+
+  const [query, setQuery] = useState(initialQuery);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  // Create fzf instance for fuzzy searching
+  const fzf = new Fzf(types, {
+    selector: (item) => `${item.raw} ${item.normalized}`,
+  });
+
+  // Get filtered results
+  const results: FzfResultItem<TypeSearchItem>[] = fzf.find(query);
+  const maxVisible = 10;
+  const visibleResults = results.slice(0, maxVisible);
+
+  // Reset selection when query changes
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  const handleSelect = useCallback(() => {
+    if (results.length > 0 && selectedIndex < results.length) {
+      const selected = results[selectedIndex].item;
+      exit();
+      onSelect(selected);
+    }
+  }, [results, selectedIndex, exit, onSelect]);
+
+  const handleCancel = useCallback(() => {
+    exit();
+    onCancel();
+  }, [exit, onCancel]);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      handleCancel();
+      return;
+    }
+
+    if (key.return) {
+      handleSelect();
+      return;
+    }
+
+    if (key.upArrow) {
+      setSelectedIndex((i) => Math.max(0, i - 1));
+      return;
+    }
+
+    if (key.downArrow) {
+      setSelectedIndex((i) => Math.min(results.length - 1, i + 1));
+      return;
+    }
+
+    if (key.backspace || key.delete) {
+      setQuery((q) => q.slice(0, -1));
+      return;
+    }
+
+    // Handle regular character input
+    if (input && !key.ctrl && !key.meta) {
+      setQuery((q) => q + input);
+    }
+  });
+
+  return (
+    <Box flexDirection="column">
+      {/* Search input */}
+      <Box>
+        <Text color="cyan" bold>
+          Search:{" "}
+        </Text>
+        <Text>{query}</Text>
+        <Text color="gray">▏</Text>
+      </Box>
+
+      {/* Results count */}
+      <Box marginTop={1}>
+        <Text dimColor>
+          {results.length} / {types.length} types
+        </Text>
+      </Box>
+
+      {/* Results list */}
+      <Box flexDirection="column" marginTop={1}>
+        {visibleResults.map((result, index) => (
+          <TypeSearchResultItem
+            key={result.item.normalized}
+            item={result.item}
+            isSelected={index === selectedIndex}
+          />
+        ))}
+        {results.length > maxVisible && (
+          <Text dimColor>... {results.length - maxVisible} more results</Text>
+        )}
+        {results.length === 0 && (
+          <Text color="yellow">No matching types found</Text>
+        )}
+      </Box>
+
+      {/* Help text */}
+      <Box marginTop={1}>
+        <Text dimColor>
+          ↑/↓: Navigate | Enter: Select | Esc: Cancel
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+interface TypeSearchResultItemProps {
+  item: TypeSearchItem;
+  isSelected: boolean;
+}
+
+/**
+ * Component to display a single search result item.
+ */
+function TypeSearchResultItem(
+  props: TypeSearchResultItemProps,
+): React.ReactElement {
+  const { item, isSelected } = props;
+
+  return (
+    <Box>
+      <Text color={isSelected ? "green" : undefined} bold={isSelected}>
+        {isSelected ? "▶ " : "  "}
+        {item.normalized}
+      </Text>
+      {item.raw !== item.normalized && <Text dimColor>({item.raw})</Text>}
+    </Box>
+  );
+}

--- a/src/presentation/output/type_search_output_test.tsx
+++ b/src/presentation/output/type_search_output_test.tsx
@@ -1,0 +1,195 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { render } from "ink-testing-library";
+import {
+  renderTypeSearch,
+  type TypeSearchData,
+  type TypeSearchItem,
+  TypeSearchUI,
+} from "./type_search_output.tsx";
+
+const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
+
+const testTypes: TypeSearchItem[] = [
+  { raw: "swamp/echo", normalized: "swamp/echo" },
+  { raw: "AWS::EC2::VPC", normalized: "aws/ec2/vpc" },
+  { raw: "docker run", normalized: "docker/run" },
+];
+
+const testData: TypeSearchData = {
+  query: "",
+  results: testTypes,
+};
+
+Deno.test({
+  name: "TypeSearchUI renders search prompt",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <TypeSearchUI
+        types={testTypes}
+        initialQuery=""
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Search:");
+  },
+});
+
+Deno.test({
+  name: "TypeSearchUI renders type count",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <TypeSearchUI
+        types={testTypes}
+        initialQuery=""
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "3 / 3 types");
+  },
+});
+
+Deno.test({
+  name: "TypeSearchUI renders all types when no query",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <TypeSearchUI
+        types={testTypes}
+        initialQuery=""
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "swamp/echo");
+    assertStringIncludes(output, "aws/ec2/vpc");
+    assertStringIncludes(output, "docker/run");
+  },
+});
+
+Deno.test({
+  name: "TypeSearchUI renders initial query",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <TypeSearchUI
+        types={testTypes}
+        initialQuery="echo"
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "echo");
+  },
+});
+
+Deno.test({
+  name: "TypeSearchUI shows raw name when different from normalized",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <TypeSearchUI
+        types={testTypes}
+        initialQuery=""
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const output = lastFrame() ?? "";
+
+    // aws/ec2/vpc should show (AWS::EC2::VPC)
+    assertStringIncludes(output, "(AWS::EC2::VPC)");
+    // docker/run should show (docker run)
+    assertStringIncludes(output, "(docker run)");
+  },
+});
+
+Deno.test({
+  name: "TypeSearchUI renders help text",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <TypeSearchUI
+        types={testTypes}
+        initialQuery=""
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Navigate");
+    assertStringIncludes(output, "Select");
+    assertStringIncludes(output, "Cancel");
+  },
+});
+
+Deno.test({
+  name: "TypeSearchUI shows no results message when empty",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <TypeSearchUI
+        types={[]}
+        initialQuery=""
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "No matching types found");
+  },
+});
+
+Deno.test("renderTypeSearch with json mode outputs valid JSON", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderTypeSearch(testData, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.query, "");
+    assertEquals(parsed.results.length, 3);
+    assertEquals(parsed.results[0].raw, "swamp/echo");
+    assertEquals(parsed.results[0].normalized, "swamp/echo");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderTypeSearch with json mode includes query", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  const dataWithQuery: TypeSearchData = {
+    query: "echo",
+    results: [{ raw: "swamp/echo", normalized: "swamp/echo" }],
+  };
+
+  try {
+    renderTypeSearch(dataWithQuery, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.query, "echo");
+    assertEquals(parsed.results.length, 1);
+  } finally {
+    console.log = originalLog;
+  }
+});


### PR DESCRIPTION
## Summary

- Add `type search` command with fuzzy matching powered by npm:fzf
- Interactive mode shows a fuzzy search UI with keyboard navigation (↑/↓, Enter, Esc)
- Non-interactive mode (`--json`) outputs filtered results as JSON
- On selection in interactive mode, displays the full type description

## Test plan

- [x] All 236 tests pass
- [x] `deno run dev type search --json` outputs all types
- [x] `deno run dev type search echo --json` filters to matching types
- [x] `deno run dev type search` shows interactive UI (requires TTY)

🤖 Generated with [Claude Code](https://claude.com/claude-code)