### PR TITLE
fix: Provide default dataOutputSpecs for user models

### DIFF
--- a/integration/data_output_specs_test.ts
+++ b/integration/data_output_specs_test.ts
@@ -1,10 +1,16 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
+import { dirname, join } from "@std/path";
 import { ModelType } from "../src/domain/models/model_type.ts";
 import { modelRegistry } from "../src/domain/models/model.ts";
 import { Definition } from "../src/domain/definitions/definition.ts";
 import { DefaultMethodExecutionService } from "../src/domain/models/method_execution_service.ts";
 import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
 import { FileSystemUnifiedDataRepository } from "../src/infrastructure/persistence/unified_data_repository.ts";
+import { UserModelLoader } from "../src/domain/models/user_model_loader.ts";
+import { generateDataId } from "../src/domain/data/data_id.ts";
+import { createDefinitionId } from "../src/domain/definitions/definition.ts";
+import type { UnifiedDataRepository } from "../src/infrastructure/persistence/unified_data_repository.ts";
+import type { DefinitionRepository } from "../src/domain/definitions/repositories.ts";
 // Import specific models to trigger registration (without AWS models that require env access)
 import "../src/domain/models/echo/echo_model.ts";
 import "../src/domain/models/command/curl/curl_model.ts";
@@ -350,5 +356,191 @@ Deno.test("Data output specs - validation detects duplicate instance names", asy
       errorMessage,
       "Duplicate data instance name 'duplicate'",
     );
+  });
+});
+
+// --- User model integration tests ---
+
+function createMockDataRepo(): UnifiedDataRepository {
+  return {
+    findByName: () => Promise.resolve(null),
+    findById: () => Promise.resolve(null),
+    listVersions: () => Promise.resolve([]),
+    findAllForModel: () => Promise.resolve([]),
+    save: () => Promise.resolve({ version: 1 }),
+    append: () => Promise.resolve(),
+    stream: async function* () {},
+    getContent: () => Promise.resolve(null),
+    delete: () => Promise.resolve(),
+    removeLatestSymlink: () => Promise.resolve(),
+    nextId: () => generateDataId(),
+    getPath: () => "",
+    getContentPath: () => "",
+    collectGarbage: () =>
+      Promise.resolve({ versionsRemoved: 0, bytesReclaimed: 0 }),
+  };
+}
+
+function createMockDefinitionRepo(): DefinitionRepository {
+  return {
+    findById: () => Promise.resolve(null),
+    findAll: () => Promise.resolve([]),
+    findByName: () => Promise.resolve(null),
+    findByNameGlobal: () => Promise.resolve(null),
+    findAllGlobal: () => Promise.resolve([]),
+    save: () => Promise.resolve(),
+    delete: () => Promise.resolve(),
+    nextId: () => createDefinitionId(crypto.randomUUID()),
+    getPath: () => "",
+  };
+}
+
+async function withTempModels(
+  models: Record<string, string>,
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const tempDir = await Deno.makeTempDir({ prefix: "swamp_integ_models_" });
+  try {
+    for (const [filename, content] of Object.entries(models)) {
+      const fullPath = join(tempDir, filename);
+      const dir = dirname(fullPath);
+      await Deno.mkdir(dir, { recursive: true });
+      await Deno.writeTextFile(fullPath, content);
+    }
+    await fn(tempDir);
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+}
+
+Deno.test("Data output specs - user model with data output passes validation", async () => {
+  const ts = Date.now();
+  const typeId = `test/integ-data-output-${ts}`;
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "${typeId}",
+  version: 1,
+  inputAttributesSchema: z.object({ message: z.string() }),
+  methods: {
+    process: {
+      description: "Process and return data",
+      execute: async (definition, _context) => {
+        return {
+          data: {
+            attributes: {
+              processed: true,
+              message: definition.attributes.message,
+            },
+          },
+        };
+      },
+    },
+  },
+};
+`;
+
+  await withTempModels({ "data_model.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const loadResult = await loader.loadModels(dir);
+
+    assertEquals(loadResult.loaded.length, 1);
+    assertEquals(loadResult.failed.length, 0);
+
+    const modelDef = modelRegistry.get(typeId);
+    assertEquals(modelDef !== undefined, true);
+
+    // Execute the method through the execution service (includes validation)
+    const executionService = new DefaultMethodExecutionService();
+    const definition = Definition.create({
+      name: "test-input",
+      attributes: { message: "Hello" },
+    });
+
+    const modelType = ModelType.create(typeId);
+
+    // This should NOT throw — the default "data" spec type covers the output
+    const result = await executionService.execute(
+      definition,
+      modelDef!.methods.process,
+      {
+        repoDir: "/tmp",
+        modelType,
+        modelId: definition.id,
+        dataRepository: createMockDataRepo(),
+        definitionRepository: createMockDefinitionRepo(),
+        modelDefinition: modelDef,
+      },
+    );
+
+    assertEquals(result.dataOutputs?.length, 1);
+    assertEquals(result.dataOutputs![0].specType.value, "data");
+    assertEquals(result.dataOutputs![0].name, "data");
+  });
+});
+
+Deno.test("Data output specs - user model with resource output passes validation", async () => {
+  const ts = Date.now();
+  const typeId = `test/integ-resource-output-${ts}`;
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "${typeId}",
+  version: 1,
+  inputAttributesSchema: z.object({ name: z.string() }),
+  methods: {
+    create: {
+      description: "Create a resource",
+      execute: async (definition, _context) => {
+        return {
+          resource: {
+            attributes: {
+              id: "res-123",
+              name: definition.attributes.name,
+            },
+          },
+        };
+      },
+    },
+  },
+};
+`;
+
+  await withTempModels({ "resource_model.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const loadResult = await loader.loadModels(dir);
+
+    assertEquals(loadResult.loaded.length, 1);
+
+    const modelDef = modelRegistry.get(typeId);
+    assertEquals(modelDef !== undefined, true);
+
+    const executionService = new DefaultMethodExecutionService();
+    const definition = Definition.create({
+      name: "test-resource",
+      attributes: { name: "my-resource" },
+    });
+
+    const modelType = ModelType.create(typeId);
+
+    // This should NOT throw — the default "resource" spec type covers the output
+    const result = await executionService.execute(
+      definition,
+      modelDef!.methods.create,
+      {
+        repoDir: "/tmp",
+        modelType,
+        modelId: definition.id,
+        dataRepository: createMockDataRepo(),
+        definitionRepository: createMockDefinitionRepo(),
+        modelDefinition: modelDef,
+      },
+    );
+
+    assertEquals(result.dataOutputs?.length, 1);
+    assertEquals(result.dataOutputs![0].specType.value, "resource");
+    assertEquals(result.dataOutputs![0].name, "resource");
   });
 });

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -4,6 +4,8 @@ import { ModelType } from "./model_type.ts";
 import type { Definition } from "../definitions/definition.ts";
 import {
   type DataOutput,
+  type DataOutputSpecification,
+  DataOutputSpecificationSchema,
   DataSpecType,
   type MethodContext,
   type MethodDefinition,
@@ -80,6 +82,8 @@ const UserModelSchema = z.object({
   inputAttributesSchema: z.custom<z.ZodTypeAny>((val) =>
     val instanceof z.ZodType
   ),
+  dataOutputSpecs: z.record(z.string(), DataOutputSpecificationSchema)
+    .optional(),
   methods: z.record(z.string(), UserMethodSchema),
 });
 
@@ -376,11 +380,41 @@ export class UserModelLoader {
       };
     }
 
+    const defaultSpecs: Record<string, DataOutputSpecification> = {
+      "data": {
+        specType: DataSpecType.create("data"),
+        description: "Data output",
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        tags: { type: "data" },
+      },
+      "resource": {
+        specType: DataSpecType.create("resource"),
+        description: "Resource output",
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        tags: { type: "resource" },
+      },
+    };
+
+    // User-declared specs need specType converted from string to DataSpecType
+    const userSpecs: Record<string, DataOutputSpecification> = {};
+    if (userModel.dataOutputSpecs) {
+      for (const [key, spec] of Object.entries(userModel.dataOutputSpecs)) {
+        userSpecs[key] = {
+          ...spec,
+          specType: DataSpecType.create(String(spec.specType)),
+        };
+      }
+    }
+
     return {
       type: modelType,
       version: userModel.version,
       inputAttributesSchema: userModel.inputAttributesSchema,
-      dataOutputSpecs: {},
+      dataOutputSpecs: { ...defaultSpecs, ...userSpecs },
       methods,
     };
   }

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -1124,3 +1124,112 @@ export const extension = {
     },
   );
 });
+
+// --- Default dataOutputSpecs tests ---
+
+Deno.test("UserModelLoader provides default data and resource spec types", async () => {
+  const typeId = `test/default-specs-${Date.now()}`;
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "${typeId}",
+  version: 1,
+  inputAttributesSchema: z.object({ message: z.string() }),
+  methods: {
+    run: {
+      description: "Run",
+      execute: async () => ({ dataOutputs: [] }),
+    },
+  },
+};
+`;
+
+  await withTempModels({ "default_specs.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 1);
+
+    const modelDef = modelRegistry.get(typeId);
+    assertEquals(modelDef !== undefined, true);
+
+    // Verify default "data" and "resource" spec types are present
+    assertEquals(Object.keys(modelDef!.dataOutputSpecs).length, 2);
+    assertEquals(modelDef!.dataOutputSpecs["data"] !== undefined, true);
+    assertEquals(modelDef!.dataOutputSpecs["resource"] !== undefined, true);
+    assertEquals(modelDef!.dataOutputSpecs["data"].specType.value, "data");
+    assertEquals(
+      modelDef!.dataOutputSpecs["resource"].specType.value,
+      "resource",
+    );
+    assertEquals(
+      modelDef!.dataOutputSpecs["data"].contentType,
+      "application/json",
+    );
+    assertEquals(
+      modelDef!.dataOutputSpecs["resource"].contentType,
+      "application/json",
+    );
+  });
+});
+
+Deno.test("UserModelLoader user-declared dataOutputSpecs override defaults", async () => {
+  const typeId = `test/custom-specs-${Date.now()}`;
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "${typeId}",
+  version: 1,
+  inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Custom data spec",
+      contentType: "text/plain",
+    },
+    "metrics": {
+      specType: "metrics",
+      description: "Metrics output",
+      contentType: "application/json",
+    },
+  },
+  methods: {
+    run: {
+      description: "Run",
+      execute: async () => ({ dataOutputs: [] }),
+    },
+  },
+};
+`;
+
+  await withTempModels({ "custom_specs.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 1);
+
+    const modelDef = modelRegistry.get(typeId);
+    assertEquals(modelDef !== undefined, true);
+
+    // User "data" spec overrides default, "resource" default preserved, "metrics" added
+    assertEquals(Object.keys(modelDef!.dataOutputSpecs).length, 3);
+    assertEquals(
+      modelDef!.dataOutputSpecs["data"].description,
+      "Custom data spec",
+    );
+    assertEquals(
+      modelDef!.dataOutputSpecs["data"].contentType,
+      "text/plain",
+    );
+    assertEquals(
+      modelDef!.dataOutputSpecs["resource"].specType.value,
+      "resource",
+    );
+    assertEquals(
+      modelDef!.dataOutputSpecs["metrics"].specType.value,
+      "metrics",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Fix bug where user model methods crash with "undeclared spec type" validation errors after successful execution
- `convertToModelDefinition()` hardcoded `dataOutputSpecs: {}` but `wrapUserExecute()` produces outputs with specType `"data"` and `"resource"`, causing post-execution validation to fail
- Populate default `"data"` and `"resource"` spec types that match what `wrapUserExecute()` produces
- Add optional `dataOutputSpecs` field to `UserModelSchema` so users can declare custom specs

## Test Plan

- Added 2 unit tests in `user_model_loader_test.ts`: default specs are present, user-declared specs override defaults
- Added 2 integration tests in `data_output_specs_test.ts`: user model methods returning `data` and `resource` outputs pass validation through the execution service
- All 1558 tests pass, `deno check`, `deno lint`, `deno fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)