### PR TITLE
fix: Unwrap single-artifact data in context builder

### DIFF
--- a/integration/cel_data_access_test.ts
+++ b/integration/cel_data_access_test.ts
@@ -218,16 +218,19 @@ Deno.test("CEL Data Access: access latest data via model.X.data.Y", async () => 
     });
     const context = await modelResolver.buildContext();
 
-    // Access latest data
+    // Access latest data (single artifact unwrapped)
     const modelData = context.model["data_source"];
     assertExists(modelData);
     assertExists(modelData.data);
-    assertExists(modelData.data["resource_state"]);
+    const dataRecord = modelData.data as {
+      version: number;
+      attributes: Record<string, unknown>;
+    };
 
     // Latest version should be 3
-    assertEquals(modelData.data["resource_state"].version, 3);
-    assertEquals(modelData.data["resource_state"].attributes.version, 3);
-    assertEquals(modelData.data["resource_state"].attributes.id, "id-3");
+    assertEquals(dataRecord.version, 3);
+    assertEquals(dataRecord.attributes.version, 3);
+    assertEquals(dataRecord.attributes.id, "id-3");
   });
 });
 
@@ -435,9 +438,9 @@ Deno.test("CEL Data Access: reference data from dependent model", async () => {
     const subnetModel = Definition.create({
       name: "my_subnet",
       attributes: {
-        // Reference VPC resource data
-        vpc_id_ref: "${{ model.my_vpc.data.resource.attributes.vpcId }}",
-        vpc_state_ref: "${{ model.my_vpc.data.resource.attributes.state }}",
+        // Reference VPC resource data (single artifact: data is unwrapped)
+        vpc_id_ref: "${{ model.my_vpc.data.attributes.vpcId }}",
+        vpc_state_ref: "${{ model.my_vpc.data.attributes.state }}",
       },
     });
     await definitionRepo.save(type, subnetModel);
@@ -515,10 +518,10 @@ Deno.test("CEL Data Access: chain data references across multiple models", async
     const modelC = Definition.create({
       name: "model_c",
       attributes: {
-        from_a: "${{ model.model_a.data.result.attributes.computed }}",
-        from_b: "${{ model.model_b.data.result.attributes.computed }}",
+        from_a: "${{ model.model_a.data.attributes.computed }}",
+        from_b: "${{ model.model_b.data.attributes.computed }}",
         sum:
-          "${{ model.model_a.data.result.attributes.computed + model.model_b.data.result.attributes.computed }}",
+          "${{ model.model_a.data.attributes.computed + model.model_b.data.attributes.computed }}",
       },
     });
     await definitionRepo.save(type, modelC);
@@ -765,9 +768,13 @@ Deno.test("CEL Data Access: multiple data items from same model", async () => {
     assertExists(modelData);
     assertExists(modelData.data);
 
+    const dataMap = modelData.data as Record<
+      string,
+      { attributes: Record<string, unknown> }
+    >;
     for (const name of dataItems) {
-      assertExists(modelData.data[name]);
-      assertEquals(modelData.data[name].attributes.name, name);
+      assertExists(dataMap[name]);
+      assertEquals(dataMap[name].attributes.name, name);
     }
   });
 });

--- a/integration/data_expression_test.ts
+++ b/integration/data_expression_test.ts
@@ -102,18 +102,21 @@ Deno.test("Integration: model.X.data.Y accesses latest version of data", async (
     });
     const context = await modelResolver.buildContext();
 
-    // Verify model.my-vpc.data.vpc-info exists and has latest version
+    // Verify model.my-vpc.data exists and has latest version (single artifact unwrapped)
     const modelData = context.model["my-vpc"];
     assertExists(modelData);
     assertExists(modelData.data);
-    assertExists(modelData.data["vpc-info"]);
-    assertEquals(modelData.data["vpc-info"].version, 2);
-    assertEquals(modelData.data["vpc-info"].attributes.vpcId, "vpc-222");
+    const dataRecord = modelData.data as {
+      version: number;
+      attributes: Record<string, unknown>;
+    };
+    assertEquals(dataRecord.version, 2);
+    assertEquals(dataRecord.attributes.vpcId, "vpc-222");
 
-    // Evaluate CEL expression
+    // Evaluate CEL expression (single artifact: data is unwrapped)
     const celEvaluator = new CelEvaluator();
     const result = celEvaluator.evaluate(
-      'model["my-vpc"].data["vpc-info"].attributes.vpcId',
+      'model["my-vpc"].data.attributes.vpcId',
       context,
     );
     assertEquals(result, "vpc-222");
@@ -533,13 +536,17 @@ Deno.test("Integration: model can have multiple named data items", async () => {
     });
     const context = await modelResolver.buildContext();
 
-    // All data items should be accessible
+    // All data items should be accessible (multi-artifact: data is a map)
     const modelData = context.model["my-command"];
     assertExists(modelData);
     assertExists(modelData.data);
-    assertExists(modelData.data["stdout"]);
-    assertExists(modelData.data["stderr"]);
-    assertExists(modelData.data["exit-code"]);
+    const dataMap = modelData.data as Record<
+      string,
+      { attributes: Record<string, unknown>; tags: Record<string, string> }
+    >;
+    assertExists(dataMap["stdout"]);
+    assertExists(dataMap["stderr"]);
+    assertExists(dataMap["exit-code"]);
 
     // Also via data functions
     assertExists(context.data);

--- a/integration/data_tagging_test.ts
+++ b/integration/data_tagging_test.ts
@@ -529,10 +529,12 @@ Deno.test("Data Tagging: access tags via model.X.data.Y.tags", async () => {
     const modelData = context.model["my-vpc"];
     assertExists(modelData);
     assertExists(modelData.data);
-    assertExists(modelData.data["vpc-state"]);
-    assertEquals(modelData.data["vpc-state"].tags.type, "resource");
-    assertEquals(modelData.data["vpc-state"].tags.provider, "aws");
-    assertEquals(modelData.data["vpc-state"].tags.region, "us-west-2");
+    const dataRecord = modelData.data as {
+      tags: Record<string, string>;
+    };
+    assertEquals(dataRecord.tags.type, "resource");
+    assertEquals(dataRecord.tags.provider, "aws");
+    assertEquals(dataRecord.tags.region, "us-west-2");
   });
 });
 
@@ -609,19 +611,23 @@ Deno.test("Data Tagging: multiple data items with different tags", async () => {
     });
     const context = await modelResolver.buildContext();
 
-    // Access all data from model
+    // Access all data from model (multi-artifact: data is a map)
     const modelData = context.model["multi-output-model"];
     assertExists(modelData);
     assertExists(modelData.data);
-    assertExists(modelData.data["stdout"]);
-    assertExists(modelData.data["stderr"]);
-    assertExists(modelData.data["exit-code"]);
-    assertExists(modelData.data["timing"]);
+    const dataMap = modelData.data as Record<
+      string,
+      { tags: Record<string, string> }
+    >;
+    assertExists(dataMap["stdout"]);
+    assertExists(dataMap["stderr"]);
+    assertExists(dataMap["exit-code"]);
+    assertExists(dataMap["timing"]);
 
     // Verify tags
-    assertEquals(modelData.data["stdout"].tags.stream, "stdout");
-    assertEquals(modelData.data["stderr"].tags.stream, "stderr");
-    assertEquals(modelData.data["timing"].tags.category, "performance");
+    assertEquals(dataMap["stdout"].tags.stream, "stdout");
+    assertEquals(dataMap["stderr"].tags.stream, "stderr");
+    assertEquals(dataMap["timing"].tags.category, "performance");
 
     // Query by tags
     assertExists(context.data);

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -52,8 +52,8 @@ export interface ModelData {
     createdAt: string;
     attributes: Record<string, unknown>;
   };
-  /** Map of data-name -> latest DataRecord for this model */
-  data?: Record<string, DataRecord>;
+  /** Latest DataRecord (single artifact) or map of data-name -> DataRecord (multiple) */
+  data?: Record<string, DataRecord> | DataRecord;
   file?: {
     id: string;
     version: number;
@@ -436,13 +436,16 @@ export class ModelResolver {
         if (modelData) {
           const dataNames = dataCache.getDataNames(modelName);
           if (dataNames.length > 0) {
-            modelData.data = {};
+            const dataMap: Record<string, DataRecord> = {};
             for (const dataName of dataNames) {
               const latestRecord = dataCache.getLatest(modelName, dataName);
               if (latestRecord) {
-                modelData.data[dataName] = latestRecord;
+                dataMap[dataName] = latestRecord;
               }
             }
+            const entries = Object.values(dataMap);
+            // Unwrap single artifact for direct DataRecord access
+            modelData.data = entries.length === 1 ? entries[0] : dataMap;
           }
         }
       }

--- a/src/domain/models/validation_service.ts
+++ b/src/domain/models/validation_service.ts
@@ -431,18 +431,23 @@ export class DefaultModelValidationService implements ModelValidationService {
       return null;
     }
 
-    // For data artifacts, validation is less strict
-    // as they may have dynamic attributes or fixed properties
+    // For data artifacts, .data resolves directly to a DataRecord.
+    // path[0] must be a valid DataRecord property.
+    // Segments after "attributes" or "tags" are user-defined.
     if (ref.type === "data") {
-      // data artifacts have .attributes like the old resource
-      if (
-        firstSegment !== "attributes" && firstSegment !== "id" &&
-        firstSegment !== "version" && firstSegment !== "createdAt"
-      ) {
+      const validDataFields = [
+        "id",
+        "name",
+        "version",
+        "createdAt",
+        "attributes",
+        "tags",
+      ];
+      if (!validDataFields.includes(firstSegment)) {
         return {
           expression: ref.rawExpression,
           error: `Invalid path segment "${firstSegment}" for data artifact`,
-          suggestion: "Data artifacts have: id, version, createdAt, attributes",
+          suggestion: `Data artifacts have: ${validDataFields.join(", ")}`,
         };
       }
       return null;

--- a/src/domain/models/validation_service_test.ts
+++ b/src/domain/models/validation_service_test.ts
@@ -462,7 +462,7 @@ Deno.test("validateModel detects simple identifier expression", async () => {
 
 // Data path reference tests
 
-Deno.test("validateModel with data path passes for valid path", async () => {
+Deno.test("validateModel with data path passes for valid DataRecord field", async () => {
   const service = new DefaultModelValidationService();
   const targetDefinition = Definition.create({
     name: "target-model",
@@ -515,7 +515,7 @@ Deno.test("validateModel fails for missing .attributes segment", async () => {
   assertStringIncludes(exprResult?.error ?? "", "message");
 });
 
-Deno.test("validateModel fails for 'attribute' instead of 'attributes'", async () => {
+Deno.test("validateModel fails for 'attribute' instead of 'attributes' in direct DataRecord access", async () => {
   const service = new DefaultModelValidationService();
   const targetDefinition = Definition.create({
     name: "target-model",
@@ -539,6 +539,79 @@ Deno.test("validateModel fails for 'attribute' instead of 'attributes'", async (
   const exprResult = results.find((r) => r.name === "Expression paths");
   assertEquals(exprResult?.passed, false);
   assertStringIncludes(exprResult?.error ?? "", "attribute");
+});
+
+Deno.test("validateModel with data path passes for nested attributes in direct DataRecord access", async () => {
+  const service = new DefaultModelValidationService();
+  const targetDefinition = Definition.create({
+    name: "target-model",
+    attributes: { message: "hello" },
+  });
+  const definition = Definition.create({
+    name: "test-definition",
+    attributes: {
+      vpcId: "${{ model.target-model.data.attributes.vpcId }}",
+    },
+  });
+
+  const mockRepo = createMockDefinitionRepo([
+    { name: "target-model", type: "swamp/echo", definition: targetDefinition },
+    { name: "test-definition", type: "swamp/echo", definition },
+  ]);
+
+  const results = await service.validateModel(definition, echoModel, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, true);
+});
+
+Deno.test("validateModel with data path passes for scalar DataRecord field", async () => {
+  const service = new DefaultModelValidationService();
+  const targetDefinition = Definition.create({
+    name: "target-model",
+    attributes: { message: "hello" },
+  });
+  const definition = Definition.create({
+    name: "test-definition",
+    attributes: {
+      allData: "${{ model.target-model.data.id }}",
+    },
+  });
+
+  const mockRepo = createMockDefinitionRepo([
+    { name: "target-model", type: "swamp/echo", definition: targetDefinition },
+    { name: "test-definition", type: "swamp/echo", definition },
+  ]);
+
+  const results = await service.validateModel(definition, echoModel, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, true);
+});
+
+Deno.test("validateModel fails for invalid field in direct DataRecord access", async () => {
+  const service = new DefaultModelValidationService();
+  const targetDefinition = Definition.create({
+    name: "target-model",
+    attributes: { message: "hello" },
+  });
+  const definition = Definition.create({
+    name: "test-definition",
+    attributes: {
+      bad: "${{ model.target-model.data.badfield }}",
+    },
+  });
+
+  const mockRepo = createMockDefinitionRepo([
+    { name: "target-model", type: "swamp/echo", definition: targetDefinition },
+    { name: "test-definition", type: "swamp/echo", definition },
+  ]);
+
+  const results = await service.validateModel(definition, echoModel, mockRepo);
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, false);
+  assertStringIncludes(exprResult?.error ?? "", "badfield");
 });
 
 // Mixed expression tests

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -28,6 +28,7 @@ import {
 } from "../expressions/expression_parser.ts";
 import { extractResourceDependencies } from "../expressions/dependency_extractor.ts";
 import {
+  type DataRecord,
   type ExpressionContext,
   ModelResolver,
 } from "../expressions/model_resolver.ts";
@@ -934,13 +935,10 @@ export class WorkflowExecutionService {
               attributes: taskOutput.resourceAttributes,
             };
           }
-          // Update data context if available (now uses Record<string, DataRecord>)
+          // Update data context if available
           if (taskOutput.dataId && taskOutput.dataAttributes) {
             const dataName = taskOutput.dataName ?? "output";
-            if (!modelData.data) {
-              modelData.data = {};
-            }
-            modelData.data[dataName] = {
+            const record: DataRecord = {
               id: taskOutput.dataId,
               name: dataName,
               version: 1,
@@ -948,6 +946,26 @@ export class WorkflowExecutionService {
               attributes: taskOutput.dataAttributes,
               tags: {},
             };
+
+            // Rebuild map from existing data (may be unwrapped or map)
+            let dataMap: Record<string, DataRecord> = {};
+            if (modelData.data) {
+              if (
+                "id" in modelData.data &&
+                typeof modelData.data.id === "string"
+              ) {
+                // Already unwrapped — re-wrap
+                const existing = modelData.data as DataRecord;
+                dataMap[existing.name] = existing;
+              } else {
+                dataMap = modelData.data as Record<string, DataRecord>;
+              }
+            }
+            dataMap[dataName] = record;
+
+            // Unwrap single artifact
+            const entries = Object.values(dataMap);
+            modelData.data = entries.length === 1 ? entries[0] : dataMap;
           }
         }
       }

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -956,23 +956,14 @@ Deno.test("updates data context between workflow steps", async () => {
     // Verify step2 saw the data context updated from step1
     const step2Context = executor.capturedContexts.get("step2");
     const authModelData = step2Context?.["auth-model"] as {
-      data?: Record<
-        string,
-        { id: string; name: string; attributes: Record<string, unknown> }
-      >;
+      data?: { id: string; name: string; attributes: Record<string, unknown> };
     };
 
     // The data should be available in the context when step2 runs
-    // Data is now a map of data-name -> DataRecord, with default name "output"
-    assertEquals(authModelData?.data?.["output"]?.id, "auth-data-123");
-    assertEquals(
-      authModelData?.data?.["output"]?.attributes?.token,
-      "secret-token",
-    );
-    assertEquals(
-      authModelData?.data?.["output"]?.attributes?.expiresAt,
-      "2024-01-01",
-    );
+    // Single artifact is unwrapped directly as a DataRecord
+    assertEquals(authModelData?.data?.id, "auth-data-123");
+    assertEquals(authModelData?.data?.attributes?.token, "secret-token");
+    assertEquals(authModelData?.data?.attributes?.expiresAt, "2024-01-01");
   });
 });
 
@@ -1037,20 +1028,17 @@ Deno.test("updates both resource and data context when step produces both", asyn
     const step2Context = executor.capturedContexts.get("step2");
     const syncModelData = step2Context?.["sync-model"] as {
       resource?: { id: string; attributes: Record<string, unknown> };
-      data?: Record<
-        string,
-        { id: string; name: string; attributes: Record<string, unknown> }
-      >;
+      data?: { id: string; name: string; attributes: Record<string, unknown> };
     };
 
     // Resource should be in context
     assertEquals(syncModelData?.resource?.id, "resource-123");
     assertEquals(syncModelData?.resource?.attributes?.status, "synced");
 
-    // Data should also be in context (now a map with default name "output")
-    assertEquals(syncModelData?.data?.["output"]?.id, "data-456");
+    // Data should also be in context (single artifact unwrapped as DataRecord)
+    assertEquals(syncModelData?.data?.id, "data-456");
     assertEquals(
-      syncModelData?.data?.["output"]?.attributes?.lastSyncTime,
+      syncModelData?.data?.attributes?.lastSyncTime,
       "2024-01-01T00:00:00Z",
     );
   });

--- a/src/infrastructure/cel/cel_evaluator_test.ts
+++ b/src/infrastructure/cel/cel_evaluator_test.ts
@@ -372,33 +372,31 @@ Deno.test("CelEvaluator handles model.foo.data.bar.attributes.x pattern", () => 
           attributes: {},
         },
         data: {
-          "vpc-info": {
-            id: "data-123",
-            name: "vpc-info",
-            version: 2,
-            createdAt: "2024-01-01T00:00:00Z",
-            attributes: {
-              vpcId: "vpc-abc123",
-              cidrBlock: "10.0.0.0/16",
-            },
-            tags: { type: "resource" },
+          id: "data-123",
+          name: "vpc-info",
+          version: 2,
+          createdAt: "2024-01-01T00:00:00Z",
+          attributes: {
+            vpcId: "vpc-abc123",
+            cidrBlock: "10.0.0.0/16",
           },
+          tags: { type: "resource" },
         },
       },
     },
   };
 
-  // Access data by name using bracket notation (required for hyphenated names)
+  // Access data directly (single artifact is unwrapped)
   assertEquals(
     evaluator.evaluate(
-      'model["my-vpc"].data["vpc-info"].attributes.vpcId',
+      'model["my-vpc"].data.attributes.vpcId',
       context,
     ),
     "vpc-abc123",
   );
   assertEquals(
     evaluator.evaluate(
-      'model["my-vpc"].data["vpc-info"].version',
+      'model["my-vpc"].data.version',
       context,
     ),
     2,


### PR DESCRIPTION
## Summary

- When a model has exactly one data artifact, `model.X.data` now resolves
  directly to the `DataRecord` instead of wrapping it in a
  `{artifactName: DataRecord}` map. This fixes CEL expressions like
  `model.X.data.attributes.vpcId` that previously couldn't find
  `.attributes` on the outer map object.
- Multi-artifact models continue to use the map form for backward
  compatibility.
- Updated `ModelData.data` type to a union
  (`Record<string, DataRecord> | DataRecord`) and updated context building
  in both `model_resolver.ts` and `execution_service.ts`.

## Test Plan

- All 1602 existing tests pass with 0 failures
- Updated single-artifact tests to verify unwrapped `DataRecord` access
- Multi-artifact tests verified unchanged (still use map access)
- `deno check`, `deno lint`, `deno fmt` all pass
- `deno run compile` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)