### PR TITLE
feat: update the upload script to also handle invalidation

### DIFF
--- a/scripts/upload-binaries.sh
+++ b/scripts/upload-binaries.sh
@@ -32,12 +32,61 @@ if ! command -v aws &> /dev/null; then
     exit 1
 fi
 
+# Check if GitHub CLI is available
+if ! command -v gh &> /dev/null; then
+    echo "Error: GitHub CLI (gh) not found. Please install it first."
+    exit 1
+fi
+
 echo "Uploading swamp binaries for version: $VERSION_CLEAN to bucket: $BUCKET"
 echo "Looking for binaries in: $BINARIES_DIR"
 
 # Create temporary directory for packaging
 TEMP_DIR=$(mktemp -d)
 trap "rm -rf $TEMP_DIR" EXIT
+
+# Download binaries from GitHub release if they don't exist locally
+download_github_binaries() {
+    local missing_binaries=false
+    
+    # Check which binaries are missing
+    for mapping in $BINARIES; do
+        binary_name=$(echo "$mapping" | cut -d':' -f1)
+        binary_path="$BINARIES_DIR/$binary_name"
+        
+        if [[ ! -f "$binary_path" ]]; then
+            missing_binaries=true
+            break
+        fi
+    done
+    
+    # If no binaries are missing, skip download
+    if [[ "$missing_binaries" == false ]]; then
+        echo "All binaries found locally, skipping GitHub download"
+        return 0
+    fi
+    
+    echo "Some binaries missing locally, downloading from GitHub release..."
+    
+    # Create binaries directory if it doesn't exist
+    mkdir -p "$BINARIES_DIR"
+    
+    # Download missing binaries
+    for mapping in $BINARIES; do
+        binary_name=$(echo "$mapping" | cut -d':' -f1)
+        binary_path="$BINARIES_DIR/$binary_name"
+        
+        if [[ ! -f "$binary_path" ]]; then
+            echo "Downloading $binary_name from GitHub release $VERSION"
+            if ! gh release download "$VERSION" --pattern "$binary_name" --dir "$BINARIES_DIR" 2>/dev/null; then
+                echo "Warning: Failed to download $binary_name from GitHub release $VERSION"
+            fi
+        fi
+    done
+}
+
+# Download binaries if needed
+download_github_binaries
 
 # Process each binary mapping
 for mapping in $BINARIES; do
@@ -87,6 +136,14 @@ for mapping in $BINARIES; do
     # Clean up temp file
     rm -f "$temp_binary" "$TEMP_DIR/$s3_filename"
 done
+
+# Invalidate CloudFront cache for all paths
+echo "Invalidating CloudFront cache for distribution E2HW6000JEVIPB..."
+if aws cloudfront create-invalidation --distribution-id E2HW6000JEVIPB --paths "/*" > /dev/null 2>&1; then
+    echo "✅ CloudFront cache invalidation initiated"
+else
+    echo "⚠️  Warning: CloudFront cache invalidation failed (continuing anyway)"
+fi
 
 echo "✅ Upload complete!"
 echo ""


### PR DESCRIPTION
With no ./dist folder locally, you can now run:
`./upload-binaries.sh v20260205.212906.0-sha.81e917b9` with the relevant creds to upload + publish the binaries to stable

