### PR TITLE
Address PR feedback from #61 and #62

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ swamp completions fish > ~/.config/fish/completions/swamp.fish
 Model and workflow name completions are directory-dependent. They return names
 from the current working directory's swamp repository.
 
+## User-Defined Models
+
+You can extend swamp with custom TypeScript models. Place your models in the
+`extensions/models/` directory (or configure via `SWAMP_MODELS_DIR` environment
+variable or `.swamp.yaml`).
+
+For detailed instructions on creating user-defined models, see the
+[swamp-extension-model skill documentation](.claude/skills/swamp-extension-model/SKILL.md).
+
 ## Development
 
 ```bash

--- a/design/models.md
+++ b/design/models.md
@@ -126,6 +126,25 @@ The valid shape of data is specfiied with a zod 4 schema.
 
 Data is not tracked in git.
 
+### When to Use Resource vs Data
+
+Use **resource artifacts** when:
+
+- The data represents state that should persist across executions (e.g., cloud
+  resource metadata, deployment status)
+- You need to track changes over time via git history
+- The data is needed for drift detection or reconciliation
+- Other team members need visibility into the current state
+
+Use **data artifacts** when:
+
+- The data is ephemeral or only relevant to a single execution (e.g., API
+  responses, query results)
+- The output changes frequently and git history would add noise
+- The data is large or contains sensitive information that shouldn't be
+  committed
+- You're capturing intermediate results that don't represent durable state
+
 ## Output
 
 Each method invocation produces an output record, which gets tracked in the

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -5,11 +5,12 @@ import {
   renderModelMethodRun,
 } from "../../presentation/output/model_method_run_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
-import {
-  createModelInputId,
-  type ModelInput,
-} from "../../domain/models/model_input.ts";
+import type { ModelInput } from "../../domain/models/model_input.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
+import {
+  findInputByIdGlobal,
+  isUuid,
+} from "../../domain/models/model_lookup.ts";
 import {
   computeInputHash,
   ModelOutput,
@@ -23,38 +24,9 @@ import { FileSystemFileRepository } from "../../infrastructure/persistence/fs_fi
 import { modelRegistry } from "../../domain/models/model.ts";
 import { DefaultMethodExecutionService } from "../../domain/models/method_execution_service.ts";
 
-/**
- * UUID v4 regex pattern for detecting if an argument is a UUID.
- */
-const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
-/**
- * Checks if a string looks like a UUID.
- */
-function isUuid(value: string): boolean {
-  return UUID_PATTERN.test(value);
-}
-
-/**
- * Finds an input by ID, searching across all registered model types.
- */
-async function findInputByIdGlobal(
-  inputRepo: YamlInputRepository,
-  id: string,
-): Promise<{ input: ModelInput; type: ModelType } | null> {
-  const inputId = createModelInputId(id);
-
-  for (const type of modelRegistry.types()) {
-    const input = await inputRepo.findById(type, inputId);
-    if (input) {
-      return { input, type };
-    }
-  }
-
-  return null;
-}
-
+// Cliffy's custom type system returns `unknown` for custom types like `model_name`,
+// but we need to pass `options` to functions expecting specific types. Using `any`
+// here is the pragmatic workaround for Cliffy's type inference limitations.
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 

--- a/src/cli/commands/model_output_get.ts
+++ b/src/cli/commands/model_output_get.ts
@@ -18,6 +18,9 @@ import {
   isUuid,
 } from "../../domain/models/model_lookup.ts";
 
+// Cliffy's custom type system returns `unknown` for custom types like `model_name`,
+// but we need to pass `options` to functions expecting specific types. Using `any`
+// here is the pragmatic workaround for Cliffy's type inference limitations.
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 

--- a/src/cli/commands/model_output_search.ts
+++ b/src/cli/commands/model_output_search.ts
@@ -14,6 +14,9 @@ import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_outp
 import type { ModelOutput } from "../../domain/models/model_output.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
 
+// Cliffy's custom type system returns `unknown` for custom types like `model_name`,
+// but we need to pass `options` to functions expecting specific types. Using `any`
+// here is the pragmatic workaround for Cliffy's type inference limitations.
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1,5 +1,5 @@
 import { Command } from "@cliffy/command";
-import { resolve } from "@std/path";
+import { isAbsolute, resolve } from "@std/path";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
 import { VERSION, versionCommand } from "./commands/version.ts";
 import { modelCommand } from "./commands/model_create.ts";
@@ -57,8 +57,8 @@ async function loadUserModels(): Promise<void> {
     const marker = await markerRepo.read(repoPath);
 
     const modelsDir = resolveModelsDir(marker);
-    // Handle both absolute and relative paths
-    const absoluteModelsDir = modelsDir.startsWith("/")
+    // Handle both absolute and relative paths (cross-platform)
+    const absoluteModelsDir = isAbsolute(modelsDir)
       ? modelsDir
       : resolve(cwd, modelsDir);
 
@@ -71,8 +71,11 @@ async function loadUserModels(): Promise<void> {
         `Warning: Failed to load user model ${failure.file}: ${failure.error}`,
       );
     }
-  } catch {
-    // Not in a swamp repo or other error - silently skip user models
+  } catch (error) {
+    // Not in a swamp repo or other error - log at debug level for troubleshooting
+    if (Deno.env.get("SWAMP_DEBUG")) {
+      console.debug(`Skipping user models: ${error}`);
+    }
   }
 }
 

--- a/src/domain/models/command/curl/curl_model.ts
+++ b/src/domain/models/command/curl/curl_model.ts
@@ -21,7 +21,13 @@ export const CurlInputAttributesSchema = z.object({
   /** Optional HTTP headers */
   headers: z.record(z.string(), z.string()).optional(),
   /** Optional filename for the downloaded file (defaults to URL basename) */
-  outputFilename: z.string().optional(),
+  outputFilename: z.string()
+    .refine(
+      (name) =>
+        !name.includes("/") && !name.includes("\\") && !name.includes(".."),
+      { message: "Filename cannot contain path separators or '..' sequences" },
+    )
+    .optional(),
   /** Whether to follow redirects (default: true) */
   followRedirects: z.boolean().default(true),
   /** Request timeout in milliseconds */

--- a/src/domain/models/model_log.ts
+++ b/src/domain/models/model_log.ts
@@ -73,16 +73,23 @@ export class LogEntry {
 
   /**
    * Converts the entry to a plain text line for storage.
-   * Returns just the raw message without JSON wrapping.
+   *
+   * Note: Despite the name, this returns plain text, not JSON. The naming is
+   * historical - these methods originally used JSON Lines format but were
+   * simplified to plain text to preserve raw command output exactly as-is.
+   * Kept for API compatibility with StreamingLogRepository.
    */
-  toJsonLine(): string {
+  toLine(): string {
     return this.message;
   }
 
   /**
    * Parses a LogEntry from a plain text line.
+   *
+   * Note: Despite the name, this parses plain text, not JSON. See toLine()
+   * for naming rationale.
    */
-  static fromJsonLine(line: string): LogEntry {
+  static fromLine(line: string): LogEntry {
     return new LogEntry(line);
   }
 }
@@ -210,15 +217,21 @@ export class ModelLog {
   /**
    * Converts entries to plain text lines format for streaming persistence.
    * Each entry is stored as a raw line.
+   *
+   * Note: Despite the name, this returns plain text, not JSON Lines format.
+   * See LogEntry.toLine() for naming rationale.
    */
-  toJsonLines(): string {
-    return this._entries.map((e) => e.toJsonLine()).join("\n");
+  toLines(): string {
+    return this._entries.map((e) => e.toLine()).join("\n");
   }
 
   /**
    * Creates a ModelLog from plain text lines format.
+   *
+   * Note: Despite the name, this parses plain text, not JSON Lines format.
+   * See LogEntry.fromLine() for naming rationale.
    */
-  static fromJsonLines(
+  static fromLines(
     id: string,
     version: number,
     createdAt: Date,
@@ -227,7 +240,7 @@ export class ModelLog {
     const entries = lines
       .split("\n")
       .filter((line) => line.length > 0)
-      .map((line) => LogEntry.fromJsonLine(line));
+      .map((line) => LogEntry.fromLine(line));
 
     return new ModelLog(
       createModelLogId(id),

--- a/src/domain/models/model_log_test.ts
+++ b/src/domain/models/model_log_test.ts
@@ -27,24 +27,24 @@ Deno.test("LogEntry toData/fromData roundtrip", () => {
   assertEquals(restored.message, entry.message);
 });
 
-Deno.test("LogEntry toJsonLine returns raw message", () => {
+Deno.test("LogEntry toLine returns raw message", () => {
   const entry = LogEntry.create("Raw log line");
-  const line = entry.toJsonLine();
+  const line = entry.toLine();
 
   assertEquals(line, "Raw log line");
 });
 
-Deno.test("LogEntry fromJsonLine parses raw line", () => {
+Deno.test("LogEntry fromLine parses raw line", () => {
   const line = "Jan 01 12:00:00 host systemd[1]: Started service";
-  const entry = LogEntry.fromJsonLine(line);
+  const entry = LogEntry.fromLine(line);
 
   assertEquals(entry.message, line);
 });
 
-Deno.test("LogEntry toJsonLine/fromJsonLine roundtrip", () => {
+Deno.test("LogEntry toLine/fromLine roundtrip", () => {
   const original = LogEntry.create("Debug info");
-  const line = original.toJsonLine();
-  const restored = LogEntry.fromJsonLine(line);
+  const line = original.toLine();
+  const restored = LogEntry.fromLine(line);
 
   assertEquals(restored.message, original.message);
 });
@@ -198,14 +198,14 @@ Deno.test("ModelLog fromData with explicit data", () => {
   assertEquals(log.entries[0].message, "Test entry");
 });
 
-Deno.test("ModelLog toJsonLines/fromJsonLines roundtrip", () => {
+Deno.test("ModelLog toLines/fromLines roundtrip", () => {
   const log = ModelLog.create({});
   log.log("Line 1");
   log.log("Line 2");
   log.log("Line 3");
 
-  const lines = log.toJsonLines();
-  const restored = ModelLog.fromJsonLines(
+  const lines = log.toLines();
+  const restored = ModelLog.fromLines(
     log.id,
     log.version,
     log.createdAt,
@@ -218,22 +218,22 @@ Deno.test("ModelLog toJsonLines/fromJsonLines roundtrip", () => {
   assertEquals(restored.entries[2].message, "Line 3");
 });
 
-Deno.test("ModelLog.toJsonLines returns plain text lines", () => {
+Deno.test("ModelLog.toLines returns plain text lines", () => {
   const log = ModelLog.create({});
   log.log("first line");
   log.log("second line");
 
-  const lines = log.toJsonLines();
+  const lines = log.toLines();
 
   assertEquals(lines, "first line\nsecond line");
 });
 
-Deno.test("ModelLog.fromJsonLines handles empty lines in input", () => {
+Deno.test("ModelLog.fromLines handles empty lines in input", () => {
   const lines = `Line 1
 
 Line 2
 `;
-  const log = ModelLog.fromJsonLines(
+  const log = ModelLog.fromLines(
     "550e8400-e29b-41d4-a716-446655440000",
     1,
     new Date(),

--- a/src/infrastructure/persistence/streaming_log_repository.ts
+++ b/src/infrastructure/persistence/streaming_log_repository.ts
@@ -54,7 +54,7 @@ export class StreamingLogRepository implements LogRepository {
         // No entries file yet is fine
       }
 
-      return ModelLog.fromJsonLines(
+      return ModelLog.fromLines(
         metadata.id,
         metadata.version,
         new Date(metadata.createdAt),
@@ -117,7 +117,7 @@ export class StreamingLogRepository implements LogRepository {
     try {
       const encoder = new TextEncoder();
       for (const entry of log.entries) {
-        await file.write(encoder.encode(entry.toJsonLine() + "\n"));
+        await file.write(encoder.encode(entry.toLine() + "\n"));
       }
     } finally {
       file.close();
@@ -133,7 +133,7 @@ export class StreamingLogRepository implements LogRepository {
     await ensureDir(dir);
 
     const entriesPath = this.getPath(type, id);
-    const line = entry.toJsonLine() + "\n";
+    const line = entry.toLine() + "\n";
 
     // Append to file (creates if doesn't exist)
     const file = await Deno.open(entriesPath, {
@@ -184,14 +184,14 @@ export class StreamingLogRepository implements LogRepository {
           buffer = buffer.slice(newlineIndex + 1);
 
           if (line.length > 0) {
-            yield LogEntry.fromJsonLine(line);
+            yield LogEntry.fromLine(line);
           }
         }
       }
 
       // Process any remaining content
       if (buffer.length > 0) {
-        yield LogEntry.fromJsonLine(buffer);
+        yield LogEntry.fromLine(buffer);
       }
     } finally {
       file.close();


### PR DESCRIPTION
- Add README section about user-defined models with link to skill documentation
- Improve error handling in `loadUserModels()` with debug logging via `SWAMP_DEBUG` env var
- Use `isAbsolute()` from `@std/path` for cross-platform Windows compatibility
- Add explanatory comments for Cliffy type workarounds in CLI commands
- Remove UUID pattern duplication by importing from `model_lookup.ts`
- Rename `toJsonLine()`/`fromJsonLine()` to `toLine()`/`fromLine()` with documentation clarifying historical
naming
- Add path traversal validation for `outputFilename` in curl model
- Add guidance on when to use data vs resource artifacts in design doc

## Test plan
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] All 1069 tests pass
- [x] Binary compiles successfully