### PR TITLE
feat: Implement declarative data output specifications for model types

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+export GIT_DIR=$PWD/../swamp/.git

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ experiments/webapp/frontend/dist/
 experiments/webapp/frontend/tsconfig.tsbuildinfo
 .vault-*/
 .claude/settings.local.json
+.envrc

--- a/integration/data_output_specs_test.ts
+++ b/integration/data_output_specs_test.ts
@@ -1,0 +1,354 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { ModelType } from "../src/domain/models/model_type.ts";
+import { modelRegistry } from "../src/domain/models/model.ts";
+import { Definition } from "../src/domain/definitions/definition.ts";
+import { DefaultMethodExecutionService } from "../src/domain/models/method_execution_service.ts";
+import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
+import { FileSystemUnifiedDataRepository } from "../src/infrastructure/persistence/unified_data_repository.ts";
+// Import specific models to trigger registration (without AWS models that require env access)
+import "../src/domain/models/echo/echo_model.ts";
+import "../src/domain/models/command/curl/curl_model.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-integration-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("Data output specs - echo model declares message spec", () => {
+  const echoModelType = ModelType.create("swamp/echo");
+  const model = modelRegistry.get(echoModelType);
+
+  assertEquals(model !== undefined, true);
+  assertEquals(Object.keys(model!.dataOutputSpecs).length, 1);
+  assertEquals(model!.dataOutputSpecs["message"] !== undefined, true);
+  assertEquals(model!.dataOutputSpecs["message"].specType.value, "message");
+  assertEquals(
+    model!.dataOutputSpecs["message"].description,
+    "Echo message with timestamp",
+  );
+});
+
+Deno.test("Data output specs - curl model declares metadata and file specs", () => {
+  const curlModelType = ModelType.create("command/curl");
+  const model = modelRegistry.get(curlModelType);
+
+  assertEquals(model !== undefined, true);
+  assertEquals(Object.keys(model!.dataOutputSpecs).length, 2);
+  assertEquals(model!.dataOutputSpecs["metadata"] !== undefined, true);
+  assertEquals(model!.dataOutputSpecs["file"] !== undefined, true);
+  assertEquals(model!.dataOutputSpecs["metadata"].specType.value, "metadata");
+  assertEquals(model!.dataOutputSpecs["file"].specType.value, "file");
+});
+
+Deno.test("Data output specs - echo model execution produces valid spec type", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const executionService = new DefaultMethodExecutionService();
+
+    const modelType = ModelType.create("swamp/echo");
+
+    // Create echo definition
+    const definition = Definition.create({
+      name: "test-echo",
+      attributes: {
+        message: "Hello, data specs!",
+      },
+    });
+
+    await definitionRepo.save(modelType, definition);
+
+    // Get model definition
+    const model = modelRegistry.get(modelType);
+    const writeMethod = model!.methods.write;
+
+    // Execute the method
+    const result = await executionService.execute(
+      definition,
+      writeMethod,
+      {
+        repoDir,
+        modelType,
+        modelId: definition.id,
+        dataRepository: dataRepo,
+        definitionRepository: definitionRepo,
+        modelDefinition: model,
+      },
+    );
+
+    // Verify data output has correct spec type
+    assertEquals(result.dataOutputs?.length, 1);
+    assertEquals(result.dataOutputs![0].specType.value, "message");
+    assertEquals(result.dataOutputs![0].name, "test-echo-message");
+
+    // Verify defaults were applied
+    assertEquals(
+      result.dataOutputs![0].metadata.contentType,
+      "application/json",
+    );
+    assertEquals(result.dataOutputs![0].metadata.lifetime, "ephemeral");
+    assertEquals(result.dataOutputs![0].metadata.garbageCollection, 10);
+  });
+});
+
+Deno.test("Data output specs - validation fails for undeclared spec type", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const executionService = new DefaultMethodExecutionService();
+
+    // Get echo model
+    const echoModelType = ModelType.create("swamp/echo");
+    const model = modelRegistry.get(echoModelType);
+
+    // Create a definition
+    const definition = Definition.create({
+      name: "test-echo",
+      attributes: {
+        message: "Test",
+      },
+    });
+
+    // Create a mock method that produces undeclared spec type
+    const badMethod = {
+      description: "Bad method",
+      inputAttributesSchema: model!.inputAttributesSchema,
+      execute: async () => {
+        const { DataSpecType } = await import("../src/domain/models/model.ts");
+        return {
+          dataOutputs: [{
+            name: "bad-output",
+            specType: DataSpecType.create("undeclared"),
+            content: new Uint8Array(),
+            metadata: {
+              contentType: "application/json",
+              lifetime: "infinite" as const,
+              garbageCollection: 10,
+              streaming: false,
+              tags: { type: "data" },
+              ownerDefinition: {
+                definitionHash: "hash",
+                ownerType: "model-method" as const,
+                ownerRef: "bad",
+              },
+            },
+          }],
+        };
+      },
+    };
+
+    // Execute the bad method
+    let errorMessage = "";
+    try {
+      await executionService.execute(
+        definition,
+        badMethod,
+        {
+          repoDir,
+          modelType: echoModelType,
+          modelId: definition.id,
+          dataRepository: dataRepo,
+          definitionRepository: definitionRepo,
+          modelDefinition: model,
+        },
+      );
+    } catch (error) {
+      errorMessage = (error as Error).message;
+    }
+
+    // Verify validation error
+    assertStringIncludes(errorMessage, "Data output validation failed");
+    assertStringIncludes(errorMessage, "undeclared spec type 'undeclared'");
+    assertStringIncludes(errorMessage, "Declared spec types: message");
+  });
+});
+
+Deno.test("Data output specs - multiple instances of same spec type", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const executionService = new DefaultMethodExecutionService();
+
+    // Get echo model
+    const echoModelType = ModelType.create("swamp/echo");
+    const model = modelRegistry.get(echoModelType);
+
+    const definition = Definition.create({
+      name: "test-echo",
+      attributes: {
+        message: "Test",
+      },
+    });
+
+    // Create a method that produces multiple message instances
+    const multiMessageMethod = {
+      description: "Multi message method",
+      inputAttributesSchema: model!.inputAttributesSchema,
+      execute: async () => {
+        const { DataSpecType } = await import("../src/domain/models/model.ts");
+
+        return {
+          dataOutputs: [
+            {
+              name: "message-1",
+              specType: DataSpecType.create("message"),
+              content: new TextEncoder().encode(
+                JSON.stringify({
+                  message: "First",
+                  timestamp: new Date().toISOString(),
+                }),
+              ),
+              metadata: {
+                contentType: "application/json",
+                lifetime: "ephemeral" as const,
+                garbageCollection: 10,
+                streaming: false,
+                tags: { type: "data" },
+                ownerDefinition: {
+                  definitionHash: "hash",
+                  ownerType: "model-method" as const,
+                  ownerRef: "multi",
+                },
+              },
+            },
+            {
+              name: "message-2",
+              specType: DataSpecType.create("message"),
+              content: new TextEncoder().encode(
+                JSON.stringify({
+                  message: "Second",
+                  timestamp: new Date().toISOString(),
+                }),
+              ),
+              metadata: {
+                contentType: "application/json",
+                lifetime: "ephemeral" as const,
+                garbageCollection: 10,
+                streaming: false,
+                tags: { type: "data" },
+                ownerDefinition: {
+                  definitionHash: "hash",
+                  ownerType: "model-method" as const,
+                  ownerRef: "multi",
+                },
+              },
+            },
+          ],
+        };
+      },
+    };
+
+    // Execute the method
+    const result = await executionService.execute(
+      definition,
+      multiMessageMethod,
+      {
+        repoDir,
+        modelType: echoModelType,
+        modelId: definition.id,
+        dataRepository: dataRepo,
+        definitionRepository: definitionRepo,
+        modelDefinition: model,
+      },
+    );
+
+    // Verify both outputs reference the same spec type
+    assertEquals(result.dataOutputs?.length, 2);
+    assertEquals(result.dataOutputs![0].specType.value, "message");
+    assertEquals(result.dataOutputs![1].specType.value, "message");
+    assertEquals(result.dataOutputs![0].name, "message-1");
+    assertEquals(result.dataOutputs![1].name, "message-2");
+  });
+});
+
+Deno.test("Data output specs - validation detects duplicate instance names", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const executionService = new DefaultMethodExecutionService();
+
+    const echoModelType = ModelType.create("swamp/echo");
+    const model = modelRegistry.get(echoModelType);
+
+    const definition = Definition.create({
+      name: "test-echo",
+      attributes: {
+        message: "Test",
+      },
+    });
+
+    // Create a method with duplicate names
+    const duplicateNamesMethod = {
+      description: "Duplicate names method",
+      inputAttributesSchema: model!.inputAttributesSchema,
+      execute: async () => {
+        const { DataSpecType } = await import("../src/domain/models/model.ts");
+        return {
+          dataOutputs: [
+            {
+              name: "duplicate",
+              specType: DataSpecType.create("message"),
+              content: new Uint8Array(),
+              metadata: {
+                contentType: "application/json",
+                lifetime: "infinite" as const,
+                garbageCollection: 10,
+                streaming: false,
+                tags: { type: "data" },
+                ownerDefinition: {
+                  definitionHash: "hash",
+                  ownerType: "model-method" as const,
+                  ownerRef: "dup",
+                },
+              },
+            },
+            {
+              name: "duplicate",
+              specType: DataSpecType.create("message"),
+              content: new Uint8Array(),
+              metadata: {
+                contentType: "application/json",
+                lifetime: "infinite" as const,
+                garbageCollection: 10,
+                streaming: false,
+                tags: { type: "data" },
+                ownerDefinition: {
+                  definitionHash: "hash",
+                  ownerType: "model-method" as const,
+                  ownerRef: "dup",
+                },
+              },
+            },
+          ],
+        };
+      },
+    };
+
+    let errorMessage = "";
+    try {
+      await executionService.execute(
+        definition,
+        duplicateNamesMethod,
+        {
+          repoDir,
+          modelType: echoModelType,
+          modelId: definition.id,
+          dataRepository: dataRepo,
+          definitionRepository: definitionRepo,
+          modelDefinition: model,
+        },
+      );
+    } catch (error) {
+      errorMessage = (error as Error).message;
+    }
+
+    assertStringIncludes(
+      errorMessage,
+      "Duplicate data instance name 'duplicate'",
+    );
+  });
+});

--- a/src/cli/commands/type_describe.ts
+++ b/src/cli/commands/type_describe.ts
@@ -8,6 +8,7 @@ import {
 import { createContext, type GlobalOptions } from "../context.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import {
+  type DataOutputSpecification,
   type MethodDefinition,
   modelRegistry,
 } from "../../domain/models/model.ts";
@@ -30,11 +31,25 @@ function zodToJsonSchema(schema: z.ZodTypeAny): object {
 function toMethodDescribeData(
   name: string,
   method: MethodDefinition,
+  dataOutputSpecs?: Record<string, DataOutputSpecification>,
 ): MethodDescribeData {
   return {
     name,
     description: method.description,
     inputAttributesSchema: zodToJsonSchema(method.inputAttributesSchema),
+    dataOutputSpecs: dataOutputSpecs
+      ? Object.values(dataOutputSpecs).map(
+        (spec) => ({
+          specType: spec.specType.value,
+          description: spec.description,
+          contentType: spec.contentType,
+          lifetime: spec.lifetime,
+          garbageCollection: spec.garbageCollection,
+          streaming: spec.streaming,
+          tags: spec.tags,
+        }),
+      )
+      : undefined,
   };
 }
 
@@ -70,7 +85,8 @@ function typeDescribeAction(options: AnyOptions, typeArg: string): void {
   // Build method descriptions
   const methods: MethodDescribeData[] = Object.entries(definition.methods)
     .map(
-      ([name, method]) => toMethodDescribeData(name, method),
+      ([name, method]) =>
+        toMethodDescribeData(name, method, definition.dataOutputSpecs),
     );
 
   // Build the output data

--- a/src/domain/models/aws/cli/aws_cli_model.ts
+++ b/src/domain/models/aws/cli/aws_cli_model.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { ModelType } from "../../model_type.ts";
 import {
+  DataSpecType,
   defineModel,
   type MethodContext,
   type MethodResult,
@@ -181,22 +182,25 @@ async function executeRun(
     const definitionHash = await definition.computeHash();
 
     return {
-      dataOutputs: [{
-        name: `${definition.name}-data`,
-        content: new TextEncoder().encode(JSON.stringify(dataAttributes)),
-        metadata: {
-          contentType: "application/json",
-          lifetime: "infinite",
-          garbageCollection: 10,
-          streaming: false,
-          tags: { type: "data" },
-          ownerDefinition: {
-            definitionHash,
-            ownerType: "model-method",
-            ownerRef: "run",
+      dataOutputs: [
+        {
+          name: `${definition.name}-data`,
+          specType: DataSpecType.create("data"),
+          content: new TextEncoder().encode(JSON.stringify(dataAttributes)),
+          metadata: {
+            contentType: "application/json",
+            lifetime: "infinite",
+            garbageCollection: 10,
+            streaming: false,
+            tags: { type: "data" },
+            ownerDefinition: {
+              definitionHash,
+              ownerType: "model-method",
+              ownerRef: "run",
+            },
           },
         },
-      }],
+      ],
     };
   } finally {
     clearTimeout(timeoutId);
@@ -221,6 +225,16 @@ export const awsCliModel: ModelDefinition<
   type: AWS_CLI_MODEL_TYPE,
   version: 1,
   inputAttributesSchema: AwsCliInputAttributesSchema,
+  dataOutputSpecs: {
+    "data": {
+      specType: DataSpecType.create("data"),
+      description: "AWS CLI command output with execution metadata",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     run: {
       description:

--- a/src/domain/models/aws/cloud_control_model.ts
+++ b/src/domain/models/aws/cloud_control_model.ts
@@ -9,6 +9,7 @@ import {
 import type { ModelType } from "../model_type.ts";
 import {
   type DataOutput,
+  DataSpecType,
   defineModel,
   type FollowUpAction,
   type MethodContext,
@@ -162,22 +163,25 @@ export abstract class AWSCloudControlModel<
     const definitionHash = await definition.computeHash();
 
     return {
-      dataOutputs: [{
-        name: `${definition.name}-data`,
-        content: new TextEncoder().encode(JSON.stringify(attributes)),
-        metadata: {
-          contentType: "application/json",
-          lifetime: "infinite",
-          garbageCollection: 10,
-          streaming: false,
-          tags: { type: "resource" },
-          ownerDefinition: {
-            definitionHash,
-            ownerType: "model-method",
-            ownerRef: methodName,
+      dataOutputs: [
+        {
+          name: `${definition.name}-data`,
+          specType: DataSpecType.create("resource"),
+          content: new TextEncoder().encode(JSON.stringify(attributes)),
+          metadata: {
+            contentType: "application/json",
+            lifetime: "infinite",
+            garbageCollection: 10,
+            streaming: false,
+            tags: { type: "resource" },
+            ownerDefinition: {
+              definitionHash,
+              ownerType: "model-method",
+              ownerRef: methodName,
+            },
           },
         },
-      }],
+      ],
     };
   }
 
@@ -193,6 +197,7 @@ export abstract class AWSCloudControlModel<
 
     return {
       name: `${definition.name}-data`,
+      specType: DataSpecType.create("resource"),
       content: new TextEncoder().encode(JSON.stringify(attributes)),
       metadata: {
         contentType: "application/json",
@@ -571,6 +576,16 @@ export abstract class AWSCloudControlModel<
       type: this.modelType,
       version: 1,
       inputAttributesSchema: this.config.inputAttributesSchema,
+      dataOutputSpecs: {
+        "resource": {
+          specType: DataSpecType.create("resource"),
+          description: `AWS ${this.typeName} resource data`,
+          contentType: "application/json",
+          lifetime: "infinite",
+          garbageCollection: 10,
+          tags: { type: "resource" },
+        },
+      },
       methods: {
         create: {
           description:

--- a/src/domain/models/aws/ec2/instance/ec2_instance_model_test.ts
+++ b/src/domain/models/aws/ec2/instance/ec2_instance_model_test.ts
@@ -89,7 +89,9 @@ function getDataOutputAttributes(
     return undefined;
   }
   const content = new TextDecoder().decode(dataOutputs[index].content);
-  return JSON.parse(content);
+  const parsed = JSON.parse(content);
+  // CloudControl resources wrap in {attributes: {...}}
+  return parsed.attributes ?? parsed;
 }
 
 Deno.test("EC2InstanceModel - model type", () => {

--- a/src/domain/models/aws/ec2/subnet/ec2_subnet_model_test.ts
+++ b/src/domain/models/aws/ec2/subnet/ec2_subnet_model_test.ts
@@ -89,7 +89,9 @@ function getDataOutputAttributes(
     return undefined;
   }
   const content = new TextDecoder().decode(dataOutputs[index].content);
-  return JSON.parse(content);
+  const parsed = JSON.parse(content);
+  // CloudControl resources wrap in {attributes: {...}}
+  return parsed.attributes ?? parsed;
 }
 
 Deno.test("EC2SubnetModel - model type", () => {

--- a/src/domain/models/aws/ec2/vpc/ec2_vpc_model_test.ts
+++ b/src/domain/models/aws/ec2/vpc/ec2_vpc_model_test.ts
@@ -89,7 +89,9 @@ function getDataOutputAttributes(
     return undefined;
   }
   const content = new TextDecoder().decode(dataOutputs[index].content);
-  return JSON.parse(content);
+  const parsed = JSON.parse(content);
+  // CloudControl resources wrap in {attributes: {...}}
+  return parsed.attributes ?? parsed;
 }
 
 Deno.test("EC2VpcModel - model type", () => {

--- a/src/domain/models/command/curl/curl_model.ts
+++ b/src/domain/models/command/curl/curl_model.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { ModelType } from "../../model_type.ts";
 import { computeChecksum } from "../../checksum.ts";
 import {
+  DataSpecType,
   defineModel,
   type MethodContext,
   type MethodResult,
@@ -177,6 +178,7 @@ async function executeDownload(
     dataOutputs: [
       {
         name: `${definition.name}-metadata`,
+        specType: DataSpecType.create("metadata"),
         content: new TextEncoder().encode(JSON.stringify(metadataAttributes)),
         metadata: {
           contentType: "application/json",
@@ -193,6 +195,7 @@ async function executeDownload(
       },
       {
         name: `${definition.name}-file`,
+        specType: DataSpecType.create("file"),
         content,
         metadata: {
           contentType,
@@ -225,6 +228,24 @@ export const curlModel: ModelDefinition<
   type: CURL_MODEL_TYPE,
   version: 1,
   inputAttributesSchema: CurlInputAttributesSchema,
+  dataOutputSpecs: {
+    "metadata": {
+      specType: DataSpecType.create("metadata"),
+      description: "Download metadata (URL, status, timing, checksum)",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+    "file": {
+      specType: DataSpecType.create("file"),
+      description: "Downloaded file content",
+      contentType: "application/octet-stream",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "file" },
+    },
+  },
   methods: {
     download: {
       description:

--- a/src/domain/models/data_output_override.ts
+++ b/src/domain/models/data_output_override.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+import type { DataSpecType } from "./model.ts";
+import {
+  type GarbageCollectionPolicy,
+  GarbageCollectionSchema,
+  type Lifetime,
+  LifetimeSchema,
+} from "../data/mod.ts";
+
+/**
+ * Override for data output specification.
+ * Value object - immutable.
+ */
+export interface DataOutputOverride {
+  /** The spec type to override */
+  specType: DataSpecType;
+
+  /** Override lifetime */
+  lifetime?: Lifetime;
+
+  /** Override garbage collection */
+  garbageCollection?: GarbageCollectionPolicy;
+
+  /** Additional tags to merge */
+  tags?: Record<string, string>;
+}
+
+export const DataOutputOverrideSchema = z.object({
+  specType: z.string().min(1),
+  lifetime: LifetimeSchema.optional(),
+  garbageCollection: GarbageCollectionSchema.optional(),
+  tags: z.record(z.string(), z.string()).optional(),
+});

--- a/src/domain/models/data_output_validation_service.ts
+++ b/src/domain/models/data_output_validation_service.ts
@@ -1,0 +1,94 @@
+import type { DataOutput, DataOutputSpecification } from "./model.ts";
+import type { DataOutputOverride } from "./data_output_override.ts";
+
+export interface DataOutputValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+/**
+ * Domain service for validating and enhancing data outputs.
+ */
+export class DataOutputValidationService {
+  /**
+   * Validates that all data outputs reference declared spec types.
+   */
+  validate(
+    dataOutputs: DataOutput[],
+    specs: Record<string, DataOutputSpecification>,
+    methodName: string,
+  ): DataOutputValidationResult {
+    const errors: string[] = [];
+    const declaredSpecTypes = new Set(Object.keys(specs));
+
+    // Check that all outputs reference declared spec types
+    for (const output of dataOutputs) {
+      const specTypeValue = output.specType.value;
+
+      if (!declaredSpecTypes.has(specTypeValue)) {
+        errors.push(
+          `Data output '${output.name}' references undeclared spec type '${specTypeValue}' ` +
+            `in method '${methodName}'. Declared spec types: ${
+              Array.from(declaredSpecTypes).join(", ")
+            }`,
+        );
+      }
+    }
+
+    // Check for duplicate instance names
+    const names = new Set<string>();
+    for (const output of dataOutputs) {
+      if (names.has(output.name)) {
+        errors.push(
+          `Duplicate data instance name '${output.name}' in method '${methodName}'`,
+        );
+      }
+      names.add(output.name);
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+    };
+  }
+
+  /**
+   * Applies defaults from spec and merges overrides.
+   */
+  applyDefaultsAndOverrides(
+    dataOutput: DataOutput,
+    spec: DataOutputSpecification,
+    overrides?: DataOutputOverride[],
+  ): DataOutput {
+    // Find override for this spec type
+    const override = overrides?.find((o) =>
+      o.specType.equals(dataOutput.specType)
+    );
+
+    return {
+      ...dataOutput,
+      metadata: {
+        ...dataOutput.metadata,
+        contentType: dataOutput.metadata.contentType ??
+          spec.contentType ??
+          "application/json",
+        lifetime: override?.lifetime ??
+          dataOutput.metadata.lifetime ??
+          spec.lifetime ??
+          "infinite",
+        garbageCollection: override?.garbageCollection ??
+          dataOutput.metadata.garbageCollection ??
+          spec.garbageCollection ??
+          10,
+        streaming: dataOutput.metadata.streaming ??
+          spec.streaming ??
+          false,
+        tags: {
+          ...(spec.tags ?? {}),
+          ...(dataOutput.metadata.tags ?? {}),
+          ...(override?.tags ?? {}),
+        },
+      },
+    };
+  }
+}

--- a/src/domain/models/data_output_validation_service_test.ts
+++ b/src/domain/models/data_output_validation_service_test.ts
@@ -1,0 +1,342 @@
+import { assertEquals } from "@std/assert";
+import { DataOutputValidationService } from "./data_output_validation_service.ts";
+import {
+  type DataOutput,
+  type DataOutputSpecification,
+  DataSpecType,
+} from "./model.ts";
+import type { DataOutputOverride } from "./data_output_override.ts";
+
+Deno.test("DataOutputValidationService - validate - accepts valid spec types", () => {
+  const service = new DataOutputValidationService();
+
+  const specs: Record<string, DataOutputSpecification> = {
+    "message": {
+      specType: DataSpecType.create("message"),
+      description: "Test message",
+    },
+    "log": {
+      specType: DataSpecType.create("log"),
+      description: "Test log",
+    },
+  };
+
+  const dataOutputs: DataOutput[] = [
+    {
+      name: "foo-message",
+      specType: DataSpecType.create("message"),
+      content: new Uint8Array(),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "data" },
+        ownerDefinition: {
+          definitionHash: "hash",
+          ownerType: "model-method",
+          ownerRef: "test",
+        },
+      },
+    },
+    {
+      name: "bar-log",
+      specType: DataSpecType.create("log"),
+      content: new Uint8Array(),
+      metadata: {
+        contentType: "text/plain",
+        lifetime: "ephemeral",
+        garbageCollection: 5,
+        streaming: false,
+        tags: { type: "log" },
+        ownerDefinition: {
+          definitionHash: "hash",
+          ownerType: "model-method",
+          ownerRef: "test",
+        },
+      },
+    },
+  ];
+
+  const result = service.validate(dataOutputs, specs, "testMethod");
+
+  assertEquals(result.valid, true);
+  assertEquals(result.errors, []);
+});
+
+Deno.test("DataOutputValidationService - validate - detects undeclared spec type", () => {
+  const service = new DataOutputValidationService();
+
+  const specs: Record<string, DataOutputSpecification> = {
+    "message": {
+      specType: DataSpecType.create("message"),
+      description: "Test message",
+    },
+  };
+
+  const dataOutputs: DataOutput[] = [
+    {
+      name: "foo-unknown",
+      specType: DataSpecType.create("unknown"),
+      content: new Uint8Array(),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "data" },
+        ownerDefinition: {
+          definitionHash: "hash",
+          ownerType: "model-method",
+          ownerRef: "test",
+        },
+      },
+    },
+  ];
+
+  const result = service.validate(dataOutputs, specs, "testMethod");
+
+  assertEquals(result.valid, false);
+  assertEquals(result.errors.length, 1);
+  assertEquals(
+    result.errors[0],
+    "Data output 'foo-unknown' references undeclared spec type 'unknown' in method 'testMethod'. Declared spec types: message",
+  );
+});
+
+Deno.test("DataOutputValidationService - validate - detects duplicate instance names", () => {
+  const service = new DataOutputValidationService();
+
+  const specs: Record<string, DataOutputSpecification> = {
+    "message": {
+      specType: DataSpecType.create("message"),
+      description: "Test message",
+    },
+  };
+
+  const dataOutputs: DataOutput[] = [
+    {
+      name: "duplicate",
+      specType: DataSpecType.create("message"),
+      content: new Uint8Array(),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "data" },
+        ownerDefinition: {
+          definitionHash: "hash",
+          ownerType: "model-method",
+          ownerRef: "test",
+        },
+      },
+    },
+    {
+      name: "duplicate",
+      specType: DataSpecType.create("message"),
+      content: new Uint8Array(),
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "data" },
+        ownerDefinition: {
+          definitionHash: "hash",
+          ownerType: "model-method",
+          ownerRef: "test",
+        },
+      },
+    },
+  ];
+
+  const result = service.validate(dataOutputs, specs, "testMethod");
+
+  assertEquals(result.valid, false);
+  assertEquals(result.errors.length, 1);
+  assertEquals(
+    result.errors[0],
+    "Duplicate data instance name 'duplicate' in method 'testMethod'",
+  );
+});
+
+Deno.test("DataOutputValidationService - applyDefaultsAndOverrides - applies spec defaults", () => {
+  const service = new DataOutputValidationService();
+
+  const spec: DataOutputSpecification = {
+    specType: DataSpecType.create("message"),
+    contentType: "text/plain",
+    lifetime: "ephemeral",
+    garbageCollection: 5,
+    streaming: true,
+    tags: { specTag: "specValue" },
+  };
+
+  const dataOutput: DataOutput = {
+    name: "test-message",
+    specType: DataSpecType.create("message"),
+    content: new Uint8Array(),
+    metadata: {
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      streaming: false,
+      tags: { type: "data" },
+      ownerDefinition: {
+        definitionHash: "hash",
+        ownerType: "model-method",
+        ownerRef: "test",
+      },
+    },
+  };
+
+  const result = service.applyDefaultsAndOverrides(dataOutput, spec);
+
+  // Existing values should be preserved
+  assertEquals(result.metadata.contentType, "application/json");
+  assertEquals(result.metadata.lifetime, "infinite");
+  assertEquals(result.metadata.garbageCollection, 10);
+  assertEquals(result.metadata.streaming, false);
+
+  // Tags should be merged (spec tags + metadata tags)
+  assertEquals(result.metadata.tags, {
+    specTag: "specValue",
+    type: "data",
+  });
+});
+
+Deno.test("DataOutputValidationService - applyDefaultsAndOverrides - fills missing values from spec", () => {
+  const service = new DataOutputValidationService();
+
+  const spec: DataOutputSpecification = {
+    specType: DataSpecType.create("message"),
+    contentType: "text/plain",
+    lifetime: "ephemeral",
+    garbageCollection: 5,
+    streaming: true,
+    tags: { specTag: "specValue" },
+  };
+
+  const dataOutput: DataOutput = {
+    name: "test-message",
+    specType: DataSpecType.create("message"),
+    content: new Uint8Array(),
+    metadata: {
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      streaming: false,
+      tags: { type: "data" },
+      ownerDefinition: {
+        definitionHash: "hash",
+        ownerType: "model-method",
+        ownerRef: "test",
+      },
+    },
+  };
+
+  // Remove some metadata to test defaults
+  delete (dataOutput.metadata as { contentType?: string }).contentType;
+  delete (dataOutput.metadata as { lifetime?: string }).lifetime;
+
+  const result = service.applyDefaultsAndOverrides(dataOutput, spec);
+
+  // Should use spec defaults
+  assertEquals(result.metadata.contentType, "text/plain");
+  assertEquals(result.metadata.lifetime, "ephemeral");
+});
+
+Deno.test("DataOutputValidationService - applyDefaultsAndOverrides - applies overrides", () => {
+  const service = new DataOutputValidationService();
+
+  const spec: DataOutputSpecification = {
+    specType: DataSpecType.create("message"),
+    contentType: "text/plain",
+    lifetime: "ephemeral",
+    garbageCollection: 5,
+    tags: { specTag: "specValue" },
+  };
+
+  const dataOutput: DataOutput = {
+    name: "test-message",
+    specType: DataSpecType.create("message"),
+    content: new Uint8Array(),
+    metadata: {
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      streaming: false,
+      tags: { type: "data" },
+      ownerDefinition: {
+        definitionHash: "hash",
+        ownerType: "model-method",
+        ownerRef: "test",
+      },
+    },
+  };
+
+  const overrides: DataOutputOverride[] = [
+    {
+      specType: DataSpecType.create("message"),
+      lifetime: "7d",
+      garbageCollection: 20,
+      tags: { overrideTag: "overrideValue" },
+    },
+  ];
+
+  const result = service.applyDefaultsAndOverrides(dataOutput, spec, overrides);
+
+  // Overrides should take precedence
+  assertEquals(result.metadata.lifetime, "7d");
+  assertEquals(result.metadata.garbageCollection, 20);
+
+  // Tags should be merged (spec + metadata + override)
+  assertEquals(result.metadata.tags, {
+    specTag: "specValue",
+    type: "data",
+    overrideTag: "overrideValue",
+  });
+});
+
+Deno.test("DataOutputValidationService - applyDefaultsAndOverrides - uses hardcoded defaults when spec has no defaults", () => {
+  const service = new DataOutputValidationService();
+
+  const spec: DataOutputSpecification = {
+    specType: DataSpecType.create("message"),
+    // No defaults provided
+  };
+
+  const dataOutput: DataOutput = {
+    name: "test-message",
+    specType: DataSpecType.create("message"),
+    content: new Uint8Array(),
+    metadata: {
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      streaming: false,
+      tags: { type: "data" },
+      ownerDefinition: {
+        definitionHash: "hash",
+        ownerType: "model-method",
+        ownerRef: "test",
+      },
+    },
+  };
+
+  // Remove metadata to test hardcoded defaults
+  delete (dataOutput.metadata as { contentType?: string }).contentType;
+  delete (dataOutput.metadata as { lifetime?: string }).lifetime;
+  delete (dataOutput.metadata as { garbageCollection?: number })
+    .garbageCollection;
+  delete (dataOutput.metadata as { streaming?: boolean }).streaming;
+
+  const result = service.applyDefaultsAndOverrides(dataOutput, spec);
+
+  // Should use hardcoded defaults
+  assertEquals(result.metadata.contentType, "application/json");
+  assertEquals(result.metadata.lifetime, "infinite");
+  assertEquals(result.metadata.garbageCollection, 10);
+  assertEquals(result.metadata.streaming, false);
+});

--- a/src/domain/models/data_spec_type_test.ts
+++ b/src/domain/models/data_spec_type_test.ts
@@ -1,0 +1,40 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { DataSpecType } from "./model.ts";
+
+Deno.test("DataSpecType - create - trims whitespace", () => {
+  const specType = DataSpecType.create("  message  ");
+  assertEquals(specType.value, "message");
+});
+
+Deno.test("DataSpecType - create - rejects empty string", () => {
+  assertThrows(
+    () => DataSpecType.create(""),
+    Error,
+    "Data spec type cannot be empty",
+  );
+});
+
+Deno.test("DataSpecType - create - rejects whitespace-only string", () => {
+  assertThrows(
+    () => DataSpecType.create("   "),
+    Error,
+    "Data spec type cannot be empty",
+  );
+});
+
+Deno.test("DataSpecType - equals - returns true for same value", () => {
+  const spec1 = DataSpecType.create("message");
+  const spec2 = DataSpecType.create("message");
+  assertEquals(spec1.equals(spec2), true);
+});
+
+Deno.test("DataSpecType - equals - returns false for different value", () => {
+  const spec1 = DataSpecType.create("message");
+  const spec2 = DataSpecType.create("log");
+  assertEquals(spec1.equals(spec2), false);
+});
+
+Deno.test("DataSpecType - toString - returns value", () => {
+  const specType = DataSpecType.create("message");
+  assertEquals(specType.toString(), "message");
+});

--- a/src/domain/models/echo/echo_model.ts
+++ b/src/domain/models/echo/echo_model.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { ModelType } from "../model_type.ts";
 import {
+  DataSpecType,
   defineModel,
   type MethodContext,
   type MethodResult,
@@ -62,6 +63,7 @@ async function executeWrite(
   return {
     dataOutputs: [{
       name: `${definition.name}-message`,
+      specType: DataSpecType.create("message"),
       content: new TextEncoder().encode(JSON.stringify(dataAttributes)),
       metadata: {
         contentType: "application/json",
@@ -93,6 +95,16 @@ export const echoModel: ModelDefinition<
   type: ECHO_MODEL_TYPE,
   version: 1,
   inputAttributesSchema: EchoInputAttributesSchema,
+  dataOutputSpecs: {
+    "message": {
+      specType: DataSpecType.create("message"),
+      description: "Echo message with timestamp",
+      contentType: "application/json",
+      lifetime: "ephemeral",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     write: {
       description:

--- a/src/domain/models/echo/echo_model_test.ts
+++ b/src/domain/models/echo/echo_model_test.ts
@@ -78,7 +78,9 @@ function getDataOutputAttributes(
     return undefined;
   }
   const content = new TextDecoder().decode(dataOutputs[index].content);
-  return JSON.parse(content);
+  const parsed = JSON.parse(content);
+  // Handle wrapped attributes format
+  return parsed.attributes ?? parsed;
 }
 
 Deno.test("ECHO_MODEL_TYPE has correct normalized type", () => {

--- a/src/domain/models/keeb/shell/shell_model.ts
+++ b/src/domain/models/keeb/shell/shell_model.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { ModelType } from "../../model_type.ts";
 import {
+  DataSpecType,
   defineModel,
   type MethodContext,
   type MethodResult,
@@ -218,6 +219,7 @@ async function executeCommand(
     dataOutputs: [
       {
         name: `${definition.name}-result`,
+        specType: DataSpecType.create("result"),
         content: new TextEncoder().encode(JSON.stringify(resultAttributes)),
         metadata: {
           contentType: "application/json",
@@ -234,6 +236,7 @@ async function executeCommand(
       },
       {
         name: `${definition.name}-output`,
+        specType: DataSpecType.create("log"),
         content: new TextEncoder().encode(outputLogContent),
         metadata: {
           contentType: "text/plain",
@@ -266,6 +269,25 @@ export const shellModel: ModelDefinition<
   type: SHELL_MODEL_TYPE,
   version: 1,
   inputAttributesSchema: ShellInputAttributesSchema,
+  dataOutputSpecs: {
+    "result": {
+      specType: DataSpecType.create("result"),
+      description:
+        "Shell command execution result (exit code, timing, command)",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+    "log": {
+      specType: DataSpecType.create("log"),
+      description: "Shell command output (stdout and stderr)",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "log" },
+    },
+  },
   methods: {
     execute: {
       description:

--- a/src/domain/models/keeb/shell/shell_model_test.ts
+++ b/src/domain/models/keeb/shell/shell_model_test.ts
@@ -80,7 +80,9 @@ function getDataOutputAttributes(
   const dataOutput = dataOutputs?.find((d) => d.name.includes(name));
   if (!dataOutput) return undefined;
   const content = new TextDecoder().decode(dataOutput.content);
-  return JSON.parse(content);
+  const parsed = JSON.parse(content);
+  // Handle wrapped attributes format
+  return parsed.attributes ?? parsed;
 }
 
 /**

--- a/src/domain/models/lets-get-sensitive/vault_model.ts
+++ b/src/domain/models/lets-get-sensitive/vault_model.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { ModelType } from "../model_type.ts";
 import {
+  DataSpecType,
   defineModel,
   type MethodContext,
   type MethodResult,
@@ -156,6 +157,7 @@ async function executeGet(
       dataOutputs: [
         {
           name: `${definition.name}-result`,
+          specType: DataSpecType.create("result"),
           content: new TextEncoder().encode(JSON.stringify(dataAttributes)),
           metadata: {
             contentType: "application/json",
@@ -172,6 +174,7 @@ async function executeGet(
         },
         {
           name: `${definition.name}-audit-log`,
+          specType: DataSpecType.create("log"),
           content: new TextEncoder().encode(logLines.join("\n")),
           metadata: {
             contentType: "text/plain",
@@ -253,6 +256,7 @@ async function executePut(
       dataOutputs: [
         {
           name: `${definition.name}-result`,
+          specType: DataSpecType.create("result"),
           content: new TextEncoder().encode(JSON.stringify(dataAttributes)),
           metadata: {
             contentType: "application/json",
@@ -269,6 +273,7 @@ async function executePut(
         },
         {
           name: `${definition.name}-audit-log`,
+          specType: DataSpecType.create("log"),
           content: new TextEncoder().encode(logLines.join("\n")),
           metadata: {
             contentType: "text/plain",
@@ -314,6 +319,24 @@ export const vaultModel: ModelDefinition<
   type: VAULT_MODEL_TYPE,
   version: 1,
   inputAttributesSchema: VaultInputAttributesSchema,
+  dataOutputSpecs: {
+    "result": {
+      specType: DataSpecType.create("result"),
+      description: "Vault operation result (success/failure, metadata)",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+    "log": {
+      specType: DataSpecType.create("log"),
+      description: "Vault operation audit log",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "log" },
+    },
+  },
   methods: {
     get: {
       description: "Retrieve a secret value from the specified vault",

--- a/src/domain/models/mermaid/workflow_diagram/workflow_diagram_model.ts
+++ b/src/domain/models/mermaid/workflow_diagram/workflow_diagram_model.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { ModelType } from "../../model_type.ts";
 import { computeChecksum } from "../../checksum.ts";
 import {
+  DataSpecType,
   defineModel,
   type MethodContext,
   type MethodResult,
@@ -317,6 +318,7 @@ async function executeGenerate(
     dataOutputs: [
       {
         name: `${definition.name}-metadata`,
+        specType: DataSpecType.create("metadata"),
         content: new TextEncoder().encode(JSON.stringify(metadataAttributes)),
         metadata: {
           contentType: "application/json",
@@ -333,6 +335,7 @@ async function executeGenerate(
       },
       {
         name: `${definition.name}-diagram`,
+        specType: DataSpecType.create("file"),
         content,
         metadata: {
           contentType: "text/plain",
@@ -365,6 +368,24 @@ export const mermaidWorkflowModel: ModelDefinition<
   type: MERMAID_WORKFLOW_MODEL_TYPE,
   version: 1,
   inputAttributesSchema: MermaidWorkflowInputAttributesSchema,
+  dataOutputSpecs: {
+    "metadata": {
+      specType: DataSpecType.create("metadata"),
+      description: "Workflow diagram metadata (job count, step count, status)",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+    "file": {
+      specType: DataSpecType.create("file"),
+      description: "Mermaid diagram file content",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "file" },
+    },
+  },
   methods: {
     generate: {
       description: "Generate a Mermaid diagram from workflow execution data",

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -11,6 +11,7 @@ import type { Definition } from "../definitions/definition.ts";
 import { Data } from "../data/mod.ts";
 import type { DataArtifactRef } from "./model_output.ts";
 import { ModelOutput } from "./model_output.ts";
+import { DataOutputValidationService } from "./data_output_validation_service.ts";
 
 /**
  * Maximum depth for recursive follow-up action processing.
@@ -77,7 +78,10 @@ export interface MethodExecutionService {
  * Validates definition attributes against the method's schema before execution.
  */
 export class DefaultMethodExecutionService implements MethodExecutionService {
-  execute(
+  private readonly dataOutputValidationService =
+    new DataOutputValidationService();
+
+  async execute(
     definition: Definition,
     method: MethodDefinition,
     context: MethodContext,
@@ -96,7 +100,40 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
     }
 
     // Execute the method
-    return method.execute(definition, context);
+    const result = await method.execute(definition, context);
+
+    // Validate and enhance data outputs if model definition is provided
+    if (result.dataOutputs && context.modelDefinition) {
+      const specs = context.modelDefinition.dataOutputSpecs;
+
+      // Find the method name (for better error messages)
+      const methodName = Object.entries(context.modelDefinition.methods)
+        .find(([_, m]) => m === method)?.[0] ?? "unknown";
+
+      // Validate spec type references
+      const validation = this.dataOutputValidationService.validate(
+        result.dataOutputs,
+        specs,
+        methodName,
+      );
+
+      if (!validation.valid) {
+        throw new Error(
+          `Data output validation failed: ${validation.errors.join("; ")}`,
+        );
+      }
+
+      // Apply defaults from specs (no overrides at this level)
+      result.dataOutputs = result.dataOutputs.map((output) => {
+        const spec = specs[output.specType.value];
+        return this.dataOutputValidationService.applyDefaultsAndOverrides(
+          output,
+          spec,
+        );
+      });
+    }
+
+    return result;
   }
 
   async executeWorkflow(

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -1,13 +1,14 @@
-import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import { DefaultMethodExecutionService } from "./method_execution_service.ts";
 import { createDefinitionId, Definition } from "../definitions/definition.ts";
 import { ModelType } from "./model_type.ts";
 import { echoModel } from "./echo/echo_model.ts";
-import type {
-  DataOutput,
-  MethodContext,
-  MethodResult,
-  ModelDefinition,
+import {
+  type DataOutput,
+  DataSpecType,
+  type MethodContext,
+  type MethodResult,
+  type ModelDefinition,
 } from "./model.ts";
 import { z } from "zod";
 import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
@@ -90,7 +91,7 @@ Deno.test("execute with valid definition returns method result", async () => {
   assertEquals(typeof content.timestamp, "string");
 });
 
-Deno.test("execute with missing required attribute throws error", () => {
+Deno.test("execute with missing required attribute throws error", async () => {
   const service = new DefaultMethodExecutionService();
   const definition = Definition.create({
     name: "test-definition",
@@ -98,19 +99,14 @@ Deno.test("execute with missing required attribute throws error", () => {
   });
 
   const context = createTestContext();
-  assertThrows(
-    () =>
-      service.execute(
-        definition,
-        echoModel.methods.write,
-        context,
-      ),
+  await assertRejects(
+    () => service.execute(definition, echoModel.methods.write, context),
     Error,
     "Definition validation failed",
   );
 });
 
-Deno.test("execute with invalid attribute type throws error", () => {
+Deno.test("execute with invalid attribute type throws error", async () => {
   const service = new DefaultMethodExecutionService();
   const definition = Definition.create({
     name: "test-definition",
@@ -118,19 +114,14 @@ Deno.test("execute with invalid attribute type throws error", () => {
   });
 
   const context = createTestContext();
-  assertThrows(
-    () =>
-      service.execute(
-        definition,
-        echoModel.methods.write,
-        context,
-      ),
+  await assertRejects(
+    () => service.execute(definition, echoModel.methods.write, context),
     Error,
     "Definition validation failed",
   );
 });
 
-Deno.test("execute with empty message throws error", () => {
+Deno.test("execute with empty message throws error", async () => {
   const service = new DefaultMethodExecutionService();
   const definition = Definition.create({
     name: "test-definition",
@@ -138,19 +129,14 @@ Deno.test("execute with empty message throws error", () => {
   });
 
   const context = createTestContext();
-  assertThrows(
-    () =>
-      service.execute(
-        definition,
-        echoModel.methods.write,
-        context,
-      ),
+  await assertRejects(
+    () => service.execute(definition, echoModel.methods.write, context),
     Error,
     "Definition validation failed",
   );
 });
 
-Deno.test("execute error message includes Zod details", () => {
+Deno.test("execute error message includes Zod details", async () => {
   const service = new DefaultMethodExecutionService();
   const definition = Definition.create({
     name: "test-definition",
@@ -159,11 +145,7 @@ Deno.test("execute error message includes Zod details", () => {
 
   const context = createTestContext();
   try {
-    service.execute(
-      definition,
-      echoModel.methods.write,
-      context,
-    );
+    await service.execute(definition, echoModel.methods.write, context);
     throw new Error("Expected error to be thrown");
   } catch (error) {
     const message = (error as Error).message;
@@ -184,6 +166,7 @@ function createTestDataOutput(
 ): DataOutput {
   return {
     name,
+    specType: DataSpecType.create("data"),
     content: new TextEncoder().encode(JSON.stringify(attributes)),
     metadata: {
       contentType: "application/json",
@@ -223,6 +206,7 @@ function createTestModel(options: {
     type: ModelType.create("test/workflow"),
     version: 1,
     inputAttributesSchema: schema,
+    dataOutputSpecs: {},
     methods: {
       start: {
         description: "Start method for testing",
@@ -262,28 +246,31 @@ function getDataOutputAttributes(
   return JSON.parse(content);
 }
 
-Deno.test("executeWorkflow - basic execution without follow-up actions", async () => {
-  const service = new DefaultMethodExecutionService();
-  const model = createTestModel({});
+Deno.test(
+  "executeWorkflow - basic execution without follow-up actions",
+  async () => {
+    const service = new DefaultMethodExecutionService();
+    const model = createTestModel({});
 
-  const definition = Definition.create({
-    name: "test-definition",
-    attributes: { value: "test" },
-  });
+    const definition = Definition.create({
+      name: "test-definition",
+      attributes: { value: "test" },
+    });
 
-  const context = createTestContext({
-    modelType: model.type,
-  });
-  const result = await service.executeWorkflow(
-    definition,
-    model,
-    "start",
-    context,
-  );
+    const context = createTestContext({
+      modelType: model.type,
+    });
+    const result = await service.executeWorkflow(
+      definition,
+      model,
+      "start",
+      context,
+    );
 
-  const attrs = getDataOutputAttributes(result);
-  assertEquals(attrs?.value, "started");
-});
+    const attrs = getDataOutputAttributes(result);
+    assertEquals(attrs?.value, "started");
+  },
+);
 
 Deno.test("executeWorkflow - throws error for unknown method", async () => {
   const service = new DefaultMethodExecutionService();
@@ -299,13 +286,7 @@ Deno.test("executeWorkflow - throws error for unknown method", async () => {
   });
 
   await assertRejects(
-    () =>
-      service.executeWorkflow(
-        definition,
-        model,
-        "nonexistent",
-        context,
-      ),
+    () => service.executeWorkflow(definition, model, "nonexistent", context),
     Error,
     "Method 'nonexistent' not found in model",
   );
@@ -470,13 +451,7 @@ Deno.test("executeWorkflow - fails after exhausting maxRetries", async () => {
   });
 
   await assertRejects(
-    () =>
-      service.executeWorkflow(
-        definition,
-        model,
-        "start",
-        context,
-      ),
+    () => service.executeWorkflow(definition, model, "start", context),
     Error,
     "Follow-up action 'followUp' failed after 1 retries",
   );
@@ -497,6 +472,7 @@ Deno.test("executeWorkflow - handles recursive follow-up actions", async () => {
     type: ModelType.create("test/recursive"),
     version: 1,
     inputAttributesSchema: schema,
+    dataOutputSpecs: {},
     methods: {
       start: {
         description: "Start method",
@@ -567,6 +543,7 @@ Deno.test("executeWorkflow - throws on max depth exceeded", async () => {
     type: ModelType.create("test/infinite"),
     version: 1,
     inputAttributesSchema: schema,
+    dataOutputSpecs: {},
     methods: {
       start: {
         description: "Start infinite loop",
@@ -592,109 +569,107 @@ Deno.test("executeWorkflow - throws on max depth exceeded", async () => {
   });
 
   await assertRejects(
-    () =>
-      service.executeWorkflow(
-        definition,
-        model,
-        "start",
-        context,
-      ),
+    () => service.executeWorkflow(definition, model, "start", context),
     Error,
     "Maximum follow-up action depth (100) exceeded",
   );
 });
 
-Deno.test("executeWorkflow - follow-up receives same definition and can use continueCondition", async () => {
-  const service = new DefaultMethodExecutionService();
-  let receivedDefinitionName = "";
-  let previousDataOutputsInCondition: DataOutput[] | undefined = undefined;
+Deno.test(
+  "executeWorkflow - follow-up receives same definition and can use continueCondition",
+  async () => {
+    const service = new DefaultMethodExecutionService();
+    let receivedDefinitionName = "";
+    let previousDataOutputsInCondition: DataOutput[] | undefined = undefined;
 
-  // This test demonstrates that:
-  // - Follow-up methods receive the same definition
-  // - continueCondition receives the dataOutputs from the previous method
-  const schema = z.object({
-    RequestToken: z.string().optional(),
-    OperationStatus: z.string().optional(),
-    OriginalValue: z.string().optional(),
-  });
+    // This test demonstrates that:
+    // - Follow-up methods receive the same definition
+    // - continueCondition receives the dataOutputs from the previous method
+    const schema = z.object({
+      RequestToken: z.string().optional(),
+      OperationStatus: z.string().optional(),
+      OriginalValue: z.string().optional(),
+    });
 
-  const model: ModelDefinition = {
-    type: ModelType.create("test/token-passing"),
-    version: 1,
-    inputAttributesSchema: schema,
-    methods: {
-      create: {
-        description: "Create method that returns RequestToken in data output",
-        inputAttributesSchema: schema,
-        execute: (_definition) => {
-          return Promise.resolve({
-            dataOutputs: [
-              createTestDataOutput("data", {
-                RequestToken: "test-request-token-123",
-                OperationStatus: "IN_PROGRESS",
-              }),
-            ],
-            followUpActions: [
-              {
-                methodName: "sync",
-                continueCondition: (dataOutputs: DataOutput[]) => {
-                  previousDataOutputsInCondition = dataOutputs;
-                  return true;
+    const model: ModelDefinition = {
+      type: ModelType.create("test/token-passing"),
+      version: 1,
+      inputAttributesSchema: schema,
+      dataOutputSpecs: {},
+      methods: {
+        create: {
+          description: "Create method that returns RequestToken in data output",
+          inputAttributesSchema: schema,
+          execute: (_definition) => {
+            return Promise.resolve({
+              dataOutputs: [
+                createTestDataOutput("data", {
+                  RequestToken: "test-request-token-123",
+                  OperationStatus: "IN_PROGRESS",
+                }),
+              ],
+              followUpActions: [
+                {
+                  methodName: "sync",
+                  continueCondition: (dataOutputs: DataOutput[]) => {
+                    previousDataOutputsInCondition = dataOutputs;
+                    return true;
+                  },
                 },
-              },
-            ],
-          });
+              ],
+            });
+          },
+        },
+        sync: {
+          description: "Sync method that uses definition",
+          inputAttributesSchema: schema,
+          execute: (definition) => {
+            // Capture the definition name to verify it's the same definition
+            receivedDefinitionName = definition.name;
+
+            return Promise.resolve({
+              dataOutputs: [
+                createTestDataOutput("data", {
+                  RequestToken: "test-request-token-123",
+                  OperationStatus: "SUCCESS",
+                }),
+              ],
+            });
+          },
         },
       },
-      sync: {
-        description: "Sync method that uses definition",
-        inputAttributesSchema: schema,
-        execute: (definition) => {
-          // Capture the definition name to verify it's the same definition
-          receivedDefinitionName = definition.name;
+    };
 
-          return Promise.resolve({
-            dataOutputs: [
-              createTestDataOutput("data", {
-                RequestToken: "test-request-token-123",
-                OperationStatus: "SUCCESS",
-              }),
-            ],
-          });
-        },
-      },
-    },
-  };
+    const definition = Definition.create({
+      name: "test-definition",
+      attributes: { OriginalValue: "from-yaml" },
+    });
 
-  const definition = Definition.create({
-    name: "test-definition",
-    attributes: { OriginalValue: "from-yaml" },
-  });
+    const context = createTestContext({
+      modelType: model.type,
+    });
+    const result = await service.executeWorkflow(
+      definition,
+      model,
+      "create",
+      context,
+    );
 
-  const context = createTestContext({
-    modelType: model.type,
-  });
-  const result = await service.executeWorkflow(
-    definition,
-    model,
-    "create",
-    context,
-  );
+    // Verify sync received the same definition
+    assertEquals(receivedDefinitionName, "test-definition");
 
-  // Verify sync received the same definition
-  assertEquals(receivedDefinitionName, "test-definition");
+    // Verify continueCondition received the data outputs from create
+    assertEquals(previousDataOutputsInCondition !== undefined, true);
+    const conditionDataOutputs = previousDataOutputsInCondition!;
+    assertEquals(conditionDataOutputs.length, 1);
+    const conditionAttrs = JSON.parse(
+      new TextDecoder().decode(conditionDataOutputs[0].content),
+    );
+    assertEquals(conditionAttrs.RequestToken, "test-request-token-123");
+    assertEquals(conditionAttrs.OperationStatus, "IN_PROGRESS");
 
-  // Verify continueCondition received the data outputs from create
-  assertEquals(previousDataOutputsInCondition !== undefined, true);
-  const conditionDataOutputs = previousDataOutputsInCondition!;
-  assertEquals(conditionDataOutputs.length, 1);
-  const conditionAttrs = JSON.parse(
-    new TextDecoder().decode(conditionDataOutputs[0].content),
-  );
-  assertEquals(conditionAttrs.RequestToken, "test-request-token-123");
-  assertEquals(conditionAttrs.OperationStatus, "IN_PROGRESS");
-
-  // Verify final result
-  const finalAttrs = getDataOutputAttributes(result);
-  assertEquals(finalAttrs?.OperationStatus, "SUCCESS");
-});
+    // Verify final result
+    const finalAttrs = getDataOutputAttributes(result);
+    assertEquals(finalAttrs?.OperationStatus, "SUCCESS");
+  },
+);

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -1,9 +1,15 @@
-import type { z } from "zod";
+import { z } from "zod";
 import type { CloudControlClient } from "@aws-sdk/client-cloudcontrol";
 import { ModelType } from "./model_type.ts";
 import type { Definition } from "../definitions/definition.ts";
 import type { DefinitionRepository } from "../definitions/repositories.ts";
-import type { DataMetadata } from "../data/mod.ts";
+import {
+  type DataMetadata,
+  type GarbageCollectionPolicy,
+  GarbageCollectionSchema,
+  type Lifetime,
+  LifetimeSchema,
+} from "../data/mod.ts";
 import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import type { OutputRepository } from "./repositories.ts";
 
@@ -21,6 +27,70 @@ export interface MethodStreamingCallbacks {
    */
   onStderr?: (line: string) => void;
 }
+
+/**
+ * Data spec type - identifies a category of data output.
+ * Value object - equality by value.
+ */
+export class DataSpecType {
+  private constructor(readonly value: string) {
+    if (!value || value.trim().length === 0) {
+      throw new Error("Data spec type cannot be empty");
+    }
+  }
+
+  static create(value: string): DataSpecType {
+    return new DataSpecType(value.trim());
+  }
+
+  equals(other: DataSpecType): boolean {
+    return this.value === other.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}
+
+/**
+ * Specification for a data output spec type.
+ * Value object - immutable.
+ */
+export interface DataOutputSpecification {
+  /** The spec type identifier */
+  specType: DataSpecType;
+
+  /** Human-readable description */
+  description?: string;
+
+  /** Default content type */
+  contentType?: string;
+
+  /** Default lifetime policy */
+  lifetime?: Lifetime;
+
+  /** Default garbage collection policy */
+  garbageCollection?: GarbageCollectionPolicy;
+
+  /** Whether this supports streaming */
+  streaming?: boolean;
+
+  /** Default tags */
+  tags?: Record<string, string>;
+}
+
+/**
+ * Zod schema for data output specification.
+ */
+export const DataOutputSpecificationSchema = z.object({
+  specType: z.string().min(1),
+  description: z.string().optional(),
+  contentType: z.string().optional(),
+  lifetime: LifetimeSchema.optional(),
+  garbageCollection: GarbageCollectionSchema.optional(),
+  streaming: z.boolean().optional(),
+  tags: z.record(z.string(), z.string()).optional(),
+});
 
 /**
  * Context provided to method execution.
@@ -65,6 +135,11 @@ export interface MethodContext {
    * Optional callbacks for streaming stdout/stderr output.
    */
   streaming?: MethodStreamingCallbacks;
+
+  /**
+   * The model definition for validation and defaults.
+   */
+  modelDefinition?: ModelDefinition;
 }
 
 /**
@@ -72,9 +147,14 @@ export interface MethodContext {
  */
 export interface DataOutput {
   /**
-   * Name of the data artifact.
+   * Unique name for this data instance.
    */
   name: string;
+
+  /**
+   * Reference to the declared spec type.
+   */
+  specType: DataSpecType;
 
   /**
    * Content of the data artifact.
@@ -82,7 +162,7 @@ export interface DataOutput {
   content: Uint8Array;
 
   /**
-   * Metadata for the data artifact.
+   * Metadata for the data artifact (can override spec defaults).
    */
   metadata: Omit<
     DataMetadata,
@@ -170,6 +250,7 @@ export interface MethodDefinition<
  * - Its type identifier
  * - Current version
  * - Schema for validating definition attributes
+ * - Data output specifications
  * - Available methods
  */
 export interface ModelDefinition<
@@ -189,6 +270,13 @@ export interface ModelDefinition<
    * Zod schema for validating definition attributes.
    */
   inputAttributesSchema: TInputAttrs;
+
+  /**
+   * Data output specifications - declares what spec types this model produces.
+   * Keys are spec type values, values are full specifications.
+   * REQUIRED for all models.
+   */
+  dataOutputSpecs: Record<string, DataOutputSpecification>;
 
   /**
    * Available methods on this model.

--- a/src/domain/models/model_test.ts
+++ b/src/domain/models/model_test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import { z } from "zod";
 import {
+  DataSpecType,
   defineModel,
   type MethodContext,
   type ModelDefinition,
@@ -85,6 +86,7 @@ function createTestModel(typeString: string): ModelDefinition {
     type,
     version: 1,
     inputAttributesSchema: z.object({ message: z.string() }),
+    dataOutputSpecs: {},
     methods: {
       write: {
         description: "Write message to data",
@@ -100,6 +102,7 @@ function createTestModel(typeString: string): ModelDefinition {
             dataOutputs: [
               {
                 name: `${definition.name}-data`,
+                specType: DataSpecType.create("data"),
                 content,
                 metadata: {
                   contentType: "application/json",

--- a/src/domain/models/systemd/journalctl/journalctl_model.ts
+++ b/src/domain/models/systemd/journalctl/journalctl_model.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { ModelType } from "../../model_type.ts";
 import {
+  DataSpecType,
   defineModel,
   type MethodContext,
   type MethodResult,
@@ -173,22 +174,25 @@ async function readLogs(
   const definitionHash = await definition.computeHash();
 
   return {
-    dataOutputs: [{
-      name: `${definition.name}-logs`,
-      content: new TextEncoder().encode(logLines.join("\n")),
-      metadata: {
-        contentType: "text/plain",
-        lifetime: "infinite",
-        garbageCollection: 10,
-        streaming: true,
-        tags: { type: "log" },
-        ownerDefinition: {
-          definitionHash,
-          ownerType: "model-method",
-          ownerRef: "read",
+    dataOutputs: [
+      {
+        name: `${definition.name}-logs`,
+        specType: DataSpecType.create("log"),
+        content: new TextEncoder().encode(logLines.join("\n")),
+        metadata: {
+          contentType: "text/plain",
+          lifetime: "infinite",
+          garbageCollection: 10,
+          streaming: true,
+          tags: { type: "log" },
+          ownerDefinition: {
+            definitionHash,
+            ownerType: "model-method",
+            ownerRef: "read",
+          },
         },
       },
-    }],
+    ],
   };
 }
 
@@ -207,6 +211,16 @@ export const journalctlModel: ModelDefinition<
   type: JOURNALCTL_MODEL_TYPE,
   version: 1,
   inputAttributesSchema: JournalctlInputAttributesSchema,
+  dataOutputSpecs: {
+    "log": {
+      specType: DataSpecType.create("log"),
+      description: "System journal logs",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "log" },
+    },
+  },
   methods: {
     read: {
       description:

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -4,6 +4,7 @@ import { ModelType } from "./model_type.ts";
 import type { Definition } from "../definitions/definition.ts";
 import {
   type DataOutput,
+  DataSpecType,
   type MethodContext,
   type MethodDefinition,
   type MethodResult,
@@ -20,6 +21,7 @@ interface UserMethodResult {
    */
   dataOutputs?: Array<{
     name: string;
+    specType?: string;
     content: Uint8Array | string;
     metadata?: {
       contentType?: string;
@@ -179,6 +181,7 @@ export class UserModelLoader {
             const resourceJson = JSON.stringify(userResult.resource.attributes);
             dataOutputs.push({
               name: "resource",
+              specType: DataSpecType.create("resource"),
               content: new TextEncoder().encode(resourceJson),
               metadata: {
                 contentType: "application/json",
@@ -200,6 +203,7 @@ export class UserModelLoader {
             const dataJson = JSON.stringify(userResult.data.attributes);
             dataOutputs.push({
               name: userResult.data.name ?? "data",
+              specType: DataSpecType.create("data"),
               content: new TextEncoder().encode(dataJson),
               metadata: {
                 contentType: "application/json",
@@ -225,6 +229,7 @@ export class UserModelLoader {
 
               dataOutputs.push({
                 name: output.name,
+                specType: DataSpecType.create(output.specType ?? "data"),
                 content,
                 metadata: {
                   contentType: output.metadata?.contentType ??
@@ -252,6 +257,7 @@ export class UserModelLoader {
       type: modelType,
       version: userModel.version,
       inputAttributesSchema: userModel.inputAttributesSchema,
+      dataOutputSpecs: {},
       methods,
     };
   }

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -32,6 +32,9 @@ import {
   ModelResolver,
 } from "../expressions/model_resolver.ts";
 import { CelEvaluator } from "../../infrastructure/cel/cel_evaluator.ts";
+import {
+  DataOutputValidationService,
+} from "../models/data_output_validation_service.ts";
 
 /**
  * Context for step execution.
@@ -49,6 +52,8 @@ export interface StepExecutionContext {
   progress?: ExecutionProgressCallback;
   /** Current workflow run for progress callbacks */
   workflowRun?: WorkflowRun;
+  /** The step being executed (for accessing data output overrides) */
+  step?: Step;
 }
 
 /**
@@ -348,8 +353,22 @@ export class DefaultStepExecutor implements StepExecutor {
           dataRepository: unifiedDataRepo,
           definitionRepository: definitionRepo,
           streaming,
+          modelDefinition: modelDef,
         },
       );
+
+      // Apply workflow step overrides (on top of definition overrides)
+      if (ctx.step?.dataOutputOverrides && result.dataOutputs) {
+        const validationService = new DataOutputValidationService();
+        result.dataOutputs = result.dataOutputs.map((output) => {
+          const spec = modelDef.dataOutputSpecs[output.specType.value];
+          return validationService.applyDefaultsAndOverrides(
+            output,
+            spec,
+            Array.from(ctx.step!.dataOutputOverrides),
+          );
+        });
+      }
 
       // Handle data output persistence
       const savedArtifacts: Array<{
@@ -863,6 +882,7 @@ export class WorkflowExecutionService {
         expressionContext,
         progress,
         workflowRun: run,
+        step, // Include step for accessing data output overrides
       };
 
       const output = await this.executor.execute(step, ctx);

--- a/src/domain/workflows/step.ts
+++ b/src/domain/workflows/step.ts
@@ -5,6 +5,9 @@ import {
   TriggerConditionSchema,
 } from "./trigger_condition.ts";
 import { StepTask, StepTaskSchema } from "./step_task.ts";
+import { DataOutputOverrideSchema } from "../models/data_output_override.ts";
+import type { DataOutputOverride } from "../models/data_output_override.ts";
+import { DataSpecType } from "../models/model.ts";
 
 /**
  * Schema for step dependency with condition.
@@ -28,6 +31,7 @@ export const StepSchema = z.object({
   task: StepTaskSchema,
   dependsOn: z.array(StepDependencySchema).default([]),
   weight: z.number().default(0),
+  dataOutputOverrides: z.array(DataOutputOverrideSchema).optional(),
 });
 
 /**
@@ -52,6 +56,7 @@ export interface CreateStepProps {
   task: StepTask;
   dependsOn?: StepDependency[];
   weight?: number;
+  dataOutputOverrides?: DataOutputOverride[];
 }
 
 /**
@@ -63,6 +68,7 @@ export interface CreateStepProps {
  * - A task to execute (model method or shell command)
  * - Dependencies on other steps with trigger conditions
  * - A weight for deterministic topological sorting
+ * - Optional data output overrides
  */
 export class Step {
   private constructor(
@@ -71,6 +77,7 @@ export class Step {
     private _task: StepTask,
     private _dependsOn: StepDependency[],
     readonly weight: number,
+    private _dataOutputOverrides: DataOutputOverride[],
   ) {}
 
   /**
@@ -86,6 +93,7 @@ export class Step {
         condition: d.condition.toData(),
       })),
       weight: props.weight ?? 0,
+      dataOutputOverrides: props.dataOutputOverrides,
     });
 
     return Step.fromData(data);
@@ -102,12 +110,22 @@ export class Step {
       condition: TriggerCondition.fromData(d.condition),
     }));
 
+    // Convert string specType to DataSpecType
+    const dataOutputOverrides: DataOutputOverride[] =
+      (validated.dataOutputOverrides ?? []).map((override) => ({
+        specType: DataSpecType.create(override.specType),
+        lifetime: override.lifetime,
+        garbageCollection: override.garbageCollection,
+        tags: override.tags,
+      }));
+
     return new Step(
       validated.name,
       validated.description,
       task,
       dependsOn,
       validated.weight,
+      dataOutputOverrides,
     );
   }
 
@@ -123,6 +141,13 @@ export class Step {
    */
   get dependsOn(): ReadonlyArray<StepDependency> {
     return this._dependsOn;
+  }
+
+  /**
+   * Returns the data output overrides for this step.
+   */
+  get dataOutputOverrides(): ReadonlyArray<DataOutputOverride> {
+    return this._dataOutputOverrides;
   }
 
   /**
@@ -145,6 +170,14 @@ export class Step {
         condition: d.condition.toData() as TriggerConditionData,
       })),
       weight: this.weight,
+      dataOutputOverrides: this._dataOutputOverrides.length > 0
+        ? this._dataOutputOverrides.map((override) => ({
+          specType: override.specType.toString(),
+          lifetime: override.lifetime,
+          garbageCollection: override.garbageCollection,
+          tags: override.tags,
+        }))
+        : undefined,
     };
   }
 }

--- a/src/presentation/output/type_describe_output.tsx
+++ b/src/presentation/output/type_describe_output.tsx
@@ -11,6 +11,15 @@ export interface MethodDescribeData {
   name: string;
   description: string;
   inputAttributesSchema: object;
+  dataOutputSpecs?: Array<{
+    specType: string;
+    description?: string;
+    contentType?: string;
+    lifetime?: string;
+    garbageCollection?: number | string;
+    streaming?: boolean;
+    tags?: Record<string, string>;
+  }>;
 }
 
 /**
@@ -79,6 +88,42 @@ function SchemaSection({
 }
 
 /**
+ * Component to display data output specs.
+ */
+function DataOutputSpecsDisplay({
+  specs,
+}: {
+  specs: MethodDescribeData["dataOutputSpecs"];
+}): React.ReactElement | null {
+  if (!specs || specs.length === 0) return null;
+
+  return (
+    <Box marginTop={1} marginLeft={2} flexDirection="column">
+      <Text color="cyan">Data Output Specs:</Text>
+      {specs.map((spec) => (
+        <Box key={spec.specType} marginLeft={2} flexDirection="column">
+          <Text>
+            • <Text color="magenta">{spec.specType}</Text>
+          </Text>
+          {spec.description && (
+            <Box marginLeft={2}>
+              <Text dimColor>{spec.description}</Text>
+            </Box>
+          )}
+          <Box marginLeft={2}>
+            <Text dimColor>
+              {spec.contentType ?? "application/json"} |{" "}
+              {spec.lifetime ?? "infinite"} | GC: {spec.garbageCollection ?? 10}
+              {spec.streaming && " | streaming"}
+            </Text>
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+/**
  * Component to display a single method.
  */
 function MethodDisplay({
@@ -98,6 +143,7 @@ function MethodDisplay({
         <Text color="cyan">Input Schema:</Text>
         <Text dimColor>{formatSchema(method.inputAttributesSchema)}</Text>
       </Box>
+      <DataOutputSpecsDisplay specs={method.dataOutputSpecs} />
     </Box>
   );
 }


### PR DESCRIPTION
Adds declarative data output specifications to model types, allowing models to declare what types of data they produce with default metadata. Enables validation to ensure methods only write declared data types, and supports workflow-level and definition-level overrides of spec defaults.

Key features:
- DataSpecType value object for spec type identifiers
- DataOutputSpecification interface with default metadata
- DataOutputOverride for workflow/definition-level customization
- DataOutputValidationService for validation and applying defaults
- Strict validation - execution fails if undeclared spec type is produced
- Override precedence: Step > Definition > Spec defaults

Changes:
- Add core domain types (DataSpecType, DataOutputSpecification)
- Add DataOutputOverride value object for metadata overrides
- Add DataOutputValidationService domain service
- Update MethodExecutionService to validate and apply defaults
- Update WorkflowExecutionService to apply step overrides
- Add dataOutputOverrides field to Step entity
- Update all built-in models with dataOutputSpecs declarations
- Update CLI type describe to show data specs
- Add integration tests for validation and overrides

All models now require dataOutputSpecs field and create DataOutputs directly without helper functions for clarity.

Resolves #162