### PR TITLE
Block PR Merges on Review Failings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
         run: deno test --allow-read --allow-write --allow-env --allow-run
 
   claude-review:
+    # NOTE: For this to block merges, enable branch protection on main with:
+    # "Require a pull request before merging" + "Require approving reviews"
+    # Claude will use --request-changes to block or --approve to allow
     name: Claude Code Review
     needs: test
     runs-on: ubuntu-latest
@@ -59,12 +62,27 @@ jobs:
             5. Security vulnerabilities and best practices
             6. Any potential bugs or edge cases
 
-            After reviewing, post your feedback as a comment on the PR using:
-            gh pr comment ${{ github.event.pull_request.number }} --body "your review here"
+            IMPORTANT: Categorize your findings into two types:
+            - **Blocking Issues**: Problems that MUST be fixed before merge (bugs, security issues, type errors, missing tests for new code, violations of CLAUDE.md requirements)
+            - **Suggestions**: Nice-to-have improvements that don't block merge (style preferences, optional refactoring, documentation improvements)
+
+            After reviewing, submit your review using ONE of these commands:
+
+            If there are NO blocking issues (only suggestions or the PR looks good):
+            ```
+            gh pr review ${{ github.event.pull_request.number }} --approve --body "your review here"
+            ```
+
+            If there ARE blocking issues that must be addressed:
+            ```
+            gh pr review ${{ github.event.pull_request.number }} --request-changes --body "your review here"
+            ```
+
+            Your review body should clearly list any blocking issues at the top, followed by suggestions.
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
             --model claude-opus-4-5-20251101
-            --allowedTools Bash(gh pr comment:*),Bash(gh pr view:*)
+            --allowedTools Bash(gh pr review:*),Bash(gh pr view:*),Bash(gh pr diff:*)
 
   auto-merge:
     name: Auto-merge PR


### PR DESCRIPTION
- Update Claude Code review to use formal GitHub PR reviews instead of comments
- Claude now blocks merges when it identifies issues that must be fixed
- Add gh pr diff to allowed tools for better code analysis

### Details

Previously, Claude would post review feedback as a PR comment, which didn't integrate with GitHub's merge protection. Now Claude submits formal PR reviews:

- --approve: When there are no blocking issues (allows merge)
- --request-changes: When blocking issues are found (prevents merge)

Claude categorizes findings as:
- Blocking Issues: Bugs, security issues, type errors, missing tests, CLAUDE.md violations
- Suggestions: Style preferences, optional refactoring, documentation improvements (don't block)

### Setup Required

To enable merge blocking, configure branch protection on main:
1. Settings → Branches → Add rule for main
2. Enable "Require a pull request before merging"
3. Enable "Require approving reviews before merging"

### Test plan

- Open a PR with a blocking issue (e.g., any type) and verify Claude requests changes
- Open a clean PR and verify Claude approves
- Verify auto-merge respects the review status