### PR TITLE
docs: Update documentation to reflect new architecture (#131)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,28 +22,64 @@ deno run dev
 swamp version
 ```
 
+## Architecture Overview
+
+Swamp uses a model-driven architecture with the following key concepts:
+
+- **Models**: Define automation tasks with typed inputs and methods
+- **Definitions**: YAML configurations that instantiate models
+- **Workflows**: Orchestrate model executions with dependencies and triggers
+- **Data**: Versioned, immutable artifacts produced by model methods
+- **Vaults**: Secure storage for sensitive data (secrets, credentials)
+- **Expressions**: CEL expressions for dynamic values and cross-model references
+
+All data is stored in the `.swamp/` directory:
+
+```
+.swamp/
+├── definitions/       # Model definitions by type
+├── definitions-evaluated/  # Evaluated definitions (with expressions resolved)
+├── workflows/         # Workflow definitions
+├── workflows-evaluated/    # Evaluated workflows
+├── workflow-runs/     # Execution history
+├── data/              # Versioned data artifacts
+├── outputs/           # Method execution outputs
+├── vault/             # Vault configurations
+├── secrets/           # Encrypted secrets (local vaults)
+└── logs/              # Execution logs
+```
+
+Logical views (`/models/`, `/workflows/`, `/vaults/`) provide symlinks for
+human-friendly exploration of the repository.
+
 ### Example: Echo Model Workflow
 
 The `swamp/echo` model demonstrates the basic model lifecycle.
 
 ```bash
-# 1. Create a new echo model input
+# 1. Initialize a swamp repository (if not already done)
+swamp repo init
+
+# 2. Create a new echo model definition
 swamp model create swamp/echo my-echo
 
-# 2. Edit the input file to add the required 'message' attribute
-#    The file is created at: inputs/swamp/echo/<id>.yaml
+# 3. Edit the definition file to add the required 'message' attribute
+#    The file is created at: .swamp/definitions/swamp/echo/<id>.yaml
 #    Add under attributes:
 #      message: "Hello, world!"
 
-# 3. Validate the model input
+# 4. Validate the model definition
 swamp model validate my-echo
 
-# 4. Execute the write method to generate a resource
+# 5. Execute the write method to generate data
 swamp model method run my-echo write
+
+# 6. View the output
+swamp model output search my-echo
 ```
 
-Model inputs are stored in `inputs/swamp/echo/` and resources are written to
-`resources/swamp/echo/`.
+Model definitions are stored in `.swamp/definitions/swamp/echo/` and data
+artifacts are written to `.swamp/data/swamp/echo/`.
 
 ## Shell Completions
 

--- a/design/expressions.md
+++ b/design/expressions.md
@@ -96,8 +96,56 @@ When accessing model data, the "latest" version is implied by default:
 message: ${{ model.foo.data.attributes.message }} # accesses latest version
 ```
 
-Data is immutable and versioned. To access older versions, use CEL functions
-(see [./models.md] for detailed versioning information).
+Data is immutable and versioned. To access specific versions or list available
+versions, use the following CEL functions:
+
+### data.latest(modelName, dataName)
+
+Returns the latest version of a data artifact for a model:
+
+```yaml
+attributes:
+  result: ${{ data.latest('my-model', 'output').attributes.value }}
+```
+
+This is equivalent to using the implicit `model.X.data.Y` syntax.
+
+### data.version(modelName, dataName, version)
+
+Returns a specific version of a data artifact:
+
+```yaml
+attributes:
+  # Get version 1 specifically
+  oldResult: ${{ data.version('my-model', 'output', 1).attributes.value }}
+  # Get version 3
+  result: ${{ data.version('my-model', 'output', 3).attributes.value }}
+```
+
+### data.listVersions(modelName, dataName)
+
+Returns an array of available version numbers for a data artifact, sorted in
+descending order (newest first):
+
+```yaml
+attributes:
+  # Get all available versions
+  versions: ${{ data.listVersions('my-model', 'output') }}
+  # Use with size() to count versions
+  versionCount: ${{ size(data.listVersions('my-model', 'output')) }}
+```
+
+### Combined Example
+
+```yaml
+attributes:
+  # Get latest result
+  current: ${{ data.latest('processor', 'result').attributes.value }}
+  # Get the first result ever produced
+  original: ${{ data.version('processor', 'result', 1).attributes.value }}
+  # Check how many versions exist
+  historySize: ${{ size(data.listVersions('processor', 'result')) }}
+```
 
 ## Sensitive Data
 

--- a/design/models.md
+++ b/design/models.md
@@ -138,13 +138,13 @@ Data has metadata, which consists of:
   have type=log tag.
 
 The raw data will be written to
-`.swamp/data/{normalized-type}/{model id}/{data id}/{data version}/raw`.
+`.swamp/data/{normalized-type}/{model-id}/{data-name}/{version}/raw`.
 
 The metadata will be written to
-`.swamp/data/{normalized-type}/{model id}/{data id}/{data version}/metadata.yaml`.
+`.swamp/data/{normalized-type}/{model-id}/{data-name}/{version}/metadata.yaml`.
 
-There will be a symlink to the latest version as
-`.swamp/data/{normalized-type}/{model id}/{data id}/latest/metadata.yaml`.
+There will be a symlink to the latest version at
+`.swamp/data/{normalized-type}/{model-id}/{data-name}/latest/`.
 
 ### Logs
 
@@ -166,7 +166,7 @@ Each method invocation produces an output record, which gets tracked in the
 git). The output record should track the state of the method execution, and the
 list of artifacts produced by the method. It should track state as the method
 executes. It should be structured as
-`/.swamp/outputs/{normalized-type}/{method}/{model-id}-{timestamp}.yaml`.
+`/.swamp/outputs/{normalized-type}/{method}/{definition-id}-{timestamp}.yaml`.
 
 ## Logical Views
 
@@ -177,10 +177,10 @@ provides human/agent-friendly exploration of models by name.
 
 ```
 /models/{model-name}/
-  definition.yaml      → symlink to /.swamp/definitions/{type}/{id}.yaml
-  {data tag key}/{data tag value/           → symlink to /.swamp/data for the data as tagged
+  definition.yaml                → symlink to /.swamp/definitions/{type}/{id}.yaml
+  {data-tag-key}/{data-tag-value}/  → symlink to /.swamp/data for the data as tagged
   outputs/
-    {method}/     → symlinks to /.swamp/outputs/{type}/{method}/{id}-*.yaml
+    {method}/                    → symlinks to /.swamp/outputs/{type}/{method}/{id}-*.yaml
 ```
 
 This structure allows exploring all artifacts for a model in one place, using

--- a/design/repo.md
+++ b/design/repo.md
@@ -126,14 +126,14 @@ The RepoIndexService maintains two primary logical views:
 
 ```
 /models/{model-name}/
-  definition.yaml → /.swamp/definitions/{type}/{id}.yaml
+  definition.yaml              → /.swamp/definitions/{type}/{id}.yaml
   type/
-    logs/         → /.swamp/data/{type}/{id}/ (filtered by type=log data tag)
-    files/        → /.swamp/data/{type}/{id}/ (filtered by type=file data tag)
-    resources/    → /.swamp/data/{type}/{id}/ (filtered by type=resource data tag)
-  {tag-key}/{tag-value}/ → data organized by tag key/value pairs
+    logs/                      → symlinks to data with type=log tag
+    files/                     → symlinks to data with type=file tag
+    resources/                 → symlinks to data with type=resource tag
+  {tag-key}/{tag-value}/       → data organized by custom tag key/value pairs
   outputs/
-    {method}/     → /.swamp/outputs/{type}/{method}/{id}-*.yaml
+    {method}/                  → /.swamp/outputs/{type}/{method}/
 ```
 
 See [./models.md] for detailed data structure including versioning, metadata,
@@ -143,15 +143,15 @@ and data tags.
 
 ```
 /workflows/{workflow-name}/
-  workflow.yaml → /.swamp/workflows/{id}.yaml
+  workflow.yaml              → /.swamp/workflows/workflow-{id}.yaml
   runs/
-    latest/ -> (points to latest timestamp)
+    latest/                  → {latest-timestamp}/
     {timestamp}/
-      run.yaml → /.swamp/workflow-runs/{workflow-id}/{run-id}.yaml
+      run.yaml               → /.swamp/workflow-runs/{workflow-id}/workflow-run-{run-id}.yaml
       steps/
         {step-name}/
-          output.yaml → symlink to step output
-          model/ → symlink to model logical view (for model method steps)
+          output.yaml        → symlink to step output
+          model/             → ../models/{model-name}/ (for model method steps)
 ```
 
 ### Symlink Naming Conventions

--- a/design/vaults.md
+++ b/design/vaults.md
@@ -66,13 +66,16 @@ All vault implementations must implement the `VaultProvider` interface:
 ```typescript
 interface VaultProvider {
   // Retrieve a secret value by key
-  get(key: string): Promise<string>;
+  get(secretKey: string): Promise<string>;
 
   // Store a secret value with the given key
-  put(key: string, value: string): Promise<void>;
+  put(secretKey: string, secretValue: string): Promise<void>;
 
-  // Validate the vault configuration
-  validateConfig(): Promise<boolean>;
+  // List all secret keys in the vault (returns key names only, not values)
+  list(): Promise<string[]>;
+
+  // Get the name/type of this vault provider
+  getName(): string;
 }
 ```
 
@@ -403,13 +406,13 @@ If no vault is specified interactively, shows a search interface.
 Editor selection: Uses $EDITOR if set, otherwise falls back to: vscode, zed,
 nvim, vim, nano, emacs.
 
-### vault <vault_name> put KEY=VALUE
+### vault put <vault_name> KEY=VALUE
 
-We should allow a user to be able to store a secret in the vault using the CLI.
-This will error if there's no vault for that name. It should prompt a user if
-they want to overwrite an existing secret if it exists.
+Stores a secret in the vault using the CLI. This will error if there's no vault
+for that name. It prompts the user if they want to overwrite an existing secret
+if it exists.
 
-### vault <vault_name> secret-list
+### vault list-keys <vault_name>
 
-This should list all of the secret names in the vault. It should NOT return any
-values that go with them.
+Lists all secret key names in the vault. This does NOT return any values, only
+the key names.


### PR DESCRIPTION
- Updates all design docs to accurately reflect the current implementation
- Adds comprehensive documentation for data versioning CEL functions
- Rewrites README with architecture overview and updated examples

## Changes

### design/expressions.md
- Added documentation for `data.version()`, `data.latest()`, and `data.listVersions()` CEL functions

### design/models.md
- Fixed data storage paths: `{data-name}` instead of `{data id}`
- Fixed output paths: `{definition-id}` instead of `{model-id}`
- Fixed typo in logical view structure

### design/repo.md
- Updated model view structure to match implementation
- Updated workflow view with correct path formats (`workflow-{id}.yaml`, `workflow-run-{run-id}.yaml`)

### design/vaults.md
- Updated `VaultProvider` interface (added `list()`, `getName()`; removed `validateConfig()`)
- Fixed CLI commands: `vault put <vault_name> KEY=VALUE`, `vault list-keys <vault_name>`

### README.md
- Added architecture overview with `.swamp/` directory structure
- Updated example workflow to use correct paths (`.swamp/definitions/`)
- Added `swamp repo init` to example workflow

## Implementation vs Plan (Issue #131)

| Requirement | Status |
|------------|--------|
| Verify `design/models.md` | ✅ |
| Verify `design/repo.md` | ✅ |
| Verify `design/expressions.md` | ✅ |
| Verify `design/vaults.md` | ✅ |
| Update `README.md` | ✅ |
| Update `CLAUDE.md` if needed | ✅ No changes needed |
| Add `docs/migration-guide.md` | ⏭️ Skipped (no longer needed) |

## Test plan
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] All 1413 tests pass
- [x] Binary compiles successfully

Closes #131

🤖 Generated with [Claude Code](https://claude.ai/code)