### PR TITLE
fix: resolve vault expressions from .swamp.yaml configuration

### DIFF
--- a/integration/vault_test.ts
+++ b/integration/vault_test.ts
@@ -1273,3 +1273,163 @@ Deno.test("CLI: vault list-keys returns keys in sorted order", async () => {
     assertEquals(output.secretKeys[2], "ZEBRA");
   });
 });
+
+// ============================================================================
+// .swamp.yaml vault configuration tests
+// ============================================================================
+
+Deno.test("CLI: vault expressions resolve with vault configured in .swamp.yaml", async () => {
+  await withTempDir(async (repoDir) => {
+    // 1. Create a .swamp.yaml file with vault configuration
+    const swampYamlContent = `
+swampVersion: "0.1.0"
+initializedAt: "${new Date().toISOString()}"
+vaults:
+  yaml-vault:
+    type: local_encryption
+    config:
+      auto_generate: true
+`;
+    await Deno.writeTextFile(join(repoDir, ".swamp.yaml"), swampYamlContent);
+
+    // 2. Store a secret using vault put (this will use the vault from .swamp.yaml)
+    const secretValue = "secret-from-yaml-config";
+    const vaultPutResult = await runCliCommand([
+      "vault",
+      "put",
+      "yaml-vault",
+      `MY_SECRET=${secretValue}`,
+      "--repo-dir",
+      repoDir,
+      "--json",
+    ]);
+
+    assertEquals(
+      vaultPutResult.code,
+      0,
+      `Vault put should succeed. stderr: ${vaultPutResult.stderr}`,
+    );
+
+    // 3. Create an echo model input with a vault.get() expression
+    const echoInputId = "c3d4e5f6-a7b8-4901-abcd-ef0123456789";
+    const echoInputContent = `
+id: ${echoInputId}
+name: yaml-vault-echo
+version: 1
+tags: {}
+attributes:
+  message: "\${{ vault.get(yaml-vault, MY_SECRET) }}"
+`;
+    const echoInputDir = join(repoDir, ".data", "inputs", "swamp", "echo");
+    await Deno.mkdir(echoInputDir, { recursive: true });
+    await Deno.writeTextFile(
+      join(echoInputDir, `${echoInputId}.yaml`),
+      echoInputContent,
+    );
+
+    // 4. Evaluate the expression using model evaluate
+    const evalResult = await runCliCommand([
+      "model",
+      "evaluate",
+      "yaml-vault-echo",
+      "--repo-dir",
+      repoDir,
+      "--json",
+    ]);
+    assertEquals(
+      evalResult.code,
+      0,
+      `Model evaluate should succeed. stderr: ${evalResult.stderr}`,
+    );
+
+    // 5. Verify the evaluated input contains the resolved secret
+    const evaluatedInputPath = join(
+      repoDir,
+      ".data",
+      "inputs-evaluated",
+      "swamp",
+      "echo",
+      `${echoInputId}.yaml`,
+    );
+    assertEquals(
+      existsSync(evaluatedInputPath),
+      true,
+      "Evaluated input should exist",
+    );
+
+    const evaluatedContent = await Deno.readTextFile(evaluatedInputPath);
+    const evaluatedData = parseYaml(evaluatedContent) as Record<
+      string,
+      unknown
+    >;
+    const attributes = evaluatedData.attributes as Record<string, unknown>;
+
+    // The secret should be resolved in the evaluated input
+    assertEquals(
+      attributes.message,
+      secretValue,
+      "Vault expression should resolve to the secret value from .swamp.yaml vault",
+    );
+  });
+});
+
+Deno.test("CLI: .data/vault/ vaults take precedence over .swamp.yaml vaults", async () => {
+  await withTempDir(async (repoDir) => {
+    // 1. Create a .swamp.yaml file with vault configuration
+    const swampYamlContent = `
+swampVersion: "0.1.0"
+initializedAt: "${new Date().toISOString()}"
+vaults:
+  precedence-vault:
+    type: local_encryption
+    config:
+      auto_generate: true
+`;
+    await Deno.writeTextFile(join(repoDir, ".swamp.yaml"), swampYamlContent);
+
+    // 2. Create the same vault via CLI (stored in .data/vault/)
+    const cliVaultResult = await runCliCommand([
+      "vault",
+      "create",
+      "local_encryption",
+      "precedence-vault",
+      "--repo-dir",
+      repoDir,
+      "--json",
+    ]);
+    assertEquals(
+      cliVaultResult.code,
+      0,
+      `Vault create should succeed. stderr: ${cliVaultResult.stderr}`,
+    );
+
+    // 3. Store a secret - should use the .data/vault/ version
+    const secretValue = "from-data-vault";
+    const vaultPutResult = await runCliCommand([
+      "vault",
+      "put",
+      "precedence-vault",
+      `TEST_KEY=${secretValue}`,
+      "--repo-dir",
+      repoDir,
+      "--json",
+    ]);
+    assertEquals(
+      vaultPutResult.code,
+      0,
+      `Vault put should succeed. stderr: ${vaultPutResult.stderr}`,
+    );
+
+    // 4. The vault from .data/vault/ should have been used
+    // Verify by checking the secret is stored in the correct location
+    const secretPath = join(
+      repoDir,
+      ".data",
+      "secrets",
+      "local_encryption",
+      "precedence-vault",
+      "TEST_KEY.enc",
+    );
+    assertEquals(existsSync(secretPath), true, "Secret should be stored");
+  });
+});

--- a/integration/workflow_test.ts
+++ b/integration/workflow_test.ts
@@ -1455,3 +1455,120 @@ Deno.test("CLI: workflow run evaluates inline env expression with surrounding te
     assertEquals(dataArtifact?.attributes.message, "prefix-middle-suffix");
   });
 });
+
+// Vault expression tests in workflows
+
+Deno.test("CLI: workflow run resolves vault expressions in model inputs", async () => {
+  await withTempDir(async (repoDir) => {
+    // 1. Create a local_encryption vault via CLI
+    const vaultCreateResult = await runCliCommand(
+      [
+        "vault",
+        "create",
+        "local_encryption",
+        "workflow-vault",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+    assertEquals(
+      vaultCreateResult.code,
+      0,
+      `Vault create should succeed. stderr: ${vaultCreateResult.stderr}`,
+    );
+
+    // 2. Store a secret in the vault using vault put
+    const secretValue = "secret-from-vault-123";
+    const vaultPutResult = await runCliCommand(
+      [
+        "vault",
+        "put",
+        "workflow-vault",
+        `API_KEY=${secretValue}`,
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+    assertEquals(
+      vaultPutResult.code,
+      0,
+      `Vault put should succeed. stderr: ${vaultPutResult.stderr}`,
+    );
+
+    // 3. Create a model that uses a vault.get() expression
+    const inputRepo = new YamlInputRepository(repoDir);
+    const input = ModelInput.create({
+      name: "vault-model",
+      attributes: {
+        // Use vault expression to get the secret
+        message: "${{ vault.get(workflow-vault, API_KEY) }}",
+      },
+    });
+    await inputRepo.save(ECHO_MODEL_TYPE, input);
+
+    // 4. Create a workflow that runs the model
+    const workflowRepo = new YamlWorkflowRepository(repoDir);
+    const workflow = Workflow.create({
+      name: "vault-workflow",
+      jobs: [
+        Job.create({
+          name: "run-vault-model",
+          steps: [
+            Step.create({
+              name: "write-echo",
+              task: StepTask.modelMethod("vault-model", "write"),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    // 5. Run the workflow
+    const result = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "vault-workflow",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Workflow run should succeed. stderr: ${result.stderr}, stdout: ${result.stdout}`,
+    );
+
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.status, "succeeded");
+    assertEquals(output.jobs[0].steps[0].status, "succeeded");
+
+    // 6. Verify the model's data has the resolved vault secret
+    const dataRepo = new YamlDataRepository(repoDir);
+    const updatedModel = await inputRepo.findByName(
+      ECHO_MODEL_TYPE,
+      input.name,
+    );
+    if (!updatedModel?.dataId) {
+      throw new Error("Expected dataId to be set after workflow run");
+    }
+
+    const dataArtifact = await dataRepo.findById(
+      ECHO_MODEL_TYPE,
+      createModelDataId(updatedModel.dataId),
+    );
+    assertEquals(
+      dataArtifact?.attributes.message,
+      secretValue,
+      "Vault expression should resolve to the secret value",
+    );
+  });
+});

--- a/src/cli/commands/vault_list_keys.ts
+++ b/src/cli/commands/vault_list_keys.ts
@@ -22,28 +22,32 @@ export const vaultListKeysCommand = new Command()
 
     const repoDir = options.repoDir ?? ".";
 
+    // Load vault service (loads from both .data/vault/ and .swamp.yaml)
+    const vaultService = await VaultService.fromRepository(repoDir);
+
     // Verify vault exists
-    const repo = new YamlVaultConfigRepository(repoDir);
-    const vaultConfig = await repo.findByName(vaultName);
-    if (!vaultConfig) {
-      // List available vaults for helpful error message
-      const allVaults = await repo.findAll();
-      if (allVaults.length === 0) {
+    const availableVaults = vaultService.getVaultNames();
+    if (!availableVaults.includes(vaultName)) {
+      if (availableVaults.length === 0) {
         throw new UserError(
           `Vault '${vaultName}' not found. No vaults are configured.\n` +
-            `Create a vault using: swamp vault create <type> ${vaultName}`,
+            `Create a vault using: swamp vault create <type> ${vaultName}\n` +
+            `Or configure a vault in .swamp.yaml`,
         );
       }
-      const vaultNames = allVaults.map((v) => v.name).join(", ");
       throw new UserError(
-        `Vault '${vaultName}' not found. Available vaults: ${vaultNames}`,
+        `Vault '${vaultName}' not found. Available vaults: ${
+          availableVaults.join(", ")
+        }`,
       );
     }
 
-    ctx.logger.debug`Found vault: ${vaultConfig.name} (${vaultConfig.type})`;
+    // Get vault type for display (from .data/vault/ if available)
+    const repo = new YamlVaultConfigRepository(repoDir);
+    const vaultConfig = await repo.findByName(vaultName);
+    const vaultType = vaultConfig?.type ?? "configured";
 
-    // Load vault service to list secrets
-    const vaultService = await VaultService.fromRepository(repoDir);
+    ctx.logger.debug`Found vault: ${vaultName} (${vaultType})`;
 
     // List secret keys
     const secretKeys = await vaultService.list(vaultName);
@@ -51,7 +55,7 @@ export const vaultListKeysCommand = new Command()
 
     const data: VaultListKeysData = {
       vaultName,
-      vaultType: vaultConfig.type,
+      vaultType,
       secretKeys,
       count: secretKeys.length,
     };

--- a/src/cli/commands/vault_put.ts
+++ b/src/cli/commands/vault_put.ts
@@ -98,28 +98,34 @@ export const vaultPutCommand = new Command()
     const { key, value } = parsed;
     ctx.logger.debug`Parsed key: ${key}`;
 
-    // Verify vault exists
-    const repo = new YamlVaultConfigRepository(repoDir);
-    const vaultConfig = await repo.findByName(vaultName);
-    if (!vaultConfig) {
-      // List available vaults for helpful error message
-      const allVaults = await repo.findAll();
-      if (allVaults.length === 0) {
+    // Load vault service to interact with secrets
+    // This loads vaults from both .data/vault/ and .swamp.yaml
+    const vaultService = await VaultService.fromRepository(repoDir);
+
+    // Verify vault exists by checking if VaultService knows about it
+    const availableVaults = vaultService.getVaultNames();
+    if (!availableVaults.includes(vaultName)) {
+      if (availableVaults.length === 0) {
         throw new UserError(
           `Vault '${vaultName}' not found. No vaults are configured.\n` +
-            `Create a vault using: swamp vault create <type> ${vaultName}`,
+            `Create a vault using: swamp vault create <type> ${vaultName}\n` +
+            `Or configure a vault in .swamp.yaml`,
         );
       }
-      const vaultNames = allVaults.map((v) => v.name).join(", ");
       throw new UserError(
-        `Vault '${vaultName}' not found. Available vaults: ${vaultNames}`,
+        `Vault '${vaultName}' not found. Available vaults: ${
+          availableVaults.join(", ")
+        }`,
       );
     }
 
-    ctx.logger.debug`Found vault: ${vaultConfig.name} (${vaultConfig.type})`;
+    // Get vault config for display purposes (from .data/vault/ if available)
+    const repo = new YamlVaultConfigRepository(repoDir);
+    const vaultConfig = await repo.findByName(vaultName);
+    // If not in .data/vault/, the vault is from .swamp.yaml - we'll report the type as "configured"
+    const vaultType = vaultConfig?.type ?? "configured";
 
-    // Load vault service to interact with secrets
-    const vaultService = await VaultService.fromRepository(repoDir);
+    ctx.logger.debug`Found vault: ${vaultName} (${vaultType})`;
 
     // Check if secret already exists
     const exists = await secretExists(vaultService, vaultName, key);
@@ -140,21 +146,23 @@ export const vaultPutCommand = new Command()
     await vaultService.put(vaultName, key, value);
     ctx.logger.debug`Secret stored successfully`;
 
-    // Emit event to update the logical view symlinks
-    const repoContext = createRepositoryContext({ repoDir });
-    const event = createVaultSecretUpdated(
-      vaultConfig.id,
-      vaultConfig.type,
-      vaultConfig.name,
-      key,
-    );
-    await repoContext.eventBus.publish(event);
-    ctx.logger.debug`Emitted VaultSecretUpdated event`;
+    // Emit event to update the logical view symlinks (only if vault is from .data/vault/)
+    if (vaultConfig) {
+      const repoContext = createRepositoryContext({ repoDir });
+      const event = createVaultSecretUpdated(
+        vaultConfig.id,
+        vaultConfig.type,
+        vaultConfig.name,
+        key,
+      );
+      await repoContext.eventBus.publish(event);
+      ctx.logger.debug`Emitted VaultSecretUpdated event`;
+    }
 
     const data: VaultPutData = {
       vaultName,
       secretKey: key,
-      vaultType: vaultConfig.type,
+      vaultType,
       overwritten: exists,
       timestamp: new Date().toISOString(),
     };

--- a/src/domain/vaults/vault_service.ts
+++ b/src/domain/vaults/vault_service.ts
@@ -7,6 +7,8 @@ import {
   LocalEncryptionVaultProvider,
 } from "./local_encryption_vault_provider.ts";
 import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
+import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
+import { RepoPath } from "../repo/repo_path.ts";
 
 /**
  * Service for managing vault providers and resolving vault operations.
@@ -19,11 +21,48 @@ export class VaultService {
    * This is the preferred way to create a VaultService that should have access to
    * all configured vaults.
    *
+   * Vaults are loaded from two sources (in order of priority):
+   * 1. .data/vault/ directory (created via `swamp vault create`)
+   * 2. .swamp.yaml file (vaults section)
+   *
+   * If the same vault name exists in both, the .data/vault/ version takes precedence.
+   *
    * @param repoDir - The repository directory containing vault configurations
    * @returns A VaultService with all configured vaults loaded
    */
   static async fromRepository(repoDir: string): Promise<VaultService> {
     const vaultService = new VaultService();
+    const logger = getLogger("vaults");
+
+    // First, load vaults from .swamp.yaml (lower priority)
+    try {
+      const repoMarkerRepo = new RepoMarkerRepository();
+      const repoPath = RepoPath.create(repoDir);
+      const markerData = await repoMarkerRepo.read(repoPath);
+
+      if (markerData?.vaults) {
+        for (
+          const [vaultName, vaultConfig] of Object.entries(markerData.vaults)
+        ) {
+          try {
+            vaultService.registerVault({
+              name: vaultName,
+              type: vaultConfig.type,
+              config: vaultConfig.config ?? {},
+            });
+            logger.debug`Loaded vault '${vaultName}' from .swamp.yaml`;
+          } catch (error) {
+            logger
+              .debug`Failed to register vault '${vaultName}' from .swamp.yaml: ${error}`;
+          }
+        }
+      }
+    } catch (error) {
+      // .swamp.yaml may not exist or be invalid
+      logger.debug`Failed to load vaults from .swamp.yaml: ${error}`;
+    }
+
+    // Then, load vaults from .data/vault/ (higher priority - will override .swamp.yaml)
     try {
       const vaultRepo = new YamlVaultConfigRepository(repoDir);
       const vaultConfigs = await vaultRepo.findAll();
@@ -33,11 +72,13 @@ export class VaultService {
           type: vaultConfig.type, // Let registerVault validate and throw for unsupported types
           config: vaultConfig.config,
         });
+        logger.debug`Loaded vault '${vaultConfig.name}' from .data/vault/`;
       }
     } catch (error) {
       // Repository may not exist yet, or vault config may be invalid
-      getLogger("vaults").debug`Failed to load vault configs: ${error}`;
+      logger.debug`Failed to load vault configs from .data/vault/: ${error}`;
     }
+
     vaultService.ensureDefaultVaults();
     return vaultService;
   }

--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -6,6 +6,15 @@ import type { RepoPath } from "../../domain/repo/repo_path.ts";
 const MARKER_FILENAME = ".swamp.yaml";
 
 /**
+ * Vault configuration as specified in .swamp.yaml.
+ * The key is the vault name, and the value contains type and config.
+ */
+export interface RepoMarkerVaultConfig {
+  type: string;
+  config?: Record<string, unknown>;
+}
+
+/**
  * Data structure for the .swamp.yaml marker file.
  */
 export interface RepoMarkerData {
@@ -13,6 +22,8 @@ export interface RepoMarkerData {
   initializedAt: string;
   upgradedAt?: string;
   modelsDir?: string;
+  /** Vault configurations keyed by vault name */
+  vaults?: Record<string, RepoMarkerVaultConfig>;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixes vault expression resolution to properly load vaults configured in `.swamp.yaml`
- Vault service now reads vault configurations from both `.data/vault/` directory and `.swamp.yaml` file
- Adds integration tests verifying vault expressions work correctly in workflows

## Test Plan

- Added integration tests in `integration/vault_test.ts` and `integration/workflow_test.ts`
- All 1300 tests pass