### PR TITLE
feat: Alias swamp repo init as swamp init

### DIFF
--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -4,7 +4,7 @@ import { initializeLogging } from "../infrastructure/logging/logger.ts";
 import { VERSION, versionCommand } from "./commands/version.ts";
 import { modelCommand } from "./commands/model_create.ts";
 import { typeCommand } from "./commands/type_describe.ts";
-import { repoCommand } from "./commands/repo_init.ts";
+import { repoCommand, repoInitCommand } from "./commands/repo_init.ts";
 import { workflowCommand } from "./commands/workflow.ts";
 import { completionCommand } from "./commands/completion.ts";
 import { vaultCommand } from "./commands/vault.ts";
@@ -107,6 +107,7 @@ export async function runCli(args: string[]): Promise<void> {
     .command("version", versionCommand)
     .command("model", modelCommand)
     .command("type", typeCommand)
+    .command("init", repoInitCommand)
     .command("repo", repoCommand)
     .command("workflow", workflowCommand)
     .command("vault", vaultCommand)


### PR DESCRIPTION
- Add init as a top-level command that aliases swamp repo init
- Both swamp init and swamp repo init now work identically

Implementation vs Plan

The implementation followed the plan exactly:
┌────────────────────────────────────┬────────────────────────────────────────────┐
│                Plan                │               Implementation               │
├────────────────────────────────────┼────────────────────────────────────────────┤
│ Import repoInitCommand in mod.ts   │ ✅ Added to existing import                │
├────────────────────────────────────┼────────────────────────────────────────────┤
│ Register init as top-level command │ ✅ Added .command("init", repoInitCommand) │
└────────────────────────────────────┴────────────────────────────────────────────┘
The change reuses the exact same command instance, so both paths behave identically:
- swamp init [path] [-f/--force]
- swamp repo init [path] [-f/--force]

Test plan

- deno check - Type checking passes
- deno lint - Linting passes
- deno fmt --check - Formatting passes
- deno run dev init --help - Help displays correctly
- deno run dev repo init --help - Original path still works
- deno run dev init - Successfully initializes repo
- deno run test - All tests pass
- deno run compile - Binary compiles successfully