### PR TITLE
fix: Resolve vault expressions when running model methods directly

### DIFF
--- a/integration/model_method_run_vault_test.ts
+++ b/integration/model_method_run_vault_test.ts
@@ -1,0 +1,330 @@
+/**
+ * Integration tests for vault expression resolution in model method run.
+ *
+ * Tests that running a model method directly (not via workflow) properly
+ * resolves vault expressions like ${{ vault.get(vault-name, SECRET_KEY) }}.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+import { stringify as stringifyYaml } from "@std/yaml";
+import { Definition } from "../src/domain/definitions/definition.ts";
+import { ModelType } from "../src/domain/models/model_type.ts";
+import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-method-vault-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+async function setupRepoDir(dir: string): Promise<void> {
+  await ensureDir(join(dir, ".swamp", "definitions"));
+  await ensureDir(join(dir, ".swamp", "vault"));
+  await ensureDir(join(dir, ".swamp", "secrets"));
+  await ensureDir(join(dir, ".swamp", "data"));
+  await ensureDir(join(dir, ".swamp", "outputs"));
+  await ensureDir(join(dir, ".swamp", "logs"));
+  await ensureDir(join(dir, ".swamp", "workflows"));
+  await ensureDir(join(dir, ".swamp", "workflow-runs"));
+
+  // Create the .swamp.yaml marker file for CLI commands
+  const markerData = {
+    swampVersion: "0.0.0",
+    initializedAt: new Date().toISOString(),
+  };
+  await Deno.writeTextFile(
+    join(dir, ".swamp.yaml"),
+    stringifyYaml(markerData as Record<string, unknown>),
+  );
+}
+
+async function runCliCommand(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      "--allow-env",
+      "--allow-run",
+      "--allow-sys",
+      "--allow-net",
+      "main.ts",
+      ...args,
+    ],
+    stdout: "piped",
+    stderr: "piped",
+    cwd: Deno.cwd(),
+  });
+
+  const { code, stdout, stderr } = await command.output();
+  return {
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+    code,
+  };
+}
+
+// ============================================================================
+// Model Method Run with Vault Expressions
+// ============================================================================
+
+Deno.test("Model Method Run: resolves vault expressions before execution", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+
+    // Create vault via CLI
+    const createVaultResult = await runCliCommand([
+      "vault",
+      "create",
+      "local_encryption",
+      "test-vault",
+      "--repo-dir",
+      repoDir,
+      "--json",
+    ]);
+    assertEquals(
+      createVaultResult.code,
+      0,
+      `Vault create failed: ${createVaultResult.stderr}`,
+    );
+
+    // Store a secret
+    const secretValue = "resolved-secret-value-12345";
+    const putResult = await runCliCommand([
+      "vault",
+      "put",
+      "test-vault",
+      `API_KEY=${secretValue}`,
+      "--repo-dir",
+      repoDir,
+      "--json",
+    ]);
+    assertEquals(putResult.code, 0, `Vault put failed: ${putResult.stderr}`);
+
+    // Create a model that uses vault expression via repository
+    // Using swamp/echo which has a "write" method that outputs the message attribute
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const modelType = ModelType.create("swamp/echo");
+    const definition = Definition.create({
+      name: "vault-test-model",
+      attributes: {
+        message: "${{ vault.get(test-vault, API_KEY) }}",
+      },
+    });
+    await definitionRepo.save(modelType, definition);
+
+    // Run the model method directly using the "write" method
+    const runResult = await runCliCommand([
+      "model",
+      "method",
+      "run",
+      "vault-test-model",
+      "write",
+      "--repo-dir",
+      repoDir,
+      "--json",
+    ]);
+
+    assertEquals(
+      runResult.code,
+      0,
+      `Model method run failed: ${runResult.stderr}`,
+    );
+
+    // Parse the output - it should contain data with the resolved secret
+    const output = JSON.parse(runResult.stdout);
+
+    // The echo model outputs the message - verify the vault expression was resolved
+    // (not passed as a literal string)
+    if (output.data?.attributes?.message) {
+      assertEquals(
+        output.data.attributes.message,
+        secretValue,
+        "Vault expression should be resolved to the actual secret value",
+      );
+    }
+
+    // Also verify the literal expression string is NOT in the output
+    const outputStr = JSON.stringify(output);
+    assertEquals(
+      outputStr.includes("vault.get(test-vault, API_KEY)"),
+      false,
+      "Output should not contain the literal vault expression",
+    );
+    assertEquals(
+      outputStr.includes("${{"),
+      false,
+      "Output should not contain unresolved expression syntax",
+    );
+  });
+});
+
+Deno.test("Model Method Run: resolves multiple vault expressions", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+
+    // Create vault
+    await runCliCommand([
+      "vault",
+      "create",
+      "local_encryption",
+      "multi-vault",
+      "--repo-dir",
+      repoDir,
+      "--json",
+    ]);
+
+    // Store multiple secrets
+    const username = "admin_user";
+    const password = "super_secret_pass";
+    await runCliCommand([
+      "vault",
+      "put",
+      "multi-vault",
+      `USERNAME=${username}`,
+      "--repo-dir",
+      repoDir,
+      "--json",
+    ]);
+    await runCliCommand([
+      "vault",
+      "put",
+      "multi-vault",
+      `PASSWORD=${password}`,
+      "--repo-dir",
+      repoDir,
+      "--json",
+    ]);
+
+    // Create model with multiple vault references combined in a single attribute
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const modelType = ModelType.create("swamp/echo");
+    const definition = Definition.create({
+      name: "multi-vault-model",
+      attributes: {
+        message:
+          '${{ vault.get(multi-vault, USERNAME) + ":" + vault.get(multi-vault, PASSWORD) }}',
+      },
+    });
+    await definitionRepo.save(modelType, definition);
+
+    // Run the model method
+    const runResult = await runCliCommand([
+      "model",
+      "method",
+      "run",
+      "multi-vault-model",
+      "write",
+      "--repo-dir",
+      repoDir,
+      "--json",
+    ]);
+
+    assertEquals(
+      runResult.code,
+      0,
+      `Model method run failed: ${runResult.stderr}`,
+    );
+
+    // Parse output and verify combined secret
+    const output = JSON.parse(runResult.stdout);
+    if (output.data?.attributes?.message) {
+      assertEquals(
+        output.data.attributes.message,
+        `${username}:${password}`,
+        "Multiple vault expressions should be resolved and combined",
+      );
+    }
+  });
+});
+
+Deno.test("Model Method Run: handles missing vault gracefully with error", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+
+    // Create model referencing non-existent vault (no vault created)
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const modelType = ModelType.create("swamp/echo");
+    const definition = Definition.create({
+      name: "missing-vault-model",
+      attributes: {
+        message: "${{ vault.get(nonexistent-vault, SECRET) }}",
+      },
+    });
+    await definitionRepo.save(modelType, definition);
+
+    // Run the model method - should fail with vault error
+    const runResult = await runCliCommand([
+      "model",
+      "method",
+      "run",
+      "missing-vault-model",
+      "write",
+      "--repo-dir",
+      repoDir,
+      "--json",
+    ]);
+
+    // Should fail because vault doesn't exist
+    assertEquals(runResult.code, 1, "Should fail when vault doesn't exist");
+
+    // Error message should mention the vault
+    assertStringIncludes(
+      runResult.stderr,
+      "vault",
+      "Error should mention vault",
+    );
+  });
+});
+
+Deno.test("Model Method Run: model without expressions works normally", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+
+    // Create a model WITHOUT vault expressions
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const modelType = ModelType.create("swamp/echo");
+    const definition = Definition.create({
+      name: "plain-model",
+      attributes: {
+        message: "Hello World",
+      },
+    });
+    await definitionRepo.save(modelType, definition);
+
+    // Run the model method
+    const runResult = await runCliCommand([
+      "model",
+      "method",
+      "run",
+      "plain-model",
+      "write",
+      "--repo-dir",
+      repoDir,
+      "--json",
+    ]);
+
+    assertEquals(
+      runResult.code,
+      0,
+      `Model method run failed: ${runResult.stderr}`,
+    );
+
+    // Parse output and verify plain message
+    const output = JSON.parse(runResult.stdout);
+    if (output.data?.attributes?.message) {
+      assertEquals(
+        output.data.attributes.message,
+        "Hello World",
+        "Plain model should work without expression evaluation",
+      );
+    }
+  });
+});

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -10,6 +10,7 @@ import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { ModelOutput } from "../../domain/models/model_output.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 import { DefaultMethodExecutionService } from "../../domain/models/method_execution_service.ts";
+import { ExpressionEvaluationService } from "../../domain/expressions/expression_evaluation_service.ts";
 
 // Cliffy's custom type system returns `unknown` for custom types like `model_name`,
 // but we need to pass `options` to functions expecting specific types. Using `any`
@@ -73,9 +74,27 @@ export const modelMethodRunCommand = new Command()
         );
       }
 
+      // Evaluate expressions (including vault expressions) before execution
+      const evaluationService = new ExpressionEvaluationService(
+        definitionRepo,
+        repoDir,
+        { dataRepo: unifiedDataRepo },
+      );
+
+      let evaluatedDefinition = definition;
+      if (evaluationService.hasDefinitionExpressions(definition)) {
+        ctx.logger.debug`Evaluating expressions in model definition`;
+        const evalResult = await evaluationService.evaluateDefinition(
+          definition,
+          modelType,
+        );
+        evaluatedDefinition = evalResult.definition;
+        ctx.logger.debug`Expression evaluation complete`;
+      }
+
       ctx.logger.debug`Executing method '${methodName}'`;
 
-      // Create ModelOutput for tracking
+      // Create ModelOutput for tracking (use original definition for provenance)
       const definitionHash = await definition.computeHash();
       const output = ModelOutput.create({
         definitionId: definition.id,
@@ -96,14 +115,15 @@ export const modelMethodRunCommand = new Command()
 
       try {
         // Execute the method (use workflow execution to handle follow-up actions)
+        // Use evaluatedDefinition which has vault expressions resolved
         const execResult = await executionService.executeWorkflow(
-          definition,
+          evaluatedDefinition,
           modelDef,
           methodName,
           {
             repoDir,
             modelType,
-            modelId: definition.id,
+            modelId: evaluatedDefinition.id,
             dataRepository: unifiedDataRepo,
             definitionRepository: definitionRepo,
           },


### PR DESCRIPTION
- Fix vault expressions (e.g., `${{ vault.get(vault-name, SECRET) }}`) not being resolved when running model methods directly via `swamp model method run`
- Expressions were being passed as literal strings instead of resolved secret values

## Problem

When running a model method directly (not via workflow), vault expressions in model attributes were not being evaluated. For example, a model with:

```yaml
attributes:
apiKey: ${{ vault.get(porkbun, API_KEY) }}
```

Would pass the literal string `${{ vault.get(porkbun, API_KEY) }}` to the method instead of the actual secret value, causing API authentication failures.

This worked correctly in workflow execution but not in direct method execution.

Solution

Added expression evaluation to model_method_run.ts before executing the method:

1. Create an ExpressionEvaluationService with the repository directory (required for vault loading)
2. Check if the definition contains expressions
3. If so, evaluate them to resolve vault secrets and other expressions
4. Pass the evaluated definition to executeWorkflow()

Test plan

- Added integration tests in integration/model_method_run_vault_test.ts:
- Resolves single vault expressions
- Resolves multiple vault expressions in combined CEL expressions
- Handles missing vault with appropriate error
- Models without expressions continue to work normally
- All 1511 existing tests pass
- Manual verification with local_encryption vault confirmed fix works