### PR TITLE
CI: Trigger UAT run on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,3 +118,11 @@ jobs:
             dist/checksums.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger UAT
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.UAT_TRIGGER_TOKEN }}
+          repository: systeminit/swamp-uat
+          event-type: run-uat
+          client-payload: '{"version": "${{ steps.version.outputs.version }}"}'


### PR DESCRIPTION
When we release a new swamp binary, we want to trigger a UAT test run so we can decide if we promote that artifact to be stable or not