### PR TITLE
feat: add swamp-vault skill for secure secret management

### DIFF
--- a/.claude/skills/swamp-vault/SKILL.md
+++ b/.claude/skills/swamp-vault/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: swamp-vault
+description: Manage swamp vaults for secure secret storage. Use when creating vaults, storing secrets, retrieving secrets, listing vault keys, or working with vault expressions in workflows. Triggers on "vault", "secret", "credentials", "api key storage", "secure storage", or vault-related CLI commands.
+---
+
+# Swamp Vault Skill
+
+Manage secure secret storage through swamp vaults. All commands support `--json`
+for machine-readable output.
+
+## Repository Structure
+
+Vaults use the dual-layer architecture:
+
+- **Data directory (`/.data/vault/`)** - Internal storage by vault type
+- **Logical views (`/vaults/`)** - Human-friendly symlinked directories
+
+```
+/vaults/{vault-name}/
+  vault.yaml → ../.data/vault/{type}/{id}.yaml
+  secrets/ → ../.data/secrets/{type}/{vault-name}/ (local_encryption only)
+```
+
+## Quick Reference
+
+| Task              | Command                                    |
+| ----------------- | ------------------------------------------ |
+| List vault types  | `swamp vault type search --json`           |
+| Create a vault    | `swamp vault create <type> <name> --json`  |
+| Search vaults     | `swamp vault search [query] --json`        |
+| Get vault details | `swamp vault get <name_or_id> --json`      |
+| Edit vault config | `swamp vault edit <name_or_id>`            |
+| Store a secret    | `swamp vault put <vault> KEY=VALUE --json` |
+| List secret keys  | `swamp vault list-keys <vault> --json`     |
+
+## Vault Types
+
+Two vault types are available:
+
+### local_encryption
+
+Stores secrets encrypted locally using AES-GCM. Best for development and local
+workflows.
+
+```yaml
+config:
+  auto_generate: true # Generate encryption key automatically
+  # OR
+  ssh_key_path: "~/.ssh/id_rsa" # Use SSH key for encryption
+```
+
+### aws
+
+Integrates with AWS Secrets Manager. Best for production environments.
+
+```yaml
+config:
+  region: "us-east-1" # Required
+  # profile: "default"  # Optional: AWS profile name
+```
+
+## Create a Vault
+
+```bash
+swamp vault create local_encryption dev-secrets --json
+swamp vault create aws prod-secrets --json
+```
+
+**Output shape:**
+
+```json
+{
+  "id": "abc-123",
+  "name": "dev-secrets",
+  "type": "local_encryption",
+  "path": ".data/vault/local_encryption/abc-123.yaml"
+}
+```
+
+After creation, edit the config if needed:
+
+```bash
+swamp vault edit dev-secrets
+```
+
+## Store Secrets
+
+```bash
+swamp vault put dev-secrets API_KEY=sk-1234567890 --json
+swamp vault put prod-secrets DB_PASSWORD=secret123 -f --json  # Skip confirmation
+```
+
+**Output shape:**
+
+```json
+{
+  "vault": "dev-secrets",
+  "key": "API_KEY",
+  "status": "stored"
+}
+```
+
+## List Secret Keys
+
+Returns key names only (never values):
+
+```bash
+swamp vault list-keys dev-secrets --json
+```
+
+**Output shape:**
+
+```json
+{
+  "vault": "dev-secrets",
+  "keys": ["API_KEY", "DB_PASSWORD"]
+}
+```
+
+## Vault Expressions
+
+Access secrets in model inputs and workflows using CEL expressions:
+
+```yaml
+attributes:
+  apiKey: ${{ vault.get(dev-secrets, API_KEY) }}
+  dbPassword: ${{ vault.get(prod-secrets, DB_PASSWORD) }}
+```
+
+**Key rules:**
+
+- Vault must exist before expression evaluation
+- Expressions are evaluated lazily at runtime
+- Failed lookups throw errors with helpful messages
+
+## Workflow Integration
+
+Use the `swamp/lets-get-sensitive` model for vault operations in workflows:
+
+```yaml
+# Store a secret via workflow
+- name: store-credentials
+  task:
+    type: model_method
+    modelIdOrName: store-creds
+    methodName: put
+
+# Where store-creds model has:
+# type: swamp/lets-get-sensitive
+# attributes:
+#   vaultName: prod-secrets
+#   secretKey: api-token
+#   secretValue: ${{ model.generator.data.attributes.token }}
+#   operation: put
+```
+
+## Security Best Practices
+
+1. **Environment separation**: Use different vaults for dev/staging/prod
+2. **Never hardcode**: Always use vault expressions for secrets
+3. **Audit access**: Monitor vault operations through logs
+4. **Key rotation**: Rotate secrets and encryption keys regularly
+
+## References
+
+- **Provider details**: See [references/providers.md](references/providers.md)
+  for encryption and configuration details
+- **Troubleshooting**: See
+  [references/troubleshooting.md](references/troubleshooting.md) for common
+  issues

--- a/.claude/skills/swamp-vault/references/providers.md
+++ b/.claude/skills/swamp-vault/references/providers.md
@@ -1,0 +1,115 @@
+# Vault Provider Reference
+
+## Local Encryption Provider
+
+### Encryption Details
+
+- **Algorithm**: AES-GCM (Advanced Encryption Standard, Galois/Counter Mode)
+- **Key derivation**: PBKDF2 with SHA-256, 100,000 iterations
+- **Salt**: 16 bytes, unique per secret
+- **IV**: 96 bits, random per encryption
+
+### Storage Layout
+
+```
+.data/secrets/{vault-type}/{vault-name}/
+├── .key                    # Auto-generated encryption key (mode 0600)
+└── {secret-key}.enc        # Encrypted secret files
+```
+
+### Configuration Options
+
+```yaml
+# .data/vault/local_encryption/{id}.yaml
+id: abc-123
+name: dev-vault
+type: local_encryption
+config:
+  # Option 1: Auto-generate key (recommended for development)
+  auto_generate: true
+
+  # Option 2: Use specific SSH key
+  ssh_key_path: "~/.ssh/vault_key"
+
+  # Option 3: Use default SSH key (~/.ssh/id_rsa)
+  # (set auto_generate: false and omit ssh_key_path)
+
+  # Optional: Custom base directory
+  base_dir: /path/to/repo
+createdAt: 2025-02-01T...
+```
+
+### Key Priority Order
+
+1. SSH key at `ssh_key_path` if specified
+2. Default SSH key at `~/.ssh/id_rsa` if `auto_generate: false`
+3. Auto-generated key in `.key` file if `auto_generate: true`
+
+### Encrypted File Format
+
+```json
+{
+  "iv": "base64-encoded-iv",
+  "data": "base64-encoded-ciphertext",
+  "salt": "base64-encoded-salt",
+  "version": 1
+}
+```
+
+## AWS Secrets Manager Provider
+
+### Configuration Options
+
+```yaml
+# .data/vault/aws/{id}.yaml
+id: def-456
+name: prod-vault
+type: aws
+config:
+  region: us-east-1 # Required
+  profile: production # Optional: AWS profile name
+  endpoint_url: http://localhost:4566 # Optional: LocalStack endpoint
+  secret_prefix: myapp/ # Optional: Prefix for all secret names
+createdAt: 2025-02-01T...
+```
+
+### Authentication
+
+AWS credentials are obtained from the default credential chain:
+
+1. Environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
+2. Shared credentials file: `~/.aws/credentials`
+3. IAM roles (EC2, ECS, Lambda)
+4. Web identity tokens (EKS)
+
+### Secret Naming
+
+Secrets in AWS Secrets Manager are named:
+
+- Without prefix: `{secret-key}`
+- With prefix: `{secret_prefix}{secret-key}`
+
+### Auto-Registration
+
+If AWS credentials are detected in the environment, swamp automatically
+registers a default `aws` vault. This vault uses:
+
+- Region from `AWS_REGION` or `AWS_DEFAULT_REGION` (defaults to `us-east-1`)
+- Default credential chain for authentication
+
+## Mock Provider (Testing Only)
+
+A mock provider exists for testing and demonstrations. It stores secrets
+in-memory and is pre-populated with demo secrets. This provider is intentionally
+excluded from the public vault type list.
+
+## Security Principles
+
+All vault providers follow these security principles:
+
+1. **Never log secrets**: Only metadata (key names, operation status) appears in
+   logs
+2. **Lazy evaluation**: Secrets retrieved only when expressions are evaluated
+3. **No cross-run caching**: Secrets not persisted between workflow executions
+4. **Error safety**: Exceptions don't expose secret values
+5. **Vault isolation**: Each vault maintains independent authentication

--- a/.claude/skills/swamp-vault/references/troubleshooting.md
+++ b/.claude/skills/swamp-vault/references/troubleshooting.md
@@ -1,0 +1,134 @@
+# Vault Troubleshooting
+
+## Common Errors
+
+### "Vault not found"
+
+**Symptom**: `Error: Vault 'my-vault' not found`
+
+**Causes and solutions**:
+
+1. Vault doesn't exist - Create it:
+   ```bash
+   swamp vault create local_encryption my-vault
+   ```
+
+2. Typo in vault name - List available vaults:
+   ```bash
+   swamp vault search --json
+   ```
+
+3. Vault config file corrupted - Check the file:
+   ```bash
+   swamp vault get my-vault --json
+   ```
+
+### "Secret not found"
+
+**Symptom**: `Error: Secret 'API_KEY' not found in vault 'dev-secrets'`
+
+**Causes and solutions**:
+
+1. Secret not stored yet:
+   ```bash
+   swamp vault put dev-secrets API_KEY=your-value
+   ```
+
+2. Wrong key name - List available keys:
+   ```bash
+   swamp vault list-keys dev-secrets --json
+   ```
+
+### AWS Authentication Errors
+
+**Symptom**: `Error: Unable to load credentials`
+
+**Solutions**:
+
+1. Check environment variables:
+   ```bash
+   echo $AWS_ACCESS_KEY_ID
+   echo $AWS_SECRET_ACCESS_KEY
+   ```
+
+2. Check AWS profile:
+   ```bash
+   aws sts get-caller-identity --profile your-profile
+   ```
+
+3. Verify region in vault config:
+   ```bash
+   swamp vault edit prod-vault
+   ```
+
+### Local Encryption Key Errors
+
+**Symptom**: `Error: Cannot read encryption key`
+
+**Causes and solutions**:
+
+1. SSH key not found at specified path - Verify the path:
+   ```bash
+   ls -la ~/.ssh/id_rsa
+   ```
+
+2. Auto-generated key missing - The key should auto-regenerate, but check:
+   ```bash
+   ls -la .data/secrets/local_encryption/{vault-name}/.key
+   ```
+
+3. Key file permissions too open - Fix permissions:
+   ```bash
+   chmod 600 .data/secrets/local_encryption/{vault-name}/.key
+   ```
+
+### Expression Evaluation Errors
+
+**Symptom**: `Error evaluating vault expression: vault.get(dev-secrets, KEY)`
+
+**Causes**:
+
+1. Vault doesn't exist
+2. Secret key doesn't exist in vault
+3. Vault provider authentication failed
+
+**Debug steps**:
+
+1. Verify vault exists:
+   ```bash
+   swamp vault get dev-secrets --json
+   ```
+
+2. Verify secret exists:
+   ```bash
+   swamp vault list-keys dev-secrets --json
+   ```
+
+3. Test retrieval manually (won't display value, but confirms access):
+   ```bash
+   # Use the swamp/lets-get-sensitive model to test
+   swamp model create swamp/lets-get-sensitive test-get
+   # Edit to set operation: get, vaultName, secretKey
+   swamp model method run test-get get
+   ```
+
+## Vault Name Validation
+
+Vault names must:
+
+- Start with a lowercase letter
+- Contain only lowercase letters, numbers, and hyphens
+- Be unique across all vault types
+
+**Invalid names**: `MyVault`, `123-vault`, `vault_name`, `VAULT` **Valid
+names**: `dev-secrets`, `prod-vault`, `api-keys-v2`
+
+## Rebuilding Logical Views
+
+If vault symlinks are missing or broken:
+
+```bash
+swamp repo index
+```
+
+This rebuilds all logical views including `/vaults/{name}/` directories.

--- a/src/infrastructure/assets/skill_assets.ts
+++ b/src/infrastructure/assets/skill_assets.ts
@@ -28,6 +28,18 @@ const BUNDLED_SKILLS: SkillInfo[] = [
     relativePath: "swamp-extension-model/references/troubleshooting.md",
     name: "swamp-extension-model",
   },
+  {
+    relativePath: "swamp-vault/SKILL.md",
+    name: "swamp-vault",
+  },
+  {
+    relativePath: "swamp-vault/references/providers.md",
+    name: "swamp-vault",
+  },
+  {
+    relativePath: "swamp-vault/references/troubleshooting.md",
+    name: "swamp-vault",
+  },
 ];
 
 /**


### PR DESCRIPTION
- Add new `swamp-vault` skill to teach agents about vault management
- Skill includes progressive disclosure with reference files for provider details and troubleshooting
- Automatically copied to repos during `swamp repo init` and `swamp repo upgrade`

## Test plan

- [x] All 1289 tests pass
- [x] Type checking passes (`deno check`)
- [x] Files formatted with `deno fmt`
- [x] Verify skill appears after `swamp repo init` in a new directory
- [x] Verify skill updates after `swamp repo upgrade