### PR TITLE
feat: Add self-update command (#167)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ experiments/webapp/frontend/tsconfig.tsbuildinfo
 .claude/settings.local.json
 CLAUDE.local.md
 .envrc
+/scripts/dist

--- a/scripts/compile.ts
+++ b/scripts/compile.ts
@@ -12,32 +12,6 @@ interface CompileOptions {
 
 const VERSION_FILE = "src/cli/commands/version.ts";
 
-async function getCalVer(): Promise<string> {
-  const now = new Date();
-  const year = now.getUTCFullYear();
-  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
-  const day = String(now.getUTCDate()).padStart(2, "0");
-  const hours = String(now.getUTCHours()).padStart(2, "0");
-  const minutes = String(now.getUTCMinutes()).padStart(2, "0");
-  const seconds = String(now.getUTCSeconds()).padStart(2, "0");
-
-  // Get short commit hash
-  let commitHash = "0000000";
-  try {
-    const cmd = new Deno.Command("git", {
-      args: ["rev-parse", "--short=8", "HEAD"],
-      stdout: "piped",
-    });
-    const { stdout } = await cmd.output();
-    commitHash = new TextDecoder().decode(stdout).trim();
-  } catch {
-    // Ignore git errors
-  }
-
-  // Format: YYYYMMDD.HHMMSS.0-sha.COMMITSHA (matches SI convention)
-  return `${year}${month}${day}.${hours}${minutes}${seconds}.0-sha.${commitHash}`;
-}
-
 async function stampVersion(version: string): Promise<string> {
   const content = await Deno.readTextFile(VERSION_FILE);
   const original = content;
@@ -71,12 +45,17 @@ async function main() {
     version: args.version,
   };
 
-  // Determine version to use
-  const version = options.version || await getCalVer();
-  console.log(`Version: ${version}`);
-
-  // Stamp version into source file
-  const originalContent = await stampVersion(version);
+  // Only stamp version when explicitly provided (CI passes --version).
+  // Local dev builds keep the source-default VERSION (with empty sha).
+  let originalContent: string | null = null;
+  if (options.version) {
+    console.log(`Version: ${options.version}`);
+    originalContent = await stampVersion(options.version);
+  } else {
+    console.log(
+      "No --version provided; using source-default version (dev build)",
+    );
+  }
 
   try {
     const baseCommand = [
@@ -130,8 +109,10 @@ async function main() {
       Deno.exit(1);
     }
   } finally {
-    // Restore original version file
-    await Deno.writeTextFile(VERSION_FILE, originalContent);
+    // Restore original version file if we stamped it
+    if (originalContent !== null) {
+      await Deno.writeTextFile(VERSION_FILE, originalContent);
+    }
   }
 }
 

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -1,0 +1,33 @@
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { VERSION } from "./version.ts";
+import { Platform } from "../../domain/update/platform.ts";
+import { UpdateService } from "../../domain/update/update_service.ts";
+import { HttpUpdateChecker } from "../../infrastructure/update/http_update_checker.ts";
+import { renderUpdateResult } from "../../presentation/output/update_output.tsx";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const updateCommand = new Command()
+  .description("Update swamp to the latest version")
+  .option("--check", "Check for updates without installing")
+  .action(async function (options: AnyOptions) {
+    const ctx = createContext(options as GlobalOptions, "update");
+    ctx.logger.debug("Executing update command");
+
+    const platform = Platform.detect();
+    ctx.logger.debug`Detected platform: ${platform}`;
+
+    const checker = new HttpUpdateChecker();
+    const binaryPath = Deno.execPath();
+    const service = new UpdateService(checker, VERSION, binaryPath);
+
+    const result = options.check
+      ? await service.check(platform)
+      : await service.update(platform);
+
+    renderUpdateResult(result, ctx.outputMode);
+
+    ctx.logger.debug("Update command completed");
+  });

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -10,6 +10,7 @@ import { completionCommand } from "./commands/completion.ts";
 import { vaultCommand } from "./commands/vault.ts";
 import { dataCommand } from "./commands/data.ts";
 import { telemetryCommand } from "./commands/telemetry_stats.ts";
+import { updateCommand } from "./commands/update.ts";
 import type { GlobalOptions } from "./context.ts";
 import {
   ModelNameType,
@@ -166,6 +167,7 @@ export async function runCli(args: string[]): Promise<void> {
     .command("vault", vaultCommand)
     .command("data", dataCommand)
     .command("telemetry", telemetryCommand)
+    .command("update", updateCommand)
     .command("completions", completionCommand);
 
   try {

--- a/src/domain/update/platform.ts
+++ b/src/domain/update/platform.ts
@@ -1,0 +1,74 @@
+import { UserError } from "../errors.ts";
+
+const ARTIFACT_BASE_URL =
+  "https://artifacts.systeminit.com/swamp/stable/binary";
+
+const SUPPORTED_OS = new Set(["darwin", "linux"]);
+const SUPPORTED_ARCH = new Set(["aarch64", "x86_64"]);
+
+/**
+ * Value object representing a supported platform for binary artifacts.
+ */
+export class Platform {
+  readonly os: string;
+  readonly arch: string;
+
+  private constructor(os: string, arch: string) {
+    this.os = os;
+    this.arch = arch;
+  }
+
+  /**
+   * Detect the current platform from Deno.build.
+   * Throws UserError for unsupported platforms.
+   */
+  static detect(): Platform {
+    return Platform.from(Deno.build.os, Deno.build.arch);
+  }
+
+  /**
+   * Create a Platform from explicit OS and arch values.
+   * Throws UserError for unsupported combinations.
+   */
+  static from(os: string, arch: string): Platform {
+    if (!SUPPORTED_OS.has(os)) {
+      throw new UserError(
+        `Unsupported operating system: ${os}. Supported: ${
+          [...SUPPORTED_OS].join(", ")
+        }`,
+      );
+    }
+    if (!SUPPORTED_ARCH.has(arch)) {
+      throw new UserError(
+        `Unsupported architecture: ${arch}. Supported: ${
+          [...SUPPORTED_ARCH].join(", ")
+        }`,
+      );
+    }
+    return new Platform(os, arch);
+  }
+
+  /**
+   * Returns the tarball filename for the stable binary.
+   * e.g. "swamp-stable-binary-darwin-aarch64.tar.gz"
+   */
+  get tarballName(): string {
+    return `swamp-stable-binary-${this.os}-${this.arch}.tar.gz`;
+  }
+
+  /**
+   * Returns the full URL for the stable binary tarball.
+   * e.g. "https://artifacts.systeminit.com/swamp/stable/binary/darwin/aarch64/swamp-stable-binary-darwin-aarch64.tar.gz"
+   */
+  stableUrl(): string {
+    return `${ARTIFACT_BASE_URL}/${this.os}/${this.arch}/${this.tarballName}`;
+  }
+
+  equals(other: Platform): boolean {
+    return this.os === other.os && this.arch === other.arch;
+  }
+
+  toString(): string {
+    return `${this.os}/${this.arch}`;
+  }
+}

--- a/src/domain/update/platform_test.ts
+++ b/src/domain/update/platform_test.ts
@@ -1,0 +1,93 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { Platform } from "./platform.ts";
+import { UserError } from "../errors.ts";
+
+Deno.test("Platform.from creates darwin aarch64 platform", () => {
+  const platform = Platform.from("darwin", "aarch64");
+  assertEquals(platform.os, "darwin");
+  assertEquals(platform.arch, "aarch64");
+});
+
+Deno.test("Platform.from creates linux x86_64 platform", () => {
+  const platform = Platform.from("linux", "x86_64");
+  assertEquals(platform.os, "linux");
+  assertEquals(platform.arch, "x86_64");
+});
+
+Deno.test("Platform.from throws UserError for unsupported OS", () => {
+  assertThrows(
+    () => Platform.from("windows", "x86_64"),
+    UserError,
+    "Unsupported operating system: windows",
+  );
+});
+
+Deno.test("Platform.from throws UserError for unsupported arch", () => {
+  assertThrows(
+    () => Platform.from("darwin", "arm"),
+    UserError,
+    "Unsupported architecture: arm",
+  );
+});
+
+Deno.test("tarballName returns correct value for darwin aarch64", () => {
+  const platform = Platform.from("darwin", "aarch64");
+  assertEquals(
+    platform.tarballName,
+    "swamp-stable-binary-darwin-aarch64.tar.gz",
+  );
+});
+
+Deno.test("tarballName returns correct value for linux x86_64", () => {
+  const platform = Platform.from("linux", "x86_64");
+  assertEquals(platform.tarballName, "swamp-stable-binary-linux-x86_64.tar.gz");
+});
+
+Deno.test("stableUrl returns correct artifact URL for darwin aarch64", () => {
+  const platform = Platform.from("darwin", "aarch64");
+  assertEquals(
+    platform.stableUrl(),
+    "https://artifacts.systeminit.com/swamp/stable/binary/darwin/aarch64/swamp-stable-binary-darwin-aarch64.tar.gz",
+  );
+});
+
+Deno.test("stableUrl returns correct artifact URL for darwin x86_64", () => {
+  const platform = Platform.from("darwin", "x86_64");
+  assertEquals(
+    platform.stableUrl(),
+    "https://artifacts.systeminit.com/swamp/stable/binary/darwin/x86_64/swamp-stable-binary-darwin-x86_64.tar.gz",
+  );
+});
+
+Deno.test("stableUrl returns correct artifact URL for linux x86_64", () => {
+  const platform = Platform.from("linux", "x86_64");
+  assertEquals(
+    platform.stableUrl(),
+    "https://artifacts.systeminit.com/swamp/stable/binary/linux/x86_64/swamp-stable-binary-linux-x86_64.tar.gz",
+  );
+});
+
+Deno.test("stableUrl returns correct artifact URL for linux aarch64", () => {
+  const platform = Platform.from("linux", "aarch64");
+  assertEquals(
+    platform.stableUrl(),
+    "https://artifacts.systeminit.com/swamp/stable/binary/linux/aarch64/swamp-stable-binary-linux-aarch64.tar.gz",
+  );
+});
+
+Deno.test("equals returns true for same platform", () => {
+  const a = Platform.from("darwin", "aarch64");
+  const b = Platform.from("darwin", "aarch64");
+  assertEquals(a.equals(b), true);
+});
+
+Deno.test("equals returns false for different platforms", () => {
+  const a = Platform.from("darwin", "aarch64");
+  const b = Platform.from("linux", "x86_64");
+  assertEquals(a.equals(b), false);
+});
+
+Deno.test("toString returns os/arch", () => {
+  const platform = Platform.from("darwin", "aarch64");
+  assertEquals(platform.toString(), "darwin/aarch64");
+});

--- a/src/domain/update/update_service.ts
+++ b/src/domain/update/update_service.ts
@@ -1,0 +1,148 @@
+import type { Platform } from "./platform.ts";
+
+/**
+ * Port for checking and performing updates.
+ * Implemented by infrastructure adapters (e.g. HttpUpdateChecker).
+ */
+export interface UpdateChecker {
+  /**
+   * Check the latest available version by inspecting the stable URL redirect.
+   * Returns the redirect URL containing the version, or null if no redirect.
+   */
+  checkForUpdate(platform: Platform): Promise<string | null>;
+
+  /**
+   * Download and install a binary from the given URL to the target path.
+   */
+  downloadAndInstall(url: string, binaryPath: string): Promise<void>;
+}
+
+/**
+ * Discriminated union for update results.
+ */
+export type UpdateResult =
+  | { status: "up_to_date"; currentVersion: string; warning?: string }
+  | {
+    status: "update_available";
+    currentVersion: string;
+    latestVersion: string;
+    warning?: string;
+  }
+  | {
+    status: "updated";
+    previousVersion: string;
+    newVersion: string;
+    warning?: string;
+  };
+
+/**
+ * Returns true when the version is a development build.
+ * Dev builds have an empty sha (e.g. "20260206.200442.0-sha.") or lack the "-sha." segment entirely.
+ */
+export function isDevBuild(version: string): boolean {
+  const shaIndex = version.indexOf("-sha.");
+  if (shaIndex === -1) {
+    return true;
+  }
+  const shaValue = version.substring(shaIndex + 5);
+  return shaValue.length === 0;
+}
+
+/**
+ * Extract a CalVer version string from a redirect URL.
+ * Expected URL pattern: .../swamp/{version}/binary/...
+ * Returns null if the pattern doesn't match.
+ */
+export function parseVersionFromRedirectUrl(url: string): string | null {
+  const match = url.match(/\/swamp\/([^/]+)\/binary\//);
+  return match ? match[1] : null;
+}
+
+/**
+ * Domain service for self-update operations.
+ */
+export class UpdateService {
+  private readonly checker: UpdateChecker;
+  private readonly currentVersion: string;
+  private readonly binaryPath: string;
+
+  constructor(
+    checker: UpdateChecker,
+    currentVersion: string,
+    binaryPath: string,
+  ) {
+    this.checker = checker;
+    this.currentVersion = currentVersion;
+    this.binaryPath = binaryPath;
+  }
+
+  private devBuildWarning(): string | undefined {
+    if (isDevBuild(this.currentVersion)) {
+      return "Replacing a development build with a release build. Run `deno run compile` to restore a dev build.";
+    }
+    return undefined;
+  }
+
+  /**
+   * Check whether an update is available without installing.
+   */
+  async check(platform: Platform): Promise<UpdateResult> {
+    const redirectUrl = await this.checker.checkForUpdate(platform);
+    if (!redirectUrl) {
+      return {
+        status: "up_to_date",
+        currentVersion: this.currentVersion,
+        warning: this.devBuildWarning(),
+      };
+    }
+
+    const latestVersion = parseVersionFromRedirectUrl(redirectUrl);
+    if (!latestVersion || latestVersion === this.currentVersion) {
+      return {
+        status: "up_to_date",
+        currentVersion: this.currentVersion,
+        warning: this.devBuildWarning(),
+      };
+    }
+
+    return {
+      status: "update_available",
+      currentVersion: this.currentVersion,
+      latestVersion,
+      warning: this.devBuildWarning(),
+    };
+  }
+
+  /**
+   * Check for and install an update.
+   * Downloads from the resolved versioned URL, not the stable redirect pointer.
+   */
+  async update(platform: Platform): Promise<UpdateResult> {
+    const redirectUrl = await this.checker.checkForUpdate(platform);
+    if (!redirectUrl) {
+      return {
+        status: "up_to_date",
+        currentVersion: this.currentVersion,
+        warning: this.devBuildWarning(),
+      };
+    }
+
+    const latestVersion = parseVersionFromRedirectUrl(redirectUrl);
+    if (!latestVersion || latestVersion === this.currentVersion) {
+      return {
+        status: "up_to_date",
+        currentVersion: this.currentVersion,
+        warning: this.devBuildWarning(),
+      };
+    }
+
+    await this.checker.downloadAndInstall(redirectUrl, this.binaryPath);
+
+    return {
+      status: "updated",
+      previousVersion: this.currentVersion,
+      newVersion: latestVersion,
+      warning: this.devBuildWarning(),
+    };
+  }
+}

--- a/src/domain/update/update_service_test.ts
+++ b/src/domain/update/update_service_test.ts
@@ -1,0 +1,186 @@
+import { assertEquals } from "@std/assert";
+import {
+  isDevBuild,
+  parseVersionFromRedirectUrl,
+  type UpdateChecker,
+  UpdateService,
+} from "./update_service.ts";
+import { Platform } from "./platform.ts";
+
+interface MockCheckerCalls {
+  downloadUrls: string[];
+}
+
+function createMockChecker(
+  redirectUrl: string | null = null,
+  calls?: MockCheckerCalls,
+): UpdateChecker {
+  return {
+    checkForUpdate: (_platform: Platform) => Promise.resolve(redirectUrl),
+    downloadAndInstall: (url: string, _binaryPath: string) => {
+      calls?.downloadUrls.push(url);
+      return Promise.resolve();
+    },
+  };
+}
+
+const platform = Platform.from("darwin", "aarch64");
+
+// --- isDevBuild tests ---
+
+Deno.test("isDevBuild returns true for empty sha", () => {
+  assertEquals(isDevBuild("20260206.200442.0-sha."), true);
+});
+
+Deno.test("isDevBuild returns true for version without -sha. segment", () => {
+  assertEquals(isDevBuild("20260206.200442.0"), true);
+});
+
+Deno.test("isDevBuild returns false for version with full sha", () => {
+  assertEquals(isDevBuild("20260207.123456.0-sha.abc12345"), false);
+});
+
+Deno.test("isDevBuild returns false for version with short sha", () => {
+  assertEquals(isDevBuild("20260207.123456.0-sha.abcd"), false);
+});
+
+// --- parseVersionFromRedirectUrl tests ---
+
+Deno.test("parseVersionFromRedirectUrl extracts version from redirect URL", () => {
+  const url =
+    "https://artifacts.systeminit.com/swamp/20260207.123456.0-sha.abc12345/binary/darwin/aarch64/swamp-stable-binary-darwin-aarch64.tar.gz";
+  assertEquals(
+    parseVersionFromRedirectUrl(url),
+    "20260207.123456.0-sha.abc12345",
+  );
+});
+
+Deno.test("parseVersionFromRedirectUrl returns null for non-matching URL", () => {
+  assertEquals(parseVersionFromRedirectUrl("https://example.com/foo"), null);
+});
+
+Deno.test("parseVersionFromRedirectUrl handles URL with dev sha", () => {
+  const url =
+    "https://artifacts.systeminit.com/swamp/20260206.200442.0-sha./binary/darwin/aarch64/swamp-stable-binary-darwin-aarch64.tar.gz";
+  assertEquals(parseVersionFromRedirectUrl(url), "20260206.200442.0-sha.");
+});
+
+// --- UpdateService.check tests ---
+
+Deno.test("check returns up_to_date when no redirect", async () => {
+  const service = new UpdateService(
+    createMockChecker(null),
+    "20260207.123456.0-sha.abc12345",
+    "/usr/local/bin/swamp",
+  );
+
+  const result = await service.check(platform);
+  assertEquals(result.status, "up_to_date");
+  if (result.status === "up_to_date") {
+    assertEquals(result.currentVersion, "20260207.123456.0-sha.abc12345");
+  }
+});
+
+Deno.test("check returns up_to_date when versions match", async () => {
+  const redirectUrl =
+    "https://artifacts.systeminit.com/swamp/20260207.123456.0-sha.abc12345/binary/darwin/aarch64/swamp-stable-binary-darwin-aarch64.tar.gz";
+  const service = new UpdateService(
+    createMockChecker(redirectUrl),
+    "20260207.123456.0-sha.abc12345",
+    "/usr/local/bin/swamp",
+  );
+
+  const result = await service.check(platform);
+  assertEquals(result.status, "up_to_date");
+});
+
+Deno.test("check returns update_available when versions differ", async () => {
+  const redirectUrl =
+    "https://artifacts.systeminit.com/swamp/20260208.000000.0-sha.def56789/binary/darwin/aarch64/swamp-stable-binary-darwin-aarch64.tar.gz";
+  const service = new UpdateService(
+    createMockChecker(redirectUrl),
+    "20260207.123456.0-sha.abc12345",
+    "/usr/local/bin/swamp",
+  );
+
+  const result = await service.check(platform);
+  assertEquals(result.status, "update_available");
+  if (result.status === "update_available") {
+    assertEquals(result.currentVersion, "20260207.123456.0-sha.abc12345");
+    assertEquals(result.latestVersion, "20260208.000000.0-sha.def56789");
+  }
+});
+
+Deno.test("check includes warning for dev build", async () => {
+  const service = new UpdateService(
+    createMockChecker(null),
+    "20260206.200442.0-sha.",
+    "/usr/local/bin/swamp",
+  );
+
+  const result = await service.check(platform);
+  assertEquals(result.status, "up_to_date");
+  assertEquals(typeof result.warning, "string");
+  assertEquals(result.warning?.includes("development build"), true);
+});
+
+Deno.test("check has no warning for release build", async () => {
+  const service = new UpdateService(
+    createMockChecker(null),
+    "20260207.123456.0-sha.abc12345",
+    "/usr/local/bin/swamp",
+  );
+
+  const result = await service.check(platform);
+  assertEquals(result.warning, undefined);
+});
+
+// --- UpdateService.update tests ---
+
+Deno.test("update returns up_to_date when already current", async () => {
+  const redirectUrl =
+    "https://artifacts.systeminit.com/swamp/20260207.123456.0-sha.abc12345/binary/darwin/aarch64/swamp-stable-binary-darwin-aarch64.tar.gz";
+  const service = new UpdateService(
+    createMockChecker(redirectUrl),
+    "20260207.123456.0-sha.abc12345",
+    "/usr/local/bin/swamp",
+  );
+
+  const result = await service.update(platform);
+  assertEquals(result.status, "up_to_date");
+});
+
+Deno.test("update returns updated when new version available", async () => {
+  const redirectUrl =
+    "https://artifacts.systeminit.com/swamp/20260208.000000.0-sha.def56789/binary/darwin/aarch64/swamp-stable-binary-darwin-aarch64.tar.gz";
+  const calls: MockCheckerCalls = { downloadUrls: [] };
+  const service = new UpdateService(
+    createMockChecker(redirectUrl, calls),
+    "20260207.123456.0-sha.abc12345",
+    "/usr/local/bin/swamp",
+  );
+
+  const result = await service.update(platform);
+  assertEquals(result.status, "updated");
+  if (result.status === "updated") {
+    assertEquals(result.previousVersion, "20260207.123456.0-sha.abc12345");
+    assertEquals(result.newVersion, "20260208.000000.0-sha.def56789");
+  }
+  // Verify download used the resolved versioned URL, not the stable URL
+  assertEquals(calls.downloadUrls, [redirectUrl]);
+});
+
+Deno.test("update includes warning for dev build", async () => {
+  const redirectUrl =
+    "https://artifacts.systeminit.com/swamp/20260208.000000.0-sha.def56789/binary/darwin/aarch64/swamp-stable-binary-darwin-aarch64.tar.gz";
+  const service = new UpdateService(
+    createMockChecker(redirectUrl),
+    "20260206.200442.0-sha.",
+    "/usr/local/bin/swamp",
+  );
+
+  const result = await service.update(platform);
+  assertEquals(result.status, "updated");
+  assertEquals(typeof result.warning, "string");
+  assertEquals(result.warning?.includes("development build"), true);
+});

--- a/src/infrastructure/update/http_update_checker.ts
+++ b/src/infrastructure/update/http_update_checker.ts
@@ -1,0 +1,141 @@
+import type { Platform } from "../../domain/update/platform.ts";
+import type { UpdateChecker } from "../../domain/update/update_service.ts";
+import { UserError } from "../../domain/errors.ts";
+
+/**
+ * Remove macOS quarantine extended attribute (best-effort).
+ * Files downloaded via fetch() get tagged with com.apple.quarantine,
+ * and Gatekeeper will SIGKILL unsigned binaries that have it.
+ */
+async function removeQuarantine(path: string): Promise<void> {
+  try {
+    const cmd = new Deno.Command("xattr", {
+      args: ["-d", "com.apple.quarantine", path],
+      stdout: "null",
+      stderr: "null",
+    });
+    await cmd.output();
+  } catch {
+    // Best-effort, ignore failures
+  }
+}
+
+/**
+ * HTTP adapter implementing UpdateChecker.
+ * Checks artifacts.systeminit.com for the latest swamp binary.
+ */
+export class HttpUpdateChecker implements UpdateChecker {
+  /**
+   * Issue a HEAD request to the stable URL with manual redirect handling.
+   * The redirect location header contains the versioned URL.
+   * Returns the redirect URL, or null if no redirect (already at latest).
+   */
+  async checkForUpdate(platform: Platform): Promise<string | null> {
+    const url = platform.stableUrl();
+    const response = await fetch(url, {
+      method: "HEAD",
+      redirect: "manual",
+    });
+
+    // Check for redirect via Location header or S3 metadata
+    const redirectLocation = response.headers.get("location") ||
+      response.headers.get("x-amz-website-redirect-location") ||
+      response.headers.get("x-amz-meta-x-amz-website-redirect-location");
+
+    if (redirectLocation) {
+      return redirectLocation;
+    }
+
+    // 200 means we're at the actual file (stable URL IS the latest)
+    if (response.ok) {
+      return url;
+    }
+
+    if (response.status === 404) {
+      throw new UserError(
+        `No binary available for ${platform}. This platform may not be supported yet.`,
+      );
+    }
+
+    throw new UserError(
+      `Failed to check for updates: HTTP ${response.status}`,
+    );
+  }
+
+  /**
+   * Download the tarball and install the binary.
+   */
+  async downloadAndInstall(url: string, binaryPath: string): Promise<void> {
+    const tempDir = await Deno.makeTempDir({ prefix: "swamp-update-" });
+
+    try {
+      const tarballPath = `${tempDir}/swamp.tar.gz`;
+
+      // Download the tarball
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new UserError(
+          `Failed to download update: HTTP ${response.status}`,
+        );
+      }
+      if (!response.body) {
+        throw new UserError("Failed to download update: empty response body");
+      }
+
+      const file = await Deno.open(tarballPath, {
+        write: true,
+        create: true,
+      });
+      try {
+        await response.body.pipeTo(file.writable);
+      } catch {
+        // writable stream may already be closed by pipeTo, that's fine
+      }
+
+      // Extract the tarball
+      const extract = new Deno.Command("tar", {
+        args: ["-xzf", tarballPath, "-C", tempDir],
+        stdout: "piped",
+        stderr: "piped",
+      });
+      const extractResult = await extract.output();
+      if (!extractResult.success) {
+        const stderr = new TextDecoder().decode(extractResult.stderr);
+        throw new UserError(`Failed to extract update: ${stderr}`);
+      }
+
+      // Find the extracted binary
+      const extractedBinary = `${tempDir}/swamp`;
+      try {
+        await Deno.stat(extractedBinary);
+      } catch {
+        throw new UserError(
+          "Failed to find swamp binary in downloaded archive",
+        );
+      }
+
+      // macOS: remove quarantine attribute from extracted binary before copying.
+      // When fetch() writes to disk, macOS tags the file with com.apple.quarantine.
+      // tar preserves this on extraction, and Gatekeeper will SIGKILL the binary.
+      if (Deno.build.os === "darwin") {
+        await removeQuarantine(extractedBinary);
+      }
+
+      // Replace the current binary
+      await Deno.copyFile(extractedBinary, binaryPath);
+      await Deno.chmod(binaryPath, 0o755);
+
+      // Also clear quarantine on the final path (in case copyFile propagates it)
+      if (Deno.build.os === "darwin") {
+        await removeQuarantine(binaryPath);
+      }
+    } finally {
+      // Cleanup temp directory
+      try {
+        await Deno.remove(tempDir, { recursive: true });
+      } catch {
+        // Best-effort cleanup
+      }
+    }
+  }
+}

--- a/src/infrastructure/update/http_update_checker_test.ts
+++ b/src/infrastructure/update/http_update_checker_test.ts
@@ -1,0 +1,61 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { Platform } from "../../domain/update/platform.ts";
+
+Deno.test("stable URL is constructed correctly for darwin aarch64", () => {
+  const platform = Platform.from("darwin", "aarch64");
+  assertEquals(
+    platform.stableUrl(),
+    "https://artifacts.systeminit.com/swamp/stable/binary/darwin/aarch64/swamp-stable-binary-darwin-aarch64.tar.gz",
+  );
+});
+
+Deno.test("stable URL is constructed correctly for linux x86_64", () => {
+  const platform = Platform.from("linux", "x86_64");
+  assertEquals(
+    platform.stableUrl(),
+    "https://artifacts.systeminit.com/swamp/stable/binary/linux/x86_64/swamp-stable-binary-linux-x86_64.tar.gz",
+  );
+});
+
+Deno.test("stable URL contains expected components", () => {
+  const platform = Platform.from("darwin", "x86_64");
+  const url = platform.stableUrl();
+  assertStringIncludes(url, "artifacts.systeminit.com");
+  assertStringIncludes(url, "swamp/stable/binary");
+  assertStringIncludes(url, "darwin/x86_64");
+  assertStringIncludes(url, "swamp-stable-binary-darwin-x86_64.tar.gz");
+});
+
+Deno.test("version extraction from redirect URL works with parseVersionFromRedirectUrl", async () => {
+  const { parseVersionFromRedirectUrl } = await import(
+    "../../domain/update/update_service.ts"
+  );
+
+  // Simulate a redirect URL that the artifact server would return
+  const redirectUrl =
+    "https://artifacts.systeminit.com/swamp/20260207.123456.0-sha.abc12345/binary/darwin/aarch64/swamp-stable-binary-darwin-aarch64.tar.gz";
+  const version = parseVersionFromRedirectUrl(redirectUrl);
+  assertEquals(version, "20260207.123456.0-sha.abc12345");
+});
+
+Deno.test("version extraction handles various CalVer formats", async () => {
+  const { parseVersionFromRedirectUrl } = await import(
+    "../../domain/update/update_service.ts"
+  );
+
+  // Standard release version
+  assertEquals(
+    parseVersionFromRedirectUrl(
+      "https://artifacts.systeminit.com/swamp/20260101.000000.0-sha.12345678/binary/linux/x86_64/swamp-stable-binary-linux-x86_64.tar.gz",
+    ),
+    "20260101.000000.0-sha.12345678",
+  );
+
+  // Dev version with empty sha
+  assertEquals(
+    parseVersionFromRedirectUrl(
+      "https://artifacts.systeminit.com/swamp/20260206.200442.0-sha./binary/darwin/aarch64/swamp-stable-binary-darwin-aarch64.tar.gz",
+    ),
+    "20260206.200442.0-sha.",
+  );
+});

--- a/src/presentation/output/update_output.tsx
+++ b/src/presentation/output/update_output.tsx
@@ -1,0 +1,75 @@
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { Box, Text } from "ink";
+import { render } from "ink-testing-library";
+import type { OutputMode } from "./output.tsx";
+import type { UpdateResult } from "../../domain/update/update_service.ts";
+
+/**
+ * Renders the update result in the appropriate output mode.
+ */
+export function renderUpdateResult(
+  result: UpdateResult,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    const { lastFrame } = render(<UpdateDisplay result={result} />);
+    console.log(lastFrame());
+  }
+}
+
+export interface UpdateDisplayProps {
+  result: UpdateResult;
+}
+
+export function UpdateDisplay(
+  { result }: UpdateDisplayProps,
+): React.ReactElement {
+  return (
+    <Box flexDirection="column">
+      <StatusMessage result={result} />
+      {result.warning && (
+        <Box marginTop={1}>
+          <Text color="yellow">{result.warning}</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+function StatusMessage(
+  { result }: { result: UpdateResult },
+): React.ReactElement {
+  switch (result.status) {
+    case "up_to_date":
+      return (
+        <Text color="green">
+          swamp is up to date ({result.currentVersion})
+        </Text>
+      );
+    case "update_available":
+      return (
+        <Box flexDirection="column">
+          <Text color="yellow">
+            Update available: {result.currentVersion} → {result.latestVersion}
+          </Text>
+          <Text>
+            Run `swamp update` to install
+          </Text>
+        </Box>
+      );
+    case "updated":
+      return (
+        <Box flexDirection="column">
+          <Text bold color="green">
+            swamp updated successfully!
+          </Text>
+          <Text>
+            {result.previousVersion} → {result.newVersion}
+          </Text>
+        </Box>
+      );
+  }
+}

--- a/src/presentation/output/update_output_test.tsx
+++ b/src/presentation/output/update_output_test.tsx
@@ -1,0 +1,199 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { renderUpdateResult } from "./update_output.tsx";
+import type { UpdateResult } from "../../domain/update/update_service.ts";
+
+const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
+
+// --- JSON output tests ---
+
+Deno.test("renderUpdateResult json mode: up_to_date", () => {
+  const result: UpdateResult = {
+    status: "up_to_date",
+    currentVersion: "20260207.123456.0-sha.abc12345",
+  };
+
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderUpdateResult(result, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.status, "up_to_date");
+    assertEquals(parsed.currentVersion, "20260207.123456.0-sha.abc12345");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderUpdateResult json mode: update_available", () => {
+  const result: UpdateResult = {
+    status: "update_available",
+    currentVersion: "20260207.123456.0-sha.abc12345",
+    latestVersion: "20260208.000000.0-sha.def56789",
+  };
+
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderUpdateResult(result, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.status, "update_available");
+    assertEquals(parsed.latestVersion, "20260208.000000.0-sha.def56789");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderUpdateResult json mode: updated", () => {
+  const result: UpdateResult = {
+    status: "updated",
+    previousVersion: "20260207.123456.0-sha.abc12345",
+    newVersion: "20260208.000000.0-sha.def56789",
+  };
+
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderUpdateResult(result, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.status, "updated");
+    assertEquals(parsed.previousVersion, "20260207.123456.0-sha.abc12345");
+    assertEquals(parsed.newVersion, "20260208.000000.0-sha.def56789");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderUpdateResult json mode: includes warning when present", () => {
+  const result: UpdateResult = {
+    status: "up_to_date",
+    currentVersion: "20260206.200442.0-sha.",
+    warning: "Replacing a development build with a release build.",
+  };
+
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderUpdateResult(result, "json");
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(
+      parsed.warning,
+      "Replacing a development build with a release build.",
+    );
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+// --- Interactive output tests ---
+
+Deno.test({
+  name: "renderUpdateResult interactive: up_to_date shows green message",
+  ...inkTestOptions,
+  fn: () => {
+    const result: UpdateResult = {
+      status: "up_to_date",
+      currentVersion: "20260207.123456.0-sha.abc12345",
+    };
+
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      renderUpdateResult(result, "interactive");
+      assertEquals(logs.length, 1);
+      assertStringIncludes(logs[0], "up to date");
+      assertStringIncludes(logs[0], "20260207.123456.0-sha.abc12345");
+    } finally {
+      console.log = originalLog;
+    }
+  },
+});
+
+Deno.test({
+  name: "renderUpdateResult interactive: update_available shows versions",
+  ...inkTestOptions,
+  fn: () => {
+    const result: UpdateResult = {
+      status: "update_available",
+      currentVersion: "20260207.123456.0-sha.abc12345",
+      latestVersion: "20260208.000000.0-sha.def56789",
+    };
+
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      renderUpdateResult(result, "interactive");
+      assertEquals(logs.length, 1);
+      assertStringIncludes(logs[0], "Update available");
+      assertStringIncludes(logs[0], "20260207.123456.0-sha.abc12345");
+      assertStringIncludes(logs[0], "20260208.000000.0-sha.def56789");
+      assertStringIncludes(logs[0], "swamp update");
+    } finally {
+      console.log = originalLog;
+    }
+  },
+});
+
+Deno.test({
+  name: "renderUpdateResult interactive: updated shows success",
+  ...inkTestOptions,
+  fn: () => {
+    const result: UpdateResult = {
+      status: "updated",
+      previousVersion: "20260207.123456.0-sha.abc12345",
+      newVersion: "20260208.000000.0-sha.def56789",
+    };
+
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      renderUpdateResult(result, "interactive");
+      assertEquals(logs.length, 1);
+      assertStringIncludes(logs[0], "updated successfully");
+      assertStringIncludes(logs[0], "20260207.123456.0-sha.abc12345");
+      assertStringIncludes(logs[0], "20260208.000000.0-sha.def56789");
+    } finally {
+      console.log = originalLog;
+    }
+  },
+});
+
+Deno.test({
+  name: "renderUpdateResult interactive: warning is displayed",
+  ...inkTestOptions,
+  fn: () => {
+    const result: UpdateResult = {
+      status: "up_to_date",
+      currentVersion: "20260206.200442.0-sha.",
+      warning: "Replacing a development build with a release build.",
+    };
+
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+
+    try {
+      renderUpdateResult(result, "interactive");
+      assertEquals(logs.length, 1);
+      assertStringIncludes(logs[0], "development build");
+    } finally {
+      console.log = originalLog;
+    }
+  },
+});


### PR DESCRIPTION
- Add `swamp update` command that self-updates the compiled binary from
`artifacts.systeminit.com`
- Add `--check` flag for check-only mode (reports available version without installing)
- Fix compile script so local dev builds keep the source-default VERSION (empty sha),
distinguishing them from CI release builds
- Dev builds show a yellow warning when updating but are not blocked

## Plan Deviations

The implementation followed the plan with three notable deviations discovered during
testing against the production artifact server:

1. **URL format**: The plan assumed target-triple URLs
(`aarch64-apple-darwin/swamp.tar.gz`). Production uses
`{os}/{arch}/swamp-stable-binary-{os}-{arch}.tar.gz`. Fixed `Platform` to use OS/arch
path segments directly instead of target triples.

2. **Download URL**: The plan had `update()` downloading from the stable URL. The stable
URL is an S3 redirect pointer (returns metadata, not the tarball). Fixed to download from
the resolved versioned URL returned by `checkForUpdate()`.

3. **Removed `verifyInstallation`**: The plan called for spawning the new binary with
`version --json` to verify. On macOS, Gatekeeper SIGKILL'd the downloaded binary due to
`com.apple.quarantine`. Fixed by stripping quarantine from the extracted binary *before*
copying, and removed the verification step since the version is already known from the
redirect URL.

## Files Created (9)

| File | Purpose |
|---|---|
| `src/domain/update/platform.ts` | Platform value object (OS/arch to artifact URL) |
| `src/domain/update/platform_test.ts` | 13 tests |
| `src/domain/update/update_service.ts` | Domain service, UpdateChecker port,
UpdateResult types |
| `src/domain/update/update_service_test.ts` | 13 tests |
| `src/infrastructure/update/http_update_checker.ts` | HTTP adapter (HEAD redirect check,
download, extract, quarantine strip) |
| `src/infrastructure/update/http_update_checker_test.ts` | 5 tests |
| `src/presentation/output/update_output.tsx` | Ink component + JSON rendering for all
result states |
| `src/presentation/output/update_output_test.tsx` | 8 tests |
| `src/cli/commands/update.ts` | CLI command with `--check` flag |

## Files Modified (3)

| File | Change |
|---|---|
| `scripts/compile.ts` | Removed `getCalVer()`; only stamp version when `--version` is
passed |
| `src/cli/mod.ts` | Import and register `updateCommand` |
| `.gitignore` | (pre-existing change on branch) |

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] `deno run test` — 1599 tests pass, 0 failures
- [x] Manual: `./swamp update --check` shows available version + dev build warning
- [x] Manual: `./swamp update` downloads, installs, and reports version transition
- [x] Manual: `swamp version` confirms new version after update

🤖 Generated with [Claude Code](https://claude.com/claude-code)