### PR TITLE
feat: Prompt users when running swamp in non-initialized directory

### DIFF
--- a/integration/data_output_flow_test.ts
+++ b/integration/data_output_flow_test.ts
@@ -12,6 +12,9 @@
  */
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+import { stringify as stringifyYaml } from "@std/yaml";
 import { Definition } from "../src/domain/definitions/definition.ts";
 import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
 import { ECHO_MODEL_TYPE } from "../src/domain/models/echo/echo_model.ts";
@@ -23,6 +26,32 @@ async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   } finally {
     await Deno.remove(dir, { recursive: true });
   }
+}
+
+/**
+ * Initializes a test repository with the required marker file and directory structure.
+ */
+async function initializeTestRepo(repoDir: string): Promise<void> {
+  // Create the .swamp directory structure
+  const subdirs = [
+    ".swamp/definitions",
+    ".swamp/outputs",
+    ".swamp/data",
+    ".swamp/logs",
+  ];
+  for (const subdir of subdirs) {
+    await ensureDir(join(repoDir, subdir));
+  }
+
+  // Create the .swamp.yaml marker file
+  const markerData = {
+    swampVersion: "0.0.0",
+    initializedAt: new Date().toISOString(),
+  };
+  await Deno.writeTextFile(
+    join(repoDir, ".swamp.yaml"),
+    stringifyYaml(markerData as Record<string, unknown>),
+  );
 }
 
 async function runCliCommand(
@@ -50,6 +79,9 @@ async function runCliCommand(
 
 Deno.test("Integration: full flow - create definition, run method, verify output and data", async () => {
   await withTempDir(async (repoDir) => {
+    // Initialize the test repo with marker file
+    await initializeTestRepo(repoDir);
+
     // 1. Create a model definition
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const definition = Definition.create({
@@ -180,6 +212,9 @@ Deno.test("Integration: full flow - create definition, run method, verify output
 
 Deno.test("Integration: data commands work with model data artifacts", async () => {
   await withTempDir(async (repoDir) => {
+    // Initialize the test repo with marker file
+    await initializeTestRepo(repoDir);
+
     // 1. Create and run a model to produce data
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const definition = Definition.create({
@@ -309,6 +344,9 @@ Deno.test("Integration: data commands work with model data artifacts", async () 
 
 Deno.test("Integration: output search with partial ID matching", async () => {
   await withTempDir(async (repoDir) => {
+    // Initialize the test repo with marker file
+    await initializeTestRepo(repoDir);
+
     // Create and run a model
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const definition = Definition.create({
@@ -378,6 +416,9 @@ Deno.test("Integration: output search with partial ID matching", async () => {
 
 Deno.test("Integration: output data with field extraction", async () => {
   await withTempDir(async (repoDir) => {
+    // Initialize the test repo with marker file
+    await initializeTestRepo(repoDir);
+
     // Create and run a model
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const definition = Definition.create({
@@ -451,6 +492,9 @@ Deno.test("Integration: output data with field extraction", async () => {
 
 Deno.test("Integration: multiple method runs create separate outputs", async () => {
   await withTempDir(async (repoDir) => {
+    // Initialize the test repo with marker file
+    await initializeTestRepo(repoDir);
+
     // Create a model
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const definition = Definition.create({
@@ -525,6 +569,9 @@ Deno.test("Integration: multiple method runs create separate outputs", async () 
 
 Deno.test("Integration: data versioning across multiple runs", async () => {
   await withTempDir(async (repoDir) => {
+    // Initialize the test repo with marker file
+    await initializeTestRepo(repoDir);
+
     // Create a model
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     let definition = Definition.create({
@@ -687,6 +734,9 @@ Deno.test("Integration: data versioning across multiple runs", async () => {
 
 Deno.test("Integration: output get fails for non-existent output", async () => {
   await withTempDir(async (repoDir) => {
+    // Initialize the test repo with marker file
+    await initializeTestRepo(repoDir);
+
     const result = await runCliCommand(
       [
         "model",
@@ -711,6 +761,9 @@ Deno.test("Integration: output get fails for non-existent output", async () => {
 
 Deno.test("Integration: data get fails for non-existent model", async () => {
   await withTempDir(async (repoDir) => {
+    // Initialize the test repo with marker file
+    await initializeTestRepo(repoDir);
+
     const result = await runCliCommand(
       [
         "data",
@@ -730,6 +783,9 @@ Deno.test("Integration: data get fails for non-existent model", async () => {
 
 Deno.test("Integration: output data fails for non-existent field", async () => {
   await withTempDir(async (repoDir) => {
+    // Initialize the test repo with marker file
+    await initializeTestRepo(repoDir);
+
     // Create and run a model
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const definition = Definition.create({

--- a/integration/definition_lifecycle_test.ts
+++ b/integration/definition_lifecycle_test.ts
@@ -11,6 +11,7 @@
 import { assertEquals, assertExists } from "@std/assert";
 import { join } from "@std/path";
 import { ensureDir } from "@std/fs";
+import { stringify as stringifyYaml } from "@std/yaml";
 import { Definition } from "../src/domain/definitions/definition.ts";
 import { ModelType } from "../src/domain/models/model_type.ts";
 import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
@@ -28,6 +29,30 @@ async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
 async function setupRepoDir(dir: string): Promise<void> {
   await ensureDir(join(dir, ".swamp", "definitions"));
   await ensureDir(join(dir, ".swamp", "data"));
+}
+
+/**
+ * Initializes a test repository with marker file for CLI commands.
+ */
+async function initializeTestRepo(repoDir: string): Promise<void> {
+  const subdirs = [
+    ".swamp/definitions",
+    ".swamp/outputs",
+    ".swamp/data",
+    ".swamp/logs",
+  ];
+  for (const subdir of subdirs) {
+    await ensureDir(join(repoDir, subdir));
+  }
+
+  const markerData = {
+    swampVersion: "0.0.0",
+    initializedAt: new Date().toISOString(),
+  };
+  await Deno.writeTextFile(
+    join(repoDir, ".swamp.yaml"),
+    stringifyYaml(markerData as Record<string, unknown>),
+  );
 }
 
 async function runCliCommand(
@@ -477,6 +502,9 @@ Deno.test("Definition Lifecycle: CEL expression with arithmetic", async () => {
 
 Deno.test("CLI: model method run creates Data with correct metadata", async () => {
   await withTempDir(async (repoDir) => {
+    // Initialize the test repo with marker file
+    await initializeTestRepo(repoDir);
+
     // Create a model definition using repository
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const modelType = ModelType.create("swamp/echo");
@@ -525,6 +553,9 @@ Deno.test("CLI: model method run creates Data with correct metadata", async () =
 
 Deno.test("CLI: model method run creates versioned Data on subsequent calls", async () => {
   await withTempDir(async (repoDir) => {
+    // Initialize the test repo with marker file
+    await initializeTestRepo(repoDir);
+
     // Create a model definition using repository
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const modelType = ModelType.create("swamp/echo");

--- a/integration/echo_model_test.ts
+++ b/integration/echo_model_test.ts
@@ -9,8 +9,8 @@
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { join } from "@std/path";
-import { existsSync } from "@std/fs";
-import { parse as parseYaml } from "@std/yaml";
+import { ensureDir, existsSync } from "@std/fs";
+import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import { Definition } from "../src/domain/definitions/definition.ts";
 import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
 import { FileSystemUnifiedDataRepository } from "../src/infrastructure/persistence/unified_data_repository.ts";
@@ -27,6 +27,27 @@ async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   } finally {
     await Deno.remove(dir, { recursive: true });
   }
+}
+
+async function initializeTestRepo(repoDir: string): Promise<void> {
+  const subdirs = [
+    ".swamp/definitions",
+    ".swamp/outputs",
+    ".swamp/data",
+    ".swamp/logs",
+  ];
+  for (const subdir of subdirs) {
+    await ensureDir(join(repoDir, subdir));
+  }
+
+  const markerData = {
+    swampVersion: "0.0.0",
+    initializedAt: new Date().toISOString(),
+  };
+  await Deno.writeTextFile(
+    join(repoDir, ".swamp.yaml"),
+    stringifyYaml(markerData as Record<string, unknown>),
+  );
 }
 
 /**
@@ -193,6 +214,7 @@ async function runCliCommand(
 
 Deno.test("CLI: model create command creates definition file", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Run the CLI command
     const result = await runCliCommand(
       [
@@ -227,6 +249,7 @@ Deno.test("CLI: model create command creates definition file", async () => {
 
 Deno.test("CLI: model create command rejects duplicate names", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create first definition
     const result1 = await runCliCommand(
       [
@@ -262,6 +285,7 @@ Deno.test("CLI: model create command rejects duplicate names", async () => {
 
 Deno.test("CLI: model create command rejects unknown model type", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const result = await runCliCommand(
       [
         "model",
@@ -283,6 +307,7 @@ Deno.test("CLI: model create command rejects unknown model type", async () => {
 
 Deno.test("CLI: model method run creates data", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // First create a model
     const createResult = await runCliCommand(
       [
@@ -345,6 +370,7 @@ Deno.test("CLI: model method run creates data", async () => {
 
 Deno.test("CLI: model method run by model ID", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a model and set up its attributes
     const createResult = await runCliCommand(
       [
@@ -393,6 +419,7 @@ Deno.test("CLI: model method run by model ID", async () => {
 
 Deno.test("CLI: model method run fails for unknown model", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const result = await runCliCommand(
       [
         "model",
@@ -413,6 +440,7 @@ Deno.test("CLI: model method run fails for unknown model", async () => {
 
 Deno.test("CLI: model method run fails for unknown method", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a model
     const createResult = await runCliCommand(
       [
@@ -450,6 +478,7 @@ Deno.test("CLI: model method run fails for unknown method", async () => {
 
 Deno.test("CLI: model method run fails for missing required attributes", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a model without setting the required 'message' attribute
     const createResult = await runCliCommand(
       [
@@ -492,6 +521,7 @@ Deno.test("CLI: model method run fails for missing required attributes", async (
 
 Deno.test("CLI: model search returns all models in JSON mode", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create two models
     await runCliCommand(
       [
@@ -537,6 +567,7 @@ Deno.test("CLI: model search returns all models in JSON mode", async () => {
 
 Deno.test("CLI: model search with multiple matches returns list in JSON mode", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create models with similar names
     await runCliCommand(
       [
@@ -579,6 +610,7 @@ Deno.test("CLI: model search with multiple matches returns list in JSON mode", a
 
 Deno.test("CLI: model search with single match returns full details in JSON mode", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create two models with different names
     const createResult = await runCliCommand(
       [

--- a/integration/keeb_shell_model_test.ts
+++ b/integration/keeb_shell_model_test.ts
@@ -3,6 +3,9 @@
  */
 
 import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+import { stringify as stringifyYaml } from "@std/yaml";
 import { Workflow } from "../src/domain/workflows/workflow.ts";
 import { Job } from "../src/domain/workflows/job.ts";
 import { Step } from "../src/domain/workflows/step.ts";
@@ -20,6 +23,29 @@ async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   } finally {
     await Deno.remove(dir, { recursive: true });
   }
+}
+
+async function initializeTestRepo(repoDir: string): Promise<void> {
+  const subdirs = [
+    ".swamp/definitions",
+    ".swamp/outputs",
+    ".swamp/data",
+    ".swamp/logs",
+    ".swamp/workflows",
+    ".swamp/workflow-runs",
+  ];
+  for (const subdir of subdirs) {
+    await ensureDir(join(repoDir, subdir));
+  }
+
+  const markerData = {
+    swampVersion: "0.0.0",
+    initializedAt: new Date().toISOString(),
+  };
+  await Deno.writeTextFile(
+    join(repoDir, ".swamp.yaml"),
+    stringifyYaml(markerData as Record<string, unknown>),
+  );
 }
 
 async function runCliCommand(
@@ -43,6 +69,8 @@ async function runCliCommand(
 
 Deno.test("CLI: keeb/shell model executes simple shell commands", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
     // Create a shell model that echoes a message
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const definition = Definition.create({
@@ -83,6 +111,8 @@ Deno.test("CLI: keeb/shell model executes simple shell commands", async () => {
 
 Deno.test("CLI: keeb/shell model handles failing commands", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
     // Create a shell model that runs a failing command
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const definition = Definition.create({
@@ -123,6 +153,8 @@ Deno.test("CLI: keeb/shell model handles failing commands", async () => {
 
 Deno.test("CLI: workflow with keeb/shell models and dependencies", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
     const definitionRepo = new YamlDefinitionRepository(repoDir);
 
     // Create first model that creates a file
@@ -212,6 +244,8 @@ Deno.test("CLI: workflow with keeb/shell models and dependencies", async () => {
 
 Deno.test("CLI: keeb/shell model with cross-model expressions", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
     const definitionRepo = new YamlDefinitionRepository(repoDir);
 
     // Create source model
@@ -291,6 +325,8 @@ Deno.test("CLI: keeb/shell model with cross-model expressions", async () => {
 
 Deno.test("CLI: keeb/shell model with self-reference expressions", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
     const definitionRepo = new YamlDefinitionRepository(repoDir);
 
     // Create model that references its own name

--- a/integration/model_validate_test.ts
+++ b/integration/model_validate_test.ts
@@ -3,6 +3,9 @@
  */
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+import { stringify as stringifyYaml } from "@std/yaml";
 import { Definition } from "../src/domain/definitions/definition.ts";
 import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
 import { ECHO_MODEL_TYPE } from "../src/domain/models/echo/echo_model.ts";
@@ -14,6 +17,27 @@ async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   } finally {
     await Deno.remove(dir, { recursive: true });
   }
+}
+
+async function initializeTestRepo(repoDir: string): Promise<void> {
+  const subdirs = [
+    ".swamp/definitions",
+    ".swamp/outputs",
+    ".swamp/data",
+    ".swamp/logs",
+  ];
+  for (const subdir of subdirs) {
+    await ensureDir(join(repoDir, subdir));
+  }
+
+  const markerData = {
+    swampVersion: "0.0.0",
+    initializedAt: new Date().toISOString(),
+  };
+  await Deno.writeTextFile(
+    join(repoDir, ".swamp.yaml"),
+    stringifyYaml(markerData as Record<string, unknown>),
+  );
 }
 
 async function runCliCommand(
@@ -37,6 +61,7 @@ async function runCliCommand(
 
 Deno.test("CLI: model validate passes for valid echo model definition", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const modelType = ECHO_MODEL_TYPE;
 
@@ -81,6 +106,7 @@ Deno.test("CLI: model validate passes for valid echo model definition", async ()
 
 Deno.test("CLI: model validate passes for valid echo model definition", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const modelType = ECHO_MODEL_TYPE;
 
@@ -120,6 +146,7 @@ Deno.test("CLI: model validate passes for valid echo model definition", async ()
 
 Deno.test("CLI: model validate fails for invalid definition attributes", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const modelType = ECHO_MODEL_TYPE;
 
@@ -168,6 +195,7 @@ Deno.test("CLI: model validate fails for invalid definition attributes", async (
 
 Deno.test("CLI: model validate can look up by UUID", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const modelType = ECHO_MODEL_TYPE;
 
@@ -206,6 +234,8 @@ Deno.test("CLI: model validate can look up by UUID", async () => {
 
 Deno.test("CLI: model validate errors for non-existent model", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
     // Run the validate command for a model that doesn't exist
     const result = await runCliCommand(
       [
@@ -230,6 +260,7 @@ Deno.test("CLI: model validate errors for non-existent model", async () => {
 
 Deno.test("CLI: model validate auto-detects non-TTY and uses JSON output", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const modelType = ECHO_MODEL_TYPE;
 
@@ -270,6 +301,7 @@ Deno.test("CLI: model validate auto-detects non-TTY and uses JSON output", async
 
 Deno.test("CLI: model validate with no args validates all models", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const modelType = ECHO_MODEL_TYPE;
 
@@ -321,6 +353,7 @@ Deno.test("CLI: model validate with no args validates all models", async () => {
 
 Deno.test("CLI: model validate with no args exits 1 when any model fails", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const modelType = ECHO_MODEL_TYPE;
 
@@ -365,6 +398,8 @@ Deno.test("CLI: model validate with no args exits 1 when any model fails", async
 
 Deno.test("CLI: model validate with no args errors when no models found", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
     // Run the validate command on an empty repo
     const result = await runCliCommand(
       [
@@ -388,6 +423,7 @@ Deno.test("CLI: model validate with no args errors when no models found", async 
 
 Deno.test("CLI: model validate with no args auto-detects non-TTY and uses JSON output", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const modelType = ECHO_MODEL_TYPE;
 

--- a/integration/repo_index_test.ts
+++ b/integration/repo_index_test.ts
@@ -11,6 +11,7 @@ import { assertEquals } from "@std/assert";
 import { join } from "@std/path";
 import { existsSync } from "@std/fs";
 import { ensureDir } from "@std/fs";
+import { stringify as stringifyYaml } from "@std/yaml";
 import { ModelType } from "../src/domain/models/model_type.ts";
 import { Definition } from "../src/domain/definitions/definition.ts";
 import { Workflow } from "../src/domain/workflows/workflow.ts";
@@ -37,6 +38,7 @@ async function setupRepoDir(dir: string): Promise<void> {
     ".swamp/definitions",
     ".swamp/data",
     ".swamp/outputs",
+    ".swamp/logs",
     // Logical view directories
     "models",
     "workflows",
@@ -44,6 +46,16 @@ async function setupRepoDir(dir: string): Promise<void> {
   for (const subdir of subdirs) {
     await ensureDir(join(dir, subdir));
   }
+
+  // Create the .swamp.yaml marker file for CLI commands
+  const markerData = {
+    swampVersion: "0.0.0",
+    initializedAt: new Date().toISOString(),
+  };
+  await Deno.writeTextFile(
+    join(dir, ".swamp.yaml"),
+    stringifyYaml(markerData as Record<string, unknown>),
+  );
 }
 
 // ============================================================================

--- a/integration/test_helpers.ts
+++ b/integration/test_helpers.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared test helpers for integration tests.
+ */
+
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+import { stringify as stringifyYaml } from "@std/yaml";
+
+/**
+ * Initializes a test repository with the required marker file and directory structure.
+ * Call this before running any CLI commands that require an initialized repo.
+ */
+export async function initializeTestRepo(repoDir: string): Promise<void> {
+  // Create the .swamp directory structure
+  const subdirs = [
+    ".swamp/definitions",
+    ".swamp/outputs",
+    ".swamp/data",
+    ".swamp/logs",
+    ".swamp/workflows",
+    ".swamp/workflow-runs",
+    ".swamp/vault",
+    ".swamp/secrets",
+  ];
+  for (const subdir of subdirs) {
+    await ensureDir(join(repoDir, subdir));
+  }
+
+  // Create the .swamp.yaml marker file
+  const markerData = {
+    swampVersion: "0.0.0",
+    initializedAt: new Date().toISOString(),
+  };
+  await Deno.writeTextFile(
+    join(repoDir, ".swamp.yaml"),
+    stringifyYaml(markerData as Record<string, unknown>),
+  );
+}
+
+/**
+ * Runs a CLI command via `deno task dev`.
+ */
+export async function runCliCommand(
+  args: string[],
+  cwd: string,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["task", "dev", ...args],
+    stdout: "piped",
+    stderr: "piped",
+    cwd,
+  });
+
+  const { code, stdout, stderr } = await command.output();
+  return {
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+    code,
+  };
+}

--- a/integration/vault_cel_integration_test.ts
+++ b/integration/vault_cel_integration_test.ts
@@ -10,6 +10,7 @@
 import { assertEquals, assertExists, assertStringIncludes } from "@std/assert";
 import { join } from "@std/path";
 import { ensureDir, existsSync } from "@std/fs";
+import { stringify as stringifyYaml } from "@std/yaml";
 import { Definition } from "../src/domain/definitions/definition.ts";
 import { ModelType } from "../src/domain/models/model_type.ts";
 import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
@@ -29,6 +30,21 @@ async function setupRepoDir(dir: string): Promise<void> {
   await ensureDir(join(dir, ".swamp", "definitions"));
   await ensureDir(join(dir, ".swamp", "vault"));
   await ensureDir(join(dir, ".swamp", "secrets"));
+  await ensureDir(join(dir, ".swamp", "data"));
+  await ensureDir(join(dir, ".swamp", "outputs"));
+  await ensureDir(join(dir, ".swamp", "logs"));
+  await ensureDir(join(dir, ".swamp", "workflows"));
+  await ensureDir(join(dir, ".swamp", "workflow-runs"));
+
+  // Create the .swamp.yaml marker file for CLI commands
+  const markerData = {
+    swampVersion: "0.0.0",
+    initializedAt: new Date().toISOString(),
+  };
+  await Deno.writeTextFile(
+    join(dir, ".swamp.yaml"),
+    stringifyYaml(markerData as Record<string, unknown>),
+  );
 }
 
 async function runCliCommand(

--- a/integration/vault_test.ts
+++ b/integration/vault_test.ts
@@ -13,8 +13,8 @@
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { join } from "@std/path";
-import { existsSync } from "@std/fs";
-import { parse as parseYaml } from "@std/yaml";
+import { ensureDir, existsSync } from "@std/fs";
+import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   const dir = await Deno.makeTempDir({ prefix: "swamp-vault-integration-" });
@@ -23,6 +23,31 @@ async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   } finally {
     await Deno.remove(dir, { recursive: true });
   }
+}
+
+async function initializeTestRepo(repoDir: string): Promise<void> {
+  const subdirs = [
+    ".swamp/definitions",
+    ".swamp/outputs",
+    ".swamp/data",
+    ".swamp/logs",
+    ".swamp/vault",
+    ".swamp/secrets",
+    ".swamp/workflows",
+    ".swamp/workflow-runs",
+  ];
+  for (const subdir of subdirs) {
+    await ensureDir(join(repoDir, subdir));
+  }
+
+  const markerData = {
+    swampVersion: "0.0.0",
+    initializedAt: new Date().toISOString(),
+  };
+  await Deno.writeTextFile(
+    join(repoDir, ".swamp.yaml"),
+    stringifyYaml(markerData as Record<string, unknown>),
+  );
 }
 
 /**
@@ -58,6 +83,7 @@ async function runCliCommand(
 
 Deno.test("CLI: vault create command creates vault config file", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const result = await runCliCommand([
       "vault",
       "create",
@@ -110,6 +136,7 @@ Deno.test("CLI: vault create command creates vault config file", async () => {
 
 Deno.test("CLI: vault create command creates local_encryption vault", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const result = await runCliCommand([
       "vault",
       "create",
@@ -140,6 +167,7 @@ Deno.test("CLI: vault create command creates local_encryption vault", async () =
 
 Deno.test("CLI: vault create command rejects duplicate vault names", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create first vault
     const result1 = await runCliCommand([
       "vault",
@@ -172,6 +200,7 @@ Deno.test("CLI: vault create command rejects duplicate vault names", async () =>
 
 Deno.test("CLI: vault create command rejects duplicate names across types", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create vault with aws type
     const result1 = await runCliCommand([
       "vault",
@@ -208,6 +237,7 @@ Deno.test("CLI: vault create command rejects duplicate names across types", asyn
 
 Deno.test("CLI: vault create command rejects unknown vault type", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const result = await runCliCommand([
       "vault",
       "create",
@@ -228,6 +258,7 @@ Deno.test("CLI: vault create command rejects unknown vault type", async () => {
 
 Deno.test("CLI: vault create command rejects invalid vault names", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Name starting with number
     const result1 = await runCliCommand([
       "vault",
@@ -301,6 +332,7 @@ Deno.test("CLI: vault type search filters by query", async () => {
 
 Deno.test("CLI: vault create creates logical view symlink", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const result = await runCliCommand([
       "vault",
       "create",
@@ -351,6 +383,7 @@ Deno.test("CLI: vault create creates logical view symlink", async () => {
 
 Deno.test("CLI: vault search returns empty results for empty repository", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const result = await runCliCommand([
       "vault",
       "search",
@@ -374,6 +407,7 @@ Deno.test("CLI: vault search returns empty results for empty repository", async 
 
 Deno.test("CLI: vault search returns all vaults in repository", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create two vaults
     await runCliCommand([
       "vault",
@@ -419,6 +453,7 @@ Deno.test("CLI: vault search returns all vaults in repository", async () => {
 
 Deno.test("CLI: vault search filters by query", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create two vaults
     await runCliCommand([
       "vault",
@@ -463,6 +498,7 @@ Deno.test("CLI: vault search filters by query", async () => {
 
 Deno.test("CLI: vault get shows vault details by name", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a vault
     await runCliCommand([
       "vault",
@@ -502,6 +538,7 @@ Deno.test("CLI: vault get shows vault details by name", async () => {
 
 Deno.test("CLI: vault get shows vault details by ID", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a vault and get its ID
     const createResult = await runCliCommand([
       "vault",
@@ -538,6 +575,7 @@ Deno.test("CLI: vault get shows vault details by ID", async () => {
 
 Deno.test("CLI: vault get fails for non-existent vault", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const result = await runCliCommand([
       "vault",
       "get",
@@ -556,6 +594,7 @@ Deno.test("CLI: vault get fails for non-existent vault", async () => {
 
 Deno.test("CLI: vault get with --type narrows search", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a vault
     await runCliCommand([
       "vault",
@@ -604,6 +643,7 @@ Deno.test("CLI: vault get with --type narrows search", async () => {
 
 Deno.test("CLI: vault edit requires vault name in non-interactive mode", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const result = await runCliCommand([
       "vault",
       "edit",
@@ -625,6 +665,7 @@ Deno.test("CLI: vault edit requires vault name in non-interactive mode", async (
 
 Deno.test("CLI: vault edit fails for non-existent vault", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const result = await runCliCommand([
       "vault",
       "edit",
@@ -643,6 +684,7 @@ Deno.test("CLI: vault edit fails for non-existent vault", async () => {
 
 Deno.test("CLI: vault edit with --type narrows search", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a vault
     await runCliCommand([
       "vault",
@@ -678,6 +720,7 @@ Deno.test("CLI: vault edit with --type narrows search", async () => {
 
 Deno.test("CLI: vault configs are loaded from .swamp/vault/ directory", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a vault using the CLI (stores in .swamp/vault/)
     const createResult = await runCliCommand([
       "vault",
@@ -732,6 +775,7 @@ Deno.test("CLI: vault configs are loaded from .swamp/vault/ directory", async ()
 
 Deno.test("CLI: vault expression resolves secrets from created vault", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // 1. Create a local_encryption vault via CLI
     const vaultCreateResult = await runCliCommand([
       "vault",
@@ -850,6 +894,7 @@ attributes:
 
 Deno.test("CLI: vault put stores secret in vault", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a local_encryption vault
     const createResult = await runCliCommand([
       "vault",
@@ -904,6 +949,7 @@ Deno.test("CLI: vault put stores secret in vault", async () => {
 
 Deno.test("CLI: vault put handles values with equals signs", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a vault
     await runCliCommand([
       "vault",
@@ -947,6 +993,7 @@ Deno.test("CLI: vault put handles values with equals signs", async () => {
 
 Deno.test("CLI: vault put fails for non-existent vault", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const result = await runCliCommand([
       "vault",
       "put",
@@ -966,6 +1013,7 @@ Deno.test("CLI: vault put fails for non-existent vault", async () => {
 
 Deno.test("CLI: vault put fails for invalid KEY=VALUE format", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a vault
     await runCliCommand([
       "vault",
@@ -997,6 +1045,7 @@ Deno.test("CLI: vault put fails for invalid KEY=VALUE format", async () => {
 
 Deno.test("CLI: vault put --force skips overwrite confirmation", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a vault
     await runCliCommand([
       "vault",
@@ -1045,6 +1094,7 @@ Deno.test("CLI: vault put --force skips overwrite confirmation", async () => {
 
 Deno.test("CLI: vault put allows empty value", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a vault
     await runCliCommand([
       "vault",
@@ -1080,6 +1130,7 @@ Deno.test("CLI: vault put allows empty value", async () => {
 
 Deno.test("CLI: vault list-keys returns empty list for vault with no secrets", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a local_encryption vault
     await runCliCommand([
       "vault",
@@ -1117,6 +1168,7 @@ Deno.test("CLI: vault list-keys returns empty list for vault with no secrets", a
 
 Deno.test("CLI: vault list-keys returns stored secret keys", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a vault
     await runCliCommand([
       "vault",
@@ -1184,6 +1236,7 @@ Deno.test("CLI: vault list-keys returns stored secret keys", async () => {
 
 Deno.test("CLI: vault list-keys fails for non-existent vault", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const result = await runCliCommand([
       "vault",
       "list-keys",
@@ -1202,6 +1255,7 @@ Deno.test("CLI: vault list-keys fails for non-existent vault", async () => {
 
 Deno.test("CLI: vault list-keys returns keys in sorted order", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a vault
     await runCliCommand([
       "vault",

--- a/integration/workflow_new_architecture_test.ts
+++ b/integration/workflow_new_architecture_test.ts
@@ -11,6 +11,7 @@
 import { assertEquals, assertExists, assertStringIncludes } from "@std/assert";
 import { join } from "@std/path";
 import { ensureDir } from "@std/fs";
+import { stringify as stringifyYaml } from "@std/yaml";
 import { Workflow } from "../src/domain/workflows/workflow.ts";
 import { Job } from "../src/domain/workflows/job.ts";
 import { Step } from "../src/domain/workflows/step.ts";
@@ -37,7 +38,19 @@ async function setupRepoDir(dir: string): Promise<void> {
   await ensureDir(join(dir, ".swamp", "workflows"));
   await ensureDir(join(dir, ".swamp", "workflow-runs"));
   await ensureDir(join(dir, ".swamp", "data"));
+  await ensureDir(join(dir, ".swamp", "outputs"));
+  await ensureDir(join(dir, ".swamp", "logs"));
   await ensureDir(join(dir, "workflows"));
+
+  // Create the .swamp.yaml marker file for CLI commands
+  const markerData = {
+    swampVersion: "0.0.0",
+    initializedAt: new Date().toISOString(),
+  };
+  await Deno.writeTextFile(
+    join(dir, ".swamp.yaml"),
+    stringifyYaml(markerData as Record<string, unknown>),
+  );
 }
 
 async function runCliCommand(

--- a/integration/workflow_test.ts
+++ b/integration/workflow_test.ts
@@ -3,6 +3,9 @@
  */
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+import { stringify as stringifyYaml } from "@std/yaml";
 import { Workflow } from "../src/domain/workflows/workflow.ts";
 import { Job } from "../src/domain/workflows/job.ts";
 import { Step } from "../src/domain/workflows/step.ts";
@@ -20,6 +23,31 @@ async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   } finally {
     await Deno.remove(dir, { recursive: true });
   }
+}
+
+async function initializeTestRepo(repoDir: string): Promise<void> {
+  const subdirs = [
+    ".swamp/definitions",
+    ".swamp/outputs",
+    ".swamp/data",
+    ".swamp/logs",
+    ".swamp/workflows",
+    ".swamp/workflow-runs",
+    ".swamp/vault",
+    ".swamp/secrets",
+  ];
+  for (const subdir of subdirs) {
+    await ensureDir(join(repoDir, subdir));
+  }
+
+  const markerData = {
+    swampVersion: "0.0.0",
+    initializedAt: new Date().toISOString(),
+  };
+  await Deno.writeTextFile(
+    join(repoDir, ".swamp.yaml"),
+    stringifyYaml(markerData as Record<string, unknown>),
+  );
 }
 
 async function runCliCommand(
@@ -79,6 +107,7 @@ function createTestWorkflow(name: string): Workflow {
 
 Deno.test("CLI: workflow create creates new workflow file", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const result = await runCliCommand(
       [
         "workflow",
@@ -108,6 +137,7 @@ Deno.test("CLI: workflow create creates new workflow file", async () => {
 
 Deno.test("CLI: workflow create creates logical view symlink", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const result = await runCliCommand(
       [
         "workflow",
@@ -160,6 +190,7 @@ Deno.test("CLI: workflow create creates logical view symlink", async () => {
 
 Deno.test("CLI: workflow create rejects duplicate names", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create first workflow
     await runCliCommand(
       ["workflow", "create", "duplicate-name", "--repo-dir", repoDir],
@@ -181,6 +212,7 @@ Deno.test("CLI: workflow create rejects duplicate names", async () => {
 
 Deno.test("CLI: workflow get shows workflow details", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const repo = new YamlWorkflowRepository(repoDir);
     const workflow = createTestWorkflow("get-test");
     await repo.save(workflow);
@@ -215,6 +247,7 @@ Deno.test("CLI: workflow get shows workflow details", async () => {
 
 Deno.test("CLI: workflow get can look up by UUID", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const repo = new YamlWorkflowRepository(repoDir);
     const workflow = createTestWorkflow("uuid-lookup-test");
     await repo.save(workflow);
@@ -245,6 +278,7 @@ Deno.test("CLI: workflow get can look up by UUID", async () => {
 
 Deno.test("CLI: workflow get errors for non-existent workflow", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const result = await runCliCommand(
       [
         "workflow",
@@ -266,6 +300,7 @@ Deno.test("CLI: workflow get errors for non-existent workflow", async () => {
 
 Deno.test("CLI: workflow validate passes for valid workflow", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const repo = new YamlWorkflowRepository(repoDir);
     const workflow = createTestWorkflow("valid-workflow");
     await repo.save(workflow);
@@ -300,6 +335,7 @@ Deno.test("CLI: workflow validate passes for valid workflow", async () => {
 
 Deno.test("CLI: workflow validate with no args validates all workflows", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const repo = new YamlWorkflowRepository(repoDir);
     const workflow1 = createTestWorkflow("workflow-1");
     const workflow2 = createTestWorkflow("workflow-2");
@@ -333,6 +369,7 @@ Deno.test("CLI: workflow validate with no args validates all workflows", async (
 
 Deno.test("CLI: workflow validate errors when no workflows found", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const result = await runCliCommand(
       [
         "workflow",
@@ -353,6 +390,7 @@ Deno.test("CLI: workflow validate errors when no workflows found", async () => {
 
 Deno.test("CLI: workflow search returns all workflows in JSON mode", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const repo = new YamlWorkflowRepository(repoDir);
     const workflow1 = createTestWorkflow("search-1");
     const workflow2 = createTestWorkflow("search-2");
@@ -387,6 +425,7 @@ Deno.test("CLI: workflow search returns all workflows in JSON mode", async () =>
 
 Deno.test("CLI: workflow search filters by query with multiple matches in JSON mode", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const repo = new YamlWorkflowRepository(repoDir);
     const workflow1 = createTestWorkflow("deploy-staging");
     const workflow2 = createTestWorkflow("deploy-production");
@@ -423,6 +462,7 @@ Deno.test("CLI: workflow search filters by query with multiple matches in JSON m
 
 Deno.test("CLI: workflow search with single match returns full details in JSON mode", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const repo = new YamlWorkflowRepository(repoDir);
     const workflow1 = createTestWorkflow("alpha-workflow");
     const workflow2 = createTestWorkflow("beta-workflow");
@@ -461,6 +501,7 @@ Deno.test("CLI: workflow search with single match returns full details in JSON m
 
 Deno.test("CLI: workflow run executes simple workflow", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const repo = new YamlWorkflowRepository(repoDir);
     const workflow = Workflow.create({
       name: "simple-run",
@@ -507,6 +548,7 @@ Deno.test("CLI: workflow run executes simple workflow", async () => {
 
 Deno.test("CLI: workflow run executes workflow with dependencies", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const repo = new YamlWorkflowRepository(repoDir);
     const workflow = createTestWorkflow("dep-run");
     await repo.save(workflow);
@@ -538,6 +580,7 @@ Deno.test("CLI: workflow run executes workflow with dependencies", async () => {
 
 Deno.test("CLI: workflow run fails when step fails", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const repo = new YamlWorkflowRepository(repoDir);
     const workflow = Workflow.create({
       name: "failing-workflow",
@@ -582,6 +625,7 @@ Deno.test("CLI: workflow run fails when step fails", async () => {
 
 Deno.test("CLI: workflow run skips job when condition not met", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const repo = new YamlWorkflowRepository(repoDir);
     const workflow = Workflow.create({
       name: "conditional-skip",
@@ -634,6 +678,7 @@ Deno.test("CLI: workflow run skips job when condition not met", async () => {
 
 Deno.test("CLI: workflow run errors for non-existent workflow", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     const result = await runCliCommand(
       [
         "workflow",
@@ -672,6 +717,7 @@ Deno.test("CLI: workflow shows help", async () => {
 
 Deno.test("CLI: workflow run fails when model has invalid expression syntax", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a model input with invalid expression (missing model. prefix)
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const input = Definition.create({
@@ -727,6 +773,7 @@ Deno.test("CLI: workflow run fails when model has invalid expression syntax", as
 
 Deno.test("CLI: workflow run fails when model has malformed expression", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a model input with malformed expression (missing $ prefix)
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const input = Definition.create({
@@ -782,6 +829,7 @@ Deno.test("CLI: workflow run fails when model has malformed expression", async (
 
 Deno.test("CLI: workflow run succeeds with valid model expressions", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create two model inputs - one will reference the other
     const definitionRepo = new YamlDefinitionRepository(repoDir);
 
@@ -858,6 +906,7 @@ Deno.test("CLI: workflow run succeeds with valid model expressions", async () =>
 
 Deno.test("CLI: workflow run succeeds with self reference expressions", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a model that references its own name
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const input = Definition.create({
@@ -915,6 +964,7 @@ Deno.test("CLI: workflow run succeeds with self reference expressions", async ()
 
 Deno.test("CLI: model delete blocked when referenced by workflow, succeeds after workflow deleted", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Step 1: Create a model using CLI
     const createModelResult = await runCliCommand(
       [
@@ -1036,6 +1086,7 @@ Deno.test("CLI: model delete blocked when referenced by workflow, succeeds after
 
 Deno.test("CLI: model delete blocked when referenced by workflow using model ID", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a model
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const input = Definition.create({
@@ -1093,6 +1144,7 @@ Deno.test("CLI: model delete blocked when referenced by workflow using model ID"
 
 Deno.test("CLI: model delete succeeds when not referenced by any workflow", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a model
     const createModelResult = await runCliCommand(
       [
@@ -1154,6 +1206,7 @@ Deno.test("CLI: model delete succeeds when not referenced by any workflow", asyn
 
 Deno.test("CLI: model delete cleans up empty type directories", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a model using CLI
     const createResult = await runCliCommand(
       [
@@ -1233,6 +1286,7 @@ Deno.test("CLI: model delete cleans up empty type directories", async () => {
 
 Deno.test("CLI: workflow delete command removes workflow and all runs", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a workflow
     const workflowRepo = new YamlWorkflowRepository(repoDir);
     const workflow = Workflow.create({
@@ -1312,6 +1366,7 @@ Deno.test("CLI: workflow delete command removes workflow and all runs", async ()
 
 Deno.test("CLI: workflow run evaluates env variable expressions", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a model with an env variable expression
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const input = Definition.create({
@@ -1369,6 +1424,7 @@ Deno.test("CLI: workflow run evaluates env variable expressions", async () => {
 
 Deno.test("CLI: workflow run evaluates inline env expression with surrounding text", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a model with an inline env expression (not the entire value)
     const definitionRepo = new YamlDefinitionRepository(repoDir);
 
@@ -1428,6 +1484,7 @@ Deno.test("CLI: workflow run evaluates inline env expression with surrounding te
 
 Deno.test("CLI: workflow run resolves vault expressions in model inputs", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // 1. Create a local_encryption vault via CLI
     const vaultCreateResult = await runCliCommand(
       [
@@ -1525,6 +1582,7 @@ Deno.test("CLI: workflow run resolves vault expressions in model inputs", async 
 
 Deno.test("CLI: workflow run creates Data with step-output tags", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a model input
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const input = Definition.create({
@@ -1611,6 +1669,7 @@ Deno.test("CLI: workflow run creates Data with step-output tags", async () => {
 
 Deno.test("CLI: workflow run persists data artifacts in workflow run record", async () => {
   await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
     // Create a model input
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const input = Definition.create({

--- a/src/cli/commands/data_gc.ts
+++ b/src/cli/commands/data_gc.ts
@@ -5,7 +5,7 @@ import {
   renderDataGCPreview,
 } from "../../presentation/output/data_gc_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
-import { createRepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import { DefaultDataLifecycleService } from "../../domain/data/data_lifecycle_service.ts";
 
 /**
@@ -39,8 +39,10 @@ export const dataGcCommand = new Command()
   .option("-f, --force", "Skip confirmation prompt")
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, "data-gc");
-    const repoDir = options.repoDir ?? ".";
-    const repoContext = createRepositoryContext({ repoDir });
+    const { repoDir, repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
 
     const service = new DefaultDataLifecycleService(
       repoContext.unifiedDataRepo,

--- a/src/cli/commands/data_get.ts
+++ b/src/cli/commands/data_get.ts
@@ -4,8 +4,7 @@ import {
   renderDataGet,
 } from "../../presentation/output/data_get_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
-import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
-import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { UserError } from "../../domain/errors.ts";
 
@@ -28,9 +27,12 @@ export const dataGetCommand = new Command()
       const ctx = createContext(options as GlobalOptions, "data-get");
       ctx.logger.debug`Getting data: model=${modelIdOrName}, name=${dataName}`;
 
-      const repoDir = options.repoDir ?? ".";
-      const definitionRepo = new YamlDefinitionRepository(repoDir);
-      const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+      const { repoContext } = await requireInitializedRepo({
+        repoDir: options.repoDir ?? ".",
+        outputMode: ctx.outputMode,
+      });
+      const definitionRepo = repoContext.definitionRepo;
+      const dataRepo = repoContext.unifiedDataRepo;
 
       // Look up the model definition
       ctx.logger.debug`Looking up model: ${modelIdOrName}`;

--- a/src/cli/commands/data_list.ts
+++ b/src/cli/commands/data_list.ts
@@ -6,8 +6,7 @@ import {
   renderDataList,
 } from "../../presentation/output/data_list_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
-import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
-import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { UserError } from "../../domain/errors.ts";
 
@@ -28,9 +27,12 @@ export const dataListCommand = new Command()
     const ctx = createContext(options as GlobalOptions, "data-list");
     ctx.logger.debug`Listing data for model: ${modelIdOrName}`;
 
-    const repoDir = options.repoDir ?? ".";
-    const definitionRepo = new YamlDefinitionRepository(repoDir);
-    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const { repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
+    const definitionRepo = repoContext.definitionRepo;
+    const dataRepo = repoContext.unifiedDataRepo;
 
     // Look up the model definition
     ctx.logger.debug`Looking up model: ${modelIdOrName}`;

--- a/src/cli/commands/data_versions.ts
+++ b/src/cli/commands/data_versions.ts
@@ -5,8 +5,7 @@ import {
   renderDataVersions,
 } from "../../presentation/output/data_versions_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
-import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
-import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { UserError } from "../../domain/errors.ts";
 
@@ -29,9 +28,12 @@ export const dataVersionsCommand = new Command()
       ctx.logger
         .debug`Listing versions: model=${modelIdOrName}, name=${dataName}`;
 
-      const repoDir = options.repoDir ?? ".";
-      const definitionRepo = new YamlDefinitionRepository(repoDir);
-      const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+      const { repoContext } = await requireInitializedRepo({
+        repoDir: options.repoDir ?? ".",
+        outputMode: ctx.outputMode,
+      });
+      const definitionRepo = repoContext.definitionRepo;
+      const dataRepo = repoContext.unifiedDataRepo;
 
       // Look up the model definition
       ctx.logger.debug`Looking up model: ${modelIdOrName}`;

--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -4,9 +4,9 @@ import {
   renderModelCreate,
 } from "../../presentation/output/model_create_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import { Definition } from "../../domain/definitions/definition.ts";
-import { createRepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 import { modelValidateCommand } from "./model_validate.ts";
 import { modelMethodCommand } from "./model_method_run.ts";
@@ -44,9 +44,11 @@ export const modelCreateCommand = new Command()
       );
     }
 
-    // Create the repository context (with indexing enabled)
-    const repoDir = options.repoDir ?? ".";
-    const repoContext = createRepositoryContext({ repoDir });
+    // Validate repo initialization and create context
+    const { repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
     const definitionRepo = repoContext.definitionRepo;
 
     // Check if name already exists (globally unique across all types)

--- a/src/cli/commands/model_delete.ts
+++ b/src/cli/commands/model_delete.ts
@@ -5,7 +5,7 @@ import {
   renderModelDeleteCancelled,
 } from "../../presentation/output/model_delete_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
-import { createRepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { UserError } from "../../domain/errors.ts";
 import type { Workflow } from "../../domain/workflows/workflow.ts";
@@ -82,8 +82,10 @@ export const modelDeleteCommand = new Command()
     const ctx = createContext(options as GlobalOptions, "model-delete");
     ctx.logger.debug`Deleting model: ${modelIdOrName}`;
 
-    const repoDir = options.repoDir ?? ".";
-    const repoContext = createRepositoryContext({ repoDir });
+    const { repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
     const definitionRepo = repoContext.definitionRepo;
     const unifiedDataRepo = repoContext.unifiedDataRepo;
     const outputRepo = repoContext.outputRepo;

--- a/src/cli/commands/model_edit.ts
+++ b/src/cli/commands/model_edit.ts
@@ -10,12 +10,13 @@ import {
   renderModelSearch,
 } from "../../presentation/output/model_search_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import {
   Definition,
   type DefinitionData,
 } from "../../domain/definitions/definition.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
-import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import type { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { EditorService } from "../../infrastructure/editor/editor_service.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { UserError } from "../../domain/errors.ts";
@@ -47,8 +48,11 @@ export const modelEditCommand = new Command()
     const ctx = createContext(options as GlobalOptions, "model-edit");
     ctx.logger.debug`Editing model: ${modelIdOrName ?? "(interactive)"}`;
 
-    const repoDir = options.repoDir ?? ".";
-    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const { repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
+    const definitionRepo = repoContext.definitionRepo;
     const editorService = new EditorService();
 
     // Look up the model definition

--- a/src/cli/commands/model_evaluate.ts
+++ b/src/cli/commands/model_evaluate.ts
@@ -6,8 +6,7 @@ import {
   renderModelEvaluateSingle,
 } from "../../presentation/output/model_evaluate_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
-import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
-import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import { ExpressionEvaluationService } from "../../domain/expressions/expression_evaluation_service.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 
@@ -23,9 +22,12 @@ export const modelEvaluateCommand = new Command()
   .action(
     async function (options: AnyOptions, modelIdOrName?: string) {
       const ctx = createContext(options as GlobalOptions, "model-evaluate");
-      const repoDir = options.repoDir ?? ".";
-      const definitionRepo = new YamlDefinitionRepository(repoDir);
-      const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+      const { repoDir, repoContext } = await requireInitializedRepo({
+        repoDir: options.repoDir ?? ".",
+        outputMode: ctx.outputMode,
+      });
+      const definitionRepo = repoContext.definitionRepo;
+      const dataRepo = repoContext.unifiedDataRepo;
       const evaluationService = new ExpressionEvaluationService(
         definitionRepo,
         repoDir,

--- a/src/cli/commands/model_get.ts
+++ b/src/cli/commands/model_get.ts
@@ -4,7 +4,7 @@ import {
   renderModelGet,
 } from "../../presentation/output/model_get_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
-import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { UserError } from "../../domain/errors.ts";
 
@@ -21,8 +21,11 @@ export const modelGetCommand = new Command()
     const ctx = createContext(options as GlobalOptions, "model-get");
     ctx.logger.debug`Getting model: ${modelIdOrName}`;
 
-    const repoDir = options.repoDir ?? ".";
-    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const { repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
+    const definitionRepo = repoContext.definitionRepo;
 
     // Look up the model definition
     ctx.logger.debug`Looking up model: ${modelIdOrName}`;

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -5,11 +5,9 @@ import {
   renderModelMethodRun,
 } from "../../presentation/output/model_method_run_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { ModelOutput } from "../../domain/models/model_output.ts";
-import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
-import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
-import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 import { DefaultMethodExecutionService } from "../../domain/models/method_execution_service.ts";
 
@@ -32,10 +30,13 @@ export const modelMethodRunCommand = new Command()
       methodName: string,
     ) {
       const ctx = createContext(options as GlobalOptions, "model-method-run");
-      const repoDir = options.repoDir ?? ".";
-      const definitionRepo = new YamlDefinitionRepository(repoDir);
-      const unifiedDataRepo = new FileSystemUnifiedDataRepository(repoDir);
-      const outputRepo = new YamlOutputRepository(repoDir);
+      const { repoDir, repoContext } = await requireInitializedRepo({
+        repoDir: options.repoDir ?? ".",
+        outputMode: ctx.outputMode,
+      });
+      const definitionRepo = repoContext.definitionRepo;
+      const unifiedDataRepo = repoContext.unifiedDataRepo;
+      const outputRepo = repoContext.outputRepo;
       const executionService = new DefaultMethodExecutionService();
 
       ctx.logger

--- a/src/cli/commands/model_output_data.ts
+++ b/src/cli/commands/model_output_data.ts
@@ -1,8 +1,6 @@
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
-import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
-import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
-import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import {
   isPartialId,
@@ -34,10 +32,13 @@ export const modelOutputDataCommand = new Command()
     const ctx = createContext(options as GlobalOptions, "model-output-data");
     ctx.logger.debug`Getting data for output: ${outputIdArg}`;
 
-    const repoDir = options.repoDir ?? ".";
-    const outputRepo = new YamlOutputRepository(repoDir);
-    const definitionRepo = new YamlDefinitionRepository(repoDir);
-    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const { repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
+    const outputRepo = repoContext.outputRepo;
+    const definitionRepo = repoContext.definitionRepo;
+    const dataRepo = repoContext.unifiedDataRepo;
 
     // Find the output using partial ID matching
     const allOutputs = await outputRepo.findAllGlobal();

--- a/src/cli/commands/model_output_get.ts
+++ b/src/cli/commands/model_output_get.ts
@@ -4,8 +4,7 @@ import {
   renderModelOutputGet,
 } from "../../presentation/output/model_output_get_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
-import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
-import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 import { UserError } from "../../domain/errors.ts";
 import {
@@ -29,9 +28,12 @@ export const modelOutputGetCommand = new Command()
     const ctx = createContext(options as GlobalOptions, "model-output-get");
     ctx.logger.debug`Getting output: ${outputIdOrModelName}`;
 
-    const repoDir = options.repoDir ?? ".";
-    const definitionRepo = new YamlDefinitionRepository(repoDir);
-    const outputRepo = new YamlOutputRepository(repoDir);
+    const { repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
+    const definitionRepo = repoContext.definitionRepo;
+    const outputRepo = repoContext.outputRepo;
 
     let outputData: ModelOutputGetData;
 

--- a/src/cli/commands/model_output_logs.ts
+++ b/src/cli/commands/model_output_logs.ts
@@ -1,7 +1,6 @@
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
-import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
-import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import {
   isPartialId,
@@ -21,9 +20,12 @@ export const modelOutputLogsCommand = new Command()
     const ctx = createContext(options as GlobalOptions, "model-output-logs");
     ctx.logger.debug`Getting logs for output: ${outputIdArg}`;
 
-    const repoDir = options.repoDir ?? ".";
-    const outputRepo = new YamlOutputRepository(repoDir);
-    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const { repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
+    const outputRepo = repoContext.outputRepo;
+    const dataRepo = repoContext.unifiedDataRepo;
 
     // Find the output using partial ID matching
     const allOutputs = await outputRepo.findAllGlobal();

--- a/src/cli/commands/model_output_search.ts
+++ b/src/cli/commands/model_output_search.ts
@@ -10,8 +10,9 @@ import {
 } from "../../presentation/output/model_output_get_output.tsx";
 import type { OutputMode } from "../../presentation/output/output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
-import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
-import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
+import type { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import type { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
 import type { ModelOutput } from "../../domain/models/model_output.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
 
@@ -85,12 +86,10 @@ export function filterOutputs(
  */
 async function displayModelOutputGet(
   item: ModelOutputSearchItem,
-  repoDir: string,
+  definitionRepo: YamlDefinitionRepository,
+  outputRepo: YamlOutputRepository,
   outputMode: OutputMode,
 ): Promise<void> {
-  const definitionRepo = new YamlDefinitionRepository(repoDir);
-  const outputRepo = new YamlOutputRepository(repoDir);
-
   // Look up the full output
   const allOutputs = await outputRepo.findAllGlobal();
   const result = allOutputs.find((r) => r.output.id === item.id);
@@ -136,9 +135,12 @@ export const modelOutputSearchCommand = new Command()
     const ctx = createContext(options as GlobalOptions, "model-output-search");
     ctx.logger.debug`Searching outputs with query: ${query ?? "(none)"}`;
 
-    const repoDir = options.repoDir ?? ".";
-    const definitionRepo = new YamlDefinitionRepository(repoDir);
-    const outputRepo = new YamlOutputRepository(repoDir);
+    const { repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
+    const definitionRepo = repoContext.definitionRepo;
+    const outputRepo = repoContext.outputRepo;
 
     // Get all outputs from repository
     const allResults = await outputRepo.findAllGlobal();
@@ -167,7 +169,12 @@ export const modelOutputSearchCommand = new Command()
       if (selected) {
         ctx.logger.debug`Selected output: ${selected.id}`;
         // Display the full output details
-        await displayModelOutputGet(selected, repoDir, ctx.outputMode);
+        await displayModelOutputGet(
+          selected,
+          definitionRepo,
+          outputRepo,
+          ctx.outputMode,
+        );
       } else {
         ctx.logger.debug`Search cancelled`;
       }

--- a/src/cli/commands/model_search.ts
+++ b/src/cli/commands/model_search.ts
@@ -10,8 +10,9 @@ import {
 } from "../../presentation/output/model_get_output.tsx";
 import type { OutputMode } from "../../presentation/output/output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import { createDefinitionId } from "../../domain/definitions/definition.ts";
-import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import type { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -54,11 +55,9 @@ export function filterModels(
  */
 async function displayModelGet(
   item: ModelSearchItem,
-  repoDir: string,
+  definitionRepo: YamlDefinitionRepository,
   outputMode: OutputMode,
 ): Promise<void> {
-  const definitionRepo = new YamlDefinitionRepository(repoDir);
-
   // Look up the full definition
   const definitionId = createDefinitionId(item.id);
   const modelType = modelRegistry.types().find(
@@ -95,8 +94,11 @@ export const modelSearchCommand = new Command()
     const ctx = createContext(options as GlobalOptions, "model-search");
     ctx.logger.debug`Searching models with query: ${query ?? "(none)"}`;
 
-    const repoDir = options.repoDir ?? ".";
-    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const { repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
+    const definitionRepo = repoContext.definitionRepo;
 
     // Get all models from repository
     const allResults = await definitionRepo.findAllGlobal();
@@ -108,7 +110,11 @@ export const modelSearchCommand = new Command()
 
       // If query matches exactly one model, show full details (same as interactive selection)
       if (query && filteredModels.length === 1) {
-        await displayModelGet(filteredModels[0], repoDir, ctx.outputMode);
+        await displayModelGet(
+          filteredModels[0],
+          definitionRepo,
+          ctx.outputMode,
+        );
       } else {
         const data: ModelSearchData = {
           query: query ?? "",
@@ -128,7 +134,7 @@ export const modelSearchCommand = new Command()
       if (selected) {
         ctx.logger.debug`Selected model: ${selected.name} (${selected.id})`;
         // Display the full model details
-        await displayModelGet(selected, repoDir, ctx.outputMode);
+        await displayModelGet(selected, definitionRepo, ctx.outputMode);
       } else {
         ctx.logger.debug`Search cancelled`;
       }

--- a/src/cli/commands/model_validate.ts
+++ b/src/cli/commands/model_validate.ts
@@ -6,7 +6,7 @@ import {
   type ValidationItemData,
 } from "../../presentation/output/model_validate_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
-import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 import {
   DefaultModelValidationService,
@@ -38,8 +38,11 @@ export const modelValidateCommand = new Command()
   .action(
     async function (options: AnyOptions, modelIdOrName?: string) {
       const ctx = createContext(options as GlobalOptions, "model-validate");
-      const repoDir = options.repoDir ?? ".";
-      const definitionRepo = new YamlDefinitionRepository(repoDir);
+      const { repoContext } = await requireInitializedRepo({
+        repoDir: options.repoDir ?? ".",
+        outputMode: ctx.outputMode,
+      });
+      const definitionRepo = repoContext.definitionRepo;
       const validationService = new DefaultModelValidationService();
 
       // If no argument provided, validate all models

--- a/src/cli/commands/repo_index.ts
+++ b/src/cli/commands/repo_index.ts
@@ -8,7 +8,7 @@ import {
   type RepoIndexVerifyData,
 } from "../../presentation/output/repo_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
-import { createRepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -20,15 +20,18 @@ export const repoIndexCommand = new Command()
   .option("--prune", "Remove broken symlinks without rebuilding")
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, "repo-index");
-    const repoDir = options.repoDir ?? ".";
+
+    // Validate repo initialization (with indexing disabled for manual operations)
+    const { repoDir, repoContext } = await requireInitializedRepo(
+      {
+        repoDir: options.repoDir ?? ".",
+        outputMode: ctx.outputMode,
+      },
+      { enableIndexing: false },
+    );
 
     ctx.logger.debug`Managing repository index at: ${repoDir}`;
 
-    // Create repository context (indexing disabled for manual operations)
-    const repoContext = createRepositoryContext({
-      repoDir,
-      enableIndexing: false,
-    });
     const indexService = repoContext.indexService;
 
     if (options.verify) {

--- a/src/cli/commands/vault_create.ts
+++ b/src/cli/commands/vault_create.ts
@@ -4,13 +4,13 @@ import {
   type VaultCreateData,
 } from "../../presentation/output/vault_create_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import { getVaultType } from "../../domain/vaults/vault_types.ts";
 import { UserError } from "../../domain/errors.ts";
 import {
   createVaultConfigId,
   VaultConfig,
 } from "../../domain/vaults/vault_config.ts";
-import { createRepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -75,7 +75,10 @@ export const vaultCreateCommand = new Command()
       vaultNameArg?: string,
     ) {
       const ctx = createContext(options as GlobalOptions, "vault-create");
-      const repoDir = options.repoDir ?? ".";
+      const { repoDir, repoContext } = await requireInitializedRepo({
+        repoDir: options.repoDir ?? ".",
+        outputMode: ctx.outputMode,
+      });
 
       // Get vault name - prompt if not provided
       let vaultName = vaultNameArg;
@@ -109,8 +112,6 @@ export const vaultCreateCommand = new Command()
         );
       }
 
-      // Create repository context for event-driven indexing
-      const repoContext = createRepositoryContext({ repoDir });
       const repo = repoContext.vaultConfigRepo;
 
       const existingVault = await repo.findByName(vaultName);

--- a/src/cli/commands/vault_edit.ts
+++ b/src/cli/commands/vault_edit.ts
@@ -10,7 +10,7 @@ import {
   type VaultSearchItem,
 } from "../../presentation/output/vault_search_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
-import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import { EditorService } from "../../infrastructure/editor/editor_service.ts";
 import { UserError } from "../../domain/errors.ts";
 import type { VaultConfig } from "../../domain/vaults/vault_config.ts";
@@ -36,9 +36,12 @@ export const vaultEditCommand = new Command()
     const ctx = createContext(options as GlobalOptions, "vault-edit");
     ctx.logger.debug`Editing vault: ${vaultNameOrId ?? "(interactive)"}`;
 
-    const repoDir = options.repoDir ?? ".";
+    const { repoDir, repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
     const vaultType = options.type as string | undefined;
-    const repo = new YamlVaultConfigRepository(repoDir);
+    const repo = repoContext.vaultConfigRepo;
     const editorService = new EditorService();
 
     let config: VaultConfig | null = null;

--- a/src/cli/commands/vault_get.ts
+++ b/src/cli/commands/vault_get.ts
@@ -4,7 +4,7 @@ import {
   type VaultGetData,
 } from "../../presentation/output/vault_get_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
-import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -20,9 +20,12 @@ export const vaultGetCommand = new Command()
     const ctx = createContext(options as GlobalOptions, "vault-get");
     ctx.logger.debug`Getting vault: ${vaultNameOrId}`;
 
-    const repoDir = options.repoDir ?? ".";
+    const { repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
     const vaultType = options.type as string | undefined;
-    const repo = new YamlVaultConfigRepository(repoDir);
+    const repo = repoContext.vaultConfigRepo;
 
     // Look up the vault
     ctx.logger.debug`Looking up vault: ${vaultNameOrId}`;

--- a/src/cli/commands/vault_list_keys.ts
+++ b/src/cli/commands/vault_list_keys.ts
@@ -4,8 +4,8 @@ import {
   type VaultListKeysData,
 } from "../../presentation/output/vault_list_keys_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import { VaultService } from "../../domain/vaults/vault_service.ts";
-import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
 import { UserError } from "../../domain/errors.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -20,10 +20,13 @@ export const vaultListKeysCommand = new Command()
     const ctx = createContext(options as GlobalOptions, "vault-list-keys");
     ctx.logger.debug`Listing secret keys in vault: ${vaultName}`;
 
-    const repoDir = options.repoDir ?? ".";
+    const { repoDir, repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
 
     // Verify vault exists
-    const repo = new YamlVaultConfigRepository(repoDir);
+    const repo = repoContext.vaultConfigRepo;
     const vaultConfig = await repo.findByName(vaultName);
     if (!vaultConfig) {
       // List available vaults for helpful error message

--- a/src/cli/commands/vault_put.ts
+++ b/src/cli/commands/vault_put.ts
@@ -5,10 +5,9 @@ import {
   type VaultPutData,
 } from "../../presentation/output/vault_put_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import { VaultService } from "../../domain/vaults/vault_service.ts";
-import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
 import { UserError } from "../../domain/errors.ts";
-import { createRepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
 import { createVaultSecretUpdated } from "../../domain/events/types.ts";
 
 /**
@@ -85,7 +84,10 @@ export const vaultPutCommand = new Command()
     const ctx = createContext(options as GlobalOptions, "vault-put");
     ctx.logger.debug`Storing secret in vault: ${vaultName}`;
 
-    const repoDir = options.repoDir ?? ".";
+    const { repoDir, repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
 
     // Parse KEY=VALUE argument
     const parsed = parseKeyValue(keyValue);
@@ -99,7 +101,7 @@ export const vaultPutCommand = new Command()
     ctx.logger.debug`Parsed key: ${key}`;
 
     // Verify vault exists
-    const repo = new YamlVaultConfigRepository(repoDir);
+    const repo = repoContext.vaultConfigRepo;
     const vaultConfig = await repo.findByName(vaultName);
     if (!vaultConfig) {
       // List available vaults for helpful error message
@@ -141,7 +143,6 @@ export const vaultPutCommand = new Command()
     ctx.logger.debug`Secret stored successfully`;
 
     // Emit event to update the logical view symlinks
-    const repoContext = createRepositoryContext({ repoDir });
     const event = createVaultSecretUpdated(
       vaultConfig.id,
       vaultConfig.type,

--- a/src/cli/commands/vault_search.ts
+++ b/src/cli/commands/vault_search.ts
@@ -9,7 +9,8 @@ import {
   renderVaultDescribe,
 } from "../../presentation/output/vault_describe_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
-import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
+import type { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
 import type { VaultConfig } from "../../domain/vaults/vault_config.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -18,8 +19,9 @@ type AnyOptions = any;
 /**
  * Gets all vaults from the repository as VaultSearchItem array.
  */
-async function getAllVaults(repoDir: string): Promise<VaultSearchItem[]> {
-  const repo = new YamlVaultConfigRepository(repoDir);
+async function getAllVaults(
+  repo: YamlVaultConfigRepository,
+): Promise<VaultSearchItem[]> {
   const configs = await repo.findAll();
   return configs.map(toVaultSearchItem);
 }
@@ -47,10 +49,9 @@ function filterVaults(
  * Gets the full vault config for displaying details.
  */
 async function getVaultConfig(
-  repoDir: string,
+  repo: YamlVaultConfigRepository,
   name: string,
 ): Promise<VaultConfig | null> {
-  const repo = new YamlVaultConfigRepository(repoDir);
   return await repo.findByName(name);
 }
 
@@ -59,11 +60,11 @@ async function getVaultConfig(
  */
 async function displayVaultDescribe(
   item: VaultSearchItem,
+  repo: YamlVaultConfigRepository,
   options: AnyOptions,
 ): Promise<void> {
   const ctx = createContext(options as GlobalOptions, "vault-search");
-  const repoDir = options.repoDir ?? ".";
-  const config = await getVaultConfig(repoDir, item.name);
+  const config = await getVaultConfig(repo, item.name);
 
   if (config) {
     renderVaultDescribe(config, ctx.outputMode);
@@ -79,8 +80,12 @@ export const vaultSearchCommand = new Command()
     const ctx = createContext(options as GlobalOptions, "vault-search");
     ctx.logger.debug`Searching vaults with query: ${query ?? "(none)"}`;
 
-    const repoDir = options.repoDir ?? ".";
-    const allVaults = await getAllVaults(repoDir);
+    const { repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
+    const repo = repoContext.vaultConfigRepo;
+    const allVaults = await getAllVaults(repo);
 
     if (ctx.outputMode === "json") {
       // Non-interactive: filter and output JSON
@@ -102,7 +107,7 @@ export const vaultSearchCommand = new Command()
       if (selected) {
         ctx.logger.debug`Selected vault: ${selected.name}`;
         // Display the vault details
-        await displayVaultDescribe(selected, options);
+        await displayVaultDescribe(selected, repo, options);
       } else {
         ctx.logger.debug`Search cancelled`;
       }

--- a/src/cli/commands/workflow_create.ts
+++ b/src/cli/commands/workflow_create.ts
@@ -4,11 +4,11 @@ import {
   type WorkflowCreateData,
 } from "../../presentation/output/workflow_create_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import { Workflow } from "../../domain/workflows/workflow.ts";
 import { Job } from "../../domain/workflows/job.ts";
 import { Step } from "../../domain/workflows/step.ts";
 import { StepTask } from "../../domain/workflows/step_task.ts";
-import { createRepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -21,8 +21,10 @@ export const workflowCreateCommand = new Command()
     const ctx = createContext(options as GlobalOptions, "workflow-create");
     ctx.logger.debug`Creating workflow: name=${name}`;
 
-    const repoDir = options.repoDir ?? ".";
-    const repoContext = createRepositoryContext({ repoDir });
+    const { repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
     const repo = repoContext.workflowRepo;
 
     // Check if name already exists

--- a/src/cli/commands/workflow_delete.ts
+++ b/src/cli/commands/workflow_delete.ts
@@ -5,12 +5,12 @@ import {
   type WorkflowDeleteData,
 } from "../../presentation/output/workflow_delete_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import {
   createWorkflowId,
   type WorkflowId,
 } from "../../domain/workflows/workflow_id.ts";
 import type { Workflow } from "../../domain/workflows/workflow.ts";
-import { createRepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
 import { YamlEvaluatedWorkflowRepository } from "../../infrastructure/persistence/yaml_evaluated_workflow_repository.ts";
 import { UserError } from "../../domain/errors.ts";
 
@@ -61,8 +61,10 @@ export const workflowDeleteCommand = new Command()
     const ctx = createContext(options as GlobalOptions, "workflow-delete");
     ctx.logger.debug`Deleting workflow: ${workflowIdOrName}`;
 
-    const repoDir = options.repoDir ?? ".";
-    const repoContext = createRepositoryContext({ repoDir });
+    const { repoDir, repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
     const workflowRepo = repoContext.workflowRepo;
     const workflowRunRepo = repoContext.workflowRunRepo;
 

--- a/src/cli/commands/workflow_edit.ts
+++ b/src/cli/commands/workflow_edit.ts
@@ -10,6 +10,7 @@ import {
   type WorkflowSearchItem,
 } from "../../presentation/output/workflow_search_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import {
   createWorkflowId,
   type WorkflowId,
@@ -18,7 +19,6 @@ import {
   Workflow,
   type WorkflowData,
 } from "../../domain/workflows/workflow.ts";
-import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 import { EditorService } from "../../infrastructure/editor/editor_service.ts";
 import { UserError } from "../../domain/errors.ts";
 import { readStdin } from "../../infrastructure/io/stdin_reader.ts";
@@ -61,8 +61,11 @@ export const workflowEditCommand = new Command()
     const ctx = createContext(options as GlobalOptions, "workflow-edit");
     ctx.logger.debug`Editing workflow: ${workflowIdOrName ?? "(interactive)"}`;
 
-    const repoDir = options.repoDir ?? ".";
-    const repo = new YamlWorkflowRepository(repoDir);
+    const { repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
+    const repo = repoContext.workflowRepo;
     const editorService = new EditorService();
 
     // Look up the workflow

--- a/src/cli/commands/workflow_get.ts
+++ b/src/cli/commands/workflow_get.ts
@@ -4,12 +4,12 @@ import {
   type WorkflowGetData,
 } from "../../presentation/output/workflow_get_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import {
   createWorkflowId,
   type WorkflowId,
 } from "../../domain/workflows/workflow_id.ts";
 import type { Workflow } from "../../domain/workflows/workflow.ts";
-import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 import { UserError } from "../../domain/errors.ts";
 
 /**
@@ -38,8 +38,11 @@ export const workflowGetCommand = new Command()
     const ctx = createContext(options as GlobalOptions, "workflow-get");
     ctx.logger.debug`Getting workflow: ${workflowIdOrName}`;
 
-    const repoDir = options.repoDir ?? ".";
-    const repo = new YamlWorkflowRepository(repoDir);
+    const { repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
+    const repo = repoContext.workflowRepo;
 
     // Look up the workflow
     let workflow: Workflow | null = null;

--- a/src/cli/commands/workflow_history_get.ts
+++ b/src/cli/commands/workflow_history_get.ts
@@ -6,8 +6,7 @@ import {
   type WorkflowRunData,
 } from "../../presentation/output/workflow_run_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
-import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
-import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
 import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
 import { UserError } from "../../domain/errors.ts";
@@ -63,9 +62,12 @@ export const workflowHistoryGetCommand = new Command()
     const ctx = createContext(options as GlobalOptions, "workflow-history-get");
     ctx.logger.debug`Getting latest run for workflow: ${workflowIdOrName}`;
 
-    const repoDir = options.repoDir ?? ".";
-    const workflowRepo = new YamlWorkflowRepository(repoDir);
-    const runRepo = new YamlWorkflowRunRepository(repoDir);
+    const { repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
+    const workflowRepo = repoContext.workflowRepo;
+    const runRepo = repoContext.workflowRunRepo;
 
     // Look up the workflow first
     const workflow = await workflowRepo.findByName(workflowIdOrName) ??

--- a/src/cli/commands/workflow_history_logs.ts
+++ b/src/cli/commands/workflow_history_logs.ts
@@ -1,7 +1,6 @@
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
-import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
-import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
 import { UserError } from "../../domain/errors.ts";
@@ -60,8 +59,12 @@ export const workflowHistoryLogsCommand = new Command()
     );
     ctx.logger.debug`Getting logs for workflow run: ${runIdOrWorkflow}`;
 
-    const repoDir = options.repoDir ?? ".";
-    const runRepo = new YamlWorkflowRunRepository(repoDir);
+    const { repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
+    const runRepo = repoContext.workflowRunRepo;
+    const workflowRepo = repoContext.workflowRepo;
 
     let run: WorkflowRun | undefined;
 
@@ -86,7 +89,6 @@ export const workflowHistoryLogsCommand = new Command()
 
     // If not found as run ID, try as workflow name and get latest run
     if (!run) {
-      const workflowRepo = new YamlWorkflowRepository(repoDir);
       const workflow = await workflowRepo.findByName(runIdOrWorkflow) ??
         await workflowRepo.findById(createWorkflowId(runIdOrWorkflow));
 

--- a/src/cli/commands/workflow_history_search.ts
+++ b/src/cli/commands/workflow_history_search.ts
@@ -11,8 +11,7 @@ import {
   type WorkflowHistorySearchItem,
 } from "../../presentation/output/workflow_history_search_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
-import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
-import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
 import {
   createWorkflowId,
@@ -111,9 +110,12 @@ export const workflowHistorySearchCommand = new Command()
       query ?? "(none)"
     }`;
 
-    const repoDir = options.repoDir ?? ".";
-    const workflowRepo = new YamlWorkflowRepository(repoDir);
-    const runRepo = new YamlWorkflowRunRepository(repoDir);
+    const { repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
+    const workflowRepo = repoContext.workflowRepo;
+    const runRepo = repoContext.workflowRunRepo;
 
     // Get all workflows
     const allWorkflows = await workflowRepo.findAll();

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -9,8 +9,7 @@ import {
 } from "../../presentation/output/workflow_run_output.tsx";
 import { renderWorkflowExecution } from "../../presentation/output/workflow_execution_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
-import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
-import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import {
   type ExecutionProgressCallback,
   type ImplicitDependencyMap,
@@ -146,9 +145,12 @@ export const workflowRunCommand = new Command()
     const ctx = createContext(options as GlobalOptions, "workflow-run");
     ctx.logger.debug`Running workflow: ${workflowIdOrName}`;
 
-    const repoDir = options.repoDir ?? ".";
-    const workflowRepo = new YamlWorkflowRepository(repoDir);
-    const runRepo = new YamlWorkflowRunRepository(repoDir);
+    const { repoDir, repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
+    const workflowRepo = repoContext.workflowRepo;
+    const runRepo = repoContext.workflowRunRepo;
 
     const executionService = new WorkflowExecutionService(
       workflowRepo,

--- a/src/cli/commands/workflow_search.ts
+++ b/src/cli/commands/workflow_search.ts
@@ -9,8 +9,9 @@ import {
   type WorkflowGetData,
 } from "../../presentation/output/workflow_get_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import type { Workflow } from "../../domain/workflows/workflow.ts";
-import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
+import type { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -90,8 +91,11 @@ export const workflowSearchCommand = new Command()
     const ctx = createContext(options as GlobalOptions, "workflow-search");
     ctx.logger.debug`Searching workflows with query: ${query ?? "(none)"}`;
 
-    const repoDir = options.repoDir ?? ".";
-    const repo = new YamlWorkflowRepository(repoDir);
+    const { repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
+    const repo = repoContext.workflowRepo;
 
     const allWorkflows = await repo.findAll();
     const searchItems = allWorkflows.map(toSearchItem);

--- a/src/cli/commands/workflow_validate.ts
+++ b/src/cli/commands/workflow_validate.ts
@@ -6,12 +6,12 @@ import {
   type WorkflowValidateData,
 } from "../../presentation/output/workflow_validate_output.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
 import {
   createWorkflowId,
   type WorkflowId,
 } from "../../domain/workflows/workflow_id.ts";
 import type { Workflow } from "../../domain/workflows/workflow.ts";
-import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 import {
   DefaultWorkflowValidationService,
   type WorkflowValidationResult,
@@ -53,8 +53,11 @@ export const workflowValidateCommand = new Command()
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .action(async function (options: AnyOptions, workflowIdOrName?: string) {
     const ctx = createContext(options as GlobalOptions, "workflow-validate");
-    const repoDir = options.repoDir ?? ".";
-    const repo = new YamlWorkflowRepository(repoDir);
+    const { repoContext } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
+    const repo = repoContext.workflowRepo;
     const validationService = new DefaultWorkflowValidationService();
 
     // If no argument provided, validate all workflows

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -1,0 +1,202 @@
+/**
+ * CLI adapter for validating repository initialization and providing interactive prompts.
+ *
+ * This module bridges CLI commands with the domain's RepoService by:
+ * - Checking if a directory is an initialized swamp repository
+ * - Prompting users interactively to initialize or specify a different path
+ * - Throwing clear errors in non-interactive mode
+ */
+
+import type { OutputMode } from "../presentation/output/output.tsx";
+import {
+  createRepositoryContext,
+  type RepositoryContext,
+  type RepositoryFactoryConfig,
+} from "../infrastructure/persistence/repository_factory.ts";
+import { RepoPath } from "../domain/repo/repo_path.ts";
+import { RepoService } from "../domain/repo/repo_service.ts";
+import { UserError } from "../domain/errors.ts";
+import { VERSION } from "./commands/version.ts";
+
+/**
+ * Options for requireInitializedRepo.
+ */
+export interface RequireRepoOptions {
+  repoDir: string;
+  outputMode: OutputMode;
+}
+
+/**
+ * Result of successful repo validation containing the validated directory
+ * and repository context.
+ */
+export interface RepoValidationContext {
+  repoDir: string;
+  repoContext: RepositoryContext;
+}
+
+/**
+ * Prompts user for a choice in interactive mode.
+ * Returns the user's single-character input.
+ */
+async function promptChoice(message: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+
+  await Deno.stdout.write(encoder.encode(`${message}: `));
+
+  const buf = new Uint8Array(1024);
+  const n = await Deno.stdin.read(buf);
+  if (n === null) {
+    return "";
+  }
+
+  return decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
+}
+
+/**
+ * Prompts user for a path in interactive mode.
+ */
+async function promptPath(message: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+
+  await Deno.stdout.write(encoder.encode(`${message}: `));
+
+  const buf = new Uint8Array(1024);
+  const n = await Deno.stdin.read(buf);
+  if (n === null) {
+    return "";
+  }
+
+  return decoder.decode(buf.subarray(0, n)).trim();
+}
+
+/**
+ * Displays the interactive menu for uninitialized repository.
+ */
+function displayMenu(repoDir: string): void {
+  console.log(`\nThis directory is not a swamp repository: ${repoDir}\n`);
+  console.log("Options:");
+  console.log("  [i] Initialize here (swamp repo init)");
+  console.log("  [p] Specify a different path");
+  console.log("  [q] Quit\n");
+}
+
+/**
+ * Handles the interactive flow when a repository is not initialized.
+ * Returns the final validated repo directory or throws if user quits.
+ */
+async function handleInteractivePrompt(
+  initialRepoDir: string,
+  _outputMode: OutputMode,
+): Promise<string> {
+  let currentDir = initialRepoDir;
+
+  while (true) {
+    displayMenu(currentDir);
+    const choice = await promptChoice("Choice");
+
+    switch (choice) {
+      case "i": {
+        // Initialize the current directory
+        const repoPath = RepoPath.create(currentDir);
+        const service = new RepoService(VERSION);
+        const result = await service.init(repoPath);
+
+        console.log(`\nRepository initialized at ${result.path}`);
+        console.log(`Version: ${result.version}`);
+        if (result.skillsCopied.length > 0) {
+          console.log(`Skills copied: ${result.skillsCopied.join(", ")}`);
+        }
+        if (result.claudeMdCreated) {
+          console.log("Created CLAUDE.md");
+        }
+        console.log("");
+
+        return currentDir;
+      }
+      case "p": {
+        // Prompt for a different path
+        const newPath = await promptPath("Enter repository path");
+        if (!newPath) {
+          console.log("No path entered, please try again.");
+          continue;
+        }
+
+        // Validate the new path
+        const repoPath = RepoPath.create(newPath);
+        const service = new RepoService(VERSION);
+        const isInit = await service.isInitialized(repoPath);
+
+        if (isInit) {
+          return repoPath.value;
+        }
+
+        // Not initialized - update currentDir and loop again
+        currentDir = repoPath.value;
+        break;
+      }
+      case "q":
+        throw new UserError("Operation cancelled by user.");
+      default:
+        console.log(`Invalid choice: '${choice}'. Please enter i, p, or q.`);
+    }
+  }
+}
+
+/**
+ * Validates that a directory is an initialized swamp repository.
+ *
+ * In interactive mode, prompts the user with options to:
+ * - Initialize the current directory
+ * - Specify a different path
+ * - Quit
+ *
+ * In non-interactive mode (json/stream), throws a UserError with
+ * helpful instructions.
+ *
+ * @param options - The repo directory and output mode
+ * @param factoryConfig - Optional factory configuration overrides
+ * @returns The validated repo context
+ * @throws UserError if not initialized and user quits or in non-interactive mode
+ */
+export async function requireInitializedRepo(
+  options: RequireRepoOptions,
+  factoryConfig?: Partial<Omit<RepositoryFactoryConfig, "repoDir">>,
+): Promise<RepoValidationContext> {
+  const { repoDir, outputMode } = options;
+
+  const repoPath = RepoPath.create(repoDir);
+  const service = new RepoService(VERSION);
+  const isInit = await service.isInitialized(repoPath);
+
+  let finalRepoDir = repoPath.value;
+
+  if (!isInit) {
+    if (outputMode === "interactive") {
+      // Interactive mode: prompt user
+      finalRepoDir = await handleInteractivePrompt(repoPath.value, outputMode);
+    } else {
+      // Non-interactive mode: throw helpful error
+      throw new UserError(
+        `Not a swamp repository: ${repoPath.value}\n\n` +
+          `To initialize a new repository, run:\n` +
+          `  swamp repo init\n\n` +
+          `Or specify an existing repository with --repo-dir:\n` +
+          `  swamp <command> --repo-dir /path/to/repo`,
+      );
+    }
+  }
+
+  // Create repository context with the final validated directory
+  const repoContext = createRepositoryContext({
+    repoDir: finalRepoDir,
+    ...factoryConfig,
+  });
+
+  return {
+    repoDir: finalRepoDir,
+    repoContext,
+  };
+}

--- a/src/cli/repo_context_test.ts
+++ b/src/cli/repo_context_test.ts
@@ -1,0 +1,190 @@
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { initializeLogging } from "../infrastructure/logging/logger.ts";
+import { requireInitializedRepo } from "./repo_context.ts";
+import { RepoPath } from "../domain/repo/repo_path.ts";
+import { RepoService } from "../domain/repo/repo_service.ts";
+import { UserError } from "../domain/errors.ts";
+import { VERSION } from "./commands/version.ts";
+
+// Initialize logging for tests
+await initializeLogging({ debugLogs: false });
+
+/**
+ * Helper to run tests with a temporary directory.
+ */
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-repo-context-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+/**
+ * Sets up a directory as an initialized swamp repository.
+ */
+async function initializeRepo(dir: string): Promise<void> {
+  const repoPath = RepoPath.create(dir);
+  const service = new RepoService(VERSION);
+  await service.init(repoPath);
+}
+
+// ============================================================================
+// Non-Interactive Mode Tests
+// ============================================================================
+
+Deno.test("requireInitializedRepo - throws UserError in json mode for non-initialized repo", async () => {
+  await withTempDir(async (dir) => {
+    const error = await assertRejects(
+      () =>
+        requireInitializedRepo({
+          repoDir: dir,
+          outputMode: "json",
+        }),
+      UserError,
+    );
+
+    assertStringIncludes(error.message, "Not a swamp repository");
+    assertStringIncludes(error.message, "swamp repo init");
+    assertStringIncludes(error.message, "--repo-dir");
+  });
+});
+
+Deno.test("requireInitializedRepo - throws UserError in stream mode for non-initialized repo", async () => {
+  await withTempDir(async (dir) => {
+    const error = await assertRejects(
+      () =>
+        requireInitializedRepo({
+          repoDir: dir,
+          outputMode: "stream",
+        }),
+      UserError,
+    );
+
+    assertStringIncludes(error.message, "Not a swamp repository");
+  });
+});
+
+Deno.test("requireInitializedRepo - error message includes the path", async () => {
+  await withTempDir(async (dir) => {
+    const error = await assertRejects(
+      () =>
+        requireInitializedRepo({
+          repoDir: dir,
+          outputMode: "json",
+        }),
+      UserError,
+    );
+
+    // The error message should contain the resolved absolute path
+    assertStringIncludes(error.message, dir);
+  });
+});
+
+// ============================================================================
+// Initialized Repo Tests
+// ============================================================================
+
+Deno.test("requireInitializedRepo - returns context for initialized repo (json mode)", async () => {
+  await withTempDir(async (dir) => {
+    // Initialize the repo first
+    await initializeRepo(dir);
+
+    // Now requireInitializedRepo should succeed
+    const result = await requireInitializedRepo({
+      repoDir: dir,
+      outputMode: "json",
+    });
+
+    assertEquals(result.repoDir, dir);
+    assertEquals(result.repoContext.definitionRepo !== undefined, true);
+    assertEquals(result.repoContext.workflowRepo !== undefined, true);
+  });
+});
+
+Deno.test("requireInitializedRepo - returns context for initialized repo (interactive mode)", async () => {
+  await withTempDir(async (dir) => {
+    await initializeRepo(dir);
+
+    const result = await requireInitializedRepo({
+      repoDir: dir,
+      outputMode: "interactive",
+    });
+
+    assertEquals(result.repoDir, dir);
+    assertEquals(result.repoContext !== undefined, true);
+  });
+});
+
+Deno.test("requireInitializedRepo - handles relative paths", async () => {
+  await withTempDir(async (dir) => {
+    await initializeRepo(dir);
+
+    // Use the full path (simulating a user passing a path)
+    const result = await requireInitializedRepo({
+      repoDir: dir,
+      outputMode: "json",
+    });
+
+    // Should resolve to the absolute path
+    assertEquals(result.repoDir, dir);
+  });
+});
+
+Deno.test("requireInitializedRepo - passes factory config", async () => {
+  await withTempDir(async (dir) => {
+    await initializeRepo(dir);
+
+    const result = await requireInitializedRepo(
+      {
+        repoDir: dir,
+        outputMode: "json",
+      },
+      { enableIndexing: false },
+    );
+
+    // Context should still be created
+    assertEquals(result.repoContext !== undefined, true);
+  });
+});
+
+// ============================================================================
+// Edge Cases
+// ============================================================================
+
+Deno.test("requireInitializedRepo - handles nested directory paths", async () => {
+  await withTempDir(async (baseDir) => {
+    const nestedDir = join(baseDir, "nested", "repo");
+    await ensureDir(nestedDir);
+    await initializeRepo(nestedDir);
+
+    const result = await requireInitializedRepo({
+      repoDir: nestedDir,
+      outputMode: "json",
+    });
+
+    assertEquals(result.repoDir, nestedDir);
+  });
+});
+
+Deno.test("requireInitializedRepo - checks .swamp marker file", async () => {
+  await withTempDir(async (dir) => {
+    // Create a directory with some files but NOT a valid swamp repo
+    await ensureDir(join(dir, ".swamp"));
+    // Missing the marker file, so it should not be considered initialized
+
+    const error = await assertRejects(
+      () =>
+        requireInitializedRepo({
+          repoDir: dir,
+          outputMode: "json",
+        }),
+      UserError,
+    );
+
+    assertStringIncludes(error.message, "Not a swamp repository");
+  });
+});

--- a/src/domain/repo/swamp_version.ts
+++ b/src/domain/repo/swamp_version.ts
@@ -1,3 +1,5 @@
+import { UserError } from "../errors.ts";
+
 /**
  * SwampVersion is a value object representing a semantic version string.
  *
@@ -20,13 +22,16 @@ export class SwampVersion {
   static create(version: string): SwampVersion {
     const trimmed = version.trim();
     if (trimmed.length === 0) {
-      throw new Error("Version cannot be empty");
+      throw new UserError("Version cannot be empty");
     }
 
-    const match = trimmed.match(/^(\d+)\.(\d+)\.(\d+)$/);
+    // Match calver format: YYYYMMDD.HHMMSS.patch with optional suffix
+    // Also matches dev format: 0.0.0-dev
+    // Examples: "20260204.202125.0", "20260204.202125.0-sha.abc123", "0.0.0-dev"
+    const match = trimmed.match(/^(\d+)\.(\d+)\.(\d+)(?:-[\w.]+)?$/);
     if (!match) {
-      throw new Error(
-        `Invalid version format: ${version}. Expected format: major.minor.patch (e.g., "1.0.0")`,
+      throw new UserError(
+        `Invalid version format: ${version}. Expected format: YYYYMMDD.HHMMSS.patch (e.g., "20260101.120000.0")`,
       );
     }
 

--- a/src/domain/repo/swamp_version_test.ts
+++ b/src/domain/repo/swamp_version_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import { SwampVersion } from "./swamp_version.ts";
+import { UserError } from "../errors.ts";
 
 Deno.test("SwampVersion.create parses valid version", () => {
   const version = SwampVersion.create("1.2.3");
@@ -29,7 +30,7 @@ Deno.test("SwampVersion.create trims whitespace", () => {
 Deno.test("SwampVersion.create throws on empty string", () => {
   assertThrows(
     () => SwampVersion.create(""),
-    Error,
+    UserError,
     "Version cannot be empty",
   );
 });
@@ -37,7 +38,7 @@ Deno.test("SwampVersion.create throws on empty string", () => {
 Deno.test("SwampVersion.create throws on invalid format - no dots", () => {
   assertThrows(
     () => SwampVersion.create("100"),
-    Error,
+    UserError,
     "Invalid version format",
   );
 });
@@ -45,7 +46,7 @@ Deno.test("SwampVersion.create throws on invalid format - no dots", () => {
 Deno.test("SwampVersion.create throws on invalid format - two parts", () => {
   assertThrows(
     () => SwampVersion.create("1.0"),
-    Error,
+    UserError,
     "Invalid version format",
   );
 });
@@ -53,15 +54,38 @@ Deno.test("SwampVersion.create throws on invalid format - two parts", () => {
 Deno.test("SwampVersion.create throws on invalid format - four parts", () => {
   assertThrows(
     () => SwampVersion.create("1.0.0.0"),
-    Error,
+    UserError,
     "Invalid version format",
   );
 });
 
-Deno.test("SwampVersion.create throws on invalid format - letters", () => {
+Deno.test("SwampVersion.create accepts pre-release suffix", () => {
+  // Pre-release suffixes like -beta, -dev are now allowed
+  const v = SwampVersion.create("1.0.0-beta");
+  assertEquals(v.major, 1);
+  assertEquals(v.minor, 0);
+  assertEquals(v.patch, 0);
+});
+
+Deno.test("SwampVersion.create accepts calver format with sha suffix", () => {
+  // Calver format: YYYYMMDD.HHMMSS.patch-sha.commit
+  const v = SwampVersion.create("20260204.165928.0-sha.06db816c");
+  assertEquals(v.major, 20260204);
+  assertEquals(v.minor, 165928);
+  assertEquals(v.patch, 0);
+});
+
+Deno.test("SwampVersion.create accepts dev version", () => {
+  const v = SwampVersion.create("0.0.0-dev");
+  assertEquals(v.major, 0);
+  assertEquals(v.minor, 0);
+  assertEquals(v.patch, 0);
+});
+
+Deno.test("SwampVersion.create throws on invalid format - letters only", () => {
   assertThrows(
-    () => SwampVersion.create("1.0.0-beta"),
-    Error,
+    () => SwampVersion.create("abc"),
+    UserError,
     "Invalid version format",
   );
 });


### PR DESCRIPTION
Fixes: #179 

- Add `requireInitializedRepo()` CLI adapter that validates repo initialization and provides interactive prompts when running commands in a non-initialized directory
- In interactive mode, users are prompted to either initialize the current directory, specify a different path, or quit
- In non-interactive mode (JSON output), throws a clear `UserError` with instructions
- Wrap `SwampVersion` validation errors in `UserError` to provide clean error messages without stack traces
- Add tests for calver format with sha suffix (e.g., `20260204.165928.0-sha.06db816c`) and dev version format (`0.0.0-dev`)

### New Files

- `src/cli/repo_context.ts` - CLI adapter with `requireInitializedRepo()` function
- `src/cli/repo_context_test.ts` - Unit tests for repo context validation

### Interactive UX

When running a command in a non-initialized directory:
This directory is not a swamp repository.

Options:
[i] Initialize here (swamp repo init)
[p] Specify a different path
[q] Quit

Choice: _

### Non-Interactive Error

Error: Not a swamp repository: /path/to/dir

To initialize a new repository, run:
swamp repo init

Or specify an existing repository with --repo-dir:
swamp model search --repo-dir /path/to/repo

## Test Plan

- All 1438 tests pass
- Added `initializeTestRepo()` helper to integration tests to create `.swamp.yaml` marker file
- Verified interactive prompts work correctly (init, path specification, quit)
- Verified non-interactive mode throws clear `UserError`
- Verified `SwampVersion.create()` accepts calver format with sha suffix
- Verified version validation errors now throw `UserError` instead of `Error`