### PR TITLE
feat: implement model delete command

### DIFF
--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -12,6 +12,7 @@ import { modelValidateCommand } from "./model_validate.ts";
 import { modelMethodCommand } from "./model_method_run.ts";
 import { modelListCommand } from "./model_list.ts";
 import { modelGetCommand } from "./model_get.ts";
+import { modelDeleteCommand } from "./model_delete.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -75,6 +76,7 @@ export const modelCommand = new Command()
     this.showHelp();
   })
   .command("create", modelCreateCommand)
+  .command("delete", modelDeleteCommand)
   .command("get", modelGetCommand)
   .command("list", modelListCommand)
   .command("validate", modelValidateCommand)

--- a/src/cli/commands/model_delete.ts
+++ b/src/cli/commands/model_delete.ts
@@ -1,0 +1,130 @@
+import { Command } from "@cliffy/command";
+import {
+  type ModelDeleteData,
+  renderModelDelete,
+  renderModelDeleteCancelled,
+} from "../../presentation/output/model_delete_output.tsx";
+import { createContext, type GlobalOptions } from "../context.ts";
+import type { ModelInput } from "../../domain/models/model_input.ts";
+import type { ModelType } from "../../domain/models/model_type.ts";
+import { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
+import { YamlResourceRepository } from "../../infrastructure/persistence/yaml_resource_repository.ts";
+import {
+  findInputByIdGlobal,
+  isUuid,
+} from "../../domain/models/model_lookup.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+/**
+ * Prompts user for confirmation in interactive mode.
+ * Uses basic stdin reading for confirmation prompt.
+ */
+async function promptConfirmation(message: string): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+
+  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
+
+  const buf = new Uint8Array(1024);
+  const n = await Deno.stdin.read(buf);
+  if (n === null) {
+    return false;
+  }
+
+  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
+  return response === "y" || response === "yes";
+}
+
+export const modelDeleteCommand = new Command()
+  .name("delete")
+  .description("Delete a model input")
+  .arguments("<model_id_or_name:string>")
+  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "-f, --force",
+    "Skip confirmation and allow deletion when resource exists",
+  )
+  .action(async function (options: AnyOptions, modelIdOrName: string) {
+    const ctx = createContext(options as GlobalOptions, "model-delete");
+    ctx.logger.debug`Deleting model: ${modelIdOrName}`;
+
+    const repoDir = options.repoDir ?? ".";
+    const inputRepo = new YamlInputRepository(repoDir);
+    const resourceRepo = new YamlResourceRepository(repoDir);
+
+    // Look up the model input
+    let input: ModelInput;
+    let modelType: ModelType;
+
+    if (isUuid(modelIdOrName)) {
+      ctx.logger.debug`Looking up by ID: ${modelIdOrName}`;
+      const result = await findInputByIdGlobal(inputRepo, modelIdOrName);
+      if (!result) {
+        throw new Error(`Model not found: ${modelIdOrName}`);
+      }
+      input = result.input;
+      modelType = result.type;
+    } else {
+      ctx.logger.debug`Looking up by name: ${modelIdOrName}`;
+      const result = await inputRepo.findByNameGlobal(modelIdOrName);
+      if (!result) {
+        throw new Error(`Model not found: ${modelIdOrName}`);
+      }
+      input = result.input;
+      modelType = result.type;
+    }
+
+    ctx.logger.debug`Found model: id=${input.id}, type=${modelType.normalized}`;
+
+    // Check for associated resource
+    const resource = await resourceRepo.findByInputId(modelType, input.id);
+    ctx.logger.debug`Resource exists: ${resource !== null}`;
+
+    // If resource exists and no --force flag, block deletion
+    if (resource && !options.force) {
+      throw new Error(
+        `Model '${input.name}' has an associated resource. Use --force to delete both.`,
+      );
+    }
+
+    // Get paths before deletion
+    const inputPath = inputRepo.getPath(modelType, input.id);
+    const resourcePath = resource
+      ? resourceRepo.getPath(modelType, resource.id)
+      : undefined;
+
+    // In interactive mode without --force, prompt for confirmation
+    if (ctx.outputMode === "interactive" && !options.force) {
+      const confirmed = await promptConfirmation(
+        `Delete model '${input.name}' (${input.id})?`,
+      );
+      if (!confirmed) {
+        renderModelDeleteCancelled(ctx.outputMode);
+        return;
+      }
+    }
+
+    // Delete resource first if it exists
+    if (resource) {
+      ctx.logger.debug`Deleting resource: ${resource.id}`;
+      await resourceRepo.delete(modelType, resource.id);
+    }
+
+    // Delete input
+    ctx.logger.debug`Deleting input: ${input.id}`;
+    await inputRepo.delete(modelType, input.id);
+
+    const data: ModelDeleteData = {
+      id: input.id,
+      name: input.name,
+      type: modelType.normalized,
+      inputPath,
+      resourcePath,
+      resourceDeleted: resource !== null,
+    };
+
+    renderModelDelete(data, ctx.outputMode);
+    ctx.logger.debug("Model delete command completed");
+  });

--- a/src/cli/commands/model_delete_test.ts
+++ b/src/cli/commands/model_delete_test.ts
@@ -1,0 +1,28 @@
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Initialize logging for tests
+await initializeLogging({ debugLogs: false });
+
+// Initialize model registry
+import "../../domain/models/registry_init.ts";
+
+Deno.test("modelDeleteCommand module loads", async () => {
+  const { modelDeleteCommand } = await import("./model_delete.ts");
+  assertEquals(modelDeleteCommand.getName(), "delete");
+});
+
+Deno.test("modelDeleteCommand has correct description", async () => {
+  const { modelDeleteCommand } = await import("./model_delete.ts");
+  assertEquals(
+    modelDeleteCommand.getDescription(),
+    "Delete a model input",
+  );
+});
+
+Deno.test("modelDeleteCommand is registered as subcommand of modelCommand", async () => {
+  const { modelCommand } = await import("./model_create.ts");
+  const commands = modelCommand.getCommands();
+  const deleteCmd = commands.find((c) => c.getName() === "delete");
+  assertEquals(deleteCmd !== undefined, true);
+});

--- a/src/presentation/output/model_delete_output.tsx
+++ b/src/presentation/output/model_delete_output.tsx
@@ -1,0 +1,122 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { Box, Text } from "ink";
+import { render } from "ink-testing-library";
+import type { OutputMode } from "./output.tsx";
+
+/**
+ * Data structure for the model delete output.
+ */
+export interface ModelDeleteData {
+  id: string;
+  name: string;
+  type: string;
+  inputPath: string;
+  resourcePath?: string;
+  resourceDeleted: boolean;
+}
+
+/**
+ * JSON output structure for model delete.
+ */
+export interface ModelDeleteJsonOutput {
+  deleted: {
+    id: string;
+    name: string;
+    type: string;
+    inputPath: string;
+    resourcePath?: string;
+  };
+  resourceDeleted: boolean;
+}
+
+/**
+ * Renders the model delete output in either interactive or JSON mode.
+ */
+export function renderModelDelete(
+  data: ModelDeleteData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    const output: ModelDeleteJsonOutput = {
+      deleted: {
+        id: data.id,
+        name: data.name,
+        type: data.type,
+        inputPath: data.inputPath,
+      },
+      resourceDeleted: data.resourceDeleted,
+    };
+    if (data.resourcePath) {
+      output.deleted.resourcePath = data.resourcePath;
+    }
+    console.log(JSON.stringify(output, null, 2));
+  } else {
+    renderInteractiveModelDelete(data);
+  }
+}
+
+function renderInteractiveModelDelete(data: ModelDeleteData): void {
+  const { lastFrame } = render(<ModelDeleteDisplay {...data} />);
+  console.log(lastFrame());
+}
+
+interface ModelDeleteDisplayProps {
+  id: string;
+  name: string;
+  type: string;
+  inputPath: string;
+  resourcePath?: string;
+  resourceDeleted: boolean;
+}
+
+/**
+ * Interactive display component for model delete.
+ */
+export function ModelDeleteDisplay(
+  props: ModelDeleteDisplayProps,
+): React.ReactElement {
+  return (
+    <Box flexDirection="column">
+      <Text color="green">Deleted model:</Text>
+      <Box marginLeft={2} flexDirection="column">
+        <Text>
+          <Text color="cyan">Type:</Text>
+          <Text>{props.type}</Text>
+        </Text>
+        <Text>
+          <Text color="cyan">Name:</Text>
+          <Text>{props.name}</Text>
+        </Text>
+        <Text>
+          <Text color="cyan">ID:</Text>
+          <Text dimColor>{props.id}</Text>
+        </Text>
+        <Text>
+          <Text color="cyan">Path:</Text>
+          <Text dimColor>{props.inputPath}</Text>
+        </Text>
+        {props.resourceDeleted && props.resourcePath && (
+          <Text>
+            <Text color="cyan">Resource also deleted:</Text>
+            <Text dimColor>{props.resourcePath}</Text>
+          </Text>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * Renders a cancellation message.
+ */
+export function renderModelDeleteCancelled(mode: OutputMode): void {
+  if (mode === "json") {
+    console.log(JSON.stringify({ cancelled: true }, null, 2));
+  } else {
+    const { lastFrame } = render(
+      <Text color="yellow">Deletion cancelled.</Text>,
+    );
+    console.log(lastFrame());
+  }
+}

--- a/src/presentation/output/model_delete_output_test.tsx
+++ b/src/presentation/output/model_delete_output_test.tsx
@@ -1,0 +1,152 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { render } from "ink-testing-library";
+import {
+  type ModelDeleteData,
+  ModelDeleteDisplay,
+  renderModelDelete,
+  renderModelDeleteCancelled,
+} from "./model_delete_output.tsx";
+
+const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
+
+const testData: ModelDeleteData = {
+  id: "550e8400-e29b-41d4-a716-446655440000",
+  name: "test-echo",
+  type: "swamp/echo",
+  inputPath: "inputs/swamp/echo/550e8400-e29b-41d4-a716-446655440000.yaml",
+  resourceDeleted: false,
+};
+
+const testDataWithResource: ModelDeleteData = {
+  id: "550e8400-e29b-41d4-a716-446655440000",
+  name: "test-echo",
+  type: "swamp/echo",
+  inputPath: "inputs/swamp/echo/550e8400-e29b-41d4-a716-446655440000.yaml",
+  resourcePath: "resources/swamp/echo/resource-id.yaml",
+  resourceDeleted: true,
+};
+
+Deno.test({
+  name: "ModelDeleteDisplay renders all fields",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<ModelDeleteDisplay {...testData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "swamp/echo");
+    assertStringIncludes(output, "test-echo");
+    assertStringIncludes(output, "550e8400-e29b-41d4-a716-446655440000");
+  },
+});
+
+Deno.test({
+  name: "ModelDeleteDisplay shows 'Deleted model' message",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<ModelDeleteDisplay {...testData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Deleted model");
+  },
+});
+
+Deno.test({
+  name:
+    "ModelDeleteDisplay shows resource deleted when resourceDeleted is true",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelDeleteDisplay {...testDataWithResource} />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Resource also deleted");
+    assertStringIncludes(output, "resources/swamp/echo/resource-id.yaml");
+  },
+});
+
+Deno.test({
+  name:
+    "ModelDeleteDisplay does not show resource when resourceDeleted is false",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<ModelDeleteDisplay {...testData} />);
+    const output = lastFrame() ?? "";
+
+    assertEquals(output.includes("Resource also deleted"), false);
+  },
+});
+
+Deno.test("renderModelDelete with json mode outputs valid JSON", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelDelete(testData, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.deleted.id, testData.id);
+    assertEquals(parsed.deleted.type, testData.type);
+    assertEquals(parsed.deleted.name, testData.name);
+    assertEquals(parsed.deleted.inputPath, testData.inputPath);
+    assertEquals(parsed.resourceDeleted, false);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderModelDelete with json mode includes resourcePath when resource deleted", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelDelete(testDataWithResource, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(
+      parsed.deleted.resourcePath,
+      testDataWithResource.resourcePath,
+    );
+    assertEquals(parsed.resourceDeleted, true);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test({
+  name:
+    "renderModelDeleteCancelled shows cancellation message in interactive mode",
+  ...inkTestOptions,
+  fn: () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      renderModelDeleteCancelled("interactive");
+      assertEquals(logs.length, 1);
+      assertStringIncludes(logs[0], "Deletion cancelled");
+    } finally {
+      console.log = originalLog;
+    }
+  },
+});
+
+Deno.test("renderModelDeleteCancelled outputs JSON in json mode", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelDeleteCancelled("json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.cancelled, true);
+  } finally {
+    console.log = originalLog;
+  }
+});


### PR DESCRIPTION
## Summary

- Add `model delete <model_id_or_name>` command to delete model inputs
- Block deletion when associated resource exists (unless `--force`)
- Interactive confirmation prompt in terminal mode
- Skip prompt with `--force` flag or `--json` mode  
- Delete both model and resource when using `--force`
- Dual-mode output support (interactive and JSON)

## Usage

```bash
# Delete with confirmation prompt
swamp model delete my-model

# Skip prompt and allow resource deletion
swamp model delete my-model --force

# JSON output (also skips prompt)
swamp model delete my-model --json
```

## Test plan

- [x] All 328 tests pass
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] Manual testing of all scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)