### PR TITLE
fix: Handle broken YAML gracefully in model/workflow edit commands

### DIFF
--- a/src/cli/commands/model_edit.ts
+++ b/src/cli/commands/model_edit.ts
@@ -1,4 +1,5 @@
 import { Command } from "@cliffy/command";
+import { join } from "@std/path";
 import { parse as parseYaml } from "@std/yaml";
 import {
   type ModelEditData,
@@ -38,6 +39,23 @@ function toModelSearchItems(
   }));
 }
 
+/**
+ * Resolves the symlink at models/{name}/definition.yaml to find the actual
+ * file path. Returns null if the symlink doesn't exist.
+ */
+export async function resolveModelSymlink(
+  repoDir: string,
+  name: string,
+): Promise<string | null> {
+  const symlinkPath = join(repoDir, "models", name, "definition.yaml");
+  try {
+    const realPath = await Deno.realPath(symlinkPath);
+    return realPath;
+  } catch {
+    return null;
+  }
+}
+
 export const modelEditCommand = new Command()
   .name("edit")
   .description("Edit a model definition file")
@@ -52,12 +70,14 @@ export const modelEditCommand = new Command()
       repoDir: options.repoDir ?? ".",
       outputMode: ctx.outputMode,
     });
+    const repoDir = options.repoDir ?? ".";
     const definitionRepo = repoContext.definitionRepo;
     const editorService = new EditorService();
 
     // Look up the model definition
-    let definition: Definition;
-    let modelType: ModelType;
+    let definition: Definition | null = null;
+    let modelType: ModelType | null = null;
+    let filePath: string | null = null;
 
     if (!modelIdOrName) {
       // No argument provided - check if interactive mode
@@ -67,7 +87,7 @@ export const modelEditCommand = new Command()
         );
       }
 
-      // Show search UI to select a model
+      // Show search UI to select a model (resilient findAllGlobal skips broken files)
       const allResults = await definitionRepo.findAllGlobal();
       const allModels = toModelSearchItems(allResults);
 
@@ -99,24 +119,42 @@ export const modelEditCommand = new Command()
       }
       definition = result.definition;
       modelType = result.type;
+      filePath = definitionRepo.getPath(modelType, definition.id);
     } else {
       ctx.logger.debug`Looking up model: ${modelIdOrName}`;
-      const result = await findDefinitionByIdOrName(
-        definitionRepo,
-        modelIdOrName,
-      );
-      if (!result) {
-        throw new UserError(`Model not found: ${modelIdOrName}`);
+      try {
+        const result = await findDefinitionByIdOrName(
+          definitionRepo,
+          modelIdOrName,
+        );
+        if (result) {
+          definition = result.definition;
+          modelType = result.type;
+          filePath = definitionRepo.getPath(modelType, definition.id);
+        }
+      } catch (error) {
+        // Lookup failed (e.g. broken YAML in the target file) — will try symlink fallback below
+        ctx.logger
+          .debug`Model lookup failed, will try symlink fallback: ${error}`;
       }
-      definition = result.definition;
-      modelType = result.type;
+
+      // If normal lookup didn't find the model, try symlink fallback
+      if (!filePath) {
+        const resolvedPath = await resolveModelSymlink(
+          repoDir,
+          modelIdOrName,
+        );
+        if (resolvedPath) {
+          ctx.logger
+            .debug`Using symlink fallback for broken model: ${resolvedPath}`;
+          filePath = resolvedPath;
+        } else {
+          throw new UserError(`Model not found: ${modelIdOrName}`);
+        }
+      }
     }
 
-    ctx.logger
-      .debug`Found model: id=${definition.id}, type=${modelType.normalized}`;
-
-    // Get the file path
-    const filePath = definitionRepo.getPath(modelType, definition.id);
+    ctx.logger.debug`Using file path: ${filePath}`;
 
     // Check for stdin content (non-interactive update mode)
     const stdinContent = await readStdin();
@@ -124,28 +162,43 @@ export const modelEditCommand = new Command()
     if (stdinContent !== null) {
       ctx.logger.debug`Reading model content from stdin`;
 
-      // Parse YAML content from stdin
-      const yamlData = parseYaml(stdinContent) as DefinitionData;
+      if (!definition || !modelType) {
+        throw new UserError(
+          "Cannot update model from stdin: the model's YAML is broken and must be fixed in an editor first",
+        );
+      }
 
-      // Preserve the original ID to ensure we update the same model
-      yamlData.id = definition.id;
+      try {
+        // Parse YAML content from stdin
+        const yamlData = parseYaml(stdinContent) as DefinitionData;
 
-      // Validate and create domain object
-      const updatedDefinition = Definition.fromData(yamlData);
+        // Preserve the original ID to ensure we update the same model
+        yamlData.id = definition.id;
 
-      // Save via repository (emits events for indexing)
-      await definitionRepo.save(modelType, updatedDefinition);
+        // Validate and create domain object
+        const updatedDefinition = Definition.fromData(yamlData);
 
-      const data: ModelEditData = {
-        path: filePath,
-        status: "updated",
-        name: updatedDefinition.name,
-        type: modelType.normalized,
-        editType: "definition",
-      };
+        // Save via repository (emits events for indexing)
+        await definitionRepo.save(modelType, updatedDefinition);
 
-      renderModelEdit(data, ctx.outputMode);
-      ctx.logger.debug("Model updated from stdin");
+        const data: ModelEditData = {
+          path: filePath,
+          status: "updated",
+          name: updatedDefinition.name,
+          type: modelType.normalized,
+          editType: "definition",
+        };
+
+        renderModelEdit(data, ctx.outputMode);
+        ctx.logger.debug("Model updated from stdin");
+      } catch (error) {
+        if (error instanceof UserError) throw error;
+        throw new UserError(
+          `Invalid model YAML from stdin: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
       return;
     }
 
@@ -158,8 +211,8 @@ export const modelEditCommand = new Command()
       path: filePath,
       editor: result.editor,
       status: "opened",
-      name: definition.name,
-      type: modelType.normalized,
+      name: definition?.name ?? modelIdOrName ?? "unknown",
+      type: modelType?.normalized ?? "unknown",
       editType: "definition",
     };
 

--- a/src/cli/commands/model_edit_test.ts
+++ b/src/cli/commands/model_edit_test.ts
@@ -1,4 +1,6 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertNotEquals } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 
 // Import models barrel to trigger self-registration
@@ -25,4 +27,41 @@ Deno.test("modelEditCommand is registered as subcommand of modelCommand", async 
   const commands = modelCommand.getCommands();
   const editCmd = commands.find((c) => c.getName() === "edit");
   assertEquals(editCmd !== undefined, true);
+});
+
+Deno.test("resolveModelSymlink resolves existing symlink", async () => {
+  const { resolveModelSymlink } = await import("./model_edit.ts");
+  const tempDir = await Deno.makeTempDir();
+  try {
+    // Resolve the temp dir to its real path (macOS /var -> /private/var)
+    const realTempDir = await Deno.realPath(tempDir);
+
+    // Create a target file
+    const targetDir = join(realTempDir, ".swamp", "definitions", "test");
+    await ensureDir(targetDir);
+    const targetFile = join(targetDir, "abc123.yaml");
+    await Deno.writeTextFile(targetFile, "name: test-model\n");
+
+    // Create the symlink structure
+    const modelDir = join(realTempDir, "models", "my-model");
+    await ensureDir(modelDir);
+    await Deno.symlink(targetFile, join(modelDir, "definition.yaml"));
+
+    const result = await resolveModelSymlink(realTempDir, "my-model");
+    assertNotEquals(result, null);
+    assertEquals(result, targetFile);
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("resolveModelSymlink returns null for nonexistent symlink", async () => {
+  const { resolveModelSymlink } = await import("./model_edit.ts");
+  const tempDir = await Deno.makeTempDir();
+  try {
+    const result = await resolveModelSymlink(tempDir, "nonexistent-model");
+    assertEquals(result, null);
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
 });

--- a/src/cli/commands/workflow_edit.ts
+++ b/src/cli/commands/workflow_edit.ts
@@ -1,4 +1,5 @@
 import { Command } from "@cliffy/command";
+import { join } from "@std/path";
 import { parse as parseYaml } from "@std/yaml";
 import {
   renderWorkflowEdit,
@@ -51,6 +52,23 @@ function toSearchItem(workflow: Workflow): WorkflowSearchItem {
   };
 }
 
+/**
+ * Resolves the symlink at workflows/{name}/workflow.yaml to find the actual
+ * file path. Returns null if the symlink doesn't exist.
+ */
+export async function resolveWorkflowSymlink(
+  repoDir: string,
+  name: string,
+): Promise<string | null> {
+  const symlinkPath = join(repoDir, "workflows", name, "workflow.yaml");
+  try {
+    const realPath = await Deno.realPath(symlinkPath);
+    return realPath;
+  } catch {
+    return null;
+  }
+}
+
 export const workflowEditCommand = new Command()
   .name("edit")
   .description("Edit a workflow file")
@@ -65,11 +83,13 @@ export const workflowEditCommand = new Command()
       repoDir: options.repoDir ?? ".",
       outputMode: ctx.outputMode,
     });
+    const repoDir = options.repoDir ?? ".";
     const repo = repoContext.workflowRepo;
     const editorService = new EditorService();
 
     // Look up the workflow
     let workflow: Workflow | null = null;
+    let filePath: string | null = null;
 
     if (!workflowIdOrName) {
       // No argument provided - check if interactive mode
@@ -79,7 +99,7 @@ export const workflowEditCommand = new Command()
         );
       }
 
-      // Show search UI to select a workflow
+      // Show search UI to select a workflow (resilient findAll skips broken files)
       const allWorkflows = await repo.findAll();
 
       if (allWorkflows.length === 0) {
@@ -107,25 +127,51 @@ export const workflowEditCommand = new Command()
       if (!workflow) {
         throw new UserError(`Workflow not found: ${selected.id}`);
       }
+      filePath = repo.getPath(workflow.id);
     } else if (isUuid(workflowIdOrName)) {
       ctx.logger.debug`Looking up by ID: ${workflowIdOrName}`;
-      const id: WorkflowId = createWorkflowId(workflowIdOrName);
-      workflow = await repo.findById(id);
-      if (!workflow) {
+      try {
+        const id: WorkflowId = createWorkflowId(workflowIdOrName);
+        workflow = await repo.findById(id);
+      } catch (error) {
+        ctx.logger
+          .debug`Workflow lookup by ID failed, will try symlink fallback: ${error}`;
+      }
+
+      if (workflow) {
+        filePath = repo.getPath(workflow.id);
+      } else {
+        // ID-based lookup doesn't have a symlink fallback (symlinks are by name)
         throw new UserError(`Workflow not found: ${workflowIdOrName}`);
       }
     } else {
       ctx.logger.debug`Looking up by name: ${workflowIdOrName}`;
-      workflow = await repo.findByName(workflowIdOrName);
-      if (!workflow) {
-        throw new UserError(`Workflow not found: ${workflowIdOrName}`);
+      try {
+        workflow = await repo.findByName(workflowIdOrName);
+      } catch (error) {
+        ctx.logger
+          .debug`Workflow lookup by name failed, will try symlink fallback: ${error}`;
+      }
+
+      if (workflow) {
+        filePath = repo.getPath(workflow.id);
+      } else {
+        // Try symlink fallback for name-based lookup
+        const resolvedPath = await resolveWorkflowSymlink(
+          repoDir,
+          workflowIdOrName,
+        );
+        if (resolvedPath) {
+          ctx.logger
+            .debug`Using symlink fallback for broken workflow: ${resolvedPath}`;
+          filePath = resolvedPath;
+        } else {
+          throw new UserError(`Workflow not found: ${workflowIdOrName}`);
+        }
       }
     }
 
-    ctx.logger.debug`Found workflow: id=${workflow.id}, name=${workflow.name}`;
-
-    // Get the file path
-    const filePath = repo.getPath(workflow.id);
+    ctx.logger.debug`Using file path: ${filePath}`;
 
     // Check for stdin content (non-interactive update mode)
     const stdinContent = await readStdin();
@@ -133,27 +179,42 @@ export const workflowEditCommand = new Command()
     if (stdinContent !== null) {
       ctx.logger.debug`Reading workflow content from stdin`;
 
-      // Parse YAML content from stdin
-      const yamlData = parseYaml(stdinContent) as WorkflowData;
+      if (!workflow) {
+        throw new UserError(
+          "Cannot update workflow from stdin: the workflow's YAML is broken and must be fixed in an editor first",
+        );
+      }
 
-      // Preserve the original ID to ensure we update the same workflow
-      yamlData.id = workflow.id;
+      try {
+        // Parse YAML content from stdin
+        const yamlData = parseYaml(stdinContent) as WorkflowData;
 
-      // Validate and create domain object
-      const updatedWorkflow = Workflow.fromData(yamlData);
+        // Preserve the original ID to ensure we update the same workflow
+        yamlData.id = workflow.id;
 
-      // Save via repository (emits events for indexing)
-      await repo.save(updatedWorkflow);
+        // Validate and create domain object
+        const updatedWorkflow = Workflow.fromData(yamlData);
 
-      const data: WorkflowEditData = {
-        path: filePath,
-        status: "updated",
-        name: updatedWorkflow.name,
-        id: updatedWorkflow.id,
-      };
+        // Save via repository (emits events for indexing)
+        await repo.save(updatedWorkflow);
 
-      renderWorkflowEdit(data, ctx.outputMode);
-      ctx.logger.debug("Workflow updated from stdin");
+        const data: WorkflowEditData = {
+          path: filePath,
+          status: "updated",
+          name: updatedWorkflow.name,
+          id: updatedWorkflow.id,
+        };
+
+        renderWorkflowEdit(data, ctx.outputMode);
+        ctx.logger.debug("Workflow updated from stdin");
+      } catch (error) {
+        if (error instanceof UserError) throw error;
+        throw new UserError(
+          `Invalid workflow YAML from stdin: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
       return;
     }
 
@@ -166,8 +227,8 @@ export const workflowEditCommand = new Command()
       path: filePath,
       editor: result.editor,
       status: "opened",
-      name: workflow.name,
-      id: workflow.id,
+      name: workflow?.name ?? workflowIdOrName ?? "unknown",
+      id: workflow?.id ?? "unknown",
     };
 
     renderWorkflowEdit(data, ctx.outputMode);

--- a/src/cli/commands/workflow_edit_test.ts
+++ b/src/cli/commands/workflow_edit_test.ts
@@ -1,4 +1,6 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertNotEquals } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 
 // Initialize logging for tests
@@ -22,4 +24,44 @@ Deno.test("workflowEditCommand is registered as subcommand of workflowCommand", 
   const commands = workflowCommand.getCommands();
   const editCmd = commands.find((c) => c.getName() === "edit");
   assertEquals(editCmd !== undefined, true);
+});
+
+Deno.test("resolveWorkflowSymlink resolves existing symlink", async () => {
+  const { resolveWorkflowSymlink } = await import("./workflow_edit.ts");
+  const tempDir = await Deno.makeTempDir();
+  try {
+    // Resolve the temp dir to its real path (macOS /var -> /private/var)
+    const realTempDir = await Deno.realPath(tempDir);
+
+    // Create a target file
+    const targetDir = join(realTempDir, ".swamp", "workflows");
+    await ensureDir(targetDir);
+    const targetFile = join(targetDir, "workflow-abc123.yaml");
+    await Deno.writeTextFile(targetFile, "name: test-workflow\n");
+
+    // Create the symlink structure
+    const workflowDir = join(realTempDir, "workflows", "my-workflow");
+    await ensureDir(workflowDir);
+    await Deno.symlink(targetFile, join(workflowDir, "workflow.yaml"));
+
+    const result = await resolveWorkflowSymlink(realTempDir, "my-workflow");
+    assertNotEquals(result, null);
+    assertEquals(result, targetFile);
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("resolveWorkflowSymlink returns null for nonexistent symlink", async () => {
+  const { resolveWorkflowSymlink } = await import("./workflow_edit.ts");
+  const tempDir = await Deno.makeTempDir();
+  try {
+    const result = await resolveWorkflowSymlink(
+      tempDir,
+      "nonexistent-workflow",
+    );
+    assertEquals(result, null);
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
 });

--- a/src/infrastructure/persistence/yaml_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository.ts
@@ -1,5 +1,6 @@
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
+import { getLogger } from "@logtape/logtape";
 import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
@@ -18,6 +19,8 @@ import {
   createDefinitionDeleted,
   createDefinitionUpdated,
 } from "../../domain/events/types.ts";
+
+const logger = getLogger(["swamp", "definition-repo"]);
 
 /**
  * YAML-based implementation of DefinitionRepository.
@@ -58,9 +61,13 @@ export class YamlDefinitionRepository implements DefinitionRepository {
       for await (const entry of Deno.readDir(dir)) {
         if (entry.isFile && entry.name.endsWith(".yaml")) {
           const path = join(dir, entry.name);
-          const content = await Deno.readTextFile(path);
-          const data = parseYaml(content) as DefinitionData;
-          definitions.push(Definition.fromData(data));
+          try {
+            const content = await Deno.readTextFile(path);
+            const data = parseYaml(content) as DefinitionData;
+            definitions.push(Definition.fromData(data));
+          } catch (parseError) {
+            logger.warn`Skipping broken definition file ${path}: ${parseError}`;
+          }
         }
       }
     } catch (error) {
@@ -99,14 +106,19 @@ export class YamlDefinitionRepository implements DefinitionRepository {
 
         if (entry.isFile && entry.name.endsWith(".yaml")) {
           // Found a YAML file, check if it matches the name
-          const content = await Deno.readTextFile(fullPath);
-          const data = parseYaml(content) as DefinitionData;
-          const definition = Definition.fromData(data);
+          try {
+            const content = await Deno.readTextFile(fullPath);
+            const data = parseYaml(content) as DefinitionData;
+            const definition = Definition.fromData(data);
 
-          if (definition.name === name) {
-            // Reconstruct the model type from the path segments
-            const typeStr = pathSegments.join("/");
-            return { definition, type: ModelType.create(typeStr) };
+            if (definition.name === name) {
+              // Reconstruct the model type from the path segments
+              const typeStr = pathSegments.join("/");
+              return { definition, type: ModelType.create(typeStr) };
+            }
+          } catch (parseError) {
+            logger
+              .warn`Skipping broken definition file ${fullPath}: ${parseError}`;
           }
         } else if (entry.isDirectory) {
           // Recursively search subdirectories
@@ -156,13 +168,18 @@ export class YamlDefinitionRepository implements DefinitionRepository {
 
         if (entry.isFile && entry.name.endsWith(".yaml")) {
           // Found a YAML file, add it to results
-          const content = await Deno.readTextFile(fullPath);
-          const data = parseYaml(content) as DefinitionData;
-          const definition = Definition.fromData(data);
+          try {
+            const content = await Deno.readTextFile(fullPath);
+            const data = parseYaml(content) as DefinitionData;
+            const definition = Definition.fromData(data);
 
-          // Reconstruct the model type from the path segments
-          const typeStr = pathSegments.join("/");
-          results.push({ definition, type: ModelType.create(typeStr) });
+            // Reconstruct the model type from the path segments
+            const typeStr = pathSegments.join("/");
+            results.push({ definition, type: ModelType.create(typeStr) });
+          } catch (parseError) {
+            logger
+              .warn`Skipping broken definition file ${fullPath}: ${parseError}`;
+          }
         } else if (entry.isDirectory) {
           // Recursively search subdirectories
           await this.collectAllDefinitions(

--- a/src/infrastructure/persistence/yaml_definition_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository_test.ts
@@ -1,0 +1,165 @@
+import { assertEquals, assertNotEquals } from "@std/assert";
+import { join } from "@std/path";
+import { stringify as stringifyYaml } from "@std/yaml";
+import { YamlDefinitionRepository } from "./yaml_definition_repository.ts";
+import { Definition } from "../../domain/definitions/definition.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
+import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const tempDir = await Deno.makeTempDir();
+  try {
+    await fn(tempDir);
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+}
+
+function createTestDefinition(name: string): Definition {
+  return Definition.create({
+    name,
+    attributes: { key: "value" },
+  });
+}
+
+const testType = ModelType.create("test/example");
+
+Deno.test("YamlDefinitionRepository.save and findById roundtrip", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const definition = createTestDefinition("test-def");
+
+    await repo.save(testType, definition);
+    const loaded = await repo.findById(testType, definition.id);
+
+    assertNotEquals(loaded, null);
+    assertEquals(loaded!.id, definition.id);
+    assertEquals(loaded!.name, definition.name);
+  });
+});
+
+Deno.test("YamlDefinitionRepository.findAll skips broken YAML files", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const goodDef = createTestDefinition("good-def");
+
+    await repo.save(testType, goodDef);
+
+    // Write a broken YAML file in the same type directory
+    const typeDir = swampPath(
+      dir,
+      SWAMP_SUBDIRS.definitions,
+      testType.toDirectoryPath(),
+    );
+    await Deno.writeTextFile(
+      join(typeDir, "broken.yaml"),
+      "this: is: not: valid: yaml: [",
+    );
+
+    const results = await repo.findAll(testType);
+
+    // Should return the good definition and skip the broken one
+    assertEquals(results.length, 1);
+    assertEquals(results[0].name, "good-def");
+  });
+});
+
+Deno.test("YamlDefinitionRepository.findAllGlobal skips broken YAML files", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const goodDef = createTestDefinition("good-def");
+
+    await repo.save(testType, goodDef);
+
+    // Write a broken YAML file in the same type directory
+    const typeDir = swampPath(
+      dir,
+      SWAMP_SUBDIRS.definitions,
+      testType.toDirectoryPath(),
+    );
+    await Deno.writeTextFile(
+      join(typeDir, "broken.yaml"),
+      "not valid yaml content {{{",
+    );
+
+    const results = await repo.findAllGlobal();
+
+    // Should return the good definition and skip the broken one
+    assertEquals(results.length, 1);
+    assertEquals(results[0].definition.name, "good-def");
+  });
+});
+
+Deno.test("YamlDefinitionRepository.findByNameGlobal skips broken YAML files", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const goodDef = createTestDefinition("good-def");
+
+    await repo.save(testType, goodDef);
+
+    // Write a broken YAML file in the same type directory
+    const typeDir = swampPath(
+      dir,
+      SWAMP_SUBDIRS.definitions,
+      testType.toDirectoryPath(),
+    );
+    await Deno.writeTextFile(
+      join(typeDir, "broken.yaml"),
+      "not valid yaml content {{{",
+    );
+
+    // Should still find the good definition despite the broken file
+    const result = await repo.findByNameGlobal("good-def");
+    assertNotEquals(result, null);
+    assertEquals(result!.definition.name, "good-def");
+  });
+});
+
+Deno.test("YamlDefinitionRepository.findAllGlobal skips schema-invalid YAML files", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const goodDef = createTestDefinition("good-def");
+
+    await repo.save(testType, goodDef);
+
+    // Write a valid YAML file that fails schema validation (missing required fields)
+    const typeDir = swampPath(
+      dir,
+      SWAMP_SUBDIRS.definitions,
+      testType.toDirectoryPath(),
+    );
+    const invalidData = { description: "no name or id field" };
+    await Deno.writeTextFile(
+      join(typeDir, "invalid-schema.yaml"),
+      stringifyYaml(invalidData),
+    );
+
+    const results = await repo.findAllGlobal();
+
+    // Should return only the good definition
+    assertEquals(results.length, 1);
+    assertEquals(results[0].definition.name, "good-def");
+  });
+});
+
+Deno.test("YamlDefinitionRepository.findAll returns empty for no definitions", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+
+    const all = await repo.findAll(testType);
+    assertEquals(all, []);
+  });
+});
+
+Deno.test("YamlDefinitionRepository.delete removes definition", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const definition = createTestDefinition("to-delete");
+
+    await repo.save(testType, definition);
+    assertEquals((await repo.findById(testType, definition.id)) !== null, true);
+
+    await repo.delete(testType, definition.id);
+    assertEquals(await repo.findById(testType, definition.id), null);
+  });
+});

--- a/src/infrastructure/persistence/yaml_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_repository.ts
@@ -1,5 +1,6 @@
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
+import { getLogger } from "@logtape/logtape";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
@@ -17,6 +18,8 @@ import {
   createWorkflowDeleted,
   createWorkflowUpdated,
 } from "../../domain/events/types.ts";
+
+const logger = getLogger(["swamp", "workflow-repo"]);
 
 /**
  * YAML-based implementation of WorkflowRepository.
@@ -60,9 +63,13 @@ export class YamlWorkflowRepository implements WorkflowRepository {
           entry.name.endsWith(".yaml")
         ) {
           const path = join(dir, entry.name);
-          const content = await Deno.readTextFile(path);
-          const data = parseYaml(content) as WorkflowData;
-          workflows.push(Workflow.fromData(data));
+          try {
+            const content = await Deno.readTextFile(path);
+            const data = parseYaml(content) as WorkflowData;
+            workflows.push(Workflow.fromData(data));
+          } catch (parseError) {
+            logger.warn`Skipping broken workflow file ${path}: ${parseError}`;
+          }
         }
       }
     } catch (error) {

--- a/src/infrastructure/persistence/yaml_workflow_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_workflow_repository_test.ts
@@ -1,10 +1,13 @@
 import { assertEquals, assertNotEquals } from "@std/assert";
+import { join } from "@std/path";
+import { stringify as stringifyYaml } from "@std/yaml";
 import { YamlWorkflowRepository } from "./yaml_workflow_repository.ts";
 import { Workflow } from "../../domain/workflows/workflow.ts";
 import { Job } from "../../domain/workflows/job.ts";
 import { Step } from "../../domain/workflows/step.ts";
 import { StepTask } from "../../domain/workflows/step_task.ts";
 import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
+import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   const tempDir = await Deno.makeTempDir();
@@ -189,5 +192,74 @@ Deno.test("YamlWorkflowRepository preserves complex workflow data", async () => 
     assertEquals(loaded!.jobs[0].weight, 5);
     assertEquals(loaded!.jobs[0].steps[0].name, "compile");
     assertEquals(loaded!.jobs[0].steps[0].weight, 10);
+  });
+});
+
+Deno.test("YamlWorkflowRepository.findAll skips broken YAML files", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlWorkflowRepository(dir);
+    const goodWorkflow = createTestWorkflow("good-workflow");
+
+    await repo.save(goodWorkflow);
+
+    // Write a broken YAML file in the workflows directory
+    const workflowsDir = swampPath(dir, SWAMP_SUBDIRS.workflows);
+    await Deno.writeTextFile(
+      join(workflowsDir, "workflow-00000000-0000-4000-8000-000000000000.yaml"),
+      "this: is: not: valid: yaml: [",
+    );
+
+    const results = await repo.findAll();
+
+    // Should return the good workflow and skip the broken one
+    assertEquals(results.length, 1);
+    assertEquals(results[0].name, "good-workflow");
+  });
+});
+
+Deno.test("YamlWorkflowRepository.findAll skips schema-invalid YAML files", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlWorkflowRepository(dir);
+    const goodWorkflow = createTestWorkflow("good-workflow");
+
+    await repo.save(goodWorkflow);
+
+    // Write a valid YAML file that fails schema validation (missing required fields)
+    const workflowsDir = swampPath(dir, SWAMP_SUBDIRS.workflows);
+    const invalidData = { description: "no name or id field" };
+    await Deno.writeTextFile(
+      join(
+        workflowsDir,
+        "workflow-00000000-0000-4000-8000-000000000001.yaml",
+      ),
+      stringifyYaml(invalidData),
+    );
+
+    const results = await repo.findAll();
+
+    // Should return only the good workflow
+    assertEquals(results.length, 1);
+    assertEquals(results[0].name, "good-workflow");
+  });
+});
+
+Deno.test("YamlWorkflowRepository.findByName skips broken YAML files", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlWorkflowRepository(dir);
+    const goodWorkflow = createTestWorkflow("good-workflow");
+
+    await repo.save(goodWorkflow);
+
+    // Write a broken YAML file in the workflows directory
+    const workflowsDir = swampPath(dir, SWAMP_SUBDIRS.workflows);
+    await Deno.writeTextFile(
+      join(workflowsDir, "workflow-00000000-0000-4000-8000-000000000000.yaml"),
+      "not valid yaml content {{{",
+    );
+
+    // Should still find the good workflow despite the broken file
+    const result = await repo.findByName("good-workflow");
+    assertNotEquals(result, null);
+    assertEquals(result!.name, "good-workflow");
   });
 });


### PR DESCRIPTION
## Summary

- Make definition and workflow repository bulk operations (`findAll`, `findAllGlobal`, `findByName`, `findByNameGlobal`) resilient to broken YAML files — broken files are logged as warnings and skipped instead of crashing the entire operation
- Add symlink-based fallback in `model edit` and `workflow edit` commands so broken models/workflows can still be opened in an editor via their logical view symlinks
- Wrap stdin YAML parse/validation errors in `UserError` for clean error messages without stack traces

Fixes #204

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] `deno run test` — 1536 tests pass, 0 failures
- [ ] Manual: create a model, corrupt its YAML, run `swamp model edit <name>` — verify editor opens
- [ ] Manual: create a workflow, corrupt its YAML, run `swamp workflow edit <name>` — verify editor opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)