### PR TITLE
Add UserError for cleaner CLI error messages

### DIFF
--- a/src/cli/commands/model_delete.ts
+++ b/src/cli/commands/model_delete.ts
@@ -14,6 +14,7 @@ import {
   findInputByIdGlobal,
   isUuid,
 } from "../../domain/models/model_lookup.ts";
+import { UserError } from "../../domain/errors.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -63,7 +64,7 @@ export const modelDeleteCommand = new Command()
       ctx.logger.debug`Looking up by ID: ${modelIdOrName}`;
       const result = await findInputByIdGlobal(inputRepo, modelIdOrName);
       if (!result) {
-        throw new Error(`Model not found: ${modelIdOrName}`);
+        throw new UserError(`Model not found: ${modelIdOrName}`);
       }
       input = result.input;
       modelType = result.type;
@@ -71,7 +72,7 @@ export const modelDeleteCommand = new Command()
       ctx.logger.debug`Looking up by name: ${modelIdOrName}`;
       const result = await inputRepo.findByNameGlobal(modelIdOrName);
       if (!result) {
-        throw new Error(`Model not found: ${modelIdOrName}`);
+        throw new UserError(`Model not found: ${modelIdOrName}`);
       }
       input = result.input;
       modelType = result.type;
@@ -88,7 +89,7 @@ export const modelDeleteCommand = new Command()
 
     // If resource exists and no --force flag, block deletion
     if (resource && !options.force) {
-      throw new Error(
+      throw new UserError(
         `Model '${input.name}' has an associated resource. Use --force to delete both.`,
       );
     }

--- a/src/cli/commands/model_edit.ts
+++ b/src/cli/commands/model_edit.ts
@@ -19,6 +19,7 @@ import {
   findInputByIdGlobal,
   isUuid,
 } from "../../domain/models/model_lookup.ts";
+import { UserError } from "../../domain/errors.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -60,7 +61,7 @@ export const modelEditCommand = new Command()
     if (!modelIdOrName) {
       // No argument provided - check if interactive mode
       if (ctx.outputMode === "json") {
-        throw new Error(
+        throw new UserError(
           "Model ID or name is required in non-interactive mode",
         );
       }
@@ -70,7 +71,7 @@ export const modelEditCommand = new Command()
       const allModels = toModelSearchItems(allResults);
 
       if (allModels.length === 0) {
-        throw new Error("No models found in repository");
+        throw new UserError("No models found in repository");
       }
 
       const searchData: ModelSearchData = {
@@ -90,7 +91,7 @@ export const modelEditCommand = new Command()
       // Find the full input data
       const result = await findInputByIdGlobal(inputRepo, selected.id);
       if (!result) {
-        throw new Error(`Model not found: ${selected.id}`);
+        throw new UserError(`Model not found: ${selected.id}`);
       }
       input = result.input;
       modelType = result.type;
@@ -98,7 +99,7 @@ export const modelEditCommand = new Command()
       ctx.logger.debug`Looking up by ID: ${modelIdOrName}`;
       const result = await findInputByIdGlobal(inputRepo, modelIdOrName);
       if (!result) {
-        throw new Error(`Model not found: ${modelIdOrName}`);
+        throw new UserError(`Model not found: ${modelIdOrName}`);
       }
       input = result.input;
       modelType = result.type;
@@ -106,7 +107,7 @@ export const modelEditCommand = new Command()
       ctx.logger.debug`Looking up by name: ${modelIdOrName}`;
       const result = await inputRepo.findByNameGlobal(modelIdOrName);
       if (!result) {
-        throw new Error(`Model not found: ${modelIdOrName}`);
+        throw new UserError(`Model not found: ${modelIdOrName}`);
       }
       input = result.input;
       modelType = result.type;
@@ -125,7 +126,7 @@ export const modelEditCommand = new Command()
         await Deno.stat(filePath);
       } catch (error) {
         if (error instanceof Deno.errors.NotFound) {
-          throw new Error(
+          throw new UserError(
             `Resource file not found for model '${input.name}'. ` +
               `Run a method to create the resource first.`,
           );

--- a/src/cli/commands/model_get.ts
+++ b/src/cli/commands/model_get.ts
@@ -14,6 +14,7 @@ import {
   findInputByIdGlobal,
   isUuid,
 } from "../../domain/models/model_lookup.ts";
+import { UserError } from "../../domain/errors.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -39,7 +40,7 @@ export const modelGetCommand = new Command()
       ctx.logger.debug`Looking up by ID: ${modelIdOrName}`;
       const result = await findInputByIdGlobal(inputRepo, modelIdOrName);
       if (!result) {
-        throw new Error(`Model not found: ${modelIdOrName}`);
+        throw new UserError(`Model not found: ${modelIdOrName}`);
       }
       input = result.input;
       modelType = result.type;
@@ -47,7 +48,7 @@ export const modelGetCommand = new Command()
       ctx.logger.debug`Looking up by name: ${modelIdOrName}`;
       const result = await inputRepo.findByNameGlobal(modelIdOrName);
       if (!result) {
-        throw new Error(`Model not found: ${modelIdOrName}`);
+        throw new UserError(`Model not found: ${modelIdOrName}`);
       }
       input = result.input;
       modelType = result.type;

--- a/src/cli/commands/type_describe.ts
+++ b/src/cli/commands/type_describe.ts
@@ -12,6 +12,7 @@ import {
   modelRegistry,
 } from "../../domain/models/model.ts";
 import { typeSearchCommand } from "./type_search.ts";
+import { UserError } from "../../domain/errors.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -53,7 +54,7 @@ export const typeDescribeCommand = new Command()
     if (!definition) {
       const availableTypes = modelRegistry.types().map((t) => t.normalized)
         .join(", ");
-      throw new Error(
+      throw new UserError(
         `Unknown model type: ${typeArg}. Available types: ${
           availableTypes || "none"
         }`,

--- a/src/cli/commands/workflow_edit.ts
+++ b/src/cli/commands/workflow_edit.ts
@@ -16,6 +16,7 @@ import {
 import type { Workflow } from "../../domain/workflows/workflow.ts";
 import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 import { EditorService } from "../../infrastructure/editor/editor_service.ts";
+import { UserError } from "../../domain/errors.ts";
 
 /**
  * UUID v4 regex pattern for detecting if an argument is a UUID.
@@ -64,7 +65,7 @@ export const workflowEditCommand = new Command()
     if (!workflowIdOrName) {
       // No argument provided - check if interactive mode
       if (ctx.outputMode === "json") {
-        throw new Error(
+        throw new UserError(
           "Workflow ID or name is required in non-interactive mode",
         );
       }
@@ -73,7 +74,7 @@ export const workflowEditCommand = new Command()
       const allWorkflows = await repo.findAll();
 
       if (allWorkflows.length === 0) {
-        throw new Error("No workflows found in repository");
+        throw new UserError("No workflows found in repository");
       }
 
       const searchItems = allWorkflows.map(toSearchItem);
@@ -95,20 +96,20 @@ export const workflowEditCommand = new Command()
       const id: WorkflowId = createWorkflowId(selected.id);
       workflow = await repo.findById(id);
       if (!workflow) {
-        throw new Error(`Workflow not found: ${selected.id}`);
+        throw new UserError(`Workflow not found: ${selected.id}`);
       }
     } else if (isUuid(workflowIdOrName)) {
       ctx.logger.debug`Looking up by ID: ${workflowIdOrName}`;
       const id: WorkflowId = createWorkflowId(workflowIdOrName);
       workflow = await repo.findById(id);
       if (!workflow) {
-        throw new Error(`Workflow not found: ${workflowIdOrName}`);
+        throw new UserError(`Workflow not found: ${workflowIdOrName}`);
       }
     } else {
       ctx.logger.debug`Looking up by name: ${workflowIdOrName}`;
       workflow = await repo.findByName(workflowIdOrName);
       if (!workflow) {
-        throw new Error(`Workflow not found: ${workflowIdOrName}`);
+        throw new UserError(`Workflow not found: ${workflowIdOrName}`);
       }
     }
 

--- a/src/cli/commands/workflow_get.ts
+++ b/src/cli/commands/workflow_get.ts
@@ -10,6 +10,7 @@ import {
 } from "../../domain/workflows/workflow_id.ts";
 import type { Workflow } from "../../domain/workflows/workflow.ts";
 import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
+import { UserError } from "../../domain/errors.ts";
 
 /**
  * UUID v4 regex pattern for detecting if an argument is a UUID.
@@ -52,7 +53,7 @@ export const workflowGetCommand = new Command()
     }
 
     if (!workflow) {
-      throw new Error(`Workflow not found: ${workflowIdOrName}`);
+      throw new UserError(`Workflow not found: ${workflowIdOrName}`);
     }
 
     ctx.logger.debug`Found workflow: id=${workflow.id}, name=${workflow.name}`;

--- a/src/cli/commands/workflow_history_get.ts
+++ b/src/cli/commands/workflow_history_get.ts
@@ -10,6 +10,7 @@ import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_wo
 import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
 import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
+import { UserError } from "../../domain/errors.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -70,7 +71,7 @@ export const workflowHistoryGetCommand = new Command()
       await workflowRepo.findById(createWorkflowId(workflowIdOrName));
 
     if (!workflow) {
-      throw new Error(`Workflow not found: ${workflowIdOrName}`);
+      throw new UserError(`Workflow not found: ${workflowIdOrName}`);
     }
 
     ctx.logger.debug`Found workflow: id=${workflow.id}, name=${workflow.name}`;
@@ -79,7 +80,7 @@ export const workflowHistoryGetCommand = new Command()
     const latestRun = await runRepo.findLatestByWorkflowId(workflow.id);
 
     if (!latestRun) {
-      throw new Error(`No runs found for workflow: ${workflow.name}`);
+      throw new UserError(`No runs found for workflow: ${workflow.name}`);
     }
 
     ctx.logger

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -1,0 +1,11 @@
+/**
+ * Base error for user-facing errors that should not show a stack trace.
+ * Use this for validation errors, "model not found" messages, and other
+ * expected error conditions where the stack trace would be noise.
+ */
+export class UserError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UserError";
+  }
+}

--- a/src/presentation/output/error_output.tsx
+++ b/src/presentation/output/error_output.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Box, Text } from "ink";
 import { render } from "ink-testing-library";
 import type { OutputMode } from "./output.tsx";
+import { UserError } from "../../domain/errors.ts";
 
 export interface ErrorData {
   error: string;
@@ -24,10 +25,12 @@ function extractStackLines(stack: string | undefined): string | undefined {
 
 /**
  * Renders an error to the console based on output mode.
+ * UserError instances do not show stack traces as they are expected user-facing errors.
  */
 export function renderError(error: unknown, mode: OutputMode): void {
   const err = error instanceof Error ? error : new Error(String(error));
-  const stackLines = extractStackLines(err.stack);
+  const isUserError = err instanceof UserError;
+  const stackLines = isUserError ? undefined : extractStackLines(err.stack);
 
   if (mode === "json") {
     const data: ErrorData = {

--- a/src/presentation/output/error_output_test.tsx
+++ b/src/presentation/output/error_output_test.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { render } from "ink-testing-library";
 import { ErrorDisplay, renderError } from "./error_output.tsx";
+import { UserError } from "../../domain/errors.ts";
 
 const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
 
@@ -102,4 +103,44 @@ Deno.test("renderError handles non-Error objects", () => {
   } finally {
     console.error = originalError;
   }
+});
+
+Deno.test("renderError omits stack for UserError in json mode", () => {
+  const logs: string[] = [];
+  const originalError = console.error;
+  console.error = (msg: string) => logs.push(msg);
+
+  try {
+    const error = new UserError("Model has an associated resource");
+    renderError(error, "json");
+
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.error, "Model has an associated resource");
+    assertEquals(parsed.stack, undefined);
+  } finally {
+    console.error = originalError;
+  }
+});
+
+Deno.test({
+  name: "renderError omits stack for UserError in interactive mode",
+  ...inkTestOptions,
+  fn: () => {
+    const logs: string[] = [];
+    const originalError = console.error;
+    console.error = (msg: string) => logs.push(msg);
+
+    try {
+      const error = new UserError("Use --force to delete");
+      renderError(error, "interactive");
+
+      assertEquals(logs.length, 1);
+      assertStringIncludes(logs[0], "Error: Use --force to delete");
+      // Should not contain any "at " stack lines
+      assertEquals(logs[0].includes("at "), false);
+    } finally {
+      console.error = originalError;
+    }
+  },
 });


### PR DESCRIPTION
- Introduces UserError class for user-facing validation errors that shouldn't display stack traces
- Updates error renderer to suppress stack traces for UserError instances
- Converts all "not found" and validation errors across CLI commands to use UserError

#### Before

```
Error: Model 'instance1' has an associated resource. Use --force to delete both.

    at Command.actionHandler (file:///...model_delete.ts:91:13)
    at eventLoopTick (ext:core/01_core.js:187:7)
    at async Command.execute (https://jsr.io/@cliffy/command/...)
    ...
```

#### After

```
Error: Model 'instance1' has an associated resource. Use --force to delete both.
```

### Files changed

- src/domain/errors.ts - New UserError class
- src/presentation/output/error_output.tsx - Skip stack trace for UserError
- src/presentation/output/error_output_test.tsx - Tests for UserError handling
- src/cli/commands/model_delete.ts
- src/cli/commands/model_get.ts
- src/cli/commands/model_edit.ts
- src/cli/commands/workflow_get.ts
- src/cli/commands/workflow_edit.ts
- src/cli/commands/workflow_history_get.ts
- src/cli/commands/type_describe.ts