### PR TITLE
feat: add interactive workflow execution UI

### DIFF
--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -1,10 +1,12 @@
 import { Command } from "@cliffy/command";
+import { stringify as stringifyYaml } from "@std/yaml";
 import {
   type JobRunData,
   renderWorkflowRun,
   type StepRunData,
   type WorkflowRunData,
 } from "../../presentation/output/workflow_run_output.tsx";
+import { renderWorkflowExecution } from "../../presentation/output/workflow_execution_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
@@ -74,34 +76,78 @@ export const workflowRunCommand = new Command()
       repoDir,
     );
 
-    // Set up progress callback for interactive mode
-    const progress: ExecutionProgressCallback = {
-      onJobStart: (_run, jobName) => {
-        ctx.logger.debug`Job started: ${jobName}`;
-      },
-      onStepStart: (_run, jobName, stepName) => {
-        ctx.logger.debug`Step started: ${jobName}/${stepName}`;
-      },
-      onStepFail: (_run, jobName, stepName, error) => {
-        ctx.logger.debug`Step failed: ${jobName}/${stepName}: ${error}`;
-      },
-    };
-
     try {
-      const run = await executionService.execute(workflowIdOrName, progress);
+      // Look up workflow first to get its data
+      const workflow = await workflowRepo.findByName(workflowIdOrName) ??
+        await workflowRepo.findById(
+          (await import("../../domain/workflows/workflow_id.ts"))
+            .createWorkflowId(workflowIdOrName),
+        );
 
-      // Get the path for the run
-      const workflow = await workflowRepo.findByName(run.workflowName);
-      const path = workflow ? runRepo.getPath(workflow.id, run.id) : undefined;
+      if (!workflow) {
+        throw new Error(`Workflow not found: ${workflowIdOrName}`);
+      }
 
-      const data = toRunData(run, path);
-      renderWorkflowRun(data, ctx.outputMode);
+      if (ctx.outputMode === "interactive") {
+        // Interactive mode: use the new live dashboard
+        const workflowData = workflow.toData();
+        const workflowYaml = stringifyYaml(
+          workflowData as Record<string, unknown>,
+        );
 
-      ctx.logger.debug`Workflow run completed: status=${run.status}`;
+        const executeWorkflow = async (
+          progress: ExecutionProgressCallback,
+        ): Promise<WorkflowRun> => {
+          return await executionService.execute(workflow.name, progress);
+        };
 
-      // Exit with code 1 if workflow failed
-      if (run.status === "failed") {
-        Deno.exit(1);
+        const data = await renderWorkflowExecution(
+          { workflow: workflowData, workflowYaml },
+          executeWorkflow,
+          ctx.outputMode,
+        );
+
+        // Get the path for the run
+        const { createWorkflowRunId } = await import(
+          "../../domain/workflows/workflow_id.ts"
+        );
+        const path = runRepo.getPath(workflow.id, createWorkflowRunId(data.id));
+        data.path = path;
+
+        ctx.logger.debug`Workflow run completed: status=${data.status}`;
+
+        // Exit with code 1 if workflow failed
+        if (data.status === "failed") {
+          Deno.exit(1);
+        }
+      } else {
+        // JSON mode: execute with debug logging, output final result
+        const progress: ExecutionProgressCallback = {
+          onJobStart: (_run, jobName) => {
+            ctx.logger.debug`Job started: ${jobName}`;
+          },
+          onStepStart: (_run, jobName, stepName) => {
+            ctx.logger.debug`Step started: ${jobName}/${stepName}`;
+          },
+          onStepFail: (_run, jobName, stepName, error) => {
+            ctx.logger.debug`Step failed: ${jobName}/${stepName}: ${error}`;
+          },
+        };
+
+        const run = await executionService.execute(workflow.name, progress);
+
+        // Get the path for the run
+        const path = runRepo.getPath(workflow.id, run.id);
+
+        const data = toRunData(run, path);
+        renderWorkflowRun(data, ctx.outputMode);
+
+        ctx.logger.debug`Workflow run completed: status=${run.status}`;
+
+        // Exit with code 1 if workflow failed
+        if (run.status === "failed") {
+          Deno.exit(1);
+        }
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/src/presentation/output/components/workflow_execution/HotkeyBar.tsx
+++ b/src/presentation/output/components/workflow_execution/HotkeyBar.tsx
@@ -1,0 +1,40 @@
+// deno-lint-ignore-file verbatim-module-syntax
+import React from "react";
+import { Box, Text } from "ink";
+import type { ActivePanel } from "./execution_reducer.ts";
+
+interface HotkeyBarProps {
+  isComplete: boolean;
+  showYamlOverlay: boolean;
+  activePanel: ActivePanel;
+}
+
+/**
+ * Displays keyboard hints at the bottom of the UI.
+ */
+export function HotkeyBar(
+  { isComplete, showYamlOverlay, activePanel }: HotkeyBarProps,
+): React.ReactElement {
+  if (showYamlOverlay) {
+    return (
+      <Box paddingX={1}>
+        <Text dimColor>Esc: Close | ↑/↓: Scroll</Text>
+      </Box>
+    );
+  }
+
+  const navHint = activePanel === "jobs"
+    ? "↑/↓: Select Job"
+    : "↑/↓: Select Step";
+
+  const hints = ["Tab: Switch Panel", navHint, "l: View YAML"];
+  if (isComplete) {
+    hints.push("q: Quit");
+  }
+
+  return (
+    <Box paddingX={1}>
+      <Text dimColor>{hints.join(" | ")}</Text>
+    </Box>
+  );
+}

--- a/src/presentation/output/components/workflow_execution/JobsPanel.tsx
+++ b/src/presentation/output/components/workflow_execution/JobsPanel.tsx
@@ -1,0 +1,109 @@
+// deno-lint-ignore-file verbatim-module-syntax
+import React from "react";
+import { Box, Text } from "ink";
+import { type RunStatus, StatusIcon } from "./StatusIcon.tsx";
+import type { JobRunData } from "../../workflow_run_output.tsx";
+
+/**
+ * Formats pending dependencies for display.
+ * Truncates with "..." if the combined length exceeds maxLength.
+ */
+function formatDependencies(deps: string[], maxLength: number = 30): string {
+  if (deps.length === 0) return "";
+
+  const prefix = "← ";
+  const joined = deps.join(", ");
+
+  if (prefix.length + joined.length <= maxLength) {
+    return prefix + joined;
+  }
+
+  // Truncate with ellipsis
+  let result = "";
+  for (let i = 0; i < deps.length; i++) {
+    const separator = i === 0 ? "" : ", ";
+    const candidate = result + separator + deps[i];
+    if (prefix.length + candidate.length + 4 > maxLength) {
+      return prefix + result + ", ...";
+    }
+    result = candidate;
+  }
+  return prefix + result;
+}
+
+interface JobItemProps {
+  job: JobRunData;
+  isSelected: boolean;
+  pendingDeps: string[];
+}
+
+function JobItem(
+  { job, isSelected, pendingDeps }: JobItemProps,
+): React.ReactElement {
+  const depsDisplay = formatDependencies(pendingDeps);
+
+  return (
+    <Box>
+      <Text color={isSelected ? "cyan" : undefined}>
+        {isSelected ? "▶ " : "  "}
+      </Text>
+      <StatusIcon status={job.status as RunStatus} />
+      {/* deno-fmt-ignore */}
+      <Text> </Text>
+      <Text bold={isSelected}>{job.name}</Text>
+      {depsDisplay && <Text dimColor>{` ${depsDisplay}`}</Text>}
+      <Text dimColor>
+        {job.status === "running"
+          ? "  running"
+          : job.status === "succeeded" || job.status === "failed"
+          ? job.duration !== undefined ? ` (${job.duration}ms)` : ""
+          : job.status === "pending"
+          ? " pending"
+          : job.status === "skipped"
+          ? " skipped"
+          : ""}
+      </Text>
+    </Box>
+  );
+}
+
+interface JobsPanelProps {
+  jobs: JobRunData[];
+  selectedIndex: number;
+  isFocused: boolean;
+  pendingDependencies: Map<string, string[]>;
+}
+
+/**
+ * Displays the list of jobs with selection indicator.
+ */
+export function JobsPanel(
+  { jobs, selectedIndex, isFocused, pendingDependencies }: JobsPanelProps,
+): React.ReactElement {
+  const borderColor = isFocused ? "cyan" : "gray";
+  const titleColor = isFocused ? "cyan" : undefined;
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="single"
+      borderColor={borderColor}
+      paddingX={1}
+    >
+      <Box>
+        <Text bold color={titleColor}>Jobs</Text>
+        <Box flexGrow={1} />
+        <Text dimColor>[{selectedIndex + 1}/{jobs.length}]</Text>
+      </Box>
+      {jobs.map((job, i) => (
+        <JobItem
+          key={i}
+          job={job}
+          isSelected={i === selectedIndex}
+          pendingDeps={pendingDependencies.get(job.name) ?? []}
+        />
+      ))}
+      {jobs.length === 0 && <Text dimColor>No jobs</Text>}
+    </Box>
+  );
+}

--- a/src/presentation/output/components/workflow_execution/StatusIcon.tsx
+++ b/src/presentation/output/components/workflow_execution/StatusIcon.tsx
@@ -1,0 +1,30 @@
+// deno-lint-ignore-file verbatim-module-syntax
+import React from "react";
+import { Text } from "ink";
+
+export type RunStatus =
+  | "pending"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "skipped";
+
+interface StatusIconProps {
+  status: RunStatus;
+}
+
+const statusConfig: Record<RunStatus, { icon: string; color: string }> = {
+  pending: { icon: "○", color: "gray" },
+  running: { icon: "◐", color: "yellow" },
+  succeeded: { icon: "✓", color: "green" },
+  failed: { icon: "✗", color: "red" },
+  skipped: { icon: "⊘", color: "gray" },
+};
+
+/**
+ * Displays a status icon with color coding.
+ */
+export function StatusIcon({ status }: StatusIconProps): React.ReactElement {
+  const { icon, color } = statusConfig[status] ?? { icon: "?", color: "white" };
+  return <Text color={color}>{icon}</Text>;
+}

--- a/src/presentation/output/components/workflow_execution/StepsPanel.tsx
+++ b/src/presentation/output/components/workflow_execution/StepsPanel.tsx
@@ -1,0 +1,113 @@
+// deno-lint-ignore-file verbatim-module-syntax
+import React from "react";
+import { Box, Text } from "ink";
+import { type RunStatus, StatusIcon } from "./StatusIcon.tsx";
+import type { StepRunData } from "../../workflow_run_output.tsx";
+
+/**
+ * Formats pending dependencies for display.
+ * Truncates with "..." if the combined length exceeds maxLength.
+ */
+function formatDependencies(deps: string[], maxLength: number = 30): string {
+  if (deps.length === 0) return "";
+
+  const prefix = "← ";
+  const joined = deps.join(", ");
+
+  if (prefix.length + joined.length <= maxLength) {
+    return prefix + joined;
+  }
+
+  // Truncate with ellipsis
+  let result = "";
+  for (let i = 0; i < deps.length; i++) {
+    const separator = i === 0 ? "" : ", ";
+    const candidate = result + separator + deps[i];
+    if (prefix.length + candidate.length + 4 > maxLength) {
+      return prefix + result + ", ...";
+    }
+    result = candidate;
+  }
+  return prefix + result;
+}
+
+interface StepItemProps {
+  step: StepRunData;
+  isSelected: boolean;
+  pendingDeps: string[];
+}
+
+function StepItem(
+  { step, isSelected, pendingDeps }: StepItemProps,
+): React.ReactElement {
+  const showDuration = step.status === "succeeded" || step.status === "failed";
+  const depsDisplay = formatDependencies(pendingDeps);
+
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text color={isSelected ? "cyan" : undefined}>
+          {isSelected ? "▶ " : "  "}
+        </Text>
+        <StatusIcon status={step.status as RunStatus} />
+        {/* deno-fmt-ignore */}
+        <Text> </Text>
+        <Text bold={isSelected}>{step.name}</Text>
+        {depsDisplay && <Text dimColor>{` ${depsDisplay}`}</Text>}
+        {showDuration && step.duration !== undefined && (
+          <Text dimColor>{` (${step.duration}ms)`}</Text>
+        )}
+        {/* deno-fmt-ignore */}
+        {step.status === "running" && <Text color="yellow">  running...</Text>}
+      </Box>
+      {step.error && (
+        <Box marginLeft={4}>
+          <Text color="red">{step.error}</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+interface StepsPanelProps {
+  jobName: string;
+  steps: StepRunData[];
+  isFocused: boolean;
+  selectedIndex: number;
+  pendingDependencies: Map<string, string[]>;
+}
+
+/**
+ * Displays the steps for a selected job.
+ */
+export function StepsPanel(
+  { jobName, steps, isFocused, selectedIndex, pendingDependencies }:
+    StepsPanelProps,
+): React.ReactElement {
+  const borderColor = isFocused ? "cyan" : "gray";
+  const titleColor = isFocused ? "cyan" : undefined;
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="single"
+      borderColor={borderColor}
+      paddingX={1}
+    >
+      <Box>
+        <Text bold color={titleColor}>Steps ({jobName})</Text>
+        <Box flexGrow={1} />
+        <Text dimColor>[{selectedIndex + 1}/{steps.length}]</Text>
+      </Box>
+      {steps.map((step, i) => (
+        <StepItem
+          key={i}
+          step={step}
+          isSelected={i === selectedIndex}
+          pendingDeps={pendingDependencies.get(step.name) ?? []}
+        />
+      ))}
+      {steps.length === 0 && <Text dimColor>No steps</Text>}
+    </Box>
+  );
+}

--- a/src/presentation/output/components/workflow_execution/WorkflowExecutionUI.tsx
+++ b/src/presentation/output/components/workflow_execution/WorkflowExecutionUI.tsx
@@ -1,0 +1,200 @@
+// deno-lint-ignore-file verbatim-module-syntax
+import React, { useCallback, useEffect, useReducer } from "react";
+import { Box, useApp, useInput, useStdout } from "ink";
+import { WorkflowHeader } from "./WorkflowHeader.tsx";
+import { JobsPanel } from "./JobsPanel.tsx";
+import { StepsPanel } from "./StepsPanel.tsx";
+import { HotkeyBar } from "./HotkeyBar.tsx";
+import { YamlOverlay } from "./YamlOverlay.tsx";
+import {
+  createInitialState,
+  type ExecutionAction,
+  executionReducer,
+} from "./execution_reducer.ts";
+import type { WorkflowData } from "../../../../domain/workflows/workflow.ts";
+import type { JobRunData } from "../../workflow_run_output.tsx";
+
+/**
+ * Computes pending dependencies (ones that haven't succeeded yet).
+ */
+function getPendingDependencies(
+  allDeps: string[],
+  statuses: Map<string, string>,
+): string[] {
+  return allDeps.filter((dep) => {
+    const status = statuses.get(dep);
+    return status !== "succeeded" && status !== "skipped";
+  });
+}
+
+interface WorkflowExecutionUIProps {
+  workflow: WorkflowData;
+  workflowYaml: string;
+  onExit: () => void;
+  registerDispatch: (dispatch: React.Dispatch<ExecutionAction>) => void;
+}
+
+/**
+ * Main interactive workflow execution UI component.
+ */
+export function WorkflowExecutionUI(
+  { workflow, workflowYaml, onExit, registerDispatch }:
+    WorkflowExecutionUIProps,
+): React.ReactElement {
+  const { exit } = useApp();
+  const { stdout } = useStdout();
+  const terminalHeight = stdout?.rows ?? 24;
+  const terminalWidth = stdout?.columns ?? 80;
+
+  const [state, dispatch] = useReducer(
+    executionReducer,
+    createInitialState(workflow, workflowYaml),
+  );
+
+  // Register dispatch with parent for event handling
+  useEffect(() => {
+    registerDispatch(dispatch);
+  }, [dispatch, registerDispatch]);
+
+  const handleExit = useCallback(() => {
+    exit();
+    onExit();
+  }, [exit, onExit]);
+
+  // Handle keyboard input - disabled when overlay is shown
+  useInput(
+    (input, key) => {
+      // Tab switches between panels
+      if (key.tab) {
+        dispatch({ type: "SWITCH_PANEL" });
+        return;
+      }
+
+      // Navigation based on active panel
+      if (key.upArrow) {
+        if (state.activePanel === "jobs") {
+          dispatch({ type: "SELECT_PREV_JOB" });
+        } else {
+          dispatch({ type: "SELECT_PREV_STEP" });
+        }
+        return;
+      }
+
+      if (key.downArrow) {
+        if (state.activePanel === "jobs") {
+          dispatch({ type: "SELECT_NEXT_JOB" });
+        } else {
+          dispatch({ type: "SELECT_NEXT_STEP" });
+        }
+        return;
+      }
+
+      // Toggle YAML overlay
+      if (input === "l") {
+        dispatch({ type: "TOGGLE_YAML_OVERLAY" });
+        return;
+      }
+
+      // Quit (only when complete)
+      if (input === "q" && state.isComplete) {
+        handleExit();
+        return;
+      }
+    },
+    { isActive: !state.showYamlOverlay },
+  );
+
+  // If showing YAML overlay, render it fullscreen
+  if (state.showYamlOverlay) {
+    return (
+      <YamlOverlay
+        yaml={workflowYaml}
+        workflowName={workflow.name}
+        onClose={() => dispatch({ type: "CLOSE_YAML_OVERLAY" })}
+        isActive={state.showYamlOverlay}
+      />
+    );
+  }
+
+  // Get current data for display
+  const jobs: JobRunData[] = state.workflowRun?.jobs ??
+    workflow.jobs.map((job) => ({
+      name: job.name,
+      status: "pending" as const,
+      steps: job.steps.map((step) => ({
+        name: step.name,
+        status: "pending" as const,
+      })),
+    }));
+
+  const selectedJob = jobs[state.selectedJobIndex];
+  const workflowStatus = state.workflowRun?.status ?? "pending";
+
+  // Compute pending dependencies for jobs
+  const jobStatuses = new Map(jobs.map((j) => [j.name, j.status]));
+  const jobPendingDeps = new Map<string, string[]>();
+  for (const job of workflow.jobs) {
+    const allDeps = job.dependsOn.map((d) => d.job);
+    const pendingDeps = getPendingDependencies(allDeps, jobStatuses);
+    jobPendingDeps.set(job.name, pendingDeps);
+  }
+
+  // Compute pending dependencies for steps of selected job
+  const stepPendingDeps = new Map<string, string[]>();
+  if (selectedJob) {
+    const stepStatuses = new Map(
+      selectedJob.steps.map((s) => [s.name, s.status]),
+    );
+    const workflowJob = workflow.jobs[state.selectedJobIndex];
+    if (workflowJob) {
+      for (const step of workflowJob.steps) {
+        const allDeps = step.dependsOn.map((d) => d.step);
+        const pendingDeps = getPendingDependencies(allDeps, stepStatuses);
+        stepPendingDeps.set(step.name, pendingDeps);
+      }
+    }
+  }
+
+  return (
+    <Box
+      flexDirection="column"
+      width={terminalWidth}
+      height={terminalHeight}
+      borderStyle="round"
+      borderColor="gray"
+    >
+      {/* Header */}
+      <WorkflowHeader
+        workflowName={workflow.name}
+        runId={state.workflowRun?.id ?? null}
+        status={workflowStatus}
+      />
+
+      {/* Jobs Panel */}
+      <JobsPanel
+        jobs={jobs}
+        selectedIndex={state.selectedJobIndex}
+        isFocused={state.activePanel === "jobs"}
+        pendingDependencies={jobPendingDeps}
+      />
+
+      {/* Steps Panel */}
+      {selectedJob && (
+        <StepsPanel
+          jobName={selectedJob.name}
+          steps={selectedJob.steps}
+          isFocused={state.activePanel === "steps"}
+          selectedIndex={state.selectedStepIndex}
+          pendingDependencies={stepPendingDeps}
+        />
+      )}
+
+      {/* Hotkey Bar */}
+      <HotkeyBar
+        isComplete={state.isComplete}
+        showYamlOverlay={state.showYamlOverlay}
+        activePanel={state.activePanel}
+      />
+    </Box>
+  );
+}

--- a/src/presentation/output/components/workflow_execution/WorkflowHeader.tsx
+++ b/src/presentation/output/components/workflow_execution/WorkflowHeader.tsx
@@ -1,0 +1,49 @@
+// deno-lint-ignore-file verbatim-module-syntax
+import React from "react";
+import { Box, Text } from "ink";
+
+interface WorkflowHeaderProps {
+  workflowName: string;
+  runId: string | null;
+  status: "pending" | "running" | "succeeded" | "failed";
+}
+
+const statusColors: Record<string, string> = {
+  pending: "gray",
+  running: "yellow",
+  succeeded: "green",
+  failed: "red",
+};
+
+/**
+ * Displays the workflow header with name, run ID, and status.
+ */
+export function WorkflowHeader(
+  { workflowName, runId, status }: WorkflowHeaderProps,
+): React.ReactElement {
+  const statusColor = statusColors[status] ?? "white";
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      {/* deno-fmt-ignore */}
+      <Box>
+        <Text bold>Workflow: </Text>
+        <Text>{workflowName}</Text>
+      </Box>
+      {runId && (
+        // deno-fmt-ignore
+        <Box>
+          <Text bold>Run ID: </Text>
+          <Text dimColor>{runId}</Text>
+        </Box>
+      )}
+      {/* deno-fmt-ignore */}
+      <Box>
+        <Text bold>Status: </Text>
+        <Text color={statusColor} bold>
+          {status.toUpperCase()}
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/presentation/output/components/workflow_execution/YamlOverlay.tsx
+++ b/src/presentation/output/components/workflow_execution/YamlOverlay.tsx
@@ -1,0 +1,135 @@
+// deno-lint-ignore-file verbatim-module-syntax
+import React, { useState } from "react";
+import { Box, Text, useInput, useStdout } from "ink";
+import {
+  getTokenColor,
+  type HighlightedLine,
+  highlightYaml,
+} from "./yaml_highlighter.ts";
+
+interface YamlOverlayProps {
+  yaml: string;
+  workflowName: string;
+  onClose: () => void;
+  isActive?: boolean;
+}
+
+/**
+ * Fullscreen YAML viewer overlay with syntax highlighting and scrolling.
+ */
+export function YamlOverlay(
+  { yaml, workflowName, onClose, isActive = true }: YamlOverlayProps,
+): React.ReactElement {
+  const { stdout } = useStdout();
+  const terminalHeight = stdout?.rows ?? 24;
+  const terminalWidth = stdout?.columns ?? 80;
+
+  // Reserve space for header (3 lines) and footer (2 lines)
+  const contentHeight = Math.max(terminalHeight - 5, 5);
+
+  const highlightedLines = highlightYaml(yaml);
+  const totalLines = highlightedLines.length;
+  const maxScroll = Math.max(0, totalLines - contentHeight);
+
+  const [scrollOffset, setScrollOffset] = useState(0);
+
+  useInput((input, key) => {
+    if (key.escape || input === "l") {
+      onClose();
+      return;
+    }
+
+    if (key.upArrow) {
+      setScrollOffset((s) => Math.max(0, s - 1));
+      return;
+    }
+
+    if (key.downArrow) {
+      setScrollOffset((s) => Math.min(maxScroll, s + 1));
+      return;
+    }
+
+    // Page up/down
+    if (key.pageUp) {
+      setScrollOffset((s) => Math.max(0, s - contentHeight));
+      return;
+    }
+
+    if (key.pageDown) {
+      setScrollOffset((s) => Math.min(maxScroll, s + contentHeight));
+      return;
+    }
+  }, { isActive });
+
+  const visibleLines = highlightedLines.slice(
+    scrollOffset,
+    scrollOffset + contentHeight,
+  );
+
+  return (
+    <Box
+      flexDirection="column"
+      width={terminalWidth}
+      height={terminalHeight}
+      borderStyle="round"
+      borderColor="cyan"
+    >
+      {/* Header */}
+      <Box
+        paddingX={1}
+        borderStyle="single"
+        borderBottom
+        borderTop={false}
+        borderLeft={false}
+        borderRight={false}
+      >
+        <Text bold color="cyan">YAML:</Text>
+        <Text>{workflowName}</Text>
+        <Box flexGrow={1} />
+        <Text dimColor>
+          {scrollOffset + 1}-{Math.min(
+            scrollOffset + contentHeight,
+            totalLines,
+          )}/{totalLines}
+        </Text>
+      </Box>
+
+      {/* Content */}
+      <Box flexDirection="column" flexGrow={1} paddingX={1} overflowY="hidden">
+        {visibleLines.map((line, i) => (
+          <HighlightedLineDisplay key={scrollOffset + i} line={line} />
+        ))}
+      </Box>
+
+      {/* Footer */}
+      <Box
+        paddingX={1}
+        borderStyle="single"
+        borderTop
+        borderBottom={false}
+        borderLeft={false}
+        borderRight={false}
+      >
+        <Text dimColor>Esc/l: Close | ↑/↓: Scroll | PgUp/PgDn: Page</Text>
+      </Box>
+    </Box>
+  );
+}
+
+interface HighlightedLineDisplayProps {
+  line: HighlightedLine;
+}
+
+function HighlightedLineDisplay(
+  { line }: HighlightedLineDisplayProps,
+): React.ReactElement {
+  return (
+    <Text>
+      {line.tokens.map((token, i) => (
+        <Text key={i} color={getTokenColor(token.type)}>
+          {token.text}
+        </Text>
+      ))}
+    </Text>
+  );
+}

--- a/src/presentation/output/components/workflow_execution/execution_reducer.ts
+++ b/src/presentation/output/components/workflow_execution/execution_reducer.ts
@@ -1,0 +1,200 @@
+import type { WorkflowData } from "../../../../domain/workflows/workflow.ts";
+import type { WorkflowRunData } from "../../workflow_run_output.tsx";
+
+/**
+ * Active panel for focus management.
+ */
+export type ActivePanel = "jobs" | "steps";
+
+/**
+ * View state for the workflow execution UI.
+ */
+export interface WorkflowExecutionViewState {
+  // Display data (derived from domain)
+  workflow: WorkflowData;
+  workflowRun: WorkflowRunData | null;
+  workflowYaml: string;
+
+  // Execution status
+  isRunning: boolean;
+  isComplete: boolean;
+
+  // UI-only state
+  selectedJobIndex: number;
+  showYamlOverlay: boolean;
+
+  // Panel focus and scrolling
+  activePanel: ActivePanel;
+  jobsScrollOffset: number;
+  stepsScrollOffset: number;
+  selectedStepIndex: number;
+}
+
+/**
+ * Actions that can be dispatched to update the view state.
+ */
+export type ExecutionAction =
+  | { type: "WORKFLOW_START"; run: WorkflowRunData }
+  | { type: "WORKFLOW_UPDATE"; run: WorkflowRunData }
+  | { type: "WORKFLOW_COMPLETE"; run: WorkflowRunData }
+  | { type: "SELECT_JOB"; index: number }
+  | { type: "SELECT_NEXT_JOB" }
+  | { type: "SELECT_PREV_JOB" }
+  | { type: "TOGGLE_YAML_OVERLAY" }
+  | { type: "CLOSE_YAML_OVERLAY" }
+  | { type: "SWITCH_PANEL" }
+  | { type: "SCROLL_JOBS"; direction: "up" | "down" }
+  | { type: "SCROLL_STEPS"; direction: "up" | "down" }
+  | { type: "SELECT_NEXT_STEP" }
+  | { type: "SELECT_PREV_STEP" };
+
+/**
+ * Creates the initial view state.
+ */
+export function createInitialState(
+  workflow: WorkflowData,
+  workflowYaml: string,
+): WorkflowExecutionViewState {
+  return {
+    workflow,
+    workflowRun: null,
+    workflowYaml,
+    isRunning: false,
+    isComplete: false,
+    selectedJobIndex: 0,
+    showYamlOverlay: false,
+    activePanel: "jobs",
+    jobsScrollOffset: 0,
+    stepsScrollOffset: 0,
+    selectedStepIndex: 0,
+  };
+}
+
+/**
+ * Reducer function for the execution view state.
+ */
+export function executionReducer(
+  state: WorkflowExecutionViewState,
+  action: ExecutionAction,
+): WorkflowExecutionViewState {
+  switch (action.type) {
+    case "WORKFLOW_START":
+      return {
+        ...state,
+        workflowRun: action.run,
+        isRunning: true,
+        isComplete: false,
+      };
+
+    case "WORKFLOW_UPDATE":
+      return {
+        ...state,
+        workflowRun: action.run,
+      };
+
+    case "WORKFLOW_COMPLETE":
+      return {
+        ...state,
+        workflowRun: action.run,
+        isRunning: false,
+        isComplete: true,
+      };
+
+    case "SELECT_JOB":
+      return {
+        ...state,
+        selectedJobIndex: action.index,
+        selectedStepIndex: 0,
+        stepsScrollOffset: 0,
+      };
+
+    case "SELECT_NEXT_JOB": {
+      const jobCount = state.workflowRun?.jobs.length ??
+        state.workflow.jobs.length;
+      const nextIndex = Math.min(state.selectedJobIndex + 1, jobCount - 1);
+      const jobChanged = nextIndex !== state.selectedJobIndex;
+      return {
+        ...state,
+        selectedJobIndex: nextIndex,
+        selectedStepIndex: jobChanged ? 0 : state.selectedStepIndex,
+        stepsScrollOffset: jobChanged ? 0 : state.stepsScrollOffset,
+      };
+    }
+
+    case "SELECT_PREV_JOB": {
+      const prevIndex = Math.max(state.selectedJobIndex - 1, 0);
+      const jobChanged = prevIndex !== state.selectedJobIndex;
+      return {
+        ...state,
+        selectedJobIndex: prevIndex,
+        selectedStepIndex: jobChanged ? 0 : state.selectedStepIndex,
+        stepsScrollOffset: jobChanged ? 0 : state.stepsScrollOffset,
+      };
+    }
+
+    case "TOGGLE_YAML_OVERLAY":
+      return {
+        ...state,
+        showYamlOverlay: !state.showYamlOverlay,
+      };
+
+    case "CLOSE_YAML_OVERLAY":
+      return {
+        ...state,
+        showYamlOverlay: false,
+      };
+
+    case "SWITCH_PANEL":
+      return {
+        ...state,
+        activePanel: state.activePanel === "jobs" ? "steps" : "jobs",
+      };
+
+    case "SCROLL_JOBS": {
+      const jobCount = state.workflowRun?.jobs.length ??
+        state.workflow.jobs.length;
+      const newOffset = action.direction === "up"
+        ? Math.max(0, state.jobsScrollOffset - 1)
+        : Math.min(Math.max(0, jobCount - 1), state.jobsScrollOffset + 1);
+      return {
+        ...state,
+        jobsScrollOffset: newOffset,
+      };
+    }
+
+    case "SCROLL_STEPS": {
+      const selectedJob = state.workflowRun?.jobs[state.selectedJobIndex] ??
+        { steps: state.workflow.jobs[state.selectedJobIndex]?.steps ?? [] };
+      const stepCount = selectedJob.steps.length;
+      const newOffset = action.direction === "up"
+        ? Math.max(0, state.stepsScrollOffset - 1)
+        : Math.min(Math.max(0, stepCount - 1), state.stepsScrollOffset + 1);
+      return {
+        ...state,
+        stepsScrollOffset: newOffset,
+      };
+    }
+
+    case "SELECT_NEXT_STEP": {
+      const selectedJob = state.workflowRun?.jobs[state.selectedJobIndex] ??
+        { steps: state.workflow.jobs[state.selectedJobIndex]?.steps ?? [] };
+      const stepCount = selectedJob.steps.length;
+      const nextIndex = Math.min(state.selectedStepIndex + 1, stepCount - 1);
+      return {
+        ...state,
+        selectedStepIndex: nextIndex,
+      };
+    }
+
+    case "SELECT_PREV_STEP": {
+      const prevIndex = Math.max(state.selectedStepIndex - 1, 0);
+      return {
+        ...state,
+        selectedStepIndex: prevIndex,
+      };
+    }
+
+    default:
+      return state;
+  }
+}

--- a/src/presentation/output/components/workflow_execution/execution_reducer_test.ts
+++ b/src/presentation/output/components/workflow_execution/execution_reducer_test.ts
@@ -1,0 +1,370 @@
+import { assertEquals } from "@std/assert";
+import {
+  createInitialState,
+  type ExecutionAction,
+  executionReducer,
+} from "./execution_reducer.ts";
+import type { WorkflowData } from "../../../../domain/workflows/workflow.ts";
+import type { WorkflowRunData } from "../../workflow_run_output.tsx";
+
+const mockWorkflow: WorkflowData = {
+  id: "test-workflow-id",
+  name: "test-workflow",
+  description: "A test workflow",
+  version: 1,
+  jobs: [
+    {
+      name: "job1",
+      dependsOn: [],
+      weight: 1,
+      steps: [{
+        name: "step1",
+        task: { type: "shell", command: "echo", args: ["hello"] },
+        dependsOn: [],
+        weight: 1,
+      }],
+    },
+    {
+      name: "job2",
+      dependsOn: [],
+      weight: 1,
+      steps: [{
+        name: "step2",
+        task: { type: "shell", command: "echo", args: ["world"] },
+        dependsOn: [],
+        weight: 1,
+      }],
+    },
+  ],
+};
+
+const mockYaml = `name: test-workflow
+jobs:
+  - name: job1
+    steps:
+      - name: step1
+`;
+
+const mockRunData: WorkflowRunData = {
+  id: "run-id-123",
+  workflowId: "test-workflow-id",
+  workflowName: "test-workflow",
+  status: "running",
+  jobs: [
+    {
+      name: "job1",
+      status: "running",
+      steps: [{ name: "step1", status: "running" }],
+    },
+    {
+      name: "job2",
+      status: "pending",
+      steps: [{ name: "step2", status: "pending" }],
+    },
+  ],
+};
+
+Deno.test("execution_reducer - createInitialState creates correct initial state", () => {
+  const state = createInitialState(mockWorkflow, mockYaml);
+
+  assertEquals(state.workflow, mockWorkflow);
+  assertEquals(state.workflowYaml, mockYaml);
+  assertEquals(state.workflowRun, null);
+  assertEquals(state.isRunning, false);
+  assertEquals(state.isComplete, false);
+  assertEquals(state.selectedJobIndex, 0);
+  assertEquals(state.showYamlOverlay, false);
+  assertEquals(state.activePanel, "jobs");
+  assertEquals(state.jobsScrollOffset, 0);
+  assertEquals(state.stepsScrollOffset, 0);
+  assertEquals(state.selectedStepIndex, 0);
+});
+
+Deno.test("execution_reducer - WORKFLOW_START sets running state", () => {
+  const state = createInitialState(mockWorkflow, mockYaml);
+  const action: ExecutionAction = { type: "WORKFLOW_START", run: mockRunData };
+
+  const newState = executionReducer(state, action);
+
+  assertEquals(newState.workflowRun, mockRunData);
+  assertEquals(newState.isRunning, true);
+  assertEquals(newState.isComplete, false);
+});
+
+Deno.test("execution_reducer - WORKFLOW_UPDATE updates run data", () => {
+  const state = createInitialState(mockWorkflow, mockYaml);
+  const startAction: ExecutionAction = {
+    type: "WORKFLOW_START",
+    run: mockRunData,
+  };
+  const stateAfterStart = executionReducer(state, startAction);
+
+  const updatedRun: WorkflowRunData = {
+    ...mockRunData,
+    jobs: [
+      {
+        name: "job1",
+        status: "succeeded",
+        steps: [{ name: "step1", status: "succeeded", duration: 100 }],
+      },
+      {
+        name: "job2",
+        status: "running",
+        steps: [{ name: "step2", status: "running" }],
+      },
+    ],
+  };
+  const updateAction: ExecutionAction = {
+    type: "WORKFLOW_UPDATE",
+    run: updatedRun,
+  };
+
+  const newState = executionReducer(stateAfterStart, updateAction);
+
+  assertEquals(newState.workflowRun, updatedRun);
+  assertEquals(newState.isRunning, true);
+});
+
+Deno.test("execution_reducer - WORKFLOW_COMPLETE sets complete state", () => {
+  const state = createInitialState(mockWorkflow, mockYaml);
+  const completedRun: WorkflowRunData = {
+    ...mockRunData,
+    status: "succeeded",
+    jobs: [
+      {
+        name: "job1",
+        status: "succeeded",
+        steps: [{ name: "step1", status: "succeeded", duration: 100 }],
+        duration: 150,
+      },
+      {
+        name: "job2",
+        status: "succeeded",
+        steps: [{ name: "step2", status: "succeeded", duration: 50 }],
+        duration: 80,
+      },
+    ],
+    duration: 250,
+  };
+  const action: ExecutionAction = {
+    type: "WORKFLOW_COMPLETE",
+    run: completedRun,
+  };
+
+  const newState = executionReducer(state, action);
+
+  assertEquals(newState.workflowRun, completedRun);
+  assertEquals(newState.isRunning, false);
+  assertEquals(newState.isComplete, true);
+});
+
+Deno.test("execution_reducer - SELECT_JOB updates selected index", () => {
+  const state = createInitialState(mockWorkflow, mockYaml);
+  const action: ExecutionAction = { type: "SELECT_JOB", index: 1 };
+
+  const newState = executionReducer(state, action);
+
+  assertEquals(newState.selectedJobIndex, 1);
+});
+
+Deno.test("execution_reducer - SELECT_NEXT_JOB increments index", () => {
+  const state = createInitialState(mockWorkflow, mockYaml);
+  const action: ExecutionAction = { type: "SELECT_NEXT_JOB" };
+
+  const newState = executionReducer(state, action);
+
+  assertEquals(newState.selectedJobIndex, 1);
+});
+
+Deno.test("execution_reducer - SELECT_NEXT_JOB does not exceed job count", () => {
+  let state = createInitialState(mockWorkflow, mockYaml);
+  state = { ...state, selectedJobIndex: 1 }; // Already at last job
+
+  const action: ExecutionAction = { type: "SELECT_NEXT_JOB" };
+  const newState = executionReducer(state, action);
+
+  assertEquals(newState.selectedJobIndex, 1); // Should stay at 1
+});
+
+Deno.test("execution_reducer - SELECT_PREV_JOB decrements index", () => {
+  let state = createInitialState(mockWorkflow, mockYaml);
+  state = { ...state, selectedJobIndex: 1 };
+
+  const action: ExecutionAction = { type: "SELECT_PREV_JOB" };
+  const newState = executionReducer(state, action);
+
+  assertEquals(newState.selectedJobIndex, 0);
+});
+
+Deno.test("execution_reducer - SELECT_PREV_JOB does not go below 0", () => {
+  const state = createInitialState(mockWorkflow, mockYaml);
+  const action: ExecutionAction = { type: "SELECT_PREV_JOB" };
+
+  const newState = executionReducer(state, action);
+
+  assertEquals(newState.selectedJobIndex, 0);
+});
+
+Deno.test("execution_reducer - TOGGLE_YAML_OVERLAY toggles overlay state", () => {
+  const state = createInitialState(mockWorkflow, mockYaml);
+
+  let newState = executionReducer(state, { type: "TOGGLE_YAML_OVERLAY" });
+  assertEquals(newState.showYamlOverlay, true);
+
+  newState = executionReducer(newState, { type: "TOGGLE_YAML_OVERLAY" });
+  assertEquals(newState.showYamlOverlay, false);
+});
+
+Deno.test("execution_reducer - CLOSE_YAML_OVERLAY closes overlay", () => {
+  let state = createInitialState(mockWorkflow, mockYaml);
+  state = { ...state, showYamlOverlay: true };
+
+  const newState = executionReducer(state, { type: "CLOSE_YAML_OVERLAY" });
+
+  assertEquals(newState.showYamlOverlay, false);
+});
+
+Deno.test("execution_reducer - SWITCH_PANEL toggles between jobs and steps", () => {
+  const state = createInitialState(mockWorkflow, mockYaml);
+  assertEquals(state.activePanel, "jobs");
+
+  let newState = executionReducer(state, { type: "SWITCH_PANEL" });
+  assertEquals(newState.activePanel, "steps");
+
+  newState = executionReducer(newState, { type: "SWITCH_PANEL" });
+  assertEquals(newState.activePanel, "jobs");
+});
+
+Deno.test("execution_reducer - SELECT_NEXT_JOB resets step selection when job changes", () => {
+  let state = createInitialState(mockWorkflow, mockYaml);
+  state = { ...state, selectedStepIndex: 2, stepsScrollOffset: 1 };
+
+  const newState = executionReducer(state, { type: "SELECT_NEXT_JOB" });
+
+  assertEquals(newState.selectedJobIndex, 1);
+  assertEquals(newState.selectedStepIndex, 0);
+  assertEquals(newState.stepsScrollOffset, 0);
+});
+
+Deno.test("execution_reducer - SELECT_PREV_JOB resets step selection when job changes", () => {
+  let state = createInitialState(mockWorkflow, mockYaml);
+  state = {
+    ...state,
+    selectedJobIndex: 1,
+    selectedStepIndex: 2,
+    stepsScrollOffset: 1,
+  };
+
+  const newState = executionReducer(state, { type: "SELECT_PREV_JOB" });
+
+  assertEquals(newState.selectedJobIndex, 0);
+  assertEquals(newState.selectedStepIndex, 0);
+  assertEquals(newState.stepsScrollOffset, 0);
+});
+
+Deno.test("execution_reducer - SELECT_JOB resets step selection", () => {
+  let state = createInitialState(mockWorkflow, mockYaml);
+  state = { ...state, selectedStepIndex: 2, stepsScrollOffset: 1 };
+
+  const newState = executionReducer(state, { type: "SELECT_JOB", index: 1 });
+
+  assertEquals(newState.selectedJobIndex, 1);
+  assertEquals(newState.selectedStepIndex, 0);
+  assertEquals(newState.stepsScrollOffset, 0);
+});
+
+Deno.test("execution_reducer - SELECT_NEXT_STEP increments step index", () => {
+  let state = createInitialState(mockWorkflow, mockYaml);
+  state = { ...state, workflowRun: mockRunData };
+
+  const newState = executionReducer(state, { type: "SELECT_NEXT_STEP" });
+
+  // job1 only has 1 step, so should stay at 0
+  assertEquals(newState.selectedStepIndex, 0);
+});
+
+Deno.test("execution_reducer - SELECT_PREV_STEP decrements step index", () => {
+  let state = createInitialState(mockWorkflow, mockYaml);
+  state = { ...state, selectedStepIndex: 1 };
+
+  const newState = executionReducer(state, { type: "SELECT_PREV_STEP" });
+
+  assertEquals(newState.selectedStepIndex, 0);
+});
+
+Deno.test("execution_reducer - SELECT_PREV_STEP does not go below 0", () => {
+  const state = createInitialState(mockWorkflow, mockYaml);
+
+  const newState = executionReducer(state, { type: "SELECT_PREV_STEP" });
+
+  assertEquals(newState.selectedStepIndex, 0);
+});
+
+Deno.test("execution_reducer - SCROLL_JOBS up decrements offset", () => {
+  let state = createInitialState(mockWorkflow, mockYaml);
+  state = { ...state, jobsScrollOffset: 1 };
+
+  const newState = executionReducer(state, {
+    type: "SCROLL_JOBS",
+    direction: "up",
+  });
+
+  assertEquals(newState.jobsScrollOffset, 0);
+});
+
+Deno.test("execution_reducer - SCROLL_JOBS down increments offset", () => {
+  const state = createInitialState(mockWorkflow, mockYaml);
+
+  const newState = executionReducer(state, {
+    type: "SCROLL_JOBS",
+    direction: "down",
+  });
+
+  assertEquals(newState.jobsScrollOffset, 1);
+});
+
+Deno.test("execution_reducer - SCROLL_JOBS up does not go below 0", () => {
+  const state = createInitialState(mockWorkflow, mockYaml);
+
+  const newState = executionReducer(state, {
+    type: "SCROLL_JOBS",
+    direction: "up",
+  });
+
+  assertEquals(newState.jobsScrollOffset, 0);
+});
+
+Deno.test("execution_reducer - SCROLL_STEPS up decrements offset", () => {
+  let state = createInitialState(mockWorkflow, mockYaml);
+  state = { ...state, stepsScrollOffset: 1 };
+
+  const newState = executionReducer(state, {
+    type: "SCROLL_STEPS",
+    direction: "up",
+  });
+
+  assertEquals(newState.stepsScrollOffset, 0);
+});
+
+Deno.test("execution_reducer - SCROLL_STEPS down increments offset", () => {
+  const state = createInitialState(mockWorkflow, mockYaml);
+
+  const newState = executionReducer(state, {
+    type: "SCROLL_STEPS",
+    direction: "down",
+  });
+
+  // job1 has only 1 step, so max is 0
+  assertEquals(newState.stepsScrollOffset, 0);
+});
+
+Deno.test("execution_reducer - SCROLL_STEPS up does not go below 0", () => {
+  const state = createInitialState(mockWorkflow, mockYaml);
+
+  const newState = executionReducer(state, {
+    type: "SCROLL_STEPS",
+    direction: "up",
+  });
+
+  assertEquals(newState.stepsScrollOffset, 0);
+});

--- a/src/presentation/output/components/workflow_execution/mod.ts
+++ b/src/presentation/output/components/workflow_execution/mod.ts
@@ -1,0 +1,20 @@
+export { WorkflowExecutionUI } from "./WorkflowExecutionUI.tsx";
+export { WorkflowHeader } from "./WorkflowHeader.tsx";
+export { JobsPanel } from "./JobsPanel.tsx";
+export { StepsPanel } from "./StepsPanel.tsx";
+export { type RunStatus, StatusIcon } from "./StatusIcon.tsx";
+export { HotkeyBar } from "./HotkeyBar.tsx";
+export { YamlOverlay } from "./YamlOverlay.tsx";
+export {
+  createInitialState,
+  type ExecutionAction,
+  executionReducer,
+  type WorkflowExecutionViewState,
+} from "./execution_reducer.ts";
+export {
+  getTokenColor,
+  type HighlightedLine,
+  type HighlightToken,
+  highlightYaml,
+  type TokenType,
+} from "./yaml_highlighter.ts";

--- a/src/presentation/output/components/workflow_execution/yaml_highlighter.ts
+++ b/src/presentation/output/components/workflow_execution/yaml_highlighter.ts
@@ -1,0 +1,189 @@
+/**
+ * Token type for YAML syntax highlighting.
+ */
+export type TokenType =
+  | "key"
+  | "string"
+  | "number"
+  | "boolean"
+  | "null"
+  | "comment"
+  | "text";
+
+/**
+ * A highlighted token with its type and text.
+ */
+export interface HighlightToken {
+  type: TokenType;
+  text: string;
+}
+
+/**
+ * A line of highlighted tokens.
+ */
+export interface HighlightedLine {
+  tokens: HighlightToken[];
+}
+
+/**
+ * Highlights YAML content with simple token-based highlighting.
+ *
+ * Colors:
+ * - cyan for keys
+ * - green for strings
+ * - yellow for numbers
+ * - magenta for booleans
+ * - gray for comments
+ * - gray for null
+ *
+ * @param yaml - The YAML content to highlight
+ * @returns Array of highlighted lines
+ */
+export function highlightYaml(yaml: string): HighlightedLine[] {
+  const lines = yaml.split("\n");
+  return lines.map(highlightLine);
+}
+
+/**
+ * Highlights a single line of YAML.
+ */
+function highlightLine(line: string): HighlightedLine {
+  const tokens: HighlightToken[] = [];
+
+  // Empty line
+  if (line.trim() === "") {
+    tokens.push({ type: "text", text: line });
+    return { tokens };
+  }
+
+  // Comment line
+  const commentMatch = line.match(/^(\s*)(#.*)$/);
+  if (commentMatch) {
+    const [, indent, comment] = commentMatch;
+    if (indent) {
+      tokens.push({ type: "text", text: indent });
+    }
+    tokens.push({ type: "comment", text: comment });
+    return { tokens };
+  }
+
+  // Key-value line
+  const kvMatch = line.match(/^(\s*)([^:\s][^:]*?)(:)(\s*)(.*)$/);
+  if (kvMatch) {
+    const [, indent, key, colon, space, value] = kvMatch;
+
+    if (indent) {
+      tokens.push({ type: "text", text: indent });
+    }
+    tokens.push({ type: "key", text: key });
+    tokens.push({ type: "text", text: colon });
+    if (space) {
+      tokens.push({ type: "text", text: space });
+    }
+
+    if (value) {
+      tokens.push(...highlightValue(value));
+    }
+
+    return { tokens };
+  }
+
+  // List item line
+  const listMatch = line.match(/^(\s*)(-)(\s*)(.*)$/);
+  if (listMatch) {
+    const [, indent, dash, space, value] = listMatch;
+
+    if (indent) {
+      tokens.push({ type: "text", text: indent });
+    }
+    tokens.push({ type: "text", text: dash });
+    if (space) {
+      tokens.push({ type: "text", text: space });
+    }
+
+    if (value) {
+      // Check if it's a key-value pair after the dash
+      const itemKvMatch = value.match(/^([^:\s][^:]*?)(:)(\s*)(.*)$/);
+      if (itemKvMatch) {
+        const [, itemKey, itemColon, itemSpace, itemValue] = itemKvMatch;
+        tokens.push({ type: "key", text: itemKey });
+        tokens.push({ type: "text", text: itemColon });
+        if (itemSpace) {
+          tokens.push({ type: "text", text: itemSpace });
+        }
+        if (itemValue) {
+          tokens.push(...highlightValue(itemValue));
+        }
+      } else {
+        tokens.push(...highlightValue(value));
+      }
+    }
+
+    return { tokens };
+  }
+
+  // Default: just text
+  tokens.push({ type: "text", text: line });
+  return { tokens };
+}
+
+/**
+ * Highlights a value portion of a YAML line.
+ */
+function highlightValue(value: string): HighlightToken[] {
+  const trimmed = value.trim();
+
+  // Check for inline comment
+  const commentIdx = value.indexOf(" #");
+  if (commentIdx !== -1) {
+    const mainValue = value.substring(0, commentIdx);
+    const comment = value.substring(commentIdx);
+    return [
+      ...highlightValue(mainValue),
+      { type: "comment", text: comment },
+    ];
+  }
+
+  // Quoted string (single or double)
+  if (/^(['"]).*\1$/.test(trimmed)) {
+    return [{ type: "string", text: value }];
+  }
+
+  // Boolean
+  if (/^(true|false|yes|no|on|off)$/i.test(trimmed)) {
+    return [{ type: "boolean", text: value }];
+  }
+
+  // Null
+  if (/^(null|~)$/i.test(trimmed)) {
+    return [{ type: "null", text: value }];
+  }
+
+  // Number (integer or float)
+  if (/^-?\d+(\.\d+)?([eE][+-]?\d+)?$/.test(trimmed)) {
+    return [{ type: "number", text: value }];
+  }
+
+  // Unquoted string (treat as string for display)
+  if (trimmed.length > 0) {
+    return [{ type: "string", text: value }];
+  }
+
+  return [{ type: "text", text: value }];
+}
+
+/**
+ * Gets the color for a token type.
+ */
+export function getTokenColor(type: TokenType): string {
+  const colors: Record<TokenType, string> = {
+    key: "cyan",
+    string: "green",
+    number: "yellow",
+    boolean: "magenta",
+    null: "gray",
+    comment: "gray",
+    text: "white",
+  };
+  return colors[type];
+}

--- a/src/presentation/output/components/workflow_execution/yaml_highlighter_test.ts
+++ b/src/presentation/output/components/workflow_execution/yaml_highlighter_test.ts
@@ -1,0 +1,125 @@
+import { assertEquals } from "@std/assert";
+import { getTokenColor, highlightYaml } from "./yaml_highlighter.ts";
+
+Deno.test("yaml_highlighter - getTokenColor returns correct colors", () => {
+  assertEquals(getTokenColor("key"), "cyan");
+  assertEquals(getTokenColor("string"), "green");
+  assertEquals(getTokenColor("number"), "yellow");
+  assertEquals(getTokenColor("boolean"), "magenta");
+  assertEquals(getTokenColor("null"), "gray");
+  assertEquals(getTokenColor("comment"), "gray");
+  assertEquals(getTokenColor("text"), "white");
+});
+
+Deno.test("yaml_highlighter - highlightYaml handles empty string", () => {
+  const result = highlightYaml("");
+  assertEquals(result.length, 1);
+  assertEquals(result[0].tokens[0].type, "text");
+});
+
+Deno.test("yaml_highlighter - highlightYaml handles simple key-value", () => {
+  const result = highlightYaml("name: test");
+  assertEquals(result.length, 1);
+
+  const tokens = result[0].tokens;
+  const keyToken = tokens.find((t) => t.type === "key");
+  const valueToken = tokens.find((t) => t.type === "string");
+
+  assertEquals(keyToken?.text, "name");
+  assertEquals(valueToken?.text, "test");
+});
+
+Deno.test("yaml_highlighter - highlightYaml handles numbers", () => {
+  const result = highlightYaml("count: 42");
+  assertEquals(result.length, 1);
+
+  const tokens = result[0].tokens;
+  const numberToken = tokens.find((t) => t.type === "number");
+
+  assertEquals(numberToken?.text, "42");
+});
+
+Deno.test("yaml_highlighter - highlightYaml handles booleans", () => {
+  const trueResult = highlightYaml("enabled: true");
+  const falseResult = highlightYaml("disabled: false");
+
+  const trueToken = trueResult[0].tokens.find((t) => t.type === "boolean");
+  const falseToken = falseResult[0].tokens.find((t) => t.type === "boolean");
+
+  assertEquals(trueToken?.text, "true");
+  assertEquals(falseToken?.text, "false");
+});
+
+Deno.test("yaml_highlighter - highlightYaml handles null", () => {
+  const result = highlightYaml("value: null");
+
+  const nullToken = result[0].tokens.find((t) => t.type === "null");
+  assertEquals(nullToken?.text, "null");
+});
+
+Deno.test("yaml_highlighter - highlightYaml handles comments", () => {
+  const result = highlightYaml("# This is a comment");
+
+  const commentToken = result[0].tokens.find((t) => t.type === "comment");
+  assertEquals(commentToken?.text, "# This is a comment");
+});
+
+Deno.test("yaml_highlighter - highlightYaml handles indented content", () => {
+  const yaml = `jobs:
+  - name: build`;
+
+  const result = highlightYaml(yaml);
+  assertEquals(result.length, 2);
+
+  // First line: "jobs:" - key
+  const firstLineKey = result[0].tokens.find((t) => t.type === "key");
+  assertEquals(firstLineKey?.text, "jobs");
+
+  // Second line: "  - name: build" - list item with key-value
+  // Note: the key token captures just "name" (without the dash prefix)
+  const secondLineTokenTypes = result[1].tokens.map((t) => t.type);
+  const hasKey = secondLineTokenTypes.includes("key");
+  const hasString = secondLineTokenTypes.includes("string");
+  assertEquals(hasKey, true);
+  assertEquals(hasString, true);
+});
+
+Deno.test("yaml_highlighter - highlightYaml handles quoted strings", () => {
+  const singleQuoted = highlightYaml("message: 'hello world'");
+  const doubleQuoted = highlightYaml('message: "hello world"');
+
+  const singleToken = singleQuoted[0].tokens.find((t) => t.type === "string");
+  const doubleToken = doubleQuoted[0].tokens.find((t) => t.type === "string");
+
+  assertEquals(singleToken?.text, "'hello world'");
+  assertEquals(doubleToken?.text, '"hello world"');
+});
+
+Deno.test("yaml_highlighter - highlightYaml handles list items without key", () => {
+  const result = highlightYaml("  - item1");
+
+  const stringToken = result[0].tokens.find((t) => t.type === "string");
+  assertEquals(stringToken?.text, "item1");
+});
+
+Deno.test("yaml_highlighter - highlightYaml handles multi-line YAML", () => {
+  const yaml = `name: my-workflow
+version: 1
+enabled: true
+description: null
+# A comment
+jobs:
+  - name: build
+    steps:
+      - name: checkout`;
+
+  const result = highlightYaml(yaml);
+
+  assertEquals(result.length, 9);
+
+  // Verify various line types are handled
+  const keyCount =
+    result.flatMap((line) => line.tokens.filter((t) => t.type === "key"))
+      .length;
+  assertEquals(keyCount >= 5, true);
+});

--- a/src/presentation/output/workflow_execution_output.tsx
+++ b/src/presentation/output/workflow_execution_output.tsx
@@ -1,0 +1,209 @@
+// deno-lint-ignore-file verbatim-module-syntax
+import React from "react";
+import { render } from "ink";
+import type { OutputMode } from "./output.tsx";
+import type { WorkflowData } from "../../domain/workflows/workflow.ts";
+import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
+import type { ExecutionProgressCallback } from "../../domain/workflows/execution_service.ts";
+import {
+  type JobRunData,
+  renderWorkflowRun,
+  type StepRunData,
+  type WorkflowRunData,
+} from "./workflow_run_output.tsx";
+import {
+  type ExecutionAction,
+  WorkflowExecutionUI,
+} from "./components/workflow_execution/mod.ts";
+
+/**
+ * Input for the workflow execution renderer.
+ */
+export interface WorkflowExecutionInput {
+  workflow: WorkflowData;
+  workflowYaml: string;
+}
+
+/**
+ * Converts a WorkflowRun domain object to WorkflowRunData for presentation.
+ */
+function toRunData(run: WorkflowRun): WorkflowRunData {
+  const startTime = run.startedAt?.getTime();
+  const endTime = run.completedAt?.getTime();
+
+  return {
+    id: run.id,
+    workflowId: run.workflowId,
+    workflowName: run.workflowName,
+    status: run.status,
+    jobs: run.jobs.map((job): JobRunData => {
+      const jobStart = job.startedAt?.getTime();
+      const jobEnd = job.completedAt?.getTime();
+
+      return {
+        name: job.jobName,
+        status: job.status,
+        steps: job.steps.map((step): StepRunData => {
+          const stepStart = step.startedAt?.getTime();
+          const stepEnd = step.completedAt?.getTime();
+
+          return {
+            name: step.stepName,
+            status: step.status,
+            error: step.error,
+            duration: stepStart && stepEnd ? stepEnd - stepStart : undefined,
+          };
+        }),
+        duration: jobStart && jobEnd ? jobEnd - jobStart : undefined,
+      };
+    }),
+    duration: startTime && endTime ? endTime - startTime : undefined,
+  };
+}
+
+/**
+ * Creates a progress callback adapter that bridges domain events to React dispatch.
+ */
+function createProgressAdapter(
+  dispatch: React.Dispatch<ExecutionAction>,
+): ExecutionProgressCallback {
+  return {
+    onWorkflowStart: (run) => {
+      dispatch({ type: "WORKFLOW_START", run: toRunData(run) });
+    },
+    onJobStart: (run) => {
+      dispatch({ type: "WORKFLOW_UPDATE", run: toRunData(run) });
+    },
+    onJobComplete: (run) => {
+      dispatch({ type: "WORKFLOW_UPDATE", run: toRunData(run) });
+    },
+    onJobSkip: (run) => {
+      dispatch({ type: "WORKFLOW_UPDATE", run: toRunData(run) });
+    },
+    onStepStart: (run) => {
+      dispatch({ type: "WORKFLOW_UPDATE", run: toRunData(run) });
+    },
+    onStepComplete: (run) => {
+      dispatch({ type: "WORKFLOW_UPDATE", run: toRunData(run) });
+    },
+    onStepSkip: (run) => {
+      dispatch({ type: "WORKFLOW_UPDATE", run: toRunData(run) });
+    },
+    onStepFail: (run) => {
+      dispatch({ type: "WORKFLOW_UPDATE", run: toRunData(run) });
+    },
+    onWorkflowComplete: (run) => {
+      dispatch({ type: "WORKFLOW_COMPLETE", run: toRunData(run) });
+    },
+  };
+}
+
+/**
+ * Result of an interactive workflow execution.
+ */
+export interface WorkflowExecutionResult {
+  run: WorkflowRunData;
+  path?: string;
+}
+
+/**
+ * Renders the workflow execution UI.
+ *
+ * In JSON mode, executes silently and outputs the final result.
+ * In interactive mode, shows a live dashboard with progress updates.
+ *
+ * @param input - The workflow data and YAML content
+ * @param executeWorkflow - Function that executes the workflow with a progress callback
+ * @param mode - Output mode (interactive or json)
+ * @param path - Optional path where the run is saved
+ * @returns Promise that resolves with the final workflow run data
+ */
+export async function renderWorkflowExecution(
+  input: WorkflowExecutionInput,
+  executeWorkflow: (
+    progress: ExecutionProgressCallback,
+  ) => Promise<WorkflowRun>,
+  mode: OutputMode,
+  path?: string,
+): Promise<WorkflowRunData> {
+  if (mode === "json") {
+    // JSON mode: execute silently, output final result
+    const run = await executeWorkflow({});
+    const data = toRunData(run);
+    if (path) {
+      data.path = path;
+    }
+    renderWorkflowRun(data, mode);
+    return data;
+  }
+
+  // Interactive mode: show live dashboard
+  return await renderInteractiveExecution(input, executeWorkflow, path);
+}
+
+/**
+ * Renders the interactive execution UI with live updates.
+ */
+function renderInteractiveExecution(
+  input: WorkflowExecutionInput,
+  executeWorkflow: (
+    progress: ExecutionProgressCallback,
+  ) => Promise<WorkflowRun>,
+  path?: string,
+): Promise<WorkflowRunData> {
+  return new Promise<WorkflowRunData>((resolve) => {
+    let dispatchRef: React.Dispatch<ExecutionAction> | null = null;
+    let finalRunData: WorkflowRunData | null = null;
+
+    const { waitUntilExit, unmount } = render(
+      <WorkflowExecutionUI
+        workflow={input.workflow}
+        workflowYaml={input.workflowYaml}
+        onExit={() => {
+          if (finalRunData) {
+            resolve(finalRunData);
+          }
+        }}
+        registerDispatch={(dispatch) => {
+          dispatchRef = dispatch;
+        }}
+      />,
+    );
+
+    // Start execution after component mounts and dispatch is registered
+    const startExecution = async () => {
+      // Wait a tick for dispatch to be registered
+      await new Promise((r) => setTimeout(r, 0));
+
+      if (!dispatchRef) {
+        throw new Error("Dispatch not registered");
+      }
+
+      const progress = createProgressAdapter(dispatchRef);
+
+      try {
+        const run = await executeWorkflow(progress);
+        finalRunData = toRunData(run);
+        if (path) {
+          finalRunData.path = path;
+        }
+      } catch (error) {
+        // Execution failed - unmount and rethrow
+        unmount();
+        throw error;
+      }
+    };
+
+    startExecution().then(() => {
+      // Wait for user to exit
+      waitUntilExit().then(() => {
+        if (finalRunData) {
+          resolve(finalRunData);
+        }
+      });
+    }).catch((error) => {
+      unmount();
+      throw error;
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Add an interactive terminal UI for workflow execution using Ink:

- **WorkflowExecutionUI**: Main component with keyboard navigation between panels
- **JobsPanel/StepsPanel**: Display jobs and steps with status indicators and dependency info
- **YamlOverlay**: Fullscreen YAML viewer with syntax highlighting and scrolling
- **StatusIcon**: Spinner, checkmark, and error icons for status display
- **HotkeyBar**: Shows available keyboard shortcuts
- **execution_reducer**: State management for the UI

Features:
- Tab to switch between jobs/steps panels
- Arrow keys for navigation within panels
- 'l' to toggle YAML overlay view
- 'q' to quit when complete
- Real-time status updates via dispatch registration

Includes fixes for overlay rendering and input timing:
- Both views use same terminal height to prevent residual content after closing overlay
- Input handling uses `isActive` prop for proper focus control between main UI and overlay

## Test Plan

- Run `deno run dev workflow run <workflow-name>` to test the interactive UI
- Press 'l' to open YAML overlay - should open immediately
- Press Escape or 'l' to close - should close immediately with no residual content
- Toggle open/close multiple times rapidly to verify timing
- All 641 tests pass