### PR TITLE
feat: Skip auto-merge for PRs with 'hold' label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,10 @@ jobs:
     needs: [test, claude-review]
     runs-on: ubuntu-latest
     # Only auto-merge PRs from the same repo (not forks) for security
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Skip auto-merge if PR has the 'hold' label
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(github.event.pull_request.labels.*.name, 'hold')
 
     steps:
       - name: Checkout code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@ Use `deno run` to get a complete list of custom tasks.
 ## Source Control & Pull Requests
 
 - Use the `github-pr` skill to create commit messages and pull requests.
+- PRs are auto-merged after passing CI and Claude review. To prevent auto-merge,
+  add the `hold` label to the PR.
 - After completing work (finishing tasks, merging PRs), run `deno run compile`
   to recompile swamp.
 


### PR DESCRIPTION
Adds support for preventing auto-merge on PRs by applying the `hold` label. Claude review still runs normally - only the auto-merge step is skipped.