### PR TITLE
Address code review feedback for model get/list commands.

### DIFF
--- a/src/cli/commands/model_get.ts
+++ b/src/cli/commands/model_get.ts
@@ -5,46 +5,14 @@ import {
   type ResourceData,
 } from "../../presentation/output/model_get_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
-import {
-  createModelInputId,
-  type ModelInput,
-} from "../../domain/models/model_input.ts";
+import type { ModelInput } from "../../domain/models/model_input.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
 import { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
 import { YamlResourceRepository } from "../../infrastructure/persistence/yaml_resource_repository.ts";
-import { modelRegistry } from "../../domain/models/model.ts";
-
-/**
- * UUID v4 regex pattern for detecting if an argument is a UUID.
- */
-const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
-/**
- * Checks if a string looks like a UUID.
- */
-function isUuid(value: string): boolean {
-  return UUID_PATTERN.test(value);
-}
-
-/**
- * Finds an input by ID, searching across all registered model types.
- */
-async function findInputByIdGlobal(
-  inputRepo: YamlInputRepository,
-  id: string,
-): Promise<{ input: ModelInput; type: ModelType } | null> {
-  const inputId = createModelInputId(id);
-
-  for (const type of modelRegistry.types()) {
-    const input = await inputRepo.findById(type, inputId);
-    if (input) {
-      return { input, type };
-    }
-  }
-
-  return null;
-}
+import {
+  findInputByIdGlobal,
+  isUuid,
+} from "../../domain/models/model_lookup.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;

--- a/src/cli/commands/model_list.ts
+++ b/src/cli/commands/model_list.ts
@@ -35,7 +35,7 @@ function toModelListItems(
 /**
  * Filters models by a query string (case-insensitive match on name, type, or id).
  */
-function filterModels(
+export function filterModels(
   models: ModelListItem[],
   query: string,
 ): ModelListItem[] {

--- a/src/cli/commands/model_list_test.ts
+++ b/src/cli/commands/model_list_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "@std/assert";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import type { ModelListItem } from "../../presentation/output/model_list_output.tsx";
 
 // Initialize logging for tests
 await initializeLogging({ debugLogs: false });
@@ -25,4 +26,82 @@ Deno.test("modelListCommand is registered as subcommand of modelCommand", async 
   const commands = modelCommand.getCommands();
   const listCmd = commands.find((c) => c.getName() === "list");
   assertEquals(listCmd !== undefined, true);
+});
+
+// filterModels tests
+Deno.test("filterModels returns all models when query is empty", async () => {
+  const { filterModels } = await import("./model_list.ts");
+  const models: ModelListItem[] = [
+    { id: "id-1", name: "model-a", type: "swamp/echo" },
+    { id: "id-2", name: "model-b", type: "swamp/echo" },
+  ];
+
+  const result = filterModels(models, "");
+  assertEquals(result.length, 2);
+});
+
+Deno.test("filterModels filters by name (case-insensitive)", async () => {
+  const { filterModels } = await import("./model_list.ts");
+  const models: ModelListItem[] = [
+    { id: "id-1", name: "Production-Server", type: "swamp/echo" },
+    { id: "id-2", name: "staging-server", type: "swamp/echo" },
+    { id: "id-3", name: "dev-database", type: "swamp/echo" },
+  ];
+
+  const result = filterModels(models, "server");
+  assertEquals(result.length, 2);
+  assertEquals(result[0].name, "Production-Server");
+  assertEquals(result[1].name, "staging-server");
+});
+
+Deno.test("filterModels filters by type", async () => {
+  const { filterModels } = await import("./model_list.ts");
+  const models: ModelListItem[] = [
+    { id: "id-1", name: "model-a", type: "swamp/echo" },
+    { id: "id-2", name: "model-b", type: "swamp/database" },
+    { id: "id-3", name: "model-c", type: "swamp/echo" },
+  ];
+
+  const result = filterModels(models, "database");
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "model-b");
+});
+
+Deno.test("filterModels filters by id", async () => {
+  const { filterModels } = await import("./model_list.ts");
+  const models: ModelListItem[] = [
+    {
+      id: "550e8400-e29b-41d4-a716-446655440000",
+      name: "model-a",
+      type: "swamp/echo",
+    },
+    {
+      id: "660e8400-e29b-41d4-a716-446655440001",
+      name: "model-b",
+      type: "swamp/echo",
+    },
+  ];
+
+  const result = filterModels(models, "550e8400");
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "model-a");
+});
+
+Deno.test("filterModels returns empty array when no matches", async () => {
+  const { filterModels } = await import("./model_list.ts");
+  const models: ModelListItem[] = [
+    { id: "id-1", name: "model-a", type: "swamp/echo" },
+    { id: "id-2", name: "model-b", type: "swamp/echo" },
+  ];
+
+  const result = filterModels(models, "nonexistent");
+  assertEquals(result.length, 0);
+});
+
+Deno.test("filterModels handles empty model list", async () => {
+  const { filterModels } = await import("./model_list.ts");
+  const models: ModelListItem[] = [];
+
+  const result = filterModels(models, "anything");
+  assertEquals(result.length, 0);
 });

--- a/src/cli/commands/model_validate.ts
+++ b/src/cli/commands/model_validate.ts
@@ -6,10 +6,7 @@ import {
   type ValidationItemData,
 } from "../../presentation/output/model_validate_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
-import {
-  createModelInputId,
-  type ModelInput,
-} from "../../domain/models/model_input.ts";
+import type { ModelInput } from "../../domain/models/model_input.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
 import { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
 import { YamlResourceRepository } from "../../infrastructure/persistence/yaml_resource_repository.ts";
@@ -18,38 +15,10 @@ import {
   DefaultModelValidationService,
   type ValidationResult,
 } from "../../domain/models/validation_service.ts";
-
-/**
- * UUID v4 regex pattern for detecting if an argument is a UUID.
- */
-const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
-/**
- * Checks if a string looks like a UUID.
- */
-function isUuid(value: string): boolean {
-  return UUID_PATTERN.test(value);
-}
-
-/**
- * Finds an input by ID, searching across all registered model types.
- */
-async function findInputByIdGlobal(
-  inputRepo: YamlInputRepository,
-  id: string,
-): Promise<{ input: ModelInput; type: ModelType } | null> {
-  const inputId = createModelInputId(id);
-
-  for (const type of modelRegistry.types()) {
-    const input = await inputRepo.findById(type, inputId);
-    if (input) {
-      return { input, type };
-    }
-  }
-
-  return null;
-}
+import {
+  findInputByIdGlobal,
+  isUuid,
+} from "../../domain/models/model_lookup.ts";
 
 /**
  * Converts ValidationResult array to ValidationItemData array for presentation.

--- a/src/domain/models/model_lookup.ts
+++ b/src/domain/models/model_lookup.ts
@@ -1,0 +1,45 @@
+import type { ModelInput } from "./model_input.ts";
+import { createModelInputId } from "./model_input.ts";
+import type { ModelType } from "./model_type.ts";
+import { modelRegistry } from "./model.ts";
+import type { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
+
+/**
+ * UUID v4 regex pattern for detecting if an argument is a UUID.
+ */
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Checks if a string looks like a UUID v4.
+ */
+export function isUuid(value: string): boolean {
+  return UUID_PATTERN.test(value);
+}
+
+/**
+ * Result of a global model lookup.
+ */
+export interface ModelLookupResult {
+  input: ModelInput;
+  type: ModelType;
+}
+
+/**
+ * Finds an input by ID, searching across all registered model types.
+ */
+export async function findInputByIdGlobal(
+  inputRepo: YamlInputRepository,
+  id: string,
+): Promise<ModelLookupResult | null> {
+  const inputId = createModelInputId(id);
+
+  for (const type of modelRegistry.types()) {
+    const input = await inputRepo.findById(type, inputId);
+    if (input) {
+      return { input, type };
+    }
+  }
+
+  return null;
+}

--- a/src/domain/models/model_lookup_test.ts
+++ b/src/domain/models/model_lookup_test.ts
@@ -1,0 +1,38 @@
+import { assertEquals } from "@std/assert";
+import { isUuid } from "./model_lookup.ts";
+
+Deno.test("isUuid returns true for valid UUID v4", () => {
+  assertEquals(isUuid("550e8400-e29b-41d4-a716-446655440000"), true);
+  assertEquals(isUuid("6ba7b810-9dad-41d4-80b4-00c04fd430c8"), true);
+  assertEquals(isUuid("f47ac10b-58cc-4372-a567-0e02b2c3d479"), true);
+});
+
+Deno.test("isUuid is case insensitive", () => {
+  assertEquals(isUuid("550E8400-E29B-41D4-A716-446655440000"), true);
+  assertEquals(isUuid("550e8400-E29B-41d4-a716-446655440000"), true);
+});
+
+Deno.test("isUuid returns false for invalid UUIDs", () => {
+  // Not a UUID at all
+  assertEquals(isUuid("hello"), false);
+  assertEquals(isUuid("my-model-name"), false);
+
+  // Wrong length
+  assertEquals(isUuid("550e8400-e29b-41d4-a716-44665544000"), false);
+  assertEquals(isUuid("550e8400-e29b-41d4-a716-4466554400000"), false);
+
+  // Wrong format (missing dashes)
+  assertEquals(isUuid("550e8400e29b41d4a716446655440000"), false);
+
+  // Not a v4 UUID (version digit is not 4)
+  assertEquals(isUuid("550e8400-e29b-11d4-a716-446655440000"), false);
+  assertEquals(isUuid("550e8400-e29b-51d4-a716-446655440000"), false);
+
+  // Invalid variant (4th group must start with 8, 9, a, or b)
+  assertEquals(isUuid("550e8400-e29b-41d4-0716-446655440000"), false);
+  assertEquals(isUuid("550e8400-e29b-41d4-c716-446655440000"), false);
+});
+
+Deno.test("isUuid returns false for empty string", () => {
+  assertEquals(isUuid(""), false);
+});

--- a/src/presentation/output/model_get_output.tsx
+++ b/src/presentation/output/model_get_output.tsx
@@ -1,7 +1,6 @@
 // deno-lint-ignore verbatim-module-syntax
 import React from "react";
-import { Box, Text } from "ink";
-import { render } from "ink-testing-library";
+import { Box, render, Text } from "ink";
 import type { OutputMode } from "./output.tsx";
 
 /**
@@ -38,8 +37,8 @@ export function renderModelGet(data: ModelGetData, mode: OutputMode): void {
 }
 
 function renderInteractiveModelGet(data: ModelGetData): void {
-  const { lastFrame } = render(<ModelGetDisplay data={data} />);
-  console.log(lastFrame());
+  const instance = render(<ModelGetDisplay data={data} />);
+  instance.unmount();
 }
 
 interface ModelGetDisplayProps {
@@ -87,7 +86,7 @@ function KeyValue({
 }): React.ReactElement {
   return (
     <Text>
-      <Text color="cyan">{label}:</Text>
+      <Text color="cyan">{`${label}: `}</Text>
       <Text>{value}</Text>
     </Text>
   );

--- a/src/presentation/output/model_list_output.tsx
+++ b/src/presentation/output/model_list_output.tsx
@@ -1,5 +1,5 @@
 // deno-lint-ignore verbatim-module-syntax
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Box, render, Text, useApp, useInput } from "ink";
 import type { OutputMode } from "./output.tsx";
 import { Fzf, type FzfResultItem } from "fzf";
@@ -89,10 +89,14 @@ export function ModelListUI(
   const [query, setQuery] = useState(initialQuery);
   const [selectedIndex, setSelectedIndex] = useState(0);
 
-  // Create fzf instance for fuzzy searching
-  const fzf = new Fzf(models, {
-    selector: (item) => `${item.name} ${item.type} ${item.id}`,
-  });
+  // Create fzf instance for fuzzy searching (memoized to avoid recreation on every render)
+  const fzf = useMemo(
+    () =>
+      new Fzf(models, {
+        selector: (item) => `${item.name} ${item.type} ${item.id}`,
+      }),
+    [models],
+  );
 
   // Get filtered results
   const results: FzfResultItem<ModelListItem>[] = fzf.find(query);

--- a/src/presentation/output/type_search_output.tsx
+++ b/src/presentation/output/type_search_output.tsx
@@ -1,5 +1,5 @@
 // deno-lint-ignore verbatim-module-syntax
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Box, render, Text, useApp, useInput } from "ink";
 import type { OutputMode } from "./output.tsx";
 import { Fzf, type FzfResultItem } from "fzf";
@@ -87,10 +87,14 @@ export function TypeSearchUI(
   const [query, setQuery] = useState(initialQuery);
   const [selectedIndex, setSelectedIndex] = useState(0);
 
-  // Create fzf instance for fuzzy searching
-  const fzf = new Fzf(types, {
-    selector: (item) => `${item.raw} ${item.normalized}`,
-  });
+  // Create fzf instance for fuzzy searching (memoized to avoid recreation on every render)
+  const fzf = useMemo(
+    () =>
+      new Fzf(types, {
+        selector: (item) => `${item.raw} ${item.normalized}`,
+      }),
+    [types],
+  );
 
   // Get filtered results
   const results: FzfResultItem<TypeSearchItem>[] = fzf.find(query);


### PR DESCRIPTION
- Extract shared UUID handling and model lookup utilities to src/domain/models/model_lookup.ts
- Fix model_get_output.tsx to use ink's render instead of ink-testing-library
- Memoize fzf instances in model_list_output.tsx and type_search_output.tsx to avoid recreation on every render
- Fix missing space in KeyValue display (now shows ID: value instead of ID:value)
- Add unit tests for isUuid() and filterModels() functions
- Export filterModels from model_list.ts to enable direct testing

### Changes

 | File | Change |
|------|--------|
| `src/domain/models/model_lookup.ts` | New shared utility with `isUuid()` and `findInputByIdGlobal()` |
| `src/domain/models/model_lookup_test.ts` | Tests for UUID validation |
| `src/cli/commands/model_get.ts` | Import from shared utility |
| `src/cli/commands/model_validate.ts` | Import from shared utility |
| `src/cli/commands/model_list.ts` | Export `filterModels` for testing |
| `src/cli/commands/model_list_test.ts` | Add tests for `filterModels()` |
| `src/presentation/output/model_get_output.tsx` | Use ink render, fix KeyValue spacing |
| `src/presentation/output/model_list_output.tsx` | Memoize fzf instance |
| `src/presentation/output/type_search_output.tsx` | Memoize fzf instance |

###Test plan

- Run deno run test - all 317 tests pass
- Run deno lint - no issues
- Run deno fmt --check - properly formatted