### PR TITLE
fix: Stop pre-creating outputs/ and type/ directories in model index

### DIFF
--- a/integration/repo_index_test.ts
+++ b/integration/repo_index_test.ts
@@ -764,17 +764,5 @@ Deno.test("Integration: repo index rebuild indexes definitions with type/ direct
       true,
       "Second definition.yaml symlink should exist",
     );
-
-    // Verify type/ directory exists for tag-based organization
-    assertEquals(
-      existsSync(join(dir1, "type")),
-      true,
-      "type/ directory should exist for tag-based data",
-    );
-    assertEquals(
-      existsSync(join(dir2, "type")),
-      true,
-      "type/ directory should exist for tag-based data",
-    );
   });
 });

--- a/src/infrastructure/repo/symlink_repo_index_service.ts
+++ b/src/infrastructure/repo/symlink_repo_index_service.ts
@@ -362,11 +362,11 @@ export class SymlinkRepoIndexService implements RepoIndexService {
    * Creates the following structure:
    * /models/{model-name}/
    *   definition.yaml → /.swamp/definitions/{type}/{id}.yaml
-   *   type/
+   *   type/            (only when tag-based data exists)
    *     logs/     → symlinks to data with type=log tag
    *     files/    → symlinks to data with type=file tag
    *     resources/→ symlinks to data with type=resource tag
-   *   outputs/
+   *   outputs/         (only when method output directories exist)
    *     {method}/ → /.swamp/outputs/{type}/{method}/
    */
   private async indexModel(
@@ -395,25 +395,23 @@ export class SymlinkRepoIndexService implements RepoIndexService {
       );
     }
 
-    // Create type/ subdirectory for tag-based data organization
-    const typeDir = join(modelDir, "type");
-    await ensureDir(typeDir);
-
     // Index tag-based data if unified data repository is available
+    // type/ directory is created on-demand by ensureDir in indexTagBasedData
     if (this.unifiedDataRepo) {
+      const typeDir = join(modelDir, "type");
       await this.indexTagBasedData(type, modelInputId, typeDir);
     }
 
     // Create outputs directory and symlink method directories
-    const outputsDir = join(modelDir, "outputs");
-    await ensureDir(outputsDir);
-
+    // outputs/ directory is only created when method output directories exist
     const methodsDir = swampPath(
       this.repoDir,
       SWAMP_SUBDIRS.outputs,
       type.normalized,
     );
     if (await this.exists(methodsDir)) {
+      const outputsDir = join(modelDir, "outputs");
+      await ensureDir(outputsDir);
       await this.indexOutputMethods(methodsDir, outputsDir);
     }
   }


### PR DESCRIPTION
## Summary

- Stop eagerly creating empty `type/` and `outputs/` directories when indexing models
- `type/` is now created on-demand by `ensureDir` in `indexTagBasedData` when there's actual tag-based data to symlink
- `outputs/` is now only created when method output directories exist to symlink

## Test Plan

- All 1517 tests pass (`deno run test`)
- Removed integration test assertions for empty `type/` directory existence (definitions with no data no longer create it)
- `deno check`, `deno lint`, `deno fmt` all pass