### PR TITLE
refactor: replace dynamic imports with static imports

### DIFF
--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -15,6 +15,10 @@ import {
   WorkflowExecutionService,
 } from "../../domain/workflows/execution_service.ts";
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
+import {
+  createWorkflowId,
+  createWorkflowRunId,
+} from "../../domain/workflows/workflow_id.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -79,10 +83,7 @@ export const workflowRunCommand = new Command()
     try {
       // Look up workflow first to get its data
       const workflow = await workflowRepo.findByName(workflowIdOrName) ??
-        await workflowRepo.findById(
-          (await import("../../domain/workflows/workflow_id.ts"))
-            .createWorkflowId(workflowIdOrName),
-        );
+        await workflowRepo.findById(createWorkflowId(workflowIdOrName));
 
       if (!workflow) {
         throw new Error(`Workflow not found: ${workflowIdOrName}`);
@@ -108,9 +109,6 @@ export const workflowRunCommand = new Command()
         );
 
         // Get the path for the run
-        const { createWorkflowRunId } = await import(
-          "../../domain/workflows/workflow_id.ts"
-        );
         const path = runRepo.getPath(workflow.id, createWorkflowRunId(data.id));
         data.path = path;
 

--- a/src/domain/models/model_resource.ts
+++ b/src/domain/models/model_resource.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { ModelInputId } from "./model_input.ts";
 
 /**
  * Branded type for ModelResource IDs.
@@ -17,7 +18,7 @@ export function createModelResourceId(id: string): ModelResourceId {
  * Since we've unified the ID system, both types represent the same underlying UUID.
  */
 export function inputIdToResourceId(
-  inputId: import("./model_input.ts").ModelInputId,
+  inputId: ModelInputId,
 ): ModelResourceId {
   return inputId as unknown as ModelResourceId;
 }

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -7,7 +7,7 @@ import {
   type GraphNode,
   TopologicalSortService,
 } from "./topological_sort_service.ts";
-import type { WorkflowId } from "./workflow_id.ts";
+import { createWorkflowId, type WorkflowId } from "./workflow_id.ts";
 import type {
   WorkflowRepository,
   WorkflowRunRepository,
@@ -447,7 +447,6 @@ export class WorkflowExecutionService {
     if (byName) return byName;
 
     // Try by ID
-    const { createWorkflowId } = await import("./workflow_id.ts");
     const id = createWorkflowId(idOrName);
     return await this.workflowRepo.findById(id);
   }


### PR DESCRIPTION
## Summary

- Replace unnecessary dynamic imports of `workflow_id.ts` with static imports
- The dynamic imports existed as a circular dependency workaround, but `workflow_id.ts` is pure (no dependencies), so static imports work fine
- Also cleaned up inline type import in `model_resource.ts`

## Files Modified

- `src/cli/commands/workflow_run.ts` - static import for `createWorkflowId` and `createWorkflowRunId`
- `src/domain/workflows/execution_service.ts` - upgraded type-only import to include `createWorkflowId`
- `src/domain/models/model_resource.ts` - replaced inline type import with static import

## Test Plan

- `deno check` passes
- `deno lint` passes
- `deno fmt --check` passes
- All 677 tests pass