### PR TITLE
Add support for workflow history get and search

### DIFF
--- a/design/workflow.md
+++ b/design/workflow.md
@@ -64,7 +64,7 @@ validate all workflows if none is specified.
 
 ### workflow search <search>
 
-Should work simiilarly to swamp type search - it uses fzf to search across all
+Should work similarly to swamp type search - it uses fzf to search across all
 the workflows by name or by id. Should produce json output or use interactive
 fuzzy search.
 
@@ -76,6 +76,17 @@ Should show the workflow yaml with syntax highlighting, and the path, similar to
 ### workflow run <id or name>
 
 Executes a workflow run.
+
+### workflow history get <id or name>
+
+Displays the run data (status, timing, step outputs/errors) for the latest
+workflow run
+
+### workflow history search <id or name>
+
+Should work similarly to workflow search - it uses fzf to search across all the
+workflow runs by name or by id. Should produce json output or use interactive
+fuzzy search.
 
 ### workflow schema get
 

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -1,6 +1,7 @@
 import { Command } from "@cliffy/command";
 import { workflowCreateCommand } from "./workflow_create.ts";
 import { workflowGetCommand } from "./workflow_get.ts";
+import { workflowHistoryCommand } from "./workflow_history.ts";
 import { workflowValidateCommand } from "./workflow_validate.ts";
 import { workflowSearchCommand } from "./workflow_search.ts";
 import { workflowRunCommand } from "./workflow_run.ts";
@@ -14,6 +15,7 @@ export const workflowCommand = new Command()
   })
   .command("create", workflowCreateCommand)
   .command("get", workflowGetCommand)
+  .command("history", workflowHistoryCommand)
   .command("validate", workflowValidateCommand)
   .command("search", workflowSearchCommand)
   .command("run", workflowRunCommand)

--- a/src/cli/commands/workflow_history.ts
+++ b/src/cli/commands/workflow_history.ts
@@ -1,0 +1,12 @@
+import { Command } from "@cliffy/command";
+import { workflowHistoryGetCommand } from "./workflow_history_get.ts";
+import { workflowHistorySearchCommand } from "./workflow_history_search.ts";
+
+export const workflowHistoryCommand = new Command()
+  .name("history")
+  .description("Workflow run history commands")
+  .action(function () {
+    this.showHelp();
+  })
+  .command("get", workflowHistoryGetCommand)
+  .command("search", workflowHistorySearchCommand);

--- a/src/cli/commands/workflow_history_get.ts
+++ b/src/cli/commands/workflow_history_get.ts
@@ -1,0 +1,95 @@
+import { Command } from "@cliffy/command";
+import {
+  type JobRunData,
+  renderWorkflowRun,
+  type StepRunData,
+  type WorkflowRunData,
+} from "../../presentation/output/workflow_run_output.tsx";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
+import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
+import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
+import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+/**
+ * Converts a WorkflowRun to WorkflowRunData for presentation.
+ */
+function toRunData(run: WorkflowRun, path?: string): WorkflowRunData {
+  const startTime = run.startedAt?.getTime();
+  const endTime = run.completedAt?.getTime();
+
+  return {
+    id: run.id,
+    workflowId: run.workflowId,
+    workflowName: run.workflowName,
+    status: run.status,
+    jobs: run.jobs.map((job): JobRunData => {
+      const jobStart = job.startedAt?.getTime();
+      const jobEnd = job.completedAt?.getTime();
+
+      return {
+        name: job.jobName,
+        status: job.status,
+        steps: job.steps.map((step): StepRunData => {
+          const stepStart = step.startedAt?.getTime();
+          const stepEnd = step.completedAt?.getTime();
+
+          return {
+            name: step.stepName,
+            status: step.status,
+            error: step.error,
+            duration: stepStart && stepEnd ? stepEnd - stepStart : undefined,
+          };
+        }),
+        duration: jobStart && jobEnd ? jobEnd - jobStart : undefined,
+      };
+    }),
+    duration: startTime && endTime ? endTime - startTime : undefined,
+    path,
+  };
+}
+
+export const workflowHistoryGetCommand = new Command()
+  .name("get")
+  .description("Show the latest run for a workflow")
+  .arguments("<workflow_id_or_name:string>")
+  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .action(async function (options: AnyOptions, workflowIdOrName: string) {
+    const ctx = createContext(options as GlobalOptions, "workflow-history-get");
+    ctx.logger.debug`Getting latest run for workflow: ${workflowIdOrName}`;
+
+    const repoDir = options.repoDir ?? ".";
+    const workflowRepo = new YamlWorkflowRepository(repoDir);
+    const runRepo = new YamlWorkflowRunRepository(repoDir);
+
+    // Look up the workflow first
+    const workflow = await workflowRepo.findByName(workflowIdOrName) ??
+      await workflowRepo.findById(createWorkflowId(workflowIdOrName));
+
+    if (!workflow) {
+      throw new Error(`Workflow not found: ${workflowIdOrName}`);
+    }
+
+    ctx.logger.debug`Found workflow: id=${workflow.id}, name=${workflow.name}`;
+
+    // Get the latest run for this workflow
+    const latestRun = await runRepo.findLatestByWorkflowId(workflow.id);
+
+    if (!latestRun) {
+      throw new Error(`No runs found for workflow: ${workflow.name}`);
+    }
+
+    ctx.logger
+      .debug`Found latest run: id=${latestRun.id}, status=${latestRun.status}`;
+
+    // Get the path for the run
+    const path = runRepo.getPath(workflow.id, latestRun.id);
+
+    const data = toRunData(latestRun, path);
+    renderWorkflowRun(data, ctx.outputMode);
+
+    ctx.logger.debug("Workflow history get command completed");
+  });

--- a/src/cli/commands/workflow_history_search.ts
+++ b/src/cli/commands/workflow_history_search.ts
@@ -1,0 +1,175 @@
+import { Command } from "@cliffy/command";
+import {
+  type JobRunData,
+  renderWorkflowRun,
+  type StepRunData,
+  type WorkflowRunData,
+} from "../../presentation/output/workflow_run_output.tsx";
+import {
+  renderWorkflowHistorySearch,
+  type WorkflowHistorySearchData,
+  type WorkflowHistorySearchItem,
+} from "../../presentation/output/workflow_history_search_output.tsx";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
+import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
+import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
+import {
+  createWorkflowId,
+  createWorkflowRunId,
+} from "../../domain/workflows/workflow_id.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+/**
+ * Converts a WorkflowRun to WorkflowRunData for presentation.
+ */
+function toRunData(run: WorkflowRun, path?: string): WorkflowRunData {
+  const startTime = run.startedAt?.getTime();
+  const endTime = run.completedAt?.getTime();
+
+  return {
+    id: run.id,
+    workflowId: run.workflowId,
+    workflowName: run.workflowName,
+    status: run.status,
+    jobs: run.jobs.map((job): JobRunData => {
+      const jobStart = job.startedAt?.getTime();
+      const jobEnd = job.completedAt?.getTime();
+
+      return {
+        name: job.jobName,
+        status: job.status,
+        steps: job.steps.map((step): StepRunData => {
+          const stepStart = step.startedAt?.getTime();
+          const stepEnd = step.completedAt?.getTime();
+
+          return {
+            name: step.stepName,
+            status: step.status,
+            error: step.error,
+            duration: stepStart && stepEnd ? stepEnd - stepStart : undefined,
+          };
+        }),
+        duration: jobStart && jobEnd ? jobEnd - jobStart : undefined,
+      };
+    }),
+    duration: startTime && endTime ? endTime - startTime : undefined,
+    path,
+  };
+}
+
+/**
+ * Converts a WorkflowRun to WorkflowHistorySearchItem.
+ */
+function toSearchItem(run: WorkflowRun): WorkflowHistorySearchItem {
+  const startTime = run.startedAt?.getTime();
+  const endTime = run.completedAt?.getTime();
+
+  return {
+    runId: run.id,
+    workflowId: run.workflowId,
+    workflowName: run.workflowName,
+    status: run.status,
+    startedAt: run.startedAt?.toISOString(),
+    completedAt: run.completedAt?.toISOString(),
+    duration: startTime && endTime ? endTime - startTime : undefined,
+  };
+}
+
+/**
+ * Filters runs by a query string (case-insensitive match on workflow name, run id, or status).
+ */
+function filterRuns(
+  runs: WorkflowHistorySearchItem[],
+  query: string,
+): WorkflowHistorySearchItem[] {
+  if (!query) {
+    return runs;
+  }
+  const lowerQuery = query.toLowerCase();
+  return runs.filter(
+    (r) =>
+      r.workflowName.toLowerCase().includes(lowerQuery) ||
+      r.runId.toLowerCase().includes(lowerQuery) ||
+      r.status.toLowerCase().includes(lowerQuery),
+  );
+}
+
+export const workflowHistorySearchCommand = new Command()
+  .name("search")
+  .description("Search workflow run history")
+  .arguments("[query:string]")
+  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .action(async function (options: AnyOptions, query?: string) {
+    const ctx = createContext(
+      options as GlobalOptions,
+      "workflow-history-search",
+    );
+    ctx.logger.debug`Searching workflow history with query: ${
+      query ?? "(none)"
+    }`;
+
+    const repoDir = options.repoDir ?? ".";
+    const workflowRepo = new YamlWorkflowRepository(repoDir);
+    const runRepo = new YamlWorkflowRunRepository(repoDir);
+
+    // Get all workflows
+    const allWorkflows = await workflowRepo.findAll();
+
+    // Get all runs for all workflows
+    const allRuns: WorkflowRun[] = [];
+    for (const workflow of allWorkflows) {
+      const runs = await runRepo.findAllByWorkflowId(workflow.id);
+      allRuns.push(...runs);
+    }
+
+    // Sort by startedAt descending (most recent first)
+    allRuns.sort((a, b) => {
+      const aTime = a.startedAt?.getTime() ?? 0;
+      const bTime = b.startedAt?.getTime() ?? 0;
+      return bTime - aTime;
+    });
+
+    const searchItems = allRuns.map(toSearchItem);
+
+    if (ctx.outputMode === "json") {
+      // Non-interactive: filter and output JSON
+      const filteredRuns = filterRuns(searchItems, query ?? "");
+      const data: WorkflowHistorySearchData = {
+        query: query ?? "",
+        results: filteredRuns,
+      };
+      await renderWorkflowHistorySearch(data, ctx.outputMode);
+    } else {
+      // Interactive: show fuzzy search UI
+      const data: WorkflowHistorySearchData = {
+        query: query ?? "",
+        results: searchItems,
+      };
+
+      const selected = await renderWorkflowHistorySearch(data, ctx.outputMode);
+
+      if (selected) {
+        ctx.logger.debug`Selected run: ${selected.runId}`;
+        // Display the run details
+        const run = await runRepo.findById(
+          createWorkflowId(selected.workflowId),
+          createWorkflowRunId(selected.runId),
+        );
+        if (run) {
+          const path = runRepo.getPath(
+            createWorkflowId(selected.workflowId),
+            createWorkflowRunId(selected.runId),
+          );
+          const runData = toRunData(run, path);
+          renderWorkflowRun(runData, ctx.outputMode);
+        }
+      } else {
+        ctx.logger.debug`Search cancelled`;
+      }
+    }
+
+    ctx.logger.debug("Workflow history search command completed");
+  });

--- a/src/presentation/output/workflow_history_search_output.tsx
+++ b/src/presentation/output/workflow_history_search_output.tsx
@@ -1,0 +1,244 @@
+// deno-lint-ignore verbatim-module-syntax
+import React, { useCallback, useEffect, useState } from "react";
+import { Box, render, Text, useApp, useInput } from "ink";
+import type { OutputMode } from "./output.tsx";
+import { Fzf, type FzfResultItem } from "fzf";
+
+/**
+ * Represents a single workflow run search result item.
+ */
+export interface WorkflowHistorySearchItem {
+  runId: string;
+  workflowId: string;
+  workflowName: string;
+  status: "pending" | "running" | "succeeded" | "failed";
+  startedAt?: string;
+  completedAt?: string;
+  duration?: number;
+}
+
+/**
+ * Data structure for workflow history search results.
+ */
+export interface WorkflowHistorySearchData {
+  query: string;
+  results: WorkflowHistorySearchItem[];
+}
+
+/**
+ * Renders workflow history search results in either interactive or JSON mode.
+ *
+ * @param data - The search data to render
+ * @param mode - The output mode (interactive or json)
+ * @returns A promise that resolves with the selected run in interactive mode, or undefined in JSON mode
+ */
+export async function renderWorkflowHistorySearch(
+  data: WorkflowHistorySearchData,
+  mode: OutputMode,
+): Promise<WorkflowHistorySearchItem | undefined> {
+  if (mode === "json") {
+    renderJsonWorkflowHistorySearch(data);
+    return undefined;
+  } else {
+    return await renderInteractiveWorkflowHistorySearch(data);
+  }
+}
+
+/**
+ * Renders workflow history search results as JSON.
+ */
+function renderJsonWorkflowHistorySearch(
+  data: WorkflowHistorySearchData,
+): void {
+  console.log(JSON.stringify(data, null, 2));
+}
+
+/**
+ * Renders an interactive workflow history search UI.
+ *
+ * @param data - The initial search data (runs to search and optional initial query)
+ * @returns A promise that resolves with the selected run, or undefined if cancelled
+ */
+export function renderInteractiveWorkflowHistorySearch(
+  data: WorkflowHistorySearchData,
+): Promise<WorkflowHistorySearchItem | undefined> {
+  return new Promise<WorkflowHistorySearchItem | undefined>((resolve) => {
+    const { waitUntilExit } = render(
+      <WorkflowHistorySearchUI
+        runs={data.results}
+        initialQuery={data.query}
+        onSelect={(item) => resolve(item)}
+        onCancel={() => resolve(undefined)}
+      />,
+    );
+    waitUntilExit();
+  });
+}
+
+interface WorkflowHistorySearchUIProps {
+  runs: WorkflowHistorySearchItem[];
+  initialQuery: string;
+  onSelect: (item: WorkflowHistorySearchItem) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Interactive workflow history search component using fzf for fuzzy matching.
+ */
+export function WorkflowHistorySearchUI(
+  props: WorkflowHistorySearchUIProps,
+): React.ReactElement {
+  const { runs, initialQuery, onSelect, onCancel } = props;
+  const { exit } = useApp();
+
+  const [query, setQuery] = useState(initialQuery);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  // Create fzf instance for fuzzy searching
+  const fzf = new Fzf(runs, {
+    selector: (item) =>
+      `${item.workflowName} ${item.runId} ${item.status} ${
+        item.startedAt ?? ""
+      }`,
+  });
+
+  // Get filtered results
+  const results: FzfResultItem<WorkflowHistorySearchItem>[] = fzf.find(query);
+  const maxVisible = 10;
+  const visibleResults = results.slice(0, maxVisible);
+
+  // Reset selection when query changes
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  const handleSelect = useCallback(() => {
+    if (results.length > 0 && selectedIndex < results.length) {
+      const selected = results[selectedIndex].item;
+      exit();
+      onSelect(selected);
+    }
+  }, [results, selectedIndex, exit, onSelect]);
+
+  const handleCancel = useCallback(() => {
+    exit();
+    onCancel();
+  }, [exit, onCancel]);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      handleCancel();
+      return;
+    }
+
+    if (key.return) {
+      handleSelect();
+      return;
+    }
+
+    if (key.upArrow) {
+      setSelectedIndex((i) => Math.max(0, i - 1));
+      return;
+    }
+
+    if (key.downArrow) {
+      setSelectedIndex((i) => Math.min(results.length - 1, i + 1));
+      return;
+    }
+
+    if (key.backspace || key.delete) {
+      setQuery((q) => q.slice(0, -1));
+      return;
+    }
+
+    // Handle regular character input
+    if (input && !key.ctrl && !key.meta) {
+      setQuery((q) => q + input);
+    }
+  });
+
+  return (
+    <Box flexDirection="column">
+      {/* Search input */}
+      <Box>
+        <Text color="cyan" bold>
+          Search:{" "}
+        </Text>
+        <Text>{query}</Text>
+        <Text color="gray">▏</Text>
+      </Box>
+
+      {/* Results count */}
+      <Box marginTop={1}>
+        <Text dimColor>
+          {results.length} / {runs.length} runs
+        </Text>
+      </Box>
+
+      {/* Results list */}
+      <Box flexDirection="column" marginTop={1}>
+        {visibleResults.map((result, index) => (
+          <WorkflowHistorySearchResultItem
+            key={result.item.runId}
+            item={result.item}
+            isSelected={index === selectedIndex}
+          />
+        ))}
+        {results.length > maxVisible && (
+          <Text dimColor>... {results.length - maxVisible} more results</Text>
+        )}
+        {results.length === 0 && (
+          <Text color="yellow">No matching runs found</Text>
+        )}
+      </Box>
+
+      {/* Help text */}
+      <Box marginTop={1}>
+        <Text dimColor>
+          ↑/↓: Navigate | Enter: Select | Esc: Cancel
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+interface WorkflowHistorySearchResultItemProps {
+  item: WorkflowHistorySearchItem;
+  isSelected: boolean;
+}
+
+/**
+ * Component to display a single search result item.
+ */
+function WorkflowHistorySearchResultItem(
+  props: WorkflowHistorySearchResultItemProps,
+): React.ReactElement {
+  const { item, isSelected } = props;
+
+  const statusColors: Record<string, string> = {
+    pending: "gray",
+    running: "yellow",
+    succeeded: "green",
+    failed: "red",
+  };
+
+  const statusColor = statusColors[item.status] ?? "white";
+
+  // Format the date if available
+  const dateStr = item.startedAt
+    ? new Date(item.startedAt).toLocaleString()
+    : "not started";
+
+  return (
+    <Box>
+      <Text color={isSelected ? "green" : undefined} bold={isSelected}>
+        {isSelected ? "▶ " : "  "}
+        {item.workflowName}
+      </Text>
+      <Text></Text>
+      <Text color={statusColor}>[{item.status}]</Text>
+      <Text></Text>
+      <Text dimColor>{dateStr}</Text>
+    </Box>
+  );
+}


### PR DESCRIPTION
Add workflow history command group for viewing workflow run history.

- workflow history get <workflow_id_or_name> - Shows the latest run for a workflow with full details (status, jobs, steps, errors, durations)
- workflow history search [query] - Interactive fuzzy search across all workflow runs with fzf-style filtering by workflow name, run ID, status, or date

Both commands support --json for non-interactive output.

Test Plan

- Verified workflow history --help shows both subcommands
- Verified workflow history get --help and workflow history search --help display correct usage
- Type checking passes (deno check)
- Linting passes (deno lint)
- Existing tests pass