### PR TITLE
feat: implement keeb/shell model for shell command execution

### DIFF
--- a/src/domain/models/keeb/shell/shell_model.ts
+++ b/src/domain/models/keeb/shell/shell_model.ts
@@ -1,0 +1,173 @@
+import { z } from "zod";
+import { ModelType } from "../../model_type.ts";
+import { ModelResource } from "../../model_resource.ts";
+import {
+  defineModel,
+  type MethodContext,
+  type MethodResult,
+  type ModelDefinition,
+} from "../../model.ts";
+import type { ModelInput } from "../../model_input.ts";
+
+/**
+ * Schema for shell model input attributes.
+ */
+export const ShellInputAttributesSchema = z.object({
+  run: z.string().min(1).describe("The shell command to execute"),
+  workingDir: z.string().optional().describe(
+    "Working directory for command execution",
+  ),
+  timeout: z.number().int().positive().optional().describe(
+    "Timeout in milliseconds",
+  ),
+  env: z.record(z.string(), z.string()).optional().describe(
+    "Environment variables",
+  ),
+});
+
+/**
+ * Type for shell model input attributes.
+ */
+export type ShellInputAttributes = z.infer<typeof ShellInputAttributesSchema>;
+
+/**
+ * Schema for shell model resource attributes.
+ */
+export const ShellResourceAttributesSchema = z.object({
+  stdout: z.string().describe("Standard output from the command"),
+  stderr: z.string().describe("Standard error from the command"),
+  exitCode: z.number().int().describe("Exit code of the command"),
+  executedAt: z.string().datetime().describe(
+    "Timestamp when execution completed",
+  ),
+  command: z.string().describe("The command that was executed"),
+  durationMs: z.number().int().nonnegative().optional().describe(
+    "Execution duration in milliseconds",
+  ),
+});
+
+/**
+ * Type for shell model resource attributes.
+ */
+export type ShellResourceAttributes = z.infer<
+  typeof ShellResourceAttributesSchema
+>;
+
+/**
+ * The shell model type identifier.
+ */
+export const SHELL_MODEL_TYPE = ModelType.create("keeb/shell");
+
+/**
+ * Executes a shell command and captures the output.
+ */
+async function executeCommand(
+  input: ModelInput,
+  _context: MethodContext,
+): Promise<MethodResult> {
+  // Validate input attributes
+  const attrs = ShellInputAttributesSchema.parse(input.attributes);
+
+  const startTime = Date.now();
+  let stdout = "";
+  let stderr = "";
+  let exitCode = 0;
+
+  try {
+    const commandOptions: Deno.CommandOptions = {
+      args: ["-c", attrs.run],
+      stdout: "piped",
+      stderr: "piped",
+    };
+
+    if (attrs.workingDir) {
+      commandOptions.cwd = attrs.workingDir;
+    }
+
+    if (attrs.env) {
+      commandOptions.env = attrs.env;
+    }
+
+    const command = new Deno.Command("sh", commandOptions);
+
+    let output: Deno.CommandOutput;
+
+    if (attrs.timeout) {
+      // Handle timeout with AbortSignal
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), attrs.timeout);
+
+      try {
+        const child = command.spawn();
+
+        // Create a race between command completion and timeout
+        const timeoutPromise = new Promise<never>((_, reject) => {
+          controller.signal.addEventListener("abort", () => {
+            child.kill("SIGTERM");
+            reject(new Error(`Command timed out after ${attrs.timeout}ms`));
+          });
+        });
+
+        output = await Promise.race([child.output(), timeoutPromise]);
+        clearTimeout(timeoutId);
+      } catch (error) {
+        clearTimeout(timeoutId);
+        throw error;
+      }
+    } else {
+      output = await command.output();
+    }
+
+    stdout = new TextDecoder().decode(output.stdout);
+    stderr = new TextDecoder().decode(output.stderr);
+    exitCode = output.code;
+  } catch (error) {
+    // Handle execution errors (command not found, timeout, etc.)
+    stderr = error instanceof Error ? error.message : String(error);
+    exitCode = -1;
+  }
+
+  const endTime = Date.now();
+  const durationMs = endTime - startTime;
+
+  // Create the resource with execution results
+  const resource = ModelResource.create({
+    id: input.id,
+    attributes: {
+      stdout,
+      stderr,
+      exitCode,
+      executedAt: new Date().toISOString(),
+      command: attrs.run,
+      durationMs,
+    },
+  });
+
+  return { resource };
+}
+
+/**
+ * The shell model definition.
+ *
+ * A model that executes shell commands on the host system and captures
+ * the output (stdout, stderr, exit code).
+ *
+ * Self-registers with the global model registry when this module is imported.
+ */
+export const shellModel: ModelDefinition<
+  typeof ShellInputAttributesSchema,
+  typeof ShellResourceAttributesSchema
+> = defineModel({
+  type: SHELL_MODEL_TYPE,
+  version: 1,
+  inputAttributesSchema: ShellInputAttributesSchema,
+  resourceAttributesSchema: ShellResourceAttributesSchema,
+  methods: {
+    execute: {
+      description:
+        "Execute the shell command and capture stdout, stderr, and exit code",
+      inputAttributesSchema: ShellInputAttributesSchema,
+      execute: executeCommand,
+    },
+  },
+});

--- a/src/domain/models/keeb/shell/shell_model_test.ts
+++ b/src/domain/models/keeb/shell/shell_model_test.ts
@@ -1,0 +1,302 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { ModelInput } from "../../model_input.ts";
+import {
+  SHELL_MODEL_TYPE,
+  ShellInputAttributesSchema,
+  shellModel,
+  ShellResourceAttributesSchema,
+} from "./shell_model.ts";
+
+Deno.test("SHELL_MODEL_TYPE has correct normalized type", () => {
+  assertEquals(SHELL_MODEL_TYPE.normalized, "keeb/shell");
+});
+
+Deno.test("shellModel has correct version", () => {
+  assertEquals(shellModel.version, 1);
+});
+
+Deno.test("shellModel.type equals SHELL_MODEL_TYPE", () => {
+  assertEquals(shellModel.type.equals(SHELL_MODEL_TYPE), true);
+});
+
+// Input schema validation tests
+Deno.test("ShellInputAttributesSchema validates run command", () => {
+  const result = ShellInputAttributesSchema.safeParse({ run: "echo hello" });
+  assertEquals(result.success, true);
+  if (result.success) {
+    assertEquals(result.data.run, "echo hello");
+  }
+});
+
+Deno.test("ShellInputAttributesSchema validates all optional fields", () => {
+  const result = ShellInputAttributesSchema.safeParse({
+    run: "echo hello",
+    workingDir: "/tmp",
+    timeout: 5000,
+    env: { FOO: "bar" },
+  });
+  assertEquals(result.success, true);
+  if (result.success) {
+    assertEquals(result.data.run, "echo hello");
+    assertEquals(result.data.workingDir, "/tmp");
+    assertEquals(result.data.timeout, 5000);
+    assertEquals(result.data.env, { FOO: "bar" });
+  }
+});
+
+Deno.test("ShellInputAttributesSchema rejects empty run command", () => {
+  const result = ShellInputAttributesSchema.safeParse({ run: "" });
+  assertEquals(result.success, false);
+});
+
+Deno.test("ShellInputAttributesSchema rejects missing run command", () => {
+  const result = ShellInputAttributesSchema.safeParse({});
+  assertEquals(result.success, false);
+});
+
+Deno.test("ShellInputAttributesSchema rejects negative timeout", () => {
+  const result = ShellInputAttributesSchema.safeParse({
+    run: "echo hello",
+    timeout: -1,
+  });
+  assertEquals(result.success, false);
+});
+
+Deno.test("ShellInputAttributesSchema rejects zero timeout", () => {
+  const result = ShellInputAttributesSchema.safeParse({
+    run: "echo hello",
+    timeout: 0,
+  });
+  assertEquals(result.success, false);
+});
+
+// Resource schema validation tests
+Deno.test("ShellResourceAttributesSchema validates correct data", () => {
+  const result = ShellResourceAttributesSchema.safeParse({
+    stdout: "hello\n",
+    stderr: "",
+    exitCode: 0,
+    executedAt: "2024-01-15T10:30:00.000Z",
+    command: "echo hello",
+    durationMs: 15,
+  });
+  assertEquals(result.success, true);
+});
+
+Deno.test("ShellResourceAttributesSchema validates without durationMs", () => {
+  const result = ShellResourceAttributesSchema.safeParse({
+    stdout: "hello\n",
+    stderr: "",
+    exitCode: 0,
+    executedAt: "2024-01-15T10:30:00.000Z",
+    command: "echo hello",
+  });
+  assertEquals(result.success, true);
+});
+
+Deno.test("ShellResourceAttributesSchema rejects invalid timestamp", () => {
+  const result = ShellResourceAttributesSchema.safeParse({
+    stdout: "",
+    stderr: "",
+    exitCode: 0,
+    executedAt: "not-a-date",
+    command: "echo hello",
+  });
+  assertEquals(result.success, false);
+});
+
+// Method definition tests
+Deno.test("shellModel has execute method", () => {
+  assertEquals("execute" in shellModel.methods, true);
+  assertEquals(
+    shellModel.methods.execute.description,
+    "Execute the shell command and capture stdout, stderr, and exit code",
+  );
+});
+
+// Execute method tests
+Deno.test("shellModel.methods.execute runs simple command", async () => {
+  const input = ModelInput.create({
+    name: "test-shell",
+    attributes: { run: "echo hello" },
+  });
+
+  const result = await shellModel.methods.execute.execute(input, {
+    repoDir: "/tmp",
+  });
+
+  assertEquals(result.resource.attributes.stdout, "hello\n");
+  assertEquals(result.resource.attributes.stderr, "");
+  assertEquals(result.resource.attributes.exitCode, 0);
+  assertEquals(result.resource.attributes.command, "echo hello");
+  assertEquals(typeof result.resource.attributes.executedAt, "string");
+  assertEquals(typeof result.resource.attributes.durationMs, "number");
+});
+
+Deno.test("shellModel.methods.execute captures stderr", async () => {
+  const input = ModelInput.create({
+    name: "test-shell",
+    attributes: { run: "echo error >&2" },
+  });
+
+  const result = await shellModel.methods.execute.execute(input, {
+    repoDir: "/tmp",
+  });
+
+  assertEquals(result.resource.attributes.stdout, "");
+  assertEquals(result.resource.attributes.stderr, "error\n");
+  assertEquals(result.resource.attributes.exitCode, 0);
+});
+
+Deno.test("shellModel.methods.execute captures exit code", async () => {
+  const input = ModelInput.create({
+    name: "test-shell",
+    attributes: { run: "exit 42" },
+  });
+
+  const result = await shellModel.methods.execute.execute(input, {
+    repoDir: "/tmp",
+  });
+
+  assertEquals(result.resource.attributes.exitCode, 42);
+});
+
+Deno.test("shellModel.methods.execute handles command failure gracefully", async () => {
+  const input = ModelInput.create({
+    name: "test-shell",
+    attributes: { run: "false" },
+  });
+
+  const result = await shellModel.methods.execute.execute(input, {
+    repoDir: "/tmp",
+  });
+
+  assertEquals(result.resource.attributes.exitCode, 1);
+});
+
+Deno.test("shellModel.methods.execute respects workingDir", async () => {
+  const input = ModelInput.create({
+    name: "test-shell",
+    attributes: {
+      run: "pwd",
+      workingDir: "/tmp",
+    },
+  });
+
+  const result = await shellModel.methods.execute.execute(input, {
+    repoDir: "/tmp",
+  });
+
+  assertEquals(result.resource.attributes.stdout, "/tmp\n");
+  assertEquals(result.resource.attributes.exitCode, 0);
+});
+
+Deno.test("shellModel.methods.execute respects env variables", async () => {
+  const input = ModelInput.create({
+    name: "test-shell",
+    attributes: {
+      run: "echo $MY_TEST_VAR",
+      env: { MY_TEST_VAR: "test_value" },
+    },
+  });
+
+  const result = await shellModel.methods.execute.execute(input, {
+    repoDir: "/tmp",
+  });
+
+  assertEquals(result.resource.attributes.stdout, "test_value\n");
+  assertEquals(result.resource.attributes.exitCode, 0);
+});
+
+Deno.test("shellModel.methods.execute handles pipes", async () => {
+  const input = ModelInput.create({
+    name: "test-shell",
+    attributes: { run: "echo 'hello world' | tr 'h' 'H'" },
+  });
+
+  const result = await shellModel.methods.execute.execute(input, {
+    repoDir: "/tmp",
+  });
+
+  assertEquals(result.resource.attributes.stdout, "Hello world\n");
+  assertEquals(result.resource.attributes.exitCode, 0);
+});
+
+Deno.test("shellModel.methods.execute handles complex commands", async () => {
+  const input = ModelInput.create({
+    name: "test-shell",
+    attributes: { run: "cd /tmp && pwd" },
+  });
+
+  const result = await shellModel.methods.execute.execute(input, {
+    repoDir: "/tmp",
+  });
+
+  assertEquals(result.resource.attributes.stdout, "/tmp\n");
+  assertEquals(result.resource.attributes.exitCode, 0);
+});
+
+Deno.test("shellModel.methods.execute validates input attributes", async () => {
+  const input = ModelInput.create({
+    name: "test-shell",
+    attributes: { notRun: "value" },
+  });
+
+  let error: Error | null = null;
+  try {
+    await shellModel.methods.execute.execute(input, { repoDir: "/tmp" });
+  } catch (e) {
+    error = e as Error;
+  }
+
+  assertEquals(error !== null, true);
+});
+
+Deno.test("shellModel.methods.execute rejects empty run command", async () => {
+  const input = ModelInput.create({
+    name: "test-shell",
+    attributes: { run: "" },
+  });
+
+  let error: Error | null = null;
+  try {
+    await shellModel.methods.execute.execute(input, { repoDir: "/tmp" });
+  } catch (e) {
+    error = e as Error;
+  }
+
+  assertEquals(error !== null, true);
+});
+
+Deno.test("shellModel.methods.execute handles nonexistent command", async () => {
+  const input = ModelInput.create({
+    name: "test-shell",
+    attributes: { run: "nonexistent_command_12345" },
+  });
+
+  const result = await shellModel.methods.execute.execute(input, {
+    repoDir: "/tmp",
+  });
+
+  // Should return non-zero exit code and error in stderr
+  assertEquals(result.resource.attributes.exitCode !== 0, true);
+  assertStringIncludes(
+    result.resource.attributes.stderr as string,
+    "nonexistent_command_12345",
+  );
+});
+
+Deno.test("shellModel.methods.execute records execution duration", async () => {
+  const input = ModelInput.create({
+    name: "test-shell",
+    attributes: { run: "sleep 0.1" },
+  });
+
+  const result = await shellModel.methods.execute.execute(input, {
+    repoDir: "/tmp",
+  });
+
+  const durationMs = result.resource.attributes.durationMs as number;
+  // Should be at least 100ms (sleep 0.1 seconds)
+  assertEquals(durationMs >= 100, true);
+});

--- a/src/domain/models/models.ts
+++ b/src/domain/models/models.ts
@@ -16,6 +16,7 @@ import "./echo/echo_model.ts";
 import "./aws/ec2/instance/ec2_instance_model.ts";
 import "./aws/ec2/subnet/ec2_subnet_model.ts";
 import "./aws/ec2/vpc/ec2_vpc_model.ts";
+import "./keeb/shell/shell_model.ts";
 
 // Re-export the registry for convenient access
 export { modelRegistry } from "./model.ts";


### PR DESCRIPTION
## Summary
- Add `keeb/shell` model type for executing shell commands on the host system
- Captures stdout, stderr, and exit code from command execution
- Supports optional `workingDir`, `timeout`, and `env` attributes

## Test plan
- [x] Unit tests for input/resource schema validation
- [x] Unit tests for execute method (simple commands, pipes, complex commands)
- [x] Unit tests for error handling (command failures, nonexistent commands)
- [x] Manual test with `deno run dev model create/method run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)