### PR TITLE
Fix search commands to show full details on single match in JSON mode

### DIFF
--- a/integration/echo_model_test.ts
+++ b/integration/echo_model_test.ts
@@ -510,3 +510,136 @@ Deno.test("CLI: model method run fails for missing required attributes", async (
     assertStringIncludes(runResult.stderr, "Input validation failed");
   });
 });
+
+// model search tests
+
+Deno.test("CLI: model search returns all models in JSON mode", async () => {
+  await withTempDir(async (repoDir) => {
+    // Create two models
+    await runCliCommand(
+      [
+        "model",
+        "create",
+        "swamp/echo",
+        "search-model-1",
+        "--repo-dir",
+        repoDir,
+      ],
+      Deno.cwd(),
+    );
+    await runCliCommand(
+      [
+        "model",
+        "create",
+        "swamp/echo",
+        "search-model-2",
+        "--repo-dir",
+        repoDir,
+      ],
+      Deno.cwd(),
+    );
+
+    const result = await runCliCommand(
+      ["model", "search", "--repo-dir", repoDir, "--json"],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Command should succeed. stderr: ${result.stderr}`,
+    );
+
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.results.length, 2);
+    const names = output.results.map((r: { name: string }) => r.name);
+    assertEquals(names.includes("search-model-1"), true);
+    assertEquals(names.includes("search-model-2"), true);
+  });
+});
+
+Deno.test("CLI: model search with multiple matches returns list in JSON mode", async () => {
+  await withTempDir(async (repoDir) => {
+    // Create models with similar names
+    await runCliCommand(
+      [
+        "model",
+        "create",
+        "swamp/echo",
+        "deploy-staging",
+        "--repo-dir",
+        repoDir,
+      ],
+      Deno.cwd(),
+    );
+    await runCliCommand(
+      ["model", "create", "swamp/echo", "deploy-prod", "--repo-dir", repoDir],
+      Deno.cwd(),
+    );
+    await runCliCommand(
+      ["model", "create", "swamp/echo", "build-app", "--repo-dir", repoDir],
+      Deno.cwd(),
+    );
+
+    const result = await runCliCommand(
+      ["model", "search", "deploy", "--repo-dir", repoDir, "--json"],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Command should succeed. stderr: ${result.stderr}`,
+    );
+
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.results.length, 2);
+    const names = output.results.map((r: { name: string }) => r.name);
+    assertEquals(names.includes("deploy-staging"), true);
+    assertEquals(names.includes("deploy-prod"), true);
+  });
+});
+
+Deno.test("CLI: model search with single match returns full details in JSON mode", async () => {
+  await withTempDir(async (repoDir) => {
+    // Create two models with different names
+    const createResult = await runCliCommand(
+      [
+        "model",
+        "create",
+        "swamp/echo",
+        "alpha-model",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+    assertEquals(createResult.code, 0);
+    const createOutput = JSON.parse(createResult.stdout);
+
+    await runCliCommand(
+      ["model", "create", "swamp/echo", "beta-model", "--repo-dir", repoDir],
+      Deno.cwd(),
+    );
+
+    const result = await runCliCommand(
+      ["model", "search", "alpha", "--repo-dir", repoDir, "--json"],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Command should succeed. stderr: ${result.stderr}`,
+    );
+
+    // When single match, returns full model details (same as model get)
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.name, "alpha-model");
+    assertEquals(output.id, createOutput.id);
+    assertEquals(output.type, "swamp/echo");
+    assertEquals(typeof output.version, "number");
+    assertEquals(typeof output.attributes, "object");
+  });
+});

--- a/integration/workflow_test.ts
+++ b/integration/workflow_test.ts
@@ -331,7 +331,43 @@ Deno.test("CLI: workflow search returns all workflows in JSON mode", async () =>
   });
 });
 
-Deno.test("CLI: workflow search filters by query in JSON mode", async () => {
+Deno.test("CLI: workflow search filters by query with multiple matches in JSON mode", async () => {
+  await withTempDir(async (repoDir) => {
+    const repo = new YamlWorkflowRepository(repoDir);
+    const workflow1 = createTestWorkflow("deploy-staging");
+    const workflow2 = createTestWorkflow("deploy-production");
+    const workflow3 = createTestWorkflow("build-app");
+    await repo.save(workflow1);
+    await repo.save(workflow2);
+    await repo.save(workflow3);
+
+    const result = await runCliCommand(
+      [
+        "workflow",
+        "search",
+        "deploy",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Command should succeed. stderr: ${result.stderr}`,
+    );
+
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.results.length, 2);
+    const names = output.results.map((r: { name: string }) => r.name);
+    assertEquals(names.includes("deploy-staging"), true);
+    assertEquals(names.includes("deploy-production"), true);
+  });
+});
+
+Deno.test("CLI: workflow search with single match returns full details in JSON mode", async () => {
   await withTempDir(async (repoDir) => {
     const repo = new YamlWorkflowRepository(repoDir);
     const workflow1 = createTestWorkflow("alpha-workflow");
@@ -357,9 +393,13 @@ Deno.test("CLI: workflow search filters by query in JSON mode", async () => {
       `Command should succeed. stderr: ${result.stderr}`,
     );
 
+    // When single match, returns full workflow details (same as workflow get)
     const output = JSON.parse(result.stdout);
-    assertEquals(output.results.length, 1);
-    assertEquals(output.results[0].name, "alpha-workflow");
+    assertEquals(output.name, "alpha-workflow");
+    assertEquals(output.id, workflow1.id);
+    assertEquals(output.jobs.length, 2);
+    assertEquals(output.jobs[0].name, "build");
+    assertEquals(output.jobs[1].name, "test");
   });
 });
 

--- a/src/cli/commands/model_search.ts
+++ b/src/cli/commands/model_search.ts
@@ -126,11 +126,17 @@ export const modelSearchCommand = new Command()
     if (ctx.outputMode === "json") {
       // Non-interactive: filter and output JSON
       const filteredModels = filterModels(allModels, query ?? "");
-      const data: ModelSearchData = {
-        query: query ?? "",
-        results: filteredModels,
-      };
-      await renderModelSearch(data, ctx.outputMode);
+
+      // If query matches exactly one model, show full details (same as interactive selection)
+      if (query && filteredModels.length === 1) {
+        await displayModelGet(filteredModels[0], repoDir, ctx.outputMode);
+      } else {
+        const data: ModelSearchData = {
+          query: query ?? "",
+          results: filteredModels,
+        };
+        await renderModelSearch(data, ctx.outputMode);
+      }
     } else {
       // Interactive: show fuzzy search UI
       const data: ModelSearchData = {

--- a/src/cli/commands/workflow_search.ts
+++ b/src/cli/commands/workflow_search.ts
@@ -99,11 +99,17 @@ export const workflowSearchCommand = new Command()
     if (ctx.outputMode === "json") {
       // Non-interactive: filter and output JSON
       const filteredWorkflows = filterWorkflows(searchItems, query ?? "");
-      const data: WorkflowSearchData = {
-        query: query ?? "",
-        results: filteredWorkflows,
-      };
-      await renderWorkflowSearch(data, ctx.outputMode);
+
+      // If query matches exactly one workflow, show full details (same as interactive selection)
+      if (query && filteredWorkflows.length === 1) {
+        await displayWorkflowGet(filteredWorkflows[0], repo, options);
+      } else {
+        const data: WorkflowSearchData = {
+          query: query ?? "",
+          results: filteredWorkflows,
+        };
+        await renderWorkflowSearch(data, ctx.outputMode);
+      }
     } else {
       // Interactive: show fuzzy search UI
       const data: WorkflowSearchData = {


### PR DESCRIPTION
- When model search <query> or workflow search <query> matches exactly one item in JSON mode, now returns full details (same output as selecting from the interactive list)
- Previously, JSON mode only returned the search results list with minimal info, while interactive mode showed full details after selection

### Test plan

- Added integration tests for model search (all models, multiple matches, single match)
- Added integration tests for workflow search (multiple matches, single match)
- deno check passes
- deno lint passes
- deno fmt passes
- All new tests pass