### PR TITLE
chore: ignore inputs/resources and add run/net permissions to compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dev-logs/*
 swamp
-inputs/swamp/echo/*
+inputs/
+resources/

--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
     "check": "deno check main.ts",
     "lint": "deno lint",
     "fmt": "deno fmt",
-    "compile": "deno compile --allow-read --allow-write --allow-env --output swamp main.ts"
+    "compile": "deno compile --allow-read --allow-write --allow-env --allow-run --allow-net --output swamp main.ts"
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@1",


### PR DESCRIPTION
## Summary
- Update `.gitignore` to ignore `inputs/` and `resources/` directories (runtime data)
- Add `--allow-run` and `--allow-net` permissions to the compile task for models that need shell execution and network access

## Test plan
- [x] Verify compile task works with new permissions
- [x] Verify inputs/resources directories are ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)