### PR TITLE
feat: Add non-interactive stdin support for edit commands

### DIFF
--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -130,14 +130,41 @@ attributes:
 
 ## Edit a Model
 
-Open model input file in your editor.
+Open model input file in your editor, or update via stdin in non-interactive
+mode.
 
 ```bash
+# Interactive: opens in editor
 swamp model edit my-echo
 swamp model edit my-echo --resource  # Edit resource file instead
+
+# Non-interactive: update from stdin
+cat updated-model.yaml | swamp model edit my-echo --json
+
+# With here-doc (agent-friendly)
+swamp model edit my-echo --json <<EOF
+id: existing-uuid
+name: my-echo
+version: 1
+attributes:
+  message: "Updated message"
+EOF
 ```
 
-Without arguments, shows a search interface to select a model.
+Without arguments in interactive mode, shows a search interface to select a
+model.
+
+**Output shape (when updating via stdin):**
+
+```json
+{
+  "path": ".swamp/definitions/swamp/echo/abc-123.yaml",
+  "status": "updated",
+  "name": "my-echo",
+  "type": "swamp/echo",
+  "editType": "definition"
+}
+```
 
 ## Delete a Model
 

--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -116,13 +116,44 @@ jobs:
 
 ## Edit a Workflow
 
-Open workflow file in your editor.
+Open workflow file in your editor, or update via stdin in non-interactive mode.
 
 ```bash
+# Interactive: opens in editor
 swamp workflow edit my-workflow
+
+# Non-interactive: update from stdin
+cat updated-workflow.yaml | swamp workflow edit my-workflow --json
+
+# With here-doc (agent-friendly)
+swamp workflow edit my-workflow --json <<EOF
+id: existing-uuid
+name: my-workflow
+version: 1
+jobs:
+  - name: updated-job
+    steps:
+      - name: step1
+        task:
+          type: shell
+          command: echo
+          args: ["updated"]
+EOF
 ```
 
-Without arguments, shows a search interface to select a workflow.
+Without arguments in interactive mode, shows a search interface to select a
+workflow.
+
+**Output shape (when updating via stdin):**
+
+```json
+{
+  "path": ".swamp/workflows/workflow-abc-123.yaml",
+  "status": "updated",
+  "name": "my-workflow",
+  "id": "abc-123"
+}
+```
 
 ## Delete a Workflow
 

--- a/src/cli/commands/model_edit.ts
+++ b/src/cli/commands/model_edit.ts
@@ -1,4 +1,5 @@
 import { Command } from "@cliffy/command";
+import { parse as parseYaml } from "@std/yaml";
 import {
   type ModelEditData,
   renderModelEdit,
@@ -9,12 +10,16 @@ import {
   renderModelSearch,
 } from "../../presentation/output/model_search_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
-import type { Definition } from "../../domain/definitions/definition.ts";
+import {
+  Definition,
+  type DefinitionData,
+} from "../../domain/definitions/definition.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { EditorService } from "../../infrastructure/editor/editor_service.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { UserError } from "../../domain/errors.ts";
+import { readStdin } from "../../infrastructure/io/stdin_reader.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -108,6 +113,37 @@ export const modelEditCommand = new Command()
 
     // Get the file path
     const filePath = definitionRepo.getPath(modelType, definition.id);
+
+    // Check for stdin content (non-interactive update mode)
+    const stdinContent = await readStdin();
+
+    if (stdinContent !== null) {
+      ctx.logger.debug`Reading model content from stdin`;
+
+      // Parse YAML content from stdin
+      const yamlData = parseYaml(stdinContent) as DefinitionData;
+
+      // Preserve the original ID to ensure we update the same model
+      yamlData.id = definition.id;
+
+      // Validate and create domain object
+      const updatedDefinition = Definition.fromData(yamlData);
+
+      // Save via repository (emits events for indexing)
+      await definitionRepo.save(modelType, updatedDefinition);
+
+      const data: ModelEditData = {
+        path: filePath,
+        status: "updated",
+        name: updatedDefinition.name,
+        type: modelType.normalized,
+        editType: "definition",
+      };
+
+      renderModelEdit(data, ctx.outputMode);
+      ctx.logger.debug("Model updated from stdin");
+      return;
+    }
 
     ctx.logger.debug`Opening file: ${filePath}`;
 

--- a/src/cli/commands/workflow_edit.ts
+++ b/src/cli/commands/workflow_edit.ts
@@ -1,4 +1,5 @@
 import { Command } from "@cliffy/command";
+import { parse as parseYaml } from "@std/yaml";
 import {
   renderWorkflowEdit,
   type WorkflowEditData,
@@ -13,10 +14,14 @@ import {
   createWorkflowId,
   type WorkflowId,
 } from "../../domain/workflows/workflow_id.ts";
-import type { Workflow } from "../../domain/workflows/workflow.ts";
+import {
+  Workflow,
+  type WorkflowData,
+} from "../../domain/workflows/workflow.ts";
 import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 import { EditorService } from "../../infrastructure/editor/editor_service.ts";
 import { UserError } from "../../domain/errors.ts";
+import { readStdin } from "../../infrastructure/io/stdin_reader.ts";
 
 /**
  * UUID v4 regex pattern for detecting if an argument is a UUID.
@@ -118,6 +123,36 @@ export const workflowEditCommand = new Command()
 
     // Get the file path
     const filePath = repo.getPath(workflow.id);
+
+    // Check for stdin content (non-interactive update mode)
+    const stdinContent = await readStdin();
+
+    if (stdinContent !== null) {
+      ctx.logger.debug`Reading workflow content from stdin`;
+
+      // Parse YAML content from stdin
+      const yamlData = parseYaml(stdinContent) as WorkflowData;
+
+      // Preserve the original ID to ensure we update the same workflow
+      yamlData.id = workflow.id;
+
+      // Validate and create domain object
+      const updatedWorkflow = Workflow.fromData(yamlData);
+
+      // Save via repository (emits events for indexing)
+      await repo.save(updatedWorkflow);
+
+      const data: WorkflowEditData = {
+        path: filePath,
+        status: "updated",
+        name: updatedWorkflow.name,
+        id: updatedWorkflow.id,
+      };
+
+      renderWorkflowEdit(data, ctx.outputMode);
+      ctx.logger.debug("Workflow updated from stdin");
+      return;
+    }
 
     ctx.logger.debug`Opening file: ${filePath}`;
 

--- a/src/infrastructure/io/stdin_reader.ts
+++ b/src/infrastructure/io/stdin_reader.ts
@@ -1,0 +1,54 @@
+/**
+ * Reads content from stdin if data is available.
+ *
+ * Returns null if stdin is a TTY (interactive mode) or if no data is available.
+ * Returns the content as a string if data was piped to stdin.
+ *
+ * This allows commands to auto-detect piped input without requiring flags.
+ *
+ * @example
+ * ```ts
+ * const stdinContent = await readStdin();
+ * if (stdinContent !== null) {
+ *   // Process piped content
+ *   const data = parseYaml(stdinContent);
+ * } else {
+ *   // Continue with interactive mode
+ * }
+ * ```
+ */
+export async function readStdin(): Promise<string | null> {
+  // If stdin is a TTY, no piped data available
+  if (Deno.stdin.isTerminal()) {
+    return null;
+  }
+
+  const reader = Deno.stdin.readable.getReader();
+  const chunks: Uint8Array[] = [];
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  if (chunks.length === 0) {
+    return null;
+  }
+
+  // Concatenate all chunks into a single Uint8Array
+  const totalLength = chunks.reduce((acc, chunk) => acc + chunk.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  const decoder = new TextDecoder();
+  return decoder.decode(result);
+}

--- a/src/presentation/output/model_edit_output.tsx
+++ b/src/presentation/output/model_edit_output.tsx
@@ -9,8 +9,8 @@ import type { OutputMode } from "./output.tsx";
  */
 export interface ModelEditData {
   path: string;
-  editor: string;
-  status: "opened";
+  editor?: string;
+  status: "opened" | "updated";
   name: string;
   type: string;
   editType: "input" | "resource" | "definition";
@@ -34,7 +34,8 @@ function renderInteractiveModelEdit(data: ModelEditData): void {
 
 interface ModelEditDisplayProps {
   path: string;
-  editor: string;
+  editor?: string;
+  status: "opened" | "updated";
   name: string;
   type: string;
   editType: "input" | "resource" | "definition";
@@ -51,9 +52,14 @@ export function ModelEditDisplay(
     : props.editType === "definition"
     ? "definition"
     : "input";
+
+  const header = props.status === "updated"
+    ? `Updated ${fileTypeLabel} from stdin:`
+    : `Opening ${fileTypeLabel} file in ${props.editor}:`;
+
   return (
     <Box flexDirection="column">
-      <Text color="green">Opening {fileTypeLabel} file in {props.editor}:</Text>
+      <Text color="green">{header}</Text>
       <Box marginLeft={2} flexDirection="column">
         <Text>
           <Text color="cyan">Name:</Text>

--- a/src/presentation/output/model_edit_output_test.tsx
+++ b/src/presentation/output/model_edit_output_test.tsx
@@ -87,3 +87,51 @@ Deno.test("renderModelEdit with json mode outputs valid JSON", () => {
     console.log = originalLog;
   }
 });
+
+Deno.test({
+  name: "ModelEditDisplay shows 'Updated' message for updated status",
+  ...inkTestOptions,
+  fn: () => {
+    const updatedData: ModelEditData = {
+      path: "inputs/swamp/echo/550e8400-e29b-41d4-a716-446655440000.yaml",
+      status: "updated",
+      name: "test-echo",
+      type: "swamp/echo",
+      editType: "definition",
+    };
+    const { lastFrame } = render(<ModelEditDisplay {...updatedData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Updated definition from stdin");
+  },
+});
+
+Deno.test(
+  "renderModelEdit with json mode outputs valid JSON for updated status",
+  () => {
+    const updatedData: ModelEditData = {
+      path: "inputs/swamp/echo/550e8400-e29b-41d4-a716-446655440000.yaml",
+      status: "updated",
+      name: "test-echo",
+      type: "swamp/echo",
+      editType: "definition",
+    };
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      renderModelEdit(updatedData, "json");
+      assertEquals(logs.length, 1);
+      const parsed = JSON.parse(logs[0]);
+      assertEquals(parsed.path, updatedData.path);
+      assertEquals(parsed.status, "updated");
+      assertEquals(parsed.name, updatedData.name);
+      assertEquals(parsed.type, updatedData.type);
+      assertEquals(parsed.editType, updatedData.editType);
+      assertEquals(parsed.editor, undefined);
+    } finally {
+      console.log = originalLog;
+    }
+  },
+);

--- a/src/presentation/output/workflow_edit_output.tsx
+++ b/src/presentation/output/workflow_edit_output.tsx
@@ -9,8 +9,8 @@ import type { OutputMode } from "./output.tsx";
  */
 export interface WorkflowEditData {
   path: string;
-  editor: string;
-  status: "opened";
+  editor?: string;
+  status: "opened" | "updated";
   name: string;
   id: string;
 }
@@ -36,7 +36,8 @@ function renderInteractiveWorkflowEdit(data: WorkflowEditData): void {
 
 interface WorkflowEditDisplayProps {
   path: string;
-  editor: string;
+  editor?: string;
+  status: "opened" | "updated";
   name: string;
   id: string;
 }
@@ -47,9 +48,13 @@ interface WorkflowEditDisplayProps {
 export function WorkflowEditDisplay(
   props: WorkflowEditDisplayProps,
 ): React.ReactElement {
+  const header = props.status === "updated"
+    ? "Updated workflow from stdin:"
+    : `Opening workflow in ${props.editor}:`;
+
   return (
     <Box flexDirection="column">
-      <Text color="green">Opening workflow in {props.editor}:</Text>
+      <Text color="green">{header}</Text>
       <Box marginLeft={2} flexDirection="column">
         <Text>
           <Text color="cyan">Name:</Text>

--- a/src/presentation/output/workflow_edit_output_test.tsx
+++ b/src/presentation/output/workflow_edit_output_test.tsx
@@ -64,3 +64,49 @@ Deno.test("renderWorkflowEdit with json mode outputs valid JSON", () => {
     console.log = originalLog;
   }
 });
+
+Deno.test({
+  name:
+    "WorkflowEditDisplay shows 'Updated workflow' message for updated status",
+  ...inkTestOptions,
+  fn: () => {
+    const updatedData: WorkflowEditData = {
+      path: "workflows/workflow-550e8400-e29b-41d4-a716-446655440000.yaml",
+      status: "updated",
+      name: "test-workflow",
+      id: "550e8400-e29b-41d4-a716-446655440000",
+    };
+    const { lastFrame } = render(<WorkflowEditDisplay {...updatedData} />);
+    const output = lastFrame() ?? "";
+
+    assertStringIncludes(output, "Updated workflow from stdin");
+  },
+});
+
+Deno.test(
+  "renderWorkflowEdit with json mode outputs valid JSON for updated status",
+  () => {
+    const updatedData: WorkflowEditData = {
+      path: "workflows/workflow-550e8400-e29b-41d4-a716-446655440000.yaml",
+      status: "updated",
+      name: "test-workflow",
+      id: "550e8400-e29b-41d4-a716-446655440000",
+    };
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      renderWorkflowEdit(updatedData, "json");
+      assertEquals(logs.length, 1);
+      const parsed = JSON.parse(logs[0]);
+      assertEquals(parsed.path, updatedData.path);
+      assertEquals(parsed.status, "updated");
+      assertEquals(parsed.name, updatedData.name);
+      assertEquals(parsed.id, updatedData.id);
+      assertEquals(parsed.editor, undefined);
+    } finally {
+      console.log = originalLog;
+    }
+  },
+);


### PR DESCRIPTION
- Add stdin support to `workflow edit` and `model edit` commands for non-interactive updates
- Create reusable `stdin_reader.ts` utility for auto-detecting piped input
- Update skill documentation with stdin usage examples

## Motivation

Enables agents and scripts to modify workflows and models without requiring an interactive editor, supporting automation workflows like:

```bash
# Pipe content directly
cat updated-workflow.yaml | swamp workflow edit my-workflow --json

# Here-doc for agent usage
swamp model edit my-echo --json <<EOF
id: existing-uuid
name: my-echo
version: 1
attributes:
message: "Updated message"
EOF

Plan Comparison
┌──────────────────────────────────────────────────┬────────────────────┬───────────────────────────────────────────────────────────────────┐
│                    Plan Item                     │       Status       │                               Notes                               │
├──────────────────────────────────────────────────┼────────────────────┼───────────────────────────────────────────────────────────────────┤
│ Files to Modify                                  │                    │                                                                   │
├──────────────────────────────────────────────────┼────────────────────┼───────────────────────────────────────────────────────────────────┤
│ src/cli/commands/workflow_edit.ts                │ ✅️ │ Stdin detection, YAML parsing, domain validation, repository save │
├──────────────────────────────────────────────────┼────────────────────┼───────────────────────────────────────────────────────────────────┤
│ src/cli/commands/model_edit.ts                   │ ✅️ │ Same pattern as workflow_edit                                     │
├──────────────────────────────────────────────────┼────────────────────┼───────────────────────────────────────────────────────────────────┤
│ src/presentation/output/workflow_edit_output.tsx │ ✅️ │ "updated" status, optional editor field                           │
├──────────────────────────────────────────────────┼────────────────────┼───────────────────────────────────────────────────────────────────┤
│ src/presentation/output/model_edit_output.tsx    │ ✅️ │ "updated" status, optional editor field                           │
├──────────────────────────────────────────────────┼────────────────────┼───────────────────────────────────────────────────────────────────┤
│ Files to Create                                  │                    │                                                                   │
├──────────────────────────────────────────────────┼────────────────────┼───────────────────────────────────────────────────────────────────┤
│ src/infrastructure/io/stdin_reader.ts            │ ✅️ │ TTY detection, chunk reading, null for no data                    │
├──────────────────────────────────────────────────┼────────────────────┼───────────────────────────────────────────────────────────────────┤
│ Skill Updates                                    │                    │                                                                   │
├──────────────────────────────────────────────────┼────────────────────┼───────────────────────────────────────────────────────────────────┤
│ .claude/skills/swamp-model/SKILL.md              │ ✅️ │ Stdin usage documented with examples                              │
├──────────────────────────────────────────────────┼────────────────────┼───────────────────────────────────────────────────────────────────┤
│ .claude/skills/swamp-workflow/SKILL.md           │ ✅️ │ Stdin usage documented with examples                              │
└──────────────────────────────────────────────────┴────────────────────┴───────────────────────────────────────────────────────────────────┘
Implementation Details vs Plan
┌─────────────────────────────┬───────────────────────────┬────────────────────┐
│         Requirement         │           Plan            │   Implementation   │
├─────────────────────────────┼───────────────────────────┼────────────────────┤
│ Auto-detect stdin (no flag) │ Deno.stdin.isTerminal()   │ ✅️ │
├─────────────────────────────┼───────────────────────────┼────────────────────┤
│ Preserve original ID        │ yamlData.id = workflow.id │ ✅️ │
├─────────────────────────────┼───────────────────────────┼────────────────────┤
│ Validate via domain model   │ Workflow.fromData()       │ ✅️ │
├─────────────────────────────┼───────────────────────────┼────────────────────┤
│ Save via repository         │ repo.save()               │ ✅️ │
├─────────────────────────────┼───────────────────────────┼────────────────────┤
│ Output status union         │ "opened" | "updated"      │ ✅️ │
├─────────────────────────────┼───────────────────────────┼────────────────────┤
│ Editor field optional       │ editor?: string           │ ✅️ │
└─────────────────────────────┴───────────────────────────┴────────────────────┘
Minor Variations

- Used manual byte concatenation instead of @std/bytes to avoid adding a dependency
- Added unit tests for "updated" status (not in plan but good practice)

Test plan

- deno check - Type checking passes
- deno lint - Linting passes (323 files)
- deno fmt - Formatting passes (360 files)
- deno run test - All 1417 tests pass
- deno run compile - Binary compiles successfully
- Manual test: swamp workflow create test-stdin && swamp workflow get test-stdin --json | swamp workflow edit test-stdin --json
- Manual test: Verify interactive mode still works (no stdin)

🤖 Generated with https://claude.ai/code