### PR TITLE
Address PR feedback for shell completion types

### DIFF
--- a/src/cli/completion_types.ts
+++ b/src/cli/completion_types.ts
@@ -4,6 +4,32 @@ import { YamlWorkflowRepository } from "../infrastructure/persistence/yaml_workf
 import { modelRegistry } from "../domain/models/model.ts";
 
 /**
+ * Custom Cliffy types for shell completion support.
+ *
+ * These types extend Cliffy's Type<string> to provide dynamic tab-completion
+ * for model names, workflow names, and model types based on repository contents.
+ *
+ * ## Cliffy Type Inference Limitation
+ *
+ * When using custom types with Cliffy's `.arguments()`, the type inference
+ * returns `unknown` instead of `string` for the action handler parameters.
+ * This is a known Cliffy limitation. The workaround is to add a
+ * `@ts-expect-error` comment before the `.action()` call:
+ *
+ * ```typescript
+ * .arguments("<name:model_name>")
+ * // @ts-expect-error - Cliffy custom type returns unknown instead of string
+ * .action(async function (options, name: string) { ... })
+ * ```
+ *
+ * ## Repository Directory
+ *
+ * Completions use "." (current working directory) as the repository path.
+ * This is intentional - shell completions run from the user's CWD, and
+ * completions should reflect the models/workflows in that directory.
+ */
+
+/**
  * Custom type for model name arguments with shell completion support.
  * Parses as string but provides completion for model names.
  */
@@ -17,7 +43,10 @@ export class ModelNameType extends Type<string> {
       const inputRepo = new YamlInputRepository(".");
       const models = await inputRepo.findAllGlobal();
       return models.map((m) => m.input.name);
-    } catch {
+    } catch (_error) {
+      // Graceful degradation: return empty completions if repository
+      // is not accessible (e.g., not in a swamp repo, permissions issue).
+      // This is expected behavior for shell completions.
       return [];
     }
   }
@@ -37,7 +66,10 @@ export class WorkflowNameType extends Type<string> {
       const workflowRepo = new YamlWorkflowRepository(".");
       const workflows = await workflowRepo.findAll();
       return workflows.map((w) => w.name);
-    } catch {
+    } catch (_error) {
+      // Graceful degradation: return empty completions if repository
+      // is not accessible (e.g., not in a swamp repo, permissions issue).
+      // This is expected behavior for shell completions.
       return [];
     }
   }

--- a/src/cli/completion_types_test.ts
+++ b/src/cli/completion_types_test.ts
@@ -1,0 +1,106 @@
+import { assertEquals } from "@std/assert";
+import {
+  ModelNameType,
+  ModelTypeType,
+  WorkflowNameType,
+} from "./completion_types.ts";
+
+// Import models barrel to ensure model types are registered
+import "../domain/models/models.ts";
+
+// ModelNameType tests
+Deno.test("ModelNameType.parse returns the input value unchanged", () => {
+  const type = new ModelNameType();
+  const result = type.parse({ value: "my-model" });
+  assertEquals(result, "my-model");
+});
+
+Deno.test("ModelNameType.parse handles empty string", () => {
+  const type = new ModelNameType();
+  const result = type.parse({ value: "" });
+  assertEquals(result, "");
+});
+
+Deno.test("ModelNameType.parse handles special characters", () => {
+  const type = new ModelNameType();
+  const result = type.parse({ value: "my-model_v2.0" });
+  assertEquals(result, "my-model_v2.0");
+});
+
+Deno.test("ModelNameType.complete returns empty array when not in a swamp repo", async () => {
+  const type = new ModelNameType();
+  // Running from a directory without a swamp repo should return empty array
+  // (graceful degradation)
+  const result = await type.complete();
+  // Result depends on whether we're in a swamp repo, but should not throw
+  assertEquals(Array.isArray(result), true);
+});
+
+// WorkflowNameType tests
+Deno.test("WorkflowNameType.parse returns the input value unchanged", () => {
+  const type = new WorkflowNameType();
+  const result = type.parse({ value: "my-workflow" });
+  assertEquals(result, "my-workflow");
+});
+
+Deno.test("WorkflowNameType.parse handles empty string", () => {
+  const type = new WorkflowNameType();
+  const result = type.parse({ value: "" });
+  assertEquals(result, "");
+});
+
+Deno.test("WorkflowNameType.parse handles special characters", () => {
+  const type = new WorkflowNameType();
+  const result = type.parse({ value: "deploy-workflow_v1" });
+  assertEquals(result, "deploy-workflow_v1");
+});
+
+Deno.test("WorkflowNameType.complete returns empty array when not in a swamp repo", async () => {
+  const type = new WorkflowNameType();
+  // Running from a directory without a swamp repo should return empty array
+  // (graceful degradation)
+  const result = await type.complete();
+  // Result depends on whether we're in a swamp repo, but should not throw
+  assertEquals(Array.isArray(result), true);
+});
+
+// ModelTypeType tests
+Deno.test("ModelTypeType.parse returns the input value unchanged", () => {
+  const type = new ModelTypeType();
+  const result = type.parse({ value: "swamp/echo" });
+  assertEquals(result, "swamp/echo");
+});
+
+Deno.test("ModelTypeType.parse handles empty string", () => {
+  const type = new ModelTypeType();
+  const result = type.parse({ value: "" });
+  assertEquals(result, "");
+});
+
+Deno.test("ModelTypeType.parse handles nested type paths", () => {
+  const type = new ModelTypeType();
+  const result = type.parse({ value: "aws/ec2/instance" });
+  assertEquals(result, "aws/ec2/instance");
+});
+
+Deno.test("ModelTypeType.complete returns registered model types", () => {
+  const type = new ModelTypeType();
+  const result = type.complete();
+
+  // Should return an array of strings
+  assertEquals(Array.isArray(result), true);
+
+  // Should include known registered types
+  assertEquals(result.includes("swamp/echo"), true);
+  assertEquals(result.includes("keeb/shell"), true);
+});
+
+Deno.test("ModelTypeType.complete returns all AWS EC2 types", () => {
+  const type = new ModelTypeType();
+  const result = type.complete();
+
+  // Should include AWS EC2 types
+  assertEquals(result.includes("aws/ec2/instance"), true);
+  assertEquals(result.includes("aws/ec2/subnet"), true);
+  assertEquals(result.includes("aws/ec2/vpc"), true);
+});


### PR DESCRIPTION
Addresses review feedback from #59.

### Changes

1. Add test file for completion_types.ts
- Added src/cli/completion_types_test.ts with 13 tests covering all three custom types
- Tests parse() returns input unchanged (including edge cases)
- Tests complete() returns expected arrays and model types
2. Document @ts-expect-error workaround
- Added module-level documentation in completion_types.ts explaining Cliffy's type inference limitation
- Included example of the workaround pattern for future maintainers
3. Improve empty catch blocks
- Changed catch { to catch (_error) { with comments explaining graceful degradation behavior
- Documents that returning empty completions on error is intentional for shell completion UX
4. Document hardcoded repository directory
- Added note in module comment explaining why "." is used intentionally (completions run from user's CWD)