### PR TITLE
feat: add environment variable support in CEL expressions

### DIFF
--- a/design/expressions.md
+++ b/design/expressions.md
@@ -57,6 +57,28 @@ tags, and a models other attributes.
 You can also use the uuid of a model in order to reference it, rather than the
 name.
 
+## Environment Variables
+
+You can access environment variables using the `env` namespace:
+
+```yaml
+attributes:
+  region: ${{ env.AWS_REGION }}
+  api_key: ${{ env.API_KEY }}
+  path: /home/${{ env.USER }}/data
+```
+
+Environment variables are resolved at runtime from the process environment. This
+allows configuration to be injected without hardcoding values in model inputs or
+workflows.
+
+You can combine environment variables with model references:
+
+```yaml
+attributes:
+  bucket: ${{ env.ENV_PREFIX }}-${{ model.vpc.resource.attributes.id }}
+```
+
 For workflows, you should be able to reference other workflows by name or id, in
 addition to any model.
 

--- a/integration/workflow_test.ts
+++ b/integration/workflow_test.ts
@@ -10,7 +10,9 @@ import { StepTask } from "../src/domain/workflows/step_task.ts";
 import { TriggerCondition } from "../src/domain/workflows/trigger_condition.ts";
 import { YamlWorkflowRepository } from "../src/infrastructure/persistence/yaml_workflow_repository.ts";
 import { YamlInputRepository } from "../src/infrastructure/persistence/yaml_input_repository.ts";
+import { YamlDataRepository } from "../src/infrastructure/persistence/yaml_data_repository.ts";
 import { ModelInput } from "../src/domain/models/model_input.ts";
+import { createModelDataId } from "../src/domain/models/model_data.ts";
 import { ECHO_MODEL_TYPE } from "../src/domain/models/echo/echo_model.ts";
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
@@ -25,12 +27,14 @@ async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
 async function runCliCommand(
   args: string[],
   cwd: string,
+  env?: Record<string, string>,
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   const command = new Deno.Command(Deno.execPath(), {
     args: ["task", "dev", ...args],
     stdout: "piped",
     stderr: "piped",
     cwd,
+    env: env ? { ...Deno.env.toObject(), ...env } : undefined,
   });
 
   const { code, stdout, stderr } = await command.output();
@@ -1249,5 +1253,153 @@ Deno.test("CLI: workflow delete command removes workflow and all runs", async ()
 
     assertEquals(getResult.code !== 0, true, "Workflow should not exist");
     assertStringIncludes(getResult.stderr, "not found");
+  });
+});
+
+// Environment variable expression tests
+
+Deno.test("CLI: workflow run evaluates env variable expressions", async () => {
+  await withTempDir(async (repoDir) => {
+    // Create a model with an env variable expression
+    const inputRepo = new YamlInputRepository(repoDir);
+    const input = ModelInput.create({
+      name: "env-test-model",
+      attributes: {
+        // Use env variable expression
+        message: "${{ env.SWAMP_TEST_VAR }}",
+      },
+    });
+    await inputRepo.save(ECHO_MODEL_TYPE, input);
+
+    // Create a workflow that runs the model
+    const workflowRepo = new YamlWorkflowRepository(repoDir);
+    const workflow = Workflow.create({
+      name: "env-var-workflow",
+      jobs: [
+        Job.create({
+          name: "run-model",
+          steps: [
+            Step.create({
+              name: "write-echo",
+              task: StepTask.modelMethod("env-test-model", "write"),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    // Run the workflow with env var set
+    const result = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "env-var-workflow",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+      { SWAMP_TEST_VAR: "hello-from-env" },
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Command should succeed. stderr: ${result.stderr}`,
+    );
+
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.status, "succeeded");
+    assertEquals(output.jobs[0].steps[0].status, "succeeded");
+
+    // Verify the data artifact contains the evaluated env var
+    const dataRepo = new YamlDataRepository(repoDir);
+    const updatedInput = await inputRepo.findByName(
+      ECHO_MODEL_TYPE,
+      input.name,
+    );
+    if (!updatedInput?.dataId) {
+      throw new Error("Expected dataId to be set after workflow run");
+    }
+
+    const dataArtifact = await dataRepo.findById(
+      ECHO_MODEL_TYPE,
+      createModelDataId(updatedInput.dataId),
+    );
+    assertEquals(dataArtifact?.attributes.message, "hello-from-env");
+  });
+});
+
+Deno.test("CLI: workflow run evaluates inline env expression with surrounding text", async () => {
+  await withTempDir(async (repoDir) => {
+    // Create a model with an inline env expression (not the entire value)
+    const inputRepo = new YamlInputRepository(repoDir);
+
+    const inlineEnvModel = ModelInput.create({
+      name: "inline-env-model",
+      attributes: {
+        // Inline env expression with surrounding text
+        message: "prefix-${{ env.SWAMP_VAR }}-suffix",
+      },
+    });
+    await inputRepo.save(ECHO_MODEL_TYPE, inlineEnvModel);
+
+    // Create a workflow that runs the model
+    const workflowRepo = new YamlWorkflowRepository(repoDir);
+    const workflow = Workflow.create({
+      name: "inline-env-workflow",
+      jobs: [
+        Job.create({
+          name: "run-model",
+          steps: [
+            Step.create({
+              name: "write-inline",
+              task: StepTask.modelMethod("inline-env-model", "write"),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    // Run the workflow with env var set
+    const result = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "inline-env-workflow",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+      { SWAMP_VAR: "middle" },
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Command should succeed. stderr: ${result.stderr}, stdout: ${result.stdout}`,
+    );
+
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.status, "succeeded");
+
+    // Verify the model's data has the evaluated expression
+    const dataRepo = new YamlDataRepository(repoDir);
+    const updatedModel = await inputRepo.findByName(
+      ECHO_MODEL_TYPE,
+      inlineEnvModel.name,
+    );
+    if (!updatedModel?.dataId) {
+      throw new Error("Expected dataId to be set after workflow run");
+    }
+
+    const dataArtifact = await dataRepo.findById(
+      ECHO_MODEL_TYPE,
+      createModelDataId(updatedModel.dataId),
+    );
+    assertEquals(dataArtifact?.attributes.message, "prefix-middle-suffix");
   });
 });

--- a/src/domain/expressions/expression_path_extractor.ts
+++ b/src/domain/expressions/expression_path_extractor.ts
@@ -36,6 +36,14 @@ const MODEL_PATH_PATTERN =
 const SELF_PATH_PATTERN = /\bself((?:\.[a-zA-Z0-9_]+|\[\d+\])*)/g;
 
 /**
+ * Pattern to match env references with full paths.
+ * Matches: env.<variable_name>
+ *
+ * Group 1: variable name (allows underscores, letters, digits)
+ */
+const ENV_PATH_PATTERN = /\benv\.([a-zA-Z_][a-zA-Z0-9_]*)/g;
+
+/**
  * Represents a self-reference path extracted from an expression.
  */
 export interface SelfPathReference {
@@ -44,6 +52,16 @@ export interface SelfPathReference {
   /** The full path string (e.g., "attributes.VpcId") */
   fullPath: string;
   /** The raw expression that was matched (e.g., "self.attributes.VpcId") */
+  rawExpression: string;
+}
+
+/**
+ * Represents an environment variable reference extracted from an expression.
+ */
+export interface EnvPathReference {
+  /** The environment variable name */
+  variableName: string;
+  /** The raw expression that was matched (e.g., "env.HOME") */
   rawExpression: string;
 }
 
@@ -139,6 +157,36 @@ export function extractSelfReferences(
       references.push({
         path,
         fullPath,
+        rawExpression,
+      });
+    }
+  }
+
+  return references;
+}
+
+/**
+ * Extracts environment variable references from a CEL expression.
+ *
+ * @param expression - The CEL expression to analyze
+ * @returns Array of env references found in the expression
+ */
+export function extractEnvReferences(
+  expression: string,
+): EnvPathReference[] {
+  const references: EnvPathReference[] = [];
+  const seen = new Set<string>();
+
+  const matches = expression.matchAll(ENV_PATH_PATTERN);
+  for (const match of matches) {
+    const variableName = match[1];
+    const rawExpression = match[0];
+
+    // Deduplicate based on raw expression
+    if (!seen.has(rawExpression)) {
+      seen.add(rawExpression);
+      references.push({
+        variableName,
         rawExpression,
       });
     }

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -18,6 +18,13 @@ import { createModelLogId } from "../models/model_log.ts";
 import { ModelNotFoundError } from "./errors.ts";
 
 /**
+ * Builds env context from Deno environment variables.
+ */
+export function buildEnvContext(): Record<string, string> {
+  return { ...Deno.env.toObject() };
+}
+
+/**
  * Data about a single model for CEL context.
  */
 export interface ModelData {
@@ -85,6 +92,8 @@ export interface ExpressionContext {
   };
   /** Workflow context (for workflow evaluation) */
   workflow?: Record<string, unknown>;
+  /** Environment variables */
+  env: Record<string, string>;
   /** Index signature for CEL evaluator compatibility */
   [key: string]: unknown;
 }
@@ -132,6 +141,7 @@ export class ModelResolver {
   ): Promise<ExpressionContext> {
     const context: ExpressionContext = {
       model: {},
+      env: buildEnvContext(),
     };
 
     // Load all inputs

--- a/src/domain/models/validation_service.ts
+++ b/src/domain/models/validation_service.ts
@@ -8,6 +8,7 @@ import { ModelResourceSchema } from "./model_resource.ts";
 import type { InputRepository } from "./repositories.ts";
 import { extractExpressions } from "../expressions/expression_parser.ts";
 import {
+  extractEnvReferences,
   extractPathReferences,
   extractSelfReferences,
 } from "../expressions/expression_path_extractor.ts";
@@ -324,8 +325,13 @@ export class DefaultModelValidationService implements ModelValidationService {
         .filter((e): e is ExpressionPathError => e !== null);
       errors.push(...selfErrors);
 
+      // Extract env references (these are always valid - resolved at runtime)
+      const envRefs = extractEnvReferences(celExpression);
+
       // Check for expressions with valid ${{...}} syntax but no valid references
-      if (pathRefs.length === 0 && selfRefs.length === 0) {
+      if (
+        pathRefs.length === 0 && selfRefs.length === 0 && envRefs.length === 0
+      ) {
         const error = this.validateExpressionContent(celExpression, raw, path);
         if (error) errors.push(error);
       }
@@ -340,7 +346,7 @@ export class DefaultModelValidationService implements ModelValidationService {
   }
 
   /**
-   * Validates expression content when no valid model or self references were found.
+   * Validates expression content when no valid model, self, or env references were found.
    * This catches cases like ${{my-vpc.VpcId}} which should be ${{ model.my-vpc.resource.attributes.VpcId }}
    */
   private validateExpressionContent(
@@ -349,7 +355,7 @@ export class DefaultModelValidationService implements ModelValidationService {
     path: string,
   ): ExpressionPathError | null {
     // First, check if it looks like a valid CEL literal or operation
-    // These are valid expressions that don't need model/self references
+    // These are valid expressions that don't need model/self/env references
     const looksLikeValidCel = /^[\d"'\[\{(]|^true$|^false$|^null$/.test(
       celExpression,
     );
@@ -380,9 +386,9 @@ export class DefaultModelValidationService implements ModelValidationService {
       return {
         expression: rawExpression,
         error:
-          `Invalid expression "${celExpression}" at "${path}". Expression must reference model or self`,
+          `Invalid expression "${celExpression}" at "${path}". Expression must reference model, self, or env`,
         suggestion:
-          `Use: model.${celExpression}.resource.attributes.<property> or self.attributes.<property>`,
+          `Use: model.${celExpression}.resource.attributes.<property>, self.attributes.<property>, or env.<VARIABLE_NAME>`,
       };
     }
 
@@ -390,9 +396,9 @@ export class DefaultModelValidationService implements ModelValidationService {
     return {
       expression: rawExpression,
       error:
-        `Expression "${celExpression}" at "${path}" does not contain valid model or self references`,
+        `Expression "${celExpression}" at "${path}" does not contain valid model, self, or env references`,
       suggestion:
-        "Expressions should use: model.<name>.resource.attributes.<property>, model.<name>.input.attributes.<property>, or self.attributes.<property>",
+        "Expressions should use: model.<name>.resource.attributes.<property>, model.<name>.input.attributes.<property>, self.attributes.<property>, or env.<VARIABLE_NAME>",
     };
   }
 

--- a/src/infrastructure/cel/cel_evaluator_test.ts
+++ b/src/infrastructure/cel/cel_evaluator_test.ts
@@ -267,3 +267,33 @@ Deno.test("transformHyphenatedModelRefs handles multiple hyphens", () => {
     'model["a-b-c-d"].resource.id',
   );
 });
+
+Deno.test("CelEvaluator evaluates env variable access", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    env: { HOME: "/home/user", USER: "testuser" },
+  };
+  assertEquals(evaluator.evaluate("env.HOME", context), "/home/user");
+  assertEquals(evaluator.evaluate("env.USER", context), "testuser");
+});
+
+Deno.test("CelEvaluator evaluates env in string concatenation", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    env: { PREFIX: "prod" },
+    model: {
+      vpc: {
+        input: {
+          attributes: {
+            name: "main",
+          },
+        },
+      },
+    },
+  };
+  const result = evaluator.evaluate(
+    'env.PREFIX + "-" + model.vpc.input.attributes.name',
+    context,
+  );
+  assertEquals(result, "prod-main");
+});


### PR DESCRIPTION
- Add `env` namespace to CEL expression context for accessing environment variables
- Support `${{ env.VARIABLE_NAME }}` syntax in model inputs and workflows
- Environment variables are resolved at runtime from the process environment

## Changes

### Core Implementation
- **model_resolver.ts**: Added `env: Record<string, string>` to `ExpressionContext` interface and `buildEnvContext()` helper
that captures `Deno.env.toObject()`

### Validation Support
- **expression_path_extractor.ts**: Added `extractEnvReferences()` function and `EnvPathReference` interface to extract env
references from expressions
- **validation_service.ts**: Updated validation to recognize env expressions as valid (previously rejected as unknown
references)

### Documentation
- **design/expressions.md**: Added "Environment Variables" section documenting the `env` namespace

## Test plan

- [x] Unit tests for CEL evaluator with env context (`cel_evaluator_test.ts`)
- [x] Integration tests that set env vars and verify evaluation in workflow execution (`workflow_test.ts`)
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] All 1171 tests pass

## Usage Examples

```yaml
# Model input
attributes:
region: ${{ env.AWS_REGION }}
api_key: ${{ env.API_KEY }}
path: /home/${{ env.USER }}/data

# Combined with model references
attributes:
bucket: ${{ env.ENV_PREFIX }}-${{ model.vpc.resource.attributes.id }}
```

🤖 Generated with https://claude.ai/code