### PR TITLE
feat: add generic aws/cli model for data chaining

### DIFF
--- a/src/domain/models/aws/cli/aws_cli_model.ts
+++ b/src/domain/models/aws/cli/aws_cli_model.ts
@@ -1,0 +1,224 @@
+import { z } from "zod";
+import { ModelType } from "../../model_type.ts";
+import { ModelData } from "../../model_data.ts";
+import {
+  defineModel,
+  type MethodContext,
+  type MethodResult,
+  type ModelDefinition,
+} from "../../model.ts";
+import type { ModelInput } from "../../model_input.ts";
+
+/**
+ * Schema for AWS CLI model input attributes.
+ */
+export const AwsCliInputAttributesSchema = z.object({
+  /** AWS CLI command to execute (without the 'aws' prefix), e.g., "ec2 describe-instances" */
+  command: z.string().min(1),
+  /** Override AWS_REGION environment variable */
+  region: z.string().optional(),
+  /** Override AWS_PROFILE environment variable */
+  profile: z.string().optional(),
+  /** Command timeout in milliseconds (default: 60000ms) */
+  timeout: z.number().int().positive().default(60000),
+  /** Parse stdout as JSON and store in 'json' attribute */
+  parseJson: z.boolean().default(false),
+});
+
+/**
+ * Type for AWS CLI model input attributes.
+ */
+export type AwsCliInputAttributes = z.infer<typeof AwsCliInputAttributesSchema>;
+
+/**
+ * Schema for AWS CLI model data attributes.
+ */
+export const AwsCliDataAttributesSchema = z.object({
+  /** Raw stdout from the command */
+  output: z.string(),
+  /** Parsed JSON output (if parseJson was true and output was valid JSON) */
+  json: z.unknown().optional(),
+  /** Command exit code */
+  exitCode: z.number(),
+  /** ISO timestamp when command was executed */
+  executedAt: z.string().datetime(),
+  /** Duration of command execution in milliseconds */
+  durationMs: z.number(),
+});
+
+/**
+ * Type for AWS CLI model data attributes.
+ */
+export type AwsCliDataAttributes = z.infer<typeof AwsCliDataAttributesSchema>;
+
+/**
+ * The AWS CLI model type identifier.
+ */
+export const AWS_CLI_MODEL_TYPE = ModelType.create("aws/cli");
+
+/**
+ * Parse a command string into an array of arguments.
+ * Handles quoted strings and escaped characters.
+ */
+function parseCommand(command: string): string[] {
+  const args: string[] = [];
+  let current = "";
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+  let escapeNext = false;
+
+  for (const char of command) {
+    if (escapeNext) {
+      current += char;
+      escapeNext = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      escapeNext = true;
+      continue;
+    }
+
+    if (char === "'" && !inDoubleQuote) {
+      inSingleQuote = !inSingleQuote;
+      continue;
+    }
+
+    if (char === '"' && !inSingleQuote) {
+      inDoubleQuote = !inDoubleQuote;
+      continue;
+    }
+
+    if (char === " " && !inSingleQuote && !inDoubleQuote) {
+      if (current.length > 0) {
+        args.push(current);
+        current = "";
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current.length > 0) {
+    args.push(current);
+  }
+
+  return args;
+}
+
+/**
+ * Executes the "run" method for the AWS CLI model.
+ *
+ * Runs an AWS CLI command and captures the output as data attributes.
+ */
+async function executeRun(
+  input: ModelInput,
+  _context: MethodContext,
+): Promise<MethodResult> {
+  const attrs = AwsCliInputAttributesSchema.parse(input.attributes);
+
+  // Build environment with optional overrides
+  const env: Record<string, string> = { ...Deno.env.toObject() };
+  if (attrs.region) {
+    env.AWS_REGION = attrs.region;
+  }
+  if (attrs.profile) {
+    env.AWS_PROFILE = attrs.profile;
+  }
+
+  // Parse command into args, handling quoted strings
+  const args = parseCommand(attrs.command);
+
+  const startTime = Date.now();
+
+  // Create abort controller for timeout
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(() => abortController.abort(), attrs.timeout);
+
+  try {
+    const command = new Deno.Command("aws", {
+      args,
+      stdout: "piped",
+      stderr: "piped",
+      env,
+      signal: abortController.signal,
+    });
+
+    const result = await command.output();
+    const stdout = new TextDecoder().decode(result.stdout);
+    const stderr = new TextDecoder().decode(result.stderr);
+    const durationMs = Date.now() - startTime;
+
+    if (!result.success) {
+      throw new Error(
+        `AWS CLI failed (exit ${result.code}): ${
+          stderr.trim() || stdout.trim()
+        }`,
+      );
+    }
+
+    // Optionally parse JSON output
+    let json: unknown = undefined;
+    if (attrs.parseJson) {
+      const trimmedOutput = stdout.trim();
+      if (trimmedOutput.length > 0) {
+        try {
+          json = JSON.parse(trimmedOutput);
+        } catch {
+          // Leave as undefined if not valid JSON
+        }
+      }
+    }
+
+    // Create the data artifact with command output
+    const data = ModelData.create({
+      id: input.id,
+      attributes: {
+        output: stdout.trim(),
+        json,
+        exitCode: result.code,
+        executedAt: new Date().toISOString(),
+        durationMs,
+      },
+    });
+
+    return { data };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * The AWS CLI model definition.
+ *
+ * A generic model that executes any AWS CLI command and captures
+ * the output as data attributes that can be referenced via CEL expressions.
+ *
+ * This enables data chaining where one model's output can be used
+ * as input to another model (e.g., looking up an AMI ID and using it
+ * to create an EC2 instance).
+ *
+ * Self-registers with the global model registry when this module is imported.
+ */
+export const awsCliModel: ModelDefinition<
+  typeof AwsCliInputAttributesSchema,
+  never,
+  typeof AwsCliDataAttributesSchema
+> = defineModel({
+  type: AWS_CLI_MODEL_TYPE,
+  version: 1,
+  inputAttributesSchema: AwsCliInputAttributesSchema,
+  dataAttributesSchema: AwsCliDataAttributesSchema,
+  methods: {
+    run: {
+      description:
+        "Run an AWS CLI command and capture output as data attributes",
+      inputAttributesSchema: AwsCliInputAttributesSchema,
+      execute: executeRun,
+    },
+  },
+});
+
+// Export parseCommand for testing
+export { parseCommand };

--- a/src/domain/models/aws/cli/aws_cli_model_test.ts
+++ b/src/domain/models/aws/cli/aws_cli_model_test.ts
@@ -1,0 +1,197 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { ModelInput } from "../../model_input.ts";
+import {
+  AWS_CLI_MODEL_TYPE,
+  AwsCliDataAttributesSchema,
+  AwsCliInputAttributesSchema,
+  awsCliModel,
+  parseCommand,
+} from "./aws_cli_model.ts";
+
+Deno.test("AWS_CLI_MODEL_TYPE has correct normalized type", () => {
+  assertEquals(AWS_CLI_MODEL_TYPE.normalized, "aws/cli");
+});
+
+Deno.test("awsCliModel has correct version", () => {
+  assertEquals(awsCliModel.version, 1);
+});
+
+Deno.test("awsCliModel.type equals AWS_CLI_MODEL_TYPE", () => {
+  assertEquals(awsCliModel.type.equals(AWS_CLI_MODEL_TYPE), true);
+});
+
+Deno.test("AwsCliInputAttributesSchema validates command", () => {
+  const result = AwsCliInputAttributesSchema.safeParse({
+    command: "s3 ls",
+  });
+  assertEquals(result.success, true);
+  if (result.success) {
+    assertEquals(result.data.command, "s3 ls");
+    assertEquals(result.data.timeout, 60000); // default
+    assertEquals(result.data.parseJson, false); // default
+  }
+});
+
+Deno.test("AwsCliInputAttributesSchema validates with all options", () => {
+  const result = AwsCliInputAttributesSchema.safeParse({
+    command: "ec2 describe-instances",
+    region: "us-west-2",
+    profile: "production",
+    timeout: 30000,
+    parseJson: true,
+  });
+  assertEquals(result.success, true);
+  if (result.success) {
+    assertEquals(result.data.command, "ec2 describe-instances");
+    assertEquals(result.data.region, "us-west-2");
+    assertEquals(result.data.profile, "production");
+    assertEquals(result.data.timeout, 30000);
+    assertEquals(result.data.parseJson, true);
+  }
+});
+
+Deno.test("AwsCliInputAttributesSchema rejects empty command", () => {
+  const result = AwsCliInputAttributesSchema.safeParse({
+    command: "",
+  });
+  assertEquals(result.success, false);
+});
+
+Deno.test("AwsCliInputAttributesSchema rejects missing command", () => {
+  const result = AwsCliInputAttributesSchema.safeParse({});
+  assertEquals(result.success, false);
+});
+
+Deno.test("AwsCliInputAttributesSchema rejects negative timeout", () => {
+  const result = AwsCliInputAttributesSchema.safeParse({
+    command: "s3 ls",
+    timeout: -1000,
+  });
+  assertEquals(result.success, false);
+});
+
+Deno.test("AwsCliInputAttributesSchema rejects zero timeout", () => {
+  const result = AwsCliInputAttributesSchema.safeParse({
+    command: "s3 ls",
+    timeout: 0,
+  });
+  assertEquals(result.success, false);
+});
+
+Deno.test("AwsCliDataAttributesSchema validates correct data", () => {
+  const result = AwsCliDataAttributesSchema.safeParse({
+    output: "bucket-1\nbucket-2",
+    exitCode: 0,
+    executedAt: "2024-01-15T10:30:00.000Z",
+    durationMs: 150,
+  });
+  assertEquals(result.success, true);
+});
+
+Deno.test("AwsCliDataAttributesSchema validates with json attribute", () => {
+  const result = AwsCliDataAttributesSchema.safeParse({
+    output: '{"Images": []}',
+    json: { Images: [] },
+    exitCode: 0,
+    executedAt: "2024-01-15T10:30:00.000Z",
+    durationMs: 150,
+  });
+  assertEquals(result.success, true);
+  if (result.success) {
+    assertEquals(result.data.json, { Images: [] });
+  }
+});
+
+Deno.test("AwsCliDataAttributesSchema rejects invalid timestamp", () => {
+  const result = AwsCliDataAttributesSchema.safeParse({
+    output: "test",
+    exitCode: 0,
+    executedAt: "not-a-date",
+    durationMs: 150,
+  });
+  assertEquals(result.success, false);
+});
+
+Deno.test("awsCliModel has run method", () => {
+  assertEquals("run" in awsCliModel.methods, true);
+  assertEquals(
+    awsCliModel.methods.run.description,
+    "Run an AWS CLI command and capture output as data attributes",
+  );
+});
+
+Deno.test("parseCommand handles simple commands", () => {
+  assertEquals(parseCommand("s3 ls"), ["s3", "ls"]);
+  assertEquals(parseCommand("ec2 describe-instances"), [
+    "ec2",
+    "describe-instances",
+  ]);
+});
+
+Deno.test("parseCommand handles multiple spaces", () => {
+  assertEquals(parseCommand("s3   ls"), ["s3", "ls"]);
+  assertEquals(parseCommand("  s3 ls  "), ["s3", "ls"]);
+});
+
+Deno.test("parseCommand handles double-quoted arguments", () => {
+  assertEquals(
+    parseCommand('ec2 describe-images --filters "Name=state,Values=available"'),
+    ["ec2", "describe-images", "--filters", "Name=state,Values=available"],
+  );
+});
+
+Deno.test("parseCommand handles single-quoted arguments", () => {
+  assertEquals(parseCommand("ec2 describe-images --filters 'Name=state'"), [
+    "ec2",
+    "describe-images",
+    "--filters",
+    "Name=state",
+  ]);
+});
+
+Deno.test("parseCommand handles mixed quotes", () => {
+  assertEquals(
+    parseCommand("s3 cp 's3://bucket/file with spaces.txt' \"local file.txt\""),
+    ["s3", "cp", "s3://bucket/file with spaces.txt", "local file.txt"],
+  );
+});
+
+Deno.test("parseCommand handles escaped characters", () => {
+  assertEquals(parseCommand("s3 ls s3://bucket/path\\ with\\ spaces"), [
+    "s3",
+    "ls",
+    "s3://bucket/path with spaces",
+  ]);
+});
+
+Deno.test("parseCommand handles complex AWS CLI command", () => {
+  const command =
+    `ec2 describe-images --owners 099720109477 --filters "Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-*" --query 'sort_by(Images,&CreationDate)[-1].ImageId' --output text`;
+  const args = parseCommand(command);
+  assertEquals(args, [
+    "ec2",
+    "describe-images",
+    "--owners",
+    "099720109477",
+    "--filters",
+    "Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-*",
+    "--query",
+    "sort_by(Images,&CreationDate)[-1].ImageId",
+    "--output",
+    "text",
+  ]);
+});
+
+Deno.test("awsCliModel.methods.run validates input attributes", async () => {
+  const input = ModelInput.create({
+    name: "test-aws-cli",
+    attributes: { notACommand: "value" },
+  });
+
+  await assertRejects(
+    async () => {
+      await awsCliModel.methods.run.execute(input, { repoDir: "/tmp" });
+    },
+    Error,
+  );
+});

--- a/src/domain/models/models.ts
+++ b/src/domain/models/models.ts
@@ -19,6 +19,7 @@ import "./aws/ec2/vpc/ec2_vpc_model.ts";
 import "./keeb/shell/shell_model.ts";
 import "./systemd/journalctl/journalctl_model.ts";
 import "./command/curl/curl_model.ts";
+import "./aws/cli/aws_cli_model.ts";
 import "./mermaid/workflow_diagram/workflow_diagram_model.ts";
 import "./lets-get-sensitive/vault_model.ts";
 


### PR DESCRIPTION
- Adds a new `aws/cli` model that executes any AWS CLI command and captures output as **data attributes**
- Enables data chaining where one model's output can be used as input to another model via CEL expressions
- Supports optional JSON parsing for structured data access

## Motivation

The existing `keeb/shell` model stores command output in **logs**, not in **data attributes**. This makes it difficult to reference output
via CEL expressions like `${{ model.foo.data.attributes.output }}`.

The `aws/cli` model solves this by capturing stdout as a data attribute that can be passed to other models.

## Example: AMI Lookup → EC2 Instance

**Step 1: Create model input for AMI lookup** (`.data/inputs/aws/cli/get-ubuntu-ami.yaml`):
```yaml
id: get-ubuntu-ami
name: get-ubuntu-ami
version: 1
attributes:
command: >-
    ec2 describe-images
    --owners 099720109477
    --filters Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*
    Name=state,Values=available
    --query sort_by(Images,&CreationDate)[-1].ImageId
    --output text
region: us-east-1
```

Step 2: Create model input for EC2 instance (.data/inputs/aws/ec2/instance/my-instance.yaml):
```yaml
id: my-instance
name: my-instance
version: 1
attributes:
  ImageId: ${{ model.get-ubuntu-ami.data.attributes.output }}
  InstanceType: t3.micro
  SubnetId: subnet-xxx
```

Step 3: Create workflow (workflows/create-ec2-with-latest-ami.yaml):
```yaml
id: create-ec2-with-latest-ami
name: create-ec2-with-latest-ami
version: 1
jobs:
- name: provision
    steps:
    - name: lookup-ami
        task:
        type: model_method
        modelIdOrName: get-ubuntu-ami
        methodName: run

    - name: create-instance
        task:
        type: model_method
        modelIdOrName: my-instance
        methodName: create
        dependsOn:
        - step: lookup-ami
```

Run it:
`swamp workflow run create-ec2-with-latest-ami`

Other Examples

List S3 buckets:
```yaml
attributes:
    command: "s3 ls"
```

Get secret from Secrets Manager (with JSON parsing):
```yaml
attributes:
    command: "secretsmanager get-secret-value --secret-id my-secret --query SecretString --output text"
    parseJson: true
# Access via: ${{ model.my-secret.data.attributes.json.password }}
```

Describe VPCs:
```yaml
attributes:
    command: "ec2 describe-vpcs --query Vpcs[0].VpcId --output text"
```

## Input Attributes

| Attribute | Type | Required | Default | Description |
|---------|------|----------|---------|-------------|
| command | string | Yes | - | AWS CLI command without aws prefix |
| region | string | No | - | Override AWS_REGION |
| profile | string | No | - | Override AWS_PROFILE |
| timeout | number | No | 60000 | Timeout in milliseconds |
| parseJson | boolean | No | false | Parse output as JSON |

## Data Attributes (Output)

| Attribute | Type | Description |
|---------|------|-------------|
| output | string | Raw stdout from the command |
| json | unknown | Parsed JSON if parseJson was true |
| exitCode | number | Command exit code |
| executedAt | string | ISO timestamp of execution |
| durationMs | number | Execution duration in ms |


Test Plan

- deno check passes
- deno lint passes
- deno fmt passes
- All 1324 tests pass (21 new tests for aws/cli model)
- swamp type search aws/cli finds the model
- swamp type describe aws/cli shows correct schema