### PR TITLE
fix: wrap repo service errors in UserError for cleaner output

### DIFF
--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -7,6 +7,7 @@ import {
   RepoMarkerRepository,
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { SkillAssets } from "../../infrastructure/assets/skill_assets.ts";
+import { UserError } from "../errors.ts";
 
 const CLAUDE_MD_FILENAME = "CLAUDE.md";
 
@@ -74,7 +75,7 @@ export class RepoService {
     const isAlreadyInit = await this.isInitialized(repoPath);
 
     if (isAlreadyInit && !options.force) {
-      throw new Error(
+      throw new UserError(
         `Repository already initialized at ${repoPath.value}. Use --force to reinitialize.`,
       );
     }
@@ -116,7 +117,7 @@ export class RepoService {
     const existingMarker = await this.markerRepo.read(repoPath);
 
     if (!existingMarker) {
-      throw new Error(
+      throw new UserError(
         `Not a swamp repository: ${repoPath.value}. Run 'swamp repo init' first.`,
       );
     }


### PR DESCRIPTION
- Wrap "repository already initialized" and "not a swamp repository" errors in UserError to suppress stack traces
- These are expected user-facing conditions where the stack trace is noise

### Test plan

- deno check passes
- deno run test src/domain/repo/ passes