### PR TITLE
chore: Add CLAUDE.local.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,5 @@ experiments/webapp/frontend/dist/
 experiments/webapp/frontend/tsconfig.tsbuildinfo
 .vault-*/
 .claude/settings.local.json
+CLAUDE.local.md
 .envrc


### PR DESCRIPTION
## Summary

- Add `CLAUDE.local.md` to `.gitignore` so user-specific Claude Code preferences don't get committed to the repo

## Test plan

- [x] Verify `CLAUDE.local.md` does not appear in `git status`