### PR TITLE
fix: workflow create now emits domain events for logical view symlinks

### DIFF
--- a/integration/workflow_test.ts
+++ b/integration/workflow_test.ts
@@ -108,6 +108,58 @@ Deno.test("CLI: workflow create creates new workflow file", async () => {
   });
 });
 
+Deno.test("CLI: workflow create creates logical view symlink", async () => {
+  await withTempDir(async (repoDir) => {
+    const result = await runCliCommand(
+      [
+        "workflow",
+        "create",
+        "symlink-test",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Command should succeed. stderr: ${result.stderr}`,
+    );
+
+    const output = JSON.parse(result.stdout);
+    const workflowId = output.id;
+
+    // Verify the logical view symlink exists at /workflows/{name}/workflow.yaml
+    const symlinkPath = `${repoDir}/workflows/symlink-test/workflow.yaml`;
+    const symlinkStat = await Deno.lstat(symlinkPath).catch(() => null);
+    assertEquals(
+      symlinkStat !== null && symlinkStat.isSymlink,
+      true,
+      "Symlink should exist at /workflows/{name}/workflow.yaml",
+    );
+
+    // Verify the symlink points to the correct data file
+    const symlinkTarget = await Deno.readLink(symlinkPath);
+    assertStringIncludes(
+      symlinkTarget,
+      `.data/workflows/workflow-${workflowId}.yaml`,
+      "Symlink should point to .data/workflows/workflow-{id}.yaml",
+    );
+
+    // Verify the runs directory was also created
+    const runsDirStat = await Deno.stat(
+      `${repoDir}/workflows/symlink-test/runs`,
+    ).catch(() => null);
+    assertEquals(
+      runsDirStat !== null && runsDirStat.isDirectory,
+      true,
+      "Runs directory should exist at /workflows/{name}/runs/",
+    );
+  });
+});
+
 Deno.test("CLI: workflow create rejects duplicate names", async () => {
   await withTempDir(async (repoDir) => {
     // Create first workflow

--- a/src/cli/commands/workflow_create.ts
+++ b/src/cli/commands/workflow_create.ts
@@ -8,7 +8,7 @@ import { Workflow } from "../../domain/workflows/workflow.ts";
 import { Job } from "../../domain/workflows/job.ts";
 import { Step } from "../../domain/workflows/step.ts";
 import { StepTask } from "../../domain/workflows/step_task.ts";
-import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
+import { createRepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -22,7 +22,8 @@ export const workflowCreateCommand = new Command()
     ctx.logger.debug`Creating workflow: name=${name}`;
 
     const repoDir = options.repoDir ?? ".";
-    const repo = new YamlWorkflowRepository(repoDir);
+    const repoContext = createRepositoryContext({ repoDir });
+    const repo = repoContext.workflowRepo;
 
     // Check if name already exists
     const existing = await repo.findByName(name);


### PR DESCRIPTION
- Fix `workflow create` command to use `createRepositoryContext()` instead of directly instantiating `YamlWorkflowRepository`
- This ensures the EventBus is wired up so `WorkflowCreated` events are emitted
- The `SymlinkRepoIndexService` now receives events and creates logical view symlinks automatically
- Add integration test to verify symlink creation on workflow create

## Test plan

- [x] Run `deno check` - passes
- [x] Run `deno lint` - passes
- [x] Run `deno fmt` - passes
- [x] Run `deno run test` - all 1290 tests pass
- [x] Run `deno run compile` - binary compiled successfully
- [x] Manual test: `swamp workflow create test-workflow` creates symlink at `/workflows/test-workflow/workflow.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)