### PR TITLE
feat: add expression evaluation and implicit dependency tracking

### DIFF
--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -15,6 +15,7 @@ machine-readable output.
 | Search model types | `swamp type search [query] --json`                    |
 | Describe a type    | `swamp type describe <type> --json`                   |
 | Create model input | `swamp model create <type> <name> --json`             |
+| Evaluate input(s)  | `swamp model evaluate [id_or_name] --json`            |
 | Run a method       | `swamp model method run <id_or_name> <method> --json` |
 
 ## Search for Model Types
@@ -105,6 +106,78 @@ attributes:
   message: "Hello, world!"
 ```
 
+## Expression Language
+
+Model inputs support CEL (Common Expression Language) expressions using the
+`${{ <expression> }}` syntax. Expressions are evaluated at runtime and can
+reference other models.
+
+### Reference Types
+
+| Reference                                  | Description                        |
+| ------------------------------------------ | ---------------------------------- |
+| `model.<name>.input.attributes.<field>`    | Another model's input attribute    |
+| `model.<name>.resource.attributes.<field>` | Another model's resource attribute |
+| `self.name`                                | This model's name                  |
+| `self.version`                             | This model's version               |
+| `self.attributes.<field>`                  | This model's own input attribute   |
+
+### CEL Operations
+
+Expressions support standard CEL operations:
+
+- **String concatenation:** `self.name + "-suffix"`
+- **Arithmetic:** `self.attributes.count * 2`
+- **Conditionals:** `self.attributes.enabled ? "yes" : "no"`
+
+### Example with Expressions
+
+```yaml
+# inputs/aws/subnet/my-subnet.yaml
+apiVersion: swamp/v1
+kind: Input
+metadata:
+  name: my-subnet
+  type: aws/subnet
+attributes:
+  vpcId: ${{ model.my-vpc.resource.attributes.vpcId }}
+  cidrBlock: "10.0.1.0/24"
+  tags:
+    Name: ${{ self.name + "-subnet" }}
+```
+
+## Evaluate Model Inputs
+
+Evaluate expressions in model inputs and write the results to
+`inputs-evaluated/`.
+
+```bash
+swamp model evaluate my-subnet --json
+swamp model evaluate --all --json
+```
+
+**Arguments:**
+
+- `<id_or_name>` - The model's name or ID (optional if using `--all`)
+- `--all` - Evaluate all model inputs
+
+**Output shape:**
+
+```json
+{
+  "evaluatedInputs": [
+    {
+      "name": "my-subnet",
+      "type": "aws/subnet",
+      "path": "inputs-evaluated/aws/subnet/my-subnet.yaml"
+    }
+  ]
+}
+```
+
+The evaluated files contain the resolved attribute values with all expressions
+replaced by their computed results.
+
 ## Run Methods
 
 Execute a method on a model input.
@@ -127,5 +200,7 @@ results to the user.
 2. **Describe** to understand the schema:
    `swamp type describe swamp/echo --json`
 3. **Create** an input file: `swamp model create swamp/echo my-message --json`
-4. **Edit** the YAML file to set `attributes.message`
-5. **Run** the method: `swamp model method run my-message write --json`
+4. **Edit** the YAML file to set `attributes.message` (use expressions if
+   needed)
+5. **Evaluate** expressions: `swamp model evaluate my-message --json`
+6. **Run** the method: `swamp model method run my-message write --json`

--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -267,6 +267,47 @@ swamp workflow run my-workflow --json
 After running, summarize results to the user including which jobs/steps
 succeeded or failed and their durations.
 
+## Expressions in Workflows
+
+Model inputs can contain CEL expressions using the `${{ <expression> }}` syntax.
+When expressions reference `model.<name>.resource.attributes.*`, they create
+**implicit step dependencies**.
+
+### Automatic Dependency Resolution
+
+Workflow execution automatically:
+
+1. Detects resource dependencies in expressions
+2. Ensures dependent steps run after the step that creates the resource
+3. Evaluates expressions just-in-time before each step executes
+
+### Example with Implicit Dependencies
+
+```yaml
+# vpc-input has no expressions
+# subnet-input has: vpcId: ${{ model.vpc-input.resource.attributes.vpcId }}
+
+jobs:
+  - name: main
+    steps:
+      - name: create-subnet # Listed first but runs second!
+        task:
+          type: model_method
+          modelIdOrName: subnet-input
+          methodName: create
+      - name: create-vpc
+        task:
+          type: model_method
+          modelIdOrName: vpc-input
+          methodName: create
+# create-vpc runs first due to implicit dependency from expression
+```
+
+In this example, `subnet-input` references
+`vpc-input.resource.attributes.vpcId`. The workflow engine detects this and
+ensures `create-vpc` runs before `create-subnet`, regardless of their declared
+order.
+
 ## Workflow Example
 
 End-to-end workflow for creating and running a new workflow:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ dev-logs/*
 swamp
 inputs/
 resources/
+inputs-evaluated/
+workflows-evaluated/

--- a/deno.json
+++ b/deno.json
@@ -24,7 +24,8 @@
     "react": "npm:react@18",
     "react/jsx-runtime": "npm:react@18/jsx-runtime",
     "@types/react": "npm:@types/react@18",
-    "@aws-sdk/client-cloudcontrol": "npm:@aws-sdk/client-cloudcontrol@3"
+    "@aws-sdk/client-cloudcontrol": "npm:@aws-sdk/client-cloudcontrol@3",
+    "cel-js": "npm:cel-js@0.4"
   },
   "compilerOptions": {
     "jsx": "react",

--- a/deno.lock
+++ b/deno.lock
@@ -18,9 +18,10 @@
     "npm:@aws-sdk/client-cloudcontrol@3": "3.978.0",
     "npm:@types/node@*": "24.2.0",
     "npm:@types/react@18": "18.3.27",
+    "npm:cel-js@0.4": "0.4.0",
     "npm:fzf@0.5.2": "0.5.2",
-    "npm:ink-testing-library@4": "4.0.0",
-    "npm:ink@5": "5.2.1_react@18.3.1",
+    "npm:ink-testing-library@4": "4.0.0_@types+react@18.3.27",
+    "npm:ink@5": "5.2.1_@types+react@18.3.27_react@18.3.1",
     "npm:react@18": "18.3.1",
     "npm:zod@4": "4.3.6"
   },
@@ -507,6 +508,30 @@
     "@aws/lambda-invoke-store@0.2.3": {
       "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw=="
     },
+    "@chevrotain/cst-dts-gen@11.0.3": {
+      "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
+      "dependencies": [
+        "@chevrotain/gast",
+        "@chevrotain/types",
+        "lodash-es"
+      ]
+    },
+    "@chevrotain/gast@11.0.3": {
+      "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
+      "dependencies": [
+        "@chevrotain/types",
+        "lodash-es"
+      ]
+    },
+    "@chevrotain/regexp-to-ast@11.0.3": {
+      "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA=="
+    },
+    "@chevrotain/types@11.0.3": {
+      "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ=="
+    },
+    "@chevrotain/utils@11.0.3": {
+      "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="
+    },
     "@smithy/abort-controller@4.2.8": {
       "integrity": "sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==",
       "dependencies": [
@@ -909,8 +934,26 @@
     "bowser@2.13.1": {
       "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw=="
     },
+    "cel-js@0.4.0": {
+      "integrity": "sha512-ANcaOr9HyrU2n+5VjYD5MFqYVy4gSWCgTj04vcyti1NyG1+VyeWwWbobj5P/mLZR/gwmdYFWnV++k5bdfBqgUQ==",
+      "dependencies": [
+        "chevrotain",
+        "ramda"
+      ]
+    },
     "chalk@5.6.2": {
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="
+    },
+    "chevrotain@11.0.3": {
+      "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
+      "dependencies": [
+        "@chevrotain/cst-dts-gen",
+        "@chevrotain/gast",
+        "@chevrotain/regexp-to-ast",
+        "@chevrotain/types",
+        "@chevrotain/utils",
+        "lodash-es"
+      ]
     },
     "cli-boxes@3.0.0": {
       "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="
@@ -968,13 +1011,20 @@
     "indent-string@5.0.0": {
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
     },
-    "ink-testing-library@4.0.0": {
-      "integrity": "sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q=="
+    "ink-testing-library@4.0.0_@types+react@18.3.27": {
+      "integrity": "sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==",
+      "dependencies": [
+        "@types/react"
+      ],
+      "optionalPeers": [
+        "@types/react"
+      ]
     },
-    "ink@5.2.1_react@18.3.1": {
+    "ink@5.2.1_@types+react@18.3.27_react@18.3.1": {
       "integrity": "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==",
       "dependencies": [
         "@alcalzone/ansi-tokenize",
+        "@types/react",
         "ansi-escapes",
         "ansi-styles",
         "auto-bind",
@@ -999,6 +1049,9 @@
         "wrap-ansi",
         "ws",
         "yoga-layout"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
     "is-fullwidth-code-point@4.0.0": {
@@ -1016,6 +1069,9 @@
     },
     "js-tokens@4.0.0": {
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "lodash-es@4.17.21": {
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "loose-envify@1.4.0": {
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
@@ -1035,6 +1091,9 @@
     },
     "patch-console@2.0.0": {
       "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="
+    },
+    "ramda@0.30.1": {
+      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw=="
     },
     "react-reconciler@0.29.2_react@18.3.1": {
       "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
@@ -1146,6 +1205,7 @@
       "jsr:@std/yaml@1",
       "npm:@aws-sdk/client-cloudcontrol@3",
       "npm:@types/react@18",
+      "npm:cel-js@0.4",
       "npm:fzf@0.5.2",
       "npm:ink-testing-library@4",
       "npm:ink@5",

--- a/design/expressions.md
+++ b/design/expressions.md
@@ -1,0 +1,82 @@
+# Expressions
+
+Inputs and Workflow are stored as YAML files, and they can contain Google CEL
+expressions which get evaluated into the data structures they return and
+injected into the final data structure after parsing. These expressions should
+be able to reference models by name, then grab data from inputs or resources,
+and manipulate it in place (such as string manipulation, concatenating array
+members, etc).
+
+## Model Data
+
+You should be able to access models by name or id, and then input data or
+resource data through dot notation.
+
+## Examples
+
+The results of the expression should be inserted into the resulting data
+structure. Given an input like this:
+
+```yaml
+id: 0bc79a8f-d9d2-4ec5-a37f-8d88bbb3ee27
+resourceId: 0bc79a8f-d9d2-4ec5-a37f-8d88bbb3ee27
+name: foo
+version: 1
+tags: {}
+attributes:
+  message: "I like cheese"
+```
+
+Another can use a CEL expression to extract the message attribute:
+
+```yaml
+id: 0bc79a8f-d9d2-4ec5-a37f-8d88bbb3ee27
+resourceId: 0bc79a8f-d9d2-4ec5-a37f-8d88bbb3ee27
+name: bar
+version: 1
+tags: {}
+attributes:
+  message: ${{ model.foo.input.attributes.message }}
+```
+
+Or the resource output of the same model:
+
+```yaml
+id: 0bc79a8f-d9d2-4ec5-a37f-8d88bbb3ee27
+resourceId: 0bc79a8f-d9d2-4ec5-a37f-8d88bbb3ee27
+name: baz
+version: 1
+tags: {}
+attributes:
+  message: ${{ model.foo.resource.attributes.message }}
+```
+
+You can refer to your own model with `self`, for things like name, version,
+tags, and a models other attributes.
+
+You can also use the uuid of a model in order to reference it, rather than the
+name.
+
+For workflows, you should be able to reference other workflows by name or id, in
+addition to any model.
+
+## Workflow dependency and lazy evaluation
+
+When a model is referenced in a workflow step, any CEL expressions that
+reference other models should create an implicit dependency on the evaluation of
+that workflow. This ensures that data in a resource, for example, will be
+available when the later data is evaluatedd.
+
+## Extensibility
+
+Users should be able to extend the functions available to the CEL expressions by
+registering custom types, functions, etc in their swamp repo.
+
+## Runtime Guidance
+
+When loading the YAML, first parse the CEL expressions. Then take the data
+structures they emit and embed them in the data structure. Write those to a
+directory in the repository called inputs-evaluated/ whose structure is the same
+as inputs. This directory should be in a swamp repos .gitignore file.
+
+The same is true for workflows-evaluated/, and it should also be in .gitignore.

--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -14,6 +14,7 @@ import { modelSearchCommand } from "./model_search.ts";
 import { modelGetCommand } from "./model_get.ts";
 import { modelDeleteCommand } from "./model_delete.ts";
 import { modelEditCommand } from "./model_edit.ts";
+import { modelEvaluateCommand } from "./model_evaluate.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -79,6 +80,7 @@ export const modelCommand = new Command()
   .command("create", modelCreateCommand)
   .command("delete", modelDeleteCommand)
   .command("edit", modelEditCommand)
+  .command("evaluate", modelEvaluateCommand)
   .command("get", modelGetCommand)
   .command("search", modelSearchCommand)
   .command("validate", modelValidateCommand)

--- a/src/cli/commands/model_evaluate.ts
+++ b/src/cli/commands/model_evaluate.ts
@@ -1,0 +1,110 @@
+import { Command } from "@cliffy/command";
+import {
+  type ModelEvaluateData,
+  type ModelEvaluateItemData,
+  renderModelEvaluate,
+  renderModelEvaluateSingle,
+} from "../../presentation/output/model_evaluate_output.tsx";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
+import { YamlResourceRepository } from "../../infrastructure/persistence/yaml_resource_repository.ts";
+import { YamlEvaluatedInputRepository } from "../../infrastructure/persistence/yaml_evaluated_input_repository.ts";
+import { ExpressionEvaluationService } from "../../domain/expressions/expression_evaluation_service.ts";
+import { isUuid } from "../../domain/models/model_lookup.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const modelEvaluateCommand = new Command()
+  .name("evaluate")
+  .description("Evaluate expressions in model inputs")
+  .arguments("[model_id_or_name:string]")
+  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option("--all", "Evaluate all model inputs")
+  .action(
+    async function (options: AnyOptions, modelIdOrName?: string) {
+      const ctx = createContext(options as GlobalOptions, "model-evaluate");
+      const repoDir = options.repoDir ?? ".";
+      const inputRepo = new YamlInputRepository(repoDir);
+      const resourceRepo = new YamlResourceRepository(repoDir);
+      const evaluatedRepo = new YamlEvaluatedInputRepository(repoDir);
+      const evaluationService = new ExpressionEvaluationService(
+        inputRepo,
+        resourceRepo,
+      );
+
+      // If --all flag or no argument, evaluate all inputs
+      if (options.all || !modelIdOrName) {
+        ctx.logger.debug`Evaluating all model inputs`;
+
+        const results = await evaluationService.evaluateAllInputs();
+        const items: ModelEvaluateItemData[] = [];
+
+        for (const result of results) {
+          // Save evaluated input
+          await evaluatedRepo.save(result.type, result.input);
+          const outputPath = evaluatedRepo.getPath(
+            result.type,
+            result.input.id,
+          );
+
+          items.push({
+            id: result.input.id,
+            name: result.input.name,
+            type: result.type.normalized,
+            hadExpressions: result.hadExpressions,
+            outputPath: result.hadExpressions ? outputPath : undefined,
+          });
+        }
+
+        const data: ModelEvaluateData = {
+          items,
+          total: results.length,
+          evaluated: results.filter((r) => r.hadExpressions).length,
+        };
+
+        renderModelEvaluate(data, ctx.outputMode);
+        ctx.logger.debug`Evaluation completed`;
+        return;
+      }
+
+      // Single model evaluation
+      ctx.logger.debug`Evaluating model: ${modelIdOrName}`;
+
+      // Look up the model input
+      let lookupResult;
+      if (isUuid(modelIdOrName)) {
+        ctx.logger.debug`Looking up by ID: ${modelIdOrName}`;
+        const allInputs = await inputRepo.findAllGlobal();
+        lookupResult = allInputs.find((i) => i.input.id === modelIdOrName);
+      } else {
+        ctx.logger.debug`Looking up by name: ${modelIdOrName}`;
+        lookupResult = await inputRepo.findByNameGlobal(modelIdOrName);
+      }
+
+      if (!lookupResult) {
+        throw new Error(`Model not found: ${modelIdOrName}`);
+      }
+
+      const { input, type } = lookupResult;
+      ctx.logger.debug`Found model: id=${input.id}, type=${type.normalized}`;
+
+      // Evaluate the input
+      const result = await evaluationService.evaluateInput(input, type);
+
+      // Save evaluated input
+      await evaluatedRepo.save(type, result.input);
+      const outputPath = evaluatedRepo.getPath(type, result.input.id);
+
+      const item: ModelEvaluateItemData = {
+        id: result.input.id,
+        name: result.input.name,
+        type: type.normalized,
+        hadExpressions: result.hadExpressions,
+        outputPath: result.hadExpressions ? outputPath : undefined,
+      };
+
+      renderModelEvaluateSingle(item, ctx.outputMode);
+      ctx.logger.debug`Evaluation completed`;
+    },
+  );

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -12,6 +12,7 @@ import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_wo
 import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
 import {
   type ExecutionProgressCallback,
+  type ImplicitDependencyMap,
   WorkflowExecutionService,
 } from "../../domain/workflows/execution_service.ts";
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
@@ -26,7 +27,11 @@ type AnyOptions = any;
 /**
  * Converts a WorkflowRun to WorkflowRunData for presentation.
  */
-function toRunData(run: WorkflowRun, path?: string): WorkflowRunData {
+function toRunData(
+  run: WorkflowRun,
+  path?: string,
+  implicitDeps?: ImplicitDependencyMap,
+): WorkflowRunData {
   const startTime = run.startedAt?.getTime();
   const endTime = run.completedAt?.getTime();
 
@@ -38,6 +43,7 @@ function toRunData(run: WorkflowRun, path?: string): WorkflowRunData {
     jobs: run.jobs.map((job): JobRunData => {
       const jobStart = job.startedAt?.getTime();
       const jobEnd = job.completedAt?.getTime();
+      const jobImplicitDeps = implicitDeps?.get(job.jobName);
 
       return {
         name: job.jobName,
@@ -45,12 +51,14 @@ function toRunData(run: WorkflowRun, path?: string): WorkflowRunData {
         steps: job.steps.map((step): StepRunData => {
           const stepStart = step.startedAt?.getTime();
           const stepEnd = step.completedAt?.getTime();
+          const stepImplicitDeps = jobImplicitDeps?.get(step.stepName);
 
           return {
             name: step.stepName,
             status: step.status,
             error: step.error,
             duration: stepStart && stepEnd ? stepEnd - stepStart : undefined,
+            implicitDependencies: stepImplicitDeps,
           };
         }),
         duration: jobStart && jobEnd ? jobEnd - jobStart : undefined,
@@ -122,7 +130,12 @@ export const workflowRunCommand = new Command()
         }
       } else {
         // JSON mode: execute with debug logging, output final result
+        let capturedImplicitDeps: ImplicitDependencyMap | undefined;
+
         const progress: ExecutionProgressCallback = {
+          onImplicitDependencies: (deps) => {
+            capturedImplicitDeps = deps;
+          },
           onJobStart: (_run, jobName) => {
             ctx.logger.debug`Job started: ${jobName}`;
           },
@@ -139,7 +152,7 @@ export const workflowRunCommand = new Command()
         // Get the path for the run
         const path = runRepo.getPath(workflow.id, run.id);
 
-        const data = toRunData(run, path);
+        const data = toRunData(run, path, capturedImplicitDeps);
         renderWorkflowRun(data, ctx.outputMode);
 
         ctx.logger.debug`Workflow run completed: status=${run.status}`;

--- a/src/domain/expressions/dependency_extractor.ts
+++ b/src/domain/expressions/dependency_extractor.ts
@@ -1,0 +1,104 @@
+/**
+ * Type of model reference in an expression.
+ */
+export type DependencyType = "input" | "resource";
+
+/**
+ * Represents a dependency extracted from an expression.
+ */
+export interface ExpressionDependency {
+  /** The model reference (name or UUID) */
+  modelRef: string;
+  /** Whether the dependency is on input or resource data */
+  type: DependencyType;
+}
+
+/**
+ * Pattern to match model references in CEL expressions.
+ * Matches: model.<name-or-uuid>.input or model.<name-or-uuid>.resource
+ */
+const MODEL_REF_PATTERN = /model\.([a-zA-Z0-9_-]+)\.(input|resource)/g;
+
+/**
+ * Extracts model dependencies from a CEL expression.
+ *
+ * @param expression - The CEL expression to analyze
+ * @returns Array of dependencies found in the expression
+ */
+export function extractDependencies(
+  expression: string,
+): ExpressionDependency[] {
+  const dependencies: ExpressionDependency[] = [];
+  const seen = new Set<string>();
+
+  const matches = expression.matchAll(MODEL_REF_PATTERN);
+  for (const match of matches) {
+    const modelRef = match[1];
+    const type = match[2] as DependencyType;
+    const key = `${modelRef}:${type}`;
+
+    // Deduplicate
+    if (!seen.has(key)) {
+      seen.add(key);
+      dependencies.push({ modelRef, type });
+    }
+  }
+
+  return dependencies;
+}
+
+/**
+ * Extracts all model references from a CEL expression (both input and resource).
+ *
+ * @param expression - The CEL expression to analyze
+ * @returns Array of unique model references
+ */
+export function extractModelRefs(expression: string): string[] {
+  const refs = new Set<string>();
+
+  const matches = expression.matchAll(MODEL_REF_PATTERN);
+  for (const match of matches) {
+    refs.add(match[1]);
+  }
+
+  return [...refs];
+}
+
+/**
+ * Checks if an expression has any resource dependencies.
+ * Resource dependencies create implicit workflow step dependencies.
+ *
+ * @param expression - The CEL expression to check
+ * @returns True if the expression references any model resources
+ */
+export function hasResourceDependency(expression: string): boolean {
+  return /model\.[a-zA-Z0-9_-]+\.resource/.test(expression);
+}
+
+/**
+ * Extracts only resource dependencies from a CEL expression.
+ * These create implicit workflow step dependencies.
+ *
+ * @param expression - The CEL expression to analyze
+ * @returns Array of model references that have resource dependencies
+ */
+export function extractResourceDependencies(expression: string): string[] {
+  const refs = new Set<string>();
+
+  const matches = expression.matchAll(/model\.([a-zA-Z0-9_-]+)\.resource/g);
+  for (const match of matches) {
+    refs.add(match[1]);
+  }
+
+  return [...refs];
+}
+
+/**
+ * Checks if an expression contains a self-reference.
+ *
+ * @param expression - The CEL expression to check
+ * @returns True if the expression references 'self'
+ */
+export function hasSelfReference(expression: string): boolean {
+  return /\bself\b/.test(expression);
+}

--- a/src/domain/expressions/dependency_extractor_test.ts
+++ b/src/domain/expressions/dependency_extractor_test.ts
@@ -1,0 +1,104 @@
+import { assertEquals } from "@std/assert";
+import {
+  extractDependencies,
+  extractModelRefs,
+  extractResourceDependencies,
+  hasResourceDependency,
+  hasSelfReference,
+} from "./dependency_extractor.ts";
+
+Deno.test("extractDependencies finds input dependencies", () => {
+  const deps = extractDependencies("model.source.input.attributes.x");
+  assertEquals(deps.length, 1);
+  assertEquals(deps[0].modelRef, "source");
+  assertEquals(deps[0].type, "input");
+});
+
+Deno.test("extractDependencies finds resource dependencies", () => {
+  const deps = extractDependencies("model.source.resource.attributes.id");
+  assertEquals(deps.length, 1);
+  assertEquals(deps[0].modelRef, "source");
+  assertEquals(deps[0].type, "resource");
+});
+
+Deno.test("extractDependencies finds multiple dependencies", () => {
+  const expr = "model.a.input.x + model.b.resource.y";
+  const deps = extractDependencies(expr);
+  assertEquals(deps.length, 2);
+  assertEquals(deps[0].modelRef, "a");
+  assertEquals(deps[0].type, "input");
+  assertEquals(deps[1].modelRef, "b");
+  assertEquals(deps[1].type, "resource");
+});
+
+Deno.test("extractDependencies deduplicates same reference", () => {
+  const expr = "model.foo.input.x + model.foo.input.y";
+  const deps = extractDependencies(expr);
+  assertEquals(deps.length, 1);
+  assertEquals(deps[0].modelRef, "foo");
+});
+
+Deno.test("extractDependencies handles model names with hyphens", () => {
+  const deps = extractDependencies("model.my-model.input.attributes.x");
+  assertEquals(deps.length, 1);
+  assertEquals(deps[0].modelRef, "my-model");
+});
+
+Deno.test("extractDependencies handles model names with underscores", () => {
+  const deps = extractDependencies("model.my_model.input.attributes.x");
+  assertEquals(deps.length, 1);
+  assertEquals(deps[0].modelRef, "my_model");
+});
+
+Deno.test("extractModelRefs returns unique model references", () => {
+  const expr = "model.a.input.x + model.b.resource.y + model.a.resource.z";
+  const refs = extractModelRefs(expr);
+  assertEquals(refs.length, 2);
+  assertEquals(refs.includes("a"), true);
+  assertEquals(refs.includes("b"), true);
+});
+
+Deno.test("extractModelRefs returns empty array for no refs", () => {
+  const refs = extractModelRefs("self.name + self.version");
+  assertEquals(refs.length, 0);
+});
+
+Deno.test("hasResourceDependency returns true for resource refs", () => {
+  assertEquals(
+    hasResourceDependency("model.foo.resource.attributes.id"),
+    true,
+  );
+});
+
+Deno.test("hasResourceDependency returns false for input refs only", () => {
+  assertEquals(
+    hasResourceDependency("model.foo.input.attributes.name"),
+    false,
+  );
+});
+
+Deno.test("hasResourceDependency returns false for self refs", () => {
+  assertEquals(hasResourceDependency("self.name"), false);
+});
+
+Deno.test("extractResourceDependencies returns only resource refs", () => {
+  const expr = "model.a.input.x + model.b.resource.y + model.c.resource.z";
+  const refs = extractResourceDependencies(expr);
+  assertEquals(refs.length, 2);
+  assertEquals(refs.includes("b"), true);
+  assertEquals(refs.includes("c"), true);
+  assertEquals(refs.includes("a"), false);
+});
+
+Deno.test("hasSelfReference returns true for self expressions", () => {
+  assertEquals(hasSelfReference("self.name"), true);
+  assertEquals(
+    hasSelfReference('self.name + " v" + string(self.version)'),
+    true,
+  );
+});
+
+Deno.test("hasSelfReference returns false without self", () => {
+  assertEquals(hasSelfReference("model.foo.input.x"), false);
+  assertEquals(hasSelfReference("myself.name"), false); // 'self' must be word boundary
+});

--- a/src/domain/expressions/errors.ts
+++ b/src/domain/expressions/errors.ts
@@ -1,0 +1,67 @@
+/**
+ * Base error for all expression-related errors.
+ */
+export class ExpressionError extends Error {
+  readonly expression?: string;
+  readonly path?: string;
+
+  constructor(
+    message: string,
+    expression?: string,
+    path?: string,
+    cause?: Error,
+  ) {
+    super(message, { cause });
+    this.name = "ExpressionError";
+    this.expression = expression;
+    this.path = path;
+  }
+}
+
+/**
+ * Error thrown when a model referenced in an expression cannot be found.
+ */
+export class ModelNotFoundError extends ExpressionError {
+  constructor(
+    readonly modelRef: string,
+    expression?: string,
+    path?: string,
+  ) {
+    super(
+      `Model not found: ${modelRef}`,
+      expression,
+      path,
+    );
+    this.name = "ModelNotFoundError";
+  }
+}
+
+/**
+ * Error thrown when an expression is syntactically or semantically invalid.
+ */
+export class InvalidExpressionError extends ExpressionError {
+  constructor(
+    message: string,
+    expression?: string,
+    path?: string,
+    cause?: Error,
+  ) {
+    super(
+      `Invalid expression: ${message}`,
+      expression,
+      path,
+      cause,
+    );
+    this.name = "InvalidExpressionError";
+  }
+}
+
+/**
+ * Error thrown when circular dependencies are detected between expressions.
+ */
+export class CyclicDependencyError extends ExpressionError {
+  constructor(readonly cycle: string[]) {
+    super(`Cyclic dependency detected: ${cycle.join(" -> ")}`);
+    this.name = "CyclicDependencyError";
+  }
+}

--- a/src/domain/expressions/errors_test.ts
+++ b/src/domain/expressions/errors_test.ts
@@ -1,0 +1,94 @@
+import { assertEquals, assertInstanceOf } from "@std/assert";
+import {
+  CyclicDependencyError,
+  ExpressionError,
+  InvalidExpressionError,
+  ModelNotFoundError,
+} from "./errors.ts";
+
+Deno.test("ExpressionError stores message and optional fields", () => {
+  const error = new ExpressionError(
+    "Test error",
+    "model.foo.input.x",
+    "attributes.value",
+  );
+
+  assertEquals(error.message, "Test error");
+  assertEquals(error.expression, "model.foo.input.x");
+  assertEquals(error.path, "attributes.value");
+  assertEquals(error.name, "ExpressionError");
+});
+
+Deno.test("ExpressionError handles undefined optional fields", () => {
+  const error = new ExpressionError("Test error");
+
+  assertEquals(error.message, "Test error");
+  assertEquals(error.expression, undefined);
+  assertEquals(error.path, undefined);
+});
+
+Deno.test("ExpressionError stores cause", () => {
+  const cause = new Error("Root cause");
+  const error = new ExpressionError("Wrapper", undefined, undefined, cause);
+
+  assertEquals(error.cause, cause);
+});
+
+Deno.test("ModelNotFoundError contains model ref in message", () => {
+  const error = new ModelNotFoundError("missing-model");
+
+  assertEquals(error.message, "Model not found: missing-model");
+  assertEquals(error.modelRef, "missing-model");
+  assertEquals(error.name, "ModelNotFoundError");
+  assertInstanceOf(error, ExpressionError);
+});
+
+Deno.test("ModelNotFoundError stores expression and path", () => {
+  const error = new ModelNotFoundError(
+    "foo",
+    "model.foo.input.x",
+    "attributes.ref",
+  );
+
+  assertEquals(error.modelRef, "foo");
+  assertEquals(error.expression, "model.foo.input.x");
+  assertEquals(error.path, "attributes.ref");
+});
+
+Deno.test("InvalidExpressionError contains message prefix", () => {
+  const error = new InvalidExpressionError("syntax error at position 5");
+
+  assertEquals(error.message, "Invalid expression: syntax error at position 5");
+  assertEquals(error.name, "InvalidExpressionError");
+  assertInstanceOf(error, ExpressionError);
+});
+
+Deno.test("InvalidExpressionError stores all fields", () => {
+  const cause = new SyntaxError("Unexpected token");
+  const error = new InvalidExpressionError(
+    "parse failed",
+    "invalid ++ syntax",
+    "attributes.expr",
+    cause,
+  );
+
+  assertEquals(error.expression, "invalid ++ syntax");
+  assertEquals(error.path, "attributes.expr");
+  assertEquals(error.cause, cause);
+});
+
+Deno.test("CyclicDependencyError shows cycle path", () => {
+  const error = new CyclicDependencyError(["a", "b", "c", "a"]);
+
+  assertEquals(error.message, "Cyclic dependency detected: a -> b -> c -> a");
+  assertEquals(error.cycle, ["a", "b", "c", "a"]);
+  assertEquals(error.name, "CyclicDependencyError");
+  assertInstanceOf(error, ExpressionError);
+});
+
+Deno.test("CyclicDependencyError handles two-node cycle", () => {
+  const error = new CyclicDependencyError(["x", "y", "x"]);
+
+  assertEquals(error.message, "Cyclic dependency detected: x -> y -> x");
+  assertEquals(error.cycle.length, 3);
+});

--- a/src/domain/expressions/expression.ts
+++ b/src/domain/expressions/expression.ts
@@ -1,0 +1,60 @@
+/**
+ * Represents a location within a YAML document where an expression was found.
+ */
+export interface ExpressionLocation {
+  /** The path to the value in the YAML structure (e.g., "attributes.message") */
+  path: string;
+  /** The raw string containing the expression (e.g., "${{ model.foo.input.attributes.x }}") */
+  raw: string;
+  /** The CEL expression extracted from the raw string (e.g., "model.foo.input.attributes.x") */
+  celExpression: string;
+}
+
+/**
+ * Expression is a value object representing a CEL expression found in input/workflow data.
+ *
+ * Expressions use the syntax ${{ <cel-expression> }} and can reference:
+ * - Other model inputs: model.<name-or-id>.input.attributes.<attr>
+ * - Model resources: model.<name-or-id>.resource.attributes.<attr>
+ * - Self-references: self.name, self.version, self.attributes.<attr>
+ * - Workflow context: workflow.<property>
+ */
+export class Expression {
+  private constructor(
+    /** The raw string containing the expression wrapper */
+    readonly raw: string,
+    /** The CEL expression without the ${{ }} wrapper */
+    readonly celExpression: string,
+    /** The path in the YAML where this expression was found */
+    readonly path: string,
+  ) {}
+
+  /**
+   * Creates an Expression from a raw string and path.
+   *
+   * @param raw - The raw string containing ${{ ... }}
+   * @param celExpression - The extracted CEL expression
+   * @param path - The path in the YAML document
+   */
+  static create(raw: string, celExpression: string, path: string): Expression {
+    return new Expression(raw, celExpression, path);
+  }
+
+  /**
+   * Creates an Expression from an ExpressionLocation.
+   */
+  static fromLocation(location: ExpressionLocation): Expression {
+    return new Expression(location.raw, location.celExpression, location.path);
+  }
+
+  /**
+   * Converts to an ExpressionLocation for compatibility.
+   */
+  toLocation(): ExpressionLocation {
+    return {
+      path: this.path,
+      raw: this.raw,
+      celExpression: this.celExpression,
+    };
+  }
+}

--- a/src/domain/expressions/expression_evaluation_service.ts
+++ b/src/domain/expressions/expression_evaluation_service.ts
@@ -1,0 +1,253 @@
+import type { ModelInput } from "../models/model_input.ts";
+import { ModelInput as ModelInputClass } from "../models/model_input.ts";
+import type { ModelType } from "../models/model_type.ts";
+import type { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
+import type { YamlResourceRepository } from "../../infrastructure/persistence/yaml_resource_repository.ts";
+import { CelEvaluator } from "../../infrastructure/cel/cel_evaluator.ts";
+import {
+  containsExpression,
+  extractExpressions,
+  replaceExpressions,
+} from "./expression_parser.ts";
+import { extractModelRefs } from "./dependency_extractor.ts";
+import { type ExpressionContext, ModelResolver } from "./model_resolver.ts";
+import { CyclicDependencyError } from "./errors.ts";
+import {
+  CyclicDependencyError as TopoCyclicError,
+  type GraphNode,
+  TopologicalSortService,
+} from "../workflows/topological_sort_service.ts";
+
+/**
+ * Result of evaluating a single input.
+ */
+export interface EvaluatedInput {
+  input: ModelInput;
+  type: ModelType;
+  /** Whether any expressions were evaluated */
+  hadExpressions: boolean;
+}
+
+/**
+ * Domain service for evaluating CEL expressions in model inputs.
+ */
+export class ExpressionEvaluationService {
+  private readonly celEvaluator: CelEvaluator;
+  private readonly sortService: TopologicalSortService;
+  private readonly modelResolver: ModelResolver;
+
+  constructor(
+    private readonly inputRepo: YamlInputRepository,
+    private readonly resourceRepo: YamlResourceRepository,
+  ) {
+    this.celEvaluator = new CelEvaluator();
+    this.sortService = new TopologicalSortService();
+    this.modelResolver = new ModelResolver(inputRepo, resourceRepo);
+  }
+
+  /**
+   * Evaluates expressions in a single input.
+   *
+   * @param input - The input to evaluate
+   * @param type - The model type
+   * @param context - Optional pre-built context (for batch evaluation)
+   * @returns The evaluated input
+   */
+  async evaluateInput(
+    input: ModelInput,
+    type: ModelType,
+    context?: ExpressionContext,
+  ): Promise<EvaluatedInput> {
+    // Build context if not provided
+    const ctx = context ?? await this.modelResolver.buildContext(input, type);
+
+    // Extract expressions from input data
+    const inputData = input.toData();
+    const expressions = extractExpressions(inputData);
+
+    if (expressions.length === 0) {
+      return { input, type, hadExpressions: false };
+    }
+
+    // Evaluate each expression
+    const evaluatedValues = new Map<string, unknown>();
+    for (const expr of expressions) {
+      const value = this.celEvaluator.evaluate(expr.celExpression, ctx);
+      evaluatedValues.set(expr.raw, value);
+    }
+
+    // Replace expressions with evaluated values
+    const evaluatedData = replaceExpressions(inputData, evaluatedValues);
+
+    // Create new ModelInput from evaluated data
+    const evaluatedInput = ModelInputClass.fromData(
+      evaluatedData as ReturnType<typeof input.toData>,
+    );
+
+    return { input: evaluatedInput, type, hadExpressions: true };
+  }
+
+  /**
+   * Evaluates all inputs in dependency order.
+   * Inputs are evaluated in topological order based on their expression dependencies.
+   *
+   * @returns Array of evaluated inputs
+   * @throws CyclicDependencyError if circular dependencies are detected
+   */
+  async evaluateAllInputs(): Promise<EvaluatedInput[]> {
+    // Load all inputs
+    const allInputs = await this.inputRepo.findAllGlobal();
+
+    // Build dependency graph
+    const nodes = this.buildDependencyGraph(allInputs);
+
+    // Sort topologically
+    let sortedNames: string[];
+    try {
+      const sortResult = this.sortService.sort(nodes);
+      sortedNames = this.sortService.flatten(sortResult);
+    } catch (error) {
+      if (error instanceof TopoCyclicError) {
+        throw new CyclicDependencyError(error.cycle);
+      }
+      throw error;
+    }
+
+    // Build initial context
+    const context = await this.modelResolver.buildContext();
+
+    // Map of input name to input data
+    const inputMap = new Map<string, { input: ModelInput; type: ModelType }>();
+    for (const { input, type } of allInputs) {
+      inputMap.set(input.name, { input, type });
+    }
+
+    // Evaluate in order
+    const results: EvaluatedInput[] = [];
+    for (const name of sortedNames) {
+      const entry = inputMap.get(name);
+      if (!entry) continue;
+
+      // Add self to context for this evaluation
+      const ctxWithSelf: ExpressionContext = {
+        ...context,
+        self: {
+          id: entry.input.id,
+          name: entry.input.name,
+          version: entry.input.version,
+          tags: entry.input.tags,
+          attributes: entry.input.attributes,
+        },
+      };
+
+      const result = await this.evaluateInput(
+        entry.input,
+        entry.type,
+        ctxWithSelf,
+      );
+      results.push(result);
+
+      // Update context with evaluated input data for subsequent evaluations
+      if (result.hadExpressions) {
+        context.model[name] = {
+          input: {
+            id: result.input.id,
+            name: result.input.name,
+            version: result.input.version,
+            tags: result.input.tags,
+            attributes: result.input.attributes,
+          },
+          resource: context.model[name]?.resource,
+        };
+        // Also update by UUID
+        context.model[result.input.id] = context.model[name];
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Builds a dependency graph from inputs based on their expressions.
+   */
+  private buildDependencyGraph(
+    inputs: { input: ModelInput; type: ModelType }[],
+  ): GraphNode[] {
+    const nodes: GraphNode[] = [];
+    const nameSet = new Set(inputs.map((i) => i.input.name));
+
+    for (const { input } of inputs) {
+      const inputData = input.toData();
+      const expressions = extractExpressions(inputData);
+
+      // Collect all model references from expressions
+      const dependencies: string[] = [];
+      for (const expr of expressions) {
+        const refs = extractModelRefs(expr.celExpression);
+        for (const ref of refs) {
+          // Only add if it's a known input name (not self, not UUID for simplicity)
+          if (nameSet.has(ref) && ref !== input.name) {
+            if (!dependencies.includes(ref)) {
+              dependencies.push(ref);
+            }
+          }
+        }
+      }
+
+      nodes.push({
+        name: input.name,
+        weight: 0, // All inputs have equal weight
+        dependencies,
+      });
+    }
+
+    return nodes;
+  }
+
+  /**
+   * Checks if any string value in the input contains expressions.
+   */
+  hasExpressions(input: ModelInput): boolean {
+    const data = input.toData();
+    return this.checkForExpressions(data);
+  }
+
+  private checkForExpressions(data: unknown): boolean {
+    if (typeof data === "string") {
+      return containsExpression(data);
+    } else if (Array.isArray(data)) {
+      return data.some((item) => this.checkForExpressions(item));
+    } else if (data !== null && typeof data === "object") {
+      return Object.values(data).some((value) =>
+        this.checkForExpressions(value)
+      );
+    }
+    return false;
+  }
+
+  /**
+   * Evaluates expressions in arbitrary data with the given context.
+   * Used for workflow evaluation.
+   *
+   * @param data - The data containing expressions
+   * @param context - The evaluation context
+   * @returns The data with expressions replaced
+   */
+  evaluateData(
+    data: unknown,
+    context: ExpressionContext,
+  ): unknown {
+    const expressions = extractExpressions(data);
+    if (expressions.length === 0) {
+      return data;
+    }
+
+    const evaluatedValues = new Map<string, unknown>();
+    for (const expr of expressions) {
+      const value = this.celEvaluator.evaluate(expr.celExpression, context);
+      evaluatedValues.set(expr.raw, value);
+    }
+
+    return replaceExpressions(data, evaluatedValues);
+  }
+}

--- a/src/domain/expressions/expression_parser.ts
+++ b/src/domain/expressions/expression_parser.ts
@@ -1,0 +1,148 @@
+import type { ExpressionLocation } from "./expression.ts";
+
+/**
+ * Pattern to match ${{ ... }} expressions.
+ * Captures the inner CEL expression.
+ */
+const EXPRESSION_PATTERN = /\$\{\{\s*(.+?)\s*\}\}/g;
+
+/**
+ * Transforms model references with hyphenated names to bracket notation.
+ *
+ * CEL interprets hyphens as subtraction operators, so `model.deploy-vpc.resource`
+ * would be parsed as `(model.deploy) - (vpc.resource)`. This function transforms
+ * hyphenated model names to bracket notation:
+ *   model.deploy-vpc.resource → model["deploy-vpc"].resource
+ *
+ * @param expression - The CEL expression to transform
+ * @returns The expression with hyphenated model names using bracket notation
+ */
+export function transformHyphenatedModelRefs(expression: string): string {
+  // Pattern matches: model.<name-with-hyphens>.(input|resource)
+  // The name must contain at least one hyphen to need transformation
+  return expression.replace(
+    /model\.([a-zA-Z0-9_]+(?:-[a-zA-Z0-9_-]+)+)\.(input|resource)/g,
+    'model["$1"].$2',
+  );
+}
+
+/**
+ * Checks if a string contains any expressions.
+ */
+export function containsExpression(value: string): boolean {
+  return /\$\{\{.+?\}\}/.test(value);
+}
+
+/**
+ * Extracts all expression locations from a nested data structure.
+ *
+ * @param data - The data structure to search (object, array, or primitive)
+ * @param basePath - The base path for nested locations (default: "")
+ * @returns Array of expression locations found in the data
+ */
+export function extractExpressions(
+  data: unknown,
+  basePath = "",
+): ExpressionLocation[] {
+  const locations: ExpressionLocation[] = [];
+  extractExpressionsRecursive(data, basePath, locations);
+  return locations;
+}
+
+function extractExpressionsRecursive(
+  data: unknown,
+  path: string,
+  locations: ExpressionLocation[],
+): void {
+  if (typeof data === "string") {
+    // Check for expressions in string values
+    const matches = data.matchAll(EXPRESSION_PATTERN);
+    for (const match of matches) {
+      locations.push({
+        path,
+        raw: match[0],
+        celExpression: match[1].trim(),
+      });
+    }
+  } else if (Array.isArray(data)) {
+    // Recursively process array elements
+    for (let i = 0; i < data.length; i++) {
+      const itemPath = path ? `${path}[${i}]` : `[${i}]`;
+      extractExpressionsRecursive(data[i], itemPath, locations);
+    }
+  } else if (data !== null && typeof data === "object") {
+    // Recursively process object properties
+    for (const [key, value] of Object.entries(data)) {
+      const propPath = path ? `${path}.${key}` : key;
+      extractExpressionsRecursive(value, propPath, locations);
+    }
+  }
+  // Primitives other than strings are ignored
+}
+
+/**
+ * Replaces expressions in a data structure with evaluated values.
+ *
+ * @param data - The data structure to process
+ * @param values - Map of expression raw strings to their evaluated values
+ * @returns A new data structure with expressions replaced
+ */
+export function replaceExpressions(
+  data: unknown,
+  values: Map<string, unknown>,
+): unknown {
+  return replaceExpressionsRecursive(data, values);
+}
+
+function replaceExpressionsRecursive(
+  data: unknown,
+  values: Map<string, unknown>,
+): unknown {
+  if (typeof data === "string") {
+    // Check if the entire string is a single expression
+    const singleMatch = data.match(/^\$\{\{\s*(.+?)\s*\}\}$/);
+    if (singleMatch) {
+      // Return the evaluated value directly (preserves type)
+      const evaluated = values.get(data);
+      return evaluated !== undefined ? evaluated : data;
+    }
+
+    // Replace inline expressions within a larger string
+    if (containsExpression(data)) {
+      let result = data;
+      for (const [rawExpr, value] of values) {
+        if (result.includes(rawExpr)) {
+          // Convert value to string for inline replacement
+          const stringValue = value === null || value === undefined
+            ? ""
+            : String(value);
+          result = result.split(rawExpr).join(stringValue);
+        }
+      }
+      return result;
+    }
+
+    return data;
+  } else if (Array.isArray(data)) {
+    return data.map((item) => replaceExpressionsRecursive(item, values));
+  } else if (data !== null && typeof data === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(data)) {
+      result[key] = replaceExpressionsRecursive(value, values);
+    }
+    return result;
+  }
+
+  return data;
+}
+
+/**
+ * Extracts the CEL expression from a raw expression string.
+ *
+ * @param raw - The raw expression string (e.g., "${{ model.foo.input }}")
+ * @returns The CEL expression (e.g., "model.foo.input") or null if not valid
+ */
+export function extractCelExpression(raw: string): string | null {
+  const match = raw.match(/^\$\{\{\s*(.+?)\s*\}\}$/);
+  return match ? match[1].trim() : null;
+}

--- a/src/domain/expressions/expression_parser_test.ts
+++ b/src/domain/expressions/expression_parser_test.ts
@@ -1,0 +1,174 @@
+import { assertEquals } from "@std/assert";
+import {
+  containsExpression,
+  extractCelExpression,
+  extractExpressions,
+  replaceExpressions,
+} from "./expression_parser.ts";
+
+Deno.test("containsExpression returns true for strings with expressions", () => {
+  assertEquals(containsExpression("${{ model.foo.input.x }}"), true);
+  assertEquals(containsExpression("Hello ${{ self.name }}!"), true);
+  assertEquals(containsExpression("${{x}}"), true);
+});
+
+Deno.test("containsExpression returns false for strings without expressions", () => {
+  assertEquals(containsExpression("Hello world"), false);
+  assertEquals(containsExpression("${ not an expression }"), false);
+  assertEquals(containsExpression("{{ also not }}"), false);
+  assertEquals(containsExpression(""), false);
+});
+
+Deno.test("extractExpressions finds expressions in string values", () => {
+  const data = {
+    message: "${{ model.source.input.attributes.text }}",
+  };
+
+  const locations = extractExpressions(data);
+  assertEquals(locations.length, 1);
+  assertEquals(locations[0].path, "message");
+  assertEquals(locations[0].raw, "${{ model.source.input.attributes.text }}");
+  assertEquals(
+    locations[0].celExpression,
+    "model.source.input.attributes.text",
+  );
+});
+
+Deno.test("extractExpressions finds multiple expressions in same string", () => {
+  const data = {
+    message: "${{ a }} and ${{ b }}",
+  };
+
+  const locations = extractExpressions(data);
+  assertEquals(locations.length, 2);
+  assertEquals(locations[0].celExpression, "a");
+  assertEquals(locations[1].celExpression, "b");
+});
+
+Deno.test("extractExpressions traverses nested objects", () => {
+  const data = {
+    level1: {
+      level2: {
+        value: "${{ deep.expression }}",
+      },
+    },
+  };
+
+  const locations = extractExpressions(data);
+  assertEquals(locations.length, 1);
+  assertEquals(locations[0].path, "level1.level2.value");
+  assertEquals(locations[0].celExpression, "deep.expression");
+});
+
+Deno.test("extractExpressions traverses arrays", () => {
+  const data = {
+    items: ["${{ first }}", "plain", "${{ third }}"],
+  };
+
+  const locations = extractExpressions(data);
+  assertEquals(locations.length, 2);
+  assertEquals(locations[0].path, "items[0]");
+  assertEquals(locations[0].celExpression, "first");
+  assertEquals(locations[1].path, "items[2]");
+  assertEquals(locations[1].celExpression, "third");
+});
+
+Deno.test("extractExpressions ignores non-string values", () => {
+  const data = {
+    number: 42,
+    boolean: true,
+    nullValue: null,
+    expression: "${{ valid }}",
+  };
+
+  const locations = extractExpressions(data);
+  assertEquals(locations.length, 1);
+  assertEquals(locations[0].path, "expression");
+});
+
+Deno.test("replaceExpressions replaces single expression with value", () => {
+  const data = {
+    message: "${{ model.foo.input.x }}",
+  };
+  const values = new Map<string, unknown>([
+    ["${{ model.foo.input.x }}", "Hello World"],
+  ]);
+
+  const result = replaceExpressions(data, values) as typeof data;
+  assertEquals(result.message, "Hello World");
+});
+
+Deno.test("replaceExpressions preserves non-string types", () => {
+  const data = {
+    count: "${{ model.foo.input.n }}",
+  };
+  const values = new Map<string, unknown>([
+    ["${{ model.foo.input.n }}", 42],
+  ]);
+
+  const result = replaceExpressions(data, values) as { count: unknown };
+  assertEquals(result.count, 42);
+});
+
+Deno.test("replaceExpressions handles inline expressions in strings", () => {
+  const data = {
+    greeting: "Hello ${{ self.name }}, version ${{ self.version }}!",
+  };
+  const values = new Map<string, unknown>([
+    ["${{ self.name }}", "Test"],
+    ["${{ self.version }}", 1],
+  ]);
+
+  const result = replaceExpressions(data, values) as typeof data;
+  assertEquals(result.greeting, "Hello Test, version 1!");
+});
+
+Deno.test("replaceExpressions traverses nested structures", () => {
+  const data = {
+    outer: {
+      inner: "${{ x }}",
+    },
+    array: ["${{ y }}", "${{ z }}"],
+  };
+  const values = new Map<string, unknown>([
+    ["${{ x }}", "a"],
+    ["${{ y }}", "b"],
+    ["${{ z }}", "c"],
+  ]);
+
+  const result = replaceExpressions(data, values) as typeof data;
+  assertEquals(result.outer.inner, "a");
+  assertEquals(result.array[0], "b");
+  assertEquals(result.array[1], "c");
+});
+
+Deno.test("replaceExpressions leaves unmatched expressions unchanged", () => {
+  const data = {
+    known: "${{ known }}",
+    unknown: "${{ unknown }}",
+  };
+  const values = new Map<string, unknown>([
+    ["${{ known }}", "replaced"],
+  ]);
+
+  const result = replaceExpressions(data, values) as typeof data;
+  assertEquals(result.known, "replaced");
+  assertEquals(result.unknown, "${{ unknown }}");
+});
+
+Deno.test("extractCelExpression extracts expression from wrapper", () => {
+  assertEquals(
+    extractCelExpression("${{ model.foo.input.x }}"),
+    "model.foo.input.x",
+  );
+  assertEquals(
+    extractCelExpression("${{   spaced   }}"),
+    "spaced",
+  );
+});
+
+Deno.test("extractCelExpression returns null for invalid format", () => {
+  assertEquals(extractCelExpression("no expression"), null);
+  assertEquals(extractCelExpression("${ single braces }"), null);
+  assertEquals(extractCelExpression("{{ no dollar }}"), null);
+});

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -1,0 +1,200 @@
+import type { ModelInput } from "../models/model_input.ts";
+import type { ModelResource } from "../models/model_resource.ts";
+import type { ModelType } from "../models/model_type.ts";
+import type { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
+import type { YamlResourceRepository } from "../../infrastructure/persistence/yaml_resource_repository.ts";
+import { createModelResourceId } from "../models/model_resource.ts";
+import { ModelNotFoundError } from "./errors.ts";
+
+/**
+ * Data about a single model for CEL context.
+ */
+export interface ModelData {
+  input: {
+    id: string;
+    name: string;
+    version: number;
+    tags: Record<string, string>;
+    attributes: Record<string, unknown>;
+  };
+  resource?: {
+    id: string;
+    version: number;
+    createdAt: string;
+    attributes: Record<string, unknown>;
+  };
+}
+
+/**
+ * Context for evaluating CEL expressions.
+ */
+export interface ExpressionContext {
+  /** Map of model name/UUID to model data */
+  model: Record<string, ModelData>;
+  /** Self-reference for the current input being evaluated */
+  self?: {
+    id: string;
+    name: string;
+    version: number;
+    tags: Record<string, string>;
+    attributes: Record<string, unknown>;
+  };
+  /** Workflow context (for workflow evaluation) */
+  workflow?: Record<string, unknown>;
+  /** Index signature for CEL evaluator compatibility */
+  [key: string]: unknown;
+}
+
+/**
+ * Resolves model references to build CEL evaluation context.
+ */
+export class ModelResolver {
+  constructor(
+    private readonly inputRepo: YamlInputRepository,
+    private readonly resourceRepo: YamlResourceRepository,
+  ) {}
+
+  /**
+   * Builds a complete expression context from all available models.
+   *
+   * @param selfInput - The input currently being evaluated (for self reference)
+   * @param selfType - The model type of the self input
+   * @returns The expression context
+   */
+  async buildContext(
+    selfInput?: ModelInput,
+    selfType?: ModelType,
+  ): Promise<ExpressionContext> {
+    const context: ExpressionContext = {
+      model: {},
+    };
+
+    // Load all inputs
+    const allInputs = await this.inputRepo.findAllGlobal();
+
+    for (const { input, type } of allInputs) {
+      const modelData = await this.buildModelData(input, type);
+
+      // Index by name
+      context.model[input.name] = modelData;
+      // Also index by UUID for direct ID references
+      context.model[input.id] = modelData;
+    }
+
+    // Build self context if provided
+    if (selfInput && selfType) {
+      context.self = {
+        id: selfInput.id,
+        name: selfInput.name,
+        version: selfInput.version,
+        tags: selfInput.tags,
+        attributes: selfInput.attributes,
+      };
+    }
+
+    return context;
+  }
+
+  /**
+   * Builds model data for a single input.
+   */
+  private async buildModelData(
+    input: ModelInput,
+    type: ModelType,
+  ): Promise<ModelData> {
+    const data: ModelData = {
+      input: {
+        id: input.id,
+        name: input.name,
+        version: input.version,
+        tags: input.tags,
+        attributes: input.attributes,
+      },
+    };
+
+    // Load resource if available
+    if (input.resourceId) {
+      const resourceId = createModelResourceId(input.resourceId);
+      const resource = await this.resourceRepo.findById(type, resourceId);
+      if (resource) {
+        data.resource = {
+          id: resource.id,
+          version: resource.version,
+          createdAt: resource.createdAt.toISOString(),
+          attributes: resource.attributes,
+        };
+      }
+    }
+
+    return data;
+  }
+
+  /**
+   * Resolves a single model reference by name or ID.
+   *
+   * @param modelRef - The model name or UUID
+   * @returns The model data
+   * @throws ModelNotFoundError if the model cannot be found
+   */
+  async resolveModel(modelRef: string): Promise<{
+    input: ModelInput;
+    type: ModelType;
+    resource?: ModelResource;
+  }> {
+    // Try by name first
+    const byName = await this.inputRepo.findByNameGlobal(modelRef);
+    if (byName) {
+      const resource = byName.input.resourceId
+        ? await this.resourceRepo.findById(
+          byName.type,
+          createModelResourceId(byName.input.resourceId),
+        )
+        : undefined;
+      return {
+        input: byName.input,
+        type: byName.type,
+        resource: resource ?? undefined,
+      };
+    }
+
+    // Try by UUID - search across all types
+    const allInputs = await this.inputRepo.findAllGlobal();
+    for (const { input, type } of allInputs) {
+      if (input.id === modelRef) {
+        const resource = input.resourceId
+          ? await this.resourceRepo.findById(
+            type,
+            createModelResourceId(input.resourceId),
+          )
+          : undefined;
+        return { input, type, resource: resource ?? undefined };
+      }
+    }
+
+    throw new ModelNotFoundError(modelRef);
+  }
+
+  /**
+   * Updates the context with fresh resource data for a specific model.
+   * Used during workflow execution when resources are created.
+   *
+   * @param context - The context to update
+   * @param modelRef - The model name or UUID
+   * @param resource - The new resource data
+   */
+  updateResourceInContext(
+    context: ExpressionContext,
+    modelRef: string,
+    resource: ModelResource,
+  ): void {
+    const modelData = context.model[modelRef];
+    if (modelData) {
+      modelData.resource = {
+        id: resource.id,
+        version: resource.version,
+        createdAt: resource.createdAt.toISOString(),
+        attributes: resource.attributes,
+      };
+    }
+  }
+}

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -1,4 +1,4 @@
-import type { Workflow } from "./workflow.ts";
+import { Workflow, type WorkflowData } from "./workflow.ts";
 import type { Job } from "./job.ts";
 import type { Step } from "./step.ts";
 // deno-lint-ignore verbatim-module-syntax
@@ -13,11 +13,23 @@ import type {
   WorkflowRunRepository,
 } from "./repositories.ts";
 import { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
+import { YamlEvaluatedInputRepository } from "../../infrastructure/persistence/yaml_evaluated_input_repository.ts";
 import { YamlResourceRepository } from "../../infrastructure/persistence/yaml_resource_repository.ts";
+import { YamlEvaluatedWorkflowRepository } from "../../infrastructure/persistence/yaml_evaluated_workflow_repository.ts";
 import { modelRegistry } from "../models/model.ts";
 import { DefaultMethodExecutionService } from "../models/method_execution_service.ts";
-import { createModelInputId, type ModelInput } from "../models/model_input.ts";
+import { createModelInputId, ModelInput } from "../models/model_input.ts";
 import type { ModelType } from "../models/model_type.ts";
+import {
+  extractExpressions,
+  replaceExpressions,
+} from "../expressions/expression_parser.ts";
+import { extractResourceDependencies } from "../expressions/dependency_extractor.ts";
+import {
+  type ExpressionContext,
+  ModelResolver,
+} from "../expressions/model_resolver.ts";
+import { CelEvaluator } from "../../infrastructure/cel/cel_evaluator.ts";
 
 /**
  * Context for step execution.
@@ -28,6 +40,8 @@ export interface StepExecutionContext {
   jobName: string;
   stepName: string;
   repoDir: string;
+  /** Expression context for evaluating ${{ }} expressions */
+  expressionContext?: ExpressionContext;
 }
 
 /**
@@ -94,6 +108,7 @@ export class DefaultStepExecutor implements StepExecutor {
     ctx: StepExecutionContext,
   ): Promise<unknown> {
     const inputRepo = new YamlInputRepository(ctx.repoDir);
+    const evaluatedInputRepo = new YamlEvaluatedInputRepository(ctx.repoDir);
     const resourceRepo = new YamlResourceRepository(ctx.repoDir);
     const executionService = new DefaultMethodExecutionService();
 
@@ -106,7 +121,19 @@ export class DefaultStepExecutor implements StepExecutor {
       throw new Error(`Model not found: ${task.modelIdOrName}`);
     }
 
-    const { input, modelType } = lookupResult;
+    // Keep original input (with expressions) for saving
+    const { input: originalInput, modelType } = lookupResult;
+
+    // Evaluate expressions for execution
+    let evaluatedInput = originalInput;
+    if (ctx.expressionContext) {
+      evaluatedInput = this.evaluateInputExpressions(
+        originalInput,
+        ctx.expressionContext,
+      );
+      // Save evaluated input to inputs-evaluated/
+      await evaluatedInputRepo.save(modelType, evaluatedInput);
+    }
 
     // Get the model definition
     const definition = modelRegistry.get(modelType);
@@ -125,9 +152,9 @@ export class DefaultStepExecutor implements StepExecutor {
       );
     }
 
-    // Execute the method
+    // Execute the method with EVALUATED input
     const result = await executionService.executeWorkflow(
-      input,
+      evaluatedInput,
       definition,
       task.methodName,
       { repoDir: ctx.repoDir, resourceRepository: resourceRepo },
@@ -145,16 +172,16 @@ export class DefaultStepExecutor implements StepExecutor {
       resourcePath = resourceRepo.getPath(modelType, result.resource.id);
     }
 
-    // Update input's resourceId based on operation type
+    // Update ORIGINAL input's resourceId (preserves expressions)
     if (result.deleteResource) {
-      if (input.resourceId) {
-        input.setResourceId(undefined);
-        await inputRepo.save(modelType, input);
+      if (originalInput.resourceId) {
+        originalInput.setResourceId(undefined);
+        await inputRepo.save(modelType, originalInput);
       }
     } else {
-      if (!input.resourceId) {
-        input.setResourceId(result.resource.id);
-        await inputRepo.save(modelType, input);
+      if (!originalInput.resourceId) {
+        originalInput.setResourceId(result.resource.id);
+        await inputRepo.save(modelType, originalInput);
       }
     }
 
@@ -173,6 +200,37 @@ export class DefaultStepExecutor implements StepExecutor {
    */
   private static readonly UUID_PATTERN =
     /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+  /**
+   * Evaluates expressions in a model input.
+   */
+  private evaluateInputExpressions(
+    input: ModelInput,
+    context: ExpressionContext,
+  ): ModelInput {
+    const celEvaluator = new CelEvaluator();
+    const inputData = input.toData();
+    const expressions = extractExpressions(inputData);
+
+    if (expressions.length === 0) {
+      return input;
+    }
+
+    // Evaluate each expression
+    const evaluatedValues = new Map<string, unknown>();
+    for (const expr of expressions) {
+      const value = celEvaluator.evaluate(expr.celExpression, context);
+      evaluatedValues.set(expr.raw, value);
+    }
+
+    // Replace expressions with evaluated values
+    const evaluatedData = replaceExpressions(inputData, evaluatedValues);
+
+    // Create new ModelInput from evaluated data
+    return ModelInput.fromData(
+      evaluatedData as ReturnType<typeof input.toData>,
+    );
+  }
 
   /**
    * Looks up a model input by ID or name.
@@ -203,6 +261,11 @@ export class DefaultStepExecutor implements StepExecutor {
 }
 
 /**
+ * Implicit dependency mapping: jobName -> stepName -> implicitDeps[]
+ */
+export type ImplicitDependencyMap = Map<string, Map<string, string[]>>;
+
+/**
  * Progress callback for workflow execution.
  */
 export interface ExecutionProgressCallback {
@@ -220,6 +283,8 @@ export interface ExecutionProgressCallback {
     error: string,
   ): void;
   onWorkflowComplete?(run: WorkflowRun): void;
+  /** Called once at start with implicit dependency mappings */
+  onImplicitDependencies?(implicitDeps: ImplicitDependencyMap): void;
 }
 
 /**
@@ -228,6 +293,9 @@ export interface ExecutionProgressCallback {
 export class WorkflowExecutionService {
   private readonly sortService = new TopologicalSortService();
   private readonly executor: StepExecutor;
+  private readonly inputRepo: YamlInputRepository;
+  private readonly resourceRepo: YamlResourceRepository;
+  private readonly modelResolver: ModelResolver;
 
   constructor(
     private readonly workflowRepo: WorkflowRepository,
@@ -236,6 +304,9 @@ export class WorkflowExecutionService {
     executor?: StepExecutor,
   ) {
     this.executor = executor ?? new DefaultStepExecutor();
+    this.inputRepo = new YamlInputRepository(repoDir);
+    this.resourceRepo = new YamlResourceRepository(repoDir);
+    this.modelResolver = new ModelResolver(this.inputRepo, this.resourceRepo);
   }
 
   /**
@@ -255,8 +326,38 @@ export class WorkflowExecutionService {
       throw new Error(`Workflow not found: ${idOrName}`);
     }
 
+    // Build expression context for the workflow
+    const expressionContext = await this.modelResolver.buildContext();
+
+    // Evaluate workflow and save to workflows-evaluated/
+    const evaluatedWorkflow = this.evaluateWorkflow(
+      workflow,
+      expressionContext,
+    );
+    const evaluatedWorkflowRepo = new YamlEvaluatedWorkflowRepository(
+      this.repoDir,
+    );
+    await evaluatedWorkflowRepo.save(evaluatedWorkflow);
+
     // Create workflow run
     const run = WorkflowRun.create(workflow);
+
+    // Build implicit dependencies for all jobs upfront
+    const allImplicitDeps: ImplicitDependencyMap = new Map();
+    for (const job of workflow.jobs) {
+      const { implicitDeps } = await this.buildStepNodesWithImplicitDeps(
+        job,
+        workflow,
+      );
+      if (implicitDeps.size > 0) {
+        allImplicitDeps.set(job.name, implicitDeps);
+      }
+    }
+
+    // Report implicit dependencies before execution starts
+    if (allImplicitDeps.size > 0) {
+      progress?.onImplicitDependencies?.(allImplicitDeps);
+    }
 
     // Start execution
     run.start();
@@ -277,7 +378,7 @@ export class WorkflowExecutionService {
       // Execute jobs in parallel within each level
       await Promise.all(
         level.map((jobName) =>
-          this.executeJob(workflow, run, jobName, progress)
+          this.executeJob(workflow, run, jobName, expressionContext, progress)
         ),
       );
       await this.saveRun(workflow.id, run);
@@ -295,6 +396,7 @@ export class WorkflowExecutionService {
     workflow: Workflow,
     run: WorkflowRun,
     jobName: string,
+    expressionContext: ExpressionContext,
     progress?: ExecutionProgressCallback,
   ): Promise<void> {
     const job = workflow.getJob(jobName);
@@ -319,12 +421,11 @@ export class WorkflowExecutionService {
     jobRun.start();
     progress?.onJobStart?.(run, jobName);
 
-    // Sort steps topologically
-    const stepNodes: GraphNode[] = job.steps.map((step) => ({
-      name: step.name,
-      weight: step.weight,
-      dependencies: step.getDependencyNames(),
-    }));
+    // Build step nodes with implicit dependencies from expressions
+    const { nodes: stepNodes } = await this.buildStepNodesWithImplicitDeps(
+      job,
+      workflow,
+    );
 
     const sortedSteps = this.sortService.sort(stepNodes);
 
@@ -336,7 +437,15 @@ export class WorkflowExecutionService {
       // Execute steps in parallel within each level
       const stepResults = await Promise.allSettled(
         level.map((stepName) =>
-          this.executeStep(workflow, run, job, jobRun, stepName, progress)
+          this.executeStep(
+            workflow,
+            run,
+            job,
+            jobRun,
+            stepName,
+            expressionContext,
+            progress,
+          )
         ),
       );
 
@@ -357,12 +466,87 @@ export class WorkflowExecutionService {
     progress?.onJobComplete?.(run, jobName);
   }
 
+  /**
+   * Builds step graph nodes including implicit dependencies from expressions.
+   * If a step's model input has ${{ model.X.resource.attributes.Y }}, then
+   * that step implicitly depends on the step that creates model X's resource.
+   *
+   * Returns both the nodes and a mapping of step names to their implicit dependencies.
+   */
+  private async buildStepNodesWithImplicitDeps(
+    job: Job,
+    _workflow: Workflow,
+  ): Promise<{ nodes: GraphNode[]; implicitDeps: Map<string, string[]> }> {
+    // Build a map from model name/id to step name
+    const modelToStep = new Map<string, string>();
+    for (const step of job.steps) {
+      if (step.task.isModelMethod()) {
+        const task = step.task.data as { modelIdOrName: string };
+        modelToStep.set(task.modelIdOrName, step.name);
+      }
+    }
+
+    const nodes: GraphNode[] = [];
+    const implicitDepsMap = new Map<string, string[]>();
+
+    for (const step of job.steps) {
+      const explicitDeps = step.getDependencyNames();
+      const implicitDeps: string[] = [];
+
+      // Check for implicit dependencies from expressions
+      if (step.task.isModelMethod()) {
+        const task = step.task.data as { modelIdOrName: string };
+
+        // Look up the model input to check for expressions
+        const lookupResult = await this.inputRepo.findByNameGlobal(
+          task.modelIdOrName,
+        );
+        if (lookupResult) {
+          const inputData = lookupResult.input.toData();
+          const expressions = extractExpressions(inputData);
+
+          // Extract resource dependencies from expressions
+          for (const expr of expressions) {
+            const resourceRefs = extractResourceDependencies(
+              expr.celExpression,
+            );
+            for (const modelRef of resourceRefs) {
+              const dependsOnStep = modelToStep.get(modelRef);
+              if (dependsOnStep && dependsOnStep !== step.name) {
+                if (
+                  !explicitDeps.includes(dependsOnStep) &&
+                  !implicitDeps.includes(dependsOnStep)
+                ) {
+                  implicitDeps.push(dependsOnStep);
+                }
+              }
+            }
+          }
+        }
+      }
+
+      // Store implicit deps for this step
+      if (implicitDeps.length > 0) {
+        implicitDepsMap.set(step.name, implicitDeps);
+      }
+
+      nodes.push({
+        name: step.name,
+        weight: step.weight,
+        dependencies: [...explicitDeps, ...implicitDeps],
+      });
+    }
+
+    return { nodes, implicitDeps: implicitDepsMap };
+  }
+
   private async executeStep(
     workflow: Workflow,
     run: WorkflowRun,
     job: Job,
     jobRun: JobRun,
     stepName: string,
+    expressionContext: ExpressionContext,
     progress?: ExecutionProgressCallback,
   ): Promise<void> {
     const step = job.getStep(stepName);
@@ -394,9 +578,35 @@ export class WorkflowExecutionService {
         jobName: job.name,
         stepName,
         repoDir: this.repoDir,
+        expressionContext,
       };
 
       const output = await this.executor.execute(step, ctx);
+
+      // Update expression context with new resource data if this was a model method
+      if (step.task.isModelMethod() && output && typeof output === "object") {
+        const taskOutput = output as {
+          model?: string;
+          resourceId?: string;
+          resourceAttributes?: Record<string, unknown>;
+        };
+        if (
+          taskOutput.model && taskOutput.resourceId &&
+          taskOutput.resourceAttributes
+        ) {
+          // Update the context with the new resource data
+          const modelData = expressionContext.model[taskOutput.model];
+          if (modelData) {
+            modelData.resource = {
+              id: taskOutput.resourceId,
+              version: 1,
+              createdAt: new Date().toISOString(),
+              attributes: taskOutput.resourceAttributes,
+            };
+          }
+        }
+      }
+
       stepRun.succeed(output);
       progress?.onStepComplete?.(run, job.name, stepName);
     } catch (error) {
@@ -456,5 +666,34 @@ export class WorkflowExecutionService {
     run: WorkflowRun,
   ): Promise<void> {
     await this.runRepo.save(workflowId, run);
+  }
+
+  /**
+   * Evaluates expressions in a workflow.
+   */
+  private evaluateWorkflow(
+    workflow: Workflow,
+    context: ExpressionContext,
+  ): Workflow {
+    const celEvaluator = new CelEvaluator();
+    const workflowData = workflow.toData();
+    const expressions = extractExpressions(workflowData);
+
+    if (expressions.length === 0) {
+      return workflow;
+    }
+
+    // Evaluate each expression
+    const evaluatedValues = new Map<string, unknown>();
+    for (const expr of expressions) {
+      const value = celEvaluator.evaluate(expr.celExpression, context);
+      evaluatedValues.set(expr.raw, value);
+    }
+
+    // Replace expressions with evaluated values
+    const evaluatedData = replaceExpressions(workflowData, evaluatedValues);
+
+    // Create new Workflow from evaluated data
+    return Workflow.fromData(evaluatedData as WorkflowData);
   }
 }

--- a/src/infrastructure/cel/cel_evaluator.ts
+++ b/src/infrastructure/cel/cel_evaluator.ts
@@ -1,0 +1,68 @@
+import { evaluate, parse } from "cel-js";
+import { InvalidExpressionError } from "../../domain/expressions/errors.ts";
+import { transformHyphenatedModelRefs } from "../../domain/expressions/expression_parser.ts";
+
+/**
+ * Result of expression validation.
+ */
+export interface ValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+/**
+ * CEL evaluator that wraps the cel-js library.
+ *
+ * Provides type-safe evaluation of CEL expressions with model, self, and workflow contexts.
+ */
+export class CelEvaluator {
+  /**
+   * Evaluates a CEL expression with the given context.
+   *
+   * @param expression - The CEL expression to evaluate
+   * @param context - The context object containing model, self, workflow data
+   * @returns The evaluated result
+   * @throws InvalidExpressionError if evaluation fails
+   */
+  evaluate(expression: string, context: Record<string, unknown>): unknown {
+    try {
+      // Transform hyphenated model names to bracket notation before evaluation
+      const transformedExpr = transformHyphenatedModelRefs(expression);
+      const result = evaluate(transformedExpr, context);
+      return result;
+    } catch (error) {
+      throw new InvalidExpressionError(
+        error instanceof Error ? error.message : String(error),
+        expression,
+        undefined,
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+
+  /**
+   * Validates a CEL expression without evaluating it.
+   *
+   * @param expression - The CEL expression to validate
+   * @returns Validation result with error message if invalid
+   */
+  validate(expression: string): ValidationResult {
+    try {
+      // Attempt to parse the expression
+      const result = parse(expression);
+      if (result.isSuccess) {
+        return { valid: true };
+      } else {
+        return {
+          valid: false,
+          error: result.errors?.join("; ") ?? "Unknown parse error",
+        };
+      }
+    } catch (error) {
+      return {
+        valid: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+}

--- a/src/infrastructure/cel/cel_evaluator_test.ts
+++ b/src/infrastructure/cel/cel_evaluator_test.ts
@@ -1,0 +1,269 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { CelEvaluator } from "./cel_evaluator.ts";
+import { InvalidExpressionError } from "../../domain/expressions/errors.ts";
+import { transformHyphenatedModelRefs } from "../../domain/expressions/expression_parser.ts";
+
+Deno.test("CelEvaluator evaluates simple property access", () => {
+  const evaluator = new CelEvaluator();
+  const result = evaluator.evaluate("x", { x: 42 });
+  assertEquals(result, 42);
+});
+
+Deno.test("CelEvaluator evaluates nested property access", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    model: {
+      foo: {
+        input: {
+          attributes: {
+            message: "Hello",
+          },
+        },
+      },
+    },
+  };
+  const result = evaluator.evaluate(
+    "model.foo.input.attributes.message",
+    context,
+  );
+  assertEquals(result, "Hello");
+});
+
+Deno.test("CelEvaluator evaluates string concatenation", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    self: {
+      name: "Test",
+      version: 1,
+    },
+  };
+  const result = evaluator.evaluate('self.name + " v1"', context);
+  assertEquals(result, "Test v1");
+});
+
+Deno.test("CelEvaluator evaluates arithmetic expressions", () => {
+  const evaluator = new CelEvaluator();
+  const context = { a: 10, b: 5 };
+  assertEquals(evaluator.evaluate("a + b", context), 15);
+  assertEquals(evaluator.evaluate("a - b", context), 5);
+  assertEquals(evaluator.evaluate("a * b", context), 50);
+});
+
+Deno.test("CelEvaluator evaluates comparison expressions", () => {
+  const evaluator = new CelEvaluator();
+  const context = { x: 10 };
+  assertEquals(evaluator.evaluate("x > 5", context), true);
+  assertEquals(evaluator.evaluate("x < 5", context), false);
+  assertEquals(evaluator.evaluate("x == 10", context), true);
+});
+
+Deno.test("CelEvaluator evaluates conditional expressions", () => {
+  const evaluator = new CelEvaluator();
+  const context = { cond: true, a: "yes", b: "no" };
+  assertEquals(evaluator.evaluate("cond ? a : b", context), "yes");
+});
+
+Deno.test("CelEvaluator throws InvalidExpressionError for invalid expressions", () => {
+  const evaluator = new CelEvaluator();
+  assertThrows(
+    () => evaluator.evaluate("nonexistent.property", {}),
+    InvalidExpressionError,
+  );
+});
+
+Deno.test("CelEvaluator validate returns valid for correct syntax", () => {
+  const evaluator = new CelEvaluator();
+  const result = evaluator.validate("x + y");
+  assertEquals(result.valid, true);
+  assertEquals(result.error, undefined);
+});
+
+Deno.test("CelEvaluator validate returns invalid for syntax errors", () => {
+  const evaluator = new CelEvaluator();
+  const result = evaluator.validate("x + + y");
+  assertEquals(result.valid, false);
+  assertEquals(typeof result.error, "string");
+});
+
+Deno.test("CelEvaluator handles model.name.input.attributes pattern", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    model: {
+      source: {
+        input: {
+          id: "abc-123",
+          name: "source",
+          version: 1,
+          tags: { env: "prod" },
+          attributes: {
+            text: "Hello World",
+            count: 42,
+          },
+        },
+      },
+    },
+  };
+
+  assertEquals(
+    evaluator.evaluate("model.source.input.attributes.text", context),
+    "Hello World",
+  );
+  assertEquals(
+    evaluator.evaluate("model.source.input.attributes.count", context),
+    42,
+  );
+  assertEquals(
+    evaluator.evaluate("model.source.input.name", context),
+    "source",
+  );
+});
+
+Deno.test("CelEvaluator handles model.name.resource.attributes pattern", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    model: {
+      vpc: {
+        input: {
+          id: "input-123",
+          name: "vpc",
+          version: 1,
+          tags: {},
+          attributes: {},
+        },
+        resource: {
+          id: "resource-456",
+          version: 1,
+          createdAt: "2024-01-01T00:00:00Z",
+          attributes: {
+            vpcId: "vpc-abc123",
+            cidrBlock: "10.0.0.0/16",
+          },
+        },
+      },
+    },
+  };
+
+  assertEquals(
+    evaluator.evaluate("model.vpc.resource.attributes.vpcId", context),
+    "vpc-abc123",
+  );
+  assertEquals(
+    evaluator.evaluate("model.vpc.resource.attributes.cidrBlock", context),
+    "10.0.0.0/16",
+  );
+});
+
+Deno.test("CelEvaluator handles self references", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    self: {
+      id: "self-123",
+      name: "my-model",
+      version: 2,
+      tags: { type: "test" },
+      attributes: {
+        enabled: true,
+      },
+    },
+  };
+
+  assertEquals(evaluator.evaluate("self.name", context), "my-model");
+  assertEquals(evaluator.evaluate("self.version", context), 2);
+  assertEquals(evaluator.evaluate("self.tags.type", context), "test");
+  assertEquals(evaluator.evaluate("self.attributes.enabled", context), true);
+});
+
+Deno.test("CelEvaluator handles hyphenated model names in resource access", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    model: {
+      "deploy-vpc": {
+        resource: {
+          attributes: {
+            VpcId: "vpc-123",
+          },
+        },
+      },
+    },
+  };
+
+  assertEquals(
+    evaluator.evaluate(
+      "model.deploy-vpc.resource.attributes.VpcId",
+      context,
+    ),
+    "vpc-123",
+  );
+});
+
+Deno.test("CelEvaluator handles hyphenated model names in input access", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    model: {
+      "my-hyphenated-model": {
+        input: {
+          attributes: {
+            name: "test-value",
+          },
+        },
+      },
+    },
+  };
+
+  assertEquals(
+    evaluator.evaluate(
+      "model.my-hyphenated-model.input.attributes.name",
+      context,
+    ),
+    "test-value",
+  );
+});
+
+Deno.test("CelEvaluator handles multiple hyphens in model name", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    model: {
+      "my-very-long-hyphenated-name": {
+        resource: {
+          id: "resource-id",
+        },
+      },
+    },
+  };
+
+  assertEquals(
+    evaluator.evaluate(
+      "model.my-very-long-hyphenated-name.resource.id",
+      context,
+    ),
+    "resource-id",
+  );
+});
+
+Deno.test("transformHyphenatedModelRefs transforms hyphenated names", () => {
+  assertEquals(
+    transformHyphenatedModelRefs("model.deploy-vpc.resource.attributes.VpcId"),
+    'model["deploy-vpc"].resource.attributes.VpcId',
+  );
+});
+
+Deno.test("transformHyphenatedModelRefs leaves non-hyphenated names unchanged", () => {
+  assertEquals(
+    transformHyphenatedModelRefs("model.vpc.resource.attributes.VpcId"),
+    "model.vpc.resource.attributes.VpcId",
+  );
+});
+
+Deno.test("transformHyphenatedModelRefs handles input references", () => {
+  assertEquals(
+    transformHyphenatedModelRefs("model.my-model.input.attributes.name"),
+    'model["my-model"].input.attributes.name',
+  );
+});
+
+Deno.test("transformHyphenatedModelRefs handles multiple hyphens", () => {
+  assertEquals(
+    transformHyphenatedModelRefs("model.a-b-c-d.resource.id"),
+    'model["a-b-c-d"].resource.id',
+  );
+});

--- a/src/infrastructure/persistence/yaml_evaluated_input_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_input_repository.ts
@@ -1,0 +1,119 @@
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import type { ModelType } from "../../domain/models/model_type.ts";
+import {
+  ModelInput,
+  type ModelInputData,
+  type ModelInputId,
+} from "../../domain/models/model_input.ts";
+
+/**
+ * Repository for storing evaluated model inputs.
+ *
+ * Writes to {repoDir}/inputs-evaluated/{normalized-type}/{id}.yaml
+ * This directory contains inputs with all expressions resolved.
+ */
+export class YamlEvaluatedInputRepository {
+  constructor(private readonly repoDir: string) {}
+
+  /**
+   * Finds an evaluated input by its ID.
+   */
+  async findById(
+    type: ModelType,
+    id: ModelInputId,
+  ): Promise<ModelInput | null> {
+    const path = this.getPath(type, id);
+    try {
+      const content = await Deno.readTextFile(path);
+      const data = parseYaml(content) as ModelInputData;
+      return ModelInput.fromData(data);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Finds all evaluated inputs of a given type.
+   */
+  async findAll(type: ModelType): Promise<ModelInput[]> {
+    const dir = this.getTypeDir(type);
+    const inputs: ModelInput[] = [];
+
+    try {
+      for await (const entry of Deno.readDir(dir)) {
+        if (entry.isFile && entry.name.endsWith(".yaml")) {
+          const path = join(dir, entry.name);
+          const content = await Deno.readTextFile(path);
+          const data = parseYaml(content) as ModelInputData;
+          inputs.push(ModelInput.fromData(data));
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+
+    return inputs;
+  }
+
+  /**
+   * Saves an evaluated input.
+   */
+  async save(type: ModelType, input: ModelInput): Promise<void> {
+    const dir = this.getTypeDir(type);
+    await ensureDir(dir);
+
+    const path = this.getPath(type, input.id);
+    const data = input.toData();
+    // Remove undefined values since YAML can't stringify them
+    const cleanData = JSON.parse(JSON.stringify(data));
+    const content = stringifyYaml(cleanData as Record<string, unknown>);
+    await Deno.writeTextFile(path, content);
+  }
+
+  /**
+   * Deletes an evaluated input.
+   */
+  async delete(type: ModelType, id: ModelInputId): Promise<void> {
+    const path = this.getPath(type, id);
+    try {
+      await Deno.remove(path);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Clears all evaluated inputs.
+   */
+  async clear(): Promise<void> {
+    const dir = join(this.repoDir, "inputs-evaluated");
+    try {
+      await Deno.remove(dir, { recursive: true });
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Returns the file path for an evaluated input.
+   */
+  getPath(type: ModelType, id: ModelInputId): string {
+    return join(this.getTypeDir(type), `${id}.yaml`);
+  }
+
+  private getTypeDir(type: ModelType): string {
+    return join(this.repoDir, "inputs-evaluated", type.toDirectoryPath());
+  }
+}

--- a/src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts
@@ -1,0 +1,103 @@
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import type { WorkflowId } from "../../domain/workflows/workflow_id.ts";
+import {
+  Workflow,
+  type WorkflowData,
+} from "../../domain/workflows/workflow.ts";
+
+/**
+ * Repository for storing evaluated workflows.
+ *
+ * Writes to {repoDir}/workflows-evaluated/workflow-{uuid}.yaml
+ * This directory contains workflows with all expressions resolved.
+ */
+export class YamlEvaluatedWorkflowRepository {
+  constructor(private readonly repoDir: string) {}
+
+  async findById(id: WorkflowId): Promise<Workflow | null> {
+    const path = this.getPath(id);
+    try {
+      const content = await Deno.readTextFile(path);
+      const data = parseYaml(content) as WorkflowData;
+      return Workflow.fromData(data);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async findAll(): Promise<Workflow[]> {
+    const dir = this.getWorkflowsDir();
+    const workflows: Workflow[] = [];
+
+    try {
+      for await (const entry of Deno.readDir(dir)) {
+        if (
+          entry.isFile && entry.name.startsWith("workflow-") &&
+          entry.name.endsWith(".yaml")
+        ) {
+          const path = join(dir, entry.name);
+          const content = await Deno.readTextFile(path);
+          const data = parseYaml(content) as WorkflowData;
+          workflows.push(Workflow.fromData(data));
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+
+    return workflows;
+  }
+
+  async save(workflow: Workflow): Promise<void> {
+    const dir = this.getWorkflowsDir();
+    await ensureDir(dir);
+
+    const path = this.getPath(workflow.id);
+    const data = workflow.toData();
+    // Remove undefined values since YAML can't stringify them
+    const cleanData = JSON.parse(JSON.stringify(data));
+    const content = stringifyYaml(cleanData as Record<string, unknown>);
+    await Deno.writeTextFile(path, content);
+  }
+
+  async delete(id: WorkflowId): Promise<void> {
+    const path = this.getPath(id);
+    try {
+      await Deno.remove(path);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Clears all evaluated workflows.
+   */
+  async clear(): Promise<void> {
+    const dir = this.getWorkflowsDir();
+    try {
+      await Deno.remove(dir, { recursive: true });
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+  }
+
+  getPath(id: WorkflowId): string {
+    return join(this.getWorkflowsDir(), `workflow-${id}.yaml`);
+  }
+
+  private getWorkflowsDir(): string {
+    return join(this.repoDir, "workflows-evaluated");
+  }
+}

--- a/src/presentation/output/components/workflow_execution/JobsPanel.tsx
+++ b/src/presentation/output/components/workflow_execution/JobsPanel.tsx
@@ -4,16 +4,22 @@ import { Box, Text } from "ink";
 import { type RunStatus, StatusIcon } from "./StatusIcon.tsx";
 import type { JobRunData } from "../../workflow_run_output.tsx";
 import { calculateScrollWindow } from "../../hooks/mod.ts";
+import type { PendingDep } from "./WorkflowExecutionUI.tsx";
 
 /**
  * Formats pending dependencies for display.
+ * Implicit dependencies are prefixed with '*' to distinguish them.
  * Truncates with "..." if the combined length exceeds maxLength.
  */
-function formatDependencies(deps: string[], maxLength: number = 30): string {
+function formatDependencies(
+  deps: PendingDep[],
+  maxLength: number = 30,
+): string {
   if (deps.length === 0) return "";
 
   const prefix = "← ";
-  const joined = deps.join(", ");
+  const formattedDeps = deps.map((d) => d.isImplicit ? `*${d.name}` : d.name);
+  const joined = formattedDeps.join(", ");
 
   if (prefix.length + joined.length <= maxLength) {
     return prefix + joined;
@@ -21,9 +27,9 @@ function formatDependencies(deps: string[], maxLength: number = 30): string {
 
   // Truncate with ellipsis
   let result = "";
-  for (let i = 0; i < deps.length; i++) {
+  for (let i = 0; i < formattedDeps.length; i++) {
     const separator = i === 0 ? "" : ", ";
-    const candidate = result + separator + deps[i];
+    const candidate = result + separator + formattedDeps[i];
     if (prefix.length + candidate.length + 4 > maxLength) {
       return prefix + result + ", ...";
     }
@@ -35,7 +41,7 @@ function formatDependencies(deps: string[], maxLength: number = 30): string {
 interface JobItemProps {
   job: JobRunData;
   isSelected: boolean;
-  pendingDeps: string[];
+  pendingDeps: PendingDep[];
 }
 
 function JobItem(
@@ -72,7 +78,7 @@ interface JobsPanelProps {
   jobs: JobRunData[];
   selectedIndex: number;
   isFocused: boolean;
-  pendingDependencies: Map<string, string[]>;
+  pendingDependencies: Map<string, PendingDep[]>;
   availableHeight?: number;
 }
 

--- a/src/presentation/output/components/workflow_execution/StepsPanel.tsx
+++ b/src/presentation/output/components/workflow_execution/StepsPanel.tsx
@@ -4,16 +4,22 @@ import { Box, Text } from "ink";
 import { type RunStatus, StatusIcon } from "./StatusIcon.tsx";
 import type { StepRunData } from "../../workflow_run_output.tsx";
 import { calculateScrollWindow } from "../../hooks/mod.ts";
+import type { PendingDep } from "./WorkflowExecutionUI.tsx";
 
 /**
  * Formats pending dependencies for display.
+ * Implicit dependencies are prefixed with '*' to distinguish them.
  * Truncates with "..." if the combined length exceeds maxLength.
  */
-function formatDependencies(deps: string[], maxLength: number = 30): string {
+function formatDependencies(
+  deps: PendingDep[],
+  maxLength: number = 30,
+): string {
   if (deps.length === 0) return "";
 
   const prefix = "← ";
-  const joined = deps.join(", ");
+  const formattedDeps = deps.map((d) => d.isImplicit ? `*${d.name}` : d.name);
+  const joined = formattedDeps.join(", ");
 
   if (prefix.length + joined.length <= maxLength) {
     return prefix + joined;
@@ -21,9 +27,9 @@ function formatDependencies(deps: string[], maxLength: number = 30): string {
 
   // Truncate with ellipsis
   let result = "";
-  for (let i = 0; i < deps.length; i++) {
+  for (let i = 0; i < formattedDeps.length; i++) {
     const separator = i === 0 ? "" : ", ";
-    const candidate = result + separator + deps[i];
+    const candidate = result + separator + formattedDeps[i];
     if (prefix.length + candidate.length + 4 > maxLength) {
       return prefix + result + ", ...";
     }
@@ -35,7 +41,7 @@ function formatDependencies(deps: string[], maxLength: number = 30): string {
 interface StepItemProps {
   step: StepRunData;
   isSelected: boolean;
-  pendingDeps: string[];
+  pendingDeps: PendingDep[];
 }
 
 function StepItem(
@@ -75,7 +81,7 @@ interface StepsPanelProps {
   steps: StepRunData[];
   isFocused: boolean;
   selectedIndex: number;
-  pendingDependencies: Map<string, string[]>;
+  pendingDependencies: Map<string, PendingDep[]>;
   availableHeight?: number;
 }
 

--- a/src/presentation/output/components/workflow_execution/WorkflowExecutionUI.tsx
+++ b/src/presentation/output/components/workflow_execution/WorkflowExecutionUI.tsx
@@ -16,16 +16,42 @@ import type { JobRunData } from "../../workflow_run_output.tsx";
 import { useTerminalSize } from "../../hooks/mod.ts";
 
 /**
+ * A dependency with type information (explicit or implicit).
+ */
+export interface PendingDep {
+  name: string;
+  isImplicit: boolean;
+}
+
+/**
  * Computes pending dependencies (ones that haven't succeeded yet).
+ * Returns dependencies with type info (explicit vs implicit).
  */
 function getPendingDependencies(
-  allDeps: string[],
+  explicitDeps: string[],
+  implicitDeps: string[],
   statuses: Map<string, string>,
-): string[] {
-  return allDeps.filter((dep) => {
+): PendingDep[] {
+  const result: PendingDep[] = [];
+
+  for (const dep of explicitDeps) {
     const status = statuses.get(dep);
-    return status !== "succeeded" && status !== "skipped";
-  });
+    if (status !== "succeeded" && status !== "skipped") {
+      result.push({ name: dep, isImplicit: false });
+    }
+  }
+
+  for (const dep of implicitDeps) {
+    const status = statuses.get(dep);
+    if (status !== "succeeded" && status !== "skipped") {
+      // Avoid duplicates if already in explicit deps
+      if (!explicitDeps.includes(dep)) {
+        result.push({ name: dep, isImplicit: true });
+      }
+    }
+  }
+
+  return result;
 }
 
 interface WorkflowExecutionUIProps {
@@ -131,24 +157,33 @@ export function WorkflowExecutionUI(
 
   // Compute pending dependencies for jobs
   const jobStatuses = new Map(jobs.map((j) => [j.name, j.status]));
-  const jobPendingDeps = new Map<string, string[]>();
+  const jobPendingDeps = new Map<string, PendingDep[]>();
   for (const job of workflow.jobs) {
-    const allDeps = job.dependsOn.map((d) => d.job);
-    const pendingDeps = getPendingDependencies(allDeps, jobStatuses);
+    const explicitDeps = job.dependsOn.map((d) => d.job);
+    // Jobs don't have implicit deps (only steps do)
+    const pendingDeps = getPendingDependencies(explicitDeps, [], jobStatuses);
     jobPendingDeps.set(job.name, pendingDeps);
   }
 
   // Compute pending dependencies for steps of selected job
-  const stepPendingDeps = new Map<string, string[]>();
+  const stepPendingDeps = new Map<string, PendingDep[]>();
   if (selectedJob) {
     const stepStatuses = new Map(
       selectedJob.steps.map((s) => [s.name, s.status]),
     );
     const workflowJob = workflow.jobs[state.selectedJobIndex];
     if (workflowJob) {
+      // Get implicit deps for this job from state
+      const jobImplicitDeps = state.implicitDependencies.get(workflowJob.name);
+
       for (const step of workflowJob.steps) {
-        const allDeps = step.dependsOn.map((d) => d.step);
-        const pendingDeps = getPendingDependencies(allDeps, stepStatuses);
+        const explicitDeps = step.dependsOn.map((d) => d.step);
+        const implicitDeps = jobImplicitDeps?.get(step.name) ?? [];
+        const pendingDeps = getPendingDependencies(
+          explicitDeps,
+          implicitDeps,
+          stepStatuses,
+        );
         stepPendingDeps.set(step.name, pendingDeps);
       }
     }

--- a/src/presentation/output/components/workflow_execution/execution_reducer.ts
+++ b/src/presentation/output/components/workflow_execution/execution_reducer.ts
@@ -7,6 +7,11 @@ import type { WorkflowRunData } from "../../workflow_run_output.tsx";
 export type ActivePanel = "jobs" | "steps";
 
 /**
+ * Implicit dependency mapping: jobName -> stepName -> implicitDeps[]
+ */
+export type ImplicitDependencyMap = Map<string, Map<string, string[]>>;
+
+/**
  * View state for the workflow execution UI.
  */
 export interface WorkflowExecutionViewState {
@@ -18,6 +23,9 @@ export interface WorkflowExecutionViewState {
   // Execution status
   isRunning: boolean;
   isComplete: boolean;
+
+  // Implicit dependencies from expressions (jobName -> stepName -> deps[])
+  implicitDependencies: ImplicitDependencyMap;
 
   // UI-only state
   selectedJobIndex: number;
@@ -37,6 +45,7 @@ export type ExecutionAction =
   | { type: "WORKFLOW_START"; run: WorkflowRunData }
   | { type: "WORKFLOW_UPDATE"; run: WorkflowRunData }
   | { type: "WORKFLOW_COMPLETE"; run: WorkflowRunData }
+  | { type: "SET_IMPLICIT_DEPENDENCIES"; deps: ImplicitDependencyMap }
   | { type: "SELECT_JOB"; index: number }
   | { type: "SELECT_NEXT_JOB" }
   | { type: "SELECT_PREV_JOB" }
@@ -61,6 +70,7 @@ export function createInitialState(
     workflowYaml,
     isRunning: false,
     isComplete: false,
+    implicitDependencies: new Map(),
     selectedJobIndex: 0,
     showYamlOverlay: false,
     activePanel: "jobs",
@@ -98,6 +108,12 @@ export function executionReducer(
         workflowRun: action.run,
         isRunning: false,
         isComplete: true,
+      };
+
+    case "SET_IMPLICIT_DEPENDENCIES":
+      return {
+        ...state,
+        implicitDependencies: action.deps,
       };
 
     case "SELECT_JOB":

--- a/src/presentation/output/model_evaluate_output.tsx
+++ b/src/presentation/output/model_evaluate_output.tsx
@@ -1,0 +1,116 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { Box, Text } from "ink";
+import { render } from "ink-testing-library";
+import type { OutputMode } from "./output.tsx";
+
+export interface ModelEvaluateItemData {
+  id: string;
+  name: string;
+  type: string;
+  hadExpressions: boolean;
+  outputPath?: string;
+}
+
+export interface ModelEvaluateData {
+  items: ModelEvaluateItemData[];
+  total: number;
+  evaluated: number;
+}
+
+export function renderModelEvaluate(
+  data: ModelEvaluateData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    renderInteractiveModelEvaluate(data);
+  }
+}
+
+function renderInteractiveModelEvaluate(data: ModelEvaluateData): void {
+  const { lastFrame } = render(<ModelEvaluateDisplay {...data} />);
+  console.log(lastFrame());
+}
+
+interface ModelEvaluateDisplayProps {
+  items: ModelEvaluateItemData[];
+  total: number;
+  evaluated: number;
+}
+
+export function ModelEvaluateDisplay(
+  props: ModelEvaluateDisplayProps,
+): React.ReactElement {
+  return (
+    <Box flexDirection="column">
+      <Text color="green">
+        Evaluated {props.evaluated} of {props.total} model inputs:
+      </Text>
+      <Box marginLeft={2} flexDirection="column" marginTop={1}>
+        {props.items.map((item) => (
+          <Box key={item.id} flexDirection="column" marginBottom={1}>
+            <Text>
+              <Text color="cyan">{item.name}</Text>
+              <Text dimColor>({item.type})</Text>
+              {item.hadExpressions
+                ? <Text color="green">[evaluated]</Text>
+                : <Text dimColor>[no expressions]</Text>}
+            </Text>
+            {item.outputPath && (
+              <Box marginLeft={2}>
+                <Text dimColor>Output: {item.outputPath}</Text>
+              </Box>
+            )}
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+export function renderModelEvaluateSingle(
+  item: ModelEvaluateItemData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(item, null, 2));
+  } else {
+    const { lastFrame } = render(<ModelEvaluateSingleDisplay {...item} />);
+    console.log(lastFrame());
+  }
+}
+
+export function ModelEvaluateSingleDisplay(
+  props: ModelEvaluateItemData,
+): React.ReactElement {
+  return (
+    <Box flexDirection="column">
+      <Text color="green">Evaluated model input:</Text>
+      <Box marginLeft={2} flexDirection="column">
+        <Text>
+          <Text color="cyan">Name:</Text>
+          <Text>{props.name}</Text>
+        </Text>
+        <Text>
+          <Text color="cyan">Type:</Text>
+          <Text>{props.type}</Text>
+        </Text>
+        <Text>
+          <Text color="cyan">ID:</Text>
+          <Text dimColor>{props.id}</Text>
+        </Text>
+        {props.hadExpressions
+          ? <Text color="green">Expressions evaluated</Text>
+          : <Text dimColor>No expressions to evaluate</Text>}
+        {props.outputPath && (
+          <Text>
+            <Text color="cyan">Output:</Text>
+            <Text dimColor>{props.outputPath}</Text>
+          </Text>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/src/presentation/output/workflow_execution_output.tsx
+++ b/src/presentation/output/workflow_execution_output.tsx
@@ -5,7 +5,10 @@ import { render } from "ink";
 import type { OutputMode } from "./output.tsx";
 import type { WorkflowData } from "../../domain/workflows/workflow.ts";
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
-import type { ExecutionProgressCallback } from "../../domain/workflows/execution_service.ts";
+import type {
+  ExecutionProgressCallback,
+  ImplicitDependencyMap,
+} from "../../domain/workflows/execution_service.ts";
 import {
   type JobRunData,
   renderWorkflowRun,
@@ -69,6 +72,9 @@ function createProgressAdapter(
   dispatch: React.Dispatch<ExecutionAction>,
 ): ExecutionProgressCallback {
   return {
+    onImplicitDependencies: (deps: ImplicitDependencyMap) => {
+      dispatch({ type: "SET_IMPLICIT_DEPENDENCIES", deps });
+    },
     onWorkflowStart: (run) => {
       dispatch({ type: "WORKFLOW_START", run: toRunData(run) });
     },

--- a/src/presentation/output/workflow_run_output.tsx
+++ b/src/presentation/output/workflow_run_output.tsx
@@ -9,6 +9,8 @@ export interface StepRunData {
   status: "pending" | "running" | "succeeded" | "failed" | "skipped";
   error?: string;
   duration?: number;
+  /** Dependencies inferred from ${{ }} expressions */
+  implicitDependencies?: string[];
 }
 
 export interface JobRunData {


### PR DESCRIPTION
## Summary

Add support for `${{ }}` expressions in model inputs and workflows, with CEL-based evaluation and automatic dependency inference.

**Expression System:**
- Expression parser to extract `${{ }}` expressions from data structures
- CEL evaluator for expression evaluation with model/resource context
- Model resolver to build expression context from inputs and resources
- Dependency extractor to find resource references in expressions
- Expression evaluation service for end-to-end evaluation

**Workflow Execution:**
- Evaluate expressions in model inputs during workflow execution
- Save evaluated inputs to `inputs-evaluated/` directory
- Save evaluated workflows to `workflows-evaluated/` directory
- Track implicit dependencies from expression references
- Show implicit deps in UI with `*` prefix (e.g., `← vpc, *subnet`)
- Include `implicitDependencies` array in JSON output for steps

**New Commands:**
- `model evaluate` command to evaluate expressions in model inputs

**Infrastructure:**
- `YamlEvaluatedInputRepository` for persisting evaluated inputs
- `YamlEvaluatedWorkflowRepository` for persisting evaluated workflows

## Test Plan

- All 733 existing tests pass
- Type checking passes (`deno check`)
- Linting passes (`deno lint`)
- Manual testing with expression-based workflows shows implicit deps in UI and JSON output