### PR TITLE
docs: add compile instruction to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@ Use `deno run` to get a complete list of custom tasks.
 ## Source Control & Pull Requests
 
 - Use the `github-pr` skill to create commit messages and pull requests.
+- After completing work (finishing tasks, merging PRs), run `deno run compile`
+  to recompile swamp.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

Add instruction to CLAUDE.md telling Claude to run `deno run compile` after completing work (finishing tasks, merging PRs) to recompile swamp.

## Test Plan

- Verified the instruction is clear and follows existing formatting
- All pre-flight checks pass (fmt, lint, test)