### PR TITLE
feat: Track Data artifacts in workflow step execution (#129)

### DIFF
--- a/integration/workflow_test.ts
+++ b/integration/workflow_test.ts
@@ -1520,3 +1520,170 @@ Deno.test("CLI: workflow run resolves vault expressions in model inputs", async 
     assertEquals(output.jobs[0].steps[0].status, "succeeded");
   });
 });
+
+// Data artifact tracking tests
+
+Deno.test("CLI: workflow run creates Data with step-output tags", async () => {
+  await withTempDir(async (repoDir) => {
+    // Create a model input
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const input = Definition.create({
+      name: "data-tag-test-model",
+      attributes: {
+        message: "test message for data tags",
+      },
+    });
+    await definitionRepo.save(ECHO_MODEL_TYPE, input);
+
+    // Create a workflow that runs the model
+    const workflowRepo = new YamlWorkflowRepository(repoDir);
+    const workflow = Workflow.create({
+      name: "data-tag-workflow",
+      jobs: [
+        Job.create({
+          name: "data-job",
+          steps: [
+            Step.create({
+              name: "write-data",
+              task: StepTask.modelMethod("data-tag-test-model", "write"),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    // Run the workflow
+    const result = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "data-tag-workflow",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Workflow run should succeed. stderr: ${result.stderr}, stdout: ${result.stdout}`,
+    );
+
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.status, "succeeded");
+    assertEquals(output.jobs[0].steps[0].status, "succeeded");
+
+    // Verify the step run has data artifacts with correct tags
+    const stepOutput = output.jobs[0].steps[0];
+    assertEquals(
+      stepOutput.dataArtifacts !== undefined,
+      true,
+      "Step output should have dataArtifacts",
+    );
+    assertEquals(
+      stepOutput.dataArtifacts.length > 0,
+      true,
+      "Should have at least one data artifact",
+    );
+
+    // Verify tags on the data artifact
+    const artifact = stepOutput.dataArtifacts[0];
+    assertEquals(
+      artifact.tags.type,
+      "step-output",
+      "Tag type should be step-output",
+    );
+    assertEquals(
+      artifact.tags.workflow,
+      "data-tag-workflow",
+      "Tag workflow should match workflow name",
+    );
+    assertEquals(
+      artifact.tags.step,
+      "write-data",
+      "Tag step should match step name",
+    );
+  });
+});
+
+Deno.test("CLI: workflow run persists data artifacts in workflow run record", async () => {
+  await withTempDir(async (repoDir) => {
+    // Create a model input
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const input = Definition.create({
+      name: "persist-test-model",
+      attributes: {
+        message: "test message for persistence",
+      },
+    });
+    await definitionRepo.save(ECHO_MODEL_TYPE, input);
+
+    // Create a workflow
+    const workflowRepo = new YamlWorkflowRepository(repoDir);
+    const workflow = Workflow.create({
+      name: "persist-workflow",
+      jobs: [
+        Job.create({
+          name: "persist-job",
+          steps: [
+            Step.create({
+              name: "write-persist",
+              task: StepTask.modelMethod("persist-test-model", "write"),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    // Run the workflow
+    const runResult = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "persist-workflow",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      runResult.code,
+      0,
+      `Workflow run should succeed. stderr: ${runResult.stderr}`,
+    );
+
+    const runOutput = JSON.parse(runResult.stdout);
+    assertEquals(runOutput.status, "succeeded", "Workflow should succeed");
+
+    // Verify data artifacts are in the run output
+    const stepData = runOutput.jobs[0].steps[0];
+    assertEquals(
+      stepData.dataArtifacts !== undefined && stepData.dataArtifacts.length > 0,
+      true,
+      "Step should have data artifacts",
+    );
+
+    // Verify tags are correct
+    assertEquals(
+      stepData.dataArtifacts[0].tags.type,
+      "step-output",
+      "Tag type should be step-output",
+    );
+    assertEquals(
+      stepData.dataArtifacts[0].tags.workflow,
+      "persist-workflow",
+      "Tag workflow should match",
+    );
+    assertEquals(
+      stepData.dataArtifacts[0].tags.step,
+      "write-persist",
+      "Tag step should match",
+    );
+  });
+});

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -116,6 +116,16 @@ function toRunData(
             }
           }
 
+          // Include data artifacts if present
+          if (step.dataArtifacts && step.dataArtifacts.length > 0) {
+            stepData.dataArtifacts = step.dataArtifacts.map((a) => ({
+              dataId: a.dataId,
+              name: a.name,
+              version: a.version,
+              tags: a.tags,
+            }));
+          }
+
           return stepData;
         }),
         duration: jobStart && jobEnd ? jobEnd - jobStart : undefined,

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -352,17 +352,32 @@ export class DefaultStepExecutor implements StepExecutor {
       );
 
       // Handle data output persistence
+      const savedArtifacts: Array<{
+        dataId: string;
+        name: string;
+        version: number;
+        tags: Record<string, string>;
+      }> = [];
       if (result.dataOutputs && result.dataOutputs.length > 0) {
         for (const dataOutput of result.dataOutputs) {
-          // Create Data entity from DataOutput
+          // Create Data entity from DataOutput with workflow-specific tags
           const { Data } = await import("../data/mod.ts");
+
+          // Merge workflow-specific tags with model output tags
+          const workflowTags: Record<string, string> = {
+            ...dataOutput.metadata.tags,
+            type: "step-output",
+            workflow: ctx.workflowName,
+            step: ctx.stepName,
+          };
+
           const data = Data.create({
             name: dataOutput.name,
             contentType: dataOutput.metadata.contentType,
             lifetime: dataOutput.metadata.lifetime,
             garbageCollection: dataOutput.metadata.garbageCollection,
             streaming: dataOutput.metadata.streaming,
-            tags: dataOutput.metadata.tags,
+            tags: workflowTags,
             ownerDefinition: dataOutput.metadata.ownerDefinition,
           });
 
@@ -374,13 +389,15 @@ export class DefaultStepExecutor implements StepExecutor {
             dataOutput.content,
           );
 
-          // Track artifact in output
-          output.addDataArtifact({
+          // Track artifact in output and for returning to step run
+          const artifactRef = {
             dataId: data.id,
             name: dataOutput.name,
             version: saveResult.version,
-            tags: dataOutput.metadata.tags,
-          });
+            tags: workflowTags,
+          };
+          output.addDataArtifact(artifactRef);
+          savedArtifacts.push(artifactRef);
 
           // Use first JSON data output for context refresh
           if (
@@ -412,6 +429,7 @@ export class DefaultStepExecutor implements StepExecutor {
         dataId: dataId ?? "",
         dataName: dataName ?? "output",
         dataAttributes,
+        dataArtifacts: savedArtifacts,
       };
     } catch (error) {
       // Mark output as failed and save
@@ -826,7 +844,20 @@ export class WorkflowExecutionService {
           dataId?: string;
           dataName?: string;
           dataAttributes?: Record<string, unknown>;
+          dataArtifacts?: Array<{
+            dataId: string;
+            name: string;
+            version: number;
+            tags: Record<string, string>;
+          }>;
         };
+
+        // Track data artifacts in step run
+        if (taskOutput.dataArtifacts) {
+          for (const artifact of taskOutput.dataArtifacts) {
+            stepRun.addDataArtifact(artifact);
+          }
+        }
         if (taskOutput.model) {
           // Create model entry if it doesn't exist
           if (!expressionContext.model[taskOutput.model]) {

--- a/src/domain/workflows/workflow_run.ts
+++ b/src/domain/workflows/workflow_run.ts
@@ -5,6 +5,8 @@ import type {
   TriggerEvaluationContext,
 } from "./trigger_condition.ts";
 import type { Workflow } from "./workflow.ts";
+import { DataArtifactRefSchema } from "../models/model_output.ts";
+import type { DataArtifactRef } from "../models/model_output.ts";
 
 /**
  * Zod schema for step run.
@@ -16,6 +18,7 @@ export const StepRunSchema = z.object({
   completedAt: z.string().datetime().optional(),
   error: z.string().optional(),
   output: z.unknown().optional(),
+  dataArtifacts: z.array(DataArtifactRefSchema).optional(),
 });
 
 /**
@@ -68,6 +71,7 @@ export class StepRun {
     private _completedAt: Date | undefined,
     private _error: string | undefined,
     private _output: unknown,
+    private _dataArtifacts: DataArtifactRef[] = [],
   ) {}
 
   /**
@@ -81,6 +85,7 @@ export class StepRun {
       undefined,
       undefined,
       undefined,
+      [],
     );
   }
 
@@ -96,6 +101,7 @@ export class StepRun {
       validated.completedAt ? new Date(validated.completedAt) : undefined,
       validated.error,
       validated.output,
+      validated.dataArtifacts ?? [],
     );
   }
 
@@ -117,6 +123,20 @@ export class StepRun {
 
   get output(): unknown {
     return this._output;
+  }
+
+  /**
+   * Gets the data artifacts produced by this step.
+   */
+  get dataArtifacts(): ReadonlyArray<DataArtifactRef> {
+    return this._dataArtifacts;
+  }
+
+  /**
+   * Adds a data artifact reference to this step.
+   */
+  addDataArtifact(artifact: DataArtifactRef): void {
+    this._dataArtifacts.push({ ...artifact });
   }
 
   /**
@@ -157,7 +177,7 @@ export class StepRun {
    * Converts to plain data for persistence.
    */
   toData(): StepRunData {
-    return {
+    const data: StepRunData = {
       stepName: this.stepName,
       status: this._status,
       startedAt: this._startedAt?.toISOString(),
@@ -165,6 +185,10 @@ export class StepRun {
       error: this._error,
       output: this._output,
     };
+    if (this._dataArtifacts.length > 0) {
+      data.dataArtifacts = this._dataArtifacts.map((a) => ({ ...a }));
+    }
+    return data;
   }
 }
 

--- a/src/presentation/output/workflow_run_output.tsx
+++ b/src/presentation/output/workflow_run_output.tsx
@@ -14,6 +14,16 @@ export interface StepArtifactsData {
   dataAttributes?: Record<string, unknown>;
 }
 
+/**
+ * Reference to a Data artifact produced by a step.
+ */
+export interface DataArtifactRefData {
+  dataId: string;
+  name: string;
+  version: number;
+  tags: Record<string, string>;
+}
+
 export interface StepRunData {
   name: string;
   status: "pending" | "running" | "succeeded" | "failed" | "skipped";
@@ -25,6 +35,8 @@ export interface StepRunData {
   outputId?: string;
   /** Step artifacts included when --verbose is set */
   artifacts?: StepArtifactsData;
+  /** Data artifacts produced by this step */
+  dataArtifacts?: DataArtifactRefData[];
 }
 
 export interface JobRunData {


### PR DESCRIPTION
- Add Data artifact tracking to workflow step runs with workflow-specific tags
- Include data artifacts in workflow run JSON output
- Add integration tests for Data creation during workflow execution

Closes #129

## Changes

### Domain Layer (`src/domain/workflows/`)
- **workflow_run.ts**: Added `dataArtifacts` field to `StepRun` class to track Data artifacts produced during step execution, with `addDataArtifact()` method and proper serialization
- **execution_service.ts**: Enhanced Data creation with workflow-specific tags (`type: "step-output"`, `workflow: "{name}"`, `step: "{step-name}"`) and track artifacts in step run output

### Presentation Layer
- **workflow_run_output.tsx**: Added `DataArtifactRefData` interface and `dataArtifacts` field to `StepRunData`
- **workflow_run.ts** (CLI): Updated `toRunData()` to include data artifacts in JSON output

### Tests
- **workflow_test.ts**: Added two integration tests verifying Data creation with correct tags

## Plan Comparison

| Plan Item | Status | Notes |
|-----------|--------|-------|
| Pass Definition to model methods | ✅ | Already implemented in execution_service.ts |
| Store step outputs as Data with tags `{type: "step-output", workflow, step}` | ✅ | Implemented |
| Update workflow run tracking to reference Data artifacts | ✅ | Added to StepRun |
| Storage path `.swamp/workflows/` | ✅ | Already correct |
| Storage path `.swamp/workflow-runs/` | ✅ | Already correct |
| Workflow tests passing | ✅ | All 32 tests pass |
| Integration test: run workflow, verify Data created | ✅ | 2 tests added |

**Note:** The plan referenced `workflow.ts` and `workflow_execution_service.ts`, but the actual execution logic resides in `execution_service.ts` and run tracking in `workflow_run.ts`. The implementation
addresses the intended functionality in the correct files.

## Test plan
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` applied
- [x] All 1318 tests pass
- [x] New integration tests verify Data artifacts have correct tags
- [x] Binary compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)