### PR TITLE
feat: Add basic telemetry layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ resources/
 .swamp/logs/
 .swamp/files/
 .swamp/secrets/
+.swamp/telemetry/
 
 test-repo/
 experiments/webapp/frontend/node_modules/

--- a/src/cli/commands/telemetry_stats.ts
+++ b/src/cli/commands/telemetry_stats.ts
@@ -1,0 +1,46 @@
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
+import { TelemetryService } from "../../domain/telemetry/telemetry_service.ts";
+import { JsonTelemetryRepository } from "../../infrastructure/persistence/json_telemetry_repository.ts";
+import {
+  renderNoTelemetry,
+  renderTelemetryStats,
+} from "../../presentation/output/telemetry_stats_output.tsx";
+import { VERSION } from "./version.ts";
+
+export const telemetryStatsCommand = new Command()
+  .name("stats")
+  .description("View telemetry usage statistics")
+  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option("--days <days:number>", "Number of days to analyze", { default: 2 })
+  .action(async function (options) {
+    const ctx = createContext(options as GlobalOptions, "telemetry-stats");
+    ctx.logger.debug`Fetching telemetry stats`;
+
+    const { repoDir } = await requireInitializedRepo({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
+
+    const repository = new JsonTelemetryRepository(repoDir);
+    const service = new TelemetryService(repository, VERSION);
+
+    const stats = await service.getStats(options.days);
+
+    if (stats.totalInvocations === 0) {
+      renderNoTelemetry(ctx.outputMode);
+      return;
+    }
+
+    renderTelemetryStats(stats, ctx.outputMode);
+    ctx.logger.debug("Telemetry stats command completed");
+  });
+
+export const telemetryCommand = new Command()
+  .name("telemetry")
+  .description("Manage CLI telemetry")
+  .action(function () {
+    this.showHelp();
+  })
+  .command("stats", telemetryStatsCommand);

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -10,6 +10,7 @@ export interface GlobalOptions {
   stream?: boolean;
   quiet?: boolean;
   verbose?: boolean;
+  noTelemetry?: boolean;
 }
 
 export interface CommandContext {

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -9,6 +9,7 @@ import { workflowCommand } from "./commands/workflow.ts";
 import { completionCommand } from "./commands/completion.ts";
 import { vaultCommand } from "./commands/vault.ts";
 import { dataCommand } from "./commands/data.ts";
+import { telemetryCommand } from "./commands/telemetry_stats.ts";
 import type { GlobalOptions } from "./context.ts";
 import {
   ModelNameType,
@@ -21,6 +22,12 @@ import {
   RepoMarkerRepository,
 } from "../infrastructure/persistence/repo_marker_repository.ts";
 import { RepoPath } from "../domain/repo/repo_path.ts";
+import { TelemetryService } from "../domain/telemetry/telemetry_service.ts";
+import { JsonTelemetryRepository } from "../infrastructure/persistence/json_telemetry_repository.ts";
+import {
+  extractCommandInfo,
+  isTelemetryDisabled,
+} from "./telemetry_integration.ts";
 
 // Import models barrel to trigger self-registration
 import "../domain/models/models.ts";
@@ -81,9 +88,47 @@ async function loadUserModels(): Promise<void> {
   }
 }
 
+/**
+ * Initialize telemetry service if in a swamp repository.
+ */
+async function initTelemetryService(): Promise<TelemetryService | null> {
+  try {
+    const cwd = Deno.cwd();
+    const markerRepo = new RepoMarkerRepository();
+    const repoPath = RepoPath.create(cwd);
+
+    const marker = await markerRepo.read(repoPath);
+    if (!marker) {
+      return null; // Not in a swamp repo
+    }
+
+    const repository = new JsonTelemetryRepository(cwd);
+    return new TelemetryService(repository, VERSION);
+  } catch {
+    // Not in a swamp repo or other error
+    return null;
+  }
+}
+
 export async function runCli(args: string[]): Promise<void> {
+  // Capture start time for telemetry
+  const startTime = new Date();
+
+  // Pre-parse check for telemetry disable flag
+  const telemetryDisabled = isTelemetryDisabled(args);
+
+  // Extract command info for telemetry (before parsing)
+  const commandInfo = extractCommandInfo(args);
+
+  // Initialize telemetry service (only if in a swamp repo)
+  let telemetryService: TelemetryService | null = null;
+  if (!telemetryDisabled) {
+    telemetryService = await initTelemetryService();
+  }
+
   // Load user models before setting up CLI
   await loadUserModels();
+
   const cli = new Command()
     .name("swamp")
     .version(VERSION)
@@ -96,6 +141,7 @@ export async function runCli(args: string[]): Promise<void> {
     .globalOption("--stream", "Stream logs in real-time during execution")
     .globalOption("-q, --quiet", "Suppress non-essential output")
     .globalOption("-v, --verbose", "Show detailed output")
+    .globalOption("--no-telemetry", "Disable telemetry for this invocation")
     .globalAction(async function (options: GlobalOptions) {
       await initializeLogging({
         debugLogs: options.debugLogs ?? false,
@@ -112,7 +158,23 @@ export async function runCli(args: string[]): Promise<void> {
     .command("workflow", workflowCommand)
     .command("vault", vaultCommand)
     .command("data", dataCommand)
+    .command("telemetry", telemetryCommand)
     .command("completions", completionCommand);
 
-  await cli.parse(args);
+  try {
+    await cli.parse(args);
+
+    // Record successful invocation
+    if (telemetryService) {
+      await telemetryService.recordSuccess(commandInfo, startTime);
+      // Trigger cleanup asynchronously (fire-and-forget)
+      telemetryService.cleanupOldTelemetry();
+    }
+  } catch (error) {
+    // Record error invocation before re-throwing
+    if (telemetryService && error instanceof Error) {
+      await telemetryService.recordError(commandInfo, startTime, error);
+    }
+    throw error;
+  }
 }

--- a/src/cli/telemetry_integration.ts
+++ b/src/cli/telemetry_integration.ts
@@ -1,0 +1,159 @@
+import type { CommandInvocationData } from "../domain/telemetry/mod.ts";
+
+/** Global options that are tracked separately */
+const GLOBAL_OPTIONS = new Set([
+  "--debug-logs",
+  "--json",
+  "--stream",
+  "-q",
+  "--quiet",
+  "-v",
+  "--verbose",
+  "--no-telemetry",
+]);
+
+/**
+ * Extracts command information from CLI arguments for telemetry.
+ * Option values are redacted - only keys are recorded.
+ *
+ * @param args - The raw CLI arguments
+ * @returns Parsed command invocation data
+ */
+export function extractCommandInfo(args: string[]): CommandInvocationData {
+  const result: CommandInvocationData = {
+    command: "",
+    args: [],
+    optionKeys: [],
+    globalOptions: [],
+  };
+
+  let i = 0;
+
+  // Skip leading global options to find the command
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg.startsWith("-")) {
+      // This is an option
+      if (GLOBAL_OPTIONS.has(arg)) {
+        result.globalOptions.push(arg);
+      }
+      // Skip value if this option takes one (next arg doesn't start with -)
+      if (
+        i + 1 < args.length &&
+        !args[i + 1].startsWith("-") &&
+        !isKnownFlag(arg)
+      ) {
+        i++; // Skip the value
+      }
+      i++;
+      continue;
+    }
+
+    // Found the command
+    result.command = arg;
+    i++;
+    break;
+  }
+
+  // Look for subcommand
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg.startsWith("-")) {
+      // Option before subcommand - record it
+      if (GLOBAL_OPTIONS.has(arg)) {
+        result.globalOptions.push(arg);
+      } else {
+        result.optionKeys.push(arg.split("=")[0]); // Handle --option=value
+      }
+      // Skip value if this option takes one
+      if (
+        i + 1 < args.length &&
+        !args[i + 1].startsWith("-") &&
+        !isKnownFlag(arg)
+      ) {
+        i++; // Skip the value
+      }
+      i++;
+      continue;
+    }
+
+    // Found the subcommand
+    result.subcommand = arg;
+    i++;
+    break;
+  }
+
+  // Process remaining args
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg.startsWith("-")) {
+      // This is an option
+      const optionKey = arg.split("=")[0]; // Handle --option=value
+
+      if (GLOBAL_OPTIONS.has(optionKey)) {
+        if (!result.globalOptions.includes(optionKey)) {
+          result.globalOptions.push(optionKey);
+        }
+      } else {
+        if (!result.optionKeys.includes(optionKey)) {
+          result.optionKeys.push(optionKey);
+        }
+      }
+
+      // Skip value if this option takes one (next arg doesn't start with -)
+      if (
+        i + 1 < args.length &&
+        !args[i + 1].startsWith("-") &&
+        !isKnownFlag(arg)
+      ) {
+        i++; // Skip the value
+      }
+    } else {
+      // Positional argument - record as redacted
+      result.args.push("<REDACTED>");
+    }
+
+    i++;
+  }
+
+  return result;
+}
+
+/**
+ * Known boolean flags that don't take values.
+ */
+function isKnownFlag(option: string): boolean {
+  const flags = new Set([
+    "--debug-logs",
+    "--json",
+    "--stream",
+    "-q",
+    "--quiet",
+    "-v",
+    "--verbose",
+    "--no-telemetry",
+    "--force",
+    "-f",
+    "--help",
+    "-h",
+    "--version",
+    "-V",
+    "--dry-run",
+    "--all",
+    "-a",
+    "--yes",
+    "-y",
+  ]);
+  return flags.has(option);
+}
+
+/**
+ * Checks if telemetry is disabled via command line args.
+ * This is a pre-parse check before Cliffy parses the full args.
+ */
+export function isTelemetryDisabled(args: string[]): boolean {
+  return args.includes("--no-telemetry");
+}

--- a/src/cli/telemetry_integration_test.ts
+++ b/src/cli/telemetry_integration_test.ts
@@ -1,0 +1,128 @@
+import { assertEquals } from "@std/assert";
+import {
+  extractCommandInfo,
+  isTelemetryDisabled,
+} from "./telemetry_integration.ts";
+
+Deno.test("extractCommandInfo extracts simple command", () => {
+  const info = extractCommandInfo(["model"]);
+
+  assertEquals(info.command, "model");
+  assertEquals(info.subcommand, undefined);
+  assertEquals(info.args, []);
+  assertEquals(info.optionKeys, []);
+  assertEquals(info.globalOptions, []);
+});
+
+Deno.test("extractCommandInfo extracts command and subcommand", () => {
+  const info = extractCommandInfo(["model", "create"]);
+
+  assertEquals(info.command, "model");
+  assertEquals(info.subcommand, "create");
+  assertEquals(info.args, []);
+  assertEquals(info.optionKeys, []);
+  assertEquals(info.globalOptions, []);
+});
+
+Deno.test("extractCommandInfo extracts command with positional args", () => {
+  const info = extractCommandInfo(["model", "create", "my-model", "MyType"]);
+
+  assertEquals(info.command, "model");
+  assertEquals(info.subcommand, "create");
+  assertEquals(info.args, ["<REDACTED>", "<REDACTED>"]);
+  assertEquals(info.optionKeys, []);
+  assertEquals(info.globalOptions, []);
+});
+
+Deno.test("extractCommandInfo extracts global options", () => {
+  const info = extractCommandInfo([
+    "--json",
+    "--debug-logs",
+    "model",
+    "create",
+  ]);
+
+  assertEquals(info.command, "model");
+  assertEquals(info.subcommand, "create");
+  assertEquals(info.globalOptions, ["--json", "--debug-logs"]);
+  assertEquals(info.optionKeys, []);
+});
+
+Deno.test("extractCommandInfo extracts command-specific options", () => {
+  const info = extractCommandInfo([
+    "model",
+    "create",
+    "my-model",
+    "--repo-dir",
+    "/path/to/repo",
+    "--force",
+  ]);
+
+  assertEquals(info.command, "model");
+  assertEquals(info.subcommand, "create");
+  assertEquals(info.args, ["<REDACTED>"]);
+  assertEquals(info.optionKeys, ["--repo-dir", "--force"]);
+  assertEquals(info.globalOptions, []);
+});
+
+Deno.test("extractCommandInfo handles mixed global and command options", () => {
+  const info = extractCommandInfo([
+    "--json",
+    "workflow",
+    "run",
+    "my-workflow",
+    "--repo-dir",
+    "/path",
+    "-q",
+  ]);
+
+  assertEquals(info.command, "workflow");
+  assertEquals(info.subcommand, "run");
+  assertEquals(info.args, ["<REDACTED>"]);
+  assertEquals(info.optionKeys, ["--repo-dir"]);
+  assertEquals(info.globalOptions, ["--json", "-q"]);
+});
+
+Deno.test("extractCommandInfo handles option=value syntax", () => {
+  const info = extractCommandInfo([
+    "model",
+    "create",
+    "--repo-dir=/path/to/repo",
+  ]);
+
+  assertEquals(info.command, "model");
+  assertEquals(info.subcommand, "create");
+  assertEquals(info.optionKeys, ["--repo-dir"]);
+});
+
+Deno.test("extractCommandInfo handles --no-telemetry flag", () => {
+  const info = extractCommandInfo([
+    "--no-telemetry",
+    "model",
+    "search",
+  ]);
+
+  assertEquals(info.command, "model");
+  assertEquals(info.subcommand, "search");
+  assertEquals(info.globalOptions, ["--no-telemetry"]);
+});
+
+Deno.test("isTelemetryDisabled returns true when flag present", () => {
+  assertEquals(
+    isTelemetryDisabled(["--no-telemetry", "model", "search"]),
+    true,
+  );
+  assertEquals(
+    isTelemetryDisabled(["model", "--no-telemetry", "search"]),
+    true,
+  );
+  assertEquals(
+    isTelemetryDisabled(["model", "search", "--no-telemetry"]),
+    true,
+  );
+});
+
+Deno.test("isTelemetryDisabled returns false when flag absent", () => {
+  assertEquals(isTelemetryDisabled(["model", "search"]), false);
+  assertEquals(isTelemetryDisabled(["--json", "model", "search"]), false);
+});

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -222,6 +222,7 @@ Use \`swamp --help\` to see available commands.
       "secrets",
       "logs",
       "files",
+      "telemetry",
     ];
 
     for (const subdir of subdirs) {

--- a/src/domain/telemetry/command_invocation.ts
+++ b/src/domain/telemetry/command_invocation.ts
@@ -1,0 +1,60 @@
+/**
+ * Represents a CLI command execution.
+ * Values are redacted for privacy - only option keys are logged, not values.
+ */
+export interface CommandInvocation {
+  /** The main command (e.g., "model", "workflow") */
+  readonly command: string;
+  /** The subcommand (e.g., "create", "run") */
+  readonly subcommand?: string;
+  /** Redacted positional arguments - shows count but not values */
+  readonly args: string[];
+  /** Command-specific option keys (e.g., ["--repo-dir", "--json"]) */
+  readonly optionKeys: string[];
+  /** Global option keys (e.g., ["--debug-logs", "--verbose"]) */
+  readonly globalOptions: string[];
+}
+
+/**
+ * Data transfer object for CommandInvocation.
+ */
+export interface CommandInvocationData {
+  command: string;
+  subcommand?: string;
+  args: string[];
+  optionKeys: string[];
+  globalOptions: string[];
+}
+
+/**
+ * Creates a CommandInvocation value object.
+ */
+export function createCommandInvocation(
+  props: CommandInvocationData,
+): CommandInvocation {
+  return {
+    command: props.command,
+    subcommand: props.subcommand,
+    args: props.args,
+    optionKeys: props.optionKeys,
+    globalOptions: props.globalOptions,
+  };
+}
+
+/**
+ * Converts a CommandInvocation to its data representation.
+ */
+export function commandInvocationToData(
+  invocation: CommandInvocation,
+): CommandInvocationData {
+  const data: CommandInvocationData = {
+    command: invocation.command,
+    args: [...invocation.args],
+    optionKeys: [...invocation.optionKeys],
+    globalOptions: [...invocation.globalOptions],
+  };
+  if (invocation.subcommand) {
+    data.subcommand = invocation.subcommand;
+  }
+  return data;
+}

--- a/src/domain/telemetry/invocation_result.ts
+++ b/src/domain/telemetry/invocation_result.ts
@@ -1,0 +1,89 @@
+/**
+ * Status of a command invocation.
+ */
+export type InvocationStatus = "success" | "error" | "user_error";
+
+/**
+ * Represents the result of a CLI command execution.
+ */
+export interface InvocationResult {
+  /** Whether the command succeeded or failed */
+  readonly status: InvocationStatus;
+  /** Error class name if an error occurred */
+  readonly errorType?: string;
+  /** First line of error message (sanitized) */
+  readonly errorMessage?: string;
+  /** Exit code of the command */
+  readonly exitCode: number;
+}
+
+/**
+ * Data transfer object for InvocationResult.
+ */
+export interface InvocationResultData {
+  status: InvocationStatus;
+  errorType?: string;
+  errorMessage?: string;
+  exitCode: number;
+}
+
+/**
+ * Creates a successful InvocationResult.
+ */
+export function createSuccessResult(): InvocationResult {
+  return {
+    status: "success",
+    exitCode: 0,
+  };
+}
+
+/**
+ * Creates an error InvocationResult from an Error.
+ */
+export function createErrorResult(
+  error: Error,
+  isUserError: boolean = false,
+): InvocationResult {
+  // Get first line of error message only (sanitize)
+  const firstLine = error.message.split("\n")[0];
+
+  return {
+    status: isUserError ? "user_error" : "error",
+    errorType: error.constructor.name,
+    errorMessage: firstLine,
+    exitCode: 1,
+  };
+}
+
+/**
+ * Converts an InvocationResult to its data representation.
+ */
+export function invocationResultToData(
+  result: InvocationResult,
+): InvocationResultData {
+  const data: InvocationResultData = {
+    status: result.status,
+    exitCode: result.exitCode,
+  };
+  if (result.errorType) {
+    data.errorType = result.errorType;
+  }
+  if (result.errorMessage) {
+    data.errorMessage = result.errorMessage;
+  }
+  return data;
+}
+
+/**
+ * Creates an InvocationResult from data.
+ */
+export function invocationResultFromData(
+  data: InvocationResultData,
+): InvocationResult {
+  return {
+    status: data.status,
+    errorType: data.errorType,
+    errorMessage: data.errorMessage,
+    exitCode: data.exitCode,
+  };
+}

--- a/src/domain/telemetry/mod.ts
+++ b/src/domain/telemetry/mod.ts
@@ -1,0 +1,32 @@
+export {
+  createTelemetryId,
+  generateTelemetryId,
+  type TelemetryId,
+} from "./telemetry_id.ts";
+
+export {
+  type CommandInvocation,
+  type CommandInvocationData,
+  commandInvocationToData,
+  createCommandInvocation,
+} from "./command_invocation.ts";
+
+export {
+  createErrorResult,
+  createSuccessResult,
+  type InvocationResult,
+  type InvocationResultData,
+  invocationResultFromData,
+  invocationResultToData,
+  type InvocationStatus,
+} from "./invocation_result.ts";
+
+export {
+  type CreateTelemetryEntryProps,
+  TelemetryEntry,
+  type TelemetryEntryData,
+} from "./telemetry_entry.ts";
+
+export type { TelemetryRepository } from "./repositories.ts";
+
+export { TelemetryService } from "./telemetry_service.ts";

--- a/src/domain/telemetry/repositories.ts
+++ b/src/domain/telemetry/repositories.ts
@@ -1,0 +1,40 @@
+import type { TelemetryEntry } from "./telemetry_entry.ts";
+
+/**
+ * Repository interface for persisting and retrieving TelemetryEntry entities.
+ */
+export interface TelemetryRepository {
+  /**
+   * Saves a telemetry entry.
+   * Returns a Promise that resolves when the write completes.
+   * Should never throw - errors are logged silently.
+   *
+   * @param entry - The telemetry entry to save
+   */
+  save(entry: TelemetryEntry): Promise<void>;
+
+  /**
+   * Finds all telemetry entries for a given date.
+   *
+   * @param date - The date to search for entries
+   * @returns Array of telemetry entries from that date
+   */
+  findByDate(date: Date): Promise<TelemetryEntry[]>;
+
+  /**
+   * Finds all telemetry entries within a date range.
+   *
+   * @param startDate - The start date (inclusive)
+   * @param endDate - The end date (inclusive)
+   * @returns Array of telemetry entries within the range
+   */
+  findByDateRange(startDate: Date, endDate: Date): Promise<TelemetryEntry[]>;
+
+  /**
+   * Deletes all telemetry entries older than the given date.
+   *
+   * @param date - Delete entries older than this date
+   * @returns The number of entries deleted
+   */
+  deleteOlderThan(date: Date): Promise<number>;
+}

--- a/src/domain/telemetry/telemetry_entry.ts
+++ b/src/domain/telemetry/telemetry_entry.ts
@@ -1,0 +1,117 @@
+import {
+  createTelemetryId,
+  generateTelemetryId,
+  type TelemetryId,
+} from "./telemetry_id.ts";
+import {
+  type CommandInvocation,
+  type CommandInvocationData,
+  commandInvocationToData,
+  createCommandInvocation,
+} from "./command_invocation.ts";
+import {
+  type InvocationResult,
+  type InvocationResultData,
+  invocationResultFromData,
+  invocationResultToData,
+} from "./invocation_result.ts";
+
+/**
+ * Properties required to create a new TelemetryEntry.
+ */
+export interface CreateTelemetryEntryProps {
+  id?: string;
+  invocation: CommandInvocationData;
+  result: InvocationResultData;
+  startedAt: Date;
+  completedAt: Date;
+  swampVersion: string;
+  denoVersion: string;
+  platform: string;
+}
+
+/**
+ * Data transfer object for TelemetryEntry.
+ */
+export interface TelemetryEntryData {
+  id: string;
+  invocation: CommandInvocationData;
+  result: InvocationResultData;
+  startedAt: string;
+  completedAt: string;
+  durationMs: number;
+  swampVersion: string;
+  denoVersion: string;
+  platform: string;
+}
+
+/**
+ * TelemetryEntry is the main entity representing a CLI invocation.
+ */
+export class TelemetryEntry {
+  private constructor(
+    readonly id: TelemetryId,
+    readonly invocation: CommandInvocation,
+    readonly result: InvocationResult,
+    readonly startedAt: Date,
+    readonly completedAt: Date,
+    readonly durationMs: number,
+    readonly swampVersion: string,
+    readonly denoVersion: string,
+    readonly platform: string,
+  ) {}
+
+  /**
+   * Creates a new TelemetryEntry.
+   */
+  static create(props: CreateTelemetryEntryProps): TelemetryEntry {
+    const id = props.id ? createTelemetryId(props.id) : generateTelemetryId();
+    const durationMs = props.completedAt.getTime() - props.startedAt.getTime();
+
+    return new TelemetryEntry(
+      id,
+      createCommandInvocation(props.invocation),
+      invocationResultFromData(props.result),
+      props.startedAt,
+      props.completedAt,
+      durationMs,
+      props.swampVersion,
+      props.denoVersion,
+      props.platform,
+    );
+  }
+
+  /**
+   * Reconstructs a TelemetryEntry from persisted data.
+   */
+  static fromData(data: TelemetryEntryData): TelemetryEntry {
+    return new TelemetryEntry(
+      createTelemetryId(data.id),
+      createCommandInvocation(data.invocation),
+      invocationResultFromData(data.result),
+      new Date(data.startedAt),
+      new Date(data.completedAt),
+      data.durationMs,
+      data.swampVersion,
+      data.denoVersion,
+      data.platform,
+    );
+  }
+
+  /**
+   * Converts the TelemetryEntry to a plain data object for persistence.
+   */
+  toData(): TelemetryEntryData {
+    return {
+      id: this.id,
+      invocation: commandInvocationToData(this.invocation),
+      result: invocationResultToData(this.result),
+      startedAt: this.startedAt.toISOString(),
+      completedAt: this.completedAt.toISOString(),
+      durationMs: this.durationMs,
+      swampVersion: this.swampVersion,
+      denoVersion: this.denoVersion,
+      platform: this.platform,
+    };
+  }
+}

--- a/src/domain/telemetry/telemetry_entry_test.ts
+++ b/src/domain/telemetry/telemetry_entry_test.ts
@@ -1,0 +1,134 @@
+import { assertEquals, assertExists } from "@std/assert";
+import { TelemetryEntry, type TelemetryEntryData } from "./telemetry_entry.ts";
+
+Deno.test("TelemetryEntry.create creates entry with generated ID", () => {
+  const entry = TelemetryEntry.create({
+    invocation: {
+      command: "model",
+      subcommand: "create",
+      args: ["<REDACTED>"],
+      optionKeys: ["--repo-dir"],
+      globalOptions: ["--json"],
+    },
+    result: {
+      status: "success",
+      exitCode: 0,
+    },
+    startedAt: new Date("2026-02-05T10:00:00Z"),
+    completedAt: new Date("2026-02-05T10:00:01Z"),
+    swampVersion: "1.0.0",
+    denoVersion: "2.1.0",
+    platform: "linux",
+  });
+
+  assertExists(entry.id);
+  assertEquals(entry.invocation.command, "model");
+  assertEquals(entry.invocation.subcommand, "create");
+  assertEquals(entry.invocation.args, ["<REDACTED>"]);
+  assertEquals(entry.invocation.optionKeys, ["--repo-dir"]);
+  assertEquals(entry.invocation.globalOptions, ["--json"]);
+  assertEquals(entry.result.status, "success");
+  assertEquals(entry.result.exitCode, 0);
+  assertEquals(entry.durationMs, 1000);
+  assertEquals(entry.swampVersion, "1.0.0");
+  assertEquals(entry.denoVersion, "2.1.0");
+  assertEquals(entry.platform, "linux");
+});
+
+Deno.test("TelemetryEntry.create with explicit ID uses provided ID", () => {
+  const entry = TelemetryEntry.create({
+    id: "test-id-123",
+    invocation: {
+      command: "workflow",
+      args: [],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    result: {
+      status: "error",
+      errorType: "Error",
+      errorMessage: "Something went wrong",
+      exitCode: 1,
+    },
+    startedAt: new Date("2026-02-05T10:00:00Z"),
+    completedAt: new Date("2026-02-05T10:00:00.500Z"),
+    swampVersion: "1.0.0",
+    denoVersion: "2.1.0",
+    platform: "darwin",
+  });
+
+  assertEquals(entry.id, "test-id-123");
+  assertEquals(entry.result.status, "error");
+  assertEquals(entry.result.errorType, "Error");
+  assertEquals(entry.result.errorMessage, "Something went wrong");
+  assertEquals(entry.durationMs, 500);
+});
+
+Deno.test("TelemetryEntry.toData serializes to data object", () => {
+  const entry = TelemetryEntry.create({
+    id: "test-id-456",
+    invocation: {
+      command: "model",
+      subcommand: "run",
+      args: ["<REDACTED>", "<REDACTED>"],
+      optionKeys: ["--verbose"],
+      globalOptions: ["--debug-logs"],
+    },
+    result: {
+      status: "user_error",
+      errorType: "UserError",
+      errorMessage: "Invalid input",
+      exitCode: 1,
+    },
+    startedAt: new Date("2026-02-05T10:00:00Z"),
+    completedAt: new Date("2026-02-05T10:00:02Z"),
+    swampVersion: "1.0.0",
+    denoVersion: "2.1.0",
+    platform: "linux",
+  });
+
+  const data = entry.toData();
+
+  assertEquals(data.id, "test-id-456");
+  assertEquals(data.invocation.command, "model");
+  assertEquals(data.invocation.subcommand, "run");
+  assertEquals(data.invocation.args, ["<REDACTED>", "<REDACTED>"]);
+  assertEquals(data.result.status, "user_error");
+  assertEquals(data.result.errorType, "UserError");
+  assertEquals(data.durationMs, 2000);
+  assertEquals(data.startedAt, "2026-02-05T10:00:00.000Z");
+  assertEquals(data.completedAt, "2026-02-05T10:00:02.000Z");
+});
+
+Deno.test("TelemetryEntry.fromData reconstructs entry from data", () => {
+  const data: TelemetryEntryData = {
+    id: "test-id-789",
+    invocation: {
+      command: "data",
+      subcommand: "gc",
+      args: [],
+      optionKeys: ["--dry-run"],
+      globalOptions: [],
+    },
+    result: {
+      status: "success",
+      exitCode: 0,
+    },
+    startedAt: "2026-02-05T12:00:00.000Z",
+    completedAt: "2026-02-05T12:00:01.500Z",
+    durationMs: 1500,
+    swampVersion: "1.0.0",
+    denoVersion: "2.1.0",
+    platform: "linux",
+  };
+
+  const entry = TelemetryEntry.fromData(data);
+
+  assertEquals(entry.id, "test-id-789");
+  assertEquals(entry.invocation.command, "data");
+  assertEquals(entry.invocation.subcommand, "gc");
+  assertEquals(entry.result.status, "success");
+  assertEquals(entry.durationMs, 1500);
+  assertEquals(entry.startedAt.toISOString(), "2026-02-05T12:00:00.000Z");
+  assertEquals(entry.completedAt.toISOString(), "2026-02-05T12:00:01.500Z");
+});

--- a/src/domain/telemetry/telemetry_id.ts
+++ b/src/domain/telemetry/telemetry_id.ts
@@ -1,0 +1,18 @@
+/**
+ * Branded type for Telemetry IDs.
+ */
+export type TelemetryId = string & { readonly _brand: unique symbol };
+
+/**
+ * Creates a TelemetryId from a string.
+ */
+export function createTelemetryId(id: string): TelemetryId {
+  return id as TelemetryId;
+}
+
+/**
+ * Generates a new unique TelemetryId.
+ */
+export function generateTelemetryId(): TelemetryId {
+  return crypto.randomUUID() as TelemetryId;
+}

--- a/src/domain/telemetry/telemetry_service.ts
+++ b/src/domain/telemetry/telemetry_service.ts
@@ -1,0 +1,216 @@
+import type { TelemetryRepository } from "./repositories.ts";
+import { TelemetryEntry } from "./telemetry_entry.ts";
+import type { CommandInvocationData } from "./command_invocation.ts";
+import {
+  createErrorResult,
+  createSuccessResult,
+  type InvocationResultData,
+} from "./invocation_result.ts";
+import { UserError } from "../errors.ts";
+
+/**
+ * Aggregated telemetry statistics.
+ */
+export interface TelemetryStats {
+  /** Total number of invocations */
+  totalInvocations: number;
+  /** Number of successful invocations */
+  successCount: number;
+  /** Number of error invocations */
+  errorCount: number;
+  /** Number of user error invocations */
+  userErrorCount: number;
+  /** Success rate as a percentage */
+  successRate: number;
+  /** Error rate as a percentage */
+  errorRate: number;
+  /** Command frequency map (command -> count) */
+  commandFrequency: Record<string, number>;
+  /** Option frequency map (option -> count) */
+  optionFrequency: Record<string, number>;
+  /** Average duration by command (command -> average ms) */
+  averageDurationByCommand: Record<string, number>;
+  /** Platform distribution (platform -> count) */
+  platformDistribution: Record<string, number>;
+  /** Number of days analyzed */
+  daysAnalyzed: number;
+}
+
+/** Default retention period in days */
+const DEFAULT_RETENTION_DAYS = 2;
+
+/**
+ * Service for recording and analyzing CLI telemetry.
+ */
+export class TelemetryService {
+  constructor(
+    private readonly repository: TelemetryRepository,
+    private readonly swampVersion: string,
+  ) {}
+
+  /**
+   * Records a successful CLI invocation.
+   *
+   * @param invocation - The command invocation data
+   * @param startedAt - When the command started
+   */
+  async recordSuccess(
+    invocation: CommandInvocationData,
+    startedAt: Date,
+  ): Promise<void> {
+    const entry = TelemetryEntry.create({
+      invocation,
+      result: createSuccessResult(),
+      startedAt,
+      completedAt: new Date(),
+      swampVersion: this.swampVersion,
+      denoVersion: Deno.version.deno,
+      platform: Deno.build.os,
+    });
+
+    await this.repository.save(entry);
+  }
+
+  /**
+   * Records a failed CLI invocation.
+   *
+   * @param invocation - The command invocation data
+   * @param startedAt - When the command started
+   * @param error - The error that occurred
+   */
+  async recordError(
+    invocation: CommandInvocationData,
+    startedAt: Date,
+    error: Error,
+  ): Promise<void> {
+    const isUserError = error instanceof UserError;
+    const result: InvocationResultData = {
+      ...createErrorResult(error, isUserError),
+    };
+
+    const entry = TelemetryEntry.create({
+      invocation,
+      result,
+      startedAt,
+      completedAt: new Date(),
+      swampVersion: this.swampVersion,
+      denoVersion: Deno.version.deno,
+      platform: Deno.build.os,
+    });
+
+    await this.repository.save(entry);
+  }
+
+  /**
+   * Cleans up telemetry entries older than the retention period.
+   * This method is fire-and-forget and does not block.
+   *
+   * @param retentionDays - Number of days to retain (default: 2)
+   */
+  cleanupOldTelemetry(retentionDays: number = DEFAULT_RETENTION_DAYS): void {
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - retentionDays);
+
+    // Fire-and-forget: don't await, don't let errors propagate
+    this.repository.deleteOlderThan(cutoffDate).catch((error) => {
+      if (Deno.env.get("SWAMP_DEBUG")) {
+        console.error("[Telemetry] Cleanup failed:", error);
+      }
+    });
+  }
+
+  /**
+   * Gets aggregated statistics from recent telemetry.
+   *
+   * @param days - Number of days to analyze (default: 2)
+   * @returns Aggregated statistics
+   */
+  async getStats(
+    days: number = DEFAULT_RETENTION_DAYS,
+  ): Promise<TelemetryStats> {
+    const endDate = new Date();
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() - days);
+
+    const entries = await this.repository.findByDateRange(startDate, endDate);
+
+    const stats: TelemetryStats = {
+      totalInvocations: entries.length,
+      successCount: 0,
+      errorCount: 0,
+      userErrorCount: 0,
+      successRate: 0,
+      errorRate: 0,
+      commandFrequency: {},
+      optionFrequency: {},
+      averageDurationByCommand: {},
+      platformDistribution: {},
+      daysAnalyzed: days,
+    };
+
+    if (entries.length === 0) {
+      return stats;
+    }
+
+    // Track durations for averaging
+    const durationsByCommand: Record<string, number[]> = {};
+
+    for (const entry of entries) {
+      // Count statuses
+      switch (entry.result.status) {
+        case "success":
+          stats.successCount++;
+          break;
+        case "error":
+          stats.errorCount++;
+          break;
+        case "user_error":
+          stats.userErrorCount++;
+          break;
+      }
+
+      // Count commands
+      const commandKey = entry.invocation.subcommand
+        ? `${entry.invocation.command} ${entry.invocation.subcommand}`
+        : entry.invocation.command;
+      stats.commandFrequency[commandKey] =
+        (stats.commandFrequency[commandKey] || 0) + 1;
+
+      // Track duration for averaging
+      if (!durationsByCommand[commandKey]) {
+        durationsByCommand[commandKey] = [];
+      }
+      durationsByCommand[commandKey].push(entry.durationMs);
+
+      // Count options
+      for (const option of entry.invocation.optionKeys) {
+        stats.optionFrequency[option] = (stats.optionFrequency[option] || 0) +
+          1;
+      }
+      for (const option of entry.invocation.globalOptions) {
+        stats.optionFrequency[option] = (stats.optionFrequency[option] || 0) +
+          1;
+      }
+
+      // Count platforms
+      stats.platformDistribution[entry.platform] =
+        (stats.platformDistribution[entry.platform] || 0) + 1;
+    }
+
+    // Calculate rates
+    stats.successRate = (stats.successCount / stats.totalInvocations) * 100;
+    stats.errorRate =
+      ((stats.errorCount + stats.userErrorCount) / stats.totalInvocations) *
+      100;
+
+    // Calculate average durations
+    for (const [command, durations] of Object.entries(durationsByCommand)) {
+      const sum = durations.reduce((a, b) => a + b, 0);
+      stats.averageDurationByCommand[command] = Math.round(
+        sum / durations.length,
+      );
+    }
+
+    return stats;
+  }
+}

--- a/src/domain/telemetry/telemetry_service_test.ts
+++ b/src/domain/telemetry/telemetry_service_test.ts
@@ -1,0 +1,186 @@
+import { assertEquals } from "@std/assert";
+import { TelemetryService } from "./telemetry_service.ts";
+import type { TelemetryRepository } from "./repositories.ts";
+import { TelemetryEntry, type TelemetryEntryData } from "./telemetry_entry.ts";
+
+/** Mock repository for testing */
+class MockTelemetryRepository implements TelemetryRepository {
+  savedEntries: TelemetryEntry[] = [];
+  mockEntries: TelemetryEntry[] = [];
+  deletedBefore: Date | null = null;
+
+  save(entry: TelemetryEntry): Promise<void> {
+    this.savedEntries.push(entry);
+    return Promise.resolve();
+  }
+
+  findByDate(_date: Date): Promise<TelemetryEntry[]> {
+    return Promise.resolve(this.mockEntries);
+  }
+
+  findByDateRange(
+    _startDate: Date,
+    _endDate: Date,
+  ): Promise<TelemetryEntry[]> {
+    return Promise.resolve(this.mockEntries);
+  }
+
+  deleteOlderThan(date: Date): Promise<number> {
+    this.deletedBefore = date;
+    return Promise.resolve(5); // Mock deleted count
+  }
+}
+
+Deno.test("TelemetryService.recordSuccess saves successful invocation", async () => {
+  const repo = new MockTelemetryRepository();
+  const service = new TelemetryService(repo, "1.0.0");
+
+  const startTime = new Date();
+  await service.recordSuccess(
+    {
+      command: "model",
+      subcommand: "create",
+      args: ["<REDACTED>"],
+      optionKeys: ["--repo-dir"],
+      globalOptions: ["--json"],
+    },
+    startTime,
+  );
+
+  assertEquals(repo.savedEntries.length, 1);
+  const saved = repo.savedEntries[0];
+  assertEquals(saved.invocation.command, "model");
+  assertEquals(saved.invocation.subcommand, "create");
+  assertEquals(saved.result.status, "success");
+  assertEquals(saved.result.exitCode, 0);
+  assertEquals(saved.swampVersion, "1.0.0");
+});
+
+Deno.test("TelemetryService.recordError saves error invocation", async () => {
+  const repo = new MockTelemetryRepository();
+  const service = new TelemetryService(repo, "1.0.0");
+
+  const startTime = new Date();
+  const error = new Error("Something went wrong");
+  await service.recordError(
+    {
+      command: "workflow",
+      subcommand: "run",
+      args: [],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    startTime,
+    error,
+  );
+
+  assertEquals(repo.savedEntries.length, 1);
+  const saved = repo.savedEntries[0];
+  assertEquals(saved.invocation.command, "workflow");
+  assertEquals(saved.result.status, "error");
+  assertEquals(saved.result.errorType, "Error");
+  assertEquals(saved.result.errorMessage, "Something went wrong");
+  assertEquals(saved.result.exitCode, 1);
+});
+
+Deno.test("TelemetryService.getStats calculates statistics correctly", async () => {
+  const repo = new MockTelemetryRepository();
+  const service = new TelemetryService(repo, "1.0.0");
+
+  // Set up mock entries
+  const now = new Date();
+  const entries: TelemetryEntryData[] = [
+    {
+      id: "1",
+      invocation: {
+        command: "model",
+        subcommand: "create",
+        args: [],
+        optionKeys: ["--repo-dir"],
+        globalOptions: ["--json"],
+      },
+      result: { status: "success", exitCode: 0 },
+      startedAt: now.toISOString(),
+      completedAt: now.toISOString(),
+      durationMs: 100,
+      swampVersion: "1.0.0",
+      denoVersion: "2.1.0",
+      platform: "linux",
+    },
+    {
+      id: "2",
+      invocation: {
+        command: "model",
+        subcommand: "create",
+        args: [],
+        optionKeys: [],
+        globalOptions: [],
+      },
+      result: { status: "success", exitCode: 0 },
+      startedAt: now.toISOString(),
+      completedAt: now.toISOString(),
+      durationMs: 200,
+      swampVersion: "1.0.0",
+      denoVersion: "2.1.0",
+      platform: "linux",
+    },
+    {
+      id: "3",
+      invocation: {
+        command: "workflow",
+        subcommand: "run",
+        args: [],
+        optionKeys: [],
+        globalOptions: [],
+      },
+      result: {
+        status: "error",
+        errorType: "Error",
+        errorMessage: "Failed",
+        exitCode: 1,
+      },
+      startedAt: now.toISOString(),
+      completedAt: now.toISOString(),
+      durationMs: 50,
+      swampVersion: "1.0.0",
+      denoVersion: "2.1.0",
+      platform: "darwin",
+    },
+  ];
+
+  repo.mockEntries = entries.map((e) => TelemetryEntry.fromData(e));
+
+  const stats = await service.getStats(2);
+
+  assertEquals(stats.totalInvocations, 3);
+  assertEquals(stats.successCount, 2);
+  assertEquals(stats.errorCount, 1);
+  assertEquals(stats.userErrorCount, 0);
+  assertEquals(Math.round(stats.successRate), 67);
+  assertEquals(Math.round(stats.errorRate), 33);
+  assertEquals(stats.commandFrequency["model create"], 2);
+  assertEquals(stats.commandFrequency["workflow run"], 1);
+  assertEquals(stats.optionFrequency["--repo-dir"], 1);
+  assertEquals(stats.optionFrequency["--json"], 1);
+  assertEquals(stats.averageDurationByCommand["model create"], 150);
+  assertEquals(stats.averageDurationByCommand["workflow run"], 50);
+  assertEquals(stats.platformDistribution["linux"], 2);
+  assertEquals(stats.platformDistribution["darwin"], 1);
+  assertEquals(stats.daysAnalyzed, 2);
+});
+
+Deno.test("TelemetryService.getStats returns empty stats for no entries", async () => {
+  const repo = new MockTelemetryRepository();
+  const service = new TelemetryService(repo, "1.0.0");
+
+  repo.mockEntries = [];
+
+  const stats = await service.getStats(2);
+
+  assertEquals(stats.totalInvocations, 0);
+  assertEquals(stats.successCount, 0);
+  assertEquals(stats.errorCount, 0);
+  assertEquals(stats.successRate, 0);
+  assertEquals(stats.errorRate, 0);
+  assertEquals(Object.keys(stats.commandFrequency).length, 0);
+});

--- a/src/infrastructure/persistence/json_telemetry_repository.ts
+++ b/src/infrastructure/persistence/json_telemetry_repository.ts
@@ -1,0 +1,155 @@
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import type { TelemetryRepository } from "../../domain/telemetry/repositories.ts";
+import {
+  TelemetryEntry,
+  type TelemetryEntryData,
+} from "../../domain/telemetry/telemetry_entry.ts";
+
+/**
+ * JSON-based implementation of TelemetryRepository.
+ *
+ * Stores telemetry entries as JSON files in the directory structure:
+ * {repoDir}/.swamp/telemetry/telemetry-{YYYY-MM-DD}-{uuid}.json
+ *
+ * Each invocation creates a single file (no locking issues).
+ * Errors are silently logged to avoid breaking CLI execution.
+ */
+export class JsonTelemetryRepository implements TelemetryRepository {
+  constructor(private readonly repoDir: string) {}
+
+  /**
+   * Saves a telemetry entry to a JSON file.
+   * Never throws - errors are logged silently if SWAMP_DEBUG is set.
+   */
+  async save(entry: TelemetryEntry): Promise<void> {
+    try {
+      const telemetryDir = this.getTelemetryDir();
+      await ensureDir(telemetryDir);
+
+      const date = entry.startedAt.toISOString().split("T")[0];
+      const filename = `telemetry-${date}-${entry.id}.json`;
+      const path = join(telemetryDir, filename);
+
+      const json = JSON.stringify(entry.toData(), null, 2);
+      await Deno.writeTextFile(path, json);
+    } catch (error) {
+      // Silent failure - log only if SWAMP_DEBUG
+      if (Deno.env.get("SWAMP_DEBUG")) {
+        console.error("[Telemetry] Failed to write:", error);
+      }
+      // Never throw - telemetry errors shouldn't break CLI
+    }
+  }
+
+  /**
+   * Finds all telemetry entries for a given date.
+   */
+  async findByDate(date: Date): Promise<TelemetryEntry[]> {
+    const entries: TelemetryEntry[] = [];
+    const dateStr = date.toISOString().split("T")[0];
+    const prefix = `telemetry-${dateStr}-`;
+
+    try {
+      const telemetryDir = this.getTelemetryDir();
+
+      for await (const entry of Deno.readDir(telemetryDir)) {
+        if (
+          entry.isFile &&
+          entry.name.startsWith(prefix) &&
+          entry.name.endsWith(".json")
+        ) {
+          try {
+            const path = join(telemetryDir, entry.name);
+            const content = await Deno.readTextFile(path);
+            const data = JSON.parse(content) as TelemetryEntryData;
+            entries.push(TelemetryEntry.fromData(data));
+          } catch {
+            // Skip files that can't be parsed
+          }
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+
+    return entries;
+  }
+
+  /**
+   * Finds all telemetry entries within a date range.
+   */
+  async findByDateRange(
+    startDate: Date,
+    endDate: Date,
+  ): Promise<TelemetryEntry[]> {
+    const entries: TelemetryEntry[] = [];
+
+    // Iterate through each day in the range
+    const current = new Date(startDate);
+    current.setHours(0, 0, 0, 0);
+
+    const end = new Date(endDate);
+    end.setHours(23, 59, 59, 999);
+
+    while (current <= end) {
+      const dayEntries = await this.findByDate(current);
+      entries.push(...dayEntries);
+      current.setDate(current.getDate() + 1);
+    }
+
+    return entries;
+  }
+
+  /**
+   * Deletes all telemetry entries older than the given date.
+   */
+  async deleteOlderThan(date: Date): Promise<number> {
+    let deletedCount = 0;
+    const cutoffDateStr = date.toISOString().split("T")[0];
+
+    try {
+      const telemetryDir = this.getTelemetryDir();
+
+      for await (const entry of Deno.readDir(telemetryDir)) {
+        if (
+          entry.isFile &&
+          entry.name.startsWith("telemetry-") &&
+          entry.name.endsWith(".json")
+        ) {
+          // Extract date from filename: telemetry-YYYY-MM-DD-uuid.json
+          const dateMatch = entry.name.match(/^telemetry-(\d{4}-\d{2}-\d{2})-/);
+          if (dateMatch) {
+            const fileDate = dateMatch[1];
+            if (fileDate < cutoffDateStr) {
+              try {
+                const path = join(telemetryDir, entry.name);
+                await Deno.remove(path);
+                deletedCount++;
+              } catch {
+                // Ignore errors when deleting individual files
+              }
+            }
+          }
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return 0;
+      }
+      // Log but don't throw for cleanup operations
+      if (Deno.env.get("SWAMP_DEBUG")) {
+        console.error("[Telemetry] Cleanup error:", error);
+      }
+    }
+
+    return deletedCount;
+  }
+
+  private getTelemetryDir(): string {
+    return join(this.repoDir, ".swamp", "telemetry");
+  }
+}

--- a/src/infrastructure/persistence/json_telemetry_repository_test.ts
+++ b/src/infrastructure/persistence/json_telemetry_repository_test.ts
@@ -1,0 +1,307 @@
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { JsonTelemetryRepository } from "./json_telemetry_repository.ts";
+import { TelemetryEntry } from "../../domain/telemetry/telemetry_entry.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const tempDir = await Deno.makeTempDir();
+  try {
+    await fn(tempDir);
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+}
+
+function createTestEntry(
+  overrides: { id?: string; date?: Date; platform?: string } = {},
+): TelemetryEntry {
+  const startedAt = overrides.date ?? new Date("2024-01-15T10:00:00Z");
+  const completedAt = new Date(startedAt.getTime() + 1000);
+
+  return TelemetryEntry.create({
+    id: overrides.id ?? "550e8400-e29b-41d4-a716-446655440000",
+    invocation: {
+      command: "model",
+      subcommand: "create",
+      args: ["arg1"],
+      optionKeys: ["--json"],
+      globalOptions: ["--debug"],
+    },
+    result: {
+      status: "success",
+      exitCode: 0,
+    },
+    startedAt,
+    completedAt,
+    swampVersion: "1.0.0",
+    denoVersion: "1.40.0",
+    platform: overrides.platform ?? "linux",
+  });
+}
+
+Deno.test("JsonTelemetryRepository.save creates directory structure and file", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new JsonTelemetryRepository(dir);
+    const entry = createTestEntry();
+
+    await repo.save(entry);
+
+    const telemetryDir = join(dir, ".swamp", "telemetry");
+    const dirInfo = await Deno.stat(telemetryDir);
+    assertEquals(dirInfo.isDirectory, true);
+
+    // Check that file was created
+    const files: string[] = [];
+    for await (const f of Deno.readDir(telemetryDir)) {
+      files.push(f.name);
+    }
+    assertEquals(files.length, 1);
+  });
+});
+
+Deno.test("JsonTelemetryRepository.save creates correctly named file", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new JsonTelemetryRepository(dir);
+    const entry = createTestEntry({
+      id: "abc12345-e29b-41d4-a716-446655440000",
+      date: new Date("2024-02-20T15:30:00Z"),
+    });
+
+    await repo.save(entry);
+
+    const telemetryDir = join(dir, ".swamp", "telemetry");
+    const expectedFilename =
+      "telemetry-2024-02-20-abc12345-e29b-41d4-a716-446655440000.json";
+    const filePath = join(telemetryDir, expectedFilename);
+
+    const fileInfo = await Deno.stat(filePath);
+    assertEquals(fileInfo.isFile, true);
+  });
+});
+
+Deno.test("JsonTelemetryRepository.save never throws on errors", async () => {
+  // Use a path that cannot be written to (non-existent parent of non-writable dir)
+  const repo = new JsonTelemetryRepository(
+    "/nonexistent/path/that/cannot/exist",
+  );
+  const entry = createTestEntry();
+
+  // Should not throw
+  await repo.save(entry);
+});
+
+Deno.test("JsonTelemetryRepository.findByDate returns entries for specific date", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new JsonTelemetryRepository(dir);
+    const date = new Date("2024-03-10T12:00:00Z");
+    const entry = createTestEntry({ id: "entry-1-uuid-1234", date });
+
+    await repo.save(entry);
+
+    const entries = await repo.findByDate(date);
+    assertEquals(entries.length, 1);
+    assertEquals(entries[0].id, "entry-1-uuid-1234");
+  });
+});
+
+Deno.test("JsonTelemetryRepository.findByDate returns empty array if no files exist", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new JsonTelemetryRepository(dir);
+    // Create the telemetry directory but don't add any files
+    await Deno.mkdir(join(dir, ".swamp", "telemetry"), { recursive: true });
+
+    const entries = await repo.findByDate(new Date("2024-01-01"));
+    assertEquals(entries, []);
+  });
+});
+
+Deno.test("JsonTelemetryRepository.findByDate returns empty array if directory doesn't exist", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new JsonTelemetryRepository(dir);
+
+    const entries = await repo.findByDate(new Date("2024-01-01"));
+    assertEquals(entries, []);
+  });
+});
+
+Deno.test("JsonTelemetryRepository.findByDate skips unparseable JSON files", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new JsonTelemetryRepository(dir);
+    const telemetryDir = join(dir, ".swamp", "telemetry");
+    await Deno.mkdir(telemetryDir, { recursive: true });
+
+    // Create a valid entry
+    const validEntry = createTestEntry({
+      id: "valid-entry-uuid",
+      date: new Date("2024-04-15T10:00:00Z"),
+    });
+    await repo.save(validEntry);
+
+    // Create an invalid JSON file
+    const invalidFilename = "telemetry-2024-04-15-invalid-entry-uuid.json";
+    await Deno.writeTextFile(
+      join(telemetryDir, invalidFilename),
+      "not valid json{{{",
+    );
+
+    const entries = await repo.findByDate(new Date("2024-04-15"));
+    assertEquals(entries.length, 1);
+    assertEquals(entries[0].id, "valid-entry-uuid");
+  });
+});
+
+Deno.test("JsonTelemetryRepository.findByDateRange returns entries across multiple days", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new JsonTelemetryRepository(dir);
+
+    // Create entries on different days - use noon UTC to avoid timezone edge cases
+    const entry1 = createTestEntry({
+      id: "day1-entry-uuid",
+      date: new Date("2024-05-01T12:00:00Z"),
+    });
+    const entry2 = createTestEntry({
+      id: "day2-entry-uuid",
+      date: new Date("2024-05-02T12:00:00Z"),
+    });
+    const entry3 = createTestEntry({
+      id: "day3-entry-uuid",
+      date: new Date("2024-05-03T12:00:00Z"),
+    });
+
+    await repo.save(entry1);
+    await repo.save(entry2);
+    await repo.save(entry3);
+
+    const entries = await repo.findByDateRange(
+      new Date("2024-05-01T00:00:00Z"),
+      new Date("2024-05-03T23:59:59Z"),
+    );
+    assertEquals(entries.length, 3);
+  });
+});
+
+Deno.test("JsonTelemetryRepository.findByDateRange includes both boundary dates", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new JsonTelemetryRepository(dir);
+
+    // Use noon UTC to avoid timezone edge cases with file naming
+    const startEntry = createTestEntry({
+      id: "start-entry-uuid",
+      date: new Date("2024-06-01T12:00:00Z"),
+    });
+    const endEntry = createTestEntry({
+      id: "end-entry-uuid",
+      date: new Date("2024-06-05T12:00:00Z"),
+    });
+
+    await repo.save(startEntry);
+    await repo.save(endEntry);
+
+    const entries = await repo.findByDateRange(
+      new Date("2024-06-01T00:00:00Z"),
+      new Date("2024-06-05T23:59:59Z"),
+    );
+    assertEquals(entries.length, 2);
+
+    const ids = entries.map((e) => e.id).sort();
+    assertEquals(ids, ["end-entry-uuid", "start-entry-uuid"]);
+  });
+});
+
+Deno.test("JsonTelemetryRepository.deleteOlderThan deletes files older than cutoff", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new JsonTelemetryRepository(dir);
+
+    // Create an old entry and a recent entry
+    const oldEntry = createTestEntry({
+      id: "old-entry-uuid",
+      date: new Date("2024-01-01T10:00:00Z"),
+    });
+    const recentEntry = createTestEntry({
+      id: "recent-entry-uuid",
+      date: new Date("2024-06-15T10:00:00Z"),
+    });
+
+    await repo.save(oldEntry);
+    await repo.save(recentEntry);
+
+    // Delete entries older than June 1st
+    const deletedCount = await repo.deleteOlderThan(new Date("2024-06-01"));
+    assertEquals(deletedCount, 1);
+
+    // Verify only recent entry remains
+    const oldEntries = await repo.findByDate(new Date("2024-01-01"));
+    assertEquals(oldEntries.length, 0);
+
+    const recentEntries = await repo.findByDate(new Date("2024-06-15"));
+    assertEquals(recentEntries.length, 1);
+  });
+});
+
+Deno.test("JsonTelemetryRepository.deleteOlderThan keeps files on/after cutoff date", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new JsonTelemetryRepository(dir);
+
+    // Create entry on the cutoff date
+    const cutoffEntry = createTestEntry({
+      id: "cutoff-entry-uuid",
+      date: new Date("2024-07-01T10:00:00Z"),
+    });
+    // Create entry after the cutoff date
+    const afterEntry = createTestEntry({
+      id: "after-entry-uuid",
+      date: new Date("2024-07-02T10:00:00Z"),
+    });
+
+    await repo.save(cutoffEntry);
+    await repo.save(afterEntry);
+
+    // Delete entries older than July 1st - should keep both
+    const deletedCount = await repo.deleteOlderThan(new Date("2024-07-01"));
+    assertEquals(deletedCount, 0);
+
+    // Verify both entries still exist
+    const cutoffEntries = await repo.findByDate(new Date("2024-07-01"));
+    assertEquals(cutoffEntries.length, 1);
+
+    const afterEntries = await repo.findByDate(new Date("2024-07-02"));
+    assertEquals(afterEntries.length, 1);
+  });
+});
+
+Deno.test("JsonTelemetryRepository.deleteOlderThan returns correct deletion count", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new JsonTelemetryRepository(dir);
+
+    // Create multiple old entries
+    const oldEntry1 = createTestEntry({
+      id: "old-entry-1-uuid",
+      date: new Date("2024-01-10T10:00:00Z"),
+    });
+    const oldEntry2 = createTestEntry({
+      id: "old-entry-2-uuid",
+      date: new Date("2024-01-15T10:00:00Z"),
+    });
+    const oldEntry3 = createTestEntry({
+      id: "old-entry-3-uuid",
+      date: new Date("2024-01-20T10:00:00Z"),
+    });
+
+    await repo.save(oldEntry1);
+    await repo.save(oldEntry2);
+    await repo.save(oldEntry3);
+
+    const deletedCount = await repo.deleteOlderThan(new Date("2024-06-01"));
+    assertEquals(deletedCount, 3);
+  });
+});
+
+Deno.test("JsonTelemetryRepository.deleteOlderThan returns 0 if directory doesn't exist", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new JsonTelemetryRepository(dir);
+    // Don't create any files or directories
+
+    const deletedCount = await repo.deleteOlderThan(new Date("2024-06-01"));
+    assertEquals(deletedCount, 0);
+  });
+});

--- a/src/presentation/output/telemetry_stats_output.tsx
+++ b/src/presentation/output/telemetry_stats_output.tsx
@@ -1,0 +1,130 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { Box, Text } from "ink";
+import { render } from "ink-testing-library";
+import type { OutputMode } from "./output.tsx";
+import type { TelemetryStats } from "../../domain/telemetry/telemetry_service.ts";
+
+/**
+ * Data for telemetry stats output.
+ */
+export interface TelemetryStatsData extends TelemetryStats {}
+
+/**
+ * Renders telemetry statistics.
+ */
+export function renderTelemetryStats(
+  data: TelemetryStatsData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    const { lastFrame } = render(<TelemetryStatsDisplay {...data} />);
+    console.log(lastFrame());
+  }
+}
+
+function TelemetryStatsDisplay(props: TelemetryStatsData): React.ReactElement {
+  // Sort commands by frequency (descending)
+  const topCommands = Object.entries(props.commandFrequency)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10);
+
+  // Sort options by frequency (descending)
+  const topOptions = Object.entries(props.optionFrequency)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10);
+
+  return (
+    <Box flexDirection="column">
+      <Text bold color="cyan">
+        Telemetry Statistics (last {props.daysAnalyzed} days)
+      </Text>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text bold>Overview</Text>
+        <Box marginLeft={2} flexDirection="column">
+          <Text>Total invocations: {props.totalInvocations}</Text>
+          <Text color="green">
+            Success: {props.successCount} ({props.successRate.toFixed(1)}%)
+          </Text>
+          <Text color="red">
+            Errors: {props.errorCount + props.userErrorCount} (
+            {props.errorRate.toFixed(1)}%)
+          </Text>
+          {props.userErrorCount > 0 && (
+            <Box marginLeft={2}>
+              <Text dimColor>User errors: {props.userErrorCount}</Text>
+            </Box>
+          )}
+        </Box>
+      </Box>
+
+      {topCommands.length > 0 && (
+        <Box marginTop={1} flexDirection="column">
+          <Text bold>Top Commands</Text>
+          <Box marginLeft={2} flexDirection="column">
+            {topCommands.map(([command, count], i) => {
+              const avgDuration = props.averageDurationByCommand[command];
+              return (
+                <Text key={i}>
+                  {command}: {count}
+                  {avgDuration !== undefined && (
+                    <Text dimColor>(avg: {avgDuration}ms)</Text>
+                  )}
+                </Text>
+              );
+            })}
+          </Box>
+        </Box>
+      )}
+
+      {topOptions.length > 0 && (
+        <Box marginTop={1} flexDirection="column">
+          <Text bold>Top Options</Text>
+          <Box marginLeft={2} flexDirection="column">
+            {topOptions.map(([option, count], i) => (
+              <Text key={i}>
+                {option}: {count}
+              </Text>
+            ))}
+          </Box>
+        </Box>
+      )}
+
+      {Object.keys(props.platformDistribution).length > 0 && (
+        <Box marginTop={1} flexDirection="column">
+          <Text bold>Platforms</Text>
+          <Box marginLeft={2} flexDirection="column">
+            {Object.entries(props.platformDistribution).map(
+              ([platform, count], i) => (
+                <Text key={i}>
+                  {platform}: {count}
+                </Text>
+              ),
+            )}
+          </Box>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+/**
+ * Renders empty telemetry message.
+ */
+export function renderNoTelemetry(mode: OutputMode): void {
+  if (mode === "json") {
+    console.log(
+      JSON.stringify({ message: "No telemetry data found" }, null, 2),
+    );
+  } else {
+    const { lastFrame } = render(
+      <Box>
+        <Text color="yellow">No telemetry data found.</Text>
+      </Box>,
+    );
+    console.log(lastFrame());
+  }
+}

--- a/src/presentation/output/telemetry_stats_output_test.tsx
+++ b/src/presentation/output/telemetry_stats_output_test.tsx
@@ -1,0 +1,296 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  renderNoTelemetry,
+  renderTelemetryStats,
+  type TelemetryStatsData,
+} from "./telemetry_stats_output.tsx";
+
+const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
+
+const testStats: TelemetryStatsData = {
+  totalInvocations: 100,
+  successCount: 85,
+  errorCount: 10,
+  userErrorCount: 5,
+  successRate: 85.0,
+  errorRate: 15.0,
+  commandFrequency: {
+    "model create": 40,
+    "workflow run": 30,
+    "model search": 20,
+    "vault put": 10,
+  },
+  optionFrequency: {
+    "--json": 50,
+    "--verbose": 25,
+    "--debug": 15,
+  },
+  averageDurationByCommand: {
+    "model create": 150,
+    "workflow run": 2500,
+    "model search": 80,
+    "vault put": 100,
+  },
+  platformDistribution: {
+    linux: 60,
+    darwin: 35,
+    windows: 5,
+  },
+  daysAnalyzed: 7,
+};
+
+Deno.test("renderTelemetryStats with json mode outputs valid JSON", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderTelemetryStats(testStats, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.totalInvocations, testStats.totalInvocations);
+    assertEquals(parsed.successCount, testStats.successCount);
+    assertEquals(parsed.errorCount, testStats.errorCount);
+    assertEquals(parsed.commandFrequency["model create"], 40);
+    assertEquals(parsed.platformDistribution.linux, 60);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test({
+  name: "renderTelemetryStats with interactive mode outputs to console",
+  ...inkTestOptions,
+  fn: () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      renderTelemetryStats(testStats, "interactive");
+      assertEquals(logs.length, 1);
+      // Interactive mode should output rendered component, not JSON
+      assertStringIncludes(logs[0], "Telemetry Statistics");
+    } finally {
+      console.log = originalLog;
+    }
+  },
+});
+
+Deno.test("renderNoTelemetry with json mode outputs message JSON", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderNoTelemetry("json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.message, "No telemetry data found");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test({
+  name: "renderNoTelemetry with interactive mode shows warning",
+  ...inkTestOptions,
+  fn: () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      renderNoTelemetry("interactive");
+      assertEquals(logs.length, 1);
+      assertStringIncludes(logs[0], "No telemetry data found");
+    } finally {
+      console.log = originalLog;
+    }
+  },
+});
+
+Deno.test({
+  name: "TelemetryStatsDisplay renders overview section with stats",
+  ...inkTestOptions,
+  fn: () => {
+    // We need to test the component indirectly through renderTelemetryStats
+    // since TelemetryStatsDisplay is not exported
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      renderTelemetryStats(testStats, "interactive");
+      const output = logs[0];
+
+      assertStringIncludes(output, "Overview");
+      assertStringIncludes(output, "Total invocations: 100");
+      assertStringIncludes(output, "Success: 85");
+      assertStringIncludes(output, "85.0%");
+      assertStringIncludes(output, "Errors: 15");
+      assertStringIncludes(output, "15.0%");
+    } finally {
+      console.log = originalLog;
+    }
+  },
+});
+
+Deno.test({
+  name: "TelemetryStatsDisplay renders top commands sorted by frequency",
+  ...inkTestOptions,
+  fn: () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      renderTelemetryStats(testStats, "interactive");
+      const output = logs[0];
+
+      assertStringIncludes(output, "Top Commands");
+      assertStringIncludes(output, "model create: 40");
+      assertStringIncludes(output, "workflow run: 30");
+      assertStringIncludes(output, "model search: 20");
+
+      // Verify commands are sorted (model create:40 should appear before workflow run:30)
+      const modelCreateIndex = output.indexOf("model create");
+      const workflowRunIndex = output.indexOf("workflow run");
+      assertEquals(modelCreateIndex < workflowRunIndex, true);
+    } finally {
+      console.log = originalLog;
+    }
+  },
+});
+
+Deno.test({
+  name: "TelemetryStatsDisplay renders top options sorted by frequency",
+  ...inkTestOptions,
+  fn: () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      renderTelemetryStats(testStats, "interactive");
+      const output = logs[0];
+
+      assertStringIncludes(output, "Top Options");
+      assertStringIncludes(output, "--json: 50");
+      assertStringIncludes(output, "--verbose: 25");
+
+      // Verify options are sorted (--json:50 should appear before --verbose:25)
+      const jsonIndex = output.indexOf("--json");
+      const verboseIndex = output.indexOf("--verbose");
+      assertEquals(jsonIndex < verboseIndex, true);
+    } finally {
+      console.log = originalLog;
+    }
+  },
+});
+
+Deno.test({
+  name: "TelemetryStatsDisplay renders platform distribution",
+  ...inkTestOptions,
+  fn: () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      renderTelemetryStats(testStats, "interactive");
+      const output = logs[0];
+
+      assertStringIncludes(output, "Platforms");
+      assertStringIncludes(output, "linux: 60");
+      assertStringIncludes(output, "darwin: 35");
+      assertStringIncludes(output, "windows: 5");
+    } finally {
+      console.log = originalLog;
+    }
+  },
+});
+
+Deno.test({
+  name: "TelemetryStatsDisplay handles empty stats gracefully",
+  ...inkTestOptions,
+  fn: () => {
+    const emptyStats: TelemetryStatsData = {
+      totalInvocations: 0,
+      successCount: 0,
+      errorCount: 0,
+      userErrorCount: 0,
+      successRate: 0,
+      errorRate: 0,
+      commandFrequency: {},
+      optionFrequency: {},
+      averageDurationByCommand: {},
+      platformDistribution: {},
+      daysAnalyzed: 7,
+    };
+
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      renderTelemetryStats(emptyStats, "interactive");
+      const output = logs[0];
+
+      // Should still render the header and overview
+      assertStringIncludes(output, "Telemetry Statistics");
+      assertStringIncludes(output, "Total invocations: 0");
+
+      // Should NOT render sections that have no data
+      assertEquals(output.includes("Top Commands"), false);
+      assertEquals(output.includes("Top Options"), false);
+      assertEquals(output.includes("Platforms"), false);
+    } finally {
+      console.log = originalLog;
+    }
+  },
+});
+
+Deno.test({
+  name: "TelemetryStatsDisplay shows user errors when present",
+  ...inkTestOptions,
+  fn: () => {
+    const statsWithUserErrors: TelemetryStatsData = {
+      ...testStats,
+      userErrorCount: 5,
+    };
+
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      renderTelemetryStats(statsWithUserErrors, "interactive");
+      const output = logs[0];
+
+      assertStringIncludes(output, "User errors: 5");
+    } finally {
+      console.log = originalLog;
+    }
+  },
+});
+
+Deno.test({
+  name: "TelemetryStatsDisplay shows average duration for commands",
+  ...inkTestOptions,
+  fn: () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      renderTelemetryStats(testStats, "interactive");
+      const output = logs[0];
+
+      assertStringIncludes(output, "avg: 150ms");
+      assertStringIncludes(output, "avg: 2500ms");
+    } finally {
+      console.log = originalLog;
+    }
+  },
+});


### PR DESCRIPTION
## Summary

Implements a DDD-style telemetry layer that records every CLI invocation as JSON logs in `.swamp/telemetry/`. The system tracks command success/failure, records option names (but not values for privacy), and operates without blocking execution.

- Record every CLI invocation to `.swamp/telemetry/telemetry-{date}-{uuid}.json`
- Track command correctness (success/error/user_error)
- Log option keys but NOT values (privacy protection)
- `--no-telemetry` global flag to disable telemetry
- 2-day telemetry retention with auto-cleanup on each invocation
- `swamp telemetry stats` command to view usage statistics

**Domain Model:**
- TelemetryEntry entity with CommandInvocation and InvocationResult value objects
- TelemetryRepository interface with JsonTelemetryRepository implementation
- TelemetryService domain service for recording and analyzing telemetry

Closes #166

## Test Plan

- [x] Unit tests for TelemetryEntry entity (creation, serialization, deserialization)
- [x] Unit tests for TelemetryService (recordSuccess, recordError, getStats)
- [x] Unit tests for extractCommandInfo (arg parsing, privacy redaction)
- [x] All existing tests pass (1456 tests)
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes