### PR TITLE
feat: Update RepoIndexService for new .swamp/ storage structure (#119)

### DIFF
--- a/integration/repo_index_test.ts
+++ b/integration/repo_index_test.ts
@@ -13,6 +13,7 @@ import { existsSync } from "@std/fs";
 import { ensureDir } from "@std/fs";
 import { ModelInput } from "../src/domain/models/model_input.ts";
 import { ModelType } from "../src/domain/models/model_type.ts";
+import { Definition } from "../src/domain/definitions/definition.ts";
 import { Workflow } from "../src/domain/workflows/workflow.ts";
 import { Job } from "../src/domain/workflows/job.ts";
 import { Step } from "../src/domain/workflows/step.ts";
@@ -31,6 +32,7 @@ async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
 
 async function setupRepoDir(dir: string): Promise<void> {
   const subdirs = [
+    // Legacy .data paths
     ".data/inputs",
     ".data/resources",
     ".data/data",
@@ -39,6 +41,11 @@ async function setupRepoDir(dir: string): Promise<void> {
     ".data/workflow-runs",
     ".data/logs",
     ".data/files",
+    // New .swamp paths
+    ".swamp/definitions",
+    ".swamp/data",
+    ".swamp/outputs",
+    // Logical view directories
     "models",
     "workflows",
   ];
@@ -502,5 +509,218 @@ Deno.test("CLI: repo index --prune removes broken symlinks", async () => {
 
     // Verify broken link was removed
     assertEquals(existsSync(brokenLink), false);
+  });
+});
+
+// ============================================================================
+// Definition-Based Model Indexing Tests (Issue #119)
+// ============================================================================
+
+Deno.test("Integration: definition create via repository context creates definition.yaml symlink", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+
+    // Create repository context with indexing enabled
+    const ctx = createRepositoryContext({ repoDir, enableIndexing: true });
+    const type = ModelType.create("swamp/echo");
+
+    // Create and save a definition
+    const definition = Definition.create({
+      name: "definition-indexed-model",
+      version: 1,
+      tags: { env: "test" },
+      attributes: { message: "hello" },
+    });
+    await ctx.definitionRepo.save(type, definition);
+
+    // Verify the index directory was created automatically
+    const modelDir = join(repoDir, "models", "definition-indexed-model");
+    assertEquals(
+      existsSync(modelDir),
+      true,
+      "Model index directory should exist",
+    );
+
+    // Verify the definition.yaml symlink exists (new format)
+    const definitionSymlink = join(modelDir, "definition.yaml");
+    assertEquals(
+      existsSync(definitionSymlink),
+      true,
+      "definition.yaml symlink should exist",
+    );
+
+    // Verify we can read through the symlink
+    const content = await Deno.readTextFile(definitionSymlink);
+    assertEquals(
+      content.includes("definition-indexed-model"),
+      true,
+      "Should be able to read definition name through symlink",
+    );
+    assertEquals(
+      content.includes("message"),
+      true,
+      "Should be able to read attributes through symlink",
+    );
+  });
+});
+
+Deno.test("Integration: definition update via repository context updates logical view", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+
+    const ctx = createRepositoryContext({ repoDir, enableIndexing: true });
+    const type = ModelType.create("swamp/echo");
+
+    // Create initial definition
+    const definition = Definition.create({
+      name: "update-test-model",
+      version: 1,
+      tags: {},
+      attributes: { value: "original" },
+    });
+    await ctx.definitionRepo.save(type, definition);
+
+    // Verify initial symlink exists and has original value
+    const definitionSymlink = join(
+      repoDir,
+      "models",
+      "update-test-model",
+      "definition.yaml",
+    );
+    let content = await Deno.readTextFile(definitionSymlink);
+    assertEquals(
+      content.includes("original"),
+      true,
+      "Initial content should have original value",
+    );
+
+    // Update the definition
+    const updatedDefinition = Definition.create({
+      id: definition.id,
+      name: "update-test-model",
+      version: 2,
+      tags: {},
+      attributes: { value: "updated" },
+    });
+    await ctx.definitionRepo.save(type, updatedDefinition);
+
+    // Verify symlink still exists and has updated value
+    assertEquals(
+      existsSync(definitionSymlink),
+      true,
+      "definition.yaml symlink should still exist after update",
+    );
+    content = await Deno.readTextFile(definitionSymlink);
+    assertEquals(
+      content.includes("updated"),
+      true,
+      "Updated content should have new value",
+    );
+  });
+});
+
+Deno.test("Integration: definition delete via repository context removes logical view", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+
+    const ctx = createRepositoryContext({ repoDir, enableIndexing: true });
+    const type = ModelType.create("swamp/echo");
+
+    // Create a definition
+    const definition = Definition.create({
+      name: "delete-definition-model",
+      version: 1,
+      tags: {},
+      attributes: {},
+    });
+    await ctx.definitionRepo.save(type, definition);
+
+    // Verify index exists
+    const modelDir = join(repoDir, "models", "delete-definition-model");
+    assertEquals(existsSync(modelDir), true, "Index should exist after create");
+
+    // Delete the definition
+    await ctx.definitionRepo.delete(type, definition.id);
+
+    // Verify index was removed
+    assertEquals(
+      existsSync(modelDir),
+      false,
+      "Index should be removed after delete",
+    );
+  });
+});
+
+Deno.test("Integration: repo index rebuild indexes definitions with type/ directory", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+
+    // Create definitions WITHOUT indexing enabled
+    const ctxNoIndex = createRepositoryContext({
+      repoDir,
+      enableIndexing: false,
+    });
+    const type = ModelType.create("swamp/echo");
+
+    const def1 = Definition.create({
+      name: "rebuild-def-1",
+      version: 1,
+      tags: {},
+      attributes: {},
+    });
+    const def2 = Definition.create({
+      name: "rebuild-def-2",
+      version: 1,
+      tags: {},
+      attributes: {},
+    });
+    await ctxNoIndex.definitionRepo.save(type, def1);
+    await ctxNoIndex.definitionRepo.save(type, def2);
+
+    // Verify no index directories exist yet
+    assertEquals(
+      existsSync(join(repoDir, "models", "rebuild-def-1")),
+      false,
+      "Index should not exist before rebuild",
+    );
+    assertEquals(
+      existsSync(join(repoDir, "models", "rebuild-def-2")),
+      false,
+      "Index should not exist before rebuild",
+    );
+
+    // Now rebuild the index
+    const result = await ctxNoIndex.indexService.rebuildAll();
+
+    assertEquals(result.modelsIndexed, 2, "Should index 2 definitions");
+
+    // Verify index directories now exist with definition.yaml symlinks
+    const dir1 = join(repoDir, "models", "rebuild-def-1");
+    const dir2 = join(repoDir, "models", "rebuild-def-2");
+    assertEquals(existsSync(dir1), true, "First model dir should exist");
+    assertEquals(existsSync(dir2), true, "Second model dir should exist");
+
+    assertEquals(
+      existsSync(join(dir1, "definition.yaml")),
+      true,
+      "First definition.yaml symlink should exist",
+    );
+    assertEquals(
+      existsSync(join(dir2, "definition.yaml")),
+      true,
+      "Second definition.yaml symlink should exist",
+    );
+
+    // Verify type/ directory exists for tag-based organization
+    assertEquals(
+      existsSync(join(dir1, "type")),
+      true,
+      "type/ directory should exist for tag-based data",
+    );
+    assertEquals(
+      existsSync(join(dir2, "type")),
+      true,
+      "type/ directory should exist for tag-based data",
+    );
   });
 });

--- a/src/domain/repo/repo_index_service.ts
+++ b/src/domain/repo/repo_index_service.ts
@@ -55,13 +55,14 @@ export interface RebuildResult {
  *
  * Model View (`/models/{model-name}/`):
  * ```
- * input.yaml      → ../.data/inputs/{type}/{id}.yaml
- * resource.yaml   → ../.data/resources/{type}/{id}.yaml
- * data.yaml       → ../.data/data/{type}/{id}.yaml
- * logs/           → ../.data/logs/{type}/{id}/
- * files/          → ../.data/files/{type}/{id}/
+ * definition.yaml → /.swamp/definitions/{type}/{id}.yaml
+ * type/
+ *   logs/         → symlinks to data with type=log tag
+ *   files/        → symlinks to data with type=file tag
+ *   resources/    → symlinks to data with type=resource tag
+ * {tag-key}/{tag-value}/ → data organized by custom tag key/value pairs
  * outputs/
- *   {method}/     → ../.data/outputs/{type}/{method}/
+ *   {method}/     → /.swamp/outputs/{type}/{method}/
  * ```
  *
  * Workflow View (`/workflows/{workflow-name}/`):

--- a/src/infrastructure/persistence/repository_factory.ts
+++ b/src/infrastructure/persistence/repository_factory.ts
@@ -39,10 +39,15 @@ import { YamlDataRepository } from "./yaml_data_repository.ts";
 import { YamlOutputRepository } from "./yaml_output_repository.ts";
 import { StreamingLogRepository } from "./streaming_log_repository.ts";
 import { FileSystemFileRepository } from "./fs_file_repository.ts";
+import { YamlDefinitionRepository } from "./yaml_definition_repository.ts";
+import { FileSystemUnifiedDataRepository } from "./unified_data_repository.ts";
 import { EventBus } from "../../domain/events/event_bus.ts";
 import { SymlinkRepoIndexService } from "../repo/symlink_repo_index_service.ts";
 import type { RepoIndexService } from "../../domain/repo/repo_index_service.ts";
 import type {
+  DefinitionCreated,
+  DefinitionDeleted,
+  DefinitionUpdated,
   ModelCreated,
   ModelDeleted,
   ModelUpdated,
@@ -74,6 +79,8 @@ export interface RepositoryContext {
   eventBus: EventBus;
   indexService: RepoIndexService;
   inputRepo: YamlInputRepository;
+  definitionRepo: YamlDefinitionRepository;
+  unifiedDataRepo: FileSystemUnifiedDataRepository;
   workflowRepo: YamlWorkflowRepository;
   workflowRunRepo: YamlWorkflowRunRepository;
   resourceRepo: YamlResourceRepository;
@@ -103,6 +110,10 @@ export function createRepositoryContext(
     repoDir,
     enableIndexing ? eventBus : undefined,
   );
+  const definitionRepo = new YamlDefinitionRepository(
+    repoDir,
+    enableIndexing ? eventBus : undefined,
+  );
   const workflowRepo = new YamlWorkflowRepository(
     repoDir,
     enableIndexing ? eventBus : undefined,
@@ -115,6 +126,7 @@ export function createRepositoryContext(
   // These repositories don't emit events (yet)
   const resourceRepo = new YamlResourceRepository(repoDir);
   const dataRepo = new YamlDataRepository(repoDir);
+  const unifiedDataRepo = new FileSystemUnifiedDataRepository(repoDir);
   const outputRepo = new YamlOutputRepository(repoDir);
   const logRepo = new StreamingLogRepository(repoDir);
   const fileRepo = new FileSystemFileRepository(repoDir);
@@ -125,10 +137,12 @@ export function createRepositoryContext(
     enableIndexing ? eventBus : undefined,
   );
 
-  // Create index service
+  // Create index service with new repositories
   const indexService = new SymlinkRepoIndexService({
     repoDir,
-    inputRepo,
+    inputRepo, // Legacy support
+    definitionRepo, // New definition repository
+    unifiedDataRepo, // New unified data repository
     workflowRepo,
     workflowRunRepo,
     vaultConfigRepo,
@@ -136,6 +150,7 @@ export function createRepositoryContext(
 
   // Subscribe index service to events
   if (enableIndexing) {
+    // Legacy model events (from InputRepository)
     eventBus.subscribe<ModelCreated>(
       "ModelCreated",
       (event) => indexService.handleModelCreated(event),
@@ -148,6 +163,42 @@ export function createRepositoryContext(
       "ModelDeleted",
       (event) => indexService.handleModelDeleted(event),
     );
+
+    // Definition events (from DefinitionRepository) - map to model events
+    eventBus.subscribe<DefinitionCreated>(
+      "DefinitionCreated",
+      (event) =>
+        indexService.handleModelCreated({
+          type: "ModelCreated",
+          timestamp: event.timestamp,
+          modelType: event.modelType,
+          modelInputId: event.definitionId,
+          modelName: event.definitionName,
+        }),
+    );
+    eventBus.subscribe<DefinitionUpdated>(
+      "DefinitionUpdated",
+      (event) =>
+        indexService.handleModelUpdated({
+          type: "ModelUpdated",
+          timestamp: event.timestamp,
+          modelType: event.modelType,
+          modelInputId: event.definitionId,
+          modelName: event.definitionName,
+        }),
+    );
+    eventBus.subscribe<DefinitionDeleted>(
+      "DefinitionDeleted",
+      (event) =>
+        indexService.handleModelDeleted({
+          type: "ModelDeleted",
+          timestamp: event.timestamp,
+          modelType: event.modelType,
+          modelInputId: event.definitionId,
+          modelName: event.definitionName,
+        }),
+    );
+
     eventBus.subscribe<WorkflowCreated>(
       "WorkflowCreated",
       (event) => indexService.handleWorkflowCreated(event),
@@ -194,6 +245,8 @@ export function createRepositoryContext(
     eventBus,
     indexService,
     inputRepo,
+    definitionRepo,
+    unifiedDataRepo,
     workflowRepo,
     workflowRunRepo,
     resourceRepo,

--- a/src/infrastructure/repo/symlink_repo_index_service.ts
+++ b/src/infrastructure/repo/symlink_repo_index_service.ts
@@ -30,6 +30,8 @@ import type {
   WorkflowUpdated,
 } from "../../domain/events/types.ts";
 import type { InputRepository } from "../../domain/models/repositories.ts";
+import type { DefinitionRepository } from "../../domain/definitions/repositories.ts";
+import type { UnifiedDataRepository } from "../persistence/unified_data_repository.ts";
 import type {
   WorkflowRepository,
   WorkflowRunRepository,
@@ -39,6 +41,7 @@ import {
   createWorkflowRunId,
 } from "../../domain/workflows/workflow_id.ts";
 import type { YamlVaultConfigRepository } from "../persistence/yaml_vault_config_repository.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
 
 const logger = getLogger(["swamp", "repo-index"]);
 
@@ -54,7 +57,12 @@ export type IndexMode = "symlink" | "junction";
  */
 export interface SymlinkRepoIndexServiceConfig {
   repoDir: string;
-  inputRepo: InputRepository;
+  /** @deprecated Use definitionRepo instead */
+  inputRepo?: InputRepository;
+  /** Repository for definitions - the new storage format */
+  definitionRepo?: DefinitionRepository;
+  /** Repository for unified versioned data with tags */
+  unifiedDataRepo?: UnifiedDataRepository;
   workflowRepo: WorkflowRepository;
   workflowRunRepo: WorkflowRunRepository;
   vaultConfigRepo?: YamlVaultConfigRepository;
@@ -66,7 +74,9 @@ export interface SymlinkRepoIndexServiceConfig {
  */
 export class SymlinkRepoIndexService implements RepoIndexService {
   private readonly repoDir: string;
-  private readonly inputRepo: InputRepository;
+  private readonly inputRepo: InputRepository | null;
+  private readonly definitionRepo: DefinitionRepository | null;
+  private readonly unifiedDataRepo: UnifiedDataRepository | null;
   private readonly workflowRepo: WorkflowRepository;
   private readonly workflowRunRepo: WorkflowRunRepository;
   private readonly vaultConfigRepo: YamlVaultConfigRepository | null;
@@ -74,7 +84,9 @@ export class SymlinkRepoIndexService implements RepoIndexService {
 
   constructor(config: SymlinkRepoIndexServiceConfig) {
     this.repoDir = config.repoDir;
-    this.inputRepo = config.inputRepo;
+    this.inputRepo = config.inputRepo ?? null;
+    this.definitionRepo = config.definitionRepo ?? null;
+    this.unifiedDataRepo = config.unifiedDataRepo ?? null;
     this.workflowRepo = config.workflowRepo;
     this.workflowRunRepo = config.workflowRunRepo;
     this.vaultConfigRepo = config.vaultConfigRepo ?? null;
@@ -222,9 +234,40 @@ export class SymlinkRepoIndexService implements RepoIndexService {
     let workflowRunsIndexed = 0;
     let vaultsIndexed = 0;
 
-    // Get all models from data directory
-    const allInputs = await this.inputRepo.findAllGlobal();
-    const dataModelNames = new Set(allInputs.map(({ input }) => input.name));
+    // Collect all model names and their sources for indexing
+    // During transition, we combine models from both definition and input repos
+    const modelSources: Map<
+      string,
+      { type: string; id: string; source: "definition" | "input" }
+    > = new Map();
+
+    // Collect from definition repo (new format)
+    if (this.definitionRepo) {
+      const allDefinitions = await this.definitionRepo.findAllGlobal();
+      for (const { definition, type } of allDefinitions) {
+        modelSources.set(definition.name, {
+          type: type.normalized,
+          id: definition.id,
+          source: "definition",
+        });
+      }
+    }
+
+    // Collect from input repo (legacy format) - don't overwrite definitions
+    if (this.inputRepo) {
+      const allInputs = await this.inputRepo.findAllGlobal();
+      for (const { input, type } of allInputs) {
+        if (!modelSources.has(input.name)) {
+          modelSources.set(input.name, {
+            type: type.normalized,
+            id: input.id,
+            source: "input",
+          });
+        }
+      }
+    }
+
+    const dataModelNames = new Set(modelSources.keys());
 
     // Get existing indexed model directories
     const indexedModelNames = await this.getIndexedNames(
@@ -239,8 +282,8 @@ export class SymlinkRepoIndexService implements RepoIndexService {
     }
 
     // Index all models (creates new or updates existing)
-    for (const { input, type } of allInputs) {
-      await this.indexModel(type.normalized, input.id, input.name);
+    for (const [name, info] of modelSources) {
+      await this.indexModel(info.type, info.id, name);
       modelsIndexed++;
     }
 
@@ -331,6 +374,16 @@ export class SymlinkRepoIndexService implements RepoIndexService {
 
   /**
    * Creates or updates the index for a model.
+   *
+   * Creates the following structure:
+   * /models/{model-name}/
+   *   definition.yaml → /.swamp/definitions/{type}/{id}.yaml
+   *   type/
+   *     logs/     → symlinks to data with type=log tag
+   *     files/    → symlinks to data with type=file tag
+   *     resources/→ symlinks to data with type=resource tag
+   *   outputs/
+   *     {method}/ → /.swamp/outputs/{type}/{method}/
    */
   private async indexModel(
     modelType: string,
@@ -340,18 +393,200 @@ export class SymlinkRepoIndexService implements RepoIndexService {
     const modelDir = join(this.repoDir, "models", modelName);
     await ensureDir(modelDir);
 
-    // Symlink to input.yaml
-    const inputTarget = join(
-      ".data",
-      "inputs",
-      modelType,
+    // Create ModelType for path generation
+    const type = ModelType.create(modelType);
+
+    // Symlink to definition.yaml (new .swamp/ path)
+    const definitionTarget = join(
+      ".swamp",
+      "definitions",
+      type.toDirectoryPath(),
       `${modelInputId}.yaml`,
     );
-    await this.createSymlink(
-      join(this.repoDir, inputTarget),
-      join(modelDir, "input.yaml"),
-    );
+    const definitionPath = join(this.repoDir, definitionTarget);
+    if (await this.exists(definitionPath)) {
+      await this.createSymlink(
+        definitionPath,
+        join(modelDir, "definition.yaml"),
+      );
+    } else {
+      // Fallback to legacy .data/inputs/ path for backward compatibility
+      const inputTarget = join(
+        ".data",
+        "inputs",
+        modelType,
+        `${modelInputId}.yaml`,
+      );
+      const inputPath = join(this.repoDir, inputTarget);
+      if (await this.exists(inputPath)) {
+        await this.createSymlink(inputPath, join(modelDir, "input.yaml"));
+      }
+    }
 
+    // Create type/ subdirectory for tag-based data organization
+    const typeDir = join(modelDir, "type");
+    await ensureDir(typeDir);
+
+    // Index tag-based data if unified data repository is available
+    if (this.unifiedDataRepo) {
+      await this.indexTagBasedData(type, modelInputId, typeDir);
+    } else {
+      // Fallback to legacy paths for backward compatibility
+      await this.indexLegacyData(modelType, modelInputId, modelDir);
+    }
+
+    // Create outputs directory and symlink method directories
+    const outputsDir = join(modelDir, "outputs");
+    await ensureDir(outputsDir);
+
+    // Try new .swamp/outputs/ path first
+    const newMethodsDir = join(
+      this.repoDir,
+      ".swamp",
+      "outputs",
+      type.normalized,
+    );
+    if (await this.exists(newMethodsDir)) {
+      await this.indexOutputMethods(newMethodsDir, outputsDir);
+    } else {
+      // Fallback to legacy .data/outputs/ path
+      const legacyMethodsDir = join(
+        this.repoDir,
+        ".data",
+        "outputs",
+        modelType,
+      );
+      if (await this.exists(legacyMethodsDir)) {
+        await this.indexOutputMethods(legacyMethodsDir, outputsDir);
+      }
+    }
+  }
+
+  /**
+   * Indexes tag-based data for a model using the unified data repository.
+   *
+   * Creates symlinks under type/ directory:
+   * - type/logs/ → data with type=log tag
+   * - type/files/ → data with type=file tag
+   * - type/resources/ → data with type=resource tag
+   * - {tag-key}/{tag-value}/ → data by custom tags
+   */
+  private async indexTagBasedData(
+    modelType: ModelType,
+    modelId: string,
+    typeDir: string,
+  ): Promise<void> {
+    if (!this.unifiedDataRepo) return;
+
+    try {
+      const allData = await this.unifiedDataRepo.findAllForModel(
+        modelType,
+        modelId,
+      );
+
+      // Group data by type tag
+      const dataByType: Record<string, typeof allData> = {
+        log: [],
+        file: [],
+        resource: [],
+      };
+      const customTags: Map<string, Map<string, typeof allData>> = new Map();
+
+      for (const data of allData) {
+        const typeTag = data.tags.type;
+        if (typeTag && typeTag in dataByType) {
+          dataByType[typeTag].push(data);
+        }
+
+        // Collect custom tags (excluding 'type')
+        for (const [key, value] of Object.entries(data.tags)) {
+          if (key === "type") continue;
+          if (!customTags.has(key)) {
+            customTags.set(key, new Map());
+          }
+          const valueMap = customTags.get(key)!;
+          if (!valueMap.has(value)) {
+            valueMap.set(value, []);
+          }
+          valueMap.get(value)!.push(data);
+        }
+      }
+
+      // Create symlinks for standard type tags
+      for (const [typeTag, dataItems] of Object.entries(dataByType)) {
+        if (dataItems.length === 0) continue;
+
+        const tagDir = join(typeDir, `${typeTag}s`); // logs, files, resources
+        await ensureDir(tagDir);
+
+        for (const data of dataItems) {
+          // Get the latest version
+          const versions = await this.unifiedDataRepo.listVersions(
+            modelType,
+            modelId,
+            data.name,
+          );
+          if (versions.length === 0) continue;
+
+          const latestVersion = Math.max(...versions);
+          const dataPath = this.unifiedDataRepo.getPath(
+            modelType,
+            modelId,
+            data.name,
+            latestVersion,
+          );
+
+          // Create symlink to the data directory
+          if (await this.exists(dataPath)) {
+            await this.createSymlink(dataPath, join(tagDir, data.name));
+          }
+        }
+      }
+
+      // Create symlinks for custom tags: {tag-key}/{tag-value}/
+      for (const [tagKey, valueMap] of customTags) {
+        const tagKeyDir = join(typeDir, "..", tagKey);
+        await ensureDir(tagKeyDir);
+
+        for (const [tagValue, dataItems] of valueMap) {
+          const tagValueDir = join(tagKeyDir, tagValue);
+          await ensureDir(tagValueDir);
+
+          for (const data of dataItems) {
+            const versions = await this.unifiedDataRepo.listVersions(
+              modelType,
+              modelId,
+              data.name,
+            );
+            if (versions.length === 0) continue;
+
+            const latestVersion = Math.max(...versions);
+            const dataPath = this.unifiedDataRepo.getPath(
+              modelType,
+              modelId,
+              data.name,
+              latestVersion,
+            );
+
+            if (await this.exists(dataPath)) {
+              await this.createSymlink(dataPath, join(tagValueDir, data.name));
+            }
+          }
+        }
+      }
+    } catch (error) {
+      logger.debug`Failed to index tag-based data: ${error}`;
+    }
+  }
+
+  /**
+   * Indexes legacy data paths for backward compatibility.
+   */
+  private async indexLegacyData(
+    modelType: string,
+    modelInputId: string,
+    modelDir: string,
+  ): Promise<void> {
     // Symlink to resource.yaml if it exists
     const resourceTarget = join(
       ".data",
@@ -384,28 +619,25 @@ export class SymlinkRepoIndexService implements RepoIndexService {
     if (await this.exists(filesPath)) {
       await this.createSymlink(filesPath, join(modelDir, "files"));
     }
+  }
 
-    // Create outputs directory and symlink method directories
-    const outputsDir = join(modelDir, "outputs");
-    await ensureDir(outputsDir);
-
-    // Scan for output method directories
-    const methodsDir = join(this.repoDir, ".data", "outputs", modelType);
-    if (await this.exists(methodsDir)) {
-      try {
-        for await (const entry of Deno.readDir(methodsDir)) {
-          if (entry.isDirectory) {
-            const methodName = entry.name;
-            const methodTarget = join(methodsDir, methodName);
-            await this.createSymlink(
-              methodTarget,
-              join(outputsDir, methodName),
-            );
-          }
+  /**
+   * Indexes output method directories.
+   */
+  private async indexOutputMethods(
+    methodsDir: string,
+    outputsDir: string,
+  ): Promise<void> {
+    try {
+      for await (const entry of Deno.readDir(methodsDir)) {
+        if (entry.isDirectory) {
+          const methodName = entry.name;
+          const methodTarget = join(methodsDir, methodName);
+          await this.createSymlink(methodTarget, join(outputsDir, methodName));
         }
-      } catch (error) {
-        logger.debug`Failed to read outputs directory: ${error}`;
       }
+    } catch (error) {
+      logger.debug`Failed to read outputs directory: ${error}`;
     }
   }
 

--- a/src/infrastructure/repo/symlink_repo_index_service_test.ts
+++ b/src/infrastructure/repo/symlink_repo_index_service_test.ts
@@ -3,9 +3,11 @@ import { join } from "@std/path";
 import { ensureDir } from "@std/fs";
 import { SymlinkRepoIndexService } from "./symlink_repo_index_service.ts";
 import { YamlInputRepository } from "../persistence/yaml_input_repository.ts";
+import { YamlDefinitionRepository } from "../persistence/yaml_definition_repository.ts";
 import { YamlWorkflowRepository } from "../persistence/yaml_workflow_repository.ts";
 import { YamlWorkflowRunRepository } from "../persistence/yaml_workflow_run_repository.ts";
 import { ModelInput } from "../../domain/models/model_input.ts";
+import { Definition } from "../../domain/definitions/definition.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import { Workflow } from "../../domain/workflows/workflow.ts";
 import { Job } from "../../domain/workflows/job.ts";
@@ -27,8 +29,9 @@ async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
 }
 
 async function setupRepoDir(dir: string): Promise<void> {
-  // Create standard data directory structure
+  // Create standard data directory structure (both legacy and new)
   const subdirs = [
+    // Legacy .data paths
     ".data/inputs",
     ".data/resources",
     ".data/data",
@@ -37,6 +40,11 @@ async function setupRepoDir(dir: string): Promise<void> {
     ".data/workflow-runs",
     ".data/logs",
     ".data/files",
+    // New .swamp paths
+    ".swamp/definitions",
+    ".swamp/data",
+    ".swamp/outputs",
+    // Logical view directories
     "models",
     "workflows",
   ];
@@ -47,6 +55,7 @@ async function setupRepoDir(dir: string): Promise<void> {
 
 function createIndexService(dir: string) {
   const inputRepo = new YamlInputRepository(dir);
+  const definitionRepo = new YamlDefinitionRepository(dir);
   const workflowRepo = new YamlWorkflowRepository(dir);
   const workflowRunRepo = new YamlWorkflowRunRepository(dir);
 
@@ -54,10 +63,12 @@ function createIndexService(dir: string) {
     indexService: new SymlinkRepoIndexService({
       repoDir: dir,
       inputRepo,
+      definitionRepo,
       workflowRepo,
       workflowRunRepo,
     }),
     inputRepo,
+    definitionRepo,
     workflowRepo,
     workflowRunRepo,
   };
@@ -81,7 +92,7 @@ Deno.test("SymlinkRepoIndexService.handleModelCreated creates model directory", 
   });
 });
 
-Deno.test("SymlinkRepoIndexService.handleModelCreated creates input.yaml symlink", async () => {
+Deno.test("SymlinkRepoIndexService.handleModelCreated creates input.yaml symlink (legacy)", async () => {
   await withTempDir(async (dir) => {
     await setupRepoDir(dir);
     const { indexService, inputRepo } = createIndexService(dir);
@@ -92,7 +103,7 @@ Deno.test("SymlinkRepoIndexService.handleModelCreated creates input.yaml symlink
     const event = createModelCreated(type.normalized, input.id, input.name);
     await indexService.handleModelCreated(event);
 
-    // Check that input.yaml symlink exists and points to correct file
+    // Check that input.yaml symlink exists and points to correct file (legacy path)
     const symlinkPath = join(dir, "models", "my-model", "input.yaml");
     const linkInfo = await Deno.lstat(symlinkPath);
     assertEquals(linkInfo.isSymlink, true);
@@ -100,6 +111,42 @@ Deno.test("SymlinkRepoIndexService.handleModelCreated creates input.yaml symlink
     // Read through symlink should work
     const content = await Deno.readTextFile(symlinkPath);
     assertEquals(content.includes("my-model"), true);
+  });
+});
+
+Deno.test("SymlinkRepoIndexService.handleModelCreated creates definition.yaml symlink (new path)", async () => {
+  await withTempDir(async (dir) => {
+    await setupRepoDir(dir);
+    const { indexService, definitionRepo } = createIndexService(dir);
+    const type = ModelType.create("swamp/echo");
+    const definition = Definition.create({
+      name: "my-definition-model",
+      version: 1,
+      tags: {},
+      attributes: { message: "hello" },
+    });
+    await definitionRepo.save(type, definition);
+
+    const event = createModelCreated(
+      type.normalized,
+      definition.id,
+      definition.name,
+    );
+    await indexService.handleModelCreated(event);
+
+    // Check that definition.yaml symlink exists and points to correct file
+    const symlinkPath = join(
+      dir,
+      "models",
+      "my-definition-model",
+      "definition.yaml",
+    );
+    const linkInfo = await Deno.lstat(symlinkPath);
+    assertEquals(linkInfo.isSymlink, true);
+
+    // Read through symlink should work
+    const content = await Deno.readTextFile(symlinkPath);
+    assertEquals(content.includes("my-definition-model"), true);
   });
 });
 
@@ -145,13 +192,13 @@ Deno.test("SymlinkRepoIndexService.handleModelDeleted removes model directory", 
   });
 });
 
-Deno.test("SymlinkRepoIndexService.rebuildAll indexes all models", async () => {
+Deno.test("SymlinkRepoIndexService.rebuildAll indexes all models (legacy)", async () => {
   await withTempDir(async (dir) => {
     await setupRepoDir(dir);
     const { indexService, inputRepo } = createIndexService(dir);
     const type = ModelType.create("swamp/echo");
 
-    // Create multiple models
+    // Create multiple models using legacy input repo
     const model1 = ModelInput.create({ name: "model-one" });
     const model2 = ModelInput.create({ name: "model-two" });
     await inputRepo.save(type, model1);
@@ -169,6 +216,51 @@ Deno.test("SymlinkRepoIndexService.rebuildAll indexes all models", async () => {
     const stat2 = await Deno.stat(dir2);
     assertEquals(stat1.isDirectory, true);
     assertEquals(stat2.isDirectory, true);
+  });
+});
+
+Deno.test("SymlinkRepoIndexService.rebuildAll indexes all definitions", async () => {
+  await withTempDir(async (dir) => {
+    await setupRepoDir(dir);
+    const { indexService, definitionRepo } = createIndexService(dir);
+    const type = ModelType.create("swamp/echo");
+
+    // Create multiple definitions
+    const def1 = Definition.create({
+      name: "def-one",
+      version: 1,
+      tags: {},
+      attributes: {},
+    });
+    const def2 = Definition.create({
+      name: "def-two",
+      version: 1,
+      tags: {},
+      attributes: {},
+    });
+    await definitionRepo.save(type, def1);
+    await definitionRepo.save(type, def2);
+
+    // Rebuild all
+    const result = await indexService.rebuildAll();
+
+    assertEquals(result.modelsIndexed, 2);
+
+    // Verify both model directories exist
+    const dir1 = join(dir, "models", "def-one");
+    const dir2 = join(dir, "models", "def-two");
+    const stat1 = await Deno.stat(dir1);
+    const stat2 = await Deno.stat(dir2);
+    assertEquals(stat1.isDirectory, true);
+    assertEquals(stat2.isDirectory, true);
+
+    // Verify definition.yaml symlinks exist
+    const symlink1 = join(dir1, "definition.yaml");
+    const symlink2 = join(dir2, "definition.yaml");
+    const linkInfo1 = await Deno.lstat(symlink1);
+    const linkInfo2 = await Deno.lstat(symlink2);
+    assertEquals(linkInfo1.isSymlink, true);
+    assertEquals(linkInfo2.isSymlink, true);
   });
 });
 


### PR DESCRIPTION
Updates the `RepoIndexService` to create logical views pointing to `.swamp/` instead of `.data/` and adds support for tag-based data organization.

Fixes #119

## Changes

### Implementation vs Plan

| Plan Item | Status | Notes |
|-----------|--------|-------|
| `indexModel()` points to `.swamp/definitions/{type}/{id}.yaml` | ✅ | With legacy `.data/inputs/` fallback |
| Tag-based symlinks: `type/logs/` | ✅ | Links to data with `type=log` tag |
| Tag-based symlinks: `type/files/` | ✅ | Links to data with `type=file` tag |
| Tag-based symlinks: `type/resources/` | ✅ | Links to data with `type=resource` tag |
| Custom tags: `{tag-key}/{tag-value}/` | ✅ | Supports arbitrary tag filtering |
| Output symlinks use `.swamp/outputs/` | ✅ | With legacy `.data/outputs/` fallback |
| Backward compatibility during transition | ✅ | Both old and new paths supported |
| Event handlers work with new paths | ✅ | Definition events mapped to model handlers |
| Multiple versions accessible | ⚠️ | Latest version symlinked; all versions in `.swamp/data/` |
| Integration test: create model | ✅ | Added |
| Integration test: update model | ✅ | Added |

### New Logical View Structure

/models/{model-name}/
definition.yaml → /.swamp/definitions/{type}/{id}.yaml
type/
    logs/         → data with type=log tag
    files/        → data with type=file tag
    resources/    → data with type=resource tag
{tag-key}/{tag-value}/ → data by custom tags
outputs/
    {method}/     → /.swamp/outputs/{type}/{method}/

### Files Changed

- `src/infrastructure/repo/symlink_repo_index_service.ts` - Main implementation
- `src/infrastructure/persistence/repository_factory.ts` - Wired up DefinitionRepo and UnifiedDataRepo
- `src/domain/repo/repo_index_service.ts` - Updated interface documentation
- `src/infrastructure/repo/symlink_repo_index_service_test.ts` - Unit tests
- `integration/repo_index_test.ts` - Integration tests

## Test Plan

- [x] All existing unit tests pass (12 tests)
- [x] All existing integration tests pass (17 tests)
- [x] New unit tests for definition-based indexing
- [x] New integration tests for definition create/update/delete
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] Full test suite passes (1412 tests)

🤖 Generated with [Claude Code](https://claude.ai/code)