### PR TITLE
Add workflow schema command and skills

### DIFF
--- a/.claude/skills/github-pr/SKILL.md
+++ b/.claude/skills/github-pr/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: github-pr
+description: |
+  Create and manage GitHub pull requests. Supports both jujutsu (jj) and git
+  version control. Use when submitting PRs, checking PR status, fixing review
+  feedback, or merging PRs. Triggers on "submit pr", "create pr", "check pr",
+  "fix review", "pr status", "merge pr".
+---
+
+# GitHub PR Workflow
+
+## Detect VCS
+
+First, determine which version control system is in use:
+
+```bash
+if [ -d ".jj" ]; then
+  echo "jujutsu"
+else
+  echo "git"
+fi
+```
+
+- **If `.jj` exists**: Read [references/jujutsu.md](references/jujutsu.md) for
+  VCS-specific commands
+- **Otherwise**: Read [references/git.md](references/git.md) for VCS-specific
+  commands
+
+## Pre-flight Checks
+
+Run these checks before submitting any PR:
+
+```bash
+deno fmt --check
+deno lint
+deno run check:models
+deno run test
+```
+
+Fix any issues before proceeding. All checks must pass.
+
+## Create PR
+
+After pushing changes (see VCS reference), create the PR:
+
+```bash
+gh pr create --head <branch-or-bookmark> --base main --title "Title here" --body "$(cat <<'EOF'
+## Summary
+
+Brief description of changes.
+
+## Test Plan
+
+- How the changes were tested
+EOF
+)"
+```
+
+## Check Merge Status
+
+To check if a PR is ready to merge:
+
+```bash
+# Check CI status
+gh pr checks <pr-number>
+
+# View PR details including review status
+gh pr view <pr-number>
+```
+
+## Handle Blocking Reviews
+
+When a PR has blocking review feedback:
+
+1. Get the review comments:
+   ```bash
+   gh pr view <pr-number> --comments
+   ```
+
+2. Enter plan mode to analyze the feedback and plan fixes
+
+3. Implement the fixes
+
+4. Push updates (see VCS reference for push commands)
+
+5. Re-request review if needed:
+   ```bash
+   gh pr edit <pr-number> --add-reviewer <username>
+   ```
+
+## Handle Suggestions
+
+When reviewers provide non-blocking suggestions:
+
+1. Get suggestions from the review:
+   ```bash
+   gh pr view <pr-number> --comments
+   ```
+
+2. Enter plan mode to evaluate each suggestion
+
+3. Decide which suggestions to implement (discuss with user if unclear)
+
+4. Implement approved suggestions and push
+
+5. Respond to suggestions you chose not to implement with reasoning
+
+## Merge PR
+
+Once all checks pass and reviews are approved:
+
+```bash
+# Squash merge (preferred)
+gh pr merge <pr-number> --squash --delete-branch
+
+# Or merge commit
+gh pr merge <pr-number> --merge --delete-branch
+```

--- a/.claude/skills/github-pr/references/git.md
+++ b/.claude/skills/github-pr/references/git.md
@@ -1,0 +1,76 @@
+# Git VCS Commands
+
+## Review Changes
+
+```bash
+# View change summary
+git diff --stat
+
+# View status
+git status
+
+# View full diff
+git diff
+```
+
+## Create Branch (If Needed)
+
+Check if already on a feature branch:
+
+```bash
+current_branch=$(git branch --show-current)
+if [ "$current_branch" = "main" ] || [ "$current_branch" = "master" ]; then
+  # On main branch, need to create feature branch
+  git checkout -b <feature-name>
+fi
+# Otherwise already on feature branch, skip creation
+```
+
+## Stage and Commit
+
+```bash
+# Stage all changes
+git add -A
+
+# Commit with message
+git commit -m "feat: add new feature
+
+Detailed description of the changes."
+```
+
+## Push
+
+For a new PR:
+
+```bash
+# Push and set upstream
+git push -u origin <branch-name>
+```
+
+## Update Existing PR
+
+When updating after review feedback:
+
+```bash
+# Stage and commit changes
+git add -A
+git commit -m "fix: address review feedback"
+
+# Push updates
+git push
+```
+
+## After Merge
+
+Clean up after PR is merged:
+
+```bash
+# Switch to main
+git checkout main
+
+# Pull latest
+git pull
+
+# Delete local feature branch
+git branch -d <feature-name>
+```

--- a/.claude/skills/github-pr/references/jujutsu.md
+++ b/.claude/skills/github-pr/references/jujutsu.md
@@ -1,0 +1,60 @@
+# Jujutsu VCS Commands
+
+Jujutsu automatically tracks changes, so no explicit staging is needed.
+
+## Review Changes
+
+```bash
+# View change summary
+jj diff --stat
+
+# View current change details
+jj log -r @
+
+# View full diff
+jj diff
+```
+
+## Describe Changes
+
+```bash
+jj describe -m "feat: add new feature
+
+Detailed description of the changes."
+```
+
+## Create Bookmark and Push
+
+For a new PR:
+
+```bash
+# Create a bookmark pointing to current change
+jj bookmark create <feature-name> -r @
+
+# Push the bookmark to origin
+jj git push --bookmark <feature-name>
+```
+
+## Update Existing PR
+
+When updating after review feedback:
+
+```bash
+# Changes are auto-tracked, just describe if needed
+jj describe -m "Updated message if changed"
+
+# Push updates (bookmark already exists)
+jj git push --bookmark <feature-name>
+```
+
+## After Merge
+
+Clean up after PR is merged:
+
+```bash
+# Fetch latest from remote
+jj git fetch
+
+# Rebase onto main
+jj rebase -d main
+```

--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: swamp-workflow
+description: Work with swamp workflows for AI-native automation. Use when searching for workflows, creating new workflows, validating workflow definitions, or running workflows. Triggers on requests involving "swamp workflow", "workflow", "run workflow", or "create workflow".
+---
+
+# Swamp Workflow Skill
+
+Work with swamp workflows through the CLI. All commands support `--json` for
+machine-readable output.
+
+## Quick Reference
+
+| Task              | Command                                       |
+| ----------------- | --------------------------------------------- |
+| Get schema        | `swamp workflow schema get --json`            |
+| Search workflows  | `swamp workflow search [query] --json`        |
+| Get a workflow    | `swamp workflow get <id_or_name> --json`      |
+| Create a workflow | `swamp workflow create <name> --json`         |
+| Validate workflow | `swamp workflow validate [id_or_name] --json` |
+| Run a workflow    | `swamp workflow run <id_or_name> --json`      |
+
+## IMPORTANT: Always Get Schema First
+
+Before creating or editing a workflow file, ALWAYS get the schema first:
+
+```bash
+swamp workflow schema get --json
+```
+
+This ensures you understand the exact structure and constraints for valid
+workflow files.
+
+## Get Workflow Schema
+
+Get the complete JSON Schema for workflow files.
+
+```bash
+swamp workflow schema get --json
+```
+
+**Output shape:**
+
+```json
+{
+  "workflow": {/* JSON Schema for top-level workflow */},
+  "job": {/* JSON Schema for job objects */},
+  "jobDependency": {/* JSON Schema for job dependency with condition */},
+  "step": {/* JSON Schema for step objects */},
+  "stepDependency": {/* JSON Schema for step dependency with condition */},
+  "stepTask": {/* JSON Schema for task (shell or model_method) */},
+  "triggerCondition": {/* JSON Schema for dependency conditions */}
+}
+```
+
+**Key schemas:**
+
+- `workflow` - Top-level structure with id, name, description, jobs, version
+- `job` - Job definition with name, steps, dependsOn, weight
+- `jobDependency` - Job dependency with target job name and trigger condition
+- `step` - Step definition with name, task, dependsOn, weight
+- `stepDependency` - Step dependency with target step name and trigger condition
+- `stepTask` - Discriminated union: `type: "shell"` or `type: "model_method"`
+- `triggerCondition` - Conditions like `always`, `succeeded(ref)`,
+  `failed(ref)`, etc.
+
+## Search for Workflows
+
+Find existing workflows in the repository.
+
+```bash
+swamp workflow search --json
+swamp workflow search "deploy" --json
+```
+
+**Output shape:**
+
+```json
+{
+  "query": "",
+  "results": [
+    { "id": "abc-123", "name": "my-workflow", "jobCount": 2 }
+  ]
+}
+```
+
+Select the workflow whose `name` best matches the user's intent.
+
+## Get a Workflow
+
+Get full details of a specific workflow including jobs and steps.
+
+```bash
+swamp workflow get my-workflow --json
+```
+
+**Output shape:**
+
+```json
+{
+  "id": "abc-123",
+  "name": "my-workflow",
+  "version": 1,
+  "jobs": [
+    {
+      "name": "main",
+      "description": "Main job",
+      "steps": [
+        {
+          "name": "example",
+          "description": "Example step",
+          "task": {
+            "type": "shell",
+            "command": "echo",
+            "args": ["Hello!"]
+          }
+        }
+      ]
+    }
+  ],
+  "path": "workflows/workflow-abc-123.yaml"
+}
+```
+
+**Key fields:**
+
+- `jobs` - Array of jobs that run in the workflow
+- `steps` - Steps within each job (run sequentially by default)
+- `path` - File path to read/edit the workflow definition
+
+## Create a Workflow
+
+Create a new workflow file.
+
+```bash
+swamp workflow create my-deploy-workflow --json
+```
+
+**Output shape:**
+
+```json
+{
+  "id": "abc-123",
+  "name": "my-deploy-workflow",
+  "path": "workflows/workflow-abc-123.yaml"
+}
+```
+
+After creation, edit the YAML file at the returned `path` to add jobs and steps.
+
+**Example workflow file structure:**
+
+```yaml
+# workflows/workflow-abc-123.yaml
+apiVersion: swamp/v1
+kind: Workflow
+metadata:
+  id: abc-123
+  name: my-deploy-workflow
+  version: 1
+jobs:
+  - name: build
+    description: Build the application
+    steps:
+      - name: compile
+        description: Compile source code
+        task:
+          type: shell
+          command: deno
+          args: ["task", "build"]
+  - name: deploy
+    description: Deploy the application
+    needs: [build]
+    steps:
+      - name: upload
+        description: Upload artifacts
+        task:
+          type: shell
+          command: ./deploy.sh
+```
+
+## Validate Workflows
+
+Validate a specific workflow or all workflows against their schemas.
+
+**Validate a single workflow:**
+
+```bash
+swamp workflow validate my-workflow --json
+```
+
+**Output shape (single):**
+
+```json
+{
+  "workflowId": "abc-123",
+  "workflowName": "my-workflow",
+  "validations": [
+    { "name": "Schema validation", "passed": true },
+    { "name": "Unique job names", "passed": true },
+    { "name": "Valid job dependency references", "passed": true },
+    { "name": "No cyclic job dependencies", "passed": true }
+  ],
+  "passed": true
+}
+```
+
+**Validate all workflows:**
+
+```bash
+swamp workflow validate --json
+```
+
+**Output shape (all):**
+
+```json
+{
+  "workflows": [
+    { "workflowId": "abc-123", "workflowName": "my-workflow", "validations": [...], "passed": true }
+  ],
+  "totalPassed": 1,
+  "totalFailed": 0,
+  "passed": true
+}
+```
+
+Always validate after editing a workflow file to catch errors early.
+
+## Run a Workflow
+
+Execute a workflow and get execution results.
+
+```bash
+swamp workflow run my-workflow --json
+```
+
+**Output shape:**
+
+```json
+{
+  "id": "run-456",
+  "workflowId": "abc-123",
+  "workflowName": "my-workflow",
+  "status": "succeeded",
+  "jobs": [
+    {
+      "name": "main",
+      "status": "succeeded",
+      "steps": [
+        { "name": "example", "status": "succeeded", "duration": 2 }
+      ],
+      "duration": 2
+    }
+  ],
+  "duration": 5,
+  "path": "workflows/workflow-abc-123/workflow-run-456-timestamp.yaml"
+}
+```
+
+**Key fields:**
+
+- `status` - Overall workflow status: `succeeded`, `failed`, or `running`
+- `jobs[].status` - Individual job status
+- `jobs[].steps[].status` - Individual step status
+- `duration` - Execution time in milliseconds
+- `path` - Path to the workflow run log file
+
+After running, summarize results to the user including which jobs/steps
+succeeded or failed and their durations.
+
+## Workflow Example
+
+End-to-end workflow for creating and running a new workflow:
+
+1. **Get schema**: `swamp workflow schema get --json` (understand valid
+   structure)
+2. **Create** a new workflow: `swamp workflow create my-task --json`
+3. **Edit** the YAML file at the returned `path` to add jobs and steps
+4. **Validate** the workflow: `swamp workflow validate my-task --json`
+5. **Fix** any validation errors and re-validate
+6. **Run** the workflow: `swamp workflow run my-task --json`

--- a/design/agent.md
+++ b/design/agent.md
@@ -29,3 +29,37 @@ neccessary.
 
 Use `swamp model method run` to run methods, then look at the resulting resource
 and report on what happened.
+
+## swamp-workflow Skill
+
+This skill knows how to write and run workflows.
+
+### Search for existing workflows
+
+Find existing workflows to work with using `swamp workflow search --json` and
+the fuzzy query syntax.
+
+### Get an existing workflow
+
+Get an existing worfklow by calling `swamp workflow get --json`, then reading
+the file directly from its path.
+
+### Create a new workflow
+
+Create a new workflow by calling `swamp workflow create <name> --json`. Then
+edit the resulting file directly.
+
+### Validate a workflow
+
+Any time you make a change to a workflow, you must validate it with
+`swamp workflow validate --json`.
+
+### Summarize a workflow
+
+Read a workflow file, and write a summary of what will happen when it is
+executed.
+
+### Run a workflow
+
+Execute a workflow with `swamp workflow run <name> --json`, and summarize the
+results by reading the output and the resulting workflow logs.

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -76,3 +76,8 @@ Should show the workflow yaml with syntax highlighting, and the path, similar to
 ### workflow run <id or name>
 
 Executes a workflow run.
+
+### workflow schema get
+
+Gets the schema for workflow files. Model it after `type describe` - used by the
+agent to understand how to write valid workflow files

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -4,6 +4,7 @@ import { workflowGetCommand } from "./workflow_get.ts";
 import { workflowValidateCommand } from "./workflow_validate.ts";
 import { workflowSearchCommand } from "./workflow_search.ts";
 import { workflowRunCommand } from "./workflow_run.ts";
+import { workflowSchemaCommand } from "./workflow_schema.ts";
 
 export const workflowCommand = new Command()
   .name("workflow")
@@ -15,4 +16,5 @@ export const workflowCommand = new Command()
   .command("get", workflowGetCommand)
   .command("validate", workflowValidateCommand)
   .command("search", workflowSearchCommand)
-  .command("run", workflowRunCommand);
+  .command("run", workflowRunCommand)
+  .command("schema", workflowSchemaCommand);

--- a/src/cli/commands/workflow_schema.ts
+++ b/src/cli/commands/workflow_schema.ts
@@ -1,0 +1,49 @@
+import { Command } from "@cliffy/command";
+import { z } from "zod";
+import { WorkflowSchema } from "../../domain/workflows/workflow.ts";
+import { JobDependencySchema, JobSchema } from "../../domain/workflows/job.ts";
+import {
+  StepDependencySchema,
+  StepSchema,
+} from "../../domain/workflows/step.ts";
+import { StepTaskSchema } from "../../domain/workflows/step_task.ts";
+import { TriggerConditionSchema } from "../../domain/workflows/trigger_condition.ts";
+import { renderWorkflowSchema } from "../../presentation/output/workflow_schema_output.tsx";
+import { createContext, type GlobalOptions } from "../context.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+/**
+ * Converts a Zod schema to JSON Schema format.
+ */
+function zodToJsonSchema(schema: z.ZodTypeAny): object {
+  return z.toJSONSchema(schema);
+}
+
+export const workflowSchemaGetCommand = new Command()
+  .description("Get the schema for workflow files")
+  .action(function (options: AnyOptions) {
+    const ctx = createContext(options as GlobalOptions, "workflow-schema-get");
+
+    const data = {
+      workflow: zodToJsonSchema(WorkflowSchema),
+      job: zodToJsonSchema(JobSchema),
+      jobDependency: zodToJsonSchema(JobDependencySchema),
+      step: zodToJsonSchema(StepSchema),
+      stepDependency: zodToJsonSchema(StepDependencySchema),
+      stepTask: zodToJsonSchema(StepTaskSchema),
+      triggerCondition: zodToJsonSchema(TriggerConditionSchema),
+    };
+
+    renderWorkflowSchema(data, ctx.outputMode);
+    ctx.logger.debug("Workflow schema get command completed");
+  });
+
+export const workflowSchemaCommand = new Command()
+  .name("schema")
+  .description("Workflow schema commands")
+  .action(function () {
+    this.showHelp();
+  })
+  .command("get", workflowSchemaGetCommand);

--- a/src/cli/commands/workflow_schema_test.ts
+++ b/src/cli/commands/workflow_schema_test.ts
@@ -1,0 +1,25 @@
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Initialize logging for tests
+await initializeLogging({ debugLogs: false });
+
+Deno.test("workflowSchemaCommand module loads", async () => {
+  const { workflowSchemaCommand } = await import("./workflow_schema.ts");
+  assertEquals(workflowSchemaCommand.getName(), "schema");
+});
+
+Deno.test("workflowSchemaGetCommand is registered as subcommand", async () => {
+  const { workflowSchemaCommand } = await import("./workflow_schema.ts");
+  const commands = workflowSchemaCommand.getCommands();
+  const getCmd = commands.find((c) => c.getName() === "get");
+  assertEquals(getCmd !== undefined, true);
+});
+
+Deno.test("workflowSchemaGetCommand has correct description", async () => {
+  const { workflowSchemaGetCommand } = await import("./workflow_schema.ts");
+  assertEquals(
+    workflowSchemaGetCommand.getDescription(),
+    "Get the schema for workflow files",
+  );
+});

--- a/src/infrastructure/assets/skill_assets.ts
+++ b/src/infrastructure/assets/skill_assets.ts
@@ -15,6 +15,7 @@ export interface SkillInfo {
  */
 const BUNDLED_SKILLS: SkillInfo[] = [
   { relativePath: "swamp-model/SKILL.md", name: "swamp-model" },
+  { relativePath: "swamp-workflow/SKILL.md", name: "swamp-workflow" },
 ];
 
 /**

--- a/src/presentation/output/workflow_schema_output.tsx
+++ b/src/presentation/output/workflow_schema_output.tsx
@@ -1,0 +1,150 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { Box, Text } from "ink";
+import { render } from "ink-testing-library";
+import type { OutputMode } from "./output.tsx";
+
+/**
+ * Data structure for the workflow schema output.
+ */
+export interface WorkflowSchemaData {
+  workflow: object;
+  job: object;
+  jobDependency: object;
+  step: object;
+  stepDependency: object;
+  stepTask: object;
+  triggerCondition: object;
+}
+
+/**
+ * Renders the workflow schema in either interactive or JSON mode.
+ */
+export function renderWorkflowSchema(
+  data: WorkflowSchemaData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    renderInteractiveWorkflowSchema(data);
+  }
+}
+
+function renderInteractiveWorkflowSchema(data: WorkflowSchemaData): void {
+  const { lastFrame } = render(<WorkflowSchemaDisplay data={data} />);
+  console.log(lastFrame());
+}
+
+interface WorkflowSchemaDisplayProps {
+  data: WorkflowSchemaData;
+}
+
+/**
+ * Formats a JSON schema object as a string with indentation.
+ */
+function formatSchema(schema: object): string {
+  return JSON.stringify(schema, null, 2);
+}
+
+/**
+ * Component to display a schema section with a header.
+ */
+function SchemaSection({
+  title,
+  description,
+  schema,
+}: {
+  title: string;
+  description: string;
+  schema: object;
+}): React.ReactElement {
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text color="cyan" bold>
+        ## {title}
+      </Text>
+      <Box marginLeft={2}>
+        <Text dimColor>{description}</Text>
+      </Box>
+      <Box marginTop={1}>
+        <Text dimColor>{formatSchema(schema)}</Text>
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * Interactive display component for workflow schema.
+ */
+export function WorkflowSchemaDisplay(
+  props: WorkflowSchemaDisplayProps,
+): React.ReactElement {
+  const { data } = props;
+
+  return (
+    <Box flexDirection="column">
+      {/* Header */}
+      <Text color="green" bold>
+        # Workflow Schema
+      </Text>
+
+      {/* Description */}
+      <Box marginTop={1}>
+        <Text>
+          These schemas define the structure of workflow files. Use them to
+          understand valid workflow definitions.
+        </Text>
+      </Box>
+
+      {/* Workflow Schema */}
+      <SchemaSection
+        title="Workflow"
+        description="Top-level workflow structure with id, name, description, jobs, and version."
+        schema={data.workflow}
+      />
+
+      {/* Job Schema */}
+      <SchemaSection
+        title="Job"
+        description="Job definition with name, description, steps, dependsOn, and weight."
+        schema={data.job}
+      />
+
+      {/* Job Dependency Schema */}
+      <SchemaSection
+        title="Job Dependency"
+        description="Job dependency specifying target job and trigger condition."
+        schema={data.jobDependency}
+      />
+
+      {/* Step Schema */}
+      <SchemaSection
+        title="Step"
+        description="Step definition with name, description, task, dependsOn, and weight."
+        schema={data.step}
+      />
+
+      {/* Step Dependency Schema */}
+      <SchemaSection
+        title="Step Dependency"
+        description="Step dependency specifying target step and trigger condition."
+        schema={data.stepDependency}
+      />
+
+      {/* Step Task Schema */}
+      <SchemaSection
+        title="Step Task"
+        description="Discriminated union: type 'shell' for shell commands or type 'model_method' for model invocations."
+        schema={data.stepTask}
+      />
+
+      {/* Trigger Condition Schema */}
+      <SchemaSection
+        title="Trigger Condition"
+        description="Conditions: always, succeeded(ref), failed(ref), completed(ref), skipped(ref), and/or/not combinators."
+        schema={data.triggerCondition}
+      />
+    </Box>
+  );
+}

--- a/src/presentation/output/workflow_schema_output_test.tsx
+++ b/src/presentation/output/workflow_schema_output_test.tsx
@@ -1,0 +1,155 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { render } from "ink-testing-library";
+import {
+  renderWorkflowSchema,
+  type WorkflowSchemaData,
+  WorkflowSchemaDisplay,
+} from "./workflow_schema_output.tsx";
+
+const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
+
+const testData: WorkflowSchemaData = {
+  workflow: {
+    type: "object",
+    properties: {
+      id: { type: "string", format: "uuid" },
+      name: { type: "string", minLength: 1 },
+    },
+    required: ["id", "name"],
+  },
+  job: {
+    type: "object",
+    properties: {
+      name: { type: "string", minLength: 1 },
+      steps: { type: "array" },
+    },
+    required: ["name", "steps"],
+  },
+  jobDependency: {
+    type: "object",
+    properties: {
+      job: { type: "string" },
+      condition: { type: "object" },
+    },
+    required: ["job", "condition"],
+  },
+  step: {
+    type: "object",
+    properties: {
+      name: { type: "string", minLength: 1 },
+      task: { type: "object" },
+    },
+    required: ["name", "task"],
+  },
+  stepDependency: {
+    type: "object",
+    properties: {
+      step: { type: "string" },
+      condition: { type: "object" },
+    },
+    required: ["step", "condition"],
+  },
+  stepTask: {
+    oneOf: [
+      { type: "object", properties: { type: { const: "shell" } } },
+      { type: "object", properties: { type: { const: "model_method" } } },
+    ],
+  },
+  triggerCondition: {
+    oneOf: [
+      { type: "object", properties: { type: { const: "always" } } },
+      { type: "object", properties: { type: { const: "succeeded" } } },
+    ],
+  },
+};
+
+Deno.test({
+  name: "WorkflowSchemaDisplay renders header",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<WorkflowSchemaDisplay data={testData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Workflow Schema");
+  },
+});
+
+Deno.test({
+  name: "WorkflowSchemaDisplay renders workflow section",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<WorkflowSchemaDisplay data={testData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "## Workflow");
+    assertStringIncludes(output, "Top-level workflow structure");
+  },
+});
+
+Deno.test({
+  name: "WorkflowSchemaDisplay renders job section",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<WorkflowSchemaDisplay data={testData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "## Job");
+    assertStringIncludes(output, "Job definition");
+  },
+});
+
+Deno.test({
+  name: "WorkflowSchemaDisplay renders step section",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<WorkflowSchemaDisplay data={testData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "## Step");
+    assertStringIncludes(output, "Step definition");
+  },
+});
+
+Deno.test({
+  name: "WorkflowSchemaDisplay renders stepTask section",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<WorkflowSchemaDisplay data={testData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "## Step Task");
+    assertStringIncludes(output, "Discriminated union");
+  },
+});
+
+Deno.test({
+  name: "WorkflowSchemaDisplay renders triggerCondition section",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<WorkflowSchemaDisplay data={testData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "## Trigger Condition");
+  },
+});
+
+Deno.test("renderWorkflowSchema with json mode outputs valid JSON", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderWorkflowSchema(testData, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(typeof parsed.workflow, "object");
+    assertEquals(typeof parsed.job, "object");
+    assertEquals(typeof parsed.step, "object");
+    assertEquals(typeof parsed.stepTask, "object");
+    assertEquals(typeof parsed.triggerCondition, "object");
+  } finally {
+    console.log = originalLog;
+  }
+});


### PR DESCRIPTION
## Summary

- Add `workflow schema` command with interactive and JSON output for viewing workflow definitions
- Create `swamp-workflow` skill for AI-native workflow automation guidance
- Create `github-pr` skill for managing GitHub PRs with both jujutsu and git support
- Update design docs for agent and workflow specifications

## Test Plan

- All existing tests pass (`deno run test`)
- `deno fmt --check` and `deno lint` pass
- New tests added for workflow schema command and output components