### PR TITLE
feat: Add shell completion command and fix cross-platform test

### DIFF
--- a/src/cli/commands/completion.ts
+++ b/src/cli/commands/completion.ts
@@ -1,0 +1,21 @@
+import { CompletionsCommand } from "@cliffy/command/completions";
+
+/**
+ * Shell completion command using Cliffy's built-in CompletionsCommand.
+ *
+ * Usage:
+ *   swamp completion bash    # Generate bash completion script
+ *   swamp completion zsh     # Generate zsh completion script
+ *   swamp completion fish    # Generate fish completion script
+ *
+ * Installation:
+ *   # Bash - add to ~/.bashrc:
+ *   source <(swamp completion bash)
+ *
+ *   # Zsh - add to ~/.zshrc:
+ *   source <(swamp completion zsh)
+ *
+ *   # Fish - save to completions directory:
+ *   swamp completion fish > ~/.config/fish/completions/swamp.fish
+ */
+export const completionCommand = new CompletionsCommand();

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -5,6 +5,7 @@ import { modelCommand } from "./commands/model_create.ts";
 import { typeCommand } from "./commands/type_describe.ts";
 import { repoCommand } from "./commands/repo_init.ts";
 import { workflowCommand } from "./commands/workflow.ts";
+import { completionCommand } from "./commands/completion.ts";
 import type { GlobalOptions } from "./context.ts";
 
 // Import models barrel to trigger self-registration
@@ -31,7 +32,8 @@ export async function runCli(args: string[]): Promise<void> {
     .command("model", modelCommand)
     .command("type", typeCommand)
     .command("repo", repoCommand)
-    .command("workflow", workflowCommand);
+    .command("workflow", workflowCommand)
+    .command("completion", completionCommand);
 
   await cli.parse(args);
 }

--- a/src/domain/models/keeb/shell/shell_model_test.ts
+++ b/src/domain/models/keeb/shell/shell_model_test.ts
@@ -187,7 +187,9 @@ Deno.test("shellModel.methods.execute respects workingDir", async () => {
     repoDir: "/tmp",
   });
 
-  assertEquals(result.resource.attributes.stdout, "/tmp\n");
+  // Use realPathSync to handle symlinks (e.g., /tmp -> /private/tmp on macOS)
+  const expectedPath = Deno.realPathSync("/tmp");
+  assertEquals(result.resource.attributes.stdout, `${expectedPath}\n`);
   assertEquals(result.resource.attributes.exitCode, 0);
 });
 
@@ -232,6 +234,7 @@ Deno.test("shellModel.methods.execute handles complex commands", async () => {
     repoDir: "/tmp",
   });
 
+  // cd /tmp && pwd outputs the logical path, not the physical path
   assertEquals(result.resource.attributes.stdout, "/tmp\n");
   assertEquals(result.resource.attributes.exitCode, 0);
 });


### PR DESCRIPTION
- Add swamp completion command to generate shell completions for bash, zsh, and fish using Cliffy's built-in CompletionsCommand
- Fix shellModel.methods.execute respects workingDir test to work across all Unix systems by using Deno.realPathSync() to handle symlinks (e.g., /tmp → /private/tmp on macOS)

### Usage

```
# Bash - add to ~/.bashrc
source <(swamp completion bash)

# Zsh - add to ~/.zshrc
source <(swamp completion zsh)

# Fish - save to completions directory
swamp completion fish > ~/.config/fish/completions/swamp.fish
```

### Test plan

- deno check passes
- deno lint passes
- deno fmt --check passes
- All 847 tests pass
- Verified swamp completion bash/zsh/fish generates valid completion scripts