### PR TITLE
feat: implement unified Data entity and repository

### DIFF
--- a/integration/unified_data_test.ts
+++ b/integration/unified_data_test.ts
@@ -1,0 +1,595 @@
+/**
+ * Integration tests for the UnifiedDataRepository.
+ *
+ * Tests the full flow:
+ * 1. Create data with versioning
+ * 2. Verify ownership enforcement
+ * 3. Test streaming data
+ */
+
+import { assertEquals, assertRejects } from "@std/assert";
+import { join } from "@std/path";
+import { existsSync } from "@std/fs";
+import { ensureDir } from "@std/fs";
+import { Data } from "../src/domain/data/data.ts";
+import { computeDefinitionHash } from "../src/domain/data/data_metadata.ts";
+import type { OwnerDefinition } from "../src/domain/data/data_metadata.ts";
+import { ModelType } from "../src/domain/models/model_type.ts";
+import {
+  FileSystemUnifiedDataRepository,
+  OwnershipValidationError,
+} from "../src/infrastructure/persistence/unified_data_repository.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-unified-data-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+async function setupRepoDir(dir: string): Promise<void> {
+  await ensureDir(join(dir, ".swamp", "data"));
+}
+
+async function createOwner(ref: string): Promise<OwnerDefinition> {
+  const definitionHash = await computeDefinitionHash("model-method", ref);
+  return {
+    definitionHash,
+    ownerType: "model-method",
+    ownerRef: ref,
+  };
+}
+
+// ============================================================================
+// Basic CRUD Operations
+// ============================================================================
+
+Deno.test("Integration: save creates directory structure and symlink", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const repo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+    const modelId = crypto.randomUUID();
+    const owner = await createOwner("test/model:create");
+
+    const data = Data.create({
+      name: "test-data",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { type: "resource" },
+      ownerDefinition: owner,
+    });
+
+    const content = new TextEncoder().encode("Hello, World!");
+    const result = await repo.save(type, modelId, data, content);
+
+    assertEquals(result.version, 1);
+
+    // Verify directory structure
+    const baseDir = join(
+      repoDir,
+      ".swamp",
+      "data",
+      type.toDirectoryPath(),
+      modelId,
+      "test-data",
+    );
+    assertEquals(existsSync(join(baseDir, "1")), true);
+    assertEquals(existsSync(join(baseDir, "1", "metadata.yaml")), true);
+    assertEquals(existsSync(join(baseDir, "1", "raw")), true);
+    assertEquals(existsSync(join(baseDir, "latest")), true);
+
+    // Verify content
+    const savedContent = await Deno.readFile(join(baseDir, "1", "raw"));
+    assertEquals(new TextDecoder().decode(savedContent), "Hello, World!");
+  });
+});
+
+Deno.test("Integration: save auto-increments version", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const repo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+    const modelId = crypto.randomUUID();
+    const owner = await createOwner("test/model:version");
+
+    const data = Data.create({
+      name: "versioned-data",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { type: "resource" },
+      ownerDefinition: owner,
+    });
+
+    // Save version 1
+    const result1 = await repo.save(
+      type,
+      modelId,
+      data,
+      new TextEncoder().encode("v1"),
+    );
+    assertEquals(result1.version, 1);
+
+    // Save version 2
+    const result2 = await repo.save(
+      type,
+      modelId,
+      data,
+      new TextEncoder().encode("v2"),
+    );
+    assertEquals(result2.version, 2);
+
+    // Save version 3
+    const result3 = await repo.save(
+      type,
+      modelId,
+      data,
+      new TextEncoder().encode("v3"),
+    );
+    assertEquals(result3.version, 3);
+
+    // Verify latest points to v3
+    const latest = await repo.findByName(type, modelId, "versioned-data");
+    assertEquals(latest?.version, 3);
+  });
+});
+
+Deno.test("Integration: save validates ownership", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const repo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+    const modelId = crypto.randomUUID();
+    const owner1 = await createOwner("test/model:owner1");
+    const owner2 = await createOwner("test/model:owner2");
+
+    // Save with owner1
+    const data1 = Data.create({
+      name: "owned-data",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { type: "resource" },
+      ownerDefinition: owner1,
+    });
+    await repo.save(type, modelId, data1, new TextEncoder().encode("owner1"));
+
+    // Try to save with owner2 - should fail
+    const data2 = Data.create({
+      name: "owned-data",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { type: "resource" },
+      ownerDefinition: owner2,
+    });
+
+    await assertRejects(
+      () => repo.save(type, modelId, data2, new TextEncoder().encode("owner2")),
+      OwnershipValidationError,
+      "Ownership validation failed",
+    );
+
+    // Same owner should succeed
+    const result = await repo.save(
+      type,
+      modelId,
+      data1,
+      new TextEncoder().encode("owner1 again"),
+    );
+    assertEquals(result.version, 2);
+  });
+});
+
+// ============================================================================
+// Find Operations
+// ============================================================================
+
+Deno.test("Integration: findByName returns latest version by default", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const repo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+    const modelId = crypto.randomUUID();
+    const owner = await createOwner("test/model:find");
+
+    const data = Data.create({
+      name: "find-test",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { type: "resource" },
+      ownerDefinition: owner,
+    });
+
+    await repo.save(type, modelId, data, new TextEncoder().encode("v1"));
+    await repo.save(type, modelId, data, new TextEncoder().encode("v2"));
+    await repo.save(type, modelId, data, new TextEncoder().encode("v3"));
+
+    const found = await repo.findByName(type, modelId, "find-test");
+    assertEquals(found?.version, 3);
+  });
+});
+
+Deno.test("Integration: findByName returns specific version when requested", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const repo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+    const modelId = crypto.randomUUID();
+    const owner = await createOwner("test/model:find");
+
+    const data = Data.create({
+      name: "version-test",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { type: "resource" },
+      ownerDefinition: owner,
+    });
+
+    await repo.save(type, modelId, data, new TextEncoder().encode("v1"));
+    await repo.save(type, modelId, data, new TextEncoder().encode("v2"));
+    await repo.save(type, modelId, data, new TextEncoder().encode("v3"));
+
+    const v1 = await repo.findByName(type, modelId, "version-test", 1);
+    assertEquals(v1?.version, 1);
+
+    const v2 = await repo.findByName(type, modelId, "version-test", 2);
+    assertEquals(v2?.version, 2);
+  });
+});
+
+Deno.test("Integration: listVersions returns sorted version list", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const repo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+    const modelId = crypto.randomUUID();
+    const owner = await createOwner("test/model:list");
+
+    const data = Data.create({
+      name: "list-test",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { type: "resource" },
+      ownerDefinition: owner,
+    });
+
+    await repo.save(type, modelId, data, new TextEncoder().encode("v1"));
+    await repo.save(type, modelId, data, new TextEncoder().encode("v2"));
+    await repo.save(type, modelId, data, new TextEncoder().encode("v3"));
+
+    const versions = await repo.listVersions(type, modelId, "list-test");
+    assertEquals(versions, [1, 2, 3]);
+  });
+});
+
+Deno.test("Integration: findAllForModel returns all data", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const repo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+    const modelId = crypto.randomUUID();
+    const owner = await createOwner("test/model:all");
+
+    const data1 = Data.create({
+      name: "data-1",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { type: "resource" },
+      ownerDefinition: owner,
+    });
+
+    const data2 = Data.create({
+      name: "data-2",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { type: "log" },
+      ownerDefinition: owner,
+    });
+
+    await repo.save(type, modelId, data1, new TextEncoder().encode("content1"));
+    await repo.save(type, modelId, data2, new TextEncoder().encode("content2"));
+
+    const all = await repo.findAllForModel(type, modelId);
+    assertEquals(all.length, 2);
+    assertEquals(
+      all.map((d) => d.name).sort(),
+      ["data-1", "data-2"],
+    );
+  });
+});
+
+// ============================================================================
+// Content Operations
+// ============================================================================
+
+Deno.test("Integration: getContent returns data content", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const repo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+    const modelId = crypto.randomUUID();
+    const owner = await createOwner("test/model:content");
+
+    const data = Data.create({
+      name: "content-test",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { type: "resource" },
+      ownerDefinition: owner,
+    });
+
+    const originalContent = "Hello, World!";
+    await repo.save(
+      type,
+      modelId,
+      data,
+      new TextEncoder().encode(originalContent),
+    );
+
+    const content = await repo.getContent(type, modelId, "content-test");
+    assertEquals(new TextDecoder().decode(content!), originalContent);
+  });
+});
+
+Deno.test("Integration: stream returns content chunks", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const repo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+    const modelId = crypto.randomUUID();
+    const owner = await createOwner("test/model:stream");
+
+    const data = Data.create({
+      name: "stream-test",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { type: "resource" },
+      ownerDefinition: owner,
+    });
+
+    const originalContent = "Hello, World!";
+    await repo.save(
+      type,
+      modelId,
+      data,
+      new TextEncoder().encode(originalContent),
+    );
+
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of repo.stream(type, modelId, "stream-test")) {
+      chunks.push(chunk);
+    }
+
+    const combined = new Uint8Array(
+      chunks.reduce((acc, chunk) => acc + chunk.length, 0),
+    );
+    let offset = 0;
+    for (const chunk of chunks) {
+      combined.set(chunk, offset);
+      offset += chunk.length;
+    }
+
+    assertEquals(new TextDecoder().decode(combined), originalContent);
+  });
+});
+
+// ============================================================================
+// Streaming Data
+// ============================================================================
+
+Deno.test("Integration: append works for streaming data", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const repo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+    const modelId = crypto.randomUUID();
+    const owner = await createOwner("test/model:append");
+
+    const data = Data.create({
+      name: "append-test",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      streaming: true,
+      tags: { type: "log" },
+      ownerDefinition: owner,
+    });
+
+    // Save initial content
+    await repo.save(type, modelId, data, new TextEncoder().encode("line1\n"));
+
+    // Append more content
+    await repo.append(
+      type,
+      modelId,
+      "append-test",
+      new TextEncoder().encode("line2\n"),
+    );
+    await repo.append(
+      type,
+      modelId,
+      "append-test",
+      new TextEncoder().encode("line3\n"),
+    );
+
+    // Verify content
+    const content = await repo.getContent(type, modelId, "append-test");
+    assertEquals(new TextDecoder().decode(content!), "line1\nline2\nline3\n");
+  });
+});
+
+// ============================================================================
+// Delete Operations
+// ============================================================================
+
+Deno.test("Integration: delete removes specific version", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const repo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+    const modelId = crypto.randomUUID();
+    const owner = await createOwner("test/model:delete");
+
+    const data = Data.create({
+      name: "delete-test",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { type: "resource" },
+      ownerDefinition: owner,
+    });
+
+    await repo.save(type, modelId, data, new TextEncoder().encode("v1"));
+    await repo.save(type, modelId, data, new TextEncoder().encode("v2"));
+    await repo.save(type, modelId, data, new TextEncoder().encode("v3"));
+
+    // Delete v2
+    await repo.delete(type, modelId, "delete-test", 2);
+
+    const versions = await repo.listVersions(type, modelId, "delete-test");
+    assertEquals(versions, [1, 3]);
+  });
+});
+
+Deno.test("Integration: delete removes all versions when no version specified", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const repo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+    const modelId = crypto.randomUUID();
+    const owner = await createOwner("test/model:delete-all");
+
+    const data = Data.create({
+      name: "delete-all-test",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { type: "resource" },
+      ownerDefinition: owner,
+    });
+
+    await repo.save(type, modelId, data, new TextEncoder().encode("v1"));
+    await repo.save(type, modelId, data, new TextEncoder().encode("v2"));
+
+    // Delete all versions
+    await repo.delete(type, modelId, "delete-all-test");
+
+    const found = await repo.findByName(type, modelId, "delete-all-test");
+    assertEquals(found, null);
+  });
+});
+
+// ============================================================================
+// Garbage Collection
+// ============================================================================
+
+Deno.test("Integration: collectGarbage removes old versions by count", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const repo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+    const modelId = crypto.randomUUID();
+    const owner = await createOwner("test/model:gc");
+
+    // Create data with keep 2 versions policy
+    const data = Data.create({
+      name: "gc-test",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 2,
+      tags: { type: "resource" },
+      ownerDefinition: owner,
+    });
+
+    await repo.save(type, modelId, data, new TextEncoder().encode("v1"));
+    await repo.save(type, modelId, data, new TextEncoder().encode("v2"));
+    await repo.save(type, modelId, data, new TextEncoder().encode("v3"));
+    await repo.save(type, modelId, data, new TextEncoder().encode("v4"));
+
+    const result = await repo.collectGarbage(type, modelId);
+
+    assertEquals(result.versionsRemoved, 2);
+    const versions = await repo.listVersions(type, modelId, "gc-test");
+    assertEquals(versions, [3, 4]);
+  });
+});
+
+// ============================================================================
+// Full Lifecycle Test
+// ============================================================================
+
+Deno.test("Integration: full lifecycle - create, write versions, read by version", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const repo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+    const modelId = crypto.randomUUID();
+    const owner = await createOwner("test/model:lifecycle");
+
+    // Create initial data
+    const data = Data.create({
+      name: "lifecycle-test",
+      contentType: "application/json",
+      lifetime: "7d",
+      garbageCollection: 10,
+      tags: { type: "state", environment: "test" },
+      ownerDefinition: owner,
+    });
+
+    // Write version 1
+    const v1Content = { version: 1, message: "Initial state" };
+    await repo.save(
+      type,
+      modelId,
+      data,
+      new TextEncoder().encode(JSON.stringify(v1Content)),
+    );
+
+    // Write version 2
+    const v2Content = { version: 2, message: "Updated state" };
+    await repo.save(
+      type,
+      modelId,
+      data,
+      new TextEncoder().encode(JSON.stringify(v2Content)),
+    );
+
+    // Read latest (v2)
+    const latest = await repo.findByName(type, modelId, "lifecycle-test");
+    assertEquals(latest?.version, 2);
+    const latestContent = await repo.getContent(
+      type,
+      modelId,
+      "lifecycle-test",
+    );
+    assertEquals(
+      JSON.parse(new TextDecoder().decode(latestContent!)),
+      v2Content,
+    );
+
+    // Read specific version (v1)
+    const v1 = await repo.findByName(type, modelId, "lifecycle-test", 1);
+    assertEquals(v1?.version, 1);
+    const v1Data = await repo.getContent(type, modelId, "lifecycle-test", 1);
+    assertEquals(JSON.parse(new TextDecoder().decode(v1Data!)), v1Content);
+
+    // Verify metadata
+    assertEquals(latest?.contentType, "application/json");
+    assertEquals(latest?.lifetime, "7d");
+    assertEquals(latest?.garbageCollection, 10);
+    assertEquals(latest?.tags.type, "state");
+    assertEquals(latest?.tags.environment, "test");
+  });
+});

--- a/src/domain/data/data.ts
+++ b/src/domain/data/data.ts
@@ -1,0 +1,196 @@
+import { createDataId, type DataId, generateDataId } from "./data_id.ts";
+import {
+  type DataMetadata,
+  DataMetadataSchema,
+  type GarbageCollectionPolicy,
+  type Lifetime,
+  type OwnerDefinition,
+} from "./data_metadata.ts";
+
+/**
+ * Properties required to create a new Data entity.
+ */
+export interface CreateDataProps {
+  name: string;
+  id?: string;
+  version?: number;
+  contentType: string;
+  lifetime: Lifetime;
+  garbageCollection: GarbageCollectionPolicy;
+  streaming?: boolean;
+  tags: Record<string, string>;
+  ownerDefinition: OwnerDefinition;
+  createdAt?: Date;
+  size?: number;
+  checksum?: string;
+}
+
+/**
+ * Data is a unified entity representing versioned data storage.
+ *
+ * Each Data entity has:
+ * - A unique ID (UUID)
+ * - A human-readable name
+ * - Version tracking
+ * - Content type (MIME type)
+ * - Lifetime policy for automatic cleanup
+ * - Garbage collection policy for version retention
+ * - Streaming flag for append-only data
+ * - Tags including a required 'type' key
+ * - Owner definition for access control
+ */
+export class Data {
+  private constructor(
+    readonly id: DataId,
+    readonly name: string,
+    readonly version: number,
+    readonly contentType: string,
+    readonly lifetime: Lifetime,
+    readonly garbageCollection: GarbageCollectionPolicy,
+    readonly streaming: boolean,
+    readonly tags: Record<string, string>,
+    readonly ownerDefinition: OwnerDefinition,
+    readonly createdAt: Date,
+    readonly size?: number,
+    readonly checksum?: string,
+  ) {}
+
+  /**
+   * Creates a new Data instance.
+   *
+   * @param props - Properties for the new data entity
+   * @returns A new Data instance
+   * @throws ZodError if validation fails
+   */
+  static create(props: CreateDataProps): Data {
+    const id = props.id ?? generateDataId();
+    const version = props.version ?? 1;
+    const createdAt = props.createdAt ?? new Date();
+
+    const validated = DataMetadataSchema.parse({
+      id,
+      name: props.name,
+      version,
+      contentType: props.contentType,
+      lifetime: props.lifetime,
+      garbageCollection: props.garbageCollection,
+      streaming: props.streaming ?? false,
+      tags: props.tags,
+      ownerDefinition: props.ownerDefinition,
+      createdAt: createdAt.toISOString(),
+      size: props.size,
+      checksum: props.checksum,
+    });
+
+    return new Data(
+      createDataId(validated.id),
+      validated.name,
+      validated.version,
+      validated.contentType,
+      validated.lifetime,
+      validated.garbageCollection,
+      validated.streaming,
+      { ...validated.tags },
+      { ...validated.ownerDefinition },
+      new Date(validated.createdAt),
+      validated.size,
+      validated.checksum,
+    );
+  }
+
+  /**
+   * Reconstructs a Data entity from persisted metadata.
+   *
+   * @param data - The persisted metadata
+   * @returns A Data instance
+   * @throws ZodError if validation fails
+   */
+  static fromData(data: DataMetadata): Data {
+    const validated = DataMetadataSchema.parse(data);
+    return new Data(
+      createDataId(validated.id),
+      validated.name,
+      validated.version,
+      validated.contentType,
+      validated.lifetime,
+      validated.garbageCollection,
+      validated.streaming,
+      { ...validated.tags },
+      { ...validated.ownerDefinition },
+      new Date(validated.createdAt),
+      validated.size,
+      validated.checksum,
+    );
+  }
+
+  /**
+   * Converts the Data entity to a plain data object for persistence.
+   */
+  toData(): DataMetadata {
+    const data: DataMetadata = {
+      id: this.id,
+      name: this.name,
+      version: this.version,
+      contentType: this.contentType,
+      lifetime: this.lifetime,
+      garbageCollection: this.garbageCollection,
+      streaming: this.streaming,
+      tags: { ...this.tags },
+      ownerDefinition: { ...this.ownerDefinition },
+      createdAt: this.createdAt.toISOString(),
+    };
+
+    if (this.size !== undefined) {
+      data.size = this.size;
+    }
+    if (this.checksum !== undefined) {
+      data.checksum = this.checksum;
+    }
+
+    return data;
+  }
+
+  /**
+   * Checks if this data is owned by the given owner definition.
+   * Ownership is verified by comparing definition hashes.
+   *
+   * @param definition - The owner definition to check
+   * @returns true if the definition hash matches
+   */
+  isOwnedBy(definition: OwnerDefinition): boolean {
+    return this.ownerDefinition.definitionHash === definition.definitionHash;
+  }
+
+  /**
+   * Gets the type tag value.
+   */
+  get type(): string {
+    return this.tags.type;
+  }
+
+  /**
+   * Creates a new version of this data with updated properties.
+   * The new version inherits most properties from the current version.
+   */
+  withNewVersion(props: {
+    version: number;
+    createdAt?: Date;
+    size?: number;
+    checksum?: string;
+  }): Data {
+    return Data.create({
+      id: this.id,
+      name: this.name,
+      version: props.version,
+      contentType: this.contentType,
+      lifetime: this.lifetime,
+      garbageCollection: this.garbageCollection,
+      streaming: this.streaming,
+      tags: this.tags,
+      ownerDefinition: this.ownerDefinition,
+      createdAt: props.createdAt ?? new Date(),
+      size: props.size,
+      checksum: props.checksum,
+    });
+  }
+}

--- a/src/domain/data/data_id.ts
+++ b/src/domain/data/data_id.ts
@@ -1,0 +1,18 @@
+/**
+ * Branded type for Data IDs.
+ */
+export type DataId = string & { readonly _brand: unique symbol };
+
+/**
+ * Creates a DataId from a string.
+ */
+export function createDataId(id: string): DataId {
+  return id as DataId;
+}
+
+/**
+ * Generates a new unique DataId.
+ */
+export function generateDataId(): DataId {
+  return crypto.randomUUID() as DataId;
+}

--- a/src/domain/data/data_metadata.ts
+++ b/src/domain/data/data_metadata.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+
+/**
+ * Lifetime determines how long data should be retained.
+ * - Duration strings: "1h", "5m", "10d", "2w" (hours, minutes, days, weeks)
+ * - "ephemeral": Deleted when the process ends
+ * - "infinite": Never automatically deleted
+ * - "Job": Lives until the job completes
+ * - "Workflow": Lives until the workflow completes
+ */
+export const LifetimeSchema = z.union([
+  z.string().regex(/^\d+[hmdw]$/, {
+    message: "Duration must match pattern like '1h', '5m', '10d', '2w'",
+  }),
+  z.literal("ephemeral"),
+  z.literal("infinite"),
+  z.literal("Job"),
+  z.literal("Workflow"),
+]);
+
+export type Lifetime = z.infer<typeof LifetimeSchema>;
+
+/**
+ * Garbage collection policy determines version retention.
+ * - number: Keep N most recent versions
+ * - duration string: Keep versions created within the duration
+ */
+export const GarbageCollectionSchema = z.union([
+  z.number().int().positive(),
+  z.string().regex(/^\d+[hmdw]$/, {
+    message: "Duration must match pattern like '1h', '5m', '10d', '2w'",
+  }),
+]);
+
+export type GarbageCollectionPolicy = z.infer<typeof GarbageCollectionSchema>;
+
+/**
+ * Owner types that can create data.
+ */
+export const OwnerTypes = ["model-method", "workflow-step", "manual"] as const;
+export type OwnerType = typeof OwnerTypes[number];
+
+/**
+ * Owner definition tracks who created/owns the data.
+ * The definitionHash allows ownership validation on updates.
+ */
+export const OwnerDefinitionSchema = z.object({
+  definitionHash: z.string().min(1),
+  ownerType: z.enum(OwnerTypes),
+  ownerRef: z.string().min(1),
+  workflowId: z.string().uuid().optional(),
+  workflowRunId: z.string().uuid().optional(),
+});
+
+export type OwnerDefinition = z.infer<typeof OwnerDefinitionSchema>;
+
+/**
+ * Complete metadata schema for Data entity.
+ * Tags must include a 'type' key for categorization.
+ */
+export const DataMetadataSchema = z.object({
+  name: z.string().min(1),
+  id: z.string().uuid(),
+  version: z.number().int().positive(),
+  contentType: z.string().min(1),
+  lifetime: LifetimeSchema,
+  garbageCollection: GarbageCollectionSchema,
+  streaming: z.boolean().default(false),
+  tags: z.record(z.string(), z.string()).refine(
+    (tags) => "type" in tags,
+    { message: "tags must include 'type' key" },
+  ),
+  ownerDefinition: OwnerDefinitionSchema,
+  createdAt: z.string().datetime(),
+  size: z.number().int().nonnegative().optional(),
+  checksum: z.string().optional(),
+});
+
+export type DataMetadata = z.infer<typeof DataMetadataSchema>;
+
+/**
+ * Computes a hash of the owner definition for comparison.
+ * This is used to verify that updates come from the same owner.
+ */
+export async function computeDefinitionHash(
+  ownerType: OwnerType,
+  ownerRef: string,
+): Promise<string> {
+  const input = `${ownerType}:${ownerRef}`;
+  const data = new TextEncoder().encode(input);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = new Uint8Array(hashBuffer);
+  return Array.from(hashArray)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/src/domain/data/data_test.ts
+++ b/src/domain/data/data_test.ts
@@ -1,0 +1,370 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { Data } from "./data.ts";
+import {
+  computeDefinitionHash,
+  type OwnerDefinition,
+} from "./data_metadata.ts";
+
+async function createTestOwner(): Promise<OwnerDefinition> {
+  const definitionHash = await computeDefinitionHash(
+    "model-method",
+    "test/model:test-method",
+  );
+  return {
+    definitionHash,
+    ownerType: "model-method",
+    ownerRef: "test/model:test-method",
+  };
+}
+
+Deno.test("Data.create generates UUID if not provided", async () => {
+  const owner = await createTestOwner();
+  const data = Data.create({
+    name: "test-data",
+    contentType: "text/plain",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: { type: "test" },
+    ownerDefinition: owner,
+  });
+  assertEquals(typeof data.id, "string");
+  assertEquals(data.id.length, 36);
+});
+
+Deno.test("Data.create uses provided ID", async () => {
+  const owner = await createTestOwner();
+  const id = "550e8400-e29b-41d4-a716-446655440001";
+  const data = Data.create({
+    id,
+    name: "test-data",
+    contentType: "text/plain",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: { type: "test" },
+    ownerDefinition: owner,
+  });
+  assertEquals(data.id, id);
+});
+
+Deno.test("Data.create sets default version to 1", async () => {
+  const owner = await createTestOwner();
+  const data = Data.create({
+    name: "test-data",
+    contentType: "text/plain",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: { type: "test" },
+    ownerDefinition: owner,
+  });
+  assertEquals(data.version, 1);
+});
+
+Deno.test("Data.create uses provided version", async () => {
+  const owner = await createTestOwner();
+  const data = Data.create({
+    name: "test-data",
+    version: 3,
+    contentType: "text/plain",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: { type: "test" },
+    ownerDefinition: owner,
+  });
+  assertEquals(data.version, 3);
+});
+
+Deno.test("Data.create sets createdAt to now if not provided", async () => {
+  const owner = await createTestOwner();
+  const before = new Date();
+  const data = Data.create({
+    name: "test-data",
+    contentType: "text/plain",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: { type: "test" },
+    ownerDefinition: owner,
+  });
+  const after = new Date();
+
+  assertEquals(data.createdAt >= before, true);
+  assertEquals(data.createdAt <= after, true);
+});
+
+Deno.test("Data.create uses provided createdAt", async () => {
+  const owner = await createTestOwner();
+  const createdAt = new Date("2023-01-01T00:00:00Z");
+  const data = Data.create({
+    name: "test-data",
+    createdAt,
+    contentType: "text/plain",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: { type: "test" },
+    ownerDefinition: owner,
+  });
+  assertEquals(data.createdAt.getTime(), createdAt.getTime());
+});
+
+Deno.test("Data.create requires type tag in tags", async () => {
+  const owner = await createTestOwner();
+  assertThrows(
+    () =>
+      Data.create({
+        name: "test-data",
+        contentType: "text/plain",
+        lifetime: "infinite",
+        garbageCollection: 5,
+        tags: { notType: "value" },
+        ownerDefinition: owner,
+      }),
+    Error,
+    "tags must include 'type' key",
+  );
+});
+
+Deno.test("Data.create validates duration lifetime format", async () => {
+  const owner = await createTestOwner();
+  // Valid durations should work
+  const dataHours = Data.create({
+    name: "test-data",
+    contentType: "text/plain",
+    lifetime: "24h",
+    garbageCollection: 5,
+    tags: { type: "test" },
+    ownerDefinition: owner,
+  });
+  assertEquals(dataHours.lifetime, "24h");
+
+  const dataDays = Data.create({
+    name: "test-data",
+    contentType: "text/plain",
+    lifetime: "7d",
+    garbageCollection: 5,
+    tags: { type: "test" },
+    ownerDefinition: owner,
+  });
+  assertEquals(dataDays.lifetime, "7d");
+
+  const dataWeeks = Data.create({
+    name: "test-data",
+    contentType: "text/plain",
+    lifetime: "2w",
+    garbageCollection: 5,
+    tags: { type: "test" },
+    ownerDefinition: owner,
+  });
+  assertEquals(dataWeeks.lifetime, "2w");
+});
+
+Deno.test("Data.create validates special lifetime values", async () => {
+  const owner = await createTestOwner();
+
+  const dataEphemeral = Data.create({
+    name: "test-data",
+    contentType: "text/plain",
+    lifetime: "ephemeral",
+    garbageCollection: 5,
+    tags: { type: "test" },
+    ownerDefinition: owner,
+  });
+  assertEquals(dataEphemeral.lifetime, "ephemeral");
+
+  const dataInfinite = Data.create({
+    name: "test-data",
+    contentType: "text/plain",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: { type: "test" },
+    ownerDefinition: owner,
+  });
+  assertEquals(dataInfinite.lifetime, "infinite");
+
+  const dataJob = Data.create({
+    name: "test-data",
+    contentType: "text/plain",
+    lifetime: "Job",
+    garbageCollection: 5,
+    tags: { type: "test" },
+    ownerDefinition: owner,
+  });
+  assertEquals(dataJob.lifetime, "Job");
+
+  const dataWorkflow = Data.create({
+    name: "test-data",
+    contentType: "text/plain",
+    lifetime: "Workflow",
+    garbageCollection: 5,
+    tags: { type: "test" },
+    ownerDefinition: owner,
+  });
+  assertEquals(dataWorkflow.lifetime, "Workflow");
+});
+
+Deno.test("Data.create throws on invalid lifetime format", async () => {
+  const owner = await createTestOwner();
+  assertThrows(
+    () =>
+      Data.create({
+        name: "test-data",
+        contentType: "text/plain",
+        lifetime: "invalid" as "infinite",
+        garbageCollection: 5,
+        tags: { type: "test" },
+        ownerDefinition: owner,
+      }),
+    Error,
+  );
+});
+
+Deno.test("Data toData/fromData roundtrip", async () => {
+  const owner = await createTestOwner();
+  const data = Data.create({
+    name: "test-data",
+    contentType: "application/json",
+    lifetime: "7d",
+    garbageCollection: 10,
+    streaming: true,
+    tags: { type: "log", source: "test" },
+    ownerDefinition: owner,
+    size: 1024,
+    checksum: "abc123",
+  });
+
+  const serialized = data.toData();
+  const restored = Data.fromData(serialized);
+
+  assertEquals(restored.id, data.id);
+  assertEquals(restored.name, data.name);
+  assertEquals(restored.version, data.version);
+  assertEquals(restored.contentType, data.contentType);
+  assertEquals(restored.lifetime, data.lifetime);
+  assertEquals(restored.garbageCollection, data.garbageCollection);
+  assertEquals(restored.streaming, data.streaming);
+  assertEquals(restored.tags, data.tags);
+  assertEquals(restored.ownerDefinition, data.ownerDefinition);
+  assertEquals(restored.createdAt.getTime(), data.createdAt.getTime());
+  assertEquals(restored.size, data.size);
+  assertEquals(restored.checksum, data.checksum);
+});
+
+Deno.test("Data.isOwnedBy validates definition hash", async () => {
+  const owner1 = await createTestOwner();
+  const data = Data.create({
+    name: "test-data",
+    contentType: "text/plain",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: { type: "test" },
+    ownerDefinition: owner1,
+  });
+
+  // Same owner should match
+  assertEquals(data.isOwnedBy(owner1), true);
+
+  // Different owner should not match
+  const differentHash = await computeDefinitionHash(
+    "model-method",
+    "other/model:other-method",
+  );
+  const owner2: OwnerDefinition = {
+    definitionHash: differentHash,
+    ownerType: "model-method",
+    ownerRef: "other/model:other-method",
+  };
+  assertEquals(data.isOwnedBy(owner2), false);
+});
+
+Deno.test("Data.type returns type tag", async () => {
+  const owner = await createTestOwner();
+  const data = Data.create({
+    name: "test-data",
+    contentType: "text/plain",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: { type: "resource" },
+    ownerDefinition: owner,
+  });
+  assertEquals(data.type, "resource");
+});
+
+Deno.test("Data.withNewVersion creates new version", async () => {
+  const owner = await createTestOwner();
+  const data = Data.create({
+    name: "test-data",
+    contentType: "text/plain",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: { type: "test" },
+    ownerDefinition: owner,
+  });
+
+  const newVersion = data.withNewVersion({
+    version: 2,
+    size: 2048,
+    checksum: "newchecksum",
+  });
+
+  assertEquals(newVersion.id, data.id);
+  assertEquals(newVersion.name, data.name);
+  assertEquals(newVersion.version, 2);
+  assertEquals(newVersion.contentType, data.contentType);
+  assertEquals(newVersion.lifetime, data.lifetime);
+  assertEquals(newVersion.garbageCollection, data.garbageCollection);
+  assertEquals(newVersion.tags, data.tags);
+  assertEquals(newVersion.ownerDefinition, data.ownerDefinition);
+  assertEquals(newVersion.size, 2048);
+  assertEquals(newVersion.checksum, "newchecksum");
+});
+
+Deno.test("Data.create with garbage collection as version count", async () => {
+  const owner = await createTestOwner();
+  const data = Data.create({
+    name: "test-data",
+    contentType: "text/plain",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: { type: "test" },
+    ownerDefinition: owner,
+  });
+  assertEquals(data.garbageCollection, 5);
+});
+
+Deno.test("Data.create with garbage collection as duration", async () => {
+  const owner = await createTestOwner();
+  const data = Data.create({
+    name: "test-data",
+    contentType: "text/plain",
+    lifetime: "infinite",
+    garbageCollection: "30d",
+    tags: { type: "test" },
+    ownerDefinition: owner,
+  });
+  assertEquals(data.garbageCollection, "30d");
+});
+
+Deno.test("Data.create defaults streaming to false", async () => {
+  const owner = await createTestOwner();
+  const data = Data.create({
+    name: "test-data",
+    contentType: "text/plain",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: { type: "test" },
+    ownerDefinition: owner,
+  });
+  assertEquals(data.streaming, false);
+});
+
+Deno.test("Data.create uses provided streaming value", async () => {
+  const owner = await createTestOwner();
+  const data = Data.create({
+    name: "test-data",
+    contentType: "text/plain",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    streaming: true,
+    tags: { type: "test" },
+    ownerDefinition: owner,
+  });
+  assertEquals(data.streaming, true);
+});

--- a/src/domain/data/mod.ts
+++ b/src/domain/data/mod.ts
@@ -1,0 +1,17 @@
+export { createDataId, type DataId, generateDataId } from "./data_id.ts";
+
+export {
+  computeDefinitionHash,
+  type DataMetadata,
+  DataMetadataSchema,
+  type GarbageCollectionPolicy,
+  GarbageCollectionSchema,
+  type Lifetime,
+  LifetimeSchema,
+  type OwnerDefinition,
+  OwnerDefinitionSchema,
+  type OwnerType,
+  OwnerTypes,
+} from "./data_metadata.ts";
+
+export { type CreateDataProps, Data } from "./data.ts";

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -1,0 +1,839 @@
+import { ensureDir } from "@std/fs";
+import { join, relative } from "@std/path";
+import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import {
+  Data,
+  type DataId,
+  type DataMetadata,
+  generateDataId,
+  type OwnerDefinition,
+} from "../../domain/data/mod.ts";
+import type { ModelType } from "../../domain/models/model_type.ts";
+
+/**
+ * Error thrown when ownership validation fails.
+ */
+export class OwnershipValidationError extends Error {
+  constructor(
+    readonly dataName: string,
+    readonly existingOwnerHash: string,
+    readonly newOwnerHash: string,
+  ) {
+    super(
+      `Ownership validation failed for "${dataName}": ` +
+        `existing owner hash "${existingOwnerHash}" does not match new owner hash "${newOwnerHash}"`,
+    );
+    this.name = "OwnershipValidationError";
+  }
+}
+
+/**
+ * Result of garbage collection operation.
+ */
+export interface GarbageCollectionResult {
+  versionsRemoved: number;
+  bytesReclaimed: number;
+}
+
+/**
+ * Repository interface for unified Data storage with versioning.
+ */
+export interface UnifiedDataRepository {
+  /**
+   * Finds data by name, optionally for a specific version.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param dataName - The data name
+   * @param version - Optional version (defaults to latest)
+   * @returns The data if found, or null
+   */
+  findByName(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): Promise<Data | null>;
+
+  /**
+   * Finds data by ID, optionally for a specific version.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param dataId - The data ID
+   * @param version - Optional version (defaults to latest)
+   * @returns The data if found, or null
+   */
+  findById(
+    type: ModelType,
+    modelId: string,
+    dataId: DataId,
+    version?: number,
+  ): Promise<Data | null>;
+
+  /**
+   * Lists all versions for a data name.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param dataName - The data name
+   * @returns Array of version numbers in ascending order
+   */
+  listVersions(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+  ): Promise<number[]>;
+
+  /**
+   * Finds all data for a model.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @returns Array of data (latest version of each)
+   */
+  findAllForModel(type: ModelType, modelId: string): Promise<Data[]>;
+
+  /**
+   * Saves data with its content, creating a new version.
+   * Validates ownership if data with the same name already exists.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param data - The data entity
+   * @param content - The content to save
+   * @returns The saved version number
+   * @throws OwnershipValidationError if ownership validation fails
+   */
+  save(
+    type: ModelType,
+    modelId: string,
+    data: Data,
+    content: Uint8Array,
+  ): Promise<{ version: number }>;
+
+  /**
+   * Appends content to streaming data.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param dataName - The data name
+   * @param content - The content to append
+   */
+  append(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    content: Uint8Array,
+  ): Promise<void>;
+
+  /**
+   * Streams content from data.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param dataName - The data name
+   * @param version - Optional version (defaults to latest)
+   * @returns Async iterable of content chunks
+   */
+  stream(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): AsyncIterable<Uint8Array>;
+
+  /**
+   * Gets the full content of data.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param dataName - The data name
+   * @param version - Optional version (defaults to latest)
+   * @returns The content or null if not found
+   */
+  getContent(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): Promise<Uint8Array | null>;
+
+  /**
+   * Deletes data, optionally for a specific version.
+   * If no version is specified, deletes all versions.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param dataName - The data name
+   * @param version - Optional version to delete (all versions if not specified)
+   */
+  delete(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): Promise<void>;
+
+  /**
+   * Generates a new unique ID.
+   */
+  nextId(): DataId;
+
+  /**
+   * Returns the directory path for a data version.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param dataName - The data name
+   * @param version - The version number
+   * @returns The directory path
+   */
+  getPath(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version: number,
+  ): string;
+
+  /**
+   * Returns the content file path for a data version.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param dataName - The data name
+   * @param version - The version number
+   * @returns The content file path
+   */
+  getContentPath(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version: number,
+  ): string;
+
+  /**
+   * Collects garbage according to each data's garbage collection policy.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @returns The result of garbage collection
+   */
+  collectGarbage(
+    type: ModelType,
+    modelId: string,
+  ): Promise<GarbageCollectionResult>;
+}
+
+/**
+ * File system implementation of UnifiedDataRepository.
+ *
+ * Storage layout:
+ * .swamp/data/{normalized-type}/{model-id}/{data-name}/
+ *   1/
+ *     raw              # Content (binary or text)
+ *     metadata.yaml    # Metadata
+ *   2/
+ *     raw
+ *     metadata.yaml
+ *   latest/            # Symlink -> 2/
+ */
+export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
+  constructor(private readonly repoDir: string) {}
+
+  async findByName(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): Promise<Data | null> {
+    const versionToRead = version ?? (await this.getLatestVersion(
+      type,
+      modelId,
+      dataName,
+    ));
+    if (versionToRead === null) return null;
+
+    const metadataPath = this.getMetadataPath(
+      type,
+      modelId,
+      dataName,
+      versionToRead,
+    );
+    try {
+      const content = await Deno.readTextFile(metadataPath);
+      const metadata = parseYaml(content) as DataMetadata;
+      return Data.fromData(metadata);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async findById(
+    type: ModelType,
+    modelId: string,
+    dataId: DataId,
+    version?: number,
+  ): Promise<Data | null> {
+    // We need to scan all data directories to find the one with this ID
+    const dataDir = this.getModelDataDir(type, modelId);
+    try {
+      for await (const entry of Deno.readDir(dataDir)) {
+        if (!entry.isDirectory) continue;
+        const dataName = entry.name;
+
+        const data = await this.findByName(type, modelId, dataName, version);
+        if (data && data.id === dataId) {
+          return data;
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+    return null;
+  }
+
+  async listVersions(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+  ): Promise<number[]> {
+    const dataNameDir = this.getDataNameDir(type, modelId, dataName);
+    const versions: number[] = [];
+
+    try {
+      for await (const entry of Deno.readDir(dataNameDir)) {
+        if (!entry.isDirectory) continue;
+        if (entry.name === "latest") continue;
+
+        const version = parseInt(entry.name, 10);
+        if (!isNaN(version) && version > 0) {
+          versions.push(version);
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+
+    return versions.sort((a, b) => a - b);
+  }
+
+  async findAllForModel(type: ModelType, modelId: string): Promise<Data[]> {
+    const dataDir = this.getModelDataDir(type, modelId);
+    const results: Data[] = [];
+
+    try {
+      for await (const entry of Deno.readDir(dataDir)) {
+        if (!entry.isDirectory) continue;
+        const dataName = entry.name;
+
+        const data = await this.findByName(type, modelId, dataName);
+        if (data) {
+          results.push(data);
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+
+    return results;
+  }
+
+  async save(
+    type: ModelType,
+    modelId: string,
+    data: Data,
+    content: Uint8Array,
+  ): Promise<{ version: number }> {
+    // Check if data with this name already exists
+    const existing = await this.findByName(type, modelId, data.name);
+    if (existing) {
+      // Validate ownership
+      if (!existing.isOwnedBy(data.ownerDefinition)) {
+        throw new OwnershipValidationError(
+          data.name,
+          existing.ownerDefinition.definitionHash,
+          data.ownerDefinition.definitionHash,
+        );
+      }
+    }
+
+    // Determine the new version
+    const versions = await this.listVersions(type, modelId, data.name);
+    const newVersion = versions.length > 0 ? Math.max(...versions) + 1 : 1;
+
+    // Create the version directory
+    const versionDir = this.getPath(type, modelId, data.name, newVersion);
+    await ensureDir(versionDir);
+
+    // Create the data with updated version and size
+    const dataToSave = data.withNewVersion({
+      version: newVersion,
+      size: content.length,
+      checksum: await this.computeChecksum(content),
+    });
+
+    // Save metadata
+    const metadataPath = this.getMetadataPath(
+      type,
+      modelId,
+      data.name,
+      newVersion,
+    );
+    const metadata = dataToSave.toData();
+    // Remove undefined values
+    const cleanData = JSON.parse(JSON.stringify(metadata));
+    const metadataContent = stringifyYaml(cleanData as Record<string, unknown>);
+    await Deno.writeTextFile(metadataPath, metadataContent);
+
+    // Save content
+    const contentPath = this.getContentPath(
+      type,
+      modelId,
+      data.name,
+      newVersion,
+    );
+    await Deno.writeFile(contentPath, content);
+
+    // Update latest symlink
+    await this.updateLatestSymlink(type, modelId, data.name, newVersion);
+
+    return { version: newVersion };
+  }
+
+  async append(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    content: Uint8Array,
+  ): Promise<void> {
+    const latestVersion = await this.getLatestVersion(type, modelId, dataName);
+    if (latestVersion === null) {
+      throw new Error(`No existing data found for "${dataName}"`);
+    }
+
+    const data = await this.findByName(type, modelId, dataName, latestVersion);
+    if (!data?.streaming) {
+      throw new Error(`Data "${dataName}" is not configured for streaming`);
+    }
+
+    const contentPath = this.getContentPath(
+      type,
+      modelId,
+      dataName,
+      latestVersion,
+    );
+    const file = await Deno.open(contentPath, { append: true });
+    try {
+      await file.write(content);
+    } finally {
+      file.close();
+    }
+
+    // Update metadata with new size
+    const currentContent = await Deno.readFile(contentPath);
+    const metadataPath = this.getMetadataPath(
+      type,
+      modelId,
+      dataName,
+      latestVersion,
+    );
+    const metadata = data.toData();
+    metadata.size = currentContent.length;
+    metadata.checksum = await this.computeChecksum(currentContent);
+    const cleanData = JSON.parse(JSON.stringify(metadata));
+    await Deno.writeTextFile(
+      metadataPath,
+      stringifyYaml(cleanData as Record<string, unknown>),
+    );
+  }
+
+  async *stream(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): AsyncIterable<Uint8Array> {
+    const versionToRead = version ??
+      await this.getLatestVersion(type, modelId, dataName);
+    if (versionToRead === null) return;
+
+    const contentPath = this.getContentPath(
+      type,
+      modelId,
+      dataName,
+      versionToRead,
+    );
+
+    try {
+      const file = await Deno.open(contentPath, { read: true });
+      try {
+        const buffer = new Uint8Array(8192);
+        while (true) {
+          const bytesRead = await file.read(buffer);
+          if (bytesRead === null) break;
+          yield buffer.slice(0, bytesRead);
+        }
+      } finally {
+        file.close();
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return;
+      }
+      throw error;
+    }
+  }
+
+  async getContent(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): Promise<Uint8Array | null> {
+    const versionToRead = version ??
+      await this.getLatestVersion(type, modelId, dataName);
+    if (versionToRead === null) return null;
+
+    const contentPath = this.getContentPath(
+      type,
+      modelId,
+      dataName,
+      versionToRead,
+    );
+    try {
+      return await Deno.readFile(contentPath);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async delete(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): Promise<void> {
+    if (version !== undefined) {
+      // Delete specific version
+      const versionDir = this.getPath(type, modelId, dataName, version);
+      try {
+        await Deno.remove(versionDir, { recursive: true });
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          throw error;
+        }
+      }
+
+      // Update latest symlink if needed
+      const versions = await this.listVersions(type, modelId, dataName);
+      if (versions.length > 0) {
+        const newLatest = Math.max(...versions);
+        await this.updateLatestSymlink(type, modelId, dataName, newLatest);
+      } else {
+        // No versions left, remove the data name directory
+        const dataNameDir = this.getDataNameDir(type, modelId, dataName);
+        await Deno.remove(dataNameDir, { recursive: true }).catch(() => {});
+      }
+    } else {
+      // Delete all versions
+      const dataNameDir = this.getDataNameDir(type, modelId, dataName);
+      try {
+        await Deno.remove(dataNameDir, { recursive: true });
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          throw error;
+        }
+      }
+    }
+  }
+
+  nextId(): DataId {
+    return generateDataId();
+  }
+
+  getPath(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version: number,
+  ): string {
+    return join(
+      this.getDataNameDir(type, modelId, dataName),
+      version.toString(),
+    );
+  }
+
+  getContentPath(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version: number,
+  ): string {
+    return join(this.getPath(type, modelId, dataName, version), "raw");
+  }
+
+  async collectGarbage(
+    type: ModelType,
+    modelId: string,
+  ): Promise<GarbageCollectionResult> {
+    let versionsRemoved = 0;
+    let bytesReclaimed = 0;
+
+    const allData = await this.findAllForModel(type, modelId);
+
+    for (const data of allData) {
+      const versions = await this.listVersions(type, modelId, data.name);
+      if (versions.length <= 1) continue;
+
+      const gc = data.garbageCollection;
+      let versionsToRemove: number[] = [];
+
+      if (typeof gc === "number") {
+        // Keep N most recent versions
+        const toKeep = gc;
+        if (versions.length > toKeep) {
+          versionsToRemove = versions.slice(0, versions.length - toKeep);
+        }
+      } else {
+        // Keep versions within duration
+        const duration = this.parseDuration(gc);
+        const cutoff = Date.now() - duration;
+
+        for (const version of versions) {
+          const versionData = await this.findByName(
+            type,
+            modelId,
+            data.name,
+            version,
+          );
+          if (versionData && versionData.createdAt.getTime() < cutoff) {
+            // Don't remove if it's the only/latest version
+            if (version !== Math.max(...versions)) {
+              versionsToRemove.push(version);
+            }
+          }
+        }
+      }
+
+      for (const version of versionsToRemove) {
+        const contentPath = this.getContentPath(
+          type,
+          modelId,
+          data.name,
+          version,
+        );
+        try {
+          const stat = await Deno.stat(contentPath);
+          bytesReclaimed += stat.size;
+        } catch {
+          // Ignore stat errors
+        }
+
+        await this.delete(type, modelId, data.name, version);
+        versionsRemoved++;
+      }
+    }
+
+    return { versionsRemoved, bytesReclaimed };
+  }
+
+  private getBaseDir(): string {
+    return join(this.repoDir, ".swamp", "data");
+  }
+
+  private getTypeDir(type: ModelType): string {
+    return join(this.getBaseDir(), type.toDirectoryPath());
+  }
+
+  private getModelDataDir(type: ModelType, modelId: string): string {
+    return join(this.getTypeDir(type), modelId);
+  }
+
+  private getDataNameDir(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+  ): string {
+    return join(this.getModelDataDir(type, modelId), dataName);
+  }
+
+  private getMetadataPath(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version: number,
+  ): string {
+    return join(
+      this.getPath(type, modelId, dataName, version),
+      "metadata.yaml",
+    );
+  }
+
+  private async getLatestVersion(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+  ): Promise<number | null> {
+    const latestPath = join(
+      this.getDataNameDir(type, modelId, dataName),
+      "latest",
+    );
+    try {
+      const linkTarget = await Deno.readLink(latestPath);
+      const version = parseInt(linkTarget.replace(/\/$/, ""), 10);
+      return isNaN(version) ? null : version;
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        // Fall back to scanning versions
+        const versions = await this.listVersions(type, modelId, dataName);
+        return versions.length > 0 ? Math.max(...versions) : null;
+      }
+      throw error;
+    }
+  }
+
+  private async updateLatestSymlink(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version: number,
+  ): Promise<void> {
+    const dataNameDir = this.getDataNameDir(type, modelId, dataName);
+    const latestPath = join(dataNameDir, "latest");
+    const target = version.toString();
+
+    // Use relative path for symlink
+    const relativeTarget = relative(dataNameDir, join(dataNameDir, target));
+
+    // Create temp symlink and atomically rename
+    const tempPath = `${latestPath}.tmp.${crypto.randomUUID()}`;
+
+    try {
+      await Deno.symlink(relativeTarget, tempPath, { type: "dir" });
+      await Deno.rename(tempPath, latestPath);
+    } catch (error) {
+      // Clean up temp symlink on failure
+      try {
+        await Deno.remove(tempPath);
+      } catch {
+        // Ignore cleanup errors
+      }
+      throw error;
+    }
+  }
+
+  private async computeChecksum(content: Uint8Array): Promise<string> {
+    const buffer = new ArrayBuffer(content.length);
+    new Uint8Array(buffer).set(content);
+    const hashBuffer = await crypto.subtle.digest("SHA-256", buffer);
+    const hashArray = new Uint8Array(hashBuffer);
+    return Array.from(hashArray)
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+  }
+
+  private parseDuration(duration: string): number {
+    const match = duration.match(/^(\d+)([hmdw])$/);
+    if (!match) {
+      throw new Error(`Invalid duration format: ${duration}`);
+    }
+
+    const value = parseInt(match[1], 10);
+    const unit = match[2];
+
+    switch (unit) {
+      case "h":
+        return value * 60 * 60 * 1000;
+      case "m":
+        return value * 60 * 1000;
+      case "d":
+        return value * 24 * 60 * 60 * 1000;
+      case "w":
+        return value * 7 * 24 * 60 * 60 * 1000;
+      default:
+        throw new Error(`Unknown duration unit: ${unit}`);
+    }
+  }
+}
+
+/**
+ * Creates an OwnerDefinition for a model method.
+ */
+export async function createModelMethodOwner(
+  modelType: string,
+  methodName: string,
+  workflowId?: string,
+  workflowRunId?: string,
+): Promise<OwnerDefinition> {
+  const ownerRef = `${modelType}:${methodName}`;
+  const { computeDefinitionHash } = await import(
+    "../../domain/data/data_metadata.ts"
+  );
+  const definitionHash = await computeDefinitionHash("model-method", ownerRef);
+
+  return {
+    definitionHash,
+    ownerType: "model-method",
+    ownerRef,
+    workflowId,
+    workflowRunId,
+  };
+}
+
+/**
+ * Creates an OwnerDefinition for a workflow step.
+ */
+export async function createWorkflowStepOwner(
+  workflowId: string,
+  jobName: string,
+  stepName: string,
+  workflowRunId?: string,
+): Promise<OwnerDefinition> {
+  const ownerRef = `${workflowId}:${jobName}:${stepName}`;
+  const { computeDefinitionHash } = await import(
+    "../../domain/data/data_metadata.ts"
+  );
+  const definitionHash = await computeDefinitionHash("workflow-step", ownerRef);
+
+  return {
+    definitionHash,
+    ownerType: "workflow-step",
+    ownerRef,
+    workflowId,
+    workflowRunId,
+  };
+}
+
+/**
+ * Creates an OwnerDefinition for manual data creation.
+ */
+export async function createManualOwner(
+  description: string,
+): Promise<OwnerDefinition> {
+  const { computeDefinitionHash } = await import(
+    "../../domain/data/data_metadata.ts"
+  );
+  const definitionHash = await computeDefinitionHash("manual", description);
+
+  return {
+    definitionHash,
+    ownerType: "manual",
+    ownerRef: description,
+  };
+}


### PR DESCRIPTION
## Summary

Implements issue #116: Create a unified Data entity and repository to eventually replace `ModelResource`, `ModelData`, `ModelFile`, and `ModelLog` with a single versioned storage system.

- Add `Data` entity with versioning, ownership tracking, and lifecycle policies
- Add `UnifiedDataRepository` with file system implementation
- Support streaming data via append operations
- Implement garbage collection by version count or time duration
- Use symlinked "latest" pointer for each data name

### Files Added

| File | Purpose |
|------|---------|
| `src/domain/data/data_id.ts` | Branded DataId type |
| `src/domain/data/data_metadata.ts` | Zod schemas for metadata |
| `src/domain/data/data.ts` | Core Data entity class |
| `src/domain/data/mod.ts` | Module exports |
| `src/infrastructure/persistence/unified_data_repository.ts` | Repository implementation |
| `src/domain/data/data_test.ts` | Unit tests (18 tests) |
| `integration/unified_data_test.ts` | Integration tests (14 tests) |

### Storage Layout

```
.swamp/data/{normalized-type}/{model-id}/{data-name}/
  1/
    raw              # Content (binary or text)
    metadata.yaml    # Metadata
  2/
    raw
    metadata.yaml
  latest/            # Symlink -> 2/
```

## Test Plan

- [x] All 18 unit tests pass for Data entity
- [x] All 14 integration tests pass for repository
- [x] Full test suite passes (1235 tests)
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes

Closes #116