### PR TITLE
refactor: remove resourceId from ModelInput, use convention-based resource linking

### DIFF
--- a/design/expressions.md
+++ b/design/expressions.md
@@ -19,7 +19,6 @@ structure. Given an input like this:
 
 ```yaml
 id: 0bc79a8f-d9d2-4ec5-a37f-8d88bbb3ee27
-resourceId: 0bc79a8f-d9d2-4ec5-a37f-8d88bbb3ee27
 name: foo
 version: 1
 tags: {}
@@ -31,7 +30,6 @@ Another can use a CEL expression to extract the message attribute:
 
 ```yaml
 id: 0bc79a8f-d9d2-4ec5-a37f-8d88bbb3ee27
-resourceId: 0bc79a8f-d9d2-4ec5-a37f-8d88bbb3ee27
 name: bar
 version: 1
 tags: {}
@@ -43,7 +41,6 @@ Or the resource output of the same model:
 
 ```yaml
 id: 0bc79a8f-d9d2-4ec5-a37f-8d88bbb3ee27
-resourceId: 0bc79a8f-d9d2-4ec5-a37f-8d88bbb3ee27
 name: baz
 version: 1
 tags: {}

--- a/design/models.md
+++ b/design/models.md
@@ -49,12 +49,14 @@ The valid shape of an input is specified with a Zod 4 schema.
 
 Each input has the following core properties:
 
-- id: the models unqiue id
-- resourceId: an optional resource id, if one exists
+- id: the models unique id
 - name: a unique human readable name
 - tags: string based key value pairs
 - attributes: domain specific data for the input (for example, the model of a
   VPC from above).
+
+Resources are linked to inputs by convention: the resource ID always equals the
+input ID. Use `inputIdToResourceId(input.id)` to find the associated resource.
 
 ## Methods
 

--- a/experiments/webapp/backend/handlers/models_handler.ts
+++ b/experiments/webapp/backend/handlers/models_handler.ts
@@ -22,7 +22,6 @@ export function createModelsHandlers(inputRepository: InputRepository) {
       name: input.name,
       type: { raw: type.raw, normalized: type.normalized },
       version: input.version,
-      resourceId: input.resourceId,
       tags: input.tags,
       attributes: input.attributes,
     }));
@@ -42,7 +41,6 @@ export function createModelsHandlers(inputRepository: InputRepository) {
         name: input.name,
         type: { raw: modelType.raw, normalized: modelType.normalized },
         version: input.version,
-        resourceId: input.resourceId,
         tags: input.tags,
         attributes: input.attributes,
       }));
@@ -71,7 +69,6 @@ export function createModelsHandlers(inputRepository: InputRepository) {
         name: input.name,
         type: { raw: modelType.raw, normalized: modelType.normalized },
         version: input.version,
-        resourceId: input.resourceId,
         tags: input.tags,
         attributes: input.attributes,
       });
@@ -101,7 +98,6 @@ export function createModelsHandlers(inputRepository: InputRepository) {
       const input = ModelInput.create({
         name: body.name,
         version: body.version,
-        resourceId: body.resourceId,
         tags: body.tags,
         attributes: body.attributes,
       });
@@ -114,7 +110,6 @@ export function createModelsHandlers(inputRepository: InputRepository) {
           name: input.name,
           type: { raw: modelType.raw, normalized: modelType.normalized },
           version: input.version,
-          resourceId: input.resourceId,
           tags: input.tags,
           attributes: input.attributes,
         },
@@ -156,7 +151,6 @@ export function createModelsHandlers(inputRepository: InputRepository) {
         id: existing.id,
         name: body.name ?? existing.name,
         version: body.version ?? existing.version,
-        resourceId: body.resourceId ?? existing.resourceId,
         tags: body.tags ?? existing.tags,
         attributes: body.attributes ?? existing.attributes,
       });
@@ -168,7 +162,6 @@ export function createModelsHandlers(inputRepository: InputRepository) {
         name: updated.name,
         type: { raw: modelType.raw, normalized: modelType.normalized },
         version: updated.version,
-        resourceId: updated.resourceId,
         tags: updated.tags,
         attributes: updated.attributes,
       });

--- a/sample-repo/inputs/swamp/echo/ac341b73-64b1-4838-bb59-58b5306c6765.yaml
+++ b/sample-repo/inputs/swamp/echo/ac341b73-64b1-4838-bb59-58b5306c6765.yaml
@@ -1,5 +1,0 @@
-id: ac341b73-64b1-4838-bb59-58b5306c6765
-name: my-input
-version: 1
-tags: {}
-attributes: {}

--- a/src/cli/commands/model_edit.ts
+++ b/src/cli/commands/model_edit.ts
@@ -31,7 +31,6 @@ function toModelSearchItems(
     id: input.id,
     name: input.name,
     type: type.normalized,
-    resourceId: input.resourceId,
   }));
 }
 

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -142,27 +142,6 @@ export const modelMethodRunCommand = new Command()
               attributes: result.resource.attributes,
             };
           }
-
-          // Update input's resourceId based on operation type
-          if (result.deleteResource) {
-            // For delete operations, clear the resourceId since the resource no longer exists
-            if (input.resourceId) {
-              input.setResourceId(undefined);
-              await inputRepo.save(modelType, input);
-              ctx.logger.debug`Input resourceId cleared after deletion`;
-            }
-          } else {
-            // For create/update operations, set the resourceId if not already set
-            if (!input.resourceId) {
-              input.setResourceId(result.resource.id);
-              await inputRepo.save(modelType, input);
-              ctx.logger
-                .debug`Input updated with resourceId: ${result.resource.id}`;
-            } else {
-              ctx.logger
-                .debug`Input already has resourceId: ${input.resourceId}`;
-            }
-          }
         }
 
         // Handle data artifact persistence

--- a/src/cli/commands/model_search.ts
+++ b/src/cli/commands/model_search.ts
@@ -29,7 +29,6 @@ function toModelSearchItems(
     id: input.id,
     name: input.name,
     type: type.normalized,
-    resourceId: input.resourceId,
   }));
 }
 

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -11,7 +11,7 @@ import type { YamlDataRepository } from "../../infrastructure/persistence/yaml_d
 import type { FileSystemFileRepository } from "../../infrastructure/persistence/fs_file_repository.ts";
 import type { StreamingLogRepository } from "../../infrastructure/persistence/streaming_log_repository.ts";
 import type { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
-import { createModelResourceId } from "../models/model_resource.ts";
+import { inputIdToResourceId } from "../models/model_resource.ts";
 import { createModelDataId } from "../models/model_data.ts";
 import { createModelFileId } from "../models/model_file.ts";
 import { createModelLogId } from "../models/model_log.ts";
@@ -187,18 +187,16 @@ export class ModelResolver {
       },
     };
 
-    // Load resource if available
-    if (input.resourceId) {
-      const resourceId = createModelResourceId(input.resourceId);
-      const resource = await this.resourceRepo.findById(type, resourceId);
-      if (resource) {
-        data.resource = {
-          id: resource.id,
-          version: resource.version,
-          createdAt: resource.createdAt.toISOString(),
-          attributes: resource.attributes,
-        };
-      }
+    // Load resource if available (resource ID equals input ID by convention)
+    const resourceId = inputIdToResourceId(input.id);
+    const resource = await this.resourceRepo.findById(type, resourceId);
+    if (resource) {
+      data.resource = {
+        id: resource.id,
+        version: resource.version,
+        createdAt: resource.createdAt.toISOString(),
+        attributes: resource.attributes,
+      };
     }
 
     // Load data artifact if available
@@ -307,12 +305,12 @@ export class ModelResolver {
     // Try by name first
     const byName = await this.inputRepo.findByNameGlobal(modelRef);
     if (byName) {
-      const resource = byName.input.resourceId
-        ? await this.resourceRepo.findById(
-          byName.type,
-          createModelResourceId(byName.input.resourceId),
-        )
-        : undefined;
+      // Resource ID equals input ID by convention
+      const resourceId = inputIdToResourceId(byName.input.id);
+      const resource = await this.resourceRepo.findById(
+        byName.type,
+        resourceId,
+      );
       return {
         input: byName.input,
         type: byName.type,
@@ -324,12 +322,9 @@ export class ModelResolver {
     const allInputs = await this.inputRepo.findAllGlobal();
     for (const { input, type } of allInputs) {
       if (input.id === modelRef) {
-        const resource = input.resourceId
-          ? await this.resourceRepo.findById(
-            type,
-            createModelResourceId(input.resourceId),
-          )
-          : undefined;
+        // Resource ID equals input ID by convention
+        const resourceId = inputIdToResourceId(input.id);
+        const resource = await this.resourceRepo.findById(type, resourceId);
         return { input, type, resource: resource ?? undefined };
       }
     }

--- a/src/domain/models/aws/cloud_control_model.ts
+++ b/src/domain/models/aws/cloud_control_model.ts
@@ -7,7 +7,11 @@ import {
   GetResourceRequestStatusCommand,
 } from "@aws-sdk/client-cloudcontrol";
 import type { ModelType } from "../model_type.ts";
-import { createModelResourceId, ModelResource } from "../model_resource.ts";
+import {
+  createModelResourceId,
+  inputIdToResourceId,
+  ModelResource,
+} from "../model_resource.ts";
 import {
   defineModel,
   type FollowUpAction,
@@ -232,29 +236,33 @@ export abstract class AWSCloudControlModel<
     input: ModelInput,
     context: MethodContext,
   ): Promise<MethodResult> {
-    if (!input.resourceId) {
-      throw new Error("Cannot delete: no resource ID found in input");
-    }
-
     if (!context.resourceRepository) {
       throw new Error(
         "Cannot delete: resourceRepository not provided in context",
       );
     }
 
+    // Look up resource by input ID (convention: resource ID equals input ID)
+    const resourceId = inputIdToResourceId(input.id);
     const existingResource = await context.resourceRepository.findById(
       this.modelType,
-      createModelResourceId(input.id),
+      resourceId,
     );
 
-    let awsResourceId = input.resourceId;
-    if (existingResource) {
-      const extractedId = this.extractResourceIdentifier(
-        existingResource.attributes,
+    if (!existingResource) {
+      // No resource exists - nothing to delete
+      return this.createDeletedResult(input.id);
+    }
+
+    // Extract AWS resource identifier from resource attributes
+    const awsResourceId = this.extractResourceIdentifier(
+      existingResource.attributes,
+    );
+
+    if (!awsResourceId) {
+      throw new Error(
+        "Cannot delete: unable to extract AWS resource identifier from resource attributes",
       );
-      if (extractedId) {
-        awsResourceId = extractedId;
-      }
     }
 
     const client = this.createClient(context);

--- a/src/domain/models/aws/ec2/instance/ec2_instance_model_test.ts
+++ b/src/domain/models/aws/ec2/instance/ec2_instance_model_test.ts
@@ -150,7 +150,7 @@ Deno.test("EC2InstanceModel - sync method without RequestToken fails", async () 
   );
 });
 
-Deno.test("EC2InstanceModel - delete method without resource ID fails", async () => {
+Deno.test("EC2InstanceModel - delete method without resource returns deleted result", async () => {
   const input = ModelInput.create({
     name: "test-instance",
     attributes: {
@@ -159,15 +159,26 @@ Deno.test("EC2InstanceModel - delete method without resource ID fails", async ()
     },
   });
 
-  const context: MethodContext = {
-    repoDir: "/tmp/test-repo",
+  const mockResourceRepository: ResourceRepository = {
+    findById: () => Promise.resolve(null),
+    findAll: () => Promise.resolve([]),
+    save: () => Promise.resolve(),
+    delete: () => Promise.resolve(),
+    nextId: () => createModelResourceId("mock-id"),
+    getPath: () => "/mock/path",
   };
 
-  await assertRejects(
-    () => ec2InstanceModel.methods.delete.execute(input, context),
-    Error,
-    "Cannot delete: no resource ID found in input",
-  );
+  const context: MethodContext = {
+    repoDir: "/tmp/test-repo",
+    resourceRepository: mockResourceRepository,
+  };
+
+  const result = await ec2InstanceModel.methods.delete.execute(input, context);
+
+  // Should return success with deleteResource flag since no resource exists
+  assertEquals(result.resource?.attributes.OperationStatus, "SUCCESS");
+  assertEquals(result.resource?.attributes.DeletionCompleted, true);
+  assertEquals(result.deleteResource, true);
 });
 
 Deno.test("EC2InstanceModel - create method uses injected CloudControl client", async () => {
@@ -208,7 +219,6 @@ Deno.test("EC2InstanceModel - create method uses injected CloudControl client", 
 Deno.test("EC2InstanceModel - delete method requires resourceRepository", async () => {
   const input = ModelInput.create({
     name: "test-instance",
-    resourceId: "00000000-0000-4000-8000-000000000001", // Valid UUID
     attributes: {
       ImageId: "ami-12345678",
       InstanceType: "t2.micro",
@@ -264,9 +274,10 @@ Deno.test("EC2InstanceModel - sync method treats 'not found' as deleted", async 
 });
 
 Deno.test("EC2InstanceModel - delete method treats 'not found' as success", async () => {
+  const inputId = "00000000-0000-4000-8000-000000000001";
   const input = ModelInput.create({
+    id: inputId,
     name: "test-instance",
-    resourceId: "00000000-0000-4000-8000-000000000001",
     attributes: {
       ImageId: "ami-12345678",
       InstanceType: "t2.micro",
@@ -275,7 +286,7 @@ Deno.test("EC2InstanceModel - delete method treats 'not found' as success", asyn
 
   // Mock resource repository that returns an existing resource with InstanceId
   const existingResource = ModelResource.create({
-    id: "00000000-0000-4000-8000-000000000001",
+    id: inputId,
     attributes: {
       InstanceId: "i-1234567890abcdef0",
     },

--- a/src/domain/models/aws/ec2/subnet/ec2_subnet_model_test.ts
+++ b/src/domain/models/aws/ec2/subnet/ec2_subnet_model_test.ts
@@ -197,7 +197,7 @@ Deno.test("EC2SubnetModel - sync method without RequestToken fails", async () =>
   );
 });
 
-Deno.test("EC2SubnetModel - delete method without resource ID fails", async () => {
+Deno.test("EC2SubnetModel - delete method without resource returns deleted result", async () => {
   const input = ModelInput.create({
     name: "test-subnet",
     attributes: {
@@ -206,15 +206,26 @@ Deno.test("EC2SubnetModel - delete method without resource ID fails", async () =
     },
   });
 
-  const context: MethodContext = {
-    repoDir: "/tmp/test-repo",
+  const mockResourceRepository: ResourceRepository = {
+    findById: () => Promise.resolve(null),
+    findAll: () => Promise.resolve([]),
+    save: () => Promise.resolve(),
+    delete: () => Promise.resolve(),
+    nextId: () => createModelResourceId("mock-id"),
+    getPath: () => "/mock/path",
   };
 
-  await assertRejects(
-    () => ec2SubnetModel.methods.delete.execute(input, context),
-    Error,
-    "Cannot delete: no resource ID found in input",
-  );
+  const context: MethodContext = {
+    repoDir: "/tmp/test-repo",
+    resourceRepository: mockResourceRepository,
+  };
+
+  const result = await ec2SubnetModel.methods.delete.execute(input, context);
+
+  // Should return success with deleteResource flag since no resource exists
+  assertEquals(result.resource?.attributes.OperationStatus, "SUCCESS");
+  assertEquals(result.resource?.attributes.DeletionCompleted, true);
+  assertEquals(result.deleteResource, true);
 });
 
 Deno.test("EC2SubnetModel - create method uses injected CloudControl client", async () => {
@@ -255,7 +266,6 @@ Deno.test("EC2SubnetModel - create method uses injected CloudControl client", as
 Deno.test("EC2SubnetModel - delete method requires resourceRepository", async () => {
   const input = ModelInput.create({
     name: "test-subnet",
-    resourceId: "00000000-0000-4000-8000-000000000001",
     attributes: {
       VpcId: "vpc-12345678",
       CidrBlock: "10.0.1.0/24",
@@ -308,9 +318,10 @@ Deno.test("EC2SubnetModel - sync method treats 'not found' as deleted", async ()
 });
 
 Deno.test("EC2SubnetModel - delete method treats 'not found' as success", async () => {
+  const inputId = "00000000-0000-4000-8000-000000000001";
   const input = ModelInput.create({
+    id: inputId,
     name: "test-subnet",
-    resourceId: "00000000-0000-4000-8000-000000000001",
     attributes: {
       VpcId: "vpc-12345678",
       CidrBlock: "10.0.1.0/24",
@@ -318,7 +329,7 @@ Deno.test("EC2SubnetModel - delete method treats 'not found' as success", async 
   });
 
   const existingResource = ModelResource.create({
-    id: "00000000-0000-4000-8000-000000000001",
+    id: inputId,
     attributes: {
       SubnetId: "subnet-12345678",
     },

--- a/src/domain/models/aws/ec2/vpc/ec2_vpc_model_test.ts
+++ b/src/domain/models/aws/ec2/vpc/ec2_vpc_model_test.ts
@@ -132,7 +132,7 @@ Deno.test("EC2VpcModel - sync method without RequestToken fails", async () => {
   );
 });
 
-Deno.test("EC2VpcModel - delete method without resource ID fails", async () => {
+Deno.test("EC2VpcModel - delete method without resource returns deleted result", async () => {
   const input = ModelInput.create({
     name: "test-vpc",
     attributes: {
@@ -140,15 +140,26 @@ Deno.test("EC2VpcModel - delete method without resource ID fails", async () => {
     },
   });
 
-  const context: MethodContext = {
-    repoDir: "/tmp/test-repo",
+  const mockResourceRepository: ResourceRepository = {
+    findById: () => Promise.resolve(null),
+    findAll: () => Promise.resolve([]),
+    save: () => Promise.resolve(),
+    delete: () => Promise.resolve(),
+    nextId: () => createModelResourceId("mock-id"),
+    getPath: () => "/mock/path",
   };
 
-  await assertRejects(
-    () => ec2VpcModel.methods.delete.execute(input, context),
-    Error,
-    "Cannot delete: no resource ID found in input",
-  );
+  const context: MethodContext = {
+    repoDir: "/tmp/test-repo",
+    resourceRepository: mockResourceRepository,
+  };
+
+  const result = await ec2VpcModel.methods.delete.execute(input, context);
+
+  // Should return success with deleteResource flag since no resource exists
+  assertEquals(result.resource?.attributes.OperationStatus, "SUCCESS");
+  assertEquals(result.resource?.attributes.DeletionCompleted, true);
+  assertEquals(result.deleteResource, true);
 });
 
 Deno.test("EC2VpcModel - create method uses injected CloudControl client", async () => {
@@ -189,7 +200,6 @@ Deno.test("EC2VpcModel - create method uses injected CloudControl client", async
 Deno.test("EC2VpcModel - delete method requires resourceRepository", async () => {
   const input = ModelInput.create({
     name: "test-vpc",
-    resourceId: "00000000-0000-4000-8000-000000000001",
     attributes: {
       CidrBlock: "10.0.0.0/16",
     },
@@ -241,16 +251,17 @@ Deno.test("EC2VpcModel - sync method treats 'not found' as deleted", async () =>
 });
 
 Deno.test("EC2VpcModel - delete method treats 'not found' as success", async () => {
+  const inputId = "00000000-0000-4000-8000-000000000001";
   const input = ModelInput.create({
+    id: inputId,
     name: "test-vpc",
-    resourceId: "00000000-0000-4000-8000-000000000001",
     attributes: {
       CidrBlock: "10.0.0.0/16",
     },
   });
 
   const existingResource = ModelResource.create({
-    id: "00000000-0000-4000-8000-000000000001",
+    id: inputId,
     attributes: {
       VpcId: "vpc-12345678",
     },

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -165,7 +165,6 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
           id: input.id, // Use same input ID
           name: input.name,
           version: input.version,
-          resourceId: input.resourceId,
           tags: input.tags,
           attributes: currentResource.attributes, // Use resource attributes as input
         });

--- a/src/domain/models/model_input.ts
+++ b/src/domain/models/model_input.ts
@@ -17,7 +17,6 @@ export function createModelInputId(id: string): ModelInputId {
  */
 export const ModelInputSchema = z.object({
   id: z.string().uuid(),
-  resourceId: z.string().uuid().optional(),
   dataId: z.string().uuid().optional(),
   fileId: z.string().uuid().optional(),
   logId: z.string().uuid().optional(),
@@ -39,7 +38,6 @@ export interface CreateModelInputProps {
   id?: string;
   name: string;
   version?: number;
-  resourceId?: string;
   dataId?: string;
   fileId?: string;
   logId?: string;
@@ -56,7 +54,6 @@ export interface CreateModelInputProps {
 export class ModelInput {
   private constructor(
     readonly id: ModelInputId,
-    private _resourceId: string | undefined,
     private _dataId: string | undefined,
     private _fileId: string | undefined,
     private _logId: string | undefined,
@@ -78,7 +75,6 @@ export class ModelInput {
 
     const validated = ModelInputSchema.parse({
       id,
-      resourceId: props.resourceId,
       dataId: props.dataId,
       fileId: props.fileId,
       logId: props.logId,
@@ -90,7 +86,6 @@ export class ModelInput {
 
     return new ModelInput(
       createModelInputId(validated.id),
-      validated.resourceId,
       validated.dataId,
       validated.fileId,
       validated.logId,
@@ -111,7 +106,6 @@ export class ModelInput {
     const validated = ModelInputSchema.parse(data);
     return new ModelInput(
       createModelInputId(validated.id),
-      validated.resourceId,
       validated.dataId,
       validated.fileId,
       validated.logId,
@@ -120,13 +114,6 @@ export class ModelInput {
       validated.tags,
       validated.attributes,
     );
-  }
-
-  /**
-   * Returns the resource ID if one has been assigned.
-   */
-  get resourceId(): string | undefined {
-    return this._resourceId;
   }
 
   /**
@@ -162,13 +149,6 @@ export class ModelInput {
    */
   get attributes(): Record<string, unknown> {
     return { ...this._attributes };
-  }
-
-  /**
-   * Sets the resource ID for this input.
-   */
-  setResourceId(resourceId: string | undefined): void {
-    this._resourceId = resourceId;
   }
 
   /**
@@ -219,7 +199,6 @@ export class ModelInput {
   toData(): ModelInputData {
     return {
       id: this.id,
-      resourceId: this._resourceId,
       dataId: this._dataId,
       fileId: this._fileId,
       logId: this._logId,

--- a/src/domain/models/model_input_test.ts
+++ b/src/domain/models/model_input_test.ts
@@ -59,15 +59,6 @@ Deno.test("ModelInput.create throws on invalid version", () => {
   );
 });
 
-Deno.test("ModelInput.setResourceId updates resourceId", () => {
-  const input = ModelInput.create({ name: "test-input" });
-  assertEquals(input.resourceId, undefined);
-
-  const resourceId = "550e8400-e29b-41d4-a716-446655440001";
-  input.setResourceId(resourceId);
-  assertEquals(input.resourceId, resourceId);
-});
-
 Deno.test("ModelInput.setTag adds/updates tags", () => {
   const input = ModelInput.create({ name: "test-input" });
   input.setTag("env", "production");
@@ -102,12 +93,10 @@ Deno.test("ModelInput.toData returns correct structure", () => {
     tags: { env: "prod" },
     attributes: { message: "hello" },
   });
-  input.setResourceId("550e8400-e29b-41d4-a716-446655440001");
 
   const data = input.toData();
   assertEquals(data, {
     id: "550e8400-e29b-41d4-a716-446655440000",
-    resourceId: "550e8400-e29b-41d4-a716-446655440001",
     dataId: undefined,
     fileId: undefined,
     logId: undefined,
@@ -121,7 +110,6 @@ Deno.test("ModelInput.toData returns correct structure", () => {
 Deno.test("ModelInput.fromData reconstructs input correctly", () => {
   const data = {
     id: "550e8400-e29b-41d4-a716-446655440000",
-    resourceId: "550e8400-e29b-41d4-a716-446655440001",
     name: "test-input",
     version: 2,
     tags: { env: "prod" },
@@ -130,7 +118,6 @@ Deno.test("ModelInput.fromData reconstructs input correctly", () => {
 
   const input = ModelInput.fromData(data);
   assertEquals(input.id, data.id);
-  assertEquals(input.resourceId, data.resourceId);
   assertEquals(input.name, data.name);
   assertEquals(input.version, data.version);
   assertEquals(input.tags, data.tags);

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -248,19 +248,6 @@ export class DefaultStepExecutor implements StepExecutor {
           // Track artifact in output
           output.setResourceId(result.resource.id);
         }
-
-        // Update ORIGINAL input's resourceId (preserves expressions)
-        if (result.deleteResource) {
-          if (originalInput.resourceId) {
-            originalInput.setResourceId(undefined);
-            await inputRepo.save(modelType, originalInput);
-          }
-        } else {
-          if (!originalInput.resourceId) {
-            originalInput.setResourceId(result.resource.id);
-            await inputRepo.save(modelType, originalInput);
-          }
-        }
       }
 
       // Handle data artifact persistence

--- a/src/presentation/output/model_search_output.tsx
+++ b/src/presentation/output/model_search_output.tsx
@@ -11,7 +11,6 @@ export interface ModelSearchItem {
   id: string;
   name: string;
   type: string;
-  resourceId?: string;
 }
 
 /**

--- a/src/presentation/output/model_search_output_test.tsx
+++ b/src/presentation/output/model_search_output_test.tsx
@@ -21,7 +21,6 @@ const testModels: ModelSearchItem[] = [
     id: "660e8400-e29b-41d4-a716-446655440001",
     name: "test-echo-2",
     type: "swamp/echo",
-    resourceId: "770e8400-e29b-41d4-a716-446655440002",
   },
 ];
 
@@ -154,24 +153,6 @@ Deno.test("renderModelSearch with json mode outputs valid JSON", () => {
     assertEquals(parsed.results.length, 2);
     assertEquals(parsed.results[0].name, "test-echo-1");
     assertEquals(parsed.results[1].name, "test-echo-2");
-  } finally {
-    console.log = originalLog;
-  }
-});
-
-Deno.test("renderModelSearch with json mode includes resourceId when present", () => {
-  const logs: string[] = [];
-  const originalLog = console.log;
-  console.log = (msg: string) => logs.push(msg);
-
-  try {
-    renderModelSearch(testData, "json");
-    const parsed = JSON.parse(logs[0]);
-    assertEquals(parsed.results[0].resourceId, undefined);
-    assertEquals(
-      parsed.results[1].resourceId,
-      "770e8400-e29b-41d4-a716-446655440002",
-    );
   } finally {
     console.log = originalLog;
   }


### PR DESCRIPTION
- Remove `resourceId` field from `ModelInput` domain entity
- Adopt convention-based linking: resource ID always equals input ID
- Use existing `inputIdToResourceId()` helper consistently across all code paths
- Update AWS CloudControl delete operations to gracefully handle missing resources

## Changes

**Domain Model:**
- Remove `resourceId` from `ModelInputSchema`, props, constructor, getter, setter, and serialization
- Delete `setResourceId()` method

**Execution Paths:**
- Remove resourceId updates in `model_method_run.ts` after method execution
- Remove resourceId updates in `execution_service.ts` during workflow execution
- Remove resourceId from `method_execution_service.ts` follow-up actions

**Resource Resolution:**
- Update `model_resolver.ts` to use `inputIdToResourceId(input.id)` for resource lookups
- Simplify `resolveModel()` to always derive resource ID from input ID

**AWS CloudControl:**
- Change delete behavior: instead of throwing when no resource exists, return "deleted" result
- Look up resource by derived ID and extract AWS identifier from attributes

**Display Commands:**
- Remove resourceId from model search and edit item mappings

## Test plan

- [x] All 1178 tests pass
- [x] `deno check` - Type checking passes
- [x] `deno lint` - No lint errors
- [x] `deno fmt` - Properly formatted
- [x] `deno run compile` - Binary compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)