### PR TITLE
feat: add Definition entity with CEL expression support (#117)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ resources/
 .data/outputs/
 .data/workflow-runs/
 .data/inputs-evaluated/
+.swamp/definitions-evaluated/
 .data/workflows-evaluated/
 .data/logs/
 .data/files/

--- a/integration/definition_test.ts
+++ b/integration/definition_test.ts
@@ -1,0 +1,407 @@
+/**
+ * Integration tests for the Definition entity with CEL expression evaluation.
+ *
+ * Tests the full flow:
+ * 1. Create definitions with CEL expressions
+ * 2. Evaluate expressions
+ * 3. Verify evaluated definitions are correct
+ */
+
+import { assertEquals } from "@std/assert";
+import { existsSync } from "@std/fs";
+import { parse as parseYaml } from "@std/yaml";
+import { Definition } from "../src/domain/definitions/definition.ts";
+import { ModelInput } from "../src/domain/models/model_input.ts";
+import { ModelType } from "../src/domain/models/model_type.ts";
+import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
+import { YamlEvaluatedDefinitionRepository } from "../src/infrastructure/persistence/yaml_evaluated_definition_repository.ts";
+import { YamlInputRepository } from "../src/infrastructure/persistence/yaml_input_repository.ts";
+import { YamlResourceRepository } from "../src/infrastructure/persistence/yaml_resource_repository.ts";
+import { ExpressionEvaluationService } from "../src/domain/expressions/expression_evaluation_service.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-definition-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("Definition: create and save definition with static attributes", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const modelType = ModelType.create("swamp/echo");
+
+    // Create a definition with static attributes
+    const definition = Definition.create({
+      name: "my-echo",
+      version: 1,
+      tags: { env: "test" },
+      attributes: {
+        message: "Hello, World!",
+        count: 42,
+      },
+    });
+
+    // Save the definition
+    await definitionRepo.save(modelType, definition);
+
+    // Verify the file was created at the correct path
+    const path = definitionRepo.getPath(modelType, definition.id);
+    assertEquals(existsSync(path), true, "Definition file should exist");
+
+    // Verify the content
+    const content = await Deno.readTextFile(path);
+    const data = parseYaml(content) as Record<string, unknown>;
+    assertEquals(data.name, "my-echo");
+    assertEquals(data.version, 1);
+    assertEquals((data.tags as Record<string, string>).env, "test");
+    assertEquals(
+      (data.attributes as Record<string, unknown>).message,
+      "Hello, World!",
+    );
+  });
+});
+
+Deno.test("Definition: definition with CEL expression is preserved on save", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const modelType = ModelType.create("swamp/echo");
+
+    // Create a definition with CEL expressions
+    const definition = Definition.create({
+      name: "my-echo-with-expression",
+      attributes: {
+        message: "${{ model.other.input.attributes.greeting }}",
+        computed: "${{ self.name + '-suffix' }}",
+      },
+    });
+
+    // Save the definition
+    await definitionRepo.save(modelType, definition);
+
+    // Load it back
+    const loaded = await definitionRepo.findById(modelType, definition.id);
+    assertEquals(loaded !== null, true, "Definition should be loaded");
+
+    // Verify CEL expressions are preserved (not evaluated)
+    assertEquals(
+      loaded!.attributes.message,
+      "${{ model.other.input.attributes.greeting }}",
+    );
+    assertEquals(
+      loaded!.attributes.computed,
+      "${{ self.name + '-suffix' }}",
+    );
+  });
+});
+
+Deno.test("Definition: evaluate definition with CEL expressions referencing self", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const inputRepo = new YamlInputRepository(repoDir);
+    const resourceRepo = new YamlResourceRepository(repoDir);
+    const modelType = ModelType.create("swamp/echo");
+
+    // Create a definition with self-referencing CEL expression
+    const definition = Definition.create({
+      name: "self-reference-test",
+      version: 1,
+      tags: { env: "test" },
+      attributes: {
+        selfName: "${{ self.name }}",
+        tagValue: "${{ self.tags.env }}",
+      },
+    });
+
+    await definitionRepo.save(modelType, definition);
+
+    // Create the expression evaluation service
+    const evalService = new ExpressionEvaluationService(
+      inputRepo,
+      resourceRepo,
+      repoDir,
+      { definitionRepo },
+    );
+
+    // Evaluate the definition
+    const result = await evalService.evaluateDefinition(
+      definition,
+      modelType,
+    );
+
+    assertEquals(result.hadExpressions, true);
+    assertEquals(
+      result.definition.attributes.selfName,
+      "self-reference-test",
+    );
+    assertEquals(result.definition.attributes.tagValue, "test");
+  });
+});
+
+Deno.test("Definition: evaluate definition with CEL expressions referencing other models", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const inputRepo = new YamlInputRepository(repoDir);
+    const resourceRepo = new YamlResourceRepository(repoDir);
+    const modelType = ModelType.create("swamp/echo");
+
+    // Create a model input that will be referenced
+    const sourceInput = ModelInput.create({
+      name: "source-model",
+      attributes: {
+        greeting: "Hello from source!",
+        count: 10,
+      },
+    });
+    await inputRepo.save(modelType, sourceInput);
+
+    // Create a definition that references the other model
+    const definition = Definition.create({
+      name: "referencing-definition",
+      attributes: {
+        message: "${{ model.source-model.input.attributes.greeting }}",
+        doubled: "${{ model.source-model.input.attributes.count * 2 }}",
+      },
+    });
+    await definitionRepo.save(modelType, definition);
+
+    // Create the expression evaluation service
+    const evalService = new ExpressionEvaluationService(
+      inputRepo,
+      resourceRepo,
+      repoDir,
+      { definitionRepo },
+    );
+
+    // Evaluate the definition
+    const result = await evalService.evaluateDefinition(
+      definition,
+      modelType,
+    );
+
+    assertEquals(result.hadExpressions, true);
+    assertEquals(
+      result.definition.attributes.message,
+      "Hello from source!",
+    );
+    assertEquals(result.definition.attributes.doubled, 20);
+  });
+});
+
+Deno.test("Definition: evaluate definition with inputs parameter", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const inputRepo = new YamlInputRepository(repoDir);
+    const resourceRepo = new YamlResourceRepository(repoDir);
+    const modelType = ModelType.create("swamp/echo");
+
+    // Create a definition with inputs schema and expression
+    const definition = Definition.create({
+      name: "parameterized-definition",
+      attributes: {
+        message: "${{ inputs.greeting }}",
+        fullMessage: '${{ inputs.greeting + " " + inputs.name + "!" }}',
+      },
+      inputs: {
+        type: "object",
+        properties: {
+          greeting: { type: "string", description: "A greeting" },
+          name: { type: "string", description: "A name" },
+        },
+        required: ["greeting", "name"],
+      },
+    });
+    await definitionRepo.save(modelType, definition);
+
+    // Create the expression evaluation service
+    const evalService = new ExpressionEvaluationService(
+      inputRepo,
+      resourceRepo,
+      repoDir,
+      { definitionRepo },
+    );
+
+    // Evaluate the definition with input values
+    const inputValues = {
+      greeting: "Hello",
+      name: "World",
+    };
+
+    const result = await evalService.evaluateDefinition(
+      definition,
+      modelType,
+      inputValues,
+    );
+
+    assertEquals(result.hadExpressions, true);
+    assertEquals(result.definition.attributes.message, "Hello");
+    assertEquals(result.definition.attributes.fullMessage, "Hello World!");
+  });
+});
+
+Deno.test("Definition: save and load evaluated definitions", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const evaluatedRepo = new YamlEvaluatedDefinitionRepository(repoDir);
+    const inputRepo = new YamlInputRepository(repoDir);
+    const resourceRepo = new YamlResourceRepository(repoDir);
+    const modelType = ModelType.create("swamp/echo");
+
+    // Create a definition with CEL expression
+    const definition = Definition.create({
+      name: "to-be-evaluated",
+      attributes: {
+        computed: "${{ 1 + 2 + 3 }}",
+      },
+    });
+    await definitionRepo.save(modelType, definition);
+
+    // Evaluate the definition
+    const evalService = new ExpressionEvaluationService(
+      inputRepo,
+      resourceRepo,
+      repoDir,
+      { definitionRepo },
+    );
+
+    const result = await evalService.evaluateDefinition(
+      definition,
+      modelType,
+    );
+
+    // Save the evaluated definition
+    await evaluatedRepo.save(modelType, result.definition);
+
+    // Load the evaluated definition
+    const loaded = await evaluatedRepo.findById(modelType, definition.id);
+    assertEquals(loaded !== null, true, "Evaluated definition should exist");
+    assertEquals(loaded!.attributes.computed, 6);
+
+    // Verify the original is unchanged
+    const original = await definitionRepo.findById(modelType, definition.id);
+    assertEquals(
+      original!.attributes.computed,
+      "${{ 1 + 2 + 3 }}",
+      "Original should preserve expression",
+    );
+  });
+});
+
+Deno.test("Definition: definition without expressions returns hadExpressions=false", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const inputRepo = new YamlInputRepository(repoDir);
+    const resourceRepo = new YamlResourceRepository(repoDir);
+    const modelType = ModelType.create("swamp/echo");
+
+    // Create a definition without any expressions
+    const definition = Definition.create({
+      name: "static-only",
+      attributes: {
+        message: "Just a static string",
+        count: 42,
+      },
+    });
+    await definitionRepo.save(modelType, definition);
+
+    const evalService = new ExpressionEvaluationService(
+      inputRepo,
+      resourceRepo,
+      repoDir,
+      { definitionRepo },
+    );
+
+    const result = await evalService.evaluateDefinition(
+      definition,
+      modelType,
+    );
+
+    assertEquals(result.hadExpressions, false);
+    assertEquals(result.definition.attributes.message, "Just a static string");
+  });
+});
+
+Deno.test("Definition: findByName works correctly", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const modelType = ModelType.create("swamp/echo");
+
+    // Create multiple definitions
+    const def1 = Definition.create({ name: "first-def", attributes: { a: 1 } });
+    const def2 = Definition.create({
+      name: "second-def",
+      attributes: { b: 2 },
+    });
+
+    await definitionRepo.save(modelType, def1);
+    await definitionRepo.save(modelType, def2);
+
+    // Find by name
+    const found = await definitionRepo.findByName(modelType, "second-def");
+    assertEquals(found !== null, true);
+    assertEquals(found!.name, "second-def");
+    assertEquals(found!.attributes.b, 2);
+
+    // Find non-existent
+    const notFound = await definitionRepo.findByName(modelType, "no-such-def");
+    assertEquals(notFound, null);
+  });
+});
+
+Deno.test("Definition: findByNameGlobal works across types", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const type1 = ModelType.create("swamp/echo");
+    const type2 = ModelType.create("aws/ec2/vpc");
+
+    // Create definitions in different types
+    const def1 = Definition.create({
+      name: "unique-name",
+      attributes: { x: 1 },
+    });
+    const def2 = Definition.create({
+      name: "another-name",
+      attributes: { y: 2 },
+    });
+
+    await definitionRepo.save(type1, def1);
+    await definitionRepo.save(type2, def2);
+
+    // Find globally
+    const found = await definitionRepo.findByNameGlobal("another-name");
+    assertEquals(found !== null, true);
+    assertEquals(found!.definition.name, "another-name");
+    assertEquals(found!.type.normalized, "aws/ec2/vpc");
+  });
+});
+
+Deno.test("Definition: hasDefinitionExpressions detects expressions correctly", () => {
+  const dir = Deno.makeTempDirSync({ prefix: "swamp-definition-test-" });
+  try {
+    const inputRepo = new YamlInputRepository(dir);
+    const resourceRepo = new YamlResourceRepository(dir);
+
+    const evalService = new ExpressionEvaluationService(
+      inputRepo,
+      resourceRepo,
+      dir,
+    );
+
+    const withExpr = Definition.create({
+      name: "with-expr",
+      attributes: { value: "${{ 1 + 1 }}" },
+    });
+
+    const withoutExpr = Definition.create({
+      name: "without-expr",
+      attributes: { value: "static" },
+    });
+
+    assertEquals(evalService.hasDefinitionExpressions(withExpr), true);
+    assertEquals(evalService.hasDefinitionExpressions(withoutExpr), false);
+  } finally {
+    Deno.removeSync(dir, { recursive: true });
+  }
+});

--- a/src/domain/definitions/definition.ts
+++ b/src/domain/definitions/definition.ts
@@ -1,0 +1,266 @@
+import { z } from "zod";
+
+/**
+ * Branded type for Definition IDs.
+ */
+export type DefinitionId = string & { readonly _brand: unique symbol };
+
+/**
+ * Creates a DefinitionId from a string.
+ */
+export function createDefinitionId(id: string): DefinitionId {
+  return id as DefinitionId;
+}
+
+/**
+ * JSON Schema property type for definition inputs.
+ * Follows JSON Schema draft-07 format.
+ */
+export interface JsonSchemaProperty {
+  type?: "string" | "number" | "integer" | "boolean" | "array" | "object";
+  description?: string;
+  default?: unknown;
+  enum?: unknown[];
+  items?: JsonSchemaProperty;
+  properties?: Record<string, JsonSchemaProperty>;
+  required?: string[];
+  additionalProperties?: boolean | JsonSchemaProperty;
+  [key: string]: unknown;
+}
+
+/**
+ * Zod schema for JSON Schema properties with recursive support.
+ */
+const baseJsonSchemaPropertySchema: z.ZodType<JsonSchemaProperty> = z.lazy(
+  () =>
+    z.object({
+      type: z.enum([
+        "string",
+        "number",
+        "integer",
+        "boolean",
+        "array",
+        "object",
+      ])
+        .optional(),
+      description: z.string().optional(),
+      default: z.unknown().optional(),
+      enum: z.array(z.unknown()).optional(),
+      items: baseJsonSchemaPropertySchema.optional(),
+      properties: z.record(z.string(), baseJsonSchemaPropertySchema).optional(),
+      required: z.array(z.string()).optional(),
+      additionalProperties: z.union([
+        z.boolean(),
+        baseJsonSchemaPropertySchema,
+      ])
+        .optional(),
+    }).passthrough(),
+);
+
+export const JsonSchemaPropertySchema = baseJsonSchemaPropertySchema;
+
+/**
+ * InputsSchema type for definition inputs.
+ */
+export interface InputsSchema {
+  type?: "object";
+  properties?: Record<string, JsonSchemaProperty>;
+  required?: string[];
+  additionalProperties?: boolean | JsonSchemaProperty;
+  [key: string]: unknown;
+}
+
+/**
+ * Zod schema for definition inputs.
+ */
+export const InputsSchemaSchema: z.ZodType<InputsSchema | undefined> = z
+  .object({
+    type: z.literal("object").optional(),
+    properties: z.record(z.string(), JsonSchemaPropertySchema).optional(),
+    required: z.array(z.string()).optional(),
+    additionalProperties: z.union([z.boolean(), JsonSchemaPropertySchema])
+      .optional(),
+  })
+  .passthrough()
+  .optional();
+
+/**
+ * Zod schema for the core properties of a Definition.
+ */
+export const DefinitionSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1),
+  version: z.number().int().positive(),
+  tags: z.record(z.string(), z.string()).default({}),
+  attributes: z.record(z.string(), z.unknown()).default({}),
+  inputs: InputsSchemaSchema,
+});
+
+/**
+ * Type representing the data stored in a Definition.
+ */
+export type DefinitionData = z.infer<typeof DefinitionSchema>;
+
+/**
+ * Properties required to create a new Definition.
+ */
+export interface CreateDefinitionProps {
+  id?: string;
+  name: string;
+  version?: number;
+  tags?: Record<string, string>;
+  attributes?: Record<string, unknown>;
+  inputs?: InputsSchema;
+}
+
+/**
+ * Definition is an entity representing the configuration for a model instance.
+ *
+ * Each definition has a unique ID (UUID), a human-readable name, version,
+ * optional tags, domain-specific attributes, and optional inputs schema.
+ *
+ * Attributes can contain CEL expressions in the format ${{ expression }}
+ * which will be evaluated when the definition is instantiated.
+ */
+export class Definition {
+  private constructor(
+    readonly id: DefinitionId,
+    readonly name: string,
+    readonly version: number,
+    private _tags: Record<string, string>,
+    private _attributes: Record<string, unknown>,
+    private _inputs: InputsSchema | undefined,
+  ) {}
+
+  /**
+   * Creates a new Definition instance.
+   *
+   * @param props - Properties for the new definition
+   * @returns A new Definition instance
+   */
+  static create(props: CreateDefinitionProps): Definition {
+    const id = props.id ?? crypto.randomUUID();
+    const version = props.version ?? 1;
+
+    const validated = DefinitionSchema.parse({
+      id,
+      name: props.name,
+      version,
+      tags: props.tags ?? {},
+      attributes: props.attributes ?? {},
+      inputs: props.inputs,
+    });
+
+    return new Definition(
+      createDefinitionId(validated.id),
+      validated.name,
+      validated.version,
+      validated.tags,
+      validated.attributes,
+      validated.inputs,
+    );
+  }
+
+  /**
+   * Reconstructs a Definition from persisted data.
+   *
+   * @param data - The persisted data
+   * @returns A Definition instance
+   */
+  static fromData(data: DefinitionData): Definition {
+    const validated = DefinitionSchema.parse(data);
+    return new Definition(
+      createDefinitionId(validated.id),
+      validated.name,
+      validated.version,
+      validated.tags,
+      validated.attributes,
+      validated.inputs,
+    );
+  }
+
+  /**
+   * Returns a copy of the tags.
+   */
+  get tags(): Record<string, string> {
+    return { ...this._tags };
+  }
+
+  /**
+   * Returns a copy of the attributes.
+   */
+  get attributes(): Record<string, unknown> {
+    return structuredClone(this._attributes);
+  }
+
+  /**
+   * Returns a copy of the inputs schema.
+   */
+  get inputs(): InputsSchema | undefined {
+    return this._inputs ? structuredClone(this._inputs) : undefined;
+  }
+
+  /**
+   * Sets a tag value.
+   */
+  setTag(key: string, value: string): void {
+    this._tags[key] = value;
+  }
+
+  /**
+   * Removes a tag.
+   */
+  removeTag(key: string): void {
+    delete this._tags[key];
+  }
+
+  /**
+   * Sets an attribute value.
+   */
+  setAttribute(key: string, value: unknown): void {
+    this._attributes[key] = value;
+  }
+
+  /**
+   * Removes an attribute.
+   */
+  removeAttribute(key: string): void {
+    delete this._attributes[key];
+  }
+
+  /**
+   * Sets the inputs schema.
+   */
+  setInputs(inputs: InputsSchema | undefined): void {
+    this._inputs = inputs ? structuredClone(inputs) : undefined;
+  }
+
+  /**
+   * Converts the definition to a plain data object for persistence.
+   */
+  toData(): DefinitionData {
+    return {
+      id: this.id,
+      name: this.name,
+      version: this.version,
+      tags: { ...this._tags },
+      attributes: structuredClone(this._attributes),
+      inputs: this._inputs ? structuredClone(this._inputs) : undefined,
+    };
+  }
+
+  /**
+   * Computes a hash of the definition for use as an instantiation ID.
+   * This hash uniquely identifies the definition configuration.
+   */
+  async computeHash(): Promise<string> {
+    const data = this.toData();
+    // Sort keys for consistent hashing
+    const sortedData = JSON.stringify(data, Object.keys(data).sort());
+    const encoder = new TextEncoder();
+    const dataBuffer = encoder.encode(sortedData);
+    const hashBuffer = await crypto.subtle.digest("SHA-256", dataBuffer);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+  }
+}

--- a/src/domain/definitions/definition_test.ts
+++ b/src/domain/definitions/definition_test.ts
@@ -1,0 +1,300 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { createDefinitionId, Definition } from "./definition.ts";
+
+Deno.test("Definition.create generates UUID if not provided", () => {
+  const definition = Definition.create({ name: "test-definition" });
+  assertEquals(typeof definition.id, "string");
+  assertEquals(definition.id.length, 36); // UUID length
+});
+
+Deno.test("Definition.create uses provided ID", () => {
+  const id = "550e8400-e29b-41d4-a716-446655440000";
+  const definition = Definition.create({ id, name: "test-definition" });
+  assertEquals(definition.id, id);
+});
+
+Deno.test("Definition.create sets default version to 1", () => {
+  const definition = Definition.create({ name: "test-definition" });
+  assertEquals(definition.version, 1);
+});
+
+Deno.test("Definition.create uses provided version", () => {
+  const definition = Definition.create({ name: "test-definition", version: 3 });
+  assertEquals(definition.version, 3);
+});
+
+Deno.test("Definition.create sets empty tags by default", () => {
+  const definition = Definition.create({ name: "test-definition" });
+  assertEquals(definition.tags, {});
+});
+
+Deno.test("Definition.create uses provided tags", () => {
+  const tags = { env: "production", team: "platform" };
+  const definition = Definition.create({ name: "test-definition", tags });
+  assertEquals(definition.tags, tags);
+});
+
+Deno.test("Definition.create sets empty attributes by default", () => {
+  const definition = Definition.create({ name: "test-definition" });
+  assertEquals(definition.attributes, {});
+});
+
+Deno.test("Definition.create uses provided attributes", () => {
+  const attributes = { message: "hello", count: 42 };
+  const definition = Definition.create({ name: "test-definition", attributes });
+  assertEquals(definition.attributes, attributes);
+});
+
+Deno.test("Definition.create supports attributes with CEL expressions", () => {
+  const attributes = {
+    message: "${{ model.other.input.attributes.greeting }}",
+    computed: "${{ inputs.value * 2 }}",
+  };
+  const definition = Definition.create({ name: "test-definition", attributes });
+  assertEquals(definition.attributes, attributes);
+});
+
+Deno.test("Definition.create sets undefined inputs by default", () => {
+  const definition = Definition.create({ name: "test-definition" });
+  assertEquals(definition.inputs, undefined);
+});
+
+Deno.test("Definition.create uses provided inputs schema", () => {
+  const inputs = {
+    type: "object" as const,
+    properties: {
+      name: { type: "string" as const, description: "The name" },
+      count: { type: "integer" as const, default: 1 },
+    },
+    required: ["name"],
+  };
+  const definition = Definition.create({ name: "test-definition", inputs });
+  assertEquals(definition.inputs, inputs);
+});
+
+Deno.test("Definition.create throws on empty name", () => {
+  assertThrows(
+    () => Definition.create({ name: "" }),
+    Error,
+  );
+});
+
+Deno.test("Definition.create throws on invalid version", () => {
+  assertThrows(
+    () => Definition.create({ name: "test", version: 0 }),
+    Error,
+  );
+});
+
+Deno.test("Definition.setTag adds/updates tags", () => {
+  const definition = Definition.create({ name: "test-definition" });
+  definition.setTag("env", "production");
+  assertEquals(definition.tags.env, "production");
+
+  definition.setTag("env", "staging");
+  assertEquals(definition.tags.env, "staging");
+});
+
+Deno.test("Definition.removeTag removes tags", () => {
+  const definition = Definition.create({
+    name: "test-definition",
+    tags: { env: "prod" },
+  });
+  assertEquals(definition.tags.env, "prod");
+
+  definition.removeTag("env");
+  assertEquals(definition.tags.env, undefined);
+});
+
+Deno.test("Definition.setAttribute adds/updates attributes", () => {
+  const definition = Definition.create({ name: "test-definition" });
+  definition.setAttribute("message", "hello");
+  assertEquals(definition.attributes.message, "hello");
+});
+
+Deno.test("Definition.removeAttribute removes attributes", () => {
+  const definition = Definition.create({
+    name: "test-definition",
+    attributes: { message: "hello" },
+  });
+  assertEquals(definition.attributes.message, "hello");
+
+  definition.removeAttribute("message");
+  assertEquals(definition.attributes.message, undefined);
+});
+
+Deno.test("Definition.setInputs sets inputs schema", () => {
+  const definition = Definition.create({ name: "test-definition" });
+  const inputs = {
+    type: "object" as const,
+    properties: { name: { type: "string" as const } },
+  };
+  definition.setInputs(inputs);
+  assertEquals(definition.inputs, inputs);
+});
+
+Deno.test("Definition.setInputs clears inputs with undefined", () => {
+  const definition = Definition.create({
+    name: "test-definition",
+    inputs: { type: "object" as const },
+  });
+  definition.setInputs(undefined);
+  assertEquals(definition.inputs, undefined);
+});
+
+Deno.test("Definition.toData returns correct structure", () => {
+  const definition = Definition.create({
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "test-definition",
+    version: 2,
+    tags: { env: "prod" },
+    attributes: { message: "hello" },
+    inputs: {
+      type: "object" as const,
+      properties: { name: { type: "string" as const } },
+    },
+  });
+
+  const data = definition.toData();
+  assertEquals(data, {
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "test-definition",
+    version: 2,
+    tags: { env: "prod" },
+    attributes: { message: "hello" },
+    inputs: {
+      type: "object",
+      properties: { name: { type: "string" } },
+    },
+  });
+});
+
+Deno.test("Definition.fromData reconstructs definition correctly", () => {
+  const data = {
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "test-definition",
+    version: 2,
+    tags: { env: "prod" },
+    attributes: { message: "hello" },
+    inputs: {
+      type: "object" as const,
+      properties: { name: { type: "string" as const } },
+    },
+  };
+
+  const definition = Definition.fromData(data);
+  assertEquals(definition.id, data.id);
+  assertEquals(definition.name, data.name);
+  assertEquals(definition.version, data.version);
+  assertEquals(definition.tags, data.tags);
+  assertEquals(definition.attributes, data.attributes);
+  assertEquals(definition.inputs, data.inputs);
+});
+
+Deno.test("Definition.tags returns a copy, not the original", () => {
+  const definition = Definition.create({
+    name: "test-definition",
+    tags: { a: "1" },
+  });
+  const tags = definition.tags;
+  tags.b = "2";
+  assertEquals(definition.tags.b, undefined);
+});
+
+Deno.test("Definition.attributes returns a copy, not the original", () => {
+  const definition = Definition.create({
+    name: "test-definition",
+    attributes: { a: 1 },
+  });
+  const attrs = definition.attributes;
+  attrs.b = 2;
+  assertEquals(definition.attributes.b, undefined);
+});
+
+Deno.test("Definition.inputs returns a copy, not the original", () => {
+  const definition = Definition.create({
+    name: "test-definition",
+    inputs: {
+      type: "object" as const,
+      properties: { a: { type: "string" as const } },
+    },
+  });
+  const inputs = definition.inputs;
+  if (inputs?.properties) {
+    inputs.properties.b = { type: "number" };
+  }
+  assertEquals(definition.inputs?.properties?.b, undefined);
+});
+
+Deno.test("Definition.attributes handles deep nesting", () => {
+  const attributes = {
+    nested: {
+      deep: {
+        value: "${{ model.foo.input.attributes.bar }}",
+        list: [1, 2, "${{ inputs.count }}"],
+      },
+    },
+  };
+  const definition = Definition.create({
+    name: "test-definition",
+    attributes,
+  });
+
+  // Modifying the returned attributes shouldn't affect the original
+  const attrs = definition.attributes;
+  (attrs.nested as Record<string, unknown>).deep = "modified";
+  assertEquals(
+    (definition.attributes.nested as Record<string, unknown>).deep,
+    {
+      value: "${{ model.foo.input.attributes.bar }}",
+      list: [1, 2, "${{ inputs.count }}"],
+    },
+  );
+});
+
+Deno.test("createDefinitionId creates branded type", () => {
+  const id = createDefinitionId("550e8400-e29b-41d4-a716-446655440000");
+  assertEquals(typeof id, "string");
+  assertEquals(id, "550e8400-e29b-41d4-a716-446655440000");
+});
+
+Deno.test("Definition.computeHash returns consistent hash", async () => {
+  const definition1 = Definition.create({
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "test-definition",
+    version: 1,
+    attributes: { message: "hello" },
+  });
+
+  const definition2 = Definition.create({
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "test-definition",
+    version: 1,
+    attributes: { message: "hello" },
+  });
+
+  const hash1 = await definition1.computeHash();
+  const hash2 = await definition2.computeHash();
+
+  assertEquals(hash1, hash2);
+  assertEquals(hash1.length, 64); // SHA-256 hex string length
+});
+
+Deno.test("Definition.computeHash returns different hash for different content", async () => {
+  const definition1 = Definition.create({
+    name: "test-definition",
+    attributes: { message: "hello" },
+  });
+
+  const definition2 = Definition.create({
+    name: "test-definition",
+    attributes: { message: "world" },
+  });
+
+  const hash1 = await definition1.computeHash();
+  const hash2 = await definition2.computeHash();
+
+  // Different content should produce different hashes
+  // Note: IDs will be different, so hashes will definitely differ
+  assertEquals(hash1 !== hash2, true);
+});

--- a/src/domain/definitions/repositories.ts
+++ b/src/domain/definitions/repositories.ts
@@ -1,0 +1,81 @@
+import type { ModelType } from "../models/model_type.ts";
+import type { Definition, DefinitionId } from "./definition.ts";
+
+/**
+ * Repository interface for persisting and retrieving Definitions.
+ */
+export interface DefinitionRepository {
+  /**
+   * Finds a definition by its ID.
+   *
+   * @param type - The model type
+   * @param id - The definition ID
+   * @returns The definition if found, or null
+   */
+  findById(type: ModelType, id: DefinitionId): Promise<Definition | null>;
+
+  /**
+   * Finds all definitions of a given type.
+   *
+   * @param type - The model type
+   * @returns Array of definitions
+   */
+  findAll(type: ModelType): Promise<Definition[]>;
+
+  /**
+   * Finds a definition by its name within a specific type.
+   *
+   * @param type - The model type
+   * @param name - The definition name
+   * @returns The definition if found, or null
+   */
+  findByName(type: ModelType, name: string): Promise<Definition | null>;
+
+  /**
+   * Finds a definition by its name across all model types.
+   * Used to enforce global name uniqueness.
+   *
+   * @param name - The definition name
+   * @returns The definition and its type if found, or null
+   */
+  findByNameGlobal(
+    name: string,
+  ): Promise<{ definition: Definition; type: ModelType } | null>;
+
+  /**
+   * Finds all definitions across all model types.
+   *
+   * @returns Array of all definitions with their types
+   */
+  findAllGlobal(): Promise<{ definition: Definition; type: ModelType }[]>;
+
+  /**
+   * Saves a definition.
+   *
+   * @param type - The model type
+   * @param definition - The definition to save
+   */
+  save(type: ModelType, definition: Definition): Promise<void>;
+
+  /**
+   * Deletes a definition.
+   *
+   * @param type - The model type
+   * @param id - The definition ID
+   */
+  delete(type: ModelType, id: DefinitionId): Promise<void>;
+
+  /**
+   * Generates a new unique ID.
+   */
+  nextId(): DefinitionId;
+
+  /**
+   * Returns the file path for a definition.
+   *
+   * @param type - The model type
+   * @param id - The definition ID
+   * @returns The file path
+   */
+  getPath(type: ModelType, id: DefinitionId): string;
+}

--- a/src/domain/events/types.ts
+++ b/src/domain/events/types.ts
@@ -48,6 +48,40 @@ export interface ModelDeleted extends DomainEvent {
 }
 
 // ============================================================================
+// Definition Events
+// ============================================================================
+
+/**
+ * Emitted when a new definition is created.
+ */
+export interface DefinitionCreated extends DomainEvent {
+  readonly type: "DefinitionCreated";
+  readonly modelType: string;
+  readonly definitionId: string;
+  readonly definitionName: string;
+}
+
+/**
+ * Emitted when a definition is updated.
+ */
+export interface DefinitionUpdated extends DomainEvent {
+  readonly type: "DefinitionUpdated";
+  readonly modelType: string;
+  readonly definitionId: string;
+  readonly definitionName: string;
+}
+
+/**
+ * Emitted when a definition is deleted.
+ */
+export interface DefinitionDeleted extends DomainEvent {
+  readonly type: "DefinitionDeleted";
+  readonly modelType: string;
+  readonly definitionId: string;
+  readonly definitionName: string;
+}
+
+// ============================================================================
 // Workflow Events
 // ============================================================================
 
@@ -123,6 +157,9 @@ export type RepositoryEvent =
   | ModelCreated
   | ModelUpdated
   | ModelDeleted
+  | DefinitionCreated
+  | DefinitionUpdated
+  | DefinitionDeleted
   | WorkflowCreated
   | WorkflowUpdated
   | WorkflowDeleted
@@ -190,6 +227,57 @@ export function createModelDeleted(
     modelType,
     modelInputId,
     modelName,
+    timestamp: new Date(),
+  };
+}
+
+/**
+ * Creates a DefinitionCreated event.
+ */
+export function createDefinitionCreated(
+  modelType: string,
+  definitionId: string,
+  definitionName: string,
+): DefinitionCreated {
+  return {
+    type: "DefinitionCreated",
+    modelType,
+    definitionId,
+    definitionName,
+    timestamp: new Date(),
+  };
+}
+
+/**
+ * Creates a DefinitionUpdated event.
+ */
+export function createDefinitionUpdated(
+  modelType: string,
+  definitionId: string,
+  definitionName: string,
+): DefinitionUpdated {
+  return {
+    type: "DefinitionUpdated",
+    modelType,
+    definitionId,
+    definitionName,
+    timestamp: new Date(),
+  };
+}
+
+/**
+ * Creates a DefinitionDeleted event.
+ */
+export function createDefinitionDeleted(
+  modelType: string,
+  definitionId: string,
+  definitionName: string,
+): DefinitionDeleted {
+  return {
+    type: "DefinitionDeleted",
+    modelType,
+    definitionId,
+    definitionName,
     timestamp: new Date(),
   };
 }

--- a/src/domain/expressions/expression_evaluation_service.ts
+++ b/src/domain/expressions/expression_evaluation_service.ts
@@ -1,8 +1,11 @@
 import type { ModelInput } from "../models/model_input.ts";
 import { ModelInput as ModelInputClass } from "../models/model_input.ts";
 import type { ModelType } from "../models/model_type.ts";
+import type { Definition } from "../definitions/definition.ts";
+import { Definition as DefinitionClass } from "../definitions/definition.ts";
 import type { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
 import type { YamlResourceRepository } from "../../infrastructure/persistence/yaml_resource_repository.ts";
+import type { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { CelEvaluator } from "../../infrastructure/cel/cel_evaluator.ts";
 import {
   containsExpression,
@@ -10,7 +13,11 @@ import {
   replaceExpressions,
 } from "./expression_parser.ts";
 import { extractModelRefs } from "./dependency_extractor.ts";
-import { type ExpressionContext, ModelResolver } from "./model_resolver.ts";
+import {
+  type ExpressionContext,
+  ModelResolver,
+  type ModelResolverRepositories,
+} from "./model_resolver.ts";
 import { CyclicDependencyError } from "./errors.ts";
 import {
   CyclicDependencyError as TopoCyclicError,
@@ -29,22 +36,36 @@ export interface EvaluatedInput {
 }
 
 /**
- * Domain service for evaluating CEL expressions in model inputs.
+ * Result of evaluating a single definition.
+ */
+export interface EvaluatedDefinition {
+  definition: Definition;
+  type: ModelType;
+  /** Whether any expressions were evaluated */
+  hadExpressions: boolean;
+}
+
+/**
+ * Domain service for evaluating CEL expressions in model inputs and definitions.
  */
 export class ExpressionEvaluationService {
   private readonly celEvaluator: CelEvaluator;
   private readonly sortService: TopologicalSortService;
   private readonly modelResolver: ModelResolver;
+  private readonly definitionRepo?: YamlDefinitionRepository;
 
   constructor(
     private readonly inputRepo: YamlInputRepository,
     private readonly resourceRepo: YamlResourceRepository,
     repoDir?: string,
+    repos?: ModelResolverRepositories,
   ) {
     this.celEvaluator = new CelEvaluator();
     this.sortService = new TopologicalSortService();
+    this.definitionRepo = repos?.definitionRepo;
     this.modelResolver = new ModelResolver(inputRepo, resourceRepo, {
       repoDir,
+      ...repos,
     });
   }
 
@@ -264,5 +285,210 @@ export class ExpressionEvaluationService {
     }
 
     return replaceExpressions(data, evaluatedValues);
+  }
+
+  /**
+   * Evaluates expressions in a single definition.
+   *
+   * @param definition - The definition to evaluate
+   * @param type - The model type
+   * @param inputValues - Optional input values to use in expression evaluation
+   * @param context - Optional pre-built context (for batch evaluation)
+   * @returns The evaluated definition
+   */
+  async evaluateDefinition(
+    definition: Definition,
+    type: ModelType,
+    inputValues?: Record<string, unknown>,
+    context?: ExpressionContext,
+  ): Promise<EvaluatedDefinition> {
+    // Build context if not provided
+    const ctx = context ?? await this.modelResolver.buildContext();
+
+    // Add inputs to context if provided
+    if (inputValues) {
+      ctx.inputs = inputValues;
+    }
+
+    // Add self reference for the definition
+    ctx.self = {
+      id: definition.id,
+      name: definition.name,
+      version: definition.version,
+      tags: definition.tags,
+      attributes: definition.attributes,
+    };
+
+    // Extract expressions from definition data
+    const definitionData = definition.toData();
+    const expressions = extractExpressions(definitionData);
+
+    if (expressions.length === 0) {
+      return { definition, type, hadExpressions: false };
+    }
+
+    // Evaluate each expression
+    const evaluatedValues = new Map<string, unknown>();
+    for (const expr of expressions) {
+      // First resolve any vault expressions in the CEL expression
+      const resolvedCelExpr = await this.modelResolver.resolveVaultExpressions(
+        expr.celExpression,
+      );
+
+      // Then evaluate the CEL expression
+      const value = this.celEvaluator.evaluate(resolvedCelExpr, ctx);
+      evaluatedValues.set(expr.raw, value);
+    }
+
+    // Replace expressions with evaluated values
+    const evaluatedData = replaceExpressions(definitionData, evaluatedValues);
+
+    // Create new Definition from evaluated data
+    const evaluatedDefinition = DefinitionClass.fromData(
+      evaluatedData as ReturnType<typeof definition.toData>,
+    );
+
+    return { definition: evaluatedDefinition, type, hadExpressions: true };
+  }
+
+  /**
+   * Evaluates all definitions in dependency order.
+   * Definitions are evaluated in topological order based on their expression dependencies.
+   *
+   * @returns Array of evaluated definitions
+   * @throws CyclicDependencyError if circular dependencies are detected
+   */
+  async evaluateAllDefinitions(): Promise<EvaluatedDefinition[]> {
+    if (!this.definitionRepo) {
+      return [];
+    }
+
+    // Load all definitions
+    const allDefinitions = await this.definitionRepo.findAllGlobal();
+
+    // Build dependency graph
+    const nodes = this.buildDefinitionDependencyGraph(allDefinitions);
+
+    // Sort topologically
+    let sortedNames: string[];
+    try {
+      const sortResult = this.sortService.sort(nodes);
+      sortedNames = this.sortService.flatten(sortResult);
+    } catch (error) {
+      if (error instanceof TopoCyclicError) {
+        throw new CyclicDependencyError(error.cycle);
+      }
+      throw error;
+    }
+
+    // Build initial context
+    const context = await this.modelResolver.buildContext();
+
+    // Map of definition name to definition data
+    const definitionMap = new Map<
+      string,
+      { definition: Definition; type: ModelType }
+    >();
+    for (const { definition, type } of allDefinitions) {
+      definitionMap.set(definition.name, { definition, type });
+    }
+
+    // Evaluate in order
+    const results: EvaluatedDefinition[] = [];
+    for (const name of sortedNames) {
+      const entry = definitionMap.get(name);
+      if (!entry) continue;
+
+      // Add self to context for this evaluation
+      const ctxWithSelf: ExpressionContext = {
+        ...context,
+        self: {
+          id: entry.definition.id,
+          name: entry.definition.name,
+          version: entry.definition.version,
+          tags: entry.definition.tags,
+          attributes: entry.definition.attributes,
+        },
+      };
+
+      const result = await this.evaluateDefinition(
+        entry.definition,
+        entry.type,
+        undefined,
+        ctxWithSelf,
+      );
+      results.push(result);
+
+      // Update context with evaluated definition data for subsequent evaluations
+      if (result.hadExpressions) {
+        const modelData = context.model[name] ?? {
+          input: {
+            id: result.definition.id,
+            name: result.definition.name,
+            version: result.definition.version,
+            tags: result.definition.tags,
+            attributes: {},
+          },
+        };
+        modelData.definition = {
+          id: result.definition.id,
+          name: result.definition.name,
+          version: result.definition.version,
+          tags: result.definition.tags,
+          attributes: result.definition.attributes,
+          inputs: result.definition.inputs,
+        };
+        context.model[name] = modelData;
+        // Also update by UUID
+        context.model[result.definition.id] = modelData;
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Builds a dependency graph from definitions based on their expressions.
+   */
+  private buildDefinitionDependencyGraph(
+    definitions: { definition: Definition; type: ModelType }[],
+  ): GraphNode[] {
+    const nodes: GraphNode[] = [];
+    const nameSet = new Set(definitions.map((d) => d.definition.name));
+
+    for (const { definition } of definitions) {
+      const definitionData = definition.toData();
+      const expressions = extractExpressions(definitionData);
+
+      // Collect all model references from expressions
+      const dependencies: string[] = [];
+      for (const expr of expressions) {
+        const refs = extractModelRefs(expr.celExpression);
+        for (const ref of refs) {
+          // Only add if it's a known definition name (not self, not UUID for simplicity)
+          if (nameSet.has(ref) && ref !== definition.name) {
+            if (!dependencies.includes(ref)) {
+              dependencies.push(ref);
+            }
+          }
+        }
+      }
+
+      nodes.push({
+        name: definition.name,
+        weight: 0, // All definitions have equal weight
+        dependencies,
+      });
+    }
+
+    return nodes;
+  }
+
+  /**
+   * Checks if any string value in the definition contains expressions.
+   */
+  hasDefinitionExpressions(definition: Definition): boolean {
+    const data = definition.toData();
+    return this.checkForExpressions(data);
   }
 }

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -5,12 +5,14 @@ import type { ModelFile } from "../models/model_file.ts";
 import type { ModelLog } from "../models/model_log.ts";
 import type { ModelOutput } from "../models/model_output.ts";
 import type { ModelType } from "../models/model_type.ts";
+import type { Definition, InputsSchema } from "../definitions/definition.ts";
 import type { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
 import type { YamlResourceRepository } from "../../infrastructure/persistence/yaml_resource_repository.ts";
 import type { YamlDataRepository } from "../../infrastructure/persistence/yaml_data_repository.ts";
 import type { FileSystemFileRepository } from "../../infrastructure/persistence/fs_file_repository.ts";
 import type { StreamingLogRepository } from "../../infrastructure/persistence/streaming_log_repository.ts";
 import type { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
+import type { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { inputIdToResourceId } from "../models/model_resource.ts";
 import { createModelDataId } from "../models/model_data.ts";
 import { createModelFileId } from "../models/model_file.ts";
@@ -35,6 +37,14 @@ export interface ModelData {
     version: number;
     tags: Record<string, string>;
     attributes: Record<string, unknown>;
+  };
+  definition?: {
+    id: string;
+    name: string;
+    version: number;
+    tags: Record<string, string>;
+    attributes: Record<string, unknown>;
+    inputs?: InputsSchema;
   };
   resource?: {
     id: string;
@@ -91,6 +101,8 @@ export interface ExpressionContext {
     tags: Record<string, string>;
     attributes: Record<string, unknown>;
   };
+  /** Input values provided when instantiating a definition */
+  inputs?: Record<string, unknown>;
   /** Workflow context (for workflow evaluation) */
   workflow?: Record<string, unknown>;
   /** Vault operations for secure secret access */
@@ -111,6 +123,7 @@ export interface ModelResolverRepositories {
   fileRepo?: FileSystemFileRepository;
   logRepo?: StreamingLogRepository;
   outputRepo?: YamlOutputRepository;
+  definitionRepo?: YamlDefinitionRepository;
   /** Optional vault service for dependency injection (useful for testing) */
   vaultService?: VaultService;
   /** Repository directory for lazy loading vault configurations */
@@ -125,6 +138,7 @@ export class ModelResolver {
   private readonly fileRepo?: FileSystemFileRepository;
   private readonly logRepo?: StreamingLogRepository;
   private readonly outputRepo?: YamlOutputRepository;
+  private readonly definitionRepo?: YamlDefinitionRepository;
   private vaultService?: VaultService;
   private readonly repoDir?: string;
   private vaultServiceInitialized = false;
@@ -138,6 +152,7 @@ export class ModelResolver {
     this.fileRepo = repos?.fileRepo;
     this.logRepo = repos?.logRepo;
     this.outputRepo = repos?.outputRepo;
+    this.definitionRepo = repos?.definitionRepo;
     this.repoDir = repos?.repoDir;
     // If a vault service was provided, use it directly
     if (repos?.vaultService) {
@@ -226,6 +241,21 @@ export class ModelResolver {
         attributes: input.attributes,
       },
     };
+
+    // Load definition if available (by name match)
+    if (this.definitionRepo) {
+      const definition = await this.definitionRepo.findByName(type, input.name);
+      if (definition) {
+        data.definition = {
+          id: definition.id,
+          name: definition.name,
+          version: definition.version,
+          tags: definition.tags,
+          attributes: definition.attributes,
+          inputs: definition.inputs,
+        };
+      }
+    }
 
     // Load resource if available (resource ID equals input ID by convention)
     const resourceId = inputIdToResourceId(input.id);
@@ -495,6 +525,31 @@ export class ModelResolver {
         completedAt: output.completedAt?.toISOString(),
         durationMs: output.durationMs,
         error: output.error,
+      };
+    }
+  }
+
+  /**
+   * Updates the context with fresh definition data for a specific model.
+   *
+   * @param context - The context to update
+   * @param modelRef - The model name or UUID
+   * @param definition - The definition data
+   */
+  updateDefinitionInContext(
+    context: ExpressionContext,
+    modelRef: string,
+    definition: Definition,
+  ): void {
+    const modelData = context.model[modelRef];
+    if (modelData) {
+      modelData.definition = {
+        id: definition.id,
+        name: definition.name,
+        version: definition.version,
+        tags: definition.tags,
+        attributes: definition.attributes,
+        inputs: definition.inputs,
       };
     }
   }

--- a/src/infrastructure/persistence/yaml_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository.ts
@@ -1,0 +1,271 @@
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
+import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import type { DefinitionRepository } from "../../domain/definitions/repositories.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
+import {
+  createDefinitionId,
+  Definition,
+  type DefinitionData,
+  type DefinitionId,
+} from "../../domain/definitions/definition.ts";
+import type { EventBus } from "../../domain/events/event_bus.ts";
+import {
+  createDefinitionCreated,
+  createDefinitionDeleted,
+  createDefinitionUpdated,
+} from "../../domain/events/types.ts";
+
+/**
+ * YAML-based implementation of DefinitionRepository.
+ *
+ * Stores definitions as YAML files in the directory structure:
+ * {repoDir}/.swamp/definitions/{normalized-type}/{id}.yaml
+ *
+ * CEL expressions in attributes are preserved as-is (not evaluated on save).
+ */
+export class YamlDefinitionRepository implements DefinitionRepository {
+  constructor(
+    private readonly repoDir: string,
+    private readonly eventBus?: EventBus,
+  ) {}
+
+  async findById(
+    type: ModelType,
+    id: DefinitionId,
+  ): Promise<Definition | null> {
+    const path = this.getPath(type, id);
+    try {
+      const content = await Deno.readTextFile(path);
+      const data = parseYaml(content) as DefinitionData;
+      return Definition.fromData(data);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async findAll(type: ModelType): Promise<Definition[]> {
+    const dir = this.getTypeDir(type);
+    const definitions: Definition[] = [];
+
+    try {
+      for await (const entry of Deno.readDir(dir)) {
+        if (entry.isFile && entry.name.endsWith(".yaml")) {
+          const path = join(dir, entry.name);
+          const content = await Deno.readTextFile(path);
+          const data = parseYaml(content) as DefinitionData;
+          definitions.push(Definition.fromData(data));
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+
+    return definitions;
+  }
+
+  async findByName(type: ModelType, name: string): Promise<Definition | null> {
+    const definitions = await this.findAll(type);
+    return definitions.find((def) => def.name === name) ?? null;
+  }
+
+  async findByNameGlobal(
+    name: string,
+  ): Promise<{ definition: Definition; type: ModelType } | null> {
+    const definitionsDir = join(this.repoDir, ".swamp", "definitions");
+    return await this.searchDefinitionByName(definitionsDir, [], name);
+  }
+
+  /**
+   * Recursively searches for a definition file by name in nested directory structures.
+   */
+  private async searchDefinitionByName(
+    currentDir: string,
+    pathSegments: string[],
+    name: string,
+  ): Promise<{ definition: Definition; type: ModelType } | null> {
+    try {
+      for await (const entry of Deno.readDir(currentDir)) {
+        const fullPath = join(currentDir, entry.name);
+
+        if (entry.isFile && entry.name.endsWith(".yaml")) {
+          // Found a YAML file, check if it matches the name
+          const content = await Deno.readTextFile(fullPath);
+          const data = parseYaml(content) as DefinitionData;
+          const definition = Definition.fromData(data);
+
+          if (definition.name === name) {
+            // Reconstruct the model type from the path segments
+            const typeStr = pathSegments.join("/");
+            return { definition, type: ModelType.create(typeStr) };
+          }
+        } else if (entry.isDirectory) {
+          // Recursively search subdirectories
+          const result = await this.searchDefinitionByName(
+            fullPath,
+            [...pathSegments, entry.name],
+            name,
+          );
+          if (result) {
+            return result;
+          }
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+
+    return null;
+  }
+
+  /**
+   * Finds all definitions across all model types in the repository.
+   */
+  async findAllGlobal(): Promise<
+    { definition: Definition; type: ModelType }[]
+  > {
+    const definitionsDir = join(this.repoDir, ".swamp", "definitions");
+    const results: { definition: Definition; type: ModelType }[] = [];
+    await this.collectAllDefinitions(definitionsDir, [], results);
+    return results;
+  }
+
+  /**
+   * Recursively collects all definition files from nested directory structures.
+   */
+  private async collectAllDefinitions(
+    currentDir: string,
+    pathSegments: string[],
+    results: { definition: Definition; type: ModelType }[],
+  ): Promise<void> {
+    try {
+      for await (const entry of Deno.readDir(currentDir)) {
+        const fullPath = join(currentDir, entry.name);
+
+        if (entry.isFile && entry.name.endsWith(".yaml")) {
+          // Found a YAML file, add it to results
+          const content = await Deno.readTextFile(fullPath);
+          const data = parseYaml(content) as DefinitionData;
+          const definition = Definition.fromData(data);
+
+          // Reconstruct the model type from the path segments
+          const typeStr = pathSegments.join("/");
+          results.push({ definition, type: ModelType.create(typeStr) });
+        } else if (entry.isDirectory) {
+          // Recursively search subdirectories
+          await this.collectAllDefinitions(
+            fullPath,
+            [...pathSegments, entry.name],
+            results,
+          );
+        }
+      }
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+  }
+
+  async save(type: ModelType, definition: Definition): Promise<void> {
+    const dir = this.getTypeDir(type);
+    await ensureDir(dir);
+
+    const path = this.getPath(type, definition.id);
+
+    // Check if this is a new definition or an update
+    const isNew = !(await this.exists(path));
+
+    const data = definition.toData();
+    // Remove undefined values since YAML can't stringify them
+    const cleanData = JSON.parse(JSON.stringify(data));
+    const content = stringifyYaml(cleanData as Record<string, unknown>);
+    await Deno.writeTextFile(path, content);
+
+    // Emit event
+    if (this.eventBus) {
+      const event = isNew
+        ? createDefinitionCreated(
+          type.normalized,
+          definition.id,
+          definition.name,
+        )
+        : createDefinitionUpdated(
+          type.normalized,
+          definition.id,
+          definition.name,
+        );
+      await this.eventBus.publish(event);
+    }
+  }
+
+  /**
+   * Checks if a file exists.
+   */
+  private async exists(path: string): Promise<boolean> {
+    try {
+      await Deno.stat(path);
+      return true;
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async delete(type: ModelType, id: DefinitionId): Promise<void> {
+    const path = this.getPath(type, id);
+
+    // Get the definition name before deleting for the event
+    let definitionName: string | undefined;
+    if (this.eventBus) {
+      const definition = await this.findById(type, id);
+      definitionName = definition?.name;
+    }
+
+    try {
+      await Deno.remove(path);
+
+      // Clean up empty parent directories
+      const definitionsDir = join(this.repoDir, ".swamp", "definitions");
+      await cleanupEmptyParentDirs(path, definitionsDir);
+
+      // Emit event if we had a name
+      if (this.eventBus && definitionName) {
+        const event = createDefinitionDeleted(
+          type.normalized,
+          id,
+          definitionName,
+        );
+        await this.eventBus.publish(event);
+      }
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+  }
+
+  nextId(): DefinitionId {
+    return createDefinitionId(crypto.randomUUID());
+  }
+
+  getPath(type: ModelType, id: DefinitionId): string {
+    return join(this.getTypeDir(type), `${id}.yaml`);
+  }
+
+  private getTypeDir(type: ModelType): string {
+    return join(this.repoDir, ".swamp", "definitions", type.toDirectoryPath());
+  }
+}

--- a/src/infrastructure/persistence/yaml_evaluated_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_definition_repository.ts
@@ -1,0 +1,299 @@
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
+import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import { ModelType } from "../../domain/models/model_type.ts";
+import {
+  createDefinitionId,
+  Definition,
+  type DefinitionData,
+  type DefinitionId,
+} from "../../domain/definitions/definition.ts";
+
+/**
+ * YAML-based repository for evaluated definitions.
+ *
+ * Stores definitions with CEL expressions already evaluated in the directory structure:
+ * {repoDir}/.swamp/definitions-evaluated/{normalized-type}/{id}.yaml
+ *
+ * This directory is gitignored as evaluated definitions are derived data
+ * that can be regenerated from the source definitions.
+ */
+export class YamlEvaluatedDefinitionRepository {
+  constructor(
+    private readonly repoDir: string,
+  ) {}
+
+  /**
+   * Finds an evaluated definition by its ID.
+   *
+   * @param type - The model type
+   * @param id - The definition ID
+   * @returns The evaluated definition if found, or null
+   */
+  async findById(
+    type: ModelType,
+    id: DefinitionId,
+  ): Promise<Definition | null> {
+    const path = this.getPath(type, id);
+    try {
+      const content = await Deno.readTextFile(path);
+      const data = parseYaml(content) as DefinitionData;
+      return Definition.fromData(data);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Finds all evaluated definitions of a given type.
+   *
+   * @param type - The model type
+   * @returns Array of evaluated definitions
+   */
+  async findAll(type: ModelType): Promise<Definition[]> {
+    const dir = this.getTypeDir(type);
+    const definitions: Definition[] = [];
+
+    try {
+      for await (const entry of Deno.readDir(dir)) {
+        if (entry.isFile && entry.name.endsWith(".yaml")) {
+          const path = join(dir, entry.name);
+          const content = await Deno.readTextFile(path);
+          const data = parseYaml(content) as DefinitionData;
+          definitions.push(Definition.fromData(data));
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+
+    return definitions;
+  }
+
+  /**
+   * Finds an evaluated definition by its name within a specific type.
+   *
+   * @param type - The model type
+   * @param name - The definition name
+   * @returns The evaluated definition if found, or null
+   */
+  async findByName(type: ModelType, name: string): Promise<Definition | null> {
+    const definitions = await this.findAll(type);
+    return definitions.find((def) => def.name === name) ?? null;
+  }
+
+  /**
+   * Finds an evaluated definition by its name across all model types.
+   *
+   * @param name - The definition name
+   * @returns The definition and its type if found, or null
+   */
+  async findByNameGlobal(
+    name: string,
+  ): Promise<{ definition: Definition; type: ModelType } | null> {
+    const definitionsDir = join(
+      this.repoDir,
+      ".swamp",
+      "definitions-evaluated",
+    );
+    return await this.searchDefinitionByName(definitionsDir, [], name);
+  }
+
+  /**
+   * Recursively searches for a definition file by name in nested directory structures.
+   */
+  private async searchDefinitionByName(
+    currentDir: string,
+    pathSegments: string[],
+    name: string,
+  ): Promise<{ definition: Definition; type: ModelType } | null> {
+    try {
+      for await (const entry of Deno.readDir(currentDir)) {
+        const fullPath = join(currentDir, entry.name);
+
+        if (entry.isFile && entry.name.endsWith(".yaml")) {
+          // Found a YAML file, check if it matches the name
+          const content = await Deno.readTextFile(fullPath);
+          const data = parseYaml(content) as DefinitionData;
+          const definition = Definition.fromData(data);
+
+          if (definition.name === name) {
+            // Reconstruct the model type from the path segments
+            const typeStr = pathSegments.join("/");
+            return { definition, type: ModelType.create(typeStr) };
+          }
+        } else if (entry.isDirectory) {
+          // Recursively search subdirectories
+          const result = await this.searchDefinitionByName(
+            fullPath,
+            [...pathSegments, entry.name],
+            name,
+          );
+          if (result) {
+            return result;
+          }
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+
+    return null;
+  }
+
+  /**
+   * Finds all evaluated definitions across all model types in the repository.
+   *
+   * @returns Array of all evaluated definitions with their types
+   */
+  async findAllGlobal(): Promise<
+    { definition: Definition; type: ModelType }[]
+  > {
+    const definitionsDir = join(
+      this.repoDir,
+      ".swamp",
+      "definitions-evaluated",
+    );
+    const results: { definition: Definition; type: ModelType }[] = [];
+    await this.collectAllDefinitions(definitionsDir, [], results);
+    return results;
+  }
+
+  /**
+   * Recursively collects all definition files from nested directory structures.
+   */
+  private async collectAllDefinitions(
+    currentDir: string,
+    pathSegments: string[],
+    results: { definition: Definition; type: ModelType }[],
+  ): Promise<void> {
+    try {
+      for await (const entry of Deno.readDir(currentDir)) {
+        const fullPath = join(currentDir, entry.name);
+
+        if (entry.isFile && entry.name.endsWith(".yaml")) {
+          // Found a YAML file, add it to results
+          const content = await Deno.readTextFile(fullPath);
+          const data = parseYaml(content) as DefinitionData;
+          const definition = Definition.fromData(data);
+
+          // Reconstruct the model type from the path segments
+          const typeStr = pathSegments.join("/");
+          results.push({ definition, type: ModelType.create(typeStr) });
+        } else if (entry.isDirectory) {
+          // Recursively search subdirectories
+          await this.collectAllDefinitions(
+            fullPath,
+            [...pathSegments, entry.name],
+            results,
+          );
+        }
+      }
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Saves an evaluated definition.
+   *
+   * @param type - The model type
+   * @param definition - The evaluated definition to save
+   */
+  async save(type: ModelType, definition: Definition): Promise<void> {
+    const dir = this.getTypeDir(type);
+    await ensureDir(dir);
+
+    const path = this.getPath(type, definition.id);
+
+    const data = definition.toData();
+    // Remove undefined values since YAML can't stringify them
+    const cleanData = JSON.parse(JSON.stringify(data));
+    const content = stringifyYaml(cleanData as Record<string, unknown>);
+    await Deno.writeTextFile(path, content);
+  }
+
+  /**
+   * Deletes an evaluated definition.
+   *
+   * @param type - The model type
+   * @param id - The definition ID
+   */
+  async delete(type: ModelType, id: DefinitionId): Promise<void> {
+    const path = this.getPath(type, id);
+
+    try {
+      await Deno.remove(path);
+
+      // Clean up empty parent directories
+      const definitionsDir = join(
+        this.repoDir,
+        ".swamp",
+        "definitions-evaluated",
+      );
+      await cleanupEmptyParentDirs(path, definitionsDir);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Generates a new unique ID.
+   */
+  nextId(): DefinitionId {
+    return createDefinitionId(crypto.randomUUID());
+  }
+
+  /**
+   * Returns the file path for an evaluated definition.
+   *
+   * @param type - The model type
+   * @param id - The definition ID
+   * @returns The file path
+   */
+  getPath(type: ModelType, id: DefinitionId): string {
+    return join(this.getTypeDir(type), `${id}.yaml`);
+  }
+
+  private getTypeDir(type: ModelType): string {
+    return join(
+      this.repoDir,
+      ".swamp",
+      "definitions-evaluated",
+      type.toDirectoryPath(),
+    );
+  }
+
+  /**
+   * Clears all evaluated definitions.
+   * Used when needing to regenerate all evaluations.
+   */
+  async clearAll(): Promise<void> {
+    const definitionsDir = join(
+      this.repoDir,
+      ".swamp",
+      "definitions-evaluated",
+    );
+    try {
+      await Deno.remove(definitionsDir, { recursive: true });
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes: #117

Implements the Definition entity that provides a declarative way to define model configurations with support for CEL expressions and parameterized inputs. This closes #117.

- Add `Definition` entity with branded ID, Zod validation, and JSON Schema support for inputs
- Add YAML-based repositories for raw and evaluated definitions
- Integrate with existing expression evaluation service for CEL expression support
- Add domain events for definition lifecycle (created, updated, deleted)
- Add comprehensive unit tests (28) and integration tests (10)

## Plan Comparison

| Planned Item | Status | Notes |
|--------------|--------|-------|
| **Files to Create** | | |
| `src/domain/definitions/definition.ts` | ✅ Created | Includes entity, schema, and branded ID (combined vs separate files) |
| `src/domain/definitions/definition_schema.ts` | ✅ Merged | Combined into `definition.ts` for cohesion |
| `src/domain/definitions/definition_id.ts` | ✅ Merged | Combined into `definition.ts` for cohesion |
| `src/infrastructure/persistence/yaml_definition_repository.ts` | ✅ Created | Storage at `.swamp/definitions/{type}/{id}.yaml` |
| `src/infrastructure/persistence/yaml_evaluated_definition_repository.ts` | ✅ Created | Storage at `.swamp/definitions-evaluated/{type}/{id}.yaml` |
| `src/domain/definitions/definition_test.ts` | ✅ Created | 28 unit tests |
| **Files to Update** | | |
| `src/domain/expressions/expression_evaluation_service.ts` | ✅ Updated | Added `evaluateDefinition()`, `evaluateAllDefinitions()`, `hasDefinitionExpressions()` |
| **Additional Files** | | |
| `src/domain/definitions/repositories.ts` | ✅ Created | Repository interface (DDD pattern) |
| `integration/definition_test.ts` | ✅ Created | 10 integration tests for CEL evaluation |
| `src/domain/expressions/model_resolver.ts` | ✅ Updated | Added definition support to context |
| `src/domain/events/types.ts` | ✅ Updated | Added definition domain events |
| `.gitignore` | ✅ Updated | Added `.swamp/definitions-evaluated/` |

### Acceptance Criteria

- [x] Definition entity supports all design doc fields (`id`, `name`, `tags`, `attributes`, `version`, `inputs`)
- [x] Repository saves/loads definitions as YAML
- [x] CEL expressions preserved in raw definitions
- [x] Evaluated definitions cached in `.swamp/definitions-evaluated/`
- [x] Integration with existing expression evaluation service
- [x] Unit tests for Definition entity (28 tests)
- [x] Integration test: create definition with CEL expressions, evaluate expressions (10 tests)

### Expression Context Support

| Context Path | Status | Notes |
|--------------|--------|-------|
| `inputs.{param}` | ✅ Supported | Access definition input values |
| `self.{field}` | ✅ Supported | Self-reference within definition |
| `model.{name}.definition.attributes` | ✅ Supported | Reference other definitions |
| `model.{name}.input.attributes` | ✅ Supported | Reference model inputs |
| `model.{name}.resource.attributes` | ✅ Supported | Reference model resources |
| `vault.get(vault_name, key)` | ✅ Supported | Already existed |
| `model.{name}.data.{data-name}.attributes` | 📋 Future | Documented as architectural enhancement |

## Test plan

- [x] Run `deno check` - Type checking passes
- [x] Run `deno lint` - Linting passes
- [x] Run `deno fmt` - Formatting applied
- [x] Run `deno run test` - All 1378 tests pass
- [x] Run `deno run compile` - Binary compiles successfully

🤖 Generated with [Claude Code](https://claude.ai/code)