### PR TITLE
feat: Migrate models to Definition entity and unified DataOutput pattern

### DIFF
--- a/experiments/extensions/models/anthropic_claude.ts
+++ b/experiments/extensions/models/anthropic_claude.ts
@@ -1,12 +1,11 @@
 import { z } from "zod";
 import { ModelType } from "../../../src/domain/models/model_type.ts";
-import { ModelData } from "../../../src/domain/models/model_data.ts";
 import {
   defineModel,
   type MethodContext,
   type MethodResult,
 } from "../../../src/domain/models/model.ts";
-import type { ModelInput } from "../../../src/domain/models/model_input.ts";
+import type { Definition } from "../../../src/domain/definitions/definition.ts";
 
 /**
  * Schema for Anthropic Claude model input attributes.
@@ -23,22 +22,6 @@ const InputAttributesSchema = z.object({
 });
 
 type InputAttributes = z.infer<typeof InputAttributesSchema>;
-
-/**
- * Schema for Anthropic Claude model data attributes.
- */
-const DataAttributesSchema = z.object({
-  /** The generated response text */
-  response: z.string(),
-  /** Number of input tokens used */
-  inputTokens: z.number().int().nonnegative(),
-  /** Number of output tokens generated */
-  outputTokens: z.number().int().nonnegative(),
-  /** Model used for generation */
-  model: z.string(),
-  /** Timestamp when generation completed */
-  generatedAt: z.string().datetime(),
-});
 
 interface ContentBlock {
   type: string;
@@ -104,10 +87,10 @@ async function callClaude(attrs: InputAttributes): Promise<ClaudeResponse> {
  * Execute the generate method.
  */
 async function executeGenerate(
-  input: ModelInput,
+  definition: Definition,
   _context: MethodContext,
 ): Promise<MethodResult> {
-  const attrs = InputAttributesSchema.parse(input.attributes);
+  const attrs = InputAttributesSchema.parse(definition.attributes);
   const result = await callClaude(attrs);
 
   // Extract text from content blocks
@@ -116,18 +99,34 @@ async function executeGenerate(
     .map((block: ContentBlock) => block.text ?? "")
     .join("");
 
-  const data = ModelData.create({
-    id: input.id,
-    attributes: {
-      response: responseText,
-      inputTokens: result.usage.input_tokens,
-      outputTokens: result.usage.output_tokens,
-      model: result.model,
-      generatedAt: new Date().toISOString(),
-    },
-  });
+  const dataAttributes = {
+    response: responseText,
+    inputTokens: result.usage.input_tokens,
+    outputTokens: result.usage.output_tokens,
+    model: result.model,
+    generatedAt: new Date().toISOString(),
+  };
 
-  return { data };
+  const definitionHash = await definition.computeHash();
+
+  return {
+    dataOutputs: [{
+      name: `${definition.name}-data`,
+      content: new TextEncoder().encode(JSON.stringify(dataAttributes)),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "data" },
+        ownerDefinition: {
+          definitionHash,
+          ownerType: "model-method",
+          ownerRef: "generate",
+        },
+      },
+    }],
+  };
 }
 
 /**
@@ -141,7 +140,6 @@ export const anthropicClaudeModel = defineModel({
   type: ModelType.create("anthropic/claude"),
   version: 1,
   inputAttributesSchema: InputAttributesSchema,
-  dataAttributesSchema: DataAttributesSchema,
   methods: {
     generate: {
       description: "Generate a response using Claude",

--- a/experiments/extensions/models/digitalocean_app.ts
+++ b/experiments/extensions/models/digitalocean_app.ts
@@ -2,16 +2,11 @@ import { z } from "zod";
 import { parse as parseYaml } from "@std/yaml";
 import { ModelType } from "../../../src/domain/models/model_type.ts";
 import {
-  createModelResourceId,
-  ModelResource,
-} from "../../../src/domain/models/model_resource.ts";
-import { ModelData } from "../../../src/domain/models/model_data.ts";
-import {
   defineModel,
   type MethodContext,
   type MethodResult,
 } from "../../../src/domain/models/model.ts";
-import type { ModelInput } from "../../../src/domain/models/model_input.ts";
+import type { Definition } from "../../../src/domain/definitions/definition.ts";
 
 /**
  * Schema for DigitalOcean App model input attributes.
@@ -70,26 +65,6 @@ const GetJobLogsInputSchema = z.object({
   tail: z.number().positive().optional(),
 });
 
-/**
- * Schema for DigitalOcean App model resource attributes.
- */
-const ResourceAttributesSchema = z.object({
-  /** App ID */
-  id: z.string().uuid(),
-  /** Default ingress URL */
-  defaultIngress: z.string().nullable(),
-  /** Active deployment ID */
-  activeDeploymentId: z.string().nullable(),
-  /** App creation timestamp */
-  createdAt: z.string().datetime(),
-  /** Last update timestamp */
-  updatedAt: z.string().datetime(),
-  /** App name */
-  name: z.string(),
-  /** Region */
-  region: z.string().nullable(),
-});
-
 interface AppResponse {
   id: string;
   default_ingress?: string;
@@ -118,32 +93,39 @@ function parseYamlSpec(spec: string): AppSpec {
 }
 
 /**
- * Gets the DigitalOcean app ID from the stored resource.
+ * Gets the DigitalOcean app ID from the stored data.
  */
-async function getAppIdFromResource(
-  input: ModelInput,
+async function getAppIdFromData(
+  definition: Definition,
   context: MethodContext,
 ): Promise<string> {
-  if (!context.resourceRepository) {
-    throw new Error(
-      "Cannot operate: resourceRepository not provided in context",
-    );
-  }
-
-  const resource = await context.resourceRepository.findById(
-    ModelType.create("digitalocean/app"),
-    createModelResourceId(input.id),
+  const dataName = `${definition.name}-data`;
+  const existingData = await context.dataRepository.findByName(
+    context.modelType,
+    context.modelId,
+    dataName,
   );
 
-  if (!resource) {
+  if (!existingData) {
     throw new Error(
-      `Resource not found for input ID: ${input.id}. Run 'create' first.`,
+      `Data not found for definition: ${definition.name}. Run 'create' first.`,
     );
   }
 
-  const appId = resource.attributes.id as string;
+  const content = await context.dataRepository.getContent(
+    context.modelType,
+    context.modelId,
+    dataName,
+  );
+
+  if (!content) {
+    throw new Error("Data content not found");
+  }
+
+  const attributes = JSON.parse(new TextDecoder().decode(content));
+  const appId = attributes.id as string;
   if (!appId) {
-    throw new Error("Resource missing 'id' attribute (DO app ID)");
+    throw new Error("Data missing 'id' attribute (DO app ID)");
   }
 
   return appId;
@@ -323,11 +305,11 @@ interface JobInvocationsResponse {
  * Note: Uses direct API call due to doctl bug returning null.
  */
 async function executeListJobInvocations(
-  input: ModelInput,
+  definition: Definition,
   context: MethodContext,
 ): Promise<MethodResult> {
-  const attrs = ListJobInvocationsInputSchema.parse(input.attributes);
-  const appId = await getAppIdFromResource(input, context);
+  const attrs = ListJobInvocationsInputSchema.parse(definition.attributes);
+  const appId = await getAppIdFromData(definition, context);
 
   // Build query params
   const params = new URLSearchParams();
@@ -346,47 +328,8 @@ async function executeListJobInvocations(
   const response = JSON.parse(output) as JobInvocationsResponse;
   const invocations = response.job_invocations ?? [];
 
-  const data = ModelData.create({
-    id: input.id,
-    attributes: {
-      invocations: invocations.map((inv) => ({
-        id: inv.id,
-        jobName: inv.job_name,
-        deploymentId: inv.deployment_id,
-        phase: inv.phase,
-        triggerType: inv.trigger.type,
-        createdAt: inv.created_at,
-        startedAt: inv.started_at,
-        completedAt: inv.completed_at,
-        errorCode: inv.progress?.steps?.[0]?.reason?.code,
-        errorMessage: inv.progress?.steps?.[0]?.reason?.message,
-      })),
-      fetchedAt: new Date().toISOString(),
-    },
-  });
-
-  return { data };
-}
-
-/**
- * Execute the getJobInvocation method.
- * Note: Uses direct API call due to doctl bug.
- */
-async function executeGetJobInvocation(
-  input: ModelInput,
-  context: MethodContext,
-): Promise<MethodResult> {
-  const attrs = GetJobInvocationInputSchema.parse(input.attributes);
-  const appId = await getAppIdFromResource(input, context);
-
-  const endpoint = `/apps/${appId}/job-invocations/${attrs.invocationId}`;
-  const output = await callDoApi(endpoint);
-  const response = JSON.parse(output) as { job_invocation: JobInvocationApi };
-  const inv = response.job_invocation;
-
-  const data = ModelData.create({
-    id: input.id,
-    attributes: {
+  const dataAttributes = {
+    invocations: invocations.map((inv) => ({
       id: inv.id,
       jobName: inv.job_name,
       deploymentId: inv.deployment_id,
@@ -397,22 +340,93 @@ async function executeGetJobInvocation(
       completedAt: inv.completed_at,
       errorCode: inv.progress?.steps?.[0]?.reason?.code,
       errorMessage: inv.progress?.steps?.[0]?.reason?.message,
-      fetchedAt: new Date().toISOString(),
-    },
-  });
+    })),
+    fetchedAt: new Date().toISOString(),
+  };
 
-  return { data };
+  const definitionHash = await definition.computeHash();
+
+  return {
+    dataOutputs: [{
+      name: `${definition.name}-invocations`,
+      content: new TextEncoder().encode(JSON.stringify(dataAttributes)),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "data" },
+        ownerDefinition: {
+          definitionHash,
+          ownerType: "model-method",
+          ownerRef: "listJobInvocations",
+        },
+      },
+    }],
+  };
+}
+
+/**
+ * Execute the getJobInvocation method.
+ * Note: Uses direct API call due to doctl bug.
+ */
+async function executeGetJobInvocation(
+  definition: Definition,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const attrs = GetJobInvocationInputSchema.parse(definition.attributes);
+  const appId = await getAppIdFromData(definition, context);
+
+  const endpoint = `/apps/${appId}/job-invocations/${attrs.invocationId}`;
+  const output = await callDoApi(endpoint);
+  const response = JSON.parse(output) as { job_invocation: JobInvocationApi };
+  const inv = response.job_invocation;
+
+  const dataAttributes = {
+    id: inv.id,
+    jobName: inv.job_name,
+    deploymentId: inv.deployment_id,
+    phase: inv.phase,
+    triggerType: inv.trigger.type,
+    createdAt: inv.created_at,
+    startedAt: inv.started_at,
+    completedAt: inv.completed_at,
+    errorCode: inv.progress?.steps?.[0]?.reason?.code,
+    errorMessage: inv.progress?.steps?.[0]?.reason?.message,
+    fetchedAt: new Date().toISOString(),
+  };
+
+  const definitionHash = await definition.computeHash();
+
+  return {
+    dataOutputs: [{
+      name: `${definition.name}-invocation`,
+      content: new TextEncoder().encode(JSON.stringify(dataAttributes)),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "data" },
+        ownerDefinition: {
+          definitionHash,
+          ownerType: "model-method",
+          ownerRef: "getJobInvocation",
+        },
+      },
+    }],
+  };
 }
 
 /**
  * Execute the getJobLogs method.
  */
 async function executeGetJobLogs(
-  input: ModelInput,
+  definition: Definition,
   context: MethodContext,
 ): Promise<MethodResult> {
-  const attrs = GetJobLogsInputSchema.parse(input.attributes);
-  const appId = await getAppIdFromResource(input, context);
+  const attrs = GetJobLogsInputSchema.parse(definition.attributes);
+  const appId = await getAppIdFromData(definition, context);
 
   const args = [
     "apps",
@@ -431,18 +445,34 @@ async function executeGetJobLogs(
 
   const logs = await runDoctlText(args);
 
-  const data = ModelData.create({
-    id: input.id,
-    attributes: {
-      logs,
-      invocationId: attrs.invocationId,
-      componentName: attrs.componentName,
-      logType: attrs.logType,
-      fetchedAt: new Date().toISOString(),
-    },
-  });
+  const dataAttributes = {
+    logs,
+    invocationId: attrs.invocationId,
+    componentName: attrs.componentName,
+    logType: attrs.logType,
+    fetchedAt: new Date().toISOString(),
+  };
 
-  return { data };
+  const definitionHash = await definition.computeHash();
+
+  return {
+    dataOutputs: [{
+      name: `${definition.name}-logs`,
+      content: new TextEncoder().encode(JSON.stringify(dataAttributes)),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: true,
+        tags: { type: "log" },
+        ownerDefinition: {
+          definitionHash,
+          ownerType: "model-method",
+          ownerRef: "getJobLogs",
+        },
+      },
+    }],
+  };
 }
 
 /**
@@ -452,10 +482,10 @@ async function executeGetJobLogs(
  * We need to fetch the actual app by name after creation.
  */
 async function executeCreate(
-  input: ModelInput,
+  definition: Definition,
   _context: MethodContext,
 ): Promise<MethodResult> {
-  const attrs = InputAttributesSchema.parse(input.attributes);
+  const attrs = InputAttributesSchema.parse(definition.attributes);
 
   // Create returns a deployment, not an app - we ignore the output
   await withTempSpec(attrs.spec, async (specPath: string) => {
@@ -466,12 +496,26 @@ async function executeCreate(
   const specObj = parseYamlSpec(attrs.spec);
   const app = await getAppByName(specObj.name);
 
-  const resource = ModelResource.create({
-    id: input.id,
-    attributes: parseAppResponse(app),
-  });
+  const definitionHash = await definition.computeHash();
 
-  return { resource };
+  return {
+    dataOutputs: [{
+      name: `${definition.name}-data`,
+      content: new TextEncoder().encode(JSON.stringify(parseAppResponse(app))),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "resource" },
+        ownerDefinition: {
+          definitionHash,
+          ownerType: "model-method",
+          ownerRef: "create",
+        },
+      },
+    }],
+  };
 }
 
 /**
@@ -481,11 +525,11 @@ async function executeCreate(
  * We fetch fresh app state using `doctl apps get` after update.
  */
 async function executeUpdate(
-  input: ModelInput,
+  definition: Definition,
   context: MethodContext,
 ): Promise<MethodResult> {
-  const attrs = UpdateInputSchema.parse(input.attributes);
-  const appId = await getAppIdFromResource(input, context);
+  const attrs = UpdateInputSchema.parse(definition.attributes);
+  const appId = await getAppIdFromData(definition, context);
 
   // Update the app - ignore the inconsistent response
   await withTempSpec(attrs.spec, async (specPath: string) => {
@@ -500,11 +544,25 @@ async function executeUpdate(
     throw new Error(`App '${appId}' not found after update`);
   }
 
+  const definitionHash = await definition.computeHash();
+
   return {
-    resource: ModelResource.create({
-      id: input.id,
-      attributes: parseAppResponse(app),
-    }),
+    dataOutputs: [{
+      name: `${definition.name}-data`,
+      content: new TextEncoder().encode(JSON.stringify(parseAppResponse(app))),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "resource" },
+        ownerDefinition: {
+          definitionHash,
+          ownerType: "model-method",
+          ownerRef: "update",
+        },
+      },
+    }],
   };
 }
 
@@ -512,22 +570,48 @@ async function executeUpdate(
  * Execute the delete method.
  */
 async function executeDelete(
-  input: ModelInput,
+  definition: Definition,
   context: MethodContext,
 ): Promise<MethodResult> {
-  const appId = await getAppIdFromResource(input, context);
+  const appId = await getAppIdFromData(definition, context);
   await runDoctl(["apps", "delete", appId, "--force"]);
-  return { deleteResource: true };
+
+  const definitionHash = await definition.computeHash();
+
+  return {
+    dataOutputs: [{
+      name: `${definition.name}-data`,
+      content: new TextEncoder().encode(
+        JSON.stringify({
+          deleted: true,
+          deletedAt: new Date().toISOString(),
+          appId,
+        }),
+      ),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "resource" },
+        ownerDefinition: {
+          definitionHash,
+          ownerType: "model-method",
+          ownerRef: "delete",
+        },
+      },
+    }],
+  };
 }
 
 /**
  * Execute the sync method.
  */
 async function executeSync(
-  input: ModelInput,
+  definition: Definition,
   context: MethodContext,
 ): Promise<MethodResult> {
-  const appId = await getAppIdFromResource(input, context);
+  const appId = await getAppIdFromData(definition, context);
 
   // doctl apps get returns an array
   const output = await runDoctl(["apps", "get", appId]);
@@ -537,11 +621,25 @@ async function executeSync(
     throw new Error(`App '${appId}' not found`);
   }
 
+  const definitionHash = await definition.computeHash();
+
   return {
-    resource: ModelResource.create({
-      id: input.id,
-      attributes: parseAppResponse(app),
-    }),
+    dataOutputs: [{
+      name: `${definition.name}-data`,
+      content: new TextEncoder().encode(JSON.stringify(parseAppResponse(app))),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "resource" },
+        ownerDefinition: {
+          definitionHash,
+          ownerType: "model-method",
+          ownerRef: "sync",
+        },
+      },
+    }],
   };
 }
 
@@ -555,7 +653,6 @@ export const digitaloceanAppModel = defineModel({
   type: ModelType.create("digitalocean/app"),
   version: 1,
   inputAttributesSchema: InputAttributesSchema,
-  resourceAttributesSchema: ResourceAttributesSchema,
   methods: {
     create: {
       description: "Create a new DigitalOcean App Platform application",

--- a/experiments/extensions/models/digitalocean_droplet.ts
+++ b/experiments/extensions/models/digitalocean_droplet.ts
@@ -1,15 +1,11 @@
 import { z } from "zod";
 import { ModelType } from "../../../src/domain/models/model_type.ts";
 import {
-  createModelResourceId,
-  ModelResource,
-} from "../../../src/domain/models/model_resource.ts";
-import {
   defineModel,
   type MethodContext,
   type MethodResult,
 } from "../../../src/domain/models/model.ts";
-import type { ModelInput } from "../../../src/domain/models/model_input.ts";
+import type { Definition } from "../../../src/domain/definitions/definition.ts";
 
 /**
  * Schema for DigitalOcean Droplet model input attributes.
@@ -40,38 +36,6 @@ const InputAttributesSchema = z.object({
  */
 const EmptyInputSchema = z.object({});
 
-/**
- * Schema for DigitalOcean Droplet model resource attributes.
- */
-const ResourceAttributesSchema = z.object({
-  /** Droplet ID */
-  id: z.number(),
-  /** Droplet name */
-  name: z.string(),
-  /** Status (e.g., "new", "active", "off") */
-  status: z.string(),
-  /** Memory in MB */
-  memory: z.number(),
-  /** Number of vCPUs */
-  vcpus: z.number(),
-  /** Disk size in GB */
-  disk: z.number(),
-  /** Region slug */
-  region: z.string(),
-  /** Image slug or name */
-  image: z.string(),
-  /** Size slug */
-  sizeSlug: z.string(),
-  /** Public IPv4 address */
-  publicIpv4: z.string().nullable(),
-  /** Private IPv4 address */
-  privateIpv4: z.string().nullable(),
-  /** Creation timestamp */
-  createdAt: z.string(),
-  /** VPC UUID */
-  vpcUuid: z.string().nullable(),
-});
-
 interface NetworkInfo {
   ip_address: string;
   type: "public" | "private";
@@ -95,32 +59,39 @@ interface DropletResponse {
 }
 
 /**
- * Gets the DigitalOcean Droplet ID from the stored resource.
+ * Gets the DigitalOcean Droplet ID from the stored data.
  */
-async function getDropletIdFromResource(
-  input: ModelInput,
+async function getDropletIdFromData(
+  definition: Definition,
   context: MethodContext,
 ): Promise<number> {
-  if (!context.resourceRepository) {
-    throw new Error(
-      "Cannot operate: resourceRepository not provided in context",
-    );
-  }
-
-  const resource = await context.resourceRepository.findById(
-    ModelType.create("digitalocean/droplet"),
-    createModelResourceId(input.id),
+  const dataName = `${definition.name}-data`;
+  const existingData = await context.dataRepository.findByName(
+    context.modelType,
+    context.modelId,
+    dataName,
   );
 
-  if (!resource) {
+  if (!existingData) {
     throw new Error(
-      `Resource not found for input ID: ${input.id}. Run 'create' first.`,
+      `Data not found for definition: ${definition.name}. Run 'create' first.`,
     );
   }
 
-  const dropletId = resource.attributes.id as number;
+  const content = await context.dataRepository.getContent(
+    context.modelType,
+    context.modelId,
+    dataName,
+  );
+
+  if (!content) {
+    throw new Error("Data content not found");
+  }
+
+  const attributes = JSON.parse(new TextDecoder().decode(content));
+  const dropletId = attributes.id as number;
   if (!dropletId) {
-    throw new Error("Resource missing 'id' attribute (DO Droplet ID)");
+    throw new Error("Data missing 'id' attribute (DO Droplet ID)");
   }
 
   return dropletId;
@@ -175,10 +146,10 @@ function parseDropletResponse(droplet: DropletResponse) {
  * Execute the create method.
  */
 async function executeCreate(
-  input: ModelInput,
+  definition: Definition,
   _context: MethodContext,
 ): Promise<MethodResult> {
-  const attrs = InputAttributesSchema.parse(input.attributes);
+  const attrs = InputAttributesSchema.parse(definition.attributes);
 
   const args = [
     "compute",
@@ -222,22 +193,38 @@ async function executeCreate(
     throw new Error("Droplet not found in create response");
   }
 
-  const resource = ModelResource.create({
-    id: input.id,
-    attributes: parseDropletResponse(droplet),
-  });
+  const definitionHash = await definition.computeHash();
 
-  return { resource };
+  return {
+    dataOutputs: [{
+      name: `${definition.name}-data`,
+      content: new TextEncoder().encode(
+        JSON.stringify(parseDropletResponse(droplet)),
+      ),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "resource" },
+        ownerDefinition: {
+          definitionHash,
+          ownerType: "model-method",
+          ownerRef: "create",
+        },
+      },
+    }],
+  };
 }
 
 /**
  * Execute the delete method.
  */
 async function executeDelete(
-  input: ModelInput,
+  definition: Definition,
   context: MethodContext,
 ): Promise<MethodResult> {
-  const dropletId = await getDropletIdFromResource(input, context);
+  const dropletId = await getDropletIdFromData(definition, context);
   await runDoctl([
     "compute",
     "droplet",
@@ -245,17 +232,43 @@ async function executeDelete(
     dropletId.toString(),
     "--force",
   ]);
-  return { deleteResource: true };
+
+  const definitionHash = await definition.computeHash();
+
+  return {
+    dataOutputs: [{
+      name: `${definition.name}-data`,
+      content: new TextEncoder().encode(
+        JSON.stringify({
+          deleted: true,
+          deletedAt: new Date().toISOString(),
+          dropletId,
+        }),
+      ),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "resource" },
+        ownerDefinition: {
+          definitionHash,
+          ownerType: "model-method",
+          ownerRef: "delete",
+        },
+      },
+    }],
+  };
 }
 
 /**
  * Execute the sync method.
  */
 async function executeSync(
-  input: ModelInput,
+  definition: Definition,
   context: MethodContext,
 ): Promise<MethodResult> {
-  const dropletId = await getDropletIdFromResource(input, context);
+  const dropletId = await getDropletIdFromData(definition, context);
 
   const output = await runDoctl([
     "compute",
@@ -269,11 +282,27 @@ async function executeSync(
     throw new Error(`Droplet '${dropletId}' not found`);
   }
 
+  const definitionHash = await definition.computeHash();
+
   return {
-    resource: ModelResource.create({
-      id: input.id,
-      attributes: parseDropletResponse(droplet),
-    }),
+    dataOutputs: [{
+      name: `${definition.name}-data`,
+      content: new TextEncoder().encode(
+        JSON.stringify(parseDropletResponse(droplet)),
+      ),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "resource" },
+        ownerDefinition: {
+          definitionHash,
+          ownerType: "model-method",
+          ownerRef: "sync",
+        },
+      },
+    }],
   };
 }
 
@@ -282,10 +311,10 @@ async function executeSync(
  */
 async function executeAction(
   action: "power-on" | "power-off" | "reboot",
-  input: ModelInput,
+  definition: Definition,
   context: MethodContext,
 ): Promise<MethodResult> {
-  const dropletId = await getDropletIdFromResource(input, context);
+  const dropletId = await getDropletIdFromData(definition, context);
 
   await runDoctl([
     "compute",
@@ -307,11 +336,27 @@ async function executeAction(
     throw new Error(`Droplet '${dropletId}' not found after ${action}`);
   }
 
+  const definitionHash = await definition.computeHash();
+
   return {
-    resource: ModelResource.create({
-      id: input.id,
-      attributes: parseDropletResponse(droplet),
-    }),
+    dataOutputs: [{
+      name: `${definition.name}-data`,
+      content: new TextEncoder().encode(
+        JSON.stringify(parseDropletResponse(droplet)),
+      ),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "resource" },
+        ownerDefinition: {
+          definitionHash,
+          ownerType: "model-method",
+          ownerRef: action,
+        },
+      },
+    }],
   };
 }
 
@@ -319,30 +364,30 @@ async function executeAction(
  * Execute the power-on method.
  */
 function executePowerOn(
-  input: ModelInput,
+  definition: Definition,
   context: MethodContext,
 ): Promise<MethodResult> {
-  return executeAction("power-on", input, context);
+  return executeAction("power-on", definition, context);
 }
 
 /**
  * Execute the power-off method.
  */
 function executePowerOff(
-  input: ModelInput,
+  definition: Definition,
   context: MethodContext,
 ): Promise<MethodResult> {
-  return executeAction("power-off", input, context);
+  return executeAction("power-off", definition, context);
 }
 
 /**
  * Execute the reboot method.
  */
 function executeReboot(
-  input: ModelInput,
+  definition: Definition,
   context: MethodContext,
 ): Promise<MethodResult> {
-  return executeAction("reboot", input, context);
+  return executeAction("reboot", definition, context);
 }
 
 /**
@@ -355,7 +400,6 @@ export const digitaloceanDropletModel = defineModel({
   type: ModelType.create("digitalocean/droplet"),
   version: 1,
   inputAttributesSchema: InputAttributesSchema,
-  resourceAttributesSchema: ResourceAttributesSchema,
   methods: {
     create: {
       description: "Create a new DigitalOcean Droplet",

--- a/experiments/extensions/models/digitalocean_ssh_key.ts
+++ b/experiments/extensions/models/digitalocean_ssh_key.ts
@@ -1,15 +1,11 @@
 import { z } from "zod";
 import { ModelType } from "../../../src/domain/models/model_type.ts";
 import {
-  createModelResourceId,
-  ModelResource,
-} from "../../../src/domain/models/model_resource.ts";
-import {
   defineModel,
   type MethodContext,
   type MethodResult,
 } from "../../../src/domain/models/model.ts";
-import type { ModelInput } from "../../../src/domain/models/model_input.ts";
+import type { Definition } from "../../../src/domain/definitions/definition.ts";
 
 /**
  * Schema for DigitalOcean SSH Key model input attributes.
@@ -34,20 +30,6 @@ const UpdateInputSchema = z.object({
  */
 const EmptyInputSchema = z.object({});
 
-/**
- * Schema for DigitalOcean SSH Key model resource attributes.
- */
-const ResourceAttributesSchema = z.object({
-  /** SSH key ID */
-  id: z.number(),
-  /** SSH key name */
-  name: z.string(),
-  /** SSH key fingerprint */
-  fingerprint: z.string(),
-  /** SSH public key content */
-  publicKey: z.string(),
-});
-
 interface SshKeyResponse {
   id: number;
   name: string;
@@ -56,32 +38,39 @@ interface SshKeyResponse {
 }
 
 /**
- * Gets the DigitalOcean SSH key ID from the stored resource.
+ * Gets the DigitalOcean SSH key ID from the stored data.
  */
-async function getKeyIdFromResource(
-  input: ModelInput,
+async function getKeyIdFromData(
+  definition: Definition,
   context: MethodContext,
 ): Promise<number> {
-  if (!context.resourceRepository) {
-    throw new Error(
-      "Cannot operate: resourceRepository not provided in context",
-    );
-  }
-
-  const resource = await context.resourceRepository.findById(
-    ModelType.create("digitalocean/ssh-key"),
-    createModelResourceId(input.id),
+  const dataName = `${definition.name}-data`;
+  const existingData = await context.dataRepository.findByName(
+    context.modelType,
+    context.modelId,
+    dataName,
   );
 
-  if (!resource) {
+  if (!existingData) {
     throw new Error(
-      `Resource not found for input ID: ${input.id}. Run 'create' first.`,
+      `Data not found for definition: ${definition.name}. Run 'create' first.`,
     );
   }
 
-  const keyId = resource.attributes.id as number;
+  const content = await context.dataRepository.getContent(
+    context.modelType,
+    context.modelId,
+    dataName,
+  );
+
+  if (!content) {
+    throw new Error("Data content not found");
+  }
+
+  const attributes = JSON.parse(new TextDecoder().decode(content));
+  const keyId = attributes.id as number;
   if (!keyId) {
-    throw new Error("Resource missing 'id' attribute (DO SSH key ID)");
+    throw new Error("Data missing 'id' attribute (DO SSH key ID)");
   }
 
   return keyId;
@@ -125,10 +114,10 @@ function parseSshKeyResponse(key: SshKeyResponse) {
  * Execute the create method.
  */
 async function executeCreate(
-  input: ModelInput,
+  definition: Definition,
   _context: MethodContext,
 ): Promise<MethodResult> {
-  const attrs = InputAttributesSchema.parse(input.attributes);
+  const attrs = InputAttributesSchema.parse(definition.attributes);
 
   const output = await runDoctl([
     "compute",
@@ -145,23 +134,39 @@ async function executeCreate(
     throw new Error("SSH key not found in create response");
   }
 
-  const resource = ModelResource.create({
-    id: input.id,
-    attributes: parseSshKeyResponse(key),
-  });
+  const definitionHash = await definition.computeHash();
 
-  return { resource };
+  return {
+    dataOutputs: [{
+      name: `${definition.name}-data`,
+      content: new TextEncoder().encode(
+        JSON.stringify(parseSshKeyResponse(key)),
+      ),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "resource" },
+        ownerDefinition: {
+          definitionHash,
+          ownerType: "model-method",
+          ownerRef: "create",
+        },
+      },
+    }],
+  };
 }
 
 /**
  * Execute the update method.
  */
 async function executeUpdate(
-  input: ModelInput,
+  definition: Definition,
   context: MethodContext,
 ): Promise<MethodResult> {
-  const attrs = UpdateInputSchema.parse(input.attributes);
-  const keyId = await getKeyIdFromResource(input, context);
+  const attrs = UpdateInputSchema.parse(definition.attributes);
+  const keyId = await getKeyIdFromData(definition, context);
 
   const output = await runDoctl([
     "compute",
@@ -178,11 +183,27 @@ async function executeUpdate(
     throw new Error(`SSH key '${keyId}' not found after update`);
   }
 
+  const definitionHash = await definition.computeHash();
+
   return {
-    resource: ModelResource.create({
-      id: input.id,
-      attributes: parseSshKeyResponse(key),
-    }),
+    dataOutputs: [{
+      name: `${definition.name}-data`,
+      content: new TextEncoder().encode(
+        JSON.stringify(parseSshKeyResponse(key)),
+      ),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "resource" },
+        ownerDefinition: {
+          definitionHash,
+          ownerType: "model-method",
+          ownerRef: "update",
+        },
+      },
+    }],
   };
 }
 
@@ -190,22 +211,48 @@ async function executeUpdate(
  * Execute the delete method.
  */
 async function executeDelete(
-  input: ModelInput,
+  definition: Definition,
   context: MethodContext,
 ): Promise<MethodResult> {
-  const keyId = await getKeyIdFromResource(input, context);
+  const keyId = await getKeyIdFromData(definition, context);
   await runDoctl(["compute", "ssh-key", "delete", keyId.toString(), "--force"]);
-  return { deleteResource: true };
+
+  const definitionHash = await definition.computeHash();
+
+  return {
+    dataOutputs: [{
+      name: `${definition.name}-data`,
+      content: new TextEncoder().encode(
+        JSON.stringify({
+          deleted: true,
+          deletedAt: new Date().toISOString(),
+          keyId,
+        }),
+      ),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "resource" },
+        ownerDefinition: {
+          definitionHash,
+          ownerType: "model-method",
+          ownerRef: "delete",
+        },
+      },
+    }],
+  };
 }
 
 /**
  * Execute the sync method.
  */
 async function executeSync(
-  input: ModelInput,
+  definition: Definition,
   context: MethodContext,
 ): Promise<MethodResult> {
-  const keyId = await getKeyIdFromResource(input, context);
+  const keyId = await getKeyIdFromData(definition, context);
 
   const output = await runDoctl([
     "compute",
@@ -219,11 +266,27 @@ async function executeSync(
     throw new Error(`SSH key '${keyId}' not found`);
   }
 
+  const definitionHash = await definition.computeHash();
+
   return {
-    resource: ModelResource.create({
-      id: input.id,
-      attributes: parseSshKeyResponse(key),
-    }),
+    dataOutputs: [{
+      name: `${definition.name}-data`,
+      content: new TextEncoder().encode(
+        JSON.stringify(parseSshKeyResponse(key)),
+      ),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "resource" },
+        ownerDefinition: {
+          definitionHash,
+          ownerType: "model-method",
+          ownerRef: "sync",
+        },
+      },
+    }],
   };
 }
 
@@ -237,7 +300,6 @@ export const digitaloceanSshKeyModel = defineModel({
   type: ModelType.create("digitalocean/ssh-key"),
   version: 1,
   inputAttributesSchema: InputAttributesSchema,
-  resourceAttributesSchema: ResourceAttributesSchema,
   methods: {
     create: {
       description: "Create a new SSH key on DigitalOcean",

--- a/experiments/extensions/models/discord_webhook.ts
+++ b/experiments/extensions/models/discord_webhook.ts
@@ -1,12 +1,11 @@
 import { z } from "zod";
 import { ModelType } from "../../../src/domain/models/model_type.ts";
-import { ModelData } from "../../../src/domain/models/model_data.ts";
 import {
   defineModel,
   type MethodContext,
   type MethodResult,
 } from "../../../src/domain/models/model.ts";
-import type { ModelInput } from "../../../src/domain/models/model_input.ts";
+import type { Definition } from "../../../src/domain/definitions/definition.ts";
 
 /**
  * Schema for Discord webhook model input attributes.
@@ -23,18 +22,6 @@ const InputAttributesSchema = z.object({
 });
 
 type InputAttributes = z.infer<typeof InputAttributesSchema>;
-
-/**
- * Schema for Discord webhook model data attributes.
- */
-const DataAttributesSchema = z.object({
-  /** Whether the message was sent successfully */
-  success: z.boolean(),
-  /** Timestamp when the message was sent */
-  sentAt: z.string().datetime(),
-  /** Content that was sent (may be truncated if over limit) */
-  contentLength: z.number().int().nonnegative(),
-});
 
 /**
  * Sends a message via Discord webhook.
@@ -84,22 +71,38 @@ async function sendWebhookMessage(attrs: InputAttributes): Promise<void> {
  * Execute the send method.
  */
 async function executeSend(
-  input: ModelInput,
+  definition: Definition,
   _context: MethodContext,
 ): Promise<MethodResult> {
-  const attrs = InputAttributesSchema.parse(input.attributes);
+  const attrs = InputAttributesSchema.parse(definition.attributes);
   await sendWebhookMessage(attrs);
 
-  const data = ModelData.create({
-    id: input.id,
-    attributes: {
-      success: true,
-      sentAt: new Date().toISOString(),
-      contentLength: attrs.content.length,
-    },
-  });
+  const dataAttributes = {
+    success: true,
+    sentAt: new Date().toISOString(),
+    contentLength: attrs.content.length,
+  };
 
-  return { data };
+  const definitionHash = await definition.computeHash();
+
+  return {
+    dataOutputs: [{
+      name: `${definition.name}-data`,
+      content: new TextEncoder().encode(JSON.stringify(dataAttributes)),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "data" },
+        ownerDefinition: {
+          definitionHash,
+          ownerType: "model-method",
+          ownerRef: "send",
+        },
+      },
+    }],
+  };
 }
 
 /**
@@ -113,7 +116,6 @@ export const discordWebhookModel = defineModel({
   type: ModelType.create("discord/webhook"),
   version: 1,
   inputAttributesSchema: InputAttributesSchema,
-  dataAttributesSchema: DataAttributesSchema,
   methods: {
     send: {
       description: "Send a message to Discord via webhook",

--- a/experiments/extensions/models/docker_image.ts
+++ b/experiments/extensions/models/docker_image.ts
@@ -1,12 +1,11 @@
 import { z } from "zod";
 import { ModelType } from "../../../src/domain/models/model_type.ts";
-import { ModelData } from "../../../src/domain/models/model_data.ts";
 import {
   defineModel,
   type MethodContext,
   type MethodResult,
 } from "../../../src/domain/models/model.ts";
-import type { ModelInput } from "../../../src/domain/models/model_input.ts";
+import type { Definition } from "../../../src/domain/definitions/definition.ts";
 
 /**
  * Schema for Docker image model input attributes.
@@ -23,20 +22,6 @@ const InputAttributesSchema = z.object({
 });
 
 type InputAttributes = z.infer<typeof InputAttributesSchema>;
-
-/**
- * Schema for Docker image model data attributes.
- */
-const DataAttributesSchema = z.object({
-  /** Full image reference (repository:tag) */
-  imageRef: z.string(),
-  /** Whether the operation succeeded */
-  success: z.boolean(),
-  /** Operation performed */
-  operation: z.enum(["build", "push", "build-push"]),
-  /** Timestamp when operation completed */
-  completedAt: z.string().datetime(),
-});
 
 /**
  * Runs a docker command.
@@ -82,70 +67,118 @@ async function pushImage(attrs: InputAttributes): Promise<void> {
  * Execute the build method.
  */
 async function executeBuild(
-  input: ModelInput,
+  definition: Definition,
   _context: MethodContext,
 ): Promise<MethodResult> {
-  const attrs = InputAttributesSchema.parse(input.attributes);
+  const attrs = InputAttributesSchema.parse(definition.attributes);
   await buildImage(attrs);
 
-  const data = ModelData.create({
-    id: input.id,
-    attributes: {
-      imageRef: `${attrs.repository}:${attrs.tag}`,
-      success: true,
-      operation: "build",
-      completedAt: new Date().toISOString(),
-    },
-  });
+  const dataAttributes = {
+    imageRef: `${attrs.repository}:${attrs.tag}`,
+    success: true,
+    operation: "build",
+    completedAt: new Date().toISOString(),
+  };
 
-  return { data };
+  const definitionHash = await definition.computeHash();
+
+  return {
+    dataOutputs: [{
+      name: `${definition.name}-data`,
+      content: new TextEncoder().encode(JSON.stringify(dataAttributes)),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "data" },
+        ownerDefinition: {
+          definitionHash,
+          ownerType: "model-method",
+          ownerRef: "build",
+        },
+      },
+    }],
+  };
 }
 
 /**
  * Execute the push method.
  */
 async function executePush(
-  input: ModelInput,
+  definition: Definition,
   _context: MethodContext,
 ): Promise<MethodResult> {
-  const attrs = InputAttributesSchema.parse(input.attributes);
+  const attrs = InputAttributesSchema.parse(definition.attributes);
   await pushImage(attrs);
 
-  const data = ModelData.create({
-    id: input.id,
-    attributes: {
-      imageRef: `${attrs.repository}:${attrs.tag}`,
-      success: true,
-      operation: "push",
-      completedAt: new Date().toISOString(),
-    },
-  });
+  const dataAttributes = {
+    imageRef: `${attrs.repository}:${attrs.tag}`,
+    success: true,
+    operation: "push",
+    completedAt: new Date().toISOString(),
+  };
 
-  return { data };
+  const definitionHash = await definition.computeHash();
+
+  return {
+    dataOutputs: [{
+      name: `${definition.name}-data`,
+      content: new TextEncoder().encode(JSON.stringify(dataAttributes)),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "data" },
+        ownerDefinition: {
+          definitionHash,
+          ownerType: "model-method",
+          ownerRef: "push",
+        },
+      },
+    }],
+  };
 }
 
 /**
  * Execute the build-push method.
  */
 async function executeBuildPush(
-  input: ModelInput,
+  definition: Definition,
   _context: MethodContext,
 ): Promise<MethodResult> {
-  const attrs = InputAttributesSchema.parse(input.attributes);
+  const attrs = InputAttributesSchema.parse(definition.attributes);
   await buildImage(attrs);
   await pushImage(attrs);
 
-  const data = ModelData.create({
-    id: input.id,
-    attributes: {
-      imageRef: `${attrs.repository}:${attrs.tag}`,
-      success: true,
-      operation: "build-push",
-      completedAt: new Date().toISOString(),
-    },
-  });
+  const dataAttributes = {
+    imageRef: `${attrs.repository}:${attrs.tag}`,
+    success: true,
+    operation: "build-push",
+    completedAt: new Date().toISOString(),
+  };
 
-  return { data };
+  const definitionHash = await definition.computeHash();
+
+  return {
+    dataOutputs: [{
+      name: `${definition.name}-data`,
+      content: new TextEncoder().encode(JSON.stringify(dataAttributes)),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "data" },
+        ownerDefinition: {
+          definitionHash,
+          ownerType: "model-method",
+          ownerRef: "build-push",
+        },
+      },
+    }],
+  };
 }
 
 /**
@@ -159,7 +192,6 @@ export const dockerImageModel = defineModel({
   type: ModelType.create("docker/image"),
   version: 1,
   inputAttributesSchema: InputAttributesSchema,
-  dataAttributesSchema: DataAttributesSchema,
   methods: {
     build: {
       description: "Build a Docker image locally",

--- a/experiments/extensions/models/github_pr_list.ts
+++ b/experiments/extensions/models/github_pr_list.ts
@@ -1,12 +1,11 @@
 import { z } from "zod";
 import { ModelType } from "../../../src/domain/models/model_type.ts";
-import { ModelData } from "../../../src/domain/models/model_data.ts";
 import {
   defineModel,
   type MethodContext,
   type MethodResult,
 } from "../../../src/domain/models/model.ts";
-import type { ModelInput } from "../../../src/domain/models/model_input.ts";
+import type { Definition } from "../../../src/domain/definitions/definition.ts";
 
 /**
  * Schema for GitHub PR list model input attributes.
@@ -25,28 +24,6 @@ const InputAttributesSchema = z.object({
 });
 
 type InputAttributes = z.infer<typeof InputAttributesSchema>;
-
-/**
- * Schema for a single PR in the output.
- */
-const PullRequestSchema = z.object({
-  number: z.number().int(),
-  title: z.string(),
-  url: z.string().url(),
-  mergedAt: z.string().datetime().nullable(),
-  author: z.string(),
-  body: z.string().nullable(),
-});
-
-/**
- * Schema for GitHub PR list model data attributes.
- */
-const DataAttributesSchema = z.object({
-  pullRequests: z.array(PullRequestSchema),
-  fetchedAt: z.string().datetime(),
-  owner: z.string(),
-  repo: z.string(),
-});
 
 interface GitHubPR {
   number: number;
@@ -125,10 +102,10 @@ async function fetchPullRequests(attrs: InputAttributes): Promise<GitHubPR[]> {
  * Execute the list method.
  */
 async function executeList(
-  input: ModelInput,
+  definition: Definition,
   _context: MethodContext,
 ): Promise<MethodResult> {
-  const attrs = InputAttributesSchema.parse(input.attributes);
+  const attrs = InputAttributesSchema.parse(definition.attributes);
   const prs = await fetchPullRequests(attrs);
 
   const pullRequests = prs.map((pr) => ({
@@ -140,17 +117,33 @@ async function executeList(
     body: pr.body,
   }));
 
-  const data = ModelData.create({
-    id: input.id,
-    attributes: {
-      pullRequests,
-      fetchedAt: new Date().toISOString(),
-      owner: attrs.owner,
-      repo: attrs.repo,
-    },
-  });
+  const dataAttributes = {
+    pullRequests,
+    fetchedAt: new Date().toISOString(),
+    owner: attrs.owner,
+    repo: attrs.repo,
+  };
 
-  return { data };
+  const definitionHash = await definition.computeHash();
+
+  return {
+    dataOutputs: [{
+      name: `${definition.name}-data`,
+      content: new TextEncoder().encode(JSON.stringify(dataAttributes)),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "data" },
+        ownerDefinition: {
+          definitionHash,
+          ownerType: "model-method",
+          ownerRef: "list",
+        },
+      },
+    }],
+  };
 }
 
 /**
@@ -163,7 +156,6 @@ export const githubPrListModel = defineModel({
   type: ModelType.create("github/pr-list"),
   version: 1,
   inputAttributesSchema: InputAttributesSchema,
-  dataAttributesSchema: DataAttributesSchema,
   methods: {
     list: {
       description: "List pull requests from a GitHub repository",

--- a/experiments/extensions/models/ssh_remote.ts
+++ b/experiments/extensions/models/ssh_remote.ts
@@ -1,14 +1,12 @@
 import { z } from "zod";
 import { ModelType } from "../../../src/domain/models/model_type.ts";
-import { ModelData } from "../../../src/domain/models/model_data.ts";
-import { ModelLog } from "../../../src/domain/models/model_log.ts";
 import {
   defineModel,
   type MethodContext,
   type MethodResult,
   type ModelDefinition,
 } from "../../../src/domain/models/model.ts";
-import type { ModelInput } from "../../../src/domain/models/model_input.ts";
+import type { Definition } from "../../../src/domain/definitions/definition.ts";
 
 /**
  * Schema for SSH remote model input attributes.
@@ -34,28 +32,6 @@ export type SshRemoteInputAttributes = z.infer<
 >;
 
 /**
- * Schema for SSH remote model data attributes.
- */
-export const SshRemoteDataAttributesSchema = z.object({
-  exitCode: z.number().int().describe("Exit code of the command"),
-  stdout: z.string().describe("Standard output from the command"),
-  stderr: z.string().describe("Standard error from the command"),
-  executedAt: z.string().datetime().describe(
-    "Timestamp when execution completed",
-  ),
-  durationMs: z.number().int().nonnegative().describe(
-    "Execution duration in milliseconds",
-  ),
-});
-
-/**
- * Type for SSH remote model data attributes.
- */
-export type SshRemoteDataAttributes = z.infer<
-  typeof SshRemoteDataAttributesSchema
->;
-
-/**
  * The SSH remote model type identifier.
  */
 export const SSH_REMOTE_MODEL_TYPE = ModelType.create("keeb/ssh-remote");
@@ -77,10 +53,10 @@ function expandHomePath(path: string): string {
  * Executes a command on a remote host via SSH.
  */
 async function executeCommand(
-  input: ModelInput,
+  definition: Definition,
   _context: MethodContext,
 ): Promise<MethodResult> {
-  const attrs = SshRemoteInputAttributesSchema.parse(input.attributes);
+  const attrs = SshRemoteInputAttributesSchema.parse(definition.attributes);
 
   const startTime = Date.now();
   let stdout = "";
@@ -150,30 +126,65 @@ async function executeCommand(
   const endTime = Date.now();
   const durationMs = endTime - startTime;
 
-  // Create log artifact for command output
-  const outputLog = ModelLog.create({ id: input.id });
-  outputLog.log(`[ssh ${attrs.user}@${attrs.host}:${attrs.port}]`);
-  outputLog.log(`[command] ${attrs.command}`);
-  if (stdout) {
-    outputLog.log(`[stdout]\n${stdout}`);
-  }
-  if (stderr) {
-    outputLog.log(`[stderr]\n${stderr}`);
-  }
+  const definitionHash = await definition.computeHash();
 
   // Create the data artifact with structured metadata
-  const data = ModelData.create({
-    id: input.id,
-    attributes: {
-      exitCode,
-      stdout,
-      stderr,
-      executedAt: new Date().toISOString(),
-      durationMs,
-    },
-  });
+  const dataAttributes = {
+    exitCode,
+    stdout,
+    stderr,
+    executedAt: new Date().toISOString(),
+    durationMs,
+  };
 
-  return { data, logs: [outputLog] };
+  // Create log output content
+  const logParts: string[] = [];
+  logParts.push(`[ssh ${attrs.user}@${attrs.host}:${attrs.port}]`);
+  logParts.push(`[command] ${attrs.command}`);
+  if (stdout) {
+    logParts.push(`[stdout]\n${stdout}`);
+  }
+  if (stderr) {
+    logParts.push(`[stderr]\n${stderr}`);
+  }
+  const logContent = logParts.join("\n");
+
+  return {
+    dataOutputs: [
+      {
+        name: `${definition.name}-result`,
+        content: new TextEncoder().encode(JSON.stringify(dataAttributes)),
+        metadata: {
+          contentType: "application/json",
+          lifetime: "infinite",
+          garbageCollection: 10,
+          streaming: false,
+          tags: { type: "data" },
+          ownerDefinition: {
+            definitionHash,
+            ownerType: "model-method",
+            ownerRef: "execute",
+          },
+        },
+      },
+      {
+        name: `${definition.name}-output`,
+        content: new TextEncoder().encode(logContent),
+        metadata: {
+          contentType: "text/plain",
+          lifetime: "infinite",
+          garbageCollection: 10,
+          streaming: true,
+          tags: { type: "log" },
+          ownerDefinition: {
+            definitionHash,
+            ownerType: "model-method",
+            ownerRef: "execute",
+          },
+        },
+      },
+    ],
+  };
 }
 
 /**
@@ -185,14 +196,11 @@ async function executeCommand(
  * Self-registers with the global model registry when this module is imported.
  */
 export const sshRemoteModel: ModelDefinition<
-  typeof SshRemoteInputAttributesSchema,
-  never,
-  typeof SshRemoteDataAttributesSchema
+  typeof SshRemoteInputAttributesSchema
 > = defineModel({
   type: SSH_REMOTE_MODEL_TYPE,
   version: 1,
   inputAttributesSchema: SshRemoteInputAttributesSchema,
-  dataAttributesSchema: SshRemoteDataAttributesSchema,
   methods: {
     execute: {
       description:

--- a/src/domain/models/aws/cloud_control_model.ts
+++ b/src/domain/models/aws/cloud_control_model.ts
@@ -170,7 +170,7 @@ export abstract class AWSCloudControlModel<
           lifetime: "infinite",
           garbageCollection: 10,
           streaming: false,
-          tags: { type: "data" },
+          tags: { type: "resource" },
           ownerDefinition: {
             definitionHash,
             ownerType: "model-method",
@@ -199,7 +199,7 @@ export abstract class AWSCloudControlModel<
         lifetime: "infinite",
         garbageCollection: 10,
         streaming: false,
-        tags: { type: "data" },
+        tags: { type: "resource" },
         ownerDefinition: {
           definitionHash,
           ownerType: "model-method",

--- a/src/domain/models/echo/echo_model.ts
+++ b/src/domain/models/echo/echo_model.ts
@@ -61,11 +61,11 @@ async function executeWrite(
 
   return {
     dataOutputs: [{
-      name: `${definition.name}-data`,
+      name: `${definition.name}-message`,
       content: new TextEncoder().encode(JSON.stringify(dataAttributes)),
       metadata: {
         contentType: "application/json",
-        lifetime: "infinite",
+        lifetime: "ephemeral",
         garbageCollection: 10,
         streaming: false,
         tags: { type: "data" },

--- a/src/domain/models/keeb/shell/shell_model.ts
+++ b/src/domain/models/keeb/shell/shell_model.ts
@@ -235,7 +235,7 @@ async function executeCommand(
           contentType: "text/plain",
           lifetime: "infinite",
           garbageCollection: 10,
-          streaming: false,
+          streaming: true,
           tags: { type: "log" },
           ownerDefinition: {
             definitionHash,

--- a/src/domain/models/lets-get-sensitive/vault_model.ts
+++ b/src/domain/models/lets-get-sensitive/vault_model.ts
@@ -169,7 +169,7 @@ async function executeGet(
             contentType: "text/plain",
             lifetime: "infinite",
             garbageCollection: 10,
-            streaming: false,
+            streaming: true,
             tags: { type: "log" },
             ownerDefinition: {
               definitionHash,
@@ -266,7 +266,7 @@ async function executePut(
             contentType: "text/plain",
             lifetime: "infinite",
             garbageCollection: 10,
-            streaming: false,
+            streaming: true,
             tags: { type: "log" },
             ownerDefinition: {
               definitionHash,


### PR DESCRIPTION
Migrates all models to the new architecture using Definition entities and the unified DataOutput pattern with proper metadata (lifetime, streaming, tags, ownerDefinition).

Implements #121 and #122.

## Changes

### Echo Model (Reference Implementation)
- Uses Definition entity with `computeHash()` for ownership tracking
- Returns `dataOutputs` array with proper metadata
- Set `lifetime: "ephemeral"` (was "infinite")
- Set `tags: { type: "data" }`

### Core Models
- **Shell Model**: Added `streaming: true` for log output, `type: "log"` tag
- **AWS CloudControl Models**: Changed all tags from `type: "data"` to `type: "resource"`
- **Vault Model**: Added `streaming: true` for audit-log outputs
- **Journalctl Model**: Already had correct `type: "log"` and `streaming: true`

### Experimental Models (Complete Rewrite)
Migrated all 8 experimental models from old `ModelInput`/`{ data }` pattern to new `Definition`/`{ dataOutputs }` pattern:
- `digitalocean_droplet.ts` - `type: "resource"`
- `digitalocean_ssh_key.ts` - `type: "resource"`
- `digitalocean_app.ts` - `type: "resource"`, `type: "data"`, `type: "log"`
- `discord_webhook.ts` - `type: "data"`
- `ssh_remote.ts` - `type: "data"` + `type: "log"` with `streaming: true`
- `anthropic_claude.ts` - `type: "data"`
- `github_pr_list.ts` - `type: "data"`
- `docker_image.ts` - `type: "data"`

## Verification Against Plan

| Requirement | Status |
|-------------|--------|
| Definition entity with `computeHash()` | ✅ |
| DataOutput with ownerDefinition | ✅ |
| Echo: `lifetime: "ephemeral"` | ✅ |
| Echo: `tags: { type: "data" }` | ✅ |
| AWS models: `type: "resource"` | ✅ |
| Shell/Journalctl: `type: "log"`, `streaming: true` | ✅ |
| Vault: unified Data with audit logs | ✅ |
| Experimental models migrated | ✅ |

### Design Decisions
- **Data naming**: Uses `${definition.name}-*` pattern (e.g., `my-echo-message`) for uniqueness across definitions, rather than bare names like `message`
- **Schema validation**: Retained Zod for input validation (consistent with codebase)

## Test Plan

- [x] All 1405 tests pass
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] `deno run compile` succeeds

Closes #121
Closes #122