### PR TITLE
fix: extend CEL hyphenated model ref transformation to all access pat…

### DIFF
--- a/src/domain/expressions/expression_parser.ts
+++ b/src/domain/expressions/expression_parser.ts
@@ -18,10 +18,10 @@ const EXPRESSION_PATTERN = /\$\{\{\s*(.+?)\s*\}\}/g;
  * @returns The expression with hyphenated model names using bracket notation
  */
 export function transformHyphenatedModelRefs(expression: string): string {
-  // Pattern matches: model.<name-with-hyphens>.(input|resource)
+  // Pattern matches: model.<name-with-hyphens>.(input|resource|data|file|log|execution)
   // The name must contain at least one hyphen to need transformation
   return expression.replace(
-    /model\.([a-zA-Z0-9_]+(?:-[a-zA-Z0-9_-]+)+)\.(input|resource)/g,
+    /model\.([a-zA-Z0-9_]+(?:-[a-zA-Z0-9_-]+)+)\.(input|resource|data|file|log|execution)/g,
     'model["$1"].$2',
   );
 }

--- a/src/infrastructure/cel/cel_evaluator_test.ts
+++ b/src/infrastructure/cel/cel_evaluator_test.ts
@@ -268,6 +268,65 @@ Deno.test("transformHyphenatedModelRefs handles multiple hyphens", () => {
   );
 });
 
+Deno.test("transformHyphenatedModelRefs handles data references", () => {
+  assertEquals(
+    transformHyphenatedModelRefs("model.proxmox-auth.data.attributes.ticket"),
+    'model["proxmox-auth"].data.attributes.ticket',
+  );
+});
+
+Deno.test("transformHyphenatedModelRefs handles file references", () => {
+  assertEquals(
+    transformHyphenatedModelRefs("model.my-config.file.path"),
+    'model["my-config"].file.path',
+  );
+});
+
+Deno.test("transformHyphenatedModelRefs handles log references", () => {
+  assertEquals(
+    transformHyphenatedModelRefs("model.my-service.log.entries"),
+    'model["my-service"].log.entries',
+  );
+});
+
+Deno.test("transformHyphenatedModelRefs handles execution references", () => {
+  assertEquals(
+    transformHyphenatedModelRefs("model.my-task.execution.status"),
+    'model["my-task"].execution.status',
+  );
+});
+
+Deno.test("CelEvaluator handles hyphenated model names in data access", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    model: {
+      "proxmox-auth": {
+        data: {
+          attributes: {
+            ticket: "PVE:user@pve:123456789::abc123",
+            csrfToken: "12345678:abcdef",
+          },
+        },
+      },
+    },
+  };
+
+  assertEquals(
+    evaluator.evaluate(
+      "model.proxmox-auth.data.attributes.ticket",
+      context,
+    ),
+    "PVE:user@pve:123456789::abc123",
+  );
+  assertEquals(
+    evaluator.evaluate(
+      "model.proxmox-auth.data.attributes.csrfToken",
+      context,
+    ),
+    "12345678:abcdef",
+  );
+});
+
 Deno.test("CelEvaluator evaluates env variable access", () => {
   const evaluator = new CelEvaluator();
   const context = {


### PR DESCRIPTION
…terns

The regex for transforming hyphenated model names to bracket notation only handled input|resource patterns. This caused expressions like `model.proxmox-auth.data.attributes.ticket` to be interpreted as subtraction.

Extended the pattern to include all access types: input, resource, data, file, log, and execution. Added unit tests for each new pattern and an integration test for data access with CelEvaluator.