### PR TITLE
fix: add --delete-branch to auto-merge workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Enable auto-merge
-        run: gh pr merge --auto --squash "$PR_NUMBER"
+        run: gh pr merge --auto --squash --delete-branch "$PR_NUMBER"
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `--delete-branch` flag to the `gh pr merge` command in the CI auto-merge workflow
- Fixes branches not being deleted after PRs are merged via the GitHub Actions auto-merge

## Test Plan

- Merge this PR and verify the branch is automatically deleted