### PR TITLE
feat: Selective telemetry argument recording

### DIFF
--- a/src/cli/telemetry_integration.ts
+++ b/src/cli/telemetry_integration.ts
@@ -1,5 +1,21 @@
 import type { CommandInvocationData } from "../domain/telemetry/mod.ts";
 
+/**
+ * Per-position sensitivity for positional arguments by command.
+ * "categorical" = system-defined value, safe to record (e.g., model type, method name).
+ * "redact" = user-identifiable value, must be redacted (e.g., name, path, query).
+ * Commands not listed here default to all-redact. Positions beyond the schema length
+ * also default to "redact".
+ */
+const ARG_SCHEMAS: Record<string, readonly ("categorical" | "redact")[]> = {
+  "model create": ["categorical", "redact"], // type, name
+  "model method": ["categorical", "redact", "categorical"], // "run", name, method
+  "model output": ["categorical", "redact"], // sub-subcmd, id/query
+  "vault create": ["categorical", "redact"], // type, name
+  "type describe": ["categorical"], // type
+  "workflow history": ["categorical", "redact"], // sub-subcmd, name
+};
+
 /** Global options that are tracked separately */
 const GLOBAL_OPTIONS = new Set([
   "--debug-logs",
@@ -86,6 +102,12 @@ export function extractCommandInfo(args: string[]): CommandInvocationData {
   }
 
   // Process remaining args
+  const schemaKey = result.subcommand
+    ? `${result.command} ${result.subcommand}`
+    : result.command;
+  const argSchema = ARG_SCHEMAS[schemaKey];
+  let positionalIndex = 0;
+
   while (i < args.length) {
     const arg = args[i];
 
@@ -112,8 +134,10 @@ export function extractCommandInfo(args: string[]): CommandInvocationData {
         i++; // Skip the value
       }
     } else {
-      // Positional argument - record as redacted
-      result.args.push("<REDACTED>");
+      // Positional argument - record categorical values, redact user-identifiable ones
+      const sensitivity = argSchema?.[positionalIndex] ?? "redact";
+      result.args.push(sensitivity === "categorical" ? arg : "<REDACTED>");
+      positionalIndex++;
     }
 
     i++;

--- a/src/cli/telemetry_integration_test.ts
+++ b/src/cli/telemetry_integration_test.ts
@@ -24,12 +24,17 @@ Deno.test("extractCommandInfo extracts command and subcommand", () => {
   assertEquals(info.globalOptions, []);
 });
 
-Deno.test("extractCommandInfo extracts command with positional args", () => {
-  const info = extractCommandInfo(["model", "create", "my-model", "MyType"]);
+Deno.test("extractCommandInfo records categorical args for model create", () => {
+  const info = extractCommandInfo([
+    "model",
+    "create",
+    "prompt",
+    "my-model",
+  ]);
 
   assertEquals(info.command, "model");
   assertEquals(info.subcommand, "create");
-  assertEquals(info.args, ["<REDACTED>", "<REDACTED>"]);
+  assertEquals(info.args, ["prompt", "<REDACTED>"]);
   assertEquals(info.optionKeys, []);
   assertEquals(info.globalOptions, []);
 });
@@ -52,7 +57,7 @@ Deno.test("extractCommandInfo extracts command-specific options", () => {
   const info = extractCommandInfo([
     "model",
     "create",
-    "my-model",
+    "prompt",
     "--repo-dir",
     "/path/to/repo",
     "--force",
@@ -60,7 +65,7 @@ Deno.test("extractCommandInfo extracts command-specific options", () => {
 
   assertEquals(info.command, "model");
   assertEquals(info.subcommand, "create");
-  assertEquals(info.args, ["<REDACTED>"]);
+  assertEquals(info.args, ["prompt"]);
   assertEquals(info.optionKeys, ["--repo-dir", "--force"]);
   assertEquals(info.globalOptions, []);
 });
@@ -125,4 +130,64 @@ Deno.test("isTelemetryDisabled returns true when flag present", () => {
 Deno.test("isTelemetryDisabled returns false when flag absent", () => {
   assertEquals(isTelemetryDisabled(["model", "search"]), false);
   assertEquals(isTelemetryDisabled(["--json", "model", "search"]), false);
+});
+
+Deno.test("extractCommandInfo records categorical args for model method", () => {
+  const info = extractCommandInfo([
+    "model",
+    "method",
+    "run",
+    "my-model",
+    "train",
+  ]);
+
+  assertEquals(info.command, "model");
+  assertEquals(info.subcommand, "method");
+  assertEquals(info.args, ["run", "<REDACTED>", "train"]);
+});
+
+Deno.test("extractCommandInfo redacts all args for commands without schema", () => {
+  const info = extractCommandInfo(["model", "get", "my-model"]);
+
+  assertEquals(info.command, "model");
+  assertEquals(info.subcommand, "get");
+  assertEquals(info.args, ["<REDACTED>"]);
+});
+
+Deno.test("extractCommandInfo redacts all args for unknown commands", () => {
+  const info = extractCommandInfo(["foo", "bar", "baz"]);
+
+  assertEquals(info.command, "foo");
+  assertEquals(info.subcommand, "bar");
+  assertEquals(info.args, ["<REDACTED>"]);
+});
+
+Deno.test("extractCommandInfo redacts args beyond schema length", () => {
+  const info = extractCommandInfo([
+    "model",
+    "create",
+    "prompt",
+    "my-model",
+    "extra",
+  ]);
+
+  assertEquals(info.command, "model");
+  assertEquals(info.subcommand, "create");
+  assertEquals(info.args, ["prompt", "<REDACTED>", "<REDACTED>"]);
+});
+
+Deno.test("extractCommandInfo records categorical arg for type describe", () => {
+  const info = extractCommandInfo(["type", "describe", "prompt"]);
+
+  assertEquals(info.command, "type");
+  assertEquals(info.subcommand, "describe");
+  assertEquals(info.args, ["prompt"]);
+});
+
+Deno.test("extractCommandInfo records categorical arg for vault create", () => {
+  const info = extractCommandInfo(["vault", "create", "aws", "my-vault"]);
+
+  assertEquals(info.command, "vault");
+  assertEquals(info.subcommand, "create");
+  assertEquals(info.args, ["aws", "<REDACTED>"]);
 });

--- a/src/domain/telemetry/command_invocation.ts
+++ b/src/domain/telemetry/command_invocation.ts
@@ -7,7 +7,7 @@ export interface CommandInvocation {
   readonly command: string;
   /** The subcommand (e.g., "create", "run") */
   readonly subcommand?: string;
-  /** Redacted positional arguments - shows count but not values */
+  /** Positional arguments - categorical values recorded, user-identifiable values redacted */
   readonly args: string[];
   /** Command-specific option keys (e.g., ["--repo-dir", "--json"]) */
   readonly optionKeys: string[];


### PR DESCRIPTION
## Summary

- Record system-defined categorical values (model types, method names, vault types, sub-subcommand names) in telemetry while keeping user-identifiable values (names, paths, queries) redacted
- Add `ARG_SCHEMAS` map classifying positional arg positions as `"categorical"` or `"redact"` for 6 commands, with safe fallback to redact for unknown commands or positions beyond schema length
- Update 2 existing tests and add 6 new tests covering selective recording, all-redact commands, unknown commands, and extra args

## Test Plan

- All 1517 tests pass (`deno run test`)
- `deno check`, `deno lint`, `deno fmt` all clean
- New tests cover: `model create`, `model method`, `model get`, `type describe`, `vault create`, unknown commands, and extra args beyond schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)