### PR TITLE
Fix install script to handle S3 redirect metadata

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -515,7 +515,7 @@ die() {
   exit 1
 }
 download() {
-  local _url _dst _code _orig_flags
+  local _url _dst _code _orig_flags _redirect_url
   _url="$1"
   _dst="$2"
   need_cmd sed
@@ -523,11 +523,19 @@ download() {
     info "Downloading $_url to $_dst (curl)"
     _orig_flags="$-"
     set +e
-    curl -sSfL "$_url" -o "$_dst"
+    
+    # Check for S3 redirect metadata first
+    _redirect_url="$(curl -sSI "$_url" | grep -i "x-amz-meta-x-amz-website-redirect-location" | cut -d' ' -f2- | tr -d '\r\n')"
+    if [ -n "$_redirect_url" ]; then
+      info "Following S3 redirect to $_redirect_url"
+      curl -sSfL "$_redirect_url" -o "$_dst"
+    else
+      curl -sSfL "$_url" -o "$_dst"
+    fi
     _code="$?"
     set "-$(echo "$_orig_flags" | sed s/s//g)"
     if [ $_code -eq 0 ]; then
-      unset _url _dst _code _orig_flags
+      unset _url _dst _code _orig_flags _redirect_url
       return 0
     else
       local _e

--- a/scripts/upload-binaries.sh
+++ b/scripts/upload-binaries.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Script to upload swamp binaries to S3
+# Usage: ./upload-binaries.sh <version> [bucket]
+#
+# Example: ./upload-binaries.sh v20260204.165928.0-sha.06db816c si-artifacts-prod
+
+VERSION="${1:-}"
+BUCKET="${2:-si-artifacts-prod}"
+
+if [[ -z "$VERSION" ]]; then
+    echo "Error: Version parameter is required"
+    echo "Usage: $0 <version> [bucket]"
+    echo "Example: $0 v20260204.165928.0-sha.06db816c si-artifacts-prod"
+    exit 1
+fi
+
+# Remove 'v' prefix if present for consistency
+VERSION_CLEAN="${VERSION#v}"
+
+# Define the binary mappings (compatible with older bash)
+BINARIES="swamp-darwin-aarch64:darwin/aarch64 swamp-darwin-x86_64:darwin/x86_64 swamp-linux-x86_64:linux/x86_64 swamp-linux-aarch64:linux/aarch64"
+
+# Base directory where binaries are expected to be
+BINARIES_DIR="${BINARIES_DIR:-./dist}"
+
+# Check if AWS CLI is available
+if ! command -v aws &> /dev/null; then
+    echo "Error: AWS CLI not found. Please install it first."
+    exit 1
+fi
+
+echo "Uploading swamp binaries for version: $VERSION_CLEAN to bucket: $BUCKET"
+echo "Looking for binaries in: $BINARIES_DIR"
+
+# Create temporary directory for packaging
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf $TEMP_DIR" EXIT
+
+# Process each binary mapping
+for mapping in $BINARIES; do
+    binary_name=$(echo "$mapping" | cut -d':' -f1)
+    os_arch=$(echo "$mapping" | cut -d':' -f2)
+    os=$(echo "$os_arch" | cut -d'/' -f1)
+    arch=$(echo "$os_arch" | cut -d'/' -f2)
+    
+    binary_path="$BINARIES_DIR/$binary_name"
+    
+    if [[ ! -f "$binary_path" ]]; then
+        echo "Warning: Binary not found: $binary_path - skipping"
+        continue
+    fi
+    
+    # Create the expected filename for S3
+    s3_filename="swamp-${VERSION_CLEAN}-binary-${os}-${arch}.tar.gz"
+    
+    # Create tar.gz with the binary
+    temp_binary="$TEMP_DIR/swamp"
+    cp "$binary_path" "$temp_binary"
+    chmod +x "$temp_binary"
+    
+    # Create tar.gz in temp directory
+    (cd "$TEMP_DIR" && tar -czf "$s3_filename" swamp)
+    
+    # Define S3 path
+    s3_path="s3://$BUCKET/swamp/$VERSION_CLEAN/binary/$os/$arch/$s3_filename"
+    
+    echo "Uploading $binary_name -> $s3_path"
+    
+    # Upload to S3
+    aws s3 cp "$TEMP_DIR/$s3_filename" "$s3_path"
+    
+    # Create stable pointer with redirect metadata
+    stable_path="s3://$BUCKET/swamp/stable/binary/$os/$arch/swamp-stable-binary-${os}-${arch}.tar.gz"
+    redirect_url="https://artifacts.systeminit.com/swamp/$VERSION_CLEAN/binary/$os/$arch/$s3_filename"
+    
+    echo "Creating stable pointer: $stable_path -> $redirect_url"
+    
+    # Create empty file with redirect metadata
+    echo "" | aws s3 cp - "$stable_path" \
+        --content-type "binary/octet-stream" \
+        --metadata-directive REPLACE \
+        --metadata "x-amz-website-redirect-location=$redirect_url"
+    
+    # Clean up temp file
+    rm -f "$temp_binary" "$TEMP_DIR/$s3_filename"
+done
+
+echo "✅ Upload complete!"
+echo ""
+echo "Binaries are now available at:"
+for mapping in $BINARIES; do
+    binary_name=$(echo "$mapping" | cut -d':' -f1)
+    os_arch=$(echo "$mapping" | cut -d':' -f2)
+    os=$(echo "$os_arch" | cut -d'/' -f1)
+    arch=$(echo "$os_arch" | cut -d'/' -f2)
+    s3_filename="swamp-${VERSION_CLEAN}-binary-${os}-${arch}.tar.gz"
+    echo "  Versioned: https://$BUCKET.s3.amazonaws.com/swamp/$VERSION_CLEAN/binary/$os/$arch/$s3_filename"
+    echo "  Stable:    https://artifacts.systeminit.com/swamp/stable/binary/$os/$arch/swamp-stable-binary-${os}-${arch}.tar.gz"
+done


### PR DESCRIPTION
Temporary measure to publish to our artifact store while we rework our publishing mechanism. Ignoring powershell for now as we have no users on that platform

- Update download function to check for x-amz-meta-x-amz-website-redirect-location
- Follow S3 redirects to actual binary files
- Change upload script from 'omnibus' to 'binary' to match install script expectations

🤖 Generated with [Claude Code](https://claude.ai/code)