### PR TITLE
feat: add webapp as experiment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ resources/
 inputs-evaluated/
 workflows-evaluated/
 test-repo/
+experiments/webapp/frontend/node_modules/
+experiments/webapp/frontend/dist/
+experiments/webapp/frontend/tsconfig.tsbuildinfo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,3 +62,15 @@ After completing work, run these checks:
 - Use `ink-testing-library` for testing Ink components
 - Test private functions indirectly through public APIs
 - Run tests with `deno task test`
+
+## Experiments
+
+The `experiments/` directory contains optional, self-contained experiments. **Do
+not** include experiments in:
+
+- Testing or test coverage considerations
+- Refactoring or code improvement efforts
+- New feature development patterns
+- Architecture decisions
+
+These are isolated experiments that may be removed at any time.

--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,9 @@
     "check": "deno check main.ts",
     "lint": "deno lint",
     "fmt": "deno fmt",
-    "compile": "deno compile --allow-read --allow-write --allow-env --allow-run --allow-sys --allow-net --include .claude/skills --output swamp main.ts"
+    "webapp:install": "cd experiments/webapp/frontend && npm install",
+    "webapp:build": "cd experiments/webapp/frontend && npm run build",
+    "compile": "deno compile --allow-read --allow-write --allow-env --allow-run --allow-sys --allow-net --include .claude/skills --include experiments/webapp/frontend/dist --output swamp main.ts"
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@1",
@@ -30,5 +32,6 @@
   "compilerOptions": {
     "jsx": "react",
     "strict": true
-  }
+  },
+  "exclude": ["experiments/"]
 }

--- a/experiments/webapp/backend/handlers/models_handler.ts
+++ b/experiments/webapp/backend/handlers/models_handler.ts
@@ -1,0 +1,245 @@
+/**
+ * HTTP handlers for model inputs API endpoints.
+ */
+
+import type { RouteContext } from "../router.ts";
+import { errorResponse, jsonResponse } from "../router.ts";
+import { ModelType } from "../../../../src/domain/models/model_type.ts";
+import {
+  createModelInputId,
+  ModelInput,
+} from "../../../../src/domain/models/model_input.ts";
+import type { InputRepository } from "../../../../src/domain/models/repositories.ts";
+import { findInputByIdGlobal } from "../../../../src/domain/models/model_lookup.ts";
+import type { YamlInputRepository } from "../../../../src/infrastructure/persistence/yaml_input_repository.ts";
+
+export function createModelsHandlers(inputRepository: InputRepository) {
+  async function listAllModels(_ctx: RouteContext): Promise<Response> {
+    const allInputs = await inputRepository.findAllGlobal();
+
+    const models = allInputs.map(({ input, type }) => ({
+      id: input.id,
+      name: input.name,
+      type: { raw: type.raw, normalized: type.normalized },
+      version: input.version,
+      resourceId: input.resourceId,
+      tags: input.tags,
+      attributes: input.attributes,
+    }));
+
+    return jsonResponse({ models });
+  }
+
+  async function listModelsByType(ctx: RouteContext): Promise<Response> {
+    const typeParam = ctx.params.type;
+
+    try {
+      const modelType = ModelType.create(typeParam);
+      const inputs = await inputRepository.findAll(modelType);
+
+      const models = inputs.map((input) => ({
+        id: input.id,
+        name: input.name,
+        type: { raw: modelType.raw, normalized: modelType.normalized },
+        version: input.version,
+        resourceId: input.resourceId,
+        tags: input.tags,
+        attributes: input.attributes,
+      }));
+
+      return jsonResponse({ models });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return errorResponse(message, 400);
+    }
+  }
+
+  async function getModel(ctx: RouteContext): Promise<Response> {
+    const { type: typeParam, id: idParam } = ctx.params;
+
+    try {
+      const modelType = ModelType.create(typeParam);
+      const id = createModelInputId(idParam);
+      const input = await inputRepository.findById(modelType, id);
+
+      if (!input) {
+        return errorResponse("Model input not found", 404);
+      }
+
+      return jsonResponse({
+        id: input.id,
+        name: input.name,
+        type: { raw: modelType.raw, normalized: modelType.normalized },
+        version: input.version,
+        resourceId: input.resourceId,
+        tags: input.tags,
+        attributes: input.attributes,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return errorResponse(message, 400);
+    }
+  }
+
+  async function createModel(ctx: RouteContext): Promise<Response> {
+    const typeParam = ctx.params.type;
+
+    try {
+      const modelType = ModelType.create(typeParam);
+      const body = await ctx.request.json();
+
+      if (body.name) {
+        const existing = await inputRepository.findByNameGlobal(body.name);
+        if (existing) {
+          return errorResponse(
+            `Model with name '${body.name}' already exists`,
+            409,
+          );
+        }
+      }
+
+      const input = ModelInput.create({
+        name: body.name,
+        version: body.version,
+        resourceId: body.resourceId,
+        tags: body.tags,
+        attributes: body.attributes,
+      });
+
+      await inputRepository.save(modelType, input);
+
+      return jsonResponse(
+        {
+          id: input.id,
+          name: input.name,
+          type: { raw: modelType.raw, normalized: modelType.normalized },
+          version: input.version,
+          resourceId: input.resourceId,
+          tags: input.tags,
+          attributes: input.attributes,
+        },
+        201,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return errorResponse(message, 400);
+    }
+  }
+
+  async function updateModel(ctx: RouteContext): Promise<Response> {
+    const { type: typeParam, id: idParam } = ctx.params;
+
+    try {
+      const modelType = ModelType.create(typeParam);
+      const id = createModelInputId(idParam);
+
+      const existing = await inputRepository.findById(modelType, id);
+      if (!existing) {
+        return errorResponse("Model input not found", 404);
+      }
+
+      const body = await ctx.request.json();
+
+      if (body.name && body.name !== existing.name) {
+        const existingWithName = await inputRepository.findByNameGlobal(
+          body.name,
+        );
+        if (existingWithName) {
+          return errorResponse(
+            `Model with name '${body.name}' already exists`,
+            409,
+          );
+        }
+      }
+
+      const updated = ModelInput.create({
+        id: existing.id,
+        name: body.name ?? existing.name,
+        version: body.version ?? existing.version,
+        resourceId: body.resourceId ?? existing.resourceId,
+        tags: body.tags ?? existing.tags,
+        attributes: body.attributes ?? existing.attributes,
+      });
+
+      await inputRepository.save(modelType, updated);
+
+      return jsonResponse({
+        id: updated.id,
+        name: updated.name,
+        type: { raw: modelType.raw, normalized: modelType.normalized },
+        version: updated.version,
+        resourceId: updated.resourceId,
+        tags: updated.tags,
+        attributes: updated.attributes,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return errorResponse(message, 400);
+    }
+  }
+
+  async function deleteModel(ctx: RouteContext): Promise<Response> {
+    const { type: typeParam, id: idParam } = ctx.params;
+
+    try {
+      const modelType = ModelType.create(typeParam);
+      const id = createModelInputId(idParam);
+
+      const existing = await inputRepository.findById(modelType, id);
+      if (!existing) {
+        return errorResponse("Model input not found", 404);
+      }
+
+      await inputRepository.delete(modelType, id);
+
+      return new Response(null, { status: 204 });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return errorResponse(message, 400);
+    }
+  }
+
+  async function lookupModelById(ctx: RouteContext): Promise<Response> {
+    const { id: idParam } = ctx.params;
+
+    try {
+      // Try by name first (most common case in workflows)
+      const byName = await inputRepository.findByNameGlobal(idParam);
+      if (byName) {
+        return jsonResponse({
+          id: byName.input.id,
+          type: byName.type.normalized,
+          name: byName.input.name,
+        });
+      }
+
+      // Fall back to searching by ID
+      const byId = await findInputByIdGlobal(
+        inputRepository as YamlInputRepository,
+        idParam,
+      );
+      if (byId) {
+        return jsonResponse({
+          id: byId.input.id,
+          type: byId.type.normalized,
+          name: byId.input.name,
+        });
+      }
+
+      return errorResponse("Model not found", 404);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return errorResponse(message, 400);
+    }
+  }
+
+  return {
+    listAllModels,
+    listModelsByType,
+    getModel,
+    createModel,
+    updateModel,
+    deleteModel,
+    lookupModelById,
+  };
+}

--- a/experiments/webapp/backend/handlers/models_handler_test.ts
+++ b/experiments/webapp/backend/handlers/models_handler_test.ts
@@ -1,0 +1,206 @@
+import { assertEquals } from "@std/assert";
+import { createModelsHandlers } from "./models_handler.ts";
+import type { InputRepository } from "../../../../src/domain/models/repositories.ts";
+import type { ModelType } from "../../../../src/domain/models/model_type.ts";
+import type {
+  ModelInput,
+  ModelInputId,
+} from "../../../../src/domain/models/model_input.ts";
+
+// Mock repository for testing
+function createMockRepository(
+  inputs: { input: ModelInput; type: ModelType }[] = [],
+): InputRepository {
+  const storage = new Map<string, { input: ModelInput; type: ModelType }>();
+
+  for (const item of inputs) {
+    storage.set(item.input.id, item);
+  }
+
+  return {
+    findById(
+      type: ModelType,
+      id: ModelInputId,
+    ): Promise<ModelInput | null> {
+      const item = storage.get(id);
+      if (item && item.type.normalized === type.normalized) {
+        return Promise.resolve(item.input);
+      }
+      return Promise.resolve(null);
+    },
+
+    findAll(type: ModelType): Promise<ModelInput[]> {
+      const result = Array.from(storage.values())
+        .filter((item) => item.type.normalized === type.normalized)
+        .map((item) => item.input);
+      return Promise.resolve(result);
+    },
+
+    findByName(
+      _type: ModelType,
+      name: string,
+    ): Promise<ModelInput | null> {
+      const item = Array.from(storage.values()).find(
+        (i) => i.input.name === name,
+      );
+      return Promise.resolve(item?.input ?? null);
+    },
+
+    findByNameGlobal(
+      name: string,
+    ): Promise<{ input: ModelInput; type: ModelType } | null> {
+      const result = Array.from(storage.values()).find(
+        (item) => item.input.name === name,
+      ) ?? null;
+      return Promise.resolve(result);
+    },
+
+    findAllGlobal(): Promise<{ input: ModelInput; type: ModelType }[]> {
+      return Promise.resolve(Array.from(storage.values()));
+    },
+
+    save(type: ModelType, input: ModelInput): Promise<void> {
+      storage.set(input.id, { input, type });
+      return Promise.resolve();
+    },
+
+    delete(_type: ModelType, id: ModelInputId): Promise<void> {
+      storage.delete(id);
+      return Promise.resolve();
+    },
+
+    nextId(): ModelInputId {
+      return crypto.randomUUID() as ModelInputId;
+    },
+
+    getPath(_type: ModelType, id: ModelInputId): string {
+      return `/test/inputs/${id}.yaml`;
+    },
+  };
+}
+
+Deno.test("listAllModels returns empty array when no models", async () => {
+  const repo = createMockRepository();
+  const handlers = createModelsHandlers(repo);
+
+  const request = new Request("http://localhost/api/v1/models");
+  const response = await handlers.listAllModels({ request, params: {} });
+
+  assertEquals(response.status, 200);
+  const body = await response.json();
+  assertEquals(body.models, []);
+});
+
+Deno.test("listModelsByType returns empty array for type with no models", async () => {
+  const repo = createMockRepository();
+  const handlers = createModelsHandlers(repo);
+
+  const request = new Request("http://localhost/api/v1/models/echo");
+  const response = await handlers.listModelsByType({
+    request,
+    params: { type: "echo" },
+  });
+
+  assertEquals(response.status, 200);
+  const body = await response.json();
+  assertEquals(body.models, []);
+});
+
+Deno.test("listModelsByType returns 400 for empty type", async () => {
+  const repo = createMockRepository();
+  const handlers = createModelsHandlers(repo);
+
+  const request = new Request("http://localhost/api/v1/models/");
+  const response = await handlers.listModelsByType({
+    request,
+    params: { type: "" },
+  });
+
+  assertEquals(response.status, 400);
+});
+
+Deno.test("getModel returns 404 when model not found", async () => {
+  const repo = createMockRepository();
+  const handlers = createModelsHandlers(repo);
+
+  const request = new Request(
+    "http://localhost/api/v1/models/echo/nonexistent",
+  );
+  const response = await handlers.getModel({
+    request,
+    params: { type: "echo", id: "nonexistent" },
+  });
+
+  assertEquals(response.status, 404);
+});
+
+Deno.test("createModel creates new model", async () => {
+  const repo = createMockRepository();
+  const handlers = createModelsHandlers(repo);
+
+  const request = new Request("http://localhost/api/v1/models/echo", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      name: "test-model",
+      attributes: { message: "hello" },
+    }),
+  });
+
+  const response = await handlers.createModel({
+    request,
+    params: { type: "echo" },
+  });
+
+  assertEquals(response.status, 201);
+  const body = await response.json();
+  assertEquals(body.name, "test-model");
+  assertEquals(body.type.normalized, "echo");
+});
+
+Deno.test("createModel returns 409 for duplicate name", async () => {
+  const repo = createMockRepository();
+  const handlers = createModelsHandlers(repo);
+
+  // Create first model
+  const firstRequest = new Request("http://localhost/api/v1/models/echo", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: "duplicate-name" }),
+  });
+  await handlers.createModel({
+    request: firstRequest,
+    params: { type: "echo" },
+  });
+
+  // Try to create another with same name
+  const secondRequest = new Request("http://localhost/api/v1/models/echo", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: "duplicate-name" }),
+  });
+  const response = await handlers.createModel({
+    request: secondRequest,
+    params: { type: "echo" },
+  });
+
+  assertEquals(response.status, 409);
+});
+
+Deno.test("deleteModel returns 404 for nonexistent model", async () => {
+  const repo = createMockRepository();
+  const handlers = createModelsHandlers(repo);
+
+  const request = new Request(
+    "http://localhost/api/v1/models/echo/nonexistent",
+    {
+      method: "DELETE",
+    },
+  );
+  const response = await handlers.deleteModel({
+    request,
+    params: { type: "echo", id: "nonexistent" },
+  });
+
+  assertEquals(response.status, 404);
+});

--- a/experiments/webapp/backend/handlers/outputs_handler.ts
+++ b/experiments/webapp/backend/handlers/outputs_handler.ts
@@ -1,0 +1,277 @@
+/**
+ * HTTP handlers for model outputs API endpoints.
+ */
+
+import type { RouteContext } from "../router.ts";
+import { errorResponse, jsonResponse } from "../router.ts";
+import type {
+  DataRepository,
+  InputRepository,
+  LogRepository,
+  OutputRepository,
+} from "../../../../src/domain/models/repositories.ts";
+import { createModelDataId } from "../../../../src/domain/models/model_data.ts";
+import { createModelLogId } from "../../../../src/domain/models/model_log.ts";
+import {
+  isPartialId,
+  matchByPartialId,
+} from "../../../../src/domain/models/model_lookup.ts";
+
+export function createOutputsHandlers(
+  outputRepository: OutputRepository,
+  inputRepository: InputRepository,
+  dataRepository: DataRepository,
+  logRepository: LogRepository,
+) {
+  async function listOutputs(_ctx: RouteContext): Promise<Response> {
+    const allOutputs = await outputRepository.findAllGlobal();
+
+    // Get model names for each output
+    const outputsWithNames = await Promise.all(
+      allOutputs.map(async ({ output, type }) => {
+        let modelName: string | undefined;
+        const input = await inputRepository.findById(type, output.modelInputId);
+        if (input) {
+          modelName = input.name;
+        }
+
+        return {
+          id: output.id,
+          modelInputId: output.modelInputId,
+          modelName,
+          type: type.normalized,
+          methodName: output.methodName,
+          status: output.status,
+          startedAt: output.startedAt.toISOString(),
+          completedAt: output.completedAt?.toISOString(),
+          durationMs: output.durationMs,
+        };
+      }),
+    );
+
+    // Sort by startedAt descending (most recent first)
+    outputsWithNames.sort(
+      (a, b) =>
+        new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+    );
+
+    return jsonResponse({ outputs: outputsWithNames });
+  }
+
+  async function getOutput(ctx: RouteContext): Promise<Response> {
+    const idParam = ctx.params.id;
+
+    if (!isPartialId(idParam)) {
+      return errorResponse(
+        `Invalid output ID format: ${idParam}. Expected a UUID or partial ID (3+ hex characters).`,
+        400,
+      );
+    }
+
+    const allOutputs = await outputRepository.findAllGlobal();
+    const matchResult = matchByPartialId(
+      allOutputs.map((o) => ({ id: o.output.id, item: o })),
+      idParam,
+    );
+
+    if (matchResult.status === "not_found") {
+      return errorResponse(`Output not found: ${idParam}`, 404);
+    }
+
+    if (matchResult.status === "ambiguous") {
+      return errorResponse(
+        `Ambiguous ID prefix "${idParam}" matches multiple outputs: ${
+          matchResult.matches.map((m) => m.id).join(", ")
+        }`,
+        400,
+      );
+    }
+
+    const { output, type } = matchResult.match;
+
+    // Get model name
+    let modelName: string | undefined;
+    const input = await inputRepository.findById(type, output.modelInputId);
+    if (input) {
+      modelName = input.name;
+    }
+
+    return jsonResponse({
+      id: output.id,
+      modelInputId: output.modelInputId,
+      modelName,
+      type: type.normalized,
+      methodName: output.methodName,
+      status: output.status,
+      startedAt: output.startedAt.toISOString(),
+      completedAt: output.completedAt?.toISOString(),
+      durationMs: output.durationMs,
+      retryCount: output.retryCount,
+      provenance: output.provenance,
+      artifacts: output.artifacts,
+      error: output.error,
+    });
+  }
+
+  async function getOutputData(ctx: RouteContext): Promise<Response> {
+    const idParam = ctx.params.id;
+    const url = new URL(ctx.request.url);
+    const fieldParam = url.searchParams.get("field");
+
+    if (!isPartialId(idParam)) {
+      return errorResponse(
+        `Invalid output ID format: ${idParam}. Expected a UUID or partial ID (3+ hex characters).`,
+        400,
+      );
+    }
+
+    const allOutputs = await outputRepository.findAllGlobal();
+    const matchResult = matchByPartialId(
+      allOutputs.map((o) => ({ id: o.output.id, item: o })),
+      idParam,
+    );
+
+    if (matchResult.status === "not_found") {
+      return errorResponse(`Output not found: ${idParam}`, 404);
+    }
+
+    if (matchResult.status === "ambiguous") {
+      return errorResponse(
+        `Ambiguous ID prefix "${idParam}" matches multiple outputs: ${
+          matchResult.matches.map((m) => m.id).join(", ")
+        }`,
+        400,
+      );
+    }
+
+    const { output, type } = matchResult.match;
+
+    // Get data ID from artifacts
+    const dataId = output.artifacts?.dataId;
+    if (!dataId) {
+      return errorResponse(
+        `Output ${output.id} has no data artifact. Status: ${output.status}, Method: ${output.methodName}`,
+        404,
+      );
+    }
+
+    // Fetch the data artifact
+    const data = await dataRepository.findById(type, createModelDataId(dataId));
+    if (!data) {
+      return errorResponse(
+        `Data artifact ${dataId} not found for output ${output.id}`,
+        404,
+      );
+    }
+
+    // Get the attributes to display
+    let displayData: unknown = data.attributes;
+
+    // If a specific field is requested, extract it
+    if (fieldParam) {
+      const fieldValue = data.attributes[fieldParam];
+      if (fieldValue === undefined) {
+        const availableFields = Object.keys(data.attributes).join(", ");
+        return errorResponse(
+          `Field "${fieldParam}" not found in data artifact. Available fields: ${
+            availableFields || "(none)"
+          }`,
+          404,
+        );
+      }
+      displayData = fieldValue;
+    }
+
+    return jsonResponse({
+      outputId: output.id,
+      methodName: output.methodName,
+      dataId,
+      field: fieldParam ?? null,
+      data: displayData,
+    });
+  }
+
+  async function getOutputLogs(ctx: RouteContext): Promise<Response> {
+    const idParam = ctx.params.id;
+    const url = new URL(ctx.request.url);
+    const tailParam = url.searchParams.get("tail");
+    const tail = tailParam ? parseInt(tailParam, 10) : undefined;
+
+    if (tailParam && (isNaN(tail!) || tail! < 0)) {
+      return errorResponse(
+        `Invalid tail parameter: ${tailParam}. Expected a positive integer.`,
+        400,
+      );
+    }
+
+    if (!isPartialId(idParam)) {
+      return errorResponse(
+        `Invalid output ID format: ${idParam}. Expected a UUID or partial ID (3+ hex characters).`,
+        400,
+      );
+    }
+
+    const allOutputs = await outputRepository.findAllGlobal();
+    const matchResult = matchByPartialId(
+      allOutputs.map((o) => ({ id: o.output.id, item: o })),
+      idParam,
+    );
+
+    if (matchResult.status === "not_found") {
+      return errorResponse(`Output not found: ${idParam}`, 404);
+    }
+
+    if (matchResult.status === "ambiguous") {
+      return errorResponse(
+        `Ambiguous ID prefix "${idParam}" matches multiple outputs: ${
+          matchResult.matches.map((m) => m.id).join(", ")
+        }`,
+        400,
+      );
+    }
+
+    const { output, type } = matchResult.match;
+
+    // Get log IDs from artifacts
+    const logIds = output.artifacts?.logIds;
+    if (!logIds || logIds.length === 0) {
+      return errorResponse(
+        `Output ${output.id} has no log artifacts. Status: ${output.status}, Method: ${output.methodName}`,
+        404,
+      );
+    }
+
+    // Fetch and collect all log entries
+    const allEntries: string[] = [];
+
+    for (const logId of logIds) {
+      const log = await logRepository.findById(type, createModelLogId(logId));
+      if (log) {
+        for (const entry of log.entries) {
+          allEntries.push(entry.message);
+        }
+      }
+    }
+
+    // Apply --tail if specified
+    const entriesToShow = tail !== undefined
+      ? allEntries.slice(-tail)
+      : allEntries;
+
+    return jsonResponse({
+      outputId: output.id,
+      methodName: output.methodName,
+      logIds,
+      lines: entriesToShow,
+      totalLines: allEntries.length,
+      showingLines: entriesToShow.length,
+    });
+  }
+
+  return {
+    listOutputs,
+    getOutput,
+    getOutputData,
+    getOutputLogs,
+  };
+}

--- a/experiments/webapp/backend/handlers/resources_handler.ts
+++ b/experiments/webapp/backend/handlers/resources_handler.ts
@@ -1,0 +1,85 @@
+/**
+ * HTTP handlers for model resources API endpoints.
+ */
+
+import type { RouteContext } from "../router.ts";
+import { errorResponse, jsonResponse } from "../router.ts";
+import type { ResourceRepository } from "../../../../src/domain/models/repositories.ts";
+import { ModelType } from "../../../../src/domain/models/model_type.ts";
+import { createModelResourceId } from "../../../../src/domain/models/model_resource.ts";
+
+export function createResourcesHandlers(
+  resourceRepository: ResourceRepository,
+) {
+  async function listResourcesByType(ctx: RouteContext): Promise<Response> {
+    const typeParam = ctx.params.type;
+
+    try {
+      const modelType = ModelType.create(typeParam);
+      const resources = await resourceRepository.findAll(modelType);
+
+      const result = resources.map((resource) => ({
+        id: resource.id,
+        version: resource.version,
+        createdAt: resource.createdAt.toISOString(),
+        attributes: resource.attributes,
+      }));
+
+      return jsonResponse({ resources: result });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return errorResponse(message, 400);
+    }
+  }
+
+  async function getResource(ctx: RouteContext): Promise<Response> {
+    const { type: typeParam, id: idParam } = ctx.params;
+
+    try {
+      const modelType = ModelType.create(typeParam);
+      const id = createModelResourceId(idParam);
+      const resource = await resourceRepository.findById(modelType, id);
+
+      if (!resource) {
+        return errorResponse("Resource not found", 404);
+      }
+
+      return jsonResponse({
+        id: resource.id,
+        version: resource.version,
+        createdAt: resource.createdAt.toISOString(),
+        attributes: resource.attributes,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return errorResponse(message, 400);
+    }
+  }
+
+  async function deleteResource(ctx: RouteContext): Promise<Response> {
+    const { type: typeParam, id: idParam } = ctx.params;
+
+    try {
+      const modelType = ModelType.create(typeParam);
+      const id = createModelResourceId(idParam);
+
+      const existing = await resourceRepository.findById(modelType, id);
+      if (!existing) {
+        return errorResponse("Resource not found", 404);
+      }
+
+      await resourceRepository.delete(modelType, id);
+
+      return new Response(null, { status: 204 });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return errorResponse(message, 400);
+    }
+  }
+
+  return {
+    listResourcesByType,
+    getResource,
+    deleteResource,
+  };
+}

--- a/experiments/webapp/backend/handlers/resources_handler_test.ts
+++ b/experiments/webapp/backend/handlers/resources_handler_test.ts
@@ -1,0 +1,119 @@
+import { assertEquals } from "@std/assert";
+import { createResourcesHandlers } from "./resources_handler.ts";
+import type { ResourceRepository } from "../../../../src/domain/models/repositories.ts";
+import type { ModelType } from "../../../../src/domain/models/model_type.ts";
+import type {
+  ModelResource,
+  ModelResourceId,
+} from "../../../../src/domain/models/model_resource.ts";
+
+// Mock repository for testing
+function createMockRepository(
+  resources: { resource: ModelResource; type: ModelType }[] = [],
+): ResourceRepository {
+  const storage = new Map<
+    string,
+    { resource: ModelResource; type: ModelType }
+  >();
+
+  for (const item of resources) {
+    storage.set(item.resource.id, item);
+  }
+
+  return {
+    findById(
+      type: ModelType,
+      id: ModelResourceId,
+    ): Promise<ModelResource | null> {
+      const item = storage.get(id);
+      if (item && item.type.normalized === type.normalized) {
+        return Promise.resolve(item.resource);
+      }
+      return Promise.resolve(null);
+    },
+
+    findAll(type: ModelType): Promise<ModelResource[]> {
+      const result = Array.from(storage.values())
+        .filter((item) => item.type.normalized === type.normalized)
+        .map((item) => item.resource);
+      return Promise.resolve(result);
+    },
+
+    save(type: ModelType, resource: ModelResource): Promise<void> {
+      storage.set(resource.id, { resource, type });
+      return Promise.resolve();
+    },
+
+    delete(_type: ModelType, id: ModelResourceId): Promise<void> {
+      storage.delete(id);
+      return Promise.resolve();
+    },
+
+    nextId(): ModelResourceId {
+      return crypto.randomUUID() as ModelResourceId;
+    },
+
+    getPath(_type: ModelType, id: ModelResourceId): string {
+      return `/test/resources/${id}.yaml`;
+    },
+  };
+}
+
+Deno.test("listResourcesByType returns empty array when no resources", async () => {
+  const repo = createMockRepository();
+  const handlers = createResourcesHandlers(repo);
+
+  const request = new Request("http://localhost/api/v1/resources/echo");
+  const response = await handlers.listResourcesByType({
+    request,
+    params: { type: "echo" },
+  });
+
+  assertEquals(response.status, 200);
+  const body = await response.json();
+  assertEquals(body.resources, []);
+});
+
+Deno.test("listResourcesByType returns 400 for empty type", async () => {
+  const repo = createMockRepository();
+  const handlers = createResourcesHandlers(repo);
+
+  const request = new Request("http://localhost/api/v1/resources/");
+  const response = await handlers.listResourcesByType({
+    request,
+    params: { type: "" },
+  });
+
+  assertEquals(response.status, 400);
+});
+
+Deno.test("getResource returns 404 when resource not found", async () => {
+  const repo = createMockRepository();
+  const handlers = createResourcesHandlers(repo);
+
+  const request = new Request(
+    "http://localhost/api/v1/resources/echo/nonexistent",
+  );
+  const response = await handlers.getResource({
+    request,
+    params: { type: "echo", id: "nonexistent" },
+  });
+
+  assertEquals(response.status, 404);
+});
+
+Deno.test("deleteResource returns 404 for nonexistent resource", async () => {
+  const repo = createMockRepository();
+  const handlers = createResourcesHandlers(repo);
+
+  const request = new Request(
+    "http://localhost/api/v1/resources/echo/nonexistent",
+    { method: "DELETE" },
+  );
+  const response = await handlers.deleteResource({
+    request,
+    params: { type: "echo", id: "nonexistent" },
+  });
+
+  assertEquals(response.status, 404);
+});

--- a/experiments/webapp/backend/handlers/static_handler.ts
+++ b/experiments/webapp/backend/handlers/static_handler.ts
@@ -1,0 +1,89 @@
+/**
+ * Static file handler for serving the Vue SPA.
+ */
+
+import { extname, join, resolve } from "@std/path";
+import type { RouteContext } from "../router.ts";
+
+const MIME_TYPES: Record<string, string> = {
+  ".html": "text/html",
+  ".css": "text/css",
+  ".js": "application/javascript",
+  ".mjs": "application/javascript",
+  ".json": "application/json",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".ttf": "font/ttf",
+  ".eot": "application/vnd.ms-fontobject",
+  ".otf": "font/otf",
+  ".map": "application/json",
+};
+
+export function createStaticHandler(baseDir: string) {
+  async function serveStatic(ctx: RouteContext): Promise<Response> {
+    const url = new URL(ctx.request.url);
+    let filePath = url.pathname;
+
+    filePath = decodeURIComponent(filePath.replace(/^\//, ""));
+
+    if (filePath.startsWith("api/")) {
+      return new Response("Not Found", { status: 404 });
+    }
+
+    const resolvedBase = resolve(baseDir);
+    const fullPath = resolve(baseDir, filePath);
+
+    // Prevent path traversal by ensuring resolved path is within base directory
+    if (!fullPath.startsWith(resolvedBase + "/") && fullPath !== resolvedBase) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
+    try {
+      const stat = await Deno.stat(fullPath);
+
+      if (stat.isFile) {
+        const content = await Deno.readFile(fullPath);
+        const ext = extname(fullPath);
+        const contentType = MIME_TYPES[ext] ?? "application/octet-stream";
+
+        return new Response(content, {
+          headers: {
+            "Content-Type": contentType,
+            "Cache-Control": ext === ".html"
+              ? "no-cache"
+              : "public, max-age=31536000",
+          },
+        });
+      }
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+
+    try {
+      const indexPath = join(baseDir, "index.html");
+      const content = await Deno.readFile(indexPath);
+
+      return new Response(content, {
+        headers: {
+          "Content-Type": "text/html",
+          "Cache-Control": "no-cache",
+        },
+      });
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return new Response("Not Found - webapp not built", { status: 404 });
+      }
+      throw error;
+    }
+  }
+
+  return { serveStatic };
+}

--- a/experiments/webapp/backend/handlers/static_handler_test.ts
+++ b/experiments/webapp/backend/handlers/static_handler_test.ts
@@ -1,0 +1,92 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { createStaticHandler } from "./static_handler.ts";
+import { join } from "@std/path";
+
+// Use a temporary directory for testing
+const testDir = await Deno.makeTempDir();
+
+// Create test files
+await Deno.writeTextFile(join(testDir, "index.html"), "<html>index</html>");
+await Deno.writeTextFile(join(testDir, "test.js"), "console.log('test');");
+await Deno.writeTextFile(join(testDir, "style.css"), "body { color: red; }");
+await Deno.mkdir(join(testDir, "subdir"));
+await Deno.writeTextFile(
+  join(testDir, "subdir", "nested.html"),
+  "<html>nested</html>",
+);
+
+Deno.test("static handler serves existing file", async () => {
+  const handler = createStaticHandler(testDir);
+  const request = new Request("http://localhost/test.js");
+  const response = await handler.serveStatic({ request, params: {} });
+
+  assertEquals(response.status, 200);
+  assertEquals(response.headers.get("Content-Type"), "application/javascript");
+  assertStringIncludes(await response.text(), "console.log");
+});
+
+Deno.test("static handler serves CSS with correct content type", async () => {
+  const handler = createStaticHandler(testDir);
+  const request = new Request("http://localhost/style.css");
+  const response = await handler.serveStatic({ request, params: {} });
+
+  assertEquals(response.status, 200);
+  assertEquals(response.headers.get("Content-Type"), "text/css");
+});
+
+Deno.test("static handler serves nested files", async () => {
+  const handler = createStaticHandler(testDir);
+  const request = new Request("http://localhost/subdir/nested.html");
+  const response = await handler.serveStatic({ request, params: {} });
+
+  assertEquals(response.status, 200);
+  assertEquals(response.headers.get("Content-Type"), "text/html");
+  assertStringIncludes(await response.text(), "nested");
+});
+
+Deno.test("static handler falls back to index.html for SPA routes", async () => {
+  const handler = createStaticHandler(testDir);
+  const request = new Request("http://localhost/some/spa/route");
+  const response = await handler.serveStatic({ request, params: {} });
+
+  assertEquals(response.status, 200);
+  assertEquals(response.headers.get("Content-Type"), "text/html");
+  assertStringIncludes(await response.text(), "index");
+});
+
+Deno.test("static handler returns 404 for api routes", async () => {
+  const handler = createStaticHandler(testDir);
+  const request = new Request("http://localhost/api/v1/models");
+  const response = await handler.serveStatic({ request, params: {} });
+
+  assertEquals(response.status, 404);
+});
+
+Deno.test("static handler sets cache-control for assets", async () => {
+  const handler = createStaticHandler(testDir);
+  const request = new Request("http://localhost/test.js");
+  const response = await handler.serveStatic({ request, params: {} });
+
+  assertEquals(
+    response.headers.get("Cache-Control"),
+    "public, max-age=31536000",
+  );
+});
+
+Deno.test("static handler sets no-cache for HTML", async () => {
+  const handler = createStaticHandler(testDir);
+  const request = new Request("http://localhost/index.html");
+  const response = await handler.serveStatic({ request, params: {} });
+
+  assertEquals(response.headers.get("Cache-Control"), "no-cache");
+});
+
+// Cleanup
+Deno.test({
+  name: "cleanup temp directory",
+  fn: async () => {
+    await Deno.remove(testDir, { recursive: true });
+  },
+  sanitizeResources: false,
+  sanitizeOps: false,
+});

--- a/experiments/webapp/backend/handlers/types_handler.ts
+++ b/experiments/webapp/backend/handlers/types_handler.ts
@@ -1,0 +1,16 @@
+/**
+ * HTTP handlers for model types API endpoints.
+ */
+
+import type { RouteContext } from "../router.ts";
+import { jsonResponse } from "../router.ts";
+import { modelRegistry } from "../../../../src/domain/models/model.ts";
+
+export function listTypes(_ctx: RouteContext): Response {
+  const types = modelRegistry.types().map((t) => ({
+    raw: t.raw,
+    normalized: t.normalized,
+  }));
+
+  return jsonResponse({ types });
+}

--- a/experiments/webapp/backend/handlers/types_handler_test.ts
+++ b/experiments/webapp/backend/handlers/types_handler_test.ts
@@ -1,0 +1,20 @@
+import { assertEquals } from "@std/assert";
+import { listTypes } from "./types_handler.ts";
+
+Deno.test("listTypes returns JSON response with types array", async () => {
+  const request = new Request("http://localhost/api/v1/types");
+  const response = listTypes({ request, params: {} });
+
+  assertEquals(response.status, 200);
+  assertEquals(response.headers.get("Content-Type"), "application/json");
+
+  const body = await response.json();
+  assertEquals(Array.isArray(body.types), true);
+
+  // Each type should have raw and normalized properties
+  if (body.types.length > 0) {
+    const firstType = body.types[0];
+    assertEquals(typeof firstType.raw, "string");
+    assertEquals(typeof firstType.normalized, "string");
+  }
+});

--- a/experiments/webapp/backend/handlers/workflow_runs_handler.ts
+++ b/experiments/webapp/backend/handlers/workflow_runs_handler.ts
@@ -1,0 +1,186 @@
+/**
+ * HTTP handlers for workflow runs API endpoints.
+ */
+
+import type { RouteContext } from "../router.ts";
+import { errorResponse, jsonResponse } from "../router.ts";
+import type {
+  WorkflowRepository,
+  WorkflowRunRepository,
+} from "../../../../src/domain/workflows/repositories.ts";
+import type { OutputRepository } from "../../../../src/domain/models/repositories.ts";
+import { createWorkflowId } from "../../../../src/domain/workflows/workflow_id.ts";
+import type { WorkflowRun } from "../../../../src/domain/workflows/workflow_run.ts";
+import {
+  isPartialId,
+  matchByPartialId,
+} from "../../../../src/domain/models/model_lookup.ts";
+
+export function createWorkflowRunsHandlers(
+  workflowRunRepository: WorkflowRunRepository,
+  workflowRepository: WorkflowRepository,
+  outputRepository: OutputRepository,
+) {
+  function runToSummary(run: WorkflowRun) {
+    return {
+      id: run.id,
+      workflowId: run.workflowId,
+      workflowName: run.workflowName,
+      status: run.status,
+      startedAt: run.startedAt?.toISOString(),
+      completedAt: run.completedAt?.toISOString(),
+      jobCount: run.jobs.length,
+    };
+  }
+
+  function runToDetail(
+    run: WorkflowRun,
+    outputsByStep: Map<string, string>,
+  ) {
+    return {
+      id: run.id,
+      workflowId: run.workflowId,
+      workflowName: run.workflowName,
+      status: run.status,
+      startedAt: run.startedAt?.toISOString(),
+      completedAt: run.completedAt?.toISOString(),
+      jobs: run.jobs.map((job) => ({
+        jobName: job.jobName,
+        status: job.status,
+        startedAt: job.startedAt?.toISOString(),
+        completedAt: job.completedAt?.toISOString(),
+        steps: job.steps.map((step) => ({
+          stepName: step.stepName,
+          status: step.status,
+          startedAt: step.startedAt?.toISOString(),
+          completedAt: step.completedAt?.toISOString(),
+          error: step.error,
+          output: step.output,
+          outputId: outputsByStep.get(step.stepName),
+        })),
+      })),
+    };
+  }
+
+  async function listWorkflowRuns(_ctx: RouteContext): Promise<Response> {
+    const allRuns = await workflowRunRepository.findAllGlobal();
+
+    // Get outputs for each run to provide output counts
+    const runsWithOutputCounts = await Promise.all(
+      allRuns.map(async ({ run }) => {
+        // Find outputs that belong to this workflow run
+        const allOutputs = await outputRepository.findAllGlobal();
+        const runOutputs = allOutputs.filter(
+          (o) => o.output.provenance.workflowRunId === run.id,
+        );
+
+        return {
+          ...runToSummary(run),
+          outputCount: runOutputs.length,
+        };
+      }),
+    );
+
+    return jsonResponse({ workflowRuns: runsWithOutputCounts });
+  }
+
+  async function getWorkflowRun(ctx: RouteContext): Promise<Response> {
+    const idParam = ctx.params.id;
+
+    if (!isPartialId(idParam)) {
+      return errorResponse(
+        `Invalid workflow run ID format: ${idParam}. Expected a UUID or partial ID (3+ hex characters).`,
+        400,
+      );
+    }
+
+    const allRuns = await workflowRunRepository.findAllGlobal();
+    const matchResult = matchByPartialId(
+      allRuns.map((r) => ({ id: r.run.id, item: r })),
+      idParam,
+    );
+
+    if (matchResult.status === "not_found") {
+      return errorResponse(`Workflow run not found: ${idParam}`, 404);
+    }
+
+    if (matchResult.status === "ambiguous") {
+      return errorResponse(
+        `Ambiguous ID prefix "${idParam}" matches multiple workflow runs: ${
+          matchResult.matches.map((m) => m.id).join(", ")
+        }`,
+        400,
+      );
+    }
+
+    const { run } = matchResult.match;
+
+    // Get all outputs for this workflow run
+    const allOutputs = await outputRepository.findAllGlobal();
+    const runOutputs = allOutputs.filter(
+      (o) => o.output.provenance.workflowRunId === run.id,
+    );
+
+    // Map outputs with their model type info
+    const outputs = runOutputs.map(({ output, type }) => ({
+      id: output.id,
+      modelInputId: output.modelInputId,
+      type: type.normalized,
+      methodName: output.methodName,
+      status: output.status,
+      startedAt: output.startedAt.toISOString(),
+      completedAt: output.completedAt?.toISOString(),
+      durationMs: output.durationMs,
+      stepName: output.provenance.stepName,
+    }));
+
+    // Sort by startedAt ascending (execution order)
+    outputs.sort((a, b) =>
+      new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime()
+    );
+
+    // Build a map of stepName -> outputId for linking steps to outputs
+    const outputsByStep = new Map<string, string>();
+    for (const output of outputs) {
+      if (output.stepName) {
+        outputsByStep.set(output.stepName, output.id);
+      }
+    }
+
+    return jsonResponse({
+      ...runToDetail(run, outputsByStep),
+      outputs,
+    });
+  }
+
+  async function listWorkflowRunsByWorkflow(
+    ctx: RouteContext,
+  ): Promise<Response> {
+    const workflowIdParam = ctx.params.workflowId;
+
+    try {
+      const workflowId = createWorkflowId(workflowIdParam);
+
+      // Verify workflow exists
+      const workflow = await workflowRepository.findById(workflowId);
+      if (!workflow) {
+        return errorResponse("Workflow not found", 404);
+      }
+
+      const runs = await workflowRunRepository.findAllByWorkflowId(workflowId);
+
+      const result = runs.map((run) => runToSummary(run));
+
+      return jsonResponse({ workflowRuns: result });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return errorResponse(message, 400);
+    }
+  }
+
+  return {
+    listWorkflowRuns,
+    getWorkflowRun,
+    listWorkflowRunsByWorkflow,
+  };
+}

--- a/experiments/webapp/backend/handlers/workflows_handler.ts
+++ b/experiments/webapp/backend/handlers/workflows_handler.ts
@@ -1,0 +1,231 @@
+/**
+ * HTTP handlers for workflows API endpoints.
+ */
+
+import type { RouteContext } from "../router.ts";
+import { errorResponse, jsonResponse } from "../router.ts";
+import type { WorkflowRepository } from "../../../../src/domain/workflows/repositories.ts";
+import { createWorkflowId } from "../../../../src/domain/workflows/workflow_id.ts";
+import { Workflow } from "../../../../src/domain/workflows/workflow.ts";
+import { Job } from "../../../../src/domain/workflows/job.ts";
+import { Step } from "../../../../src/domain/workflows/step.ts";
+import { StepTask } from "../../../../src/domain/workflows/step_task.ts";
+import { TriggerCondition } from "../../../../src/domain/workflows/trigger_condition.ts";
+
+export function createWorkflowsHandlers(
+  workflowRepository: WorkflowRepository,
+) {
+  function workflowToResponse(workflow: Workflow) {
+    return {
+      id: workflow.id,
+      name: workflow.name,
+      description: workflow.description,
+      version: workflow.version,
+      jobs: workflow.jobs.map((job) => ({
+        name: job.name,
+        description: job.description,
+        dependsOn: job.dependsOn.map((d) => ({
+          job: d.job,
+          condition: d.condition.toData(),
+        })),
+        weight: job.weight,
+        steps: job.steps.map((step) => ({
+          name: step.name,
+          description: step.description,
+          task: step.task.toData(),
+          dependsOn: step.dependsOn.map((d) => ({
+            step: d.step,
+            condition: d.condition.toData(),
+          })),
+          weight: step.weight,
+        })),
+      })),
+    };
+  }
+
+  async function listWorkflows(_ctx: RouteContext): Promise<Response> {
+    const workflows = await workflowRepository.findAll();
+
+    const result = workflows.map((workflow) => ({
+      id: workflow.id,
+      name: workflow.name,
+      description: workflow.description,
+      version: workflow.version,
+      jobCount: workflow.jobs.length,
+    }));
+
+    return jsonResponse({ workflows: result });
+  }
+
+  async function getWorkflow(ctx: RouteContext): Promise<Response> {
+    const idParam = ctx.params.id;
+
+    try {
+      const id = createWorkflowId(idParam);
+      const workflow = await workflowRepository.findById(id);
+
+      if (!workflow) {
+        return errorResponse("Workflow not found", 404);
+      }
+
+      return jsonResponse(workflowToResponse(workflow));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return errorResponse(message, 400);
+    }
+  }
+
+  function parseStepData(stepData: Record<string, unknown>): Step {
+    const taskData = stepData.task as Record<string, unknown>;
+    const task = StepTask.fromData(
+      taskData as Parameters<typeof StepTask.fromData>[0],
+    );
+
+    const dependsOn =
+      (stepData.dependsOn as Array<{ step: string; condition: unknown }>) ?? [];
+
+    return Step.create({
+      name: stepData.name as string,
+      description: stepData.description as string | undefined,
+      task,
+      dependsOn: dependsOn.map((d) => ({
+        step: d.step,
+        condition: TriggerCondition.fromData(
+          d.condition as Parameters<typeof TriggerCondition.fromData>[0],
+        ),
+      })),
+      weight: stepData.weight as number | undefined,
+    });
+  }
+
+  function parseJobData(jobData: Record<string, unknown>): Job {
+    const stepsData = (jobData.steps as Array<Record<string, unknown>>) ?? [];
+    const steps = stepsData.map(parseStepData);
+
+    const dependsOn =
+      (jobData.dependsOn as Array<{ job: string; condition: unknown }>) ?? [];
+
+    return Job.create({
+      name: jobData.name as string,
+      description: jobData.description as string | undefined,
+      steps,
+      dependsOn: dependsOn.map((d) => ({
+        job: d.job,
+        condition: TriggerCondition.fromData(
+          d.condition as Parameters<typeof TriggerCondition.fromData>[0],
+        ),
+      })),
+      weight: jobData.weight as number | undefined,
+    });
+  }
+
+  async function createWorkflow(ctx: RouteContext): Promise<Response> {
+    try {
+      const body = await ctx.request.json();
+
+      if (body.name) {
+        const existing = await workflowRepository.findByName(body.name);
+        if (existing) {
+          return errorResponse(
+            `Workflow with name '${body.name}' already exists`,
+            409,
+          );
+        }
+      }
+
+      const jobsData = (body.jobs as Array<Record<string, unknown>>) ?? [];
+      const jobs = jobsData.map(parseJobData);
+
+      const workflow = Workflow.create({
+        name: body.name,
+        description: body.description,
+        version: body.version,
+        jobs,
+      });
+
+      await workflowRepository.save(workflow);
+
+      return jsonResponse(workflowToResponse(workflow), 201);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return errorResponse(message, 400);
+    }
+  }
+
+  async function updateWorkflow(ctx: RouteContext): Promise<Response> {
+    const idParam = ctx.params.id;
+
+    try {
+      const id = createWorkflowId(idParam);
+
+      const existing = await workflowRepository.findById(id);
+      if (!existing) {
+        return errorResponse("Workflow not found", 404);
+      }
+
+      const body = await ctx.request.json();
+
+      if (body.name && body.name !== existing.name) {
+        const existingWithName = await workflowRepository.findByName(body.name);
+        if (existingWithName) {
+          return errorResponse(
+            `Workflow with name '${body.name}' already exists`,
+            409,
+          );
+        }
+      }
+
+      let jobs: Job[];
+      if (body.jobs && Array.isArray(body.jobs)) {
+        jobs = body.jobs.map((jobData: Record<string, unknown>) =>
+          parseJobData(jobData)
+        );
+      } else {
+        jobs = [...existing.jobs];
+      }
+
+      const updated = Workflow.create({
+        id: existing.id,
+        name: body.name ?? existing.name,
+        description: body.description ?? existing.description,
+        version: body.version ?? existing.version,
+        jobs,
+      });
+
+      await workflowRepository.save(updated);
+
+      return jsonResponse(workflowToResponse(updated));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return errorResponse(message, 400);
+    }
+  }
+
+  async function deleteWorkflow(ctx: RouteContext): Promise<Response> {
+    const idParam = ctx.params.id;
+
+    try {
+      const id = createWorkflowId(idParam);
+
+      const existing = await workflowRepository.findById(id);
+      if (!existing) {
+        return errorResponse("Workflow not found", 404);
+      }
+
+      await workflowRepository.delete(id);
+
+      return new Response(null, { status: 204 });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return errorResponse(message, 400);
+    }
+  }
+
+  return {
+    listWorkflows,
+    getWorkflow,
+    createWorkflow,
+    updateWorkflow,
+    deleteWorkflow,
+  };
+}

--- a/experiments/webapp/backend/handlers/workflows_handler_test.ts
+++ b/experiments/webapp/backend/handlers/workflows_handler_test.ts
@@ -1,0 +1,180 @@
+import { assertEquals } from "@std/assert";
+import { createWorkflowsHandlers } from "./workflows_handler.ts";
+import type { WorkflowRepository } from "../../../../src/domain/workflows/repositories.ts";
+import type { Workflow } from "../../../../src/domain/workflows/workflow.ts";
+import type { WorkflowId } from "../../../../src/domain/workflows/workflow_id.ts";
+
+// Mock repository for testing
+function createMockRepository(
+  workflows: Workflow[] = [],
+): WorkflowRepository {
+  const storage = new Map<string, Workflow>();
+
+  for (const workflow of workflows) {
+    storage.set(workflow.id, workflow);
+  }
+
+  return {
+    findById(id: WorkflowId): Promise<Workflow | null> {
+      return Promise.resolve(storage.get(id) ?? null);
+    },
+
+    findAll(): Promise<Workflow[]> {
+      return Promise.resolve(Array.from(storage.values()));
+    },
+
+    findByName(name: string): Promise<Workflow | null> {
+      const result =
+        Array.from(storage.values()).find((w) => w.name === name) ??
+          null;
+      return Promise.resolve(result);
+    },
+
+    save(workflow: Workflow): Promise<void> {
+      storage.set(workflow.id, workflow);
+      return Promise.resolve();
+    },
+
+    delete(id: WorkflowId): Promise<void> {
+      storage.delete(id);
+      return Promise.resolve();
+    },
+
+    nextId(): WorkflowId {
+      return crypto.randomUUID() as WorkflowId;
+    },
+
+    getPath(id: WorkflowId): string {
+      return `/test/workflows/${id}.yaml`;
+    },
+  };
+}
+
+Deno.test("listWorkflows returns empty array when no workflows", async () => {
+  const repo = createMockRepository();
+  const handlers = createWorkflowsHandlers(repo);
+
+  const request = new Request("http://localhost/api/v1/workflows");
+  const response = await handlers.listWorkflows({ request, params: {} });
+
+  assertEquals(response.status, 200);
+  const body = await response.json();
+  assertEquals(body.workflows, []);
+});
+
+Deno.test("getWorkflow returns 404 when workflow not found", async () => {
+  const repo = createMockRepository();
+  const handlers = createWorkflowsHandlers(repo);
+
+  const request = new Request("http://localhost/api/v1/workflows/nonexistent");
+  const response = await handlers.getWorkflow({
+    request,
+    params: { id: "nonexistent" },
+  });
+
+  assertEquals(response.status, 404);
+});
+
+Deno.test("createWorkflow creates new workflow", async () => {
+  const repo = createMockRepository();
+  const handlers = createWorkflowsHandlers(repo);
+
+  const request = new Request("http://localhost/api/v1/workflows", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      name: "test-workflow",
+      description: "A test workflow",
+      jobs: [
+        {
+          name: "test-job",
+          steps: [
+            {
+              name: "test-step",
+              task: {
+                type: "model_method",
+                modelIdOrName: "test-model",
+                methodName: "apply",
+              },
+            },
+          ],
+        },
+      ],
+    }),
+  });
+
+  const response = await handlers.createWorkflow({ request, params: {} });
+
+  assertEquals(response.status, 201);
+  const body = await response.json();
+  assertEquals(body.name, "test-workflow");
+  assertEquals(body.jobs.length, 1);
+});
+
+Deno.test("createWorkflow returns 409 for duplicate name", async () => {
+  const repo = createMockRepository();
+  const handlers = createWorkflowsHandlers(repo);
+
+  // Create first workflow
+  const firstRequest = new Request("http://localhost/api/v1/workflows", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      name: "duplicate-workflow",
+      jobs: [],
+    }),
+  });
+  await handlers.createWorkflow({ request: firstRequest, params: {} });
+
+  // Try to create another with same name
+  const secondRequest = new Request("http://localhost/api/v1/workflows", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      name: "duplicate-workflow",
+      jobs: [],
+    }),
+  });
+  const response = await handlers.createWorkflow({
+    request: secondRequest,
+    params: {},
+  });
+
+  assertEquals(response.status, 409);
+});
+
+Deno.test("deleteWorkflow returns 404 for nonexistent workflow", async () => {
+  const repo = createMockRepository();
+  const handlers = createWorkflowsHandlers(repo);
+
+  const request = new Request(
+    "http://localhost/api/v1/workflows/nonexistent",
+    { method: "DELETE" },
+  );
+  const response = await handlers.deleteWorkflow({
+    request,
+    params: { id: "nonexistent" },
+  });
+
+  assertEquals(response.status, 404);
+});
+
+Deno.test("updateWorkflow returns 404 for nonexistent workflow", async () => {
+  const repo = createMockRepository();
+  const handlers = createWorkflowsHandlers(repo);
+
+  const request = new Request(
+    "http://localhost/api/v1/workflows/nonexistent",
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "updated-name" }),
+    },
+  );
+  const response = await handlers.updateWorkflow({
+    request,
+    params: { id: "nonexistent" },
+  });
+
+  assertEquals(response.status, 404);
+});

--- a/experiments/webapp/backend/middleware/cors.ts
+++ b/experiments/webapp/backend/middleware/cors.ts
@@ -1,0 +1,86 @@
+/**
+ * CORS middleware for handling cross-origin requests.
+ */
+
+import type { Middleware } from "../server.ts";
+
+export interface CorsConfig {
+  origins?: string[];
+  methods?: string[];
+  headers?: string[];
+  exposeHeaders?: string[];
+  credentials?: boolean;
+  maxAge?: number;
+}
+
+const DEFAULT_CONFIG: CorsConfig = {
+  origins: ["*"],
+  methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+  headers: ["Content-Type", "Authorization"],
+  exposeHeaders: [],
+  credentials: false,
+  maxAge: 86400,
+};
+
+export function cors(config: CorsConfig = {}): Middleware {
+  const mergedConfig = { ...DEFAULT_CONFIG, ...config };
+
+  return async (request: Request, next: () => Promise<Response>) => {
+    const origin = request.headers.get("Origin") ?? "";
+
+    const isAllowed = mergedConfig.origins?.includes("*") ||
+      mergedConfig.origins?.includes(origin);
+
+    if (request.method === "OPTIONS") {
+      if (!isAllowed) {
+        return new Response(null, { status: 403 });
+      }
+
+      const headers: Record<string, string> = {
+        "Access-Control-Allow-Methods": mergedConfig.methods?.join(", ") ?? "",
+        "Access-Control-Allow-Headers": mergedConfig.headers?.join(", ") ?? "",
+        "Access-Control-Max-Age": String(mergedConfig.maxAge ?? 86400),
+      };
+
+      if (mergedConfig.origins?.includes("*")) {
+        headers["Access-Control-Allow-Origin"] = "*";
+      } else if (isAllowed) {
+        headers["Access-Control-Allow-Origin"] = origin;
+        headers["Vary"] = "Origin";
+      }
+
+      if (mergedConfig.credentials) {
+        headers["Access-Control-Allow-Credentials"] = "true";
+      }
+
+      return new Response(null, { status: 204, headers });
+    }
+
+    const response = await next();
+    const newHeaders = new Headers(response.headers);
+
+    if (mergedConfig.origins?.includes("*")) {
+      newHeaders.set("Access-Control-Allow-Origin", "*");
+    } else if (isAllowed) {
+      newHeaders.set("Access-Control-Allow-Origin", origin);
+      newHeaders.set("Vary", "Origin");
+    }
+
+    if (mergedConfig.credentials) {
+      newHeaders.set("Access-Control-Allow-Credentials", "true");
+    }
+
+    if (mergedConfig.exposeHeaders?.length) {
+      newHeaders.set(
+        "Access-Control-Expose-Headers",
+        mergedConfig.exposeHeaders.join(", "),
+      );
+    }
+
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: newHeaders,
+    });
+  };
+}

--- a/experiments/webapp/backend/middleware/cors_test.ts
+++ b/experiments/webapp/backend/middleware/cors_test.ts
@@ -1,0 +1,167 @@
+import { assertEquals } from "@std/assert";
+import { cors } from "./cors.ts";
+
+Deno.test("cors - handles OPTIONS preflight with default config", async () => {
+  const middleware = cors();
+  const request = new Request("http://localhost/api/test", {
+    method: "OPTIONS",
+    headers: { Origin: "http://example.com" },
+  });
+
+  const response = await middleware(
+    request,
+    () => Promise.resolve(new Response("ok")),
+  );
+
+  assertEquals(response.status, 204);
+  assertEquals(response.headers.get("Access-Control-Allow-Origin"), "*");
+  assertEquals(
+    response.headers.get("Access-Control-Allow-Methods"),
+    "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+  );
+  assertEquals(
+    response.headers.get("Access-Control-Allow-Headers"),
+    "Content-Type, Authorization",
+  );
+});
+
+Deno.test("cors - adds CORS headers to regular response", async () => {
+  const middleware = cors();
+  const request = new Request("http://localhost/api/test", {
+    method: "GET",
+    headers: { Origin: "http://example.com" },
+  });
+
+  const response = await middleware(
+    request,
+    () => Promise.resolve(new Response("ok", { status: 200 })),
+  );
+
+  assertEquals(response.status, 200);
+  assertEquals(response.headers.get("Access-Control-Allow-Origin"), "*");
+});
+
+Deno.test("cors - respects custom origins config", async () => {
+  const middleware = cors({ origins: ["http://allowed.com"] });
+  const request = new Request("http://localhost/api/test", {
+    method: "OPTIONS",
+    headers: { Origin: "http://allowed.com" },
+  });
+
+  const response = await middleware(
+    request,
+    () => Promise.resolve(new Response("ok")),
+  );
+
+  assertEquals(response.status, 204);
+  assertEquals(
+    response.headers.get("Access-Control-Allow-Origin"),
+    "http://allowed.com",
+  );
+  assertEquals(response.headers.get("Vary"), "Origin");
+});
+
+Deno.test("cors - rejects OPTIONS from disallowed origin", async () => {
+  const middleware = cors({ origins: ["http://allowed.com"] });
+  const request = new Request("http://localhost/api/test", {
+    method: "OPTIONS",
+    headers: { Origin: "http://notallowed.com" },
+  });
+
+  const response = await middleware(
+    request,
+    () => Promise.resolve(new Response("ok")),
+  );
+
+  assertEquals(response.status, 403);
+});
+
+Deno.test("cors - handles credentials option", async () => {
+  const middleware = cors({
+    origins: ["http://example.com"],
+    credentials: true,
+  });
+  const request = new Request("http://localhost/api/test", {
+    method: "OPTIONS",
+    headers: { Origin: "http://example.com" },
+  });
+
+  const response = await middleware(
+    request,
+    () => Promise.resolve(new Response("ok")),
+  );
+
+  assertEquals(
+    response.headers.get("Access-Control-Allow-Credentials"),
+    "true",
+  );
+});
+
+Deno.test("cors - handles exposeHeaders option", async () => {
+  const middleware = cors({ exposeHeaders: ["X-Custom-Header", "X-Another"] });
+  const request = new Request("http://localhost/api/test", {
+    method: "GET",
+    headers: { Origin: "http://example.com" },
+  });
+
+  const response = await middleware(
+    request,
+    () => Promise.resolve(new Response("ok")),
+  );
+
+  assertEquals(
+    response.headers.get("Access-Control-Expose-Headers"),
+    "X-Custom-Header, X-Another",
+  );
+});
+
+Deno.test("cors - handles maxAge option", async () => {
+  const middleware = cors({ maxAge: 3600 });
+  const request = new Request("http://localhost/api/test", {
+    method: "OPTIONS",
+    headers: { Origin: "http://example.com" },
+  });
+
+  const response = await middleware(
+    request,
+    () => Promise.resolve(new Response("ok")),
+  );
+
+  assertEquals(response.headers.get("Access-Control-Max-Age"), "3600");
+});
+
+Deno.test("cors - custom methods config", async () => {
+  const middleware = cors({ methods: ["GET", "POST"] });
+  const request = new Request("http://localhost/api/test", {
+    method: "OPTIONS",
+    headers: { Origin: "http://example.com" },
+  });
+
+  const response = await middleware(
+    request,
+    () => Promise.resolve(new Response("ok")),
+  );
+
+  assertEquals(
+    response.headers.get("Access-Control-Allow-Methods"),
+    "GET, POST",
+  );
+});
+
+Deno.test("cors - custom headers config", async () => {
+  const middleware = cors({ headers: ["Content-Type", "X-API-Key"] });
+  const request = new Request("http://localhost/api/test", {
+    method: "OPTIONS",
+    headers: { Origin: "http://example.com" },
+  });
+
+  const response = await middleware(
+    request,
+    () => Promise.resolve(new Response("ok")),
+  );
+
+  assertEquals(
+    response.headers.get("Access-Control-Allow-Headers"),
+    "Content-Type, X-API-Key",
+  );
+});

--- a/experiments/webapp/backend/mod.ts
+++ b/experiments/webapp/backend/mod.ts
@@ -1,0 +1,27 @@
+/**
+ * HTTP infrastructure module.
+ */
+
+export {
+  errorResponse,
+  type HttpMethod,
+  jsonResponse,
+  type RouteContext,
+  type RouteHandler,
+  type RouteParams,
+  Router,
+} from "./router.ts";
+export {
+  createServer,
+  HttpServer,
+  type Middleware,
+  type ServerConfig,
+} from "./server.ts";
+export { cors, type CorsConfig } from "./middleware/cors.ts";
+export { listTypes } from "./handlers/types_handler.ts";
+export { createModelsHandlers } from "./handlers/models_handler.ts";
+export { createResourcesHandlers } from "./handlers/resources_handler.ts";
+export { createWorkflowsHandlers } from "./handlers/workflows_handler.ts";
+export { createStaticHandler } from "./handlers/static_handler.ts";
+export { createOutputsHandlers } from "./handlers/outputs_handler.ts";
+export { createWorkflowRunsHandlers } from "./handlers/workflow_runs_handler.ts";

--- a/experiments/webapp/backend/router.ts
+++ b/experiments/webapp/backend/router.ts
@@ -1,0 +1,178 @@
+/**
+ * HTTP router with path pattern matching and method-based dispatch.
+ */
+
+export type RouteParams = Record<string, string>;
+
+export interface RouteContext {
+  request: Request;
+  params: RouteParams;
+}
+
+export type RouteHandler = (ctx: RouteContext) => Promise<Response> | Response;
+
+export type HttpMethod =
+  | "GET"
+  | "POST"
+  | "PUT"
+  | "PATCH"
+  | "DELETE"
+  | "OPTIONS";
+
+interface Route {
+  method: HttpMethod;
+  pattern: string;
+  segments: RouteSegment[];
+  handler: RouteHandler;
+}
+
+type RouteSegment =
+  | { type: "static"; value: string }
+  | { type: "param"; name: string }
+  | { type: "wildcard" };
+
+function parsePattern(pattern: string): RouteSegment[] {
+  const segments: RouteSegment[] = [];
+  const parts = pattern.split("/").filter((p) => p !== "");
+
+  for (const part of parts) {
+    if (part === "*") {
+      segments.push({ type: "wildcard" });
+    } else if (part.startsWith(":")) {
+      segments.push({ type: "param", name: part.slice(1) });
+    } else {
+      segments.push({ type: "static", value: part });
+    }
+  }
+
+  return segments;
+}
+
+function matchPath(
+  pathSegments: string[],
+  routeSegments: RouteSegment[],
+): RouteParams | null {
+  const params: RouteParams = {};
+
+  for (let i = 0; i < routeSegments.length; i++) {
+    const routeSeg = routeSegments[i];
+
+    if (routeSeg.type === "wildcard") {
+      return params;
+    }
+
+    if (i >= pathSegments.length) {
+      return null;
+    }
+
+    const pathSeg = pathSegments[i];
+
+    if (routeSeg.type === "static") {
+      if (routeSeg.value !== pathSeg) {
+        return null;
+      }
+    } else if (routeSeg.type === "param") {
+      params[routeSeg.name] = decodeURIComponent(pathSeg);
+    }
+  }
+
+  if (pathSegments.length !== routeSegments.length) {
+    const lastRoute = routeSegments[routeSegments.length - 1];
+    if (!lastRoute || lastRoute.type !== "wildcard") {
+      return null;
+    }
+  }
+
+  return params;
+}
+
+export class Router {
+  private routes: Route[] = [];
+
+  add(method: HttpMethod, pattern: string, handler: RouteHandler): this {
+    this.routes.push({
+      method,
+      pattern,
+      segments: parsePattern(pattern),
+      handler,
+    });
+    return this;
+  }
+
+  get(pattern: string, handler: RouteHandler): this {
+    return this.add("GET", pattern, handler);
+  }
+
+  post(pattern: string, handler: RouteHandler): this {
+    return this.add("POST", pattern, handler);
+  }
+
+  put(pattern: string, handler: RouteHandler): this {
+    return this.add("PUT", pattern, handler);
+  }
+
+  patch(pattern: string, handler: RouteHandler): this {
+    return this.add("PATCH", pattern, handler);
+  }
+
+  delete(pattern: string, handler: RouteHandler): this {
+    return this.add("DELETE", pattern, handler);
+  }
+
+  options(pattern: string, handler: RouteHandler): this {
+    return this.add("OPTIONS", pattern, handler);
+  }
+
+  match(
+    request: Request,
+  ): { handler: RouteHandler; params: RouteParams } | null {
+    const url = new URL(request.url);
+    const method = request.method as HttpMethod;
+    const pathSegments = url.pathname.split("/").filter((p) => p !== "");
+
+    for (const route of this.routes) {
+      if (route.method !== method) {
+        continue;
+      }
+
+      const params = matchPath(pathSegments, route.segments);
+      if (params !== null) {
+        return { handler: route.handler, params };
+      }
+    }
+
+    return null;
+  }
+
+  async handle(request: Request): Promise<Response> {
+    const match = this.match(request);
+
+    if (!match) {
+      return new Response("Not Found", { status: 404 });
+    }
+
+    return await match.handler({ request, params: match.params });
+  }
+}
+
+export function jsonResponse(
+  data: unknown,
+  status = 200,
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+  });
+}
+
+export function errorResponse(
+  message: string,
+  status = 500,
+  headers: Record<string, string> = {},
+): Response {
+  return jsonResponse({ error: message }, status, headers);
+}

--- a/experiments/webapp/backend/router_test.ts
+++ b/experiments/webapp/backend/router_test.ts
@@ -1,0 +1,187 @@
+import { assertEquals } from "@std/assert";
+import { errorResponse, jsonResponse, Router } from "./router.ts";
+
+Deno.test("Router - matches simple static path", () => {
+  const router = new Router();
+  router.get("/api/test", () => new Response("ok"));
+
+  const request = new Request("http://localhost/api/test");
+  const match = router.match(request);
+
+  assertEquals(match !== null, true);
+  assertEquals(match?.params, {});
+});
+
+Deno.test("Router - matches path with single parameter", () => {
+  const router = new Router();
+  router.get("/api/models/:type", () => new Response("ok"));
+
+  const request = new Request("http://localhost/api/models/aws-ec2-instance");
+  const match = router.match(request);
+
+  assertEquals(match !== null, true);
+  assertEquals(match?.params, { type: "aws-ec2-instance" });
+});
+
+Deno.test("Router - matches path with multiple parameters", () => {
+  const router = new Router();
+  router.get("/api/models/:type/:id", () => new Response("ok"));
+
+  const request = new Request("http://localhost/api/models/echo/test-123");
+  const match = router.match(request);
+
+  assertEquals(match !== null, true);
+  assertEquals(match?.params, { type: "echo", id: "test-123" });
+});
+
+Deno.test("Router - matches wildcard path", () => {
+  const router = new Router();
+  router.get("/*", () => new Response("ok"));
+
+  const request = new Request("http://localhost/any/path/here");
+  const match = router.match(request);
+
+  assertEquals(match !== null, true);
+});
+
+Deno.test("Router - returns null for non-matching path", () => {
+  const router = new Router();
+  router.get("/api/test", () => new Response("ok"));
+
+  const request = new Request("http://localhost/api/other");
+  const match = router.match(request);
+
+  assertEquals(match, null);
+});
+
+Deno.test("Router - distinguishes HTTP methods", () => {
+  const router = new Router();
+  router.get("/api/test", () => new Response("GET"));
+  router.post("/api/test", () => new Response("POST"));
+
+  const getRequest = new Request("http://localhost/api/test", {
+    method: "GET",
+  });
+  const postRequest = new Request("http://localhost/api/test", {
+    method: "POST",
+  });
+
+  const getMatch = router.match(getRequest);
+  const postMatch = router.match(postRequest);
+
+  assertEquals(getMatch !== null, true);
+  assertEquals(postMatch !== null, true);
+});
+
+Deno.test("Router - handle returns 404 for unmatched route", async () => {
+  const router = new Router();
+  router.get("/api/test", () => new Response("ok"));
+
+  const request = new Request("http://localhost/api/other");
+  const response = await router.handle(request);
+
+  assertEquals(response.status, 404);
+});
+
+Deno.test("Router - handle invokes matched handler", async () => {
+  const router = new Router();
+  router.get("/api/test", () => new Response("success", { status: 200 }));
+
+  const request = new Request("http://localhost/api/test");
+  const response = await router.handle(request);
+
+  assertEquals(response.status, 200);
+  assertEquals(await response.text(), "success");
+});
+
+Deno.test("Router - all HTTP method helpers work", () => {
+  const router = new Router();
+  const handler = () => new Response("ok");
+
+  router.get("/get", handler);
+  router.post("/post", handler);
+  router.put("/put", handler);
+  router.patch("/patch", handler);
+  router.delete("/delete", handler);
+  router.options("/options", handler);
+
+  assertEquals(
+    router.match(new Request("http://localhost/get", { method: "GET" })) !==
+      null,
+    true,
+  );
+  assertEquals(
+    router.match(new Request("http://localhost/post", { method: "POST" })) !==
+      null,
+    true,
+  );
+  assertEquals(
+    router.match(new Request("http://localhost/put", { method: "PUT" })) !==
+      null,
+    true,
+  );
+  assertEquals(
+    router.match(new Request("http://localhost/patch", { method: "PATCH" })) !==
+      null,
+    true,
+  );
+  assertEquals(
+    router.match(
+      new Request("http://localhost/delete", { method: "DELETE" }),
+    ) !==
+      null,
+    true,
+  );
+  assertEquals(
+    router.match(
+      new Request("http://localhost/options", { method: "OPTIONS" }),
+    ) !== null,
+    true,
+  );
+});
+
+Deno.test("jsonResponse creates JSON response with correct headers", async () => {
+  const data = { foo: "bar" };
+  const response = jsonResponse(data);
+
+  assertEquals(response.status, 200);
+  assertEquals(response.headers.get("Content-Type"), "application/json");
+  assertEquals(await response.json(), data);
+});
+
+Deno.test("jsonResponse accepts custom status code", () => {
+  const response = jsonResponse({ created: true }, 201);
+  assertEquals(response.status, 201);
+});
+
+Deno.test("jsonResponse accepts custom headers", () => {
+  const response = jsonResponse({}, 200, { "X-Custom": "value" });
+  assertEquals(response.headers.get("X-Custom"), "value");
+});
+
+Deno.test("errorResponse creates error JSON response", async () => {
+  const response = errorResponse("Something went wrong", 400);
+
+  assertEquals(response.status, 400);
+  assertEquals(response.headers.get("Content-Type"), "application/json");
+  assertEquals(await response.json(), { error: "Something went wrong" });
+});
+
+Deno.test("errorResponse defaults to 500 status", () => {
+  const response = errorResponse("Internal error");
+  assertEquals(response.status, 500);
+});
+
+Deno.test("Router - decodes URL-encoded path parameters", () => {
+  const router = new Router();
+  router.get("/api/models/:type/:id", () => new Response("ok"));
+
+  // URL with encoded slashes: aws/ec2/vpc becomes aws%2Fec2%2Fvpc
+  const request = new Request(
+    "http://localhost/api/models/aws%2Fec2%2Fvpc/test-123",
+  );
+  const match = router.match(request);
+
+  assertEquals(match !== null, true);
+  assertEquals(match?.params, { type: "aws/ec2/vpc", id: "test-123" });
+});

--- a/experiments/webapp/backend/server.ts
+++ b/experiments/webapp/backend/server.ts
@@ -1,0 +1,124 @@
+/**
+ * HTTP server wrapper using Deno.serve() with graceful shutdown.
+ */
+
+import type { Logger } from "@logtape/logtape";
+import { type RouteHandler, Router } from "./router.ts";
+
+export interface ServerConfig {
+  port: number;
+  host: string;
+  logger: Logger;
+}
+
+export type Middleware = (
+  request: Request,
+  next: () => Promise<Response>,
+) => Promise<Response>;
+
+export class HttpServer {
+  private router: Router;
+  private middlewares: Middleware[] = [];
+  private abortController: AbortController | null = null;
+
+  constructor(private config: ServerConfig) {
+    this.router = new Router();
+  }
+
+  use(middleware: Middleware): this {
+    this.middlewares.push(middleware);
+    return this;
+  }
+
+  getRouter(): Router {
+    return this.router;
+  }
+
+  get(pattern: string, handler: RouteHandler): this {
+    this.router.get(pattern, handler);
+    return this;
+  }
+
+  post(pattern: string, handler: RouteHandler): this {
+    this.router.post(pattern, handler);
+    return this;
+  }
+
+  put(pattern: string, handler: RouteHandler): this {
+    this.router.put(pattern, handler);
+    return this;
+  }
+
+  patch(pattern: string, handler: RouteHandler): this {
+    this.router.patch(pattern, handler);
+    return this;
+  }
+
+  delete(pattern: string, handler: RouteHandler): this {
+    this.router.delete(pattern, handler);
+    return this;
+  }
+
+  options(pattern: string, handler: RouteHandler): this {
+    this.router.options(pattern, handler);
+    return this;
+  }
+
+  private async handleRequest(request: Request): Promise<Response> {
+    let index = 0;
+
+    const next = async (): Promise<Response> => {
+      if (index < this.middlewares.length) {
+        const middleware = this.middlewares[index++];
+        return await middleware(request, next);
+      }
+      return await this.router.handle(request);
+    };
+
+    try {
+      return await next();
+    } catch (error) {
+      this.config.logger.error`Request error: ${error}`;
+      return new Response("Internal Server Error", { status: 500 });
+    }
+  }
+
+  async start(): Promise<void> {
+    this.abortController = new AbortController();
+
+    const server = Deno.serve(
+      {
+        port: this.config.port,
+        hostname: this.config.host,
+        signal: this.abortController.signal,
+        onListen: ({ hostname, port }) => {
+          this.config.logger
+            .info`Server listening on http://${hostname}:${port}`;
+        },
+      },
+      (request) => this.handleRequest(request),
+    );
+
+    const shutdown = async () => {
+      this.config.logger.info`Shutting down server...`;
+      this.stop();
+      await server.finished;
+    };
+
+    Deno.addSignalListener("SIGINT", shutdown);
+    Deno.addSignalListener("SIGTERM", shutdown);
+
+    await server.finished;
+  }
+
+  stop(): void {
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = null;
+    }
+  }
+}
+
+export function createServer(config: ServerConfig): HttpServer {
+  return new HttpServer(config);
+}

--- a/experiments/webapp/backend/server_test.ts
+++ b/experiments/webapp/backend/server_test.ts
@@ -1,0 +1,91 @@
+import { assertEquals } from "@std/assert";
+import { getLogger } from "@logtape/logtape";
+import { createServer, HttpServer } from "./server.ts";
+import { initializeLogging } from "../../../src/infrastructure/logging/logger.ts";
+
+// Initialize logging for tests
+await initializeLogging({ debugLogs: false });
+
+const testLogger = getLogger(["test"]);
+
+Deno.test("createServer returns HttpServer instance", () => {
+  const server = createServer({
+    port: 8080,
+    host: "localhost",
+    logger: testLogger,
+  });
+
+  assertEquals(server instanceof HttpServer, true);
+});
+
+Deno.test("HttpServer - can add routes via convenience methods", () => {
+  const server = createServer({
+    port: 8080,
+    host: "localhost",
+    logger: testLogger,
+  });
+
+  const handler = () => new Response("ok");
+
+  // All methods should return this for chaining
+  const result = server.get("/get", handler);
+  assertEquals(result, server);
+
+  server.post("/post", handler);
+  server.put("/put", handler);
+  server.patch("/patch", handler);
+  server.delete("/delete", handler);
+  server.options("/options", handler);
+
+  // Verify routes are registered on underlying router
+  const router = server.getRouter();
+  assertEquals(
+    router.match(new Request("http://localhost/get", { method: "GET" })) !==
+      null,
+    true,
+  );
+  assertEquals(
+    router.match(new Request("http://localhost/post", { method: "POST" })) !==
+      null,
+    true,
+  );
+});
+
+Deno.test("HttpServer - can add middleware", () => {
+  const server = createServer({
+    port: 8080,
+    host: "localhost",
+    logger: testLogger,
+  });
+
+  const middleware = async (_req: Request, next: () => Promise<Response>) => {
+    return await next();
+  };
+
+  const result = server.use(middleware);
+  assertEquals(result, server);
+});
+
+Deno.test("HttpServer - getRouter returns Router instance", () => {
+  const server = createServer({
+    port: 8080,
+    host: "localhost",
+    logger: testLogger,
+  });
+
+  const router = server.getRouter();
+  assertEquals(typeof router.get, "function");
+  assertEquals(typeof router.post, "function");
+  assertEquals(typeof router.match, "function");
+});
+
+Deno.test("HttpServer - stop is callable without starting", () => {
+  const server = createServer({
+    port: 8080,
+    host: "localhost",
+    logger: testLogger,
+  });
+
+  // Should not throw even if server hasn't started
+  server.stop();
+});

--- a/experiments/webapp/cli/webapp_command.ts
+++ b/experiments/webapp/cli/webapp_command.ts
@@ -1,0 +1,181 @@
+import { Command } from "@cliffy/command";
+import { dirname, fromFileUrl, join } from "@std/path";
+import { createContext, type GlobalOptions } from "../../../src/cli/context.ts";
+import { RepoPath } from "../../../src/domain/repo/repo_path.ts";
+import {
+  cors,
+  createModelsHandlers,
+  createOutputsHandlers,
+  createResourcesHandlers,
+  createServer,
+  createStaticHandler,
+  createWorkflowRunsHandlers,
+  createWorkflowsHandlers,
+  listTypes,
+} from "../backend/mod.ts";
+import { YamlInputRepository } from "../../../src/infrastructure/persistence/yaml_input_repository.ts";
+import { YamlResourceRepository } from "../../../src/infrastructure/persistence/yaml_resource_repository.ts";
+import { YamlWorkflowRepository } from "../../../src/infrastructure/persistence/yaml_workflow_repository.ts";
+import { YamlWorkflowRunRepository } from "../../../src/infrastructure/persistence/yaml_workflow_run_repository.ts";
+import { YamlOutputRepository } from "../../../src/infrastructure/persistence/yaml_output_repository.ts";
+import { YamlDataRepository } from "../../../src/infrastructure/persistence/yaml_data_repository.ts";
+import { StreamingLogRepository } from "../../../src/infrastructure/persistence/streaming_log_repository.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+/**
+ * Resolves the webapp dist directory path.
+ * When compiled, the frontend dist is embedded and accessible relative to the executable.
+ * When running with deno run, resolve relative to this source file.
+ */
+function resolveWebappDir(): string {
+  // import.meta.url gives us the URL of this module
+  // When compiled, this will be something like file:///path/to/swamp
+  // When running with deno run, it's file:///path/to/experiments/webapp/cli/webapp_command.ts
+  const moduleUrl = import.meta.url;
+
+  if (moduleUrl.startsWith("file://")) {
+    const modulePath = fromFileUrl(moduleUrl);
+    const moduleDir = dirname(modulePath);
+
+    // Check if we're in the compiled binary (module path won't have /experiments/)
+    if (!modulePath.includes("/experiments/")) {
+      // Compiled binary - experiments/webapp/frontend/dist is alongside the binary
+      return join(moduleDir, "experiments", "webapp", "frontend", "dist");
+    }
+
+    // Running from source - go up to frontend/dist
+    return join(moduleDir, "..", "frontend", "dist");
+  }
+
+  // Fallback for other protocols
+  return "experiments/webapp/frontend/dist";
+}
+
+export const repoWebappCommand = new Command()
+  .description("Start the swamp webapp server")
+  .arguments("[path:string]")
+  .option("-p, --port <port:number>", "Port to serve on", { default: 8080 })
+  .option("--host <host:string>", "Host to bind to", { default: "localhost" })
+  .action(async function (options: AnyOptions, pathArg?: string) {
+    const ctx = createContext(options as GlobalOptions, "repo-webapp");
+    ctx.logger.debug`Starting webapp server for: ${pathArg ?? "."}`;
+
+    const repoPath = RepoPath.create(pathArg ?? ".");
+    const repoDir = repoPath.value;
+
+    // Initialize repositories
+    const inputRepository = new YamlInputRepository(repoDir);
+    const resourceRepository = new YamlResourceRepository(repoDir);
+    const workflowRepository = new YamlWorkflowRepository(repoDir);
+    const workflowRunRepository = new YamlWorkflowRunRepository(repoDir);
+    const outputRepository = new YamlOutputRepository(repoDir);
+    const dataRepository = new YamlDataRepository(repoDir);
+    const logRepository = new StreamingLogRepository(repoDir);
+
+    // Create handlers
+    const modelsHandlers = createModelsHandlers(inputRepository);
+    const resourcesHandlers = createResourcesHandlers(resourceRepository);
+    const workflowsHandlers = createWorkflowsHandlers(workflowRepository);
+    const workflowRunsHandlers = createWorkflowRunsHandlers(
+      workflowRunRepository,
+      workflowRepository,
+      outputRepository,
+    );
+    const outputsHandlers = createOutputsHandlers(
+      outputRepository,
+      inputRepository,
+      dataRepository,
+      logRepository,
+    );
+
+    // Resolve webapp directory
+    const webappDir = resolveWebappDir();
+    ctx.logger.debug`Webapp directory: ${webappDir}`;
+
+    const staticHandler = createStaticHandler(webappDir);
+
+    // Create server
+    const server = createServer({
+      port: options.port,
+      host: options.host,
+      logger: ctx.logger,
+    });
+
+    // Add CORS middleware
+    server.use(cors());
+
+    // Register API routes
+    const router = server.getRouter();
+
+    // Types endpoints
+    router.get("/api/v1/types", listTypes);
+
+    // Models endpoints
+    router.get("/api/v1/models", modelsHandlers.listAllModels);
+    router.get("/api/v1/models/lookup/:id", modelsHandlers.lookupModelById);
+    router.get("/api/v1/models/:type", modelsHandlers.listModelsByType);
+    router.get("/api/v1/models/:type/:id", modelsHandlers.getModel);
+    router.post("/api/v1/models/:type", modelsHandlers.createModel);
+    router.put("/api/v1/models/:type/:id", modelsHandlers.updateModel);
+    router.delete("/api/v1/models/:type/:id", modelsHandlers.deleteModel);
+
+    // Resources endpoints
+    router.get(
+      "/api/v1/resources/:type",
+      resourcesHandlers.listResourcesByType,
+    );
+    router.get("/api/v1/resources/:type/:id", resourcesHandlers.getResource);
+    router.delete(
+      "/api/v1/resources/:type/:id",
+      resourcesHandlers.deleteResource,
+    );
+
+    // Workflows endpoints
+    router.get("/api/v1/workflows", workflowsHandlers.listWorkflows);
+    router.get("/api/v1/workflows/:id", workflowsHandlers.getWorkflow);
+    router.post("/api/v1/workflows", workflowsHandlers.createWorkflow);
+    router.put("/api/v1/workflows/:id", workflowsHandlers.updateWorkflow);
+    router.delete("/api/v1/workflows/:id", workflowsHandlers.deleteWorkflow);
+
+    // Workflow runs endpoints
+    router.get("/api/v1/workflow-runs", workflowRunsHandlers.listWorkflowRuns);
+    router.get(
+      "/api/v1/workflow-runs/:id",
+      workflowRunsHandlers.getWorkflowRun,
+    );
+    router.get(
+      "/api/v1/workflows/:workflowId/runs",
+      workflowRunsHandlers.listWorkflowRunsByWorkflow,
+    );
+
+    // Outputs endpoints
+    router.get("/api/v1/outputs", outputsHandlers.listOutputs);
+    router.get("/api/v1/outputs/:id", outputsHandlers.getOutput);
+    router.get("/api/v1/outputs/:id/data", outputsHandlers.getOutputData);
+    router.get("/api/v1/outputs/:id/logs", outputsHandlers.getOutputLogs);
+
+    // Static file serving (catch-all for SPA)
+    router.get("/*", staticHandler.serveStatic);
+
+    // Output startup info
+    if (ctx.outputMode === "json") {
+      console.log(
+        JSON.stringify({
+          status: "started",
+          url: `http://${options.host}:${options.port}`,
+          repoDir,
+        }),
+      );
+    } else {
+      console.log(
+        `\nSwamp webapp server starting at http://${options.host}:${options.port}`,
+      );
+      console.log(`Repository: ${repoDir}`);
+      console.log("Press Ctrl+C to stop\n");
+    }
+
+    // Start server
+    await server.start();
+  });

--- a/experiments/webapp/cli/webapp_command_test.ts
+++ b/experiments/webapp/cli/webapp_command_test.ts
@@ -1,0 +1,37 @@
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../../src/infrastructure/logging/logger.ts";
+
+// Initialize logging for tests
+await initializeLogging({ debugLogs: false });
+
+Deno.test("repoWebappCommand module loads", async () => {
+  const { repoWebappCommand } = await import("./webapp_command.ts");
+  // Command has description and options, meaning it loaded correctly
+  assertEquals(
+    repoWebappCommand.getDescription(),
+    "Start the swamp webapp server",
+  );
+});
+
+Deno.test("repoWebappCommand is registered as subcommand of repo", async () => {
+  const { repoCommand } = await import("../../../src/cli/commands/repo_init.ts");
+  const commands = repoCommand.getCommands();
+  const webappCmd = commands.find((c) => c.getName() === "webapp");
+  assertEquals(webappCmd !== undefined, true);
+});
+
+Deno.test("repoWebappCommand has port option", async () => {
+  const { repoWebappCommand } = await import("./webapp_command.ts");
+  const options = repoWebappCommand.getOptions();
+
+  const portOption = options.find((o) => o.name === "port");
+  assertEquals(portOption !== undefined, true);
+});
+
+Deno.test("repoWebappCommand has host option", async () => {
+  const { repoWebappCommand } = await import("./webapp_command.ts");
+  const options = repoWebappCommand.getOptions();
+
+  const hostOption = options.find((o) => o.name === "host");
+  assertEquals(hostOption !== undefined, true);
+});

--- a/experiments/webapp/frontend/index.html
+++ b/experiments/webapp/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Swamp Webapp</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/experiments/webapp/frontend/package-lock.json
+++ b/experiments/webapp/frontend/package-lock.json
@@ -1,0 +1,2594 @@
+{
+  "name": "swamp-webapp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "swamp-webapp",
+      "version": "0.1.0",
+      "dependencies": {
+        "vue": "^3.5.13",
+        "vue-router": "^4.5.1"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-vue": "^5.2.4",
+        "autoprefixer": "^10.4.20",
+        "postcss": "^8.4.49",
+        "tailwindcss": "^3.4.17",
+        "typescript": "~5.6.3",
+        "vite": "^6.0.7",
+        "vue-tsc": "^2.2.0"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
+      "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.6"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
+      "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.0.tgz",
+      "integrity": "sha512-tPgXB6cDTndIe1ah7u6amCI1T0SsnlOuKgg10Xh3uizJk4e5M1JGaUMk7J4ciuAUcFpbOiNhm2XIjP9ON0dUqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.0.tgz",
+      "integrity": "sha512-sa4LyseLLXr1onr97StkU1Nb7fWcg6niokTwEVNOO7awaKaoRObQ54+V/hrF/BP1noMEaaAW6Fg2d/CfLiq3Mg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.0.tgz",
+      "integrity": "sha512-/NNIj9A7yLjKdmkx5dC2XQ9DmjIECpGpwHoGmA5E1AhU0fuICSqSWScPhN1yLCkEdkCwJIDu2xIeLPs60MNIVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.0.tgz",
+      "integrity": "sha512-xoh8abqgPrPYPr7pTYipqnUi1V3em56JzE/HgDgitTqZBZ3yKCWI+7KUkceM6tNweyUKYru1UMi7FC060RyKwA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.0.tgz",
+      "integrity": "sha512-PCkMh7fNahWSbA0OTUQ2OpYHpjZZr0hPr8lId8twD7a7SeWrvT3xJVyza+dQwXSSq4yEQTMoXgNOfMCsn8584g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.0.tgz",
+      "integrity": "sha512-1j3stGx+qbhXql4OCDZhnK7b01s6rBKNybfsX+TNrEe9JNq4DLi1yGiR1xW+nL+FNVvI4D02PUnl6gJ/2y6WJA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.0.tgz",
+      "integrity": "sha512-eyrr5W08Ms9uM0mLcKfM/Uzx7hjhz2bcjv8P2uynfj0yU8GGPdz8iYrBPhiLOZqahoAMB8ZiolRZPbbU2MAi6Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.0.tgz",
+      "integrity": "sha512-Xds90ITXJCNyX9pDhqf85MKWUI4lqjiPAipJ8OLp8xqI2Ehk+TCVhF9rvOoN8xTbcafow3QOThkNnrM33uCFQA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.0.tgz",
+      "integrity": "sha512-Xws2KA4CLvZmXjy46SQaXSejuKPhwVdaNinldoYfqruZBaJHqVo6hnRa8SDo9z7PBW5x84SH64+izmldCgbezw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.0.tgz",
+      "integrity": "sha512-hrKXKbX5FdaRJj7lTMusmvKbhMJSGWJ+w++4KmjiDhpTgNlhYobMvKfDoIWecy4O60K6yA4SnztGuNTQF+Lplw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.0.tgz",
+      "integrity": "sha512-6A+nccfSDGKsPm00d3xKcrsBcbqzCTAukjwWK6rbuAnB2bHaL3r9720HBVZ/no7+FhZLz/U3GwwZZEh6tOSI8Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.0.tgz",
+      "integrity": "sha512-4P1VyYUe6XAJtQH1Hh99THxr0GKMMwIXsRNOceLrJnaHTDgk1FTcTimDgneRJPvB3LqDQxUmroBclQ1S0cIJwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.0.tgz",
+      "integrity": "sha512-8Vv6pLuIZCMcgXre6c3nOPhE0gjz1+nZP6T+hwWjr7sVH8k0jRkH+XnfjjOTglyMBdSKBPPz54/y1gToSKwrSQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.0.tgz",
+      "integrity": "sha512-r1te1M0Sm2TBVD/RxBPC6RZVwNqUTwJTA7w+C/IW5v9Ssu6xmxWEi+iJQlpBhtUiT1raJ5b48pI8tBvEjEFnFA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.0.tgz",
+      "integrity": "sha512-say0uMU/RaPm3CDQLxUUTF2oNWL8ysvHkAjcCzV2znxBr23kFfaxocS9qJm+NdkRhF8wtdEEAJuYcLPhSPbjuQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.0.tgz",
+      "integrity": "sha512-/MU7/HizQGsnBREtRpcSbSV1zfkoxSTR7wLsRmBPQ8FwUj5sykrP1MyJTvsxP5KBq9SyE6kH8UQQQwa0ASeoQQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.0.tgz",
+      "integrity": "sha512-Q9eh+gUGILIHEaJf66aF6a414jQbDnn29zeu0eX3dHMuysnhTvsUvZTCAyZ6tJhUjnvzBKE4FtuaYxutxRZpOg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.0.tgz",
+      "integrity": "sha512-OR5p5yG5OKSxHReWmwvM0P+VTPMwoBS45PXTMYaskKQqybkS3Kmugq1W+YbNWArF8/s7jQScgzXUhArzEQ7x0A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.0.tgz",
+      "integrity": "sha512-XeatKzo4lHDsVEbm1XDHZlhYZZSQYym6dg2X/Ko0kSFgio+KXLsxwJQprnR48GvdIKDOpqWqssC3iBCjoMcMpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.0.tgz",
+      "integrity": "sha512-Lu71y78F5qOfYmubYLHPcJm74GZLU6UJ4THkf/a1K7Tz2ycwC2VUbsqbJAXaR6Bx70SRdlVrt2+n5l7F0agTUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.0.tgz",
+      "integrity": "sha512-v5xwKDWcu7qhAEcsUubiav7r+48Uk/ENWdr82MBZZRIm7zThSxCIVDfb3ZeRRq9yqk+oIzMdDo6fCcA5DHfMyA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.0.tgz",
+      "integrity": "sha512-XnaaaSMGSI6Wk8F4KK3QP7GfuuhjGchElsVerCplUuxRIzdvZ7hRBpLR0omCmw+kI2RFJB80nenhOoGXlJ5TfQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.0.tgz",
+      "integrity": "sha512-3K1lP+3BXY4t4VihLw5MEg6IZD3ojSYzqzBG571W3kNQe4G4CcFpSUQVgurYgib5d+YaCjeFow8QivWp8vuSvA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.0.tgz",
+      "integrity": "sha512-MDk610P/vJGc5L5ImE4k5s+GZT3en0KoK1MKPXCRgzmksAMk79j4h3k1IerxTNqwDLxsGxStEZVBqG0gIqZqoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.0.tgz",
+      "integrity": "sha512-Zv7v6q6aV+VslnpwzqKAmrk5JdVkLUzok2208ZXGipjb+msxBr/fJPZyeEXiFgH7k62Ak0SLIfxQRZQvTuf7rQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.15.tgz",
+      "integrity": "sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.15"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.15.tgz",
+      "integrity": "sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.15.tgz",
+      "integrity": "sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.15",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.27.tgz",
+      "integrity": "sha512-gnSBQjZA+//qDZen+6a2EdHqJ68Z7uybrMf3SPjEGgG4dicklwDVmMC1AeIHxtLVPT7sn6sH1KOO+tS6gwOUeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@vue/shared": "3.5.27",
+        "entities": "^7.0.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.27.tgz",
+      "integrity": "sha512-oAFea8dZgCtVVVTEC7fv3T5CbZW9BxpFzGGxC79xakTr6ooeEqmRuvQydIiDAkglZEAd09LgVf1RoDnL54fu5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.27",
+        "@vue/shared": "3.5.27"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.27.tgz",
+      "integrity": "sha512-sHZu9QyDPeDmN/MRoshhggVOWE5WlGFStKFwu8G52swATgSny27hJRWteKDSUUzUH+wp+bmeNbhJnEAel/auUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@vue/compiler-core": "3.5.27",
+        "@vue/compiler-dom": "3.5.27",
+        "@vue/compiler-ssr": "3.5.27",
+        "@vue/shared": "3.5.27",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.6",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.27.tgz",
+      "integrity": "sha512-Sj7h+JHt512fV1cTxKlYhg7qxBvack+BGncSpH+8vnN+KN95iPIcqB5rsbblX40XorP+ilO7VIKlkuu3Xq2vjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.27",
+        "@vue/shared": "3.5.27"
+      }
+    },
+    "node_modules/@vue/compiler-vue2": {
+      "version": "2.7.16",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
+      "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "de-indent": "^1.0.2",
+        "he": "^1.2.0"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/language-core": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.12.tgz",
+      "integrity": "sha512-IsGljWbKGU1MZpBPN+BvPAdr55YPkj2nB/TBNGNC32Vy2qLG25DYu/NBN2vNtZqdRbTRjaoYrahLrToim2NanA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.15",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/compiler-vue2": "^2.7.16",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^1.0.3",
+        "minimatch": "^9.0.3",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.27.tgz",
+      "integrity": "sha512-vvorxn2KXfJ0nBEnj4GYshSgsyMNFnIQah/wczXlsNXt+ijhugmW+PpJ2cNPe4V6jpnBcs0MhCODKllWG+nvoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.27"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.27.tgz",
+      "integrity": "sha512-fxVuX/fzgzeMPn/CLQecWeDIFNt3gQVhxM0rW02Tvp/YmZfXQgcTXlakq7IMutuZ/+Ogbn+K0oct9J3JZfyk3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.27",
+        "@vue/shared": "3.5.27"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.27.tgz",
+      "integrity": "sha512-/QnLslQgYqSJ5aUmb5F0z0caZPGHRB8LEAQ1s81vHFM5CBfnun63rxhvE/scVb/j3TbBuoZwkJyiLCkBluMpeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.27",
+        "@vue/runtime-core": "3.5.27",
+        "@vue/shared": "3.5.27",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.27.tgz",
+      "integrity": "sha512-qOz/5thjeP1vAFc4+BY3Nr6wxyLhpeQgAE/8dDtKo6a6xdk+L4W46HDZgNmLOBUDEkFXV3G7pRiUqxjX0/2zWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.27",
+        "@vue/shared": "3.5.27"
+      },
+      "peerDependencies": {
+        "vue": "3.5.27"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.27.tgz",
+      "integrity": "sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ==",
+      "license": "MIT"
+    },
+    "node_modules/alien-signals": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-1.0.13.tgz",
+      "integrity": "sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.23",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.23.tgz",
+      "integrity": "sha512-YYTXSFulfwytnjAPlw8QHncHJmlvFKtczb8InXaAx9Q0LbfDnfEYDE55omerIJKihhmU61Ft+cAOSzQVaBUmeA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001760",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.9.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
+      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001766",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz",
+      "integrity": "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.282",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.282.tgz",
+      "integrity": "sha512-FCPkJtpst28UmFzd903iU7PdeVTfY0KAeJy+Lk0GLZRwgwYHn/irRcaCbQQOmr5Vytc/7rcavsYLvTM8RiHYhQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.0.tgz",
+      "integrity": "sha512-e5lPJi/aui4TO1LpAXIRLySmwXSE8k3b9zoGfd42p67wzxog4WHjiZF3M2uheQih4DGyc25QEV4yRBbpueNiUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.0",
+        "@rollup/rollup-android-arm64": "4.57.0",
+        "@rollup/rollup-darwin-arm64": "4.57.0",
+        "@rollup/rollup-darwin-x64": "4.57.0",
+        "@rollup/rollup-freebsd-arm64": "4.57.0",
+        "@rollup/rollup-freebsd-x64": "4.57.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.0",
+        "@rollup/rollup-linux-arm64-musl": "4.57.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.0",
+        "@rollup/rollup-linux-loong64-musl": "4.57.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.0",
+        "@rollup/rollup-linux-x64-gnu": "4.57.0",
+        "@rollup/rollup-linux-x64-musl": "4.57.0",
+        "@rollup/rollup-openbsd-x64": "4.57.0",
+        "@rollup/rollup-openharmony-arm64": "4.57.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.0",
+        "@rollup/rollup-win32-x64-gnu": "4.57.0",
+        "@rollup/rollup-win32-x64-msvc": "4.57.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vue": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.27.tgz",
+      "integrity": "sha512-aJ/UtoEyFySPBGarREmN4z6qNKpbEguYHMmXSiOGk69czc+zhs0NF6tEFrY8TZKAl8N/LYAkd4JHVd5E/AsSmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.27",
+        "@vue/compiler-sfc": "3.5.27",
+        "@vue/runtime-dom": "3.5.27",
+        "@vue/server-renderer": "3.5.27",
+        "@vue/shared": "3.5.27"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
+      "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.12.tgz",
+      "integrity": "sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/typescript": "2.4.15",
+        "@vue/language-core": "2.2.12"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      }
+    }
+  }
+}

--- a/experiments/webapp/frontend/package.json
+++ b/experiments/webapp/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "swamp-webapp",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.5.13",
+    "vue-router": "^4.5.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.2.4",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "typescript": "~5.6.3",
+    "vite": "^6.0.7",
+    "vue-tsc": "^2.2.0"
+  }
+}

--- a/experiments/webapp/frontend/postcss.config.js
+++ b/experiments/webapp/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/experiments/webapp/frontend/public/favicon.svg
+++ b/experiments/webapp/frontend/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="20" fill="#2d3748"/>
+  <text x="50" y="70" font-size="60" text-anchor="middle" fill="#68d391">S</text>
+</svg>

--- a/experiments/webapp/frontend/src/App.vue
+++ b/experiments/webapp/frontend/src/App.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import NavBar from "./components/NavBar.vue";
+</script>
+
+<template>
+  <div class="min-h-screen">
+    <NavBar />
+    <main class="container mx-auto px-4 py-8">
+      <RouterView />
+    </main>
+  </div>
+</template>

--- a/experiments/webapp/frontend/src/api/client.ts
+++ b/experiments/webapp/frontend/src/api/client.ts
@@ -1,0 +1,461 @@
+const API_BASE = "/api/v1";
+
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options?.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const errorData = await response
+      .json()
+      .catch(() => ({ error: "Unknown error" }));
+    throw new ApiError(
+      response.status,
+      errorData.error || `HTTP ${response.status}`,
+    );
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return response.json();
+}
+
+export interface ModelType {
+  raw: string;
+  normalized: string;
+}
+
+export interface Model {
+  id: string;
+  name: string;
+  type: ModelType;
+  version: number;
+  resourceId?: string;
+  tags: Record<string, string>;
+  attributes: Record<string, unknown>;
+}
+
+export interface Resource {
+  id: string;
+  version: number;
+  createdAt: string;
+  attributes: Record<string, unknown>;
+}
+
+export interface WorkflowSummary {
+  id: string;
+  name: string;
+  description?: string;
+  version: number;
+  jobCount: number;
+}
+
+export interface StepTask {
+  type: "model_method" | "shell";
+  modelIdOrName?: string;
+  methodName?: string;
+  command?: string;
+  args?: string[];
+  workingDir?: string;
+  timeout?: number;
+  env?: Record<string, string>;
+}
+
+export interface TriggerCondition {
+  type:
+    | "always"
+    | "succeeded"
+    | "failed"
+    | "completed"
+    | "skipped"
+    | "and"
+    | "or"
+    | "not";
+  ref?: string;
+  conditions?: TriggerCondition[];
+  condition?: TriggerCondition;
+}
+
+export interface StepDependency {
+  step: string;
+  condition: TriggerCondition;
+}
+
+export interface JobDependency {
+  job: string;
+  condition: TriggerCondition;
+}
+
+export interface WorkflowStep {
+  name: string;
+  description?: string;
+  task: StepTask;
+  dependsOn: StepDependency[];
+  weight: number;
+}
+
+export interface WorkflowJob {
+  name: string;
+  description?: string;
+  dependsOn: JobDependency[];
+  weight: number;
+  steps: WorkflowStep[];
+}
+
+export interface Workflow {
+  id: string;
+  name: string;
+  description?: string;
+  version: number;
+  jobs: WorkflowJob[];
+}
+
+export interface CreateModelInput {
+  name: string;
+  version?: number;
+  resourceId?: string;
+  tags?: Record<string, string>;
+  attributes?: Record<string, unknown>;
+}
+
+export interface UpdateModelInput {
+  name?: string;
+  version?: number;
+  resourceId?: string;
+  tags?: Record<string, string>;
+  attributes?: Record<string, unknown>;
+}
+
+export interface CreateWorkflowInput {
+  name: string;
+  description?: string;
+  version?: number;
+  jobs?: WorkflowJob[];
+}
+
+export interface UpdateWorkflowInput {
+  name?: string;
+  description?: string;
+  version?: number;
+  jobs?: WorkflowJob[];
+}
+
+// Output types
+export type ExecutionStatus = "pending" | "running" | "succeeded" | "failed";
+export type TriggerType = "manual" | "workflow";
+
+export interface ExecutionError {
+  message: string;
+  stack?: string;
+}
+
+export interface ExecutionProvenance {
+  inputHash: string;
+  modelVersion: number;
+  triggeredBy: TriggerType;
+  workflowId?: string;
+  workflowRunId?: string;
+  stepName?: string;
+}
+
+export interface ArtifactsProduced {
+  resourceId?: string;
+  dataId?: string;
+  fileId?: string;
+  logIds?: string[];
+}
+
+export interface OutputSummary {
+  id: string;
+  modelInputId: string;
+  modelName?: string;
+  type: string;
+  methodName: string;
+  status: ExecutionStatus;
+  startedAt: string;
+  completedAt?: string;
+  durationMs?: number;
+}
+
+export interface Output extends OutputSummary {
+  retryCount: number;
+  provenance: ExecutionProvenance;
+  artifacts?: ArtifactsProduced;
+  error?: ExecutionError;
+}
+
+export interface OutputDataResponse {
+  outputId: string;
+  methodName: string;
+  dataId: string;
+  field: string | null;
+  data: unknown;
+}
+
+export interface OutputLogsResponse {
+  outputId: string;
+  methodName: string;
+  logIds: string[];
+  lines: string[];
+  totalLines: number;
+  showingLines: number;
+}
+
+// Workflow Run types
+export type WorkflowRunStatus = "pending" | "running" | "succeeded" | "failed";
+
+export interface WorkflowRunSummary {
+  id: string;
+  workflowId: string;
+  workflowName: string;
+  status: WorkflowRunStatus;
+  startedAt?: string;
+  completedAt?: string;
+  jobCount: number;
+  outputCount: number;
+}
+
+export interface StepRunInfo {
+  stepName: string;
+  status: ExecutionStatus;
+  startedAt?: string;
+  completedAt?: string;
+  error?: string;
+  output?: unknown;
+  outputId?: string;
+}
+
+export interface JobRunInfo {
+  jobName: string;
+  status: ExecutionStatus;
+  startedAt?: string;
+  completedAt?: string;
+  steps: StepRunInfo[];
+}
+
+export interface WorkflowRunOutput {
+  id: string;
+  modelInputId: string;
+  type: string;
+  methodName: string;
+  status: ExecutionStatus;
+  startedAt: string;
+  completedAt?: string;
+  durationMs?: number;
+  stepName?: string;
+}
+
+export interface WorkflowRunDetail {
+  id: string;
+  workflowId: string;
+  workflowName: string;
+  status: WorkflowRunStatus;
+  startedAt?: string;
+  completedAt?: string;
+  jobs: JobRunInfo[];
+  outputs: WorkflowRunOutput[];
+}
+
+export async function listTypes(): Promise<ModelType[]> {
+  const data = await fetchJson<{ types: ModelType[] }>(`${API_BASE}/types`);
+  return data.types;
+}
+
+export interface ModelLookup {
+  id: string;
+  type: string;
+  name: string;
+}
+
+export async function lookupModel(id: string): Promise<ModelLookup> {
+  return fetchJson<ModelLookup>(
+    `${API_BASE}/models/lookup/${encodeURIComponent(id)}`,
+  );
+}
+
+export async function listAllModels(): Promise<Model[]> {
+  const data = await fetchJson<{ models: Model[] }>(`${API_BASE}/models`);
+  return data.models;
+}
+
+export async function listModelsByType(type: string): Promise<Model[]> {
+  const data = await fetchJson<{ models: Model[] }>(
+    `${API_BASE}/models/${encodeURIComponent(type)}`,
+  );
+  return data.models;
+}
+
+export async function getModel(type: string, id: string): Promise<Model> {
+  return fetchJson<Model>(
+    `${API_BASE}/models/${encodeURIComponent(type)}/${encodeURIComponent(id)}`,
+  );
+}
+
+export async function createModel(
+  type: string,
+  input: CreateModelInput,
+): Promise<Model> {
+  return fetchJson<Model>(`${API_BASE}/models/${encodeURIComponent(type)}`, {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+export async function updateModel(
+  type: string,
+  id: string,
+  input: UpdateModelInput,
+): Promise<Model> {
+  return fetchJson<Model>(
+    `${API_BASE}/models/${encodeURIComponent(type)}/${encodeURIComponent(id)}`,
+    {
+      method: "PUT",
+      body: JSON.stringify(input),
+    },
+  );
+}
+
+export async function deleteModel(type: string, id: string): Promise<void> {
+  await fetchJson<void>(
+    `${API_BASE}/models/${encodeURIComponent(type)}/${encodeURIComponent(id)}`,
+    {
+      method: "DELETE",
+    },
+  );
+}
+
+export async function listResourcesByType(type: string): Promise<Resource[]> {
+  const data = await fetchJson<{ resources: Resource[] }>(
+    `${API_BASE}/resources/${encodeURIComponent(type)}`,
+  );
+  return data.resources;
+}
+
+export async function getResource(type: string, id: string): Promise<Resource> {
+  return fetchJson<Resource>(
+    `${API_BASE}/resources/${encodeURIComponent(type)}/${encodeURIComponent(id)}`,
+  );
+}
+
+export async function deleteResource(type: string, id: string): Promise<void> {
+  await fetchJson<void>(
+    `${API_BASE}/resources/${encodeURIComponent(type)}/${encodeURIComponent(id)}`,
+    {
+      method: "DELETE",
+    },
+  );
+}
+
+export async function listWorkflows(): Promise<WorkflowSummary[]> {
+  const data = await fetchJson<{ workflows: WorkflowSummary[] }>(
+    `${API_BASE}/workflows`,
+  );
+  return data.workflows;
+}
+
+export async function getWorkflow(id: string): Promise<Workflow> {
+  return fetchJson<Workflow>(
+    `${API_BASE}/workflows/${encodeURIComponent(id)}`,
+  );
+}
+
+export async function createWorkflow(
+  input: CreateWorkflowInput,
+): Promise<Workflow> {
+  return fetchJson<Workflow>(`${API_BASE}/workflows`, {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+export async function updateWorkflow(
+  id: string,
+  input: UpdateWorkflowInput,
+): Promise<Workflow> {
+  return fetchJson<Workflow>(
+    `${API_BASE}/workflows/${encodeURIComponent(id)}`,
+    {
+      method: "PUT",
+      body: JSON.stringify(input),
+    },
+  );
+}
+
+export async function deleteWorkflow(id: string): Promise<void> {
+  await fetchJson<void>(`${API_BASE}/workflows/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+  });
+}
+
+// Output API functions
+export async function listOutputs(): Promise<OutputSummary[]> {
+  const data = await fetchJson<{ outputs: OutputSummary[] }>(
+    `${API_BASE}/outputs`,
+  );
+  return data.outputs;
+}
+
+export async function getOutput(id: string): Promise<Output> {
+  return fetchJson<Output>(
+    `${API_BASE}/outputs/${encodeURIComponent(id)}`,
+  );
+}
+
+export async function getOutputData(
+  id: string,
+  field?: string,
+): Promise<OutputDataResponse> {
+  const params = field ? `?field=${encodeURIComponent(field)}` : "";
+  return fetchJson<OutputDataResponse>(
+    `${API_BASE}/outputs/${encodeURIComponent(id)}/data${params}`,
+  );
+}
+
+export async function getOutputLogs(
+  id: string,
+  tail?: number,
+): Promise<OutputLogsResponse> {
+  const params = tail !== undefined ? `?tail=${tail}` : "";
+  return fetchJson<OutputLogsResponse>(
+    `${API_BASE}/outputs/${encodeURIComponent(id)}/logs${params}`,
+  );
+}
+
+// Workflow Run API functions
+export async function listWorkflowRuns(): Promise<WorkflowRunSummary[]> {
+  const data = await fetchJson<{ workflowRuns: WorkflowRunSummary[] }>(
+    `${API_BASE}/workflow-runs`,
+  );
+  return data.workflowRuns;
+}
+
+export async function getWorkflowRun(id: string): Promise<WorkflowRunDetail> {
+  return fetchJson<WorkflowRunDetail>(
+    `${API_BASE}/workflow-runs/${encodeURIComponent(id)}`,
+  );
+}
+
+export async function listWorkflowRunsByWorkflow(
+  workflowId: string,
+): Promise<WorkflowRunSummary[]> {
+  const data = await fetchJson<{ workflowRuns: WorkflowRunSummary[] }>(
+    `${API_BASE}/workflows/${encodeURIComponent(workflowId)}/runs`,
+  );
+  return data.workflowRuns;
+}

--- a/experiments/webapp/frontend/src/components/DataTable.vue
+++ b/experiments/webapp/frontend/src/components/DataTable.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts" generic="T extends Record<string, unknown>">
+import { useSlots } from "vue";
+
+defineProps<{
+  columns: Array<{
+    key: string;
+    label: string;
+    format?: (value: unknown, row: T) => string;
+  }>;
+  data: T[];
+  loading?: boolean;
+  emptyMessage?: string;
+}>();
+
+defineEmits<{
+  rowClick: [row: T];
+}>();
+
+const slots = useSlots();
+
+function hasSlot(name: string): boolean {
+  return !!slots[name];
+}
+
+function getValue(row: T, key: string): unknown {
+  const keys = key.split(".");
+  let value: unknown = row;
+  for (const k of keys) {
+    if (value && typeof value === "object" && k in value) {
+      value = (value as Record<string, unknown>)[k];
+    } else {
+      return undefined;
+    }
+  }
+  return value;
+}
+
+function formatValue(
+  value: unknown,
+  row: T,
+  format?: (value: unknown, row: T) => string,
+): string {
+  if (format) {
+    return format(value, row);
+  }
+  if (value === null || value === undefined) {
+    return "-";
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+</script>
+
+<template>
+  <div class="overflow-x-auto">
+    <table class="min-w-full divide-y divide-gray-200">
+      <thead class="bg-gray-50">
+        <tr>
+          <th
+            v-for="column in columns"
+            :key="column.key"
+            scope="col"
+            class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+          >
+            {{ column.label }}
+          </th>
+        </tr>
+      </thead>
+      <tbody class="bg-white divide-y divide-gray-200">
+        <tr v-if="loading">
+          <td
+            :colspan="columns.length"
+            class="px-6 py-4 text-center text-gray-500"
+          >
+            Loading...
+          </td>
+        </tr>
+        <tr v-else-if="data.length === 0">
+          <td
+            :colspan="columns.length"
+            class="px-6 py-4 text-center text-gray-500"
+          >
+            {{ emptyMessage || "No data available" }}
+          </td>
+        </tr>
+        <tr
+          v-else
+          v-for="(row, index) in data"
+          :key="index"
+          class="hover:bg-gray-50 cursor-pointer transition-colors"
+          @click="$emit('rowClick', row)"
+        >
+          <td
+            v-for="column in columns"
+            :key="column.key"
+            class="px-6 py-4 whitespace-nowrap text-sm text-gray-900"
+          >
+            <slot
+              v-if="hasSlot(`cell-${column.key}`)"
+              :name="`cell-${column.key}`"
+              :value="getValue(row, column.key)"
+              :row="row"
+            />
+            <template v-else>
+              {{ formatValue(getValue(row, column.key), row, column.format) }}
+            </template>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>

--- a/experiments/webapp/frontend/src/components/NavBar.vue
+++ b/experiments/webapp/frontend/src/components/NavBar.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { RouterLink } from "vue-router";
+</script>
+
+<template>
+  <nav class="bg-gray-800 text-white shadow-lg">
+    <div class="container mx-auto px-4">
+      <div class="flex items-center justify-between h-16">
+        <RouterLink to="/" class="flex items-center space-x-2">
+          <span class="text-2xl font-bold text-green-400">Swamp</span>
+        </RouterLink>
+
+        <div class="flex items-center space-x-4">
+          <RouterLink
+            to="/"
+            class="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-700 transition-colors"
+            active-class="bg-gray-700"
+          >
+            Dashboard
+          </RouterLink>
+          <RouterLink
+            to="/models"
+            class="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-700 transition-colors"
+            active-class="bg-gray-700"
+          >
+            Models
+          </RouterLink>
+          <RouterLink
+            to="/outputs"
+            class="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-700 transition-colors"
+            active-class="bg-gray-700"
+          >
+            Outputs
+          </RouterLink>
+          <RouterLink
+            to="/workflows"
+            class="px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-700 transition-colors"
+            active-class="bg-gray-700"
+          >
+            Workflows
+          </RouterLink>
+        </div>
+      </div>
+    </div>
+  </nav>
+</template>

--- a/experiments/webapp/frontend/src/main.ts
+++ b/experiments/webapp/frontend/src/main.ts
@@ -1,0 +1,6 @@
+import { createApp } from "vue";
+import App from "./App.vue";
+import router from "./router";
+import "./style.css";
+
+createApp(App).use(router).mount("#app");

--- a/experiments/webapp/frontend/src/router/index.ts
+++ b/experiments/webapp/frontend/src/router/index.ts
@@ -1,0 +1,65 @@
+import { createRouter, createWebHistory } from "vue-router";
+import DashboardView from "../views/DashboardView.vue";
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    {
+      path: "/",
+      name: "dashboard",
+      component: DashboardView,
+    },
+    {
+      path: "/models",
+      name: "models",
+      component: () => import("../views/models/ModelListView.vue"),
+    },
+    {
+      path: "/models/:type/:id",
+      name: "model-detail",
+      component: () => import("../views/models/ModelDetailView.vue"),
+    },
+    {
+      path: "/models/:type/:id/edit",
+      name: "model-edit",
+      component: () => import("../views/models/ModelEditView.vue"),
+    },
+    {
+      path: "/models/new/:type?",
+      name: "model-new",
+      component: () => import("../views/models/ModelEditView.vue"),
+    },
+    {
+      path: "/outputs",
+      name: "outputs",
+      component: () => import("../views/outputs/OutputListView.vue"),
+    },
+    {
+      path: "/outputs/:id",
+      name: "output-detail",
+      component: () => import("../views/outputs/OutputDetailView.vue"),
+    },
+    {
+      path: "/workflows",
+      name: "workflows",
+      component: () => import("../views/workflows/WorkflowListView.vue"),
+    },
+    {
+      path: "/workflows/:id",
+      name: "workflow-detail",
+      component: () => import("../views/workflows/WorkflowDetailView.vue"),
+    },
+    {
+      path: "/workflows/:id/edit",
+      name: "workflow-edit",
+      component: () => import("../views/workflows/WorkflowEditView.vue"),
+    },
+    {
+      path: "/workflows/new",
+      name: "workflow-new",
+      component: () => import("../views/workflows/WorkflowEditView.vue"),
+    },
+  ],
+});
+
+export default router;

--- a/experiments/webapp/frontend/src/style.css
+++ b/experiments/webapp/frontend/src/style.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-100 text-gray-900;
+}

--- a/experiments/webapp/frontend/src/views/DashboardView.vue
+++ b/experiments/webapp/frontend/src/views/DashboardView.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { RouterLink } from "vue-router";
+import { listAllModels, listWorkflows, listTypes } from "../api/client";
+
+const modelCount = ref(0);
+const workflowCount = ref(0);
+const typeCount = ref(0);
+const loading = ref(true);
+const error = ref<string | null>(null);
+
+onMounted(async () => {
+  try {
+    const [models, workflows, types] = await Promise.all([
+      listAllModels(),
+      listWorkflows(),
+      listTypes(),
+    ]);
+    modelCount.value = models.length;
+    workflowCount.value = workflows.length;
+    typeCount.value = types.length;
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to load data";
+  } finally {
+    loading.value = false;
+  }
+});
+</script>
+
+<template>
+  <div>
+    <h1 class="text-3xl font-bold text-gray-900 mb-8">Dashboard</h1>
+
+    <div v-if="error" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-8">
+      {{ error }}
+    </div>
+
+    <div v-else-if="loading" class="text-gray-500">Loading...</div>
+
+    <div v-else class="grid grid-cols-1 md:grid-cols-3 gap-6">
+      <RouterLink
+        to="/models"
+        class="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow"
+      >
+        <div class="text-sm font-medium text-gray-500 uppercase tracking-wider">
+          Models
+        </div>
+        <div class="mt-2 text-3xl font-bold text-gray-900">
+          {{ modelCount }}
+        </div>
+        <div class="mt-2 text-sm text-gray-600">
+          Model inputs in repository
+        </div>
+      </RouterLink>
+
+      <RouterLink
+        to="/workflows"
+        class="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow"
+      >
+        <div class="text-sm font-medium text-gray-500 uppercase tracking-wider">
+          Workflows
+        </div>
+        <div class="mt-2 text-3xl font-bold text-gray-900">
+          {{ workflowCount }}
+        </div>
+        <div class="mt-2 text-sm text-gray-600">
+          Workflow definitions
+        </div>
+      </RouterLink>
+
+      <div class="bg-white rounded-lg shadow-md p-6">
+        <div class="text-sm font-medium text-gray-500 uppercase tracking-wider">
+          Types
+        </div>
+        <div class="mt-2 text-3xl font-bold text-gray-900">
+          {{ typeCount }}
+        </div>
+        <div class="mt-2 text-sm text-gray-600">
+          Registered model types
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/experiments/webapp/frontend/src/views/models/ModelDetailView.vue
+++ b/experiments/webapp/frontend/src/views/models/ModelDetailView.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { getModel, deleteModel, type Model } from "../../api/client";
+
+const route = useRoute();
+const router = useRouter();
+const model = ref<Model | null>(null);
+const loading = ref(true);
+const error = ref<string | null>(null);
+const deleting = ref(false);
+
+const typeParam = route.params.type as string;
+const idParam = route.params.id as string;
+
+onMounted(async () => {
+  try {
+    model.value = await getModel(typeParam, idParam);
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to load model";
+  } finally {
+    loading.value = false;
+  }
+});
+
+async function handleDelete() {
+  if (!confirm("Are you sure you want to delete this model?")) return;
+
+  deleting.value = true;
+  try {
+    await deleteModel(typeParam, idParam);
+    router.push({ name: "models" });
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to delete model";
+    deleting.value = false;
+  }
+}
+</script>
+
+<template>
+  <div>
+    <div class="mb-6">
+      <RouterLink to="/models" class="text-blue-600 hover:text-blue-800 text-sm">
+        &larr; Back to Models
+      </RouterLink>
+    </div>
+
+    <div v-if="error" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-6">
+      {{ error }}
+    </div>
+
+    <div v-if="loading" class="text-gray-500">Loading...</div>
+
+    <div v-else-if="model" class="bg-white rounded-lg shadow">
+      <div class="px-6 py-4 border-b border-gray-200">
+        <div class="flex items-center justify-between">
+          <h1 class="text-2xl font-bold text-gray-900">{{ model.name }}</h1>
+          <div class="space-x-2">
+            <RouterLink
+              :to="{ name: 'model-edit', params: { type: typeParam, id: idParam } }"
+              class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+            >
+              Edit
+            </RouterLink>
+            <button
+              @click="handleDelete"
+              :disabled="deleting"
+              class="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 transition-colors disabled:opacity-50"
+            >
+              {{ deleting ? "Deleting..." : "Delete" }}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div class="p-6 space-y-6">
+        <div class="grid grid-cols-2 gap-6">
+          <div>
+            <div class="text-sm font-medium text-gray-500">ID</div>
+            <div class="mt-1 text-sm text-gray-900 font-mono">{{ model.id }}</div>
+          </div>
+          <div>
+            <div class="text-sm font-medium text-gray-500">Type</div>
+            <div class="mt-1 text-sm text-gray-900">{{ model.type.normalized }}</div>
+          </div>
+          <div>
+            <div class="text-sm font-medium text-gray-500">Version</div>
+            <div class="mt-1 text-sm text-gray-900">{{ model.version }}</div>
+          </div>
+          <div>
+            <div class="text-sm font-medium text-gray-500">Resource ID</div>
+            <div class="mt-1 text-sm text-gray-900 font-mono">
+              {{ model.resourceId || "-" }}
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div class="text-sm font-medium text-gray-500 mb-2">Tags</div>
+          <div v-if="Object.keys(model.tags).length === 0" class="text-sm text-gray-500">
+            No tags
+          </div>
+          <div v-else class="flex flex-wrap gap-2">
+            <span
+              v-for="(value, key) in model.tags"
+              :key="key"
+              class="px-2 py-1 bg-gray-100 text-gray-700 rounded text-sm"
+            >
+              {{ key }}={{ value }}
+            </span>
+          </div>
+        </div>
+
+        <div>
+          <div class="text-sm font-medium text-gray-500 mb-2">Attributes</div>
+          <pre class="bg-gray-50 p-4 rounded text-sm overflow-auto">{{ JSON.stringify(model.attributes, null, 2) }}</pre>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/experiments/webapp/frontend/src/views/models/ModelEditView.vue
+++ b/experiments/webapp/frontend/src/views/models/ModelEditView.vue
@@ -1,0 +1,205 @@
+<script setup lang="ts">
+import { ref, onMounted, computed } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import {
+  getModel,
+  createModel,
+  updateModel,
+  listTypes,
+  type Model,
+  type ModelType,
+} from "../../api/client";
+
+const route = useRoute();
+const router = useRouter();
+
+const isNew = computed(() => route.name === "model-new");
+const typeParam = computed(() => route.params.type as string | undefined);
+const idParam = computed(() => route.params.id as string | undefined);
+
+const loading = ref(true);
+const saving = ref(false);
+const error = ref<string | null>(null);
+const types = ref<ModelType[]>([]);
+
+const form = ref({
+  name: "",
+  type: "",
+  version: 1,
+  tags: "",
+  attributes: "{}",
+});
+
+onMounted(async () => {
+  try {
+    types.value = await listTypes();
+
+    if (isNew.value) {
+      form.value.type = typeParam.value || (types.value[0]?.normalized ?? "");
+    } else if (typeParam.value && idParam.value) {
+      const model = await getModel(typeParam.value, idParam.value);
+      form.value = {
+        name: model.name,
+        type: model.type.normalized,
+        version: model.version,
+        tags: Object.entries(model.tags)
+          .map(([k, v]) => `${k}=${v}`)
+          .join("\n"),
+        attributes: JSON.stringify(model.attributes, null, 2),
+      };
+    }
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to load data";
+  } finally {
+    loading.value = false;
+  }
+});
+
+function parseTags(tagsStr: string): Record<string, string> {
+  const tags: Record<string, string> = {};
+  for (const line of tagsStr.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed) {
+      const [key, ...valueParts] = trimmed.split("=");
+      if (key) {
+        tags[key.trim()] = valueParts.join("=").trim();
+      }
+    }
+  }
+  return tags;
+}
+
+async function handleSubmit() {
+  saving.value = true;
+  error.value = null;
+
+  try {
+    let attributes: Record<string, unknown>;
+    try {
+      attributes = JSON.parse(form.value.attributes);
+    } catch {
+      throw new Error("Invalid JSON in attributes");
+    }
+
+    const input = {
+      name: form.value.name,
+      version: form.value.version,
+      tags: parseTags(form.value.tags),
+      attributes,
+    };
+
+    let savedModel: Model;
+    if (isNew.value) {
+      savedModel = await createModel(form.value.type, input);
+    } else {
+      savedModel = await updateModel(typeParam.value!, idParam.value!, input);
+    }
+
+    router.push({
+      name: "model-detail",
+      params: { type: savedModel.type.normalized, id: savedModel.id },
+    });
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to save model";
+    saving.value = false;
+  }
+}
+</script>
+
+<template>
+  <div>
+    <div class="mb-6">
+      <RouterLink
+        :to="isNew ? '/models' : { name: 'model-detail', params: { type: typeParam, id: idParam } }"
+        class="text-blue-600 hover:text-blue-800 text-sm"
+      >
+        &larr; Back
+      </RouterLink>
+    </div>
+
+    <h1 class="text-3xl font-bold text-gray-900 mb-6">
+      {{ isNew ? "Create Model" : "Edit Model" }}
+    </h1>
+
+    <div v-if="error" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-6">
+      {{ error }}
+    </div>
+
+    <div v-if="loading" class="text-gray-500">Loading...</div>
+
+    <form v-else @submit.prevent="handleSubmit" class="bg-white rounded-lg shadow p-6 space-y-6">
+      <div v-if="isNew">
+        <label class="block text-sm font-medium text-gray-700 mb-1">Type</label>
+        <select
+          v-model="form.type"
+          class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          required
+        >
+          <option v-for="t in types" :key="t.normalized" :value="t.normalized">
+            {{ t.normalized }}
+          </option>
+        </select>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">Name</label>
+        <input
+          v-model="form.name"
+          type="text"
+          class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          required
+        />
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">Version</label>
+        <input
+          v-model.number="form.version"
+          type="number"
+          min="1"
+          class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          required
+        />
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">
+          Tags (one per line, key=value format)
+        </label>
+        <textarea
+          v-model="form.tags"
+          rows="3"
+          class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono text-sm"
+          placeholder="env=prod&#10;team=platform"
+        ></textarea>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">
+          Attributes (JSON)
+        </label>
+        <textarea
+          v-model="form.attributes"
+          rows="10"
+          class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono text-sm"
+        ></textarea>
+      </div>
+
+      <div class="flex justify-end space-x-4">
+        <RouterLink
+          :to="isNew ? '/models' : { name: 'model-detail', params: { type: typeParam, id: idParam } }"
+          class="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors"
+        >
+          Cancel
+        </RouterLink>
+        <button
+          type="submit"
+          :disabled="saving"
+          class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors disabled:opacity-50"
+        >
+          {{ saving ? "Saving..." : "Save" }}
+        </button>
+      </div>
+    </form>
+  </div>
+</template>

--- a/experiments/webapp/frontend/src/views/models/ModelListView.vue
+++ b/experiments/webapp/frontend/src/views/models/ModelListView.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { useRouter } from "vue-router";
+import DataTable from "../../components/DataTable.vue";
+import { listAllModels, type Model } from "../../api/client";
+
+const router = useRouter();
+const models = ref<Model[]>([]);
+const loading = ref(true);
+const error = ref<string | null>(null);
+
+const columns = [
+  { key: "name", label: "Name" },
+  { key: "type.normalized", label: "Type" },
+  { key: "version", label: "Version" },
+  {
+    key: "tags",
+    label: "Tags",
+    format: (value: unknown) => {
+      const tags = value as Record<string, string>;
+      return Object.keys(tags).length > 0
+        ? Object.entries(tags)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(", ")
+        : "-";
+    },
+  },
+];
+
+onMounted(async () => {
+  try {
+    models.value = await listAllModels();
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to load models";
+  } finally {
+    loading.value = false;
+  }
+});
+
+function handleRowClick(model: Model) {
+  router.push({
+    name: "model-detail",
+    params: { type: model.type.normalized, id: model.id },
+  });
+}
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center justify-between mb-6">
+      <h1 class="text-3xl font-bold text-gray-900">Models</h1>
+    </div>
+
+    <div
+      v-if="error"
+      class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-6"
+    >
+      {{ error }}
+    </div>
+
+    <div class="bg-white rounded-lg shadow">
+      <DataTable
+        :columns="columns"
+        :data="models"
+        :loading="loading"
+        empty-message="No models found"
+        @row-click="handleRowClick"
+      />
+    </div>
+  </div>
+</template>

--- a/experiments/webapp/frontend/src/views/outputs/OutputDetailView.vue
+++ b/experiments/webapp/frontend/src/views/outputs/OutputDetailView.vue
@@ -1,0 +1,448 @@
+<script setup lang="ts">
+import { ref, onMounted, computed } from "vue";
+import { useRoute } from "vue-router";
+import {
+  getOutput,
+  getOutputData,
+  getOutputLogs,
+  type Output,
+  type OutputDataResponse,
+  type OutputLogsResponse,
+} from "../../api/client";
+
+const route = useRoute();
+const output = ref<Output | null>(null);
+const loading = ref(true);
+const error = ref<string | null>(null);
+const activeTab = ref<"info" | "logs">("info");
+
+// Data for Info tab (auto-loaded)
+const dataResponse = ref<OutputDataResponse | null>(null);
+
+// Logs tab state
+const logsResponse = ref<OutputLogsResponse | null>(null);
+const logsLoading = ref(false);
+const logsError = ref<string | null>(null);
+const tailLines = ref<number | undefined>(undefined);
+const tailInput = ref("");
+
+const idParam = route.params.id as string;
+
+function formatDuration(ms: number | undefined): string {
+  if (ms === undefined) return "-";
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+  const minutes = Math.floor(ms / 60000);
+  const seconds = Math.floor((ms % 60000) / 1000);
+  return `${minutes}m ${seconds}s`;
+}
+
+function formatDate(dateStr: string | undefined): string {
+  if (!dateStr) return "-";
+  const date = new Date(dateStr);
+  return date.toLocaleString();
+}
+
+// Strip ANSI escape codes from log lines
+// Matches: CSI sequences, OSC sequences, and other escape sequences
+const ansiRegex = /\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b\[[?\d;]*[hl]|\x1b[PX^_].*?\x1b\\|\x1b\[[\d;]*m/g;
+
+function stripAnsi(str: string): string {
+  return str.replace(ansiRegex, "");
+}
+
+function getStatusColor(status: string): string {
+  switch (status) {
+    case "succeeded":
+      return "text-green-600 bg-green-100";
+    case "failed":
+      return "text-red-600 bg-red-100";
+    case "running":
+      return "text-blue-600 bg-blue-100";
+    case "pending":
+      return "text-yellow-600 bg-yellow-100";
+    default:
+      return "text-gray-600 bg-gray-100";
+  }
+}
+
+const hasLogArtifacts = computed(
+  () => output.value?.artifacts?.logIds && output.value.artifacts.logIds.length > 0
+);
+
+// Extract execution data fields with type safety
+interface ExecutionData {
+  command?: string;
+  exitCode?: number;
+  timestamp?: string;
+  durationMs?: number;
+}
+
+const executionData = computed((): ExecutionData | null => {
+  const data = dataResponse.value?.data;
+  if (!data || typeof data !== "object") return null;
+  const d = data as Record<string, unknown>;
+  const result: ExecutionData = {
+    command: typeof d.command === "string" ? d.command : undefined,
+    exitCode: typeof d.exitCode === "number" ? d.exitCode : undefined,
+    timestamp: typeof d.timestamp === "string" ? d.timestamp : undefined,
+    durationMs: typeof d.durationMs === "number" ? d.durationMs : undefined,
+  };
+  // Only return if at least one field has data
+  if (
+    result.command === undefined &&
+    result.exitCode === undefined &&
+    result.timestamp === undefined &&
+    result.durationMs === undefined
+  ) {
+    return null;
+  }
+  return result;
+});
+
+// Strip ANSI codes from log lines for display
+const cleanedLogLines = computed(() => {
+  if (!logsResponse.value) return [];
+  return logsResponse.value.lines.map(stripAnsi);
+});
+
+onMounted(async () => {
+  try {
+    output.value = await getOutput(idParam);
+    // Auto-load data if available
+    if (output.value?.artifacts?.dataId) {
+      try {
+        dataResponse.value = await getOutputData(output.value.id);
+      } catch {
+        // Silently ignore data load errors - section just won't show
+      }
+    }
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to load output";
+  } finally {
+    loading.value = false;
+  }
+});
+
+async function loadLogs() {
+  if (!output.value) return;
+  logsLoading.value = true;
+  logsError.value = null;
+  try {
+    const tail = tailInput.value ? parseInt(tailInput.value, 10) : undefined;
+    logsResponse.value = await getOutputLogs(output.value.id, tail);
+    tailLines.value = tail;
+  } catch (e) {
+    logsError.value = e instanceof Error ? e.message : "Failed to load logs";
+  } finally {
+    logsLoading.value = false;
+  }
+}
+
+function handleTabChange(tab: "info" | "logs") {
+  activeTab.value = tab;
+  if (tab === "logs" && !logsResponse.value && hasLogArtifacts.value) {
+    loadLogs();
+  }
+}
+</script>
+
+<template>
+  <div>
+    <div class="mb-6">
+      <RouterLink
+        to="/outputs"
+        class="text-blue-600 hover:text-blue-800 text-sm"
+      >
+        &larr; Back to Outputs
+      </RouterLink>
+    </div>
+
+    <div
+      v-if="error"
+      class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-6"
+    >
+      {{ error }}
+    </div>
+
+    <div v-if="loading" class="text-gray-500">Loading...</div>
+
+    <div v-else-if="output" class="bg-white rounded-lg shadow">
+      <div class="px-6 py-4 border-b border-gray-200">
+        <div class="flex items-center justify-between">
+          <div>
+            <h1 class="text-2xl font-bold text-gray-900">
+              {{ output.modelName || "Unknown Model" }}
+            </h1>
+            <p class="text-sm text-gray-500 mt-1">
+              {{ output.methodName }} - {{ output.type }}
+            </p>
+          </div>
+          <span
+            :class="[
+              'px-3 py-1 rounded-full text-sm font-medium',
+              getStatusColor(output.status),
+            ]"
+          >
+            {{ output.status }}
+          </span>
+        </div>
+      </div>
+
+      <!-- Tabs -->
+      <div class="border-b border-gray-200">
+        <nav class="flex -mb-px">
+          <button
+            @click="handleTabChange('info')"
+            :class="[
+              'px-6 py-3 border-b-2 font-medium text-sm',
+              activeTab === 'info'
+                ? 'border-blue-500 text-blue-600'
+                : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300',
+            ]"
+          >
+            Info
+          </button>
+          <button
+            @click="handleTabChange('logs')"
+            :class="[
+              'px-6 py-3 border-b-2 font-medium text-sm',
+              activeTab === 'logs'
+                ? 'border-blue-500 text-blue-600'
+                : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300',
+            ]"
+          >
+            Logs
+          </button>
+        </nav>
+      </div>
+
+      <!-- Tab Content -->
+      <div class="p-6">
+        <!-- Info Tab -->
+        <div v-if="activeTab === 'info'" class="space-y-6">
+          <div class="grid grid-cols-2 gap-6">
+            <div>
+              <div class="text-sm font-medium text-gray-500">Output ID</div>
+              <div class="mt-1 text-sm text-gray-900 font-mono">
+                {{ output.id }}
+              </div>
+            </div>
+            <div>
+              <div class="text-sm font-medium text-gray-500">Model Input ID</div>
+              <div class="mt-1 text-sm text-gray-900 font-mono">
+                {{ output.modelInputId }}
+              </div>
+            </div>
+            <div>
+              <div class="text-sm font-medium text-gray-500">Type</div>
+              <div class="mt-1 text-sm text-gray-900">{{ output.type }}</div>
+            </div>
+            <div>
+              <div class="text-sm font-medium text-gray-500">Method</div>
+              <div class="mt-1 text-sm text-gray-900">{{ output.methodName }}</div>
+            </div>
+            <div>
+              <div class="text-sm font-medium text-gray-500">Started At</div>
+              <div class="mt-1 text-sm text-gray-900">
+                {{ formatDate(output.startedAt) }}
+              </div>
+            </div>
+            <div>
+              <div class="text-sm font-medium text-gray-500">Completed At</div>
+              <div class="mt-1 text-sm text-gray-900">
+                {{ formatDate(output.completedAt) }}
+              </div>
+            </div>
+            <div>
+              <div class="text-sm font-medium text-gray-500">Duration</div>
+              <div class="mt-1 text-sm text-gray-900">
+                {{ formatDuration(output.durationMs) }}
+              </div>
+            </div>
+            <div>
+              <div class="text-sm font-medium text-gray-500">Retry Count</div>
+              <div class="mt-1 text-sm text-gray-900">{{ output.retryCount }}</div>
+            </div>
+          </div>
+
+          <!-- Provenance -->
+          <div>
+            <div class="text-sm font-medium text-gray-500 mb-2">Provenance</div>
+            <div class="bg-gray-50 p-4 rounded">
+              <div class="grid grid-cols-2 gap-4 text-sm">
+                <div>
+                  <span class="text-gray-500">Triggered By:</span>
+                  <span class="ml-2 text-gray-900">{{ output.provenance.triggeredBy }}</span>
+                </div>
+                <div>
+                  <span class="text-gray-500">Model Version:</span>
+                  <span class="ml-2 text-gray-900">{{ output.provenance.modelVersion }}</span>
+                </div>
+                <div v-if="output.provenance.workflowId">
+                  <span class="text-gray-500">Workflow ID:</span>
+                  <span class="ml-2 text-gray-900 font-mono">{{ output.provenance.workflowId }}</span>
+                </div>
+                <div v-if="output.provenance.workflowRunId">
+                  <span class="text-gray-500">Workflow Run ID:</span>
+                  <span class="ml-2 text-gray-900 font-mono">{{ output.provenance.workflowRunId }}</span>
+                </div>
+                <div v-if="output.provenance.stepName">
+                  <span class="text-gray-500">Step Name:</span>
+                  <span class="ml-2 text-gray-900">{{ output.provenance.stepName }}</span>
+                </div>
+                <div class="col-span-2">
+                  <span class="text-gray-500">Input Hash:</span>
+                  <span class="ml-2 text-gray-900 font-mono text-xs">{{ output.provenance.inputHash }}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Artifacts -->
+          <div v-if="output.artifacts">
+            <div class="text-sm font-medium text-gray-500 mb-2">Artifacts</div>
+            <div class="bg-gray-50 p-4 rounded">
+              <div class="grid grid-cols-2 gap-4 text-sm">
+                <div v-if="output.artifacts.dataId">
+                  <span class="text-gray-500">Data ID:</span>
+                  <span class="ml-2 text-gray-900 font-mono">{{ output.artifacts.dataId }}</span>
+                </div>
+                <div v-if="output.artifacts.resourceId">
+                  <span class="text-gray-500">Resource ID:</span>
+                  <span class="ml-2 text-gray-900 font-mono">{{ output.artifacts.resourceId }}</span>
+                </div>
+                <div v-if="output.artifacts.fileId">
+                  <span class="text-gray-500">File ID:</span>
+                  <span class="ml-2 text-gray-900 font-mono">{{ output.artifacts.fileId }}</span>
+                </div>
+                <div v-if="output.artifacts.logIds && output.artifacts.logIds.length > 0">
+                  <span class="text-gray-500">Log IDs:</span>
+                  <div class="ml-2">
+                    <span
+                      v-for="logId in output.artifacts.logIds"
+                      :key="logId"
+                      class="block text-gray-900 font-mono text-xs"
+                    >
+                      {{ logId }}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Execution Data -->
+          <div v-if="executionData">
+            <div class="text-sm font-medium text-gray-500 mb-2">Execution Data</div>
+            <div class="bg-gray-50 p-4 rounded">
+              <div class="grid grid-cols-2 gap-4 text-sm">
+                <div v-if="executionData.command" class="col-span-2">
+                  <span class="text-gray-500">Command:</span>
+                  <code class="ml-2 text-gray-900 bg-gray-100 px-2 py-1 rounded">{{ executionData.command }}</code>
+                </div>
+                <div v-if="executionData.exitCode !== undefined">
+                  <span class="text-gray-500">Exit Code:</span>
+                  <span
+                    :class="[
+                      'ml-2 font-mono',
+                      executionData.exitCode === 0 ? 'text-green-600' : 'text-red-600'
+                    ]"
+                  >{{ executionData.exitCode }}</span>
+                </div>
+                <div v-if="executionData.timestamp">
+                  <span class="text-gray-500">Executed At:</span>
+                  <span class="ml-2 text-gray-900">{{ formatDate(executionData.timestamp) }}</span>
+                </div>
+                <div v-if="executionData.durationMs !== undefined">
+                  <span class="text-gray-500">Duration:</span>
+                  <span class="ml-2 text-gray-900">{{ formatDuration(executionData.durationMs) }}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Error -->
+          <div v-if="output.error">
+            <div class="text-sm font-medium text-red-500 mb-2">Error</div>
+            <div class="bg-red-50 p-4 rounded border border-red-200">
+              <div class="text-sm text-red-700 font-medium">
+                {{ output.error.message }}
+              </div>
+              <pre
+                v-if="output.error.stack"
+                class="mt-2 text-xs text-red-600 overflow-auto"
+              >{{ output.error.stack }}</pre>
+            </div>
+          </div>
+        </div>
+
+        <!-- Logs Tab -->
+        <div v-else-if="activeTab === 'logs'">
+          <!-- No logs available message -->
+          <div v-if="!hasLogArtifacts" class="bg-gray-50 border border-gray-200 rounded-lg p-6 text-center">
+            <div class="text-gray-400 text-4xl mb-3">📋</div>
+            <div class="text-gray-600 font-medium mb-1">No logs available</div>
+            <div class="text-sm text-gray-500">
+              This execution did not produce any log output.
+              <br />
+              Logs are typically generated by methods that perform streaming operations or verbose processing.
+            </div>
+          </div>
+
+          <!-- Logs available -->
+          <div v-else>
+            <div class="mb-4 flex items-center gap-4">
+              <div class="flex items-center gap-2">
+                <label class="text-sm text-gray-600">Tail lines:</label>
+                <input
+                  v-model="tailInput"
+                  type="number"
+                  min="1"
+                  placeholder="All"
+                  class="w-24 px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <button
+                @click="loadLogs"
+                :disabled="logsLoading"
+                class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+              >
+                {{ logsLoading ? "Loading..." : "Fetch" }}
+              </button>
+            </div>
+
+            <div
+              v-if="logsError"
+              class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4"
+            >
+              {{ logsError }}
+            </div>
+
+            <div v-if="logsLoading" class="text-gray-500">Loading logs...</div>
+
+            <div v-else-if="logsResponse">
+              <div class="mb-2 text-sm text-gray-500">
+                Showing {{ logsResponse.showingLines }} of {{ logsResponse.totalLines }} lines
+              </div>
+              <div class="bg-gray-900 text-gray-100 p-4 rounded font-mono text-sm overflow-auto max-h-96">
+                <div
+                  v-for="(line, index) in cleanedLogLines"
+                  :key="index"
+                  class="whitespace-pre-wrap"
+                >{{ line }}</div>
+                <div v-if="cleanedLogLines.length === 0" class="text-gray-500">
+                  No log entries
+                </div>
+              </div>
+            </div>
+
+            <div v-else class="text-gray-500">
+              Click "Fetch" to load log entries
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/experiments/webapp/frontend/src/views/outputs/OutputListView.vue
+++ b/experiments/webapp/frontend/src/views/outputs/OutputListView.vue
@@ -1,0 +1,505 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { useRouter } from "vue-router";
+import {
+  listWorkflowRuns,
+  listOutputs,
+  getWorkflowRun,
+  type WorkflowRunSummary,
+  type OutputSummary,
+  type WorkflowRunDetail,
+} from "../../api/client";
+
+interface ShellOutput {
+  type: "shell";
+  command: string;
+  args: string[];
+  stdout?: string;
+  exitCode?: number;
+}
+
+interface ModelMethodOutput {
+  type: "model_method";
+  model: string;
+  method: string;
+  resourceId?: string;
+  resourcePath?: string;
+  resourceAttributes?: Record<string, unknown>;
+}
+
+function isShellOutput(output: unknown): output is ShellOutput {
+  return (
+    typeof output === "object" &&
+    output !== null &&
+    "type" in output &&
+    (output as { type: unknown }).type === "shell"
+  );
+}
+
+function isModelMethodOutput(output: unknown): output is ModelMethodOutput {
+  return (
+    typeof output === "object" &&
+    output !== null &&
+    "type" in output &&
+    (output as { type: unknown }).type === "model_method"
+  );
+}
+
+const router = useRouter();
+const workflowRuns = ref<WorkflowRunSummary[]>([]);
+const outputs = ref<OutputSummary[]>([]);
+const loading = ref(true);
+const error = ref<string | null>(null);
+const expandedRuns = ref<Set<string>>(new Set());
+const runDetails = ref<Map<string, WorkflowRunDetail>>(new Map());
+const loadingRun = ref<string | null>(null);
+
+function formatDuration(ms: number | undefined): string {
+  if (ms === undefined) return "-";
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+  const minutes = Math.floor(ms / 60000);
+  const seconds = Math.floor((ms % 60000) / 1000);
+  return `${minutes}m ${seconds}s`;
+}
+
+function formatDate(dateStr: string | undefined): string {
+  if (!dateStr) return "-";
+  const date = new Date(dateStr);
+  return date.toLocaleString();
+}
+
+function formatRelativeTime(dateStr: string | undefined): string {
+  if (!dateStr) return "-";
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return "just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+}
+
+function getStatusColor(status: string): string {
+  switch (status) {
+    case "succeeded":
+      return "text-green-600 bg-green-100";
+    case "failed":
+      return "text-red-600 bg-red-100";
+    case "running":
+      return "text-blue-600 bg-blue-100";
+    case "pending":
+      return "text-yellow-600 bg-yellow-100";
+    default:
+      return "text-gray-600 bg-gray-100";
+  }
+}
+
+function getStatusIcon(status: string): string {
+  switch (status) {
+    case "succeeded":
+      return "✓";
+    case "failed":
+      return "✗";
+    case "running":
+      return "●";
+    case "pending":
+      return "○";
+    default:
+      return "?";
+  }
+}
+
+async function toggleRunExpanded(runId: string) {
+  if (expandedRuns.value.has(runId)) {
+    expandedRuns.value.delete(runId);
+  } else {
+    expandedRuns.value.add(runId);
+    // Fetch run details if not already loaded
+    if (!runDetails.value.has(runId)) {
+      loadingRun.value = runId;
+      try {
+        const runDetail = await getWorkflowRun(runId);
+        runDetails.value.set(runId, runDetail);
+      } catch (e) {
+        console.error("Failed to load run details:", e);
+      } finally {
+        loadingRun.value = null;
+      }
+    }
+  }
+}
+
+function isRunExpanded(runId: string): boolean {
+  return expandedRuns.value.has(runId);
+}
+
+function getRunDetail(runId: string): WorkflowRunDetail | undefined {
+  return runDetails.value.get(runId);
+}
+
+onMounted(async () => {
+  try {
+    const [runsData, outputsData] = await Promise.all([
+      listWorkflowRuns(),
+      listOutputs(),
+    ]);
+    workflowRuns.value = runsData;
+    outputs.value = outputsData;
+
+    // Auto-expand the first run if there are any
+    if (runsData.length > 0) {
+      await toggleRunExpanded(runsData[0].id);
+    }
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to load data";
+  } finally {
+    loading.value = false;
+  }
+});
+
+function handleOutputClick(outputId: string) {
+  router.push({
+    name: "output-detail",
+    params: { id: outputId },
+  });
+}
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center justify-between mb-6">
+      <h1 class="text-3xl font-bold text-gray-900">Outputs</h1>
+    </div>
+
+    <div
+      v-if="error"
+      class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-6"
+    >
+      {{ error }}
+    </div>
+
+    <div v-if="loading" class="text-gray-500">Loading...</div>
+
+    <div v-else>
+      <!-- Workflow Runs Section -->
+      <div v-if="workflowRuns.length > 0" class="space-y-4">
+        <h2 class="text-lg font-semibold text-gray-700 mb-3">Workflow Runs</h2>
+
+        <div
+          v-for="run in workflowRuns"
+          :key="run.id"
+          class="bg-white rounded-lg shadow overflow-hidden"
+        >
+          <!-- Run Header -->
+          <div
+            class="px-4 py-3 border-b border-gray-200 cursor-pointer hover:bg-gray-50"
+            @click="toggleRunExpanded(run.id)"
+          >
+            <div class="flex items-center justify-between">
+              <div class="flex items-center gap-3">
+                <span
+                  class="text-gray-400 transition-transform"
+                  :class="{ 'rotate-90': isRunExpanded(run.id) }"
+                >
+                  ▶
+                </span>
+                <div>
+                  <div class="font-medium text-gray-900">
+                    {{ run.workflowName }}
+                  </div>
+                  <div class="text-sm text-gray-500">
+                    {{ formatRelativeTime(run.startedAt) }}
+                    <span class="mx-1">·</span>
+                    {{ run.outputCount }} output{{
+                      run.outputCount !== 1 ? "s" : ""
+                    }}
+                  </div>
+                </div>
+              </div>
+              <span
+                :class="[
+                  'px-2 py-1 rounded-full text-xs font-medium',
+                  getStatusColor(run.status),
+                ]"
+              >
+                {{ getStatusIcon(run.status) }} {{ run.status }}
+              </span>
+            </div>
+          </div>
+
+          <!-- Expanded Run Details -->
+          <div v-if="isRunExpanded(run.id)" class="px-4 py-3 bg-gray-50">
+            <div class="text-xs text-gray-500 mb-3">
+              <span>Run ID: {{ run.id.slice(0, 8) }}...</span>
+              <span class="mx-2">·</span>
+              <span>Started: {{ formatDate(run.startedAt) }}</span>
+              <span v-if="run.completedAt" class="mx-2">·</span>
+              <span v-if="run.completedAt"
+                >Completed: {{ formatDate(run.completedAt) }}</span
+              >
+            </div>
+
+            <!-- Loading state -->
+            <div
+              v-if="loadingRun === run.id"
+              class="text-sm text-gray-500 py-2"
+            >
+              Loading details...
+            </div>
+
+            <!-- Jobs and Steps for this run -->
+            <div
+              v-else-if="getRunDetail(run.id)?.jobs.length"
+              class="space-y-3"
+            >
+              <div
+                v-for="job in getRunDetail(run.id)?.jobs"
+                :key="job.jobName"
+                class="bg-white rounded border border-gray-200 overflow-hidden"
+              >
+                <!-- Job Header -->
+                <div
+                  class="px-3 py-2 bg-gray-100 border-b border-gray-200 flex items-center justify-between"
+                >
+                  <span class="font-medium text-gray-700">{{
+                    job.jobName
+                  }}</span>
+                  <span
+                    :class="[
+                      'px-2 py-0.5 rounded-full text-xs font-medium',
+                      getStatusColor(job.status),
+                    ]"
+                  >
+                    {{ getStatusIcon(job.status) }} {{ job.status }}
+                  </span>
+                </div>
+
+                <!-- Steps -->
+                <div class="divide-y divide-gray-100">
+                  <div
+                    v-for="step in job.steps"
+                    :key="step.stepName"
+                    :class="[
+                      'px-3 py-2',
+                      step.outputId && 'cursor-pointer hover:bg-gray-50 transition-colors',
+                    ]"
+                    @click="step.outputId && handleOutputClick(step.outputId)"
+                  >
+                    <div class="flex items-center justify-between">
+                      <div class="flex items-center gap-2">
+                        <span
+                          :class="[
+                            'w-5 h-5 rounded-full text-xs font-medium flex items-center justify-center',
+                            getStatusColor(step.status),
+                          ]"
+                        >
+                          {{ getStatusIcon(step.status) }}
+                        </span>
+                        <span class="text-gray-800">{{ step.stepName }}</span>
+
+                        <!-- Task type badge -->
+                        <span
+                          v-if="isShellOutput(step.output)"
+                          class="px-1.5 py-0.5 bg-purple-100 text-purple-700 text-xs rounded"
+                        >
+                          shell
+                        </span>
+                        <span
+                          v-else-if="isModelMethodOutput(step.output)"
+                          class="px-1.5 py-0.5 bg-blue-100 text-blue-700 text-xs rounded"
+                        >
+                          model
+                        </span>
+                      </div>
+                    </div>
+
+                    <!-- Step output details -->
+                    <div
+                      v-if="isShellOutput(step.output)"
+                      class="mt-1 ml-7 text-xs text-gray-500"
+                    >
+                      <span class="font-mono"
+                        >{{ step.output.command }}
+                        {{ step.output.args.join(" ") }}</span
+                      >
+                      <span
+                        v-if="step.output.exitCode !== undefined"
+                        class="ml-2 text-gray-400"
+                      >
+                        → exit {{ step.output.exitCode }}
+                      </span>
+                      <pre
+                        v-if="step.output.stdout"
+                        class="mt-1 p-2 bg-gray-900 text-gray-100 rounded text-xs overflow-x-auto max-h-32"
+                        >{{ step.output.stdout }}</pre
+                      >
+                    </div>
+                    <div
+                      v-else-if="isModelMethodOutput(step.output)"
+                      class="mt-1 ml-7 text-xs text-gray-500"
+                    >
+                      <span class="font-mono"
+                        >{{ step.output.model }}.{{ step.output.method }}()</span
+                      >
+                      <span
+                        v-if="step.output.resourceId"
+                        class="ml-2 text-gray-400"
+                      >
+                        → {{ step.output.resourceId.slice(0, 8) }}...
+                      </span>
+                    </div>
+
+                    <!-- Error display -->
+                    <div
+                      v-if="step.error"
+                      class="mt-1 ml-7 text-xs text-red-600 bg-red-50 p-2 rounded"
+                    >
+                      {{ step.error }}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Outputs for this run (fallback if no jobs) -->
+            <div
+              v-else-if="getRunDetail(run.id)?.outputs.length"
+              class="space-y-2"
+            >
+              <div
+                v-for="output in getRunDetail(run.id)?.outputs"
+                :key="output.id"
+                class="bg-white rounded border border-gray-200 px-3 py-2 hover:border-blue-300 cursor-pointer transition-colors"
+                @click.stop="handleOutputClick(output.id)"
+              >
+                <div class="flex items-center justify-between">
+                  <div class="flex items-center gap-2">
+                    <span
+                      :class="[
+                        'w-5 h-5 rounded-full text-xs font-medium flex items-center justify-center',
+                        getStatusColor(output.status),
+                      ]"
+                    >
+                      {{ getStatusIcon(output.status) }}
+                    </span>
+                    <div>
+                      <span class="font-medium text-gray-800">{{
+                        output.type
+                      }}</span>
+                      <span class="text-gray-400 mx-1">·</span>
+                      <span class="text-gray-600">{{ output.methodName }}</span>
+                      <span v-if="output.stepName" class="text-gray-400 ml-2"
+                        >({{ output.stepName }})</span
+                      >
+                    </div>
+                  </div>
+                  <div class="text-sm text-gray-500">
+                    {{ formatDuration(output.durationMs) }}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div v-else class="text-sm text-gray-500 italic py-2">
+              No details recorded for this run
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- All Outputs Table (fallback/full view) -->
+      <div v-if="outputs.length > 0" class="mt-8">
+        <h2 class="text-lg font-semibold text-gray-700 mb-3">All Outputs</h2>
+
+        <div class="bg-white rounded-lg shadow overflow-hidden">
+          <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+              <tr>
+                <th
+                  class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                >
+                  Model
+                </th>
+                <th
+                  class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                >
+                  Type
+                </th>
+                <th
+                  class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                >
+                  Method
+                </th>
+                <th
+                  class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                >
+                  Status
+                </th>
+                <th
+                  class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                >
+                  Started
+                </th>
+                <th
+                  class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                >
+                  Duration
+                </th>
+              </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-gray-200">
+              <tr
+                v-for="output in outputs"
+                :key="output.id"
+                class="hover:bg-gray-50 cursor-pointer"
+                @click="handleOutputClick(output.id)"
+              >
+                <td class="px-4 py-3 whitespace-nowrap">
+                  <span class="text-gray-900">{{
+                    output.modelName || "-"
+                  }}</span>
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap text-gray-500">
+                  {{ output.type }}
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap text-gray-500">
+                  {{ output.methodName }}
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap">
+                  <span
+                    :class="[
+                      'px-2 py-1 rounded-full text-xs font-medium',
+                      getStatusColor(output.status),
+                    ]"
+                  >
+                    {{ output.status }}
+                  </span>
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap text-gray-500">
+                  {{ formatDate(output.startedAt) }}
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap text-gray-500">
+                  {{ formatDuration(output.durationMs) }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Empty State -->
+      <div
+        v-if="workflowRuns.length === 0 && outputs.length === 0"
+        class="bg-white rounded-lg shadow p-8 text-center text-gray-500"
+      >
+        No outputs found. Run a workflow or model method to see results here.
+      </div>
+    </div>
+  </div>
+</template>

--- a/experiments/webapp/frontend/src/views/workflows/WorkflowDetailView.vue
+++ b/experiments/webapp/frontend/src/views/workflows/WorkflowDetailView.vue
@@ -1,0 +1,310 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { useRoute, useRouter, RouterLink } from "vue-router";
+import {
+  deleteWorkflow,
+  getWorkflow,
+  getModel,
+  lookupModel,
+  type Model,
+  type TriggerCondition,
+  type Workflow,
+} from "../../api/client";
+
+const route = useRoute();
+const router = useRouter();
+const workflow = ref<Workflow | null>(null);
+const loading = ref(true);
+const error = ref<string | null>(null);
+const deleting = ref(false);
+const expandedSteps = ref<Set<string>>(new Set());
+const modelLinks = ref<Map<string, { type: string; id: string }>>(new Map());
+const modelDetails = ref<Map<string, Model>>(new Map());
+
+const idParam = route.params.id as string;
+
+onMounted(async () => {
+  try {
+    workflow.value = await getWorkflow(idParam);
+
+    // Resolve model links and fetch model details for all model_method steps
+    if (workflow.value) {
+      for (const job of workflow.value.jobs) {
+        for (const step of job.steps) {
+          if (step.task.type === "model_method" && step.task.modelIdOrName) {
+            try {
+              const lookup = await lookupModel(step.task.modelIdOrName);
+              modelLinks.value.set(step.task.modelIdOrName, {
+                type: lookup.type,
+                id: lookup.id,
+              });
+              // Fetch full model details to get attributes
+              const model = await getModel(lookup.type, lookup.id);
+              modelDetails.value.set(step.task.modelIdOrName, model);
+            } catch {
+              // Model not found, link will be disabled
+            }
+          }
+        }
+      }
+    }
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to load workflow";
+  } finally {
+    loading.value = false;
+  }
+});
+
+async function handleDelete() {
+  if (!confirm("Are you sure you want to delete this workflow?")) return;
+
+  deleting.value = true;
+  try {
+    await deleteWorkflow(idParam);
+    router.push({ name: "workflows" });
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to delete workflow";
+    deleting.value = false;
+  }
+}
+
+function toggleStep(jobName: string, stepName: string) {
+  const key = `${jobName}:${stepName}`;
+  if (expandedSteps.value.has(key)) {
+    expandedSteps.value.delete(key);
+  } else {
+    expandedSteps.value.add(key);
+  }
+}
+
+function isStepExpanded(jobName: string, stepName: string): boolean {
+  return expandedSteps.value.has(`${jobName}:${stepName}`);
+}
+
+function formatCondition(condition: TriggerCondition): string {
+  if (condition.type === "and" || condition.type === "or") {
+    const parts = condition.conditions?.map(formatCondition) || [];
+    return parts.join(` ${condition.type} `);
+  }
+  if (condition.type === "not") {
+    return `not(${formatCondition(condition.condition!)})`;
+  }
+  return condition.type;
+}
+
+function getModelLink(modelIdOrName: string): { name: string; params: { type: string; id: string } } | null {
+  const link = modelLinks.value.get(modelIdOrName);
+  if (!link) return null;
+  return { name: "model-detail", params: { type: link.type, id: link.id } };
+}
+
+function getModelAttributes(modelIdOrName: string): Record<string, unknown> | null {
+  const model = modelDetails.value.get(modelIdOrName);
+  return model?.attributes ?? null;
+}
+</script>
+
+<template>
+  <div>
+    <div class="mb-6">
+      <RouterLink to="/workflows" class="text-blue-600 hover:text-blue-800 text-sm">
+        &larr; Back to Workflows
+      </RouterLink>
+    </div>
+
+    <div v-if="error" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-6">
+      {{ error }}
+    </div>
+
+    <div v-if="loading" class="text-gray-500">Loading...</div>
+
+    <div v-else-if="workflow" class="space-y-6">
+      <div class="bg-white rounded-lg shadow">
+        <div class="px-6 py-4 border-b border-gray-200">
+          <div class="flex items-center justify-between">
+            <h1 class="text-2xl font-bold text-gray-900">{{ workflow.name }}</h1>
+            <div class="space-x-2">
+              <RouterLink
+                :to="{ name: 'workflow-edit', params: { id: idParam } }"
+                class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+              >
+                Edit
+              </RouterLink>
+              <button
+                @click="handleDelete"
+                :disabled="deleting"
+                class="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 transition-colors disabled:opacity-50"
+              >
+                {{ deleting ? "Deleting..." : "Delete" }}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div class="p-6 space-y-6">
+          <div class="grid grid-cols-2 gap-6">
+            <div>
+              <div class="text-sm font-medium text-gray-500">ID</div>
+              <div class="mt-1 text-sm text-gray-900 font-mono">{{ workflow.id }}</div>
+            </div>
+            <div>
+              <div class="text-sm font-medium text-gray-500">Version</div>
+              <div class="mt-1 text-sm text-gray-900">{{ workflow.version }}</div>
+            </div>
+          </div>
+
+          <div v-if="workflow.description">
+            <div class="text-sm font-medium text-gray-500">Description</div>
+            <div class="mt-1 text-sm text-gray-900">{{ workflow.description }}</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="bg-white rounded-lg shadow">
+        <div class="px-6 py-4 border-b border-gray-200">
+          <h2 class="text-lg font-semibold text-gray-900">Jobs ({{ workflow.jobs.length }})</h2>
+        </div>
+        <div class="divide-y divide-gray-200">
+          <div v-for="job in workflow.jobs" :key="job.name" class="p-6">
+            <div class="flex items-center justify-between mb-4">
+              <h3 class="text-md font-medium text-gray-900">{{ job.name }}</h3>
+              <span class="text-sm text-gray-500">{{ job.steps.length }} step(s)</span>
+            </div>
+            <p v-if="job.description" class="text-sm text-gray-600 mb-4">{{ job.description }}</p>
+
+            <div class="space-y-3">
+              <div
+                v-for="step in job.steps"
+                :key="step.name"
+                class="bg-gray-50 rounded p-3 cursor-pointer hover:bg-gray-100 transition-colors"
+                @click="toggleStep(job.name, step.name)"
+              >
+                <div class="flex items-center justify-between">
+                  <div class="flex items-center gap-2">
+                    <svg
+                      class="w-4 h-4 text-gray-400 transition-transform"
+                      :class="{ 'rotate-90': isStepExpanded(job.name, step.name) }"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M9 5l7 7-7 7"
+                      />
+                    </svg>
+                    <span class="text-sm font-medium text-gray-800">{{ step.name }}</span>
+                  </div>
+                  <span class="text-xs text-gray-500 bg-gray-200 px-2 py-1 rounded">
+                    {{ step.task.type }}
+                  </span>
+                </div>
+                <div v-if="step.task.type === 'model_method'" class="text-xs text-gray-600 mt-1 ml-6 font-mono">
+                  {{ getModelAttributes(step.task.modelIdOrName!)?.run || `${step.task.modelIdOrName}.${step.task.methodName}()` }}
+                </div>
+                <div
+                  v-else-if="step.task.type === 'shell'"
+                  class="text-xs text-gray-600 mt-1 ml-6 font-mono"
+                >
+                  {{ step.task.command }} {{ (step.task.args || []).join(" ") }}
+                </div>
+
+                <!-- Expanded details section -->
+                <div
+                  v-if="isStepExpanded(job.name, step.name)"
+                  class="mt-3 pt-3 border-t border-gray-200 ml-6"
+                >
+                  <!-- Description -->
+                  <div v-if="step.description" class="mb-3">
+                    <div class="text-xs font-medium text-gray-500">Description</div>
+                    <div class="text-sm text-gray-700 mt-1">{{ step.description }}</div>
+                  </div>
+
+                  <!-- Task Configuration -->
+                  <div class="mb-3">
+                    <div class="text-xs font-medium text-gray-500">Task Configuration</div>
+                    <dl class="mt-1 text-xs grid grid-cols-2 gap-x-4 gap-y-1">
+                      <template v-if="step.task.type === 'model_method'">
+                        <dt class="text-gray-500">Model:</dt>
+                        <dd class="font-mono">
+                          <RouterLink
+                            v-if="getModelLink(step.task.modelIdOrName!)"
+                            :to="getModelLink(step.task.modelIdOrName!)!"
+                            class="text-blue-600 hover:text-blue-800 hover:underline"
+                            @click.stop
+                          >
+                            {{ step.task.modelIdOrName }}
+                          </RouterLink>
+                          <span v-else>{{ step.task.modelIdOrName }}</span>
+                        </dd>
+                        <dt class="text-gray-500">Method:</dt>
+                        <dd class="font-mono">{{ step.task.methodName }}</dd>
+                        <template v-if="getModelAttributes(step.task.modelIdOrName!)?.run">
+                          <dt class="text-gray-500">Command:</dt>
+                          <dd class="font-mono">{{ getModelAttributes(step.task.modelIdOrName!)?.run }}</dd>
+                        </template>
+                        <template v-if="getModelAttributes(step.task.modelIdOrName!)?.workingDir">
+                          <dt class="text-gray-500">Working Dir:</dt>
+                          <dd class="font-mono">{{ getModelAttributes(step.task.modelIdOrName!)?.workingDir }}</dd>
+                        </template>
+                      </template>
+                      <template v-else-if="step.task.type === 'shell'">
+                        <dt class="text-gray-500">Command:</dt>
+                        <dd class="font-mono">{{ step.task.command }}</dd>
+                        <template v-if="step.task.args?.length">
+                          <dt class="text-gray-500">Args:</dt>
+                          <dd class="font-mono">{{ step.task.args.join(" ") }}</dd>
+                        </template>
+                      </template>
+                      <template v-if="step.task.workingDir">
+                        <dt class="text-gray-500">Working Dir:</dt>
+                        <dd class="font-mono">{{ step.task.workingDir }}</dd>
+                      </template>
+                      <template v-if="step.task.timeout">
+                        <dt class="text-gray-500">Timeout:</dt>
+                        <dd>{{ step.task.timeout }}ms</dd>
+                      </template>
+                    </dl>
+                    <div
+                      v-if="step.task.env && Object.keys(step.task.env).length > 0"
+                      class="mt-2"
+                    >
+                      <div class="text-xs text-gray-500">Environment:</div>
+                      <div class="font-mono text-xs mt-1 bg-white rounded p-2">
+                        <div v-for="(value, key) in step.task.env" :key="key">
+                          {{ key }}={{ value }}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- Dependencies -->
+                  <div v-if="step.dependsOn.length > 0" class="mb-3">
+                    <div class="text-xs font-medium text-gray-500">Dependencies</div>
+                    <ul class="mt-1 text-xs space-y-1">
+                      <li v-for="dep in step.dependsOn" :key="dep.step" class="text-gray-700">
+                        <span class="font-medium">{{ dep.step }}</span>
+                        <span class="text-gray-500 ml-1">({{ formatCondition(dep.condition) }})</span>
+                      </li>
+                    </ul>
+                  </div>
+
+                  <!-- Weight -->
+                  <div class="text-xs text-gray-500">
+                    Weight: {{ step.weight }}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div v-if="workflow.jobs.length === 0" class="p-6 text-center text-gray-500">
+            No jobs defined
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/experiments/webapp/frontend/src/views/workflows/WorkflowEditView.vue
+++ b/experiments/webapp/frontend/src/views/workflows/WorkflowEditView.vue
@@ -1,0 +1,165 @@
+<script setup lang="ts">
+import { ref, onMounted, computed } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import {
+  getWorkflow,
+  createWorkflow,
+  updateWorkflow,
+  type Workflow,
+} from "../../api/client";
+
+const route = useRoute();
+const router = useRouter();
+
+const isNew = computed(() => route.name === "workflow-new");
+const idParam = computed(() => route.params.id as string | undefined);
+
+const loading = ref(true);
+const saving = ref(false);
+const error = ref<string | null>(null);
+
+const form = ref({
+  name: "",
+  description: "",
+  version: 1,
+  jobsYaml: "[]",
+});
+
+onMounted(async () => {
+  try {
+    if (!isNew.value && idParam.value) {
+      const workflow = await getWorkflow(idParam.value);
+      form.value = {
+        name: workflow.name,
+        description: workflow.description || "",
+        version: workflow.version,
+        jobsYaml: JSON.stringify(workflow.jobs, null, 2),
+      };
+    }
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to load workflow";
+  } finally {
+    loading.value = false;
+  }
+});
+
+async function handleSubmit() {
+  saving.value = true;
+  error.value = null;
+
+  try {
+    let jobs;
+    try {
+      jobs = JSON.parse(form.value.jobsYaml);
+    } catch {
+      throw new Error("Invalid JSON in jobs definition");
+    }
+
+    const input = {
+      name: form.value.name,
+      description: form.value.description || undefined,
+      version: form.value.version,
+      jobs,
+    };
+
+    let savedWorkflow: Workflow;
+    if (isNew.value) {
+      savedWorkflow = await createWorkflow(input);
+    } else {
+      savedWorkflow = await updateWorkflow(idParam.value!, input);
+    }
+
+    router.push({
+      name: "workflow-detail",
+      params: { id: savedWorkflow.id },
+    });
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to save workflow";
+    saving.value = false;
+  }
+}
+</script>
+
+<template>
+  <div>
+    <div class="mb-6">
+      <RouterLink
+        :to="isNew ? '/workflows' : { name: 'workflow-detail', params: { id: idParam } }"
+        class="text-blue-600 hover:text-blue-800 text-sm"
+      >
+        &larr; Back
+      </RouterLink>
+    </div>
+
+    <h1 class="text-3xl font-bold text-gray-900 mb-6">
+      {{ isNew ? "Create Workflow" : "Edit Workflow" }}
+    </h1>
+
+    <div v-if="error" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-6">
+      {{ error }}
+    </div>
+
+    <div v-if="loading" class="text-gray-500">Loading...</div>
+
+    <form v-else @submit.prevent="handleSubmit" class="bg-white rounded-lg shadow p-6 space-y-6">
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">Name</label>
+        <input
+          v-model="form.name"
+          type="text"
+          class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          required
+        />
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">Description</label>
+        <textarea
+          v-model="form.description"
+          rows="2"
+          class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+        ></textarea>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">Version</label>
+        <input
+          v-model.number="form.version"
+          type="number"
+          min="1"
+          class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          required
+        />
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">Jobs (JSON)</label>
+        <textarea
+          v-model="form.jobsYaml"
+          rows="20"
+          class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono text-sm"
+        ></textarea>
+        <p class="mt-1 text-sm text-gray-500">
+          Define jobs as a JSON array. Each job needs: name, steps array.
+          Each step needs: name, task (type: "model_method" or "shell").
+        </p>
+      </div>
+
+      <div class="flex justify-end space-x-4">
+        <RouterLink
+          :to="isNew ? '/workflows' : { name: 'workflow-detail', params: { id: idParam } }"
+          class="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors"
+        >
+          Cancel
+        </RouterLink>
+        <button
+          type="submit"
+          :disabled="saving"
+          class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors disabled:opacity-50"
+        >
+          {{ saving ? "Saving..." : "Save" }}
+        </button>
+      </div>
+    </form>
+  </div>
+</template>

--- a/experiments/webapp/frontend/src/views/workflows/WorkflowListView.vue
+++ b/experiments/webapp/frontend/src/views/workflows/WorkflowListView.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { useRouter } from "vue-router";
+import DataTable from "../../components/DataTable.vue";
+import { listWorkflows, type WorkflowSummary } from "../../api/client";
+
+const router = useRouter();
+const workflows = ref<WorkflowSummary[]>([]);
+const loading = ref(true);
+const error = ref<string | null>(null);
+
+const columns = [
+  { key: "name", label: "Name" },
+  { key: "description", label: "Description" },
+  { key: "version", label: "Version" },
+  { key: "jobCount", label: "Jobs" },
+];
+
+onMounted(async () => {
+  try {
+    workflows.value = await listWorkflows();
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to load workflows";
+  } finally {
+    loading.value = false;
+  }
+});
+
+function handleRowClick(workflow: WorkflowSummary) {
+  router.push({
+    name: "workflow-detail",
+    params: { id: workflow.id },
+  });
+}
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center justify-between mb-6">
+      <h1 class="text-3xl font-bold text-gray-900">Workflows</h1>
+      <RouterLink
+        to="/workflows/new"
+        class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+      >
+        Create Workflow
+      </RouterLink>
+    </div>
+
+    <div v-if="error" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-6">
+      {{ error }}
+    </div>
+
+    <div class="bg-white rounded-lg shadow">
+      <DataTable
+        :columns="columns"
+        :data="workflows"
+        :loading="loading"
+        empty-message="No workflows found"
+        @row-click="handleRowClick"
+      />
+    </div>
+  </div>
+</template>

--- a/experiments/webapp/frontend/src/vite-env.d.ts
+++ b/experiments/webapp/frontend/src/vite-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+declare module "*.vue" {
+  import type { DefineComponent } from "vue";
+  const component: DefineComponent<object, object, unknown>;
+  export default component;
+}

--- a/experiments/webapp/frontend/tailwind.config.js
+++ b/experiments/webapp/frontend/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{vue,js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/experiments/webapp/frontend/tsconfig.json
+++ b/experiments/webapp/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "preserve",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
+}

--- a/experiments/webapp/frontend/vite.config.ts
+++ b/experiments/webapp/frontend/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:8080",
+        changeOrigin: true,
+      },
+    },
+  },
+});

--- a/src/cli/commands/repo_init.ts
+++ b/src/cli/commands/repo_init.ts
@@ -9,6 +9,7 @@ import { createContext, type GlobalOptions } from "../context.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { RepoService } from "../../domain/repo/repo_service.ts";
 import { VERSION } from "./version.ts";
+import { repoWebappCommand } from "../../../experiments/webapp/cli/webapp_command.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -73,4 +74,5 @@ export const repoCommand = new Command()
     this.showHelp();
   })
   .command("init", repoInitCommand)
-  .command("upgrade", repoUpgradeCommand);
+  .command("upgrade", repoUpgradeCommand)
+  .command("webapp", repoWebappCommand);

--- a/src/domain/models/repositories.ts
+++ b/src/domain/models/repositories.ts
@@ -48,6 +48,13 @@ export interface InputRepository {
   ): Promise<{ input: ModelInput; type: ModelType } | null>;
 
   /**
+   * Finds all inputs across all model types.
+   *
+   * @returns Array of all inputs with their types
+   */
+  findAllGlobal(): Promise<{ input: ModelInput; type: ModelType }[]>;
+
+  /**
    * Saves an input.
    *
    * @param type - The model type

--- a/src/domain/models/validation_service_test.ts
+++ b/src/domain/models/validation_service_test.ts
@@ -262,6 +262,10 @@ function createMockInputRepo(
       }
       return Promise.resolve(null);
     },
+    findAllGlobal: () =>
+      Promise.resolve(
+        models.map((m) => ({ input: m.input, type: ModelType.create(m.type) })),
+      ),
     save: () => Promise.resolve(),
     delete: () => Promise.resolve(),
     nextId: () => crypto.randomUUID() as ModelInputId,

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -106,6 +106,16 @@ class InMemoryWorkflowRunRepository implements WorkflowRunRepository {
     return Promise.resolve(workflowRuns[workflowRuns.length - 1] ?? null);
   }
 
+  findAllGlobal(): Promise<{ run: WorkflowRun; workflowId: WorkflowId }[]> {
+    const results: { run: WorkflowRun; workflowId: WorkflowId }[] = [];
+    for (const [workflowId, runs] of this.runs.entries()) {
+      for (const run of runs) {
+        results.push({ run, workflowId: workflowId as WorkflowId });
+      }
+    }
+    return Promise.resolve(results);
+  }
+
   save(workflowId: WorkflowId, run: WorkflowRun): Promise<void> {
     const existing = this.runs.get(workflowId) ?? [];
     const idx = existing.findIndex((r) => r.id === run.id);

--- a/src/domain/workflows/repositories.ts
+++ b/src/domain/workflows/repositories.ts
@@ -65,6 +65,11 @@ export interface WorkflowRunRepository {
   findLatestByWorkflowId(workflowId: WorkflowId): Promise<WorkflowRun | null>;
 
   /**
+   * Finds all workflow runs across all workflows.
+   */
+  findAllGlobal(): Promise<{ run: WorkflowRun; workflowId: WorkflowId }[]>;
+
+  /**
    * Saves a workflow run.
    */
   save(workflowId: WorkflowId, run: WorkflowRun): Promise<void>;


### PR DESCRIPTION
## Summary

Add a self-contained webapp in `experiments/webapp/` directory with:
- **frontend/**: Vue SPA for browsing models, workflows, and outputs
- **backend/**: HTTP server with REST API handlers
- **cli/**: CLI command `repo webapp` to start the server

Also adds `findAllGlobal` methods to `InputRepository` and `WorkflowRunRepository` interfaces to support the webapp API.

The `experiments/` directory is excluded from deno type checking and is marked in `CLAUDE.md` as isolated code that may be removed.

## Test Plan

- [x] `deno check` - Type checking passes
- [x] `deno lint` - Linting passes  
- [x] `deno fmt` - Formatting passes
- [x] `deno run test` - All 1095 tests pass
- [x] `deno run webapp:install` - npm install works
- [x] `deno run webapp:build` - Vite build works
- [x] `deno run compile` - Binary compiles with webapp included