### PR TITLE
Address PR review feedback for model registry code generation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Run deno fmt --check
         run: deno fmt --check
 
+      - name: Check model registry is up-to-date
+        run: deno task check:models
+
       - name: Run deno test
         run: deno test --allow-read --allow-write --allow-env --allow-run
 

--- a/deno.json
+++ b/deno.json
@@ -9,6 +9,7 @@
     "lint": "deno lint",
     "fmt": "deno fmt",
     "generate:models": "deno run --allow-read --allow-write scripts/generate_model_registry.ts",
+    "check:models": "deno run --allow-read --allow-write --allow-run scripts/check_model_registry.ts",
     "compile": "deno task generate:models && deno compile --allow-read --allow-write --allow-env --allow-run --allow-sys --allow-net --include .claude/skills --output swamp main.ts"
   },
   "imports": {

--- a/scripts/check_model_registry.ts
+++ b/scripts/check_model_registry.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-run
+/**
+ * CI check script to verify registry.generated.ts is up-to-date.
+ *
+ * This script:
+ * 1. Saves the current registry.generated.ts content
+ * 2. Runs the generator
+ * 3. Compares the output
+ * 4. Restores the original and exits with error if different
+ *
+ * Usage:
+ *   deno run --allow-read --allow-write --allow-run scripts/check_model_registry.ts
+ *
+ * Or via task:
+ *   deno task check:models
+ */
+
+const REGISTRY_FILE = new URL(
+  "../src/domain/models/registry.generated.ts",
+  import.meta.url,
+).pathname;
+
+const GENERATOR_SCRIPT = new URL(
+  "./generate_model_registry.ts",
+  import.meta.url,
+).pathname;
+
+async function main() {
+  console.log("🔍 Checking if registry.generated.ts is up-to-date...\n");
+
+  // Read current content
+  let originalContent: string;
+  try {
+    originalContent = await Deno.readTextFile(REGISTRY_FILE);
+  } catch {
+    console.error("❌ registry.generated.ts not found!");
+    console.error("   Run `deno task generate:models` to create it.");
+    Deno.exit(1);
+  }
+
+  // Run the generator
+  const command = new Deno.Command("deno", {
+    args: ["run", "--allow-read", "--allow-write", GENERATOR_SCRIPT],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const { code, stdout, stderr } = await command.output();
+
+  if (code !== 0) {
+    console.error("❌ Generator failed:");
+    console.error(new TextDecoder().decode(stderr));
+    Deno.exit(1);
+  }
+
+  // Show generator output
+  console.log(new TextDecoder().decode(stdout));
+
+  // Read new content
+  const newContent = await Deno.readTextFile(REGISTRY_FILE);
+
+  // Compare
+  if (originalContent === newContent) {
+    console.log("✅ registry.generated.ts is up-to-date!");
+    Deno.exit(0);
+  } else {
+    // Restore original
+    await Deno.writeTextFile(REGISTRY_FILE, originalContent);
+
+    console.error("❌ registry.generated.ts is out of date!");
+    console.error("");
+    console.error(
+      "   The generated registry does not match the committed file.",
+    );
+    console.error("   This usually means a model was added or removed without");
+    console.error("   regenerating the registry.");
+    console.error("");
+    console.error("   To fix, run:");
+    console.error("     deno task generate:models");
+    console.error("");
+    console.error("   Then commit the updated registry.generated.ts file.");
+    Deno.exit(1);
+  }
+}
+
+main();

--- a/scripts/generate_model_registry.ts
+++ b/scripts/generate_model_registry.ts
@@ -52,11 +52,25 @@ async function discoverModelFiles(): Promise<string[]> {
 }
 
 /**
+ * Strips comments from TypeScript/JavaScript content.
+ * Removes both single-line (//) and multi-line (/* *\/) comments.
+ */
+function stripComments(content: string): string {
+  // Remove single-line comments
+  const withoutSingleLine = content.replace(/\/\/.*$/gm, "");
+  // Remove multi-line comments (including JSDoc)
+  return withoutSingleLine.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+/**
  * Extracts model export names from a file by parsing its content.
  * Looks for exports matching the pattern: export const xxxModel
+ * Ignores commented-out code.
  */
 async function extractModelExports(filePath: string): Promise<string[]> {
   const content = await Deno.readTextFile(filePath);
+  // Strip comments to avoid matching commented-out exports
+  const contentWithoutComments = stripComments(content);
   const exports: string[] = [];
 
   // Match: export const someNameModel = or export const someNameModel:
@@ -64,7 +78,7 @@ async function extractModelExports(filePath: string): Promise<string[]> {
   const exportRegex = /export\s+const\s+(\w+Model)\s*[=:]/g;
   let match;
 
-  while ((match = exportRegex.exec(content)) !== null) {
+  while ((match = exportRegex.exec(contentWithoutComments)) !== null) {
     const name = match[1];
     // Skip MODEL_TYPE constants (e.g., EC2_INSTANCE_MODEL_TYPE)
     if (!name.includes("MODEL_TYPE") && !name.includes("_MODEL_")) {

--- a/scripts/generate_model_registry_test.ts
+++ b/scripts/generate_model_registry_test.ts
@@ -1,0 +1,105 @@
+import { assertEquals } from "@std/assert";
+
+/**
+ * Regex for matching model exports - same as in generate_model_registry.ts
+ */
+const MODEL_EXPORT_REGEX = /export\s+const\s+(\w+Model)\s*[=:]/g;
+
+/**
+ * Extracts model export names from content, skipping comments.
+ */
+function extractModelExports(content: string): string[] {
+  // Remove single-line comments
+  const withoutSingleLineComments = content.replace(/\/\/.*$/gm, "");
+  // Remove multi-line comments
+  const withoutComments = withoutSingleLineComments.replace(
+    /\/\*[\s\S]*?\*\//g,
+    "",
+  );
+
+  const exports: string[] = [];
+  let match;
+
+  while ((match = MODEL_EXPORT_REGEX.exec(withoutComments)) !== null) {
+    const name = match[1];
+    if (!name.includes("MODEL_TYPE") && !name.includes("_MODEL_")) {
+      exports.push(name);
+    }
+  }
+
+  // Reset regex state
+  MODEL_EXPORT_REGEX.lastIndex = 0;
+
+  return exports;
+}
+
+Deno.test("extractModelExports - matches standard model export", () => {
+  const content = `export const ec2InstanceModel = createModel();`;
+  assertEquals(extractModelExports(content), ["ec2InstanceModel"]);
+});
+
+Deno.test("extractModelExports - matches typed model export", () => {
+  const content = `export const ec2VpcModel: ModelDefinition = {};`;
+  assertEquals(extractModelExports(content), ["ec2VpcModel"]);
+});
+
+Deno.test("extractModelExports - ignores MODEL_TYPE constants", () => {
+  const content = `
+export const EC2_INSTANCE_MODEL_TYPE = ModelType.create("AWS::EC2::Instance");
+export const ec2InstanceModel = createModel();
+`;
+  assertEquals(extractModelExports(content), ["ec2InstanceModel"]);
+});
+
+Deno.test("extractModelExports - ignores single-line commented exports", () => {
+  const content = `
+// export const oldModel = deprecated();
+export const newModel = createModel();
+`;
+  assertEquals(extractModelExports(content), ["newModel"]);
+});
+
+Deno.test("extractModelExports - ignores multi-line commented exports", () => {
+  const content = `
+/*
+export const commentedOutModel = deprecated();
+*/
+export const activeModel = createModel();
+`;
+  assertEquals(extractModelExports(content), ["activeModel"]);
+});
+
+Deno.test("extractModelExports - ignores block comment with model", () => {
+  const content = `
+/**
+ * Example: export const exampleModel = ...
+ */
+export const realModel = createModel();
+`;
+  assertEquals(extractModelExports(content), ["realModel"]);
+});
+
+Deno.test("extractModelExports - handles multiple models in one file", () => {
+  const content = `
+export const fooModel = createModel();
+export const barModel: ModelDefinition = {};
+export const BAZ_MODEL_TYPE = ModelType.create("baz");
+`;
+  assertEquals(extractModelExports(content), ["fooModel", "barModel"]);
+});
+
+Deno.test("extractModelExports - handles no models", () => {
+  const content = `
+export const someUtility = () => {};
+export function helper() {}
+`;
+  assertEquals(extractModelExports(content), []);
+});
+
+Deno.test("extractModelExports - handles model with whitespace variations", () => {
+  const content = `
+export const   spacedModel   =   createModel();
+export const tabModel	: ModelDefinition = {};
+`;
+  assertEquals(extractModelExports(content), ["spacedModel", "tabModel"]);
+});


### PR DESCRIPTION
### Test plan

- All 599 tests pass (including 9 new generator tests)
- deno task check:models passes
- deno lint passes
- deno fmt --check passes

### Changes

1. Generator Unit Tests

Added scripts/generate_model_registry_test.ts with 9 tests covering:
- Standard and typed model exports
- MODEL_TYPE constant filtering
- Single-line comment handling (// export const oldModel = ...)
- Multi-line comment handling (/* export const oldModel = ... */)
- JSDoc comment handling
- Multiple models per file
- Whitespace variations

2. Comment Stripping in Generator

Updated scripts/generate_model_registry.ts:
- Added stripComments() function to remove // and /* */ comments
- Regex now only matches actual code, preventing false positives from commented-out exports

3. CI Integration

Added scripts/check_model_registry.ts - a CI check script that:
- Saves current registry.generated.ts
- Runs the generator
- Compares output and fails if different
- Restores original file and provides clear fix instructions

New task: deno task check:models

Updated .github/workflows/ci.yml:
- name: Check model registry is up-to-date
run: deno task check:models

🤖 Generated with https://claude.ai/code