### PR TITLE
Add deno fmt auto-fix hint to github-pr skill

### DIFF
--- a/.claude/skills/github-pr/SKILL.md
+++ b/.claude/skills/github-pr/SKILL.md
@@ -39,6 +39,9 @@ deno run test
 
 Fix any issues before proceeding. All checks must pass.
 
+If `deno fmt --check` fails, run `deno fmt` to auto-fix formatting, then re-run
+the checks.
+
 ## Create PR
 
 After pushing changes (see VCS reference), create the PR:


### PR DESCRIPTION
## Summary

Adds a hint to the github-pr skill's pre-flight checks section: when `deno fmt --check` fails, remind users to run `deno fmt` to auto-fix formatting issues before re-running checks.

Addresses review feedback from #33.

## Test Plan

- Reviewed the updated SKILL.md for clarity