### PR TITLE
Add support for model get and list

### DIFF
--- a/design/models.md
+++ b/design/models.md
@@ -95,9 +95,22 @@ Creates a new instance of a type with the given unqiue name. Type should accept
 either the domain specific type or the normalized type. It should return the id
 and path to the model that is created.
 
+### model list <string>
+
+When run interactively, it should show a text box that says "type to search",
+and then use the npm:fzf package to search the list of available models (by
+either normalized type or actual type name). Then the user can use the arrow
+keys to select the type they want, and the result will be the same as type
+describe.
+
+When run non-interactively, it should produce a json output that has the list.
+
 ### model get <model_id_or_name>
 
-Shows the models input, schema, resource, methods, etc.
+Shows the entire details of the model. It should not include the type schema or
+the methods.
+
+when specifying json, it should have the same content.
 
 ### model validate <model_id_or_name>
 

--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -10,6 +10,8 @@ import { YamlInputRepository } from "../../infrastructure/persistence/yaml_input
 import { modelRegistry } from "../../domain/models/model.ts";
 import { modelValidateCommand } from "./model_validate.ts";
 import { modelMethodCommand } from "./model_method_run.ts";
+import { modelListCommand } from "./model_list.ts";
+import { modelGetCommand } from "./model_get.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -73,5 +75,7 @@ export const modelCommand = new Command()
     this.showHelp();
   })
   .command("create", modelCreateCommand)
+  .command("get", modelGetCommand)
+  .command("list", modelListCommand)
   .command("validate", modelValidateCommand)
   .command("method", modelMethodCommand);

--- a/src/cli/commands/model_get.ts
+++ b/src/cli/commands/model_get.ts
@@ -1,0 +1,115 @@
+import { Command } from "@cliffy/command";
+import {
+  type ModelGetData,
+  renderModelGet,
+  type ResourceData,
+} from "../../presentation/output/model_get_output.tsx";
+import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createModelInputId,
+  type ModelInput,
+} from "../../domain/models/model_input.ts";
+import type { ModelType } from "../../domain/models/model_type.ts";
+import { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
+import { YamlResourceRepository } from "../../infrastructure/persistence/yaml_resource_repository.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
+
+/**
+ * UUID v4 regex pattern for detecting if an argument is a UUID.
+ */
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Checks if a string looks like a UUID.
+ */
+function isUuid(value: string): boolean {
+  return UUID_PATTERN.test(value);
+}
+
+/**
+ * Finds an input by ID, searching across all registered model types.
+ */
+async function findInputByIdGlobal(
+  inputRepo: YamlInputRepository,
+  id: string,
+): Promise<{ input: ModelInput; type: ModelType } | null> {
+  const inputId = createModelInputId(id);
+
+  for (const type of modelRegistry.types()) {
+    const input = await inputRepo.findById(type, inputId);
+    if (input) {
+      return { input, type };
+    }
+  }
+
+  return null;
+}
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const modelGetCommand = new Command()
+  .name("get")
+  .description("Show details of a model input")
+  .arguments("<model_id_or_name:string>")
+  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .action(async function (options: AnyOptions, modelIdOrName: string) {
+    const ctx = createContext(options as GlobalOptions, "model-get");
+    ctx.logger.debug`Getting model: ${modelIdOrName}`;
+
+    const repoDir = options.repoDir ?? ".";
+    const inputRepo = new YamlInputRepository(repoDir);
+    const resourceRepo = new YamlResourceRepository(repoDir);
+
+    // Look up the model input
+    let input: ModelInput;
+    let modelType: ModelType;
+
+    if (isUuid(modelIdOrName)) {
+      ctx.logger.debug`Looking up by ID: ${modelIdOrName}`;
+      const result = await findInputByIdGlobal(inputRepo, modelIdOrName);
+      if (!result) {
+        throw new Error(`Model not found: ${modelIdOrName}`);
+      }
+      input = result.input;
+      modelType = result.type;
+    } else {
+      ctx.logger.debug`Looking up by name: ${modelIdOrName}`;
+      const result = await inputRepo.findByNameGlobal(modelIdOrName);
+      if (!result) {
+        throw new Error(`Model not found: ${modelIdOrName}`);
+      }
+      input = result.input;
+      modelType = result.type;
+    }
+
+    ctx.logger.debug`Found model: id=${input.id}, type=${modelType.normalized}`;
+
+    // Load the resource if it exists
+    const resource = await resourceRepo.findByInputId(modelType, input.id);
+    ctx.logger.debug`Resource exists: ${resource !== null}`;
+
+    // Build resource data
+    let resourceData: ResourceData | undefined;
+    if (resource) {
+      resourceData = {
+        id: resource.id,
+        createdAt: resource.createdAt.toISOString(),
+        attributes: resource.attributes,
+      };
+    }
+
+    const data: ModelGetData = {
+      id: input.id,
+      name: input.name,
+      type: modelType.normalized,
+      version: input.version,
+      tags: input.tags,
+      attributes: input.attributes,
+      resource: resourceData,
+    };
+
+    renderModelGet(data, ctx.outputMode);
+    ctx.logger.debug("Model get command completed");
+  });

--- a/src/cli/commands/model_get_test.ts
+++ b/src/cli/commands/model_get_test.ts
@@ -1,0 +1,28 @@
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Initialize logging for tests
+await initializeLogging({ debugLogs: false });
+
+// Initialize model registry
+import "../../domain/models/registry_init.ts";
+
+Deno.test("modelGetCommand module loads", async () => {
+  const { modelGetCommand } = await import("./model_get.ts");
+  assertEquals(modelGetCommand.getName(), "get");
+});
+
+Deno.test("modelGetCommand has correct description", async () => {
+  const { modelGetCommand } = await import("./model_get.ts");
+  assertEquals(
+    modelGetCommand.getDescription(),
+    "Show details of a model input",
+  );
+});
+
+Deno.test("modelGetCommand is registered as subcommand of modelCommand", async () => {
+  const { modelCommand } = await import("./model_create.ts");
+  const commands = modelCommand.getCommands();
+  const getCmd = commands.find((c) => c.getName() === "get");
+  assertEquals(getCmd !== undefined, true);
+});

--- a/src/cli/commands/model_list.ts
+++ b/src/cli/commands/model_list.ts
@@ -1,0 +1,149 @@
+import { Command } from "@cliffy/command";
+import {
+  type ModelListData,
+  type ModelListItem,
+  renderModelList,
+} from "../../presentation/output/model_list_output.tsx";
+import {
+  type ModelGetData,
+  renderModelGet,
+  type ResourceData,
+} from "../../presentation/output/model_get_output.tsx";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { createModelInputId } from "../../domain/models/model_input.ts";
+import { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
+import { YamlResourceRepository } from "../../infrastructure/persistence/yaml_resource_repository.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+/**
+ * Converts repository results to ModelListItem array.
+ */
+function toModelListItems(
+  results: Awaited<ReturnType<YamlInputRepository["findAllGlobal"]>>,
+): ModelListItem[] {
+  return results.map(({ input, type }) => ({
+    id: input.id,
+    name: input.name,
+    type: type.normalized,
+    resourceId: input.resourceId,
+  }));
+}
+
+/**
+ * Filters models by a query string (case-insensitive match on name, type, or id).
+ */
+function filterModels(
+  models: ModelListItem[],
+  query: string,
+): ModelListItem[] {
+  if (!query) {
+    return models;
+  }
+  const lowerQuery = query.toLowerCase();
+  return models.filter(
+    (m) =>
+      m.name.toLowerCase().includes(lowerQuery) ||
+      m.type.toLowerCase().includes(lowerQuery) ||
+      m.id.toLowerCase().includes(lowerQuery),
+  );
+}
+
+/**
+ * Displays the model get output for a selected model.
+ */
+async function displayModelGet(
+  item: ModelListItem,
+  repoDir: string,
+  outputMode: "interactive" | "json",
+): Promise<void> {
+  const inputRepo = new YamlInputRepository(repoDir);
+  const resourceRepo = new YamlResourceRepository(repoDir);
+
+  // Look up the full input
+  const inputId = createModelInputId(item.id);
+  const modelType = modelRegistry.types().find(
+    (t) => t.normalized === item.type,
+  );
+
+  if (!modelType) {
+    throw new Error(`Unknown model type: ${item.type}`);
+  }
+
+  const input = await inputRepo.findById(modelType, inputId);
+  if (!input) {
+    throw new Error(`Model not found: ${item.id}`);
+  }
+
+  // Load the resource if it exists
+  const resource = await resourceRepo.findByInputId(modelType, input.id);
+
+  // Build resource data
+  let resourceData: ResourceData | undefined;
+  if (resource) {
+    resourceData = {
+      id: resource.id,
+      createdAt: resource.createdAt.toISOString(),
+      attributes: resource.attributes,
+    };
+  }
+
+  const data: ModelGetData = {
+    id: input.id,
+    name: input.name,
+    type: modelType.normalized,
+    version: input.version,
+    tags: input.tags,
+    attributes: input.attributes,
+    resource: resourceData,
+  };
+
+  renderModelGet(data, outputMode);
+}
+
+export const modelListCommand = new Command()
+  .name("list")
+  .description("List and search model inputs")
+  .arguments("[query:string]")
+  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .action(async function (options: AnyOptions, query?: string) {
+    const ctx = createContext(options as GlobalOptions, "model-list");
+    ctx.logger.debug`Listing models with query: ${query ?? "(none)"}`;
+
+    const repoDir = options.repoDir ?? ".";
+    const inputRepo = new YamlInputRepository(repoDir);
+
+    // Get all models from repository
+    const allResults = await inputRepo.findAllGlobal();
+    const allModels = toModelListItems(allResults);
+
+    if (ctx.outputMode === "json") {
+      // Non-interactive: filter and output JSON
+      const filteredModels = filterModels(allModels, query ?? "");
+      const data: ModelListData = {
+        query: query ?? "",
+        results: filteredModels,
+      };
+      await renderModelList(data, ctx.outputMode);
+    } else {
+      // Interactive: show fuzzy search UI
+      const data: ModelListData = {
+        query: query ?? "",
+        results: allModels,
+      };
+
+      const selected = await renderModelList(data, ctx.outputMode);
+
+      if (selected) {
+        ctx.logger.debug`Selected model: ${selected.name} (${selected.id})`;
+        // Display the full model details
+        await displayModelGet(selected, repoDir, ctx.outputMode);
+      } else {
+        ctx.logger.debug`Search cancelled`;
+      }
+    }
+
+    ctx.logger.debug("Model list command completed");
+  });

--- a/src/cli/commands/model_list_test.ts
+++ b/src/cli/commands/model_list_test.ts
@@ -1,0 +1,28 @@
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Initialize logging for tests
+await initializeLogging({ debugLogs: false });
+
+// Initialize model registry
+import "../../domain/models/registry_init.ts";
+
+Deno.test("modelListCommand module loads", async () => {
+  const { modelListCommand } = await import("./model_list.ts");
+  assertEquals(modelListCommand.getName(), "list");
+});
+
+Deno.test("modelListCommand has correct description", async () => {
+  const { modelListCommand } = await import("./model_list.ts");
+  assertEquals(
+    modelListCommand.getDescription(),
+    "List and search model inputs",
+  );
+});
+
+Deno.test("modelListCommand is registered as subcommand of modelCommand", async () => {
+  const { modelCommand } = await import("./model_create.ts");
+  const commands = modelCommand.getCommands();
+  const listCmd = commands.find((c) => c.getName() === "list");
+  assertEquals(listCmd !== undefined, true);
+});

--- a/src/presentation/output/model_get_output.tsx
+++ b/src/presentation/output/model_get_output.tsx
@@ -1,0 +1,155 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { Box, Text } from "ink";
+import { render } from "ink-testing-library";
+import type { OutputMode } from "./output.tsx";
+
+/**
+ * Data structure for resource information.
+ */
+export interface ResourceData {
+  id: string;
+  createdAt: string;
+  attributes: Record<string, unknown>;
+}
+
+/**
+ * Data structure for the model get output.
+ */
+export interface ModelGetData {
+  id: string;
+  name: string;
+  type: string;
+  version: number;
+  tags: Record<string, string>;
+  attributes: Record<string, unknown>;
+  resource?: ResourceData;
+}
+
+/**
+ * Renders the model get output in either interactive or JSON mode.
+ */
+export function renderModelGet(data: ModelGetData, mode: OutputMode): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    renderInteractiveModelGet(data);
+  }
+}
+
+function renderInteractiveModelGet(data: ModelGetData): void {
+  const { lastFrame } = render(<ModelGetDisplay data={data} />);
+  console.log(lastFrame());
+}
+
+interface ModelGetDisplayProps {
+  data: ModelGetData;
+}
+
+/**
+ * Formats a JSON object as a string with indentation.
+ */
+function formatJson(obj: object): string {
+  return JSON.stringify(obj, null, 2);
+}
+
+/**
+ * Component to display a section with a header.
+ */
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text color="cyan" bold>
+        ## {title}
+      </Text>
+      <Box marginTop={1} marginLeft={2} flexDirection="column">
+        {children}
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * Component to display a key-value pair.
+ */
+function KeyValue({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}): React.ReactElement {
+  return (
+    <Text>
+      <Text color="cyan">{label}:</Text>
+      <Text>{value}</Text>
+    </Text>
+  );
+}
+
+/**
+ * Interactive display component for model get.
+ */
+export function ModelGetDisplay(
+  props: ModelGetDisplayProps,
+): React.ReactElement {
+  const { data } = props;
+  const hasTags = Object.keys(data.tags).length > 0;
+  const hasAttributes = Object.keys(data.attributes).length > 0;
+
+  return (
+    <Box flexDirection="column">
+      {/* Header */}
+      <Text color="green" bold>
+        # {data.name}
+      </Text>
+
+      {/* Basic Info */}
+      <Section title="Model Info">
+        <KeyValue label="ID" value={data.id} />
+        <KeyValue label="Type" value={data.type} />
+        <KeyValue label="Version" value={String(data.version)} />
+      </Section>
+
+      {/* Tags */}
+      {hasTags && (
+        <Section title="Tags">
+          {Object.entries(data.tags).map(([key, value]) => (
+            <KeyValue key={key} label={key} value={value} />
+          ))}
+        </Section>
+      )}
+
+      {/* Input Attributes */}
+      <Section title="Input Attributes">
+        {hasAttributes
+          ? <Text dimColor>{formatJson(data.attributes)}</Text>
+          : <Text dimColor>(none)</Text>}
+      </Section>
+
+      {/* Resource */}
+      {data.resource
+        ? (
+          <Section title="Resource">
+            <KeyValue label="ID" value={data.resource.id} />
+            <KeyValue label="Created At" value={data.resource.createdAt} />
+            <Box marginTop={1} flexDirection="column">
+              <Text color="cyan">Attributes:</Text>
+              <Text dimColor>{formatJson(data.resource.attributes)}</Text>
+            </Box>
+          </Section>
+        )
+        : (
+          <Section title="Resource">
+            <Text dimColor>(no resource created yet)</Text>
+          </Section>
+        )}
+    </Box>
+  );
+}

--- a/src/presentation/output/model_get_output_test.tsx
+++ b/src/presentation/output/model_get_output_test.tsx
@@ -1,0 +1,174 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { render } from "ink-testing-library";
+import {
+  type ModelGetData,
+  ModelGetDisplay,
+  renderModelGet,
+} from "./model_get_output.tsx";
+
+const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
+
+const testDataWithoutResource: ModelGetData = {
+  id: "550e8400-e29b-41d4-a716-446655440000",
+  name: "test-echo",
+  type: "swamp/echo",
+  version: 1,
+  tags: { env: "test", project: "demo" },
+  attributes: { message: "Hello World" },
+};
+
+const testDataWithResource: ModelGetData = {
+  ...testDataWithoutResource,
+  resource: {
+    id: "660e8400-e29b-41d4-a716-446655440001",
+    createdAt: "2024-01-15T10:30:00.000Z",
+    attributes: { result: "processed", timestamp: "2024-01-15T10:30:00.000Z" },
+  },
+};
+
+Deno.test({
+  name: "ModelGetDisplay renders model name as header",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelGetDisplay data={testDataWithoutResource} />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "test-echo");
+  },
+});
+
+Deno.test({
+  name: "ModelGetDisplay renders model ID",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelGetDisplay data={testDataWithoutResource} />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "550e8400-e29b-41d4-a716-446655440000");
+  },
+});
+
+Deno.test({
+  name: "ModelGetDisplay renders model type",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelGetDisplay data={testDataWithoutResource} />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "swamp/echo");
+  },
+});
+
+Deno.test({
+  name: "ModelGetDisplay renders tags",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelGetDisplay data={testDataWithoutResource} />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "env");
+    assertStringIncludes(output, "test");
+    assertStringIncludes(output, "project");
+    assertStringIncludes(output, "demo");
+  },
+});
+
+Deno.test({
+  name: "ModelGetDisplay renders input attributes",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelGetDisplay data={testDataWithoutResource} />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "message");
+    assertStringIncludes(output, "Hello World");
+  },
+});
+
+Deno.test({
+  name: "ModelGetDisplay shows no resource message when resource is undefined",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelGetDisplay data={testDataWithoutResource} />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "no resource created yet");
+  },
+});
+
+Deno.test({
+  name: "ModelGetDisplay renders resource when present",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelGetDisplay data={testDataWithResource} />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "660e8400-e29b-41d4-a716-446655440001");
+    assertStringIncludes(output, "2024-01-15T10:30:00.000Z");
+  },
+});
+
+Deno.test("renderModelGet with json mode outputs valid JSON", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelGet(testDataWithoutResource, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.id, testDataWithoutResource.id);
+    assertEquals(parsed.name, testDataWithoutResource.name);
+    assertEquals(parsed.type, testDataWithoutResource.type);
+    assertEquals(parsed.version, testDataWithoutResource.version);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderModelGet JSON includes resource when present", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelGet(testDataWithResource, "json");
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.resource.id, "660e8400-e29b-41d4-a716-446655440001");
+    assertEquals(parsed.resource.createdAt, "2024-01-15T10:30:00.000Z");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderModelGet JSON includes tags and attributes", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelGet(testDataWithoutResource, "json");
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.tags.env, "test");
+    assertEquals(parsed.tags.project, "demo");
+    assertEquals(parsed.attributes.message, "Hello World");
+  } finally {
+    console.log = originalLog;
+  }
+});

--- a/src/presentation/output/model_list_output.tsx
+++ b/src/presentation/output/model_list_output.tsx
@@ -1,0 +1,219 @@
+// deno-lint-ignore verbatim-module-syntax
+import React, { useCallback, useEffect, useState } from "react";
+import { Box, render, Text, useApp, useInput } from "ink";
+import type { OutputMode } from "./output.tsx";
+import { Fzf, type FzfResultItem } from "fzf";
+
+/**
+ * Represents a single model list item.
+ */
+export interface ModelListItem {
+  id: string;
+  name: string;
+  type: string;
+  resourceId?: string;
+}
+
+/**
+ * Data structure for model list results.
+ */
+export interface ModelListData {
+  query: string;
+  results: ModelListItem[];
+}
+
+/**
+ * Renders model list in either interactive or JSON mode.
+ *
+ * @param data - The list data to render
+ * @param mode - The output mode (interactive or json)
+ * @returns A promise that resolves with the selected model in interactive mode, or undefined in JSON mode
+ */
+export async function renderModelList(
+  data: ModelListData,
+  mode: OutputMode,
+): Promise<ModelListItem | undefined> {
+  if (mode === "json") {
+    renderJsonModelList(data);
+    return undefined;
+  } else {
+    return await renderInteractiveModelList(data);
+  }
+}
+
+/**
+ * Renders model list as JSON.
+ */
+function renderJsonModelList(data: ModelListData): void {
+  console.log(JSON.stringify(data, null, 2));
+}
+
+/**
+ * Renders an interactive model list UI.
+ *
+ * @param data - The initial list data (models to search and optional initial query)
+ * @returns A promise that resolves with the selected model, or undefined if cancelled
+ */
+export function renderInteractiveModelList(
+  data: ModelListData,
+): Promise<ModelListItem | undefined> {
+  return new Promise<ModelListItem | undefined>((resolve) => {
+    const { waitUntilExit } = render(
+      <ModelListUI
+        models={data.results}
+        initialQuery={data.query}
+        onSelect={(item) => resolve(item)}
+        onCancel={() => resolve(undefined)}
+      />,
+    );
+    waitUntilExit();
+  });
+}
+
+interface ModelListUIProps {
+  models: ModelListItem[];
+  initialQuery: string;
+  onSelect: (item: ModelListItem) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Interactive model list component using fzf for fuzzy matching.
+ */
+export function ModelListUI(
+  props: ModelListUIProps,
+): React.ReactElement {
+  const { models, initialQuery, onSelect, onCancel } = props;
+  const { exit } = useApp();
+
+  const [query, setQuery] = useState(initialQuery);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  // Create fzf instance for fuzzy searching
+  const fzf = new Fzf(models, {
+    selector: (item) => `${item.name} ${item.type} ${item.id}`,
+  });
+
+  // Get filtered results
+  const results: FzfResultItem<ModelListItem>[] = fzf.find(query);
+  const maxVisible = 10;
+  const visibleResults = results.slice(0, maxVisible);
+
+  // Reset selection when query changes
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  const handleSelect = useCallback(() => {
+    if (results.length > 0 && selectedIndex < results.length) {
+      const selected = results[selectedIndex].item;
+      exit();
+      onSelect(selected);
+    }
+  }, [results, selectedIndex, exit, onSelect]);
+
+  const handleCancel = useCallback(() => {
+    exit();
+    onCancel();
+  }, [exit, onCancel]);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      handleCancel();
+      return;
+    }
+
+    if (key.return) {
+      handleSelect();
+      return;
+    }
+
+    if (key.upArrow) {
+      setSelectedIndex((i) => Math.max(0, i - 1));
+      return;
+    }
+
+    if (key.downArrow) {
+      setSelectedIndex((i) => Math.min(results.length - 1, i + 1));
+      return;
+    }
+
+    if (key.backspace || key.delete) {
+      setQuery((q) => q.slice(0, -1));
+      return;
+    }
+
+    // Handle regular character input
+    if (input && !key.ctrl && !key.meta) {
+      setQuery((q) => q + input);
+    }
+  });
+
+  return (
+    <Box flexDirection="column">
+      {/* Search input */}
+      <Box>
+        <Text color="cyan" bold>
+          Search:{" "}
+        </Text>
+        <Text>{query}</Text>
+        <Text color="gray">|</Text>
+      </Box>
+
+      {/* Results count */}
+      <Box marginTop={1}>
+        <Text dimColor>
+          {results.length} / {models.length} models
+        </Text>
+      </Box>
+
+      {/* Results list */}
+      <Box flexDirection="column" marginTop={1}>
+        {visibleResults.map((result, index) => (
+          <ModelListResultItem
+            key={result.item.id}
+            item={result.item}
+            isSelected={index === selectedIndex}
+          />
+        ))}
+        {results.length > maxVisible && (
+          <Text dimColor>... {results.length - maxVisible} more results</Text>
+        )}
+        {results.length === 0 && (
+          <Text color="yellow">No matching models found</Text>
+        )}
+      </Box>
+
+      {/* Help text */}
+      <Box marginTop={1}>
+        <Text dimColor>
+          Up/Down: Navigate | Enter: Select | Esc: Cancel
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+interface ModelListResultItemProps {
+  item: ModelListItem;
+  isSelected: boolean;
+}
+
+/**
+ * Component to display a single model list item.
+ */
+function ModelListResultItem(
+  props: ModelListResultItemProps,
+): React.ReactElement {
+  const { item, isSelected } = props;
+
+  return (
+    <Box>
+      <Text color={isSelected ? "green" : undefined} bold={isSelected}>
+        {isSelected ? "> " : "  "}
+        {item.name}
+      </Text>
+      <Text dimColor>({item.type})</Text>
+    </Box>
+  );
+}

--- a/src/presentation/output/model_list_output_test.tsx
+++ b/src/presentation/output/model_list_output_test.tsx
@@ -1,0 +1,178 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { render } from "ink-testing-library";
+import {
+  type ModelListData,
+  type ModelListItem,
+  ModelListUI,
+  renderModelList,
+} from "./model_list_output.tsx";
+
+const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
+
+const testModels: ModelListItem[] = [
+  {
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "test-echo-1",
+    type: "swamp/echo",
+  },
+  {
+    id: "660e8400-e29b-41d4-a716-446655440001",
+    name: "test-echo-2",
+    type: "swamp/echo",
+    resourceId: "770e8400-e29b-41d4-a716-446655440002",
+  },
+];
+
+const testData: ModelListData = {
+  query: "",
+  results: testModels,
+};
+
+Deno.test({
+  name: "ModelListUI renders search prompt",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelListUI
+        models={testModels}
+        initialQuery=""
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Search:");
+  },
+});
+
+Deno.test({
+  name: "ModelListUI renders model names",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelListUI
+        models={testModels}
+        initialQuery=""
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "test-echo-1");
+    assertStringIncludes(output, "test-echo-2");
+  },
+});
+
+Deno.test({
+  name: "ModelListUI renders model types",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelListUI
+        models={testModels}
+        initialQuery=""
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "swamp/echo");
+  },
+});
+
+Deno.test({
+  name: "ModelListUI renders results count",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelListUI
+        models={testModels}
+        initialQuery=""
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "2 / 2 models");
+  },
+});
+
+Deno.test({
+  name: "ModelListUI renders help text",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelListUI
+        models={testModels}
+        initialQuery=""
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Navigate");
+    assertStringIncludes(output, "Select");
+    assertStringIncludes(output, "Cancel");
+  },
+});
+
+Deno.test({
+  name: "ModelListUI shows no results message when empty",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelListUI
+        models={[]}
+        initialQuery=""
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "No matching models found");
+  },
+});
+
+Deno.test("renderModelList with json mode outputs valid JSON", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelList(testData, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.query, "");
+    assertEquals(parsed.results.length, 2);
+    assertEquals(parsed.results[0].name, "test-echo-1");
+    assertEquals(parsed.results[1].name, "test-echo-2");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderModelList with json mode includes resourceId when present", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelList(testData, "json");
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.results[0].resourceId, undefined);
+    assertEquals(
+      parsed.results[1].resourceId,
+      "770e8400-e29b-41d4-a716-446655440002",
+    );
+  } finally {
+    console.log = originalLog;
+  }
+});


### PR DESCRIPTION
- Implement model list command with interactive fuzzy search for browsing model instances
- Implement model get command for displaying detailed information about a specific model instance

### Changes

#### model list Command

- Interactive mode provides a fzf-powered fuzzy search interface
- Search matches against model name, type, and ID
- Displays up to 10 results at a time with keyboard navigation (Up/Down/Enter/Esc)
- Selecting a model automatically shows its full details via model get
- JSON mode outputs the filtered results as structured JSON

#### model get Command

- Accepts model ID (UUID) or name as argument
- Displays model instance information: ID, name, type, version, tags, and input attributes
- Shows associated resource data (ID, createdAt, attributes) when present
- Supports both interactive (colored terminal UI) and JSON output modes

### Files Added

- src/cli/commands/model_list.ts - List command implementation
- src/cli/commands/model_get.ts - Get command implementation
- src/presentation/output/model_list_output.tsx - Interactive list UI with fzf
- src/presentation/output/model_get_output.tsx - Model detail display component
- Test files for all new modules

### Test plan

- Run deno run test - all 260 tests pass
- Verify swamp model list shows interactive fuzzy search
- Verify swamp model list --output json outputs JSON array
- Verify swamp model get <name> displays model details
- Verify swamp model get <uuid> works with UUID lookup
- Verify resource data displays when present

🤖 Generated with https://claude.com/claude-code