### PR TITLE
feat: add env support for shell tasks in workflows

### DIFF
--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -83,17 +83,24 @@ export class DefaultStepExecutor implements StepExecutor {
       args: string[];
       workingDir?: string;
       timeout?: number;
+      env?: Record<string, string>;
     },
     ctx: StepExecutionContext,
   ): Promise<unknown> {
     const cwd = task.workingDir ?? ctx.repoDir;
 
-    const command = new Deno.Command(task.command, {
+    const commandOptions: Deno.CommandOptions = {
       args: task.args,
       cwd,
       stdout: "piped",
       stderr: "piped",
-    });
+    };
+
+    if (task.env) {
+      commandOptions.env = task.env;
+    }
+
+    const command = new Deno.Command(task.command, commandOptions);
 
     const result = await command.output();
 

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -622,6 +622,30 @@ Deno.test("executes dependent jobs sequentially across levels", async () => {
   assertEquals(dStartIdx > bCompleteIdx, true);
 });
 
+Deno.test("DefaultStepExecutor passes env to shell commands", async () => {
+  const { DefaultStepExecutor } = await import("./execution_service.ts");
+  const executor = new DefaultStepExecutor();
+
+  const step = Step.create({
+    name: "env-test",
+    task: StepTask.shell("printenv", {
+      args: ["TEST_VAR"],
+      env: { TEST_VAR: "hello_from_env" },
+    }),
+  });
+
+  const ctx: StepExecutionContext = {
+    workflowId: createWorkflowId("test-workflow-id"),
+    workflowName: "test-workflow",
+    repoDir: ".",
+    jobName: "test-job",
+    stepName: "env-test",
+  };
+
+  const result = await executor.execute(step, ctx) as { stdout: string };
+  assertEquals(result.stdout, "hello_from_env");
+});
+
 Deno.test("executes independent steps within a job in parallel", async () => {
   const workflowRepo = new InMemoryWorkflowRepository();
   const runRepo = new InMemoryWorkflowRunRepository();

--- a/src/domain/workflows/step_task.ts
+++ b/src/domain/workflows/step_task.ts
@@ -19,6 +19,7 @@ export const StepTaskSchema = z.discriminatedUnion("type", [
     args: z.array(z.string()).default([]),
     workingDir: z.string().optional(),
     timeout: z.number().positive().optional(),
+    env: z.record(z.string(), z.string()).optional(),
   }),
 ]);
 
@@ -63,6 +64,7 @@ export class StepTask {
       args?: string[];
       workingDir?: string;
       timeout?: number;
+      env?: Record<string, string>;
     },
   ): StepTask {
     return new StepTask({
@@ -71,6 +73,7 @@ export class StepTask {
       args: options?.args ?? [],
       workingDir: options?.workingDir,
       timeout: options?.timeout,
+      env: options?.env,
     });
   }
 

--- a/src/domain/workflows/step_task_test.ts
+++ b/src/domain/workflows/step_task_test.ts
@@ -20,6 +20,7 @@ Deno.test("StepTask.shell creates shell task with defaults", () => {
     args: [],
     workingDir: undefined,
     timeout: undefined,
+    env: undefined,
   });
   assertEquals(task.isModelMethod(), false);
   assertEquals(task.isShell(), true);
@@ -30,6 +31,7 @@ Deno.test("StepTask.shell creates shell task with options", () => {
     args: ["install", "--production"],
     workingDir: "/app",
     timeout: 60000,
+    env: { NODE_ENV: "production" },
   });
   assertEquals(task.data, {
     type: "shell",
@@ -37,6 +39,7 @@ Deno.test("StepTask.shell creates shell task with options", () => {
     args: ["install", "--production"],
     workingDir: "/app",
     timeout: 60000,
+    env: { NODE_ENV: "production" },
   });
 });
 
@@ -69,6 +72,7 @@ Deno.test("StepTask.toData returns correct structure", () => {
     args: ["hello"],
     workingDir: undefined,
     timeout: undefined,
+    env: undefined,
   });
 });
 
@@ -133,5 +137,18 @@ Deno.test("StepTaskSchema sets default args for shell task", () => {
   assertEquals(result.type, "shell");
   if (result.type === "shell") {
     assertEquals(result.args, []);
+  }
+});
+
+Deno.test("StepTask.fromData creates shell task with env", () => {
+  const task = StepTask.fromData({
+    type: "shell",
+    command: "npm",
+    args: ["install"],
+    env: { NODE_ENV: "production", CI: "true" },
+  });
+  assertEquals(task.isShell(), true);
+  if (task.data.type === "shell") {
+    assertEquals(task.data.env, { NODE_ENV: "production", CI: "true" });
   }
 });


### PR DESCRIPTION
## Summary

Adds the ability to pass environment variables to shell commands in workflow steps.

- Add `env` field to shell task schema (`Record<string, string>`)
- Pass env to `Deno.Command` when executing shell tasks
- Add tests for env support in both `step_task_test.ts` and `execution_service_test.ts`

## Test Plan

- [x] Unit tests for `StepTask` with env field
- [x] Integration test verifying env is passed to actual shell commands
- [x] All existing tests pass
- [x] `deno fmt`, `deno lint`, `deno run test` all pass