### PR TITLE
docs: add aws/cli data chaining examples to swamp skills

### DIFF
--- a/.claude/skills/swamp-extension-model/references/examples.md
+++ b/.claude/skills/swamp-extension-model/references/examples.md
@@ -165,3 +165,83 @@ export const model = {
   },
 };
 ```
+
+## Data Chaining Model
+
+Models that produce data can be chained together using CEL expressions. The
+output from one model's `data.attributes` can be referenced by another model.
+
+```typescript
+// extensions/models/config_generator.ts
+import { z } from "npm:zod@4";
+
+const InputSchema = z.object({
+  environment: z.enum(["dev", "staging", "prod"]),
+  serviceName: z.string(),
+});
+
+const DataSchema = z.object({
+  configJson: z.object({
+    endpoint: z.string(),
+    timeout: z.number(),
+    retries: z.number(),
+  }),
+  generatedAt: z.string(),
+});
+
+export const model = {
+  type: "myorg/config-generator",
+  version: 1,
+  inputAttributesSchema: InputSchema,
+  dataAttributesSchema: DataSchema,
+  methods: {
+    generate: {
+      description: "Generate service configuration based on environment",
+      execute: async (input, _context) => {
+        const { environment, serviceName } = input.attributes;
+
+        // Generate environment-specific configuration
+        const configs = {
+          dev: { timeout: 30000, retries: 1 },
+          staging: { timeout: 15000, retries: 2 },
+          prod: { timeout: 5000, retries: 3 },
+        };
+
+        const envConfig = configs[environment];
+        const endpoint =
+          `https://${serviceName}.${environment}.example.com/api`;
+
+        return {
+          data: {
+            id: input.id,
+            attributes: {
+              configJson: {
+                endpoint,
+                timeout: envConfig.timeout,
+                retries: envConfig.retries,
+              },
+              generatedAt: new Date().toISOString(),
+            },
+          },
+        };
+      },
+    },
+  },
+};
+```
+
+**Using the chained output in another model input:**
+
+```yaml
+# Model input that references config-generator output
+name: my-service-client
+attributes:
+  # Reference the generated config from another model's data output
+  endpoint: ${{ model.api-config.data.attributes.configJson.endpoint }}
+  timeout: ${{ model.api-config.data.attributes.configJson.timeout }}
+  retries: ${{ model.api-config.data.attributes.configJson.retries }}
+```
+
+This pattern enables dynamic configuration where one model generates values that
+are consumed by dependent models, with the workflow engine automatically
+resolving execution order based on expression dependencies.

--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -139,6 +139,7 @@ reference other models.
 | ------------------------------------------ | ---------------------------------- |
 | `model.<name>.input.attributes.<field>`    | Another model's input attribute    |
 | `model.<name>.resource.attributes.<field>` | Another model's resource attribute |
+| `model.<name>.data.attributes.<field>`     | Another model's data attribute     |
 | `self.name`                                | This model's name                  |
 | `self.version`                             | This model's version               |
 | `self.attributes.<field>`                  | This model's own input attribute   |
@@ -224,3 +225,9 @@ results to the user.
    needed)
 5. **Evaluate** expressions: `swamp model evaluate my-message --json`
 6. **Run** the method: `swamp model method run my-message write --json`
+
+## References
+
+- **Data chaining**: See
+  [references/data-chaining.md](references/data-chaining.md) for aws/cli model
+  examples and chaining patterns

--- a/.claude/skills/swamp-model/references/data-chaining.md
+++ b/.claude/skills/swamp-model/references/data-chaining.md
@@ -1,0 +1,101 @@
+# Data Chaining with aws/cli Model
+
+The `aws/cli` model enables data chaining by running AWS CLI commands and
+capturing output for use in other models. Use `parseJson: true` to parse JSON
+output and access it via `data.attributes.json`.
+
+## aws/cli Data Attributes
+
+| Attribute    | Description                                   |
+| ------------ | --------------------------------------------- |
+| `output`     | Raw stdout from the command                   |
+| `json`       | Parsed JSON output (when `parseJson: true`)   |
+| `exitCode`   | Command exit code                             |
+| `executedAt` | ISO timestamp when command was executed       |
+| `durationMs` | Duration of command execution in milliseconds |
+
+## Example: Dynamic AMI Lookup
+
+**Step 1: Create an aws/cli model to look up an AMI:**
+
+```yaml
+# .data/inputs/aws/cli/<uuid>.yaml
+id: 550e8400-e29b-41d4-a716-446655440002
+name: latest-ami
+version: 1
+tags: {}
+attributes:
+  command: >-
+    ec2 describe-images --owners amazon
+    --filters "Name=name,Values=amzn2-ami-hvm-*-x86_64-gp2"
+    --query "sort_by(Images,&CreationDate)[-1]"
+  region: us-east-1
+  parseJson: true
+```
+
+**Step 2: Reference the CLI output in another model:**
+
+```yaml
+# .data/inputs/myorg/ec2-instance/<uuid>.yaml
+id: 550e8400-e29b-41d4-a716-446655440003
+name: my-instance
+version: 1
+tags: {}
+attributes:
+  # Reference parsed JSON fields from the aws/cli model's data output
+  imageId: ${{ model.latest-ami.data.attributes.json.ImageId }}
+  instanceType: t3.micro
+  tags:
+    Name: ${{ self.name }}
+    AmiName: ${{ model.latest-ami.data.attributes.json.Name }}
+```
+
+## Example: Security Group Lookup
+
+```yaml
+# Look up default VPC security group
+name: default-sg
+attributes:
+  command: >-
+    ec2 describe-security-groups
+    --filters "Name=group-name,Values=default"
+    --query "SecurityGroups[0]"
+  parseJson: true
+```
+
+```yaml
+# Reference in EC2 instance
+name: my-server
+attributes:
+  securityGroupIds:
+    - ${{ model.default-sg.data.attributes.json.GroupId }}
+```
+
+## Example: Chaining Multiple Lookups
+
+```yaml
+# Step 1: Get VPC ID
+name: vpc-lookup
+attributes:
+  command: ec2 describe-vpcs --filters "Name=isDefault,Values=true" --query "Vpcs[0]"
+  parseJson: true
+```
+
+```yaml
+# Step 2: Get subnet in that VPC
+name: subnet-lookup
+attributes:
+  command: >-
+    ec2 describe-subnets
+    --filters "Name=vpc-id,Values=${{ model.vpc-lookup.data.attributes.json.VpcId }}"
+    --query "Subnets[0]"
+  parseJson: true
+```
+
+```yaml
+# Step 3: Use both in instance creation
+name: my-instance
+attributes:
+  subnetId: ${{ model.subnet-lookup.data.attributes.json.SubnetId }}
+  vpcId: ${{ model.vpc-lookup.data.attributes.json.VpcId }}
+```

--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -624,3 +624,9 @@ End-to-end workflow for creating and running a new workflow:
 4. **Validate** the workflow: `swamp workflow validate my-task --json`
 5. **Fix** any validation errors and re-validate
 6. **Run** the workflow: `swamp workflow run my-task --json`
+
+## References
+
+- **Data chaining**: See
+  [references/data-chaining.md](references/data-chaining.md) for aws/cli model
+  workflow examples and chaining patterns

--- a/.claude/skills/swamp-workflow/references/data-chaining.md
+++ b/.claude/skills/swamp-workflow/references/data-chaining.md
@@ -1,0 +1,158 @@
+# Data Chaining in Workflows
+
+The `aws/cli` model enables powerful data chaining in workflows by running AWS
+CLI commands and making the output available to other models. This is useful for
+dynamic lookups like finding the latest AMI, checking resource state, or
+querying AWS for configuration values.
+
+## Implicit Dependency Resolution
+
+When a model input contains an expression like
+`${{ model.<name>.data.attributes.json.<field> }}`, the workflow engine
+automatically:
+
+1. Detects the dependency on the referenced model
+2. Ensures the referenced model's method runs first
+3. Evaluates expressions just-in-time before each step executes
+
+## Example: Dynamic AMI Lookup Workflow
+
+```yaml
+id: ec2-with-latest-ami
+name: ec2-with-latest-ami
+description: Create EC2 instance with dynamically looked-up AMI
+version: 1
+jobs:
+  - name: provision
+    description: Provision EC2 with latest Amazon Linux AMI
+    steps:
+      - name: lookup-ami
+        description: Find latest Amazon Linux 2 AMI
+        task:
+          type: model_method
+          modelIdOrName: latest-ami
+          methodName: run
+      - name: create-instance
+        description: Create EC2 instance using looked-up AMI
+        task:
+          type: model_method
+          modelIdOrName: my-instance
+          methodName: create
+```
+
+### Model Inputs
+
+```yaml
+# latest-ami input (aws/cli model)
+name: latest-ami
+attributes:
+  command: >-
+    ec2 describe-images --owners amazon
+    --filters "Name=name,Values=amzn2-ami-hvm-*-x86_64-gp2"
+    --query "sort_by(Images,&CreationDate)[-1]"
+  region: us-east-1
+  parseJson: true
+```
+
+```yaml
+# my-instance input (references aws/cli output)
+name: my-instance
+attributes:
+  imageId: ${{ model.latest-ami.data.attributes.json.ImageId }}
+  instanceType: t3.micro
+```
+
+The workflow engine detects that `my-instance` references
+`latest-ami.data.attributes`, creating an implicit dependency.
+
+## Example: Multi-Step Infrastructure Workflow
+
+```yaml
+id: full-stack-provision
+name: full-stack-provision
+description: Provision complete infrastructure with dynamic lookups
+version: 1
+jobs:
+  - name: lookup
+    description: Look up existing infrastructure
+    steps:
+      - name: find-vpc
+        task:
+          type: model_method
+          modelIdOrName: vpc-lookup
+          methodName: run
+      - name: find-subnet
+        task:
+          type: model_method
+          modelIdOrName: subnet-lookup
+          methodName: run
+  - name: provision
+    description: Create resources using lookup results
+    dependsOn:
+      - job: lookup
+        condition:
+          type: succeeded
+          ref: lookup
+    steps:
+      - name: create-security-group
+        task:
+          type: model_method
+          modelIdOrName: app-security-group
+          methodName: create
+      - name: create-instance
+        task:
+          type: model_method
+          modelIdOrName: app-server
+          methodName: create
+```
+
+### Model Inputs for Multi-Step Workflow
+
+```yaml
+# vpc-lookup (aws/cli)
+name: vpc-lookup
+attributes:
+  command: ec2 describe-vpcs --filters "Name=isDefault,Values=true" --query "Vpcs[0]"
+  parseJson: true
+```
+
+```yaml
+# subnet-lookup (aws/cli) - chains from vpc-lookup
+name: subnet-lookup
+attributes:
+  command: >-
+    ec2 describe-subnets
+    --filters "Name=vpc-id,Values=${{ model.vpc-lookup.data.attributes.json.VpcId }}"
+    --query "Subnets[0]"
+  parseJson: true
+```
+
+```yaml
+# app-security-group - chains from vpc-lookup
+name: app-security-group
+attributes:
+  vpcId: ${{ model.vpc-lookup.data.attributes.json.VpcId }}
+  groupName: app-sg
+  description: Security group for application
+```
+
+```yaml
+# app-server - chains from multiple lookups
+name: app-server
+attributes:
+  imageId: ${{ model.latest-ami.data.attributes.json.ImageId }}
+  subnetId: ${{ model.subnet-lookup.data.attributes.json.SubnetId }}
+  securityGroupIds:
+    - ${{ model.app-security-group.resource.attributes.groupId }}
+  instanceType: t3.micro
+```
+
+## Mixing Data and Resource References
+
+Workflows can chain both `data.attributes` (from aws/cli and similar models) and
+`resource.attributes` (from infrastructure models):
+
+| Reference Type    | Use Case                  | Example                                         |
+| ----------------- | ------------------------- | ----------------------------------------------- |
+| `data.attributes` | CLI output, API responses | `model.ami-lookup.data.attributes.json.ImageId` |
+| `resource`        | Created infrastructure    | `model.my-vpc.resource.attributes.vpcId`        |

--- a/src/infrastructure/assets/skill_assets.ts
+++ b/src/infrastructure/assets/skill_assets.ts
@@ -15,7 +15,15 @@ export interface SkillInfo {
  */
 const BUNDLED_SKILLS: SkillInfo[] = [
   { relativePath: "swamp-model/SKILL.md", name: "swamp-model" },
+  {
+    relativePath: "swamp-model/references/data-chaining.md",
+    name: "swamp-model",
+  },
   { relativePath: "swamp-workflow/SKILL.md", name: "swamp-workflow" },
+  {
+    relativePath: "swamp-workflow/references/data-chaining.md",
+    name: "swamp-workflow",
+  },
   {
     relativePath: "swamp-extension-model/SKILL.md",
     name: "swamp-extension-model",


### PR DESCRIPTION
- Add `model.<name>.data.attributes.<field>` reference type to swamp-model skill
- Create `references/data-chaining.md` for swamp-model with aws/cli examples
- Create `references/data-chaining.md` for swamp-workflow with workflow chaining examples
- Add data chaining model example to swamp-extension-model examples
- Register new reference files in `skill_assets.ts` for repo init/upgrade

## Test plan
- [x] All 1324 tests pass
- [x] Type checking passes (`deno check`)
- [x] Linting passes (`deno lint`)
- [x] Formatting passes (`deno fmt --check`)
- [ ] Verify `swamp repo init` copies new reference files to target repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)