### PR TITLE
feat: update ModelOutput to reference unified Data artifacts (#118)

### DIFF
--- a/experiments/webapp/backend/handlers/outputs_handler.ts
+++ b/experiments/webapp/backend/handlers/outputs_handler.ts
@@ -10,6 +10,7 @@ import type {
   LogRepository,
   OutputRepository,
 } from "../../../../src/domain/models/repositories.ts";
+import type { ModelInputId } from "../../../../src/domain/models/model_input.ts";
 import { createModelDataId } from "../../../../src/domain/models/model_data.ts";
 import { createModelLogId } from "../../../../src/domain/models/model_log.ts";
 import {
@@ -30,14 +31,18 @@ export function createOutputsHandlers(
     const outputsWithNames = await Promise.all(
       allOutputs.map(async ({ output, type }) => {
         let modelName: string | undefined;
-        const input = await inputRepository.findById(type, output.modelInputId);
+        // definitionId was previously modelInputId - cast for compatibility
+        const input = await inputRepository.findById(
+          type,
+          output.definitionId as unknown as ModelInputId,
+        );
         if (input) {
           modelName = input.name;
         }
 
         return {
           id: output.id,
-          modelInputId: output.modelInputId,
+          definitionId: output.definitionId,
           modelName,
           type: type.normalized,
           methodName: output.methodName,
@@ -90,15 +95,19 @@ export function createOutputsHandlers(
     const { output, type } = matchResult.match;
 
     // Get model name
+    // definitionId was previously modelInputId - cast for compatibility
     let modelName: string | undefined;
-    const input = await inputRepository.findById(type, output.modelInputId);
+    const input = await inputRepository.findById(
+      type,
+      output.definitionId as unknown as ModelInputId,
+    );
     if (input) {
       modelName = input.name;
     }
 
     return jsonResponse({
       id: output.id,
-      modelInputId: output.modelInputId,
+      definitionId: output.definitionId,
       modelName,
       type: type.normalized,
       methodName: output.methodName,
@@ -146,8 +155,11 @@ export function createOutputsHandlers(
 
     const { output, type } = matchResult.match;
 
-    // Get data ID from artifacts
-    const dataId = output.artifacts?.dataId;
+    // Get data ID from artifacts (find first data artifact with type "data")
+    const dataArtifact = output.artifacts.dataArtifacts.find(
+      (a) => a.tags.type === "data",
+    );
+    const dataId = dataArtifact?.dataId;
     if (!dataId) {
       return errorResponse(
         `Output ${output.id} has no data artifact. Status: ${output.status}, Method: ${output.methodName}`,
@@ -232,9 +244,12 @@ export function createOutputsHandlers(
 
     const { output, type } = matchResult.match;
 
-    // Get log IDs from artifacts
-    const logIds = output.artifacts?.logIds;
-    if (!logIds || logIds.length === 0) {
+    // Get log IDs from artifacts (find all artifacts with type "log")
+    const logArtifacts = output.artifacts.dataArtifacts.filter(
+      (a) => a.tags.type === "log",
+    );
+    const logIds = logArtifacts.map((a) => a.dataId);
+    if (logIds.length === 0) {
       return errorResponse(
         `Output ${output.id} has no log artifacts. Status: ${output.status}, Method: ${output.methodName}`,
         404,

--- a/experiments/webapp/backend/handlers/workflow_runs_handler.ts
+++ b/experiments/webapp/backend/handlers/workflow_runs_handler.ts
@@ -124,7 +124,7 @@ export function createWorkflowRunsHandlers(
     // Map outputs with their model type info
     const outputs = runOutputs.map(({ output, type }) => ({
       id: output.id,
-      modelInputId: output.modelInputId,
+      definitionId: output.definitionId,
       type: type.normalized,
       methodName: output.methodName,
       status: output.status,

--- a/src/cli/commands/model_delete.ts
+++ b/src/cli/commands/model_delete.ts
@@ -140,8 +140,12 @@ export const modelDeleteCommand = new Command()
       ? resourceRepo.getPath(modelType, resource.id)
       : undefined;
 
-    // Find outputs related to this model
-    const outputs = await outputRepo.findByModelInput(modelType, input.id);
+    // Find outputs related to this model (use input.id as definitionId during migration)
+    const outputs = await outputRepo.findByDefinition(
+      modelType,
+      input
+        .id as unknown as import("../../domain/definitions/definition.ts").DefinitionId,
+    );
     ctx.logger.debug`Found ${outputs.length} outputs to delete`;
 
     // Check for evaluated input

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -7,9 +7,10 @@ import {
 import { createContext, type GlobalOptions } from "../context.ts";
 import { findByIdOrName } from "../../domain/models/model_lookup.ts";
 import {
-  computeInputHash,
+  computeDefinitionHash,
   ModelOutput,
 } from "../../domain/models/model_output.ts";
+import type { DefinitionId } from "../../domain/definitions/definition.ts";
 import { YamlInputRepository } from "../../infrastructure/persistence/yaml_input_repository.ts";
 import { YamlResourceRepository } from "../../infrastructure/persistence/yaml_resource_repository.ts";
 import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
@@ -81,12 +82,13 @@ export const modelMethodRunCommand = new Command()
       ctx.logger.debug`Executing method '${methodName}'`;
 
       // Create ModelOutput for tracking
-      const inputHash = await computeInputHash(input.attributes);
+      // Use input.id as definitionId (for backwards compatibility during migration)
+      const definitionHash = await computeDefinitionHash(input.attributes);
       const output = ModelOutput.create({
-        modelInputId: input.id,
+        definitionId: input.id as unknown as DefinitionId,
         methodName,
         provenance: {
-          inputHash,
+          definitionHash,
           modelVersion: input.version,
           triggeredBy: "manual",
         },
@@ -135,7 +137,12 @@ export const modelMethodRunCommand = new Command()
             ctx.logger.debug`Resource saved to: ${resourcePath}`;
 
             // Track artifact in output
-            output.setResourceId(result.resource.id);
+            output.addDataArtifact({
+              dataId: result.resource.id,
+              name: `${input.name}-resource`,
+              version: result.resource.version,
+              tags: { type: "resource" },
+            });
             resourceArtifact = {
               id: result.resource.id,
               path: resourcePath,
@@ -154,7 +161,12 @@ export const modelMethodRunCommand = new Command()
             await dataRepo.save(modelType, result.data);
             const dataPath = dataRepo.getPath(modelType, result.data.id);
             ctx.logger.debug`Data saved to: ${dataPath}`;
-            output.setDataId(result.data.id);
+            output.addDataArtifact({
+              dataId: result.data.id,
+              name: `${input.name}-data`,
+              version: result.data.version,
+              tags: { type: "data" },
+            });
 
             // Track artifact for output
             dataArtifact = {
@@ -190,15 +202,18 @@ export const modelMethodRunCommand = new Command()
               ctx.logger.debug`Log deleted: ${log.id}`;
             }
           } else {
-            const logIds: string[] = [];
             for (const log of result.logs) {
               await logRepo.save(modelType, log);
               const logPath = logRepo.getPath(modelType, log.id);
               ctx.logger.debug`Log saved to: ${logPath}`;
-              logIds.push(log.id);
+              output.addDataArtifact({
+                dataId: log.id,
+                name: `${input.name}-log`,
+                version: 1,
+                tags: { type: "log" },
+              });
               logArtifacts.push({ id: log.id, path: logPath });
             }
-            output.setLogIds(logIds);
           }
         }
 
@@ -227,7 +242,12 @@ export const modelMethodRunCommand = new Command()
               result.file.metadata.id,
             );
             ctx.logger.debug`File saved to: ${filePath}`;
-            output.setFileId(result.file.metadata.id);
+            output.addDataArtifact({
+              dataId: result.file.metadata.id,
+              name: result.file.metadata.filename,
+              version: 1,
+              tags: { type: "file" },
+            });
             fileArtifact = {
               id: result.file.metadata.id,
               path: filePath,

--- a/src/cli/commands/model_output_data.ts
+++ b/src/cli/commands/model_output_data.ts
@@ -54,8 +54,11 @@ export const modelOutputDataCommand = new Command()
 
     const { output, type } = result.match;
 
-    // Get data ID from artifacts
-    const dataId = output.artifacts?.dataId;
+    // Get data ID from artifacts (find first data artifact with type "data")
+    const dataArtifact = output.artifacts.dataArtifacts.find(
+      (a) => a.tags.type === "data",
+    );
+    const dataId = dataArtifact?.dataId;
     if (!dataId) {
       throw new UserError(
         `Output ${output.id} has no data artifact. ` +

--- a/src/cli/commands/model_output_get.ts
+++ b/src/cli/commands/model_output_get.ts
@@ -47,17 +47,19 @@ export const modelOutputGetCommand = new Command()
       if (matchResult.status === "found") {
         const { output, type } = matchResult.match;
 
-        // Try to get model name
+        // Try to get model name using definitionId
         let modelName: string | undefined;
         for (const modelType of modelRegistry.types()) {
-          const outputs = await outputRepo.findByModelInput(
+          const outputs = await outputRepo.findByDefinition(
             modelType,
-            output.modelInputId,
+            output.definitionId,
           );
           if (outputs.length > 0) {
+            // During migration, definitionId may be a modelInputId
             const input = await inputRepo.findById(
               modelType,
-              output.modelInputId,
+              output
+                .definitionId as unknown as import("../../domain/models/model_input.ts").ModelInputId,
             );
             if (input) {
               modelName = input.name;
@@ -68,7 +70,7 @@ export const modelOutputGetCommand = new Command()
 
         outputData = {
           id: output.id,
-          modelInputId: output.modelInputId,
+          definitionId: output.definitionId,
           modelName,
           type: type.normalized,
           methodName: output.methodName,
@@ -99,9 +101,11 @@ export const modelOutputGetCommand = new Command()
           );
         }
 
-        const latestOutput = await outputRepo.findLatestByModelInput(
+        // During migration, definitionId is used as modelInputId
+        const latestOutput = await outputRepo.findLatestByDefinition(
           inputResult.type,
-          inputResult.input.id,
+          inputResult.input
+            .id as unknown as import("../../domain/definitions/definition.ts").DefinitionId,
         );
         if (!latestOutput) {
           throw new UserError(
@@ -111,7 +115,7 @@ export const modelOutputGetCommand = new Command()
 
         outputData = {
           id: latestOutput.id,
-          modelInputId: latestOutput.modelInputId,
+          definitionId: latestOutput.definitionId,
           modelName: inputResult.input.name,
           type: inputResult.type.normalized,
           methodName: latestOutput.methodName,
@@ -133,9 +137,11 @@ export const modelOutputGetCommand = new Command()
         throw new UserError(`Model not found: ${outputIdOrModelName}`);
       }
 
-      const latestOutput = await outputRepo.findLatestByModelInput(
+      // During migration, definitionId is used as modelInputId
+      const latestOutput = await outputRepo.findLatestByDefinition(
         inputResult.type,
-        inputResult.input.id,
+        inputResult.input
+          .id as unknown as import("../../domain/definitions/definition.ts").DefinitionId,
       );
       if (!latestOutput) {
         throw new UserError(
@@ -145,7 +151,7 @@ export const modelOutputGetCommand = new Command()
 
       outputData = {
         id: latestOutput.id,
-        modelInputId: latestOutput.modelInputId,
+        definitionId: latestOutput.definitionId,
         modelName: inputResult.input.name,
         type: inputResult.type.normalized,
         methodName: latestOutput.methodName,

--- a/src/cli/commands/model_output_logs.ts
+++ b/src/cli/commands/model_output_logs.ts
@@ -54,9 +54,12 @@ export const modelOutputLogsCommand = new Command()
 
     const { output, type } = result.match;
 
-    // Get log IDs from artifacts
-    const logIds = output.artifacts?.logIds;
-    if (!logIds || logIds.length === 0) {
+    // Get log IDs from artifacts (find all artifacts with type "log")
+    const logArtifacts = output.artifacts.dataArtifacts.filter(
+      (a) => a.tags.type === "log",
+    );
+    const logIds = logArtifacts.map((a) => a.dataId);
+    if (logIds.length === 0) {
       throw new UserError(
         `Output ${output.id} has no log artifacts. ` +
           `Status: ${output.status}, Method: ${output.methodName}`,

--- a/src/cli/commands/model_output_search.ts
+++ b/src/cli/commands/model_output_search.ts
@@ -31,16 +31,20 @@ async function toModelOutputSearchItems(
   const items: ModelOutputSearchItem[] = [];
 
   for (const { output, type } of results) {
-    // Try to get model name
+    // Try to get model name using definitionId (which may be a modelInputId during migration)
     let modelName: string | undefined;
-    const input = await inputRepo.findById(type, output.modelInputId);
+    const input = await inputRepo.findById(
+      type,
+      output
+        .definitionId as unknown as import("../../domain/models/model_input.ts").ModelInputId,
+    );
     if (input) {
       modelName = input.name;
     }
 
     items.push({
       id: output.id,
-      modelInputId: output.modelInputId,
+      definitionId: output.definitionId,
       modelName,
       type: type.normalized,
       methodName: output.methodName,
@@ -76,7 +80,7 @@ export function filterOutputs(
       o.methodName.toLowerCase().includes(lowerQuery) ||
       o.status.toLowerCase().includes(lowerQuery) ||
       o.id.toLowerCase().includes(lowerQuery) ||
-      o.modelInputId.toLowerCase().includes(lowerQuery),
+      o.definitionId.toLowerCase().includes(lowerQuery),
   );
 }
 
@@ -101,16 +105,20 @@ async function displayModelOutputGet(
 
   const { output, type } = result;
 
-  // Try to get model name
+  // Try to get model name using definitionId (which may be a modelInputId during migration)
   let modelName: string | undefined;
-  const input = await inputRepo.findById(type, output.modelInputId);
+  const input = await inputRepo.findById(
+    type,
+    output
+      .definitionId as unknown as import("../../domain/models/model_input.ts").ModelInputId,
+  );
   if (input) {
     modelName = input.name;
   }
 
   const data: ModelOutputGetData = {
     id: output.id,
-    modelInputId: output.modelInputId,
+    definitionId: output.definitionId,
     modelName,
     type: type.normalized,
     methodName: output.methodName,

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -289,9 +289,11 @@ export class ModelResolver {
     if (input.fileId && this.fileRepo && this.outputRepo) {
       const fileId = createModelFileId(input.fileId);
       // Find the output that created this file to get the method name
-      const latestOutput = await this.outputRepo.findLatestByModelInput(
+      // During migration, use input.id as definitionId
+      const latestOutput = await this.outputRepo.findLatestByDefinition(
         type,
-        input.id,
+        input
+          .id as unknown as import("../definitions/definition.ts").DefinitionId,
       );
       const methodName = latestOutput?.methodName;
 
@@ -340,9 +342,11 @@ export class ModelResolver {
 
     // Load latest output if available
     if (this.outputRepo) {
-      const latestOutput = await this.outputRepo.findLatestByModelInput(
+      // During migration, use input.id as definitionId
+      const latestOutput = await this.outputRepo.findLatestByDefinition(
         type,
-        input.id,
+        input
+          .id as unknown as import("../definitions/definition.ts").DefinitionId,
       );
       if (latestOutput) {
         data.execution = {

--- a/src/domain/models/model_output.ts
+++ b/src/domain/models/model_output.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { ModelInputId } from "./model_input.ts";
+import type { DefinitionId } from "../definitions/definition.ts";
 
 /**
  * Branded type for ModelOutput IDs.
@@ -47,7 +47,7 @@ export type ExecutionError = z.infer<typeof ExecutionErrorSchema>;
  * Zod schema for execution provenance.
  */
 export const ExecutionProvenanceSchema = z.object({
-  inputHash: z.string(),
+  definitionHash: z.string(),
   modelVersion: z.number().int().positive(),
   triggeredBy: z.enum(TriggerTypes),
   workflowId: z.string().optional(),
@@ -61,13 +61,30 @@ export const ExecutionProvenanceSchema = z.object({
 export type ExecutionProvenance = z.infer<typeof ExecutionProvenanceSchema>;
 
 /**
+ * Represents a reference to a Data artifact.
+ */
+export interface DataArtifactRef {
+  dataId: string;
+  name: string;
+  version: number;
+  tags: Record<string, string>;
+}
+
+/**
+ * Zod schema for a data artifact reference.
+ */
+export const DataArtifactRefSchema = z.object({
+  dataId: z.string().uuid(),
+  name: z.string().min(1),
+  version: z.number().int().positive(),
+  tags: z.record(z.string(), z.string()),
+});
+
+/**
  * Zod schema for artifacts produced by the execution.
  */
 export const ArtifactsProducedSchema = z.object({
-  resourceId: z.string().uuid().optional(),
-  dataId: z.string().uuid().optional(),
-  fileId: z.string().uuid().optional(),
-  logIds: z.array(z.string().uuid()).optional(),
+  dataArtifacts: z.array(DataArtifactRefSchema).default([]),
 });
 
 /**
@@ -80,7 +97,7 @@ export type ArtifactsProduced = z.infer<typeof ArtifactsProducedSchema>;
  */
 export const ModelOutputSchema = z.object({
   id: z.string().uuid(),
-  modelInputId: z.string().uuid(),
+  definitionId: z.string().uuid(),
   methodName: z.string().min(1),
   status: z.enum(ExecutionStatuses),
   startedAt: z.string().datetime(),
@@ -102,7 +119,7 @@ export type ModelOutputData = z.infer<typeof ModelOutputSchema>;
  */
 export interface CreateModelOutputProps {
   id?: string;
-  modelInputId: ModelInputId;
+  definitionId: DefinitionId;
   methodName: string;
   status?: ExecutionStatus;
   startedAt?: Date;
@@ -122,7 +139,7 @@ export interface CreateModelOutputProps {
 export class ModelOutput {
   private constructor(
     readonly id: ModelOutputId,
-    readonly modelInputId: ModelInputId,
+    readonly definitionId: DefinitionId,
     readonly methodName: string,
     private _status: ExecutionStatus,
     readonly startedAt: Date,
@@ -131,7 +148,7 @@ export class ModelOutput {
     private _error: ExecutionError | undefined,
     private _retryCount: number,
     readonly provenance: ExecutionProvenance,
-    private _artifacts: ArtifactsProduced | undefined,
+    private _artifacts: ArtifactsProduced,
   ) {}
 
   /**
@@ -146,7 +163,7 @@ export class ModelOutput {
 
     const validated = ModelOutputSchema.parse({
       id,
-      modelInputId: props.modelInputId,
+      definitionId: props.definitionId,
       methodName: props.methodName,
       status: props.status ?? "pending",
       startedAt: startedAt.toISOString(),
@@ -155,12 +172,12 @@ export class ModelOutput {
       error: props.error,
       retryCount: props.retryCount ?? 0,
       provenance: props.provenance,
-      artifacts: props.artifacts,
+      artifacts: props.artifacts ?? { dataArtifacts: [] },
     });
 
     return new ModelOutput(
       createModelOutputId(validated.id),
-      validated.modelInputId as ModelInputId,
+      validated.definitionId as DefinitionId,
       validated.methodName,
       validated.status,
       new Date(validated.startedAt),
@@ -169,7 +186,7 @@ export class ModelOutput {
       validated.error,
       validated.retryCount,
       validated.provenance,
-      validated.artifacts,
+      validated.artifacts ?? { dataArtifacts: [] },
     );
   }
 
@@ -183,7 +200,7 @@ export class ModelOutput {
     const validated = ModelOutputSchema.parse(data);
     return new ModelOutput(
       createModelOutputId(validated.id),
-      validated.modelInputId as ModelInputId,
+      validated.definitionId as DefinitionId,
       validated.methodName,
       validated.status,
       new Date(validated.startedAt),
@@ -192,7 +209,7 @@ export class ModelOutput {
       validated.error,
       validated.retryCount,
       validated.provenance,
-      validated.artifacts,
+      validated.artifacts ?? { dataArtifacts: [] },
     );
   }
 
@@ -234,8 +251,10 @@ export class ModelOutput {
   /**
    * Gets the artifacts produced by this execution.
    */
-  get artifacts(): ArtifactsProduced | undefined {
-    return this._artifacts ? { ...this._artifacts } : undefined;
+  get artifacts(): ArtifactsProduced {
+    return {
+      dataArtifacts: [...this._artifacts.dataArtifacts],
+    };
   }
 
   /**
@@ -294,41 +313,14 @@ export class ModelOutput {
   }
 
   /**
-   * Sets the artifacts produced by this execution.
+   * Adds a data artifact reference to this execution.
+   *
+   * @param artifact - The data artifact reference to add
    */
-  setArtifacts(artifacts: ArtifactsProduced): void {
-    this._artifacts = { ...artifacts };
-  }
-
-  /**
-   * Sets a specific artifact ID.
-   */
-  setResourceId(resourceId: string): void {
-    if (!this._artifacts) {
-      this._artifacts = {};
-    }
-    this._artifacts.resourceId = resourceId;
-  }
-
-  setDataId(dataId: string): void {
-    if (!this._artifacts) {
-      this._artifacts = {};
-    }
-    this._artifacts.dataId = dataId;
-  }
-
-  setFileId(fileId: string): void {
-    if (!this._artifacts) {
-      this._artifacts = {};
-    }
-    this._artifacts.fileId = fileId;
-  }
-
-  setLogIds(logIds: string[]): void {
-    if (!this._artifacts) {
-      this._artifacts = {};
-    }
-    this._artifacts.logIds = logIds;
+  addDataArtifact(artifact: DataArtifactRef): void {
+    // Validate the artifact
+    DataArtifactRefSchema.parse(artifact);
+    this._artifacts.dataArtifacts.push({ ...artifact });
   }
 
   /**
@@ -344,12 +336,15 @@ export class ModelOutput {
   toData(): ModelOutputData {
     const data: ModelOutputData = {
       id: this.id,
-      modelInputId: this.modelInputId,
+      definitionId: this.definitionId,
       methodName: this.methodName,
       status: this._status,
       startedAt: this.startedAt.toISOString(),
       retryCount: this._retryCount,
       provenance: { ...this.provenance },
+      artifacts: {
+        dataArtifacts: this._artifacts.dataArtifacts.map((a) => ({ ...a })),
+      },
     };
 
     if (this._completedAt) {
@@ -361,21 +356,18 @@ export class ModelOutput {
     if (this._error) {
       data.error = { ...this._error };
     }
-    if (this._artifacts) {
-      data.artifacts = { ...this._artifacts };
-    }
 
     return data;
   }
 }
 
 /**
- * Computes a hash of the input attributes for provenance tracking.
+ * Computes a hash of the definition attributes for provenance tracking.
  *
  * @param attributes - The attributes to hash
  * @returns The hex-encoded SHA-256 hash
  */
-export async function computeInputHash(
+export async function computeDefinitionHash(
   attributes: Record<string, unknown>,
 ): Promise<string> {
   const json = JSON.stringify(attributes, Object.keys(attributes).sort());

--- a/src/domain/models/model_output_test.ts
+++ b/src/domain/models/model_output_test.ts
@@ -1,20 +1,20 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import {
-  computeInputHash,
+  computeDefinitionHash,
   type ExecutionProvenance,
   ModelOutput,
 } from "./model_output.ts";
-import { createModelInputId } from "./model_input.ts";
+import { createDefinitionId } from "../definitions/definition.ts";
 
 const defaultProvenance: ExecutionProvenance = {
-  inputHash: "abc123",
+  definitionHash: "abc123",
   modelVersion: 1,
   triggeredBy: "manual",
 };
 
 Deno.test("ModelOutput.create generates UUID if not provided", () => {
   const output = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     provenance: defaultProvenance,
   });
@@ -26,7 +26,7 @@ Deno.test("ModelOutput.create uses provided ID", () => {
   const id = "550e8400-e29b-41d4-a716-446655440001";
   const output = ModelOutput.create({
     id,
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     provenance: defaultProvenance,
   });
@@ -35,7 +35,7 @@ Deno.test("ModelOutput.create uses provided ID", () => {
 
 Deno.test("ModelOutput.create defaults to pending status", () => {
   const output = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     provenance: defaultProvenance,
   });
@@ -44,7 +44,7 @@ Deno.test("ModelOutput.create defaults to pending status", () => {
 
 Deno.test("ModelOutput.create uses provided status", () => {
   const output = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     status: "running",
     provenance: defaultProvenance,
@@ -55,7 +55,7 @@ Deno.test("ModelOutput.create uses provided status", () => {
 Deno.test("ModelOutput.create sets startedAt to now if not provided", () => {
   const before = new Date();
   const output = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     provenance: defaultProvenance,
   });
@@ -68,7 +68,7 @@ Deno.test("ModelOutput.create sets startedAt to now if not provided", () => {
 Deno.test("ModelOutput.create uses provided startedAt", () => {
   const startedAt = new Date("2023-01-01T00:00:00Z");
   const output = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     startedAt,
     provenance: defaultProvenance,
@@ -78,7 +78,7 @@ Deno.test("ModelOutput.create uses provided startedAt", () => {
 
 Deno.test("ModelOutput.create stores method name", () => {
   const output = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "deploy",
     provenance: defaultProvenance,
   });
@@ -87,7 +87,7 @@ Deno.test("ModelOutput.create stores method name", () => {
 
 Deno.test("ModelOutput.create stores provenance", () => {
   const provenance: ExecutionProvenance = {
-    inputHash: "xyz789",
+    definitionHash: "xyz789",
     modelVersion: 2,
     triggeredBy: "workflow",
     workflowId: "wf-123",
@@ -95,7 +95,7 @@ Deno.test("ModelOutput.create stores provenance", () => {
     stepName: "deploy-step",
   };
   const output = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     provenance,
   });
@@ -104,7 +104,7 @@ Deno.test("ModelOutput.create stores provenance", () => {
 
 Deno.test("ModelOutput.create defaults retry count to 0", () => {
   const output = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     provenance: defaultProvenance,
   });
@@ -113,7 +113,7 @@ Deno.test("ModelOutput.create defaults retry count to 0", () => {
 
 Deno.test("ModelOutput.markRunning transitions from pending", () => {
   const output = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     provenance: defaultProvenance,
   });
@@ -125,7 +125,7 @@ Deno.test("ModelOutput.markRunning transitions from pending", () => {
 
 Deno.test("ModelOutput.markRunning throws if not pending", () => {
   const output = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     status: "running",
     provenance: defaultProvenance,
@@ -140,7 +140,7 @@ Deno.test("ModelOutput.markRunning throws if not pending", () => {
 
 Deno.test("ModelOutput.markSucceeded transitions from running", () => {
   const output = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     status: "running",
     provenance: defaultProvenance,
@@ -158,7 +158,7 @@ Deno.test("ModelOutput.markSucceeded calculates duration", () => {
   const startedAt = new Date("2023-01-01T00:00:00.000Z");
   const completedAt = new Date("2023-01-01T00:00:05.000Z");
   const output = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     status: "running",
     startedAt,
@@ -172,7 +172,7 @@ Deno.test("ModelOutput.markSucceeded calculates duration", () => {
 
 Deno.test("ModelOutput.markSucceeded throws if not running", () => {
   const output = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     provenance: defaultProvenance,
   });
@@ -186,7 +186,7 @@ Deno.test("ModelOutput.markSucceeded throws if not running", () => {
 
 Deno.test("ModelOutput.markFailed transitions from running", () => {
   const output = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     status: "running",
     provenance: defaultProvenance,
@@ -202,7 +202,7 @@ Deno.test("ModelOutput.markFailed transitions from running", () => {
 
 Deno.test("ModelOutput.markFailed throws if not running", () => {
   const output = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     provenance: defaultProvenance,
   });
@@ -216,7 +216,7 @@ Deno.test("ModelOutput.markFailed throws if not running", () => {
 
 Deno.test("ModelOutput.incrementRetryCount", () => {
   const output = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     provenance: defaultProvenance,
   });
@@ -228,50 +228,69 @@ Deno.test("ModelOutput.incrementRetryCount", () => {
   assertEquals(output.retryCount, 2);
 });
 
-Deno.test("ModelOutput.setArtifacts", () => {
+Deno.test("ModelOutput.addDataArtifact", () => {
   const output = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     provenance: defaultProvenance,
   });
 
-  output.setArtifacts({
-    resourceId: "resource-123",
-    dataId: "data-456",
+  output.addDataArtifact({
+    dataId: "550e8400-e29b-41d4-a716-446655440001",
+    name: "test-resource",
+    version: 1,
+    tags: { type: "resource" },
   });
 
-  assertEquals(output.artifacts?.resourceId, "resource-123");
-  assertEquals(output.artifacts?.dataId, "data-456");
+  assertEquals(output.artifacts.dataArtifacts.length, 1);
+  assertEquals(
+    output.artifacts.dataArtifacts[0].dataId,
+    "550e8400-e29b-41d4-a716-446655440001",
+  );
+  assertEquals(output.artifacts.dataArtifacts[0].name, "test-resource");
+  assertEquals(output.artifacts.dataArtifacts[0].version, 1);
+  assertEquals(output.artifacts.dataArtifacts[0].tags.type, "resource");
 });
 
-Deno.test("ModelOutput individual artifact setters", () => {
+Deno.test("ModelOutput.addDataArtifact multiple artifacts", () => {
   const output = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     provenance: defaultProvenance,
   });
 
-  output.setResourceId("resource-123");
-  output.setDataId("data-456");
-  output.setFileId("file-789");
-  output.setLogIds(["log-abc", "log-def"]);
+  output.addDataArtifact({
+    dataId: "550e8400-e29b-41d4-a716-446655440001",
+    name: "test-resource",
+    version: 1,
+    tags: { type: "resource" },
+  });
+  output.addDataArtifact({
+    dataId: "550e8400-e29b-41d4-a716-446655440002",
+    name: "test-data",
+    version: 1,
+    tags: { type: "data" },
+  });
+  output.addDataArtifact({
+    dataId: "550e8400-e29b-41d4-a716-446655440003",
+    name: "test-log",
+    version: 1,
+    tags: { type: "log" },
+  });
 
-  assertEquals(output.artifacts?.resourceId, "resource-123");
-  assertEquals(output.artifacts?.dataId, "data-456");
-  assertEquals(output.artifacts?.fileId, "file-789");
-  assertEquals(output.artifacts?.logIds, ["log-abc", "log-def"]);
+  assertEquals(output.artifacts.dataArtifacts.length, 3);
 });
 
 Deno.test("ModelOutput.isComplete returns false for pending/running", () => {
   const pending = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     provenance: defaultProvenance,
   });
   assertEquals(pending.isComplete, false);
 
   const running = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     status: "running",
     provenance: defaultProvenance,
@@ -281,52 +300,61 @@ Deno.test("ModelOutput.isComplete returns false for pending/running", () => {
 
 Deno.test("ModelOutput toData/fromData roundtrip", () => {
   const output = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "deploy",
     status: "running",
     provenance: {
-      inputHash: "hash123",
+      definitionHash: "hash123",
       modelVersion: 3,
       triggeredBy: "workflow",
       workflowId: "wf-1",
     },
   });
   output.markSucceeded();
-  output.setArtifacts({
-    resourceId: "550e8400-e29b-41d4-a716-446655440001",
-    logIds: ["550e8400-e29b-41d4-a716-446655440002"],
+  output.addDataArtifact({
+    dataId: "550e8400-e29b-41d4-a716-446655440001",
+    name: "test-resource",
+    version: 1,
+    tags: { type: "resource" },
+  });
+  output.addDataArtifact({
+    dataId: "550e8400-e29b-41d4-a716-446655440002",
+    name: "test-log",
+    version: 1,
+    tags: { type: "log" },
   });
 
   const data = output.toData();
   const restored = ModelOutput.fromData(data);
 
   assertEquals(restored.id, output.id);
-  assertEquals(restored.modelInputId, output.modelInputId);
+  assertEquals(restored.definitionId, output.definitionId);
   assertEquals(restored.methodName, output.methodName);
   assertEquals(restored.status, output.status);
   assertEquals(restored.startedAt.getTime(), output.startedAt.getTime());
   assertEquals(restored.completedAt?.getTime(), output.completedAt?.getTime());
   assertEquals(restored.durationMs, output.durationMs);
   assertEquals(restored.provenance, output.provenance);
+  assertEquals(restored.artifacts.dataArtifacts.length, 2);
   assertEquals(
-    restored.artifacts?.resourceId,
+    restored.artifacts.dataArtifacts[0].dataId,
     "550e8400-e29b-41d4-a716-446655440001",
   );
   assertEquals(
-    restored.artifacts?.logIds,
-    ["550e8400-e29b-41d4-a716-446655440002"],
+    restored.artifacts.dataArtifacts[1].dataId,
+    "550e8400-e29b-41d4-a716-446655440002",
   );
 });
 
 Deno.test("ModelOutput fromData with explicit data", () => {
   const id = "550e8400-e29b-41d4-a716-446655440000";
-  const modelInputId = "660e8400-e29b-41d4-a716-446655440000";
+  const definitionId = "660e8400-e29b-41d4-a716-446655440000";
   const startedAt = "2023-01-01T00:00:00.000Z";
   const completedAt = "2023-01-01T00:00:10.000Z";
 
   const data = {
     id,
-    modelInputId,
+    definitionId,
     methodName: "delete",
     status: "failed" as const,
     startedAt,
@@ -335,46 +363,63 @@ Deno.test("ModelOutput fromData with explicit data", () => {
     error: { message: "Resource not found" },
     retryCount: 2,
     provenance: {
-      inputHash: "hash",
+      definitionHash: "hash",
       modelVersion: 1,
       triggeredBy: "manual" as const,
     },
     artifacts: {
-      logIds: ["550e8400-e29b-41d4-a716-446655440003"],
+      dataArtifacts: [
+        {
+          dataId: "550e8400-e29b-41d4-a716-446655440003",
+          name: "test-log",
+          version: 1,
+          tags: { type: "log" },
+        },
+      ],
     },
   };
 
   const output = ModelOutput.fromData(data);
   assertEquals(output.id, id);
-  assertEquals(output.modelInputId, modelInputId);
+  assertEquals(output.definitionId, definitionId);
   assertEquals(output.methodName, "delete");
   assertEquals(output.status, "failed");
   assertEquals(output.error?.message, "Resource not found");
   assertEquals(output.retryCount, 2);
-  assertEquals(output.artifacts?.logIds, [
+  assertEquals(output.artifacts.dataArtifacts.length, 1);
+  assertEquals(
+    output.artifacts.dataArtifacts[0].dataId,
     "550e8400-e29b-41d4-a716-446655440003",
-  ]);
+  );
 });
 
 Deno.test("ModelOutput artifacts getter returns copy", () => {
   const output = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     provenance: defaultProvenance,
   });
-  output.setResourceId("res-1");
+  output.addDataArtifact({
+    dataId: "550e8400-e29b-41d4-a716-446655440001",
+    name: "test-resource",
+    version: 1,
+    tags: { type: "resource" },
+  });
 
   const artifacts = output.artifacts;
-  if (artifacts) {
-    artifacts.dataId = "modified";
-  }
+  artifacts.dataArtifacts.push({
+    dataId: "550e8400-e29b-41d4-a716-446655440002",
+    name: "modified",
+    version: 1,
+    tags: {},
+  });
 
-  assertEquals(output.artifacts?.dataId, undefined);
+  assertEquals(output.artifacts.dataArtifacts.length, 1);
 });
 
 Deno.test("ModelOutput error getter returns copy", () => {
   const output = ModelOutput.create({
-    modelInputId: createModelInputId(crypto.randomUUID()),
+    definitionId: createDefinitionId(crypto.randomUUID()),
     methodName: "create",
     status: "running",
     provenance: defaultProvenance,
@@ -389,34 +434,34 @@ Deno.test("ModelOutput error getter returns copy", () => {
   assertEquals(output.error?.message, "original");
 });
 
-// computeInputHash tests
+// computeDefinitionHash tests
 
-Deno.test("computeInputHash produces consistent hash", async () => {
+Deno.test("computeDefinitionHash produces consistent hash", async () => {
   const attributes = { name: "test", count: 42 };
 
-  const hash1 = await computeInputHash(attributes);
-  const hash2 = await computeInputHash(attributes);
+  const hash1 = await computeDefinitionHash(attributes);
+  const hash2 = await computeDefinitionHash(attributes);
 
   assertEquals(hash1, hash2);
   assertEquals(hash1.length, 64); // SHA-256 produces 64 hex chars
 });
 
-Deno.test("computeInputHash is order-independent", async () => {
+Deno.test("computeDefinitionHash is order-independent", async () => {
   const attrs1 = { b: 2, a: 1 };
   const attrs2 = { a: 1, b: 2 };
 
-  const hash1 = await computeInputHash(attrs1);
-  const hash2 = await computeInputHash(attrs2);
+  const hash1 = await computeDefinitionHash(attrs1);
+  const hash2 = await computeDefinitionHash(attrs2);
 
   assertEquals(hash1, hash2);
 });
 
-Deno.test("computeInputHash different for different values", async () => {
+Deno.test("computeDefinitionHash different for different values", async () => {
   const attrs1 = { name: "test1" };
   const attrs2 = { name: "test2" };
 
-  const hash1 = await computeInputHash(attrs1);
-  const hash2 = await computeInputHash(attrs2);
+  const hash1 = await computeDefinitionHash(attrs1);
+  const hash2 = await computeDefinitionHash(attrs2);
 
   assertEquals(hash1 !== hash2, true);
 });

--- a/src/domain/models/repositories.ts
+++ b/src/domain/models/repositories.ts
@@ -5,6 +5,7 @@ import type { ModelData, ModelDataId } from "./model_data.ts";
 import type { ModelFile, ModelFileId } from "./model_file.ts";
 import type { LogEntry, ModelLog, ModelLogId } from "./model_log.ts";
 import type { ModelOutput, ModelOutputId } from "./model_output.ts";
+import type { DefinitionId } from "../definitions/definition.ts";
 
 /**
  * Repository interface for persisting and retrieving ModelInputs.
@@ -399,27 +400,27 @@ export interface OutputRepository {
   ): Promise<ModelOutput | null>;
 
   /**
-   * Finds all outputs for a given model input.
+   * Finds all outputs for a given definition.
    *
    * @param type - The model type
-   * @param inputId - The model input ID
+   * @param definitionId - The definition ID
    * @returns Array of outputs
    */
-  findByModelInput(
+  findByDefinition(
     type: ModelType,
-    inputId: ModelInputId,
+    definitionId: DefinitionId,
   ): Promise<ModelOutput[]>;
 
   /**
-   * Finds the latest output for a given model input.
+   * Finds the latest output for a given definition.
    *
    * @param type - The model type
-   * @param inputId - The model input ID
+   * @param definitionId - The definition ID
    * @returns The latest output if found, or null
    */
-  findLatestByModelInput(
+  findLatestByDefinition(
     type: ModelType,
-    inputId: ModelInputId,
+    definitionId: DefinitionId,
   ): Promise<ModelOutput | null>;
 
   /**

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -25,7 +25,8 @@ import { DefaultMethodExecutionService } from "../models/method_execution_servic
 import { DefaultModelValidationService } from "../models/validation_service.ts";
 import { ModelInput } from "../models/model_input.ts";
 import { findByIdOrName } from "../models/model_lookup.ts";
-import { computeInputHash, ModelOutput } from "../models/model_output.ts";
+import { computeDefinitionHash, ModelOutput } from "../models/model_output.ts";
+import type { DefinitionId } from "../definitions/definition.ts";
 import {
   extractExpressions,
   replaceExpressions,
@@ -296,12 +297,15 @@ export class DefaultStepExecutor implements StepExecutor {
     }
 
     // Create ModelOutput for tracking
-    const inputHash = await computeInputHash(evaluatedInput.attributes);
+    // Use originalInput.id as definitionId (for backwards compatibility during migration)
+    const definitionHash = await computeDefinitionHash(
+      evaluatedInput.attributes,
+    );
     const output = ModelOutput.create({
-      modelInputId: originalInput.id,
+      definitionId: originalInput.id as unknown as DefinitionId,
       methodName: task.methodName,
       provenance: {
-        inputHash,
+        definitionHash,
         modelVersion: originalInput.version,
         triggeredBy: "workflow",
         workflowId: ctx.workflowId,
@@ -371,7 +375,12 @@ export class DefaultStepExecutor implements StepExecutor {
           resourceAttributes = result.resource.attributes;
 
           // Track artifact in output
-          output.setResourceId(result.resource.id);
+          output.addDataArtifact({
+            dataId: result.resource.id,
+            name: `${originalInput.name}-resource`,
+            version: result.resource.version,
+            tags: { type: "resource" },
+          });
         }
       }
 
@@ -381,7 +390,12 @@ export class DefaultStepExecutor implements StepExecutor {
           await dataRepo.delete(modelType, result.data.id);
         } else {
           await dataRepo.save(modelType, result.data);
-          output.setDataId(result.data.id);
+          output.addDataArtifact({
+            dataId: result.data.id,
+            name: `${originalInput.name}-data`,
+            version: result.data.version,
+            tags: { type: "data" },
+          });
         }
 
         // Update ORIGINAL input's dataId (preserves expressions)
@@ -420,7 +434,12 @@ export class DefaultStepExecutor implements StepExecutor {
             result.file.metadata,
             result.file.content,
           );
-          output.setFileId(result.file.metadata.id);
+          output.addDataArtifact({
+            dataId: result.file.metadata.id,
+            name: result.file.metadata.filename,
+            version: 1,
+            tags: { type: "file" },
+          });
         }
       }
 
@@ -431,12 +450,15 @@ export class DefaultStepExecutor implements StepExecutor {
             await logRepo.delete(modelType, log.id);
           }
         } else {
-          const logIds: string[] = [];
           for (const log of result.logs) {
             await logRepo.save(modelType, log);
-            logIds.push(log.id);
+            output.addDataArtifact({
+              dataId: log.id,
+              name: `${originalInput.name}-log`,
+              version: 1,
+              tags: { type: "log" },
+            });
           }
-          output.setLogIds(logIds);
         }
       }
 

--- a/src/infrastructure/persistence/yaml_output_repository.ts
+++ b/src/infrastructure/persistence/yaml_output_repository.ts
@@ -3,7 +3,7 @@ import { join } from "@std/path";
 import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import type { OutputRepository } from "../../domain/models/repositories.ts";
-import type { ModelInputId } from "../../domain/models/model_input.ts";
+import type { DefinitionId } from "../../domain/definitions/definition.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
 import {
   createModelOutputId,
@@ -17,7 +17,7 @@ import { modelRegistry } from "../../domain/models/model.ts";
  * YAML-based implementation of OutputRepository.
  *
  * Stores outputs as YAML files in the directory structure:
- * {repoDir}/.data/outputs/{normalized-type}/{method}/{model-id}-{timestamp}.yaml
+ * {repoDir}/.swamp/outputs/{normalized-type}/{method}/{definition-id}-{timestamp}.yaml
  */
 export class YamlOutputRepository implements OutputRepository {
   constructor(private readonly repoDir: string) {}
@@ -49,19 +49,19 @@ export class YamlOutputRepository implements OutputRepository {
     return null;
   }
 
-  async findByModelInput(
+  async findByDefinition(
     type: ModelType,
-    inputId: ModelInputId,
+    definitionId: DefinitionId,
   ): Promise<ModelOutput[]> {
     const all = await this.findAll(type);
-    return all.filter((output) => output.modelInputId === inputId);
+    return all.filter((output) => output.definitionId === definitionId);
   }
 
-  async findLatestByModelInput(
+  async findLatestByDefinition(
     type: ModelType,
-    inputId: ModelInputId,
+    definitionId: DefinitionId,
   ): Promise<ModelOutput | null> {
-    const outputs = await this.findByModelInput(type, inputId);
+    const outputs = await this.findByDefinition(type, definitionId);
     if (outputs.length === 0) {
       return null;
     }
@@ -155,7 +155,7 @@ export class YamlOutputRepository implements OutputRepository {
             await Deno.remove(path);
 
             // Clean up empty parent directories
-            const outputsDir = join(this.repoDir, ".data", "outputs");
+            const outputsDir = join(this.repoDir, ".swamp", "outputs");
             await cleanupEmptyParentDirs(path, outputsDir);
             return;
           }
@@ -174,12 +174,12 @@ export class YamlOutputRepository implements OutputRepository {
 
   getPath(type: ModelType, method: string, output: ModelOutput): string {
     const timestamp = output.startedAt.toISOString().replace(/[:.]/g, "-");
-    const filename = `${output.modelInputId}-${timestamp}.yaml`;
+    const filename = `${output.definitionId}-${timestamp}.yaml`;
     return join(this.getMethodDir(type, method), filename);
   }
 
   private getOutputsDir(): string {
-    return join(this.repoDir, ".data", "outputs");
+    return join(this.repoDir, ".swamp", "outputs");
   }
 
   private getTypeDir(type: ModelType): string {

--- a/src/infrastructure/persistence/yaml_output_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_output_repository_test.ts
@@ -5,7 +5,7 @@ import {
   type ExecutionProvenance,
   ModelOutput,
 } from "../../domain/models/model_output.ts";
-import { createModelInputId } from "../../domain/models/model_input.ts";
+import { createDefinitionId } from "../../domain/definitions/definition.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import { YamlOutputRepository } from "./yaml_output_repository.ts";
 
@@ -19,7 +19,7 @@ async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
 }
 
 const defaultProvenance: ExecutionProvenance = {
-  inputHash: "abc123",
+  definitionHash: "abc123",
   modelVersion: 1,
   triggeredBy: "manual",
 };
@@ -30,7 +30,7 @@ Deno.test("YamlOutputRepository.save creates directory structure", async () => {
   await withTempDir(async (dir) => {
     const repo = new YamlOutputRepository(dir);
     const output = ModelOutput.create({
-      modelInputId: createModelInputId(crypto.randomUUID()),
+      definitionId: createDefinitionId(crypto.randomUUID()),
       methodName: "create",
       provenance: defaultProvenance,
     });
@@ -39,7 +39,7 @@ Deno.test("YamlOutputRepository.save creates directory structure", async () => {
 
     const expectedDir = join(
       dir,
-      ".data",
+      ".swamp",
       "outputs",
       testType.normalized,
       "create",
@@ -52,12 +52,12 @@ Deno.test("YamlOutputRepository.save creates directory structure", async () => {
 Deno.test("YamlOutputRepository.save creates yaml file with correct path structure", async () => {
   await withTempDir(async (dir) => {
     const repo = new YamlOutputRepository(dir);
-    const modelInputId = createModelInputId(crypto.randomUUID());
+    const definitionId = createDefinitionId(crypto.randomUUID());
     const output = ModelOutput.create({
-      modelInputId,
+      definitionId,
       methodName: "deploy",
       provenance: {
-        inputHash: "xyz789",
+        definitionHash: "xyz789",
         modelVersion: 2,
         triggeredBy: "workflow",
         workflowId: "wf-123",
@@ -67,11 +67,11 @@ Deno.test("YamlOutputRepository.save creates yaml file with correct path structu
     await repo.save(testType, "deploy", output);
 
     const path = repo.getPath(testType, "deploy", output);
-    // Path should be: outputs/{type}/{method}/{model-id}-{timestamp}.yaml
+    // Path should be: outputs/{type}/{method}/{definition-id}-{timestamp}.yaml
     assertStringIncludes(path, "outputs");
     assertStringIncludes(path, testType.normalized);
     assertStringIncludes(path, "deploy");
-    assertStringIncludes(path, modelInputId);
+    assertStringIncludes(path, definitionId);
     assertStringIncludes(path, ".yaml");
 
     const content = await Deno.readTextFile(path);
@@ -84,9 +84,9 @@ Deno.test("YamlOutputRepository.save creates yaml file with correct path structu
 Deno.test("YamlOutputRepository.findById returns saved output", async () => {
   await withTempDir(async (dir) => {
     const repo = new YamlOutputRepository(dir);
-    const modelInputId = createModelInputId(crypto.randomUUID());
+    const definitionId = createDefinitionId(crypto.randomUUID());
     const output = ModelOutput.create({
-      modelInputId,
+      definitionId,
       methodName: "create",
       provenance: defaultProvenance,
     });
@@ -95,10 +95,10 @@ Deno.test("YamlOutputRepository.findById returns saved output", async () => {
     const found = await repo.findById(testType, "create", output.id);
 
     assertEquals(found?.id, output.id);
-    assertEquals(found?.modelInputId, modelInputId);
+    assertEquals(found?.definitionId, definitionId);
     assertEquals(found?.methodName, "create");
     assertEquals(found?.status, "pending");
-    assertEquals(found?.provenance.inputHash, "abc123");
+    assertEquals(found?.provenance.definitionHash, "abc123");
   });
 });
 
@@ -117,12 +117,12 @@ Deno.test("YamlOutputRepository.findAll returns all outputs for a type", async (
     const repo = new YamlOutputRepository(dir);
 
     const output1 = ModelOutput.create({
-      modelInputId: createModelInputId(crypto.randomUUID()),
+      definitionId: createDefinitionId(crypto.randomUUID()),
       methodName: "create",
       provenance: defaultProvenance,
     });
     const output2 = ModelOutput.create({
-      modelInputId: createModelInputId(crypto.randomUUID()),
+      definitionId: createDefinitionId(crypto.randomUUID()),
       methodName: "delete",
       provenance: defaultProvenance,
     });
@@ -144,24 +144,24 @@ Deno.test("YamlOutputRepository.findAll returns empty array when none", async ()
   });
 });
 
-Deno.test("YamlOutputRepository.findByModelInput filters by input ID", async () => {
+Deno.test("YamlOutputRepository.findByDefinition filters by definition ID", async () => {
   await withTempDir(async (dir) => {
     const repo = new YamlOutputRepository(dir);
-    const inputId1 = createModelInputId(crypto.randomUUID());
-    const inputId2 = createModelInputId(crypto.randomUUID());
+    const defId1 = createDefinitionId(crypto.randomUUID());
+    const defId2 = createDefinitionId(crypto.randomUUID());
 
     const output1 = ModelOutput.create({
-      modelInputId: inputId1,
+      definitionId: defId1,
       methodName: "create",
       provenance: defaultProvenance,
     });
     const output2 = ModelOutput.create({
-      modelInputId: inputId1,
+      definitionId: defId1,
       methodName: "update",
       provenance: defaultProvenance,
     });
     const output3 = ModelOutput.create({
-      modelInputId: inputId2,
+      definitionId: defId2,
       methodName: "create",
       provenance: defaultProvenance,
     });
@@ -170,33 +170,33 @@ Deno.test("YamlOutputRepository.findByModelInput filters by input ID", async () 
     await repo.save(testType, "update", output2);
     await repo.save(testType, "create", output3);
 
-    const forInput1 = await repo.findByModelInput(testType, inputId1);
-    assertEquals(forInput1.length, 2);
+    const forDef1 = await repo.findByDefinition(testType, defId1);
+    assertEquals(forDef1.length, 2);
 
-    const forInput2 = await repo.findByModelInput(testType, inputId2);
-    assertEquals(forInput2.length, 1);
+    const forDef2 = await repo.findByDefinition(testType, defId2);
+    assertEquals(forDef2.length, 1);
   });
 });
 
-Deno.test("YamlOutputRepository.findLatestByModelInput returns most recent", async () => {
+Deno.test("YamlOutputRepository.findLatestByDefinition returns most recent", async () => {
   await withTempDir(async (dir) => {
     const repo = new YamlOutputRepository(dir);
-    const inputId = createModelInputId(crypto.randomUUID());
+    const defId = createDefinitionId(crypto.randomUUID());
 
     const output1 = ModelOutput.create({
-      modelInputId: inputId,
+      definitionId: defId,
       methodName: "create",
       startedAt: new Date("2023-01-01T00:00:00Z"),
       provenance: defaultProvenance,
     });
     const output2 = ModelOutput.create({
-      modelInputId: inputId,
+      definitionId: defId,
       methodName: "update",
       startedAt: new Date("2023-01-02T00:00:00Z"),
       provenance: defaultProvenance,
     });
     const output3 = ModelOutput.create({
-      modelInputId: inputId,
+      definitionId: defId,
       methodName: "delete",
       startedAt: new Date("2023-01-01T12:00:00Z"),
       provenance: defaultProvenance,
@@ -206,18 +206,18 @@ Deno.test("YamlOutputRepository.findLatestByModelInput returns most recent", asy
     await repo.save(testType, "update", output2);
     await repo.save(testType, "delete", output3);
 
-    const latest = await repo.findLatestByModelInput(testType, inputId);
+    const latest = await repo.findLatestByDefinition(testType, defId);
     assertEquals(latest?.id, output2.id);
     assertEquals(latest?.methodName, "update");
   });
 });
 
-Deno.test("YamlOutputRepository.findLatestByModelInput returns null when none", async () => {
+Deno.test("YamlOutputRepository.findLatestByDefinition returns null when none", async () => {
   await withTempDir(async (dir) => {
     const repo = new YamlOutputRepository(dir);
-    const inputId = createModelInputId(crypto.randomUUID());
+    const defId = createDefinitionId(crypto.randomUUID());
 
-    const latest = await repo.findLatestByModelInput(testType, inputId);
+    const latest = await repo.findLatestByDefinition(testType, defId);
     assertEquals(latest, null);
   });
 });
@@ -226,7 +226,7 @@ Deno.test("YamlOutputRepository.delete removes output file", async () => {
   await withTempDir(async (dir) => {
     const repo = new YamlOutputRepository(dir);
     const output = ModelOutput.create({
-      modelInputId: createModelInputId(crypto.randomUUID()),
+      definitionId: createDefinitionId(crypto.randomUUID()),
       methodName: "create",
       provenance: defaultProvenance,
     });
@@ -263,15 +263,23 @@ Deno.test("YamlOutputRepository preserves completed output state", async () => {
   await withTempDir(async (dir) => {
     const repo = new YamlOutputRepository(dir);
     const output = ModelOutput.create({
-      modelInputId: createModelInputId(crypto.randomUUID()),
+      definitionId: createDefinitionId(crypto.randomUUID()),
       methodName: "create",
       status: "running",
       provenance: defaultProvenance,
     });
     output.markSucceeded();
-    output.setArtifacts({
-      resourceId: "550e8400-e29b-41d4-a716-446655440010",
-      logIds: ["550e8400-e29b-41d4-a716-446655440011"],
+    output.addDataArtifact({
+      dataId: "550e8400-e29b-41d4-a716-446655440010",
+      name: "test-resource",
+      version: 1,
+      tags: { type: "resource" },
+    });
+    output.addDataArtifact({
+      dataId: "550e8400-e29b-41d4-a716-446655440011",
+      name: "test-log",
+      version: 1,
+      tags: { type: "log" },
     });
 
     await repo.save(testType, "create", output);
@@ -279,13 +287,14 @@ Deno.test("YamlOutputRepository preserves completed output state", async () => {
 
     assertEquals(found?.status, "succeeded");
     assertEquals(found?.isComplete, true);
+    assertEquals(found?.artifacts.dataArtifacts.length, 2);
     assertEquals(
-      found?.artifacts?.resourceId,
+      found?.artifacts.dataArtifacts[0].dataId,
       "550e8400-e29b-41d4-a716-446655440010",
     );
     assertEquals(
-      found?.artifacts?.logIds,
-      ["550e8400-e29b-41d4-a716-446655440011"],
+      found?.artifacts.dataArtifacts[1].dataId,
+      "550e8400-e29b-41d4-a716-446655440011",
     );
   });
 });
@@ -294,7 +303,7 @@ Deno.test("YamlOutputRepository preserves failed output state", async () => {
   await withTempDir(async (dir) => {
     const repo = new YamlOutputRepository(dir);
     const output = ModelOutput.create({
-      modelInputId: createModelInputId(crypto.randomUUID()),
+      definitionId: createDefinitionId(crypto.randomUUID()),
       methodName: "deploy",
       status: "running",
       provenance: defaultProvenance,
@@ -315,11 +324,11 @@ Deno.test("YamlOutputRepository preserves failed output state", async () => {
 
 Deno.test("YamlOutputRepository.getPath uses correct format", () => {
   const repo = new YamlOutputRepository("/tmp/test");
-  const modelInputId = createModelInputId(
+  const definitionId = createDefinitionId(
     "550e8400-e29b-41d4-a716-446655440000",
   );
   const output = ModelOutput.create({
-    modelInputId,
+    definitionId,
     methodName: "create",
     startedAt: new Date("2023-01-15T10:30:00.000Z"),
     provenance: defaultProvenance,
@@ -327,7 +336,7 @@ Deno.test("YamlOutputRepository.getPath uses correct format", () => {
 
   const path = repo.getPath(testType, "create", output);
 
-  // Path should include: outputs/{type}/{method}/{model-id}-{timestamp}.yaml
+  // Path should include: outputs/{type}/{method}/{definition-id}-{timestamp}.yaml
   assertStringIncludes(path, "outputs");
   assertStringIncludes(path, testType.normalized);
   assertStringIncludes(path, "create");

--- a/src/presentation/output/model_output_get_output.tsx
+++ b/src/presentation/output/model_output_get_output.tsx
@@ -7,7 +7,7 @@ import type { OutputMode } from "./output.tsx";
  * Data structure for provenance information.
  */
 export interface ProvenanceData {
-  inputHash: string;
+  definitionHash: string;
   modelVersion: number;
   triggeredBy: string;
   workflowId?: string;
@@ -16,13 +16,20 @@ export interface ProvenanceData {
 }
 
 /**
+ * Data structure for a data artifact reference.
+ */
+export interface DataArtifactRefData {
+  dataId: string;
+  name: string;
+  version: number;
+  tags: Record<string, string>;
+}
+
+/**
  * Data structure for artifacts information.
  */
 export interface ArtifactsData {
-  resourceId?: string;
-  dataId?: string;
-  fileId?: string;
-  logId?: string;
+  dataArtifacts: DataArtifactRefData[];
 }
 
 /**
@@ -38,7 +45,7 @@ export interface ErrorData {
  */
 export interface ModelOutputGetData {
   id: string;
-  modelInputId: string;
+  definitionId: string;
   modelName?: string;
   type: string;
   methodName: string;
@@ -158,19 +165,19 @@ export function ModelOutputGetDisplay(
 ): React.ReactElement {
   const { data } = props;
   const hasArtifacts = data.artifacts &&
-    Object.values(data.artifacts).some((v) => v !== undefined);
+    data.artifacts.dataArtifacts.length > 0;
 
   return (
     <Box flexDirection="column">
       {/* Header */}
       <Text color="green" bold>
-        # Output: {data.methodName} on {data.modelName ?? data.modelInputId}
+        # Output: {data.methodName} on {data.modelName ?? data.definitionId}
       </Text>
 
       {/* Basic Info */}
       <Section title="Output Info">
         <KeyValue label="ID" value={data.id} />
-        <KeyValue label="Model Input ID" value={data.modelInputId} />
+        <KeyValue label="Definition ID" value={data.definitionId} />
         {data.modelName && (
           <KeyValue label="Model Name" value={data.modelName} />
         )}
@@ -204,8 +211,8 @@ export function ModelOutputGetDisplay(
           value={String(data.provenance.modelVersion)}
         />
         <KeyValue
-          label="Input Hash"
-          value={data.provenance.inputHash.slice(0, 16) + "..."}
+          label="Definition Hash"
+          value={data.provenance.definitionHash.slice(0, 16) + "..."}
         />
         {data.provenance.workflowId && (
           <KeyValue label="Workflow ID" value={data.provenance.workflowId} />
@@ -224,18 +231,17 @@ export function ModelOutputGetDisplay(
       {/* Artifacts */}
       {hasArtifacts && (
         <Section title="Artifacts">
-          {data.artifacts?.resourceId && (
-            <KeyValue label="Resource ID" value={data.artifacts.resourceId} />
-          )}
-          {data.artifacts?.dataId && (
-            <KeyValue label="Data ID" value={data.artifacts.dataId} />
-          )}
-          {data.artifacts?.fileId && (
-            <KeyValue label="File ID" value={data.artifacts.fileId} />
-          )}
-          {data.artifacts?.logId && (
-            <KeyValue label="Log ID" value={data.artifacts.logId} />
-          )}
+          {data.artifacts?.dataArtifacts.map((artifact, index) => (
+            <Box key={index} flexDirection="column" marginBottom={1}>
+              <KeyValue label="Data ID" value={artifact.dataId} />
+              <KeyValue label="Name" value={artifact.name} />
+              <KeyValue label="Version" value={String(artifact.version)} />
+              <KeyValue
+                label="Type"
+                value={artifact.tags.type ?? "unknown"}
+              />
+            </Box>
+          ))}
         </Section>
       )}
 

--- a/src/presentation/output/model_output_search_output.tsx
+++ b/src/presentation/output/model_output_search_output.tsx
@@ -9,7 +9,7 @@ import { Fzf, type FzfResultItem } from "fzf";
  */
 export interface ModelOutputSearchItem {
   id: string;
-  modelInputId: string;
+  definitionId: string;
   modelName?: string;
   type: string;
   methodName: string;
@@ -134,7 +134,7 @@ export function ModelOutputSearchUI(
       new Fzf(outputs, {
         selector: (item) =>
           `${
-            item.modelName ?? item.modelInputId
+            item.modelName ?? item.definitionId
           } ${item.type} ${item.methodName} ${item.status} ${item.id}`,
       }),
     [outputs],
@@ -257,7 +257,7 @@ function ModelOutputSearchResultItem(
     <Box>
       <Text color={isSelected ? "green" : undefined} bold={isSelected}>
         {isSelected ? "> " : "  "}
-        {item.modelName ?? item.modelInputId.slice(0, 8)}
+        {item.modelName ?? item.definitionId.slice(0, 8)}
       </Text>
       <Text dimColor></Text>
       <Text color="cyan">{item.methodName}</Text>


### PR DESCRIPTION
## Summary

Refactor ModelOutput to track unified Data artifacts instead of 4 separate artifact types (resource, data, file, log), aligning with the unified Data entity architecture from issues #116/#117.

- Replace `modelInputId` with `definitionId` in ModelOutput
- Replace `inputHash` with `definitionHash` in ExecutionProvenance
- Replace separate artifact fields (`resourceId`, `dataId`, `fileId`, `logIds`) with unified `dataArtifacts` array containing `DataArtifactRef` entries
- Rename repository methods `findByModelInput` → `findByDefinition`
- Change output storage path from `.data/outputs` to `.swamp/outputs`
- Remove individual artifact setters, add `addDataArtifact()` method
- Rename `computeInputHash()` to `computeDefinitionHash()`

## Test Plan

- All 1410 tests pass
- `deno check` passes
- `deno lint` passes
- `deno fmt --check` passes
- `deno run compile` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)