### PR TITLE
Add shell completion support with dynamic model and workflow completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,50 @@ swamp model method run my-echo write
 Model inputs are stored in `inputs/swamp/echo/` and resources are written to
 `resources/swamp/echo/`.
 
+## Shell Completions
+
+Generate shell completions for tab-completion of commands, model names, and
+workflow names.
+
+### Bash
+
+Add to your `~/.bashrc`:
+
+```bash
+eval "$(swamp completions bash)"
+```
+
+### Zsh with oh-my-zsh
+
+Save the completion script to oh-my-zsh's completions directory:
+
+```bash
+mkdir -p ~/.oh-my-zsh/completions
+swamp completions zsh > ~/.oh-my-zsh/completions/_swamp
+rm -f ~/.zcompdump* && exec zsh
+```
+
+### Zsh without oh-my-zsh
+
+Add to your `~/.zshrc`:
+
+```bash
+eval "$(swamp completions zsh)"
+```
+
+### Fish
+
+Save the completion script to fish's completions directory:
+
+```bash
+swamp completions fish > ~/.config/fish/completions/swamp.fish
+```
+
+### Note
+
+Model and workflow name completions are directory-dependent. They return names
+from the current working directory's swamp repository.
+
 ## Development
 
 ```bash

--- a/src/cli/commands/completion.ts
+++ b/src/cli/commands/completion.ts
@@ -4,18 +4,27 @@ import { CompletionsCommand } from "@cliffy/command/completions";
  * Shell completion command using Cliffy's built-in CompletionsCommand.
  *
  * Usage:
- *   swamp completion bash    # Generate bash completion script
- *   swamp completion zsh     # Generate zsh completion script
- *   swamp completion fish    # Generate fish completion script
+ *   swamp completions bash    # Generate bash completion script
+ *   swamp completions zsh     # Generate zsh completion script
+ *   swamp completions fish    # Generate fish completion script
  *
  * Installation:
- *   # Bash - add to ~/.bashrc:
- *   source <(swamp completion bash)
  *
- *   # Zsh - add to ~/.zshrc:
- *   source <(swamp completion zsh)
+ *   # Bash - add to ~/.bashrc:
+ *   eval "$(swamp completions bash)"
+ *
+ *   # Zsh with oh-my-zsh - save to completions directory:
+ *   mkdir -p ~/.oh-my-zsh/completions
+ *   swamp completions zsh > ~/.oh-my-zsh/completions/_swamp
+ *   rm -f ~/.zcompdump* && exec zsh
+ *
+ *   # Zsh without oh-my-zsh - add to ~/.zshrc:
+ *   eval "$(swamp completions zsh)"
  *
  *   # Fish - save to completions directory:
- *   swamp completion fish > ~/.config/fish/completions/swamp.fish
+ *   swamp completions fish > ~/.config/fish/completions/swamp.fish
+ *
+ * Note: Model and workflow name completions are directory-dependent.
+ * They return names from the current working directory's swamp repository.
  */
 export const completionCommand = new CompletionsCommand();

--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -21,8 +21,9 @@ type AnyOptions = any;
 
 export const modelCreateCommand = new Command()
   .description("Create a new model input")
-  .arguments("<type:string> <name:string>")
+  .arguments("<type:model_type> <name:string>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(async function (options: AnyOptions, typeArg: string, name: string) {
     const ctx = createContext(options as GlobalOptions, "model-create");
     ctx.logger.debug`Creating model input: type=${typeArg}, name=${name}`;

--- a/src/cli/commands/model_delete.ts
+++ b/src/cli/commands/model_delete.ts
@@ -42,12 +42,13 @@ async function promptConfirmation(message: string): Promise<boolean> {
 export const modelDeleteCommand = new Command()
   .name("delete")
   .description("Delete a model input")
-  .arguments("<model_id_or_name:string>")
+  .arguments("<model_id_or_name:model_name>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option(
     "-f, --force",
     "Skip confirmation and allow deletion when resource exists",
   )
+  // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(async function (options: AnyOptions, modelIdOrName: string) {
     const ctx = createContext(options as GlobalOptions, "model-delete");
     ctx.logger.debug`Deleting model: ${modelIdOrName}`;

--- a/src/cli/commands/model_edit.ts
+++ b/src/cli/commands/model_edit.ts
@@ -41,9 +41,10 @@ function toModelSearchItems(
 export const modelEditCommand = new Command()
   .name("edit")
   .description("Edit a model input or resource file")
-  .arguments("[model_id_or_name:string]")
+  .arguments("[model_id_or_name:model_name]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("--resource", "Edit the resource file instead of the input")
+  // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(async function (options: AnyOptions, modelIdOrName?: string) {
     const ctx = createContext(options as GlobalOptions, "model-edit");
     ctx.logger.debug`Editing model: ${modelIdOrName ?? "(interactive)"}`;

--- a/src/cli/commands/model_get.ts
+++ b/src/cli/commands/model_get.ts
@@ -22,8 +22,9 @@ type AnyOptions = any;
 export const modelGetCommand = new Command()
   .name("get")
   .description("Show details of a model input")
-  .arguments("<model_id_or_name:string>")
+  .arguments("<model_id_or_name:model_name>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(async function (options: AnyOptions, modelIdOrName: string) {
     const ctx = createContext(options as GlobalOptions, "model-get");
     ctx.logger.debug`Getting model: ${modelIdOrName}`;

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -52,9 +52,10 @@ type AnyOptions = any;
 export const modelMethodRunCommand = new Command()
   .name("run")
   .description("Execute a method on a model")
-  .arguments("<model_id_or_name:string> <method_name:string>")
+  .arguments("<model_id_or_name:model_name> <method_name:string>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .action(
+    // @ts-expect-error - Cliffy custom type returns unknown instead of string
     async function (
       options: AnyOptions,
       modelIdOrName: string,

--- a/src/cli/commands/type_describe.ts
+++ b/src/cli/commands/type_describe.ts
@@ -40,7 +40,8 @@ function toMethodDescribeData(
 
 export const typeDescribeCommand = new Command()
   .description("Describe a model type with schema details")
-  .arguments("<type:string>")
+  .arguments("<type:model_type>")
+  // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(function (options: AnyOptions, typeArg: string) {
     const ctx = createContext(options as GlobalOptions, "type-describe");
     ctx.logger.debug`Describing type: ${typeArg}`;

--- a/src/cli/commands/workflow_edit.ts
+++ b/src/cli/commands/workflow_edit.ts
@@ -49,8 +49,9 @@ function toSearchItem(workflow: Workflow): WorkflowSearchItem {
 export const workflowEditCommand = new Command()
   .name("edit")
   .description("Edit a workflow file")
-  .arguments("[workflow_id_or_name:string]")
+  .arguments("[workflow_id_or_name:workflow_name]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(async function (options: AnyOptions, workflowIdOrName?: string) {
     const ctx = createContext(options as GlobalOptions, "workflow-edit");
     ctx.logger.debug`Editing workflow: ${workflowIdOrName ?? "(interactive)"}`;

--- a/src/cli/commands/workflow_get.ts
+++ b/src/cli/commands/workflow_get.ts
@@ -31,8 +31,9 @@ type AnyOptions = any;
 export const workflowGetCommand = new Command()
   .name("get")
   .description("Show details of a workflow")
-  .arguments("<workflow_id_or_name:string>")
+  .arguments("<workflow_id_or_name:workflow_name>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(async function (options: AnyOptions, workflowIdOrName: string) {
     const ctx = createContext(options as GlobalOptions, "workflow-get");
     ctx.logger.debug`Getting workflow: ${workflowIdOrName}`;

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -72,8 +72,9 @@ function toRunData(
 export const workflowRunCommand = new Command()
   .name("run")
   .description("Execute a workflow")
-  .arguments("<workflow_id_or_name:string>")
+  .arguments("<workflow_id_or_name:workflow_name>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(async function (options: AnyOptions, workflowIdOrName: string) {
     const ctx = createContext(options as GlobalOptions, "workflow-run");
     ctx.logger.debug`Running workflow: ${workflowIdOrName}`;

--- a/src/cli/completion_types.ts
+++ b/src/cli/completion_types.ts
@@ -1,0 +1,58 @@
+import { Type } from "@cliffy/command";
+import { YamlInputRepository } from "../infrastructure/persistence/yaml_input_repository.ts";
+import { YamlWorkflowRepository } from "../infrastructure/persistence/yaml_workflow_repository.ts";
+import { modelRegistry } from "../domain/models/model.ts";
+
+/**
+ * Custom type for model name arguments with shell completion support.
+ * Parses as string but provides completion for model names.
+ */
+export class ModelNameType extends Type<string> {
+  override parse({ value }: { value: string }): string {
+    return value;
+  }
+
+  override async complete(): Promise<string[]> {
+    try {
+      const inputRepo = new YamlInputRepository(".");
+      const models = await inputRepo.findAllGlobal();
+      return models.map((m) => m.input.name);
+    } catch {
+      return [];
+    }
+  }
+}
+
+/**
+ * Custom type for workflow name arguments with shell completion support.
+ * Parses as string but provides completion for workflow names.
+ */
+export class WorkflowNameType extends Type<string> {
+  override parse({ value }: { value: string }): string {
+    return value;
+  }
+
+  override async complete(): Promise<string[]> {
+    try {
+      const workflowRepo = new YamlWorkflowRepository(".");
+      const workflows = await workflowRepo.findAll();
+      return workflows.map((w) => w.name);
+    } catch {
+      return [];
+    }
+  }
+}
+
+/**
+ * Custom type for model type arguments with shell completion support.
+ * Parses as string but provides completion for registered model types.
+ */
+export class ModelTypeType extends Type<string> {
+  override parse({ value }: { value: string }): string {
+    return value;
+  }
+
+  override complete(): string[] {
+    return modelRegistry.types().map((t) => t.normalized);
+  }
+}

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -7,6 +7,11 @@ import { repoCommand } from "./commands/repo_init.ts";
 import { workflowCommand } from "./commands/workflow.ts";
 import { completionCommand } from "./commands/completion.ts";
 import type { GlobalOptions } from "./context.ts";
+import {
+  ModelNameType,
+  ModelTypeType,
+  WorkflowNameType,
+} from "./completion_types.ts";
 
 // Import models barrel to trigger self-registration
 import "../domain/models/models.ts";
@@ -16,6 +21,9 @@ export async function runCli(args: string[]): Promise<void> {
     .name("swamp")
     .version(VERSION)
     .description("AI Native Automation CLI")
+    .globalType("model_name", new ModelNameType())
+    .globalType("model_type", new ModelTypeType())
+    .globalType("workflow_name", new WorkflowNameType())
     .globalOption("--debug-logs", "Enable debug logging to dev-logs directory")
     .globalOption("--json", "Output in JSON format (non-interactive)")
     .globalOption("-q, --quiet", "Suppress non-essential output")
@@ -33,7 +41,7 @@ export async function runCli(args: string[]): Promise<void> {
     .command("type", typeCommand)
     .command("repo", repoCommand)
     .command("workflow", workflowCommand)
-    .command("completion", completionCommand);
+    .command("completions", completionCommand);
 
   await cli.parse(args);
 }


### PR DESCRIPTION
- Add swamp completions command for generating shell completion scripts (bash, zsh, fish)
- Add dynamic tab-completion for model names, workflow names, and model types based on repository contents
- Fix cross-platform test compatibility for shell model on macOS (symlink handling)
- Add shell completion installation instructions to README

### Changes

- New completion.ts command using Cliffy's built-in CompletionsCommand
- New completion_types.ts with custom Cliffy types (ModelNameType, WorkflowNameType, ModelTypeType) that
provide dynamic completions by querying the repository
- Register global types in CLI for shell completion integration
- Update argument types across model and workflow commands to use custom completion types
- Fix shell_model_test.ts to use Deno.realPathSync() for /tmp symlink resolution on macOS

### Test plan

- All 849 tests pass
- deno check passes
- deno lint passes
- deno fmt passes
- Verify completions work: swamp completions zsh > ~/.oh-my-zsh/completions/_swamp && rm -f ~/.zcompdump* &&
exec zsh
- Test tab-completion on swamp model get <TAB> shows model names