### PR TITLE
docs: align design documents with repo.md dual-layer architecture

### DIFF
--- a/design/agent.md
+++ b/design/agent.md
@@ -1,8 +1,36 @@
 # AI Agent
 
 The primary method for working with swamp is through an AI agent. Each
-repository will have skills dedicated to working with swamp, through the cli,
+repository will have skills dedicated to working with swamp, through the CLI,
 writing files, etc.
+
+## Repository Exploration
+
+Agents can explore a swamp repository through two layers:
+
+### Logical Views (Recommended)
+
+The logical views provide human/agent-friendly exploration:
+
+- **`/models/{name}/`** - Model-centric view with inputs, resources, outputs,
+  logs, and files organized by model name
+- **`/workflows/{name}/`** - Workflow-centric view with definitions and run
+  history organized by workflow name
+
+These views use symlinks to reference data in the internal data directory. They
+are the recommended way to explore and understand the repository structure.
+
+### Data Directory (Direct Access)
+
+The `/data/` directory contains the internal storage format. Agents can access
+it directly when needed, but the layout reflects swamp's internal architecture
+rather than user-facing concerns.
+
+### CLI Abstraction
+
+The CLI commands (`swamp model`, `swamp workflow`, etc.) abstract away the
+storage layer entirely. Agents should prefer using CLI commands for operations,
+and use the logical views for exploration and understanding context.
 
 ## swamp-model Skill
 

--- a/design/expressions.md
+++ b/design/expressions.md
@@ -76,7 +76,13 @@ registering custom types, functions, etc in their swamp repo.
 
 When loading the YAML, first parse the CEL expressions. Then take the data
 structures they emit and embed them in the data structure. Write those to a
-directory in the repository called inputs-evaluated/ whose structure is the same
-as inputs. This directory should be in a swamp repos .gitignore file.
+directory in the repository called `/data/inputs-evaluated/` whose structure is
+the same as `/data/inputs/`. This directory should be in a swamp repo's
+.gitignore file.
 
-The same is true for workflows-evaluated/, and it should also be in .gitignore.
+The same is true for `/data/workflows-evaluated/`, and it should also be in
+.gitignore.
+
+These evaluated directories are internal working directories in the data layer,
+used by the expression evaluation system. They are not exposed through logical
+views.

--- a/design/high-level.md
+++ b/design/high-level.md
@@ -20,6 +20,38 @@ configuration drift.
 
 All this is stored in a 'swamp repo', which is a git repository.
 
+## Storage Architecture
+
+A swamp repo uses a dual-layer storage architecture:
+
+### Data Directory (`data/`)
+
+The `data/` directory is the internal storage format optimized for swamp's
+software architecture. Aggregate repositories (ModelRepository,
+WorkflowRepository, WorkflowRunRepository) persist domain objects here.
+
+Both agents and humans can explore the data directory directly, but its layout
+reflects swamp's internal domain model rather than user-facing concerns.
+
+### Logical Views
+
+Logical views are symlinked directories that provide human/agent-friendly
+perspectives into the data directory. They are automatically maintained by the
+RepoIndexService whenever aggregate repositories mutate data.
+
+**Model View (`/models/`):** Explore models by name, with easy access to inputs,
+resources, outputs, logs, and files for each model.
+
+**Workflow View (`/workflows/`):** Explore workflows by name, with access to
+workflow definitions and run history.
+
+These views allow exploration of the same underlying data from different
+perspectives. For example, a method output can be viewed from the model's
+perspective (`/models/{name}/outputs/`) or from the workflow run that triggered
+it (`/workflows/{name}/runs/{run}/steps/{step}/`).
+
+See [./repo.md] for detailed architecture documentation.
+
 ## Models
 
 See [./models.md].

--- a/design/models.md
+++ b/design/models.md
@@ -40,10 +40,10 @@ A model can migrate its inputs and resources from one version to the next.
 
 ## Inputs
 
-Inputs are specified as YAML files that live in the /inputs directory of a
-repository, underneath the normalized type as a directory. The file name is
-'${id}.yaml'. For example,
-'aws/ec2/vpc/input-fc7fd41e-ae16-4b31-b57a-86de716e3ece.yaml'.
+Inputs are specified as YAML files that live in the `/data/inputs/` directory of
+a repository, underneath the normalized type as a directory. The file name is
+`${id}.yaml`. For example,
+`data/inputs/aws/ec2/vpc/fc7fd41e-ae16-4b31-b57a-86de716e3ece.yaml`.
 
 The valid shape of an input is specified with a Zod 4 schema.
 
@@ -77,9 +77,9 @@ method.
 ### Logs
 
 A method may produce 0..* log artifacts. They have a name, can have lines
-streamed to them, and by default are stored in /logs in the repository
+streamed to them, and by default are stored in `/data/logs/` in the repository
 underneath the normalized model type as a directory. Logs are named like
-{model-id}-{method name}-{log name}-{timestamp}.log.
+`{model-id}-{method name}-{log name}-{timestamp}.log`.
 
 They are unstructured, line oriented data.
 
@@ -89,16 +89,17 @@ artifact named 'k8slog'.
 The stream of log output should have an event emitter attached to it, so we can
 stream logs in real time.
 
-By default, the /logs directory is not stored in git.
+By default, the `/data/logs/` directory is not stored in git.
 
 ### Files
 
 A method may store 0..* file artifacts. They have a name, and can be written to
-directly. By default they will be stored in the /files directory of the
-repository underneath the normalized model type as a directoy plus the model ID
-and method name. For example aws/s3/bucket/{model-id}/{method-name}/{filename}.
+directly. By default they will be stored in the `/data/files/` directory of the
+repository underneath the normalized model type as a directory plus the model ID
+and method name. For example
+`data/files/aws/s3/bucket/{model-id}/{method-name}/{filename}`.
 
-By default, the /files directory is not stored in git.
+By default, the `/data/files/` directory is not stored in git.
 
 ## Resource
 
@@ -106,9 +107,9 @@ Resource artifacts are used to track data about an external resource that should
 be persisted over time (for example, the data about an AWS cloud resource).
 
 A method may produce 0..1 resource as specified as YAML files that live in the
-/resources directory of a repository, underneath the normalized type as a
-directory. The file name is '${id}.yaml'. For example,
-'aws/ec2/vpc/resource-fc7fd41e-ae16-4b31-b57a-86de716e3ece.yaml'.
+`/data/resources/` directory of a repository, underneath the normalized type as
+a directory. The file name is `${id}.yaml`. For example,
+`data/resources/aws/ec2/vpc/fc7fd41e-ae16-4b31-b57a-86de716e3ece.yaml`.
 
 The valid shape of a resource is specified with a Zod 4 schema.
 
@@ -118,11 +119,11 @@ Resources are tracked in git.
 
 Data artifacts are pure data objects that are not persisted over time in git.
 
-A method may produce 0..1 data artifacts, stored as YAML files that in in the
-/data directory of a repository, underneath the normalized type as a directory.
-The file name is ${id}.yaml.
+A method may produce 0..1 data artifacts, stored as YAML files in the
+`/data/data/` directory of a repository, underneath the normalized type as a
+directory. The file name is `${id}.yaml`.
 
-The valid shape of data is specfiied with a zod 4 schema.
+The valid shape of data is specified with a Zod 4 schema.
 
 Data is not tracked in git.
 
@@ -148,11 +149,44 @@ Use **data artifacts** when:
 ## Output
 
 Each method invocation produces an output record, which gets tracked in the
-/outputs directory of a repository (which should not be tracked in git). The
-output record should track the state of the method execution, and the list of
-artifacts produced by the method. It should track state as the method executes.
-it should be structured as
-/outputs/{normalized-type}/{method}/{model-id}-{timestamp}.yaml
+`/data/outputs/` directory of a repository (which should not be tracked in git).
+The output record should track the state of the method execution, and the list
+of artifacts produced by the method. It should track state as the method
+executes. It should be structured as
+`/data/outputs/{normalized-type}/{method}/{model-id}-{timestamp}.yaml`.
+
+## Logical Views
+
+The RepoIndexService maintains a model-centric logical view at `/models/` that
+provides human/agent-friendly exploration of models by name.
+
+### Model View Structure
+
+```
+/models/{model-name}/
+  input.yaml      → symlink to /data/inputs/{type}/{id}.yaml
+  resource.yaml   → symlink to /data/resources/{type}/{id}.yaml
+  data.yaml       → symlink to /data/data/{type}/{id}.yaml
+  logs/           → symlink to /data/logs/{type}/{id}/
+  files/          → symlink to /data/files/{type}/{id}/
+  outputs/
+    {method}/     → symlinks to /data/outputs/{type}/{method}/{id}-*.yaml
+```
+
+This structure allows exploring all artifacts for a model in one place, using
+the model's human-readable name rather than UUIDs or type-based paths.
+
+### Domain Events
+
+The ModelRepository emits domain events when model data changes:
+
+- `ModelCreated` - Emitted when a new model input is created via `model create`
+- `ModelUpdated` - Emitted when a model input or resource is modified
+- `ModelDeleted` - Emitted when a model is deleted
+
+The RepoIndexService subscribes to these events and updates the logical views
+accordingly, ensuring the `/models/` view stays synchronized with the data
+directory.
 
 ## CLI Commands
 

--- a/design/repo.md
+++ b/design/repo.md
@@ -20,6 +20,37 @@ The compiled swamp binary should include everything it needs to initialize a
 repository, including the skill files, so that they can be written out by the
 cli.
 
+## Data directory
+
+Swamp repos store information from the various infrastructure repositories (in
+the domain driven design sense) in the 'data' directory. This is the internal
+format for swamp data.
+
+Both agents and humans are free to explore the data directory, but it is laid
+out in a way that is useful for swamps internal software architecture.
+
+## Logical view
+
+The swamp repo represents a logical view into the data directory that is useful
+for humans and agents. It is constructed by making symlinks into information in
+the data directory, laid out in ways that make sense for exploration of the
+information.
+
+For example, a person might want to explore the outputs of a given method run on
+a model both from the perspective of that model and from the perspective of the
+workflow that triggered it. There should be a logical directory called 'models'
+that shows the model perspective, and one called 'workflows' that shows it from
+the perspective of workflows and workflow runs.
+
+### Constructing logical views
+
+Logical views should be constructed automatically when any mutation occurs in an
+entity repository, by calling an logical index service that maintains the tree.
+
+So any time a change is made through a given entities repository, the index
+service will analyze the repo and update the logical views, ensuring they are
+always up to date.
+
 ## CLI Commands
 
 ### repo init <path>
@@ -33,3 +64,84 @@ Writes the swamp version to the marker file.
 
 Should pull the new skills into the repo from the swamp binary and update the
 files in the repository.
+
+### repo index
+
+Should update the logical views through the same mechanism the entity
+repositories use. This is the equivalent of "event replay" - it rebuilds all
+read models (logical views) by scanning the data directory.
+
+## RepoIndexService
+
+The RepoIndexService is a domain event handler that maintains the logical views
+(read models) whenever aggregate repositories mutate data.
+
+### Domain Events
+
+Aggregate repositories emit domain events when data changes:
+
+**Model Events:**
+
+- `ModelCreated` - A new model input was created
+- `ModelUpdated` - A model input or resource was modified
+- `ModelDeleted` - A model was deleted
+
+**Workflow Events:**
+
+- `WorkflowCreated` - A new workflow definition was created
+- `WorkflowUpdated` - A workflow definition was modified
+- `WorkflowDeleted` - A workflow was deleted
+
+**WorkflowRun Events:**
+
+- `WorkflowRunStarted` - A workflow run began execution
+- `WorkflowRunCompleted` - A workflow run completed successfully
+- `WorkflowRunFailed` - A workflow run failed
+
+### Event Handling
+
+When an aggregate repository emits an event:
+
+1. The repository persists the aggregate to the data directory
+2. The repository emits the appropriate domain event
+3. The RepoIndexService receives the event
+4. The RepoIndexService updates the relevant logical views (symlinks)
+
+### Logical View Structure
+
+The RepoIndexService maintains two primary logical views:
+
+**Model View (`/models/`):**
+
+```
+/models/{model-name}/
+  input.yaml → /data/inputs/{type}/{id}.yaml
+  resource.yaml → /data/resources/{type}/{id}.yaml
+  data.yaml → /data/data/{type}/{id}.yaml
+  logs/ → /data/logs/{type}/{id}/
+  files/ → /data/files/{type}/{id}/
+  outputs/
+    {method}/ → /data/outputs/{type}/{method}/{id}-{timestamp}.yaml
+```
+
+**Workflow View (`/workflows/`):**
+
+```
+/workflows/{workflow-name}/
+  workflow.yaml → /data/workflows/{id}.yaml
+  runs/
+    latest/ -> (points to latest timestamp)
+    {timestamp}/
+      run.yaml → /data/workflow-runs/{workflow-id}/{run-id}.yaml
+      steps/
+        {step-name}/
+          output.yaml → symlink to step output
+          model/ → symlink to model logical view (for model method steps)
+```
+
+### Symlink Naming Conventions
+
+- Model logical views use the model's unique `name` as the directory name
+- Workflow logical views use the workflow's unique `name` as the directory name
+- Run directories use a shortened run ID or timestamp-based identifier
+- All symlinks point to absolute paths within the data directory

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -17,15 +17,15 @@ Jobs can have dependencies on other jobs. The entire workflow is executed with a
 weighted topological sort, so thtat htye have maximum paralleism through the
 workflow. Like steps, jobs also have conditions that trigger them.
 
-Workflows are specified in YAML files, that are validated with zod, in a
-workflows/ directory of the repository, with their workflow-{uuid}.yaml.
-Workflow run output is in subdirectories of workflows at
-workfows/workflow-{uuid}/workflow-run-{uuid}-{timestamp}.yaml.
+Workflows are specified in YAML files, that are validated with Zod, in the
+`/data/workflows/` directory of the repository, with their `{uuid}.yaml`.
+Workflow run output is stored in `/data/workflow-runs/` at
+`/data/workflow-runs/{workflow-uuid}/{run-uuid}.yaml`.
 
 ## Workflow Definition
 
-Workflows are specified in workflows/workflow-{uuid}.yaml. They have a unique
-id, a globally unique name, and a set of jobs.
+Workflows are specified in `/data/workflows/{uuid}.yaml`. They have a unique id,
+a globally unique name, and a set of jobs.
 
 ## Jobs
 
@@ -49,7 +49,63 @@ not vary between identical inputs. (If the inputs are identical, the run order
 should be deterministic.)
 
 The output of the run will be written to a workflow run log, kept in
-workflows/workflow-{uuid}/workflow-run-{uuid}-{timestamp}.yaml
+`/data/workflow-runs/{workflow-uuid}/{run-uuid}.yaml`.
+
+## Logical Views
+
+The RepoIndexService maintains a workflow-centric logical view at `/workflows/`
+that provides human/agent-friendly exploration of workflows by name.
+
+### Workflow View Structure
+
+```
+/workflows/{workflow-name}/
+  workflow.yaml   → symlink to /data/workflows/{uuid}.yaml
+  runs/
+    {run-id}/
+      run.yaml    → symlink to /data/workflow-runs/{workflow-uuid}/{run-uuid}.yaml
+      steps/
+        {step-name}/
+          output.yaml → symlink to step output
+          model/      → symlink to /models/{model-name}/ (for model method steps)
+```
+
+This structure allows exploring workflow definitions and their run history using
+human-readable names.
+
+### Cross-View References
+
+When a workflow step executes a model method, the output appears in both views:
+
+- **Model view:** `/models/{model-name}/outputs/{method}/` contains the method
+  output
+- **Workflow view:** `/workflows/{workflow-name}/runs/{run-id}/steps/{step}/`
+  contains a symlink to the same output, plus a reference to the model's logical
+  view
+
+This enables exploration from either the model's perspective or the workflow's
+perspective.
+
+### Domain Events
+
+The WorkflowRepository and WorkflowRunRepository emit domain events:
+
+**Workflow Events:**
+
+- `WorkflowCreated` - Emitted when a new workflow is created via
+  `workflow create`
+- `WorkflowUpdated` - Emitted when a workflow definition is modified
+- `WorkflowDeleted` - Emitted when a workflow is deleted
+
+**WorkflowRun Events:**
+
+- `WorkflowRunStarted` - Emitted when `workflow run` begins execution
+- `WorkflowRunCompleted` - Emitted when a workflow run completes successfully
+- `WorkflowRunFailed` - Emitted when a workflow run fails
+
+The RepoIndexService subscribes to these events and updates the logical views
+accordingly, ensuring the `/workflows/` view stays synchronized with the data
+directory.
 
 ## CLI Commands
 


### PR DESCRIPTION
## Summary

- Update all design documents to reflect the new storage architecture from `repo.md`
- Add **RepoIndexService** documentation with domain events and logical view structure
- Move all storage paths under `/data/` directory across all documents
- Add **Logical Views** sections explaining model-centric and workflow-centric exploration
- Add **Repository Exploration** guidance for agents

### Files Changed

| Document | Changes |
|----------|---------|
| `repo.md` | Add RepoIndexService, domain events, symlink structure |
| `high-level.md` | Add Storage Architecture section |
| `models.md` | Update paths to `/data/*`, add logical views section |
| `workflow.md` | Update paths to `/data/*`, add logical views and cross-view references |
| `expressions.md` | Update evaluated directory paths to `/data/*` |
| `agent.md` | Add Repository Exploration guidance |

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes  
- [x] `deno run test` passes (1104 tests)
- [x] Verified all path references are consistent across documents
- [x] Verified cross-references between documents are correct