### PR TITLE
fix: improve terminal resize handling in workflow execution UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,16 @@ Use `deno run` to get a complete list of custom tasks.
 
 - Use the `github-pr` skill to create commit messages and pull requests.
 
+## Verification
+
+After completing work, run these checks:
+
+1. `deno check` - Type checking
+2. `deno lint` - Linting
+3. `deno fmt` - Formatting
+4. `deno run test` - Tests
+5. `deno run compile` - Recompile the binary
+
 ## Architecture
 
 - Follows domain driven design principles. Use the `ddd` skill when designing or

--- a/src/presentation/output/components/workflow_execution/HotkeyBar.tsx
+++ b/src/presentation/output/components/workflow_execution/HotkeyBar.tsx
@@ -17,7 +17,7 @@ export function HotkeyBar(
 ): React.ReactElement {
   if (showYamlOverlay) {
     return (
-      <Box paddingX={1}>
+      <Box paddingX={1} flexShrink={0}>
         <Text dimColor>Esc: Close | ↑/↓: Scroll</Text>
       </Box>
     );
@@ -28,12 +28,18 @@ export function HotkeyBar(
     : "↑/↓: Select Step";
 
   const hints = ["Tab: Switch Panel", navHint, "l: View YAML"];
+
   if (isComplete) {
-    hints.push("q: Quit");
+    return (
+      <Box paddingX={1} flexShrink={0}>
+        <Text dimColor>{hints.join(" | ")} |</Text>
+        <Text color="green" bold>q: Quit</Text>
+      </Box>
+    );
   }
 
   return (
-    <Box paddingX={1}>
+    <Box paddingX={1} flexShrink={0}>
       <Text dimColor>{hints.join(" | ")}</Text>
     </Box>
   );

--- a/src/presentation/output/components/workflow_execution/JobsPanel.tsx
+++ b/src/presentation/output/components/workflow_execution/JobsPanel.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Box, Text } from "ink";
 import { type RunStatus, StatusIcon } from "./StatusIcon.tsx";
 import type { JobRunData } from "../../workflow_run_output.tsx";
+import { calculateScrollWindow } from "../../hooks/mod.ts";
 
 /**
  * Formats pending dependencies for display.
@@ -72,16 +73,31 @@ interface JobsPanelProps {
   selectedIndex: number;
   isFocused: boolean;
   pendingDependencies: Map<string, string[]>;
+  availableHeight?: number;
 }
 
 /**
  * Displays the list of jobs with selection indicator.
  */
 export function JobsPanel(
-  { jobs, selectedIndex, isFocused, pendingDependencies }: JobsPanelProps,
+  { jobs, selectedIndex, isFocused, pendingDependencies, availableHeight }:
+    JobsPanelProps,
 ): React.ReactElement {
   const borderColor = isFocused ? "cyan" : "gray";
   const titleColor = isFocused ? "cyan" : undefined;
+
+  // Reserve 3 lines for border (2) and header (1)
+  const contentHeight = availableHeight !== undefined
+    ? Math.max(1, availableHeight - 3)
+    : jobs.length;
+
+  const { start, end } = calculateScrollWindow(
+    jobs.length,
+    selectedIndex,
+    contentHeight,
+  );
+
+  const visibleJobs = jobs.slice(start, end);
 
   return (
     <Box
@@ -89,17 +105,19 @@ export function JobsPanel(
       borderStyle="single"
       borderColor={borderColor}
       paddingX={1}
+      flexGrow={1}
+      overflow="hidden"
     >
-      <Box>
+      <Box flexShrink={0}>
         <Text bold color={titleColor}>Jobs</Text>
         <Box flexGrow={1} />
         <Text dimColor>[{selectedIndex + 1}/{jobs.length}]</Text>
       </Box>
-      {jobs.map((job, i) => (
+      {visibleJobs.map((job, i) => (
         <JobItem
-          key={i}
+          key={start + i}
           job={job}
-          isSelected={i === selectedIndex}
+          isSelected={start + i === selectedIndex}
           pendingDeps={pendingDependencies.get(job.name) ?? []}
         />
       ))}

--- a/src/presentation/output/components/workflow_execution/StepsPanel.tsx
+++ b/src/presentation/output/components/workflow_execution/StepsPanel.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Box, Text } from "ink";
 import { type RunStatus, StatusIcon } from "./StatusIcon.tsx";
 import type { StepRunData } from "../../workflow_run_output.tsx";
+import { calculateScrollWindow } from "../../hooks/mod.ts";
 
 /**
  * Formats pending dependencies for display.
@@ -75,17 +76,37 @@ interface StepsPanelProps {
   isFocused: boolean;
   selectedIndex: number;
   pendingDependencies: Map<string, string[]>;
+  availableHeight?: number;
 }
 
 /**
  * Displays the steps for a selected job.
  */
 export function StepsPanel(
-  { jobName, steps, isFocused, selectedIndex, pendingDependencies }:
-    StepsPanelProps,
+  {
+    jobName,
+    steps,
+    isFocused,
+    selectedIndex,
+    pendingDependencies,
+    availableHeight,
+  }: StepsPanelProps,
 ): React.ReactElement {
   const borderColor = isFocused ? "cyan" : "gray";
   const titleColor = isFocused ? "cyan" : undefined;
+
+  // Reserve 3 lines for border (2) and header (1)
+  const contentHeight = availableHeight !== undefined
+    ? Math.max(1, availableHeight - 3)
+    : steps.length;
+
+  const { start, end } = calculateScrollWindow(
+    steps.length,
+    selectedIndex,
+    contentHeight,
+  );
+
+  const visibleSteps = steps.slice(start, end);
 
   return (
     <Box
@@ -93,17 +114,19 @@ export function StepsPanel(
       borderStyle="single"
       borderColor={borderColor}
       paddingX={1}
+      flexGrow={1}
+      overflow="hidden"
     >
-      <Box>
+      <Box flexShrink={0}>
         <Text bold color={titleColor}>Steps ({jobName})</Text>
         <Box flexGrow={1} />
         <Text dimColor>[{selectedIndex + 1}/{steps.length}]</Text>
       </Box>
-      {steps.map((step, i) => (
+      {visibleSteps.map((step, i) => (
         <StepItem
-          key={i}
+          key={start + i}
           step={step}
-          isSelected={i === selectedIndex}
+          isSelected={start + i === selectedIndex}
           pendingDeps={pendingDependencies.get(step.name) ?? []}
         />
       ))}

--- a/src/presentation/output/components/workflow_execution/WorkflowExecutionUI.tsx
+++ b/src/presentation/output/components/workflow_execution/WorkflowExecutionUI.tsx
@@ -1,6 +1,6 @@
 // deno-lint-ignore-file verbatim-module-syntax
 import React, { useCallback, useEffect, useReducer } from "react";
-import { Box, useApp, useInput, useStdout } from "ink";
+import { Box, Text, useApp, useInput } from "ink";
 import { WorkflowHeader } from "./WorkflowHeader.tsx";
 import { JobsPanel } from "./JobsPanel.tsx";
 import { StepsPanel } from "./StepsPanel.tsx";
@@ -13,6 +13,7 @@ import {
 } from "./execution_reducer.ts";
 import type { WorkflowData } from "../../../../domain/workflows/workflow.ts";
 import type { JobRunData } from "../../workflow_run_output.tsx";
+import { useTerminalSize } from "../../hooks/mod.ts";
 
 /**
  * Computes pending dependencies (ones that haven't succeeded yet).
@@ -42,9 +43,7 @@ export function WorkflowExecutionUI(
     WorkflowExecutionUIProps,
 ): React.ReactElement {
   const { exit } = useApp();
-  const { stdout } = useStdout();
-  const terminalHeight = stdout?.rows ?? 24;
-  const terminalWidth = stdout?.columns ?? 80;
+  const { width: terminalWidth, height: terminalHeight } = useTerminalSize();
 
   const [state, dispatch] = useReducer(
     executionReducer,
@@ -155,6 +154,36 @@ export function WorkflowExecutionUI(
     }
   }
 
+  // Calculate available height for panels
+  // Total height minus: outer border (2) + header (3) + hotkey bar (1)
+  const availableContentHeight = terminalHeight - 6;
+
+  // Split evenly between JobsPanel and StepsPanel
+  const panelHeight = Math.floor(availableContentHeight / 2);
+
+  // Show warning if terminal is too small
+  const minWidth = 60;
+  const minHeight = 15;
+  if (terminalWidth < minWidth || terminalHeight < minHeight) {
+    return (
+      <Box
+        flexDirection="column"
+        width={terminalWidth}
+        height={terminalHeight}
+        borderStyle="round"
+        borderColor="yellow"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <Text color="yellow" bold>Terminal too small</Text>
+        <Text dimColor>
+          Minimum: {minWidth}x{minHeight}, Current: {terminalWidth}x
+          {terminalHeight}
+        </Text>
+      </Box>
+    );
+  }
+
   return (
     <Box
       flexDirection="column"
@@ -162,6 +191,7 @@ export function WorkflowExecutionUI(
       height={terminalHeight}
       borderStyle="round"
       borderColor="gray"
+      overflow="hidden"
     >
       {/* Header */}
       <WorkflowHeader
@@ -176,6 +206,7 @@ export function WorkflowExecutionUI(
         selectedIndex={state.selectedJobIndex}
         isFocused={state.activePanel === "jobs"}
         pendingDependencies={jobPendingDeps}
+        availableHeight={panelHeight}
       />
 
       {/* Steps Panel */}
@@ -186,6 +217,7 @@ export function WorkflowExecutionUI(
           isFocused={state.activePanel === "steps"}
           selectedIndex={state.selectedStepIndex}
           pendingDependencies={stepPendingDeps}
+          availableHeight={panelHeight}
         />
       )}
 

--- a/src/presentation/output/components/workflow_execution/YamlOverlay.tsx
+++ b/src/presentation/output/components/workflow_execution/YamlOverlay.tsx
@@ -1,11 +1,12 @@
 // deno-lint-ignore-file verbatim-module-syntax
 import React, { useState } from "react";
-import { Box, Text, useInput, useStdout } from "ink";
+import { Box, Text, useInput } from "ink";
 import {
   getTokenColor,
   type HighlightedLine,
   highlightYaml,
 } from "./yaml_highlighter.ts";
+import { useTerminalSize } from "../../hooks/mod.ts";
 
 interface YamlOverlayProps {
   yaml: string;
@@ -20,9 +21,7 @@ interface YamlOverlayProps {
 export function YamlOverlay(
   { yaml, workflowName, onClose, isActive = true }: YamlOverlayProps,
 ): React.ReactElement {
-  const { stdout } = useStdout();
-  const terminalHeight = stdout?.rows ?? 24;
-  const terminalWidth = stdout?.columns ?? 80;
+  const { width: terminalWidth, height: terminalHeight } = useTerminalSize();
 
   // Reserve space for header (3 lines) and footer (2 lines)
   const contentHeight = Math.max(terminalHeight - 5, 5);

--- a/src/presentation/output/hooks/mod.ts
+++ b/src/presentation/output/hooks/mod.ts
@@ -1,0 +1,2 @@
+export { calculateScrollWindow } from "./useScrollableList.ts";
+export { useTerminalSize } from "./useTerminalSize.ts";

--- a/src/presentation/output/hooks/useScrollableList.ts
+++ b/src/presentation/output/hooks/useScrollableList.ts
@@ -1,0 +1,33 @@
+/**
+ * Calculates visible window for a scrollable list.
+ * Keeps the selected item visible by auto-scrolling.
+ */
+export function calculateScrollWindow(
+  totalItems: number,
+  selectedIndex: number,
+  visibleHeight: number,
+): { start: number; end: number } {
+  if (totalItems === 0 || visibleHeight <= 0) {
+    return { start: 0, end: 0 };
+  }
+
+  // Calculate the window that keeps selectedIndex visible
+  const maxStart = Math.max(0, totalItems - visibleHeight);
+  let start = 0;
+
+  // If selected item is below the visible window, scroll down
+  if (selectedIndex >= start + visibleHeight) {
+    start = selectedIndex - visibleHeight + 1;
+  }
+
+  // If selected item is above the visible window, scroll up
+  if (selectedIndex < start) {
+    start = selectedIndex;
+  }
+
+  // Clamp to valid range
+  start = Math.min(Math.max(0, start), maxStart);
+  const end = Math.min(start + visibleHeight, totalItems);
+
+  return { start, end };
+}

--- a/src/presentation/output/hooks/useScrollableList_test.ts
+++ b/src/presentation/output/hooks/useScrollableList_test.ts
@@ -1,0 +1,67 @@
+import { assertEquals } from "@std/assert";
+import { calculateScrollWindow } from "./useScrollableList.ts";
+
+Deno.test("calculateScrollWindow returns empty range for empty list", () => {
+  const result = calculateScrollWindow(0, 0, 5);
+  assertEquals(result, { start: 0, end: 0 });
+});
+
+Deno.test("calculateScrollWindow returns empty range for zero visible height", () => {
+  const result = calculateScrollWindow(10, 0, 0);
+  assertEquals(result, { start: 0, end: 0 });
+});
+
+Deno.test("calculateScrollWindow returns empty range for negative visible height", () => {
+  const result = calculateScrollWindow(10, 0, -5);
+  assertEquals(result, { start: 0, end: 0 });
+});
+
+Deno.test("calculateScrollWindow shows first items when selected is at start", () => {
+  const result = calculateScrollWindow(10, 0, 5);
+  assertEquals(result, { start: 0, end: 5 });
+});
+
+Deno.test("calculateScrollWindow shows first items when selected is within first window", () => {
+  const result = calculateScrollWindow(10, 2, 5);
+  assertEquals(result, { start: 0, end: 5 });
+});
+
+Deno.test("calculateScrollWindow scrolls down when selected is below visible window", () => {
+  const result = calculateScrollWindow(10, 7, 5);
+  assertEquals(result, { start: 3, end: 8 });
+});
+
+Deno.test("calculateScrollWindow scrolls to end when selected is last item", () => {
+  const result = calculateScrollWindow(10, 9, 5);
+  assertEquals(result, { start: 5, end: 10 });
+});
+
+Deno.test("calculateScrollWindow handles list smaller than visible height", () => {
+  const result = calculateScrollWindow(3, 1, 5);
+  assertEquals(result, { start: 0, end: 3 });
+});
+
+Deno.test("calculateScrollWindow handles visible height equal to total items", () => {
+  const result = calculateScrollWindow(5, 2, 5);
+  assertEquals(result, { start: 0, end: 5 });
+});
+
+Deno.test("calculateScrollWindow keeps selected item visible at bottom edge", () => {
+  const result = calculateScrollWindow(10, 4, 5);
+  assertEquals(result, { start: 0, end: 5 });
+});
+
+Deno.test("calculateScrollWindow scrolls when selected moves to index 5", () => {
+  const result = calculateScrollWindow(10, 5, 5);
+  assertEquals(result, { start: 1, end: 6 });
+});
+
+Deno.test("calculateScrollWindow handles single item list", () => {
+  const result = calculateScrollWindow(1, 0, 5);
+  assertEquals(result, { start: 0, end: 1 });
+});
+
+Deno.test("calculateScrollWindow handles visible height of 1", () => {
+  const result = calculateScrollWindow(10, 5, 1);
+  assertEquals(result, { start: 5, end: 6 });
+});

--- a/src/presentation/output/hooks/useTerminalSize.ts
+++ b/src/presentation/output/hooks/useTerminalSize.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { useStdout } from "ink";
+
+interface TerminalSize {
+  width: number;
+  height: number;
+}
+
+/**
+ * Hook that returns current terminal dimensions and updates on resize.
+ * Uses both event-based and polling approaches for reliability.
+ */
+export function useTerminalSize(): TerminalSize {
+  const { stdout } = useStdout();
+
+  const getSize = (): TerminalSize => ({
+    width: stdout?.columns ?? 80,
+    height: stdout?.rows ?? 24,
+  });
+
+  const [size, setSize] = useState<TerminalSize>(getSize);
+
+  useEffect(() => {
+    if (!stdout) return;
+
+    const updateSize = () => {
+      const newSize = getSize();
+      setSize((prev) => {
+        // Only update if dimensions actually changed
+        if (prev.width !== newSize.width || prev.height !== newSize.height) {
+          return newSize;
+        }
+        return prev;
+      });
+    };
+
+    // Listen to resize events
+    stdout.on("resize", updateSize);
+
+    // Poll as fallback (every 100ms)
+    const interval = setInterval(updateSize, 100);
+
+    return () => {
+      stdout.off("resize", updateSize);
+      clearInterval(interval);
+    };
+  }, [stdout]);
+
+  return size;
+}

--- a/src/presentation/output/workflow_execution_output.tsx
+++ b/src/presentation/output/workflow_execution_output.tsx
@@ -1,4 +1,5 @@
 // deno-lint-ignore-file verbatim-module-syntax
+import process from "node:process";
 import React from "react";
 import { render } from "ink";
 import type { OutputMode } from "./output.tsx";
@@ -141,69 +142,76 @@ export async function renderWorkflowExecution(
   return await renderInteractiveExecution(input, executeWorkflow, path);
 }
 
+// ANSI escape sequences for alternate screen buffer (like vim/htop use)
+const ENTER_ALT_SCREEN = "\x1b[?1049h";
+const EXIT_ALT_SCREEN = "\x1b[?1049l";
+
 /**
  * Renders the interactive execution UI with live updates.
+ * Uses alternate screen buffer for clean fullscreen rendering.
  */
-function renderInteractiveExecution(
+async function renderInteractiveExecution(
   input: WorkflowExecutionInput,
   executeWorkflow: (
     progress: ExecutionProgressCallback,
   ) => Promise<WorkflowRun>,
   path?: string,
 ): Promise<WorkflowRunData> {
-  return new Promise<WorkflowRunData>((resolve) => {
-    let dispatchRef: React.Dispatch<ExecutionAction> | null = null;
-    let finalRunData: WorkflowRunData | null = null;
+  let dispatchRef: React.Dispatch<ExecutionAction> | null = null;
+  let finalRunData: WorkflowRunData | null = null;
 
-    const { waitUntilExit, unmount } = render(
-      <WorkflowExecutionUI
-        workflow={input.workflow}
-        workflowYaml={input.workflowYaml}
-        onExit={() => {
-          if (finalRunData) {
-            resolve(finalRunData);
-          }
-        }}
-        registerDispatch={(dispatch) => {
-          dispatchRef = dispatch;
-        }}
-      />,
-    );
+  // Enter alternate screen buffer for clean fullscreen rendering
+  process.stdout.write(ENTER_ALT_SCREEN);
 
-    // Start execution after component mounts and dispatch is registered
-    const startExecution = async () => {
-      // Wait a tick for dispatch to be registered
-      await new Promise((r) => setTimeout(r, 0));
+  const { waitUntilExit, unmount } = render(
+    <WorkflowExecutionUI
+      workflow={input.workflow}
+      workflowYaml={input.workflowYaml}
+      onExit={() => {
+        // Resolved when user presses 'q' - finalRunData will be set
+      }}
+      registerDispatch={(dispatch) => {
+        dispatchRef = dispatch;
+      }}
+    />,
+  );
 
-      if (!dispatchRef) {
-        throw new Error("Dispatch not registered");
-      }
+  // Helper to clean up and exit alternate screen
+  const cleanup = () => {
+    unmount();
+    process.stdout.write(EXIT_ALT_SCREEN);
+  };
 
-      const progress = createProgressAdapter(dispatchRef);
+  // Wait a tick for dispatch to be registered
+  await new Promise((r) => setTimeout(r, 0));
 
-      try {
-        const run = await executeWorkflow(progress);
-        finalRunData = toRunData(run);
-        if (path) {
-          finalRunData.path = path;
-        }
-      } catch (error) {
-        // Execution failed - unmount and rethrow
-        unmount();
-        throw error;
-      }
-    };
+  if (!dispatchRef) {
+    cleanup();
+    throw new Error("Dispatch not registered");
+  }
 
-    startExecution().then(() => {
-      // Wait for user to exit
-      waitUntilExit().then(() => {
-        if (finalRunData) {
-          resolve(finalRunData);
-        }
-      });
-    }).catch((error) => {
-      unmount();
-      throw error;
-    });
-  });
+  const progress = createProgressAdapter(dispatchRef);
+
+  try {
+    const run = await executeWorkflow(progress);
+    finalRunData = toRunData(run);
+    if (path) {
+      finalRunData.path = path;
+    }
+  } catch (error) {
+    cleanup();
+    throw error;
+  }
+
+  // Wait for user to exit (press 'q')
+  await waitUntilExit();
+
+  // Exit alternate screen buffer
+  process.stdout.write(EXIT_ALT_SCREEN);
+
+  if (!finalRunData) {
+    throw new Error("Workflow execution completed without run data");
+  }
+
+  return finalRunData;
 }


### PR DESCRIPTION
## Summary

- Add polling fallback (100ms) to `useTerminalSize` hook for reliable resize detection
- Combine event-based and polling approaches to catch missed resize events
- Only update state when dimensions actually change to prevent unnecessary re-renders
- Add `useScrollableList` hook for virtualized list scrolling in panels
- Implement height constraints for JobsPanel and StepsPanel with auto-scrolling
- Use alternate screen buffer for clean fullscreen rendering (like vim/htop)
- Add minimum terminal size warning (60x15) instead of broken UI
- Highlight quit hotkey in green when workflow completes

## Test Plan

- [x] `deno check` - Type checking passes
- [x] `deno lint` - Linting passes
- [x] `deno fmt` - Formatting passes
- [x] `deno run test` - All 677 tests pass
- [x] `deno run compile` - Binary recompiles successfully
- [ ] Manual testing: Resize terminal while running a workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)