### PR TITLE
fix workflow run command

### DIFF
--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -92,8 +92,10 @@ export const workflowRunCommand = new Command()
       if (ctx.outputMode === "interactive") {
         // Interactive mode: use the new live dashboard
         const workflowData = workflow.toData();
+        // Remove undefined values since YAML can't stringify them
+        const cleanData = JSON.parse(JSON.stringify(workflowData));
         const workflowYaml = stringifyYaml(
-          workflowData as Record<string, unknown>,
+          cleanData as Record<string, unknown>,
         );
 
         const executeWorkflow = async (
@@ -103,7 +105,7 @@ export const workflowRunCommand = new Command()
         };
 
         const data = await renderWorkflowExecution(
-          { workflow: workflowData, workflowYaml },
+          { workflow: cleanData, workflowYaml },
           executeWorkflow,
           ctx.outputMode,
         );


### PR DESCRIPTION
The error "Cannot stringify undefined" was caused by calling stringifyYaml() on workflow data that contains
undefined values (like description: undefined). The @std/yaml library throws this error when encountering
undefined values.

The fix at src/cli/commands/workflow_run.ts:94-99 adds the same cleanup pattern used elsewhere in the
codebase:

```
const workflowData = workflow.toData();
// Remove undefined values since YAML can't stringify them
const cleanData = JSON.parse(JSON.stringify(workflowData));
const workflowYaml = stringifyYaml(
    cleanData as Record<string, unknown>,
);
```

The JSON.parse(JSON.stringify(...)) pattern strips out all undefined values before passing to the YAML
serializer.