### PR TITLE
feat: implement workflow delete and enhance model delete with comprehensive cleanup

### DIFF
--- a/design/models.md
+++ b/design/models.md
@@ -76,7 +76,7 @@ method.
 
 ### Logs
 
-A method may produce 0..* log artifacts. They have a name, can have lines
+A method may produce 0..\* log artifacts. They have a name, can have lines
 streamed to them, and by default are stored in `/data/logs/` in the repository
 underneath the normalized model type as a directory. Logs are named like
 `{model-id}-{method name}-{log name}-{timestamp}.log`.
@@ -93,7 +93,7 @@ By default, the `/data/logs/` directory is not stored in git.
 
 ### Files
 
-A method may store 0..* file artifacts. They have a name, and can be written to
+A method may store 0..\* file artifacts. They have a name, and can be written to
 directly. By default they will be stored in the `/data/files/` directory of the
 repository underneath the normalized model type as a directory plus the model ID
 and method name. For example
@@ -230,6 +230,13 @@ Shows the entire details of the model. It should not include the type schema or
 the methods.
 
 when specifying json, it should have the same content.
+
+### model delete <model_id_or_name>
+
+Delete a specific model and all of its inputs, inputs-evaluated and outputs -
+and anything else related! A model should not be able to be deleted if it's part
+of a workflow or if it has a resource associated. The user should be told to
+delete the resource first
 
 ### model validate <model_id_or_name>
 

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -129,6 +129,10 @@ fuzzy search.
 Should show the workflow yaml with syntax highlighting, and the path, similar to
 `model get`.
 
+### workflow delete <id or name>
+
+Should delete the workflow yaml as well as any run history for that workflow
+
 ### workflow run <id or name>
 
 Executes a workflow run.

--- a/integration/workflow_test.ts
+++ b/integration/workflow_test.ts
@@ -856,3 +856,398 @@ Deno.test("CLI: workflow run succeeds with self reference expressions", async ()
     assertEquals(output.status, "succeeded");
   });
 });
+
+// Model deletion blocked by workflow reference tests
+
+Deno.test("CLI: model delete blocked when referenced by workflow, succeeds after workflow deleted", async () => {
+  await withTempDir(async (repoDir) => {
+    // Step 1: Create a model using CLI
+    const createModelResult = await runCliCommand(
+      [
+        "model",
+        "create",
+        "swamp/echo",
+        "my-test-model",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      createModelResult.code,
+      0,
+      `Model create should succeed. stderr: ${createModelResult.stderr}`,
+    );
+
+    const modelOutput = JSON.parse(createModelResult.stdout);
+    assertEquals(modelOutput.name, "my-test-model");
+    const modelId = modelOutput.id;
+
+    // Step 2: Create a workflow that references the model
+    const workflowRepo = new YamlWorkflowRepository(repoDir);
+    const workflow = Workflow.create({
+      name: "workflow-using-model",
+      jobs: [
+        Job.create({
+          name: "run-model",
+          steps: [
+            Step.create({
+              name: "write-echo",
+              task: StepTask.modelMethod("my-test-model", "write"),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    // Step 3: Try to delete the model - should fail because workflow references it
+    const deleteModelBlockedResult = await runCliCommand(
+      [
+        "model",
+        "delete",
+        "my-test-model",
+        "--repo-dir",
+        repoDir,
+        "--force",
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      deleteModelBlockedResult.code !== 0,
+      true,
+      "Model delete should fail when referenced by workflow",
+    );
+    assertStringIncludes(
+      deleteModelBlockedResult.stderr,
+      "workflow-using-model",
+    );
+    assertStringIncludes(
+      deleteModelBlockedResult.stderr,
+      "referenced by workflow",
+    );
+
+    // Step 4: Delete the workflow using CLI
+    const deleteWorkflowResult = await runCliCommand(
+      [
+        "workflow",
+        "delete",
+        "workflow-using-model",
+        "--repo-dir",
+        repoDir,
+        "--force",
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      deleteWorkflowResult.code,
+      0,
+      `Workflow delete should succeed. stderr: ${deleteWorkflowResult.stderr}`,
+    );
+
+    const workflowDeleteOutput = JSON.parse(deleteWorkflowResult.stdout);
+    assertEquals(workflowDeleteOutput.deleted.name, "workflow-using-model");
+
+    // Step 5: Now model delete should succeed
+    const deleteModelSuccessResult = await runCliCommand(
+      [
+        "model",
+        "delete",
+        modelId,
+        "--repo-dir",
+        repoDir,
+        "--force",
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      deleteModelSuccessResult.code,
+      0,
+      `Model delete should succeed after workflow deleted. stderr: ${deleteModelSuccessResult.stderr}`,
+    );
+
+    const modelDeleteOutput = JSON.parse(deleteModelSuccessResult.stdout);
+    assertEquals(modelDeleteOutput.deleted.name, "my-test-model");
+    assertEquals(modelDeleteOutput.deleted.id, modelId);
+  });
+});
+
+Deno.test("CLI: model delete blocked when referenced by workflow using model ID", async () => {
+  await withTempDir(async (repoDir) => {
+    // Create a model
+    const inputRepo = new YamlInputRepository(repoDir);
+    const input = ModelInput.create({
+      name: "id-ref-model",
+      attributes: {
+        message: "test message",
+      },
+    });
+    await inputRepo.save(ECHO_MODEL_TYPE, input);
+
+    // Create a workflow that references the model by ID (not name)
+    const workflowRepo = new YamlWorkflowRepository(repoDir);
+    const workflow = Workflow.create({
+      name: "workflow-using-id",
+      jobs: [
+        Job.create({
+          name: "run-model",
+          steps: [
+            Step.create({
+              name: "write-echo",
+              // Reference by ID instead of name
+              task: StepTask.modelMethod(input.id, "write"),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    // Try to delete the model - should fail because workflow references it by ID
+    const deleteModelResult = await runCliCommand(
+      [
+        "model",
+        "delete",
+        "id-ref-model",
+        "--repo-dir",
+        repoDir,
+        "--force",
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      deleteModelResult.code !== 0,
+      true,
+      "Model delete should fail when referenced by workflow using ID",
+    );
+    assertStringIncludes(
+      deleteModelResult.stderr,
+      "workflow-using-id",
+    );
+  });
+});
+
+Deno.test("CLI: model delete succeeds when not referenced by any workflow", async () => {
+  await withTempDir(async (repoDir) => {
+    // Create a model
+    const createModelResult = await runCliCommand(
+      [
+        "model",
+        "create",
+        "swamp/echo",
+        "standalone-model",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(createModelResult.code, 0);
+
+    // Create a workflow that does NOT reference the model
+    const workflowRepo = new YamlWorkflowRepository(repoDir);
+    const workflow = Workflow.create({
+      name: "unrelated-workflow",
+      jobs: [
+        Job.create({
+          name: "shell-job",
+          steps: [
+            Step.create({
+              name: "echo-step",
+              task: StepTask.shell("echo", { args: ["hello"] }),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    // Delete the model - should succeed because workflow doesn't reference it
+    const deleteModelResult = await runCliCommand(
+      [
+        "model",
+        "delete",
+        "standalone-model",
+        "--repo-dir",
+        repoDir,
+        "--force",
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      deleteModelResult.code,
+      0,
+      `Model delete should succeed. stderr: ${deleteModelResult.stderr}`,
+    );
+
+    const output = JSON.parse(deleteModelResult.stdout);
+    assertEquals(output.deleted.name, "standalone-model");
+  });
+});
+
+Deno.test("CLI: model delete cleans up empty type directories", async () => {
+  await withTempDir(async (repoDir) => {
+    // Create a model using CLI
+    const createResult = await runCliCommand(
+      [
+        "model",
+        "create",
+        "swamp/echo",
+        "cleanup-test-model",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(createResult.code, 0, "Model create should succeed");
+
+    // Verify the directory structure was created
+    const inputsDir = `${repoDir}/data/inputs`;
+    const echoDir = `${inputsDir}/swamp/echo`;
+    const swampDir = `${inputsDir}/swamp`;
+
+    // Check that directories exist using Deno.stat
+    const echoStatBefore = await Deno.stat(echoDir).catch(() => null);
+    assertEquals(
+      echoStatBefore !== null && echoStatBefore.isDirectory,
+      true,
+      "swamp/echo directory should exist before delete",
+    );
+
+    // Delete the model
+    const deleteResult = await runCliCommand(
+      [
+        "model",
+        "delete",
+        "cleanup-test-model",
+        "--repo-dir",
+        repoDir,
+        "--force",
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      deleteResult.code,
+      0,
+      `Model delete should succeed. stderr: ${deleteResult.stderr}`,
+    );
+
+    // Verify the swamp/echo directory was cleaned up (should not exist)
+    const echoStatAfter = await Deno.stat(echoDir).catch(() => null);
+    assertEquals(
+      echoStatAfter,
+      null,
+      "swamp/echo directory should be cleaned up",
+    );
+
+    // Verify the swamp directory was also cleaned up
+    const swampStatAfter = await Deno.stat(swampDir).catch(() => null);
+    assertEquals(
+      swampStatAfter,
+      null,
+      "swamp directory should be cleaned up",
+    );
+
+    // But inputs directory should still exist
+    const inputsStatAfter = await Deno.stat(inputsDir).catch(() => null);
+    assertEquals(
+      inputsStatAfter !== null && inputsStatAfter.isDirectory,
+      true,
+      "inputs directory should still exist",
+    );
+  });
+});
+
+Deno.test("CLI: workflow delete command removes workflow and all runs", async () => {
+  await withTempDir(async (repoDir) => {
+    // Create a workflow
+    const workflowRepo = new YamlWorkflowRepository(repoDir);
+    const workflow = Workflow.create({
+      name: "delete-test-workflow",
+      jobs: [
+        Job.create({
+          name: "echo-job",
+          steps: [
+            Step.create({
+              name: "echo-step",
+              task: StepTask.shell("echo", { args: ["hello"] }),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    // Run the workflow to create run history
+    const runResult = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "delete-test-workflow",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(runResult.code, 0, "Workflow run should succeed");
+
+    // Delete the workflow
+    const deleteResult = await runCliCommand(
+      [
+        "workflow",
+        "delete",
+        "delete-test-workflow",
+        "--repo-dir",
+        repoDir,
+        "--force",
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      deleteResult.code,
+      0,
+      `Workflow delete should succeed. stderr: ${deleteResult.stderr}`,
+    );
+
+    const output = JSON.parse(deleteResult.stdout);
+    assertEquals(output.deleted.name, "delete-test-workflow");
+    assertEquals(output.runsDeleted, 1);
+
+    // Verify workflow is gone
+    const getResult = await runCliCommand(
+      [
+        "workflow",
+        "get",
+        "delete-test-workflow",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(getResult.code !== 0, true, "Workflow should not exist");
+    assertStringIncludes(getResult.stderr, "not found");
+  });
+});

--- a/src/cli/commands/model_delete.ts
+++ b/src/cli/commands/model_delete.ts
@@ -6,9 +6,12 @@ import {
 } from "../../presentation/output/model_delete_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { inputIdToResourceId } from "../../domain/models/model_resource.ts";
+import { inputIdToDataId } from "../../domain/models/model_data.ts";
 import { createRepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
+import { YamlEvaluatedInputRepository } from "../../infrastructure/persistence/yaml_evaluated_input_repository.ts";
 import { findByIdOrName } from "../../domain/models/model_lookup.ts";
 import { UserError } from "../../domain/errors.ts";
+import type { Workflow } from "../../domain/workflows/workflow.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -33,9 +36,44 @@ async function promptConfirmation(message: string): Promise<boolean> {
   return response === "y" || response === "yes";
 }
 
+/**
+ * Finds all workflows that reference a model by ID or name.
+ */
+function findWorkflowsReferencingModel(
+  workflows: Workflow[],
+  modelId: string,
+  modelName: string,
+): Workflow[] {
+  const referencingWorkflows: Workflow[] = [];
+
+  for (const workflow of workflows) {
+    let found = false;
+    for (const job of workflow.jobs) {
+      for (const step of job.steps) {
+        if (step.task.isModelMethod()) {
+          const taskData = step.task.data;
+          if (taskData.type === "model_method") {
+            const ref = taskData.modelIdOrName;
+            if (ref === modelId || ref === modelName) {
+              found = true;
+              break;
+            }
+          }
+        }
+      }
+      if (found) break;
+    }
+    if (found) {
+      referencingWorkflows.push(workflow);
+    }
+  }
+
+  return referencingWorkflows;
+}
+
 export const modelDeleteCommand = new Command()
   .name("delete")
-  .description("Delete a model input")
+  .description("Delete a model and all related artifacts")
   .arguments("<model_id_or_name:model_name>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option(
@@ -51,6 +89,9 @@ export const modelDeleteCommand = new Command()
     const repoContext = createRepositoryContext({ repoDir });
     const inputRepo = repoContext.inputRepo;
     const resourceRepo = repoContext.resourceRepo;
+    const outputRepo = repoContext.outputRepo;
+    const dataRepo = repoContext.dataRepo;
+    const workflowRepo = repoContext.workflowRepo;
 
     // Look up the model input
     ctx.logger.debug`Looking up model: ${modelIdOrName}`;
@@ -62,6 +103,22 @@ export const modelDeleteCommand = new Command()
 
     ctx.logger.debug`Found model: id=${input.id}, type=${modelType.normalized}`;
 
+    // Check if model is referenced in any workflow
+    const allWorkflows = await workflowRepo.findAll();
+    const referencingWorkflows = findWorkflowsReferencingModel(
+      allWorkflows,
+      input.id,
+      input.name,
+    );
+
+    if (referencingWorkflows.length > 0) {
+      const workflowNames = referencingWorkflows.map((w) => w.name).join(", ");
+      throw new UserError(
+        `Model '${input.name}' is referenced by workflow(s): ${workflowNames}. ` +
+          `Remove the model from these workflows before deleting.`,
+      );
+    }
+
     // Check for associated resource (resource ID equals input ID)
     const resource = await resourceRepo.findById(
       modelType,
@@ -72,7 +129,8 @@ export const modelDeleteCommand = new Command()
     // If resource exists and no --force flag, block deletion
     if (resource && !options.force) {
       throw new UserError(
-        `Model '${input.name}' has an associated resource. Use --force to delete both.`,
+        `Model '${input.name}' has an associated resource. ` +
+          `Delete the resource first, or use --force to delete both.`,
       );
     }
 
@@ -82,10 +140,44 @@ export const modelDeleteCommand = new Command()
       ? resourceRepo.getPath(modelType, resource.id)
       : undefined;
 
+    // Find outputs related to this model
+    const outputs = await outputRepo.findByModelInput(modelType, input.id);
+    ctx.logger.debug`Found ${outputs.length} outputs to delete`;
+
+    // Check for evaluated input
+    const evaluatedInputRepo = new YamlEvaluatedInputRepository(repoDir);
+    const evaluatedInput = await evaluatedInputRepo.findById(
+      modelType,
+      input.id,
+    );
+    ctx.logger.debug`Evaluated input exists: ${evaluatedInput !== null}`;
+
+    // Check for data artifact (data uses the same ID as the input)
+    const dataId = inputIdToDataId(input.id);
+    const dataArtifact = await dataRepo.findById(modelType, dataId);
+    ctx.logger.debug`Data artifact exists: ${dataArtifact !== null}`;
+
     // In interactive mode without --force, prompt for confirmation
     if (ctx.outputMode === "interactive" && !options.force) {
+      let deleteDetails = "";
+      if (outputs.length > 0) {
+        deleteDetails += ` ${outputs.length} output(s),`;
+      }
+      if (evaluatedInput) {
+        deleteDetails += " evaluated input,";
+      }
+      if (dataArtifact) {
+        deleteDetails += " data artifact,";
+      }
+      if (resource) {
+        deleteDetails += " resource,";
+      }
+      if (deleteDetails) {
+        deleteDetails = ` This will also delete:${deleteDetails.slice(0, -1)}.`;
+      }
+
       const confirmed = await promptConfirmation(
-        `Delete model '${input.name}' (${input.id})?`,
+        `Delete model '${input.name}' (${input.id})?${deleteDetails}`,
       );
       if (!confirmed) {
         renderModelDeleteCancelled(ctx.outputMode);
@@ -93,13 +185,37 @@ export const modelDeleteCommand = new Command()
       }
     }
 
-    // Delete resource first if it exists
+    // Delete outputs first
+    let outputsDeleted = 0;
+    for (const output of outputs) {
+      ctx.logger.debug`Deleting output: ${output.id}`;
+      await outputRepo.delete(modelType, output.methodName, output.id);
+      outputsDeleted++;
+    }
+
+    // Delete data artifact if it exists
+    let dataDeleted = false;
+    if (dataArtifact) {
+      ctx.logger.debug`Deleting data artifact: ${dataId}`;
+      await dataRepo.delete(modelType, dataId);
+      dataDeleted = true;
+    }
+
+    // Delete evaluated input if it exists
+    let evaluatedInputDeleted = false;
+    if (evaluatedInput) {
+      ctx.logger.debug`Deleting evaluated input: ${input.id}`;
+      await evaluatedInputRepo.delete(modelType, input.id);
+      evaluatedInputDeleted = true;
+    }
+
+    // Delete resource if it exists
     if (resource) {
       ctx.logger.debug`Deleting resource: ${resource.id}`;
       await resourceRepo.delete(modelType, resource.id);
     }
 
-    // Delete input
+    // Delete input (this emits ModelDeleted event which cleans up logical views)
     ctx.logger.debug`Deleting input: ${input.id}`;
     await inputRepo.delete(modelType, input.id);
 
@@ -110,6 +226,9 @@ export const modelDeleteCommand = new Command()
       inputPath,
       resourcePath,
       resourceDeleted: resource !== null,
+      outputsDeleted,
+      evaluatedInputDeleted,
+      dataDeleted,
     };
 
     renderModelDelete(data, ctx.outputMode);

--- a/src/cli/commands/model_delete_test.ts
+++ b/src/cli/commands/model_delete_test.ts
@@ -16,7 +16,7 @@ Deno.test("modelDeleteCommand has correct description", async () => {
   const { modelDeleteCommand } = await import("./model_delete.ts");
   assertEquals(
     modelDeleteCommand.getDescription(),
-    "Delete a model input",
+    "Delete a model and all related artifacts",
   );
 });
 

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -1,5 +1,6 @@
 import { Command } from "@cliffy/command";
 import { workflowCreateCommand } from "./workflow_create.ts";
+import { workflowDeleteCommand } from "./workflow_delete.ts";
 import { workflowEditCommand } from "./workflow_edit.ts";
 import { workflowGetCommand } from "./workflow_get.ts";
 import { workflowHistoryCommand } from "./workflow_history.ts";
@@ -15,6 +16,7 @@ export const workflowCommand = new Command()
     this.showHelp();
   })
   .command("create", workflowCreateCommand)
+  .command("delete", workflowDeleteCommand)
   .command("edit", workflowEditCommand)
   .command("get", workflowGetCommand)
   .command("history", workflowHistoryCommand)

--- a/src/cli/commands/workflow_delete.ts
+++ b/src/cli/commands/workflow_delete.ts
@@ -1,0 +1,133 @@
+import { Command } from "@cliffy/command";
+import {
+  renderWorkflowDelete,
+  renderWorkflowDeleteCancelled,
+  type WorkflowDeleteData,
+} from "../../presentation/output/workflow_delete_output.tsx";
+import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createWorkflowId,
+  type WorkflowId,
+} from "../../domain/workflows/workflow_id.ts";
+import type { Workflow } from "../../domain/workflows/workflow.ts";
+import { createRepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
+import { YamlEvaluatedWorkflowRepository } from "../../infrastructure/persistence/yaml_evaluated_workflow_repository.ts";
+import { UserError } from "../../domain/errors.ts";
+
+/**
+ * UUID v4 regex pattern for detecting if an argument is a UUID.
+ */
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Checks if a string looks like a UUID.
+ */
+function isUuid(value: string): boolean {
+  return UUID_PATTERN.test(value);
+}
+
+/**
+ * Prompts user for confirmation in interactive mode.
+ * Uses basic stdin reading for confirmation prompt.
+ */
+async function promptConfirmation(message: string): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+
+  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
+
+  const buf = new Uint8Array(1024);
+  const n = await Deno.stdin.read(buf);
+  if (n === null) {
+    return false;
+  }
+
+  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
+  return response === "y" || response === "yes";
+}
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const workflowDeleteCommand = new Command()
+  .name("delete")
+  .description("Delete a workflow and its run history")
+  .arguments("<workflow_id_or_name:workflow_name>")
+  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option("-f, --force", "Skip confirmation prompt")
+  // @ts-expect-error - Cliffy custom type returns unknown instead of string
+  .action(async function (options: AnyOptions, workflowIdOrName: string) {
+    const ctx = createContext(options as GlobalOptions, "workflow-delete");
+    ctx.logger.debug`Deleting workflow: ${workflowIdOrName}`;
+
+    const repoDir = options.repoDir ?? ".";
+    const repoContext = createRepositoryContext({ repoDir });
+    const workflowRepo = repoContext.workflowRepo;
+    const workflowRunRepo = repoContext.workflowRunRepo;
+
+    // Look up the workflow
+    let workflow: Workflow | null = null;
+
+    if (isUuid(workflowIdOrName)) {
+      ctx.logger.debug`Looking up by ID: ${workflowIdOrName}`;
+      const id: WorkflowId = createWorkflowId(workflowIdOrName);
+      workflow = await workflowRepo.findById(id);
+    } else {
+      ctx.logger.debug`Looking up by name: ${workflowIdOrName}`;
+      workflow = await workflowRepo.findByName(workflowIdOrName);
+    }
+
+    if (!workflow) {
+      throw new UserError(`Workflow not found: ${workflowIdOrName}`);
+    }
+
+    ctx.logger.debug`Found workflow: id=${workflow.id}, name=${workflow.name}`;
+
+    // Get path before deletion
+    const workflowPath = workflowRepo.getPath(workflow.id);
+
+    // Check how many runs exist
+    const runs = await workflowRunRepo.findAllByWorkflowId(workflow.id);
+    const runCount = runs.length;
+
+    // In interactive mode without --force, prompt for confirmation
+    if (ctx.outputMode === "interactive" && !options.force) {
+      const runWarning = runCount > 0
+        ? ` This will also delete ${runCount} run${runCount === 1 ? "" : "s"}.`
+        : "";
+      const confirmed = await promptConfirmation(
+        `Delete workflow '${workflow.name}' (${workflow.id})?${runWarning}`,
+      );
+      if (!confirmed) {
+        renderWorkflowDeleteCancelled(ctx.outputMode);
+        return;
+      }
+    }
+
+    // Delete workflow runs first
+    let runsDeleted = 0;
+    if (runCount > 0) {
+      ctx.logger.debug`Deleting ${runCount} workflow runs`;
+      runsDeleted = await workflowRunRepo.deleteAllByWorkflowId(workflow.id);
+    }
+
+    // Delete evaluated workflow if it exists
+    const evaluatedWorkflowRepo = new YamlEvaluatedWorkflowRepository(repoDir);
+    ctx.logger.debug`Deleting evaluated workflow: ${workflow.id}`;
+    await evaluatedWorkflowRepo.delete(workflow.id);
+
+    // Delete the workflow (this will emit WorkflowDeleted event which cleans up logical views)
+    ctx.logger.debug`Deleting workflow: ${workflow.id}`;
+    await workflowRepo.delete(workflow.id);
+
+    const data: WorkflowDeleteData = {
+      id: workflow.id,
+      name: workflow.name,
+      workflowPath,
+      runsDeleted,
+    };
+
+    renderWorkflowDelete(data, ctx.outputMode);
+    ctx.logger.debug("Workflow delete command completed");
+  });

--- a/src/cli/commands/workflow_delete_test.ts
+++ b/src/cli/commands/workflow_delete_test.ts
@@ -1,0 +1,41 @@
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Initialize logging for tests
+await initializeLogging({ debugLogs: false });
+
+Deno.test("workflowDeleteCommand module loads", async () => {
+  const { workflowDeleteCommand } = await import("./workflow_delete.ts");
+  assertEquals(workflowDeleteCommand.getName(), "delete");
+});
+
+Deno.test("workflowDeleteCommand has correct description", async () => {
+  const { workflowDeleteCommand } = await import("./workflow_delete.ts");
+  assertEquals(
+    workflowDeleteCommand.getDescription(),
+    "Delete a workflow and its run history",
+  );
+});
+
+Deno.test("workflowDeleteCommand is registered as subcommand of workflowCommand", async () => {
+  const { workflowCommand } = await import("./workflow.ts");
+  const commands = workflowCommand.getCommands();
+  const deleteCmd = commands.find((c) => c.getName() === "delete");
+  assertEquals(deleteCmd !== undefined, true);
+});
+
+Deno.test("workflowDeleteCommand has --force option", async () => {
+  const { workflowDeleteCommand } = await import("./workflow_delete.ts");
+  const options = workflowDeleteCommand.getOptions();
+  const forceOption = options.find((o) =>
+    o.flags.includes("-f") || o.flags.includes("--force")
+  );
+  assertEquals(forceOption !== undefined, true);
+});
+
+Deno.test("workflowDeleteCommand has --repo-dir option", async () => {
+  const { workflowDeleteCommand } = await import("./workflow_delete.ts");
+  const options = workflowDeleteCommand.getOptions();
+  const repoDirOption = options.find((o) => o.flags.includes("--repo-dir"));
+  assertEquals(repoDirOption !== undefined, true);
+});

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -144,6 +144,13 @@ class InMemoryWorkflowRunRepository implements WorkflowRunRepository {
   getPath(workflowId: WorkflowId, runId: WorkflowRunId): string {
     return `workflows/workflow-${workflowId}/workflow-run-${runId}.yaml`;
   }
+
+  deleteAllByWorkflowId(workflowId: WorkflowId): Promise<number> {
+    const runs = this.runs.get(workflowId) ?? [];
+    const count = runs.length;
+    this.runs.delete(workflowId);
+    return Promise.resolve(count);
+  }
 }
 
 function createSimpleWorkflow(): Workflow {

--- a/src/domain/workflows/repositories.ts
+++ b/src/domain/workflows/repositories.ts
@@ -83,4 +83,9 @@ export interface WorkflowRunRepository {
    * Gets the file path for a workflow run.
    */
   getPath(workflowId: WorkflowId, runId: WorkflowRunId): string;
+
+  /**
+   * Deletes all runs for a workflow.
+   */
+  deleteAllByWorkflowId(workflowId: WorkflowId): Promise<number>;
 }

--- a/src/infrastructure/persistence/directory_cleanup.ts
+++ b/src/infrastructure/persistence/directory_cleanup.ts
@@ -1,0 +1,43 @@
+import { dirname } from "@std/path";
+
+/**
+ * Removes empty parent directories up to but not including the stopAt directory.
+ *
+ * This is useful when deleting files from nested directory structures
+ * (e.g., data/inputs/aws/ec2/vpc/uuid.yaml) to clean up empty folders.
+ *
+ * @param filePath The path of the file that was deleted
+ * @param stopAtDir The directory to stop at (will not be deleted)
+ */
+export async function cleanupEmptyParentDirs(
+  filePath: string,
+  stopAtDir: string,
+): Promise<void> {
+  let currentDir = dirname(filePath);
+
+  while (currentDir !== stopAtDir && currentDir.startsWith(stopAtDir)) {
+    try {
+      // Check if directory is empty
+      const entries = [];
+      for await (const entry of Deno.readDir(currentDir)) {
+        entries.push(entry);
+      }
+
+      if (entries.length === 0) {
+        await Deno.remove(currentDir);
+        currentDir = dirname(currentDir);
+      } else {
+        // Directory not empty, stop cleaning
+        break;
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        // Directory already gone, try parent
+        currentDir = dirname(currentDir);
+      } else {
+        // Other error, stop cleaning
+        break;
+      }
+    }
+  }
+}

--- a/src/infrastructure/persistence/directory_cleanup_test.ts
+++ b/src/infrastructure/persistence/directory_cleanup_test.ts
@@ -1,0 +1,120 @@
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir, exists } from "@std/fs";
+import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-cleanup-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("cleanupEmptyParentDirs removes empty parent directories", async () => {
+  await withTempDir(async (tempDir) => {
+    // Create nested directory structure: tempDir/data/inputs/aws/ec2/vpc
+    const inputsDir = join(tempDir, "data", "inputs");
+    const vpcDir = join(inputsDir, "aws", "ec2", "vpc");
+    await ensureDir(vpcDir);
+
+    // Create a file in vpc directory
+    const filePath = join(vpcDir, "test.yaml");
+    await Deno.writeTextFile(filePath, "test: content");
+
+    // Delete the file
+    await Deno.remove(filePath);
+
+    // Clean up empty parent directories
+    await cleanupEmptyParentDirs(filePath, inputsDir);
+
+    // All nested directories should be removed
+    assertEquals(await exists(join(inputsDir, "aws", "ec2", "vpc")), false);
+    assertEquals(await exists(join(inputsDir, "aws", "ec2")), false);
+    assertEquals(await exists(join(inputsDir, "aws")), false);
+
+    // But inputs directory should still exist (it's the stop point)
+    assertEquals(await exists(inputsDir), true);
+  });
+});
+
+Deno.test("cleanupEmptyParentDirs stops at non-empty directory", async () => {
+  await withTempDir(async (tempDir) => {
+    // Create nested directory structure
+    const inputsDir = join(tempDir, "data", "inputs");
+    const vpcDir = join(inputsDir, "aws", "ec2", "vpc");
+    const subnetDir = join(inputsDir, "aws", "ec2", "subnet");
+    await ensureDir(vpcDir);
+    await ensureDir(subnetDir);
+
+    // Create a file in vpc directory
+    const vpcFile = join(vpcDir, "vpc.yaml");
+    await Deno.writeTextFile(vpcFile, "test: content");
+
+    // Create a file in subnet directory
+    const subnetFile = join(subnetDir, "subnet.yaml");
+    await Deno.writeTextFile(subnetFile, "test: content");
+
+    // Delete the vpc file
+    await Deno.remove(vpcFile);
+
+    // Clean up empty parent directories
+    await cleanupEmptyParentDirs(vpcFile, inputsDir);
+
+    // vpc directory should be removed
+    assertEquals(await exists(vpcDir), false);
+
+    // ec2 directory should still exist (it has subnet subdir)
+    assertEquals(await exists(join(inputsDir, "aws", "ec2")), true);
+
+    // aws directory should still exist
+    assertEquals(await exists(join(inputsDir, "aws")), true);
+
+    // subnet directory and file should still exist
+    assertEquals(await exists(subnetDir), true);
+    assertEquals(await exists(subnetFile), true);
+  });
+});
+
+Deno.test("cleanupEmptyParentDirs handles already deleted directories", async () => {
+  await withTempDir(async (tempDir) => {
+    const inputsDir = join(tempDir, "data", "inputs");
+    await ensureDir(inputsDir);
+
+    // Try to clean up a path that doesn't exist
+    const nonExistentFile = join(inputsDir, "aws", "ec2", "vpc", "test.yaml");
+
+    // Should not throw
+    await cleanupEmptyParentDirs(nonExistentFile, inputsDir);
+
+    // inputs directory should still exist
+    assertEquals(await exists(inputsDir), true);
+  });
+});
+
+Deno.test("cleanupEmptyParentDirs does not go above stop directory", async () => {
+  await withTempDir(async (tempDir) => {
+    // Create structure
+    const dataDir = join(tempDir, "data");
+    const inputsDir = join(dataDir, "inputs");
+    const typeDir = join(inputsDir, "swamp", "echo");
+    await ensureDir(typeDir);
+
+    // Create and delete a file
+    const filePath = join(typeDir, "test.yaml");
+    await Deno.writeTextFile(filePath, "test: content");
+    await Deno.remove(filePath);
+
+    // Clean up with inputs as stop directory
+    await cleanupEmptyParentDirs(filePath, inputsDir);
+
+    // Nested dirs should be removed
+    assertEquals(await exists(typeDir), false);
+    assertEquals(await exists(join(inputsDir, "swamp")), false);
+
+    // But inputs and data should still exist
+    assertEquals(await exists(inputsDir), true);
+    assertEquals(await exists(dataDir), true);
+  });
+});

--- a/src/infrastructure/persistence/yaml_data_repository.ts
+++ b/src/infrastructure/persistence/yaml_data_repository.ts
@@ -1,5 +1,6 @@
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
+import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import type { DataRepository } from "../../domain/models/repositories.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
@@ -75,6 +76,10 @@ export class YamlDataRepository implements DataRepository {
     const path = this.getPath(type, id);
     try {
       await Deno.remove(path);
+
+      // Clean up empty parent directories
+      const dataDir = join(this.repoDir, "data", "data");
+      await cleanupEmptyParentDirs(path, dataDir);
     } catch (error) {
       if (!(error instanceof Deno.errors.NotFound)) {
         throw error;

--- a/src/infrastructure/persistence/yaml_evaluated_input_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_input_repository.ts
@@ -1,5 +1,6 @@
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
+import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import type { ModelType } from "../../domain/models/model_type.ts";
 import {
@@ -85,6 +86,10 @@ export class YamlEvaluatedInputRepository {
     const path = this.getPath(type, id);
     try {
       await Deno.remove(path);
+
+      // Clean up empty parent directories
+      const evaluatedDir = join(this.repoDir, "data", "inputs-evaluated");
+      await cleanupEmptyParentDirs(path, evaluatedDir);
     } catch (error) {
       if (!(error instanceof Deno.errors.NotFound)) {
         throw error;

--- a/src/infrastructure/persistence/yaml_input_repository.ts
+++ b/src/infrastructure/persistence/yaml_input_repository.ts
@@ -1,5 +1,6 @@
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
+import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import type { InputRepository } from "../../domain/models/repositories.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
@@ -223,6 +224,10 @@ export class YamlInputRepository implements InputRepository {
 
     try {
       await Deno.remove(path);
+
+      // Clean up empty parent directories
+      const inputsDir = join(this.repoDir, "data", "inputs");
+      await cleanupEmptyParentDirs(path, inputsDir);
 
       // Emit event if we had a name
       if (this.eventBus && inputName) {

--- a/src/infrastructure/persistence/yaml_output_repository.ts
+++ b/src/infrastructure/persistence/yaml_output_repository.ts
@@ -1,5 +1,6 @@
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
+import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import type { OutputRepository } from "../../domain/models/repositories.ts";
 import type { ModelInputId } from "../../domain/models/model_input.ts";
@@ -152,6 +153,10 @@ export class YamlOutputRepository implements OutputRepository {
           const data = parseYaml(content) as ModelOutputData;
           if (data.id === id) {
             await Deno.remove(path);
+
+            // Clean up empty parent directories
+            const outputsDir = join(this.repoDir, "data", "outputs");
+            await cleanupEmptyParentDirs(path, outputsDir);
             return;
           }
         }

--- a/src/infrastructure/persistence/yaml_resource_repository.ts
+++ b/src/infrastructure/persistence/yaml_resource_repository.ts
@@ -1,5 +1,6 @@
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
+import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import type { ResourceRepository } from "../../domain/models/repositories.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
@@ -75,6 +76,10 @@ export class YamlResourceRepository implements ResourceRepository {
     const path = this.getPath(type, id);
     try {
       await Deno.remove(path);
+
+      // Clean up empty parent directories
+      const resourcesDir = join(this.repoDir, "data", "resources");
+      await cleanupEmptyParentDirs(path, resourcesDir);
     } catch (error) {
       if (!(error instanceof Deno.errors.NotFound)) {
         throw error;

--- a/src/infrastructure/persistence/yaml_workflow_run_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository.ts
@@ -203,4 +203,26 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
   private getRunsDir(workflowId: WorkflowId): string {
     return join(this.repoDir, "data", "workflow-runs", workflowId);
   }
+
+  async deleteAllByWorkflowId(workflowId: WorkflowId): Promise<number> {
+    const dir = this.getRunsDir(workflowId);
+
+    // Count the runs before deleting
+    const runs = await this.findAllByWorkflowId(workflowId);
+    const count = runs.length;
+
+    if (count === 0) {
+      return 0;
+    }
+
+    try {
+      await Deno.remove(dir, { recursive: true });
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+
+    return count;
+  }
 }

--- a/src/infrastructure/persistence/yaml_workflow_run_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository_test.ts
@@ -273,3 +273,69 @@ Deno.test("YamlWorkflowRunRepository.findAllGlobal sorts by startedAt descending
     assertEquals(allRuns[1].run.id, run1.id);
   });
 });
+
+Deno.test("YamlWorkflowRunRepository.deleteAllByWorkflowId deletes all runs for workflow", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlWorkflowRunRepository(dir);
+    const workflow = createTestWorkflow();
+
+    // Create and save multiple runs
+    const run1 = WorkflowRun.create(workflow);
+    run1.start();
+    await repo.save(workflow.id, run1);
+
+    const run2 = WorkflowRun.create(workflow);
+    run2.start();
+    await repo.save(workflow.id, run2);
+
+    // Verify runs exist
+    const runsBefore = await repo.findAllByWorkflowId(workflow.id);
+    assertEquals(runsBefore.length, 2);
+
+    // Delete all runs
+    const deletedCount = await repo.deleteAllByWorkflowId(workflow.id);
+    assertEquals(deletedCount, 2);
+
+    // Verify runs are gone
+    const runsAfter = await repo.findAllByWorkflowId(workflow.id);
+    assertEquals(runsAfter.length, 0);
+  });
+});
+
+Deno.test("YamlWorkflowRunRepository.deleteAllByWorkflowId returns 0 for no runs", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlWorkflowRunRepository(dir);
+    const workflowId = createWorkflowId("550e8400-e29b-41d4-a716-446655440000");
+
+    const deletedCount = await repo.deleteAllByWorkflowId(workflowId);
+    assertEquals(deletedCount, 0);
+  });
+});
+
+Deno.test("YamlWorkflowRunRepository.deleteAllByWorkflowId does not affect other workflows", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlWorkflowRunRepository(dir);
+    const workflow1 = createTestWorkflow();
+    const workflow2 = createTestWorkflow2();
+
+    // Create runs for both workflows
+    const run1 = WorkflowRun.create(workflow1);
+    run1.start();
+    await repo.save(workflow1.id, run1);
+
+    const run2 = WorkflowRun.create(workflow2);
+    run2.start();
+    await repo.save(workflow2.id, run2);
+
+    // Delete only workflow1's runs
+    await repo.deleteAllByWorkflowId(workflow1.id);
+
+    // Verify workflow1 runs are gone
+    const runs1After = await repo.findAllByWorkflowId(workflow1.id);
+    assertEquals(runs1After.length, 0);
+
+    // Verify workflow2 runs still exist
+    const runs2After = await repo.findAllByWorkflowId(workflow2.id);
+    assertEquals(runs2After.length, 1);
+  });
+});

--- a/src/presentation/output/model_delete_output.tsx
+++ b/src/presentation/output/model_delete_output.tsx
@@ -14,6 +14,9 @@ export interface ModelDeleteData {
   inputPath: string;
   resourcePath?: string;
   resourceDeleted: boolean;
+  outputsDeleted: number;
+  evaluatedInputDeleted: boolean;
+  dataDeleted: boolean;
 }
 
 /**
@@ -28,6 +31,9 @@ export interface ModelDeleteJsonOutput {
     resourcePath?: string;
   };
   resourceDeleted: boolean;
+  outputsDeleted: number;
+  evaluatedInputDeleted: boolean;
+  dataDeleted: boolean;
 }
 
 /**
@@ -46,6 +52,9 @@ export function renderModelDelete(
         inputPath: data.inputPath,
       },
       resourceDeleted: data.resourceDeleted,
+      outputsDeleted: data.outputsDeleted,
+      evaluatedInputDeleted: data.evaluatedInputDeleted,
+      dataDeleted: data.dataDeleted,
     };
     if (data.resourcePath) {
       output.deleted.resourcePath = data.resourcePath;
@@ -68,6 +77,9 @@ interface ModelDeleteDisplayProps {
   inputPath: string;
   resourcePath?: string;
   resourceDeleted: boolean;
+  outputsDeleted: number;
+  evaluatedInputDeleted: boolean;
+  dataDeleted: boolean;
 }
 
 /**
@@ -98,8 +110,26 @@ export function ModelDeleteDisplay(
         </Text>
         {props.resourceDeleted && props.resourcePath && (
           <Text>
-            <Text color="cyan">Resource also deleted:</Text>
+            <Text color="cyan">Resource deleted:</Text>
             <Text dimColor>{props.resourcePath}</Text>
+          </Text>
+        )}
+        {props.outputsDeleted > 0 && (
+          <Text>
+            <Text color="cyan">Outputs deleted:</Text>
+            <Text>{props.outputsDeleted}</Text>
+          </Text>
+        )}
+        {props.evaluatedInputDeleted && (
+          <Text>
+            <Text color="cyan">Evaluated input deleted:</Text>
+            <Text>yes</Text>
+          </Text>
+        )}
+        {props.dataDeleted && (
+          <Text>
+            <Text color="cyan">Data artifact deleted:</Text>
+            <Text>yes</Text>
           </Text>
         )}
       </Box>

--- a/src/presentation/output/model_delete_output_test.tsx
+++ b/src/presentation/output/model_delete_output_test.tsx
@@ -17,6 +17,9 @@ const testData: ModelDeleteData = {
   type: "swamp/echo",
   inputPath: "inputs/swamp/echo/550e8400-e29b-41d4-a716-446655440000.yaml",
   resourceDeleted: false,
+  outputsDeleted: 0,
+  evaluatedInputDeleted: false,
+  dataDeleted: false,
 };
 
 const testDataWithResource: ModelDeleteData = {
@@ -26,6 +29,21 @@ const testDataWithResource: ModelDeleteData = {
   inputPath: "inputs/swamp/echo/550e8400-e29b-41d4-a716-446655440000.yaml",
   resourcePath: "resources/swamp/echo/resource-id.yaml",
   resourceDeleted: true,
+  outputsDeleted: 0,
+  evaluatedInputDeleted: false,
+  dataDeleted: false,
+};
+
+const testDataWithAllArtifacts: ModelDeleteData = {
+  id: "550e8400-e29b-41d4-a716-446655440000",
+  name: "test-echo",
+  type: "swamp/echo",
+  inputPath: "inputs/swamp/echo/550e8400-e29b-41d4-a716-446655440000.yaml",
+  resourcePath: "resources/swamp/echo/resource-id.yaml",
+  resourceDeleted: true,
+  outputsDeleted: 5,
+  evaluatedInputDeleted: true,
+  dataDeleted: true,
 };
 
 Deno.test({
@@ -62,7 +80,7 @@ Deno.test({
     );
     const output = lastFrame() ?? "";
 
-    assertStringIncludes(output, "Resource also deleted");
+    assertStringIncludes(output, "Resource deleted");
     assertStringIncludes(output, "resources/swamp/echo/resource-id.yaml");
   },
 });
@@ -75,7 +93,58 @@ Deno.test({
     const { lastFrame } = render(<ModelDeleteDisplay {...testData} />);
     const output = lastFrame() ?? "";
 
-    assertEquals(output.includes("Resource also deleted"), false);
+    assertEquals(output.includes("Resource deleted"), false);
+  },
+});
+
+Deno.test({
+  name: "ModelDeleteDisplay shows outputs deleted count when > 0",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelDeleteDisplay {...testDataWithAllArtifacts} />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Outputs deleted");
+    assertStringIncludes(output, "5");
+  },
+});
+
+Deno.test({
+  name: "ModelDeleteDisplay does not show outputs when count is 0",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<ModelDeleteDisplay {...testData} />);
+    const output = lastFrame() ?? "";
+
+    assertEquals(output.includes("Outputs deleted"), false);
+  },
+});
+
+Deno.test({
+  name: "ModelDeleteDisplay shows evaluated input deleted when true",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelDeleteDisplay {...testDataWithAllArtifacts} />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Evaluated input deleted");
+  },
+});
+
+Deno.test({
+  name: "ModelDeleteDisplay shows data artifact deleted when true",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <ModelDeleteDisplay {...testDataWithAllArtifacts} />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Data artifact deleted");
   },
 });
 
@@ -93,6 +162,9 @@ Deno.test("renderModelDelete with json mode outputs valid JSON", () => {
     assertEquals(parsed.deleted.name, testData.name);
     assertEquals(parsed.deleted.inputPath, testData.inputPath);
     assertEquals(parsed.resourceDeleted, false);
+    assertEquals(parsed.outputsDeleted, 0);
+    assertEquals(parsed.evaluatedInputDeleted, false);
+    assertEquals(parsed.dataDeleted, false);
   } finally {
     console.log = originalLog;
   }
@@ -112,6 +184,23 @@ Deno.test("renderModelDelete with json mode includes resourcePath when resource 
       testDataWithResource.resourcePath,
     );
     assertEquals(parsed.resourceDeleted, true);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderModelDelete with json mode includes all artifact counts", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelDelete(testDataWithAllArtifacts, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.outputsDeleted, 5);
+    assertEquals(parsed.evaluatedInputDeleted, true);
+    assertEquals(parsed.dataDeleted, true);
   } finally {
     console.log = originalLog;
   }

--- a/src/presentation/output/workflow_delete_output.tsx
+++ b/src/presentation/output/workflow_delete_output.tsx
@@ -1,0 +1,108 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { Box, Text } from "ink";
+import { render } from "ink-testing-library";
+import type { OutputMode } from "./output.tsx";
+
+/**
+ * Data structure for the workflow delete output.
+ */
+export interface WorkflowDeleteData {
+  id: string;
+  name: string;
+  workflowPath: string;
+  runsDeleted: number;
+}
+
+/**
+ * JSON output structure for workflow delete.
+ */
+export interface WorkflowDeleteJsonOutput {
+  deleted: {
+    id: string;
+    name: string;
+    workflowPath: string;
+  };
+  runsDeleted: number;
+}
+
+/**
+ * Renders the workflow delete output in either interactive or JSON mode.
+ */
+export function renderWorkflowDelete(
+  data: WorkflowDeleteData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    const output: WorkflowDeleteJsonOutput = {
+      deleted: {
+        id: data.id,
+        name: data.name,
+        workflowPath: data.workflowPath,
+      },
+      runsDeleted: data.runsDeleted,
+    };
+    console.log(JSON.stringify(output, null, 2));
+  } else {
+    renderInteractiveWorkflowDelete(data);
+  }
+}
+
+function renderInteractiveWorkflowDelete(data: WorkflowDeleteData): void {
+  const { lastFrame } = render(<WorkflowDeleteDisplay {...data} />);
+  console.log(lastFrame());
+}
+
+interface WorkflowDeleteDisplayProps {
+  id: string;
+  name: string;
+  workflowPath: string;
+  runsDeleted: number;
+}
+
+/**
+ * Interactive display component for workflow delete.
+ */
+export function WorkflowDeleteDisplay(
+  props: WorkflowDeleteDisplayProps,
+): React.ReactElement {
+  return (
+    <Box flexDirection="column">
+      <Text color="green">Deleted workflow:</Text>
+      <Box marginLeft={2} flexDirection="column">
+        <Text>
+          <Text color="cyan">Name:</Text>
+          <Text>{props.name}</Text>
+        </Text>
+        <Text>
+          <Text color="cyan">ID:</Text>
+          <Text dimColor>{props.id}</Text>
+        </Text>
+        <Text>
+          <Text color="cyan">Path:</Text>
+          <Text dimColor>{props.workflowPath}</Text>
+        </Text>
+        {props.runsDeleted > 0 && (
+          <Text>
+            <Text color="cyan">Runs deleted:</Text>
+            <Text>{props.runsDeleted}</Text>
+          </Text>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * Renders a cancellation message.
+ */
+export function renderWorkflowDeleteCancelled(mode: OutputMode): void {
+  if (mode === "json") {
+    console.log(JSON.stringify({ cancelled: true }, null, 2));
+  } else {
+    const { lastFrame } = render(
+      <Text color="yellow">Deletion cancelled.</Text>,
+    );
+    console.log(lastFrame());
+  }
+}

--- a/src/presentation/output/workflow_delete_output_test.tsx
+++ b/src/presentation/output/workflow_delete_output_test.tsx
@@ -1,0 +1,143 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { render } from "ink-testing-library";
+import {
+  renderWorkflowDelete,
+  renderWorkflowDeleteCancelled,
+  type WorkflowDeleteData,
+  WorkflowDeleteDisplay,
+} from "./workflow_delete_output.tsx";
+
+const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
+
+const testData: WorkflowDeleteData = {
+  id: "550e8400-e29b-41d4-a716-446655440000",
+  name: "test-workflow",
+  workflowPath:
+    "data/workflows/workflow-550e8400-e29b-41d4-a716-446655440000.yaml",
+  runsDeleted: 0,
+};
+
+const testDataWithRuns: WorkflowDeleteData = {
+  id: "550e8400-e29b-41d4-a716-446655440000",
+  name: "test-workflow",
+  workflowPath:
+    "data/workflows/workflow-550e8400-e29b-41d4-a716-446655440000.yaml",
+  runsDeleted: 5,
+};
+
+Deno.test({
+  name: "WorkflowDeleteDisplay renders all fields",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<WorkflowDeleteDisplay {...testData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "test-workflow");
+    assertStringIncludes(output, "550e8400-e29b-41d4-a716-446655440000");
+  },
+});
+
+Deno.test({
+  name: "WorkflowDeleteDisplay shows 'Deleted workflow' message",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<WorkflowDeleteDisplay {...testData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Deleted workflow");
+  },
+});
+
+Deno.test({
+  name: "WorkflowDeleteDisplay shows runs deleted count when > 0",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <WorkflowDeleteDisplay {...testDataWithRuns} />,
+    );
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Runs deleted");
+    assertStringIncludes(output, "5");
+  },
+});
+
+Deno.test({
+  name: "WorkflowDeleteDisplay does not show runs deleted when count is 0",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(<WorkflowDeleteDisplay {...testData} />);
+    const output = lastFrame() ?? "";
+
+    assertEquals(output.includes("Runs deleted"), false);
+  },
+});
+
+Deno.test("renderWorkflowDelete with json mode outputs valid JSON", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderWorkflowDelete(testData, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.deleted.id, testData.id);
+    assertEquals(parsed.deleted.name, testData.name);
+    assertEquals(parsed.deleted.workflowPath, testData.workflowPath);
+    assertEquals(parsed.runsDeleted, 0);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderWorkflowDelete with json mode includes runsDeleted count", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderWorkflowDelete(testDataWithRuns, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.runsDeleted, 5);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test({
+  name:
+    "renderWorkflowDeleteCancelled shows cancellation message in interactive mode",
+  ...inkTestOptions,
+  fn: () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      renderWorkflowDeleteCancelled("interactive");
+      assertEquals(logs.length, 1);
+      assertStringIncludes(logs[0], "Deletion cancelled");
+    } finally {
+      console.log = originalLog;
+    }
+  },
+});
+
+Deno.test("renderWorkflowDeleteCancelled outputs JSON in json mode", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderWorkflowDeleteCancelled("json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.cancelled, true);
+  } finally {
+    console.log = originalLog;
+  }
+});


### PR DESCRIPTION
- Implement `workflow delete` command that removes workflows and all associated data
- Enhance `model delete` to remove all related artifacts and block deletion when referenced by workflows
- Add automatic cleanup of empty parent directories when deleting models

## Changes

### Workflow Delete Command
- New `workflow delete <id_or_name>` command with `--force` flag to skip confirmation
- Deletes the workflow definition (`/data/workflows/`)
- Deletes all workflow run history (`/data/workflow-runs/{workflow-id}/`)
- Deletes evaluated workflow (`/data/workflows-evaluated/`)
- Cleans up logical views (`/workflows/{name}/`) via WorkflowDeleted event
- Added `deleteAllByWorkflowId` method to `WorkflowRunRepository`

### Model Delete Enhancements
- Now deletes all related artifacts:
- Model input (`/data/inputs/`)
- Evaluated input (`/data/inputs-evaluated/`)
- Outputs (`/data/outputs/`)
- Data artifacts (`/data/data/`)
- Resource (with `--force` flag)
- Blocks deletion if model is referenced by any workflow (by ID or name)
- Shows which workflows reference the model in the error message
- Updated output to show counts of deleted artifacts

### Directory Cleanup
- Empty parent directories are now cleaned up after model deletion
- Applies to: inputs, inputs-evaluated, resources, data, outputs directories
- Stops at the base data directory (e.g., `data/inputs/` is preserved)
- Shared utility `cleanupEmptyParentDirs` used by all repositories

## Test Plan

- [x] Unit tests for `workflow delete` command and output (13 tests)
- [x] Unit tests for `deleteAllByWorkflowId` repository method (3 tests)
- [x] Unit tests for directory cleanup utility (4 tests)
- [x] Updated unit tests for enhanced `model delete` output (5 new tests)
- [x] Integration test: model delete blocked by workflow reference, succeeds after workflow deleted
- [x] Integration test: model delete blocked when workflow references by ID
- [x] Integration test: model delete succeeds when not referenced by workflows
- [x] Integration test: workflow delete removes workflow and all runs
- [x] Integration test: model delete cleans up empty type directories
- [x] All 1167 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)