### PR TITLE
feat: add expression path validation for model validate and workflow execution

### DIFF
--- a/integration/model_validate_test.ts
+++ b/integration/model_validate_test.ts
@@ -73,7 +73,7 @@ Deno.test("CLI: model validate passes for valid echo model input", async () => {
     assertEquals(output.modelName, "valid-echo-input");
     assertEquals(output.type, "swamp/echo");
     assertEquals(output.passed, true);
-    assertEquals(output.validations.length, 2); // Input schema + Input attributes
+    assertEquals(output.validations.length, 3); // Input schema + Input attributes + Expression paths
     assertEquals(
       output.validations.every((v: { passed: boolean }) => v.passed),
       true,
@@ -126,7 +126,7 @@ Deno.test("CLI: model validate passes for valid echo model with resource", async
     // Parse and verify JSON output
     const output = JSON.parse(result.stdout);
     assertEquals(output.passed, true);
-    assertEquals(output.validations.length, 4); // Input + Resource validations
+    assertEquals(output.validations.length, 5); // Input + Resource + Expression paths validations
   });
 });
 

--- a/integration/workflow_test.ts
+++ b/integration/workflow_test.ts
@@ -9,6 +9,9 @@ import { Step } from "../src/domain/workflows/step.ts";
 import { StepTask } from "../src/domain/workflows/step_task.ts";
 import { TriggerCondition } from "../src/domain/workflows/trigger_condition.ts";
 import { YamlWorkflowRepository } from "../src/infrastructure/persistence/yaml_workflow_repository.ts";
+import { YamlInputRepository } from "../src/infrastructure/persistence/yaml_input_repository.ts";
+import { ModelInput } from "../src/domain/models/model_input.ts";
+import { ECHO_MODEL_TYPE } from "../src/domain/models/echo/echo_model.ts";
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   const dir = await Deno.makeTempDir({ prefix: "swamp-workflow-" });
@@ -569,4 +572,247 @@ Deno.test("CLI: workflow shows help", async () => {
   assertStringIncludes(result.stdout, "validate");
   assertStringIncludes(result.stdout, "search");
   assertStringIncludes(result.stdout, "run");
+});
+
+// Model validation during workflow execution
+
+Deno.test("CLI: workflow run fails when model has invalid expression syntax", async () => {
+  await withTempDir(async (repoDir) => {
+    // Create a model input with invalid expression (missing model. prefix)
+    const inputRepo = new YamlInputRepository(repoDir);
+    const input = ModelInput.create({
+      name: "invalid-expr-model",
+      attributes: {
+        // Invalid: should be ${{ model.some-vpc.resource.attributes.VpcId }}
+        message: "${{some-vpc.VpcId}}",
+      },
+    });
+    await inputRepo.save(ECHO_MODEL_TYPE, input);
+
+    // Create a workflow that references this model
+    const workflowRepo = new YamlWorkflowRepository(repoDir);
+    const workflow = Workflow.create({
+      name: "validate-expr-workflow",
+      jobs: [
+        Job.create({
+          name: "run-model",
+          steps: [
+            Step.create({
+              name: "write-echo",
+              task: StepTask.modelMethod("invalid-expr-model", "write"),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    // Run the workflow - should fail validation
+    const result = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "validate-expr-workflow",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    // Should fail due to validation error
+    assertEquals(result.code, 1, "Command should fail with exit code 1");
+
+    // Error message should mention expression validation
+    assertStringIncludes(
+      result.stderr + result.stdout,
+      "Expression paths",
+    );
+  });
+});
+
+Deno.test("CLI: workflow run fails when model has malformed expression", async () => {
+  await withTempDir(async (repoDir) => {
+    // Create a model input with malformed expression (missing $ prefix)
+    const inputRepo = new YamlInputRepository(repoDir);
+    const input = ModelInput.create({
+      name: "malformed-expr-model",
+      attributes: {
+        // Malformed: missing $ prefix
+        message: "{{some-vpc.VpcId}}",
+      },
+    });
+    await inputRepo.save(ECHO_MODEL_TYPE, input);
+
+    // Create a workflow that references this model
+    const workflowRepo = new YamlWorkflowRepository(repoDir);
+    const workflow = Workflow.create({
+      name: "malformed-expr-workflow",
+      jobs: [
+        Job.create({
+          name: "run-model",
+          steps: [
+            Step.create({
+              name: "write-echo",
+              task: StepTask.modelMethod("malformed-expr-model", "write"),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    // Run the workflow - should fail validation
+    const result = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "malformed-expr-workflow",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    // Should fail due to malformed expression
+    assertEquals(result.code, 1, "Command should fail with exit code 1");
+
+    // Error message should mention the malformed expression
+    assertStringIncludes(
+      result.stderr + result.stdout,
+      "Expression paths",
+    );
+  });
+});
+
+Deno.test("CLI: workflow run succeeds with valid model expressions", async () => {
+  await withTempDir(async (repoDir) => {
+    // Create two model inputs - one will reference the other
+    const inputRepo = new YamlInputRepository(repoDir);
+
+    const sourceModel = ModelInput.create({
+      name: "source-model",
+      attributes: {
+        message: "Hello from source",
+      },
+    });
+    await inputRepo.save(ECHO_MODEL_TYPE, sourceModel);
+
+    const dependentModel = ModelInput.create({
+      name: "dependent-model",
+      attributes: {
+        // Valid expression referencing source-model's input attribute
+        message: "${{ model.source-model.input.attributes.message }}",
+      },
+    });
+    await inputRepo.save(ECHO_MODEL_TYPE, dependentModel);
+
+    // Create a workflow that runs both models
+    const workflowRepo = new YamlWorkflowRepository(repoDir);
+    const workflow = Workflow.create({
+      name: "valid-expr-workflow",
+      jobs: [
+        Job.create({
+          name: "run-models",
+          steps: [
+            Step.create({
+              name: "write-source",
+              task: StepTask.modelMethod("source-model", "write"),
+            }),
+            Step.create({
+              name: "write-dependent",
+              task: StepTask.modelMethod("dependent-model", "write"),
+              dependsOn: [
+                {
+                  step: "write-source",
+                  condition: TriggerCondition.succeeded("write-source"),
+                },
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    // Run the workflow - should succeed
+    const result = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "valid-expr-workflow",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Command should succeed. stderr: ${result.stderr}`,
+    );
+
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.status, "succeeded");
+    assertEquals(output.jobs[0].steps[0].status, "succeeded");
+    assertEquals(output.jobs[0].steps[1].status, "succeeded");
+  });
+});
+
+Deno.test("CLI: workflow run succeeds with self reference expressions", async () => {
+  await withTempDir(async (repoDir) => {
+    // Create a model that references its own name
+    const inputRepo = new YamlInputRepository(repoDir);
+    const input = ModelInput.create({
+      name: "self-ref-model",
+      attributes: {
+        // Valid self reference
+        message: "${{ self.name }}",
+      },
+    });
+    await inputRepo.save(ECHO_MODEL_TYPE, input);
+
+    // Create a workflow that runs the model
+    const workflowRepo = new YamlWorkflowRepository(repoDir);
+    const workflow = Workflow.create({
+      name: "self-ref-workflow",
+      jobs: [
+        Job.create({
+          name: "run-model",
+          steps: [
+            Step.create({
+              name: "write-echo",
+              task: StepTask.modelMethod("self-ref-model", "write"),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    // Run the workflow - should succeed
+    const result = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "self-ref-workflow",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Command should succeed. stderr: ${result.stderr}`,
+    );
+
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.status, "succeeded");
+  });
 });

--- a/src/cli/commands/model_validate.ts
+++ b/src/cli/commands/model_validate.ts
@@ -74,6 +74,7 @@ export const modelValidateCommand = new Command()
             input,
             definition,
             resource,
+            inputRepo,
           );
 
           const validations = toValidationItemData(validationResults);
@@ -145,6 +146,7 @@ export const modelValidateCommand = new Command()
         input,
         definition,
         resource,
+        inputRepo,
       );
 
       const validations = toValidationItemData(results);

--- a/src/domain/expressions/expression_path_extractor.ts
+++ b/src/domain/expressions/expression_path_extractor.ts
@@ -1,0 +1,148 @@
+import type { DependencyType } from "./dependency_extractor.ts";
+
+/**
+ * Represents a full path reference extracted from an expression.
+ */
+export interface ExpressionPathReference {
+  /** The model reference (name or UUID) */
+  modelRef: string;
+  /** Whether the reference is to input or resource data */
+  type: DependencyType;
+  /** The path segments after input/resource (e.g., ["attributes", "VpcId"]) */
+  path: string[];
+  /** The full path string (e.g., "resource.attributes.VpcId") */
+  fullPath: string;
+  /** The raw expression that was matched (e.g., "model.my-vpc.resource.attributes.VpcId") */
+  rawExpression: string;
+}
+
+/**
+ * Pattern to match model references with full paths in CEL expressions.
+ * Matches: model.<name-or-uuid>.(input|resource)(.<property>|[<index>])*
+ *
+ * Group 1: model name or UUID
+ * Group 2: "input" or "resource"
+ * Group 3: remaining path (property accesses and array indices)
+ */
+const MODEL_PATH_PATTERN =
+  /model\.([a-zA-Z0-9_-]+)\.(input|resource)((?:\.[a-zA-Z0-9_]+|\[\d+\])*)/g;
+
+/**
+ * Pattern to match self references with full paths.
+ * Matches: self(.<property>|[<index>])*
+ *
+ * Group 1: remaining path (property accesses and array indices)
+ */
+const SELF_PATH_PATTERN = /\bself((?:\.[a-zA-Z0-9_]+|\[\d+\])*)/g;
+
+/**
+ * Represents a self-reference path extracted from an expression.
+ */
+export interface SelfPathReference {
+  /** The path segments after self (e.g., ["attributes", "VpcId"]) */
+  path: string[];
+  /** The full path string (e.g., "attributes.VpcId") */
+  fullPath: string;
+  /** The raw expression that was matched (e.g., "self.attributes.VpcId") */
+  rawExpression: string;
+}
+
+/**
+ * Parses a path string into segments, handling both dot notation and array indices.
+ *
+ * @param pathStr - The path string to parse (e.g., ".attributes.Tags[0].Key")
+ * @returns Array of path segments
+ */
+function parsePathSegments(pathStr: string): string[] {
+  if (!pathStr) return [];
+
+  const segments: string[] = [];
+  // Match either .propertyName or [index]
+  const segmentPattern = /\.([a-zA-Z0-9_]+)|\[(\d+)\]/g;
+  let match;
+
+  while ((match = segmentPattern.exec(pathStr)) !== null) {
+    if (match[1] !== undefined) {
+      // Property access (e.g., .attributes)
+      segments.push(match[1]);
+    } else if (match[2] !== undefined) {
+      // Array index (e.g., [0])
+      segments.push(match[2]);
+    }
+  }
+
+  return segments;
+}
+
+/**
+ * Extracts full path references from a CEL expression.
+ *
+ * @param expression - The CEL expression to analyze
+ * @returns Array of path references found in the expression
+ */
+export function extractPathReferences(
+  expression: string,
+): ExpressionPathReference[] {
+  const references: ExpressionPathReference[] = [];
+  const seen = new Set<string>();
+
+  const matches = expression.matchAll(MODEL_PATH_PATTERN);
+  for (const match of matches) {
+    const modelRef = match[1];
+    const type = match[2] as DependencyType;
+    const remainingPath = match[3] || "";
+
+    const path = parsePathSegments(remainingPath);
+    const fullPath = type + remainingPath;
+    const rawExpression = match[0];
+
+    // Deduplicate based on raw expression
+    if (!seen.has(rawExpression)) {
+      seen.add(rawExpression);
+      references.push({
+        modelRef,
+        type,
+        path,
+        fullPath,
+        rawExpression,
+      });
+    }
+  }
+
+  return references;
+}
+
+/**
+ * Extracts self-reference paths from a CEL expression.
+ *
+ * @param expression - The CEL expression to analyze
+ * @returns Array of self-references found in the expression
+ */
+export function extractSelfReferences(
+  expression: string,
+): SelfPathReference[] {
+  const references: SelfPathReference[] = [];
+  const seen = new Set<string>();
+
+  const matches = expression.matchAll(SELF_PATH_PATTERN);
+  for (const match of matches) {
+    const remainingPath = match[1] || "";
+    const path = parsePathSegments(remainingPath);
+    const fullPath = remainingPath.startsWith(".")
+      ? remainingPath.slice(1)
+      : remainingPath;
+    const rawExpression = match[0];
+
+    // Deduplicate based on raw expression
+    if (!seen.has(rawExpression)) {
+      seen.add(rawExpression);
+      references.push({
+        path,
+        fullPath,
+        rawExpression,
+      });
+    }
+  }
+
+  return references;
+}

--- a/src/domain/expressions/expression_path_extractor_test.ts
+++ b/src/domain/expressions/expression_path_extractor_test.ts
@@ -1,0 +1,153 @@
+import { assertEquals } from "@std/assert";
+import {
+  extractPathReferences,
+  extractSelfReferences,
+} from "./expression_path_extractor.ts";
+
+// extractPathReferences tests
+
+Deno.test("extractPathReferences extracts simple resource path", () => {
+  const refs = extractPathReferences("model.my-vpc.resource.attributes.VpcId");
+  assertEquals(refs.length, 1);
+  assertEquals(refs[0].modelRef, "my-vpc");
+  assertEquals(refs[0].type, "resource");
+  assertEquals(refs[0].path, ["attributes", "VpcId"]);
+  assertEquals(refs[0].fullPath, "resource.attributes.VpcId");
+  assertEquals(refs[0].rawExpression, "model.my-vpc.resource.attributes.VpcId");
+});
+
+Deno.test("extractPathReferences extracts simple input path", () => {
+  const refs = extractPathReferences("model.my-vpc.input.attributes.CidrBlock");
+  assertEquals(refs.length, 1);
+  assertEquals(refs[0].modelRef, "my-vpc");
+  assertEquals(refs[0].type, "input");
+  assertEquals(refs[0].path, ["attributes", "CidrBlock"]);
+  assertEquals(refs[0].fullPath, "input.attributes.CidrBlock");
+});
+
+Deno.test("extractPathReferences handles path with array index", () => {
+  const refs = extractPathReferences(
+    "model.vpc.resource.attributes.Tags[0].Key",
+  );
+  assertEquals(refs.length, 1);
+  assertEquals(refs[0].path, ["attributes", "Tags", "0", "Key"]);
+  assertEquals(refs[0].fullPath, "resource.attributes.Tags[0].Key");
+});
+
+Deno.test("extractPathReferences handles multiple array indices", () => {
+  const refs = extractPathReferences("model.vpc.resource.data[0][1].value");
+  assertEquals(refs.length, 1);
+  assertEquals(refs[0].path, ["data", "0", "1", "value"]);
+});
+
+Deno.test("extractPathReferences extracts multiple references", () => {
+  const expr =
+    "model.vpc.resource.attributes.VpcId + model.subnet.input.attributes.CidrBlock";
+  const refs = extractPathReferences(expr);
+  assertEquals(refs.length, 2);
+  assertEquals(refs[0].modelRef, "vpc");
+  assertEquals(refs[0].type, "resource");
+  assertEquals(refs[1].modelRef, "subnet");
+  assertEquals(refs[1].type, "input");
+});
+
+Deno.test("extractPathReferences deduplicates identical references", () => {
+  const expr =
+    "model.vpc.resource.attributes.VpcId + model.vpc.resource.attributes.VpcId";
+  const refs = extractPathReferences(expr);
+  assertEquals(refs.length, 1);
+});
+
+Deno.test("extractPathReferences handles reference without path", () => {
+  const refs = extractPathReferences("model.vpc.resource");
+  assertEquals(refs.length, 1);
+  assertEquals(refs[0].path, []);
+  assertEquals(refs[0].fullPath, "resource");
+});
+
+Deno.test("extractPathReferences handles model names with hyphens", () => {
+  const refs = extractPathReferences(
+    "model.deploy-vpc-123.resource.attributes.id",
+  );
+  assertEquals(refs.length, 1);
+  assertEquals(refs[0].modelRef, "deploy-vpc-123");
+});
+
+Deno.test("extractPathReferences handles model names with underscores", () => {
+  const refs = extractPathReferences(
+    "model.my_vpc_instance.input.attributes.name",
+  );
+  assertEquals(refs.length, 1);
+  assertEquals(refs[0].modelRef, "my_vpc_instance");
+});
+
+Deno.test("extractPathReferences returns empty array for no references", () => {
+  const refs = extractPathReferences("self.name + 42");
+  assertEquals(refs.length, 0);
+});
+
+Deno.test("extractPathReferences handles deeply nested paths", () => {
+  const refs = extractPathReferences(
+    "model.config.input.attributes.settings.network.vpc.cidr",
+  );
+  assertEquals(refs.length, 1);
+  assertEquals(refs[0].path, [
+    "attributes",
+    "settings",
+    "network",
+    "vpc",
+    "cidr",
+  ]);
+});
+
+// extractSelfReferences tests
+
+Deno.test("extractSelfReferences extracts simple self reference", () => {
+  const refs = extractSelfReferences("self.attributes.VpcId");
+  assertEquals(refs.length, 1);
+  assertEquals(refs[0].path, ["attributes", "VpcId"]);
+  assertEquals(refs[0].fullPath, "attributes.VpcId");
+  assertEquals(refs[0].rawExpression, "self.attributes.VpcId");
+});
+
+Deno.test("extractSelfReferences handles just self", () => {
+  const refs = extractSelfReferences("self");
+  assertEquals(refs.length, 1);
+  assertEquals(refs[0].path, []);
+  assertEquals(refs[0].fullPath, "");
+});
+
+Deno.test("extractSelfReferences handles self.name", () => {
+  const refs = extractSelfReferences("self.name");
+  assertEquals(refs.length, 1);
+  assertEquals(refs[0].path, ["name"]);
+  assertEquals(refs[0].fullPath, "name");
+});
+
+Deno.test("extractSelfReferences handles multiple self references", () => {
+  const refs = extractSelfReferences("self.name + self.version");
+  assertEquals(refs.length, 2);
+  assertEquals(refs[0].path, ["name"]);
+  assertEquals(refs[1].path, ["version"]);
+});
+
+Deno.test("extractSelfReferences handles array index", () => {
+  const refs = extractSelfReferences("self.attributes.Tags[0].Key");
+  assertEquals(refs.length, 1);
+  assertEquals(refs[0].path, ["attributes", "Tags", "0", "Key"]);
+});
+
+Deno.test("extractSelfReferences deduplicates identical references", () => {
+  const refs = extractSelfReferences("self.name + self.name");
+  assertEquals(refs.length, 1);
+});
+
+Deno.test("extractSelfReferences does not match 'myself'", () => {
+  const refs = extractSelfReferences("myself.name");
+  assertEquals(refs.length, 0);
+});
+
+Deno.test("extractSelfReferences returns empty for no self references", () => {
+  const refs = extractSelfReferences("model.vpc.input.x");
+  assertEquals(refs.length, 0);
+});

--- a/src/domain/expressions/schema_path_validator.ts
+++ b/src/domain/expressions/schema_path_validator.ts
@@ -1,0 +1,266 @@
+import type { z } from "zod";
+
+/**
+ * Result of validating a path against a Zod schema.
+ */
+export interface PathValidationResult {
+  /** Whether the path is valid in the schema */
+  valid: boolean;
+  /** Error message if the path is invalid */
+  error?: string;
+  /** Suggestion for fixing the error (e.g., "Did you mean 'resource' instead of 'resources'?") */
+  suggestion?: string;
+  /** Available keys at the point where validation failed */
+  availableKeys?: string[];
+}
+
+/**
+ * Internal type for Zod v4 schema definition.
+ */
+interface ZodDef {
+  type: string;
+  innerType?: z.ZodTypeAny;
+  element?: z.ZodTypeAny;
+  shape?: Record<string, z.ZodTypeAny>;
+  valueType?: z.ZodTypeAny;
+  options?: z.ZodTypeAny[];
+  schema?: z.ZodTypeAny;
+}
+
+/**
+ * Computes Levenshtein distance between two strings for typo detection.
+ */
+function levenshteinDistance(a: string, b: string): number {
+  const matrix: number[][] = [];
+
+  for (let i = 0; i <= b.length; i++) {
+    matrix[i] = [i];
+  }
+  for (let j = 0; j <= a.length; j++) {
+    matrix[0][j] = j;
+  }
+
+  for (let i = 1; i <= b.length; i++) {
+    for (let j = 1; j <= a.length; j++) {
+      if (b.charAt(i - 1) === a.charAt(j - 1)) {
+        matrix[i][j] = matrix[i - 1][j - 1];
+      } else {
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j - 1] + 1, // substitution
+          matrix[i][j - 1] + 1, // insertion
+          matrix[i - 1][j] + 1, // deletion
+        );
+      }
+    }
+  }
+
+  return matrix[b.length][a.length];
+}
+
+/**
+ * Finds the closest match to a key among available keys.
+ */
+function findClosestKey(
+  key: string,
+  availableKeys: string[],
+): string | undefined {
+  if (availableKeys.length === 0) return undefined;
+
+  let closest: string | undefined;
+  let minDistance = Infinity;
+  const threshold = Math.max(2, Math.floor(key.length / 2));
+
+  for (const available of availableKeys) {
+    const distance = levenshteinDistance(
+      key.toLowerCase(),
+      available.toLowerCase(),
+    );
+    if (distance < minDistance && distance <= threshold) {
+      minDistance = distance;
+      closest = available;
+    }
+  }
+
+  return closest;
+}
+
+/**
+ * Gets the definition type from a Zod schema (Zod v4 compatible).
+ */
+function getSchemaType(schema: z.ZodTypeAny): string {
+  const def = (schema as unknown as { _def: ZodDef })._def;
+  return def?.type ?? "";
+}
+
+/**
+ * Gets the definition from a Zod schema.
+ */
+function getSchemaDef(schema: z.ZodTypeAny): ZodDef {
+  return (schema as unknown as { _def: ZodDef })._def;
+}
+
+/**
+ * Gets the keys from a Zod object schema.
+ */
+function getObjectKeys(schema: z.ZodTypeAny): string[] | null {
+  const unwrapped = unwrapSchema(schema);
+  const schemaType = getSchemaType(unwrapped);
+  if (schemaType === "object") {
+    const def = getSchemaDef(unwrapped);
+    return def.shape ? Object.keys(def.shape) : null;
+  }
+  return null;
+}
+
+/**
+ * Unwraps optional, nullable, and other wrapper types to get the underlying schema.
+ */
+function unwrapSchema(schema: z.ZodTypeAny): z.ZodTypeAny {
+  const schemaType = getSchemaType(schema);
+  const def = getSchemaDef(schema);
+
+  const wrapperTypes = ["optional", "nullable", "default"];
+  if (wrapperTypes.includes(schemaType) && def.innerType) {
+    return unwrapSchema(def.innerType);
+  }
+  if (schemaType === "effects" && def.schema) {
+    return unwrapSchema(def.schema);
+  }
+  return schema;
+}
+
+/**
+ * Gets the element schema from an array type.
+ */
+function getArrayElement(schema: z.ZodTypeAny): z.ZodTypeAny | null {
+  const unwrapped = unwrapSchema(schema);
+  const schemaType = getSchemaType(unwrapped);
+  if (schemaType === "array") {
+    const def = getSchemaDef(unwrapped);
+    return def.element ?? null;
+  }
+  return null;
+}
+
+/**
+ * Gets the property schema from an object by key.
+ */
+function getObjectProperty(
+  schema: z.ZodTypeAny,
+  key: string,
+): z.ZodTypeAny | null {
+  const unwrapped = unwrapSchema(schema);
+  const schemaType = getSchemaType(unwrapped);
+  const def = getSchemaDef(unwrapped);
+
+  if (schemaType === "object" && def.shape) {
+    if (key in def.shape) {
+      return def.shape[key];
+    }
+    return null;
+  }
+
+  if (schemaType === "record" && def.valueType) {
+    // Records allow any string key
+    return def.valueType;
+  }
+
+  const unionTypes = ["union", "discriminatedUnion"];
+  if (unionTypes.includes(schemaType) && def.options) {
+    for (const option of def.options) {
+      const result = getObjectProperty(option, key);
+      if (result) return result;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Validates a path against a Zod schema.
+ *
+ * @param schema - The Zod schema to validate against
+ * @param path - The path segments to validate (e.g., ["attributes", "VpcId"])
+ * @returns Validation result with error details if invalid
+ */
+export function validateSchemaPath(
+  schema: z.ZodTypeAny,
+  path: string[],
+): PathValidationResult {
+  if (path.length === 0) {
+    return { valid: true };
+  }
+
+  let currentSchema = schema;
+  const visitedPath: string[] = [];
+
+  for (let i = 0; i < path.length; i++) {
+    const segment = path[i];
+    const unwrapped = unwrapSchema(currentSchema);
+
+    // Check if segment is an array index
+    const isArrayIndex = /^\d+$/.test(segment);
+
+    if (isArrayIndex) {
+      const elementSchema = getArrayElement(unwrapped);
+      if (!elementSchema) {
+        return {
+          valid: false,
+          error:
+            `Cannot use array index [${segment}] on non-array type at path "${
+              visitedPath.join(".")
+            }"`,
+        };
+      }
+      currentSchema = elementSchema;
+      visitedPath.push(`[${segment}]`);
+    } else {
+      // Property access
+      const propertySchema = getObjectProperty(unwrapped, segment);
+
+      if (!propertySchema) {
+        const availableKeys = getObjectKeys(unwrapped);
+        const suggestion = availableKeys
+          ? findClosestKey(segment, availableKeys)
+          : undefined;
+
+        const pathSoFar = visitedPath.length > 0 ? visitedPath.join(".") : "";
+        const location = pathSoFar ? ` at path "${pathSoFar}"` : "";
+
+        return {
+          valid: false,
+          error: `Property "${segment}" not found${location}`,
+          suggestion: suggestion
+            ? `Did you mean "${suggestion}" instead of "${segment}"?`
+            : undefined,
+          availableKeys: availableKeys ?? undefined,
+        };
+      }
+
+      currentSchema = propertySchema;
+      visitedPath.push(segment);
+    }
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Formats available keys into a readable string.
+ *
+ * @param keys - The keys to format
+ * @param maxKeys - Maximum number of keys to show (default: 5)
+ * @returns Formatted string of available keys
+ */
+export function formatAvailableKeys(keys: string[], maxKeys = 5): string {
+  if (keys.length === 0) return "";
+
+  const sortedKeys = [...keys].sort();
+  if (sortedKeys.length <= maxKeys) {
+    return sortedKeys.join(", ");
+  }
+
+  const shown = sortedKeys.slice(0, maxKeys);
+  const remaining = sortedKeys.length - maxKeys;
+  return `${shown.join(", ")}, ... (${remaining} more)`;
+}

--- a/src/domain/expressions/schema_path_validator_test.ts
+++ b/src/domain/expressions/schema_path_validator_test.ts
@@ -1,0 +1,193 @@
+import { assertEquals } from "@std/assert";
+import { z } from "zod";
+import {
+  formatAvailableKeys,
+  validateSchemaPath,
+} from "./schema_path_validator.ts";
+
+// Test schema definitions
+
+const SimpleSchema = z.object({
+  name: z.string(),
+  count: z.number(),
+});
+
+const NestedSchema = z.object({
+  attributes: z.object({
+    VpcId: z.string(),
+    CidrBlock: z.string(),
+    Tags: z.array(z.object({
+      Key: z.string(),
+      Value: z.string(),
+    })),
+  }),
+  metadata: z.object({
+    createdAt: z.string(),
+  }),
+});
+
+const OptionalSchema = z.object({
+  required: z.string(),
+  optional: z.string().optional(),
+  nullable: z.string().nullable(),
+});
+
+const RecordSchema = z.object({
+  data: z.record(z.string(), z.string()),
+});
+
+const UnionSchema = z.object({
+  config: z.union([
+    z.object({ type: z.literal("a"), valueA: z.string() }),
+    z.object({ type: z.literal("b"), valueB: z.number() }),
+  ]),
+});
+
+// validateSchemaPath tests - valid paths
+
+Deno.test("validateSchemaPath returns valid for empty path", () => {
+  const result = validateSchemaPath(SimpleSchema, []);
+  assertEquals(result.valid, true);
+  assertEquals(result.error, undefined);
+});
+
+Deno.test("validateSchemaPath returns valid for simple property access", () => {
+  const result = validateSchemaPath(SimpleSchema, ["name"]);
+  assertEquals(result.valid, true);
+});
+
+Deno.test("validateSchemaPath returns valid for nested property access", () => {
+  const result = validateSchemaPath(NestedSchema, ["attributes", "VpcId"]);
+  assertEquals(result.valid, true);
+});
+
+Deno.test("validateSchemaPath returns valid for deeply nested path", () => {
+  const result = validateSchemaPath(NestedSchema, ["metadata", "createdAt"]);
+  assertEquals(result.valid, true);
+});
+
+Deno.test("validateSchemaPath returns valid for array element access", () => {
+  const result = validateSchemaPath(NestedSchema, ["attributes", "Tags", "0"]);
+  assertEquals(result.valid, true);
+});
+
+Deno.test("validateSchemaPath returns valid for array element property access", () => {
+  const result = validateSchemaPath(NestedSchema, [
+    "attributes",
+    "Tags",
+    "0",
+    "Key",
+  ]);
+  assertEquals(result.valid, true);
+});
+
+Deno.test("validateSchemaPath returns valid for optional property", () => {
+  const result = validateSchemaPath(OptionalSchema, ["optional"]);
+  assertEquals(result.valid, true);
+});
+
+Deno.test("validateSchemaPath returns valid for nullable property", () => {
+  const result = validateSchemaPath(OptionalSchema, ["nullable"]);
+  assertEquals(result.valid, true);
+});
+
+Deno.test("validateSchemaPath returns valid for record access", () => {
+  // Records allow any string key
+  const result = validateSchemaPath(RecordSchema, ["data", "anyKey"]);
+  assertEquals(result.valid, true);
+});
+
+Deno.test("validateSchemaPath returns valid for union member property", () => {
+  const result = validateSchemaPath(UnionSchema, ["config", "valueA"]);
+  assertEquals(result.valid, true);
+});
+
+// validateSchemaPath tests - invalid paths
+
+Deno.test("validateSchemaPath returns invalid for non-existent property", () => {
+  const result = validateSchemaPath(SimpleSchema, ["nonExistent"]);
+  assertEquals(result.valid, false);
+  assertEquals(result.error?.includes("nonExistent"), true);
+  assertEquals(result.error?.includes("not found"), true);
+});
+
+Deno.test("validateSchemaPath returns invalid for typo with suggestion", () => {
+  const result = validateSchemaPath(NestedSchema, ["attributes", "vpcID"]);
+  assertEquals(result.valid, false);
+  assertEquals(result.suggestion?.includes("VpcId"), true);
+});
+
+Deno.test("validateSchemaPath returns invalid for wrong nested property", () => {
+  const result = validateSchemaPath(NestedSchema, [
+    "attributes",
+    "NonExistent",
+  ]);
+  assertEquals(result.valid, false);
+  assertEquals(result.availableKeys?.includes("VpcId"), true);
+  assertEquals(result.availableKeys?.includes("CidrBlock"), true);
+});
+
+Deno.test("validateSchemaPath returns invalid for array index on non-array", () => {
+  const result = validateSchemaPath(SimpleSchema, ["name", "0"]);
+  assertEquals(result.valid, false);
+  assertEquals(result.error?.includes("non-array"), true);
+});
+
+Deno.test("validateSchemaPath returns invalid for property on array without index", () => {
+  const result = validateSchemaPath(NestedSchema, [
+    "attributes",
+    "Tags",
+    "Key",
+  ]);
+  assertEquals(result.valid, false);
+  assertEquals(result.error?.includes("not found"), true);
+});
+
+Deno.test("validateSchemaPath suggests similar property name", () => {
+  const result = validateSchemaPath(NestedSchema, ["atributes"]);
+  assertEquals(result.valid, false);
+  assertEquals(result.suggestion?.includes("attributes"), true);
+});
+
+Deno.test("validateSchemaPath provides available keys on failure", () => {
+  const result = validateSchemaPath(SimpleSchema, ["wrong"]);
+  assertEquals(result.valid, false);
+  assertEquals(result.availableKeys?.length, 2);
+  assertEquals(result.availableKeys?.includes("name"), true);
+  assertEquals(result.availableKeys?.includes("count"), true);
+});
+
+Deno.test("validateSchemaPath handles path at nested failure point", () => {
+  const result = validateSchemaPath(NestedSchema, ["attributes", "wrong"]);
+  assertEquals(result.valid, false);
+  assertEquals(result.error?.includes("attributes"), true);
+});
+
+// formatAvailableKeys tests
+
+Deno.test("formatAvailableKeys formats empty array", () => {
+  const result = formatAvailableKeys([]);
+  assertEquals(result, "");
+});
+
+Deno.test("formatAvailableKeys formats single key", () => {
+  const result = formatAvailableKeys(["name"]);
+  assertEquals(result, "name");
+});
+
+Deno.test("formatAvailableKeys formats multiple keys sorted", () => {
+  const result = formatAvailableKeys(["count", "name", "age"]);
+  assertEquals(result, "age, count, name");
+});
+
+Deno.test("formatAvailableKeys truncates with ellipsis when exceeding limit", () => {
+  const keys = ["a", "b", "c", "d", "e", "f", "g"];
+  const result = formatAvailableKeys(keys, 3);
+  assertEquals(result, "a, b, c, ... (4 more)");
+});
+
+Deno.test("formatAvailableKeys shows all when at limit", () => {
+  const keys = ["a", "b", "c"];
+  const result = formatAvailableKeys(keys, 3);
+  assertEquals(result, "a, b, c");
+});

--- a/src/domain/models/validation_service.ts
+++ b/src/domain/models/validation_service.ts
@@ -1,9 +1,99 @@
 import type { z } from "zod";
 import type { ModelDefinition } from "./model.ts";
+import { modelRegistry } from "./model.ts";
 import type { ModelInput } from "./model_input.ts";
 import { ModelInputSchema } from "./model_input.ts";
 import type { ModelResource } from "./model_resource.ts";
 import { ModelResourceSchema } from "./model_resource.ts";
+import type { InputRepository } from "./repositories.ts";
+import { extractExpressions } from "../expressions/expression_parser.ts";
+import {
+  extractPathReferences,
+  extractSelfReferences,
+} from "../expressions/expression_path_extractor.ts";
+import {
+  formatAvailableKeys,
+  validateSchemaPath,
+} from "../expressions/schema_path_validator.ts";
+
+/**
+ * Represents a malformed expression found in the data.
+ */
+interface MalformedExpression {
+  /** The path where the malformed expression was found */
+  path: string;
+  /** The raw string containing the malformed expression */
+  raw: string;
+  /** The type of malformation detected */
+  issue: string;
+  /** Suggestion for fixing the malformation */
+  suggestion: string;
+}
+
+/**
+ * Patterns that indicate a malformed expression.
+ */
+const MALFORMED_PATTERNS: Array<{
+  pattern: RegExp;
+  issue: string;
+  suggestion: string;
+}> = [
+  {
+    // {{...}} without the $ prefix (negative lookbehind ensures no $ before)
+    pattern: /(?<!\$)\{\{(?!\{)[^}]+\}\}/,
+    issue: "Expression uses {{...}} instead of ${{...}}",
+    suggestion: 'Add "$" prefix: ${{...}}',
+  },
+  {
+    // ${...} with single braces (common mistake)
+    pattern: /\$\{(?!\{)[^}]+\}/,
+    issue: "Expression uses ${...} instead of ${{...}}",
+    suggestion: "Use double braces: ${{...}}",
+  },
+];
+
+/**
+ * Scans a data structure for malformed expressions.
+ */
+function findMalformedExpressions(
+  data: unknown,
+  basePath = "",
+): MalformedExpression[] {
+  const malformed: MalformedExpression[] = [];
+  findMalformedExpressionsRecursive(data, basePath, malformed);
+  return malformed;
+}
+
+function findMalformedExpressionsRecursive(
+  data: unknown,
+  path: string,
+  malformed: MalformedExpression[],
+): void {
+  if (typeof data === "string") {
+    // Check for malformed expression patterns
+    for (const { pattern, issue, suggestion } of MALFORMED_PATTERNS) {
+      const match = data.match(pattern);
+      if (match) {
+        malformed.push({
+          path,
+          raw: match[0],
+          issue,
+          suggestion,
+        });
+      }
+    }
+  } else if (Array.isArray(data)) {
+    for (let i = 0; i < data.length; i++) {
+      const itemPath = path ? `${path}[${i}]` : `[${i}]`;
+      findMalformedExpressionsRecursive(data[i], itemPath, malformed);
+    }
+  } else if (data !== null && typeof data === "object") {
+    for (const [key, value] of Object.entries(data)) {
+      const propPath = path ? `${path}.${key}` : key;
+      findMalformedExpressionsRecursive(value, propPath, malformed);
+    }
+  }
+}
 
 /**
  * Value object representing the result of a single validation.
@@ -72,13 +162,29 @@ export interface ModelValidationService {
    * @param input - The model input to validate
    * @param definition - The model definition containing schemas
    * @param resource - The model resource if one exists, or null
+   * @param inputRepo - Optional input repository for resolving model references in expressions
    * @returns Array of validation results
    */
   validateModel(
     input: ModelInput,
     definition: ModelDefinition,
     resource: ModelResource | null,
+    inputRepo?: InputRepository,
   ): Promise<ValidationResult[]>;
+}
+
+/**
+ * Error detail for a single expression path validation failure.
+ */
+export interface ExpressionPathError {
+  /** The raw expression that failed validation */
+  expression: string;
+  /** The error message */
+  error: string;
+  /** Optional suggestion for fixing the error */
+  suggestion?: string;
+  /** Optional available keys at the failure point */
+  availableKeys?: string[];
 }
 
 /**
@@ -89,6 +195,7 @@ export class DefaultModelValidationService implements ModelValidationService {
     input: ModelInput,
     definition: ModelDefinition,
     resource: ModelResource | null,
+    inputRepo?: InputRepository,
   ): Promise<ValidationResult[]> {
     const validations: Promise<ValidationResult>[] = [
       this.validateInputSchema(input),
@@ -102,16 +209,34 @@ export class DefaultModelValidationService implements ModelValidationService {
       );
     }
 
+    // Add expression path validation if inputRepo is provided
+    if (inputRepo) {
+      validations.push(
+        this.validateExpressionPaths(input, definition, inputRepo),
+      );
+    }
+
     return Promise.all(validations);
   }
 
-  private validateInputSchema(input: ModelInput): Promise<ValidationResult> {
-    const result = ModelInputSchema.safeParse(input.toData());
-    if (result.success) {
-      return Promise.resolve(ValidationResult.pass("Input schema"));
-    }
+  private validateWithSchema(
+    name: string,
+    schema: z.ZodTypeAny,
+    data: unknown,
+  ): Promise<ValidationResult> {
+    const result = schema.safeParse(data);
     return Promise.resolve(
-      ValidationResult.fail("Input schema", formatZodError(result.error)),
+      result.success
+        ? ValidationResult.pass(name)
+        : ValidationResult.fail(name, formatZodError(result.error)),
+    );
+  }
+
+  private validateInputSchema(input: ModelInput): Promise<ValidationResult> {
+    return this.validateWithSchema(
+      "Input schema",
+      ModelInputSchema,
+      input.toData(),
     );
   }
 
@@ -119,24 +244,20 @@ export class DefaultModelValidationService implements ModelValidationService {
     input: ModelInput,
     definition: ModelDefinition,
   ): Promise<ValidationResult> {
-    const result = definition.inputAttributesSchema.safeParse(input.attributes);
-    if (result.success) {
-      return Promise.resolve(ValidationResult.pass("Input attributes"));
-    }
-    return Promise.resolve(
-      ValidationResult.fail("Input attributes", formatZodError(result.error)),
+    return this.validateWithSchema(
+      "Input attributes",
+      definition.inputAttributesSchema,
+      input.attributes,
     );
   }
 
   private validateResourceSchema(
     resource: ModelResource,
   ): Promise<ValidationResult> {
-    const result = ModelResourceSchema.safeParse(resource.toData());
-    if (result.success) {
-      return Promise.resolve(ValidationResult.pass("Resource schema"));
-    }
-    return Promise.resolve(
-      ValidationResult.fail("Resource schema", formatZodError(result.error)),
+    return this.validateWithSchema(
+      "Resource schema",
+      ModelResourceSchema,
+      resource.toData(),
     );
   }
 
@@ -144,17 +265,269 @@ export class DefaultModelValidationService implements ModelValidationService {
     resource: ModelResource,
     definition: ModelDefinition,
   ): Promise<ValidationResult> {
-    const result = definition.resourceAttributesSchema.safeParse(
+    return this.validateWithSchema(
+      "Resource attributes",
+      definition.resourceAttributesSchema,
       resource.attributes,
     );
-    if (result.success) {
-      return Promise.resolve(ValidationResult.pass("Resource attributes"));
-    }
-    return Promise.resolve(
-      ValidationResult.fail(
-        "Resource attributes",
-        formatZodError(result.error),
-      ),
+  }
+
+  /**
+   * Validates expression paths in the model input attributes.
+   *
+   * Extracts all expressions from input attributes, resolves model references,
+   * and validates that the paths exist in the referenced schemas.
+   * Also detects malformed expressions that don't match the proper ${{...}} syntax.
+   */
+  private async validateExpressionPaths(
+    input: ModelInput,
+    definition: ModelDefinition,
+    inputRepo: InputRepository,
+  ): Promise<ValidationResult> {
+    const errors: ExpressionPathError[] = [];
+
+    // First, check for malformed expressions
+    const malformedErrors = findMalformedExpressions(input.attributes).map(
+      (m) => ({
+        expression: m.raw,
+        error: `${m.issue} at "${m.path}"`,
+        suggestion: m.suggestion,
+      }),
     );
+    errors.push(...malformedErrors);
+
+    // Extract and validate all expressions from input attributes
+    for (const exprLocation of extractExpressions(input.attributes)) {
+      const { celExpression, raw, path } = exprLocation;
+
+      // Validate model references
+      const pathRefs = extractPathReferences(celExpression);
+      const modelErrors = await Promise.all(
+        pathRefs.map((ref) => this.validateModelPathReference(ref, inputRepo)),
+      );
+      errors.push(
+        ...modelErrors.filter((e): e is ExpressionPathError => e !== null),
+      );
+
+      // Validate self references
+      const selfRefs = extractSelfReferences(celExpression);
+      const selfErrors = selfRefs
+        .map((ref) => this.validateSelfPathReference(ref, definition))
+        .filter((e): e is ExpressionPathError => e !== null);
+      errors.push(...selfErrors);
+
+      // Check for expressions with valid ${{...}} syntax but no valid references
+      if (pathRefs.length === 0 && selfRefs.length === 0) {
+        const error = this.validateExpressionContent(celExpression, raw, path);
+        if (error) errors.push(error);
+      }
+    }
+
+    if (errors.length === 0) {
+      return ValidationResult.pass("Expression paths");
+    }
+
+    const errorMessage = this.formatExpressionPathErrors(errors);
+    return ValidationResult.fail("Expression paths", errorMessage);
+  }
+
+  /**
+   * Validates expression content when no valid model or self references were found.
+   * This catches cases like ${{my-vpc.VpcId}} which should be ${{ model.my-vpc.resource.attributes.VpcId }}
+   */
+  private validateExpressionContent(
+    celExpression: string,
+    rawExpression: string,
+    path: string,
+  ): ExpressionPathError | null {
+    // First, check if it looks like a valid CEL literal or operation
+    // These are valid expressions that don't need model/self references
+    const looksLikeValidCel = /^[\d"'\[\{(]|^true$|^false$|^null$/.test(
+      celExpression,
+    );
+    if (looksLikeValidCel) {
+      return null;
+    }
+
+    // Check if it looks like an incomplete model reference (e.g., "my-vpc.VpcId")
+    // Pattern: word characters/hyphens followed by dot and more content
+    const incompleteModelRefPattern = /^([a-zA-Z0-9_-]+)\.([a-zA-Z0-9_.]+)$/;
+    const match = celExpression.match(incompleteModelRefPattern);
+
+    if (match) {
+      const modelName = match[1];
+      const propertyPath = match[2];
+      return {
+        expression: rawExpression,
+        error:
+          `Invalid expression "${celExpression}" at "${path}". Missing "model." prefix and path structure`,
+        suggestion:
+          `Use: model.${modelName}.resource.attributes.${propertyPath} or model.${modelName}.input.attributes.${propertyPath}`,
+      };
+    }
+
+    // Check if it's just a simple identifier that might be a model name (must start with letter)
+    const simpleIdentifierPattern = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+    if (simpleIdentifierPattern.test(celExpression)) {
+      return {
+        expression: rawExpression,
+        error:
+          `Invalid expression "${celExpression}" at "${path}". Expression must reference model or self`,
+        suggestion:
+          `Use: model.${celExpression}.resource.attributes.<property> or self.attributes.<property>`,
+      };
+    }
+
+    // For other unrecognized expressions, provide a generic error
+    return {
+      expression: rawExpression,
+      error:
+        `Expression "${celExpression}" at "${path}" does not contain valid model or self references`,
+      suggestion:
+        "Expressions should use: model.<name>.resource.attributes.<property>, model.<name>.input.attributes.<property>, or self.attributes.<property>",
+    };
+  }
+
+  /**
+   * Validates a model path reference (e.g., model.my-vpc.resource.attributes.VpcId).
+   */
+  private async validateModelPathReference(
+    ref: {
+      modelRef: string;
+      type: "input" | "resource";
+      path: string[];
+      rawExpression: string;
+    },
+    inputRepo: InputRepository,
+  ): Promise<ExpressionPathError | null> {
+    // Look up the referenced model
+    const result = await inputRepo.findByNameGlobal(ref.modelRef);
+    if (!result) {
+      return {
+        expression: ref.rawExpression,
+        error: `Referenced model "${ref.modelRef}" not found`,
+      };
+    }
+
+    // Get the model definition
+    const targetDefinition = modelRegistry.get(result.type);
+    if (!targetDefinition) {
+      return {
+        expression: ref.rawExpression,
+        error:
+          `Unknown model type "${result.type.normalized}" for model "${ref.modelRef}"`,
+      };
+    }
+
+    // Get the appropriate schema based on type and determine path to validate
+    // The path includes "attributes" as the first segment (e.g., ["attributes", "VpcId"])
+    // but the schema is already for the attributes object itself
+    const firstSegment = ref.path[0];
+
+    // Validate the path structure
+    if (ref.path.length === 0) {
+      // Just "input" or "resource" without a path is valid
+      return null;
+    }
+
+    if (firstSegment !== "attributes") {
+      // For now, we only support .attributes paths
+      // Other valid paths like .id could be added later
+      return {
+        expression: ref.rawExpression,
+        error: `Invalid path segment "${firstSegment}". Expected "attributes"`,
+        suggestion: firstSegment === "attribute"
+          ? 'Did you mean "attributes" instead of "attribute"?'
+          : undefined,
+      };
+    }
+
+    // Skip the "attributes" segment and validate the rest against the schema
+    const pathToValidate = ref.path.slice(1);
+    if (pathToValidate.length === 0) {
+      // Just ".attributes" is valid
+      return null;
+    }
+
+    const schema = ref.type === "input"
+      ? targetDefinition.inputAttributesSchema
+      : targetDefinition.resourceAttributesSchema;
+
+    // Validate the path against the schema
+    const validationResult = validateSchemaPath(schema, pathToValidate);
+    if (!validationResult.valid) {
+      return {
+        expression: ref.rawExpression,
+        error: validationResult.error!,
+        suggestion: validationResult.suggestion,
+        availableKeys: validationResult.availableKeys,
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Validates a self path reference (e.g., self.attributes.VpcId).
+   */
+  private validateSelfPathReference(
+    ref: { path: string[]; rawExpression: string },
+    definition: ModelDefinition,
+  ): ExpressionPathError | null {
+    if (ref.path.length === 0) {
+      return null;
+    }
+
+    const [firstSegment, ...remainingPath] = ref.path;
+    const validPrimitiveSegments = ["name", "version", "tags"];
+
+    if (validPrimitiveSegments.includes(firstSegment)) {
+      return null;
+    }
+
+    if (firstSegment !== "attributes") {
+      return {
+        expression: ref.rawExpression,
+        error:
+          `Invalid self reference segment "${firstSegment}". Valid segments: name, version, tags, attributes`,
+      };
+    }
+
+    if (remainingPath.length === 0) {
+      return null;
+    }
+
+    const validationResult = validateSchemaPath(
+      definition.inputAttributesSchema,
+      remainingPath,
+    );
+    if (!validationResult.valid) {
+      return {
+        expression: ref.rawExpression,
+        error: validationResult.error!,
+        suggestion: validationResult.suggestion,
+        availableKeys: validationResult.availableKeys,
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Formats expression path errors into a human-readable string.
+   */
+  private formatExpressionPathErrors(errors: ExpressionPathError[]): string {
+    return errors
+      .map((err) => {
+        const lines = [`  - ${err.expression}`, `    ${err.error}`];
+        if (err.suggestion) lines.push(`    ${err.suggestion}`);
+        if (err.availableKeys?.length) {
+          lines.push(
+            `    Available: ${formatAvailableKeys(err.availableKeys)}`,
+          );
+        }
+        return lines.join("\n");
+      })
+      .join("\n");
   }
 }

--- a/src/domain/models/validation_service_test.ts
+++ b/src/domain/models/validation_service_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import {
   DefaultModelValidationService,
   ValidationResult,
@@ -6,6 +6,9 @@ import {
 import { ModelInput } from "./model_input.ts";
 import { ModelResource } from "./model_resource.ts";
 import { echoModel } from "./echo/echo_model.ts";
+import type { InputRepository } from "./repositories.ts";
+import { ModelType } from "./model_type.ts";
+import type { ModelInputId } from "./model_input.ts";
 
 // ValidationResult value object tests
 
@@ -205,4 +208,562 @@ Deno.test("validateModel runs validations in parallel", async () => {
     assertEquals(results.length, 4);
     assertEquals(results.every((r) => r.passed), true);
   }
+});
+
+// Expression path validation tests
+
+/**
+ * Creates a mock input repository for testing expression path validation.
+ */
+function createMockInputRepo(
+  models: { name: string; type: string; input: ModelInput }[],
+): InputRepository {
+  return {
+    findById: () => Promise.resolve(null),
+    findAll: () => Promise.resolve([]),
+    findByName: () => Promise.resolve(null),
+    findByNameGlobal: (name: string) => {
+      const found = models.find((m) => m.name === name);
+      if (found) {
+        return Promise.resolve({
+          input: found.input,
+          type: ModelType.create(found.type),
+        });
+      }
+      return Promise.resolve(null);
+    },
+    save: () => Promise.resolve(),
+    delete: () => Promise.resolve(),
+    nextId: () => crypto.randomUUID() as ModelInputId,
+    getPath: () => "",
+  };
+}
+
+Deno.test("validateModel with expression paths passes for valid path", async () => {
+  const service = new DefaultModelValidationService();
+  const targetInput = ModelInput.create({
+    name: "target-model",
+    attributes: { message: "hello" },
+  });
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: {
+      message: "${{ model.target-model.input.attributes.message }}",
+    },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "target-model", type: "swamp/echo", input: targetInput },
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, true);
+});
+
+Deno.test("validateModel with expression paths fails for invalid attribute", async () => {
+  const service = new DefaultModelValidationService();
+  const targetInput = ModelInput.create({
+    name: "target-model",
+    attributes: { message: "hello" },
+  });
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: {
+      message: "${{ model.target-model.input.attributes.nonExistent }}",
+    },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "target-model", type: "swamp/echo", input: targetInput },
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, false);
+  assertStringIncludes(exprResult?.error ?? "", "nonExistent");
+  assertStringIncludes(exprResult?.error ?? "", "not found");
+});
+
+Deno.test("validateModel with expression paths fails for non-existent model", async () => {
+  const service = new DefaultModelValidationService();
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: {
+      message: "${{ model.missing-model.input.attributes.message }}",
+    },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, false);
+  assertStringIncludes(exprResult?.error ?? "", "missing-model");
+  assertStringIncludes(exprResult?.error ?? "", "not found");
+});
+
+Deno.test("validateModel with expression paths validates self references", async () => {
+  const service = new DefaultModelValidationService();
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: { message: "${{ self.name }}" },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, true);
+});
+
+Deno.test("validateModel with expression paths fails for invalid self attribute", async () => {
+  const service = new DefaultModelValidationService();
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: { message: "${{ self.attributes.nonExistent }}" },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, false);
+  assertStringIncludes(exprResult?.error ?? "", "nonExistent");
+});
+
+Deno.test("validateModel with expression paths fails for invalid self segment", async () => {
+  const service = new DefaultModelValidationService();
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: { message: "${{ self.wrongSegment }}" },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, false);
+  assertStringIncludes(exprResult?.error ?? "", "wrongSegment");
+});
+
+Deno.test("validateModel with expression paths provides typo suggestion", async () => {
+  const service = new DefaultModelValidationService();
+  const targetInput = ModelInput.create({
+    name: "target-model",
+    attributes: { message: "hello" },
+  });
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: {
+      // "mesage" is a typo for "message"
+      message: "${{ model.target-model.input.attributes.mesage }}",
+    },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "target-model", type: "swamp/echo", input: targetInput },
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, false);
+  assertStringIncludes(exprResult?.error ?? "", "message");
+});
+
+Deno.test("validateModel without inputRepo skips expression validation", async () => {
+  const service = new DefaultModelValidationService();
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: {
+      message: "${{ model.missing.input.attributes.foo }}",
+    },
+  });
+
+  // No inputRepo provided - expression validation should be skipped
+  const results = await service.validateModel(input, echoModel, null);
+
+  // Should only have input schema and input attributes validations
+  assertEquals(results.length, 2);
+  assertEquals(results.every((r) => r.name !== "Expression paths"), true);
+});
+
+Deno.test("validateModel with no expressions passes validation", async () => {
+  const service = new DefaultModelValidationService();
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: { message: "plain string with no expressions" },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, true);
+});
+
+// Malformed expression detection tests
+
+Deno.test("validateModel detects malformed expression with missing $ prefix", async () => {
+  const service = new DefaultModelValidationService();
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: {
+      // Missing $ prefix - should be ${{ ... }}
+      message: "{{my-vpc.VpcId}}",
+    },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, false);
+  assertStringIncludes(exprResult?.error ?? "", "{{my-vpc.VpcId}}");
+  assertStringIncludes(exprResult?.error ?? "", "instead of ${{");
+});
+
+Deno.test("validateModel detects malformed expression with single braces", async () => {
+  const service = new DefaultModelValidationService();
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: {
+      // Single braces - should be ${{ ... }}
+      message: "${model.my-vpc.resource.attributes.VpcId}",
+    },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, false);
+  assertStringIncludes(exprResult?.error ?? "", "${model.my-vpc");
+  assertStringIncludes(exprResult?.error ?? "", "double braces");
+});
+
+Deno.test("validateModel detects malformed expression in nested attributes", async () => {
+  const service = new DefaultModelValidationService();
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: {
+      message: "valid",
+      nested: {
+        value: "{{invalid-expression}}",
+      },
+    },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, false);
+  assertStringIncludes(exprResult?.error ?? "", "nested.value");
+});
+
+Deno.test("validateModel detects incomplete model reference like my-vpc.VpcId", async () => {
+  const service = new DefaultModelValidationService();
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: {
+      // Missing "model." prefix and ".resource.attributes" path
+      message: "${{my-vpc.VpcId}}",
+    },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, false);
+  assertStringIncludes(exprResult?.error ?? "", "my-vpc.VpcId");
+  assertStringIncludes(exprResult?.error ?? "", "model.");
+});
+
+Deno.test("validateModel detects simple identifier expression", async () => {
+  const service = new DefaultModelValidationService();
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: {
+      // Just a model name without any path
+      message: "${{ my-vpc }}",
+    },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, false);
+  assertStringIncludes(exprResult?.error ?? "", "my-vpc");
+});
+
+// Resource path reference tests
+
+Deno.test("validateModel with resource path passes for valid path", async () => {
+  const service = new DefaultModelValidationService();
+  const targetInput = ModelInput.create({
+    name: "target-model",
+    attributes: { message: "hello" },
+  });
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: {
+      message: "${{ model.target-model.resource.attributes.message }}",
+    },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "target-model", type: "swamp/echo", input: targetInput },
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, true);
+});
+
+Deno.test("validateModel with resource path fails for invalid attribute", async () => {
+  const service = new DefaultModelValidationService();
+  const targetInput = ModelInput.create({
+    name: "target-model",
+    attributes: { message: "hello" },
+  });
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: {
+      message: "${{ model.target-model.resource.attributes.wrongAttr }}",
+    },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "target-model", type: "swamp/echo", input: targetInput },
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, false);
+  assertStringIncludes(exprResult?.error ?? "", "wrongAttr");
+});
+
+// Invalid path segment tests
+
+Deno.test("validateModel fails for missing .attributes segment", async () => {
+  const service = new DefaultModelValidationService();
+  const targetInput = ModelInput.create({
+    name: "target-model",
+    attributes: { message: "hello" },
+  });
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: {
+      // Missing .attributes - directly accessing .message
+      message: "${{ model.target-model.input.message }}",
+    },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "target-model", type: "swamp/echo", input: targetInput },
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, false);
+  // Should mention that "message" is not valid, expecting "attributes"
+  assertStringIncludes(exprResult?.error ?? "", "message");
+});
+
+Deno.test("validateModel fails for 'attribute' instead of 'attributes'", async () => {
+  const service = new DefaultModelValidationService();
+  const targetInput = ModelInput.create({
+    name: "target-model",
+    attributes: { message: "hello" },
+  });
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: {
+      // Common typo: "attribute" instead of "attributes"
+      message: "${{ model.target-model.resource.attribute.message }}",
+    },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "target-model", type: "swamp/echo", input: targetInput },
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, false);
+  assertStringIncludes(exprResult?.error ?? "", "attribute");
+  // Should suggest "attributes"
+  assertStringIncludes(exprResult?.error ?? "", "attributes");
+});
+
+// Mixed expression tests
+
+Deno.test("validateModel validates multiple model references in same expression", async () => {
+  const service = new DefaultModelValidationService();
+  const model1 = ModelInput.create({
+    name: "model-1",
+    attributes: { message: "hello" },
+  });
+  const model2 = ModelInput.create({
+    name: "model-2",
+    attributes: { message: "world" },
+  });
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: {
+      message:
+        "${{ model.model-1.input.attributes.message + model.model-2.input.attributes.message }}",
+    },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "model-1", type: "swamp/echo", input: model1 },
+    { name: "model-2", type: "swamp/echo", input: model2 },
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, true);
+});
+
+Deno.test("validateModel fails when one of multiple model references is invalid", async () => {
+  const service = new DefaultModelValidationService();
+  const model1 = ModelInput.create({
+    name: "model-1",
+    attributes: { message: "hello" },
+  });
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: {
+      // model-1 is valid, model-2 doesn't exist
+      message:
+        "${{ model.model-1.input.attributes.message + model.model-2.input.attributes.message }}",
+    },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "model-1", type: "swamp/echo", input: model1 },
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, false);
+  assertStringIncludes(exprResult?.error ?? "", "model-2");
+  assertStringIncludes(exprResult?.error ?? "", "not found");
+});
+
+Deno.test("validateModel validates mixed model and self references", async () => {
+  const service = new DefaultModelValidationService();
+  const targetModel = ModelInput.create({
+    name: "target-model",
+    attributes: { message: "hello" },
+  });
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: {
+      message: "${{ model.target-model.input.attributes.message + self.name }}",
+    },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "target-model", type: "swamp/echo", input: targetModel },
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, true);
+});
+
+// Edge case: valid ${{ }} without references (CEL literals)
+
+Deno.test("validateModel passes for CEL literal expressions", async () => {
+  const service = new DefaultModelValidationService();
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: {
+      // Valid CEL literal - should not be flagged as invalid
+      message: "${{ 'hello world' }}",
+    },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, true);
+});
+
+Deno.test("validateModel passes for CEL numeric expressions", async () => {
+  const service = new DefaultModelValidationService();
+  const input = ModelInput.create({
+    name: "test-input",
+    attributes: {
+      message: "${{ 42 }}",
+    },
+  });
+
+  const mockRepo = createMockInputRepo([
+    { name: "test-input", type: "swamp/echo", input },
+  ]);
+
+  const results = await service.validateModel(input, echoModel, null, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, true);
 });

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -18,6 +18,7 @@ import { YamlResourceRepository } from "../../infrastructure/persistence/yaml_re
 import { YamlEvaluatedWorkflowRepository } from "../../infrastructure/persistence/yaml_evaluated_workflow_repository.ts";
 import { modelRegistry } from "../models/model.ts";
 import { DefaultMethodExecutionService } from "../models/method_execution_service.ts";
+import { DefaultModelValidationService } from "../models/validation_service.ts";
 import { createModelInputId, ModelInput } from "../models/model_input.ts";
 import type { ModelType } from "../models/model_type.ts";
 import {
@@ -124,21 +125,49 @@ export class DefaultStepExecutor implements StepExecutor {
     // Keep original input (with expressions) for saving
     const { input: originalInput, modelType } = lookupResult;
 
-    // Evaluate expressions for execution
+    // Get the model definition
+    const definition = modelRegistry.get(modelType);
+    if (!definition) {
+      throw new Error(`Unknown model type: ${modelType.normalized}`);
+    }
+
+    // Validate the model input (including expression paths) BEFORE evaluation
+    // This catches malformed expressions and invalid paths early
+    const validationService = new DefaultModelValidationService();
+    const validationResults = await validationService.validateModel(
+      originalInput,
+      definition,
+      null, // resource doesn't exist yet
+      inputRepo,
+    );
+
+    // Fail fast if validation fails
+    const failures = validationResults.filter((r) => !r.passed);
+    if (failures.length > 0) {
+      const errors = failures.map((f) => `  ${f.name}: ${f.error}`).join("\n");
+      throw new Error(
+        `Model validation failed for "${originalInput.name}":\n${errors}`,
+      );
+    }
+
+    // Evaluate expressions for execution (after validation passes)
     let evaluatedInput = originalInput;
     if (ctx.expressionContext) {
+      // Set self context for this specific model before evaluating
+      ctx.expressionContext.self = {
+        id: originalInput.id,
+        name: originalInput.name,
+        version: originalInput.version,
+        tags: originalInput.tags,
+        attributes: originalInput.attributes,
+      };
+
       evaluatedInput = this.evaluateInputExpressions(
         originalInput,
         ctx.expressionContext,
       );
       // Save evaluated input to inputs-evaluated/
       await evaluatedInputRepo.save(modelType, evaluatedInput);
-    }
-
-    // Get the model definition
-    const definition = modelRegistry.get(modelType);
-    if (!definition) {
-      throw new Error(`Unknown model type: ${modelType.normalized}`);
     }
 
     // Validate method exists on the model


### PR DESCRIPTION
- Add expression path validation to catch invalid expressions early before execution
- Validate expressions during both `model validate` command and workflow runtime
- Add support for `self` references in workflow execution context

## What's New

### Expression Path Validation
Validates that expression paths reference valid schema properties:
- `${{ model.my-vpc.resource.attributes.VpcId }}` - **valid** (if VpcId exists)
- `${{ model.my-vpc.resource.attributes.NonExistent }}` - **invalid** (property not found)
- `${{ model.my-vpc.resource.attribute.VpcId }}` - **invalid** (suggests "attributes")

### Malformed Expression Detection
Catches common expression syntax mistakes:
- `{{my-vpc.VpcId}}` - missing `$` prefix
- `${model.X.resource.attributes.Y}` - single braces instead of double
- `${{my-vpc.VpcId}}` - missing `model.` prefix and path structure

### Self References in Workflows
Models can now reference their own properties during workflow execution:
```yaml
attributes:
message: "${{ self.name }}"
```

### Runtime Validation

Workflow execution now validates model inputs before running methods, providing clear error messages instead
of cryptic CEL evaluation failures.

### Files Changed

New Files:
- src/domain/expressions/expression_path_extractor.ts - Extract path references from expressions
- src/domain/expressions/schema_path_validator.ts - Validate paths against Zod schemas
- Tests for both new modules

Modified:
- src/domain/models/validation_service.ts - Add expression validation methods
- src/domain/workflows/execution_service.ts - Add validation before execution, set self context
- integration/workflow_test.ts - Add workflow expression tests
- src/domain/models/validation_service_test.ts - Add expression validation tests

### Test Plan

- deno check passes
- deno lint passes
- deno fmt passes
- 840 tests pass (1 pre-existing macOS-specific failure)
- Manual test: model validate catches invalid expressions
- Manual test: workflow run fails early with clear error for invalid expressions

🤖 Generated with https://claude.ai/code