### PR TITLE
fix: correct YAML structure examples in skill documentation

### DIFF
--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -118,12 +118,11 @@ attributes according to the `inputAttributesSchema` from `type describe`.
 **Example input file structure:**
 
 ```yaml
-# inputs/swamp/echo/my-echo.yaml
-apiVersion: swamp/v1
-kind: Input
-metadata:
-  name: my-echo
-  type: swamp/echo
+# .data/inputs/swamp/echo/<uuid>.yaml
+id: 550e8400-e29b-41d4-a716-446655440000
+name: my-echo
+version: 1
+tags: {}
 attributes:
   message: "Hello, world!"
 ```
@@ -155,12 +154,11 @@ Expressions support standard CEL operations:
 ### Example with Expressions
 
 ```yaml
-# inputs/aws/subnet/my-subnet.yaml
-apiVersion: swamp/v1
-kind: Input
-metadata:
-  name: my-subnet
-  type: aws/subnet
+# .data/inputs/aws/subnet/<uuid>.yaml
+id: 550e8400-e29b-41d4-a716-446655440001
+name: my-subnet
+version: 1
+tags: {}
 attributes:
   vpcId: ${{ model.my-vpc.resource.attributes.vpcId }}
   cidrBlock: "10.0.1.0/24"

--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -171,13 +171,11 @@ After creation, edit the YAML file at the returned `path` to add jobs and steps.
 **Example workflow file structure:**
 
 ```yaml
-# workflows/workflow-abc-123.yaml
-apiVersion: swamp/v1
-kind: Workflow
-metadata:
-  id: abc-123
-  name: my-deploy-workflow
-  version: 1
+# .data/workflows/workflow-abc-123.yaml
+id: abc-123
+name: my-deploy-workflow
+description: Deploy workflow with build and deploy jobs
+version: 1
 jobs:
   - name: build
     description: Build the application
@@ -190,7 +188,11 @@ jobs:
           args: ["task", "build"]
   - name: deploy
     description: Deploy the application
-    needs: [build]
+    dependsOn:
+      - job: build
+        condition:
+          type: succeeded
+          ref: build
     steps:
       - name: upload
         description: Upload artifacts


### PR DESCRIPTION
- Fix model input YAML examples in swamp-model skill to match actual implementation
- Fix workflow YAML example in swamp-workflow skill to match actual implementation
- Update job dependency syntax from deprecated `needs` to `dependsOn` with trigger conditions

## Details
The skill documentation examples were using a Kubernetes-style manifest structure with `apiVersion`, `kind`, and `metadata` fields
that don't exist in the actual implementation. The correct structure uses flat top-level fields (`id`, `name`, `version`, `tags`,
`attributes` for models; `id`, `name`, `description`, `version`, `jobs` for workflows).

## Test plan
- [ ] Review updated examples match actual YAML files created by `swamp model create` and `swamp workflow create`
- [ ] Verify examples are valid according to their respective schemas