### PR TITLE
chore: Only allow 1 Code Review at a time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
     name: Claude Code Review
     needs: test
     runs-on: ubuntu-latest
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
We don’t want claude to post old reviews when force push or a new push has happened