### PR TITLE
docs: Update swamp skills to document unified Data entity and ownership

### DIFF
--- a/.claude/skills/swamp-data/SKILL.md
+++ b/.claude/skills/swamp-data/SKILL.md
@@ -204,14 +204,103 @@ Use CEL expressions to access model data in workflows and model inputs:
 value: ${{ model.my-model.data.attributes.result }}
 
 # Access specific version
-value: ${{ data.version(my-model, output, 2).attributes.result }}
+value: ${{ data.version("my-model", "output", 2).attributes.result }}
+```
+
+### Data Namespace Functions
+
+| Function                                     | Description                            |
+| -------------------------------------------- | -------------------------------------- |
+| `data.version(modelName, dataName, version)` | Get specific version of data           |
+| `data.latest(modelName, dataName)`           | Get latest version of data             |
+| `data.listVersions(modelName, dataName)`     | Get array of available version numbers |
+| `data.findByTag(tagKey, tagValue)`           | Find all data matching a tag           |
+
+**DataRecord structure** returned by these functions:
+
+```json
+{
+  "id": "uuid",
+  "name": "data-name",
+  "version": 3,
+  "createdAt": "2025-01-15T10:30:00Z",
+  "attributes": {/* data content */},
+  "tags": { "type": "resource" }
+}
+```
+
+**Example usage:**
+
+```yaml
+# Get specific version
+oldValue: ${{ data.version("my-model", "state", 2).attributes.value }}
+
+# Get latest (same as model.my-model.data)
+current: ${{ data.latest("my-model", "output").attributes.result }}
+
+# List versions for conditional logic
+hasHistory: ${{ size(data.listVersions("my-model", "state")) > 1 }}
+
+# Find all logs across models
+allLogs: ${{ data.findByTag("type", "log") }}
+
+# Find data from a specific workflow
+workflowData: ${{ data.findByTag("workflow", "my-workflow") }}
 ```
 
 **Key rules:**
 
 - `model.<name>.data` always refers to the latest version
 - Use `data.version()` function for specific versions
+- Use `data.findByTag()` to query across models
 - Data expressions create implicit step dependencies in workflows
+
+## Data Ownership
+
+Data artifacts are owned by the model (definition) that created them. This
+ensures data integrity and prevents accidental overwrites.
+
+### Owner Definition
+
+Each data item tracks its owner through the `ownerDefinition` field:
+
+| Field            | Description                                  |
+| ---------------- | -------------------------------------------- |
+| `type`           | `model-method`, `workflow-step`, or `manual` |
+| `ref`            | Reference to the creating entity             |
+| `definitionHash` | Hash of the definition at creation time      |
+| `workflowId`     | Set when created during workflow execution   |
+| `workflowRunId`  | Specific run that created this data          |
+
+### Ownership Validation
+
+When a model method writes data:
+
+1. **New data**: Created with current model as owner
+2. **Existing data**: Validates `ownerDefinition.definitionHash` matches
+3. **Hash mismatch**: Write fails with ownership error
+
+This prevents scenarios where multiple models accidentally share data names.
+
+### Viewing Ownership
+
+Use `swamp data get` to see ownership information:
+
+```bash
+swamp data get my-model state --json
+```
+
+```json
+{
+  "name": "state",
+  "version": 3,
+  "ownerDefinition": {
+    "type": "model-method",
+    "ref": "my-model:create",
+    "definitionHash": "abc123..."
+  }
+}
+```
 
 ## Data Storage
 

--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -25,25 +25,34 @@ startup.
 import { z } from "npm:zod@4";
 
 const InputSchema = z.object({ message: z.string() });
-const DataSchema = z.object({ result: z.string(), timestamp: z.string() });
 
 export const model = {
   type: "myorg/my-model",
   version: 1,
   inputAttributesSchema: InputSchema,
-  dataAttributesSchema: DataSchema, // Use resourceAttributesSchema for persistent output
   methods: {
     run: {
-      description: "Process the input",
-      execute: async (input, _context) => ({
-        data: {
-          id: input.id,
-          attributes: {
-            result: input.attributes.message.toUpperCase(),
-            timestamp: new Date().toISOString(),
-          },
-        },
-      }),
+      description: "Process the input message",
+      execute: async (definition, _context) => {
+        const result = {
+          message: definition.attributes.message.toUpperCase(),
+          timestamp: new Date().toISOString(),
+        };
+
+        return {
+          dataOutputs: [
+            {
+              name: "result",
+              content: JSON.stringify(result),
+              metadata: {
+                contentType: "application/json",
+                lifetime: "infinite",
+                tags: { type: "data" },
+              },
+            },
+          ],
+        };
+      },
     },
   },
 };
@@ -51,39 +60,72 @@ export const model = {
 
 ## Model Structure
 
-| Field                      | Required | Description                            |
-| -------------------------- | -------- | -------------------------------------- |
-| `type`                     | Yes      | Unique identifier (`namespace/name`)   |
-| `version`                  | Yes      | Schema version number                  |
-| `inputAttributesSchema`    | Yes      | Zod schema for input validation        |
-| `dataAttributesSchema`     | Pick one | For ephemeral output (not git-tracked) |
-| `resourceAttributesSchema` | Pick one | For persistent output (git-tracked)    |
-| `methods`                  | Yes      | Object of method definitions           |
-
-### Output Schema Choice
-
-- **`dataAttributesSchema`**: Use for ephemeral data that doesn't need to be
-  tracked in git (logs, temporary results, intermediate state)
-- **`resourceAttributesSchema`**: Use for persistent data that represents
-  external resources or should be version controlled (AWS resources, configs)
+| Field                   | Required | Description                          |
+| ----------------------- | -------- | ------------------------------------ |
+| `type`                  | Yes      | Unique identifier (`namespace/name`) |
+| `version`               | Yes      | Schema version number                |
+| `inputAttributesSchema` | Yes      | Zod schema for input validation      |
+| `methods`               | Yes      | Object of method definitions         |
 
 ## Execute Function
 
+The execute function receives the definition and context, returns data outputs:
+
 ```typescript
-execute: (async (input, context) => {
-  // input.id        - UUID
-  // input.name      - User-provided name
-  // input.attributes - Validated input data
-  // context.repoDir - Repository root path
+execute: (async (definition, context) => {
+  // definition.id         - UUID
+  // definition.name       - User-provided name
+  // definition.attributes - Validated input data
+  // context.repoDir       - Repository root path
+  // context.dataRepository - For advanced data operations
 
   return {
-    data: { // Or 'resource' for resourceAttributesSchema
-      id: input.id,
-      attributes: {/* output fields */},
-    },
+    dataOutputs: [
+      {
+        name: "output-name",
+        content: "string or Uint8Array",
+        metadata: {
+          contentType: "application/json",
+          lifetime: "infinite",
+          tags: { type: "data" },
+        },
+      },
+    ],
   };
 });
 ```
+
+## Data Output Structure
+
+Each data output in the `dataOutputs` array has:
+
+| Field                  | Required | Description                                  |
+| ---------------------- | -------- | -------------------------------------------- |
+| `name`                 | Yes      | Unique name for this data artifact           |
+| `content`              | Yes      | Data as `string` or `Uint8Array`             |
+| `metadata.contentType` | No       | MIME type (default: `application/json`)      |
+| `metadata.lifetime`    | No       | How long data persists (default: `infinite`) |
+| `metadata.tags`        | No       | Key-value pairs for categorization           |
+| `metadata.streaming`   | No       | True for line-oriented log data              |
+
+### Lifetime Values
+
+| Value       | Behavior                                     |
+| ----------- | -------------------------------------------- |
+| `ephemeral` | Deleted after method/workflow completes      |
+| `job`       | Persists while creating job runs             |
+| `workflow`  | Persists while creating workflow runs        |
+| Duration    | Expires after time (e.g., `1h`, `7d`, `1mo`) |
+| `infinite`  | Never expires (default)                      |
+
+### Standard Tags
+
+| Tag                | Use for                          |
+| ------------------ | -------------------------------- |
+| `type: "data"`     | General model data (default)     |
+| `type: "log"`      | Execution logs (streaming, text) |
+| `type: "file"`     | File artifacts                   |
+| `type: "resource"` | External resource state          |
 
 ## Model Discovery
 
@@ -102,36 +144,15 @@ Repository models take precedence, allowing you to override built-in types.
 4. **No type annotations**: Avoid TypeScript types in execute parameters
 5. **File naming**: Use snake_case (`my_model.ts`), test files excluded
 
-## Advanced: Method Input Schema
+## Data Ownership
 
-Methods can define their own input schema for runtime parameters:
+Data artifacts are tracked with ownership information. This prevents other
+models from accidentally overwriting data.
 
-```typescript
-methods: {
-  deploy: {
-    description: "Deploy with environment-specific config",
-    inputAttributesSchema: z.object({
-      environment: z.enum(["dev", "staging", "prod"]),
-      dryRun: z.boolean().optional(),
-    }),
-    execute: async (input, context, methodInput) => {
-      const env = methodInput?.environment ?? "dev";
-      // ...
-    },
-  },
-},
-```
-
-## Advanced: Context Usage
-
-The context provides access to repository information:
-
-```typescript
-execute: (async (input, context) => {
-  const configPath = `${context.repoDir}/config.yaml`;
-  // Read config, access other files, etc.
-});
-```
+- Each model "owns" the data it creates
+- Multiple models can read the same data via CEL expressions
+- Only the creating model can update its own data
+- Use unique data names to avoid conflicts
 
 ## Examples
 
@@ -145,34 +166,86 @@ const InputSchema = z.object({
   args: z.array(z.string()).optional(),
 });
 
-const DataSchema = z.object({
-  stdout: z.string(),
-  stderr: z.string(),
-  exitCode: z.number(),
-});
-
 export const model = {
   type: "myorg/shell",
   version: 1,
   inputAttributesSchema: InputSchema,
-  dataAttributesSchema: DataSchema,
   methods: {
     run: {
       description: "Execute shell command",
-      execute: async (input, _context) => {
-        const cmd = new Deno.Command(input.attributes.command, {
-          args: input.attributes.args ?? [],
+      execute: async (definition, _context) => {
+        const cmd = new Deno.Command(definition.attributes.command, {
+          args: definition.attributes.args ?? [],
         });
         const output = await cmd.output();
+
         return {
-          data: {
-            id: input.id,
-            attributes: {
-              stdout: new TextDecoder().decode(output.stdout),
-              stderr: new TextDecoder().decode(output.stderr),
-              exitCode: output.code,
+          dataOutputs: [
+            {
+              name: "output",
+              content: JSON.stringify({
+                stdout: new TextDecoder().decode(output.stdout),
+                stderr: new TextDecoder().decode(output.stderr),
+                exitCode: output.code,
+              }),
+              metadata: {
+                contentType: "application/json",
+                lifetime: "infinite",
+                tags: { type: "data" },
+              },
             },
-          },
+          ],
+        };
+      },
+    },
+  },
+};
+```
+
+### Model with Multiple Outputs
+
+```typescript
+import { z } from "npm:zod@4";
+
+const InputSchema = z.object({ query: z.string() });
+
+export const model = {
+  type: "myorg/search",
+  version: 1,
+  inputAttributesSchema: InputSchema,
+  methods: {
+    search: {
+      description: "Search and store results with log",
+      execute: async (definition, _context) => {
+        const results = ["result1", "result2"];
+
+        return {
+          dataOutputs: [
+            // Primary result data
+            {
+              name: "results",
+              content: JSON.stringify({ results }),
+              metadata: {
+                contentType: "application/json",
+                lifetime: "infinite",
+                tags: { type: "data" },
+              },
+            },
+            // Execution log
+            {
+              name: "search-log",
+              content: JSON.stringify({
+                query: definition.attributes.query,
+                timestamp: new Date().toISOString(),
+                resultCount: results.length,
+              }),
+              metadata: {
+                contentType: "application/json",
+                lifetime: "7d",
+                tags: { type: "log" },
+              },
+            },
+          ],
         };
       },
     },
@@ -190,40 +263,76 @@ const InputSchema = z.object({
   apiKey: z.string(), // Use vault expression: ${{ vault.get(my-vault, API_KEY) }}
 });
 
-const ResourceSchema = z.object({
-  resourceId: z.string(),
-  status: z.string(),
-  createdAt: z.string(),
-});
-
 export const model = {
   type: "myorg/api-resource",
   version: 1,
   inputAttributesSchema: InputSchema,
-  resourceAttributesSchema: ResourceSchema,
   methods: {
     create: {
       description: "Create resource via API",
-      execute: async (input, _context) => {
-        const response = await fetch(input.attributes.endpoint, {
+      execute: async (definition, _context) => {
+        const response = await fetch(definition.attributes.endpoint, {
           method: "POST",
-          headers: { Authorization: `Bearer ${input.attributes.apiKey}` },
+          headers: {
+            Authorization: `Bearer ${definition.attributes.apiKey}`,
+          },
         });
         const data = await response.json();
+
         return {
-          resource: {
-            id: input.id,
-            attributes: {
-              resourceId: data.id,
-              status: data.status,
-              createdAt: new Date().toISOString(),
+          dataOutputs: [
+            {
+              name: "resource",
+              content: JSON.stringify({
+                resourceId: data.id,
+                status: data.status,
+                createdAt: new Date().toISOString(),
+              }),
+              metadata: {
+                contentType: "application/json",
+                lifetime: "infinite",
+                tags: { type: "resource" },
+              },
             },
-          },
+          ],
         };
       },
     },
   },
 };
+```
+
+### Method with Input Schema
+
+Methods can define their own input schema for runtime parameters:
+
+```typescript
+methods: {
+  deploy: {
+    description: "Deploy with environment-specific config",
+    inputAttributesSchema: z.object({
+      environment: z.enum(["dev", "staging", "prod"]),
+      dryRun: z.boolean().optional(),
+    }),
+    execute: async (definition, context, methodInput) => {
+      const env = methodInput?.environment ?? "dev";
+      // Use env for deployment logic...
+
+      return {
+        dataOutputs: [
+          {
+            name: "deployment",
+            content: JSON.stringify({ environment: env, status: "deployed" }),
+            metadata: {
+              contentType: "application/json",
+              tags: { type: "resource" },
+            },
+          },
+        ],
+      };
+    },
+  },
+},
 ```
 
 ## Verify
@@ -247,8 +356,6 @@ swamp type describe myorg/my-model    # Check schema
 
 ## References
 
-- **Complete examples**: See [references/examples.md](references/examples.md)
-- **Troubleshooting**: See
-  [references/troubleshooting.md](references/troubleshooting.md)
-- **Model design**: See [design/models.md](design/models.md) for data structures
-  and lifecycle concepts
+- **Built-in example**: See `src/domain/models/echo/echo_model.ts` for reference
+- **Model loader**: See `src/domain/models/user_model_loader.ts` for API details
+- **Model design**: See [design/models.md](design/models.md) for concepts

--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -220,6 +220,46 @@ Model inputs support CEL expressions using `${{ <expression> }}` syntax.
 - **Arithmetic:** `self.attributes.count * 2`
 - **Conditionals:** `self.attributes.enabled ? "yes" : "no"`
 
+### Data Versioning Functions
+
+Access specific versions of model data using the `data` namespace:
+
+| Function                                     | Description                            |
+| -------------------------------------------- | -------------------------------------- |
+| `data.version(modelName, dataName, version)` | Get specific version of data           |
+| `data.latest(modelName, dataName)`           | Get latest version of data             |
+| `data.listVersions(modelName, dataName)`     | Get array of available version numbers |
+| `data.findByTag(tagKey, tagValue)`           | Find all data matching a tag           |
+
+**DataRecord structure** returned by these functions:
+
+```json
+{
+  "id": "uuid",
+  "name": "data-name",
+  "version": 3,
+  "createdAt": "2025-01-15T10:30:00Z",
+  "attributes": {/* data content */},
+  "tags": { "type": "resource" }
+}
+```
+
+**Example usage:**
+
+```yaml
+# Get specific version
+oldValue: ${{ data.version("my-model", "state", 2).attributes.value }}
+
+# Get latest (same as model.my-model.data)
+current: ${{ data.latest("my-model", "output").attributes.result }}
+
+# List versions for conditional logic
+hasHistory: ${{ size(data.listVersions("my-model", "state")) > 1 }}
+
+# Find by tag
+allLogs: ${{ data.findByTag("type", "log") }}
+```
+
 ### Example with Expressions
 
 ```yaml
@@ -385,6 +425,30 @@ swamp model output data output-789 --json
 5. **Validate** the model: `swamp model validate my-message --json`
 6. **Run** the method: `swamp model method run my-message write --json`
 7. **View** the output: `swamp model output get my-message --json`
+
+## Data Ownership
+
+Data artifacts are owned by the model (definition) that created them. This
+prevents accidental overwrites from other models.
+
+### Ownership Rules
+
+- Data can only be written by the model that originally created it
+- Ownership is verified through `definitionHash` comparison
+- Owner information includes:
+  - **type**: `model-method`, `workflow-step`, or `manual`
+  - **ref**: Reference to the creating entity
+  - **workflow/run IDs**: Set when created during workflow execution
+
+### Ownership Validation
+
+When a model method writes data, swamp validates:
+
+1. If data doesn't exist → create with current model as owner
+2. If data exists → verify `ownerDefinition.definitionHash` matches
+3. If hash mismatch → write fails with ownership error
+
+This ensures data integrity when multiple models reference the same data names.
 
 ## When to Use Other Skills
 

--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -187,7 +187,14 @@ swamp workflow run my-workflow --json
       "name": "main",
       "status": "succeeded",
       "steps": [
-        { "name": "example", "status": "succeeded", "duration": 2 }
+        {
+          "name": "example",
+          "status": "succeeded",
+          "duration": 2,
+          "dataArtifacts": [
+            { "dataId": "data-789", "name": "output", "version": 1 }
+          ]
+        }
       ],
       "duration": 2
     }
@@ -267,6 +274,33 @@ swamp workflow history logs run-456 build.compile --json  # Specific step logs
   "logs": "Building application...\nCompilation complete.",
   "exitCode": 0
 }
+```
+
+## Data Artifact Tracking
+
+Workflow steps track all Data artifacts produced during execution. Each step run
+includes a `dataArtifacts` array with references to created data.
+
+### Automatic Tagging
+
+Data created during workflow execution receives automatic tags:
+
+| Tag        | Value               | Description                      |
+| ---------- | ------------------- | -------------------------------- |
+| `type`     | `step-output`       | Identifies workflow-created data |
+| `workflow` | `{workflow-name}`   | Source workflow name             |
+| `step`     | `{job-name}.{step}` | Full step path                   |
+
+### Querying Workflow Data
+
+Use CEL expressions to find data from workflows:
+
+```yaml
+# Find all data from a specific workflow
+workflowOutputs: ${{ data.findByTag("workflow", "my-deploy") }}
+
+# Find data from a specific step
+stepData: ${{ data.findByTag("step", "build.compile") }}
 ```
 
 ## Expressions in Workflows


### PR DESCRIPTION
Updates swamp skill documentation to reflect the unified Data entity architecture and fixes incorrect API documentation in the extension model skill.

### swamp-model
- Add CEL data versioning functions (`data.version()`, `data.latest()`, `data.listVersions()`, `data.findByTag()`)
- Document DataRecord structure returned by these functions
- Add data ownership section explaining `definitionHash` validation

### swamp-data
- Add data namespace functions table with all CEL functions
- Document owner definition fields and ownership validation workflow
- Add CLI example for viewing ownership information

### swamp-workflow
- Add data artifact tracking section (`dataArtifacts` array in step runs)
- Document automatic tagging (`type: "step-output"`, `workflow`, `step` tags)
- Add examples for querying workflow data with `data.findByTag()`

### swamp-extension-model (complete rewrite)
The previous documentation described a fictional API. This PR rewrites the entire skill to match the actual implementation.

**Removed (incorrect):**
- `dataAttributesSchema` / `resourceAttributesSchema` model fields
- `data: { id, attributes }` and `resource: { id, attributes }` return patterns
- `additionalData` array

**Added (correct):**
- `dataOutputs` array return pattern matching `UserMethodResult` interface
- `DataOutput` structure: `name`, `content` (string/Uint8Array), `metadata`
- Metadata fields: `contentType`, `lifetime`, `tags`, `streaming`
- Lifetime values: `ephemeral`, `job`, `workflow`, duration strings, `infinite`
- Standard tags: `type: "data"`, `type: "log"`, `type: "file"`, `type: "resource"`
- All examples rewritten to use correct API
- References to actual source files for verification

## Verification

- [x] `deno fmt --check .claude/skills/` passes
- [x] CEL functions verified against `src/domain/expressions/model_resolver.ts`
- [x] Extension model API verified against `src/domain/models/user_model_loader.ts`
- [x] Workflow data tracking verified against `src/domain/workflows/execution_service.ts`

## Test plan

- [ ] Create a test extension model using documented API
- [ ] Verify CEL data functions work in model expressions
- [ ] Verify workflow data artifact tagging works as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)