### PR TITLE
feat: update entity repositories to use /data/ directory paths (#72)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,15 @@
 dev-logs/*
 swamp
-inputs/
-resources/
-inputs-evaluated/
-workflows-evaluated/
+
+# Generated/runtime data (ignored)
+data/data/
+data/outputs/
+data/workflow-runs/
+data/inputs-evaluated/
+data/workflows-evaluated/
+data/logs/
+data/files/
+
 test-repo/
 experiments/webapp/frontend/node_modules/
 experiments/webapp/frontend/dist/

--- a/integration/echo_model_test.ts
+++ b/integration/echo_model_test.ts
@@ -122,8 +122,8 @@ Deno.test("Echo model: directory structure is correct", async () => {
     await dataRepo.save(modelType, result.data!);
 
     // Verify directory structure
-    const inputDir = join(repoDir, "inputs", "swamp/echo");
-    const dataDir = join(repoDir, "data", "swamp/echo");
+    const inputDir = join(repoDir, "data", "inputs", "swamp/echo");
+    const dataDir = join(repoDir, "data", "data", "swamp/echo");
 
     assertEquals(existsSync(inputDir), true, "Input directory should exist");
     assertEquals(

--- a/src/cli/commands/type_describe.ts
+++ b/src/cli/commands/type_describe.ts
@@ -38,63 +38,70 @@ function toMethodDescribeData(
   };
 }
 
+/**
+ * Core action for describing a model type.
+ * Shared between 'describe' and 'get' commands.
+ */
+function typeDescribeAction(options: AnyOptions, typeArg: string): void {
+  const ctx = createContext(options as GlobalOptions, "type-describe");
+  ctx.logger.debug`Describing type: ${typeArg}`;
+
+  // Parse and validate the model type
+  const modelType = ModelType.create(typeArg);
+  ctx.logger.debug`Normalized type: ${modelType.normalized}`;
+
+  // Look up the model definition
+  const definition = modelRegistry.get(modelType);
+  if (!definition) {
+    const availableTypes = modelRegistry.types().map((t) => t.normalized)
+      .join(", ");
+    throw new UserError(
+      `Unknown model type: ${typeArg}. Available types: ${
+        availableTypes || "none"
+      }`,
+    );
+  }
+
+  // Convert Zod schemas to JSON Schema
+  const inputAttributesSchema = zodToJsonSchema(
+    definition.inputAttributesSchema,
+  );
+  const resourceAttributesSchema = definition.resourceAttributesSchema
+    ? zodToJsonSchema(definition.resourceAttributesSchema)
+    : undefined;
+  const dataAttributesSchema = definition.dataAttributesSchema
+    ? zodToJsonSchema(definition.dataAttributesSchema)
+    : undefined;
+
+  // Build method descriptions
+  const methods: MethodDescribeData[] = Object.entries(definition.methods)
+    .map(
+      ([name, method]) => toMethodDescribeData(name, method),
+    );
+
+  // Build the output data
+  const data: TypeDescribeData = {
+    type: {
+      raw: modelType.raw,
+      normalized: modelType.normalized,
+    },
+    version: definition.version,
+    inputAttributesSchema,
+    resourceAttributesSchema,
+    dataAttributesSchema,
+    methods,
+  };
+
+  renderTypeDescribe(data, ctx.outputMode);
+  ctx.logger.debug("Type describe command completed");
+}
+
 export const typeDescribeCommand = new Command()
   .description("Describe a model type with schema details")
+  .alias("get")
   .arguments("<type:model_type>")
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
-  .action(function (options: AnyOptions, typeArg: string) {
-    const ctx = createContext(options as GlobalOptions, "type-describe");
-    ctx.logger.debug`Describing type: ${typeArg}`;
-
-    // Parse and validate the model type
-    const modelType = ModelType.create(typeArg);
-    ctx.logger.debug`Normalized type: ${modelType.normalized}`;
-
-    // Look up the model definition
-    const definition = modelRegistry.get(modelType);
-    if (!definition) {
-      const availableTypes = modelRegistry.types().map((t) => t.normalized)
-        .join(", ");
-      throw new UserError(
-        `Unknown model type: ${typeArg}. Available types: ${
-          availableTypes || "none"
-        }`,
-      );
-    }
-
-    // Convert Zod schemas to JSON Schema
-    const inputAttributesSchema = zodToJsonSchema(
-      definition.inputAttributesSchema,
-    );
-    const resourceAttributesSchema = definition.resourceAttributesSchema
-      ? zodToJsonSchema(definition.resourceAttributesSchema)
-      : undefined;
-    const dataAttributesSchema = definition.dataAttributesSchema
-      ? zodToJsonSchema(definition.dataAttributesSchema)
-      : undefined;
-
-    // Build method descriptions
-    const methods: MethodDescribeData[] = Object.entries(definition.methods)
-      .map(
-        ([name, method]) => toMethodDescribeData(name, method),
-      );
-
-    // Build the output data
-    const data: TypeDescribeData = {
-      type: {
-        raw: modelType.raw,
-        normalized: modelType.normalized,
-      },
-      version: definition.version,
-      inputAttributesSchema,
-      resourceAttributesSchema,
-      dataAttributesSchema,
-      methods,
-    };
-
-    renderTypeDescribe(data, ctx.outputMode);
-    ctx.logger.debug("Type describe command completed");
-  });
+  .action(typeDescribeAction);
 
 export const typeCommand = new Command()
   .name("type")

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -86,6 +86,9 @@ export class RepoService {
     const markerData = this.markerRepo.createInitMarker(this.currentVersion);
     await this.markerRepo.write(repoPath, markerData);
 
+    // Create data directory structure
+    await this.createDataDirectoryStructure(repoPath);
+
     // Copy skills
     const skillsDir = join(repoPath.value, ".claude", "skills");
     await this.skillAssets.copySkillsTo(skillsDir);
@@ -194,5 +197,30 @@ Always start by using the \`swamp-model\` skill to work with swamp models.
 
 Use \`swamp --help\` to see available commands.
 `;
+  }
+
+  /**
+   * Creates the data directory structure for storing repository artifacts.
+   */
+  private async createDataDirectoryStructure(
+    repoPath: RepoPath,
+  ): Promise<void> {
+    const dataDir = join(repoPath.value, "data");
+    const subdirs = [
+      "inputs",
+      "resources",
+      "workflows",
+      "data",
+      "outputs",
+      "workflow-runs",
+      "inputs-evaluated",
+      "workflows-evaluated",
+      "logs",
+      "files",
+    ];
+
+    for (const subdir of subdirs) {
+      await ensureDir(join(dataDir, subdir));
+    }
   }
 }

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -83,6 +83,35 @@ Deno.test("RepoService.init copies skills", async () => {
   });
 });
 
+Deno.test("RepoService.init creates data directory structure", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath);
+
+    // Check all data subdirectories exist
+    const expectedDirs = [
+      "data/inputs",
+      "data/resources",
+      "data/workflows",
+      "data/data",
+      "data/outputs",
+      "data/workflow-runs",
+      "data/inputs-evaluated",
+      "data/workflows-evaluated",
+      "data/logs",
+      "data/files",
+    ];
+
+    for (const dir of expectedDirs) {
+      const dirPath = join(tempDir, dir);
+      const stat = await Deno.stat(dirPath);
+      assertEquals(stat.isDirectory, true, `${dir} should exist`);
+    }
+  });
+});
+
 Deno.test("RepoService.init throws if already initialized without force", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -21,6 +21,15 @@ import type {
 } from "./repositories.ts";
 import type { WorkflowRun } from "./workflow_run.ts";
 
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
 /**
  * Mock step executor for testing.
  */
@@ -155,298 +164,319 @@ function createSimpleWorkflow(): Workflow {
 }
 
 Deno.test("executes simple workflow with one job and one step", async () => {
-  const workflowRepo = new InMemoryWorkflowRepository();
-  const runRepo = new InMemoryWorkflowRunRepository();
-  const executor = new MockStepExecutor();
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
 
-  const workflow = createSimpleWorkflow();
-  await workflowRepo.save(workflow);
+    const workflow = createSimpleWorkflow();
+    await workflowRepo.save(workflow);
 
-  const service = new WorkflowExecutionService(
-    workflowRepo,
-    runRepo,
-    ".",
-    executor,
-  );
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+    );
 
-  const run = await service.execute(workflow.name);
+    const run = await service.execute(workflow.name);
 
-  assertEquals(run.status, "succeeded");
-  assertEquals(run.getJob("job1")?.status, "succeeded");
-  assertEquals(run.getJob("job1")?.getStep("step1")?.status, "succeeded");
-  assertEquals(executor.executedSteps, ["job1/step1"]);
+    assertEquals(run.status, "succeeded");
+    assertEquals(run.getJob("job1")?.status, "succeeded");
+    assertEquals(run.getJob("job1")?.getStep("step1")?.status, "succeeded");
+    assertEquals(executor.executedSteps, ["job1/step1"]);
+  });
 });
 
 Deno.test("executes workflow with multiple jobs", async () => {
-  const workflowRepo = new InMemoryWorkflowRepository();
-  const runRepo = new InMemoryWorkflowRunRepository();
-  const executor = new MockStepExecutor();
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
 
-  const workflow = Workflow.create({
-    name: "multi-job",
-    jobs: [
-      Job.create({
-        name: "build",
-        steps: [
-          Step.create({ name: "compile", task: StepTask.shell("echo") }),
-        ],
-      }),
-      Job.create({
-        name: "test",
-        steps: [
-          Step.create({ name: "unit", task: StepTask.shell("echo") }),
-        ],
-        dependsOn: [
-          { job: "build", condition: TriggerCondition.succeeded("build") },
-        ],
-      }),
-    ],
+    const workflow = Workflow.create({
+      name: "multi-job",
+      jobs: [
+        Job.create({
+          name: "build",
+          steps: [
+            Step.create({ name: "compile", task: StepTask.shell("echo") }),
+          ],
+        }),
+        Job.create({
+          name: "test",
+          steps: [
+            Step.create({ name: "unit", task: StepTask.shell("echo") }),
+          ],
+          dependsOn: [
+            { job: "build", condition: TriggerCondition.succeeded("build") },
+          ],
+        }),
+      ],
+    });
+
+    await workflowRepo.save(workflow);
+
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+    );
+
+    const run = await service.execute(workflow.name);
+
+    assertEquals(run.status, "succeeded");
+    assertEquals(executor.executedSteps, ["build/compile", "test/unit"]);
   });
-
-  await workflowRepo.save(workflow);
-
-  const service = new WorkflowExecutionService(
-    workflowRepo,
-    runRepo,
-    ".",
-    executor,
-  );
-
-  const run = await service.execute(workflow.name);
-
-  assertEquals(run.status, "succeeded");
-  assertEquals(executor.executedSteps, ["build/compile", "test/unit"]);
 });
 
 Deno.test("executes workflow with step dependencies", async () => {
-  const workflowRepo = new InMemoryWorkflowRepository();
-  const runRepo = new InMemoryWorkflowRunRepository();
-  const executor = new MockStepExecutor();
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
 
-  const workflow = Workflow.create({
-    name: "step-deps",
-    jobs: [
-      Job.create({
-        name: "build",
-        steps: [
-          Step.create({
-            name: "setup",
-            task: StepTask.shell("echo"),
-          }),
-          Step.create({
-            name: "compile",
-            task: StepTask.shell("echo"),
-            dependsOn: [
-              { step: "setup", condition: TriggerCondition.succeeded("setup") },
-            ],
-          }),
-        ],
-      }),
-    ],
+    const workflow = Workflow.create({
+      name: "step-deps",
+      jobs: [
+        Job.create({
+          name: "build",
+          steps: [
+            Step.create({
+              name: "setup",
+              task: StepTask.shell("echo"),
+            }),
+            Step.create({
+              name: "compile",
+              task: StepTask.shell("echo"),
+              dependsOn: [
+                {
+                  step: "setup",
+                  condition: TriggerCondition.succeeded("setup"),
+                },
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    await workflowRepo.save(workflow);
+
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+    );
+
+    const run = await service.execute(workflow.name);
+
+    assertEquals(run.status, "succeeded");
+    // Setup must run before compile
+    const setupIdx = executor.executedSteps.indexOf("build/setup");
+    const compileIdx = executor.executedSteps.indexOf("build/compile");
+    assertEquals(setupIdx < compileIdx, true);
   });
-
-  await workflowRepo.save(workflow);
-
-  const service = new WorkflowExecutionService(
-    workflowRepo,
-    runRepo,
-    ".",
-    executor,
-  );
-
-  const run = await service.execute(workflow.name);
-
-  assertEquals(run.status, "succeeded");
-  // Setup must run before compile
-  const setupIdx = executor.executedSteps.indexOf("build/setup");
-  const compileIdx = executor.executedSteps.indexOf("build/compile");
-  assertEquals(setupIdx < compileIdx, true);
 });
 
 Deno.test("marks workflow as failed when step fails", async () => {
-  const workflowRepo = new InMemoryWorkflowRepository();
-  const runRepo = new InMemoryWorkflowRunRepository();
-  const executor = new MockStepExecutor();
-  executor.shouldFail.add("step1");
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
+    executor.shouldFail.add("step1");
 
-  const workflow = createSimpleWorkflow();
-  await workflowRepo.save(workflow);
+    const workflow = createSimpleWorkflow();
+    await workflowRepo.save(workflow);
 
-  const service = new WorkflowExecutionService(
-    workflowRepo,
-    runRepo,
-    ".",
-    executor,
-  );
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+    );
 
-  const run = await service.execute(workflow.name);
+    const run = await service.execute(workflow.name);
 
-  assertEquals(run.status, "failed");
-  assertEquals(run.getJob("job1")?.status, "failed");
-  assertEquals(run.getJob("job1")?.getStep("step1")?.status, "failed");
-  assertNotEquals(run.getJob("job1")?.getStep("step1")?.error, undefined);
+    assertEquals(run.status, "failed");
+    assertEquals(run.getJob("job1")?.status, "failed");
+    assertEquals(run.getJob("job1")?.getStep("step1")?.status, "failed");
+    assertNotEquals(run.getJob("job1")?.getStep("step1")?.error, undefined);
+  });
 });
 
 Deno.test("skips job when trigger condition not met", async () => {
-  const workflowRepo = new InMemoryWorkflowRepository();
-  const runRepo = new InMemoryWorkflowRunRepository();
-  const executor = new MockStepExecutor();
-  executor.shouldFail.add("compile"); // Build fails
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
+    executor.shouldFail.add("compile"); // Build fails
 
-  const workflow = Workflow.create({
-    name: "conditional",
-    jobs: [
-      Job.create({
-        name: "build",
-        steps: [
-          Step.create({ name: "compile", task: StepTask.shell("echo") }),
-        ],
-      }),
-      Job.create({
-        name: "test",
-        steps: [
-          Step.create({ name: "unit", task: StepTask.shell("echo") }),
-        ],
-        dependsOn: [
-          { job: "build", condition: TriggerCondition.succeeded("build") },
-        ],
-      }),
-    ],
+    const workflow = Workflow.create({
+      name: "conditional",
+      jobs: [
+        Job.create({
+          name: "build",
+          steps: [
+            Step.create({ name: "compile", task: StepTask.shell("echo") }),
+          ],
+        }),
+        Job.create({
+          name: "test",
+          steps: [
+            Step.create({ name: "unit", task: StepTask.shell("echo") }),
+          ],
+          dependsOn: [
+            { job: "build", condition: TriggerCondition.succeeded("build") },
+          ],
+        }),
+      ],
+    });
+
+    await workflowRepo.save(workflow);
+
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+    );
+
+    const run = await service.execute(workflow.name);
+
+    assertEquals(run.status, "failed");
+    assertEquals(run.getJob("build")?.status, "failed");
+    assertEquals(run.getJob("test")?.status, "skipped");
   });
-
-  await workflowRepo.save(workflow);
-
-  const service = new WorkflowExecutionService(
-    workflowRepo,
-    runRepo,
-    ".",
-    executor,
-  );
-
-  const run = await service.execute(workflow.name);
-
-  assertEquals(run.status, "failed");
-  assertEquals(run.getJob("build")?.status, "failed");
-  assertEquals(run.getJob("test")?.status, "skipped");
 });
 
 Deno.test("runs job on failure condition", async () => {
-  const workflowRepo = new InMemoryWorkflowRepository();
-  const runRepo = new InMemoryWorkflowRunRepository();
-  const executor = new MockStepExecutor();
-  executor.shouldFail.add("compile"); // Build fails
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
+    executor.shouldFail.add("compile"); // Build fails
 
-  const workflow = Workflow.create({
-    name: "on-failure",
-    jobs: [
-      Job.create({
-        name: "build",
-        steps: [
-          Step.create({ name: "compile", task: StepTask.shell("echo") }),
-        ],
-      }),
-      Job.create({
-        name: "notify",
-        steps: [
-          Step.create({ name: "alert", task: StepTask.shell("echo") }),
-        ],
-        dependsOn: [
-          { job: "build", condition: TriggerCondition.failed("build") },
-        ],
-      }),
-    ],
+    const workflow = Workflow.create({
+      name: "on-failure",
+      jobs: [
+        Job.create({
+          name: "build",
+          steps: [
+            Step.create({ name: "compile", task: StepTask.shell("echo") }),
+          ],
+        }),
+        Job.create({
+          name: "notify",
+          steps: [
+            Step.create({ name: "alert", task: StepTask.shell("echo") }),
+          ],
+          dependsOn: [
+            { job: "build", condition: TriggerCondition.failed("build") },
+          ],
+        }),
+      ],
+    });
+
+    await workflowRepo.save(workflow);
+
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+    );
+
+    const run = await service.execute(workflow.name);
+
+    assertEquals(run.getJob("build")?.status, "failed");
+    assertEquals(run.getJob("notify")?.status, "succeeded");
+    assertEquals(executor.executedSteps.includes("notify/alert"), true);
   });
-
-  await workflowRepo.save(workflow);
-
-  const service = new WorkflowExecutionService(
-    workflowRepo,
-    runRepo,
-    ".",
-    executor,
-  );
-
-  const run = await service.execute(workflow.name);
-
-  assertEquals(run.getJob("build")?.status, "failed");
-  assertEquals(run.getJob("notify")?.status, "succeeded");
-  assertEquals(executor.executedSteps.includes("notify/alert"), true);
 });
 
 Deno.test("throws error for nonexistent workflow", async () => {
-  const workflowRepo = new InMemoryWorkflowRepository();
-  const runRepo = new InMemoryWorkflowRunRepository();
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
 
-  const service = new WorkflowExecutionService(
-    workflowRepo,
-    runRepo,
-    ".",
-  );
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+    );
 
-  try {
-    await service.execute("nonexistent");
-    throw new Error("Expected error");
-  } catch (error) {
-    assertEquals((error as Error).message.includes("not found"), true);
-  }
+    try {
+      await service.execute("nonexistent");
+      throw new Error("Expected error");
+    } catch (error) {
+      assertEquals((error as Error).message.includes("not found"), true);
+    }
+  });
 });
 
 Deno.test("saves workflow run to repository", async () => {
-  const workflowRepo = new InMemoryWorkflowRepository();
-  const runRepo = new InMemoryWorkflowRunRepository();
-  const executor = new MockStepExecutor();
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
 
-  const workflow = createSimpleWorkflow();
-  await workflowRepo.save(workflow);
+    const workflow = createSimpleWorkflow();
+    await workflowRepo.save(workflow);
 
-  const service = new WorkflowExecutionService(
-    workflowRepo,
-    runRepo,
-    ".",
-    executor,
-  );
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+    );
 
-  const run = await service.execute(workflow.name);
+    const run = await service.execute(workflow.name);
 
-  const savedRuns = await runRepo.findAllByWorkflowId(workflow.id);
-  assertEquals(savedRuns.length >= 1, true);
-  assertEquals(savedRuns[savedRuns.length - 1].id, run.id);
+    const savedRuns = await runRepo.findAllByWorkflowId(workflow.id);
+    assertEquals(savedRuns.length >= 1, true);
+    assertEquals(savedRuns[savedRuns.length - 1].id, run.id);
+  });
 });
 
 Deno.test("calls progress callbacks during execution", async () => {
-  const workflowRepo = new InMemoryWorkflowRepository();
-  const runRepo = new InMemoryWorkflowRunRepository();
-  const executor = new MockStepExecutor();
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
 
-  const workflow = createSimpleWorkflow();
-  await workflowRepo.save(workflow);
+    const workflow = createSimpleWorkflow();
+    await workflowRepo.save(workflow);
 
-  const service = new WorkflowExecutionService(
-    workflowRepo,
-    runRepo,
-    ".",
-    executor,
-  );
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+    );
 
-  const events: string[] = [];
+    const events: string[] = [];
 
-  await service.execute(workflow.name, {
-    onWorkflowStart: () => events.push("workflow-start"),
-    onJobStart: (_, jobName) => events.push(`job-start:${jobName}`),
-    onStepStart: (_, jobName, stepName) =>
-      events.push(`step-start:${jobName}/${stepName}`),
-    onStepComplete: (_, jobName, stepName) =>
-      events.push(`step-complete:${jobName}/${stepName}`),
-    onJobComplete: (_, jobName) => events.push(`job-complete:${jobName}`),
-    onWorkflowComplete: () => events.push("workflow-complete"),
+    await service.execute(workflow.name, {
+      onWorkflowStart: () => events.push("workflow-start"),
+      onJobStart: (_, jobName) => events.push(`job-start:${jobName}`),
+      onStepStart: (_, jobName, stepName) =>
+        events.push(`step-start:${jobName}/${stepName}`),
+      onStepComplete: (_, jobName, stepName) =>
+        events.push(`step-complete:${jobName}/${stepName}`),
+      onJobComplete: (_, jobName) => events.push(`job-complete:${jobName}`),
+      onWorkflowComplete: () => events.push("workflow-complete"),
+    });
+
+    assertEquals(events.includes("workflow-start"), true);
+    assertEquals(events.includes("job-start:job1"), true);
+    assertEquals(events.includes("step-start:job1/step1"), true);
+    assertEquals(events.includes("step-complete:job1/step1"), true);
+    assertEquals(events.includes("job-complete:job1"), true);
+    assertEquals(events.includes("workflow-complete"), true);
   });
-
-  assertEquals(events.includes("workflow-start"), true);
-  assertEquals(events.includes("job-start:job1"), true);
-  assertEquals(events.includes("step-start:job1/step1"), true);
-  assertEquals(events.includes("step-complete:job1/step1"), true);
-  assertEquals(events.includes("job-complete:job1"), true);
-  assertEquals(events.includes("workflow-complete"), true);
 });
 
 /**
@@ -488,219 +518,227 @@ class ConcurrencyTrackingExecutor implements StepExecutor {
 }
 
 Deno.test("executes independent jobs in parallel", async () => {
-  const workflowRepo = new InMemoryWorkflowRepository();
-  const runRepo = new InMemoryWorkflowRunRepository();
-  const executor = new ConcurrencyTrackingExecutor(50);
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new ConcurrencyTrackingExecutor(50);
 
-  // Create workflow with 3 independent jobs (no dependencies)
-  const workflow = Workflow.create({
-    name: "parallel-jobs",
-    jobs: [
-      Job.create({
-        name: "job-a",
-        steps: [
-          Step.create({ name: "step1", task: StepTask.shell("echo") }),
-        ],
-      }),
-      Job.create({
-        name: "job-b",
-        steps: [
-          Step.create({ name: "step1", task: StepTask.shell("echo") }),
-        ],
-      }),
-      Job.create({
-        name: "job-c",
-        steps: [
-          Step.create({ name: "step1", task: StepTask.shell("echo") }),
-        ],
-      }),
-    ],
+    // Create workflow with 3 independent jobs (no dependencies)
+    const workflow = Workflow.create({
+      name: "parallel-jobs",
+      jobs: [
+        Job.create({
+          name: "job-a",
+          steps: [
+            Step.create({ name: "step1", task: StepTask.shell("echo") }),
+          ],
+        }),
+        Job.create({
+          name: "job-b",
+          steps: [
+            Step.create({ name: "step1", task: StepTask.shell("echo") }),
+          ],
+        }),
+        Job.create({
+          name: "job-c",
+          steps: [
+            Step.create({ name: "step1", task: StepTask.shell("echo") }),
+          ],
+        }),
+      ],
+    });
+
+    await workflowRepo.save(workflow);
+
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+    );
+
+    const startTime = Date.now();
+    const run = await service.execute(workflow.name);
+    const elapsed = Date.now() - startTime;
+
+    assertEquals(run.status, "succeeded");
+    assertEquals(executor.executedSteps.length, 3);
+
+    // Verify jobs ran in parallel: max concurrency should be 3
+    assertEquals(executor.getMaxConcurrency(), 3);
+
+    // If running sequentially, it would take ~150ms (3 * 50ms)
+    // Running in parallel should take ~50-100ms
+    // Allow generous margin but should be less than sequential time
+    assertEquals(
+      elapsed < 140,
+      true,
+      `Expected parallel execution to be faster than 140ms, got ${elapsed}ms`,
+    );
   });
-
-  await workflowRepo.save(workflow);
-
-  const service = new WorkflowExecutionService(
-    workflowRepo,
-    runRepo,
-    ".",
-    executor,
-  );
-
-  const startTime = Date.now();
-  const run = await service.execute(workflow.name);
-  const elapsed = Date.now() - startTime;
-
-  assertEquals(run.status, "succeeded");
-  assertEquals(executor.executedSteps.length, 3);
-
-  // Verify jobs ran in parallel: max concurrency should be 3
-  assertEquals(executor.getMaxConcurrency(), 3);
-
-  // If running sequentially, it would take ~150ms (3 * 50ms)
-  // Running in parallel should take ~50-100ms
-  // Allow generous margin but should be less than sequential time
-  assertEquals(
-    elapsed < 140,
-    true,
-    `Expected parallel execution to be faster than 140ms, got ${elapsed}ms`,
-  );
 });
 
 Deno.test("executes dependent jobs sequentially across levels", async () => {
-  const workflowRepo = new InMemoryWorkflowRepository();
-  const runRepo = new InMemoryWorkflowRunRepository();
-  const executor = new ConcurrencyTrackingExecutor(30);
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new ConcurrencyTrackingExecutor(30);
 
-  // Create workflow with diamond dependency pattern:
-  // job-a and job-b have no deps (level 1, parallel)
-  // job-c depends on job-a (level 2)
-  // job-d depends on both job-a and job-b (level 3)
-  const workflow = Workflow.create({
-    name: "diamond-deps",
-    jobs: [
-      Job.create({
-        name: "job-a",
-        steps: [
-          Step.create({ name: "step1", task: StepTask.shell("echo") }),
-        ],
-      }),
-      Job.create({
-        name: "job-b",
-        steps: [
-          Step.create({ name: "step1", task: StepTask.shell("echo") }),
-        ],
-      }),
-      Job.create({
-        name: "job-c",
-        steps: [
-          Step.create({ name: "step1", task: StepTask.shell("echo") }),
-        ],
-        dependsOn: [
-          { job: "job-a", condition: TriggerCondition.succeeded("job-a") },
-        ],
-      }),
-      Job.create({
-        name: "job-d",
-        steps: [
-          Step.create({ name: "step1", task: StepTask.shell("echo") }),
-        ],
-        dependsOn: [
-          { job: "job-a", condition: TriggerCondition.succeeded("job-a") },
-          { job: "job-b", condition: TriggerCondition.succeeded("job-b") },
-        ],
-      }),
-    ],
+    // Create workflow with diamond dependency pattern:
+    // job-a and job-b have no deps (level 1, parallel)
+    // job-c depends on job-a (level 2)
+    // job-d depends on both job-a and job-b (level 3)
+    const workflow = Workflow.create({
+      name: "diamond-deps",
+      jobs: [
+        Job.create({
+          name: "job-a",
+          steps: [
+            Step.create({ name: "step1", task: StepTask.shell("echo") }),
+          ],
+        }),
+        Job.create({
+          name: "job-b",
+          steps: [
+            Step.create({ name: "step1", task: StepTask.shell("echo") }),
+          ],
+        }),
+        Job.create({
+          name: "job-c",
+          steps: [
+            Step.create({ name: "step1", task: StepTask.shell("echo") }),
+          ],
+          dependsOn: [
+            { job: "job-a", condition: TriggerCondition.succeeded("job-a") },
+          ],
+        }),
+        Job.create({
+          name: "job-d",
+          steps: [
+            Step.create({ name: "step1", task: StepTask.shell("echo") }),
+          ],
+          dependsOn: [
+            { job: "job-a", condition: TriggerCondition.succeeded("job-a") },
+            { job: "job-b", condition: TriggerCondition.succeeded("job-b") },
+          ],
+        }),
+      ],
+    });
+
+    await workflowRepo.save(workflow);
+
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+    );
+
+    const events: string[] = [];
+    const run = await service.execute(workflow.name, {
+      onJobStart: (_, jobName) => events.push(`start:${jobName}`),
+      onJobComplete: (_, jobName) => events.push(`complete:${jobName}`),
+    });
+
+    assertEquals(run.status, "succeeded");
+    assertEquals(executor.executedSteps.length, 4);
+
+    // Verify job-a and job-b both start before either completes (parallel in level 1)
+    const aStartIdx = events.indexOf("start:job-a");
+    const bStartIdx = events.indexOf("start:job-b");
+    const aCompleteIdx = events.indexOf("complete:job-a");
+    const bCompleteIdx = events.indexOf("complete:job-b");
+
+    // Both should start before both complete (proves parallel execution)
+    assertEquals(aStartIdx < aCompleteIdx, true);
+    assertEquals(bStartIdx < bCompleteIdx, true);
+    assertEquals(aStartIdx < bCompleteIdx, true);
+    assertEquals(bStartIdx < aCompleteIdx, true);
+
+    // job-c should start only after job-a completes
+    const cStartIdx = events.indexOf("start:job-c");
+    assertEquals(cStartIdx > aCompleteIdx, true);
+
+    // job-d should start only after both job-a and job-b complete
+    const dStartIdx = events.indexOf("start:job-d");
+    assertEquals(dStartIdx > aCompleteIdx, true);
+    assertEquals(dStartIdx > bCompleteIdx, true);
   });
-
-  await workflowRepo.save(workflow);
-
-  const service = new WorkflowExecutionService(
-    workflowRepo,
-    runRepo,
-    ".",
-    executor,
-  );
-
-  const events: string[] = [];
-  const run = await service.execute(workflow.name, {
-    onJobStart: (_, jobName) => events.push(`start:${jobName}`),
-    onJobComplete: (_, jobName) => events.push(`complete:${jobName}`),
-  });
-
-  assertEquals(run.status, "succeeded");
-  assertEquals(executor.executedSteps.length, 4);
-
-  // Verify job-a and job-b both start before either completes (parallel in level 1)
-  const aStartIdx = events.indexOf("start:job-a");
-  const bStartIdx = events.indexOf("start:job-b");
-  const aCompleteIdx = events.indexOf("complete:job-a");
-  const bCompleteIdx = events.indexOf("complete:job-b");
-
-  // Both should start before both complete (proves parallel execution)
-  assertEquals(aStartIdx < aCompleteIdx, true);
-  assertEquals(bStartIdx < bCompleteIdx, true);
-  assertEquals(aStartIdx < bCompleteIdx, true);
-  assertEquals(bStartIdx < aCompleteIdx, true);
-
-  // job-c should start only after job-a completes
-  const cStartIdx = events.indexOf("start:job-c");
-  assertEquals(cStartIdx > aCompleteIdx, true);
-
-  // job-d should start only after both job-a and job-b complete
-  const dStartIdx = events.indexOf("start:job-d");
-  assertEquals(dStartIdx > aCompleteIdx, true);
-  assertEquals(dStartIdx > bCompleteIdx, true);
 });
 
 Deno.test("DefaultStepExecutor passes env to shell commands", async () => {
-  const { DefaultStepExecutor } = await import("./execution_service.ts");
-  const executor = new DefaultStepExecutor();
+  await withTempDir(async (tempDir) => {
+    const { DefaultStepExecutor } = await import("./execution_service.ts");
+    const executor = new DefaultStepExecutor();
 
-  const step = Step.create({
-    name: "env-test",
-    task: StepTask.shell("printenv", {
-      args: ["TEST_VAR"],
-      env: { TEST_VAR: "hello_from_env" },
-    }),
+    const step = Step.create({
+      name: "env-test",
+      task: StepTask.shell("printenv", {
+        args: ["TEST_VAR"],
+        env: { TEST_VAR: "hello_from_env" },
+      }),
+    });
+
+    const ctx: StepExecutionContext = {
+      workflowId: createWorkflowId("test-workflow-id"),
+      workflowRunId: "test-run-id",
+      workflowName: "test-workflow",
+      repoDir: tempDir,
+      jobName: "test-job",
+      stepName: "env-test",
+    };
+
+    const result = await executor.execute(step, ctx) as { stdout: string };
+    assertEquals(result.stdout, "hello_from_env");
   });
-
-  const ctx: StepExecutionContext = {
-    workflowId: createWorkflowId("test-workflow-id"),
-    workflowRunId: "test-run-id",
-    workflowName: "test-workflow",
-    repoDir: ".",
-    jobName: "test-job",
-    stepName: "env-test",
-  };
-
-  const result = await executor.execute(step, ctx) as { stdout: string };
-  assertEquals(result.stdout, "hello_from_env");
 });
 
 Deno.test("executes independent steps within a job in parallel", async () => {
-  const workflowRepo = new InMemoryWorkflowRepository();
-  const runRepo = new InMemoryWorkflowRunRepository();
-  const executor = new ConcurrencyTrackingExecutor(50);
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new ConcurrencyTrackingExecutor(50);
 
-  // Create workflow with one job that has 3 independent steps
-  const workflow = Workflow.create({
-    name: "parallel-steps",
-    jobs: [
-      Job.create({
-        name: "job1",
-        steps: [
-          Step.create({ name: "step-a", task: StepTask.shell("echo") }),
-          Step.create({ name: "step-b", task: StepTask.shell("echo") }),
-          Step.create({ name: "step-c", task: StepTask.shell("echo") }),
-        ],
-      }),
-    ],
+    // Create workflow with one job that has 3 independent steps
+    const workflow = Workflow.create({
+      name: "parallel-steps",
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({ name: "step-a", task: StepTask.shell("echo") }),
+            Step.create({ name: "step-b", task: StepTask.shell("echo") }),
+            Step.create({ name: "step-c", task: StepTask.shell("echo") }),
+          ],
+        }),
+      ],
+    });
+
+    await workflowRepo.save(workflow);
+
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+    );
+
+    const startTime = Date.now();
+    const run = await service.execute(workflow.name);
+    const elapsed = Date.now() - startTime;
+
+    assertEquals(run.status, "succeeded");
+    assertEquals(executor.executedSteps.length, 3);
+
+    // Verify steps ran in parallel: max concurrency should be 3
+    assertEquals(executor.getMaxConcurrency(), 3);
+
+    // If running sequentially, it would take ~150ms (3 * 50ms)
+    // Running in parallel should take ~50-100ms
+    assertEquals(
+      elapsed < 140,
+      true,
+      `Expected parallel execution to be faster than 140ms, got ${elapsed}ms`,
+    );
   });
-
-  await workflowRepo.save(workflow);
-
-  const service = new WorkflowExecutionService(
-    workflowRepo,
-    runRepo,
-    ".",
-    executor,
-  );
-
-  const startTime = Date.now();
-  const run = await service.execute(workflow.name);
-  const elapsed = Date.now() - startTime;
-
-  assertEquals(run.status, "succeeded");
-  assertEquals(executor.executedSteps.length, 3);
-
-  // Verify steps ran in parallel: max concurrency should be 3
-  assertEquals(executor.getMaxConcurrency(), 3);
-
-  // If running sequentially, it would take ~150ms (3 * 50ms)
-  // Running in parallel should take ~50-100ms
-  assertEquals(
-    elapsed < 140,
-    true,
-    `Expected parallel execution to be faster than 140ms, got ${elapsed}ms`,
-  );
 });

--- a/src/infrastructure/persistence/fs_file_repository.ts
+++ b/src/infrastructure/persistence/fs_file_repository.ts
@@ -21,8 +21,8 @@ interface FileMetadata extends ModelFileData {
  * File system implementation of FileRepository.
  *
  * Stores file artifacts with metadata and content as separate files:
- * - Metadata: {repoDir}/files/{normalized-type}/{model-id}/{method-name}/{file-id}.yaml
- * - Content:  {repoDir}/files/{normalized-type}/{model-id}/{method-name}/{actual-filename}
+ * - Metadata: {repoDir}/data/files/{normalized-type}/{model-id}/{method-name}/{file-id}.yaml
+ * - Content:  {repoDir}/data/files/{normalized-type}/{model-id}/{method-name}/{actual-filename}
  */
 export class FileSystemFileRepository implements FileRepository {
   constructor(private readonly repoDir: string) {}
@@ -178,7 +178,7 @@ export class FileSystemFileRepository implements FileRepository {
   }
 
   private getTypeDir(type: ModelType): string {
-    return join(this.repoDir, "files", type.toDirectoryPath());
+    return join(this.repoDir, "data", "files", type.toDirectoryPath());
   }
 
   private getFileDir(

--- a/src/infrastructure/persistence/fs_file_repository_test.ts
+++ b/src/infrastructure/persistence/fs_file_repository_test.ts
@@ -45,6 +45,7 @@ Deno.test("FileSystemFileRepository.save creates directory structure", async () 
 
     const expectedDir = join(
       dir,
+      "data",
       "files",
       "swamp/echo",
       testModelId,
@@ -268,7 +269,7 @@ Deno.test("FileSystemFileRepository.getPath returns correct path", () => {
   const path = repo.getPath(type, testModelId, testMethodName, id);
   assertEquals(
     path,
-    `/repo/files/swamp/echo/${testModelId}/${testMethodName}/550e8400-e29b-41d4-a716-446655440001.yaml`,
+    `/repo/data/files/swamp/echo/${testModelId}/${testMethodName}/550e8400-e29b-41d4-a716-446655440001.yaml`,
   );
 });
 
@@ -283,7 +284,7 @@ Deno.test("FileSystemFileRepository.getContentPath returns correct path with act
   const path = repo.getContentPath(type, testModelId, testMethodName, file);
   assertEquals(
     path,
-    `/repo/files/swamp/echo/${testModelId}/${testMethodName}/my-downloaded-file.tar.gz`,
+    `/repo/data/files/swamp/echo/${testModelId}/${testMethodName}/my-downloaded-file.tar.gz`,
   );
 });
 

--- a/src/infrastructure/persistence/streaming_log_repository.ts
+++ b/src/infrastructure/persistence/streaming_log_repository.ts
@@ -24,8 +24,8 @@ interface LogMetadata {
  * Streaming implementation of LogRepository using plain text lines format.
  *
  * Stores log artifacts in two files:
- * - Metadata: {repoDir}/logs/{normalized-type}/{id}.yaml
- * - Entries:  {repoDir}/logs/{normalized-type}/{id}.log
+ * - Metadata: {repoDir}/data/logs/{normalized-type}/{id}.yaml
+ * - Entries:  {repoDir}/data/logs/{normalized-type}/{id}.log
  *
  * The .log format stores raw lines, allowing appending entries without
  * reading/rewriting the whole file.
@@ -233,6 +233,6 @@ export class StreamingLogRepository implements LogRepository {
   }
 
   private getTypeDir(type: ModelType): string {
-    return join(this.repoDir, "logs", type.toDirectoryPath());
+    return join(this.repoDir, "data", "logs", type.toDirectoryPath());
   }
 }

--- a/src/infrastructure/persistence/streaming_log_repository_test.ts
+++ b/src/infrastructure/persistence/streaming_log_repository_test.ts
@@ -25,7 +25,7 @@ Deno.test("StreamingLogRepository.save creates directory structure", async () =>
 
     await repo.save(type, log);
 
-    const expectedDir = join(dir, "logs", "swamp/echo");
+    const expectedDir = join(dir, "data", "logs", "swamp/echo");
     const stat = await Deno.stat(expectedDir);
     assertEquals(stat.isDirectory, true);
   });
@@ -42,7 +42,13 @@ Deno.test("StreamingLogRepository.save creates metadata and entries files", asyn
     await repo.save(type, log);
 
     // Check metadata file
-    const metadataPath = join(dir, "logs", "swamp/echo", `${log.id}.yaml`);
+    const metadataPath = join(
+      dir,
+      "data",
+      "logs",
+      "swamp/echo",
+      `${log.id}.yaml`,
+    );
     const metadataContent = await Deno.readTextFile(metadataPath);
     assertStringIncludes(metadataContent, `id: ${log.id}`);
     assertStringIncludes(metadataContent, "version: 1");
@@ -255,7 +261,7 @@ Deno.test("StreamingLogRepository.getPath returns correct path", () => {
   const path = repo.getPath(type, id);
   assertEquals(
     path,
-    "/repo/logs/swamp/echo/550e8400-e29b-41d4-a716-446655440001.log",
+    "/repo/data/logs/swamp/echo/550e8400-e29b-41d4-a716-446655440001.log",
   );
 });
 

--- a/src/infrastructure/persistence/yaml_data_repository.ts
+++ b/src/infrastructure/persistence/yaml_data_repository.ts
@@ -14,7 +14,7 @@ import {
  * YAML-based implementation of DataRepository.
  *
  * Stores data artifacts as YAML files in the directory structure:
- * {repoDir}/data/{normalized-type}/{id}.yaml
+ * {repoDir}/data/data/{normalized-type}/{id}.yaml
  */
 export class YamlDataRepository implements DataRepository {
   constructor(private readonly repoDir: string) {}
@@ -91,6 +91,6 @@ export class YamlDataRepository implements DataRepository {
   }
 
   private getTypeDir(type: ModelType): string {
-    return join(this.repoDir, "data", type.toDirectoryPath());
+    return join(this.repoDir, "data", "data", type.toDirectoryPath());
   }
 }

--- a/src/infrastructure/persistence/yaml_data_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_data_repository_test.ts
@@ -24,7 +24,7 @@ Deno.test("YamlDataRepository.save creates directory structure", async () => {
 
     await repo.save(type, data);
 
-    const expectedDir = join(dir, "data", "swamp/echo");
+    const expectedDir = join(dir, "data", "data", "swamp/echo");
     const stat = await Deno.stat(expectedDir);
     assertEquals(stat.isDirectory, true);
   });
@@ -143,7 +143,7 @@ Deno.test("YamlDataRepository.getPath returns correct path", () => {
   const path = repo.getPath(type, id);
   assertEquals(
     path,
-    "/repo/data/swamp/echo/550e8400-e29b-41d4-a716-446655440001.yaml",
+    "/repo/data/data/swamp/echo/550e8400-e29b-41d4-a716-446655440001.yaml",
   );
 });
 

--- a/src/infrastructure/persistence/yaml_evaluated_input_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_input_repository.ts
@@ -11,7 +11,7 @@ import {
 /**
  * Repository for storing evaluated model inputs.
  *
- * Writes to {repoDir}/inputs-evaluated/{normalized-type}/{id}.yaml
+ * Writes to {repoDir}/data/inputs-evaluated/{normalized-type}/{id}.yaml
  * This directory contains inputs with all expressions resolved.
  */
 export class YamlEvaluatedInputRepository {
@@ -96,7 +96,7 @@ export class YamlEvaluatedInputRepository {
    * Clears all evaluated inputs.
    */
   async clear(): Promise<void> {
-    const dir = join(this.repoDir, "inputs-evaluated");
+    const dir = join(this.repoDir, "data", "inputs-evaluated");
     try {
       await Deno.remove(dir, { recursive: true });
     } catch (error) {
@@ -114,6 +114,11 @@ export class YamlEvaluatedInputRepository {
   }
 
   private getTypeDir(type: ModelType): string {
-    return join(this.repoDir, "inputs-evaluated", type.toDirectoryPath());
+    return join(
+      this.repoDir,
+      "data",
+      "inputs-evaluated",
+      type.toDirectoryPath(),
+    );
   }
 }

--- a/src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts
@@ -10,7 +10,7 @@ import {
 /**
  * Repository for storing evaluated workflows.
  *
- * Writes to {repoDir}/workflows-evaluated/workflow-{uuid}.yaml
+ * Writes to {repoDir}/data/workflows-evaluated/workflow-{uuid}.yaml
  * This directory contains workflows with all expressions resolved.
  */
 export class YamlEvaluatedWorkflowRepository {
@@ -98,6 +98,6 @@ export class YamlEvaluatedWorkflowRepository {
   }
 
   private getWorkflowsDir(): string {
-    return join(this.repoDir, "workflows-evaluated");
+    return join(this.repoDir, "data", "workflows-evaluated");
   }
 }

--- a/src/infrastructure/persistence/yaml_input_repository.ts
+++ b/src/infrastructure/persistence/yaml_input_repository.ts
@@ -14,7 +14,7 @@ import {
  * YAML-based implementation of InputRepository.
  *
  * Stores inputs as YAML files in the directory structure:
- * {repoDir}/inputs/{normalized-type}/{id}.yaml
+ * {repoDir}/data/inputs/{normalized-type}/{id}.yaml
  */
 export class YamlInputRepository implements InputRepository {
   constructor(private readonly repoDir: string) {}
@@ -67,7 +67,7 @@ export class YamlInputRepository implements InputRepository {
   async findByNameGlobal(
     name: string,
   ): Promise<{ input: ModelInput; type: ModelType } | null> {
-    const inputsDir = join(this.repoDir, "inputs");
+    const inputsDir = join(this.repoDir, "data", "inputs");
     return await this.searchInputByName(inputsDir, [], name);
   }
 
@@ -120,7 +120,7 @@ export class YamlInputRepository implements InputRepository {
    * Finds all inputs across all model types in the repository.
    */
   async findAllGlobal(): Promise<{ input: ModelInput; type: ModelType }[]> {
-    const inputsDir = join(this.repoDir, "inputs");
+    const inputsDir = join(this.repoDir, "data", "inputs");
     const results: { input: ModelInput; type: ModelType }[] = [];
     await this.collectAllInputs(inputsDir, [], results);
     return results;
@@ -195,6 +195,6 @@ export class YamlInputRepository implements InputRepository {
   }
 
   private getTypeDir(type: ModelType): string {
-    return join(this.repoDir, "inputs", type.toDirectoryPath());
+    return join(this.repoDir, "data", "inputs", type.toDirectoryPath());
   }
 }

--- a/src/infrastructure/persistence/yaml_input_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_input_repository_test.ts
@@ -24,7 +24,7 @@ Deno.test("YamlInputRepository.save creates directory structure", async () => {
 
     await repo.save(type, input);
 
-    const expectedDir = join(dir, "inputs", "swamp/echo");
+    const expectedDir = join(dir, "data", "inputs", "swamp/echo");
     const stat = await Deno.stat(expectedDir);
     assertEquals(stat.isDirectory, true);
   });
@@ -169,7 +169,7 @@ Deno.test("YamlInputRepository.getPath returns correct path", () => {
   const path = repo.getPath(type, id);
   assertEquals(
     path,
-    "/repo/inputs/swamp/echo/550e8400-e29b-41d4-a716-446655440000.yaml",
+    "/repo/data/inputs/swamp/echo/550e8400-e29b-41d4-a716-446655440000.yaml",
   );
 });
 

--- a/src/infrastructure/persistence/yaml_output_repository.ts
+++ b/src/infrastructure/persistence/yaml_output_repository.ts
@@ -16,7 +16,7 @@ import { modelRegistry } from "../../domain/models/model.ts";
  * YAML-based implementation of OutputRepository.
  *
  * Stores outputs as YAML files in the directory structure:
- * {repoDir}/outputs/{normalized-type}/{method}/{model-id}-{timestamp}.yaml
+ * {repoDir}/data/outputs/{normalized-type}/{method}/{model-id}-{timestamp}.yaml
  */
 export class YamlOutputRepository implements OutputRepository {
   constructor(private readonly repoDir: string) {}
@@ -174,7 +174,7 @@ export class YamlOutputRepository implements OutputRepository {
   }
 
   private getOutputsDir(): string {
-    return join(this.repoDir, "outputs");
+    return join(this.repoDir, "data", "outputs");
   }
 
   private getTypeDir(type: ModelType): string {

--- a/src/infrastructure/persistence/yaml_output_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_output_repository_test.ts
@@ -37,7 +37,13 @@ Deno.test("YamlOutputRepository.save creates directory structure", async () => {
 
     await repo.save(testType, "create", output);
 
-    const expectedDir = join(dir, "outputs", testType.normalized, "create");
+    const expectedDir = join(
+      dir,
+      "data",
+      "outputs",
+      testType.normalized,
+      "create",
+    );
     const stat = await Deno.stat(expectedDir);
     assertEquals(stat.isDirectory, true);
   });

--- a/src/infrastructure/persistence/yaml_resource_repository.ts
+++ b/src/infrastructure/persistence/yaml_resource_repository.ts
@@ -14,7 +14,7 @@ import {
  * YAML-based implementation of ResourceRepository.
  *
  * Stores resources as YAML files in the directory structure:
- * {repoDir}/resources/{normalized-type}/{id}.yaml
+ * {repoDir}/data/resources/{normalized-type}/{id}.yaml
  */
 export class YamlResourceRepository implements ResourceRepository {
   constructor(private readonly repoDir: string) {}
@@ -91,6 +91,6 @@ export class YamlResourceRepository implements ResourceRepository {
   }
 
   private getTypeDir(type: ModelType): string {
-    return join(this.repoDir, "resources", type.toDirectoryPath());
+    return join(this.repoDir, "data", "resources", type.toDirectoryPath());
   }
 }

--- a/src/infrastructure/persistence/yaml_resource_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_resource_repository_test.ts
@@ -24,7 +24,7 @@ Deno.test("YamlResourceRepository.save creates directory structure", async () =>
 
     await repo.save(type, resource);
 
-    const expectedDir = join(dir, "resources", "swamp/echo");
+    const expectedDir = join(dir, "data", "resources", "swamp/echo");
     const stat = await Deno.stat(expectedDir);
     assertEquals(stat.isDirectory, true);
   });
@@ -143,6 +143,6 @@ Deno.test("YamlResourceRepository.getPath returns correct path", () => {
   const path = repo.getPath(type, id);
   assertEquals(
     path,
-    "/repo/resources/swamp/echo/550e8400-e29b-41d4-a716-446655440001.yaml",
+    "/repo/data/resources/swamp/echo/550e8400-e29b-41d4-a716-446655440001.yaml",
   );
 });

--- a/src/infrastructure/persistence/yaml_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_repository.ts
@@ -15,7 +15,7 @@ import {
  * YAML-based implementation of WorkflowRepository.
  *
  * Stores workflows as YAML files in the directory structure:
- * {repoDir}/workflows/workflow-{uuid}.yaml
+ * {repoDir}/data/workflows/workflow-{uuid}.yaml
  */
 export class YamlWorkflowRepository implements WorkflowRepository {
   constructor(private readonly repoDir: string) {}
@@ -97,6 +97,6 @@ export class YamlWorkflowRepository implements WorkflowRepository {
   }
 
   private getWorkflowsDir(): string {
-    return join(this.repoDir, "workflows");
+    return join(this.repoDir, "data", "workflows");
   }
 }

--- a/src/infrastructure/persistence/yaml_workflow_run_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository.ts
@@ -16,7 +16,7 @@ import {
  * YAML-based implementation of WorkflowRunRepository.
  *
  * Stores workflow runs as YAML files in the directory structure:
- * {repoDir}/workflows/workflow-{workflowId}/workflow-run-{runId}-{timestamp}.yaml
+ * {repoDir}/data/workflow-runs/{workflowId}/workflow-run-{runId}.yaml
  */
 export class YamlWorkflowRunRepository implements WorkflowRunRepository {
   constructor(private readonly repoDir: string) {}
@@ -96,13 +96,13 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
     { run: WorkflowRun; workflowId: WorkflowId }[]
   > {
     const results: { run: WorkflowRun; workflowId: WorkflowId }[] = [];
-    const workflowsDir = join(this.repoDir, "workflows");
+    const workflowRunsDir = join(this.repoDir, "data", "workflow-runs");
 
     try {
-      for await (const entry of Deno.readDir(workflowsDir)) {
-        if (entry.isDirectory && entry.name.startsWith("workflow-")) {
-          // Extract workflow ID from directory name (format: workflow-{uuid})
-          const workflowIdStr = entry.name.slice("workflow-".length);
+      for await (const entry of Deno.readDir(workflowRunsDir)) {
+        if (entry.isDirectory) {
+          // Directory name is the workflow ID
+          const workflowIdStr = entry.name;
           const workflowId = workflowIdStr as WorkflowId;
           const runs = await this.findAllByWorkflowId(workflowId);
           for (const run of runs) {
@@ -149,6 +149,6 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
   }
 
   private getRunsDir(workflowId: WorkflowId): string {
-    return join(this.repoDir, "workflows", `workflow-${workflowId}`);
+    return join(this.repoDir, "data", "workflow-runs", workflowId);
   }
 }


### PR DESCRIPTION
- Migrate all entity repository storage from root-level directories to `/data/` subdirectories
- Add `swamp type get` as an alias for `swamp type describe`

## Changes

### Repository Path Migration (closes #72)

Updated all 10 repository implementations to store data under `/data/`:

| Repository | Old Path | New Path |
|------------|----------|----------|
| InputRepository | `inputs/` | `data/inputs/` |
| ResourceRepository | `resources/` | `data/resources/` |
| DataRepository | `data/` | `data/data/` |
| OutputRepository | `outputs/` | `data/outputs/` |
| WorkflowRepository | `workflows/` | `data/workflows/` |
| WorkflowRunRepository | `workflows/{id}/` | `data/workflow-runs/{id}/` |
| EvaluatedInputRepository | `inputs-evaluated/` | `data/inputs-evaluated/` |
| EvaluatedWorkflowRepository | `workflows-evaluated/` | `data/workflows-evaluated/` |
| LogRepository | `logs/` | `data/logs/` |
| FileRepository | `files/` | `data/files/` |

### Repo Initialization

- `repo init` now creates the full `/data/` directory structure
- Added test to verify all data subdirectories are created

### .gitignore Updates

Updated to ignore generated/runtime data while tracking user-authored content:
- **Tracked:** `data/inputs/`, `data/resources/`, `data/workflows/`
- **Ignored:** `data/data/`, `data/outputs/`, `data/workflow-runs/`, `data/inputs-evaluated/`, `data/workflows-evaluated/`,
`data/logs/`, `data/files/`

### CLI Enhancement

- Added `get` as an alias for `swamp type describe` using Cliffy's `.alias()` method

## Test plan

- [x] All 1105 tests pass
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] Manual test: `swamp type get swamp/echo` works
- [x] Binary recompiled

🤖 Generated with [Claude Code](https://claude.ai/code)