### PR TITLE
refactor: Centralize .swamp directory paths into shared constants module

### DIFF
--- a/src/cli/commands/vault_edit.ts
+++ b/src/cli/commands/vault_edit.ts
@@ -14,7 +14,10 @@ import { requireInitializedRepo } from "../repo_context.ts";
 import { EditorService } from "../../infrastructure/editor/editor_service.ts";
 import { UserError } from "../../domain/errors.ts";
 import type { VaultConfig } from "../../domain/vaults/vault_config.ts";
-import { join } from "@std/path";
+import {
+  SWAMP_SUBDIRS,
+  swampPath,
+} from "../../infrastructure/persistence/paths.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -23,7 +26,12 @@ type AnyOptions = any;
  * Gets the file path for a vault configuration.
  */
 function getVaultPath(repoDir: string, config: VaultConfig): string {
-  return join(repoDir, ".swamp", "vault", config.type, `${config.id}.yaml`);
+  return swampPath(
+    repoDir,
+    SWAMP_SUBDIRS.vault,
+    config.type,
+    `${config.id}.yaml`,
+  );
 }
 
 export const vaultEditCommand = new Command()

--- a/src/cli/commands/vault_get.ts
+++ b/src/cli/commands/vault_get.ts
@@ -6,6 +6,10 @@ import {
 import { createContext, type GlobalOptions } from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
+import {
+  SWAMP_DATA_DIR,
+  SWAMP_SUBDIRS,
+} from "../../infrastructure/persistence/paths.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -66,7 +70,8 @@ export const vaultGetCommand = new Command()
       type: config.type,
       config: config.config,
       createdAt: config.createdAt.toISOString(),
-      storagePath: `.swamp/vault/${config.type}/${config.id}.yaml`,
+      storagePath:
+        `${SWAMP_DATA_DIR}/${SWAMP_SUBDIRS.vault}/${config.type}/${config.id}.yaml`,
     };
 
     renderVaultGet(data, ctx.outputMode);

--- a/src/domain/data/data_lifecycle_service.ts
+++ b/src/domain/data/data_lifecycle_service.ts
@@ -1,6 +1,10 @@
 import { join } from "@std/path";
 import type { Data } from "./data.ts";
 import type { Lifetime } from "./data_metadata.ts";
+import {
+  SWAMP_SUBDIRS,
+  swampPath,
+} from "../../infrastructure/persistence/paths.ts";
 import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import type { WorkflowRunRepository } from "../workflows/repositories.ts";
 import { ModelType } from "../models/model_type.ts";
@@ -157,7 +161,7 @@ export class DefaultDataLifecycleService implements DataLifecycleService {
 
   async findExpiredData(): Promise<ExpiredDataInfo[]> {
     const expired: ExpiredDataInfo[] = [];
-    const dataDir = join(this.repoDir, ".swamp", "data");
+    const dataDir = swampPath(this.repoDir, SWAMP_SUBDIRS.data);
 
     try {
       // Scan model types
@@ -268,7 +272,7 @@ export class DefaultDataLifecycleService implements DataLifecycleService {
     // Now run version-based garbage collection on all models
     // This hard-deletes old versions based on garbageCollection policy
     if (!dryRun) {
-      const dataDir = join(this.repoDir, ".swamp", "data");
+      const dataDir = swampPath(this.repoDir, SWAMP_SUBDIRS.data);
       try {
         for await (const typeEntry of Deno.readDir(dataDir)) {
           if (!typeEntry.isDirectory) continue;

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -1,6 +1,10 @@
 import { join } from "@std/path";
 import { ensureDir } from "@std/fs";
 import type { RepoPath } from "./repo_path.ts";
+import {
+  SWAMP_SUBDIRS,
+  swampPath,
+} from "../../infrastructure/persistence/paths.ts";
 import { SwampVersion } from "./swamp_version.ts";
 import {
   type RepoMarkerData,
@@ -206,27 +210,26 @@ Use \`swamp --help\` to see available commands.
   private async createDataDirectoryStructure(
     repoPath: RepoPath,
   ): Promise<void> {
-    const dataDir = join(repoPath.value, ".swamp");
     const subdirs = [
-      "inputs",
-      "resources",
-      "workflows",
-      "data",
-      "outputs",
-      "workflow-runs",
-      "inputs-evaluated",
-      "workflows-evaluated",
-      "definitions",
-      "definitions-evaluated",
-      "vault",
-      "secrets",
-      "logs",
-      "files",
-      "telemetry",
+      SWAMP_SUBDIRS.inputs,
+      SWAMP_SUBDIRS.resources,
+      SWAMP_SUBDIRS.workflows,
+      SWAMP_SUBDIRS.data,
+      SWAMP_SUBDIRS.outputs,
+      SWAMP_SUBDIRS.workflowRuns,
+      SWAMP_SUBDIRS.inputsEvaluated,
+      SWAMP_SUBDIRS.workflowsEvaluated,
+      SWAMP_SUBDIRS.definitions,
+      SWAMP_SUBDIRS.definitionsEvaluated,
+      SWAMP_SUBDIRS.vault,
+      SWAMP_SUBDIRS.secrets,
+      SWAMP_SUBDIRS.logs,
+      SWAMP_SUBDIRS.files,
+      SWAMP_SUBDIRS.telemetry,
     ];
 
     for (const subdir of subdirs) {
-      await ensureDir(join(dataDir, subdir));
+      await ensureDir(swampPath(repoPath.value, subdir));
     }
   }
 }

--- a/src/domain/vaults/local_encryption_vault_provider.ts
+++ b/src/domain/vaults/local_encryption_vault_provider.ts
@@ -1,5 +1,9 @@
 import { join } from "@std/path";
 import type { VaultProvider } from "./vault_provider.ts";
+import {
+  SWAMP_SUBDIRS,
+  swampPath,
+} from "../../infrastructure/persistence/paths.ts";
 
 /**
  * Configuration options for local encryption vault.
@@ -47,10 +51,9 @@ export class LocalEncryptionVaultProvider implements VaultProvider {
     // Compute secrets directory from base_dir + vault name
     // Path: {base_dir}/.swamp/secrets/local_encryption/{vault_name}
     const baseDir = config.base_dir ?? Deno.cwd();
-    this.vaultDir = join(
+    this.vaultDir = swampPath(
       baseDir,
-      ".swamp",
-      "secrets",
+      SWAMP_SUBDIRS.secrets,
       "local_encryption",
       name,
     );

--- a/src/infrastructure/persistence/json_telemetry_repository.ts
+++ b/src/infrastructure/persistence/json_telemetry_repository.ts
@@ -1,6 +1,7 @@
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import type { TelemetryRepository } from "../../domain/telemetry/repositories.ts";
+import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
 import {
   TelemetryEntry,
   type TelemetryEntryData,
@@ -150,6 +151,6 @@ export class JsonTelemetryRepository implements TelemetryRepository {
   }
 
   private getTelemetryDir(): string {
-    return join(this.repoDir, ".swamp", "telemetry");
+    return swampPath(this.repoDir, SWAMP_SUBDIRS.telemetry);
   }
 }

--- a/src/infrastructure/persistence/paths.ts
+++ b/src/infrastructure/persistence/paths.ts
@@ -1,0 +1,75 @@
+import { join } from "@std/path";
+
+/**
+ * Central constants for swamp data storage paths.
+ *
+ * All code that references the .swamp directory should use these constants
+ * to ensure consistency and make future path changes easier.
+ */
+
+/** The main data directory name (hidden directory in repo root) */
+export const SWAMP_DATA_DIR = ".swamp";
+
+/** The marker file name for initialized repositories */
+export const SWAMP_MARKER_FILE = ".swamp.yaml";
+
+/**
+ * Subdirectory names within the .swamp directory.
+ */
+export const SWAMP_SUBDIRS = {
+  /** Model and resource definitions */
+  definitions: "definitions",
+  /** Evaluated definitions with resolved expressions */
+  definitionsEvaluated: "definitions-evaluated",
+  /** Workflow definitions */
+  workflows: "workflows",
+  /** Evaluated workflows */
+  workflowsEvaluated: "workflows-evaluated",
+  /** Workflow execution runs */
+  workflowRuns: "workflow-runs",
+  /** Method execution outputs */
+  outputs: "outputs",
+  /** Unified data storage (resources, logs, files) */
+  data: "data",
+  /** Vault configurations */
+  vault: "vault",
+  /** Encrypted secrets for local vaults */
+  secrets: "secrets",
+  /** Telemetry data */
+  telemetry: "telemetry",
+  /** Log files */
+  logs: "logs",
+  /** Arbitrary files */
+  files: "files",
+  /** Legacy: input definitions (now use definitions) */
+  inputs: "inputs",
+  /** Legacy: evaluated inputs */
+  inputsEvaluated: "inputs-evaluated",
+  /** Legacy: resource definitions */
+  resources: "resources",
+} as const;
+
+/**
+ * Constructs a path within the .swamp data directory.
+ *
+ * @param repoDir - The repository root directory
+ * @param segments - Path segments to join after .swamp/
+ * @returns The full path
+ *
+ * @example
+ * swampPath("/repo", "definitions", "aws/ec2", "my-vpc.yaml")
+ * // Returns: "/repo/.swamp/definitions/aws/ec2/my-vpc.yaml"
+ */
+export function swampPath(repoDir: string, ...segments: string[]): string {
+  return join(repoDir, SWAMP_DATA_DIR, ...segments);
+}
+
+/**
+ * Constructs the path to the repository marker file.
+ *
+ * @param repoDir - The repository root directory
+ * @returns The full path to .swamp.yaml
+ */
+export function swampMarkerPath(repoDir: string): string {
+  return join(repoDir, SWAMP_MARKER_FILE);
+}

--- a/src/infrastructure/persistence/paths_test.ts
+++ b/src/infrastructure/persistence/paths_test.ts
@@ -1,0 +1,64 @@
+import { assertEquals } from "@std/assert";
+import {
+  SWAMP_DATA_DIR,
+  SWAMP_MARKER_FILE,
+  SWAMP_SUBDIRS,
+  swampMarkerPath,
+  swampPath,
+} from "./paths.ts";
+
+Deno.test("SWAMP_DATA_DIR is .swamp", () => {
+  assertEquals(SWAMP_DATA_DIR, ".swamp");
+});
+
+Deno.test("SWAMP_MARKER_FILE is .swamp.yaml", () => {
+  assertEquals(SWAMP_MARKER_FILE, ".swamp.yaml");
+});
+
+Deno.test("swampPath joins segments correctly", () => {
+  assertEquals(
+    swampPath("/repo", "definitions", "aws/ec2", "my-vpc.yaml"),
+    "/repo/.swamp/definitions/aws/ec2/my-vpc.yaml",
+  );
+});
+
+Deno.test("swampPath with no segments returns data dir", () => {
+  assertEquals(swampPath("/repo"), "/repo/.swamp");
+});
+
+Deno.test("swampPath with single segment", () => {
+  assertEquals(swampPath("/repo", "workflows"), "/repo/.swamp/workflows");
+});
+
+Deno.test("swampMarkerPath returns marker file path", () => {
+  assertEquals(swampMarkerPath("/repo"), "/repo/.swamp.yaml");
+});
+
+Deno.test("SWAMP_SUBDIRS has all expected directories", () => {
+  assertEquals(SWAMP_SUBDIRS.definitions, "definitions");
+  assertEquals(SWAMP_SUBDIRS.definitionsEvaluated, "definitions-evaluated");
+  assertEquals(SWAMP_SUBDIRS.workflows, "workflows");
+  assertEquals(SWAMP_SUBDIRS.workflowsEvaluated, "workflows-evaluated");
+  assertEquals(SWAMP_SUBDIRS.workflowRuns, "workflow-runs");
+  assertEquals(SWAMP_SUBDIRS.outputs, "outputs");
+  assertEquals(SWAMP_SUBDIRS.data, "data");
+  assertEquals(SWAMP_SUBDIRS.vault, "vault");
+  assertEquals(SWAMP_SUBDIRS.secrets, "secrets");
+  assertEquals(SWAMP_SUBDIRS.telemetry, "telemetry");
+  assertEquals(SWAMP_SUBDIRS.logs, "logs");
+  assertEquals(SWAMP_SUBDIRS.files, "files");
+  assertEquals(SWAMP_SUBDIRS.inputs, "inputs");
+  assertEquals(SWAMP_SUBDIRS.inputsEvaluated, "inputs-evaluated");
+  assertEquals(SWAMP_SUBDIRS.resources, "resources");
+});
+
+Deno.test("swampPath with SWAMP_SUBDIRS constants", () => {
+  assertEquals(
+    swampPath("/repo", SWAMP_SUBDIRS.definitions),
+    "/repo/.swamp/definitions",
+  );
+  assertEquals(
+    swampPath("/repo", SWAMP_SUBDIRS.workflowRuns, "workflow-123"),
+    "/repo/.swamp/workflow-runs/workflow-123",
+  );
+});

--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -1,9 +1,7 @@
-import { join } from "@std/path";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import type { SwampVersion } from "../../domain/repo/swamp_version.ts";
 import type { RepoPath } from "../../domain/repo/repo_path.ts";
-
-const MARKER_FILENAME = ".swamp.yaml";
+import { swampMarkerPath } from "./paths.ts";
 
 /**
  * Data structure for the .swamp.yaml marker file.
@@ -23,7 +21,7 @@ export class RepoMarkerRepository {
    * Gets the path to the marker file for a given repository.
    */
   getMarkerPath(repoPath: RepoPath): string {
-    return join(repoPath.value, MARKER_FILENAME);
+    return swampMarkerPath(repoPath.value);
   }
 
   /**

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -1,6 +1,7 @@
 import { ensureDir } from "@std/fs";
 import { join, relative } from "@std/path";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
 import {
   Data,
   type DataId,
@@ -690,7 +691,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
   }
 
   private getBaseDir(): string {
-    return join(this.repoDir, ".swamp", "data");
+    return swampPath(this.repoDir, SWAMP_SUBDIRS.data);
   }
 
   private getTypeDir(type: ModelType): string {

--- a/src/infrastructure/persistence/yaml_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository.ts
@@ -2,6 +2,7 @@ import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
 import type { DefinitionRepository } from "../../domain/definitions/repositories.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import {
@@ -79,7 +80,7 @@ export class YamlDefinitionRepository implements DefinitionRepository {
   async findByNameGlobal(
     name: string,
   ): Promise<{ definition: Definition; type: ModelType } | null> {
-    const definitionsDir = join(this.repoDir, ".swamp", "definitions");
+    const definitionsDir = swampPath(this.repoDir, SWAMP_SUBDIRS.definitions);
     return await this.searchDefinitionByName(definitionsDir, [], name);
   }
 
@@ -134,7 +135,7 @@ export class YamlDefinitionRepository implements DefinitionRepository {
   async findAllGlobal(): Promise<
     { definition: Definition; type: ModelType }[]
   > {
-    const definitionsDir = join(this.repoDir, ".swamp", "definitions");
+    const definitionsDir = swampPath(this.repoDir, SWAMP_SUBDIRS.definitions);
     const results: { definition: Definition; type: ModelType }[] = [];
     await this.collectAllDefinitions(definitionsDir, [], results);
     return results;
@@ -238,7 +239,7 @@ export class YamlDefinitionRepository implements DefinitionRepository {
       await Deno.remove(path);
 
       // Clean up empty parent directories
-      const definitionsDir = join(this.repoDir, ".swamp", "definitions");
+      const definitionsDir = swampPath(this.repoDir, SWAMP_SUBDIRS.definitions);
       await cleanupEmptyParentDirs(path, definitionsDir);
 
       // Emit event if we had a name
@@ -266,6 +267,10 @@ export class YamlDefinitionRepository implements DefinitionRepository {
   }
 
   private getTypeDir(type: ModelType): string {
-    return join(this.repoDir, ".swamp", "definitions", type.toDirectoryPath());
+    return swampPath(
+      this.repoDir,
+      SWAMP_SUBDIRS.definitions,
+      type.toDirectoryPath(),
+    );
   }
 }

--- a/src/infrastructure/persistence/yaml_evaluated_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_definition_repository.ts
@@ -3,6 +3,7 @@ import { join } from "@std/path";
 import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import { ModelType } from "../../domain/models/model_type.ts";
+import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
 import {
   createDefinitionId,
   Definition,
@@ -98,10 +99,9 @@ export class YamlEvaluatedDefinitionRepository {
   async findByNameGlobal(
     name: string,
   ): Promise<{ definition: Definition; type: ModelType } | null> {
-    const definitionsDir = join(
+    const definitionsDir = swampPath(
       this.repoDir,
-      ".swamp",
-      "definitions-evaluated",
+      SWAMP_SUBDIRS.definitionsEvaluated,
     );
     return await this.searchDefinitionByName(definitionsDir, [], name);
   }
@@ -159,10 +159,9 @@ export class YamlEvaluatedDefinitionRepository {
   async findAllGlobal(): Promise<
     { definition: Definition; type: ModelType }[]
   > {
-    const definitionsDir = join(
+    const definitionsDir = swampPath(
       this.repoDir,
-      ".swamp",
-      "definitions-evaluated",
+      SWAMP_SUBDIRS.definitionsEvaluated,
     );
     const results: { definition: Definition; type: ModelType }[] = [];
     await this.collectAllDefinitions(definitionsDir, [], results);
@@ -238,10 +237,9 @@ export class YamlEvaluatedDefinitionRepository {
       await Deno.remove(path);
 
       // Clean up empty parent directories
-      const definitionsDir = join(
+      const definitionsDir = swampPath(
         this.repoDir,
-        ".swamp",
-        "definitions-evaluated",
+        SWAMP_SUBDIRS.definitionsEvaluated,
       );
       await cleanupEmptyParentDirs(path, definitionsDir);
     } catch (error) {
@@ -270,10 +268,9 @@ export class YamlEvaluatedDefinitionRepository {
   }
 
   private getTypeDir(type: ModelType): string {
-    return join(
+    return swampPath(
       this.repoDir,
-      ".swamp",
-      "definitions-evaluated",
+      SWAMP_SUBDIRS.definitionsEvaluated,
       type.toDirectoryPath(),
     );
   }
@@ -283,10 +280,9 @@ export class YamlEvaluatedDefinitionRepository {
    * Used when needing to regenerate all evaluations.
    */
   async clearAll(): Promise<void> {
-    const definitionsDir = join(
+    const definitionsDir = swampPath(
       this.repoDir,
-      ".swamp",
-      "definitions-evaluated",
+      SWAMP_SUBDIRS.definitionsEvaluated,
     );
     try {
       await Deno.remove(definitionsDir, { recursive: true });

--- a/src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts
@@ -2,6 +2,7 @@ import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import type { WorkflowId } from "../../domain/workflows/workflow_id.ts";
+import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
 import {
   Workflow,
   type WorkflowData,
@@ -98,6 +99,6 @@ export class YamlEvaluatedWorkflowRepository {
   }
 
   private getWorkflowsDir(): string {
-    return join(this.repoDir, ".swamp", "workflows-evaluated");
+    return swampPath(this.repoDir, SWAMP_SUBDIRS.workflowsEvaluated);
   }
 }

--- a/src/infrastructure/persistence/yaml_output_repository.ts
+++ b/src/infrastructure/persistence/yaml_output_repository.ts
@@ -2,6 +2,7 @@ import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
 import type { OutputRepository } from "../../domain/models/repositories.ts";
 import type { DefinitionId } from "../../domain/definitions/definition.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
@@ -155,7 +156,7 @@ export class YamlOutputRepository implements OutputRepository {
             await Deno.remove(path);
 
             // Clean up empty parent directories
-            const outputsDir = join(this.repoDir, ".swamp", "outputs");
+            const outputsDir = swampPath(this.repoDir, SWAMP_SUBDIRS.outputs);
             await cleanupEmptyParentDirs(path, outputsDir);
             return;
           }
@@ -179,7 +180,7 @@ export class YamlOutputRepository implements OutputRepository {
   }
 
   private getOutputsDir(): string {
-    return join(this.repoDir, ".swamp", "outputs");
+    return swampPath(this.repoDir, SWAMP_SUBDIRS.outputs);
   }
 
   private getTypeDir(type: ModelType): string {

--- a/src/infrastructure/persistence/yaml_vault_config_repository.ts
+++ b/src/infrastructure/persistence/yaml_vault_config_repository.ts
@@ -1,6 +1,7 @@
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
 import {
   VaultConfig,
   type VaultConfigData,
@@ -206,7 +207,7 @@ export class YamlVaultConfigRepository {
    * Gets the base vault directory.
    */
   private getVaultDir(): string {
-    return join(this.repoDir, ".swamp", "vault");
+    return swampPath(this.repoDir, SWAMP_SUBDIRS.vault);
   }
 
   /**

--- a/src/infrastructure/persistence/yaml_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_repository.ts
@@ -2,6 +2,7 @@ import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
+import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
 import {
   createWorkflowId,
   type WorkflowId,
@@ -147,6 +148,6 @@ export class YamlWorkflowRepository implements WorkflowRepository {
   }
 
   private getWorkflowsDir(): string {
-    return join(this.repoDir, ".swamp", "workflows");
+    return swampPath(this.repoDir, SWAMP_SUBDIRS.workflows);
   }
 }

--- a/src/infrastructure/persistence/yaml_workflow_run_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository.ts
@@ -2,6 +2,7 @@ import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import type { WorkflowRunRepository } from "../../domain/workflows/repositories.ts";
+import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
 import {
   createWorkflowRunId,
   type WorkflowId,
@@ -105,7 +106,7 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
     { run: WorkflowRun; workflowId: WorkflowId }[]
   > {
     const results: { run: WorkflowRun; workflowId: WorkflowId }[] = [];
-    const workflowRunsDir = join(this.repoDir, ".swamp", "workflow-runs");
+    const workflowRunsDir = swampPath(this.repoDir, SWAMP_SUBDIRS.workflowRuns);
 
     try {
       for await (const entry of Deno.readDir(workflowRunsDir)) {
@@ -201,7 +202,7 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
   }
 
   private getRunsDir(workflowId: WorkflowId): string {
-    return join(this.repoDir, ".swamp", "workflow-runs", workflowId);
+    return swampPath(this.repoDir, SWAMP_SUBDIRS.workflowRuns, workflowId);
   }
 
   async deleteAllByWorkflowId(workflowId: WorkflowId): Promise<number> {

--- a/src/infrastructure/repo/symlink_repo_index_service.ts
+++ b/src/infrastructure/repo/symlink_repo_index_service.ts
@@ -8,6 +8,11 @@
 import { ensureDir } from "@std/fs";
 import { join, relative } from "@std/path";
 import { getLogger } from "@logtape/logtape";
+import {
+  SWAMP_DATA_DIR,
+  SWAMP_SUBDIRS,
+  swampPath,
+} from "../persistence/paths.ts";
 import type {
   PruneResult,
   RebuildResult,
@@ -377,8 +382,8 @@ export class SymlinkRepoIndexService implements RepoIndexService {
 
     // Symlink to definition.yaml
     const definitionTarget = join(
-      ".swamp",
-      "definitions",
+      SWAMP_DATA_DIR,
+      SWAMP_SUBDIRS.definitions,
       type.toDirectoryPath(),
       `${modelInputId}.yaml`,
     );
@@ -403,10 +408,9 @@ export class SymlinkRepoIndexService implements RepoIndexService {
     const outputsDir = join(modelDir, "outputs");
     await ensureDir(outputsDir);
 
-    const methodsDir = join(
+    const methodsDir = swampPath(
       this.repoDir,
-      ".swamp",
-      "outputs",
+      SWAMP_SUBDIRS.outputs,
       type.normalized,
     );
     if (await this.exists(methodsDir)) {
@@ -562,10 +566,9 @@ export class SymlinkRepoIndexService implements RepoIndexService {
     await ensureDir(workflowDir);
 
     // Symlink to workflow.yaml
-    const workflowTarget = join(
+    const workflowTarget = swampPath(
       this.repoDir,
-      ".swamp",
-      "workflows",
+      SWAMP_SUBDIRS.workflows,
       `workflow-${workflowId}.yaml`,
     );
     await this.createSymlink(
@@ -608,10 +611,9 @@ export class SymlinkRepoIndexService implements RepoIndexService {
     await ensureDir(runDir);
 
     // Symlink to run.yaml
-    const runTarget = join(
+    const runTarget = swampPath(
       this.repoDir,
-      ".swamp",
-      "workflow-runs",
+      SWAMP_SUBDIRS.workflowRuns,
       workflowId,
       `workflow-run-${runId}.yaml`,
     );
@@ -653,10 +655,9 @@ export class SymlinkRepoIndexService implements RepoIndexService {
     await ensureDir(vaultDir);
 
     // Symlink to vault.yaml
-    const vaultTarget = join(
+    const vaultTarget = swampPath(
       this.repoDir,
-      ".swamp",
-      "vault",
+      SWAMP_SUBDIRS.vault,
       vaultType,
       `${vaultId}.yaml`,
     );
@@ -664,10 +665,9 @@ export class SymlinkRepoIndexService implements RepoIndexService {
 
     // For local_encryption vaults, create secrets directory with individual key symlinks
     if (vaultType === "local_encryption") {
-      const actualSecretsDir = join(
+      const actualSecretsDir = swampPath(
         this.repoDir,
-        ".swamp",
-        "secrets",
+        SWAMP_SUBDIRS.secrets,
         vaultType,
         vaultName,
       );

--- a/src/presentation/output/components/workflow_execution/LogStreamService.ts
+++ b/src/presentation/output/components/workflow_execution/LogStreamService.ts
@@ -1,5 +1,9 @@
 import { join } from "@std/path";
 import { parse as parseYaml } from "@std/yaml";
+import {
+  SWAMP_SUBDIRS,
+  swampPath,
+} from "../../../../infrastructure/persistence/paths.ts";
 import type {
   JobRunData,
   StepRunData,
@@ -177,7 +181,7 @@ export class LogStreamService {
   ): Promise<{ status: string } | null> {
     try {
       // Find the workflow run file
-      const baseRunsDir = join(this.repoDir, ".swamp", "workflow-runs");
+      const baseRunsDir = swampPath(this.repoDir, SWAMP_SUBDIRS.workflowRuns);
       let runFile: string | null = null;
 
       // Search through all workflow template directories
@@ -226,7 +230,7 @@ export class LogStreamService {
   private getLogPath(_target: LogStreamTarget): string {
     // Logs are stored in .swamp/logs/{type}/{id}/
     // For workflow steps, we need to map to model outputs
-    return join(this.repoDir, ".swamp", "logs");
+    return swampPath(this.repoDir, SWAMP_SUBDIRS.logs);
   }
 
   /**
@@ -264,7 +268,7 @@ export class LogStreamService {
     try {
       // Find the workflow run file by searching all workflow directories
       // File structure: .swamp/workflow-runs/{workflowTemplateId}/workflow-run-{runInstanceId}.yaml
-      const baseRunsDir = join(this.repoDir, ".swamp", "workflow-runs");
+      const baseRunsDir = swampPath(this.repoDir, SWAMP_SUBDIRS.workflowRuns);
       let runFile: string | null = null;
 
       try {

--- a/src/presentation/output/vault_create_output.tsx
+++ b/src/presentation/output/vault_create_output.tsx
@@ -3,6 +3,10 @@ import React from "react";
 import { Box, Text } from "ink";
 import { render } from "ink-testing-library";
 import type { OutputMode } from "./output.tsx";
+import {
+  SWAMP_DATA_DIR,
+  SWAMP_SUBDIRS,
+} from "../../infrastructure/persistence/paths.ts";
 
 /**
  * Data for vault create output.
@@ -81,8 +85,9 @@ export function VaultCreateDisplay(
       </Box>
       <Box marginTop={1}>
         <Text dimColor>
-          Edit .swamp/vault/{props.type}/{props.id}.yaml to customize the vault
-          configuration.
+          Edit{" "}
+          {SWAMP_DATA_DIR}/{SWAMP_SUBDIRS.vault}/{props.type}/{props.id}.yaml to
+          customize the vault configuration.
         </Text>
       </Box>
     </Box>

--- a/src/presentation/output/vault_describe_output.tsx
+++ b/src/presentation/output/vault_describe_output.tsx
@@ -3,6 +3,10 @@ import React from "react";
 import { Box, render, Text } from "ink";
 import type { OutputMode } from "./output.tsx";
 import type { VaultConfig } from "../../domain/vaults/vault_config.ts";
+import {
+  SWAMP_DATA_DIR,
+  SWAMP_SUBDIRS,
+} from "../../infrastructure/persistence/paths.ts";
 
 /**
  * Renders vault description in either interactive or JSON mode.
@@ -79,7 +83,9 @@ function VaultDescribeUI(props: VaultDescribeUIProps): React.ReactElement {
       {/* Storage path */}
       <Box marginTop={1}>
         <Text bold>Storage:</Text>
-        <Text dimColor>.swamp/vault/{config.type}/{config.id}.yaml</Text>
+        <Text dimColor>
+          {SWAMP_DATA_DIR}/{SWAMP_SUBDIRS.vault}/{config.type}/{config.id}.yaml
+        </Text>
       </Box>
 
       {/* Configuration */}

--- a/src/presentation/output/vault_type_describe_output.tsx
+++ b/src/presentation/output/vault_type_describe_output.tsx
@@ -3,6 +3,10 @@ import React from "react";
 import { Box, render, Text } from "ink";
 import type { OutputMode } from "./output.tsx";
 import type { VaultTypeSearchItem } from "./vault_type_search_output.tsx";
+import {
+  SWAMP_DATA_DIR,
+  SWAMP_SUBDIRS,
+} from "../../infrastructure/persistence/paths.ts";
 
 /**
  * Configuration example for each vault type.
@@ -48,7 +52,8 @@ function renderJsonVaultTypeDescribe(data: VaultTypeSearchItem): void {
   const output = {
     ...data,
     configExample: CONFIG_EXAMPLES[data.type] ?? "",
-    storagePath: `.swamp/vault/${data.type}/{id}.yaml`,
+    storagePath:
+      `${SWAMP_DATA_DIR}/${SWAMP_SUBDIRS.vault}/${data.type}/{id}.yaml`,
   };
   console.log(JSON.stringify(output, null, 2));
 }
@@ -92,7 +97,9 @@ function VaultTypeDescribeUI(
       {/* Storage path */}
       <Box>
         <Text bold>Storage:</Text>
-        <Text dimColor>.swamp/vault/{data.type}/</Text>
+        <Text dimColor>
+          {SWAMP_DATA_DIR}/{SWAMP_SUBDIRS.vault}/{data.type}/
+        </Text>
         <Text dimColor>{"<id>"}.yaml</Text>
       </Box>
 


### PR DESCRIPTION
Introduces a centralized `paths.ts` module to eliminate hardcoded `.swamp` directory strings throughout the codebase, preventing path inconsistencies and making future changes easier.

## Changes

### New files
- `src/infrastructure/persistence/paths.ts` - Central constants module
- `src/infrastructure/persistence/paths_test.ts` - Unit tests

### Constants introduced
- `SWAMP_DATA_DIR` - The `.swamp` directory name
- `SWAMP_MARKER_FILE` - The `.swamp.yaml` marker file name
- `SWAMP_SUBDIRS` - Object containing all subdirectory names (definitions, workflows, vault, secrets, etc.)
- `swampPath(repoDir, ...segments)` - Helper to build paths within `.swamp/`
- `swampMarkerPath(repoDir)` - Helper to get the marker file path

### Files refactored (20 files)

**Infrastructure persistence (10 files):**
- `repo_marker_repository.ts`
- `json_telemetry_repository.ts`
- `yaml_vault_config_repository.ts`
- `yaml_workflow_repository.ts`
- `yaml_workflow_run_repository.ts`
- `yaml_evaluated_workflow_repository.ts`
- `yaml_definition_repository.ts`
- `yaml_evaluated_definition_repository.ts`
- `yaml_output_repository.ts`
- `unified_data_repository.ts`

**Infrastructure repo (1 file):**
- `symlink_repo_index_service.ts`

**Domain layer (3 files):**
- `repo_service.ts`
- `data_lifecycle_service.ts`
- `local_encryption_vault_provider.ts`

**CLI/Presentation layer (6 files):**
- `vault_edit.ts`
- `vault_get.ts`
- `vault_create_output.tsx`
- `vault_describe_output.tsx`
- `vault_type_describe_output.tsx`
- `LogStreamService.ts`

## Test Plan

- [x] `deno check` - Type checking passes
- [x] `deno lint` - No lint errors
- [x] `deno fmt` - Properly formatted
- [x] `deno run test` - All 1488 tests pass
- [x] New unit tests for `paths.ts` module

Relates to #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)