### PR TITLE
feat: show secret keys in vault logical view

### DIFF
--- a/src/cli/commands/vault_put.ts
+++ b/src/cli/commands/vault_put.ts
@@ -8,6 +8,8 @@ import { createContext, type GlobalOptions } from "../context.ts";
 import { VaultService } from "../../domain/vaults/vault_service.ts";
 import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
 import { UserError } from "../../domain/errors.ts";
+import { createRepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
+import { createVaultSecretUpdated } from "../../domain/events/types.ts";
 
 /**
  * Prompts user for confirmation in interactive mode.
@@ -137,6 +139,17 @@ export const vaultPutCommand = new Command()
     // Store the secret
     await vaultService.put(vaultName, key, value);
     ctx.logger.debug`Secret stored successfully`;
+
+    // Emit event to update the logical view symlinks
+    const repoContext = createRepositoryContext({ repoDir });
+    const event = createVaultSecretUpdated(
+      vaultConfig.id,
+      vaultConfig.type,
+      vaultConfig.name,
+      key,
+    );
+    await repoContext.eventBus.publish(event);
+    ctx.logger.debug`Emitted VaultSecretUpdated event`;
 
     const data: VaultPutData = {
       vaultName,

--- a/src/domain/events/types.ts
+++ b/src/domain/events/types.ts
@@ -131,7 +131,8 @@ export type RepositoryEvent =
   | WorkflowRunFailed
   | VaultCreated
   | VaultUpdated
-  | VaultDeleted;
+  | VaultDeleted
+  | VaultSecretUpdated;
 
 /**
  * Event type discriminator values.
@@ -324,6 +325,17 @@ export interface VaultDeleted extends DomainEvent {
 }
 
 /**
+ * Emitted when a secret is added or updated in a vault.
+ */
+export interface VaultSecretUpdated extends DomainEvent {
+  readonly type: "VaultSecretUpdated";
+  readonly vaultId: string;
+  readonly vaultType: string;
+  readonly vaultName: string;
+  readonly secretKey: string;
+}
+
+/**
  * Creates a VaultCreated event.
  */
 export function createVaultCreated(
@@ -370,6 +382,25 @@ export function createVaultDeleted(
     vaultId,
     vaultType,
     vaultName,
+    timestamp: new Date(),
+  };
+}
+
+/**
+ * Creates a VaultSecretUpdated event.
+ */
+export function createVaultSecretUpdated(
+  vaultId: string,
+  vaultType: string,
+  vaultName: string,
+  secretKey: string,
+): VaultSecretUpdated {
+  return {
+    type: "VaultSecretUpdated",
+    vaultId,
+    vaultType,
+    vaultName,
+    secretKey,
     timestamp: new Date(),
   };
 }

--- a/src/domain/repo/repo_index_service.ts
+++ b/src/domain/repo/repo_index_service.ts
@@ -12,6 +12,7 @@ import type {
   ModelUpdated,
   VaultCreated,
   VaultDeleted,
+  VaultSecretUpdated,
   VaultUpdated,
   WorkflowCreated,
   WorkflowDeleted,
@@ -169,6 +170,12 @@ export interface RepoIndexService {
    * Removes the vault view directory.
    */
   handleVaultDeleted(event: VaultDeleted): Promise<void>;
+
+  /**
+   * Handles a VaultSecretUpdated event.
+   * Updates the secrets symlinks for the vault.
+   */
+  handleVaultSecretUpdated(event: VaultSecretUpdated): Promise<void>;
 
   // ============================================================================
   // Maintenance Operations

--- a/src/infrastructure/persistence/repository_factory.ts
+++ b/src/infrastructure/persistence/repository_factory.ts
@@ -48,6 +48,7 @@ import type {
   ModelUpdated,
   VaultCreated,
   VaultDeleted,
+  VaultSecretUpdated,
   VaultUpdated,
   WorkflowCreated,
   WorkflowDeleted,
@@ -182,6 +183,10 @@ export function createRepositoryContext(
     eventBus.subscribe<VaultDeleted>(
       "VaultDeleted",
       (event) => indexService.handleVaultDeleted(event),
+    );
+    eventBus.subscribe<VaultSecretUpdated>(
+      "VaultSecretUpdated",
+      (event) => indexService.handleVaultSecretUpdated(event),
     );
   }
 

--- a/src/infrastructure/repo/symlink_repo_index_service.ts
+++ b/src/infrastructure/repo/symlink_repo_index_service.ts
@@ -20,6 +20,7 @@ import type {
   ModelUpdated,
   VaultCreated,
   VaultDeleted,
+  VaultSecretUpdated,
   VaultUpdated,
   WorkflowCreated,
   WorkflowDeleted,
@@ -158,6 +159,11 @@ export class SymlinkRepoIndexService implements RepoIndexService {
   async handleVaultDeleted(event: VaultDeleted): Promise<void> {
     const vaultDir = join(this.repoDir, "vaults", event.vaultName);
     await this.removeDirectory(vaultDir);
+  }
+
+  async handleVaultSecretUpdated(event: VaultSecretUpdated): Promise<void> {
+    // Re-index the vault to update the secrets symlinks
+    await this.indexVault(event.vaultId, event.vaultType, event.vaultName);
   }
 
   // ============================================================================
@@ -494,7 +500,7 @@ export class SymlinkRepoIndexService implements RepoIndexService {
    * Creates or updates the index for a vault.
    * Structure:
    *   /vaults/{vault-name}/vault.yaml -> /.data/vault/{vault-type}/{id}.yaml
-   *   /vaults/{vault-name}/secrets/   -> /.data/secrets/{vault-type}/{vault-name}/ (local vaults only)
+   *   /vaults/{vault-name}/secrets/{key} -> /.data/secrets/{vault-type}/{vault-name}/{key}.enc (local vaults only)
    */
   private async indexVault(
     vaultId: string,
@@ -514,24 +520,74 @@ export class SymlinkRepoIndexService implements RepoIndexService {
     );
     await this.createSymlink(vaultTarget, join(vaultDir, "vault.yaml"));
 
-    // For local_encryption vaults, also create secrets symlink
+    // For local_encryption vaults, create secrets directory with individual key symlinks
     if (vaultType === "local_encryption") {
-      const secretsDir = join(
+      const actualSecretsDir = join(
         this.repoDir,
         ".data",
         "secrets",
         vaultType,
         vaultName,
       );
-      // Ensure secrets directory exists with restricted permissions
-      await ensureDir(secretsDir);
+      // Ensure actual secrets directory exists with restricted permissions
+      await ensureDir(actualSecretsDir);
       try {
-        await Deno.chmod(secretsDir, 0o700);
+        await Deno.chmod(actualSecretsDir, 0o700);
       } catch {
         // chmod may fail on some systems (e.g., Windows), ignore
       }
 
-      await this.createSymlink(secretsDir, join(vaultDir, "secrets"));
+      // Create logical view secrets directory
+      const logicalSecretsDir = join(vaultDir, "secrets");
+      await this.refreshSecretsIndex(
+        logicalSecretsDir,
+        actualSecretsDir,
+        vaultName,
+      );
+    }
+  }
+
+  /**
+   * Refreshes the secrets index for a local_encryption vault.
+   * Creates symlinks for each secret key, removing the .enc extension.
+   */
+  private async refreshSecretsIndex(
+    logicalSecretsDir: string,
+    actualSecretsDir: string,
+    vaultName: string,
+  ): Promise<void> {
+    // Remove existing logical secrets directory if it exists (could be old symlink or directory)
+    try {
+      const stat = await Deno.lstat(logicalSecretsDir);
+      if (stat.isSymlink || stat.isDirectory) {
+        await Deno.remove(logicalSecretsDir, { recursive: true });
+      }
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+
+    // Create fresh logical secrets directory
+    await ensureDir(logicalSecretsDir);
+
+    // List all .enc files in the actual secrets directory
+    try {
+      for await (const entry of Deno.readDir(actualSecretsDir)) {
+        if (entry.isFile && entry.name.endsWith(".enc")) {
+          // Remove .enc extension for the symlink name
+          const keyName = entry.name.slice(0, -4);
+          const targetPath = join(actualSecretsDir, entry.name);
+          const linkPath = join(logicalSecretsDir, keyName);
+          await this.createSymlink(targetPath, linkPath);
+        }
+      }
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        logger
+          .warn`Failed to read secrets directory for vault '${vaultName}': ${error}`;
+      }
+      // Directory may not exist yet, that's OK
     }
   }
 


### PR DESCRIPTION
- Display individual secret key names in the vault logical view instead of symlinking the entire secrets directory
- Auto-update the logical view when secrets are added via `vault put`

## Changes

### Logical View Structure

Before:
vaults/my-local-vault/
├── vault.yaml
└── secrets/ -> .data/secrets/local_encryption/my-local-vault/
    ├── .key
    ├── api-key.enc
    └── db-password.enc

After:
vaults/my-local-vault/
├── vault.yaml
└── secrets/
    ├── api-key -> .data/secrets/local_encryption/my-local-vault/api-key.enc
    └── db-password -> .data/secrets/local_encryption/my-local-vault/db-password.enc

### Event System

Added `VaultSecretUpdated` event that triggers when `vault put` stores a secret, automatically refreshing the
logical view symlinks.

## Test plan

- [x] All 1289 tests passing
- [x] Verified `repo index` creates correct symlinks
- [x] Verified `vault put` auto-updates the logical view
- [x] Secret keys display without `.enc` extension
- [x] `.key` file is not shown in logical view