### PR TITLE
feat: add extension models and improve workflow data context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 dev-logs/*
 swamp
 
+# Local swamp repo data
+.swamp.yaml
+workflows/
+workflows-evaluated/
+resources/
+
 # Generated/runtime data (ignored)
 .data/data/
 .data/outputs/

--- a/deno.json
+++ b/deno.json
@@ -34,5 +34,5 @@
     "jsx": "react",
     "strict": true
   },
-  "exclude": ["experiments/"]
+  "exclude": ["experiments/webapp/"]
 }

--- a/experiments/extensions/models/anthropic_claude.ts
+++ b/experiments/extensions/models/anthropic_claude.ts
@@ -1,0 +1,152 @@
+import { z } from "zod";
+import { ModelType } from "../../../src/domain/models/model_type.ts";
+import { ModelData } from "../../../src/domain/models/model_data.ts";
+import {
+  defineModel,
+  type MethodContext,
+  type MethodResult,
+} from "../../../src/domain/models/model.ts";
+import type { ModelInput } from "../../../src/domain/models/model_input.ts";
+
+/**
+ * Schema for Anthropic Claude model input attributes.
+ */
+const InputAttributesSchema = z.object({
+  /** The user prompt to send to Claude */
+  prompt: z.string().min(1),
+  /** Optional system prompt */
+  systemPrompt: z.string().optional(),
+  /** Maximum tokens to generate (default: 4096) */
+  maxTokens: z.number().int().positive().default(4096),
+  /** Model to use (default: claude-sonnet-4-20250514) */
+  model: z.string().default("claude-sonnet-4-20250514"),
+});
+
+type InputAttributes = z.infer<typeof InputAttributesSchema>;
+
+/**
+ * Schema for Anthropic Claude model data attributes.
+ */
+const DataAttributesSchema = z.object({
+  /** The generated response text */
+  response: z.string(),
+  /** Number of input tokens used */
+  inputTokens: z.number().int().nonnegative(),
+  /** Number of output tokens generated */
+  outputTokens: z.number().int().nonnegative(),
+  /** Model used for generation */
+  model: z.string(),
+  /** Timestamp when generation completed */
+  generatedAt: z.string().datetime(),
+});
+
+interface ContentBlock {
+  type: string;
+  text?: string;
+}
+
+interface ClaudeResponse {
+  content: ContentBlock[];
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+  };
+  model: string;
+}
+
+/**
+ * Calls the Anthropic Messages API.
+ */
+async function callClaude(attrs: InputAttributes): Promise<ClaudeResponse> {
+  const apiKey = Deno.env.get("ANTHROPIC_API_KEY");
+  if (!apiKey) {
+    throw new Error("ANTHROPIC_API_KEY environment variable is required");
+  }
+
+  const messages = [{ role: "user", content: attrs.prompt }];
+
+  const body: {
+    model: string;
+    max_tokens: number;
+    messages: Array<{ role: string; content: string }>;
+    system?: string;
+  } = {
+    model: attrs.model,
+    max_tokens: attrs.maxTokens,
+    messages,
+  };
+
+  if (attrs.systemPrompt) {
+    body.system = attrs.systemPrompt;
+  }
+
+  const response = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(
+      `Anthropic API error: ${response.status} ${response.statusText} - ${errorBody}`,
+    );
+  }
+
+  return await response.json();
+}
+
+/**
+ * Execute the generate method.
+ */
+async function executeGenerate(
+  input: ModelInput,
+  _context: MethodContext,
+): Promise<MethodResult> {
+  const attrs = InputAttributesSchema.parse(input.attributes);
+  const result = await callClaude(attrs);
+
+  // Extract text from content blocks
+  const responseText = result.content
+    .filter((block: ContentBlock) => block.type === "text")
+    .map((block: ContentBlock) => block.text ?? "")
+    .join("");
+
+  const data = ModelData.create({
+    id: input.id,
+    attributes: {
+      response: responseText,
+      inputTokens: result.usage.input_tokens,
+      outputTokens: result.usage.output_tokens,
+      model: result.model,
+      generatedAt: new Date().toISOString(),
+    },
+  });
+
+  return { data };
+}
+
+/**
+ * Anthropic Claude model definition.
+ *
+ * Calls the Anthropic Messages API to generate text with Claude.
+ * Supports system prompts, configurable max tokens, and model selection.
+ * Returns the response text and token usage.
+ */
+export const anthropicClaudeModel = defineModel({
+  type: ModelType.create("anthropic/claude"),
+  version: 1,
+  inputAttributesSchema: InputAttributesSchema,
+  dataAttributesSchema: DataAttributesSchema,
+  methods: {
+    generate: {
+      description: "Generate a response using Claude",
+      inputAttributesSchema: InputAttributesSchema,
+      execute: executeGenerate,
+    },
+  },
+});

--- a/experiments/extensions/models/digitalocean_app.ts
+++ b/experiments/extensions/models/digitalocean_app.ts
@@ -1,0 +1,597 @@
+import { z } from "zod";
+import { parse as parseYaml } from "@std/yaml";
+import { ModelType } from "../../../src/domain/models/model_type.ts";
+import {
+  createModelResourceId,
+  ModelResource,
+} from "../../../src/domain/models/model_resource.ts";
+import { ModelData } from "../../../src/domain/models/model_data.ts";
+import {
+  defineModel,
+  type MethodContext,
+  type MethodResult,
+} from "../../../src/domain/models/model.ts";
+import type { ModelInput } from "../../../src/domain/models/model_input.ts";
+
+/**
+ * Schema for DigitalOcean App model input attributes.
+ */
+const InputAttributesSchema = z.object({
+  /** App name */
+  name: z.string().min(1),
+  /** Region (e.g., "nyc", "sfo", "ams") */
+  region: z.string().min(1).optional(),
+  /** App spec as YAML string */
+  spec: z.string().min(1),
+});
+
+/**
+ * Schema for update method input - only needs spec (appId comes from resource).
+ */
+const UpdateInputSchema = z.object({
+  /** App spec as YAML string */
+  spec: z.string().min(1),
+});
+
+/**
+ * Schema for sync/delete methods - no attributes needed (appId comes from resource).
+ */
+const EmptyInputSchema = z.object({});
+
+/**
+ * Schema for listJobInvocations method input.
+ */
+const ListJobInvocationsInputSchema = z.object({
+  /** Filter by job name */
+  jobName: z.string().optional(),
+  /** Filter by deployment ID */
+  deploymentId: z.string().optional(),
+});
+
+/**
+ * Schema for getJobInvocation method input.
+ */
+const GetJobInvocationInputSchema = z.object({
+  /** The invocation ID to fetch */
+  invocationId: z.string().min(1),
+});
+
+/**
+ * Schema for getJobLogs method input.
+ */
+const GetJobLogsInputSchema = z.object({
+  /** The invocation ID */
+  invocationId: z.string().min(1),
+  /** The component name (job name) */
+  componentName: z.string().min(1),
+  /** Log type: "build" or "run" (default: "run") */
+  logType: z.enum(["build", "run"]).default("run"),
+  /** Number of log lines to tail */
+  tail: z.number().positive().optional(),
+});
+
+/**
+ * Schema for DigitalOcean App model resource attributes.
+ */
+const ResourceAttributesSchema = z.object({
+  /** App ID */
+  id: z.string().uuid(),
+  /** Default ingress URL */
+  defaultIngress: z.string().nullable(),
+  /** Active deployment ID */
+  activeDeploymentId: z.string().nullable(),
+  /** App creation timestamp */
+  createdAt: z.string().datetime(),
+  /** Last update timestamp */
+  updatedAt: z.string().datetime(),
+  /** App name */
+  name: z.string(),
+  /** Region */
+  region: z.string().nullable(),
+});
+
+interface AppResponse {
+  id: string;
+  default_ingress?: string;
+  active_deployment?: { id: string };
+  created_at: string;
+  updated_at: string;
+  spec: {
+    name: string;
+    region?: string;
+  };
+}
+
+/**
+ * App spec structure from YAML.
+ */
+interface AppSpec {
+  name: string;
+  region?: string;
+}
+
+/**
+ * Parses a YAML spec string into an AppSpec object.
+ */
+function parseYamlSpec(spec: string): AppSpec {
+  return parseYaml(spec) as AppSpec;
+}
+
+/**
+ * Gets the DigitalOcean app ID from the stored resource.
+ */
+async function getAppIdFromResource(
+  input: ModelInput,
+  context: MethodContext,
+): Promise<string> {
+  if (!context.resourceRepository) {
+    throw new Error(
+      "Cannot operate: resourceRepository not provided in context",
+    );
+  }
+
+  const resource = await context.resourceRepository.findById(
+    ModelType.create("digitalocean/app"),
+    createModelResourceId(input.id),
+  );
+
+  if (!resource) {
+    throw new Error(
+      `Resource not found for input ID: ${input.id}. Run 'create' first.`,
+    );
+  }
+
+  const appId = resource.attributes.id as string;
+  if (!appId) {
+    throw new Error("Resource missing 'id' attribute (DO app ID)");
+  }
+
+  return appId;
+}
+
+/**
+ * Gets an app by name from the list of apps.
+ */
+async function getAppByName(name: string): Promise<AppResponse> {
+  const output = await runDoctl(["apps", "list"]);
+  const apps = JSON.parse(output) as AppResponse[];
+  const app = apps.find((a) => a.spec?.name === name);
+  if (!app) {
+    throw new Error(`App '${name}' not found after creation`);
+  }
+  return app;
+}
+
+/**
+ * Runs a doctl command and returns the JSON output.
+ */
+async function runDoctl(args: string[]): Promise<string> {
+  const command = new Deno.Command("doctl", {
+    args: [...args, "--output", "json"],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const output = await command.output();
+  const stdout = new TextDecoder().decode(output.stdout);
+
+  if (!output.success) {
+    // doctl outputs JSON errors to stdout when using --output json
+    const stderr = new TextDecoder().decode(output.stderr);
+    const errorMsg = stdout || stderr || "unknown error";
+    throw new Error(`doctl command failed: ${errorMsg}`);
+  }
+
+  return stdout;
+}
+
+/**
+ * Runs a doctl command and returns raw text output (for commands that don't support JSON).
+ */
+async function runDoctlText(args: string[]): Promise<string> {
+  const command = new Deno.Command("doctl", {
+    args,
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const output = await command.output();
+  const stdout = new TextDecoder().decode(output.stdout);
+
+  if (!output.success) {
+    const stderr = new TextDecoder().decode(output.stderr);
+    const errorMsg = stdout || stderr || "unknown error";
+    throw new Error(`doctl command failed: ${errorMsg}`);
+  }
+
+  return stdout;
+}
+
+/**
+ * Gets the DO API token from doctl config.
+ */
+async function getDoctlToken(): Promise<string> {
+  const homeDir = Deno.env.get("HOME") || "~";
+  const configPath = `${homeDir}/.config/doctl/config.yaml`;
+  const configContent = await Deno.readTextFile(configPath);
+  const match = configContent.match(/access-token:\s*(\S+)/);
+  if (!match) {
+    throw new Error("Could not find access-token in doctl config");
+  }
+  return match[1];
+}
+
+/**
+ * Calls the DigitalOcean API directly (workaround for doctl bugs).
+ */
+async function callDoApi(endpoint: string): Promise<string> {
+  const token = await getDoctlToken();
+  const command = new Deno.Command("curl", {
+    args: [
+      "-s",
+      `https://api.digitalocean.com/v2${endpoint}`,
+      "-H",
+      `Authorization: Bearer ${token}`,
+    ],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const output = await command.output();
+  const stdout = new TextDecoder().decode(output.stdout);
+
+  if (!output.success) {
+    const stderr = new TextDecoder().decode(output.stderr);
+    throw new Error(`DO API call failed: ${stderr}`);
+  }
+
+  return stdout;
+}
+
+/**
+ * Creates a temporary file with the spec content.
+ */
+async function withTempSpec<T>(
+  spec: string,
+  fn: (specPath: string) => Promise<T>,
+): Promise<T> {
+  const tempDir = await Deno.makeTempDir();
+  const specPath = `${tempDir}/app-spec.yaml`;
+
+  try {
+    await Deno.writeTextFile(specPath, spec);
+    return await fn(specPath);
+  } finally {
+    try {
+      await Deno.remove(tempDir, { recursive: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+}
+
+/**
+ * Parses doctl app JSON response into resource attributes.
+ */
+function parseAppResponse(app: AppResponse) {
+  return {
+    id: app.id,
+    defaultIngress: app.default_ingress || null,
+    activeDeploymentId: app.active_deployment?.id || null,
+    createdAt: app.created_at,
+    updatedAt: app.updated_at,
+    name: app.spec.name,
+    region: app.spec.region || null,
+  };
+}
+
+/**
+ * Job invocation response from DO API.
+ */
+interface JobInvocationApi {
+  id: string;
+  job_name: string;
+  deployment_id: string;
+  phase: string;
+  trigger: {
+    type: string;
+  };
+  created_at: string;
+  started_at?: string;
+  completed_at?: string;
+  progress?: {
+    steps: Array<{
+      name: string;
+      status: string;
+      reason?: {
+        code: string;
+        message: string;
+      };
+    }>;
+  };
+}
+
+/**
+ * Job invocations API response wrapper.
+ */
+interface JobInvocationsResponse {
+  job_invocations: JobInvocationApi[];
+}
+
+/**
+ * Execute the listJobInvocations method.
+ * Note: Uses direct API call due to doctl bug returning null.
+ */
+async function executeListJobInvocations(
+  input: ModelInput,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const attrs = ListJobInvocationsInputSchema.parse(input.attributes);
+  const appId = await getAppIdFromResource(input, context);
+
+  // Build query params
+  const params = new URLSearchParams();
+  if (attrs.jobName) {
+    params.append("job_names", attrs.jobName);
+  }
+  if (attrs.deploymentId) {
+    params.append("deployment_ids", attrs.deploymentId);
+  }
+
+  const queryString = params.toString();
+  const endpoint = `/apps/${appId}/job-invocations${
+    queryString ? `?${queryString}` : ""
+  }`;
+  const output = await callDoApi(endpoint);
+  const response = JSON.parse(output) as JobInvocationsResponse;
+  const invocations = response.job_invocations ?? [];
+
+  const data = ModelData.create({
+    id: input.id,
+    attributes: {
+      invocations: invocations.map((inv) => ({
+        id: inv.id,
+        jobName: inv.job_name,
+        deploymentId: inv.deployment_id,
+        phase: inv.phase,
+        triggerType: inv.trigger.type,
+        createdAt: inv.created_at,
+        startedAt: inv.started_at,
+        completedAt: inv.completed_at,
+        errorCode: inv.progress?.steps?.[0]?.reason?.code,
+        errorMessage: inv.progress?.steps?.[0]?.reason?.message,
+      })),
+      fetchedAt: new Date().toISOString(),
+    },
+  });
+
+  return { data };
+}
+
+/**
+ * Execute the getJobInvocation method.
+ * Note: Uses direct API call due to doctl bug.
+ */
+async function executeGetJobInvocation(
+  input: ModelInput,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const attrs = GetJobInvocationInputSchema.parse(input.attributes);
+  const appId = await getAppIdFromResource(input, context);
+
+  const endpoint = `/apps/${appId}/job-invocations/${attrs.invocationId}`;
+  const output = await callDoApi(endpoint);
+  const response = JSON.parse(output) as { job_invocation: JobInvocationApi };
+  const inv = response.job_invocation;
+
+  const data = ModelData.create({
+    id: input.id,
+    attributes: {
+      id: inv.id,
+      jobName: inv.job_name,
+      deploymentId: inv.deployment_id,
+      phase: inv.phase,
+      triggerType: inv.trigger.type,
+      createdAt: inv.created_at,
+      startedAt: inv.started_at,
+      completedAt: inv.completed_at,
+      errorCode: inv.progress?.steps?.[0]?.reason?.code,
+      errorMessage: inv.progress?.steps?.[0]?.reason?.message,
+      fetchedAt: new Date().toISOString(),
+    },
+  });
+
+  return { data };
+}
+
+/**
+ * Execute the getJobLogs method.
+ */
+async function executeGetJobLogs(
+  input: ModelInput,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const attrs = GetJobLogsInputSchema.parse(input.attributes);
+  const appId = await getAppIdFromResource(input, context);
+
+  const args = [
+    "apps",
+    "logs",
+    appId,
+    attrs.componentName,
+    "--job-invocation",
+    attrs.invocationId,
+    "--type",
+    attrs.logType,
+  ];
+
+  if (attrs.tail) {
+    args.push("--tail", attrs.tail.toString());
+  }
+
+  const logs = await runDoctlText(args);
+
+  const data = ModelData.create({
+    id: input.id,
+    attributes: {
+      logs,
+      invocationId: attrs.invocationId,
+      componentName: attrs.componentName,
+      logType: attrs.logType,
+      fetchedAt: new Date().toISOString(),
+    },
+  });
+
+  return { data };
+}
+
+/**
+ * Execute the create method.
+ *
+ * Note: `doctl apps create` returns a deployment object, not an app object.
+ * We need to fetch the actual app by name after creation.
+ */
+async function executeCreate(
+  input: ModelInput,
+  _context: MethodContext,
+): Promise<MethodResult> {
+  const attrs = InputAttributesSchema.parse(input.attributes);
+
+  // Create returns a deployment, not an app - we ignore the output
+  await withTempSpec(attrs.spec, async (specPath: string) => {
+    await runDoctl(["apps", "create", "--spec", specPath]);
+  });
+
+  // Get the actual app by name from the spec
+  const specObj = parseYamlSpec(attrs.spec);
+  const app = await getAppByName(specObj.name);
+
+  const resource = ModelResource.create({
+    id: input.id,
+    attributes: parseAppResponse(app),
+  });
+
+  return { resource };
+}
+
+/**
+ * Execute the update method.
+ *
+ * Note: `doctl apps update` returns inconsistent data structures.
+ * We fetch fresh app state using `doctl apps get` after update.
+ */
+async function executeUpdate(
+  input: ModelInput,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const attrs = UpdateInputSchema.parse(input.attributes);
+  const appId = await getAppIdFromResource(input, context);
+
+  // Update the app - ignore the inconsistent response
+  await withTempSpec(attrs.spec, async (specPath: string) => {
+    await runDoctl(["apps", "update", appId, "--spec", specPath]);
+  });
+
+  // Get fresh app state (doctl apps get returns an array)
+  const output = await runDoctl(["apps", "get", appId]);
+  const apps = JSON.parse(output) as AppResponse[];
+  const app = apps[0];
+  if (!app) {
+    throw new Error(`App '${appId}' not found after update`);
+  }
+
+  return {
+    resource: ModelResource.create({
+      id: input.id,
+      attributes: parseAppResponse(app),
+    }),
+  };
+}
+
+/**
+ * Execute the delete method.
+ */
+async function executeDelete(
+  input: ModelInput,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const appId = await getAppIdFromResource(input, context);
+  await runDoctl(["apps", "delete", appId, "--force"]);
+  return { deleteResource: true };
+}
+
+/**
+ * Execute the sync method.
+ */
+async function executeSync(
+  input: ModelInput,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const appId = await getAppIdFromResource(input, context);
+
+  // doctl apps get returns an array
+  const output = await runDoctl(["apps", "get", appId]);
+  const apps = JSON.parse(output) as AppResponse[];
+  const app = apps[0];
+  if (!app) {
+    throw new Error(`App '${appId}' not found`);
+  }
+
+  return {
+    resource: ModelResource.create({
+      id: input.id,
+      attributes: parseAppResponse(app),
+    }),
+  };
+}
+
+/**
+ * DigitalOcean App model definition.
+ *
+ * Wraps doctl apps commands to manage DigitalOcean App Platform applications.
+ * Requires doctl to be installed and authenticated (doctl auth init).
+ */
+export const digitaloceanAppModel = defineModel({
+  type: ModelType.create("digitalocean/app"),
+  version: 1,
+  inputAttributesSchema: InputAttributesSchema,
+  resourceAttributesSchema: ResourceAttributesSchema,
+  methods: {
+    create: {
+      description: "Create a new DigitalOcean App Platform application",
+      inputAttributesSchema: InputAttributesSchema,
+      execute: executeCreate,
+    },
+    update: {
+      description: "Update an existing DigitalOcean App Platform application",
+      inputAttributesSchema: UpdateInputSchema,
+      execute: executeUpdate,
+    },
+    delete: {
+      description: "Delete a DigitalOcean App Platform application",
+      inputAttributesSchema: EmptyInputSchema,
+      execute: executeDelete,
+    },
+    sync: {
+      description:
+        "Sync the current state of a DigitalOcean App Platform application",
+      inputAttributesSchema: EmptyInputSchema,
+      execute: executeSync,
+    },
+    listJobInvocations: {
+      description: "List recent job invocations for the app",
+      inputAttributesSchema: ListJobInvocationsInputSchema,
+      execute: executeListJobInvocations,
+    },
+    getJobInvocation: {
+      description: "Get details of a specific job invocation",
+      inputAttributesSchema: GetJobInvocationInputSchema,
+      execute: executeGetJobInvocation,
+    },
+    getJobLogs: {
+      description: "Get logs for a job invocation",
+      inputAttributesSchema: GetJobLogsInputSchema,
+      execute: executeGetJobLogs,
+    },
+  },
+});

--- a/experiments/extensions/models/digitalocean_droplet.ts
+++ b/experiments/extensions/models/digitalocean_droplet.ts
@@ -1,0 +1,391 @@
+import { z } from "zod";
+import { ModelType } from "../../../src/domain/models/model_type.ts";
+import {
+  createModelResourceId,
+  ModelResource,
+} from "../../../src/domain/models/model_resource.ts";
+import {
+  defineModel,
+  type MethodContext,
+  type MethodResult,
+} from "../../../src/domain/models/model.ts";
+import type { ModelInput } from "../../../src/domain/models/model_input.ts";
+
+/**
+ * Schema for DigitalOcean Droplet model input attributes.
+ */
+const InputAttributesSchema = z.object({
+  /** Droplet name */
+  name: z.string().min(1),
+  /** Region (e.g., "sfo3", "nyc3") */
+  region: z.string().min(1),
+  /** Size slug (e.g., "s-1vcpu-1gb") */
+  size: z.string().min(1),
+  /** Image slug (defaults to Docker on Ubuntu 20.04) */
+  image: z.string().default("docker-20-04"),
+  /** SSH key IDs or fingerprints */
+  sshKeys: z.array(z.string()).optional(),
+  /** Enable monitoring */
+  enableMonitoring: z.boolean().default(true),
+  /** Enable backups */
+  enableBackups: z.boolean().default(false),
+  /** Cloud-init user data script */
+  userData: z.string().optional(),
+  /** Tags to apply to the Droplet */
+  tags: z.array(z.string()).optional(),
+});
+
+/**
+ * Schema for sync/delete/action methods - no attributes needed (dropletId comes from resource).
+ */
+const EmptyInputSchema = z.object({});
+
+/**
+ * Schema for DigitalOcean Droplet model resource attributes.
+ */
+const ResourceAttributesSchema = z.object({
+  /** Droplet ID */
+  id: z.number(),
+  /** Droplet name */
+  name: z.string(),
+  /** Status (e.g., "new", "active", "off") */
+  status: z.string(),
+  /** Memory in MB */
+  memory: z.number(),
+  /** Number of vCPUs */
+  vcpus: z.number(),
+  /** Disk size in GB */
+  disk: z.number(),
+  /** Region slug */
+  region: z.string(),
+  /** Image slug or name */
+  image: z.string(),
+  /** Size slug */
+  sizeSlug: z.string(),
+  /** Public IPv4 address */
+  publicIpv4: z.string().nullable(),
+  /** Private IPv4 address */
+  privateIpv4: z.string().nullable(),
+  /** Creation timestamp */
+  createdAt: z.string(),
+  /** VPC UUID */
+  vpcUuid: z.string().nullable(),
+});
+
+interface NetworkInfo {
+  ip_address: string;
+  type: "public" | "private";
+}
+
+interface DropletResponse {
+  id: number;
+  name: string;
+  status: string;
+  memory: number;
+  vcpus: number;
+  disk: number;
+  region: { slug: string };
+  image: { slug?: string; name: string };
+  size_slug: string;
+  networks: {
+    v4: NetworkInfo[];
+  };
+  created_at: string;
+  vpc_uuid?: string;
+}
+
+/**
+ * Gets the DigitalOcean Droplet ID from the stored resource.
+ */
+async function getDropletIdFromResource(
+  input: ModelInput,
+  context: MethodContext,
+): Promise<number> {
+  if (!context.resourceRepository) {
+    throw new Error(
+      "Cannot operate: resourceRepository not provided in context",
+    );
+  }
+
+  const resource = await context.resourceRepository.findById(
+    ModelType.create("digitalocean/droplet"),
+    createModelResourceId(input.id),
+  );
+
+  if (!resource) {
+    throw new Error(
+      `Resource not found for input ID: ${input.id}. Run 'create' first.`,
+    );
+  }
+
+  const dropletId = resource.attributes.id as number;
+  if (!dropletId) {
+    throw new Error("Resource missing 'id' attribute (DO Droplet ID)");
+  }
+
+  return dropletId;
+}
+
+/**
+ * Runs a doctl command and returns the JSON output.
+ */
+async function runDoctl(args: string[]): Promise<string> {
+  const command = new Deno.Command("doctl", {
+    args: [...args, "--output", "json"],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const output = await command.output();
+  const stdout = new TextDecoder().decode(output.stdout);
+
+  if (!output.success) {
+    const stderr = new TextDecoder().decode(output.stderr);
+    const errorMsg = stdout || stderr || "unknown error";
+    throw new Error(`doctl command failed: ${errorMsg}`);
+  }
+
+  return stdout;
+}
+
+/**
+ * Parses doctl Droplet JSON response into resource attributes.
+ */
+function parseDropletResponse(droplet: DropletResponse) {
+  return {
+    id: droplet.id,
+    name: droplet.name,
+    status: droplet.status,
+    memory: droplet.memory,
+    vcpus: droplet.vcpus,
+    disk: droplet.disk,
+    region: droplet.region.slug,
+    image: droplet.image.slug || droplet.image.name,
+    sizeSlug: droplet.size_slug,
+    publicIpv4:
+      droplet.networks.v4.find((n) => n.type === "public")?.ip_address || null,
+    privateIpv4:
+      droplet.networks.v4.find((n) => n.type === "private")?.ip_address || null,
+    createdAt: droplet.created_at,
+    vpcUuid: droplet.vpc_uuid || null,
+  };
+}
+
+/**
+ * Execute the create method.
+ */
+async function executeCreate(
+  input: ModelInput,
+  _context: MethodContext,
+): Promise<MethodResult> {
+  const attrs = InputAttributesSchema.parse(input.attributes);
+
+  const args = [
+    "compute",
+    "droplet",
+    "create",
+    attrs.name,
+    "--size",
+    attrs.size,
+    "--image",
+    attrs.image,
+    "--region",
+    attrs.region,
+    "--wait",
+  ];
+
+  if (attrs.sshKeys && attrs.sshKeys.length > 0) {
+    args.push("--ssh-keys", attrs.sshKeys.join(","));
+  }
+
+  if (attrs.enableMonitoring) {
+    args.push("--enable-monitoring");
+  }
+
+  if (attrs.enableBackups) {
+    args.push("--enable-backups");
+  }
+
+  if (attrs.userData) {
+    args.push("--user-data", attrs.userData);
+  }
+
+  if (attrs.tags && attrs.tags.length > 0) {
+    args.push("--tag-names", attrs.tags.join(","));
+  }
+
+  const output = await runDoctl(args);
+
+  const droplets = JSON.parse(output) as DropletResponse[];
+  const droplet = droplets[0];
+  if (!droplet) {
+    throw new Error("Droplet not found in create response");
+  }
+
+  const resource = ModelResource.create({
+    id: input.id,
+    attributes: parseDropletResponse(droplet),
+  });
+
+  return { resource };
+}
+
+/**
+ * Execute the delete method.
+ */
+async function executeDelete(
+  input: ModelInput,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const dropletId = await getDropletIdFromResource(input, context);
+  await runDoctl([
+    "compute",
+    "droplet",
+    "delete",
+    dropletId.toString(),
+    "--force",
+  ]);
+  return { deleteResource: true };
+}
+
+/**
+ * Execute the sync method.
+ */
+async function executeSync(
+  input: ModelInput,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const dropletId = await getDropletIdFromResource(input, context);
+
+  const output = await runDoctl([
+    "compute",
+    "droplet",
+    "get",
+    dropletId.toString(),
+  ]);
+  const droplets = JSON.parse(output) as DropletResponse[];
+  const droplet = droplets[0];
+  if (!droplet) {
+    throw new Error(`Droplet '${dropletId}' not found`);
+  }
+
+  return {
+    resource: ModelResource.create({
+      id: input.id,
+      attributes: parseDropletResponse(droplet),
+    }),
+  };
+}
+
+/**
+ * Execute a droplet action (power-on, power-off, reboot).
+ */
+async function executeAction(
+  action: "power-on" | "power-off" | "reboot",
+  input: ModelInput,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const dropletId = await getDropletIdFromResource(input, context);
+
+  await runDoctl([
+    "compute",
+    "droplet-action",
+    action,
+    dropletId.toString(),
+  ]);
+
+  // Fetch updated state after action
+  const output = await runDoctl([
+    "compute",
+    "droplet",
+    "get",
+    dropletId.toString(),
+  ]);
+  const droplets = JSON.parse(output) as DropletResponse[];
+  const droplet = droplets[0];
+  if (!droplet) {
+    throw new Error(`Droplet '${dropletId}' not found after ${action}`);
+  }
+
+  return {
+    resource: ModelResource.create({
+      id: input.id,
+      attributes: parseDropletResponse(droplet),
+    }),
+  };
+}
+
+/**
+ * Execute the power-on method.
+ */
+function executePowerOn(
+  input: ModelInput,
+  context: MethodContext,
+): Promise<MethodResult> {
+  return executeAction("power-on", input, context);
+}
+
+/**
+ * Execute the power-off method.
+ */
+function executePowerOff(
+  input: ModelInput,
+  context: MethodContext,
+): Promise<MethodResult> {
+  return executeAction("power-off", input, context);
+}
+
+/**
+ * Execute the reboot method.
+ */
+function executeReboot(
+  input: ModelInput,
+  context: MethodContext,
+): Promise<MethodResult> {
+  return executeAction("reboot", input, context);
+}
+
+/**
+ * DigitalOcean Droplet model definition.
+ *
+ * Wraps doctl compute droplet commands to manage Droplets on DigitalOcean.
+ * Requires doctl to be installed and authenticated (doctl auth init).
+ */
+export const digitaloceanDropletModel = defineModel({
+  type: ModelType.create("digitalocean/droplet"),
+  version: 1,
+  inputAttributesSchema: InputAttributesSchema,
+  resourceAttributesSchema: ResourceAttributesSchema,
+  methods: {
+    create: {
+      description: "Create a new DigitalOcean Droplet",
+      inputAttributesSchema: InputAttributesSchema,
+      execute: executeCreate,
+    },
+    delete: {
+      description: "Destroy a DigitalOcean Droplet",
+      inputAttributesSchema: EmptyInputSchema,
+      execute: executeDelete,
+    },
+    sync: {
+      description: "Sync the current state of a Droplet",
+      inputAttributesSchema: EmptyInputSchema,
+      execute: executeSync,
+    },
+    "power-on": {
+      description: "Power on a Droplet",
+      inputAttributesSchema: EmptyInputSchema,
+      execute: executePowerOn,
+    },
+    "power-off": {
+      description: "Power off a Droplet",
+      inputAttributesSchema: EmptyInputSchema,
+      execute: executePowerOff,
+    },
+    reboot: {
+      description: "Reboot a Droplet",
+      inputAttributesSchema: EmptyInputSchema,
+      execute: executeReboot,
+    },
+  },
+});

--- a/experiments/extensions/models/digitalocean_ssh_key.ts
+++ b/experiments/extensions/models/digitalocean_ssh_key.ts
@@ -1,0 +1,263 @@
+import { z } from "zod";
+import { ModelType } from "../../../src/domain/models/model_type.ts";
+import {
+  createModelResourceId,
+  ModelResource,
+} from "../../../src/domain/models/model_resource.ts";
+import {
+  defineModel,
+  type MethodContext,
+  type MethodResult,
+} from "../../../src/domain/models/model.ts";
+import type { ModelInput } from "../../../src/domain/models/model_input.ts";
+
+/**
+ * Schema for DigitalOcean SSH Key model input attributes.
+ */
+const InputAttributesSchema = z.object({
+  /** SSH key name */
+  name: z.string().min(1),
+  /** SSH public key content */
+  publicKey: z.string().min(1),
+});
+
+/**
+ * Schema for update method input - only name can be changed.
+ */
+const UpdateInputSchema = z.object({
+  /** New SSH key name */
+  name: z.string().min(1),
+});
+
+/**
+ * Schema for sync/delete methods - no attributes needed (keyId comes from resource).
+ */
+const EmptyInputSchema = z.object({});
+
+/**
+ * Schema for DigitalOcean SSH Key model resource attributes.
+ */
+const ResourceAttributesSchema = z.object({
+  /** SSH key ID */
+  id: z.number(),
+  /** SSH key name */
+  name: z.string(),
+  /** SSH key fingerprint */
+  fingerprint: z.string(),
+  /** SSH public key content */
+  publicKey: z.string(),
+});
+
+interface SshKeyResponse {
+  id: number;
+  name: string;
+  fingerprint: string;
+  public_key: string;
+}
+
+/**
+ * Gets the DigitalOcean SSH key ID from the stored resource.
+ */
+async function getKeyIdFromResource(
+  input: ModelInput,
+  context: MethodContext,
+): Promise<number> {
+  if (!context.resourceRepository) {
+    throw new Error(
+      "Cannot operate: resourceRepository not provided in context",
+    );
+  }
+
+  const resource = await context.resourceRepository.findById(
+    ModelType.create("digitalocean/ssh-key"),
+    createModelResourceId(input.id),
+  );
+
+  if (!resource) {
+    throw new Error(
+      `Resource not found for input ID: ${input.id}. Run 'create' first.`,
+    );
+  }
+
+  const keyId = resource.attributes.id as number;
+  if (!keyId) {
+    throw new Error("Resource missing 'id' attribute (DO SSH key ID)");
+  }
+
+  return keyId;
+}
+
+/**
+ * Runs a doctl command and returns the JSON output.
+ */
+async function runDoctl(args: string[]): Promise<string> {
+  const command = new Deno.Command("doctl", {
+    args: [...args, "--output", "json"],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const output = await command.output();
+  const stdout = new TextDecoder().decode(output.stdout);
+
+  if (!output.success) {
+    const stderr = new TextDecoder().decode(output.stderr);
+    const errorMsg = stdout || stderr || "unknown error";
+    throw new Error(`doctl command failed: ${errorMsg}`);
+  }
+
+  return stdout;
+}
+
+/**
+ * Parses doctl SSH key JSON response into resource attributes.
+ */
+function parseSshKeyResponse(key: SshKeyResponse) {
+  return {
+    id: key.id,
+    name: key.name,
+    fingerprint: key.fingerprint,
+    publicKey: key.public_key,
+  };
+}
+
+/**
+ * Execute the create method.
+ */
+async function executeCreate(
+  input: ModelInput,
+  _context: MethodContext,
+): Promise<MethodResult> {
+  const attrs = InputAttributesSchema.parse(input.attributes);
+
+  const output = await runDoctl([
+    "compute",
+    "ssh-key",
+    "create",
+    attrs.name,
+    "--public-key",
+    attrs.publicKey,
+  ]);
+
+  const keys = JSON.parse(output) as SshKeyResponse[];
+  const key = keys[0];
+  if (!key) {
+    throw new Error("SSH key not found in create response");
+  }
+
+  const resource = ModelResource.create({
+    id: input.id,
+    attributes: parseSshKeyResponse(key),
+  });
+
+  return { resource };
+}
+
+/**
+ * Execute the update method.
+ */
+async function executeUpdate(
+  input: ModelInput,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const attrs = UpdateInputSchema.parse(input.attributes);
+  const keyId = await getKeyIdFromResource(input, context);
+
+  const output = await runDoctl([
+    "compute",
+    "ssh-key",
+    "update",
+    keyId.toString(),
+    "--key-name",
+    attrs.name,
+  ]);
+
+  const keys = JSON.parse(output) as SshKeyResponse[];
+  const key = keys[0];
+  if (!key) {
+    throw new Error(`SSH key '${keyId}' not found after update`);
+  }
+
+  return {
+    resource: ModelResource.create({
+      id: input.id,
+      attributes: parseSshKeyResponse(key),
+    }),
+  };
+}
+
+/**
+ * Execute the delete method.
+ */
+async function executeDelete(
+  input: ModelInput,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const keyId = await getKeyIdFromResource(input, context);
+  await runDoctl(["compute", "ssh-key", "delete", keyId.toString(), "--force"]);
+  return { deleteResource: true };
+}
+
+/**
+ * Execute the sync method.
+ */
+async function executeSync(
+  input: ModelInput,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const keyId = await getKeyIdFromResource(input, context);
+
+  const output = await runDoctl([
+    "compute",
+    "ssh-key",
+    "get",
+    keyId.toString(),
+  ]);
+  const keys = JSON.parse(output) as SshKeyResponse[];
+  const key = keys[0];
+  if (!key) {
+    throw new Error(`SSH key '${keyId}' not found`);
+  }
+
+  return {
+    resource: ModelResource.create({
+      id: input.id,
+      attributes: parseSshKeyResponse(key),
+    }),
+  };
+}
+
+/**
+ * DigitalOcean SSH Key model definition.
+ *
+ * Wraps doctl compute ssh-key commands to manage SSH keys on DigitalOcean.
+ * Requires doctl to be installed and authenticated (doctl auth init).
+ */
+export const digitaloceanSshKeyModel = defineModel({
+  type: ModelType.create("digitalocean/ssh-key"),
+  version: 1,
+  inputAttributesSchema: InputAttributesSchema,
+  resourceAttributesSchema: ResourceAttributesSchema,
+  methods: {
+    create: {
+      description: "Create a new SSH key on DigitalOcean",
+      inputAttributesSchema: InputAttributesSchema,
+      execute: executeCreate,
+    },
+    update: {
+      description: "Rename an existing SSH key",
+      inputAttributesSchema: UpdateInputSchema,
+      execute: executeUpdate,
+    },
+    delete: {
+      description: "Delete an SSH key from DigitalOcean",
+      inputAttributesSchema: EmptyInputSchema,
+      execute: executeDelete,
+    },
+    sync: {
+      description: "Sync the current state of an SSH key",
+      inputAttributesSchema: EmptyInputSchema,
+      execute: executeSync,
+    },
+  },
+});

--- a/experiments/extensions/models/discord_webhook.ts
+++ b/experiments/extensions/models/discord_webhook.ts
@@ -1,0 +1,124 @@
+import { z } from "zod";
+import { ModelType } from "../../../src/domain/models/model_type.ts";
+import { ModelData } from "../../../src/domain/models/model_data.ts";
+import {
+  defineModel,
+  type MethodContext,
+  type MethodResult,
+} from "../../../src/domain/models/model.ts";
+import type { ModelInput } from "../../../src/domain/models/model_input.ts";
+
+/**
+ * Schema for Discord webhook model input attributes.
+ */
+const InputAttributesSchema = z.object({
+  /** Discord webhook URL (optional - falls back to DISCORD_WEBHOOK_URL env var) */
+  webhookUrl: z.string().url().optional(),
+  /** Message content (max 2000 characters) */
+  content: z.string().min(1).max(2000),
+  /** Optional username override */
+  username: z.string().max(80).optional(),
+  /** Optional avatar URL override */
+  avatarUrl: z.string().url().optional(),
+});
+
+type InputAttributes = z.infer<typeof InputAttributesSchema>;
+
+/**
+ * Schema for Discord webhook model data attributes.
+ */
+const DataAttributesSchema = z.object({
+  /** Whether the message was sent successfully */
+  success: z.boolean(),
+  /** Timestamp when the message was sent */
+  sentAt: z.string().datetime(),
+  /** Content that was sent (may be truncated if over limit) */
+  contentLength: z.number().int().nonnegative(),
+});
+
+/**
+ * Sends a message via Discord webhook.
+ */
+async function sendWebhookMessage(attrs: InputAttributes): Promise<void> {
+  // Get webhook URL from attrs or fall back to env var
+  const webhookUrl = attrs.webhookUrl || Deno.env.get("DISCORD_WEBHOOK_URL");
+  if (!webhookUrl) {
+    throw new Error(
+      "Discord webhook URL required: provide webhookUrl attribute or set DISCORD_WEBHOOK_URL env var",
+    );
+  }
+
+  const body: {
+    content: string;
+    username?: string;
+    avatar_url?: string;
+  } = {
+    content: attrs.content,
+  };
+
+  if (attrs.username) {
+    body.username = attrs.username;
+  }
+
+  if (attrs.avatarUrl) {
+    body.avatar_url = attrs.avatarUrl;
+  }
+
+  const response = await fetch(webhookUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(
+      `Discord webhook error: ${response.status} ${response.statusText} - ${errorBody}`,
+    );
+  }
+}
+
+/**
+ * Execute the send method.
+ */
+async function executeSend(
+  input: ModelInput,
+  _context: MethodContext,
+): Promise<MethodResult> {
+  const attrs = InputAttributesSchema.parse(input.attributes);
+  await sendWebhookMessage(attrs);
+
+  const data = ModelData.create({
+    id: input.id,
+    attributes: {
+      success: true,
+      sentAt: new Date().toISOString(),
+      contentLength: attrs.content.length,
+    },
+  });
+
+  return { data };
+}
+
+/**
+ * Discord Webhook model definition.
+ *
+ * Sends messages to a Discord channel via webhook URL.
+ * Supports custom username and avatar overrides.
+ * Content is limited to 2000 characters per Discord's limit.
+ */
+export const discordWebhookModel = defineModel({
+  type: ModelType.create("discord/webhook"),
+  version: 1,
+  inputAttributesSchema: InputAttributesSchema,
+  dataAttributesSchema: DataAttributesSchema,
+  methods: {
+    send: {
+      description: "Send a message to Discord via webhook",
+      inputAttributesSchema: InputAttributesSchema,
+      execute: executeSend,
+    },
+  },
+});

--- a/experiments/extensions/models/docker_image.ts
+++ b/experiments/extensions/models/docker_image.ts
@@ -1,0 +1,180 @@
+import { z } from "zod";
+import { ModelType } from "../../../src/domain/models/model_type.ts";
+import { ModelData } from "../../../src/domain/models/model_data.ts";
+import {
+  defineModel,
+  type MethodContext,
+  type MethodResult,
+} from "../../../src/domain/models/model.ts";
+import type { ModelInput } from "../../../src/domain/models/model_input.ts";
+
+/**
+ * Schema for Docker image model input attributes.
+ */
+const InputAttributesSchema = z.object({
+  /** Docker Hub repository (e.g., "keeb/discord-project-summarizer") */
+  repository: z.string().min(1),
+  /** Image tag (default: "latest") */
+  tag: z.string().default("latest"),
+  /** Path to Dockerfile (default: "Dockerfile") */
+  dockerfile: z.string().default("Dockerfile"),
+  /** Build context path (default: ".") */
+  context: z.string().default("."),
+});
+
+type InputAttributes = z.infer<typeof InputAttributesSchema>;
+
+/**
+ * Schema for Docker image model data attributes.
+ */
+const DataAttributesSchema = z.object({
+  /** Full image reference (repository:tag) */
+  imageRef: z.string(),
+  /** Whether the operation succeeded */
+  success: z.boolean(),
+  /** Operation performed */
+  operation: z.enum(["build", "push", "build-push"]),
+  /** Timestamp when operation completed */
+  completedAt: z.string().datetime(),
+});
+
+/**
+ * Runs a docker command.
+ */
+async function runDocker(args: string[]): Promise<void> {
+  const command = new Deno.Command("docker", {
+    args,
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+
+  const output = await command.output();
+
+  if (!output.success) {
+    throw new Error(`docker command failed with exit code ${output.code}`);
+  }
+}
+
+/**
+ * Build a Docker image.
+ */
+async function buildImage(attrs: InputAttributes): Promise<void> {
+  const imageRef = `${attrs.repository}:${attrs.tag}`;
+  await runDocker([
+    "build",
+    "-t",
+    imageRef,
+    "-f",
+    attrs.dockerfile,
+    attrs.context,
+  ]);
+}
+
+/**
+ * Push a Docker image.
+ */
+async function pushImage(attrs: InputAttributes): Promise<void> {
+  const imageRef = `${attrs.repository}:${attrs.tag}`;
+  await runDocker(["push", imageRef]);
+}
+
+/**
+ * Execute the build method.
+ */
+async function executeBuild(
+  input: ModelInput,
+  _context: MethodContext,
+): Promise<MethodResult> {
+  const attrs = InputAttributesSchema.parse(input.attributes);
+  await buildImage(attrs);
+
+  const data = ModelData.create({
+    id: input.id,
+    attributes: {
+      imageRef: `${attrs.repository}:${attrs.tag}`,
+      success: true,
+      operation: "build",
+      completedAt: new Date().toISOString(),
+    },
+  });
+
+  return { data };
+}
+
+/**
+ * Execute the push method.
+ */
+async function executePush(
+  input: ModelInput,
+  _context: MethodContext,
+): Promise<MethodResult> {
+  const attrs = InputAttributesSchema.parse(input.attributes);
+  await pushImage(attrs);
+
+  const data = ModelData.create({
+    id: input.id,
+    attributes: {
+      imageRef: `${attrs.repository}:${attrs.tag}`,
+      success: true,
+      operation: "push",
+      completedAt: new Date().toISOString(),
+    },
+  });
+
+  return { data };
+}
+
+/**
+ * Execute the build-push method.
+ */
+async function executeBuildPush(
+  input: ModelInput,
+  _context: MethodContext,
+): Promise<MethodResult> {
+  const attrs = InputAttributesSchema.parse(input.attributes);
+  await buildImage(attrs);
+  await pushImage(attrs);
+
+  const data = ModelData.create({
+    id: input.id,
+    attributes: {
+      imageRef: `${attrs.repository}:${attrs.tag}`,
+      success: true,
+      operation: "build-push",
+      completedAt: new Date().toISOString(),
+    },
+  });
+
+  return { data };
+}
+
+/**
+ * Docker Image model definition.
+ *
+ * Builds and pushes Docker images to Docker Hub.
+ * Assumes docker CLI is pre-authenticated (docker login already done).
+ * Uses Deno.Command to run docker build and push commands.
+ */
+export const dockerImageModel = defineModel({
+  type: ModelType.create("docker/image"),
+  version: 1,
+  inputAttributesSchema: InputAttributesSchema,
+  dataAttributesSchema: DataAttributesSchema,
+  methods: {
+    build: {
+      description: "Build a Docker image locally",
+      inputAttributesSchema: InputAttributesSchema,
+      execute: executeBuild,
+    },
+    push: {
+      description: "Push a Docker image to Docker Hub",
+      inputAttributesSchema: InputAttributesSchema,
+      execute: executePush,
+    },
+    "build-push": {
+      description: "Build and push a Docker image in one step",
+      inputAttributesSchema: InputAttributesSchema,
+      execute: executeBuildPush,
+    },
+  },
+});

--- a/experiments/extensions/models/github_pr_list.ts
+++ b/experiments/extensions/models/github_pr_list.ts
@@ -1,0 +1,174 @@
+import { z } from "zod";
+import { ModelType } from "../../../src/domain/models/model_type.ts";
+import { ModelData } from "../../../src/domain/models/model_data.ts";
+import {
+  defineModel,
+  type MethodContext,
+  type MethodResult,
+} from "../../../src/domain/models/model.ts";
+import type { ModelInput } from "../../../src/domain/models/model_input.ts";
+
+/**
+ * Schema for GitHub PR list model input attributes.
+ */
+const InputAttributesSchema = z.object({
+  /** GitHub repository owner */
+  owner: z.string().min(1),
+  /** GitHub repository name */
+  repo: z.string().min(1),
+  /** PR state filter */
+  state: z.enum(["open", "closed", "all"]).default("closed"),
+  /** Only return PRs updated after this ISO date */
+  since: z.string().datetime().optional(),
+  /** Maximum number of PRs to fetch */
+  limit: z.number().int().positive().default(100),
+});
+
+type InputAttributes = z.infer<typeof InputAttributesSchema>;
+
+/**
+ * Schema for a single PR in the output.
+ */
+const PullRequestSchema = z.object({
+  number: z.number().int(),
+  title: z.string(),
+  url: z.string().url(),
+  mergedAt: z.string().datetime().nullable(),
+  author: z.string(),
+  body: z.string().nullable(),
+});
+
+/**
+ * Schema for GitHub PR list model data attributes.
+ */
+const DataAttributesSchema = z.object({
+  pullRequests: z.array(PullRequestSchema),
+  fetchedAt: z.string().datetime(),
+  owner: z.string(),
+  repo: z.string(),
+});
+
+interface GitHubPR {
+  number: number;
+  title: string;
+  html_url: string;
+  merged_at: string | null;
+  updated_at: string;
+  user: { login: string } | null;
+  body: string | null;
+}
+
+/**
+ * Fetches pull requests using GitHub REST API.
+ * Uses GITHUB_TOKEN environment variable for authentication.
+ */
+async function fetchPullRequests(attrs: InputAttributes): Promise<GitHubPR[]> {
+  const token = Deno.env.get("GITHUB_TOKEN");
+  if (!token) {
+    throw new Error("GITHUB_TOKEN environment variable is required");
+  }
+
+  const headers: Record<string, string> = {
+    "Accept": "application/vnd.github+json",
+    "Authorization": `Bearer ${token}`,
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+
+  const allPRs: GitHubPR[] = [];
+  let page = 1;
+  const perPage = Math.min(attrs.limit, 100);
+
+  // Default to 24 hours ago if since not provided
+  const sinceDate = attrs.since
+    ? new Date(attrs.since)
+    : new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+  while (allPRs.length < attrs.limit) {
+    const url = new URL(
+      `https://api.github.com/repos/${attrs.owner}/${attrs.repo}/pulls`,
+    );
+    url.searchParams.set("state", attrs.state);
+    url.searchParams.set("sort", "updated");
+    url.searchParams.set("direction", "desc");
+    url.searchParams.set("per_page", perPage.toString());
+    url.searchParams.set("page", page.toString());
+
+    const response = await fetch(url.toString(), { headers });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`GitHub API error (${response.status}): ${text}`);
+    }
+
+    const prs = (await response.json()) as GitHubPR[];
+
+    if (prs.length === 0) break;
+
+    // Filter by since date and add to results
+    for (const pr of prs) {
+      if (new Date(pr.updated_at) < sinceDate) {
+        // PRs are sorted by updated_at desc, so we can stop here
+        return allPRs.slice(0, attrs.limit);
+      }
+      if (allPRs.length < attrs.limit) {
+        allPRs.push(pr);
+      }
+    }
+
+    page++;
+  }
+
+  return allPRs.slice(0, attrs.limit);
+}
+
+/**
+ * Execute the list method.
+ */
+async function executeList(
+  input: ModelInput,
+  _context: MethodContext,
+): Promise<MethodResult> {
+  const attrs = InputAttributesSchema.parse(input.attributes);
+  const prs = await fetchPullRequests(attrs);
+
+  const pullRequests = prs.map((pr) => ({
+    number: pr.number,
+    title: pr.title,
+    url: pr.html_url,
+    mergedAt: pr.merged_at,
+    author: pr.user?.login ?? "unknown",
+    body: pr.body,
+  }));
+
+  const data = ModelData.create({
+    id: input.id,
+    attributes: {
+      pullRequests,
+      fetchedAt: new Date().toISOString(),
+      owner: attrs.owner,
+      repo: attrs.repo,
+    },
+  });
+
+  return { data };
+}
+
+/**
+ * GitHub PR List model definition.
+ *
+ * Fetches pull requests from a GitHub repository using the GitHub REST API.
+ * Requires GITHUB_TOKEN environment variable to be set.
+ */
+export const githubPrListModel = defineModel({
+  type: ModelType.create("github/pr-list"),
+  version: 1,
+  inputAttributesSchema: InputAttributesSchema,
+  dataAttributesSchema: DataAttributesSchema,
+  methods: {
+    list: {
+      description: "List pull requests from a GitHub repository",
+      inputAttributesSchema: InputAttributesSchema,
+      execute: executeList,
+    },
+  },
+});

--- a/experiments/extensions/models/ssh_remote.ts
+++ b/experiments/extensions/models/ssh_remote.ts
@@ -1,0 +1,204 @@
+import { z } from "zod";
+import { ModelType } from "../../../src/domain/models/model_type.ts";
+import { ModelData } from "../../../src/domain/models/model_data.ts";
+import { ModelLog } from "../../../src/domain/models/model_log.ts";
+import {
+  defineModel,
+  type MethodContext,
+  type MethodResult,
+  type ModelDefinition,
+} from "../../../src/domain/models/model.ts";
+import type { ModelInput } from "../../../src/domain/models/model_input.ts";
+
+/**
+ * Schema for SSH remote model input attributes.
+ */
+export const SshRemoteInputAttributesSchema = z.object({
+  host: z.string().min(1).describe("IP address or hostname of the remote host"),
+  user: z.string().default("root").describe("SSH user (default: root)"),
+  privateKeyPath: z.string().min(1).describe("Path to SSH private key"),
+  command: z.string().min(1).describe("Command to execute on the remote host"),
+  port: z.number().int().positive().default(22).describe(
+    "SSH port (default: 22)",
+  ),
+  timeout: z.number().int().positive().optional().describe(
+    "Timeout in milliseconds",
+  ),
+});
+
+/**
+ * Type for SSH remote model input attributes.
+ */
+export type SshRemoteInputAttributes = z.infer<
+  typeof SshRemoteInputAttributesSchema
+>;
+
+/**
+ * Schema for SSH remote model data attributes.
+ */
+export const SshRemoteDataAttributesSchema = z.object({
+  exitCode: z.number().int().describe("Exit code of the command"),
+  stdout: z.string().describe("Standard output from the command"),
+  stderr: z.string().describe("Standard error from the command"),
+  executedAt: z.string().datetime().describe(
+    "Timestamp when execution completed",
+  ),
+  durationMs: z.number().int().nonnegative().describe(
+    "Execution duration in milliseconds",
+  ),
+});
+
+/**
+ * Type for SSH remote model data attributes.
+ */
+export type SshRemoteDataAttributes = z.infer<
+  typeof SshRemoteDataAttributesSchema
+>;
+
+/**
+ * The SSH remote model type identifier.
+ */
+export const SSH_REMOTE_MODEL_TYPE = ModelType.create("keeb/ssh-remote");
+
+/**
+ * Expands ~ to home directory in paths.
+ */
+function expandHomePath(path: string): string {
+  if (path.startsWith("~/")) {
+    const home = Deno.env.get("HOME");
+    if (home) {
+      return path.replace("~", home);
+    }
+  }
+  return path;
+}
+
+/**
+ * Executes a command on a remote host via SSH.
+ */
+async function executeCommand(
+  input: ModelInput,
+  _context: MethodContext,
+): Promise<MethodResult> {
+  const attrs = SshRemoteInputAttributesSchema.parse(input.attributes);
+
+  const startTime = Date.now();
+  let stdout = "";
+  let stderr = "";
+  let exitCode = 0;
+
+  try {
+    const privateKeyPath = expandHomePath(attrs.privateKeyPath);
+
+    const sshArgs = [
+      "-i",
+      privateKeyPath,
+      "-o",
+      "StrictHostKeyChecking=no",
+      "-o",
+      "UserKnownHostsFile=/dev/null",
+      "-o",
+      "BatchMode=yes",
+      "-p",
+      attrs.port.toString(),
+      `${attrs.user}@${attrs.host}`,
+      attrs.command,
+    ];
+
+    const commandOptions: Deno.CommandOptions = {
+      args: sshArgs,
+      stdout: "piped",
+      stderr: "piped",
+    };
+
+    const command = new Deno.Command("ssh", commandOptions);
+
+    let output: Deno.CommandOutput;
+
+    if (attrs.timeout) {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), attrs.timeout);
+
+      try {
+        const child = command.spawn();
+
+        const timeoutPromise = new Promise<never>((_, reject) => {
+          controller.signal.addEventListener("abort", () => {
+            child.kill("SIGTERM");
+            reject(new Error(`SSH command timed out after ${attrs.timeout}ms`));
+          });
+        });
+
+        output = await Promise.race([child.output(), timeoutPromise]);
+        clearTimeout(timeoutId);
+      } catch (error) {
+        clearTimeout(timeoutId);
+        throw error;
+      }
+    } else {
+      output = await command.output();
+    }
+
+    stdout = new TextDecoder().decode(output.stdout);
+    stderr = new TextDecoder().decode(output.stderr);
+    exitCode = output.code;
+  } catch (error) {
+    stderr = error instanceof Error ? error.message : String(error);
+    exitCode = -1;
+  }
+
+  const endTime = Date.now();
+  const durationMs = endTime - startTime;
+
+  // Create log artifact for command output
+  const outputLog = ModelLog.create({ id: input.id });
+  outputLog.log(`[ssh ${attrs.user}@${attrs.host}:${attrs.port}]`);
+  outputLog.log(`[command] ${attrs.command}`);
+  if (stdout) {
+    outputLog.log(`[stdout]\n${stdout}`);
+  }
+  if (stderr) {
+    outputLog.log(`[stderr]\n${stderr}`);
+  }
+
+  // Create the data artifact with structured metadata
+  const data = ModelData.create({
+    id: input.id,
+    attributes: {
+      exitCode,
+      stdout,
+      stderr,
+      executedAt: new Date().toISOString(),
+      durationMs,
+    },
+  });
+
+  return { data, logs: [outputLog] };
+}
+
+/**
+ * The SSH remote model definition.
+ *
+ * A model that executes commands on remote hosts via SSH and captures
+ * the output (stdout, stderr, exit code).
+ *
+ * Self-registers with the global model registry when this module is imported.
+ */
+export const sshRemoteModel: ModelDefinition<
+  typeof SshRemoteInputAttributesSchema,
+  never,
+  typeof SshRemoteDataAttributesSchema
+> = defineModel({
+  type: SSH_REMOTE_MODEL_TYPE,
+  version: 1,
+  inputAttributesSchema: SshRemoteInputAttributesSchema,
+  dataAttributesSchema: SshRemoteDataAttributesSchema,
+  methods: {
+    execute: {
+      description:
+        "Execute a command on a remote host via SSH and capture stdout, stderr, and exit code",
+      inputAttributesSchema: SshRemoteInputAttributesSchema,
+      execute: executeCommand,
+    },
+  },
+});

--- a/src/domain/expressions/expression_parser.ts
+++ b/src/domain/expressions/expression_parser.ts
@@ -113,9 +113,15 @@ function replaceExpressionsRecursive(
       for (const [rawExpr, value] of values) {
         if (result.includes(rawExpr)) {
           // Convert value to string for inline replacement
-          const stringValue = value === null || value === undefined
-            ? ""
-            : String(value);
+          // JSON stringify arrays/objects to preserve structure
+          let stringValue: string;
+          if (value === null || value === undefined) {
+            stringValue = "";
+          } else if (typeof value === "object") {
+            stringValue = JSON.stringify(value, null, 2);
+          } else {
+            stringValue = String(value);
+          }
           result = result.split(rawExpr).join(stringValue);
         }
       }

--- a/src/domain/expressions/expression_parser_test.ts
+++ b/src/domain/expressions/expression_parser_test.ts
@@ -156,6 +156,82 @@ Deno.test("replaceExpressions leaves unmatched expressions unchanged", () => {
   assertEquals(result.unknown, "${{ unknown }}");
 });
 
+Deno.test("replaceExpressions JSON stringifies arrays in inline expressions", () => {
+  const data = {
+    message: "Items: ${{ items }}",
+  };
+  const values = new Map<string, unknown>([
+    ["${{ items }}", ["apple", "banana", "cherry"]],
+  ]);
+
+  const result = replaceExpressions(data, values) as typeof data;
+  assertEquals(
+    result.message,
+    `Items: [
+  "apple",
+  "banana",
+  "cherry"
+]`,
+  );
+});
+
+Deno.test("replaceExpressions JSON stringifies objects in inline expressions", () => {
+  const data = {
+    message: "Config: ${{ config }}",
+  };
+  const values = new Map<string, unknown>([
+    ["${{ config }}", { host: "localhost", port: 8080 }],
+  ]);
+
+  const result = replaceExpressions(data, values) as typeof data;
+  assertEquals(
+    result.message,
+    `Config: {
+  "host": "localhost",
+  "port": 8080
+}`,
+  );
+});
+
+Deno.test("replaceExpressions handles null and undefined in inline expressions", () => {
+  const data = {
+    withNull: "Value: ${{ nullVal }}",
+    withUndefined: "Value: ${{ undefinedVal }}",
+  };
+  const values = new Map<string, unknown>([
+    ["${{ nullVal }}", null],
+    ["${{ undefinedVal }}", undefined],
+  ]);
+
+  const result = replaceExpressions(data, values) as typeof data;
+  assertEquals(result.withNull, "Value: ");
+  assertEquals(result.withUndefined, "Value: ");
+});
+
+Deno.test("replaceExpressions preserves array type for single expression", () => {
+  const data = {
+    items: "${{ items }}",
+  };
+  const values = new Map<string, unknown>([
+    ["${{ items }}", ["apple", "banana"]],
+  ]);
+
+  const result = replaceExpressions(data, values) as { items: unknown };
+  assertEquals(result.items, ["apple", "banana"]);
+});
+
+Deno.test("replaceExpressions preserves object type for single expression", () => {
+  const data = {
+    config: "${{ config }}",
+  };
+  const values = new Map<string, unknown>([
+    ["${{ config }}", { host: "localhost", port: 8080 }],
+  ]);
+
+  const result = replaceExpressions(data, values) as { config: unknown };
+  assertEquals(result.config, { host: "localhost", port: 8080 });
+});
+
 Deno.test("extractCelExpression extracts expression from wrapper", () => {
   assertEquals(
     extractCelExpression("${{ model.foo.input.x }}"),


### PR DESCRIPTION
## Summary

- **Extension models**: Add extension models to `experiments/extensions/models/` (anthropic_claude, digitalocean_app, digitalocean_droplet, digitalocean_ssh_key, discord_webhook, docker_image, github_pr_list, ssh_remote)
- **Data context in workflows**: Extend workflow execution to track `data` outputs (not just `resource`) in the expression context, enabling subsequent steps to reference data from previous model executions
- **Object serialization**: JSON stringify arrays/objects in expression parser to preserve structure when interpolating complex values
- **Gitignore**: Add entries for local swamp repo data (.swamp.yaml, workflows/, workflows-evaluated/, resources/)

## Test Plan

- `deno check` passes
- `deno lint` passes  
- `deno fmt --check` passes
- `deno run test` passes (1178 tests)