### PR TITLE
feat: add support for user-defined TypeScript models

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: swamp-extension-model
+description: Create user-defined TypeScript models for swamp. Use when users want to extend swamp with custom model types, create automation models, or add new integrations. Triggers on "create model", "new model type", "custom model", "extension model", or "user model".
+---
+
+# Swamp Extension Model
+
+Create TypeScript models in `extensions/models/*.ts` that swamp loads at
+startup.
+
+## Quick Start
+
+```typescript
+// extensions/models/my_model.ts
+import { z } from "npm:zod@4";
+
+const InputSchema = z.object({ message: z.string() });
+const DataSchema = z.object({ result: z.string(), timestamp: z.string() });
+
+export const model = {
+  type: "myorg/my-model",
+  version: 1,
+  inputAttributesSchema: InputSchema,
+  dataAttributesSchema: DataSchema, // Use resourceAttributesSchema for persistent output
+  methods: {
+    run: {
+      description: "Process the input",
+      execute: async (input, _context) => ({
+        data: {
+          id: input.id,
+          attributes: {
+            result: input.attributes.message.toUpperCase(),
+            timestamp: new Date().toISOString(),
+          },
+        },
+      }),
+    },
+  },
+};
+```
+
+## Model Structure
+
+| Field                      | Required | Description                            |
+| -------------------------- | -------- | -------------------------------------- |
+| `type`                     | Yes      | Unique identifier (`namespace/name`)   |
+| `version`                  | Yes      | Schema version number                  |
+| `inputAttributesSchema`    | Yes      | Zod schema for input validation        |
+| `dataAttributesSchema`     | Pick one | For ephemeral output (not git-tracked) |
+| `resourceAttributesSchema` | Pick one | For persistent output (git-tracked)    |
+| `methods`                  | Yes      | Object of method definitions           |
+
+## Execute Function
+
+```typescript
+execute: (async (input, context) => {
+  // input.id        - UUID
+  // input.name      - User-provided name
+  // input.attributes - Validated input data
+  // context.repoDir - Repository root path
+
+  return {
+    data: { // Or 'resource' for resourceAttributesSchema
+      id: input.id,
+      attributes: {/* output fields */},
+    },
+  };
+});
+```
+
+## Key Rules
+
+1. **Export**: Must use `export const model = { ... }`
+2. **Import**: Only `import { z } from "npm:zod@4";` is needed
+3. **Type naming**: Use `namespace/name` format to avoid conflicts
+4. **No type annotations**: Avoid TypeScript types in execute parameters
+5. **File naming**: Use snake_case (`my_model.ts`), test files excluded
+
+## References
+
+- **Complete examples**: See [references/examples.md](references/examples.md)
+- **Troubleshooting**: See
+  [references/troubleshooting.md](references/troubleshooting.md)
+
+## Verify
+
+```bash
+swamp type search --json              # Model should appear
+swamp type describe myorg/my-model    # Check schema
+```

--- a/.claude/skills/swamp-extension-model/references/examples.md
+++ b/.claude/skills/swamp-extension-model/references/examples.md
@@ -1,0 +1,167 @@
+# Extension Model Examples
+
+## Data Model (Ephemeral Output)
+
+```typescript
+// extensions/models/text_processor.ts
+import { z } from "npm:zod@4";
+
+const InputSchema = z.object({
+  text: z.string(),
+  operation: z.enum(["uppercase", "lowercase", "reverse"]),
+});
+
+const DataSchema = z.object({
+  originalText: z.string(),
+  processedText: z.string(),
+  operation: z.string(),
+  processedAt: z.string(),
+});
+
+export const model = {
+  type: "myorg/text-processor",
+  version: 1,
+  inputAttributesSchema: InputSchema,
+  dataAttributesSchema: DataSchema,
+  methods: {
+    process: {
+      description: "Process text according to the specified operation",
+      execute: async (input, _context) => {
+        const { text, operation } = input.attributes;
+
+        let processedText: string;
+        switch (operation) {
+          case "uppercase":
+            processedText = text.toUpperCase();
+            break;
+          case "lowercase":
+            processedText = text.toLowerCase();
+            break;
+          case "reverse":
+            processedText = text.split("").reverse().join("");
+            break;
+        }
+
+        return {
+          data: {
+            id: input.id,
+            attributes: {
+              originalText: text,
+              processedText,
+              operation,
+              processedAt: new Date().toISOString(),
+            },
+          },
+        };
+      },
+    },
+  },
+};
+```
+
+## Resource Model (Persistent Output)
+
+```typescript
+// extensions/models/deployment.ts
+import { z } from "npm:zod@4";
+
+const InputSchema = z.object({
+  appName: z.string(),
+  version: z.string(),
+  environment: z.enum(["dev", "staging", "prod"]).default("dev"),
+  replicas: z.number().min(1).max(10).default(1),
+});
+
+const ResourceSchema = z.object({
+  deploymentId: z.string(),
+  appName: z.string(),
+  version: z.string(),
+  environment: z.string(),
+  replicas: z.number(),
+  status: z.enum(["pending", "deployed", "failed"]),
+  deployedAt: z.string(),
+});
+
+export const model = {
+  type: "myorg/deployment",
+  version: 1,
+  inputAttributesSchema: InputSchema,
+  resourceAttributesSchema: ResourceSchema,
+  methods: {
+    deploy: {
+      description: "Deploy the application",
+      execute: async (input, _context) => {
+        const attrs = input.attributes;
+        const deploymentId = `deploy-${attrs.appName}-${Date.now()}`;
+
+        return {
+          resource: {
+            id: input.id,
+            attributes: {
+              deploymentId,
+              appName: attrs.appName,
+              version: attrs.version,
+              environment: attrs.environment ?? "dev",
+              replicas: attrs.replicas ?? 1,
+              status: "deployed",
+              deployedAt: new Date().toISOString(),
+            },
+          },
+        };
+      },
+    },
+    scale: {
+      description: "Scale the deployment replicas",
+      execute: async (input, _context) => {
+        const attrs = input.attributes;
+
+        return {
+          resource: {
+            id: input.id,
+            attributes: {
+              deploymentId: `deploy-${attrs.appName}-scaled`,
+              appName: attrs.appName,
+              version: attrs.version,
+              environment: attrs.environment ?? "dev",
+              replicas: attrs.replicas ?? 1,
+              status: "deployed",
+              deployedAt: new Date().toISOString(),
+            },
+          },
+        };
+      },
+    },
+  },
+};
+```
+
+## Minimal Data Model
+
+```typescript
+// extensions/models/echo.ts
+import { z } from "npm:zod@4";
+
+const InputSchema = z.object({ message: z.string() });
+const DataSchema = z.object({ message: z.string(), timestamp: z.string() });
+
+export const model = {
+  type: "myorg/echo",
+  version: 1,
+  inputAttributesSchema: InputSchema,
+  dataAttributesSchema: DataSchema,
+  methods: {
+    run: {
+      description: "Echo the message with timestamp",
+      execute: async (input, _context) => ({
+        data: {
+          id: input.id,
+          attributes: {
+            message: input.attributes.message,
+            timestamp: new Date().toISOString(),
+          },
+        },
+      }),
+    },
+  },
+};
+```

--- a/.claude/skills/swamp-extension-model/references/troubleshooting.md
+++ b/.claude/skills/swamp-extension-model/references/troubleshooting.md
@@ -1,0 +1,78 @@
+# Troubleshooting Extension Models
+
+## Common Errors
+
+### "No 'model' export found"
+
+Must use named export:
+
+```typescript
+// Wrong
+const model = { ... };
+
+// Correct
+export const model = { ... };
+```
+
+### "Model must have at least one of resourceAttributesSchema or dataAttributesSchema"
+
+Add either `dataAttributesSchema` (ephemeral) or `resourceAttributesSchema`
+(persistent):
+
+```typescript
+export const model = {
+  type: "...",
+  version: 1,
+  inputAttributesSchema: InputSchema,
+  dataAttributesSchema: DataSchema,  // Add this
+  methods: { ... },
+};
+```
+
+### "Model type already registered"
+
+Type name conflicts with built-in or another user model. Use namespaced names:
+
+```typescript
+// Avoid
+type: "echo"; // May conflict
+
+// Use
+type: "mycompany/echo"; // Unique
+```
+
+### Syntax errors on load
+
+Avoid inline TypeScript type annotations in execute parameters:
+
+```typescript
+// Wrong - causes syntax error
+execute: async (input: { id: string }, context: any) => { ... }
+
+// Correct
+execute: async (input, _context) => { ... }
+```
+
+## Configuration
+
+Models directory priority:
+
+| Priority | Method               | Example                          |
+| -------- | -------------------- | -------------------------------- |
+| 1        | Environment variable | `SWAMP_MODELS_DIR=./custom/path` |
+| 2        | `.swamp.yaml` config | `modelsDir: "lib/models"`        |
+| 3        | Default              | `extensions/models`              |
+
+## Verification Commands
+
+```bash
+# Verify model loads
+swamp type search --json
+
+# Check model schema
+swamp type describe myorg/my-model --json
+
+# Test the model
+swamp model create myorg/my-model test --set fieldName="test"
+swamp model method run test methodName --json
+```

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1,4 +1,5 @@
 import { Command } from "@cliffy/command";
+import { resolve } from "@std/path";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
 import { VERSION, versionCommand } from "./commands/version.ts";
 import { modelCommand } from "./commands/model_create.ts";
@@ -12,11 +13,72 @@ import {
   ModelTypeType,
   WorkflowNameType,
 } from "./completion_types.ts";
+import { UserModelLoader } from "../domain/models/user_model_loader.ts";
+import {
+  type RepoMarkerData,
+  RepoMarkerRepository,
+} from "../infrastructure/persistence/repo_marker_repository.ts";
+import { RepoPath } from "../domain/repo/repo_path.ts";
 
 // Import models barrel to trigger self-registration
 import "../domain/models/models.ts";
 
+/**
+ * Resolves the models directory path.
+ * Priority: SWAMP_MODELS_DIR env var > .swamp.yaml config > default "extensions/models"
+ *
+ * @internal Exported for testing
+ */
+export function resolveModelsDir(marker: RepoMarkerData | null): string {
+  // Environment variable takes highest priority
+  const envModelsDir = Deno.env.get("SWAMP_MODELS_DIR");
+  if (envModelsDir) {
+    return envModelsDir;
+  }
+
+  // Then .swamp.yaml config
+  if (marker?.modelsDir) {
+    return marker.modelsDir;
+  }
+
+  // Default
+  return "extensions/models";
+}
+
+/**
+ * Load user models from configured directory.
+ */
+async function loadUserModels(): Promise<void> {
+  const cwd = Deno.cwd();
+  const markerRepo = new RepoMarkerRepository();
+
+  try {
+    const repoPath = RepoPath.create(cwd);
+    const marker = await markerRepo.read(repoPath);
+
+    const modelsDir = resolveModelsDir(marker);
+    // Handle both absolute and relative paths
+    const absoluteModelsDir = modelsDir.startsWith("/")
+      ? modelsDir
+      : resolve(cwd, modelsDir);
+
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(absoluteModelsDir);
+
+    // Log failures as warnings (don't block CLI startup)
+    for (const failure of result.failed) {
+      console.error(
+        `Warning: Failed to load user model ${failure.file}: ${failure.error}`,
+      );
+    }
+  } catch {
+    // Not in a swamp repo or other error - silently skip user models
+  }
+}
+
 export async function runCli(args: string[]): Promise<void> {
+  // Load user models before setting up CLI
+  await loadUserModels();
   const cli = new Command()
     .name("swamp")
     .version(VERSION)

--- a/src/cli/mod_test.ts
+++ b/src/cli/mod_test.ts
@@ -1,0 +1,91 @@
+import { assertEquals } from "@std/assert";
+import { resolveModelsDir } from "./mod.ts";
+
+Deno.test("resolveModelsDir returns default 'extensions/models' when no config", () => {
+  // Ensure env var is not set
+  const original = Deno.env.get("SWAMP_MODELS_DIR");
+  try {
+    Deno.env.delete("SWAMP_MODELS_DIR");
+
+    const result = resolveModelsDir(null);
+    assertEquals(result, "extensions/models");
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_MODELS_DIR", original);
+    }
+  }
+});
+
+Deno.test("resolveModelsDir returns default when marker has no modelsDir", () => {
+  const original = Deno.env.get("SWAMP_MODELS_DIR");
+  try {
+    Deno.env.delete("SWAMP_MODELS_DIR");
+
+    const marker = {
+      swampVersion: "0.1.0",
+      initializedAt: "2024-01-01T00:00:00Z",
+    };
+    const result = resolveModelsDir(marker);
+    assertEquals(result, "extensions/models");
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_MODELS_DIR", original);
+    }
+  }
+});
+
+Deno.test("resolveModelsDir uses marker.modelsDir when set", () => {
+  const original = Deno.env.get("SWAMP_MODELS_DIR");
+  try {
+    Deno.env.delete("SWAMP_MODELS_DIR");
+
+    const marker = {
+      swampVersion: "0.1.0",
+      initializedAt: "2024-01-01T00:00:00Z",
+      modelsDir: "custom/models/path",
+    };
+    const result = resolveModelsDir(marker);
+    assertEquals(result, "custom/models/path");
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_MODELS_DIR", original);
+    }
+  }
+});
+
+Deno.test("resolveModelsDir env var takes priority over marker.modelsDir", () => {
+  const original = Deno.env.get("SWAMP_MODELS_DIR");
+  try {
+    Deno.env.set("SWAMP_MODELS_DIR", "/env/var/path");
+
+    const marker = {
+      swampVersion: "0.1.0",
+      initializedAt: "2024-01-01T00:00:00Z",
+      modelsDir: "custom/models/path",
+    };
+    const result = resolveModelsDir(marker);
+    assertEquals(result, "/env/var/path");
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_MODELS_DIR", original);
+    } else {
+      Deno.env.delete("SWAMP_MODELS_DIR");
+    }
+  }
+});
+
+Deno.test("resolveModelsDir env var takes priority over default", () => {
+  const original = Deno.env.get("SWAMP_MODELS_DIR");
+  try {
+    Deno.env.set("SWAMP_MODELS_DIR", "env/models");
+
+    const result = resolveModelsDir(null);
+    assertEquals(result, "env/models");
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_MODELS_DIR", original);
+    } else {
+      Deno.env.delete("SWAMP_MODELS_DIR");
+    }
+  }
+});

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -1,0 +1,220 @@
+import { z } from "zod";
+import { resolve } from "@std/path";
+import { ModelType } from "./model_type.ts";
+import { ModelResource } from "./model_resource.ts";
+import { ModelData } from "./model_data.ts";
+import type { ModelInput } from "./model_input.ts";
+import {
+  type MethodContext,
+  type MethodDefinition,
+  type MethodResult,
+  type ModelDefinition,
+  modelRegistry,
+} from "./model.ts";
+
+/**
+ * Plain object result returned by user methods before conversion.
+ */
+interface UserMethodResult {
+  resource?: {
+    id: string;
+    attributes: Record<string, unknown>;
+  };
+  data?: {
+    id: string;
+    attributes: Record<string, unknown>;
+  };
+  [key: string]: unknown;
+}
+
+/**
+ * User method execute function type.
+ */
+type UserExecuteFn = (
+  input: ModelInput,
+  context: MethodContext,
+) => Promise<UserMethodResult>;
+
+/**
+ * Schema for validating user method exports.
+ */
+const UserMethodSchema = z.object({
+  description: z.string(),
+  inputAttributesSchema: z.custom<z.ZodTypeAny>((val) =>
+    val instanceof z.ZodType
+  ).optional(),
+  execute: z.custom<UserExecuteFn>((val) => typeof val === "function"),
+}).passthrough();
+
+/**
+ * Schema for validating user model exports.
+ * At least one of resourceAttributesSchema or dataAttributesSchema should be provided.
+ */
+const UserModelSchema = z.object({
+  type: z.string(),
+  version: z.number(),
+  inputAttributesSchema: z.custom<z.ZodTypeAny>((val) =>
+    val instanceof z.ZodType
+  ),
+  resourceAttributesSchema: z.custom<z.ZodTypeAny>((val) =>
+    val instanceof z.ZodType
+  ).optional(),
+  dataAttributesSchema: z.custom<z.ZodTypeAny>((val) =>
+    val instanceof z.ZodType
+  ).optional(),
+  methods: z.record(z.string(), UserMethodSchema),
+}).refine(
+  (data) => data.resourceAttributesSchema || data.dataAttributesSchema,
+  {
+    message:
+      "Model must have at least one of resourceAttributesSchema or dataAttributesSchema",
+  },
+);
+
+/**
+ * Result of loading user models from a directory.
+ */
+export interface LoadResult {
+  loaded: string[];
+  failed: Array<{ file: string; error: string }>;
+}
+
+/**
+ * Loader for user-defined TypeScript models.
+ *
+ * Users export a plain `model` object from their TypeScript files.
+ * This loader validates the structure and registers models with the global registry.
+ */
+export class UserModelLoader {
+  /**
+   * Loads all user models from the specified directory.
+   *
+   * @param modelsDir - The directory containing user model files
+   * @returns Result containing lists of loaded and failed files
+   */
+  async loadModels(modelsDir: string): Promise<LoadResult> {
+    const result: LoadResult = { loaded: [], failed: [] };
+
+    // Check if directory exists
+    try {
+      await Deno.stat(modelsDir);
+    } catch {
+      return result; // No user models directory - not an error
+    }
+
+    const files = await this.discoverModels(modelsDir);
+
+    for (const file of files) {
+      try {
+        const absolutePath = resolve(modelsDir, file);
+        const module = await import(`file://${absolutePath}`);
+
+        if (!module.model) {
+          result.failed.push({ file, error: "No 'model' export found" });
+          continue;
+        }
+
+        // Validate the model structure
+        const parsed = UserModelSchema.safeParse(module.model);
+        if (!parsed.success) {
+          result.failed.push({ file, error: parsed.error.message });
+          continue;
+        }
+
+        // Convert to ModelDefinition and register
+        const userModel = parsed.data;
+        const modelDef = this.convertToModelDefinition(userModel);
+
+        if (!modelRegistry.has(modelDef.type)) {
+          modelRegistry.register(modelDef);
+          result.loaded.push(file);
+        } else {
+          result.failed.push({
+            file,
+            error: `Model type '${userModel.type}' already registered`,
+          });
+        }
+      } catch (error) {
+        result.failed.push({ file, error: String(error) });
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Converts a user model export to a proper ModelDefinition.
+   */
+  private convertToModelDefinition(
+    userModel: z.infer<typeof UserModelSchema>,
+  ): ModelDefinition {
+    const modelType = ModelType.create(userModel.type);
+
+    // Wrap user's execute functions to convert plain objects to proper entities
+    const methods: Record<string, MethodDefinition> = {};
+    for (const [name, method] of Object.entries(userModel.methods)) {
+      methods[name] = {
+        description: method.description,
+        inputAttributesSchema: method.inputAttributesSchema ??
+          userModel.inputAttributesSchema,
+        execute: async (input, context): Promise<MethodResult> => {
+          const userResult = await method.execute(input, context);
+
+          // Convert plain resource object to ModelResource if present
+          let resource: ModelResource | undefined;
+          if (userResult.resource) {
+            if (userResult.resource instanceof ModelResource) {
+              resource = userResult.resource;
+            } else {
+              resource = ModelResource.create({
+                id: userResult.resource.id,
+                attributes: userResult.resource.attributes,
+              });
+            }
+          }
+
+          // Convert plain data object to ModelData if present
+          let data: ModelData | undefined;
+          if (userResult.data) {
+            if (userResult.data instanceof ModelData) {
+              data = userResult.data;
+            } else {
+              data = ModelData.create({
+                id: userResult.data.id,
+                attributes: userResult.data.attributes,
+              });
+            }
+          }
+
+          return { resource, data };
+        },
+      };
+    }
+
+    return {
+      type: modelType,
+      version: userModel.version,
+      inputAttributesSchema: userModel.inputAttributesSchema,
+      resourceAttributesSchema: userModel.resourceAttributesSchema,
+      dataAttributesSchema: userModel.dataAttributesSchema,
+      methods,
+    };
+  }
+
+  /**
+   * Discovers TypeScript model files in the given directory.
+   * Excludes test files.
+   */
+  private async discoverModels(dir: string): Promise<string[]> {
+    const files: string[] = [];
+    for await (const entry of Deno.readDir(dir)) {
+      if (
+        entry.isFile && entry.name.endsWith(".ts") &&
+        !entry.name.endsWith("_test.ts")
+      ) {
+        files.push(entry.name);
+      }
+    }
+    return files.sort();
+  }
+}

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -1,0 +1,481 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { UserModelLoader } from "./user_model_loader.ts";
+import { modelRegistry } from "./model.ts";
+import { ModelResource } from "./model_resource.ts";
+import { ModelData } from "./model_data.ts";
+import { ModelInput } from "./model_input.ts";
+
+// Import models barrel to ensure swamp/echo is registered for duplicate test
+import "./models.ts";
+
+// Helper to create a temporary directory with model files
+async function withTempModels(
+  models: Record<string, string>,
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const tempDir = await Deno.makeTempDir({ prefix: "swamp_test_models_" });
+  try {
+    for (const [filename, content] of Object.entries(models)) {
+      await Deno.writeTextFile(join(tempDir, filename), content);
+    }
+    await fn(tempDir);
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+}
+
+Deno.test("UserModelLoader loads valid model with dataAttributesSchema", async () => {
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+const InputSchema = z.object({
+  message: z.string(),
+});
+
+const DataSchema = z.object({
+  message: z.string(),
+  processedAt: z.string(),
+});
+
+export const model = {
+  type: "test/data-model-${Date.now()}",
+  version: 1,
+  inputAttributesSchema: InputSchema,
+  dataAttributesSchema: DataSchema,
+  methods: {
+    process: {
+      description: "Process the message",
+      execute: async (input, _context) => {
+        return {
+          data: {
+            id: input.id,
+            attributes: {
+              message: input.attributes.message,
+              processedAt: new Date().toISOString(),
+            },
+          },
+        };
+      },
+    },
+  },
+};
+`;
+
+  await withTempModels({ "data_model.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 1);
+    assertEquals(result.loaded[0], "data_model.ts");
+    assertEquals(result.failed.length, 0);
+  });
+});
+
+Deno.test("UserModelLoader loads valid model with resourceAttributesSchema", async () => {
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+const InputSchema = z.object({
+  name: z.string(),
+});
+
+const ResourceSchema = z.object({
+  resourceId: z.string(),
+  status: z.string(),
+});
+
+export const model = {
+  type: "test/resource-model-${Date.now()}",
+  version: 1,
+  inputAttributesSchema: InputSchema,
+  resourceAttributesSchema: ResourceSchema,
+  methods: {
+    create: {
+      description: "Create a resource",
+      execute: async (input, _context) => {
+        return {
+          resource: {
+            id: input.id,
+            attributes: {
+              resourceId: "res-123",
+              status: "created",
+            },
+          },
+        };
+      },
+    },
+  },
+};
+`;
+
+  await withTempModels({ "resource_model.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 1);
+    assertEquals(result.loaded[0], "resource_model.ts");
+    assertEquals(result.failed.length, 0);
+  });
+});
+
+Deno.test("UserModelLoader rejects model with neither schema", async () => {
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+const InputSchema = z.object({
+  message: z.string(),
+});
+
+export const model = {
+  type: "test/invalid-model",
+  version: 1,
+  inputAttributesSchema: InputSchema,
+  methods: {
+    process: {
+      description: "Process something",
+      execute: async () => ({}),
+    },
+  },
+};
+`;
+
+  await withTempModels({ "invalid_model.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 0);
+    assertEquals(result.failed.length, 1);
+    assertEquals(result.failed[0].file, "invalid_model.ts");
+    assertStringIncludes(
+      result.failed[0].error,
+      "Model must have at least one of resourceAttributesSchema or dataAttributesSchema",
+    );
+  });
+});
+
+Deno.test("UserModelLoader handles missing model export", async () => {
+  const modelCode = `
+export const notAModel = { foo: "bar" };
+`;
+
+  await withTempModels({ "no_export.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 0);
+    assertEquals(result.failed.length, 1);
+    assertEquals(result.failed[0].file, "no_export.ts");
+    assertEquals(result.failed[0].error, "No 'model' export found");
+  });
+});
+
+Deno.test("UserModelLoader handles invalid model structure", async () => {
+  const modelCode = `
+export const model = {
+  type: "test/invalid",
+  // Missing required fields
+};
+`;
+
+  await withTempModels({ "invalid_structure.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 0);
+    assertEquals(result.failed.length, 1);
+    assertEquals(result.failed[0].file, "invalid_structure.ts");
+  });
+});
+
+Deno.test("UserModelLoader handles non-existent directory", async () => {
+  const loader = new UserModelLoader();
+  const result = await loader.loadModels("/nonexistent/path/to/models");
+
+  assertEquals(result.loaded.length, 0);
+  assertEquals(result.failed.length, 0);
+});
+
+Deno.test("UserModelLoader skips test files", async () => {
+  const testFile = `
+export const model = { type: "test/should-skip" };
+`;
+  const regularFile = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "test/regular-${Date.now()}",
+  version: 1,
+  inputAttributesSchema: z.object({ msg: z.string() }),
+  dataAttributesSchema: z.object({ result: z.string() }),
+  methods: {
+    run: {
+      description: "Run",
+      execute: async () => ({ data: { id: crypto.randomUUID(), attributes: { result: "ok" } } }),
+    },
+  },
+};
+`;
+
+  await withTempModels(
+    { "model_test.ts": testFile, "model.ts": regularFile },
+    async (dir) => {
+      const loader = new UserModelLoader();
+      const result = await loader.loadModels(dir);
+
+      assertEquals(result.loaded.length, 1);
+      assertEquals(result.loaded[0], "model.ts");
+      // Test file should not appear in failed either
+      assertEquals(result.failed.length, 0);
+    },
+  );
+});
+
+Deno.test("UserModelLoader prevents duplicate type registration", async () => {
+  // First, ensure swamp/echo is registered (it's already in the global registry)
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "swamp/echo",
+  version: 1,
+  inputAttributesSchema: z.object({ message: z.string() }),
+  dataAttributesSchema: z.object({ message: z.string() }),
+  methods: {
+    write: {
+      description: "Write message",
+      execute: async () => ({}),
+    },
+  },
+};
+`;
+
+  await withTempModels({ "duplicate.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 0);
+    assertEquals(result.failed.length, 1);
+    assertEquals(result.failed[0].file, "duplicate.ts");
+    assertStringIncludes(result.failed[0].error, "already registered");
+  });
+});
+
+Deno.test("UserModelLoader converts plain resource objects to ModelResource", async () => {
+  const typeId = `test/convert-resource-${Date.now()}`;
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+const InputSchema = z.object({
+  name: z.string(),
+});
+
+const ResourceSchema = z.object({
+  id: z.string(),
+});
+
+export const model = {
+  type: "${typeId}",
+  version: 1,
+  inputAttributesSchema: InputSchema,
+  resourceAttributesSchema: ResourceSchema,
+  methods: {
+    create: {
+      description: "Create a resource",
+      execute: async (input, _context) => {
+        // Return a plain object, not a ModelResource instance
+        return {
+          resource: {
+            id: input.id,
+            attributes: {
+              id: "resource-" + input.id,
+            },
+          },
+        };
+      },
+    },
+  },
+};
+`;
+
+  await withTempModels({ "convert_resource.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 1);
+
+    // Get the registered model and execute its method
+    const modelDef = modelRegistry.get(typeId);
+    assertEquals(modelDef !== undefined, true);
+
+    const input = ModelInput.create({
+      name: "test-input",
+      attributes: { name: "test" },
+    });
+    const methodResult = await modelDef!.methods.create.execute(input, {
+      repoDir: "/tmp",
+    });
+
+    // Verify the resource was converted to a ModelResource instance
+    assertEquals(methodResult.resource instanceof ModelResource, true);
+    assertEquals(String(methodResult.resource?.id), String(input.id));
+  });
+});
+
+Deno.test("UserModelLoader converts plain data objects to ModelData", async () => {
+  const typeId = `test/convert-data-${Date.now()}`;
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+const InputSchema = z.object({
+  value: z.string(),
+});
+
+const DataSchema = z.object({
+  processedValue: z.string(),
+});
+
+export const model = {
+  type: "${typeId}",
+  version: 1,
+  inputAttributesSchema: InputSchema,
+  dataAttributesSchema: DataSchema,
+  methods: {
+    process: {
+      description: "Process data",
+      execute: async (input, _context) => {
+        // Return a plain object, not a ModelData instance
+        return {
+          data: {
+            id: input.id,
+            attributes: {
+              processedValue: input.attributes.value.toUpperCase(),
+            },
+          },
+        };
+      },
+    },
+  },
+};
+`;
+
+  await withTempModels({ "convert_data.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 1);
+
+    // Get the registered model and execute its method
+    const modelDef = modelRegistry.get(typeId);
+    assertEquals(modelDef !== undefined, true);
+
+    const input = ModelInput.create({
+      name: "test-input",
+      attributes: { value: "hello" },
+    });
+    const methodResult = await modelDef!.methods.process.execute(input, {
+      repoDir: "/tmp",
+    });
+
+    // Verify the data was converted to a ModelData instance
+    assertEquals(methodResult.data instanceof ModelData, true);
+    assertEquals(String(methodResult.data?.id), String(input.id));
+    assertEquals(methodResult.data?.attributes.processedValue, "HELLO");
+  });
+});
+
+Deno.test("UserModelLoader uses model inputAttributesSchema when method lacks one", async () => {
+  const typeId = `test/method-inherits-schema-${Date.now()}`;
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+const InputSchema = z.object({
+  message: z.string(),
+});
+
+const DataSchema = z.object({
+  result: z.string(),
+});
+
+export const model = {
+  type: "${typeId}",
+  version: 1,
+  inputAttributesSchema: InputSchema,
+  dataAttributesSchema: DataSchema,
+  methods: {
+    run: {
+      description: "Run without own schema",
+      // No inputAttributesSchema here - should inherit from model
+      execute: async (input, _context) => {
+        return {
+          data: {
+            id: input.id,
+            attributes: {
+              result: "processed",
+            },
+          },
+        };
+      },
+    },
+  },
+};
+`;
+
+  await withTempModels({ "inherit_schema.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 1);
+
+    const modelDef = modelRegistry.get(typeId);
+    assertEquals(modelDef !== undefined, true);
+
+    // Verify the method has an inputAttributesSchema (inherited from model)
+    assertEquals(
+      modelDef!.methods.run.inputAttributesSchema !== undefined,
+      true,
+    );
+  });
+});
+
+Deno.test("UserModelLoader loads multiple models from directory", async () => {
+  const model1 = `
+import { z } from "npm:zod@4";
+export const model = {
+  type: "test/multi-a-${Date.now()}",
+  version: 1,
+  inputAttributesSchema: z.object({ a: z.string() }),
+  dataAttributesSchema: z.object({ a: z.string() }),
+  methods: {
+    run: { description: "Run A", execute: async (i) => ({ data: { id: i.id, attributes: { a: "a" } } }) },
+  },
+};
+`;
+
+  const model2 = `
+import { z } from "npm:zod@4";
+export const model = {
+  type: "test/multi-b-${Date.now()}",
+  version: 1,
+  inputAttributesSchema: z.object({ b: z.string() }),
+  dataAttributesSchema: z.object({ b: z.string() }),
+  methods: {
+    run: { description: "Run B", execute: async (i) => ({ data: { id: i.id, attributes: { b: "b" } } }) },
+  },
+};
+`;
+
+  await withTempModels(
+    { "model_a.ts": model1, "model_b.ts": model2 },
+    async (dir) => {
+      const loader = new UserModelLoader();
+      const result = await loader.loadModels(dir);
+
+      assertEquals(result.loaded.length, 2);
+      assertEquals(result.failed.length, 0);
+      // Files should be sorted alphabetically
+      assertEquals(result.loaded[0], "model_a.ts");
+      assertEquals(result.loaded[1], "model_b.ts");
+    },
+  );
+});

--- a/src/infrastructure/assets/skill_assets.ts
+++ b/src/infrastructure/assets/skill_assets.ts
@@ -16,6 +16,18 @@ export interface SkillInfo {
 const BUNDLED_SKILLS: SkillInfo[] = [
   { relativePath: "swamp-model/SKILL.md", name: "swamp-model" },
   { relativePath: "swamp-workflow/SKILL.md", name: "swamp-workflow" },
+  {
+    relativePath: "swamp-extension-model/SKILL.md",
+    name: "swamp-extension-model",
+  },
+  {
+    relativePath: "swamp-extension-model/references/examples.md",
+    name: "swamp-extension-model",
+  },
+  {
+    relativePath: "swamp-extension-model/references/troubleshooting.md",
+    name: "swamp-extension-model",
+  },
 ];
 
 /**

--- a/src/infrastructure/assets/skill_assets_test.ts
+++ b/src/infrastructure/assets/skill_assets_test.ts
@@ -112,3 +112,41 @@ Deno.test("SkillAssets.copySkillsTo rejects path traversal attempts", async () =
     assertEquals(realPath.startsWith(await Deno.realPath(dir)), true);
   });
 });
+
+Deno.test("SkillAssets includes swamp-extension-model skill", () => {
+  const assets = new SkillAssets();
+  const names = assets.getSkillNames();
+
+  assertEquals(names.includes("swamp-extension-model"), true);
+});
+
+Deno.test("SkillAssets.copySkillsTo copies nested reference files", async () => {
+  await withTempDir(async (dir) => {
+    const assets = new SkillAssets();
+    await assets.copySkillsTo(dir);
+
+    // Check that swamp-extension-model skill and references were copied
+    const skillPath = join(dir, "swamp-extension-model", "SKILL.md");
+    const examplesPath = join(
+      dir,
+      "swamp-extension-model",
+      "references",
+      "examples.md",
+    );
+    const troubleshootingPath = join(
+      dir,
+      "swamp-extension-model",
+      "references",
+      "troubleshooting.md",
+    );
+
+    const skillStat = await Deno.stat(skillPath);
+    assertEquals(skillStat.isFile, true);
+
+    const examplesStat = await Deno.stat(examplesPath);
+    assertEquals(examplesStat.isFile, true);
+
+    const troubleshootingStat = await Deno.stat(troubleshootingPath);
+    assertEquals(troubleshootingStat.isFile, true);
+  });
+});

--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -12,6 +12,7 @@ export interface RepoMarkerData {
   swampVersion: string;
   initializedAt: string;
   upgradedAt?: string;
+  modelsDir?: string;
 }
 
 /**


### PR DESCRIPTION
- Add support for user-defined TypeScript models loaded from `extensions/models/`
- Users export a plain `model` object with Zod schemas - no swamp imports needed
- Models are validated and registered at CLI startup
- Create `swamp-extension-model` skill to guide model creation

## Changes

### User Model Loader
- New `UserModelLoader` class that discovers, validates, and registers user models
- Validates model structure using Zod schemas
- Requires at least one of `dataAttributesSchema` or `resourceAttributesSchema`
- Converts plain result objects to `ModelResource`/`ModelData` instances
- Added `modelsDir` config option to `.swamp.yaml`

### Configuration
Models directory resolution (priority order):
1. `SWAMP_MODELS_DIR` environment variable
2. `modelsDir` in `.swamp.yaml`
3. Default: `extensions/models`

### Skill
- Created `swamp-extension-model` skill with progressive disclosure
- Core workflow in SKILL.md (~70 lines)
- Complete examples in `references/examples.md`
- Troubleshooting guide in `references/troubleshooting.md`
- Skill is bundled with `swamp repo init` and `swamp repo upgrade`

### Zod Version Consistency
- User models use `npm:zod@4` to match swamp's internal zod version
- Ensures schema compatibility between user models and swamp core