### PR TITLE
feat: Add calver version stamping and GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,114 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Generate version
+        id: version
+        run: |
+          # Format: YYYYMMDD.HHMMSS.0-sha.COMMITSHA (matches SI convention)
+          VERSION=$(date -u +%Y%m%d.%H%M%S).0-sha.$(git rev-parse --short=8 HEAD)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION"
+
+      - name: Build binaries
+        run: |
+          mkdir -p dist
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Linux x86_64
+          deno run -A scripts/compile.ts \
+            --version "$VERSION" \
+            --target x86_64-unknown-linux-gnu \
+            --output dist/swamp-linux-x86_64
+
+          # Linux aarch64
+          deno run -A scripts/compile.ts \
+            --version "$VERSION" \
+            --target aarch64-unknown-linux-gnu \
+            --output dist/swamp-linux-aarch64
+
+          # macOS x86_64
+          deno run -A scripts/compile.ts \
+            --version "$VERSION" \
+            --target x86_64-apple-darwin \
+            --output dist/swamp-darwin-x86_64
+
+          # macOS aarch64 (Apple Silicon)
+          deno run -A scripts/compile.ts \
+            --version "$VERSION" \
+            --target aarch64-apple-darwin \
+            --output dist/swamp-darwin-aarch64
+
+          # Windows x86_64
+          deno run -A scripts/compile.ts \
+            --version "$VERSION" \
+            --target x86_64-pc-windows-msvc \
+            --output dist/swamp-windows-x86_64.exe
+
+      - name: Create checksums
+        working-directory: dist
+        run: |
+          sha256sum swamp-* > checksums.txt
+          cat checksums.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: swamp ${{ steps.version.outputs.version }}
+          body: |
+            ## swamp ${{ steps.version.outputs.version }}
+
+            ### Installation
+
+            **macOS (Apple Silicon):**
+            ```bash
+            curl -L https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/swamp-darwin-aarch64 -o swamp
+            chmod +x swamp && sudo mv swamp /usr/local/bin/
+            ```
+
+            **macOS (Intel):**
+            ```bash
+            curl -L https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/swamp-darwin-x86_64 -o swamp
+            chmod +x swamp && sudo mv swamp /usr/local/bin/
+            ```
+
+            **Linux (x86_64):**
+            ```bash
+            curl -L https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/swamp-linux-x86_64 -o swamp
+            chmod +x swamp && sudo mv swamp /usr/local/bin/
+            ```
+
+            **Linux (aarch64):**
+            ```bash
+            curl -L https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/swamp-linux-aarch64 -o swamp
+            chmod +x swamp && sudo mv swamp /usr/local/bin/
+            ```
+          files: |
+            dist/swamp-linux-x86_64
+            dist/swamp-linux-aarch64
+            dist/swamp-darwin-x86_64
+            dist/swamp-darwin-aarch64
+            dist/swamp-windows-x86_64.exe
+            dist/checksums.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/integration/cli_test.ts
+++ b/integration/cli_test.ts
@@ -37,19 +37,19 @@ Deno.test("CLI with --help shows help", async () => {
 
 Deno.test("CLI with --version shows version", async () => {
   const { stdout } = await runCliCommand(["--version"]);
-  assertStringIncludes(stdout, "0.1.0");
+  assertStringIncludes(stdout, "0.0.0-dev");
 });
 
 Deno.test("CLI version command works (auto-detects non-TTY for JSON)", async () => {
   const { stdout } = await runCliCommand(["version"]);
   // In non-TTY environment, output is auto-detected as JSON
   const parsed = JSON.parse(stdout);
-  assertStringIncludes(parsed.version, "0.1.0");
+  assertStringIncludes(parsed.version, "0.0.0-dev");
 });
 
 Deno.test("CLI version command with --json outputs JSON", async () => {
   const { stdout } = await runCliCommand(["--json", "version"]);
-  // Should be valid JSON with version and haiku fields
+  // Should be valid JSON with version field
   const parsed = JSON.parse(stdout);
-  assertStringIncludes(parsed.version, "0.1.0");
+  assertStringIncludes(parsed.version, "0.0.0-dev");
 });

--- a/main_test.ts
+++ b/main_test.ts
@@ -3,5 +3,4 @@ import { VERSION } from "./src/cli/commands/version.ts";
 
 Deno.test("swamp version is defined", () => {
   assertEquals(typeof VERSION, "string");
-  assertEquals(VERSION, "0.1.0");
 });

--- a/scripts/compile.ts
+++ b/scripts/compile.ts
@@ -5,66 +5,133 @@ import { exists } from "@std/fs/exists";
 
 interface CompileOptions {
   includeExperiment: string[];
+  output: string;
+  target?: string;
+  version?: string;
+}
+
+const VERSION_FILE = "src/cli/commands/version.ts";
+
+async function getCalVer(): Promise<string> {
+  const now = new Date();
+  const year = now.getUTCFullYear();
+  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(now.getUTCDate()).padStart(2, "0");
+  const hours = String(now.getUTCHours()).padStart(2, "0");
+  const minutes = String(now.getUTCMinutes()).padStart(2, "0");
+  const seconds = String(now.getUTCSeconds()).padStart(2, "0");
+
+  // Get short commit hash
+  let commitHash = "0000000";
+  try {
+    const cmd = new Deno.Command("git", {
+      args: ["rev-parse", "--short=8", "HEAD"],
+      stdout: "piped",
+    });
+    const { stdout } = await cmd.output();
+    commitHash = new TextDecoder().decode(stdout).trim();
+  } catch {
+    // Ignore git errors
+  }
+
+  // Format: YYYYMMDD.HHMMSS.0-sha.COMMITSHA (matches SI convention)
+  return `${year}${month}${day}.${hours}${minutes}${seconds}.0-sha.${commitHash}`;
+}
+
+async function stampVersion(version: string): Promise<string> {
+  const content = await Deno.readTextFile(VERSION_FILE);
+  const original = content;
+  const updated = content.replace(
+    /export const VERSION = "[^"]+";/,
+    `export const VERSION = "${version}";`,
+  );
+  await Deno.writeTextFile(VERSION_FILE, updated);
+  return original;
 }
 
 async function main() {
   const args = parseArgs(Deno.args, {
-    string: ["include-experiment"],
+    string: ["include-experiment", "output", "target", "version"],
     collect: ["include-experiment"],
     alias: {
       "include-experiment": "includeExperiment",
+      "o": "output",
+      "t": "target",
+      "v": "version",
+    },
+    default: {
+      "output": "swamp",
     },
   });
 
   const options: CompileOptions = {
     includeExperiment: args.includeExperiment || [],
+    output: args.output || "swamp",
+    target: args.target,
+    version: args.version,
   };
 
-  const baseCommand = [
-    "deno",
-    "compile",
-    "--allow-read",
-    "--allow-write",
-    "--allow-env",
-    "--allow-run",
-    "--allow-sys",
-    "--allow-net",
-    "--include",
-    ".claude/skills",
-  ];
+  // Determine version to use
+  const version = options.version || await getCalVer();
+  console.log(`Version: ${version}`);
 
-  for (const experiment of options.includeExperiment) {
-    if (experiment === "web") {
-      const webDistPath = "experiments/webapp/frontend/dist";
-      if (await exists(webDistPath)) {
-        console.log(`Including web experiment from ${webDistPath}`);
-        baseCommand.push("--include", webDistPath);
+  // Stamp version into source file
+  const originalContent = await stampVersion(version);
+
+  try {
+    const baseCommand = [
+      "deno",
+      "compile",
+      "--allow-read",
+      "--allow-write",
+      "--allow-env",
+      "--allow-run",
+      "--allow-sys",
+      "--allow-net",
+      "--include",
+      ".claude/skills",
+    ];
+
+    for (const experiment of options.includeExperiment) {
+      if (experiment === "web") {
+        const webDistPath = "experiments/webapp/frontend/dist";
+        if (await exists(webDistPath)) {
+          console.log(`Including web experiment from ${webDistPath}`);
+          baseCommand.push("--include", webDistPath);
+        } else {
+          console.error(
+            `Error: Web experiment not built. Run 'deno run webapp:build' first.`,
+          );
+          Deno.exit(1);
+        }
       } else {
-        console.error(
-          `Error: Web experiment not built. Run 'deno run webapp:build' first.`,
-        );
+        console.error(`Error: Unknown experiment '${experiment}'`);
         Deno.exit(1);
       }
-    } else {
-      console.error(`Error: Unknown experiment '${experiment}'`);
+    }
+
+    if (options.target) {
+      baseCommand.push("--target", options.target);
+    }
+
+    baseCommand.push("--output", options.output, "main.ts");
+
+    console.log(`Running: ${baseCommand.join(" ")}`);
+
+    const command = new Deno.Command(baseCommand[0], {
+      args: baseCommand.slice(1),
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+
+    const { success } = await command.output();
+
+    if (!success) {
       Deno.exit(1);
     }
-  }
-
-  baseCommand.push("--output", "swamp", "main.ts");
-
-  console.log(`Running: ${baseCommand.join(" ")}`);
-
-  const command = new Deno.Command(baseCommand[0], {
-    args: baseCommand.slice(1),
-    stdout: "inherit",
-    stderr: "inherit",
-  });
-
-  const { success } = await command.output();
-
-  if (!success) {
-    Deno.exit(1);
+  } finally {
+    // Restore original version file
+    await Deno.writeTextFile(VERSION_FILE, originalContent);
   }
 }
 

--- a/src/cli/commands/version.ts
+++ b/src/cli/commands/version.ts
@@ -5,24 +5,18 @@ import {
 } from "../../presentation/output/output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
 
-export const VERSION = "0.1.0";
-
-export const FROG_HAIKU = `Old pond, still water—
-A frog leaps in with a splash,
-Silence returns slow.`;
+// This gets replaced by the compile script during release builds
+export const VERSION = "0.0.0-dev";
 
 export function getVersionData(): VersionData {
-  return {
-    version: VERSION,
-    haiku: FROG_HAIKU,
-  };
+  return { version: VERSION };
 }
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
 export const versionCommand = new Command()
-  .description("Display the version of swamp and a frog haiku")
+  .description("Display the version of swamp")
   .action(function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, "version");
     ctx.logger.debug("Executing version command");

--- a/src/cli/commands/version_test.ts
+++ b/src/cli/commands/version_test.ts
@@ -1,25 +1,11 @@
-import { assertEquals, assertStringIncludes } from "@std/assert";
-import { FROG_HAIKU, getVersionData, VERSION } from "./version.ts";
+import { assertEquals } from "@std/assert";
+import { getVersionData, VERSION } from "./version.ts";
 
 Deno.test("getVersionData returns correct version", () => {
   const data = getVersionData();
   assertEquals(data.version, VERSION);
 });
 
-Deno.test("getVersionData returns haiku", () => {
-  const data = getVersionData();
-  assertEquals(data.haiku, FROG_HAIKU);
-});
-
-Deno.test("VERSION is 0.1.0", () => {
-  assertEquals(VERSION, "0.1.0");
-});
-
-Deno.test("FROG_HAIKU contains frog reference", () => {
-  assertStringIncludes(FROG_HAIKU, "frog");
-});
-
-Deno.test("FROG_HAIKU has three lines (haiku structure)", () => {
-  const lines = FROG_HAIKU.split("\n");
-  assertEquals(lines.length, 3);
+Deno.test("VERSION is a string", () => {
+  assertEquals(typeof VERSION, "string");
 });

--- a/src/presentation/output/components/VersionDisplay.tsx
+++ b/src/presentation/output/components/VersionDisplay.tsx
@@ -1,30 +1,15 @@
 // deno-lint-ignore verbatim-module-syntax
-import React, { Fragment } from "react";
-import { Box, Newline, Text } from "ink";
+import React from "react";
+import { Text } from "ink";
 
 export interface VersionDisplayProps {
   version: string;
-  haiku: string;
 }
 
-export function VersionDisplay({ version, haiku }: VersionDisplayProps) {
-  const haikuLines = haiku.split("\n");
-
+export function VersionDisplay({ version }: VersionDisplayProps) {
   return (
-    <Box flexDirection="column">
-      <Text bold color="green">
-        swamp v{version}
-      </Text>
-      <Box paddingLeft={2}>
-        <Text color="cyan" italic>
-          {haikuLines.map((line, index) => (
-            <Fragment key={index}>
-              {line}
-              {index < haikuLines.length - 1 && <Newline />}
-            </Fragment>
-          ))}
-        </Text>
-      </Box>
-    </Box>
+    <Text bold color="green">
+      swamp {version}
+    </Text>
   );
 }

--- a/src/presentation/output/components/VersionDisplay_test.tsx
+++ b/src/presentation/output/components/VersionDisplay_test.tsx
@@ -8,43 +8,11 @@ import { VersionDisplay } from "./VersionDisplay.tsx";
 const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
 
 Deno.test({
-  name: "VersionDisplay renders version with prefix",
+  name: "VersionDisplay renders version",
   ...inkTestOptions,
   fn: () => {
-    const { lastFrame } = render(
-      <VersionDisplay version="1.0.0" haiku="test haiku" />,
-    );
-
+    const { lastFrame } = render(<VersionDisplay version="1.0.0" />);
     const output = lastFrame() ?? "";
-    assertStringIncludes(output, "swamp v1.0.0");
-  },
-});
-
-Deno.test({
-  name: "VersionDisplay renders haiku text",
-  ...inkTestOptions,
-  fn: () => {
-    const { lastFrame } = render(
-      <VersionDisplay version="1.0.0" haiku="line one\nline two\nline three" />,
-    );
-
-    const output = lastFrame() ?? "";
-    assertStringIncludes(output, "line one");
-    assertStringIncludes(output, "line two");
-    assertStringIncludes(output, "line three");
-  },
-});
-
-Deno.test({
-  name: "VersionDisplay renders multi-line haiku with indentation",
-  ...inkTestOptions,
-  fn: () => {
-    const { lastFrame } = render(
-      <VersionDisplay version="1.0.0" haiku="test line" />,
-    );
-
-    const output = lastFrame() ?? "";
-    // Box paddingLeft={2} adds 2 spaces of indentation
-    assertStringIncludes(output, "  test line");
+    assertStringIncludes(output, "swamp 1.0.0");
   },
 });

--- a/src/presentation/output/output.tsx
+++ b/src/presentation/output/output.tsx
@@ -7,7 +7,6 @@ export type OutputMode = "interactive" | "json" | "stream";
 
 export interface VersionData {
   version: string;
-  haiku: string;
 }
 
 export function renderVersion(data: VersionData, mode: OutputMode): void {
@@ -19,8 +18,6 @@ export function renderVersion(data: VersionData, mode: OutputMode): void {
 }
 
 function renderInteractiveVersion(data: VersionData): void {
-  const { lastFrame } = render(
-    <VersionDisplay version={data.version} haiku={data.haiku} />,
-  );
+  const { lastFrame } = render(<VersionDisplay version={data.version} />);
   console.log(lastFrame());
 }

--- a/src/presentation/output/output_test.ts
+++ b/src/presentation/output/output_test.ts
@@ -3,7 +3,6 @@ import { renderVersion, type VersionData } from "./output.tsx";
 
 const testData: VersionData = {
   version: "1.0.0",
-  haiku: "line one\nline two\nline three",
 };
 
 Deno.test("renderVersion with json mode outputs valid JSON", () => {
@@ -17,7 +16,6 @@ Deno.test("renderVersion with json mode outputs valid JSON", () => {
 
     const parsed = JSON.parse(logs[0]);
     assertEquals(parsed.version, "1.0.0");
-    assertEquals(parsed.haiku, "line one\nline two\nline three");
   } finally {
     console.log = originalLog;
   }
@@ -32,38 +30,6 @@ Deno.test("renderVersion with json mode includes version field", () => {
     renderVersion(testData, "json");
     assertStringIncludes(logs[0], '"version"');
     assertStringIncludes(logs[0], '"1.0.0"');
-  } finally {
-    console.log = originalLog;
-  }
-});
-
-Deno.test("renderVersion with json mode includes haiku field", () => {
-  const logs: string[] = [];
-  const originalLog = console.log;
-  console.log = (msg: string) => logs.push(msg);
-
-  try {
-    renderVersion(testData, "json");
-    assertStringIncludes(logs[0], '"haiku"');
-  } finally {
-    console.log = originalLog;
-  }
-});
-
-// Interactive mode rendering is tested via ink-testing-library
-// in components/VersionDisplay_test.tsx
-
-Deno.test("renderVersion with json mode formats haiku with indentation in output", () => {
-  const logs: string[] = [];
-  const originalLog = console.log;
-  console.log = (msg: string) => logs.push(msg);
-
-  try {
-    renderVersion(testData, "json");
-    // JSON output preserves the original haiku without formatting
-    // The formatHaiku function is only used for interactive mode
-    const parsed = JSON.parse(logs[0]);
-    assertEquals(parsed.haiku, "line one\nline two\nline three");
   } finally {
     console.log = originalLog;
   }


### PR DESCRIPTION
- Add calendar versioning (calver) that stamps versions into compiled binaries in the format `YYYYMMDD.HHMMSS.0-sha.XXXXXXXX` (matching SI convention)
- Add GitHub Actions workflow that builds and releases binaries on merge to main
- Simplify version command output (removed haiku)

## Changes

- `scripts/compile.ts` - Now stamps version into binary at compile time, restores source after
- `src/cli/commands/version.ts` - Simplified to just version string
- `.github/workflows/release.yml` - New workflow that:
- Triggers on push to main
- Builds binaries for Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows
- Creates GitHub release with checksums and install instructions

## Usage

Local dev shows `0.0.0-dev`. Compiled binaries get stamped:
```bash
deno run compile              # Auto-generates calver
deno run compile --version X  # Use explicit version

Test plan

- deno check passes
- deno lint passes
- deno fmt --check passes
- deno test passes
- Verified compile stamps version correctly
- Verified source file restored after compile