### PR TITLE
feat: add comprehensive artifact system for model method execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: deno fmt --check
 
       - name: Run deno test
-        run: deno test --allow-read --allow-write --allow-env --allow-run
+        run: deno test --allow-read --allow-write --allow-env --allow-run --allow-net
 
   claude-review:
     # NOTE: For this to block merges, enable branch protection on main with:

--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,7 @@
   "exports": "./main.ts",
   "tasks": {
     "dev": "deno run --allow-read --allow-write --allow-env --allow-run --allow-sys main.ts",
-    "test": "deno test --allow-read --allow-write --allow-env --allow-run",
+    "test": "deno test --allow-read --allow-write --allow-env --allow-run --allow-net",
     "check": "deno check main.ts",
     "lint": "deno lint",
     "fmt": "deno fmt",

--- a/design/models.md
+++ b/design/models.md
@@ -1,7 +1,10 @@
 # Models
 
-A model in swamp specifies _inputs_, that are passed to _methods_, that produce
-_outputs_, which may be _model inputs_ or _resources_.
+A model in swamp specifies an _input_, that is passed to many possible
+_methods_, that produce an _output_, which tracks the status of the method as it
+executes, and any artifacts the method has produced (such as _logs_, _files_, a
+_resource_, or ephemeral _data_. A method may produce many logs or files, but
+only a single resource or data artifact.
 
 ## Type
 
@@ -55,20 +58,82 @@ Each input has the following core properties:
 
 ## Methods
 
-Are named functions that take the model as an input, and produce other model
-inputs or resources as outputs.
+Are named functions that take the model as an input, and produce artifacts as
+outputs.
 
 The method should use a MethodInput zod schema to validate that any specific
 inputs it needs are present in the input model.
 
-## Resources
+The function body can create Artifacts, which will then be tracked, so when the
+function finishes we have a complete record of them.
 
-Resources are specified as YAML files that live in the /resources directory of a
-repository, underneath the normalized type as a directory. The file name is
-'${id}.yaml'. For example,
+## Artifacts
+
+Artifacts are information that is produced and stored by a method execution.
+They are created inline as the method executes, and tracked with some context
+that allows the output of the method to track every artifact created by the
+method.
+
+### Logs
+
+A method may produce 0..* log artifacts. They have a name, can have lines
+streamed to them, and by default are stored in /logs in the repository
+underneath the normalized model type as a directory. Logs are named like
+{model-id}-{method name}-{log name}-{timestamp}.log.
+
+They are unstructured, line oriented data.
+
+For example, a method might stream the logs for a remote kubernetes job to a log
+artifact named 'k8slog'.
+
+The stream of log output should have an event emitter attached to it, so we can
+stream logs in real time.
+
+By default, the /logs directory is not stored in git.
+
+### Files
+
+A method may store 0..* file artifacts. They have a name, and can be written to
+directly. By default they will be stored in the /files directory of the
+repository underneath the normalized model type as a directoy plus the model ID
+and method name. For example aws/s3/bucket/{model-id}/{method-name}/{filename}.
+
+By default, the /files directory is not stored in git.
+
+## Resource
+
+Resource artifacts are used to track data about an external resource that should
+be persisted over time (for example, the data about an AWS cloud resource).
+
+A method may produce 0..1 resource as specified as YAML files that live in the
+/resources directory of a repository, underneath the normalized type as a
+directory. The file name is '${id}.yaml'. For example,
 'aws/ec2/vpc/resource-fc7fd41e-ae16-4b31-b57a-86de716e3ece.yaml'.
 
 The valid shape of a resource is specified with a Zod 4 schema.
+
+Resources are tracked in git.
+
+## Data
+
+Data artifacts are pure data objects that are not persisted over time in git.
+
+A method may produce 0..1 data artifacts, stored as YAML files that in in the
+/data directory of a repository, underneath the normalized type as a directory.
+The file name is ${id}.yaml.
+
+The valid shape of data is specfiied with a zod 4 schema.
+
+Data is not tracked in git.
+
+## Output
+
+Each method invocation produces an output record, which gets tracked in the
+/outputs directory of a repository (which should not be tracked in git). The
+output record should track the state of the method execution, and the list of
+artifacts produced by the method. It should track state as the method executes.
+it should be structured as
+/outputs/{normalized-type}/{method}/{model-id}-{timestamp}.yaml
 
 ## CLI Commands
 

--- a/integration/echo_model_test.ts
+++ b/integration/echo_model_test.ts
@@ -4,7 +4,7 @@
  * Tests the full flow:
  * 1. Create an echo model input
  * 2. Execute the write method
- * 3. Verify the resource is created with correct content
+ * 3. Verify the data artifact is created with correct content
  */
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
@@ -12,9 +12,9 @@ import { join } from "@std/path";
 import { existsSync } from "@std/fs";
 import { parse as parseYaml } from "@std/yaml";
 import { ModelInput } from "../src/domain/models/model_input.ts";
-import { inputIdToResourceId } from "../src/domain/models/model_resource.ts";
+import { inputIdToDataId } from "../src/domain/models/model_data.ts";
 import { YamlInputRepository } from "../src/infrastructure/persistence/yaml_input_repository.ts";
-import { YamlResourceRepository } from "../src/infrastructure/persistence/yaml_resource_repository.ts";
+import { YamlDataRepository } from "../src/infrastructure/persistence/yaml_data_repository.ts";
 import {
   ECHO_MODEL_TYPE,
   echoModel,
@@ -29,11 +29,11 @@ async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   }
 }
 
-Deno.test("Echo model: full flow - create input, execute write, verify resource", async () => {
+Deno.test("Echo model: full flow - create input, execute write, verify data", async () => {
   await withTempDir(async (repoDir) => {
     // Setup repositories
     const inputRepo = new YamlInputRepository(repoDir);
-    const resourceRepo = new YamlResourceRepository(repoDir);
+    const dataRepo = new YamlDataRepository(repoDir);
     const modelType = ECHO_MODEL_TYPE;
 
     // Create and save an input
@@ -60,36 +60,44 @@ Deno.test("Echo model: full flow - create input, execute write, verify resource"
     // Execute the write method
     const result = await echoModel.methods.write.execute(input, { repoDir });
 
-    // Save the resource
-    await resourceRepo.save(modelType, result.resource);
-
-    // Verify resource file was created
-    const resourcePath = resourceRepo.getPath(modelType, result.resource.id);
-    assertEquals(existsSync(resourcePath), true, "Resource file should exist");
-
-    // Read and verify resource file contents
-    const resourceContent = await Deno.readTextFile(resourcePath);
-    const resourceData = parseYaml(resourceContent) as Record<string, unknown>;
+    // Verify data exists
     assertEquals(
-      resourceData.id,
-      result.resource.id,
-      "Resource should have the correct ID",
+      result.data !== undefined,
+      true,
+      "Result should have data",
+    );
+    const data = result.data!;
+
+    // Save the data
+    await dataRepo.save(modelType, data);
+
+    // Verify data file was created
+    const dataPath = dataRepo.getPath(modelType, data.id);
+    assertEquals(existsSync(dataPath), true, "Data file should exist");
+
+    // Read and verify data file contents
+    const dataContent = await Deno.readTextFile(dataPath);
+    const dataObj = parseYaml(dataContent) as Record<string, unknown>;
+    assertEquals(
+      dataObj.id,
+      data.id,
+      "Data should have the correct ID",
     );
 
-    const resourceAttrs = resourceData.attributes as Record<string, unknown>;
+    const dataAttrs = dataObj.attributes as Record<string, unknown>;
     assertEquals(
-      resourceAttrs.message,
+      dataAttrs.message,
       testMessage,
-      "Resource should contain the message",
+      "Data should contain the message",
     );
     assertEquals(
-      typeof resourceAttrs.timestamp,
+      typeof dataAttrs.timestamp,
       "string",
-      "Resource should have a timestamp",
+      "Data should have a timestamp",
     );
 
     // Verify timestamp is a valid ISO date
-    const timestamp = new Date(resourceAttrs.timestamp as string);
+    const timestamp = new Date(dataAttrs.timestamp as string);
     assertEquals(
       isNaN(timestamp.getTime()),
       false,
@@ -101,7 +109,7 @@ Deno.test("Echo model: full flow - create input, execute write, verify resource"
 Deno.test("Echo model: directory structure is correct", async () => {
   await withTempDir(async (repoDir) => {
     const inputRepo = new YamlInputRepository(repoDir);
-    const resourceRepo = new YamlResourceRepository(repoDir);
+    const dataRepo = new YamlDataRepository(repoDir);
     const modelType = ECHO_MODEL_TYPE;
 
     const input = ModelInput.create({
@@ -111,25 +119,25 @@ Deno.test("Echo model: directory structure is correct", async () => {
     await inputRepo.save(modelType, input);
 
     const result = await echoModel.methods.write.execute(input, { repoDir });
-    await resourceRepo.save(modelType, result.resource);
+    await dataRepo.save(modelType, result.data!);
 
     // Verify directory structure
     const inputDir = join(repoDir, "inputs", "swamp/echo");
-    const resourceDir = join(repoDir, "resources", "swamp/echo");
+    const dataDir = join(repoDir, "data", "swamp/echo");
 
     assertEquals(existsSync(inputDir), true, "Input directory should exist");
     assertEquals(
-      existsSync(resourceDir),
+      existsSync(dataDir),
       true,
-      "Resource directory should exist",
+      "Data directory should exist",
     );
   });
 });
 
-Deno.test("Echo model: multiple inputs and resources", async () => {
+Deno.test("Echo model: multiple inputs and data", async () => {
   await withTempDir(async (repoDir) => {
     const inputRepo = new YamlInputRepository(repoDir);
-    const resourceRepo = new YamlResourceRepository(repoDir);
+    const dataRepo = new YamlDataRepository(repoDir);
     const modelType = ECHO_MODEL_TYPE;
 
     // Create multiple inputs
@@ -152,28 +160,28 @@ Deno.test("Echo model: multiple inputs and resources", async () => {
     // Execute write for each input
     for (const input of inputs) {
       const result = await echoModel.methods.write.execute(input, { repoDir });
-      await resourceRepo.save(modelType, result.resource);
+      await dataRepo.save(modelType, result.data!);
     }
 
-    // Verify all resources exist
-    const allResources = await resourceRepo.findAll(modelType);
-    assertEquals(allResources.length, 3, "Should have 3 resources");
+    // Verify all data artifacts exist
+    const allData = await dataRepo.findAll(modelType);
+    assertEquals(allData.length, 3, "Should have 3 data artifacts");
 
-    // Verify each resource has correct message
+    // Verify each data artifact has correct message
     for (const input of inputs) {
-      const resource = await resourceRepo.findById(
+      const data = await dataRepo.findById(
         modelType,
-        inputIdToResourceId(input.id),
+        inputIdToDataId(input.id),
       );
       assertEquals(
-        resource !== null,
+        data !== null,
         true,
-        `Resource should exist for input ${input.name}`,
+        `Data should exist for input ${input.name}`,
       );
       assertEquals(
-        resource?.attributes.message,
+        data?.attributes.message,
         input.attributes.message,
-        "Resource message should match input",
+        "Data message should match input",
       );
     }
   });
@@ -289,7 +297,7 @@ Deno.test("CLI: model create command rejects unknown model type", async () => {
 
 // model method run integration tests
 
-Deno.test("CLI: model method run creates resource", async () => {
+Deno.test("CLI: model method run creates data", async () => {
   await withTempDir(async (repoDir) => {
     // First create a model
     const createResult = await runCliCommand(
@@ -347,24 +355,24 @@ Deno.test("CLI: model method run creates resource", async () => {
     assertEquals(runOutput.modelName, "method-run-test");
     assertEquals(runOutput.type, "swamp/echo");
     assertEquals(runOutput.methodName, "write");
-    assertEquals(typeof runOutput.resourceId, "string");
-    assertStringIncludes(runOutput.resourcePath, "resources/swamp/echo");
-    assertEquals(runOutput.resourceAttributes.message, "Hello from CLI!");
-    assertEquals(typeof runOutput.resourceAttributes.timestamp, "string");
+    assertEquals(typeof runOutput.data.id, "string");
+    assertStringIncludes(runOutput.data.path, "data/swamp/echo");
+    assertEquals(runOutput.data.attributes.message, "Hello from CLI!");
+    assertEquals(typeof runOutput.data.attributes.timestamp, "string");
 
-    // Verify resource file was created
+    // Verify data file was created
     assertEquals(
-      existsSync(runOutput.resourcePath),
+      existsSync(runOutput.data.path),
       true,
-      "Resource file should exist",
+      "Data file should exist",
     );
 
-    // Verify input was updated with resourceId
+    // Verify input was updated with dataId
     const updatedInput = await inputRepo.findByName(
       ECHO_MODEL_TYPE,
       "method-run-test",
     );
-    assertEquals(updatedInput!.resourceId, runOutput.resourceId);
+    assertEquals(updatedInput!.dataId, runOutput.data.id);
   });
 });
 
@@ -410,7 +418,7 @@ Deno.test("CLI: model method run by model ID", async () => {
 
     const runOutput = JSON.parse(runResult.stdout);
     assertEquals(runOutput.modelId, createOutput.id);
-    assertEquals(runOutput.resourceAttributes.message, "Using ID");
+    assertEquals(runOutput.data.attributes.message, "Using ID");
   });
 });
 

--- a/integration/model_validate_test.ts
+++ b/integration/model_validate_test.ts
@@ -4,9 +4,9 @@
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { ModelInput } from "../src/domain/models/model_input.ts";
-import { ModelResource } from "../src/domain/models/model_resource.ts";
+import { ModelData } from "../src/domain/models/model_data.ts";
 import { YamlInputRepository } from "../src/infrastructure/persistence/yaml_input_repository.ts";
-import { YamlResourceRepository } from "../src/infrastructure/persistence/yaml_resource_repository.ts";
+import { YamlDataRepository } from "../src/infrastructure/persistence/yaml_data_repository.ts";
 import { ECHO_MODEL_TYPE } from "../src/domain/models/echo/echo_model.ts";
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
@@ -81,35 +81,36 @@ Deno.test("CLI: model validate passes for valid echo model input", async () => {
   });
 });
 
-Deno.test("CLI: model validate passes for valid echo model with resource", async () => {
+Deno.test("CLI: model validate passes for valid echo model with data", async () => {
   await withTempDir(async (repoDir) => {
     const inputRepo = new YamlInputRepository(repoDir);
-    const resourceRepo = new YamlResourceRepository(repoDir);
+    const dataRepo = new YamlDataRepository(repoDir);
     const modelType = ECHO_MODEL_TYPE;
 
     // Create a valid echo model input
     const input = ModelInput.create({
-      name: "echo-with-resource",
+      name: "echo-with-data",
       attributes: { message: "Hello, world!" },
     });
     await inputRepo.save(modelType, input);
 
-    // Create a valid resource
-    const resource = ModelResource.create({
+    // Create a valid data artifact (note: data artifacts aren't validated by default,
+    // this is just to verify they don't cause validation errors)
+    const data = ModelData.create({
       id: input.id,
       attributes: {
         message: "Hello, world!",
         timestamp: new Date().toISOString(),
       },
     });
-    await resourceRepo.save(modelType, resource);
+    await dataRepo.save(modelType, data);
 
     // Run the validate command
     const result = await runCliCommand(
       [
         "model",
         "validate",
-        "echo-with-resource",
+        "echo-with-data",
         "--repo-dir",
         repoDir,
         "--json",
@@ -126,7 +127,9 @@ Deno.test("CLI: model validate passes for valid echo model with resource", async
     // Parse and verify JSON output
     const output = JSON.parse(result.stdout);
     assertEquals(output.passed, true);
-    assertEquals(output.validations.length, 5); // Input + Resource + Expression paths validations
+    // Echo model only validates: Input schema, Input attributes, Expression paths
+    // (no resource validation since echo uses data artifacts which aren't validated)
+    assertEquals(output.validations.length, 3);
   });
 });
 
@@ -174,60 +177,9 @@ Deno.test("CLI: model validate fails for invalid input attributes", async () => 
   });
 });
 
-Deno.test("CLI: model validate fails for invalid resource attributes", async () => {
-  await withTempDir(async (repoDir) => {
-    const inputRepo = new YamlInputRepository(repoDir);
-    const resourceRepo = new YamlResourceRepository(repoDir);
-    const modelType = ECHO_MODEL_TYPE;
-
-    // Create a valid echo model input
-    const input = ModelInput.create({
-      name: "echo-invalid-resource",
-      attributes: { message: "Hello" },
-    });
-    await inputRepo.save(modelType, input);
-
-    // Create an invalid resource (missing timestamp)
-    const resource = ModelResource.create({
-      id: input.id,
-      attributes: {
-        message: "Hello",
-        // Missing required timestamp
-      },
-    });
-    await resourceRepo.save(modelType, resource);
-
-    // Run the validate command
-    const result = await runCliCommand(
-      [
-        "model",
-        "validate",
-        "echo-invalid-resource",
-        "--repo-dir",
-        repoDir,
-        "--json",
-      ],
-      Deno.cwd(),
-    );
-
-    assertEquals(
-      result.code,
-      1,
-      `Command should fail with exit code 1`,
-    );
-
-    // Parse and verify JSON output
-    const output = JSON.parse(result.stdout);
-    assertEquals(output.passed, false);
-
-    // Find the failing resource validation
-    const failedValidation = output.validations.find(
-      (v: { name: string; passed: boolean }) =>
-        v.name === "Resource attributes" && !v.passed,
-    );
-    assertEquals(failedValidation !== undefined, true);
-  });
-});
+// Note: Test for invalid resource attributes was removed because
+// the echo model now uses data artifacts instead of resources.
+// Resource validation tests should use models that produce resources (like AWS models).
 
 Deno.test("CLI: model validate can look up by UUID", async () => {
   await withTempDir(async (repoDir) => {

--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -15,6 +15,7 @@ import { modelGetCommand } from "./model_get.ts";
 import { modelDeleteCommand } from "./model_delete.ts";
 import { modelEditCommand } from "./model_edit.ts";
 import { modelEvaluateCommand } from "./model_evaluate.ts";
+import { modelOutputCommand } from "./model_output.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -85,4 +86,5 @@ export const modelCommand = new Command()
   .command("get", modelGetCommand)
   .command("search", modelSearchCommand)
   .command("validate", modelValidateCommand)
-  .command("method", modelMethodCommand);
+  .command("method", modelMethodCommand)
+  .command("output", modelOutputCommand);

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -1,5 +1,6 @@
 import { Command } from "@cliffy/command";
 import {
+  type ArtifactInfo,
   type ModelMethodRunData,
   renderModelMethodRun,
 } from "../../presentation/output/model_method_run_output.tsx";
@@ -9,8 +10,16 @@ import {
   type ModelInput,
 } from "../../domain/models/model_input.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
+import {
+  computeInputHash,
+  ModelOutput,
+} from "../../domain/models/model_output.ts";
 import { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
 import { YamlResourceRepository } from "../../infrastructure/persistence/yaml_resource_repository.ts";
+import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
+import { YamlDataRepository } from "../../infrastructure/persistence/yaml_data_repository.ts";
+import { StreamingLogRepository } from "../../infrastructure/persistence/streaming_log_repository.ts";
+import { FileSystemFileRepository } from "../../infrastructure/persistence/fs_file_repository.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 import { DefaultMethodExecutionService } from "../../domain/models/method_execution_service.ts";
 
@@ -65,6 +74,10 @@ export const modelMethodRunCommand = new Command()
       const repoDir = options.repoDir ?? ".";
       const inputRepo = new YamlInputRepository(repoDir);
       const resourceRepo = new YamlResourceRepository(repoDir);
+      const dataRepo = new YamlDataRepository(repoDir);
+      const outputRepo = new YamlOutputRepository(repoDir);
+      const logRepo = new StreamingLogRepository(repoDir);
+      const fileRepo = new FileSystemFileRepository(repoDir);
       const executionService = new DefaultMethodExecutionService();
 
       ctx.logger
@@ -114,49 +127,194 @@ export const modelMethodRunCommand = new Command()
 
       ctx.logger.debug`Executing method '${methodName}'`;
 
-      // Execute the method (use workflow execution to handle follow-up actions)
-      const result = await executionService.executeWorkflow(
-        input,
-        definition,
+      // Create ModelOutput for tracking
+      const inputHash = await computeInputHash(input.attributes);
+      const output = ModelOutput.create({
+        modelInputId: input.id,
         methodName,
-        { repoDir, resourceRepository: resourceRepo },
-      );
+        provenance: {
+          inputHash,
+          modelVersion: input.version,
+          triggeredBy: "manual",
+        },
+      });
 
-      ctx.logger
-        .debug`Method executed, resource created: ${result.resource.id}`;
+      // Mark as running and save
+      output.markRunning();
+      await outputRepo.save(modelType, methodName, output);
 
-      // Handle resource persistence based on operation type
-      let resourcePath: string;
-      if (result.deleteResource) {
-        // Delete the resource file
-        await resourceRepo.delete(modelType, result.resource.id);
-        resourcePath = ""; // No path since resource was deleted
-        ctx.logger.debug`Resource deleted: ${result.resource.id}`;
-      } else {
-        // Save the resource
-        await resourceRepo.save(modelType, result.resource);
-        resourcePath = resourceRepo.getPath(modelType, result.resource.id);
-        ctx.logger.debug`Resource saved to: ${resourcePath}`;
-      }
+      // Track artifacts for output
+      let resourceArtifact: ArtifactInfo | undefined;
+      let dataArtifact: ArtifactInfo | undefined;
+      let fileArtifact: ArtifactInfo | undefined;
+      const logArtifacts: ArtifactInfo[] = [];
 
-      // Update input's resourceId based on operation type
-      if (result.deleteResource) {
-        // For delete operations, clear the resourceId since the resource no longer exists
-        if (input.resourceId) {
-          input.setResourceId(undefined);
-          await inputRepo.save(modelType, input);
-          ctx.logger.debug`Input resourceId cleared after deletion`;
+      try {
+        // Execute the method (use workflow execution to handle follow-up actions)
+        const result = await executionService.executeWorkflow(
+          input,
+          definition,
+          methodName,
+          {
+            repoDir,
+            resourceRepository: resourceRepo,
+            logRepository: logRepo,
+            fileRepository: fileRepo,
+          },
+        );
+
+        ctx.logger.debug`Method executed`;
+
+        // Handle resource persistence based on operation type
+        if (result.resource) {
+          ctx.logger.debug`Resource created: ${result.resource.id}`;
+          if (result.deleteResource) {
+            // Delete the resource file
+            await resourceRepo.delete(modelType, result.resource.id);
+            ctx.logger.debug`Resource deleted: ${result.resource.id}`;
+          } else {
+            // Save the resource
+            await resourceRepo.save(modelType, result.resource);
+            const resourcePath = resourceRepo.getPath(
+              modelType,
+              result.resource.id,
+            );
+            ctx.logger.debug`Resource saved to: ${resourcePath}`;
+
+            // Track artifact in output
+            output.setResourceId(result.resource.id);
+            resourceArtifact = {
+              id: result.resource.id,
+              path: resourcePath,
+              attributes: result.resource.attributes,
+            };
+          }
+
+          // Update input's resourceId based on operation type
+          if (result.deleteResource) {
+            // For delete operations, clear the resourceId since the resource no longer exists
+            if (input.resourceId) {
+              input.setResourceId(undefined);
+              await inputRepo.save(modelType, input);
+              ctx.logger.debug`Input resourceId cleared after deletion`;
+            }
+          } else {
+            // For create/update operations, set the resourceId if not already set
+            if (!input.resourceId) {
+              input.setResourceId(result.resource.id);
+              await inputRepo.save(modelType, input);
+              ctx.logger
+                .debug`Input updated with resourceId: ${result.resource.id}`;
+            } else {
+              ctx.logger
+                .debug`Input already has resourceId: ${input.resourceId}`;
+            }
+          }
         }
-      } else {
-        // For create/update operations, set the resourceId if not already set
-        if (!input.resourceId) {
-          input.setResourceId(result.resource.id);
-          await inputRepo.save(modelType, input);
-          ctx.logger
-            .debug`Input updated with resourceId: ${result.resource.id}`;
-        } else {
-          ctx.logger.debug`Input already has resourceId: ${input.resourceId}`;
+
+        // Handle data artifact persistence
+        if (result.data) {
+          ctx.logger.debug`Data created: ${result.data.id}`;
+          if (result.deleteData) {
+            await dataRepo.delete(modelType, result.data.id);
+            ctx.logger.debug`Data deleted: ${result.data.id}`;
+          } else {
+            await dataRepo.save(modelType, result.data);
+            const dataPath = dataRepo.getPath(modelType, result.data.id);
+            ctx.logger.debug`Data saved to: ${dataPath}`;
+            output.setDataId(result.data.id);
+
+            // Track artifact for output
+            dataArtifact = {
+              id: result.data.id,
+              path: dataPath,
+              attributes: result.data.attributes,
+            };
+          }
+
+          // Update input's dataId based on operation type
+          if (result.deleteData) {
+            if (input.dataId) {
+              input.setDataId(undefined);
+              await inputRepo.save(modelType, input);
+              ctx.logger.debug`Input dataId cleared after deletion`;
+            }
+          } else {
+            if (!input.dataId) {
+              input.setDataId(result.data.id);
+              await inputRepo.save(modelType, input);
+              ctx.logger.debug`Input updated with dataId: ${result.data.id}`;
+            } else {
+              ctx.logger.debug`Input already has dataId: ${input.dataId}`;
+            }
+          }
         }
+
+        // Handle log persistence
+        if (result.logs && result.logs.length > 0) {
+          if (result.deleteLogs) {
+            for (const log of result.logs) {
+              await logRepo.delete(modelType, log.id);
+              ctx.logger.debug`Log deleted: ${log.id}`;
+            }
+          } else {
+            const logIds: string[] = [];
+            for (const log of result.logs) {
+              await logRepo.save(modelType, log);
+              const logPath = logRepo.getPath(modelType, log.id);
+              ctx.logger.debug`Log saved to: ${logPath}`;
+              logIds.push(log.id);
+              logArtifacts.push({ id: log.id, path: logPath });
+            }
+            output.setLogIds(logIds);
+          }
+        }
+
+        // Handle file artifact persistence
+        if (result.file) {
+          if (result.deleteFile) {
+            await fileRepo.delete(
+              modelType,
+              input.id,
+              methodName,
+              result.file.metadata,
+            );
+            ctx.logger.debug`File deleted: ${result.file.metadata.id}`;
+          } else {
+            await fileRepo.save(
+              modelType,
+              input.id,
+              methodName,
+              result.file.metadata,
+              result.file.content,
+            );
+            const filePath = fileRepo.getPath(
+              modelType,
+              input.id,
+              methodName,
+              result.file.metadata.id,
+            );
+            ctx.logger.debug`File saved to: ${filePath}`;
+            output.setFileId(result.file.metadata.id);
+            fileArtifact = {
+              id: result.file.metadata.id,
+              path: filePath,
+            };
+          }
+        }
+
+        // Mark output as succeeded and save
+        output.markSucceeded();
+        await outputRepo.save(modelType, methodName, output);
+      } catch (error) {
+        // Mark output as failed and save
+        const errorMessage = error instanceof Error
+          ? error.message
+          : String(error);
+        const errorStack = error instanceof Error ? error.stack : undefined;
+        output.markFailed({ message: errorMessage, stack: errorStack });
+        await outputRepo.save(modelType, methodName, output);
+        throw error;
       }
 
       // Render output
@@ -165,9 +323,10 @@ export const modelMethodRunCommand = new Command()
         modelName: input.name,
         type: modelType.normalized,
         methodName,
-        resourceId: result.resource.id,
-        resourcePath,
-        resourceAttributes: result.resource.attributes,
+        resource: resourceArtifact,
+        data: dataArtifact,
+        file: fileArtifact,
+        logs: logArtifacts.length > 0 ? logArtifacts : undefined,
       };
 
       renderModelMethodRun(data, ctx.outputMode);

--- a/src/cli/commands/model_output.ts
+++ b/src/cli/commands/model_output.ts
@@ -1,0 +1,12 @@
+import { Command } from "@cliffy/command";
+import { modelOutputGetCommand } from "./model_output_get.ts";
+import { modelOutputSearchCommand } from "./model_output_search.ts";
+
+export const modelOutputCommand = new Command()
+  .name("output")
+  .description("Manage model outputs")
+  .action(function () {
+    this.showHelp();
+  })
+  .command("get", modelOutputGetCommand)
+  .command("search", modelOutputSearchCommand);

--- a/src/cli/commands/model_output_get.ts
+++ b/src/cli/commands/model_output_get.ts
@@ -1,0 +1,181 @@
+import { Command } from "@cliffy/command";
+import {
+  type ModelOutputGetData,
+  renderModelOutputGet,
+} from "../../presentation/output/model_output_get_output.tsx";
+import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createModelOutputId,
+  type ModelOutputId,
+} from "../../domain/models/model_output.ts";
+import type { ModelType } from "../../domain/models/model_type.ts";
+import { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
+import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
+import { UserError } from "../../domain/errors.ts";
+import {
+  findInputByIdGlobal,
+  isUuid,
+} from "../../domain/models/model_lookup.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+/**
+ * Finds an output by ID across all types and methods.
+ */
+async function findOutputByIdGlobal(
+  outputRepo: YamlOutputRepository,
+  id: ModelOutputId,
+): Promise<
+  | {
+    output: NonNullable<Awaited<ReturnType<YamlOutputRepository["findById"]>>>;
+    type: ModelType;
+    method: string;
+  }
+  | null
+> {
+  const allOutputs = await outputRepo.findAllGlobal();
+  for (const result of allOutputs) {
+    if (result.output.id === id) {
+      return result;
+    }
+  }
+  return null;
+}
+
+export const modelOutputGetCommand = new Command()
+  .name("get")
+  .description("Show details of a model output")
+  .arguments("<output_id_or_model_name:string>")
+  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .action(async function (options: AnyOptions, outputIdOrModelName: string) {
+    const ctx = createContext(options as GlobalOptions, "model-output-get");
+    ctx.logger.debug`Getting output: ${outputIdOrModelName}`;
+
+    const repoDir = options.repoDir ?? ".";
+    const inputRepo = new YamlInputRepository(repoDir);
+    const outputRepo = new YamlOutputRepository(repoDir);
+
+    let outputData: ModelOutputGetData;
+
+    if (isUuid(outputIdOrModelName)) {
+      // Try to find by output ID first
+      ctx.logger.debug`Looking up output by ID: ${outputIdOrModelName}`;
+      const outputId = createModelOutputId(outputIdOrModelName);
+      const result = await findOutputByIdGlobal(outputRepo, outputId);
+
+      if (result) {
+        const { output, type } = result;
+
+        // Try to get model name
+        let modelName: string | undefined;
+        for (const modelType of modelRegistry.types()) {
+          const outputs = await outputRepo.findByModelInput(
+            modelType,
+            output.modelInputId,
+          );
+          if (outputs.length > 0) {
+            const input = await inputRepo.findById(
+              modelType,
+              output.modelInputId,
+            );
+            if (input) {
+              modelName = input.name;
+              break;
+            }
+          }
+        }
+
+        outputData = {
+          id: output.id,
+          modelInputId: output.modelInputId,
+          modelName,
+          type: type.normalized,
+          methodName: output.methodName,
+          status: output.status,
+          startedAt: output.startedAt.toISOString(),
+          completedAt: output.completedAt?.toISOString(),
+          durationMs: output.durationMs,
+          retryCount: output.retryCount,
+          provenance: output.provenance,
+          artifacts: output.artifacts,
+          error: output.error,
+        };
+      } else {
+        // Maybe it's a model input ID - get the latest output for that model
+        ctx.logger.debug`Output not found, trying as model input ID`;
+        const inputResult = await findInputByIdGlobal(
+          inputRepo,
+          outputIdOrModelName,
+        );
+        if (!inputResult) {
+          throw new UserError(
+            `Output or model not found: ${outputIdOrModelName}`,
+          );
+        }
+
+        const latestOutput = await outputRepo.findLatestByModelInput(
+          inputResult.type,
+          inputResult.input.id,
+        );
+        if (!latestOutput) {
+          throw new UserError(
+            `No outputs found for model: ${inputResult.input.name}`,
+          );
+        }
+
+        outputData = {
+          id: latestOutput.id,
+          modelInputId: latestOutput.modelInputId,
+          modelName: inputResult.input.name,
+          type: inputResult.type.normalized,
+          methodName: latestOutput.methodName,
+          status: latestOutput.status,
+          startedAt: latestOutput.startedAt.toISOString(),
+          completedAt: latestOutput.completedAt?.toISOString(),
+          durationMs: latestOutput.durationMs,
+          retryCount: latestOutput.retryCount,
+          provenance: latestOutput.provenance,
+          artifacts: latestOutput.artifacts,
+          error: latestOutput.error,
+        };
+      }
+    } else {
+      // Look up by model name and get latest output
+      ctx.logger.debug`Looking up by model name: ${outputIdOrModelName}`;
+      const inputResult = await inputRepo.findByNameGlobal(outputIdOrModelName);
+      if (!inputResult) {
+        throw new UserError(`Model not found: ${outputIdOrModelName}`);
+      }
+
+      const latestOutput = await outputRepo.findLatestByModelInput(
+        inputResult.type,
+        inputResult.input.id,
+      );
+      if (!latestOutput) {
+        throw new UserError(
+          `No outputs found for model: ${inputResult.input.name}`,
+        );
+      }
+
+      outputData = {
+        id: latestOutput.id,
+        modelInputId: latestOutput.modelInputId,
+        modelName: inputResult.input.name,
+        type: inputResult.type.normalized,
+        methodName: latestOutput.methodName,
+        status: latestOutput.status,
+        startedAt: latestOutput.startedAt.toISOString(),
+        completedAt: latestOutput.completedAt?.toISOString(),
+        durationMs: latestOutput.durationMs,
+        retryCount: latestOutput.retryCount,
+        provenance: latestOutput.provenance,
+        artifacts: latestOutput.artifacts,
+        error: latestOutput.error,
+      };
+    }
+
+    renderModelOutputGet(outputData, ctx.outputMode);
+    ctx.logger.debug("Model output get command completed");
+  });

--- a/src/cli/commands/model_output_search.ts
+++ b/src/cli/commands/model_output_search.ts
@@ -1,0 +1,170 @@
+import { Command } from "@cliffy/command";
+import {
+  type ModelOutputSearchData,
+  type ModelOutputSearchItem,
+  renderModelOutputSearch,
+} from "../../presentation/output/model_output_search_output.tsx";
+import {
+  type ModelOutputGetData,
+  renderModelOutputGet,
+} from "../../presentation/output/model_output_get_output.tsx";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
+import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
+import type { ModelOutput } from "../../domain/models/model_output.ts";
+import type { ModelType } from "../../domain/models/model_type.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+/**
+ * Converts repository results to ModelOutputSearchItem array.
+ */
+async function toModelOutputSearchItems(
+  results: { output: ModelOutput; type: ModelType; method: string }[],
+  inputRepo: YamlInputRepository,
+): Promise<ModelOutputSearchItem[]> {
+  const items: ModelOutputSearchItem[] = [];
+
+  for (const { output, type } of results) {
+    // Try to get model name
+    let modelName: string | undefined;
+    const input = await inputRepo.findById(type, output.modelInputId);
+    if (input) {
+      modelName = input.name;
+    }
+
+    items.push({
+      id: output.id,
+      modelInputId: output.modelInputId,
+      modelName,
+      type: type.normalized,
+      methodName: output.methodName,
+      status: output.status,
+      startedAt: output.startedAt.toISOString(),
+      durationMs: output.durationMs,
+    });
+  }
+
+  // Sort by startedAt descending (most recent first)
+  items.sort(
+    (a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+  );
+
+  return items;
+}
+
+/**
+ * Filters outputs by a query string (case-insensitive match on model name, type, method, status, or id).
+ */
+export function filterOutputs(
+  outputs: ModelOutputSearchItem[],
+  query: string,
+): ModelOutputSearchItem[] {
+  if (!query) {
+    return outputs;
+  }
+  const lowerQuery = query.toLowerCase();
+  return outputs.filter(
+    (o) =>
+      (o.modelName?.toLowerCase().includes(lowerQuery) ?? false) ||
+      o.type.toLowerCase().includes(lowerQuery) ||
+      o.methodName.toLowerCase().includes(lowerQuery) ||
+      o.status.toLowerCase().includes(lowerQuery) ||
+      o.id.toLowerCase().includes(lowerQuery) ||
+      o.modelInputId.toLowerCase().includes(lowerQuery),
+  );
+}
+
+/**
+ * Displays the model output get output for a selected output.
+ */
+async function displayModelOutputGet(
+  item: ModelOutputSearchItem,
+  repoDir: string,
+  outputMode: "interactive" | "json",
+): Promise<void> {
+  const inputRepo = new YamlInputRepository(repoDir);
+  const outputRepo = new YamlOutputRepository(repoDir);
+
+  // Look up the full output
+  const allOutputs = await outputRepo.findAllGlobal();
+  const result = allOutputs.find((r) => r.output.id === item.id);
+
+  if (!result) {
+    throw new Error(`Output not found: ${item.id}`);
+  }
+
+  const { output, type } = result;
+
+  // Try to get model name
+  let modelName: string | undefined;
+  const input = await inputRepo.findById(type, output.modelInputId);
+  if (input) {
+    modelName = input.name;
+  }
+
+  const data: ModelOutputGetData = {
+    id: output.id,
+    modelInputId: output.modelInputId,
+    modelName,
+    type: type.normalized,
+    methodName: output.methodName,
+    status: output.status,
+    startedAt: output.startedAt.toISOString(),
+    completedAt: output.completedAt?.toISOString(),
+    durationMs: output.durationMs,
+    retryCount: output.retryCount,
+    provenance: output.provenance,
+    artifacts: output.artifacts,
+    error: output.error,
+  };
+
+  renderModelOutputGet(data, outputMode);
+}
+
+export const modelOutputSearchCommand = new Command()
+  .name("search")
+  .description("Search for model outputs")
+  .arguments("[query:string]")
+  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .action(async function (options: AnyOptions, query?: string) {
+    const ctx = createContext(options as GlobalOptions, "model-output-search");
+    ctx.logger.debug`Searching outputs with query: ${query ?? "(none)"}`;
+
+    const repoDir = options.repoDir ?? ".";
+    const inputRepo = new YamlInputRepository(repoDir);
+    const outputRepo = new YamlOutputRepository(repoDir);
+
+    // Get all outputs from repository
+    const allResults = await outputRepo.findAllGlobal();
+    const allOutputs = await toModelOutputSearchItems(allResults, inputRepo);
+
+    if (ctx.outputMode === "json") {
+      // Non-interactive: filter and output JSON
+      const filteredOutputs = filterOutputs(allOutputs, query ?? "");
+      const data: ModelOutputSearchData = {
+        query: query ?? "",
+        results: filteredOutputs,
+      };
+      await renderModelOutputSearch(data, ctx.outputMode);
+    } else {
+      // Interactive: show fuzzy search UI
+      const data: ModelOutputSearchData = {
+        query: query ?? "",
+        results: allOutputs,
+      };
+
+      const selected = await renderModelOutputSearch(data, ctx.outputMode);
+
+      if (selected) {
+        ctx.logger.debug`Selected output: ${selected.id}`;
+        // Display the full output details
+        await displayModelOutputGet(selected, repoDir, ctx.outputMode);
+      } else {
+        ctx.logger.debug`Search cancelled`;
+      }
+    }
+
+    ctx.logger.debug("Model output search command completed");
+  });

--- a/src/cli/commands/type_describe.ts
+++ b/src/cli/commands/type_describe.ts
@@ -66,9 +66,12 @@ export const typeDescribeCommand = new Command()
     const inputAttributesSchema = zodToJsonSchema(
       definition.inputAttributesSchema,
     );
-    const resourceAttributesSchema = zodToJsonSchema(
-      definition.resourceAttributesSchema,
-    );
+    const resourceAttributesSchema = definition.resourceAttributesSchema
+      ? zodToJsonSchema(definition.resourceAttributesSchema)
+      : undefined;
+    const dataAttributesSchema = definition.dataAttributesSchema
+      ? zodToJsonSchema(definition.dataAttributesSchema)
+      : undefined;
 
     // Build method descriptions
     const methods: MethodDescribeData[] = Object.entries(definition.methods)
@@ -85,6 +88,7 @@ export const typeDescribeCommand = new Command()
       version: definition.version,
       inputAttributesSchema,
       resourceAttributesSchema,
+      dataAttributesSchema,
       methods,
     };
 

--- a/src/cli/commands/type_search.ts
+++ b/src/cli/commands/type_search.ts
@@ -60,9 +60,12 @@ function displayTypeDescribe(item: TypeSearchItem, options: AnyOptions): void {
   const inputAttributesSchema = zodToJsonSchema(
     definition.inputAttributesSchema,
   );
-  const resourceAttributesSchema = zodToJsonSchema(
-    definition.resourceAttributesSchema,
-  );
+  const resourceAttributesSchema = definition.resourceAttributesSchema
+    ? zodToJsonSchema(definition.resourceAttributesSchema)
+    : undefined;
+  const dataAttributesSchema = definition.dataAttributesSchema
+    ? zodToJsonSchema(definition.dataAttributesSchema)
+    : undefined;
 
   const methods = Object.entries(definition.methods).map(([name, method]) => ({
     name,
@@ -79,6 +82,7 @@ function displayTypeDescribe(item: TypeSearchItem, options: AnyOptions): void {
       version: definition.version,
       inputAttributesSchema,
       resourceAttributesSchema,
+      dataAttributesSchema,
       methods,
     },
     ctx.outputMode,

--- a/src/domain/expressions/dependency_extractor.ts
+++ b/src/domain/expressions/dependency_extractor.ts
@@ -1,7 +1,23 @@
 /**
  * Type of model reference in an expression.
  */
-export type DependencyType = "input" | "resource";
+export type DependencyType =
+  | "input"
+  | "resource"
+  | "data"
+  | "file"
+  | "log"
+  | "execution";
+
+/**
+ * Artifact types that create implicit workflow dependencies.
+ */
+export const ArtifactDependencyTypes: readonly DependencyType[] = [
+  "resource",
+  "data",
+  "file",
+  "log",
+] as const;
 
 /**
  * Represents a dependency extracted from an expression.
@@ -15,9 +31,10 @@ export interface ExpressionDependency {
 
 /**
  * Pattern to match model references in CEL expressions.
- * Matches: model.<name-or-uuid>.input or model.<name-or-uuid>.resource
+ * Matches: model.<name-or-uuid>.(input|resource|data|file|log|execution)
  */
-const MODEL_REF_PATTERN = /model\.([a-zA-Z0-9_-]+)\.(input|resource)/g;
+const MODEL_REF_PATTERN =
+  /model\.([a-zA-Z0-9_-]+)\.(input|resource|data|file|log|execution)/g;
 
 /**
  * Extracts model dependencies from a CEL expression.
@@ -65,6 +82,17 @@ export function extractModelRefs(expression: string): string[] {
 }
 
 /**
+ * Checks if an expression has any artifact dependencies (resource, data, file, log).
+ * Artifact dependencies create implicit workflow step dependencies.
+ *
+ * @param expression - The CEL expression to check
+ * @returns True if the expression references any model artifacts
+ */
+export function hasArtifactDependency(expression: string): boolean {
+  return /model\.[a-zA-Z0-9_-]+\.(resource|data|file|log)/.test(expression);
+}
+
+/**
  * Checks if an expression has any resource dependencies.
  * Resource dependencies create implicit workflow step dependencies.
  *
@@ -73,6 +101,35 @@ export function extractModelRefs(expression: string): string[] {
  */
 export function hasResourceDependency(expression: string): boolean {
   return /model\.[a-zA-Z0-9_-]+\.resource/.test(expression);
+}
+
+/**
+ * Extracts all artifact dependencies from a CEL expression.
+ * These create implicit workflow step dependencies.
+ *
+ * @param expression - The CEL expression to analyze
+ * @returns Array of dependencies with artifact types (resource, data, file, log)
+ */
+export function extractArtifactDependencies(
+  expression: string,
+): ExpressionDependency[] {
+  const dependencies: ExpressionDependency[] = [];
+  const seen = new Set<string>();
+
+  const pattern = /model\.([a-zA-Z0-9_-]+)\.(resource|data|file|log)/g;
+  const matches = expression.matchAll(pattern);
+  for (const match of matches) {
+    const modelRef = match[1];
+    const type = match[2] as DependencyType;
+    const key = `${modelRef}:${type}`;
+
+    if (!seen.has(key)) {
+      seen.add(key);
+      dependencies.push({ modelRef, type });
+    }
+  }
+
+  return dependencies;
 }
 
 /**

--- a/src/domain/expressions/expression_path_extractor.ts
+++ b/src/domain/expressions/expression_path_extractor.ts
@@ -6,9 +6,9 @@ import type { DependencyType } from "./dependency_extractor.ts";
 export interface ExpressionPathReference {
   /** The model reference (name or UUID) */
   modelRef: string;
-  /** Whether the reference is to input or resource data */
+  /** The artifact type (input, resource, data, file, log, execution) */
   type: DependencyType;
-  /** The path segments after input/resource (e.g., ["attributes", "VpcId"]) */
+  /** The path segments after the artifact type (e.g., ["attributes", "VpcId"]) */
   path: string[];
   /** The full path string (e.g., "resource.attributes.VpcId") */
   fullPath: string;
@@ -18,14 +18,14 @@ export interface ExpressionPathReference {
 
 /**
  * Pattern to match model references with full paths in CEL expressions.
- * Matches: model.<name-or-uuid>.(input|resource)(.<property>|[<index>])*
+ * Matches: model.<name-or-uuid>.(input|resource|data|file|log|execution)(.<property>|[<index>])*
  *
  * Group 1: model name or UUID
- * Group 2: "input" or "resource"
+ * Group 2: artifact type
  * Group 3: remaining path (property accesses and array indices)
  */
 const MODEL_PATH_PATTERN =
-  /model\.([a-zA-Z0-9_-]+)\.(input|resource)((?:\.[a-zA-Z0-9_]+|\[\d+\])*)/g;
+  /model\.([a-zA-Z0-9_-]+)\.(input|resource|data|file|log|execution)((?:\.[a-zA-Z0-9_]+|\[\d+\])*)/g;
 
 /**
  * Pattern to match self references with full paths.

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -1,9 +1,20 @@
 import type { ModelInput } from "../models/model_input.ts";
 import type { ModelResource } from "../models/model_resource.ts";
+import type { ModelData as ModelDataEntity } from "../models/model_data.ts";
+import type { ModelFile } from "../models/model_file.ts";
+import type { ModelLog } from "../models/model_log.ts";
+import type { ModelOutput } from "../models/model_output.ts";
 import type { ModelType } from "../models/model_type.ts";
 import type { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
 import type { YamlResourceRepository } from "../../infrastructure/persistence/yaml_resource_repository.ts";
+import type { YamlDataRepository } from "../../infrastructure/persistence/yaml_data_repository.ts";
+import type { FileSystemFileRepository } from "../../infrastructure/persistence/fs_file_repository.ts";
+import type { StreamingLogRepository } from "../../infrastructure/persistence/streaming_log_repository.ts";
+import type { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
 import { createModelResourceId } from "../models/model_resource.ts";
+import { createModelDataId } from "../models/model_data.ts";
+import { createModelFileId } from "../models/model_file.ts";
+import { createModelLogId } from "../models/model_log.ts";
 import { ModelNotFoundError } from "./errors.ts";
 
 /**
@@ -22,6 +33,39 @@ export interface ModelData {
     version: number;
     createdAt: string;
     attributes: Record<string, unknown>;
+  };
+  data?: {
+    id: string;
+    version: number;
+    createdAt: string;
+    attributes: Record<string, unknown>;
+  };
+  file?: {
+    id: string;
+    version: number;
+    createdAt: string;
+    filename: string;
+    contentType: string;
+    size: number;
+    checksum: string;
+    path: string;
+  };
+  log?: {
+    id: string;
+    version: number;
+    createdAt: string;
+    entries: Array<{
+      message: string;
+    }>;
+  };
+  execution?: {
+    id: string;
+    methodName: string;
+    status: string;
+    startedAt: string;
+    completedAt?: string;
+    durationMs?: number;
+    error?: { message: string; stack?: string };
   };
 }
 
@@ -46,13 +90,34 @@ export interface ExpressionContext {
 }
 
 /**
+ * Configuration for optional repositories.
+ */
+export interface ModelResolverRepositories {
+  dataRepo?: YamlDataRepository;
+  fileRepo?: FileSystemFileRepository;
+  logRepo?: StreamingLogRepository;
+  outputRepo?: YamlOutputRepository;
+}
+
+/**
  * Resolves model references to build CEL evaluation context.
  */
 export class ModelResolver {
+  private readonly dataRepo?: YamlDataRepository;
+  private readonly fileRepo?: FileSystemFileRepository;
+  private readonly logRepo?: StreamingLogRepository;
+  private readonly outputRepo?: YamlOutputRepository;
+
   constructor(
     private readonly inputRepo: YamlInputRepository,
     private readonly resourceRepo: YamlResourceRepository,
-  ) {}
+    repos?: ModelResolverRepositories,
+  ) {
+    this.dataRepo = repos?.dataRepo;
+    this.fileRepo = repos?.fileRepo;
+    this.logRepo = repos?.logRepo;
+    this.outputRepo = repos?.outputRepo;
+  }
 
   /**
    * Builds a complete expression context from all available models.
@@ -126,6 +191,94 @@ export class ModelResolver {
       }
     }
 
+    // Load data artifact if available
+    if (input.dataId && this.dataRepo) {
+      const dataId = createModelDataId(input.dataId);
+      const dataArtifact = await this.dataRepo.findById(type, dataId);
+      if (dataArtifact) {
+        data.data = {
+          id: dataArtifact.id,
+          version: dataArtifact.version,
+          createdAt: dataArtifact.createdAt.toISOString(),
+          attributes: dataArtifact.attributes,
+        };
+      }
+    }
+
+    // Load file artifact if available
+    // Note: We need to find the file using the output that created it
+    // to get the method name for the path structure
+    if (input.fileId && this.fileRepo && this.outputRepo) {
+      const fileId = createModelFileId(input.fileId);
+      // Find the output that created this file to get the method name
+      const latestOutput = await this.outputRepo.findLatestByModelInput(
+        type,
+        input.id,
+      );
+      const methodName = latestOutput?.methodName;
+
+      if (methodName) {
+        const fileArtifact = await this.fileRepo.findById(
+          type,
+          input.id,
+          methodName,
+          fileId,
+        );
+        if (fileArtifact) {
+          data.file = {
+            id: fileArtifact.id,
+            version: fileArtifact.version,
+            createdAt: fileArtifact.createdAt.toISOString(),
+            filename: fileArtifact.filename,
+            contentType: fileArtifact.contentType,
+            size: fileArtifact.size,
+            checksum: fileArtifact.checksum,
+            path: this.fileRepo.getContentPath(
+              type,
+              input.id,
+              methodName,
+              fileArtifact,
+            ),
+          };
+        }
+      }
+    }
+
+    // Load log artifact if available
+    if (input.logId && this.logRepo) {
+      const logId = createModelLogId(input.logId);
+      const logArtifact = await this.logRepo.findById(type, logId);
+      if (logArtifact) {
+        data.log = {
+          id: logArtifact.id,
+          version: logArtifact.version,
+          createdAt: logArtifact.createdAt.toISOString(),
+          entries: logArtifact.entries.map((e) => ({
+            message: e.message,
+          })),
+        };
+      }
+    }
+
+    // Load latest output if available
+    if (this.outputRepo) {
+      const latestOutput = await this.outputRepo.findLatestByModelInput(
+        type,
+        input.id,
+      );
+      if (latestOutput) {
+        data.execution = {
+          id: latestOutput.id,
+          methodName: latestOutput.methodName,
+          status: latestOutput.status,
+          startedAt: latestOutput.startedAt.toISOString(),
+          completedAt: latestOutput.completedAt?.toISOString(),
+          durationMs: latestOutput.durationMs,
+          error: latestOutput.error,
+        };
+      }
+    }
+
     return data;
   }
 
@@ -194,6 +347,109 @@ export class ModelResolver {
         version: resource.version,
         createdAt: resource.createdAt.toISOString(),
         attributes: resource.attributes,
+      };
+    }
+  }
+
+  /**
+   * Updates the context with fresh data artifact for a specific model.
+   *
+   * @param context - The context to update
+   * @param modelRef - The model name or UUID
+   * @param dataArtifact - The new data artifact
+   */
+  updateDataInContext(
+    context: ExpressionContext,
+    modelRef: string,
+    dataArtifact: ModelDataEntity,
+  ): void {
+    const modelData = context.model[modelRef];
+    if (modelData) {
+      modelData.data = {
+        id: dataArtifact.id,
+        version: dataArtifact.version,
+        createdAt: dataArtifact.createdAt.toISOString(),
+        attributes: dataArtifact.attributes,
+      };
+    }
+  }
+
+  /**
+   * Updates the context with fresh file artifact for a specific model.
+   *
+   * @param context - The context to update
+   * @param modelRef - The model name or UUID
+   * @param fileArtifact - The new file artifact
+   * @param filePath - The path to the file content
+   */
+  updateFileInContext(
+    context: ExpressionContext,
+    modelRef: string,
+    fileArtifact: ModelFile,
+    filePath: string,
+  ): void {
+    const modelData = context.model[modelRef];
+    if (modelData) {
+      modelData.file = {
+        id: fileArtifact.id,
+        version: fileArtifact.version,
+        createdAt: fileArtifact.createdAt.toISOString(),
+        filename: fileArtifact.filename,
+        contentType: fileArtifact.contentType,
+        size: fileArtifact.size,
+        checksum: fileArtifact.checksum,
+        path: filePath,
+      };
+    }
+  }
+
+  /**
+   * Updates the context with fresh log artifact for a specific model.
+   *
+   * @param context - The context to update
+   * @param modelRef - The model name or UUID
+   * @param logArtifact - The new log artifact
+   */
+  updateLogInContext(
+    context: ExpressionContext,
+    modelRef: string,
+    logArtifact: ModelLog,
+  ): void {
+    const modelData = context.model[modelRef];
+    if (modelData) {
+      modelData.log = {
+        id: logArtifact.id,
+        version: logArtifact.version,
+        createdAt: logArtifact.createdAt.toISOString(),
+        entries: logArtifact.entries.map((e) => ({
+          message: e.message,
+        })),
+      };
+    }
+  }
+
+  /**
+   * Updates the context with fresh output state for a specific model.
+   *
+   * @param context - The context to update
+   * @param modelRef - The model name or UUID
+   * @param output - The output state
+   */
+  updateOutputInContext(
+    context: ExpressionContext,
+    modelRef: string,
+    output: ModelOutput,
+  ): void {
+    const modelData = context.model[modelRef];
+    if (modelData) {
+      modelData.execution = {
+        id: output.id,
+        methodName: output.methodName,
+        status: output.status,
+        startedAt: output.startedAt.toISOString(),
+        completedAt: output.completedAt?.toISOString(),
+        durationMs: output.durationMs,
+        error: output.error,
       };
     }
   }

--- a/src/domain/models/aws/ec2/instance/ec2_instance_model_test.ts
+++ b/src/domain/models/aws/ec2/instance/ec2_instance_model_test.ts
@@ -199,8 +199,8 @@ Deno.test("EC2InstanceModel - create method uses injected CloudControl client", 
 
   const result = await ec2InstanceModel.methods.create.execute(input, context);
 
-  assertEquals(result.resource.attributes.RequestToken, "request-123");
-  assertEquals(result.resource.attributes.OperationStatus, "IN_PROGRESS");
+  assertEquals(result.resource?.attributes.RequestToken, "request-123");
+  assertEquals(result.resource?.attributes.OperationStatus, "IN_PROGRESS");
   assertEquals(result.followUpActions?.length, 1);
   assertEquals(result.followUpActions?.[0].methodName, "sync");
 });
@@ -257,8 +257,8 @@ Deno.test("EC2InstanceModel - sync method treats 'not found' as deleted", async 
   const result = await ec2InstanceModel.methods.sync.execute(input, context);
 
   // Should return success with deleteResource flag
-  assertEquals(result.resource.attributes.OperationStatus, "SUCCESS");
-  assertEquals(result.resource.attributes.DeletionCompleted, true);
+  assertEquals(result.resource?.attributes.OperationStatus, "SUCCESS");
+  assertEquals(result.resource?.attributes.DeletionCompleted, true);
   assertEquals(result.deleteResource, true);
   assertEquals(result.followUpActions, undefined);
 });
@@ -310,8 +310,8 @@ Deno.test("EC2InstanceModel - delete method treats 'not found' as success", asyn
   const result = await ec2InstanceModel.methods.delete.execute(input, context);
 
   // Should return success with deleteResource flag
-  assertEquals(result.resource.attributes.OperationStatus, "SUCCESS");
-  assertEquals(result.resource.attributes.DeletionCompleted, true);
+  assertEquals(result.resource?.attributes.OperationStatus, "SUCCESS");
+  assertEquals(result.resource?.attributes.DeletionCompleted, true);
   assertEquals(result.deleteResource, true);
   assertEquals(result.followUpActions, undefined);
 });

--- a/src/domain/models/aws/ec2/subnet/ec2_subnet_model_test.ts
+++ b/src/domain/models/aws/ec2/subnet/ec2_subnet_model_test.ts
@@ -246,8 +246,8 @@ Deno.test("EC2SubnetModel - create method uses injected CloudControl client", as
 
   const result = await ec2SubnetModel.methods.create.execute(input, context);
 
-  assertEquals(result.resource.attributes.RequestToken, "request-123");
-  assertEquals(result.resource.attributes.OperationStatus, "IN_PROGRESS");
+  assertEquals(result.resource?.attributes.RequestToken, "request-123");
+  assertEquals(result.resource?.attributes.OperationStatus, "IN_PROGRESS");
   assertEquals(result.followUpActions?.length, 1);
   assertEquals(result.followUpActions?.[0].methodName, "sync");
 });
@@ -301,8 +301,8 @@ Deno.test("EC2SubnetModel - sync method treats 'not found' as deleted", async ()
 
   const result = await ec2SubnetModel.methods.sync.execute(input, context);
 
-  assertEquals(result.resource.attributes.OperationStatus, "SUCCESS");
-  assertEquals(result.resource.attributes.DeletionCompleted, true);
+  assertEquals(result.resource?.attributes.OperationStatus, "SUCCESS");
+  assertEquals(result.resource?.attributes.DeletionCompleted, true);
   assertEquals(result.deleteResource, true);
   assertEquals(result.followUpActions, undefined);
 });
@@ -351,8 +351,8 @@ Deno.test("EC2SubnetModel - delete method treats 'not found' as success", async 
 
   const result = await ec2SubnetModel.methods.delete.execute(input, context);
 
-  assertEquals(result.resource.attributes.OperationStatus, "SUCCESS");
-  assertEquals(result.resource.attributes.DeletionCompleted, true);
+  assertEquals(result.resource?.attributes.OperationStatus, "SUCCESS");
+  assertEquals(result.resource?.attributes.DeletionCompleted, true);
   assertEquals(result.deleteResource, true);
   assertEquals(result.followUpActions, undefined);
 });

--- a/src/domain/models/aws/ec2/vpc/ec2_vpc_model_test.ts
+++ b/src/domain/models/aws/ec2/vpc/ec2_vpc_model_test.ts
@@ -180,8 +180,8 @@ Deno.test("EC2VpcModel - create method uses injected CloudControl client", async
 
   const result = await ec2VpcModel.methods.create.execute(input, context);
 
-  assertEquals(result.resource.attributes.RequestToken, "request-123");
-  assertEquals(result.resource.attributes.OperationStatus, "IN_PROGRESS");
+  assertEquals(result.resource?.attributes.RequestToken, "request-123");
+  assertEquals(result.resource?.attributes.OperationStatus, "IN_PROGRESS");
   assertEquals(result.followUpActions?.length, 1);
   assertEquals(result.followUpActions?.[0].methodName, "sync");
 });
@@ -234,8 +234,8 @@ Deno.test("EC2VpcModel - sync method treats 'not found' as deleted", async () =>
 
   const result = await ec2VpcModel.methods.sync.execute(input, context);
 
-  assertEquals(result.resource.attributes.OperationStatus, "SUCCESS");
-  assertEquals(result.resource.attributes.DeletionCompleted, true);
+  assertEquals(result.resource?.attributes.OperationStatus, "SUCCESS");
+  assertEquals(result.resource?.attributes.DeletionCompleted, true);
   assertEquals(result.deleteResource, true);
   assertEquals(result.followUpActions, undefined);
 });
@@ -283,8 +283,8 @@ Deno.test("EC2VpcModel - delete method treats 'not found' as success", async () 
 
   const result = await ec2VpcModel.methods.delete.execute(input, context);
 
-  assertEquals(result.resource.attributes.OperationStatus, "SUCCESS");
-  assertEquals(result.resource.attributes.DeletionCompleted, true);
+  assertEquals(result.resource?.attributes.OperationStatus, "SUCCESS");
+  assertEquals(result.resource?.attributes.DeletionCompleted, true);
   assertEquals(result.deleteResource, true);
   assertEquals(result.followUpActions, undefined);
 });

--- a/src/domain/models/command/curl/curl_model.ts
+++ b/src/domain/models/command/curl/curl_model.ts
@@ -1,0 +1,214 @@
+import { z } from "zod";
+import { ModelType } from "../../model_type.ts";
+import { ModelResource } from "../../model_resource.ts";
+import { computeChecksum, ModelFile } from "../../model_file.ts";
+import {
+  defineModel,
+  type MethodContext,
+  type MethodResult,
+  type ModelDefinition,
+} from "../../model.ts";
+import type { ModelInput } from "../../model_input.ts";
+
+/**
+ * Schema for curl model input attributes.
+ */
+export const CurlInputAttributesSchema = z.object({
+  /** URL to download */
+  url: z.string().url(),
+  /** HTTP method (default: GET) */
+  method: z.enum(["GET", "HEAD", "POST", "PUT", "DELETE"]).default("GET"),
+  /** Optional HTTP headers */
+  headers: z.record(z.string(), z.string()).optional(),
+  /** Optional filename for the downloaded file (defaults to URL basename) */
+  outputFilename: z.string().optional(),
+  /** Whether to follow redirects (default: true) */
+  followRedirects: z.boolean().default(true),
+  /** Request timeout in milliseconds */
+  timeout: z.number().int().positive().optional(),
+});
+
+/**
+ * Type for curl model input attributes.
+ */
+export type CurlInputAttributes = z.infer<typeof CurlInputAttributesSchema>;
+
+/**
+ * Schema for curl model resource attributes.
+ */
+export const CurlResourceAttributesSchema = z.object({
+  /** The URL that was downloaded */
+  url: z.string().url(),
+  /** HTTP status code */
+  statusCode: z.number().int(),
+  /** Content-Type header from the response */
+  contentType: z.string(),
+  /** Content-Length from response (or actual size) */
+  contentLength: z.number().int().nonnegative(),
+  /** Timestamp when download completed */
+  downloadedAt: z.string().datetime(),
+  /** Duration of the download in milliseconds */
+  durationMs: z.number().int().nonnegative(),
+  /** Reference to the file artifact containing the downloaded content */
+  fileId: z.string().uuid(),
+});
+
+/**
+ * Type for curl model resource attributes.
+ */
+export type CurlResourceAttributes = z.infer<
+  typeof CurlResourceAttributesSchema
+>;
+
+/**
+ * The curl model type identifier.
+ */
+export const CURL_MODEL_TYPE = ModelType.create("command/curl");
+
+/**
+ * Extracts filename from URL or Content-Disposition header.
+ */
+function extractFilename(url: string, headers: Headers): string {
+  // Check Content-Disposition header first
+  const disposition = headers.get("content-disposition");
+  if (disposition) {
+    const match = disposition.match(/filename[*]?=['"]?([^'"\s;]+)['"]?/i);
+    if (match) {
+      return match[1];
+    }
+  }
+
+  // Fall back to URL path
+  try {
+    const urlObj = new URL(url);
+    const pathname = urlObj.pathname;
+    const basename = pathname.split("/").pop();
+    if (basename && basename.length > 0) {
+      return basename;
+    }
+  } catch {
+    // URL parsing failed
+  }
+
+  // Default filename
+  return "download";
+}
+
+/**
+ * Executes the "download" method for the curl model.
+ *
+ * Downloads the URL and returns both resource metadata and file artifact.
+ */
+async function executeDownload(
+  input: ModelInput,
+  _context: MethodContext,
+): Promise<MethodResult> {
+  const attrs = CurlInputAttributesSchema.parse(input.attributes);
+  const startTime = Date.now();
+
+  // Build fetch options
+  const fetchOptions: RequestInit = {
+    method: attrs.method,
+    redirect: attrs.followRedirects ? "follow" : "manual",
+  };
+
+  // Add headers if provided
+  if (attrs.headers) {
+    fetchOptions.headers = new Headers(
+      Object.entries(attrs.headers) as [string, string][],
+    );
+  }
+
+  // Add timeout via AbortController if specified
+  let abortController: AbortController | undefined;
+  if (attrs.timeout) {
+    abortController = new AbortController();
+    fetchOptions.signal = abortController.signal;
+    setTimeout(() => abortController?.abort(), attrs.timeout);
+  }
+
+  // Perform the fetch
+  const response = await fetch(attrs.url, fetchOptions);
+
+  if (!response.ok) {
+    // Consume the response body to avoid resource leak
+    await response.body?.cancel();
+    throw new Error(
+      `HTTP request failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  // Read the response body
+  const content = new Uint8Array(await response.arrayBuffer());
+  const endTime = Date.now();
+  const durationMs = endTime - startTime;
+
+  // Determine filename
+  const filename = attrs.outputFilename ??
+    extractFilename(attrs.url, response.headers);
+
+  // Get content type
+  const contentType = response.headers.get("content-type") ??
+    "application/octet-stream";
+
+  // Compute checksum
+  const checksum = await computeChecksum(content);
+
+  // Create file artifact
+  const fileId = crypto.randomUUID();
+  const file = ModelFile.create({
+    id: fileId,
+    filename,
+    contentType,
+    size: content.length,
+    checksum,
+  });
+
+  // Create the resource with download metadata
+  const resource = ModelResource.create({
+    id: input.id,
+    attributes: {
+      url: attrs.url,
+      statusCode: response.status,
+      contentType,
+      contentLength: content.length,
+      downloadedAt: new Date().toISOString(),
+      durationMs,
+      fileId,
+    },
+  });
+
+  return {
+    resource,
+    file: {
+      metadata: file,
+      content,
+    },
+  };
+}
+
+/**
+ * The curl model definition.
+ *
+ * A model that downloads files via HTTP and stores them as file artifacts.
+ * Returns both resource metadata (URL, status, timing) and the actual file content.
+ *
+ * Self-registers with the global model registry when this module is imported.
+ */
+export const curlModel: ModelDefinition<
+  typeof CurlInputAttributesSchema,
+  typeof CurlResourceAttributesSchema
+> = defineModel({
+  type: CURL_MODEL_TYPE,
+  version: 1,
+  inputAttributesSchema: CurlInputAttributesSchema,
+  resourceAttributesSchema: CurlResourceAttributesSchema,
+  methods: {
+    download: {
+      description:
+        "Download a file from the URL and store it as a file artifact",
+      inputAttributesSchema: CurlInputAttributesSchema,
+      execute: executeDownload,
+    },
+  },
+});

--- a/src/domain/models/command/curl/curl_model_test.ts
+++ b/src/domain/models/command/curl/curl_model_test.ts
@@ -1,0 +1,232 @@
+import { assertEquals, assertExists } from "@std/assert";
+import { ModelInput } from "../../model_input.ts";
+import {
+  CURL_MODEL_TYPE,
+  CurlInputAttributesSchema,
+  curlModel,
+  CurlResourceAttributesSchema,
+} from "./curl_model.ts";
+
+// Check if we have network permission for integration tests
+const hasNetworkPermission = await (async () => {
+  const status = await Deno.permissions.query({
+    name: "net",
+    host: "httpbin.org",
+  });
+  return status.state === "granted";
+})();
+
+Deno.test("CURL_MODEL_TYPE has correct normalized type", () => {
+  assertEquals(CURL_MODEL_TYPE.normalized, "command/curl");
+});
+
+Deno.test("curlModel has correct version", () => {
+  assertEquals(curlModel.version, 1);
+});
+
+Deno.test("curlModel.type equals CURL_MODEL_TYPE", () => {
+  assertEquals(curlModel.type.equals(CURL_MODEL_TYPE), true);
+});
+
+Deno.test("CurlInputAttributesSchema validates url", () => {
+  const result = CurlInputAttributesSchema.safeParse({
+    url: "https://example.com/file.txt",
+  });
+  assertEquals(result.success, true);
+  if (result.success) {
+    assertEquals(result.data.url, "https://example.com/file.txt");
+    assertEquals(result.data.method, "GET"); // default
+    assertEquals(result.data.followRedirects, true); // default
+  }
+});
+
+Deno.test("CurlInputAttributesSchema validates with all options", () => {
+  const result = CurlInputAttributesSchema.safeParse({
+    url: "https://example.com/api",
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    outputFilename: "response.json",
+    followRedirects: false,
+    timeout: 5000,
+  });
+  assertEquals(result.success, true);
+  if (result.success) {
+    assertEquals(result.data.url, "https://example.com/api");
+    assertEquals(result.data.method, "POST");
+    assertEquals(result.data.headers?.["Content-Type"], "application/json");
+    assertEquals(result.data.outputFilename, "response.json");
+    assertEquals(result.data.followRedirects, false);
+    assertEquals(result.data.timeout, 5000);
+  }
+});
+
+Deno.test("CurlInputAttributesSchema rejects invalid url", () => {
+  const result = CurlInputAttributesSchema.safeParse({
+    url: "not-a-valid-url",
+  });
+  assertEquals(result.success, false);
+});
+
+Deno.test("CurlInputAttributesSchema rejects missing url", () => {
+  const result = CurlInputAttributesSchema.safeParse({});
+  assertEquals(result.success, false);
+});
+
+Deno.test("CurlInputAttributesSchema rejects invalid method", () => {
+  const result = CurlInputAttributesSchema.safeParse({
+    url: "https://example.com",
+    method: "INVALID",
+  });
+  assertEquals(result.success, false);
+});
+
+Deno.test("CurlInputAttributesSchema rejects negative timeout", () => {
+  const result = CurlInputAttributesSchema.safeParse({
+    url: "https://example.com",
+    timeout: -1000,
+  });
+  assertEquals(result.success, false);
+});
+
+Deno.test("CurlResourceAttributesSchema validates correct data", () => {
+  const result = CurlResourceAttributesSchema.safeParse({
+    url: "https://example.com/file.txt",
+    statusCode: 200,
+    contentType: "text/plain",
+    contentLength: 1024,
+    downloadedAt: "2024-01-15T10:30:00.000Z",
+    durationMs: 150,
+    fileId: "a1b2c3d4-e5f6-4a5b-8c9d-0e1f2a3b4c5d",
+  });
+  assertEquals(result.success, true);
+});
+
+Deno.test("CurlResourceAttributesSchema rejects invalid fileId", () => {
+  const result = CurlResourceAttributesSchema.safeParse({
+    url: "https://example.com/file.txt",
+    statusCode: 200,
+    contentType: "text/plain",
+    contentLength: 1024,
+    downloadedAt: "2024-01-15T10:30:00.000Z",
+    durationMs: 150,
+    fileId: "not-a-uuid",
+  });
+  assertEquals(result.success, false);
+});
+
+Deno.test("CurlResourceAttributesSchema rejects invalid timestamp", () => {
+  const result = CurlResourceAttributesSchema.safeParse({
+    url: "https://example.com/file.txt",
+    statusCode: 200,
+    contentType: "text/plain",
+    contentLength: 1024,
+    downloadedAt: "not-a-date",
+    durationMs: 150,
+    fileId: "a1b2c3d4-e5f6-4a5b-8c9d-0e1f2a3b4c5d",
+  });
+  assertEquals(result.success, false);
+});
+
+Deno.test("curlModel has download method", () => {
+  assertEquals("download" in curlModel.methods, true);
+  assertEquals(
+    curlModel.methods.download.description,
+    "Download a file from the URL and store it as a file artifact",
+  );
+});
+
+Deno.test("curlModel.methods.download validates input attributes", async () => {
+  const input = ModelInput.create({
+    name: "test-curl",
+    attributes: { notAUrl: "value" },
+  });
+
+  let error: Error | null = null;
+  try {
+    await curlModel.methods.download.execute(input, { repoDir: "/tmp" });
+  } catch (e) {
+    error = e as Error;
+  }
+
+  assertEquals(error !== null, true);
+});
+
+Deno.test({
+  name: "curlModel.methods.download executes correctly",
+  ignore: !hasNetworkPermission,
+  fn: async () => {
+    const input = ModelInput.create({
+      name: "test-curl",
+      attributes: { url: "https://httpbin.org/json" },
+    });
+
+    const result = await curlModel.methods.download.execute(input, {
+      repoDir: "/tmp",
+    });
+
+    // Check resource was created
+    assertExists(result.resource);
+    assertEquals(result.resource.attributes.url, "https://httpbin.org/json");
+    assertEquals(result.resource.attributes.statusCode, 200);
+    assertEquals(typeof result.resource.attributes.contentType, "string");
+    assertEquals(typeof result.resource.attributes.contentLength, "number");
+    assertEquals(typeof result.resource.attributes.downloadedAt, "string");
+    assertEquals(typeof result.resource.attributes.durationMs, "number");
+    assertEquals(typeof result.resource.attributes.fileId, "string");
+
+    // Verify downloadedAt is valid ISO date
+    const downloadedAt = new Date(
+      result.resource.attributes.downloadedAt as string,
+    );
+    assertEquals(isNaN(downloadedAt.getTime()), false);
+
+    // Check file artifact was created
+    assertExists(result.file);
+    assertExists(result.file.metadata);
+    assertExists(result.file.content);
+    assertEquals(result.file.content.length > 0, true);
+    assertEquals(result.file.metadata.id, result.resource.attributes.fileId);
+  },
+});
+
+Deno.test({
+  name: "curlModel.methods.download handles custom filename",
+  ignore: !hasNetworkPermission,
+  fn: async () => {
+    const input = ModelInput.create({
+      name: "test-curl-filename",
+      attributes: {
+        url: "https://httpbin.org/json",
+        outputFilename: "custom-response.json",
+      },
+    });
+
+    const result = await curlModel.methods.download.execute(input, {
+      repoDir: "/tmp",
+    });
+
+    assertExists(result.file);
+    assertEquals(result.file.metadata.filename, "custom-response.json");
+  },
+});
+
+Deno.test({
+  name: "curlModel.methods.download handles HTTP errors",
+  ignore: !hasNetworkPermission,
+  fn: async () => {
+    const input = ModelInput.create({
+      name: "test-curl-error",
+      attributes: { url: "https://httpbin.org/status/404" },
+    });
+
+    let error: Error | null = null;
+    try {
+      await curlModel.methods.download.execute(input, { repoDir: "/tmp" });
+    } catch (e) {
+      error = e as Error;
+    }
+
+    assertEquals(error !== null, true);
+    assertEquals(error!.message.includes("404"), true);
+  },
+});

--- a/src/domain/models/echo/echo_model.ts
+++ b/src/domain/models/echo/echo_model.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { ModelType } from "../model_type.ts";
-import { ModelResource } from "../model_resource.ts";
+import { ModelData } from "../model_data.ts";
 import {
   defineModel,
   type MethodContext,
@@ -22,19 +22,17 @@ export const EchoInputAttributesSchema = z.object({
 export type EchoInputAttributes = z.infer<typeof EchoInputAttributesSchema>;
 
 /**
- * Schema for echo model resource attributes.
+ * Schema for echo model data attributes.
  */
-export const EchoResourceAttributesSchema = z.object({
+export const EchoDataAttributesSchema = z.object({
   message: z.string(),
   timestamp: z.string().datetime(),
 });
 
 /**
- * Type for echo model resource attributes.
+ * Type for echo model data attributes.
  */
-export type EchoResourceAttributes = z.infer<
-  typeof EchoResourceAttributesSchema
->;
+export type EchoDataAttributes = z.infer<typeof EchoDataAttributesSchema>;
 
 /**
  * The echo model type identifier.
@@ -44,7 +42,7 @@ export const ECHO_MODEL_TYPE = ModelType.create("swamp/echo");
 /**
  * Executes the "write" method for the echo model.
  *
- * Takes the message from the input and writes it to a resource
+ * Takes the message from the input and writes it to a data artifact
  * along with a timestamp.
  */
 function executeWrite(
@@ -54,8 +52,8 @@ function executeWrite(
   // Validate input attributes
   const attrs = EchoInputAttributesSchema.parse(input.attributes);
 
-  // Create the resource with message and timestamp
-  const resource = ModelResource.create({
+  // Create the data artifact with message and timestamp
+  const data = ModelData.create({
     id: input.id, // Use same ID as input for consistency
     attributes: {
       message: attrs.message,
@@ -63,28 +61,30 @@ function executeWrite(
     },
   });
 
-  return Promise.resolve({ resource });
+  return Promise.resolve({ data });
 }
 
 /**
  * The echo model definition.
  *
  * A simple model that takes a string message input and writes it
- * to a resource with a timestamp.
+ * to a data artifact with a timestamp.
  *
  * Self-registers with the global model registry when this module is imported.
  */
 export const echoModel: ModelDefinition<
   typeof EchoInputAttributesSchema,
-  typeof EchoResourceAttributesSchema
+  never,
+  typeof EchoDataAttributesSchema
 > = defineModel({
   type: ECHO_MODEL_TYPE,
   version: 1,
   inputAttributesSchema: EchoInputAttributesSchema,
-  resourceAttributesSchema: EchoResourceAttributesSchema,
+  dataAttributesSchema: EchoDataAttributesSchema,
   methods: {
     write: {
-      description: "Write the input message to a resource with a timestamp",
+      description:
+        "Write the input message to a data artifact with a timestamp",
       inputAttributesSchema: EchoInputAttributesSchema,
       execute: executeWrite,
     },

--- a/src/domain/models/echo/echo_model_test.ts
+++ b/src/domain/models/echo/echo_model_test.ts
@@ -2,9 +2,9 @@ import { assertEquals } from "@std/assert";
 import { ModelInput } from "../model_input.ts";
 import {
   ECHO_MODEL_TYPE,
+  EchoDataAttributesSchema,
   EchoInputAttributesSchema,
   echoModel,
-  EchoResourceAttributesSchema,
 } from "./echo_model.ts";
 
 Deno.test("ECHO_MODEL_TYPE has correct normalized type", () => {
@@ -37,16 +37,16 @@ Deno.test("EchoInputAttributesSchema rejects missing message", () => {
   assertEquals(result.success, false);
 });
 
-Deno.test("EchoResourceAttributesSchema validates correct data", () => {
-  const result = EchoResourceAttributesSchema.safeParse({
+Deno.test("EchoDataAttributesSchema validates correct data", () => {
+  const result = EchoDataAttributesSchema.safeParse({
     message: "hello",
     timestamp: "2024-01-15T10:30:00.000Z",
   });
   assertEquals(result.success, true);
 });
 
-Deno.test("EchoResourceAttributesSchema rejects invalid timestamp", () => {
-  const result = EchoResourceAttributesSchema.safeParse({
+Deno.test("EchoDataAttributesSchema rejects invalid timestamp", () => {
+  const result = EchoDataAttributesSchema.safeParse({
     message: "hello",
     timestamp: "not-a-date",
   });
@@ -57,7 +57,7 @@ Deno.test("echoModel has write method", () => {
   assertEquals("write" in echoModel.methods, true);
   assertEquals(
     echoModel.methods.write.description,
-    "Write the input message to a resource with a timestamp",
+    "Write the input message to a data artifact with a timestamp",
   );
 });
 
@@ -71,11 +71,11 @@ Deno.test("echoModel.methods.write executes correctly", async () => {
     repoDir: "/tmp",
   });
 
-  assertEquals(result.resource.attributes.message, "hello world");
-  assertEquals(typeof result.resource.attributes.timestamp, "string");
+  assertEquals(result.data?.attributes.message, "hello world");
+  assertEquals(typeof result.data?.attributes.timestamp, "string");
 
   // Verify timestamp is valid ISO date
-  const timestamp = new Date(result.resource.attributes.timestamp as string);
+  const timestamp = new Date(result.data?.attributes.timestamp as string);
   assertEquals(isNaN(timestamp.getTime()), false);
 });
 

--- a/src/domain/models/keeb/shell/shell_model.ts
+++ b/src/domain/models/keeb/shell/shell_model.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { ModelType } from "../../model_type.ts";
-import { ModelResource } from "../../model_resource.ts";
+import { ModelData } from "../../model_data.ts";
 import {
   defineModel,
   type MethodContext,
@@ -31,9 +31,9 @@ export const ShellInputAttributesSchema = z.object({
 export type ShellInputAttributes = z.infer<typeof ShellInputAttributesSchema>;
 
 /**
- * Schema for shell model resource attributes.
+ * Schema for shell model data attributes.
  */
-export const ShellResourceAttributesSchema = z.object({
+export const ShellDataAttributesSchema = z.object({
   stdout: z.string().describe("Standard output from the command"),
   stderr: z.string().describe("Standard error from the command"),
   exitCode: z.number().int().describe("Exit code of the command"),
@@ -47,11 +47,9 @@ export const ShellResourceAttributesSchema = z.object({
 });
 
 /**
- * Type for shell model resource attributes.
+ * Type for shell model data attributes.
  */
-export type ShellResourceAttributes = z.infer<
-  typeof ShellResourceAttributesSchema
->;
+export type ShellDataAttributes = z.infer<typeof ShellDataAttributesSchema>;
 
 /**
  * The shell model type identifier.
@@ -130,8 +128,8 @@ async function executeCommand(
   const endTime = Date.now();
   const durationMs = endTime - startTime;
 
-  // Create the resource with execution results
-  const resource = ModelResource.create({
+  // Create the data artifact with execution results
+  const data = ModelData.create({
     id: input.id,
     attributes: {
       stdout,
@@ -143,7 +141,7 @@ async function executeCommand(
     },
   });
 
-  return { resource };
+  return { data };
 }
 
 /**
@@ -156,12 +154,13 @@ async function executeCommand(
  */
 export const shellModel: ModelDefinition<
   typeof ShellInputAttributesSchema,
-  typeof ShellResourceAttributesSchema
+  never,
+  typeof ShellDataAttributesSchema
 > = defineModel({
   type: SHELL_MODEL_TYPE,
   version: 1,
   inputAttributesSchema: ShellInputAttributesSchema,
-  resourceAttributesSchema: ShellResourceAttributesSchema,
+  dataAttributesSchema: ShellDataAttributesSchema,
   methods: {
     execute: {
       description:

--- a/src/domain/models/keeb/shell/shell_model_test.ts
+++ b/src/domain/models/keeb/shell/shell_model_test.ts
@@ -2,9 +2,9 @@ import { assertEquals, assertStringIncludes } from "@std/assert";
 import { ModelInput } from "../../model_input.ts";
 import {
   SHELL_MODEL_TYPE,
+  ShellDataAttributesSchema,
   ShellInputAttributesSchema,
   shellModel,
-  ShellResourceAttributesSchema,
 } from "./shell_model.ts";
 
 Deno.test("SHELL_MODEL_TYPE has correct normalized type", () => {
@@ -70,9 +70,9 @@ Deno.test("ShellInputAttributesSchema rejects zero timeout", () => {
   assertEquals(result.success, false);
 });
 
-// Resource schema validation tests
-Deno.test("ShellResourceAttributesSchema validates correct data", () => {
-  const result = ShellResourceAttributesSchema.safeParse({
+// Data schema validation tests
+Deno.test("ShellDataAttributesSchema validates correct data", () => {
+  const result = ShellDataAttributesSchema.safeParse({
     stdout: "hello\n",
     stderr: "",
     exitCode: 0,
@@ -83,8 +83,8 @@ Deno.test("ShellResourceAttributesSchema validates correct data", () => {
   assertEquals(result.success, true);
 });
 
-Deno.test("ShellResourceAttributesSchema validates without durationMs", () => {
-  const result = ShellResourceAttributesSchema.safeParse({
+Deno.test("ShellDataAttributesSchema validates without durationMs", () => {
+  const result = ShellDataAttributesSchema.safeParse({
     stdout: "hello\n",
     stderr: "",
     exitCode: 0,
@@ -94,8 +94,8 @@ Deno.test("ShellResourceAttributesSchema validates without durationMs", () => {
   assertEquals(result.success, true);
 });
 
-Deno.test("ShellResourceAttributesSchema rejects invalid timestamp", () => {
-  const result = ShellResourceAttributesSchema.safeParse({
+Deno.test("ShellDataAttributesSchema rejects invalid timestamp", () => {
+  const result = ShellDataAttributesSchema.safeParse({
     stdout: "",
     stderr: "",
     exitCode: 0,
@@ -125,12 +125,12 @@ Deno.test("shellModel.methods.execute runs simple command", async () => {
     repoDir: "/tmp",
   });
 
-  assertEquals(result.resource.attributes.stdout, "hello\n");
-  assertEquals(result.resource.attributes.stderr, "");
-  assertEquals(result.resource.attributes.exitCode, 0);
-  assertEquals(result.resource.attributes.command, "echo hello");
-  assertEquals(typeof result.resource.attributes.executedAt, "string");
-  assertEquals(typeof result.resource.attributes.durationMs, "number");
+  assertEquals(result.data?.attributes.stdout, "hello\n");
+  assertEquals(result.data?.attributes.stderr, "");
+  assertEquals(result.data?.attributes.exitCode, 0);
+  assertEquals(result.data?.attributes.command, "echo hello");
+  assertEquals(typeof result.data?.attributes.executedAt, "string");
+  assertEquals(typeof result.data?.attributes.durationMs, "number");
 });
 
 Deno.test("shellModel.methods.execute captures stderr", async () => {
@@ -143,9 +143,9 @@ Deno.test("shellModel.methods.execute captures stderr", async () => {
     repoDir: "/tmp",
   });
 
-  assertEquals(result.resource.attributes.stdout, "");
-  assertEquals(result.resource.attributes.stderr, "error\n");
-  assertEquals(result.resource.attributes.exitCode, 0);
+  assertEquals(result.data?.attributes.stdout, "");
+  assertEquals(result.data?.attributes.stderr, "error\n");
+  assertEquals(result.data?.attributes.exitCode, 0);
 });
 
 Deno.test("shellModel.methods.execute captures exit code", async () => {
@@ -158,7 +158,7 @@ Deno.test("shellModel.methods.execute captures exit code", async () => {
     repoDir: "/tmp",
   });
 
-  assertEquals(result.resource.attributes.exitCode, 42);
+  assertEquals(result.data?.attributes.exitCode, 42);
 });
 
 Deno.test("shellModel.methods.execute handles command failure gracefully", async () => {
@@ -171,7 +171,7 @@ Deno.test("shellModel.methods.execute handles command failure gracefully", async
     repoDir: "/tmp",
   });
 
-  assertEquals(result.resource.attributes.exitCode, 1);
+  assertEquals(result.data?.attributes.exitCode, 1);
 });
 
 Deno.test("shellModel.methods.execute respects workingDir", async () => {
@@ -189,8 +189,8 @@ Deno.test("shellModel.methods.execute respects workingDir", async () => {
 
   // Use realPathSync to handle symlinks (e.g., /tmp -> /private/tmp on macOS)
   const expectedPath = Deno.realPathSync("/tmp");
-  assertEquals(result.resource.attributes.stdout, `${expectedPath}\n`);
-  assertEquals(result.resource.attributes.exitCode, 0);
+  assertEquals(result.data?.attributes.stdout, `${expectedPath}\n`);
+  assertEquals(result.data?.attributes.exitCode, 0);
 });
 
 Deno.test("shellModel.methods.execute respects env variables", async () => {
@@ -206,8 +206,8 @@ Deno.test("shellModel.methods.execute respects env variables", async () => {
     repoDir: "/tmp",
   });
 
-  assertEquals(result.resource.attributes.stdout, "test_value\n");
-  assertEquals(result.resource.attributes.exitCode, 0);
+  assertEquals(result.data?.attributes.stdout, "test_value\n");
+  assertEquals(result.data?.attributes.exitCode, 0);
 });
 
 Deno.test("shellModel.methods.execute handles pipes", async () => {
@@ -220,8 +220,8 @@ Deno.test("shellModel.methods.execute handles pipes", async () => {
     repoDir: "/tmp",
   });
 
-  assertEquals(result.resource.attributes.stdout, "Hello world\n");
-  assertEquals(result.resource.attributes.exitCode, 0);
+  assertEquals(result.data?.attributes.stdout, "Hello world\n");
+  assertEquals(result.data?.attributes.exitCode, 0);
 });
 
 Deno.test("shellModel.methods.execute handles complex commands", async () => {
@@ -235,8 +235,8 @@ Deno.test("shellModel.methods.execute handles complex commands", async () => {
   });
 
   // cd /tmp && pwd outputs the logical path, not the physical path
-  assertEquals(result.resource.attributes.stdout, "/tmp\n");
-  assertEquals(result.resource.attributes.exitCode, 0);
+  assertEquals(result.data?.attributes.stdout, "/tmp\n");
+  assertEquals(result.data?.attributes.exitCode, 0);
 });
 
 Deno.test("shellModel.methods.execute validates input attributes", async () => {
@@ -282,9 +282,9 @@ Deno.test("shellModel.methods.execute handles nonexistent command", async () => 
   });
 
   // Should return non-zero exit code and error in stderr
-  assertEquals(result.resource.attributes.exitCode !== 0, true);
+  assertEquals(result.data?.attributes.exitCode !== 0, true);
   assertStringIncludes(
-    result.resource.attributes.stderr as string,
+    result.data?.attributes.stderr as string,
     "nonexistent_command_12345",
   );
 });
@@ -299,7 +299,7 @@ Deno.test("shellModel.methods.execute records execution duration", async () => {
     repoDir: "/tmp",
   });
 
-  const durationMs = result.resource.attributes.durationMs as number;
+  const durationMs = result.data?.attributes.durationMs as number;
   // Should be at least 100ms (sleep 0.1 seconds)
   assertEquals(durationMs >= 100, true);
 });

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -109,8 +109,8 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
     const result = await this.execute(input, method, context);
     let currentResource = result.resource;
 
-    // Process follow-up actions
-    if (result.followUpActions) {
+    // Process follow-up actions (requires resource)
+    if (result.followUpActions && currentResource) {
       const finalResult = await this.processFollowUpActions(
         input,
         modelDef,
@@ -122,7 +122,10 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
       currentResource = finalResult.resource;
     }
 
-    return { resource: currentResource };
+    return {
+      ...result,
+      resource: currentResource,
+    };
   }
 
   private async processFollowUpActions(
@@ -180,6 +183,13 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
             followUpMethod,
             context,
           );
+
+          // Follow-up actions require resources to continue
+          if (!result.resource) {
+            throw new Error(
+              `Follow-up method '${action.methodName}' must return a resource`,
+            );
+          }
           currentResource = result.resource;
 
           // If this follow-up method has its own follow-up actions, process them recursively

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -20,8 +20,9 @@ Deno.test("execute with valid input returns method result", async () => {
     { repoDir: "." },
   );
 
-  assertEquals(result.resource.attributes.message, "Hello, world!");
-  assertEquals(typeof result.resource.attributes.timestamp, "string");
+  // Echo model now returns data artifacts instead of resources
+  assertEquals(result.data?.attributes.message, "Hello, world!");
+  assertEquals(typeof result.data?.attributes.timestamp, "string");
 });
 
 Deno.test("execute with missing required attribute throws error", () => {
@@ -174,7 +175,7 @@ Deno.test("executeWorkflow - basic execution without follow-up actions", async (
     { repoDir: "." },
   );
 
-  assertEquals(result.resource.attributes.value, "started");
+  assertEquals(result.resource?.attributes.value, "started");
 });
 
 Deno.test("executeWorkflow - throws error for unknown method", async () => {
@@ -232,8 +233,8 @@ Deno.test("executeWorkflow - processes follow-up actions", async () => {
     { repoDir: "." },
   );
 
-  assertEquals(result.resource.attributes.value, "completed");
-  assertEquals(result.resource.attributes.counter, 2);
+  assertEquals(result.resource?.attributes.value, "completed");
+  assertEquals(result.resource?.attributes.counter, 2);
 });
 
 Deno.test("executeWorkflow - respects continueCondition", async () => {
@@ -281,7 +282,7 @@ Deno.test("executeWorkflow - respects continueCondition", async () => {
 
   // Follow-up should not be called because condition was false
   assertEquals(followUpCallCount, 0);
-  assertEquals(result.resource.attributes.value, "started");
+  assertEquals(result.resource?.attributes.value, "started");
 });
 
 Deno.test("executeWorkflow - retries on failure with maxRetries", async () => {
@@ -325,7 +326,7 @@ Deno.test("executeWorkflow - retries on failure with maxRetries", async () => {
 
   // Should have succeeded on the 3rd attempt (1 initial + 2 retries)
   assertEquals(attemptCount, 3);
-  assertEquals(result.resource.attributes.value, "succeeded-on-retry");
+  assertEquals(result.resource?.attributes.value, "succeeded-on-retry");
 });
 
 Deno.test("executeWorkflow - fails after exhausting maxRetries", async () => {
@@ -431,7 +432,7 @@ Deno.test("executeWorkflow - handles recursive follow-up actions", async () => {
   );
 
   assertEquals(callSequence, ["start", "increment-1", "increment-2"]);
-  assertEquals(result.resource.attributes.step, 3);
+  assertEquals(result.resource?.attributes.step, 3);
 });
 
 Deno.test("executeWorkflow - throws on max depth exceeded", async () => {
@@ -561,5 +562,5 @@ Deno.test("executeWorkflow - follow-up receives resource attributes from previou
   assertEquals(receivedAttributes.OperationStatus, "IN_PROGRESS");
 
   // Verify final result
-  assertEquals(result.resource.attributes.OperationStatus, "SUCCESS");
+  assertEquals(result.resource?.attributes.OperationStatus, "SUCCESS");
 });

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -3,7 +3,16 @@ import type { CloudControlClient } from "@aws-sdk/client-cloudcontrol";
 import { ModelType } from "./model_type.ts";
 import type { ModelInput } from "./model_input.ts";
 import type { ModelResource } from "./model_resource.ts";
-import type { ResourceRepository } from "./repositories.ts";
+import type { ModelData } from "./model_data.ts";
+import type { ModelFile } from "./model_file.ts";
+import type { ModelLog } from "./model_log.ts";
+import type {
+  DataRepository,
+  FileRepository,
+  LogRepository,
+  OutputRepository,
+  ResourceRepository,
+} from "./repositories.ts";
 
 /**
  * Context provided to method execution.
@@ -23,6 +32,26 @@ export interface MethodContext {
    * Optional resource repository for accessing persisted resources.
    */
   resourceRepository?: ResourceRepository;
+
+  /**
+   * Optional data repository for accessing persisted data artifacts.
+   */
+  dataRepository?: DataRepository;
+
+  /**
+   * Optional file repository for accessing persisted file artifacts.
+   */
+  fileRepository?: FileRepository;
+
+  /**
+   * Optional log repository for accessing persisted log artifacts.
+   */
+  logRepository?: LogRepository;
+
+  /**
+   * Optional output repository for tracking execution history.
+   */
+  outputRepository?: OutputRepository;
 }
 
 /**
@@ -56,9 +85,27 @@ export interface FollowUpAction {
  */
 export interface MethodResult {
   /**
-   * The resource created by the method.
+   * The resource created by the method (optional with new artifact types).
    */
-  resource: ModelResource;
+  resource?: ModelResource;
+
+  /**
+   * Structured data output produced by the method.
+   */
+  data?: ModelData;
+
+  /**
+   * File output produced by the method.
+   */
+  file?: {
+    metadata: ModelFile;
+    content: Uint8Array;
+  };
+
+  /**
+   * Log outputs produced by the method.
+   */
+  logs?: ModelLog[];
 
   /**
    * Optional follow-up actions to execute.
@@ -70,6 +117,21 @@ export interface MethodResult {
    * Used for operations like delete that complete by removing the resource.
    */
   deleteResource?: boolean;
+
+  /**
+   * If true, the data artifact should be deleted.
+   */
+  deleteData?: boolean;
+
+  /**
+   * If true, the file artifact should be deleted.
+   */
+  deleteFile?: boolean;
+
+  /**
+   * If true, the log artifacts should be deleted.
+   */
+  deleteLogs?: boolean;
 }
 
 /**
@@ -106,12 +168,16 @@ export interface MethodDefinition<
  * - Its type identifier
  * - Current version
  * - Schema for input attributes
- * - Schema for resource attributes
+ * - Schema for resource attributes (optional, for persistent resources)
+ * - Schema for data attributes (optional, for ephemeral data)
  * - Available methods
+ *
+ * At least one of resourceAttributesSchema or dataAttributesSchema should be provided.
  */
 export interface ModelDefinition<
   TInputAttrs extends z.ZodTypeAny = z.ZodTypeAny,
   TResourceAttrs extends z.ZodTypeAny = z.ZodTypeAny,
+  TDataAttrs extends z.ZodTypeAny = z.ZodTypeAny,
 > {
   /**
    * The model type.
@@ -129,9 +195,14 @@ export interface ModelDefinition<
   inputAttributesSchema: TInputAttrs;
 
   /**
-   * Zod schema for validating resource attributes.
+   * Zod schema for validating resource attributes (persistent, git-tracked).
    */
-  resourceAttributesSchema: TResourceAttrs;
+  resourceAttributesSchema?: TResourceAttrs;
+
+  /**
+   * Zod schema for validating data attributes (ephemeral, not git-tracked).
+   */
+  dataAttributesSchema?: TDataAttrs;
 
   /**
    * Available methods on this model.
@@ -204,10 +275,11 @@ export const modelRegistry = new ModelRegistry();
  */
 export function defineModel<
   TInputAttrs extends z.ZodTypeAny,
-  TResourceAttrs extends z.ZodTypeAny,
+  TResourceAttrs extends z.ZodTypeAny = z.ZodTypeAny,
+  TDataAttrs extends z.ZodTypeAny = z.ZodTypeAny,
 >(
-  definition: ModelDefinition<TInputAttrs, TResourceAttrs>,
-): ModelDefinition<TInputAttrs, TResourceAttrs> {
+  definition: ModelDefinition<TInputAttrs, TResourceAttrs, TDataAttrs>,
+): ModelDefinition<TInputAttrs, TResourceAttrs, TDataAttrs> {
   if (!modelRegistry.has(definition.type)) {
     modelRegistry.register(definition);
   }

--- a/src/domain/models/model_data.ts
+++ b/src/domain/models/model_data.ts
@@ -1,0 +1,130 @@
+import { z } from "zod";
+import type { ModelInputId } from "./model_input.ts";
+
+/**
+ * Branded type for ModelData IDs.
+ */
+export type ModelDataId = string & { readonly _brand: unique symbol };
+
+/**
+ * Creates a ModelDataId from a string.
+ */
+export function createModelDataId(id: string): ModelDataId {
+  return id as ModelDataId;
+}
+
+/**
+ * Converts a ModelInputId to a ModelDataId.
+ * By convention, data artifacts share their ID with their originating input.
+ */
+export function inputIdToDataId(inputId: ModelInputId): ModelDataId {
+  return inputId as unknown as ModelDataId;
+}
+
+/**
+ * Zod schema for the core properties of a ModelData.
+ */
+export const ModelDataSchema = z.object({
+  id: z.string().uuid(),
+  version: z.number().int().positive(),
+  createdAt: z.string().datetime(),
+  attributes: z.record(z.string(), z.unknown()).default({}),
+});
+
+/**
+ * Type representing the data stored in a ModelData.
+ */
+export type ModelDataData = z.infer<typeof ModelDataSchema>;
+
+/**
+ * Properties required to create a new ModelData.
+ */
+export interface CreateModelDataProps {
+  id?: string;
+  version?: number;
+  createdAt?: Date;
+  attributes?: Record<string, unknown>;
+}
+
+/**
+ * ModelData is an entity representing structured data output produced by methods.
+ *
+ * Each data artifact has a unique ID (UUID), creation timestamp,
+ * version, and domain-specific attributes.
+ */
+export class ModelData {
+  private constructor(
+    readonly id: ModelDataId,
+    readonly version: number,
+    readonly createdAt: Date,
+    private _attributes: Record<string, unknown>,
+  ) {}
+
+  /**
+   * Creates a new ModelData instance.
+   *
+   * @param props - Properties for the new data artifact
+   * @returns A new ModelData instance
+   */
+  static create(props: CreateModelDataProps): ModelData {
+    const id = props.id ?? crypto.randomUUID();
+    const version = props.version ?? 1;
+    const createdAt = props.createdAt ?? new Date();
+
+    const validated = ModelDataSchema.parse({
+      id,
+      version,
+      createdAt: createdAt.toISOString(),
+      attributes: props.attributes ?? {},
+    });
+
+    return new ModelData(
+      createModelDataId(validated.id),
+      validated.version,
+      new Date(validated.createdAt),
+      validated.attributes,
+    );
+  }
+
+  /**
+   * Reconstructs a ModelData from persisted data.
+   *
+   * @param data - The persisted data
+   * @returns A ModelData instance
+   */
+  static fromData(data: ModelDataData): ModelData {
+    const validated = ModelDataSchema.parse(data);
+    return new ModelData(
+      createModelDataId(validated.id),
+      validated.version,
+      new Date(validated.createdAt),
+      validated.attributes,
+    );
+  }
+
+  /**
+   * Returns a copy of the attributes.
+   */
+  get attributes(): Record<string, unknown> {
+    return { ...this._attributes };
+  }
+
+  /**
+   * Sets an attribute value.
+   */
+  setAttribute(key: string, value: unknown): void {
+    this._attributes[key] = value;
+  }
+
+  /**
+   * Converts the data artifact to a plain data object for persistence.
+   */
+  toData(): ModelDataData {
+    return {
+      id: this.id,
+      version: this.version,
+      createdAt: this.createdAt.toISOString(),
+      attributes: { ...this._attributes },
+    };
+  }
+}

--- a/src/domain/models/model_data_test.ts
+++ b/src/domain/models/model_data_test.ts
@@ -1,0 +1,105 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { ModelData } from "./model_data.ts";
+
+Deno.test("ModelData.create generates UUID if not provided", () => {
+  const data = ModelData.create({});
+  assertEquals(typeof data.id, "string");
+  assertEquals(data.id.length, 36);
+});
+
+Deno.test("ModelData.create uses provided ID", () => {
+  const id = "550e8400-e29b-41d4-a716-446655440001";
+  const data = ModelData.create({ id });
+  assertEquals(data.id, id);
+});
+
+Deno.test("ModelData.create sets default version to 1", () => {
+  const data = ModelData.create({});
+  assertEquals(data.version, 1);
+});
+
+Deno.test("ModelData.create uses provided version", () => {
+  const data = ModelData.create({ version: 3 });
+  assertEquals(data.version, 3);
+});
+
+Deno.test("ModelData.create sets createdAt to now if not provided", () => {
+  const before = new Date();
+  const data = ModelData.create({});
+  const after = new Date();
+
+  assertEquals(data.createdAt >= before, true);
+  assertEquals(data.createdAt <= after, true);
+});
+
+Deno.test("ModelData.create uses provided createdAt", () => {
+  const createdAt = new Date("2023-01-01T00:00:00Z");
+  const data = ModelData.create({ createdAt });
+  assertEquals(data.createdAt, createdAt);
+});
+
+Deno.test("ModelData.create sets empty attributes by default", () => {
+  const data = ModelData.create({});
+  assertEquals(data.attributes, {});
+});
+
+Deno.test("ModelData.create uses provided attributes", () => {
+  const attributes = { test: "value", count: 42 };
+  const data = ModelData.create({ attributes });
+  assertEquals(data.attributes, attributes);
+});
+
+Deno.test("ModelData.create throws on invalid version", () => {
+  assertThrows(
+    () => ModelData.create({ version: 0 }),
+    Error,
+    "Too small: expected number to be >0",
+  );
+});
+
+Deno.test("ModelData toData/fromData roundtrip", () => {
+  const data = ModelData.create({
+    attributes: { key: "value", nested: { foo: "bar" } },
+  });
+  const serialized = data.toData();
+  const restored = ModelData.fromData(serialized);
+
+  assertEquals(restored.id, data.id);
+  assertEquals(restored.version, data.version);
+  assertEquals(restored.createdAt.getTime(), data.createdAt.getTime());
+  assertEquals(restored.attributes, data.attributes);
+});
+
+Deno.test("ModelData fromData with explicit data", () => {
+  const id = "550e8400-e29b-41d4-a716-446655440000";
+  const createdAt = "2023-01-01T00:00:00.000Z";
+  const attributes = { key: "value", items: [1, 2, 3] };
+
+  const serialized = {
+    id,
+    version: 2,
+    createdAt,
+    attributes,
+  };
+
+  const data = ModelData.fromData(serialized);
+  assertEquals(data.id, id);
+  assertEquals(data.version, 2);
+  assertEquals(data.createdAt, new Date(createdAt));
+  assertEquals(data.attributes, attributes);
+});
+
+Deno.test("ModelData setAttribute", () => {
+  const data = ModelData.create({});
+  data.setAttribute("test", "value");
+  assertEquals(data.attributes.test, "value");
+});
+
+Deno.test("ModelData attributes are immutable via getter", () => {
+  const data = ModelData.create({ attributes: { original: "value" } });
+  const attrs = data.attributes;
+  attrs.modified = "should not affect original";
+
+  assertEquals(data.attributes.modified, undefined);
+  assertEquals(data.attributes.original, "value");
+});

--- a/src/domain/models/model_file.ts
+++ b/src/domain/models/model_file.ts
@@ -1,0 +1,153 @@
+import { z } from "zod";
+
+/**
+ * Branded type for ModelFile IDs.
+ */
+export type ModelFileId = string & { readonly _brand: unique symbol };
+
+/**
+ * Creates a ModelFileId from a string.
+ */
+export function createModelFileId(id: string): ModelFileId {
+  return id as ModelFileId;
+}
+
+/**
+ * Zod schema for the core properties of a ModelFile.
+ */
+export const ModelFileSchema = z.object({
+  id: z.string().uuid(),
+  version: z.number().int().positive(),
+  createdAt: z.string().datetime(),
+  filename: z.string().min(1),
+  contentType: z.string().min(1),
+  size: z.number().int().nonnegative(),
+  checksum: z.string().min(1),
+});
+
+/**
+ * Type representing the data stored in a ModelFile.
+ */
+export type ModelFileData = z.infer<typeof ModelFileSchema>;
+
+/**
+ * Properties required to create a new ModelFile.
+ */
+export interface CreateModelFileProps {
+  id?: string;
+  version?: number;
+  createdAt?: Date;
+  filename: string;
+  contentType: string;
+  size: number;
+  checksum: string;
+}
+
+/**
+ * ModelFile is an entity representing file outputs (binaries, configs, generated code, etc.)
+ *
+ * Each file artifact has a unique ID (UUID), creation timestamp,
+ * version, filename, MIME type, size, and checksum.
+ */
+export class ModelFile {
+  private constructor(
+    readonly id: ModelFileId,
+    readonly version: number,
+    readonly createdAt: Date,
+    readonly filename: string,
+    readonly contentType: string,
+    readonly size: number,
+    readonly checksum: string,
+  ) {}
+
+  /**
+   * Creates a new ModelFile instance.
+   *
+   * @param props - Properties for the new file artifact
+   * @returns A new ModelFile instance
+   */
+  static create(props: CreateModelFileProps): ModelFile {
+    const id = props.id ?? crypto.randomUUID();
+    const version = props.version ?? 1;
+    const createdAt = props.createdAt ?? new Date();
+
+    const validated = ModelFileSchema.parse({
+      id,
+      version,
+      createdAt: createdAt.toISOString(),
+      filename: props.filename,
+      contentType: props.contentType,
+      size: props.size,
+      checksum: props.checksum,
+    });
+
+    return new ModelFile(
+      createModelFileId(validated.id),
+      validated.version,
+      new Date(validated.createdAt),
+      validated.filename,
+      validated.contentType,
+      validated.size,
+      validated.checksum,
+    );
+  }
+
+  /**
+   * Reconstructs a ModelFile from persisted data.
+   *
+   * @param data - The persisted data
+   * @returns A ModelFile instance
+   */
+  static fromData(data: ModelFileData): ModelFile {
+    const validated = ModelFileSchema.parse(data);
+    return new ModelFile(
+      createModelFileId(validated.id),
+      validated.version,
+      new Date(validated.createdAt),
+      validated.filename,
+      validated.contentType,
+      validated.size,
+      validated.checksum,
+    );
+  }
+
+  /**
+   * Converts the file artifact to a plain data object for persistence.
+   */
+  toData(): ModelFileData {
+    return {
+      id: this.id,
+      version: this.version,
+      createdAt: this.createdAt.toISOString(),
+      filename: this.filename,
+      contentType: this.contentType,
+      size: this.size,
+      checksum: this.checksum,
+    };
+  }
+
+  /**
+   * Gets the file extension from the filename.
+   */
+  get extension(): string {
+    const lastDot = this.filename.lastIndexOf(".");
+    return lastDot >= 0 ? this.filename.slice(lastDot + 1) : "";
+  }
+}
+
+/**
+ * Computes SHA-256 checksum of content.
+ *
+ * @param content - The content to hash
+ * @returns The hex-encoded SHA-256 checksum
+ */
+export async function computeChecksum(content: Uint8Array): Promise<string> {
+  // Create a new ArrayBuffer from the Uint8Array to avoid SharedArrayBuffer issues
+  const buffer = new ArrayBuffer(content.length);
+  new Uint8Array(buffer).set(content);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", buffer);
+  const hashArray = new Uint8Array(hashBuffer);
+  return Array.from(hashArray)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/src/domain/models/model_file_test.ts
+++ b/src/domain/models/model_file_test.ts
@@ -1,0 +1,250 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { computeChecksum, ModelFile } from "./model_file.ts";
+
+Deno.test("ModelFile.create generates UUID if not provided", () => {
+  const file = ModelFile.create({
+    filename: "test.txt",
+    contentType: "text/plain",
+    size: 100,
+    checksum: "abc123",
+  });
+  assertEquals(typeof file.id, "string");
+  assertEquals(file.id.length, 36);
+});
+
+Deno.test("ModelFile.create uses provided ID", () => {
+  const id = "550e8400-e29b-41d4-a716-446655440001";
+  const file = ModelFile.create({
+    id,
+    filename: "test.txt",
+    contentType: "text/plain",
+    size: 100,
+    checksum: "abc123",
+  });
+  assertEquals(file.id, id);
+});
+
+Deno.test("ModelFile.create sets default version to 1", () => {
+  const file = ModelFile.create({
+    filename: "test.txt",
+    contentType: "text/plain",
+    size: 100,
+    checksum: "abc123",
+  });
+  assertEquals(file.version, 1);
+});
+
+Deno.test("ModelFile.create uses provided version", () => {
+  const file = ModelFile.create({
+    version: 3,
+    filename: "test.txt",
+    contentType: "text/plain",
+    size: 100,
+    checksum: "abc123",
+  });
+  assertEquals(file.version, 3);
+});
+
+Deno.test("ModelFile.create sets createdAt to now if not provided", () => {
+  const before = new Date();
+  const file = ModelFile.create({
+    filename: "test.txt",
+    contentType: "text/plain",
+    size: 100,
+    checksum: "abc123",
+  });
+  const after = new Date();
+
+  assertEquals(file.createdAt >= before, true);
+  assertEquals(file.createdAt <= after, true);
+});
+
+Deno.test("ModelFile.create uses provided createdAt", () => {
+  const createdAt = new Date("2023-01-01T00:00:00Z");
+  const file = ModelFile.create({
+    createdAt,
+    filename: "test.txt",
+    contentType: "text/plain",
+    size: 100,
+    checksum: "abc123",
+  });
+  assertEquals(file.createdAt, createdAt);
+});
+
+Deno.test("ModelFile.create stores file properties", () => {
+  const file = ModelFile.create({
+    filename: "config.json",
+    contentType: "application/json",
+    size: 2048,
+    checksum: "sha256hash",
+  });
+
+  assertEquals(file.filename, "config.json");
+  assertEquals(file.contentType, "application/json");
+  assertEquals(file.size, 2048);
+  assertEquals(file.checksum, "sha256hash");
+});
+
+Deno.test("ModelFile.create throws on invalid version", () => {
+  assertThrows(
+    () =>
+      ModelFile.create({
+        version: 0,
+        filename: "test.txt",
+        contentType: "text/plain",
+        size: 100,
+        checksum: "abc123",
+      }),
+    Error,
+    "Too small: expected number to be >0",
+  );
+});
+
+Deno.test("ModelFile.create throws on empty filename", () => {
+  assertThrows(
+    () =>
+      ModelFile.create({
+        filename: "",
+        contentType: "text/plain",
+        size: 100,
+        checksum: "abc123",
+      }),
+    Error,
+    "Too small: expected string to have >=1 characters",
+  );
+});
+
+Deno.test("ModelFile.create throws on empty contentType", () => {
+  assertThrows(
+    () =>
+      ModelFile.create({
+        filename: "test.txt",
+        contentType: "",
+        size: 100,
+        checksum: "abc123",
+      }),
+    Error,
+    "Too small: expected string to have >=1 characters",
+  );
+});
+
+Deno.test("ModelFile.create throws on negative size", () => {
+  assertThrows(
+    () =>
+      ModelFile.create({
+        filename: "test.txt",
+        contentType: "text/plain",
+        size: -1,
+        checksum: "abc123",
+      }),
+    Error,
+    "Too small: expected number to be >=0",
+  );
+});
+
+Deno.test("ModelFile.create allows zero size", () => {
+  const file = ModelFile.create({
+    filename: "empty.txt",
+    contentType: "text/plain",
+    size: 0,
+    checksum:
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  });
+  assertEquals(file.size, 0);
+});
+
+Deno.test("ModelFile toData/fromData roundtrip", () => {
+  const file = ModelFile.create({
+    filename: "output.bin",
+    contentType: "application/octet-stream",
+    size: 1024,
+    checksum: "deadbeef",
+  });
+  const data = file.toData();
+  const restored = ModelFile.fromData(data);
+
+  assertEquals(restored.id, file.id);
+  assertEquals(restored.version, file.version);
+  assertEquals(restored.createdAt.getTime(), file.createdAt.getTime());
+  assertEquals(restored.filename, file.filename);
+  assertEquals(restored.contentType, file.contentType);
+  assertEquals(restored.size, file.size);
+  assertEquals(restored.checksum, file.checksum);
+});
+
+Deno.test("ModelFile fromData with explicit data", () => {
+  const id = "550e8400-e29b-41d4-a716-446655440000";
+  const createdAt = "2023-01-01T00:00:00.000Z";
+
+  const data = {
+    id,
+    version: 2,
+    createdAt,
+    filename: "report.pdf",
+    contentType: "application/pdf",
+    size: 4096,
+    checksum: "abc123def456",
+  };
+
+  const file = ModelFile.fromData(data);
+  assertEquals(file.id, id);
+  assertEquals(file.version, 2);
+  assertEquals(file.createdAt, new Date(createdAt));
+  assertEquals(file.filename, "report.pdf");
+  assertEquals(file.contentType, "application/pdf");
+  assertEquals(file.size, 4096);
+  assertEquals(file.checksum, "abc123def456");
+});
+
+Deno.test("ModelFile.extension extracts file extension", () => {
+  const file = ModelFile.create({
+    filename: "document.pdf",
+    contentType: "application/pdf",
+    size: 100,
+    checksum: "abc",
+  });
+  assertEquals(file.extension, "pdf");
+});
+
+Deno.test("ModelFile.extension handles no extension", () => {
+  const file = ModelFile.create({
+    filename: "Dockerfile",
+    contentType: "text/plain",
+    size: 100,
+    checksum: "abc",
+  });
+  assertEquals(file.extension, "");
+});
+
+Deno.test("ModelFile.extension handles multiple dots", () => {
+  const file = ModelFile.create({
+    filename: "archive.tar.gz",
+    contentType: "application/gzip",
+    size: 100,
+    checksum: "abc",
+  });
+  assertEquals(file.extension, "gz");
+});
+
+Deno.test("computeChecksum produces correct SHA-256", async () => {
+  // "hello" in UTF-8
+  const content = new TextEncoder().encode("hello");
+  const checksum = await computeChecksum(content);
+
+  // Known SHA-256 hash of "hello"
+  assertEquals(
+    checksum,
+    "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+  );
+});
+
+Deno.test("computeChecksum produces correct hash for empty content", async () => {
+  const content = new Uint8Array(0);
+  const checksum = await computeChecksum(content);
+
+  // Known SHA-256 hash of empty string
+  assertEquals(
+    checksum,
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  );
+});

--- a/src/domain/models/model_input.ts
+++ b/src/domain/models/model_input.ts
@@ -18,6 +18,9 @@ export function createModelInputId(id: string): ModelInputId {
 export const ModelInputSchema = z.object({
   id: z.string().uuid(),
   resourceId: z.string().uuid().optional(),
+  dataId: z.string().uuid().optional(),
+  fileId: z.string().uuid().optional(),
+  logId: z.string().uuid().optional(),
   name: z.string().min(1),
   version: z.number().int().positive(),
   tags: z.record(z.string(), z.string()).default({}),
@@ -37,6 +40,9 @@ export interface CreateModelInputProps {
   name: string;
   version?: number;
   resourceId?: string;
+  dataId?: string;
+  fileId?: string;
+  logId?: string;
   tags?: Record<string, string>;
   attributes?: Record<string, unknown>;
 }
@@ -51,6 +57,9 @@ export class ModelInput {
   private constructor(
     readonly id: ModelInputId,
     private _resourceId: string | undefined,
+    private _dataId: string | undefined,
+    private _fileId: string | undefined,
+    private _logId: string | undefined,
     readonly name: string,
     readonly version: number,
     private _tags: Record<string, string>,
@@ -70,6 +79,9 @@ export class ModelInput {
     const validated = ModelInputSchema.parse({
       id,
       resourceId: props.resourceId,
+      dataId: props.dataId,
+      fileId: props.fileId,
+      logId: props.logId,
       name: props.name,
       version,
       tags: props.tags ?? {},
@@ -79,6 +91,9 @@ export class ModelInput {
     return new ModelInput(
       createModelInputId(validated.id),
       validated.resourceId,
+      validated.dataId,
+      validated.fileId,
+      validated.logId,
       validated.name,
       validated.version,
       validated.tags,
@@ -97,6 +112,9 @@ export class ModelInput {
     return new ModelInput(
       createModelInputId(validated.id),
       validated.resourceId,
+      validated.dataId,
+      validated.fileId,
+      validated.logId,
       validated.name,
       validated.version,
       validated.tags,
@@ -109,6 +127,27 @@ export class ModelInput {
    */
   get resourceId(): string | undefined {
     return this._resourceId;
+  }
+
+  /**
+   * Returns the data artifact ID if one has been assigned.
+   */
+  get dataId(): string | undefined {
+    return this._dataId;
+  }
+
+  /**
+   * Returns the file artifact ID if one has been assigned.
+   */
+  get fileId(): string | undefined {
+    return this._fileId;
+  }
+
+  /**
+   * Returns the log artifact ID if one has been assigned.
+   */
+  get logId(): string | undefined {
+    return this._logId;
   }
 
   /**
@@ -130,6 +169,27 @@ export class ModelInput {
    */
   setResourceId(resourceId: string | undefined): void {
     this._resourceId = resourceId;
+  }
+
+  /**
+   * Sets the data artifact ID for this input.
+   */
+  setDataId(dataId: string | undefined): void {
+    this._dataId = dataId;
+  }
+
+  /**
+   * Sets the file artifact ID for this input.
+   */
+  setFileId(fileId: string | undefined): void {
+    this._fileId = fileId;
+  }
+
+  /**
+   * Sets the log artifact ID for this input.
+   */
+  setLogId(logId: string | undefined): void {
+    this._logId = logId;
   }
 
   /**
@@ -160,6 +220,9 @@ export class ModelInput {
     return {
       id: this.id,
       resourceId: this._resourceId,
+      dataId: this._dataId,
+      fileId: this._fileId,
+      logId: this._logId,
       name: this.name,
       version: this.version,
       tags: { ...this._tags },

--- a/src/domain/models/model_input_test.ts
+++ b/src/domain/models/model_input_test.ts
@@ -108,6 +108,9 @@ Deno.test("ModelInput.toData returns correct structure", () => {
   assertEquals(data, {
     id: "550e8400-e29b-41d4-a716-446655440000",
     resourceId: "550e8400-e29b-41d4-a716-446655440001",
+    dataId: undefined,
+    fileId: undefined,
+    logId: undefined,
     name: "test-input",
     version: 2,
     tags: { env: "prod" },

--- a/src/domain/models/model_log.ts
+++ b/src/domain/models/model_log.ts
@@ -1,0 +1,239 @@
+import { z } from "zod";
+
+/**
+ * Branded type for ModelLog IDs.
+ */
+export type ModelLogId = string & { readonly _brand: unique symbol };
+
+/**
+ * Creates a ModelLogId from a string.
+ */
+export function createModelLogId(id: string): ModelLogId {
+  return id as ModelLogId;
+}
+
+/**
+ * Zod schema for a single log entry.
+ * Simplified to store just the raw message string.
+ */
+export const LogEntrySchema = z.object({
+  message: z.string(),
+});
+
+/**
+ * Type representing a single log entry.
+ */
+export type LogEntryData = z.infer<typeof LogEntrySchema>;
+
+/**
+ * Zod schema for the core properties of a ModelLog.
+ */
+export const ModelLogSchema = z.object({
+  id: z.string().uuid(),
+  version: z.number().int().positive(),
+  createdAt: z.string().datetime(),
+  entries: z.array(LogEntrySchema).default([]),
+});
+
+/**
+ * Type representing the data stored in a ModelLog.
+ */
+export type ModelLogData = z.infer<typeof ModelLogSchema>;
+
+/**
+ * A single log entry containing a raw message string.
+ */
+export class LogEntry {
+  private constructor(
+    readonly message: string,
+  ) {}
+
+  /**
+   * Creates a new LogEntry instance.
+   */
+  static create(message: string): LogEntry {
+    const validated = LogEntrySchema.parse({ message });
+    return new LogEntry(validated.message);
+  }
+
+  /**
+   * Reconstructs a LogEntry from persisted data.
+   */
+  static fromData(data: LogEntryData): LogEntry {
+    const validated = LogEntrySchema.parse(data);
+    return new LogEntry(validated.message);
+  }
+
+  /**
+   * Converts the entry to a plain data object for persistence.
+   */
+  toData(): LogEntryData {
+    return { message: this.message };
+  }
+
+  /**
+   * Converts the entry to a plain text line for storage.
+   * Returns just the raw message without JSON wrapping.
+   */
+  toJsonLine(): string {
+    return this.message;
+  }
+
+  /**
+   * Parses a LogEntry from a plain text line.
+   */
+  static fromJsonLine(line: string): LogEntry {
+    return new LogEntry(line);
+  }
+}
+
+/**
+ * Properties required to create a new ModelLog.
+ */
+export interface CreateModelLogProps {
+  id?: string;
+  version?: number;
+  createdAt?: Date;
+  entries?: LogEntry[];
+}
+
+/**
+ * ModelLog is an entity representing execution logs and output.
+ *
+ * Each log artifact has a unique ID (UUID), creation timestamp,
+ * version, and an array of log entries. Supports streaming/async writes.
+ *
+ * Log entries are raw message strings - no timestamps, levels, or metadata
+ * are added by swamp. This allows capturing raw output from external commands
+ * like journalctl exactly as they appear.
+ */
+export class ModelLog {
+  private constructor(
+    readonly id: ModelLogId,
+    readonly version: number,
+    readonly createdAt: Date,
+    private _entries: LogEntry[],
+  ) {}
+
+  /**
+   * Creates a new ModelLog instance.
+   *
+   * @param props - Properties for the new log artifact
+   * @returns A new ModelLog instance
+   */
+  static create(props: CreateModelLogProps): ModelLog {
+    const id = props.id ?? crypto.randomUUID();
+    const version = props.version ?? 1;
+    const createdAt = props.createdAt ?? new Date();
+
+    const validated = ModelLogSchema.parse({
+      id,
+      version,
+      createdAt: createdAt.toISOString(),
+      entries: (props.entries ?? []).map((e) => e.toData()),
+    });
+
+    return new ModelLog(
+      createModelLogId(validated.id),
+      validated.version,
+      new Date(validated.createdAt),
+      validated.entries.map((e) => LogEntry.fromData(e)),
+    );
+  }
+
+  /**
+   * Reconstructs a ModelLog from persisted data.
+   *
+   * @param data - The persisted data
+   * @returns A ModelLog instance
+   */
+  static fromData(data: ModelLogData): ModelLog {
+    const validated = ModelLogSchema.parse(data);
+    return new ModelLog(
+      createModelLogId(validated.id),
+      validated.version,
+      new Date(validated.createdAt),
+      validated.entries.map((e) => LogEntry.fromData(e)),
+    );
+  }
+
+  /**
+   * Returns a copy of the entries.
+   */
+  get entries(): LogEntry[] {
+    return [...this._entries];
+  }
+
+  /**
+   * Returns the number of entries.
+   */
+  get entryCount(): number {
+    return this._entries.length;
+  }
+
+  /**
+   * Appends a new log entry.
+   */
+  append(entry: LogEntry): void {
+    this._entries.push(entry);
+  }
+
+  /**
+   * Appends a new log entry by creating it from a message string.
+   */
+  log(message: string): void {
+    this.append(LogEntry.create(message));
+  }
+
+  /**
+   * Gets the last N entries.
+   */
+  lastEntries(count: number): LogEntry[] {
+    if (count >= this._entries.length) {
+      return [...this._entries];
+    }
+    return this._entries.slice(-count);
+  }
+
+  /**
+   * Converts the log artifact to a plain data object for persistence.
+   */
+  toData(): ModelLogData {
+    return {
+      id: this.id,
+      version: this.version,
+      createdAt: this.createdAt.toISOString(),
+      entries: this._entries.map((e) => e.toData()),
+    };
+  }
+
+  /**
+   * Converts entries to plain text lines format for streaming persistence.
+   * Each entry is stored as a raw line.
+   */
+  toJsonLines(): string {
+    return this._entries.map((e) => e.toJsonLine()).join("\n");
+  }
+
+  /**
+   * Creates a ModelLog from plain text lines format.
+   */
+  static fromJsonLines(
+    id: string,
+    version: number,
+    createdAt: Date,
+    lines: string,
+  ): ModelLog {
+    const entries = lines
+      .split("\n")
+      .filter((line) => line.length > 0)
+      .map((line) => LogEntry.fromJsonLine(line));
+
+    return new ModelLog(
+      createModelLogId(id),
+      version,
+      createdAt,
+      entries,
+    );
+  }
+}

--- a/src/domain/models/model_log_test.ts
+++ b/src/domain/models/model_log_test.ts
@@ -1,0 +1,269 @@
+import { assertEquals } from "@std/assert";
+import { LogEntry, ModelLog } from "./model_log.ts";
+
+// LogEntry tests
+
+Deno.test("LogEntry.create stores message", () => {
+  const entry = LogEntry.create("test message");
+  assertEquals(entry.message, "test message");
+});
+
+Deno.test("LogEntry.create handles empty message", () => {
+  const entry = LogEntry.create("");
+  assertEquals(entry.message, "");
+});
+
+Deno.test("LogEntry.create handles multiline message", () => {
+  const message = "line 1\nline 2\nline 3";
+  const entry = LogEntry.create(message);
+  assertEquals(entry.message, message);
+});
+
+Deno.test("LogEntry toData/fromData roundtrip", () => {
+  const entry = LogEntry.create("Test message");
+  const data = entry.toData();
+  const restored = LogEntry.fromData(data);
+
+  assertEquals(restored.message, entry.message);
+});
+
+Deno.test("LogEntry toJsonLine returns raw message", () => {
+  const entry = LogEntry.create("Raw log line");
+  const line = entry.toJsonLine();
+
+  assertEquals(line, "Raw log line");
+});
+
+Deno.test("LogEntry fromJsonLine parses raw line", () => {
+  const line = "Jan 01 12:00:00 host systemd[1]: Started service";
+  const entry = LogEntry.fromJsonLine(line);
+
+  assertEquals(entry.message, line);
+});
+
+Deno.test("LogEntry toJsonLine/fromJsonLine roundtrip", () => {
+  const original = LogEntry.create("Debug info");
+  const line = original.toJsonLine();
+  const restored = LogEntry.fromJsonLine(line);
+
+  assertEquals(restored.message, original.message);
+});
+
+// ModelLog tests
+
+Deno.test("ModelLog.create generates UUID if not provided", () => {
+  const log = ModelLog.create({});
+  assertEquals(typeof log.id, "string");
+  assertEquals(log.id.length, 36);
+});
+
+Deno.test("ModelLog.create uses provided ID", () => {
+  const id = "550e8400-e29b-41d4-a716-446655440001";
+  const log = ModelLog.create({ id });
+  assertEquals(log.id, id);
+});
+
+Deno.test("ModelLog.create sets default version to 1", () => {
+  const log = ModelLog.create({});
+  assertEquals(log.version, 1);
+});
+
+Deno.test("ModelLog.create uses provided version", () => {
+  const log = ModelLog.create({ version: 3 });
+  assertEquals(log.version, 3);
+});
+
+Deno.test("ModelLog.create sets createdAt to now if not provided", () => {
+  const before = new Date();
+  const log = ModelLog.create({});
+  const after = new Date();
+
+  assertEquals(log.createdAt >= before, true);
+  assertEquals(log.createdAt <= after, true);
+});
+
+Deno.test("ModelLog.create uses provided createdAt", () => {
+  const createdAt = new Date("2023-01-01T00:00:00Z");
+  const log = ModelLog.create({ createdAt });
+  assertEquals(log.createdAt, createdAt);
+});
+
+Deno.test("ModelLog.create sets empty entries by default", () => {
+  const log = ModelLog.create({});
+  assertEquals(log.entries, []);
+  assertEquals(log.entryCount, 0);
+});
+
+Deno.test("ModelLog.create uses provided entries", () => {
+  const entries = [
+    LogEntry.create("First"),
+    LogEntry.create("Second"),
+  ];
+  const log = ModelLog.create({ entries });
+
+  assertEquals(log.entryCount, 2);
+  assertEquals(log.entries[0].message, "First");
+  assertEquals(log.entries[1].message, "Second");
+});
+
+Deno.test("ModelLog.append adds entry", () => {
+  const log = ModelLog.create({});
+  const entry = LogEntry.create("test");
+
+  log.append(entry);
+
+  assertEquals(log.entryCount, 1);
+  assertEquals(log.entries[0].message, "test");
+});
+
+Deno.test("ModelLog.log creates and appends entry", () => {
+  const log = ModelLog.create({});
+
+  log.log("Log message");
+
+  assertEquals(log.entryCount, 1);
+  assertEquals(log.entries[0].message, "Log message");
+});
+
+Deno.test("ModelLog.log handles multiple messages", () => {
+  const log = ModelLog.create({});
+
+  log.log("First line");
+  log.log("Second line");
+  log.log("Third line");
+
+  assertEquals(log.entryCount, 3);
+  assertEquals(log.entries[0].message, "First line");
+  assertEquals(log.entries[1].message, "Second line");
+  assertEquals(log.entries[2].message, "Third line");
+});
+
+Deno.test("ModelLog.lastEntries returns last N entries", () => {
+  const log = ModelLog.create({});
+  log.log("First");
+  log.log("Second");
+  log.log("Third");
+
+  const last2 = log.lastEntries(2);
+
+  assertEquals(last2.length, 2);
+  assertEquals(last2[0].message, "Second");
+  assertEquals(last2[1].message, "Third");
+});
+
+Deno.test("ModelLog.lastEntries returns all if count exceeds length", () => {
+  const log = ModelLog.create({});
+  log.log("Only one");
+
+  const last10 = log.lastEntries(10);
+
+  assertEquals(last10.length, 1);
+  assertEquals(last10[0].message, "Only one");
+});
+
+Deno.test("ModelLog toData/fromData roundtrip", () => {
+  const log = ModelLog.create({});
+  log.log("Entry 1");
+  log.log("Entry 2");
+
+  const data = log.toData();
+  const restored = ModelLog.fromData(data);
+
+  assertEquals(restored.id, log.id);
+  assertEquals(restored.version, log.version);
+  assertEquals(restored.createdAt.getTime(), log.createdAt.getTime());
+  assertEquals(restored.entryCount, 2);
+  assertEquals(restored.entries[0].message, "Entry 1");
+  assertEquals(restored.entries[1].message, "Entry 2");
+});
+
+Deno.test("ModelLog fromData with explicit data", () => {
+  const id = "550e8400-e29b-41d4-a716-446655440000";
+  const createdAt = "2023-01-01T00:00:00.000Z";
+
+  const data = {
+    id,
+    version: 2,
+    createdAt,
+    entries: [
+      { message: "Test entry" },
+    ],
+  };
+
+  const log = ModelLog.fromData(data);
+  assertEquals(log.id, id);
+  assertEquals(log.version, 2);
+  assertEquals(log.createdAt, new Date(createdAt));
+  assertEquals(log.entryCount, 1);
+  assertEquals(log.entries[0].message, "Test entry");
+});
+
+Deno.test("ModelLog toJsonLines/fromJsonLines roundtrip", () => {
+  const log = ModelLog.create({});
+  log.log("Line 1");
+  log.log("Line 2");
+  log.log("Line 3");
+
+  const lines = log.toJsonLines();
+  const restored = ModelLog.fromJsonLines(
+    log.id,
+    log.version,
+    log.createdAt,
+    lines,
+  );
+
+  assertEquals(restored.entryCount, 3);
+  assertEquals(restored.entries[0].message, "Line 1");
+  assertEquals(restored.entries[1].message, "Line 2");
+  assertEquals(restored.entries[2].message, "Line 3");
+});
+
+Deno.test("ModelLog.toJsonLines returns plain text lines", () => {
+  const log = ModelLog.create({});
+  log.log("first line");
+  log.log("second line");
+
+  const lines = log.toJsonLines();
+
+  assertEquals(lines, "first line\nsecond line");
+});
+
+Deno.test("ModelLog.fromJsonLines handles empty lines in input", () => {
+  const lines = `Line 1
+
+Line 2
+`;
+  const log = ModelLog.fromJsonLines(
+    "550e8400-e29b-41d4-a716-446655440000",
+    1,
+    new Date(),
+    lines,
+  );
+
+  assertEquals(log.entryCount, 2);
+  assertEquals(log.entries[0].message, "Line 1");
+  assertEquals(log.entries[1].message, "Line 2");
+});
+
+Deno.test("ModelLog entries are immutable via getter", () => {
+  const log = ModelLog.create({});
+  log.log("Original");
+
+  const entries = log.entries;
+  entries.push(LogEntry.create("Added"));
+
+  assertEquals(log.entryCount, 1);
+});
+
+Deno.test("ModelLog handles journalctl-style output", () => {
+  const log = ModelLog.create({});
+  log.log("Jan 01 12:00:00 myhost sshd[1234]: Accepted publickey");
+  log.log("Jan 01 12:00:01 myhost sshd[1234]: Starting session");
+  log.log("Jan 01 12:00:02 myhost sshd[1234]: Session closed");
+
+  assertEquals(log.entryCount, 3);
+  assertEquals(
+    log.entries[0].message,
+    "Jan 01 12:00:00 myhost sshd[1234]: Accepted publickey",
+  );
+});

--- a/src/domain/models/model_output.ts
+++ b/src/domain/models/model_output.ts
@@ -1,0 +1,388 @@
+import { z } from "zod";
+import type { ModelInputId } from "./model_input.ts";
+
+/**
+ * Branded type for ModelOutput IDs.
+ */
+export type ModelOutputId = string & { readonly _brand: unique symbol };
+
+/**
+ * Creates a ModelOutputId from a string.
+ */
+export function createModelOutputId(id: string): ModelOutputId {
+  return id as ModelOutputId;
+}
+
+/**
+ * Valid execution statuses.
+ */
+export const ExecutionStatuses = [
+  "pending",
+  "running",
+  "succeeded",
+  "failed",
+] as const;
+export type ExecutionStatus = typeof ExecutionStatuses[number];
+
+/**
+ * What triggered the execution.
+ */
+export const TriggerTypes = ["manual", "workflow"] as const;
+export type TriggerType = typeof TriggerTypes[number];
+
+/**
+ * Zod schema for execution error details.
+ */
+export const ExecutionErrorSchema = z.object({
+  message: z.string(),
+  stack: z.string().optional(),
+});
+
+/**
+ * Type representing execution error details.
+ */
+export type ExecutionError = z.infer<typeof ExecutionErrorSchema>;
+
+/**
+ * Zod schema for execution provenance.
+ */
+export const ExecutionProvenanceSchema = z.object({
+  inputHash: z.string(),
+  modelVersion: z.number().int().positive(),
+  triggeredBy: z.enum(TriggerTypes),
+  workflowId: z.string().optional(),
+  workflowRunId: z.string().optional(),
+  stepName: z.string().optional(),
+});
+
+/**
+ * Type representing execution provenance.
+ */
+export type ExecutionProvenance = z.infer<typeof ExecutionProvenanceSchema>;
+
+/**
+ * Zod schema for artifacts produced by the execution.
+ */
+export const ArtifactsProducedSchema = z.object({
+  resourceId: z.string().uuid().optional(),
+  dataId: z.string().uuid().optional(),
+  fileId: z.string().uuid().optional(),
+  logIds: z.array(z.string().uuid()).optional(),
+});
+
+/**
+ * Type representing artifacts produced.
+ */
+export type ArtifactsProduced = z.infer<typeof ArtifactsProducedSchema>;
+
+/**
+ * Zod schema for the core properties of a ModelOutput.
+ */
+export const ModelOutputSchema = z.object({
+  id: z.string().uuid(),
+  modelInputId: z.string().uuid(),
+  methodName: z.string().min(1),
+  status: z.enum(ExecutionStatuses),
+  startedAt: z.string().datetime(),
+  completedAt: z.string().datetime().optional(),
+  durationMs: z.number().int().nonnegative().optional(),
+  error: ExecutionErrorSchema.optional(),
+  retryCount: z.number().int().nonnegative().default(0),
+  provenance: ExecutionProvenanceSchema,
+  artifacts: ArtifactsProducedSchema.optional(),
+});
+
+/**
+ * Type representing the data stored in a ModelOutput.
+ */
+export type ModelOutputData = z.infer<typeof ModelOutputSchema>;
+
+/**
+ * Properties required to create a new ModelOutput.
+ */
+export interface CreateModelOutputProps {
+  id?: string;
+  modelInputId: ModelInputId;
+  methodName: string;
+  status?: ExecutionStatus;
+  startedAt?: Date;
+  completedAt?: Date;
+  durationMs?: number;
+  error?: ExecutionError;
+  retryCount?: number;
+  provenance: ExecutionProvenance;
+  artifacts?: ArtifactsProduced;
+}
+
+/**
+ * ModelOutput is an entity tracking execution state and metadata for each method run.
+ *
+ * Tracks status, timing, errors, provenance (what triggered it), and artifacts produced.
+ */
+export class ModelOutput {
+  private constructor(
+    readonly id: ModelOutputId,
+    readonly modelInputId: ModelInputId,
+    readonly methodName: string,
+    private _status: ExecutionStatus,
+    readonly startedAt: Date,
+    private _completedAt: Date | undefined,
+    private _durationMs: number | undefined,
+    private _error: ExecutionError | undefined,
+    private _retryCount: number,
+    readonly provenance: ExecutionProvenance,
+    private _artifacts: ArtifactsProduced | undefined,
+  ) {}
+
+  /**
+   * Creates a new ModelOutput instance.
+   *
+   * @param props - Properties for the new output
+   * @returns A new ModelOutput instance
+   */
+  static create(props: CreateModelOutputProps): ModelOutput {
+    const id = props.id ?? crypto.randomUUID();
+    const startedAt = props.startedAt ?? new Date();
+
+    const validated = ModelOutputSchema.parse({
+      id,
+      modelInputId: props.modelInputId,
+      methodName: props.methodName,
+      status: props.status ?? "pending",
+      startedAt: startedAt.toISOString(),
+      completedAt: props.completedAt?.toISOString(),
+      durationMs: props.durationMs,
+      error: props.error,
+      retryCount: props.retryCount ?? 0,
+      provenance: props.provenance,
+      artifacts: props.artifacts,
+    });
+
+    return new ModelOutput(
+      createModelOutputId(validated.id),
+      validated.modelInputId as ModelInputId,
+      validated.methodName,
+      validated.status,
+      new Date(validated.startedAt),
+      validated.completedAt ? new Date(validated.completedAt) : undefined,
+      validated.durationMs,
+      validated.error,
+      validated.retryCount,
+      validated.provenance,
+      validated.artifacts,
+    );
+  }
+
+  /**
+   * Reconstructs a ModelOutput from persisted data.
+   *
+   * @param data - The persisted data
+   * @returns A ModelOutput instance
+   */
+  static fromData(data: ModelOutputData): ModelOutput {
+    const validated = ModelOutputSchema.parse(data);
+    return new ModelOutput(
+      createModelOutputId(validated.id),
+      validated.modelInputId as ModelInputId,
+      validated.methodName,
+      validated.status,
+      new Date(validated.startedAt),
+      validated.completedAt ? new Date(validated.completedAt) : undefined,
+      validated.durationMs,
+      validated.error,
+      validated.retryCount,
+      validated.provenance,
+      validated.artifacts,
+    );
+  }
+
+  /**
+   * Gets the current execution status.
+   */
+  get status(): ExecutionStatus {
+    return this._status;
+  }
+
+  /**
+   * Gets the completion timestamp.
+   */
+  get completedAt(): Date | undefined {
+    return this._completedAt;
+  }
+
+  /**
+   * Gets the duration in milliseconds.
+   */
+  get durationMs(): number | undefined {
+    return this._durationMs;
+  }
+
+  /**
+   * Gets the error details if the execution failed.
+   */
+  get error(): ExecutionError | undefined {
+    return this._error ? { ...this._error } : undefined;
+  }
+
+  /**
+   * Gets the retry count.
+   */
+  get retryCount(): number {
+    return this._retryCount;
+  }
+
+  /**
+   * Gets the artifacts produced by this execution.
+   */
+  get artifacts(): ArtifactsProduced | undefined {
+    return this._artifacts ? { ...this._artifacts } : undefined;
+  }
+
+  /**
+   * Marks the execution as running.
+   */
+  markRunning(): void {
+    if (this._status !== "pending") {
+      throw new Error(
+        `Cannot mark output as running: status is ${this._status}`,
+      );
+    }
+    this._status = "running";
+  }
+
+  /**
+   * Marks the execution as succeeded.
+   *
+   * @param completedAt - The completion timestamp (defaults to now)
+   */
+  markSucceeded(completedAt?: Date): void {
+    if (this._status !== "running") {
+      throw new Error(
+        `Cannot mark output as succeeded: status is ${this._status}`,
+      );
+    }
+    const completed = completedAt ?? new Date();
+    this._status = "succeeded";
+    this._completedAt = completed;
+    this._durationMs = completed.getTime() - this.startedAt.getTime();
+  }
+
+  /**
+   * Marks the execution as failed.
+   *
+   * @param error - The error details
+   * @param completedAt - The completion timestamp (defaults to now)
+   */
+  markFailed(error: ExecutionError, completedAt?: Date): void {
+    if (this._status !== "running") {
+      throw new Error(
+        `Cannot mark output as failed: status is ${this._status}`,
+      );
+    }
+    const completed = completedAt ?? new Date();
+    this._status = "failed";
+    this._completedAt = completed;
+    this._durationMs = completed.getTime() - this.startedAt.getTime();
+    this._error = error;
+  }
+
+  /**
+   * Increments the retry count.
+   */
+  incrementRetryCount(): void {
+    this._retryCount++;
+  }
+
+  /**
+   * Sets the artifacts produced by this execution.
+   */
+  setArtifacts(artifacts: ArtifactsProduced): void {
+    this._artifacts = { ...artifacts };
+  }
+
+  /**
+   * Sets a specific artifact ID.
+   */
+  setResourceId(resourceId: string): void {
+    if (!this._artifacts) {
+      this._artifacts = {};
+    }
+    this._artifacts.resourceId = resourceId;
+  }
+
+  setDataId(dataId: string): void {
+    if (!this._artifacts) {
+      this._artifacts = {};
+    }
+    this._artifacts.dataId = dataId;
+  }
+
+  setFileId(fileId: string): void {
+    if (!this._artifacts) {
+      this._artifacts = {};
+    }
+    this._artifacts.fileId = fileId;
+  }
+
+  setLogIds(logIds: string[]): void {
+    if (!this._artifacts) {
+      this._artifacts = {};
+    }
+    this._artifacts.logIds = logIds;
+  }
+
+  /**
+   * Checks if the execution is in a terminal state.
+   */
+  get isComplete(): boolean {
+    return this._status === "succeeded" || this._status === "failed";
+  }
+
+  /**
+   * Converts the output to a plain data object for persistence.
+   */
+  toData(): ModelOutputData {
+    const data: ModelOutputData = {
+      id: this.id,
+      modelInputId: this.modelInputId,
+      methodName: this.methodName,
+      status: this._status,
+      startedAt: this.startedAt.toISOString(),
+      retryCount: this._retryCount,
+      provenance: { ...this.provenance },
+    };
+
+    if (this._completedAt) {
+      data.completedAt = this._completedAt.toISOString();
+    }
+    if (this._durationMs !== undefined) {
+      data.durationMs = this._durationMs;
+    }
+    if (this._error) {
+      data.error = { ...this._error };
+    }
+    if (this._artifacts) {
+      data.artifacts = { ...this._artifacts };
+    }
+
+    return data;
+  }
+}
+
+/**
+ * Computes a hash of the input attributes for provenance tracking.
+ *
+ * @param attributes - The attributes to hash
+ * @returns The hex-encoded SHA-256 hash
+ */
+export async function computeInputHash(
+  attributes: Record<string, unknown>,
+): Promise<string> {
+  const json = JSON.stringify(attributes, Object.keys(attributes).sort());
+  const data = new TextEncoder().encode(json);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = new Uint8Array(hashBuffer);
+  return Array.from(hashArray)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/src/domain/models/model_output_test.ts
+++ b/src/domain/models/model_output_test.ts
@@ -1,0 +1,422 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  computeInputHash,
+  type ExecutionProvenance,
+  ModelOutput,
+} from "./model_output.ts";
+import { createModelInputId } from "./model_input.ts";
+
+const defaultProvenance: ExecutionProvenance = {
+  inputHash: "abc123",
+  modelVersion: 1,
+  triggeredBy: "manual",
+};
+
+Deno.test("ModelOutput.create generates UUID if not provided", () => {
+  const output = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    provenance: defaultProvenance,
+  });
+  assertEquals(typeof output.id, "string");
+  assertEquals(output.id.length, 36);
+});
+
+Deno.test("ModelOutput.create uses provided ID", () => {
+  const id = "550e8400-e29b-41d4-a716-446655440001";
+  const output = ModelOutput.create({
+    id,
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    provenance: defaultProvenance,
+  });
+  assertEquals(output.id, id);
+});
+
+Deno.test("ModelOutput.create defaults to pending status", () => {
+  const output = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    provenance: defaultProvenance,
+  });
+  assertEquals(output.status, "pending");
+});
+
+Deno.test("ModelOutput.create uses provided status", () => {
+  const output = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    status: "running",
+    provenance: defaultProvenance,
+  });
+  assertEquals(output.status, "running");
+});
+
+Deno.test("ModelOutput.create sets startedAt to now if not provided", () => {
+  const before = new Date();
+  const output = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    provenance: defaultProvenance,
+  });
+  const after = new Date();
+
+  assertEquals(output.startedAt >= before, true);
+  assertEquals(output.startedAt <= after, true);
+});
+
+Deno.test("ModelOutput.create uses provided startedAt", () => {
+  const startedAt = new Date("2023-01-01T00:00:00Z");
+  const output = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    startedAt,
+    provenance: defaultProvenance,
+  });
+  assertEquals(output.startedAt, startedAt);
+});
+
+Deno.test("ModelOutput.create stores method name", () => {
+  const output = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "deploy",
+    provenance: defaultProvenance,
+  });
+  assertEquals(output.methodName, "deploy");
+});
+
+Deno.test("ModelOutput.create stores provenance", () => {
+  const provenance: ExecutionProvenance = {
+    inputHash: "xyz789",
+    modelVersion: 2,
+    triggeredBy: "workflow",
+    workflowId: "wf-123",
+    workflowRunId: "run-456",
+    stepName: "deploy-step",
+  };
+  const output = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    provenance,
+  });
+  assertEquals(output.provenance, provenance);
+});
+
+Deno.test("ModelOutput.create defaults retry count to 0", () => {
+  const output = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    provenance: defaultProvenance,
+  });
+  assertEquals(output.retryCount, 0);
+});
+
+Deno.test("ModelOutput.markRunning transitions from pending", () => {
+  const output = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    provenance: defaultProvenance,
+  });
+
+  output.markRunning();
+
+  assertEquals(output.status, "running");
+});
+
+Deno.test("ModelOutput.markRunning throws if not pending", () => {
+  const output = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    status: "running",
+    provenance: defaultProvenance,
+  });
+
+  assertThrows(
+    () => output.markRunning(),
+    Error,
+    "Cannot mark output as running: status is running",
+  );
+});
+
+Deno.test("ModelOutput.markSucceeded transitions from running", () => {
+  const output = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    status: "running",
+    provenance: defaultProvenance,
+  });
+
+  output.markSucceeded();
+
+  assertEquals(output.status, "succeeded");
+  assertEquals(output.isComplete, true);
+  assertEquals(output.completedAt !== undefined, true);
+  assertEquals(output.durationMs !== undefined, true);
+});
+
+Deno.test("ModelOutput.markSucceeded calculates duration", () => {
+  const startedAt = new Date("2023-01-01T00:00:00.000Z");
+  const completedAt = new Date("2023-01-01T00:00:05.000Z");
+  const output = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    status: "running",
+    startedAt,
+    provenance: defaultProvenance,
+  });
+
+  output.markSucceeded(completedAt);
+
+  assertEquals(output.durationMs, 5000);
+});
+
+Deno.test("ModelOutput.markSucceeded throws if not running", () => {
+  const output = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    provenance: defaultProvenance,
+  });
+
+  assertThrows(
+    () => output.markSucceeded(),
+    Error,
+    "Cannot mark output as succeeded: status is pending",
+  );
+});
+
+Deno.test("ModelOutput.markFailed transitions from running", () => {
+  const output = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    status: "running",
+    provenance: defaultProvenance,
+  });
+
+  output.markFailed({ message: "Something went wrong", stack: "Error: ..." });
+
+  assertEquals(output.status, "failed");
+  assertEquals(output.isComplete, true);
+  assertEquals(output.error?.message, "Something went wrong");
+  assertEquals(output.error?.stack, "Error: ...");
+});
+
+Deno.test("ModelOutput.markFailed throws if not running", () => {
+  const output = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    provenance: defaultProvenance,
+  });
+
+  assertThrows(
+    () => output.markFailed({ message: "error" }),
+    Error,
+    "Cannot mark output as failed: status is pending",
+  );
+});
+
+Deno.test("ModelOutput.incrementRetryCount", () => {
+  const output = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    provenance: defaultProvenance,
+  });
+
+  assertEquals(output.retryCount, 0);
+  output.incrementRetryCount();
+  assertEquals(output.retryCount, 1);
+  output.incrementRetryCount();
+  assertEquals(output.retryCount, 2);
+});
+
+Deno.test("ModelOutput.setArtifacts", () => {
+  const output = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    provenance: defaultProvenance,
+  });
+
+  output.setArtifacts({
+    resourceId: "resource-123",
+    dataId: "data-456",
+  });
+
+  assertEquals(output.artifacts?.resourceId, "resource-123");
+  assertEquals(output.artifacts?.dataId, "data-456");
+});
+
+Deno.test("ModelOutput individual artifact setters", () => {
+  const output = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    provenance: defaultProvenance,
+  });
+
+  output.setResourceId("resource-123");
+  output.setDataId("data-456");
+  output.setFileId("file-789");
+  output.setLogIds(["log-abc", "log-def"]);
+
+  assertEquals(output.artifacts?.resourceId, "resource-123");
+  assertEquals(output.artifacts?.dataId, "data-456");
+  assertEquals(output.artifacts?.fileId, "file-789");
+  assertEquals(output.artifacts?.logIds, ["log-abc", "log-def"]);
+});
+
+Deno.test("ModelOutput.isComplete returns false for pending/running", () => {
+  const pending = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    provenance: defaultProvenance,
+  });
+  assertEquals(pending.isComplete, false);
+
+  const running = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    status: "running",
+    provenance: defaultProvenance,
+  });
+  assertEquals(running.isComplete, false);
+});
+
+Deno.test("ModelOutput toData/fromData roundtrip", () => {
+  const output = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "deploy",
+    status: "running",
+    provenance: {
+      inputHash: "hash123",
+      modelVersion: 3,
+      triggeredBy: "workflow",
+      workflowId: "wf-1",
+    },
+  });
+  output.markSucceeded();
+  output.setArtifacts({
+    resourceId: "550e8400-e29b-41d4-a716-446655440001",
+    logIds: ["550e8400-e29b-41d4-a716-446655440002"],
+  });
+
+  const data = output.toData();
+  const restored = ModelOutput.fromData(data);
+
+  assertEquals(restored.id, output.id);
+  assertEquals(restored.modelInputId, output.modelInputId);
+  assertEquals(restored.methodName, output.methodName);
+  assertEquals(restored.status, output.status);
+  assertEquals(restored.startedAt.getTime(), output.startedAt.getTime());
+  assertEquals(restored.completedAt?.getTime(), output.completedAt?.getTime());
+  assertEquals(restored.durationMs, output.durationMs);
+  assertEquals(restored.provenance, output.provenance);
+  assertEquals(
+    restored.artifacts?.resourceId,
+    "550e8400-e29b-41d4-a716-446655440001",
+  );
+  assertEquals(
+    restored.artifacts?.logIds,
+    ["550e8400-e29b-41d4-a716-446655440002"],
+  );
+});
+
+Deno.test("ModelOutput fromData with explicit data", () => {
+  const id = "550e8400-e29b-41d4-a716-446655440000";
+  const modelInputId = "660e8400-e29b-41d4-a716-446655440000";
+  const startedAt = "2023-01-01T00:00:00.000Z";
+  const completedAt = "2023-01-01T00:00:10.000Z";
+
+  const data = {
+    id,
+    modelInputId,
+    methodName: "delete",
+    status: "failed" as const,
+    startedAt,
+    completedAt,
+    durationMs: 10000,
+    error: { message: "Resource not found" },
+    retryCount: 2,
+    provenance: {
+      inputHash: "hash",
+      modelVersion: 1,
+      triggeredBy: "manual" as const,
+    },
+    artifacts: {
+      logIds: ["550e8400-e29b-41d4-a716-446655440003"],
+    },
+  };
+
+  const output = ModelOutput.fromData(data);
+  assertEquals(output.id, id);
+  assertEquals(output.modelInputId, modelInputId);
+  assertEquals(output.methodName, "delete");
+  assertEquals(output.status, "failed");
+  assertEquals(output.error?.message, "Resource not found");
+  assertEquals(output.retryCount, 2);
+  assertEquals(output.artifacts?.logIds, [
+    "550e8400-e29b-41d4-a716-446655440003",
+  ]);
+});
+
+Deno.test("ModelOutput artifacts getter returns copy", () => {
+  const output = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    provenance: defaultProvenance,
+  });
+  output.setResourceId("res-1");
+
+  const artifacts = output.artifacts;
+  if (artifacts) {
+    artifacts.dataId = "modified";
+  }
+
+  assertEquals(output.artifacts?.dataId, undefined);
+});
+
+Deno.test("ModelOutput error getter returns copy", () => {
+  const output = ModelOutput.create({
+    modelInputId: createModelInputId(crypto.randomUUID()),
+    methodName: "create",
+    status: "running",
+    provenance: defaultProvenance,
+  });
+  output.markFailed({ message: "original" });
+
+  const error = output.error;
+  if (error) {
+    error.message = "modified";
+  }
+
+  assertEquals(output.error?.message, "original");
+});
+
+// computeInputHash tests
+
+Deno.test("computeInputHash produces consistent hash", async () => {
+  const attributes = { name: "test", count: 42 };
+
+  const hash1 = await computeInputHash(attributes);
+  const hash2 = await computeInputHash(attributes);
+
+  assertEquals(hash1, hash2);
+  assertEquals(hash1.length, 64); // SHA-256 produces 64 hex chars
+});
+
+Deno.test("computeInputHash is order-independent", async () => {
+  const attrs1 = { b: 2, a: 1 };
+  const attrs2 = { a: 1, b: 2 };
+
+  const hash1 = await computeInputHash(attrs1);
+  const hash2 = await computeInputHash(attrs2);
+
+  assertEquals(hash1, hash2);
+});
+
+Deno.test("computeInputHash different for different values", async () => {
+  const attrs1 = { name: "test1" };
+  const attrs2 = { name: "test2" };
+
+  const hash1 = await computeInputHash(attrs1);
+  const hash2 = await computeInputHash(attrs2);
+
+  assertEquals(hash1 !== hash2, true);
+});

--- a/src/domain/models/model_test.ts
+++ b/src/domain/models/model_test.ts
@@ -137,8 +137,8 @@ Deno.test("ModelDefinition method can execute", async () => {
   });
 
   const result = await model.methods.write.execute(input, { repoDir: "/tmp" });
-  assertEquals(result.resource.attributes.message, "hello world");
-  assertEquals(typeof result.resource.attributes.timestamp, "string");
+  assertEquals(result.resource?.attributes.message, "hello world");
+  assertEquals(typeof result.resource?.attributes.timestamp, "string");
 });
 
 // defineModel tests use unique type names to avoid conflicts with other tests

--- a/src/domain/models/models.ts
+++ b/src/domain/models/models.ts
@@ -17,6 +17,8 @@ import "./aws/ec2/instance/ec2_instance_model.ts";
 import "./aws/ec2/subnet/ec2_subnet_model.ts";
 import "./aws/ec2/vpc/ec2_vpc_model.ts";
 import "./keeb/shell/shell_model.ts";
+import "./systemd/journalctl/journalctl_model.ts";
+import "./command/curl/curl_model.ts";
 
 // Re-export the registry for convenient access
 export { modelRegistry } from "./model.ts";

--- a/src/domain/models/repositories.ts
+++ b/src/domain/models/repositories.ts
@@ -1,6 +1,10 @@
 import type { ModelType } from "./model_type.ts";
 import type { ModelInput, ModelInputId } from "./model_input.ts";
 import type { ModelResource, ModelResourceId } from "./model_resource.ts";
+import type { ModelData, ModelDataId } from "./model_data.ts";
+import type { ModelFile, ModelFileId } from "./model_file.ts";
+import type { LogEntry, ModelLog, ModelLogId } from "./model_log.ts";
+import type { ModelOutput, ModelOutputId } from "./model_output.ts";
 
 /**
  * Repository interface for persisting and retrieving ModelInputs.
@@ -124,4 +128,340 @@ export interface ResourceRepository {
    * @returns The file path
    */
   getPath(type: ModelType, id: ModelResourceId): string;
+}
+
+/**
+ * Repository interface for persisting and retrieving ModelData.
+ */
+export interface DataRepository {
+  /**
+   * Finds a data artifact by its ID.
+   *
+   * @param type - The model type
+   * @param id - The data ID
+   * @returns The data if found, or null
+   */
+  findById(type: ModelType, id: ModelDataId): Promise<ModelData | null>;
+
+  /**
+   * Finds all data artifacts of a given type.
+   *
+   * @param type - The model type
+   * @returns Array of data artifacts
+   */
+  findAll(type: ModelType): Promise<ModelData[]>;
+
+  /**
+   * Saves a data artifact.
+   *
+   * @param type - The model type
+   * @param data - The data to save
+   */
+  save(type: ModelType, data: ModelData): Promise<void>;
+
+  /**
+   * Deletes a data artifact.
+   *
+   * @param type - The model type
+   * @param id - The data ID
+   */
+  delete(type: ModelType, id: ModelDataId): Promise<void>;
+
+  /**
+   * Generates a new unique ID.
+   */
+  nextId(): ModelDataId;
+
+  /**
+   * Returns the file path for a data artifact.
+   *
+   * @param type - The model type
+   * @param id - The data ID
+   * @returns The file path
+   */
+  getPath(type: ModelType, id: ModelDataId): string;
+}
+
+/**
+ * Repository interface for persisting and retrieving ModelFiles.
+ *
+ * Stores files in the path structure:
+ * /files/{normalized-type}/{model-id}/{method-name}/{actual-filename}
+ */
+export interface FileRepository {
+  /**
+   * Finds a file artifact by its ID.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param methodName - The method name
+   * @param id - The file ID
+   * @returns The file metadata if found, or null
+   */
+  findById(
+    type: ModelType,
+    modelId: string,
+    methodName: string,
+    id: ModelFileId,
+  ): Promise<ModelFile | null>;
+
+  /**
+   * Finds all file artifacts of a given type.
+   *
+   * @param type - The model type
+   * @returns Array of file metadata
+   */
+  findAll(type: ModelType): Promise<ModelFile[]>;
+
+  /**
+   * Saves a file artifact with its content.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param methodName - The method name
+   * @param file - The file metadata
+   * @param content - The file content
+   */
+  save(
+    type: ModelType,
+    modelId: string,
+    methodName: string,
+    file: ModelFile,
+    content: Uint8Array,
+  ): Promise<void>;
+
+  /**
+   * Gets the content of a file artifact.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param methodName - The method name
+   * @param file - The file metadata (for filename)
+   * @returns The file content if found, or null
+   */
+  getContent(
+    type: ModelType,
+    modelId: string,
+    methodName: string,
+    file: ModelFile,
+  ): Promise<Uint8Array | null>;
+
+  /**
+   * Deletes a file artifact and its content.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param methodName - The method name
+   * @param file - The file metadata (for filename)
+   */
+  delete(
+    type: ModelType,
+    modelId: string,
+    methodName: string,
+    file: ModelFile,
+  ): Promise<void>;
+
+  /**
+   * Generates a new unique ID.
+   */
+  nextId(): ModelFileId;
+
+  /**
+   * Returns the metadata file path for a file artifact.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param methodName - The method name
+   * @param id - The file ID
+   * @returns The metadata file path
+   */
+  getPath(
+    type: ModelType,
+    modelId: string,
+    methodName: string,
+    id: ModelFileId,
+  ): string;
+
+  /**
+   * Returns the content file path for a file artifact.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param methodName - The method name
+   * @param file - The file metadata (for filename)
+   * @returns The content file path
+   */
+  getContentPath(
+    type: ModelType,
+    modelId: string,
+    methodName: string,
+    file: ModelFile,
+  ): string;
+}
+
+/**
+ * Repository interface for persisting and retrieving ModelLogs.
+ * Supports streaming writes for log entries.
+ */
+export interface LogRepository {
+  /**
+   * Finds a log artifact by its ID.
+   *
+   * @param type - The model type
+   * @param id - The log ID
+   * @returns The log if found, or null
+   */
+  findById(type: ModelType, id: ModelLogId): Promise<ModelLog | null>;
+
+  /**
+   * Finds all log artifacts of a given type.
+   *
+   * @param type - The model type
+   * @returns Array of logs
+   */
+  findAll(type: ModelType): Promise<ModelLog[]>;
+
+  /**
+   * Saves a complete log artifact.
+   *
+   * @param type - The model type
+   * @param log - The log to save
+   */
+  save(type: ModelType, log: ModelLog): Promise<void>;
+
+  /**
+   * Appends a single entry to an existing log (streaming support).
+   *
+   * @param type - The model type
+   * @param id - The log ID
+   * @param entry - The entry to append
+   */
+  append(type: ModelType, id: ModelLogId, entry: LogEntry): Promise<void>;
+
+  /**
+   * Reads log entries as an async iterable (streaming support).
+   *
+   * @param type - The model type
+   * @param id - The log ID
+   * @returns Async iterable of log entries
+   */
+  stream(type: ModelType, id: ModelLogId): AsyncIterable<LogEntry>;
+
+  /**
+   * Deletes a log artifact.
+   *
+   * @param type - The model type
+   * @param id - The log ID
+   */
+  delete(type: ModelType, id: ModelLogId): Promise<void>;
+
+  /**
+   * Generates a new unique ID.
+   */
+  nextId(): ModelLogId;
+
+  /**
+   * Returns the file path for a log artifact.
+   *
+   * @param type - The model type
+   * @param id - The log ID
+   * @returns The file path
+   */
+  getPath(type: ModelType, id: ModelLogId): string;
+}
+
+/**
+ * Repository interface for persisting and retrieving ModelOutputs.
+ *
+ * Stores outputs in the path structure:
+ * /outputs/{normalized-type}/{method}/{model-id}-{timestamp}.yaml
+ */
+export interface OutputRepository {
+  /**
+   * Finds an output by its ID.
+   *
+   * @param type - The model type
+   * @param method - The method name
+   * @param id - The output ID
+   * @returns The output if found, or null
+   */
+  findById(
+    type: ModelType,
+    method: string,
+    id: ModelOutputId,
+  ): Promise<ModelOutput | null>;
+
+  /**
+   * Finds all outputs for a given model input.
+   *
+   * @param type - The model type
+   * @param inputId - The model input ID
+   * @returns Array of outputs
+   */
+  findByModelInput(
+    type: ModelType,
+    inputId: ModelInputId,
+  ): Promise<ModelOutput[]>;
+
+  /**
+   * Finds the latest output for a given model input.
+   *
+   * @param type - The model type
+   * @param inputId - The model input ID
+   * @returns The latest output if found, or null
+   */
+  findLatestByModelInput(
+    type: ModelType,
+    inputId: ModelInputId,
+  ): Promise<ModelOutput | null>;
+
+  /**
+   * Finds all outputs of a given type.
+   *
+   * @param type - The model type
+   * @returns Array of outputs
+   */
+  findAll(type: ModelType): Promise<ModelOutput[]>;
+
+  /**
+   * Finds all outputs across all types.
+   *
+   * @returns Array of all outputs with their types and methods
+   */
+  findAllGlobal(): Promise<
+    { output: ModelOutput; type: ModelType; method: string }[]
+  >;
+
+  /**
+   * Saves an output.
+   *
+   * @param type - The model type
+   * @param method - The method name
+   * @param output - The output to save
+   */
+  save(type: ModelType, method: string, output: ModelOutput): Promise<void>;
+
+  /**
+   * Deletes an output.
+   *
+   * @param type - The model type
+   * @param method - The method name
+   * @param id - The output ID
+   */
+  delete(type: ModelType, method: string, id: ModelOutputId): Promise<void>;
+
+  /**
+   * Generates a new unique ID.
+   */
+  nextId(): ModelOutputId;
+
+  /**
+   * Returns the file path for an output.
+   *
+   * @param type - The model type
+   * @param method - The method name
+   * @param output - The output
+   * @returns The file path
+   */
+  getPath(type: ModelType, method: string, output: ModelOutput): string;
 }

--- a/src/domain/models/systemd/journalctl/journalctl_model.ts
+++ b/src/domain/models/systemd/journalctl/journalctl_model.ts
@@ -1,0 +1,202 @@
+import { z } from "zod";
+import { ModelType } from "../../model_type.ts";
+import { ModelLog } from "../../model_log.ts";
+import {
+  defineModel,
+  type MethodContext,
+  type MethodResult,
+  type ModelDefinition,
+} from "../../model.ts";
+import type { ModelInput } from "../../model_input.ts";
+
+/**
+ * Schema for journalctl model input attributes.
+ * All fields are optional filters for the journalctl command.
+ */
+export const JournalctlInputAttributesSchema = z.object({
+  unit: z.string().optional().describe(
+    "Filter by systemd unit (e.g., nginx.service)",
+  ),
+  since: z.string().optional().describe(
+    "Show logs since time (e.g., '1 hour ago', '2024-01-01')",
+  ),
+  until: z.string().optional().describe("Show logs until time"),
+  lines: z.number().int().positive().optional().describe(
+    "Number of lines to return",
+  ),
+  priority: z.string().optional().describe(
+    "Filter by priority (0-7 or names: emerg, alert, crit, err, warning, notice, info, debug)",
+  ),
+  boot: z.number().int().optional().describe(
+    "Boot ID (0=current, -1=previous, etc.)",
+  ),
+  grep: z.string().optional().describe("Filter by pattern"),
+  identifier: z.string().optional().describe("Filter by syslog identifier"),
+});
+
+/**
+ * Type for journalctl model input attributes.
+ */
+export type JournalctlInputAttributes = z.infer<
+  typeof JournalctlInputAttributesSchema
+>;
+
+/**
+ * Schema for journalctl model resource attributes.
+ * Empty because this model returns only logs, no resources.
+ */
+export const JournalctlResourceAttributesSchema = z.object({});
+
+/**
+ * Type for journalctl model resource attributes.
+ */
+export type JournalctlResourceAttributes = z.infer<
+  typeof JournalctlResourceAttributesSchema
+>;
+
+/**
+ * The journalctl model type identifier.
+ */
+export const JOURNALCTL_MODEL_TYPE = ModelType.create("systemd/journalctl");
+
+/**
+ * Builds the journalctl command arguments from input attributes.
+ */
+export function buildJournalctlArgs(
+  attrs: JournalctlInputAttributes,
+): string[] {
+  const args: string[] = [];
+
+  if (attrs.unit) {
+    args.push(`--unit=${attrs.unit}`);
+  }
+  if (attrs.since) {
+    args.push(`--since=${attrs.since}`);
+  }
+  if (attrs.until) {
+    args.push(`--until=${attrs.until}`);
+  }
+  if (attrs.lines !== undefined) {
+    args.push(`--lines=${attrs.lines}`);
+  }
+  if (attrs.priority) {
+    args.push(`--priority=${attrs.priority}`);
+  }
+  if (attrs.boot !== undefined) {
+    args.push(`--boot=${attrs.boot}`);
+  }
+  if (attrs.grep) {
+    args.push(`--grep=${attrs.grep}`);
+  }
+  if (attrs.identifier) {
+    args.push(`--identifier=${attrs.identifier}`);
+  }
+
+  // Always use plain text output (no pager)
+  args.push("--no-pager");
+
+  return args;
+}
+
+/**
+ * Reads system logs via journalctl and returns them as log entries.
+ * Uses streaming to handle arbitrarily large outputs without buffer overflow.
+ */
+async function readLogs(
+  input: ModelInput,
+  _context: MethodContext,
+): Promise<MethodResult> {
+  // Validate input attributes
+  const attrs = JournalctlInputAttributesSchema.parse(input.attributes);
+
+  const args = buildJournalctlArgs(attrs);
+
+  const log = ModelLog.create({});
+
+  const command = new Deno.Command("journalctl", {
+    args,
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const child = command.spawn();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  // Stream stdout using ReadableStream API
+  const reader = child.stdout.getReader();
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+
+      // Process complete lines
+      let newlineIndex: number;
+      while ((newlineIndex = buffer.indexOf("\n")) >= 0) {
+        const line = buffer.slice(0, newlineIndex);
+        buffer = buffer.slice(newlineIndex + 1);
+        if (line.length > 0) {
+          log.log(line);
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  // Handle remaining buffer (final line without trailing newline)
+  if (buffer.length > 0) {
+    log.log(buffer);
+  }
+
+  const status = await child.status;
+  if (!status.success) {
+    // Read stderr for error message
+    const stderrReader = child.stderr.getReader();
+    const stderrChunks: Uint8Array[] = [];
+    try {
+      while (true) {
+        const { done, value } = await stderrReader.read();
+        if (done) break;
+        stderrChunks.push(value);
+      }
+    } finally {
+      stderrReader.releaseLock();
+    }
+    const stderrDecoder = new TextDecoder();
+    const stderr = stderrChunks.map((c) => stderrDecoder.decode(c)).join("");
+    throw new Error(`journalctl failed: ${stderr}`);
+  }
+
+  return { logs: [log] };
+}
+
+/**
+ * The journalctl model definition.
+ *
+ * A model that reads system logs via the journalctl command and returns
+ * them as log artifacts. Supports various filters like unit, time range,
+ * priority, and pattern matching.
+ *
+ * Self-registers with the global model registry when this module is imported.
+ */
+export const journalctlModel: ModelDefinition<
+  typeof JournalctlInputAttributesSchema,
+  typeof JournalctlResourceAttributesSchema
+> = defineModel({
+  type: JOURNALCTL_MODEL_TYPE,
+  version: 1,
+  inputAttributesSchema: JournalctlInputAttributesSchema,
+  resourceAttributesSchema: JournalctlResourceAttributesSchema,
+  methods: {
+    read: {
+      description:
+        "Read system logs via journalctl with optional filters. Returns logs only, no resources.",
+      inputAttributesSchema: JournalctlInputAttributesSchema,
+      execute: readLogs,
+    },
+  },
+});

--- a/src/domain/models/systemd/journalctl/journalctl_model_test.ts
+++ b/src/domain/models/systemd/journalctl/journalctl_model_test.ts
@@ -1,0 +1,187 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  buildJournalctlArgs,
+  JournalctlInputAttributesSchema,
+} from "./journalctl_model.ts";
+
+// Schema validation tests
+
+Deno.test("JournalctlInputAttributesSchema accepts empty object", () => {
+  const result = JournalctlInputAttributesSchema.parse({});
+  assertEquals(result, {});
+});
+
+Deno.test("JournalctlInputAttributesSchema accepts unit", () => {
+  const result = JournalctlInputAttributesSchema.parse({
+    unit: "nginx.service",
+  });
+  assertEquals(result.unit, "nginx.service");
+});
+
+Deno.test("JournalctlInputAttributesSchema accepts since", () => {
+  const result = JournalctlInputAttributesSchema.parse({
+    since: "1 hour ago",
+  });
+  assertEquals(result.since, "1 hour ago");
+});
+
+Deno.test("JournalctlInputAttributesSchema accepts until", () => {
+  const result = JournalctlInputAttributesSchema.parse({
+    until: "2024-01-01 12:00:00",
+  });
+  assertEquals(result.until, "2024-01-01 12:00:00");
+});
+
+Deno.test("JournalctlInputAttributesSchema accepts positive lines", () => {
+  const result = JournalctlInputAttributesSchema.parse({
+    lines: 100,
+  });
+  assertEquals(result.lines, 100);
+});
+
+Deno.test("JournalctlInputAttributesSchema rejects zero lines", () => {
+  assertThrows(
+    () => JournalctlInputAttributesSchema.parse({ lines: 0 }),
+    Error,
+  );
+});
+
+Deno.test("JournalctlInputAttributesSchema rejects negative lines", () => {
+  assertThrows(
+    () => JournalctlInputAttributesSchema.parse({ lines: -5 }),
+    Error,
+  );
+});
+
+Deno.test("JournalctlInputAttributesSchema accepts priority", () => {
+  const result = JournalctlInputAttributesSchema.parse({
+    priority: "err",
+  });
+  assertEquals(result.priority, "err");
+});
+
+Deno.test("JournalctlInputAttributesSchema accepts boot 0", () => {
+  const result = JournalctlInputAttributesSchema.parse({
+    boot: 0,
+  });
+  assertEquals(result.boot, 0);
+});
+
+Deno.test("JournalctlInputAttributesSchema accepts negative boot", () => {
+  const result = JournalctlInputAttributesSchema.parse({
+    boot: -1,
+  });
+  assertEquals(result.boot, -1);
+});
+
+Deno.test("JournalctlInputAttributesSchema accepts grep", () => {
+  const result = JournalctlInputAttributesSchema.parse({
+    grep: "error",
+  });
+  assertEquals(result.grep, "error");
+});
+
+Deno.test("JournalctlInputAttributesSchema accepts identifier", () => {
+  const result = JournalctlInputAttributesSchema.parse({
+    identifier: "sshd",
+  });
+  assertEquals(result.identifier, "sshd");
+});
+
+Deno.test("JournalctlInputAttributesSchema accepts all attributes", () => {
+  const result = JournalctlInputAttributesSchema.parse({
+    unit: "nginx.service",
+    since: "1 hour ago",
+    until: "now",
+    lines: 50,
+    priority: "warning",
+    boot: 0,
+    grep: "error",
+    identifier: "nginx",
+  });
+  assertEquals(result.unit, "nginx.service");
+  assertEquals(result.since, "1 hour ago");
+  assertEquals(result.until, "now");
+  assertEquals(result.lines, 50);
+  assertEquals(result.priority, "warning");
+  assertEquals(result.boot, 0);
+  assertEquals(result.grep, "error");
+  assertEquals(result.identifier, "nginx");
+});
+
+// buildJournalctlArgs tests
+
+Deno.test("buildJournalctlArgs returns --no-pager for empty attributes", () => {
+  const args = buildJournalctlArgs({});
+  assertEquals(args, ["--no-pager"]);
+});
+
+Deno.test("buildJournalctlArgs includes unit", () => {
+  const args = buildJournalctlArgs({ unit: "sshd.service" });
+  assertEquals(args.includes("--unit=sshd.service"), true);
+  assertEquals(args.includes("--no-pager"), true);
+});
+
+Deno.test("buildJournalctlArgs includes since", () => {
+  const args = buildJournalctlArgs({ since: "yesterday" });
+  assertEquals(args.includes("--since=yesterday"), true);
+});
+
+Deno.test("buildJournalctlArgs includes until", () => {
+  const args = buildJournalctlArgs({ until: "today" });
+  assertEquals(args.includes("--until=today"), true);
+});
+
+Deno.test("buildJournalctlArgs includes lines", () => {
+  const args = buildJournalctlArgs({ lines: 100 });
+  assertEquals(args.includes("--lines=100"), true);
+});
+
+Deno.test("buildJournalctlArgs includes priority", () => {
+  const args = buildJournalctlArgs({ priority: "err" });
+  assertEquals(args.includes("--priority=err"), true);
+});
+
+Deno.test("buildJournalctlArgs includes boot 0", () => {
+  const args = buildJournalctlArgs({ boot: 0 });
+  assertEquals(args.includes("--boot=0"), true);
+});
+
+Deno.test("buildJournalctlArgs includes negative boot", () => {
+  const args = buildJournalctlArgs({ boot: -1 });
+  assertEquals(args.includes("--boot=-1"), true);
+});
+
+Deno.test("buildJournalctlArgs includes grep", () => {
+  const args = buildJournalctlArgs({ grep: "failed" });
+  assertEquals(args.includes("--grep=failed"), true);
+});
+
+Deno.test("buildJournalctlArgs includes identifier", () => {
+  const args = buildJournalctlArgs({ identifier: "kernel" });
+  assertEquals(args.includes("--identifier=kernel"), true);
+});
+
+Deno.test("buildJournalctlArgs combines multiple attributes", () => {
+  const args = buildJournalctlArgs({
+    unit: "nginx.service",
+    lines: 10,
+    priority: "warning",
+  });
+
+  assertEquals(args.includes("--unit=nginx.service"), true);
+  assertEquals(args.includes("--lines=10"), true);
+  assertEquals(args.includes("--priority=warning"), true);
+  assertEquals(args.includes("--no-pager"), true);
+  assertEquals(args.length, 4);
+});
+
+Deno.test("buildJournalctlArgs handles time range", () => {
+  const args = buildJournalctlArgs({
+    since: "2024-01-01 00:00:00",
+    until: "2024-01-01 23:59:59",
+  });
+
+  assertEquals(args.includes("--since=2024-01-01 00:00:00"), true);
+  assertEquals(args.includes("--until=2024-01-01 23:59:59"), true);
+});

--- a/src/domain/models/validation_service.ts
+++ b/src/domain/models/validation_service.ts
@@ -265,6 +265,14 @@ export class DefaultModelValidationService implements ModelValidationService {
     resource: ModelResource,
     definition: ModelDefinition,
   ): Promise<ValidationResult> {
+    if (!definition.resourceAttributesSchema) {
+      return Promise.resolve(
+        ValidationResult.fail(
+          "Resource attributes",
+          "Model definition has no resource attributes schema but a resource was provided",
+        ),
+      );
+    }
     return this.validateWithSchema(
       "Resource attributes",
       definition.resourceAttributesSchema,
@@ -394,7 +402,7 @@ export class DefaultModelValidationService implements ModelValidationService {
   private async validateModelPathReference(
     ref: {
       modelRef: string;
-      type: "input" | "resource";
+      type: "input" | "resource" | "data" | "file" | "log" | "execution";
       path: string[];
       rawExpression: string;
     },
@@ -430,6 +438,77 @@ export class DefaultModelValidationService implements ModelValidationService {
       return null;
     }
 
+    // For new artifact types (data, file, log, execution), validation is less strict
+    // as they may have dynamic attributes or fixed properties
+    if (ref.type === "data") {
+      // data artifacts have .attributes like resource
+      if (
+        firstSegment !== "attributes" && firstSegment !== "id" &&
+        firstSegment !== "version" && firstSegment !== "createdAt"
+      ) {
+        return {
+          expression: ref.rawExpression,
+          error: `Invalid path segment "${firstSegment}" for data artifact`,
+          suggestion: "Data artifacts have: id, version, createdAt, attributes",
+        };
+      }
+      return null;
+    }
+
+    if (ref.type === "file") {
+      const validFileSegments = [
+        "id",
+        "version",
+        "createdAt",
+        "filename",
+        "contentType",
+        "size",
+        "checksum",
+        "path",
+      ];
+      if (!validFileSegments.includes(firstSegment)) {
+        return {
+          expression: ref.rawExpression,
+          error: `Invalid path segment "${firstSegment}" for file artifact`,
+          suggestion: `File artifacts have: ${validFileSegments.join(", ")}`,
+        };
+      }
+      return null;
+    }
+
+    if (ref.type === "log") {
+      const validLogSegments = ["id", "version", "createdAt", "entries"];
+      if (!validLogSegments.includes(firstSegment)) {
+        return {
+          expression: ref.rawExpression,
+          error: `Invalid path segment "${firstSegment}" for log artifact`,
+          suggestion: `Log artifacts have: ${validLogSegments.join(", ")}`,
+        };
+      }
+      return null;
+    }
+
+    if (ref.type === "execution") {
+      const validExecSegments = [
+        "id",
+        "methodName",
+        "status",
+        "startedAt",
+        "completedAt",
+        "durationMs",
+        "error",
+      ];
+      if (!validExecSegments.includes(firstSegment)) {
+        return {
+          expression: ref.rawExpression,
+          error: `Invalid path segment "${firstSegment}" for execution`,
+          suggestion: `Execution has: ${validExecSegments.join(", ")}`,
+        };
+      }
+      return null;
+    }
+
+    // For input and resource, validate attributes path
     if (firstSegment !== "attributes") {
       // For now, we only support .attributes paths
       // Other valid paths like .id could be added later
@@ -449,9 +528,19 @@ export class DefaultModelValidationService implements ModelValidationService {
       return null;
     }
 
-    const schema = ref.type === "input"
-      ? targetDefinition.inputAttributesSchema
-      : targetDefinition.resourceAttributesSchema;
+    let schema;
+    if (ref.type === "input") {
+      schema = targetDefinition.inputAttributesSchema;
+    } else if (ref.type === "resource") {
+      schema = targetDefinition.resourceAttributesSchema;
+    } else if (ref.type === "data") {
+      schema = targetDefinition.dataAttributesSchema;
+    }
+
+    // If no schema is available for this artifact type, skip validation
+    if (!schema) {
+      return null;
+    }
 
     // Validate the path against the schema
     const validationResult = validateSchemaPath(schema, pathToValidate);

--- a/src/domain/models/validation_service_test.ts
+++ b/src/domain/models/validation_service_test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
+import { z } from "zod";
 import {
   DefaultModelValidationService,
   ValidationResult,
@@ -9,6 +10,29 @@ import { echoModel } from "./echo/echo_model.ts";
 import type { InputRepository } from "./repositories.ts";
 import { ModelType } from "./model_type.ts";
 import type { ModelInputId } from "./model_input.ts";
+import { type ModelDefinition, modelRegistry } from "./model.ts";
+
+/**
+ * Test model with resource attributes schema for validation tests.
+ * This simulates models that produce persistent resources (like AWS models).
+ */
+const testResourceModel: ModelDefinition = {
+  type: ModelType.create("test/resource"),
+  version: 1,
+  inputAttributesSchema: z.object({
+    message: z.string().min(1),
+  }),
+  resourceAttributesSchema: z.object({
+    message: z.string(),
+    timestamp: z.string().datetime(),
+  }),
+  methods: {},
+};
+
+// Register the test model if not already registered
+if (!modelRegistry.has(testResourceModel.type)) {
+  modelRegistry.register(testResourceModel);
+}
 
 // ValidationResult value object tests
 
@@ -91,7 +115,12 @@ Deno.test("validateModel with valid input and valid resource returns 4 passing r
     },
   });
 
-  const results = await service.validateModel(input, echoModel, resource);
+  // Use testResourceModel which has resourceAttributesSchema
+  const results = await service.validateModel(
+    input,
+    testResourceModel,
+    resource,
+  );
 
   assertEquals(results.length, 4);
   assertEquals(results[0].name, "Input schema");
@@ -197,9 +226,10 @@ Deno.test("validateModel runs validations in parallel", async () => {
   });
 
   // Run multiple times to verify parallel execution doesn't cause issues
+  // Use testResourceModel which has resourceAttributesSchema
   const promises = Array.from(
     { length: 10 },
-    () => service.validateModel(input, echoModel, resource),
+    () => service.validateModel(input, testResourceModel, resource),
   );
 
   const allResults = await Promise.all(promises);
@@ -550,12 +580,18 @@ Deno.test("validateModel with resource path passes for valid path", async () => 
     },
   });
 
+  // Use test/resource type which has resourceAttributesSchema
   const mockRepo = createMockInputRepo([
-    { name: "target-model", type: "swamp/echo", input: targetInput },
-    { name: "test-input", type: "swamp/echo", input },
+    { name: "target-model", type: "test/resource", input: targetInput },
+    { name: "test-input", type: "test/resource", input },
   ]);
 
-  const results = await service.validateModel(input, echoModel, null, mockRepo);
+  const results = await service.validateModel(
+    input,
+    testResourceModel,
+    null,
+    mockRepo,
+  );
 
   const exprResult = results.find((r) => r.name === "Expression paths");
   assertEquals(exprResult?.passed, true);
@@ -574,12 +610,18 @@ Deno.test("validateModel with resource path fails for invalid attribute", async 
     },
   });
 
+  // Use test/resource type which has resourceAttributesSchema
   const mockRepo = createMockInputRepo([
-    { name: "target-model", type: "swamp/echo", input: targetInput },
-    { name: "test-input", type: "swamp/echo", input },
+    { name: "target-model", type: "test/resource", input: targetInput },
+    { name: "test-input", type: "test/resource", input },
   ]);
 
-  const results = await service.validateModel(input, echoModel, null, mockRepo);
+  const results = await service.validateModel(
+    input,
+    testResourceModel,
+    null,
+    mockRepo,
+  );
 
   const exprResult = results.find((r) => r.name === "Expression paths");
   assertEquals(exprResult?.passed, false);

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -15,12 +15,16 @@ import type {
 import { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
 import { YamlEvaluatedInputRepository } from "../../infrastructure/persistence/yaml_evaluated_input_repository.ts";
 import { YamlResourceRepository } from "../../infrastructure/persistence/yaml_resource_repository.ts";
+import { YamlDataRepository } from "../../infrastructure/persistence/yaml_data_repository.ts";
 import { YamlEvaluatedWorkflowRepository } from "../../infrastructure/persistence/yaml_evaluated_workflow_repository.ts";
+import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
+import { FileSystemFileRepository } from "../../infrastructure/persistence/fs_file_repository.ts";
 import { modelRegistry } from "../models/model.ts";
 import { DefaultMethodExecutionService } from "../models/method_execution_service.ts";
 import { DefaultModelValidationService } from "../models/validation_service.ts";
 import { createModelInputId, ModelInput } from "../models/model_input.ts";
 import type { ModelType } from "../models/model_type.ts";
+import { computeInputHash, ModelOutput } from "../models/model_output.ts";
 import {
   extractExpressions,
   replaceExpressions,
@@ -37,6 +41,7 @@ import { CelEvaluator } from "../../infrastructure/cel/cel_evaluator.ts";
  */
 export interface StepExecutionContext {
   workflowId: WorkflowId;
+  workflowRunId: string;
   workflowName: string;
   jobName: string;
   stepName: string;
@@ -120,6 +125,9 @@ export class DefaultStepExecutor implements StepExecutor {
     const inputRepo = new YamlInputRepository(ctx.repoDir);
     const evaluatedInputRepo = new YamlEvaluatedInputRepository(ctx.repoDir);
     const resourceRepo = new YamlResourceRepository(ctx.repoDir);
+    const dataRepo = new YamlDataRepository(ctx.repoDir);
+    const outputRepo = new YamlOutputRepository(ctx.repoDir);
+    const fileRepo = new FileSystemFileRepository(ctx.repoDir);
     const executionService = new DefaultMethodExecutionService();
 
     // Look up the model input by ID or name
@@ -189,46 +197,137 @@ export class DefaultStepExecutor implements StepExecutor {
       );
     }
 
-    // Execute the method with EVALUATED input
-    const result = await executionService.executeWorkflow(
-      evaluatedInput,
-      definition,
-      task.methodName,
-      { repoDir: ctx.repoDir, resourceRepository: resourceRepo },
-    );
+    // Create ModelOutput for tracking
+    const inputHash = await computeInputHash(evaluatedInput.attributes);
+    const output = ModelOutput.create({
+      modelInputId: originalInput.id,
+      methodName: task.methodName,
+      provenance: {
+        inputHash,
+        modelVersion: originalInput.version,
+        triggeredBy: "workflow",
+        workflowId: ctx.workflowId,
+        workflowRunId: ctx.workflowRunId,
+        stepName: ctx.stepName,
+      },
+    });
 
-    // Handle resource persistence based on operation type
-    let resourcePath: string;
-    if (result.deleteResource) {
-      // Delete the resource file
-      await resourceRepo.delete(modelType, result.resource.id);
-      resourcePath = "";
-    } else {
-      // Save the resource
-      await resourceRepo.save(modelType, result.resource);
-      resourcePath = resourceRepo.getPath(modelType, result.resource.id);
-    }
+    // Mark as running and save
+    output.markRunning();
+    await outputRepo.save(modelType, task.methodName, output);
 
-    // Update ORIGINAL input's resourceId (preserves expressions)
-    if (result.deleteResource) {
-      if (originalInput.resourceId) {
-        originalInput.setResourceId(undefined);
-        await inputRepo.save(modelType, originalInput);
+    let resourceId: string | undefined;
+    let resourcePath = "";
+    let resourceAttributes: Record<string, unknown> = {};
+
+    try {
+      // Execute the method with EVALUATED input
+      const result = await executionService.executeWorkflow(
+        evaluatedInput,
+        definition,
+        task.methodName,
+        {
+          repoDir: ctx.repoDir,
+          resourceRepository: resourceRepo,
+          fileRepository: fileRepo,
+        },
+      );
+
+      // Handle resource persistence based on operation type
+      if (result.resource) {
+        if (result.deleteResource) {
+          // Delete the resource file
+          await resourceRepo.delete(modelType, result.resource.id);
+        } else {
+          // Save the resource
+          await resourceRepo.save(modelType, result.resource);
+          resourcePath = resourceRepo.getPath(modelType, result.resource.id);
+          resourceId = result.resource.id;
+          resourceAttributes = result.resource.attributes;
+
+          // Track artifact in output
+          output.setResourceId(result.resource.id);
+        }
+
+        // Update ORIGINAL input's resourceId (preserves expressions)
+        if (result.deleteResource) {
+          if (originalInput.resourceId) {
+            originalInput.setResourceId(undefined);
+            await inputRepo.save(modelType, originalInput);
+          }
+        } else {
+          if (!originalInput.resourceId) {
+            originalInput.setResourceId(result.resource.id);
+            await inputRepo.save(modelType, originalInput);
+          }
+        }
       }
-    } else {
-      if (!originalInput.resourceId) {
-        originalInput.setResourceId(result.resource.id);
-        await inputRepo.save(modelType, originalInput);
+
+      // Handle data artifact persistence
+      if (result.data) {
+        if (result.deleteData) {
+          await dataRepo.delete(modelType, result.data.id);
+        } else {
+          await dataRepo.save(modelType, result.data);
+          output.setDataId(result.data.id);
+        }
+
+        // Update ORIGINAL input's dataId (preserves expressions)
+        if (result.deleteData) {
+          if (originalInput.dataId) {
+            originalInput.setDataId(undefined);
+            await inputRepo.save(modelType, originalInput);
+          }
+        } else {
+          if (!originalInput.dataId) {
+            originalInput.setDataId(result.data.id);
+            await inputRepo.save(modelType, originalInput);
+          }
+        }
       }
+
+      // Handle file artifact persistence
+      if (result.file) {
+        if (result.deleteFile) {
+          await fileRepo.delete(
+            modelType,
+            evaluatedInput.id,
+            task.methodName,
+            result.file.metadata,
+          );
+        } else {
+          await fileRepo.save(
+            modelType,
+            evaluatedInput.id,
+            task.methodName,
+            result.file.metadata,
+            result.file.content,
+          );
+          output.setFileId(result.file.metadata.id);
+        }
+      }
+
+      // Mark output as succeeded and save
+      output.markSucceeded();
+      await outputRepo.save(modelType, task.methodName, output);
+    } catch (error) {
+      // Mark output as failed and save
+      const errorMessage = error instanceof Error
+        ? error.message
+        : String(error);
+      const errorStack = error instanceof Error ? error.stack : undefined;
+      output.markFailed({ message: errorMessage, stack: errorStack });
+      await outputRepo.save(modelType, task.methodName, output);
+      throw error;
     }
 
     return {
       type: "model_method",
       model: task.modelIdOrName,
       method: task.methodName,
-      resourceId: result.resource.id,
+      resourceId: resourceId ?? "",
       resourcePath,
-      resourceAttributes: result.resource.attributes,
+      resourceAttributes,
     };
   }
 
@@ -611,6 +710,7 @@ export class WorkflowExecutionService {
     try {
       const ctx: StepExecutionContext = {
         workflowId: workflow.id,
+        workflowRunId: run.id,
         workflowName: workflow.name,
         jobName: job.name,
         stepName,

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -636,6 +636,7 @@ Deno.test("DefaultStepExecutor passes env to shell commands", async () => {
 
   const ctx: StepExecutionContext = {
     workflowId: createWorkflowId("test-workflow-id"),
+    workflowRunId: "test-run-id",
     workflowName: "test-workflow",
     repoDir: ".",
     jobName: "test-job",

--- a/src/infrastructure/persistence/fs_file_repository.ts
+++ b/src/infrastructure/persistence/fs_file_repository.ts
@@ -1,0 +1,191 @@
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import type { FileRepository } from "../../domain/models/repositories.ts";
+import type { ModelType } from "../../domain/models/model_type.ts";
+import {
+  createModelFileId,
+  ModelFile,
+  type ModelFileData,
+  type ModelFileId,
+} from "../../domain/models/model_file.ts";
+
+/**
+ * Metadata file schema stored alongside the content.
+ */
+interface FileMetadata extends ModelFileData {
+  contentFilename: string;
+}
+
+/**
+ * File system implementation of FileRepository.
+ *
+ * Stores file artifacts with metadata and content as separate files:
+ * - Metadata: {repoDir}/files/{normalized-type}/{model-id}/{method-name}/{file-id}.yaml
+ * - Content:  {repoDir}/files/{normalized-type}/{model-id}/{method-name}/{actual-filename}
+ */
+export class FileSystemFileRepository implements FileRepository {
+  constructor(private readonly repoDir: string) {}
+
+  async findById(
+    type: ModelType,
+    modelId: string,
+    methodName: string,
+    id: ModelFileId,
+  ): Promise<ModelFile | null> {
+    const metadataPath = this.getPath(type, modelId, methodName, id);
+    try {
+      const content = await Deno.readTextFile(metadataPath);
+      const metadata = parseYaml(content) as FileMetadata;
+      return ModelFile.fromData(metadata);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async findAll(type: ModelType): Promise<ModelFile[]> {
+    const baseDir = this.getTypeDir(type);
+    const files: ModelFile[] = [];
+
+    try {
+      // Walk through model-id directories
+      for await (const modelEntry of Deno.readDir(baseDir)) {
+        if (!modelEntry.isDirectory) continue;
+
+        const modelDir = join(baseDir, modelEntry.name);
+        // Walk through method-name directories
+        for await (const methodEntry of Deno.readDir(modelDir)) {
+          if (!methodEntry.isDirectory) continue;
+
+          const methodDir = join(modelDir, methodEntry.name);
+          // Find yaml metadata files
+          for await (const fileEntry of Deno.readDir(methodDir)) {
+            if (fileEntry.isFile && fileEntry.name.endsWith(".yaml")) {
+              const path = join(methodDir, fileEntry.name);
+              const content = await Deno.readTextFile(path);
+              const metadata = parseYaml(content) as FileMetadata;
+              files.push(ModelFile.fromData(metadata));
+            }
+          }
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+
+    return files;
+  }
+
+  async save(
+    type: ModelType,
+    modelId: string,
+    methodName: string,
+    file: ModelFile,
+    content: Uint8Array,
+  ): Promise<void> {
+    const dir = this.getFileDir(type, modelId, methodName);
+    await ensureDir(dir);
+
+    // Use actual filename for content storage
+    const contentFilename = file.filename;
+
+    // Save metadata
+    const metadataPath = this.getPath(type, modelId, methodName, file.id);
+    const metadata: FileMetadata = {
+      ...file.toData(),
+      contentFilename,
+    };
+    // Remove undefined values since YAML can't stringify them
+    const cleanData = JSON.parse(JSON.stringify(metadata));
+    const metadataContent = stringifyYaml(cleanData as Record<string, unknown>);
+    await Deno.writeTextFile(metadataPath, metadataContent);
+
+    // Save content using actual filename
+    const contentPath = this.getContentPath(type, modelId, methodName, file);
+    await Deno.writeFile(contentPath, content);
+  }
+
+  async getContent(
+    type: ModelType,
+    modelId: string,
+    methodName: string,
+    file: ModelFile,
+  ): Promise<Uint8Array | null> {
+    const contentPath = this.getContentPath(type, modelId, methodName, file);
+    try {
+      return await Deno.readFile(contentPath);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async delete(
+    type: ModelType,
+    modelId: string,
+    methodName: string,
+    file: ModelFile,
+  ): Promise<void> {
+    const metadataPath = this.getPath(type, modelId, methodName, file.id);
+    const contentPath = this.getContentPath(type, modelId, methodName, file);
+
+    // Delete both files, ignoring NotFound errors
+    try {
+      await Deno.remove(metadataPath);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+
+    try {
+      await Deno.remove(contentPath);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+  }
+
+  nextId(): ModelFileId {
+    return createModelFileId(crypto.randomUUID());
+  }
+
+  getPath(
+    type: ModelType,
+    modelId: string,
+    methodName: string,
+    id: ModelFileId,
+  ): string {
+    return join(this.getFileDir(type, modelId, methodName), `${id}.yaml`);
+  }
+
+  getContentPath(
+    type: ModelType,
+    modelId: string,
+    methodName: string,
+    file: ModelFile,
+  ): string {
+    return join(this.getFileDir(type, modelId, methodName), file.filename);
+  }
+
+  private getTypeDir(type: ModelType): string {
+    return join(this.repoDir, "files", type.toDirectoryPath());
+  }
+
+  private getFileDir(
+    type: ModelType,
+    modelId: string,
+    methodName: string,
+  ): string {
+    return join(this.getTypeDir(type), modelId, methodName);
+  }
+}

--- a/src/infrastructure/persistence/fs_file_repository_test.ts
+++ b/src/infrastructure/persistence/fs_file_repository_test.ts
@@ -1,0 +1,345 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { ModelType } from "../../domain/models/model_type.ts";
+import {
+  computeChecksum,
+  createModelFileId,
+  ModelFile,
+} from "../../domain/models/model_file.ts";
+import { FileSystemFileRepository } from "./fs_file_repository.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+async function createTestFile(
+  content: Uint8Array,
+  filename = "test.txt",
+  contentType = "text/plain",
+): Promise<ModelFile> {
+  const checksum = await computeChecksum(content);
+  return ModelFile.create({
+    filename,
+    contentType,
+    size: content.length,
+    checksum,
+  });
+}
+
+const testModelId = "test-model-123";
+const testMethodName = "download";
+
+Deno.test("FileSystemFileRepository.save creates directory structure", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new FileSystemFileRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const content = new TextEncoder().encode("hello world");
+    const file = await createTestFile(content);
+
+    await repo.save(type, testModelId, testMethodName, file, content);
+
+    const expectedDir = join(
+      dir,
+      "files",
+      "swamp/echo",
+      testModelId,
+      testMethodName,
+    );
+    const stat = await Deno.stat(expectedDir);
+    assertEquals(stat.isDirectory, true);
+  });
+});
+
+Deno.test("FileSystemFileRepository.save creates metadata and content files", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new FileSystemFileRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const content = new TextEncoder().encode("test content");
+    const file = await createTestFile(
+      content,
+      "output.json",
+      "application/json",
+    );
+
+    await repo.save(type, testModelId, testMethodName, file, content);
+
+    // Check metadata file
+    const metadataPath = repo.getPath(
+      type,
+      testModelId,
+      testMethodName,
+      file.id,
+    );
+    const metadataContent = await Deno.readTextFile(metadataPath);
+    assertStringIncludes(metadataContent, "filename: output.json");
+    assertStringIncludes(metadataContent, "contentType: application/json");
+
+    // Check content file - should use actual filename
+    const contentPath = repo.getContentPath(
+      type,
+      testModelId,
+      testMethodName,
+      file,
+    );
+    assertEquals(contentPath.endsWith("output.json"), true);
+    const savedContent = await Deno.readFile(contentPath);
+    assertEquals(savedContent, content);
+  });
+});
+
+Deno.test("FileSystemFileRepository.findById returns saved file metadata", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new FileSystemFileRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const content = new TextEncoder().encode("hello");
+    const file = await createTestFile(
+      content,
+      "data.bin",
+      "application/octet-stream",
+    );
+
+    await repo.save(type, testModelId, testMethodName, file, content);
+    const found = await repo.findById(
+      type,
+      testModelId,
+      testMethodName,
+      file.id,
+    );
+
+    assertEquals(found?.id, file.id);
+    assertEquals(found?.filename, "data.bin");
+    assertEquals(found?.contentType, "application/octet-stream");
+    assertEquals(found?.size, content.length);
+    assertEquals(found?.checksum, file.checksum);
+  });
+});
+
+Deno.test("FileSystemFileRepository.findById returns null for non-existent", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new FileSystemFileRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const id = createModelFileId("550e8400-e29b-41d4-a716-446655440001");
+
+    const found = await repo.findById(type, testModelId, testMethodName, id);
+    assertEquals(found, null);
+  });
+});
+
+Deno.test("FileSystemFileRepository.findAll returns all files of type", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new FileSystemFileRepository(dir);
+    const type = ModelType.create("swamp/echo");
+
+    const content1 = new TextEncoder().encode("file1");
+    const content2 = new TextEncoder().encode("file2");
+    const file1 = await createTestFile(content1, "file1.txt");
+    const file2 = await createTestFile(content2, "file2.txt");
+
+    await repo.save(type, testModelId, testMethodName, file1, content1);
+    await repo.save(type, testModelId, testMethodName, file2, content2);
+
+    const all = await repo.findAll(type);
+    assertEquals(all.length, 2);
+  });
+});
+
+Deno.test("FileSystemFileRepository.findAll returns files across models and methods", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new FileSystemFileRepository(dir);
+    const type = ModelType.create("swamp/echo");
+
+    const content1 = new TextEncoder().encode("file1");
+    const content2 = new TextEncoder().encode("file2");
+    const file1 = await createTestFile(content1, "file1.txt");
+    const file2 = await createTestFile(content2, "file2.txt");
+
+    // Save files in different model/method combinations
+    await repo.save(type, "model-a", "download", file1, content1);
+    await repo.save(type, "model-b", "upload", file2, content2);
+
+    const all = await repo.findAll(type);
+    assertEquals(all.length, 2);
+  });
+});
+
+Deno.test("FileSystemFileRepository.findAll returns empty array when no files", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new FileSystemFileRepository(dir);
+    const type = ModelType.create("swamp/echo");
+
+    const all = await repo.findAll(type);
+    assertEquals(all, []);
+  });
+});
+
+Deno.test("FileSystemFileRepository.getContent returns file content", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new FileSystemFileRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const originalContent = new TextEncoder().encode("binary content here");
+    const file = await createTestFile(originalContent);
+
+    await repo.save(type, testModelId, testMethodName, file, originalContent);
+    const retrievedContent = await repo.getContent(
+      type,
+      testModelId,
+      testMethodName,
+      file,
+    );
+
+    assertEquals(retrievedContent, originalContent);
+  });
+});
+
+Deno.test("FileSystemFileRepository.getContent returns null for non-existent", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new FileSystemFileRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const file = await createTestFile(new Uint8Array(0), "nonexistent.txt");
+
+    const content = await repo.getContent(
+      type,
+      testModelId,
+      testMethodName,
+      file,
+    );
+    assertEquals(content, null);
+  });
+});
+
+Deno.test("FileSystemFileRepository.delete removes both files", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new FileSystemFileRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const content = new TextEncoder().encode("to be deleted");
+    const file = await createTestFile(content);
+
+    await repo.save(type, testModelId, testMethodName, file, content);
+    assertEquals(
+      await repo.findById(type, testModelId, testMethodName, file.id) !== null,
+      true,
+    );
+    assertEquals(
+      await repo.getContent(type, testModelId, testMethodName, file) !== null,
+      true,
+    );
+
+    await repo.delete(type, testModelId, testMethodName, file);
+
+    assertEquals(
+      await repo.findById(type, testModelId, testMethodName, file.id),
+      null,
+    );
+    assertEquals(
+      await repo.getContent(type, testModelId, testMethodName, file),
+      null,
+    );
+  });
+});
+
+Deno.test("FileSystemFileRepository.delete is idempotent", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new FileSystemFileRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const file = await createTestFile(new Uint8Array(0), "nonexistent.txt");
+
+    // Should not throw even if files don't exist
+    await repo.delete(type, testModelId, testMethodName, file);
+  });
+});
+
+Deno.test("FileSystemFileRepository.nextId generates valid UUID", () => {
+  const repo = new FileSystemFileRepository("/tmp");
+  const id = repo.nextId();
+  assertEquals(typeof id, "string");
+  assertEquals(id.length, 36);
+});
+
+Deno.test("FileSystemFileRepository.getPath returns correct path", () => {
+  const repo = new FileSystemFileRepository("/repo");
+  const type = ModelType.create("swamp/echo");
+  const id = createModelFileId("550e8400-e29b-41d4-a716-446655440001");
+
+  const path = repo.getPath(type, testModelId, testMethodName, id);
+  assertEquals(
+    path,
+    `/repo/files/swamp/echo/${testModelId}/${testMethodName}/550e8400-e29b-41d4-a716-446655440001.yaml`,
+  );
+});
+
+Deno.test("FileSystemFileRepository.getContentPath returns correct path with actual filename", async () => {
+  const repo = new FileSystemFileRepository("/repo");
+  const type = ModelType.create("swamp/echo");
+  const file = await createTestFile(
+    new Uint8Array(0),
+    "my-downloaded-file.tar.gz",
+  );
+
+  const path = repo.getContentPath(type, testModelId, testMethodName, file);
+  assertEquals(
+    path,
+    `/repo/files/swamp/echo/${testModelId}/${testMethodName}/my-downloaded-file.tar.gz`,
+  );
+});
+
+Deno.test("FileSystemFileRepository handles binary content", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new FileSystemFileRepository(dir);
+    const type = ModelType.create("swamp/binary");
+
+    // Create binary content with all byte values
+    const binaryContent = new Uint8Array(256);
+    for (let i = 0; i < 256; i++) {
+      binaryContent[i] = i;
+    }
+
+    const file = await createTestFile(
+      binaryContent,
+      "data.bin",
+      "application/octet-stream",
+    );
+
+    await repo.save(type, testModelId, testMethodName, file, binaryContent);
+    const retrieved = await repo.getContent(
+      type,
+      testModelId,
+      testMethodName,
+      file,
+    );
+
+    assertEquals(retrieved, binaryContent);
+  });
+});
+
+Deno.test("FileSystemFileRepository handles empty content", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new FileSystemFileRepository(dir);
+    const type = ModelType.create("swamp/echo");
+
+    const emptyContent = new Uint8Array(0);
+    const file = await createTestFile(emptyContent, "empty.txt");
+
+    await repo.save(type, testModelId, testMethodName, file, emptyContent);
+
+    const foundMeta = await repo.findById(
+      type,
+      testModelId,
+      testMethodName,
+      file.id,
+    );
+    assertEquals(foundMeta?.size, 0);
+
+    const retrieved = await repo.getContent(
+      type,
+      testModelId,
+      testMethodName,
+      file,
+    );
+    assertEquals(retrieved?.length, 0);
+  });
+});

--- a/src/infrastructure/persistence/streaming_log_repository.ts
+++ b/src/infrastructure/persistence/streaming_log_repository.ts
@@ -1,0 +1,238 @@
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import type { LogRepository } from "../../domain/models/repositories.ts";
+import type { ModelType } from "../../domain/models/model_type.ts";
+import {
+  createModelLogId,
+  LogEntry,
+  ModelLog,
+  type ModelLogId,
+} from "../../domain/models/model_log.ts";
+
+/**
+ * Metadata stored alongside the log entries.
+ */
+interface LogMetadata {
+  id: string;
+  version: number;
+  createdAt: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Streaming implementation of LogRepository using plain text lines format.
+ *
+ * Stores log artifacts in two files:
+ * - Metadata: {repoDir}/logs/{normalized-type}/{id}.yaml
+ * - Entries:  {repoDir}/logs/{normalized-type}/{id}.log
+ *
+ * The .log format stores raw lines, allowing appending entries without
+ * reading/rewriting the whole file.
+ */
+export class StreamingLogRepository implements LogRepository {
+  constructor(private readonly repoDir: string) {}
+
+  async findById(
+    type: ModelType,
+    id: ModelLogId,
+  ): Promise<ModelLog | null> {
+    const metadataPath = this.getMetadataPath(type, id);
+    try {
+      const metadataContent = await Deno.readTextFile(metadataPath);
+      const metadata = parseYaml(metadataContent) as LogMetadata;
+
+      // Read entries from log file
+      const entriesPath = this.getPath(type, id);
+      let entriesContent = "";
+      try {
+        entriesContent = await Deno.readTextFile(entriesPath);
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          throw error;
+        }
+        // No entries file yet is fine
+      }
+
+      return ModelLog.fromJsonLines(
+        metadata.id,
+        metadata.version,
+        new Date(metadata.createdAt),
+        entriesContent,
+      );
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async findAll(type: ModelType): Promise<ModelLog[]> {
+    const dir = this.getTypeDir(type);
+    const logs: ModelLog[] = [];
+
+    try {
+      for await (const entry of Deno.readDir(dir)) {
+        if (entry.isFile && entry.name.endsWith(".yaml")) {
+          const id = entry.name.slice(0, -5); // Remove .yaml
+          const log = await this.findById(type, createModelLogId(id));
+          if (log) {
+            logs.push(log);
+          }
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+
+    return logs;
+  }
+
+  async save(type: ModelType, log: ModelLog): Promise<void> {
+    const dir = this.getTypeDir(type);
+    await ensureDir(dir);
+
+    // Save metadata
+    const metadataPath = this.getMetadataPath(type, log.id);
+    const metadata: LogMetadata = {
+      id: log.id,
+      version: log.version,
+      createdAt: log.createdAt.toISOString(),
+    };
+    const metadataContent = stringifyYaml(metadata as Record<string, unknown>);
+    await Deno.writeTextFile(metadataPath, metadataContent);
+
+    // Save entries as plain text lines (overwrites existing) using streaming writes
+    // to avoid "Invalid string length" errors with very large logs
+    const entriesPath = this.getPath(type, log.id);
+    const file = await Deno.open(entriesPath, {
+      write: true,
+      create: true,
+      truncate: true,
+    });
+    try {
+      const encoder = new TextEncoder();
+      for (const entry of log.entries) {
+        await file.write(encoder.encode(entry.toJsonLine() + "\n"));
+      }
+    } finally {
+      file.close();
+    }
+  }
+
+  async append(
+    type: ModelType,
+    id: ModelLogId,
+    entry: LogEntry,
+  ): Promise<void> {
+    const dir = this.getTypeDir(type);
+    await ensureDir(dir);
+
+    const entriesPath = this.getPath(type, id);
+    const line = entry.toJsonLine() + "\n";
+
+    // Append to file (creates if doesn't exist)
+    const file = await Deno.open(entriesPath, {
+      write: true,
+      create: true,
+      append: true,
+    });
+    try {
+      await file.write(new TextEncoder().encode(line));
+    } finally {
+      file.close();
+    }
+  }
+
+  async *stream(
+    type: ModelType,
+    id: ModelLogId,
+  ): AsyncIterable<LogEntry> {
+    const entriesPath = this.getPath(type, id);
+
+    let file: Deno.FsFile;
+    try {
+      file = await Deno.open(entriesPath, { read: true });
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return;
+      }
+      throw error;
+    }
+
+    try {
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      // Read in chunks
+      const chunk = new Uint8Array(4096);
+      let bytesRead: number | null;
+
+      while ((bytesRead = await file.read(chunk)) !== null) {
+        buffer += decoder.decode(chunk.subarray(0, bytesRead), {
+          stream: true,
+        });
+
+        // Process complete lines
+        let newlineIndex: number;
+        while ((newlineIndex = buffer.indexOf("\n")) >= 0) {
+          const line = buffer.slice(0, newlineIndex);
+          buffer = buffer.slice(newlineIndex + 1);
+
+          if (line.length > 0) {
+            yield LogEntry.fromJsonLine(line);
+          }
+        }
+      }
+
+      // Process any remaining content
+      if (buffer.length > 0) {
+        yield LogEntry.fromJsonLine(buffer);
+      }
+    } finally {
+      file.close();
+    }
+  }
+
+  async delete(type: ModelType, id: ModelLogId): Promise<void> {
+    const metadataPath = this.getMetadataPath(type, id);
+    const entriesPath = this.getPath(type, id);
+
+    // Delete both files, ignoring NotFound errors
+    try {
+      await Deno.remove(metadataPath);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+
+    try {
+      await Deno.remove(entriesPath);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+  }
+
+  nextId(): ModelLogId {
+    return createModelLogId(crypto.randomUUID());
+  }
+
+  getPath(type: ModelType, id: ModelLogId): string {
+    return join(this.getTypeDir(type), `${id}.log`);
+  }
+
+  private getMetadataPath(type: ModelType, id: ModelLogId): string {
+    return join(this.getTypeDir(type), `${id}.yaml`);
+  }
+
+  private getTypeDir(type: ModelType): string {
+    return join(this.repoDir, "logs", type.toDirectoryPath());
+  }
+}

--- a/src/infrastructure/persistence/streaming_log_repository_test.ts
+++ b/src/infrastructure/persistence/streaming_log_repository_test.ts
@@ -1,0 +1,293 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { ModelType } from "../../domain/models/model_type.ts";
+import {
+  createModelLogId,
+  LogEntry,
+  ModelLog,
+} from "../../domain/models/model_log.ts";
+import { StreamingLogRepository } from "./streaming_log_repository.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("StreamingLogRepository.save creates directory structure", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new StreamingLogRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const log = ModelLog.create({});
+
+    await repo.save(type, log);
+
+    const expectedDir = join(dir, "logs", "swamp/echo");
+    const stat = await Deno.stat(expectedDir);
+    assertEquals(stat.isDirectory, true);
+  });
+});
+
+Deno.test("StreamingLogRepository.save creates metadata and entries files", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new StreamingLogRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const log = ModelLog.create({});
+    log.log("First entry");
+    log.log("Second entry");
+
+    await repo.save(type, log);
+
+    // Check metadata file
+    const metadataPath = join(dir, "logs", "swamp/echo", `${log.id}.yaml`);
+    const metadataContent = await Deno.readTextFile(metadataPath);
+    assertStringIncludes(metadataContent, `id: ${log.id}`);
+    assertStringIncludes(metadataContent, "version: 1");
+
+    // Check entries file
+    const entriesPath = repo.getPath(type, log.id);
+    const entriesContent = await Deno.readTextFile(entriesPath);
+    assertStringIncludes(entriesContent, "First entry");
+    assertStringIncludes(entriesContent, "Second entry");
+  });
+});
+
+Deno.test("StreamingLogRepository.findById returns saved log", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new StreamingLogRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const log = ModelLog.create({});
+    log.log("Test message");
+    log.log("Warning message");
+
+    await repo.save(type, log);
+    const found = await repo.findById(type, log.id);
+
+    assertEquals(found?.id, log.id);
+    assertEquals(found?.version, log.version);
+    assertEquals(found?.entryCount, 2);
+    assertEquals(found?.entries[0].message, "Test message");
+    assertEquals(found?.entries[1].message, "Warning message");
+  });
+});
+
+Deno.test("StreamingLogRepository.findById returns null for non-existent", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new StreamingLogRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const id = createModelLogId("550e8400-e29b-41d4-a716-446655440001");
+
+    const found = await repo.findById(type, id);
+    assertEquals(found, null);
+  });
+});
+
+Deno.test("StreamingLogRepository.findAll returns all logs of type", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new StreamingLogRepository(dir);
+    const type = ModelType.create("swamp/echo");
+
+    const log1 = ModelLog.create({});
+    log1.log("Log 1");
+    const log2 = ModelLog.create({});
+    log2.log("Log 2");
+
+    await repo.save(type, log1);
+    await repo.save(type, log2);
+
+    const all = await repo.findAll(type);
+    assertEquals(all.length, 2);
+  });
+});
+
+Deno.test("StreamingLogRepository.findAll returns empty array when no logs", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new StreamingLogRepository(dir);
+    const type = ModelType.create("swamp/echo");
+
+    const all = await repo.findAll(type);
+    assertEquals(all, []);
+  });
+});
+
+Deno.test("StreamingLogRepository.append adds entry without reading file", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new StreamingLogRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const log = ModelLog.create({});
+    log.log("Initial entry");
+
+    await repo.save(type, log);
+
+    // Append new entries
+    const entry1 = LogEntry.create("Appended 1");
+    const entry2 = LogEntry.create("Appended 2");
+    await repo.append(type, log.id, entry1);
+    await repo.append(type, log.id, entry2);
+
+    const found = await repo.findById(type, log.id);
+    assertEquals(found?.entryCount, 3);
+    assertEquals(found?.entries[0].message, "Initial entry");
+    assertEquals(found?.entries[1].message, "Appended 1");
+    assertEquals(found?.entries[2].message, "Appended 2");
+  });
+});
+
+Deno.test("StreamingLogRepository.append creates file if not exists", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new StreamingLogRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const id = createModelLogId(crypto.randomUUID());
+
+    const entry = LogEntry.create("First append");
+    await repo.append(type, id, entry);
+
+    // File should be created
+    const entriesPath = repo.getPath(type, id);
+    const content = await Deno.readTextFile(entriesPath);
+    assertStringIncludes(content, "First append");
+  });
+});
+
+Deno.test("StreamingLogRepository.stream yields entries", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new StreamingLogRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const log = ModelLog.create({});
+    log.log("Entry 1");
+    log.log("Entry 2");
+    log.log("Entry 3");
+
+    await repo.save(type, log);
+
+    const entries: LogEntry[] = [];
+    for await (const entry of repo.stream(type, log.id)) {
+      entries.push(entry);
+    }
+
+    assertEquals(entries.length, 3);
+    assertEquals(entries[0].message, "Entry 1");
+    assertEquals(entries[1].message, "Entry 2");
+    assertEquals(entries[2].message, "Entry 3");
+  });
+});
+
+Deno.test("StreamingLogRepository.stream handles non-existent file", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new StreamingLogRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const id = createModelLogId("550e8400-e29b-41d4-a716-446655440001");
+
+    const entries: LogEntry[] = [];
+    for await (const entry of repo.stream(type, id)) {
+      entries.push(entry);
+    }
+
+    assertEquals(entries.length, 0);
+  });
+});
+
+Deno.test("StreamingLogRepository.stream handles large files", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new StreamingLogRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const log = ModelLog.create({});
+
+    // Add many entries
+    for (let i = 0; i < 100; i++) {
+      log.log(`Message ${i}`);
+    }
+
+    await repo.save(type, log);
+
+    const entries: LogEntry[] = [];
+    for await (const entry of repo.stream(type, log.id)) {
+      entries.push(entry);
+    }
+
+    assertEquals(entries.length, 100);
+    assertEquals(entries[0].message, "Message 0");
+    assertEquals(entries[99].message, "Message 99");
+  });
+});
+
+Deno.test("StreamingLogRepository.delete removes both files", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new StreamingLogRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const log = ModelLog.create({});
+    log.log("To be deleted");
+
+    await repo.save(type, log);
+    assertEquals(await repo.findById(type, log.id) !== null, true);
+
+    await repo.delete(type, log.id);
+    assertEquals(await repo.findById(type, log.id), null);
+  });
+});
+
+Deno.test("StreamingLogRepository.delete is idempotent", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new StreamingLogRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const id = createModelLogId("550e8400-e29b-41d4-a716-446655440001");
+
+    // Should not throw even if files don't exist
+    await repo.delete(type, id);
+  });
+});
+
+Deno.test("StreamingLogRepository.nextId generates valid UUID", () => {
+  const repo = new StreamingLogRepository("/tmp");
+  const id = repo.nextId();
+  assertEquals(typeof id, "string");
+  assertEquals(id.length, 36);
+});
+
+Deno.test("StreamingLogRepository.getPath returns correct path", () => {
+  const repo = new StreamingLogRepository("/repo");
+  const type = ModelType.create("swamp/echo");
+  const id = createModelLogId("550e8400-e29b-41d4-a716-446655440001");
+
+  const path = repo.getPath(type, id);
+  assertEquals(
+    path,
+    "/repo/logs/swamp/echo/550e8400-e29b-41d4-a716-446655440001.log",
+  );
+});
+
+Deno.test("StreamingLogRepository stores raw lines", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new StreamingLogRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const log = ModelLog.create({});
+    log.log("Jan 01 12:00:00 host sshd[1234]: Accepted publickey");
+
+    await repo.save(type, log);
+
+    // Check entries file contains raw line
+    const entriesPath = repo.getPath(type, log.id);
+    const content = await Deno.readTextFile(entriesPath);
+    assertEquals(
+      content,
+      "Jan 01 12:00:00 host sshd[1234]: Accepted publickey\n",
+    );
+  });
+});
+
+Deno.test("StreamingLogRepository handles empty log", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new StreamingLogRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const log = ModelLog.create({});
+
+    await repo.save(type, log);
+    const found = await repo.findById(type, log.id);
+
+    assertEquals(found?.entryCount, 0);
+    assertEquals(found?.entries, []);
+  });
+});

--- a/src/infrastructure/persistence/yaml_data_repository.ts
+++ b/src/infrastructure/persistence/yaml_data_repository.ts
@@ -1,0 +1,96 @@
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import type { DataRepository } from "../../domain/models/repositories.ts";
+import type { ModelType } from "../../domain/models/model_type.ts";
+import {
+  createModelDataId,
+  ModelData,
+  type ModelDataData,
+  type ModelDataId,
+} from "../../domain/models/model_data.ts";
+
+/**
+ * YAML-based implementation of DataRepository.
+ *
+ * Stores data artifacts as YAML files in the directory structure:
+ * {repoDir}/data/{normalized-type}/{id}.yaml
+ */
+export class YamlDataRepository implements DataRepository {
+  constructor(private readonly repoDir: string) {}
+
+  async findById(
+    type: ModelType,
+    id: ModelDataId,
+  ): Promise<ModelData | null> {
+    const path = this.getPath(type, id);
+    try {
+      const content = await Deno.readTextFile(path);
+      const data = parseYaml(content) as ModelDataData;
+      return ModelData.fromData(data);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async findAll(type: ModelType): Promise<ModelData[]> {
+    const dir = this.getTypeDir(type);
+    const dataArtifacts: ModelData[] = [];
+
+    try {
+      for await (const entry of Deno.readDir(dir)) {
+        if (entry.isFile && entry.name.endsWith(".yaml")) {
+          const path = join(dir, entry.name);
+          const content = await Deno.readTextFile(path);
+          const data = parseYaml(content) as ModelDataData;
+          dataArtifacts.push(ModelData.fromData(data));
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+
+    return dataArtifacts;
+  }
+
+  async save(type: ModelType, data: ModelData): Promise<void> {
+    const dir = this.getTypeDir(type);
+    await ensureDir(dir);
+
+    const path = this.getPath(type, data.id);
+    const dataObj = data.toData();
+    // Remove undefined values since YAML can't stringify them
+    const cleanData = JSON.parse(JSON.stringify(dataObj));
+    const content = stringifyYaml(cleanData as Record<string, unknown>);
+    await Deno.writeTextFile(path, content);
+  }
+
+  async delete(type: ModelType, id: ModelDataId): Promise<void> {
+    const path = this.getPath(type, id);
+    try {
+      await Deno.remove(path);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+  }
+
+  nextId(): ModelDataId {
+    return createModelDataId(crypto.randomUUID());
+  }
+
+  getPath(type: ModelType, id: ModelDataId): string {
+    return join(this.getTypeDir(type), `${id}.yaml`);
+  }
+
+  private getTypeDir(type: ModelType): string {
+    return join(this.repoDir, "data", type.toDirectoryPath());
+  }
+}

--- a/src/infrastructure/persistence/yaml_data_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_data_repository_test.ts
@@ -1,0 +1,173 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { ModelType } from "../../domain/models/model_type.ts";
+import {
+  createModelDataId,
+  ModelData,
+} from "../../domain/models/model_data.ts";
+import { YamlDataRepository } from "./yaml_data_repository.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("YamlDataRepository.save creates directory structure", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDataRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const data = ModelData.create({});
+
+    await repo.save(type, data);
+
+    const expectedDir = join(dir, "data", "swamp/echo");
+    const stat = await Deno.stat(expectedDir);
+    assertEquals(stat.isDirectory, true);
+  });
+});
+
+Deno.test("YamlDataRepository.save creates yaml file", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDataRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const data = ModelData.create({
+      attributes: { result: "success", count: 42 },
+    });
+
+    await repo.save(type, data);
+
+    const path = repo.getPath(type, data.id);
+    const content = await Deno.readTextFile(path);
+    assertStringIncludes(content, "result: success");
+    assertStringIncludes(content, "count: 42");
+  });
+});
+
+Deno.test("YamlDataRepository.findById returns saved data", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDataRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const data = ModelData.create({
+      attributes: { items: [1, 2, 3], total: 6 },
+    });
+
+    await repo.save(type, data);
+    const found = await repo.findById(type, data.id);
+
+    assertEquals(found?.id, data.id);
+    assertEquals(found?.attributes, { items: [1, 2, 3], total: 6 });
+  });
+});
+
+Deno.test("YamlDataRepository.findById returns null for non-existent", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDataRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const id = createModelDataId("550e8400-e29b-41d4-a716-446655440001");
+
+    const found = await repo.findById(type, id);
+    assertEquals(found, null);
+  });
+});
+
+Deno.test("YamlDataRepository.findAll returns all data of type", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDataRepository(dir);
+    const type = ModelType.create("swamp/echo");
+
+    const data1 = ModelData.create({
+      attributes: { n: 1 },
+    });
+    const data2 = ModelData.create({
+      attributes: { n: 2 },
+    });
+    await repo.save(type, data1);
+    await repo.save(type, data2);
+
+    const all = await repo.findAll(type);
+    assertEquals(all.length, 2);
+  });
+});
+
+Deno.test("YamlDataRepository.findAll returns empty array when no data", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDataRepository(dir);
+    const type = ModelType.create("swamp/echo");
+
+    const all = await repo.findAll(type);
+    assertEquals(all, []);
+  });
+});
+
+Deno.test("YamlDataRepository.delete removes data file", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDataRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const data = ModelData.create({});
+
+    await repo.save(type, data);
+    assertEquals(await repo.findById(type, data.id) !== null, true);
+
+    await repo.delete(type, data.id);
+    assertEquals(await repo.findById(type, data.id), null);
+  });
+});
+
+Deno.test("YamlDataRepository.delete is idempotent", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDataRepository(dir);
+    const type = ModelType.create("swamp/echo");
+    const id = createModelDataId("550e8400-e29b-41d4-a716-446655440001");
+
+    // Should not throw even if file doesn't exist
+    await repo.delete(type, id);
+  });
+});
+
+Deno.test("YamlDataRepository.nextId generates valid UUID", () => {
+  const repo = new YamlDataRepository("/tmp");
+  const id = repo.nextId();
+  assertEquals(typeof id, "string");
+  assertEquals(id.length, 36);
+});
+
+Deno.test("YamlDataRepository.getPath returns correct path", () => {
+  const repo = new YamlDataRepository("/repo");
+  const type = ModelType.create("swamp/echo");
+  const id = createModelDataId("550e8400-e29b-41d4-a716-446655440001");
+
+  const path = repo.getPath(type, id);
+  assertEquals(
+    path,
+    "/repo/data/swamp/echo/550e8400-e29b-41d4-a716-446655440001.yaml",
+  );
+});
+
+Deno.test("YamlDataRepository preserves complex nested attributes", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDataRepository(dir);
+    const type = ModelType.create("swamp/query");
+    const data = ModelData.create({
+      attributes: {
+        results: [
+          { id: 1, name: "first" },
+          { id: 2, name: "second" },
+        ],
+        metadata: {
+          totalCount: 2,
+          page: 1,
+          filters: { status: "active" },
+        },
+      },
+    });
+
+    await repo.save(type, data);
+    const found = await repo.findById(type, data.id);
+
+    assertEquals(found?.attributes, data.attributes);
+  });
+});

--- a/src/infrastructure/persistence/yaml_output_repository.ts
+++ b/src/infrastructure/persistence/yaml_output_repository.ts
@@ -1,0 +1,187 @@
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import type { OutputRepository } from "../../domain/models/repositories.ts";
+import type { ModelInputId } from "../../domain/models/model_input.ts";
+import type { ModelType } from "../../domain/models/model_type.ts";
+import {
+  createModelOutputId,
+  ModelOutput,
+  type ModelOutputData,
+  type ModelOutputId,
+} from "../../domain/models/model_output.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
+
+/**
+ * YAML-based implementation of OutputRepository.
+ *
+ * Stores outputs as YAML files in the directory structure:
+ * {repoDir}/outputs/{normalized-type}/{method}/{model-id}-{timestamp}.yaml
+ */
+export class YamlOutputRepository implements OutputRepository {
+  constructor(private readonly repoDir: string) {}
+
+  async findById(
+    type: ModelType,
+    method: string,
+    id: ModelOutputId,
+  ): Promise<ModelOutput | null> {
+    // We need to scan the directory since the filename includes a timestamp
+    const dir = this.getMethodDir(type, method);
+    try {
+      for await (const entry of Deno.readDir(dir)) {
+        if (entry.isFile && entry.name.endsWith(".yaml")) {
+          const path = join(dir, entry.name);
+          const content = await Deno.readTextFile(path);
+          const data = parseYaml(content) as ModelOutputData;
+          if (data.id === id) {
+            return ModelOutput.fromData(data);
+          }
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+    return null;
+  }
+
+  async findByModelInput(
+    type: ModelType,
+    inputId: ModelInputId,
+  ): Promise<ModelOutput[]> {
+    const all = await this.findAll(type);
+    return all.filter((output) => output.modelInputId === inputId);
+  }
+
+  async findLatestByModelInput(
+    type: ModelType,
+    inputId: ModelInputId,
+  ): Promise<ModelOutput | null> {
+    const outputs = await this.findByModelInput(type, inputId);
+    if (outputs.length === 0) {
+      return null;
+    }
+
+    // Sort by startedAt descending and return the first one
+    outputs.sort((a, b) => b.startedAt.getTime() - a.startedAt.getTime());
+    return outputs[0];
+  }
+
+  async findAll(type: ModelType): Promise<ModelOutput[]> {
+    const typeDir = this.getTypeDir(type);
+    const outputs: ModelOutput[] = [];
+
+    try {
+      // Iterate over method directories
+      for await (const methodEntry of Deno.readDir(typeDir)) {
+        if (methodEntry.isDirectory) {
+          const methodDir = join(typeDir, methodEntry.name);
+          // Iterate over output files in method directory
+          for await (const entry of Deno.readDir(methodDir)) {
+            if (entry.isFile && entry.name.endsWith(".yaml")) {
+              const path = join(methodDir, entry.name);
+              const content = await Deno.readTextFile(path);
+              const data = parseYaml(content) as ModelOutputData;
+              outputs.push(ModelOutput.fromData(data));
+            }
+          }
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+
+    return outputs;
+  }
+
+  async findAllGlobal(): Promise<
+    { output: ModelOutput; type: ModelType; method: string }[]
+  > {
+    const results: { output: ModelOutput; type: ModelType; method: string }[] =
+      [];
+
+    // Iterate over all registered model types
+    for (const modelType of modelRegistry.types()) {
+      const typeOutputs = await this.findAll(modelType);
+      for (const output of typeOutputs) {
+        results.push({
+          output,
+          type: modelType,
+          method: output.methodName,
+        });
+      }
+    }
+
+    return results;
+  }
+
+  async save(
+    type: ModelType,
+    method: string,
+    output: ModelOutput,
+  ): Promise<void> {
+    const dir = this.getMethodDir(type, method);
+    await ensureDir(dir);
+
+    const path = this.getPath(type, method, output);
+    const data = output.toData();
+    // Remove undefined values since YAML can't stringify them
+    const cleanData = JSON.parse(JSON.stringify(data));
+    const content = stringifyYaml(cleanData as Record<string, unknown>);
+    await Deno.writeTextFile(path, content);
+  }
+
+  async delete(
+    type: ModelType,
+    method: string,
+    id: ModelOutputId,
+  ): Promise<void> {
+    // We need to find the file first since filename includes timestamp
+    const dir = this.getMethodDir(type, method);
+    try {
+      for await (const entry of Deno.readDir(dir)) {
+        if (entry.isFile && entry.name.endsWith(".yaml")) {
+          const path = join(dir, entry.name);
+          const content = await Deno.readTextFile(path);
+          const data = parseYaml(content) as ModelOutputData;
+          if (data.id === id) {
+            await Deno.remove(path);
+            return;
+          }
+        }
+      }
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+  }
+
+  nextId(): ModelOutputId {
+    return createModelOutputId(crypto.randomUUID());
+  }
+
+  getPath(type: ModelType, method: string, output: ModelOutput): string {
+    const timestamp = output.startedAt.toISOString().replace(/[:.]/g, "-");
+    const filename = `${output.modelInputId}-${timestamp}.yaml`;
+    return join(this.getMethodDir(type, method), filename);
+  }
+
+  private getOutputsDir(): string {
+    return join(this.repoDir, "outputs");
+  }
+
+  private getTypeDir(type: ModelType): string {
+    return join(this.getOutputsDir(), type.normalized);
+  }
+
+  private getMethodDir(type: ModelType, method: string): string {
+    return join(this.getTypeDir(type), method);
+  }
+}

--- a/src/infrastructure/persistence/yaml_output_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_output_repository_test.ts
@@ -1,0 +1,331 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import {
+  createModelOutputId,
+  type ExecutionProvenance,
+  ModelOutput,
+} from "../../domain/models/model_output.ts";
+import { createModelInputId } from "../../domain/models/model_input.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
+import { YamlOutputRepository } from "./yaml_output_repository.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+const defaultProvenance: ExecutionProvenance = {
+  inputHash: "abc123",
+  modelVersion: 1,
+  triggeredBy: "manual",
+};
+
+const testType = ModelType.create("test/type");
+
+Deno.test("YamlOutputRepository.save creates directory structure", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlOutputRepository(dir);
+    const output = ModelOutput.create({
+      modelInputId: createModelInputId(crypto.randomUUID()),
+      methodName: "create",
+      provenance: defaultProvenance,
+    });
+
+    await repo.save(testType, "create", output);
+
+    const expectedDir = join(dir, "outputs", testType.normalized, "create");
+    const stat = await Deno.stat(expectedDir);
+    assertEquals(stat.isDirectory, true);
+  });
+});
+
+Deno.test("YamlOutputRepository.save creates yaml file with correct path structure", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlOutputRepository(dir);
+    const modelInputId = createModelInputId(crypto.randomUUID());
+    const output = ModelOutput.create({
+      modelInputId,
+      methodName: "deploy",
+      provenance: {
+        inputHash: "xyz789",
+        modelVersion: 2,
+        triggeredBy: "workflow",
+        workflowId: "wf-123",
+      },
+    });
+
+    await repo.save(testType, "deploy", output);
+
+    const path = repo.getPath(testType, "deploy", output);
+    // Path should be: outputs/{type}/{method}/{model-id}-{timestamp}.yaml
+    assertStringIncludes(path, "outputs");
+    assertStringIncludes(path, testType.normalized);
+    assertStringIncludes(path, "deploy");
+    assertStringIncludes(path, modelInputId);
+    assertStringIncludes(path, ".yaml");
+
+    const content = await Deno.readTextFile(path);
+    assertStringIncludes(content, "methodName: deploy");
+    assertStringIncludes(content, "status: pending");
+    assertStringIncludes(content, "workflowId: wf-123");
+  });
+});
+
+Deno.test("YamlOutputRepository.findById returns saved output", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlOutputRepository(dir);
+    const modelInputId = createModelInputId(crypto.randomUUID());
+    const output = ModelOutput.create({
+      modelInputId,
+      methodName: "create",
+      provenance: defaultProvenance,
+    });
+
+    await repo.save(testType, "create", output);
+    const found = await repo.findById(testType, "create", output.id);
+
+    assertEquals(found?.id, output.id);
+    assertEquals(found?.modelInputId, modelInputId);
+    assertEquals(found?.methodName, "create");
+    assertEquals(found?.status, "pending");
+    assertEquals(found?.provenance.inputHash, "abc123");
+  });
+});
+
+Deno.test("YamlOutputRepository.findById returns null for non-existent", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlOutputRepository(dir);
+    const id = createModelOutputId("550e8400-e29b-41d4-a716-446655440001");
+
+    const found = await repo.findById(testType, "create", id);
+    assertEquals(found, null);
+  });
+});
+
+Deno.test("YamlOutputRepository.findAll returns all outputs for a type", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlOutputRepository(dir);
+
+    const output1 = ModelOutput.create({
+      modelInputId: createModelInputId(crypto.randomUUID()),
+      methodName: "create",
+      provenance: defaultProvenance,
+    });
+    const output2 = ModelOutput.create({
+      modelInputId: createModelInputId(crypto.randomUUID()),
+      methodName: "delete",
+      provenance: defaultProvenance,
+    });
+
+    await repo.save(testType, "create", output1);
+    await repo.save(testType, "delete", output2);
+
+    const all = await repo.findAll(testType);
+    assertEquals(all.length, 2);
+  });
+});
+
+Deno.test("YamlOutputRepository.findAll returns empty array when none", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlOutputRepository(dir);
+
+    const all = await repo.findAll(testType);
+    assertEquals(all, []);
+  });
+});
+
+Deno.test("YamlOutputRepository.findByModelInput filters by input ID", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlOutputRepository(dir);
+    const inputId1 = createModelInputId(crypto.randomUUID());
+    const inputId2 = createModelInputId(crypto.randomUUID());
+
+    const output1 = ModelOutput.create({
+      modelInputId: inputId1,
+      methodName: "create",
+      provenance: defaultProvenance,
+    });
+    const output2 = ModelOutput.create({
+      modelInputId: inputId1,
+      methodName: "update",
+      provenance: defaultProvenance,
+    });
+    const output3 = ModelOutput.create({
+      modelInputId: inputId2,
+      methodName: "create",
+      provenance: defaultProvenance,
+    });
+
+    await repo.save(testType, "create", output1);
+    await repo.save(testType, "update", output2);
+    await repo.save(testType, "create", output3);
+
+    const forInput1 = await repo.findByModelInput(testType, inputId1);
+    assertEquals(forInput1.length, 2);
+
+    const forInput2 = await repo.findByModelInput(testType, inputId2);
+    assertEquals(forInput2.length, 1);
+  });
+});
+
+Deno.test("YamlOutputRepository.findLatestByModelInput returns most recent", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlOutputRepository(dir);
+    const inputId = createModelInputId(crypto.randomUUID());
+
+    const output1 = ModelOutput.create({
+      modelInputId: inputId,
+      methodName: "create",
+      startedAt: new Date("2023-01-01T00:00:00Z"),
+      provenance: defaultProvenance,
+    });
+    const output2 = ModelOutput.create({
+      modelInputId: inputId,
+      methodName: "update",
+      startedAt: new Date("2023-01-02T00:00:00Z"),
+      provenance: defaultProvenance,
+    });
+    const output3 = ModelOutput.create({
+      modelInputId: inputId,
+      methodName: "delete",
+      startedAt: new Date("2023-01-01T12:00:00Z"),
+      provenance: defaultProvenance,
+    });
+
+    await repo.save(testType, "create", output1);
+    await repo.save(testType, "update", output2);
+    await repo.save(testType, "delete", output3);
+
+    const latest = await repo.findLatestByModelInput(testType, inputId);
+    assertEquals(latest?.id, output2.id);
+    assertEquals(latest?.methodName, "update");
+  });
+});
+
+Deno.test("YamlOutputRepository.findLatestByModelInput returns null when none", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlOutputRepository(dir);
+    const inputId = createModelInputId(crypto.randomUUID());
+
+    const latest = await repo.findLatestByModelInput(testType, inputId);
+    assertEquals(latest, null);
+  });
+});
+
+Deno.test("YamlOutputRepository.delete removes output file", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlOutputRepository(dir);
+    const output = ModelOutput.create({
+      modelInputId: createModelInputId(crypto.randomUUID()),
+      methodName: "create",
+      provenance: defaultProvenance,
+    });
+
+    await repo.save(testType, "create", output);
+    assertEquals(
+      await repo.findById(testType, "create", output.id) !== null,
+      true,
+    );
+
+    await repo.delete(testType, "create", output.id);
+    assertEquals(await repo.findById(testType, "create", output.id), null);
+  });
+});
+
+Deno.test("YamlOutputRepository.delete is idempotent", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlOutputRepository(dir);
+    const id = createModelOutputId("550e8400-e29b-41d4-a716-446655440001");
+
+    // Should not throw even if file doesn't exist
+    await repo.delete(testType, "create", id);
+  });
+});
+
+Deno.test("YamlOutputRepository.nextId generates valid UUID", () => {
+  const repo = new YamlOutputRepository("/tmp");
+  const id = repo.nextId();
+  assertEquals(typeof id, "string");
+  assertEquals(id.length, 36);
+});
+
+Deno.test("YamlOutputRepository preserves completed output state", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlOutputRepository(dir);
+    const output = ModelOutput.create({
+      modelInputId: createModelInputId(crypto.randomUUID()),
+      methodName: "create",
+      status: "running",
+      provenance: defaultProvenance,
+    });
+    output.markSucceeded();
+    output.setArtifacts({
+      resourceId: "550e8400-e29b-41d4-a716-446655440010",
+      logIds: ["550e8400-e29b-41d4-a716-446655440011"],
+    });
+
+    await repo.save(testType, "create", output);
+    const found = await repo.findById(testType, "create", output.id);
+
+    assertEquals(found?.status, "succeeded");
+    assertEquals(found?.isComplete, true);
+    assertEquals(
+      found?.artifacts?.resourceId,
+      "550e8400-e29b-41d4-a716-446655440010",
+    );
+    assertEquals(
+      found?.artifacts?.logIds,
+      ["550e8400-e29b-41d4-a716-446655440011"],
+    );
+  });
+});
+
+Deno.test("YamlOutputRepository preserves failed output state", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlOutputRepository(dir);
+    const output = ModelOutput.create({
+      modelInputId: createModelInputId(crypto.randomUUID()),
+      methodName: "deploy",
+      status: "running",
+      provenance: defaultProvenance,
+    });
+    output.markFailed({
+      message: "Deployment failed",
+      stack: "Error: Connection timeout\n  at deploy()",
+    });
+
+    await repo.save(testType, "deploy", output);
+    const found = await repo.findById(testType, "deploy", output.id);
+
+    assertEquals(found?.status, "failed");
+    assertEquals(found?.error?.message, "Deployment failed");
+    assertEquals(found?.error?.stack?.includes("Connection timeout"), true);
+  });
+});
+
+Deno.test("YamlOutputRepository.getPath uses correct format", () => {
+  const repo = new YamlOutputRepository("/tmp/test");
+  const modelInputId = createModelInputId(
+    "550e8400-e29b-41d4-a716-446655440000",
+  );
+  const output = ModelOutput.create({
+    modelInputId,
+    methodName: "create",
+    startedAt: new Date("2023-01-15T10:30:00.000Z"),
+    provenance: defaultProvenance,
+  });
+
+  const path = repo.getPath(testType, "create", output);
+
+  // Path should include: outputs/{type}/{method}/{model-id}-{timestamp}.yaml
+  assertStringIncludes(path, "outputs");
+  assertStringIncludes(path, testType.normalized);
+  assertStringIncludes(path, "create");
+  assertStringIncludes(path, "550e8400-e29b-41d4-a716-446655440000");
+  assertStringIncludes(path, "2023-01-15T10-30-00-000Z");
+  assertStringIncludes(path, ".yaml");
+});

--- a/src/presentation/output/model_method_run_output.tsx
+++ b/src/presentation/output/model_method_run_output.tsx
@@ -4,14 +4,25 @@ import { Box, Text } from "ink";
 import { render } from "ink-testing-library";
 import type { OutputMode } from "./output.tsx";
 
+/**
+ * Artifact information for method output.
+ */
+export interface ArtifactInfo {
+  id: string;
+  path: string;
+  attributes?: Record<string, unknown>;
+}
+
 export interface ModelMethodRunData {
   modelId: string;
   modelName: string;
   type: string;
   methodName: string;
-  resourceId: string;
-  resourcePath: string;
-  resourceAttributes: Record<string, unknown>;
+  // Artifact outputs (all optional, depends on what the method produces)
+  resource?: ArtifactInfo;
+  data?: ArtifactInfo;
+  file?: ArtifactInfo;
+  logs?: ArtifactInfo[];
 }
 
 export function renderModelMethodRun(
@@ -48,11 +59,42 @@ function AttributeItem(props: AttributeItemProps): React.ReactElement {
   );
 }
 
+interface ArtifactSectionProps {
+  label: string;
+  artifact: ArtifactInfo;
+}
+
+function ArtifactSection(props: ArtifactSectionProps): React.ReactElement {
+  const attributeEntries = props.artifact.attributes
+    ? Object.entries(props.artifact.attributes)
+    : [];
+
+  return (
+    <Box flexDirection="column">
+      <Text>
+        <Text></Text>
+        {props.label} ID: <Text dimColor>{props.artifact.id}</Text>
+      </Text>
+      <Text>
+        <Text></Text>
+        {props.label} Path: <Text dimColor>{props.artifact.path}</Text>
+      </Text>
+      {attributeEntries.length > 0 && (
+        <Box flexDirection="column">
+          <Text>{props.label} Attributes:</Text>
+          {attributeEntries.map(([name, value]) => (
+            <AttributeItem key={name} name={name} value={value} />
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
 export function ModelMethodRunDisplay(
   props: ModelMethodRunData,
 ): React.ReactElement {
   const checkmark = "\u2713";
-  const attributeEntries = Object.entries(props.resourceAttributes);
 
   return (
     <Box flexDirection="column">
@@ -65,17 +107,31 @@ export function ModelMethodRunDisplay(
         <Text></Text>Model: <Text bold>{props.modelName}</Text> (
         <Text dimColor>{props.type}</Text>)
       </Text>
-      <Text>
-        <Text></Text>Resource ID: <Text dimColor>{props.resourceId}</Text>
-      </Text>
-      <Text>
-        <Text></Text>Resource Path: <Text dimColor>{props.resourcePath}</Text>
-      </Text>
-      <Text />
-      <Text>Resource Attributes:</Text>
-      {attributeEntries.map(([name, value]) => (
-        <AttributeItem key={name} name={name} value={value} />
-      ))}
+      {props.resource && (
+        <Box flexDirection="column" marginTop={1}>
+          <ArtifactSection label="Resource" artifact={props.resource} />
+        </Box>
+      )}
+      {props.data && (
+        <Box flexDirection="column" marginTop={1}>
+          <ArtifactSection label="Data" artifact={props.data} />
+        </Box>
+      )}
+      {props.file && (
+        <Box flexDirection="column" marginTop={1}>
+          <ArtifactSection label="File" artifact={props.file} />
+        </Box>
+      )}
+      {props.logs && props.logs.length > 0 && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text>Logs:</Text>
+          {props.logs.map((log, index) => (
+            <Text key={log.id}>
+              <Text></Text>Log {index + 1}: <Text dimColor>{log.path}</Text>
+            </Text>
+          ))}
+        </Box>
+      )}
     </Box>
   );
 }

--- a/src/presentation/output/model_method_run_output_test.tsx
+++ b/src/presentation/output/model_method_run_output_test.tsx
@@ -10,17 +10,34 @@ import {
 
 const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
 
-const testData: ModelMethodRunData = {
+const testDataWithResource: ModelMethodRunData = {
+  modelId: "550e8400-e29b-41d4-a716-446655440000",
+  modelName: "test-model",
+  type: "aws/ec2/instance",
+  methodName: "create",
+  resource: {
+    id: "660e8400-e29b-41d4-a716-446655440000",
+    path:
+      "/path/to/resources/aws/ec2/instance/660e8400-e29b-41d4-a716-446655440000.yaml",
+    attributes: {
+      instanceId: "i-1234567890abcdef0",
+      state: "running",
+    },
+  },
+};
+
+const testDataWithData: ModelMethodRunData = {
   modelId: "550e8400-e29b-41d4-a716-446655440000",
   modelName: "test-model",
   type: "swamp/echo",
   methodName: "write",
-  resourceId: "660e8400-e29b-41d4-a716-446655440000",
-  resourcePath:
-    "/path/to/resources/swamp/echo/660e8400-e29b-41d4-a716-446655440000.yaml",
-  resourceAttributes: {
-    message: "Hello, world!",
-    timestamp: "2026-01-28T12:00:00.000Z",
+  data: {
+    id: "660e8400-e29b-41d4-a716-446655440000",
+    path: "/path/to/data/swamp/echo/660e8400-e29b-41d4-a716-446655440000.yaml",
+    attributes: {
+      message: "Hello, world!",
+      timestamp: "2026-01-28T12:00:00.000Z",
+    },
   },
 };
 
@@ -28,7 +45,9 @@ Deno.test({
   name: "ModelMethodRunDisplay renders method name",
   ...inkTestOptions,
   fn: () => {
-    const { lastFrame } = render(<ModelMethodRunDisplay {...testData} />);
+    const { lastFrame } = render(
+      <ModelMethodRunDisplay {...testDataWithData} />,
+    );
     const output = lastFrame() ?? "";
 
     assertStringIncludes(output, "write");
@@ -40,7 +59,9 @@ Deno.test({
   name: "ModelMethodRunDisplay renders model name and type",
   ...inkTestOptions,
   fn: () => {
-    const { lastFrame } = render(<ModelMethodRunDisplay {...testData} />);
+    const { lastFrame } = render(
+      <ModelMethodRunDisplay {...testDataWithData} />,
+    );
     const output = lastFrame() ?? "";
 
     assertStringIncludes(output, "test-model");
@@ -49,10 +70,12 @@ Deno.test({
 });
 
 Deno.test({
-  name: "ModelMethodRunDisplay renders resource ID",
+  name: "ModelMethodRunDisplay renders data ID",
   ...inkTestOptions,
   fn: () => {
-    const { lastFrame } = render(<ModelMethodRunDisplay {...testData} />);
+    const { lastFrame } = render(
+      <ModelMethodRunDisplay {...testDataWithData} />,
+    );
     const output = lastFrame() ?? "";
 
     assertStringIncludes(output, "660e8400-e29b-41d4-a716-446655440000");
@@ -60,21 +83,25 @@ Deno.test({
 });
 
 Deno.test({
-  name: "ModelMethodRunDisplay renders resource path",
+  name: "ModelMethodRunDisplay renders data path",
   ...inkTestOptions,
   fn: () => {
-    const { lastFrame } = render(<ModelMethodRunDisplay {...testData} />);
+    const { lastFrame } = render(
+      <ModelMethodRunDisplay {...testDataWithData} />,
+    );
     const output = lastFrame() ?? "";
 
-    assertStringIncludes(output, "/path/to/resources/swamp/echo");
+    assertStringIncludes(output, "/path/to/data/swamp/echo");
   },
 });
 
 Deno.test({
-  name: "ModelMethodRunDisplay renders resource attributes",
+  name: "ModelMethodRunDisplay renders data attributes",
   ...inkTestOptions,
   fn: () => {
-    const { lastFrame } = render(<ModelMethodRunDisplay {...testData} />);
+    const { lastFrame } = render(
+      <ModelMethodRunDisplay {...testDataWithData} />,
+    );
     const output = lastFrame() ?? "";
 
     assertStringIncludes(output, "message:");
@@ -85,34 +112,52 @@ Deno.test({
 });
 
 Deno.test({
+  name: "ModelMethodRunDisplay renders resource attributes",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelMethodRunDisplay {...testDataWithResource} />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "instanceId:");
+    assertStringIncludes(output, "i-1234567890abcdef0");
+    assertStringIncludes(output, "state:");
+    assertStringIncludes(output, "running");
+  },
+});
+
+Deno.test({
   name: "ModelMethodRunDisplay renders checkmark",
   ...inkTestOptions,
   fn: () => {
-    const { lastFrame } = render(<ModelMethodRunDisplay {...testData} />);
+    const { lastFrame } = render(
+      <ModelMethodRunDisplay {...testDataWithData} />,
+    );
     const output = lastFrame() ?? "";
 
     assertStringIncludes(output, "\u2713");
   },
 });
 
-Deno.test("renderModelMethodRun with json mode outputs valid JSON", () => {
+Deno.test("renderModelMethodRun with json mode outputs valid JSON for data", () => {
   const logs: string[] = [];
   const originalLog = console.log;
   console.log = (msg: string) => logs.push(msg);
 
   try {
-    renderModelMethodRun(testData, "json");
+    renderModelMethodRun(testDataWithData, "json");
     assertEquals(logs.length, 1);
     const parsed = JSON.parse(logs[0]);
-    assertEquals(parsed.modelId, testData.modelId);
-    assertEquals(parsed.modelName, testData.modelName);
-    assertEquals(parsed.type, testData.type);
-    assertEquals(parsed.methodName, testData.methodName);
-    assertEquals(parsed.resourceId, testData.resourceId);
-    assertEquals(parsed.resourcePath, testData.resourcePath);
-    assertEquals(parsed.resourceAttributes.message, "Hello, world!");
+    assertEquals(parsed.modelId, testDataWithData.modelId);
+    assertEquals(parsed.modelName, testDataWithData.modelName);
+    assertEquals(parsed.type, testDataWithData.type);
+    assertEquals(parsed.methodName, testDataWithData.methodName);
+    assertEquals(parsed.data.id, testDataWithData.data!.id);
+    assertEquals(parsed.data.path, testDataWithData.data!.path);
+    assertEquals(parsed.data.attributes.message, "Hello, world!");
     assertEquals(
-      parsed.resourceAttributes.timestamp,
+      parsed.data.attributes.timestamp,
       "2026-01-28T12:00:00.000Z",
     );
   } finally {
@@ -120,12 +165,33 @@ Deno.test("renderModelMethodRun with json mode outputs valid JSON", () => {
   }
 });
 
+Deno.test("renderModelMethodRun with json mode outputs valid JSON for resource", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelMethodRun(testDataWithResource, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.modelId, testDataWithResource.modelId);
+    assertEquals(parsed.resource.id, testDataWithResource.resource!.id);
+    assertEquals(parsed.resource.attributes.instanceId, "i-1234567890abcdef0");
+    assertEquals(parsed.resource.attributes.state, "running");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
 Deno.test("renderModelMethodRun JSON preserves attribute types", () => {
   const dataWithNumber: ModelMethodRunData = {
-    ...testData,
-    resourceAttributes: {
-      count: 42,
-      enabled: true,
+    ...testDataWithData,
+    data: {
+      ...testDataWithData.data!,
+      attributes: {
+        count: 42,
+        enabled: true,
+      },
     },
   };
 
@@ -137,8 +203,8 @@ Deno.test("renderModelMethodRun JSON preserves attribute types", () => {
     renderModelMethodRun(dataWithNumber, "json");
     assertEquals(logs.length, 1);
     const parsed = JSON.parse(logs[0]);
-    assertEquals(parsed.resourceAttributes.count, 42);
-    assertEquals(parsed.resourceAttributes.enabled, true);
+    assertEquals(parsed.data.attributes.count, 42);
+    assertEquals(parsed.data.attributes.enabled, true);
   } finally {
     console.log = originalLog;
   }

--- a/src/presentation/output/model_output_get_output.tsx
+++ b/src/presentation/output/model_output_get_output.tsx
@@ -1,0 +1,255 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { Box, render, Text } from "ink";
+import type { OutputMode } from "./output.tsx";
+
+/**
+ * Data structure for provenance information.
+ */
+export interface ProvenanceData {
+  inputHash: string;
+  modelVersion: number;
+  triggeredBy: string;
+  workflowId?: string;
+  workflowRunId?: string;
+  stepName?: string;
+}
+
+/**
+ * Data structure for artifacts information.
+ */
+export interface ArtifactsData {
+  resourceId?: string;
+  dataId?: string;
+  fileId?: string;
+  logId?: string;
+}
+
+/**
+ * Data structure for error information.
+ */
+export interface ErrorData {
+  message: string;
+  stack?: string;
+}
+
+/**
+ * Data structure for the model output get output.
+ */
+export interface ModelOutputGetData {
+  id: string;
+  modelInputId: string;
+  modelName?: string;
+  type: string;
+  methodName: string;
+  status: string;
+  startedAt: string;
+  completedAt?: string;
+  durationMs?: number;
+  retryCount: number;
+  provenance: ProvenanceData;
+  artifacts?: ArtifactsData;
+  error?: ErrorData;
+}
+
+/**
+ * Renders the model output get output in either interactive or JSON mode.
+ */
+export function renderModelOutputGet(
+  data: ModelOutputGetData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    renderInteractiveModelOutputGet(data);
+  }
+}
+
+function renderInteractiveModelOutputGet(data: ModelOutputGetData): void {
+  const instance = render(<ModelOutputGetDisplay data={data} />);
+  instance.unmount();
+}
+
+interface ModelOutputGetDisplayProps {
+  data: ModelOutputGetData;
+}
+
+/**
+ * Component to display a section with a header.
+ */
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text color="cyan" bold>
+        ## {title}
+      </Text>
+      <Box marginTop={1} marginLeft={2} flexDirection="column">
+        {children}
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * Component to display a key-value pair.
+ */
+function KeyValue({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}): React.ReactElement {
+  return (
+    <Text>
+      <Text color="cyan">{`${label}: `}</Text>
+      <Text>{value}</Text>
+    </Text>
+  );
+}
+
+/**
+ * Gets the status color based on execution status.
+ */
+function getStatusColor(
+  status: string,
+): "green" | "yellow" | "red" | "blue" | undefined {
+  switch (status) {
+    case "succeeded":
+      return "green";
+    case "failed":
+      return "red";
+    case "running":
+      return "yellow";
+    case "pending":
+      return "blue";
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Formats duration in a human-readable way.
+ */
+function formatDuration(ms: number): string {
+  if (ms < 1000) {
+    return `${ms}ms`;
+  } else if (ms < 60000) {
+    return `${(ms / 1000).toFixed(2)}s`;
+  } else {
+    const minutes = Math.floor(ms / 60000);
+    const seconds = ((ms % 60000) / 1000).toFixed(0);
+    return `${minutes}m ${seconds}s`;
+  }
+}
+
+/**
+ * Interactive display component for model output get.
+ */
+export function ModelOutputGetDisplay(
+  props: ModelOutputGetDisplayProps,
+): React.ReactElement {
+  const { data } = props;
+  const hasArtifacts = data.artifacts &&
+    Object.values(data.artifacts).some((v) => v !== undefined);
+
+  return (
+    <Box flexDirection="column">
+      {/* Header */}
+      <Text color="green" bold>
+        # Output: {data.methodName} on {data.modelName ?? data.modelInputId}
+      </Text>
+
+      {/* Basic Info */}
+      <Section title="Output Info">
+        <KeyValue label="ID" value={data.id} />
+        <KeyValue label="Model Input ID" value={data.modelInputId} />
+        {data.modelName && (
+          <KeyValue label="Model Name" value={data.modelName} />
+        )}
+        <KeyValue label="Type" value={data.type} />
+        <KeyValue label="Method" value={data.methodName} />
+        <Box>
+          <Text color="cyan">Status:</Text>
+          <Text color={getStatusColor(data.status)} bold>
+            {data.status.toUpperCase()}
+          </Text>
+        </Box>
+      </Section>
+
+      {/* Timing */}
+      <Section title="Timing">
+        <KeyValue label="Started At" value={data.startedAt} />
+        {data.completedAt && (
+          <KeyValue label="Completed At" value={data.completedAt} />
+        )}
+        {data.durationMs !== undefined && (
+          <KeyValue label="Duration" value={formatDuration(data.durationMs)} />
+        )}
+        <KeyValue label="Retry Count" value={String(data.retryCount)} />
+      </Section>
+
+      {/* Provenance */}
+      <Section title="Provenance">
+        <KeyValue label="Triggered By" value={data.provenance.triggeredBy} />
+        <KeyValue
+          label="Model Version"
+          value={String(data.provenance.modelVersion)}
+        />
+        <KeyValue
+          label="Input Hash"
+          value={data.provenance.inputHash.slice(0, 16) + "..."}
+        />
+        {data.provenance.workflowId && (
+          <KeyValue label="Workflow ID" value={data.provenance.workflowId} />
+        )}
+        {data.provenance.workflowRunId && (
+          <KeyValue
+            label="Workflow Run ID"
+            value={data.provenance.workflowRunId}
+          />
+        )}
+        {data.provenance.stepName && (
+          <KeyValue label="Step Name" value={data.provenance.stepName} />
+        )}
+      </Section>
+
+      {/* Artifacts */}
+      {hasArtifacts && (
+        <Section title="Artifacts">
+          {data.artifacts?.resourceId && (
+            <KeyValue label="Resource ID" value={data.artifacts.resourceId} />
+          )}
+          {data.artifacts?.dataId && (
+            <KeyValue label="Data ID" value={data.artifacts.dataId} />
+          )}
+          {data.artifacts?.fileId && (
+            <KeyValue label="File ID" value={data.artifacts.fileId} />
+          )}
+          {data.artifacts?.logId && (
+            <KeyValue label="Log ID" value={data.artifacts.logId} />
+          )}
+        </Section>
+      )}
+
+      {/* Error */}
+      {data.error && (
+        <Section title="Error">
+          <Text color="red">{data.error.message}</Text>
+          {data.error.stack && (
+            <Box marginTop={1}>
+              <Text dimColor>{data.error.stack}</Text>
+            </Box>
+          )}
+        </Section>
+      )}
+    </Box>
+  );
+}

--- a/src/presentation/output/model_output_search_output.tsx
+++ b/src/presentation/output/model_output_search_output.tsx
@@ -1,0 +1,272 @@
+// deno-lint-ignore verbatim-module-syntax
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Box, render, Text, useApp, useInput } from "ink";
+import type { OutputMode } from "./output.tsx";
+import { Fzf, type FzfResultItem } from "fzf";
+
+/**
+ * Represents a single model output search item.
+ */
+export interface ModelOutputSearchItem {
+  id: string;
+  modelInputId: string;
+  modelName?: string;
+  type: string;
+  methodName: string;
+  status: string;
+  startedAt: string;
+  durationMs?: number;
+}
+
+/**
+ * Data structure for model output search results.
+ */
+export interface ModelOutputSearchData {
+  query: string;
+  results: ModelOutputSearchItem[];
+}
+
+/**
+ * Renders model output search in either interactive or JSON mode.
+ *
+ * @param data - The search data to render
+ * @param mode - The output mode (interactive or json)
+ * @returns A promise that resolves with the selected output in interactive mode, or undefined in JSON mode
+ */
+export async function renderModelOutputSearch(
+  data: ModelOutputSearchData,
+  mode: OutputMode,
+): Promise<ModelOutputSearchItem | undefined> {
+  if (mode === "json") {
+    renderJsonModelOutputSearch(data);
+    return undefined;
+  } else {
+    return await renderInteractiveModelOutputSearch(data);
+  }
+}
+
+/**
+ * Renders model output search as JSON.
+ */
+function renderJsonModelOutputSearch(data: ModelOutputSearchData): void {
+  console.log(JSON.stringify(data, null, 2));
+}
+
+/**
+ * Renders an interactive model output search UI.
+ *
+ * @param data - The initial search data (outputs to search and optional initial query)
+ * @returns A promise that resolves with the selected output, or undefined if cancelled
+ */
+export function renderInteractiveModelOutputSearch(
+  data: ModelOutputSearchData,
+): Promise<ModelOutputSearchItem | undefined> {
+  return new Promise<ModelOutputSearchItem | undefined>((resolve) => {
+    const { waitUntilExit } = render(
+      <ModelOutputSearchUI
+        outputs={data.results}
+        initialQuery={data.query}
+        onSelect={(item) => resolve(item)}
+        onCancel={() => resolve(undefined)}
+      />,
+    );
+    waitUntilExit();
+  });
+}
+
+interface ModelOutputSearchUIProps {
+  outputs: ModelOutputSearchItem[];
+  initialQuery: string;
+  onSelect: (item: ModelOutputSearchItem) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Gets the status color based on execution status.
+ */
+function getStatusColor(
+  status: string,
+): "green" | "yellow" | "red" | "blue" | undefined {
+  switch (status) {
+    case "succeeded":
+      return "green";
+    case "failed":
+      return "red";
+    case "running":
+      return "yellow";
+    case "pending":
+      return "blue";
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Formats duration in a human-readable way.
+ */
+function formatDuration(ms: number): string {
+  if (ms < 1000) {
+    return `${ms}ms`;
+  } else if (ms < 60000) {
+    return `${(ms / 1000).toFixed(1)}s`;
+  } else {
+    const minutes = Math.floor(ms / 60000);
+    const seconds = ((ms % 60000) / 1000).toFixed(0);
+    return `${minutes}m ${seconds}s`;
+  }
+}
+
+/**
+ * Interactive model output search component using fzf for fuzzy matching.
+ */
+export function ModelOutputSearchUI(
+  props: ModelOutputSearchUIProps,
+): React.ReactElement {
+  const { outputs, initialQuery, onSelect, onCancel } = props;
+  const { exit } = useApp();
+
+  const [query, setQuery] = useState(initialQuery);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  // Create fzf instance for fuzzy searching (memoized to avoid recreation on every render)
+  const fzf = useMemo(
+    () =>
+      new Fzf(outputs, {
+        selector: (item) =>
+          `${
+            item.modelName ?? item.modelInputId
+          } ${item.type} ${item.methodName} ${item.status} ${item.id}`,
+      }),
+    [outputs],
+  );
+
+  // Get filtered results
+  const results: FzfResultItem<ModelOutputSearchItem>[] = fzf.find(query);
+  const maxVisible = 10;
+  const visibleResults = results.slice(0, maxVisible);
+
+  // Reset selection when query changes
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  const handleSelect = useCallback(() => {
+    if (results.length > 0 && selectedIndex < results.length) {
+      const selected = results[selectedIndex].item;
+      exit();
+      onSelect(selected);
+    }
+  }, [results, selectedIndex, exit, onSelect]);
+
+  const handleCancel = useCallback(() => {
+    exit();
+    onCancel();
+  }, [exit, onCancel]);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      handleCancel();
+      return;
+    }
+
+    if (key.return) {
+      handleSelect();
+      return;
+    }
+
+    if (key.upArrow) {
+      setSelectedIndex((i) => Math.max(0, i - 1));
+      return;
+    }
+
+    if (key.downArrow) {
+      setSelectedIndex((i) => Math.min(results.length - 1, i + 1));
+      return;
+    }
+
+    if (key.backspace || key.delete) {
+      setQuery((q) => q.slice(0, -1));
+      return;
+    }
+
+    // Handle regular character input
+    if (input && !key.ctrl && !key.meta) {
+      setQuery((q) => q + input);
+    }
+  });
+
+  return (
+    <Box flexDirection="column">
+      {/* Search input */}
+      <Box>
+        <Text color="cyan" bold>
+          Search:{" "}
+        </Text>
+        <Text>{query}</Text>
+        <Text color="gray">|</Text>
+      </Box>
+
+      {/* Results count */}
+      <Box marginTop={1}>
+        <Text dimColor>
+          {results.length} / {outputs.length} outputs
+        </Text>
+      </Box>
+
+      {/* Results list */}
+      <Box flexDirection="column" marginTop={1}>
+        {visibleResults.map((result, index) => (
+          <ModelOutputSearchResultItem
+            key={result.item.id}
+            item={result.item}
+            isSelected={index === selectedIndex}
+          />
+        ))}
+        {results.length > maxVisible && (
+          <Text dimColor>... {results.length - maxVisible} more results</Text>
+        )}
+        {results.length === 0 && (
+          <Text color="yellow">No matching outputs found</Text>
+        )}
+      </Box>
+
+      {/* Help text */}
+      <Box marginTop={1}>
+        <Text dimColor>
+          Up/Down: Navigate | Enter: Select | Esc: Cancel
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+interface ModelOutputSearchResultItemProps {
+  item: ModelOutputSearchItem;
+  isSelected: boolean;
+}
+
+/**
+ * Component to display a single model output search item.
+ */
+function ModelOutputSearchResultItem(
+  props: ModelOutputSearchResultItemProps,
+): React.ReactElement {
+  const { item, isSelected } = props;
+
+  return (
+    <Box>
+      <Text color={isSelected ? "green" : undefined} bold={isSelected}>
+        {isSelected ? "> " : "  "}
+        {item.modelName ?? item.modelInputId.slice(0, 8)}
+      </Text>
+      <Text dimColor></Text>
+      <Text color="cyan">{item.methodName}</Text>
+      <Text dimColor></Text>
+      <Text color={getStatusColor(item.status)}>{item.status}</Text>
+      <Text dimColor></Text>
+      {item.durationMs !== undefined && (
+        <Text dimColor>({formatDuration(item.durationMs)})</Text>
+      )}
+    </Box>
+  );
+}

--- a/src/presentation/output/type_describe_output.tsx
+++ b/src/presentation/output/type_describe_output.tsx
@@ -23,7 +23,8 @@ export interface TypeDescribeData {
   };
   version: number;
   inputAttributesSchema: object;
-  resourceAttributesSchema: object;
+  resourceAttributesSchema?: object;
+  dataAttributesSchema?: object;
   methods: MethodDescribeData[];
 }
 
@@ -137,10 +138,20 @@ export function TypeDescribeDisplay(
       />
 
       {/* Resource Attributes Schema */}
-      <SchemaSection
-        title="Resource Attributes Schema"
-        schema={data.resourceAttributesSchema}
-      />
+      {data.resourceAttributesSchema && (
+        <SchemaSection
+          title="Resource Attributes Schema"
+          schema={data.resourceAttributesSchema}
+        />
+      )}
+
+      {/* Data Attributes Schema */}
+      {data.dataAttributesSchema && (
+        <SchemaSection
+          title="Data Attributes Schema"
+          schema={data.dataAttributesSchema}
+        />
+      )}
 
       {/* Methods */}
       <Box flexDirection="column" marginTop={1}>


### PR DESCRIPTION
## Summary

This PR introduces a complete artifact system that tracks all outputs from model method execution. The refactor establishes a unified architecture for capturing and persisting execution results including logs, files, structured data, and resources.

### Domain Model Changes

**New Artifact Entities:**
- `ModelOutput`: Tracks execution state (pending/running/succeeded/failed), timing, provenance (input hash, trigger type, workflow context), and references to all artifacts produced
- `ModelData`: Ephemeral structured data artifacts stored as YAML in `/data` (not git-tracked)
- `ModelFile`: File artifact metadata (filename, content type, size, SHA-256 checksum) with content stored separately in `/files`
- `ModelLog`: Streaming log artifacts stored as plain text lines in `/logs`, supporting raw output capture

**Repository Interfaces:**
- `OutputRepository`: Execution history at `/outputs/{type}/{method}/{model-id}-{timestamp}.yaml`
- `DataRepository`: Ephemeral data at `/data/{type}/{id}.yaml`
- `FileRepository`: File metadata and content at `/files/{type}/{model-id}/{method}/{filename}`
- `LogRepository`: Streaming log persistence with append support

**Model Definition Updates:**
- Extended `MethodResult` to return data, files, and logs alongside resources
- Added `dataAttributesSchema` to `ModelDefinition` for ephemeral data models
- `MethodContext` includes all repository interfaces

### New Models

**command/curl:**
- HTTP file downloader demonstrating the new artifact system
- Returns resource metadata (URL, status, timing) and file artifact
- Supports configurable method, headers, redirects, and timeout

**systemd/journalctl:**
- System log reader demonstrating log artifacts
- Executes journalctl with configurable filters (unit, time range, priority, grep)
- Streams output line-by-line to ModelLog artifact

### Infrastructure Implementation

**YAML Repositories:**
- `YamlOutputRepository`: Outputs with timestamp-based filenames
- `YamlDataRepository`: Simple YAML persistence for data artifacts

**File System Repositories:**
- `FsFileRepository`: File metadata as YAML with separate content files
- `StreamingLogRepository`: Plain text line appending with metadata header

### CLI Commands

**model output search:**
- Interactive fuzzy search for execution outputs across all model types
- Shows model name, type, method, status, and timing
- Selecting an output displays full details

**model output get:**
- Display detailed execution output by ID or model name
- Shows provenance, artifacts, errors, and timing
- Supports lookup by output ID or model input ID/name

### Updated Components

- **Method Execution Service**: Creates `ModelOutput` to track execution lifecycle, persists all artifact types
- **Echo Model**: Migrated from resource-based to data-based output (demonstrates ephemeral data pattern)
- **Validation Service**: Added data validation support
- **Expression System**: Extended model resolver and dependency extractor for new artifact types

## Test Plan

- All 1031 existing tests pass
- New unit tests for all artifact entities (`model_output_test.ts`, `model_data_test.ts`, `model_file_test.ts`, `model_log_test.ts`)
- New unit tests for all repositories (`yaml_output_repository_test.ts`, `yaml_data_repository_test.ts`, `fs_file_repository_test.ts`, `streaming_log_repository_test.ts`)
- New unit tests for curl model (`curl_model_test.ts`) and journalctl model (`journalctl_model_test.ts`)
- Integration tests updated for new echo model data-based output
- Verified `deno fmt`, `deno lint`, and `deno check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)