### PR TITLE
Adds edit subcommands to open YAML files in the user's preferred editor for models and workflows

### DIFF
--- a/design/models.md
+++ b/design/models.md
@@ -118,6 +118,16 @@ when specifying json, it should have the same content.
 Runs the models zod validations for the models inputs and resources. Run them in
 parallel and print the output as it comes.
 
+### model edit [model_id_or_name]
+
+Opens the model input file in the user's preferred editor. Use `--resource` to
+edit the resource file instead.
+
+If no model is specified interactively, shows a search interface.
+
+Editor selection: Uses $EDITOR if set, otherwise falls back to: vscode, zed,
+nvim, vim, nano, emacs.
+
 ### model method run <model_id_or_name> <method_name>
 
 Runs a method for the given model.

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -77,6 +77,15 @@ Should show the workflow yaml with syntax highlighting, and the path, similar to
 
 Executes a workflow run.
 
+### workflow edit [id or name]
+
+Opens the workflow file in the user's preferred editor.
+
+If no workflow is specified interactively, shows a search interface.
+
+Editor selection: Uses $EDITOR if set, otherwise falls back to: vscode, zed,
+nvim, vim, nano, emacs.
+
 ### workflow history get <id or name>
 
 Displays the run data (status, timing, step outputs/errors) for the latest

--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -13,6 +13,7 @@ import { modelMethodCommand } from "./model_method_run.ts";
 import { modelSearchCommand } from "./model_search.ts";
 import { modelGetCommand } from "./model_get.ts";
 import { modelDeleteCommand } from "./model_delete.ts";
+import { modelEditCommand } from "./model_edit.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -77,6 +78,7 @@ export const modelCommand = new Command()
   })
   .command("create", modelCreateCommand)
   .command("delete", modelDeleteCommand)
+  .command("edit", modelEditCommand)
   .command("get", modelGetCommand)
   .command("search", modelSearchCommand)
   .command("validate", modelValidateCommand)

--- a/src/cli/commands/model_edit.ts
+++ b/src/cli/commands/model_edit.ts
@@ -1,0 +1,155 @@
+import { Command } from "@cliffy/command";
+import {
+  type ModelEditData,
+  renderModelEdit,
+} from "../../presentation/output/model_edit_output.tsx";
+import {
+  type ModelSearchData,
+  type ModelSearchItem,
+  renderModelSearch,
+} from "../../presentation/output/model_search_output.tsx";
+import { createContext, type GlobalOptions } from "../context.ts";
+import type { ModelInput } from "../../domain/models/model_input.ts";
+import type { ModelType } from "../../domain/models/model_type.ts";
+import { inputIdToResourceId } from "../../domain/models/model_resource.ts";
+import { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
+import { YamlResourceRepository } from "../../infrastructure/persistence/yaml_resource_repository.ts";
+import { EditorService } from "../../infrastructure/editor/editor_service.ts";
+import {
+  findInputByIdGlobal,
+  isUuid,
+} from "../../domain/models/model_lookup.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+/**
+ * Converts repository results to ModelSearchItem array.
+ */
+function toModelSearchItems(
+  results: Awaited<ReturnType<YamlInputRepository["findAllGlobal"]>>,
+): ModelSearchItem[] {
+  return results.map(({ input, type }) => ({
+    id: input.id,
+    name: input.name,
+    type: type.normalized,
+    resourceId: input.resourceId,
+  }));
+}
+
+export const modelEditCommand = new Command()
+  .name("edit")
+  .description("Edit a model input or resource file")
+  .arguments("[model_id_or_name:string]")
+  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option("--resource", "Edit the resource file instead of the input")
+  .action(async function (options: AnyOptions, modelIdOrName?: string) {
+    const ctx = createContext(options as GlobalOptions, "model-edit");
+    ctx.logger.debug`Editing model: ${modelIdOrName ?? "(interactive)"}`;
+
+    const repoDir = options.repoDir ?? ".";
+    const inputRepo = new YamlInputRepository(repoDir);
+    const resourceRepo = new YamlResourceRepository(repoDir);
+    const editorService = new EditorService();
+    const editResource = options.resource === true;
+
+    // Look up the model input
+    let input: ModelInput;
+    let modelType: ModelType;
+
+    if (!modelIdOrName) {
+      // No argument provided - check if interactive mode
+      if (ctx.outputMode === "json") {
+        throw new Error(
+          "Model ID or name is required in non-interactive mode",
+        );
+      }
+
+      // Show search UI to select a model
+      const allResults = await inputRepo.findAllGlobal();
+      const allModels = toModelSearchItems(allResults);
+
+      if (allModels.length === 0) {
+        throw new Error("No models found in repository");
+      }
+
+      const searchData: ModelSearchData = {
+        query: "",
+        results: allModels,
+      };
+
+      const selected = await renderModelSearch(searchData, ctx.outputMode);
+
+      if (!selected) {
+        ctx.logger.debug`Search cancelled`;
+        return;
+      }
+
+      ctx.logger.debug`Selected model: ${selected.name} (${selected.id})`;
+
+      // Find the full input data
+      const result = await findInputByIdGlobal(inputRepo, selected.id);
+      if (!result) {
+        throw new Error(`Model not found: ${selected.id}`);
+      }
+      input = result.input;
+      modelType = result.type;
+    } else if (isUuid(modelIdOrName)) {
+      ctx.logger.debug`Looking up by ID: ${modelIdOrName}`;
+      const result = await findInputByIdGlobal(inputRepo, modelIdOrName);
+      if (!result) {
+        throw new Error(`Model not found: ${modelIdOrName}`);
+      }
+      input = result.input;
+      modelType = result.type;
+    } else {
+      ctx.logger.debug`Looking up by name: ${modelIdOrName}`;
+      const result = await inputRepo.findByNameGlobal(modelIdOrName);
+      if (!result) {
+        throw new Error(`Model not found: ${modelIdOrName}`);
+      }
+      input = result.input;
+      modelType = result.type;
+    }
+
+    ctx.logger.debug`Found model: id=${input.id}, type=${modelType.normalized}`;
+
+    // Get the file path
+    let filePath: string;
+    if (editResource) {
+      const resourceId = inputIdToResourceId(input.id);
+      filePath = resourceRepo.getPath(modelType, resourceId);
+
+      // Check if resource file exists
+      try {
+        await Deno.stat(filePath);
+      } catch (error) {
+        if (error instanceof Deno.errors.NotFound) {
+          throw new Error(
+            `Resource file not found for model '${input.name}'. ` +
+              `Run a method to create the resource first.`,
+          );
+        }
+        throw error;
+      }
+    } else {
+      filePath = inputRepo.getPath(modelType, input.id);
+    }
+
+    ctx.logger.debug`Opening file: ${filePath}`;
+
+    // Open the editor (auto-detects whether to wait based on editor type)
+    const result = await editorService.openFile(filePath);
+
+    const data: ModelEditData = {
+      path: filePath,
+      editor: result.editor,
+      status: "opened",
+      name: input.name,
+      type: modelType.normalized,
+      editType: editResource ? "resource" : "input",
+    };
+
+    renderModelEdit(data, ctx.outputMode);
+    ctx.logger.debug("Model edit command completed");
+  });

--- a/src/cli/commands/model_edit_test.ts
+++ b/src/cli/commands/model_edit_test.ts
@@ -1,0 +1,28 @@
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Import models barrel to trigger self-registration
+import "../../domain/models/models.ts";
+
+// Initialize logging for tests
+await initializeLogging({ debugLogs: false });
+
+Deno.test("modelEditCommand module loads", async () => {
+  const { modelEditCommand } = await import("./model_edit.ts");
+  assertEquals(modelEditCommand.getName(), "edit");
+});
+
+Deno.test("modelEditCommand has correct description", async () => {
+  const { modelEditCommand } = await import("./model_edit.ts");
+  assertEquals(
+    modelEditCommand.getDescription(),
+    "Edit a model input or resource file",
+  );
+});
+
+Deno.test("modelEditCommand is registered as subcommand of modelCommand", async () => {
+  const { modelCommand } = await import("./model_create.ts");
+  const commands = modelCommand.getCommands();
+  const editCmd = commands.find((c) => c.getName() === "edit");
+  assertEquals(editCmd !== undefined, true);
+});

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -1,5 +1,6 @@
 import { Command } from "@cliffy/command";
 import { workflowCreateCommand } from "./workflow_create.ts";
+import { workflowEditCommand } from "./workflow_edit.ts";
 import { workflowGetCommand } from "./workflow_get.ts";
 import { workflowHistoryCommand } from "./workflow_history.ts";
 import { workflowValidateCommand } from "./workflow_validate.ts";
@@ -14,6 +15,7 @@ export const workflowCommand = new Command()
     this.showHelp();
   })
   .command("create", workflowCreateCommand)
+  .command("edit", workflowEditCommand)
   .command("get", workflowGetCommand)
   .command("history", workflowHistoryCommand)
   .command("validate", workflowValidateCommand)

--- a/src/cli/commands/workflow_edit.ts
+++ b/src/cli/commands/workflow_edit.ts
@@ -1,0 +1,135 @@
+import { Command } from "@cliffy/command";
+import {
+  renderWorkflowEdit,
+  type WorkflowEditData,
+} from "../../presentation/output/workflow_edit_output.tsx";
+import {
+  renderWorkflowSearch,
+  type WorkflowSearchData,
+  type WorkflowSearchItem,
+} from "../../presentation/output/workflow_search_output.tsx";
+import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createWorkflowId,
+  type WorkflowId,
+} from "../../domain/workflows/workflow_id.ts";
+import type { Workflow } from "../../domain/workflows/workflow.ts";
+import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
+import { EditorService } from "../../infrastructure/editor/editor_service.ts";
+
+/**
+ * UUID v4 regex pattern for detecting if an argument is a UUID.
+ */
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Checks if a string looks like a UUID.
+ */
+function isUuid(value: string): boolean {
+  return UUID_PATTERN.test(value);
+}
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+/**
+ * Converts a Workflow to WorkflowSearchItem.
+ */
+function toSearchItem(workflow: Workflow): WorkflowSearchItem {
+  return {
+    id: workflow.id,
+    name: workflow.name,
+    description: workflow.description,
+    jobCount: workflow.jobs.length,
+  };
+}
+
+export const workflowEditCommand = new Command()
+  .name("edit")
+  .description("Edit a workflow file")
+  .arguments("[workflow_id_or_name:string]")
+  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .action(async function (options: AnyOptions, workflowIdOrName?: string) {
+    const ctx = createContext(options as GlobalOptions, "workflow-edit");
+    ctx.logger.debug`Editing workflow: ${workflowIdOrName ?? "(interactive)"}`;
+
+    const repoDir = options.repoDir ?? ".";
+    const repo = new YamlWorkflowRepository(repoDir);
+    const editorService = new EditorService();
+
+    // Look up the workflow
+    let workflow: Workflow | null = null;
+
+    if (!workflowIdOrName) {
+      // No argument provided - check if interactive mode
+      if (ctx.outputMode === "json") {
+        throw new Error(
+          "Workflow ID or name is required in non-interactive mode",
+        );
+      }
+
+      // Show search UI to select a workflow
+      const allWorkflows = await repo.findAll();
+
+      if (allWorkflows.length === 0) {
+        throw new Error("No workflows found in repository");
+      }
+
+      const searchItems = allWorkflows.map(toSearchItem);
+      const searchData: WorkflowSearchData = {
+        query: "",
+        results: searchItems,
+      };
+
+      const selected = await renderWorkflowSearch(searchData, ctx.outputMode);
+
+      if (!selected) {
+        ctx.logger.debug`Search cancelled`;
+        return;
+      }
+
+      ctx.logger.debug`Selected workflow: ${selected.name} (${selected.id})`;
+
+      // Find the full workflow data
+      const id: WorkflowId = createWorkflowId(selected.id);
+      workflow = await repo.findById(id);
+      if (!workflow) {
+        throw new Error(`Workflow not found: ${selected.id}`);
+      }
+    } else if (isUuid(workflowIdOrName)) {
+      ctx.logger.debug`Looking up by ID: ${workflowIdOrName}`;
+      const id: WorkflowId = createWorkflowId(workflowIdOrName);
+      workflow = await repo.findById(id);
+      if (!workflow) {
+        throw new Error(`Workflow not found: ${workflowIdOrName}`);
+      }
+    } else {
+      ctx.logger.debug`Looking up by name: ${workflowIdOrName}`;
+      workflow = await repo.findByName(workflowIdOrName);
+      if (!workflow) {
+        throw new Error(`Workflow not found: ${workflowIdOrName}`);
+      }
+    }
+
+    ctx.logger.debug`Found workflow: id=${workflow.id}, name=${workflow.name}`;
+
+    // Get the file path
+    const filePath = repo.getPath(workflow.id);
+
+    ctx.logger.debug`Opening file: ${filePath}`;
+
+    // Open the editor (auto-detects whether to wait based on editor type)
+    const result = await editorService.openFile(filePath);
+
+    const data: WorkflowEditData = {
+      path: filePath,
+      editor: result.editor,
+      status: "opened",
+      name: workflow.name,
+      id: workflow.id,
+    };
+
+    renderWorkflowEdit(data, ctx.outputMode);
+    ctx.logger.debug("Workflow edit command completed");
+  });

--- a/src/cli/commands/workflow_edit_test.ts
+++ b/src/cli/commands/workflow_edit_test.ts
@@ -1,0 +1,25 @@
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Initialize logging for tests
+await initializeLogging({ debugLogs: false });
+
+Deno.test("workflowEditCommand module loads", async () => {
+  const { workflowEditCommand } = await import("./workflow_edit.ts");
+  assertEquals(workflowEditCommand.getName(), "edit");
+});
+
+Deno.test("workflowEditCommand has correct description", async () => {
+  const { workflowEditCommand } = await import("./workflow_edit.ts");
+  assertEquals(
+    workflowEditCommand.getDescription(),
+    "Edit a workflow file",
+  );
+});
+
+Deno.test("workflowEditCommand is registered as subcommand of workflowCommand", async () => {
+  const { workflowCommand } = await import("./workflow.ts");
+  const commands = workflowCommand.getCommands();
+  const editCmd = commands.find((c) => c.getName() === "edit");
+  assertEquals(editCmd !== undefined, true);
+});

--- a/src/infrastructure/editor/editor_service.ts
+++ b/src/infrastructure/editor/editor_service.ts
@@ -1,0 +1,193 @@
+/**
+ * Result of opening a file in an editor.
+ */
+export interface EditorResult {
+  editor: string;
+  path: string;
+}
+
+/**
+ * Options for opening a file in an editor.
+ */
+export interface OpenFileOptions {
+  /**
+   * Whether to wait for the editor to close before returning.
+   * If not specified, automatically detects based on editor type:
+   * - Terminal editors (vim, nvim, nano, etc.): wait
+   * - GUI editors (code, zed, subl, etc.): don't wait
+   */
+  wait?: boolean;
+}
+
+/**
+ * The list of fallback editors to try when $EDITOR is not set.
+ */
+const FALLBACK_EDITORS = ["code", "zed", "nvim", "vim", "nano", "emacs"];
+
+/**
+ * Terminal editors that run inside the terminal and require waiting.
+ */
+const TERMINAL_EDITORS = new Set([
+  "vim",
+  "vi",
+  "nvim",
+  "nano",
+  "emacs",
+  "pico",
+  "joe",
+  "ne",
+  "micro",
+  "helix",
+  "hx",
+]);
+
+/**
+ * Service for finding and launching the user's preferred editor.
+ */
+export class EditorService {
+  /**
+   * Finds the user's preferred editor.
+   *
+   * Checks $EDITOR environment variable first, then falls back to common editors.
+   *
+   * @returns The name of the editor command
+   * @throws Error if no editor could be found
+   */
+  async findEditor(): Promise<string> {
+    // First check $EDITOR environment variable
+    const editorEnv = Deno.env.get("EDITOR");
+    if (editorEnv) {
+      // Extract just the command name (in case it has arguments)
+      const editorCmd = editorEnv.split(" ")[0];
+      if (await this.isCommandAvailable(editorCmd)) {
+        return editorEnv;
+      }
+    }
+
+    // Try fallback editors
+    for (const editor of FALLBACK_EDITORS) {
+      if (await this.isCommandAvailable(editor)) {
+        return editor;
+      }
+    }
+
+    throw new Error(
+      "No editor found. Set $EDITOR environment variable or install one of: " +
+        FALLBACK_EDITORS.join(", "),
+    );
+  }
+
+  /**
+   * Opens a file in the user's preferred editor.
+   *
+   * @param filePath - The path to the file to edit
+   * @param options - Options for opening the file
+   * @returns Information about the editor that was launched
+   */
+  async openFile(
+    filePath: string,
+    options: OpenFileOptions = {},
+  ): Promise<EditorResult> {
+    const editor = await this.findEditor();
+
+    // Determine whether to wait: use explicit option, or auto-detect based on editor type
+    const shouldWait = options.wait ?? this.isTerminalEditor(editor);
+
+    const args = this.buildEditorArgs(editor, filePath, { wait: shouldWait });
+
+    const command = new Deno.Command(args[0], {
+      args: args.slice(1),
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+
+    if (shouldWait) {
+      // Wait for the editor to close (terminal editors)
+      const process = command.spawn();
+      await process.status;
+    } else {
+      // Spawn and return immediately (GUI editors)
+      command.spawn();
+    }
+
+    return {
+      editor: this.getEditorDisplayName(editor),
+      path: filePath,
+    };
+  }
+
+  /**
+   * Checks if an editor is a terminal-based editor that requires waiting.
+   */
+  private isTerminalEditor(editor: string): boolean {
+    const baseEditor = editor.split(" ")[0];
+    return TERMINAL_EDITORS.has(baseEditor);
+  }
+
+  /**
+   * Checks if a command is available in the system PATH.
+   */
+  private async isCommandAvailable(cmd: string): Promise<boolean> {
+    try {
+      const command = new Deno.Command("which", {
+        args: [cmd],
+        stdout: "null",
+        stderr: "null",
+      });
+      const { success } = await command.output();
+      return success;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Builds the arguments array for launching the editor.
+   */
+  private buildEditorArgs(
+    editor: string,
+    filePath: string,
+    options: OpenFileOptions,
+  ): string[] {
+    const args: string[] = [];
+
+    // Handle editors that may have arguments in $EDITOR
+    const editorParts = editor.split(" ");
+    args.push(...editorParts);
+
+    // Add wait flag for supported editors
+    if (options.wait) {
+      const baseEditor = editorParts[0];
+      if (baseEditor === "code" || baseEditor === "code-insiders") {
+        args.push("--wait");
+      } else if (baseEditor === "zed") {
+        args.push("--wait");
+      } else if (baseEditor === "subl" || baseEditor === "sublime") {
+        args.push("--wait");
+      }
+    }
+
+    args.push(filePath);
+    return args;
+  }
+
+  /**
+   * Gets a human-readable display name for an editor.
+   */
+  private getEditorDisplayName(editor: string): string {
+    const baseEditor = editor.split(" ")[0];
+    const displayNames: Record<string, string> = {
+      code: "VS Code",
+      "code-insiders": "VS Code Insiders",
+      zed: "Zed",
+      nvim: "Neovim",
+      vim: "Vim",
+      nano: "nano",
+      emacs: "Emacs",
+      subl: "Sublime Text",
+      sublime: "Sublime Text",
+    };
+    return displayNames[baseEditor] ?? baseEditor;
+  }
+}

--- a/src/infrastructure/editor/editor_service_test.ts
+++ b/src/infrastructure/editor/editor_service_test.ts
@@ -1,0 +1,91 @@
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { EditorService } from "./editor_service.ts";
+
+Deno.test("EditorService.findEditor returns $EDITOR when set", async () => {
+  const originalEditor = Deno.env.get("EDITOR");
+  try {
+    // Set EDITOR to a command that exists
+    Deno.env.set("EDITOR", "cat");
+    const service = new EditorService();
+    const editor = await service.findEditor();
+    assertEquals(editor, "cat");
+  } finally {
+    if (originalEditor) {
+      Deno.env.set("EDITOR", originalEditor);
+    } else {
+      Deno.env.delete("EDITOR");
+    }
+  }
+});
+
+Deno.test("EditorService.findEditor handles $EDITOR with arguments", async () => {
+  const originalEditor = Deno.env.get("EDITOR");
+  try {
+    // Set EDITOR to a command with arguments
+    Deno.env.set("EDITOR", "cat -n");
+    const service = new EditorService();
+    const editor = await service.findEditor();
+    assertEquals(editor, "cat -n");
+  } finally {
+    if (originalEditor) {
+      Deno.env.set("EDITOR", originalEditor);
+    } else {
+      Deno.env.delete("EDITOR");
+    }
+  }
+});
+
+Deno.test("EditorService.findEditor falls back when $EDITOR is not available", async () => {
+  const originalEditor = Deno.env.get("EDITOR");
+  try {
+    // Set EDITOR to a non-existent command
+    Deno.env.set("EDITOR", "nonexistent-editor-12345");
+    const service = new EditorService();
+    // Should fall back to an available editor or throw
+    try {
+      const editor = await service.findEditor();
+      // If we get here, a fallback editor was found
+      assertEquals(typeof editor, "string");
+    } catch (error) {
+      // If no editor is found, error message should list fallbacks
+      assertStringIncludes(
+        (error as Error).message,
+        "No editor found",
+      );
+    }
+  } finally {
+    if (originalEditor) {
+      Deno.env.set("EDITOR", originalEditor);
+    } else {
+      Deno.env.delete("EDITOR");
+    }
+  }
+});
+
+Deno.test("EditorService.findEditor throws when no editor is available", async () => {
+  const originalEditor = Deno.env.get("EDITOR");
+  const originalPath = Deno.env.get("PATH");
+  try {
+    // Clear EDITOR and set PATH to empty to ensure no editors are found
+    Deno.env.delete("EDITOR");
+    Deno.env.set("PATH", "");
+    const service = new EditorService();
+    await assertRejects(
+      () => service.findEditor(),
+      Error,
+      "No editor found",
+    );
+  } finally {
+    if (originalEditor) {
+      Deno.env.set("EDITOR", originalEditor);
+    }
+    if (originalPath) {
+      Deno.env.set("PATH", originalPath);
+    }
+  }
+});
+
+Deno.test("EditorService module exports EditorService class", async () => {
+  const module = await import("./editor_service.ts");
+  assertEquals(typeof module.EditorService, "function");
+});

--- a/src/presentation/output/model_edit_output.tsx
+++ b/src/presentation/output/model_edit_output.tsx
@@ -1,0 +1,69 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { Box, Text } from "ink";
+import { render } from "ink-testing-library";
+import type { OutputMode } from "./output.tsx";
+
+/**
+ * Data structure for model edit output.
+ */
+export interface ModelEditData {
+  path: string;
+  editor: string;
+  status: "opened";
+  name: string;
+  type: string;
+  editType: "input" | "resource";
+}
+
+/**
+ * Renders model edit output in either interactive or JSON mode.
+ */
+export function renderModelEdit(data: ModelEditData, mode: OutputMode): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    renderInteractiveModelEdit(data);
+  }
+}
+
+function renderInteractiveModelEdit(data: ModelEditData): void {
+  const { lastFrame } = render(<ModelEditDisplay {...data} />);
+  console.log(lastFrame());
+}
+
+interface ModelEditDisplayProps {
+  path: string;
+  editor: string;
+  name: string;
+  type: string;
+  editType: "input" | "resource";
+}
+
+/**
+ * Interactive display component for model edit output.
+ */
+export function ModelEditDisplay(
+  props: ModelEditDisplayProps,
+): React.ReactElement {
+  const fileTypeLabel = props.editType === "resource" ? "resource" : "input";
+  return (
+    <Box flexDirection="column">
+      <Text color="green">Opening {fileTypeLabel} file in {props.editor}:</Text>
+      <Box marginLeft={2} flexDirection="column">
+        <Text>
+          <Text color="cyan">Name:</Text>
+          <Text>{props.name}</Text>
+        </Text>
+        <Text>
+          <Text color="cyan">Type:</Text>
+          <Text>{props.type}</Text>
+        </Text>
+        <Text>
+          <Text color="cyan">Path:</Text>
+          <Text dimColor>{props.path}</Text>
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/presentation/output/model_edit_output_test.tsx
+++ b/src/presentation/output/model_edit_output_test.tsx
@@ -1,0 +1,89 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { render } from "ink-testing-library";
+import {
+  type ModelEditData,
+  ModelEditDisplay,
+  renderModelEdit,
+} from "./model_edit_output.tsx";
+
+const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
+
+const testInputData: ModelEditData = {
+  path: "inputs/swamp/echo/550e8400-e29b-41d4-a716-446655440000.yaml",
+  editor: "VS Code",
+  status: "opened",
+  name: "test-echo",
+  type: "swamp/echo",
+  editType: "input",
+};
+
+const testResourceData: ModelEditData = {
+  path: "resources/swamp/echo/550e8400-e29b-41d4-a716-446655440000.yaml",
+  editor: "VS Code",
+  status: "opened",
+  name: "test-echo",
+  type: "swamp/echo",
+  editType: "resource",
+};
+
+Deno.test({
+  name: "ModelEditDisplay renders all fields for input",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<ModelEditDisplay {...testInputData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "test-echo");
+    assertStringIncludes(output, "swamp/echo");
+    assertStringIncludes(output, "VS Code");
+    assertStringIncludes(output, "input file");
+    assertStringIncludes(
+      output,
+      "inputs/swamp/echo/550e8400-e29b-41d4-a716-446655440000.yaml",
+    );
+  },
+});
+
+Deno.test({
+  name: "ModelEditDisplay renders resource type correctly",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<ModelEditDisplay {...testResourceData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "resource file");
+  },
+});
+
+Deno.test({
+  name: "ModelEditDisplay shows 'Opening' message",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<ModelEditDisplay {...testInputData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Opening");
+  },
+});
+
+Deno.test("renderModelEdit with json mode outputs valid JSON", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelEdit(testInputData, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.path, testInputData.path);
+    assertEquals(parsed.editor, testInputData.editor);
+    assertEquals(parsed.status, testInputData.status);
+    assertEquals(parsed.name, testInputData.name);
+    assertEquals(parsed.type, testInputData.type);
+    assertEquals(parsed.editType, testInputData.editType);
+  } finally {
+    console.log = originalLog;
+  }
+});

--- a/src/presentation/output/workflow_edit_output.tsx
+++ b/src/presentation/output/workflow_edit_output.tsx
@@ -1,0 +1,69 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { Box, Text } from "ink";
+import { render } from "ink-testing-library";
+import type { OutputMode } from "./output.tsx";
+
+/**
+ * Data structure for workflow edit output.
+ */
+export interface WorkflowEditData {
+  path: string;
+  editor: string;
+  status: "opened";
+  name: string;
+  id: string;
+}
+
+/**
+ * Renders workflow edit output in either interactive or JSON mode.
+ */
+export function renderWorkflowEdit(
+  data: WorkflowEditData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    renderInteractiveWorkflowEdit(data);
+  }
+}
+
+function renderInteractiveWorkflowEdit(data: WorkflowEditData): void {
+  const { lastFrame } = render(<WorkflowEditDisplay {...data} />);
+  console.log(lastFrame());
+}
+
+interface WorkflowEditDisplayProps {
+  path: string;
+  editor: string;
+  name: string;
+  id: string;
+}
+
+/**
+ * Interactive display component for workflow edit output.
+ */
+export function WorkflowEditDisplay(
+  props: WorkflowEditDisplayProps,
+): React.ReactElement {
+  return (
+    <Box flexDirection="column">
+      <Text color="green">Opening workflow in {props.editor}:</Text>
+      <Box marginLeft={2} flexDirection="column">
+        <Text>
+          <Text color="cyan">Name:</Text>
+          <Text>{props.name}</Text>
+        </Text>
+        <Text>
+          <Text color="cyan">ID:</Text>
+          <Text dimColor>{props.id}</Text>
+        </Text>
+        <Text>
+          <Text color="cyan">Path:</Text>
+          <Text dimColor>{props.path}</Text>
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/presentation/output/workflow_edit_output_test.tsx
+++ b/src/presentation/output/workflow_edit_output_test.tsx
@@ -1,0 +1,66 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { render } from "ink-testing-library";
+import {
+  renderWorkflowEdit,
+  type WorkflowEditData,
+  WorkflowEditDisplay,
+} from "./workflow_edit_output.tsx";
+
+const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
+
+const testData: WorkflowEditData = {
+  path: "workflows/workflow-550e8400-e29b-41d4-a716-446655440000.yaml",
+  editor: "VS Code",
+  status: "opened",
+  name: "test-workflow",
+  id: "550e8400-e29b-41d4-a716-446655440000",
+};
+
+Deno.test({
+  name: "WorkflowEditDisplay renders all fields",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<WorkflowEditDisplay {...testData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "test-workflow");
+    assertStringIncludes(output, "550e8400-e29b-41d4-a716-446655440000");
+    assertStringIncludes(output, "VS Code");
+    assertStringIncludes(
+      output,
+      "workflows/workflow-550e8400-e29b-41d4-a716-446655440000.yaml",
+    );
+  },
+});
+
+Deno.test({
+  name: "WorkflowEditDisplay shows 'Opening workflow' message",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<WorkflowEditDisplay {...testData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Opening workflow");
+  },
+});
+
+Deno.test("renderWorkflowEdit with json mode outputs valid JSON", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderWorkflowEdit(testData, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.path, testData.path);
+    assertEquals(parsed.editor, testData.editor);
+    assertEquals(parsed.status, testData.status);
+    assertEquals(parsed.name, testData.name);
+    assertEquals(parsed.id, testData.id);
+  } finally {
+    console.log = originalLog;
+  }
+});


### PR DESCRIPTION
Fixes #47

- swamp model edit [name_or_id] - opens model input files in editor
- --resource flag to edit resource files instead of inputs
- Shows interactive search UI when no argument provided
- swamp workflow edit [name_or_id] - opens workflow files in editor
- Shows interactive search UI when no argument provided
- Editor selection: Uses $EDITOR env var if set, otherwise falls back to: code, zed, nvim, vim, nano, emacs
- Smart wait behavior based on editor type:
- Terminal editors (vim, nvim, nano, emacs, etc.) - waits for editor to close
- GUI editors (code, zed, subl, etc.) - spawns and returns immediately

### New files

- src/infrastructure/editor/editor_service.ts - service to find and launch editors with terminal/GUI
detection
- src/cli/commands/model_edit.ts - model edit command
- src/cli/commands/workflow_edit.ts - workflow edit command
- src/presentation/output/model_edit_output.tsx - model edit output renderer
- src/presentation/output/workflow_edit_output.tsx - workflow edit output renderer
- Tests for all new files

### Test plan

- deno check passes
- deno lint passes
- deno fmt passes
- All new tests pass
- Manual: swamp model edit (no args) - shows search UI
- Manual: swamp model edit <name> - opens input file in editor
- Manual: swamp model edit <name> --resource - opens resource file
- Manual: swamp model edit <name> --json - outputs JSON with path
- Manual: swamp workflow edit (no args) - shows search UI
- Manual: swamp workflow edit <name> - opens workflow in editor
- Manual: GUI editor (e.g., VS Code) returns immediately
- Manual: Terminal editor (e.g., vim) waits for close