### PR TITLE
Add github-pr skill for PR workflow management

### DIFF
--- a/.claude/skills/github-pr/SKILL.md
+++ b/.claude/skills/github-pr/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: github-pr
+description: |
+  Create and manage GitHub pull requests. Supports both jujutsu (jj) and git
+  version control. Use when submitting PRs, checking PR status, fixing review
+  feedback, or merging PRs. Triggers on "submit pr", "create pr", "check pr",
+  "fix review", "pr status", "merge pr".
+---
+
+# GitHub PR Workflow
+
+## Detect VCS
+
+First, determine which version control system is in use:
+
+```bash
+if [ -d ".jj" ]; then
+  echo "jujutsu"
+else
+  echo "git"
+fi
+```
+
+- **If `.jj` exists**: Read [references/jujutsu.md](references/jujutsu.md) for
+  VCS-specific commands
+- **Otherwise**: Read [references/git.md](references/git.md) for VCS-specific
+  commands
+
+## Pre-flight Checks
+
+Run these checks before submitting any PR:
+
+```bash
+deno fmt --check
+deno lint
+deno run check:models
+deno run test
+```
+
+Fix any issues before proceeding. All checks must pass.
+
+## Create PR
+
+After pushing changes (see VCS reference), create the PR:
+
+```bash
+gh pr create --head <branch-or-bookmark> --base main --title "Title here" --body "$(cat <<'EOF'
+## Summary
+
+Brief description of changes.
+
+## Test Plan
+
+- How the changes were tested
+EOF
+)"
+```
+
+## Check Merge Status
+
+To check if a PR is ready to merge:
+
+```bash
+# Check CI status
+gh pr checks <pr-number>
+
+# View PR details including review status
+gh pr view <pr-number>
+```
+
+## Handle Blocking Reviews
+
+When a PR has blocking review feedback:
+
+1. Get the review comments:
+   ```bash
+   gh pr view <pr-number> --comments
+   ```
+
+2. Enter plan mode to analyze the feedback and plan fixes
+
+3. Implement the fixes
+
+4. Push updates (see VCS reference for push commands)
+
+5. Re-request review if needed:
+   ```bash
+   gh pr edit <pr-number> --add-reviewer <username>
+   ```
+
+## Handle Suggestions
+
+When reviewers provide non-blocking suggestions:
+
+1. Get suggestions from the review:
+   ```bash
+   gh pr view <pr-number> --comments
+   ```
+
+2. Enter plan mode to evaluate each suggestion
+
+3. Decide which suggestions to implement (discuss with user if unclear)
+
+4. Implement approved suggestions and push
+
+5. Respond to suggestions you chose not to implement with reasoning
+
+## Merge PR
+
+Once all checks pass and reviews are approved:
+
+```bash
+# Squash merge (preferred)
+gh pr merge <pr-number> --squash --delete-branch
+
+# Or merge commit
+gh pr merge <pr-number> --merge --delete-branch
+```

--- a/.claude/skills/github-pr/references/git.md
+++ b/.claude/skills/github-pr/references/git.md
@@ -1,0 +1,76 @@
+# Git VCS Commands
+
+## Review Changes
+
+```bash
+# View change summary
+git diff --stat
+
+# View status
+git status
+
+# View full diff
+git diff
+```
+
+## Create Branch (If Needed)
+
+Check if already on a feature branch:
+
+```bash
+current_branch=$(git branch --show-current)
+if [ "$current_branch" = "main" ] || [ "$current_branch" = "master" ]; then
+  # On main branch, need to create feature branch
+  git checkout -b <feature-name>
+fi
+# Otherwise already on feature branch, skip creation
+```
+
+## Stage and Commit
+
+```bash
+# Stage all changes
+git add -A
+
+# Commit with message
+git commit -m "feat: add new feature
+
+Detailed description of the changes."
+```
+
+## Push
+
+For a new PR:
+
+```bash
+# Push and set upstream
+git push -u origin <branch-name>
+```
+
+## Update Existing PR
+
+When updating after review feedback:
+
+```bash
+# Stage and commit changes
+git add -A
+git commit -m "fix: address review feedback"
+
+# Push updates
+git push
+```
+
+## After Merge
+
+Clean up after PR is merged:
+
+```bash
+# Switch to main
+git checkout main
+
+# Pull latest
+git pull
+
+# Delete local feature branch
+git branch -d <feature-name>
+```

--- a/.claude/skills/github-pr/references/jujutsu.md
+++ b/.claude/skills/github-pr/references/jujutsu.md
@@ -1,0 +1,60 @@
+# Jujutsu VCS Commands
+
+Jujutsu automatically tracks changes, so no explicit staging is needed.
+
+## Review Changes
+
+```bash
+# View change summary
+jj diff --stat
+
+# View current change details
+jj log -r @
+
+# View full diff
+jj diff
+```
+
+## Describe Changes
+
+```bash
+jj describe -m "feat: add new feature
+
+Detailed description of the changes."
+```
+
+## Create Bookmark and Push
+
+For a new PR:
+
+```bash
+# Create a bookmark pointing to current change
+jj bookmark create <feature-name> -r @
+
+# Push the bookmark to origin
+jj git push --bookmark <feature-name>
+```
+
+## Update Existing PR
+
+When updating after review feedback:
+
+```bash
+# Changes are auto-tracked, just describe if needed
+jj describe -m "Updated message if changed"
+
+# Push updates (bookmark already exists)
+jj git push --bookmark <feature-name>
+```
+
+## After Merge
+
+Clean up after PR is merged:
+
+```bash
+# Fetch latest from remote
+jj git fetch
+
+# Rebase onto main
+jj rebase -d main
+```


### PR DESCRIPTION
## Summary

Adds a Claude Code skill for creating and managing GitHub PRs with support for both git and jujutsu version control systems.

The skill provides guidance for:
- **VCS detection**: Automatically detects git vs jujutsu and loads appropriate reference
- **Pre-flight checks**: Runs deno fmt, lint, check:models, and tests before PR submission
- **PR creation**: Creates PRs with proper formatting via gh CLI
- **Review handling**: Guidance for addressing blocking reviews and suggestions
- **Merge workflow**: Commands for checking status and merging approved PRs

## Test Plan

- Tested the skill by using it to create this PR