### PR TITLE
refactor: Remove redundant ref from TriggerCondition simple variants

### DIFF
--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -105,7 +105,6 @@ jobs:
       - job: build
         condition:
           type: succeeded
-          ref: build
     steps:
       - name: upload
         description: Upload artifacts

--- a/.claude/skills/swamp-workflow/references/data-chaining.md
+++ b/.claude/skills/swamp-workflow/references/data-chaining.md
@@ -92,7 +92,6 @@ jobs:
       - job: lookup
         condition:
           type: succeeded
-          ref: lookup
     steps:
       - name: create-security-group
         task:

--- a/integration/keeb_shell_model_test.ts
+++ b/integration/keeb_shell_model_test.ts
@@ -205,7 +205,7 @@ Deno.test("CLI: workflow with keeb/shell models and dependencies", async () => {
           dependsOn: [
             {
               job: "download",
-              condition: TriggerCondition.succeeded("download"),
+              condition: TriggerCondition.succeeded(),
             },
           ],
         }),
@@ -287,7 +287,7 @@ Deno.test("CLI: keeb/shell model with cross-model expressions", async () => {
               dependsOn: [
                 {
                   step: "run-source",
-                  condition: TriggerCondition.succeeded("run-source"),
+                  condition: TriggerCondition.succeeded(),
                 },
               ],
             }),

--- a/integration/workflow_new_architecture_test.ts
+++ b/integration/workflow_new_architecture_test.ts
@@ -303,7 +303,7 @@ Deno.test("Workflow Architecture: multiple steps create multiple Data artifacts"
               dependsOn: [
                 {
                   step: "step-one",
-                  condition: TriggerCondition.succeeded("step-one"),
+                  condition: TriggerCondition.succeeded(),
                 },
               ],
             }),
@@ -706,7 +706,7 @@ Deno.test("Workflow Architecture: dependent step skipped on failure", async () =
               dependsOn: [
                 {
                   step: "failing-step",
-                  condition: TriggerCondition.succeeded("failing-step"),
+                  condition: TriggerCondition.succeeded(),
                 },
               ],
             }),
@@ -868,7 +868,7 @@ Deno.test("Workflow Architecture: multi-job workflow with dependencies", async (
             }),
           ],
           dependsOn: [
-            { job: "build", condition: TriggerCondition.succeeded("build") },
+            { job: "build", condition: TriggerCondition.succeeded() },
           ],
         }),
         Job.create({
@@ -880,7 +880,7 @@ Deno.test("Workflow Architecture: multi-job workflow with dependencies", async (
             }),
           ],
           dependsOn: [
-            { job: "test", condition: TriggerCondition.succeeded("test") },
+            { job: "test", condition: TriggerCondition.succeeded() },
           ],
         }),
       ],
@@ -947,7 +947,7 @@ Deno.test("Workflow Architecture: mixed shell and model steps", async () => {
               dependsOn: [
                 {
                   step: "shell-step",
-                  condition: TriggerCondition.succeeded("shell-step"),
+                  condition: TriggerCondition.succeeded(),
                 },
               ],
             }),
@@ -957,7 +957,7 @@ Deno.test("Workflow Architecture: mixed shell and model steps", async () => {
               dependsOn: [
                 {
                   step: "model-step",
-                  condition: TriggerCondition.succeeded("model-step"),
+                  condition: TriggerCondition.succeeded(),
                 },
               ],
             }),

--- a/integration/workflow_test.ts
+++ b/integration/workflow_test.ts
@@ -96,7 +96,7 @@ function createTestWorkflow(name: string): Workflow {
           }),
         ],
         dependsOn: [
-          { job: "build", condition: TriggerCondition.succeeded("build") },
+          { job: "build", condition: TriggerCondition.succeeded() },
         ],
       }),
     ],
@@ -648,7 +648,7 @@ Deno.test("CLI: workflow run skips job when condition not met", async () => {
             }),
           ],
           dependsOn: [
-            { job: "build", condition: TriggerCondition.succeeded("build") },
+            { job: "build", condition: TriggerCondition.succeeded() },
           ],
         }),
       ],
@@ -868,7 +868,7 @@ Deno.test("CLI: workflow run succeeds with valid model expressions", async () =>
               dependsOn: [
                 {
                   step: "write-source",
-                  condition: TriggerCondition.succeeded("write-source"),
+                  condition: TriggerCondition.succeeded(),
                 },
               ],
             }),

--- a/src/domain/models/mermaid/workflow_diagram/workflow_diagram_model.ts
+++ b/src/domain/models/mermaid/workflow_diagram/workflow_diagram_model.ts
@@ -23,7 +23,6 @@ export const WorkflowExecutionSchema = z.object({
       job: z.string(),
       condition: z.object({
         type: z.string(),
-        jobName: z.string(),
       }),
     })).optional(),
     steps: z.array(z.object({
@@ -39,7 +38,6 @@ export const WorkflowExecutionSchema = z.object({
         step: z.string(),
         condition: z.object({
           type: z.string(),
-          stepName: z.string(),
         }),
       })).optional(),
     })),

--- a/src/domain/models/mermaid/workflow_diagram/workflow_diagram_model_test.ts
+++ b/src/domain/models/mermaid/workflow_diagram/workflow_diagram_model_test.ts
@@ -117,7 +117,6 @@ Deno.test("mermaidWorkflowModel: generate creates Mermaid diagram for simple wor
             job: "build",
             condition: {
               type: "succeeded",
-              jobName: "build",
             },
           },
         ],
@@ -255,7 +254,7 @@ Deno.test("mermaidWorkflowModel: generate handles complex workflow with multiple
         dependsOn: [
           {
             job: "setup",
-            condition: { type: "succeeded", jobName: "setup" },
+            condition: { type: "succeeded" },
           },
         ],
         steps: [
@@ -272,7 +271,7 @@ Deno.test("mermaidWorkflowModel: generate handles complex workflow with multiple
         dependsOn: [
           {
             job: "setup",
-            condition: { type: "succeeded", jobName: "setup" },
+            condition: { type: "succeeded" },
           },
         ],
         steps: [
@@ -289,11 +288,11 @@ Deno.test("mermaidWorkflowModel: generate handles complex workflow with multiple
         dependsOn: [
           {
             job: "build-frontend",
-            condition: { type: "succeeded", jobName: "build-frontend" },
+            condition: { type: "succeeded" },
           },
           {
             job: "build-backend",
-            condition: { type: "succeeded", jobName: "build-backend" },
+            condition: { type: "succeeded" },
           },
         ],
         steps: [

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -1060,7 +1060,7 @@ export class WorkflowExecutionService {
 
     // Check all dependency conditions
     for (const dep of job.dependsOn) {
-      if (!dep.condition.evaluate(run)) {
+      if (!dep.condition.evaluate(run, dep.job)) {
         return false;
       }
     }
@@ -1076,7 +1076,7 @@ export class WorkflowExecutionService {
 
     // Check all dependency conditions
     for (const dep of step.dependsOn) {
-      if (!dep.condition.evaluate(jobRun)) {
+      if (!dep.condition.evaluate(jobRun, dep.step)) {
         return false;
       }
     }

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -242,7 +242,7 @@ Deno.test("executes workflow with multiple jobs", async () => {
             Step.create({ name: "unit", task: StepTask.shell("echo") }),
           ],
           dependsOn: [
-            { job: "build", condition: TriggerCondition.succeeded("build") },
+            { job: "build", condition: TriggerCondition.succeeded() },
           ],
         }),
       ],
@@ -286,7 +286,7 @@ Deno.test("executes workflow with step dependencies", async () => {
               dependsOn: [
                 {
                   step: "setup",
-                  condition: TriggerCondition.succeeded("setup"),
+                  condition: TriggerCondition.succeeded(),
                 },
               ],
             }),
@@ -362,7 +362,7 @@ Deno.test("skips job when trigger condition not met", async () => {
             Step.create({ name: "unit", task: StepTask.shell("echo") }),
           ],
           dependsOn: [
-            { job: "build", condition: TriggerCondition.succeeded("build") },
+            { job: "build", condition: TriggerCondition.succeeded() },
           ],
         }),
       ],
@@ -407,7 +407,7 @@ Deno.test("runs job on failure condition", async () => {
             Step.create({ name: "alert", task: StepTask.shell("echo") }),
           ],
           dependsOn: [
-            { job: "build", condition: TriggerCondition.failed("build") },
+            { job: "build", condition: TriggerCondition.failed() },
           ],
         }),
       ],
@@ -642,7 +642,7 @@ Deno.test("executes dependent jobs sequentially across levels", async () => {
             Step.create({ name: "step1", task: StepTask.shell("echo") }),
           ],
           dependsOn: [
-            { job: "job-a", condition: TriggerCondition.succeeded("job-a") },
+            { job: "job-a", condition: TriggerCondition.succeeded() },
           ],
         }),
         Job.create({
@@ -651,8 +651,8 @@ Deno.test("executes dependent jobs sequentially across levels", async () => {
             Step.create({ name: "step1", task: StepTask.shell("echo") }),
           ],
           dependsOn: [
-            { job: "job-a", condition: TriggerCondition.succeeded("job-a") },
-            { job: "job-b", condition: TriggerCondition.succeeded("job-b") },
+            { job: "job-a", condition: TriggerCondition.succeeded() },
+            { job: "job-b", condition: TriggerCondition.succeeded() },
           ],
         }),
       ],
@@ -930,7 +930,7 @@ Deno.test("updates data context between workflow steps", async () => {
               dependsOn: [
                 {
                   step: "step1",
-                  condition: TriggerCondition.succeeded("step1"),
+                  condition: TriggerCondition.succeeded(),
                 },
               ],
             }),
@@ -1002,7 +1002,7 @@ Deno.test("updates both resource and data context when step produces both", asyn
               dependsOn: [
                 {
                   step: "step1",
-                  condition: TriggerCondition.succeeded("step1"),
+                  condition: TriggerCondition.succeeded(),
                 },
               ],
             }),

--- a/src/domain/workflows/job_test.ts
+++ b/src/domain/workflows/job_test.ts
@@ -33,7 +33,7 @@ Deno.test("Job.create creates job with all props", () => {
     description: "Deploys the application",
     steps: [step1, step2],
     dependsOn: [
-      { job: "build", condition: TriggerCondition.succeeded("build") },
+      { job: "build", condition: TriggerCondition.succeeded() },
     ],
     weight: 10,
   });
@@ -64,8 +64,8 @@ Deno.test("Job.getDependencyNames returns job names", () => {
     name: "final",
     steps: [step],
     dependsOn: [
-      { job: "job1", condition: TriggerCondition.succeeded("job1") },
-      { job: "job2", condition: TriggerCondition.completed("job2") },
+      { job: "job1", condition: TriggerCondition.succeeded() },
+      { job: "job2", condition: TriggerCondition.completed() },
     ],
   });
 
@@ -152,17 +152,17 @@ Deno.test("Job.fromData and toData roundtrip correctly", () => {
         name: "step2",
         task: StepTask.modelMethod("model", "run"),
         dependsOn: [
-          { step: "step1", condition: TriggerCondition.succeeded("step1") },
+          { step: "step1", condition: TriggerCondition.succeeded() },
         ],
       }),
     ],
     dependsOn: [
-      { job: "setup", condition: TriggerCondition.succeeded("setup") },
+      { job: "setup", condition: TriggerCondition.succeeded() },
       {
         job: "check",
         condition: TriggerCondition.or([
-          TriggerCondition.succeeded("check"),
-          TriggerCondition.skipped("check"),
+          TriggerCondition.succeeded(),
+          TriggerCondition.skipped(),
         ]),
       },
     ],

--- a/src/domain/workflows/step_test.ts
+++ b/src/domain/workflows/step_test.ts
@@ -24,7 +24,7 @@ Deno.test("Step.create creates step with all props", () => {
     description: "Runs the model",
     task,
     dependsOn: [
-      { step: "prepare", condition: TriggerCondition.succeeded("prepare") },
+      { step: "prepare", condition: TriggerCondition.succeeded() },
     ],
     weight: 10,
   });
@@ -43,8 +43,8 @@ Deno.test("Step.getDependencyNames returns step names", () => {
     name: "final",
     task,
     dependsOn: [
-      { step: "step1", condition: TriggerCondition.succeeded("step1") },
-      { step: "step2", condition: TriggerCondition.succeeded("step2") },
+      { step: "step1", condition: TriggerCondition.succeeded() },
+      { step: "step2", condition: TriggerCondition.succeeded() },
     ],
   });
 
@@ -106,12 +106,12 @@ Deno.test("Step.fromData and toData roundtrip correctly", () => {
     description: "A complex step",
     task: StepTask.modelMethod("model", "method"),
     dependsOn: [
-      { step: "step1", condition: TriggerCondition.succeeded("step1") },
+      { step: "step1", condition: TriggerCondition.succeeded() },
       {
         step: "step2",
         condition: TriggerCondition.or([
-          TriggerCondition.failed("step2"),
-          TriggerCondition.skipped("step2"),
+          TriggerCondition.failed(),
+          TriggerCondition.skipped(),
         ]),
       },
     ],

--- a/src/domain/workflows/trigger_condition.ts
+++ b/src/domain/workflows/trigger_condition.ts
@@ -7,10 +7,10 @@ const baseTriggerConditionSchema: z.ZodType<TriggerConditionData> = z.lazy(
   () =>
     z.discriminatedUnion("type", [
       z.object({ type: z.literal("always") }),
-      z.object({ type: z.literal("succeeded"), ref: z.string().min(1) }),
-      z.object({ type: z.literal("failed"), ref: z.string().min(1) }),
-      z.object({ type: z.literal("completed"), ref: z.string().min(1) }),
-      z.object({ type: z.literal("skipped"), ref: z.string().min(1) }),
+      z.object({ type: z.literal("succeeded") }),
+      z.object({ type: z.literal("failed") }),
+      z.object({ type: z.literal("completed") }),
+      z.object({ type: z.literal("skipped") }),
       z.object({
         type: z.literal("and"),
         conditions: z.array(baseTriggerConditionSchema).min(2),
@@ -31,13 +31,16 @@ const baseTriggerConditionSchema: z.ZodType<TriggerConditionData> = z.lazy(
  *
  * Supports:
  * - always: Always triggers
- * - succeeded(ref): Triggers if referenced step/job succeeded
- * - failed(ref): Triggers if referenced step/job failed
- * - completed(ref): Triggers if referenced step/job completed (success or failure)
- * - skipped(ref): Triggers if referenced step/job was skipped
+ * - succeeded: Triggers if the dependency succeeded
+ * - failed: Triggers if the dependency failed
+ * - completed: Triggers if the dependency completed (success or failure)
+ * - skipped: Triggers if the dependency was skipped
  * - and(...): Boolean AND of multiple conditions
  * - or(...): Boolean OR of multiple conditions
  * - not(...): Boolean NOT of a condition
+ *
+ * The ref (which step/job to check) is provided by the parent dependency
+ * object, not by the condition itself.
  */
 export const TriggerConditionSchema = baseTriggerConditionSchema;
 
@@ -46,10 +49,10 @@ export const TriggerConditionSchema = baseTriggerConditionSchema;
  */
 export type TriggerConditionData =
   | { type: "always" }
-  | { type: "succeeded"; ref: string }
-  | { type: "failed"; ref: string }
-  | { type: "completed"; ref: string }
-  | { type: "skipped"; ref: string }
+  | { type: "succeeded" }
+  | { type: "failed" }
+  | { type: "completed" }
+  | { type: "skipped" }
   | { type: "and"; conditions: TriggerConditionData[] }
   | { type: "or"; conditions: TriggerConditionData[] }
   | { type: "not"; condition: TriggerConditionData };
@@ -101,29 +104,29 @@ export class TriggerCondition {
   /**
    * Creates a "succeeded" trigger condition.
    */
-  static succeeded(ref: string): TriggerCondition {
-    return new TriggerCondition({ type: "succeeded", ref });
+  static succeeded(): TriggerCondition {
+    return new TriggerCondition({ type: "succeeded" });
   }
 
   /**
    * Creates a "failed" trigger condition.
    */
-  static failed(ref: string): TriggerCondition {
-    return new TriggerCondition({ type: "failed", ref });
+  static failed(): TriggerCondition {
+    return new TriggerCondition({ type: "failed" });
   }
 
   /**
    * Creates a "completed" trigger condition.
    */
-  static completed(ref: string): TriggerCondition {
-    return new TriggerCondition({ type: "completed", ref });
+  static completed(): TriggerCondition {
+    return new TriggerCondition({ type: "completed" });
   }
 
   /**
    * Creates a "skipped" trigger condition.
    */
-  static skipped(ref: string): TriggerCondition {
-    return new TriggerCondition({ type: "skipped", ref });
+  static skipped(): TriggerCondition {
+    return new TriggerCondition({ type: "skipped" });
   }
 
   /**
@@ -159,75 +162,51 @@ export class TriggerCondition {
   /**
    * Evaluates this trigger condition against the given context.
    *
+   * @param ctx - The evaluation context that provides step/job statuses
+   * @param ref - The step or job name whose status to check
    * @returns true if the condition is satisfied, false otherwise
    */
-  evaluate(ctx: TriggerEvaluationContext): boolean {
-    return this.evaluateData(this.data, ctx);
+  evaluate(ctx: TriggerEvaluationContext, ref: string): boolean {
+    return this.evaluateData(this.data, ctx, ref);
   }
 
   private evaluateData(
     data: TriggerConditionData,
     ctx: TriggerEvaluationContext,
+    ref: string,
   ): boolean {
     switch (data.type) {
       case "always":
         return true;
 
       case "succeeded": {
-        const status = ctx.getStatus(data.ref);
+        const status = ctx.getStatus(ref);
         return status === "succeeded";
       }
 
       case "failed": {
-        const status = ctx.getStatus(data.ref);
+        const status = ctx.getStatus(ref);
         return status === "failed";
       }
 
       case "completed": {
-        const status = ctx.getStatus(data.ref);
+        const status = ctx.getStatus(ref);
         return status === "succeeded" || status === "failed";
       }
 
       case "skipped": {
-        const status = ctx.getStatus(data.ref);
+        const status = ctx.getStatus(ref);
         return status === "skipped";
       }
 
       case "and":
-        return data.conditions.every((c) => this.evaluateData(c, ctx));
+        return data.conditions.every((c) => this.evaluateData(c, ctx, ref));
 
       case "or":
-        return data.conditions.some((c) => this.evaluateData(c, ctx));
+        return data.conditions.some((c) => this.evaluateData(c, ctx, ref));
 
       case "not":
-        return !this.evaluateData(data.condition, ctx);
-    }
-  }
-
-  /**
-   * Extracts all referenced step/job names from this condition.
-   */
-  getRefs(): string[] {
-    return this.getRefsFromData(this.data);
-  }
-
-  private getRefsFromData(data: TriggerConditionData): string[] {
-    switch (data.type) {
-      case "always":
-        return [];
-
-      case "succeeded":
-      case "failed":
-      case "completed":
-      case "skipped":
-        return [data.ref];
-
-      case "and":
-      case "or":
-        return data.conditions.flatMap((c) => this.getRefsFromData(c));
-
-      case "not":
-        return this.getRefsFromData(data.condition);
+        return !this.evaluateData(data.condition, ctx, ref);
     }
   }
 

--- a/src/domain/workflows/trigger_condition_test.ts
+++ b/src/domain/workflows/trigger_condition_test.ts
@@ -25,43 +25,43 @@ Deno.test("TriggerCondition.always creates always condition", () => {
 });
 
 Deno.test("TriggerCondition.succeeded creates succeeded condition", () => {
-  const cond = TriggerCondition.succeeded("step1");
-  assertEquals(cond.data, { type: "succeeded", ref: "step1" });
+  const cond = TriggerCondition.succeeded();
+  assertEquals(cond.data, { type: "succeeded" });
 });
 
 Deno.test("TriggerCondition.failed creates failed condition", () => {
-  const cond = TriggerCondition.failed("step1");
-  assertEquals(cond.data, { type: "failed", ref: "step1" });
+  const cond = TriggerCondition.failed();
+  assertEquals(cond.data, { type: "failed" });
 });
 
 Deno.test("TriggerCondition.completed creates completed condition", () => {
-  const cond = TriggerCondition.completed("step1");
-  assertEquals(cond.data, { type: "completed", ref: "step1" });
+  const cond = TriggerCondition.completed();
+  assertEquals(cond.data, { type: "completed" });
 });
 
 Deno.test("TriggerCondition.skipped creates skipped condition", () => {
-  const cond = TriggerCondition.skipped("step1");
-  assertEquals(cond.data, { type: "skipped", ref: "step1" });
+  const cond = TriggerCondition.skipped();
+  assertEquals(cond.data, { type: "skipped" });
 });
 
 Deno.test("TriggerCondition.and creates and condition", () => {
   const cond = TriggerCondition.and([
-    TriggerCondition.succeeded("step1"),
-    TriggerCondition.succeeded("step2"),
+    TriggerCondition.succeeded(),
+    TriggerCondition.succeeded(),
   ]);
   assertEquals(cond.data.type, "and");
 });
 
 Deno.test("TriggerCondition.or creates or condition", () => {
   const cond = TriggerCondition.or([
-    TriggerCondition.failed("step1"),
-    TriggerCondition.failed("step2"),
+    TriggerCondition.failed(),
+    TriggerCondition.failed(),
   ]);
   assertEquals(cond.data.type, "or");
 });
 
 Deno.test("TriggerCondition.not creates not condition", () => {
-  const cond = TriggerCondition.not(TriggerCondition.failed("step1"));
+  const cond = TriggerCondition.not(TriggerCondition.failed());
   assertEquals(cond.data.type, "not");
 });
 
@@ -70,186 +70,144 @@ Deno.test("TriggerCondition.not creates not condition", () => {
 Deno.test("always condition evaluates to true", () => {
   const cond = TriggerCondition.always();
   const ctx = createContext({});
-  assertEquals(cond.evaluate(ctx), true);
+  assertEquals(cond.evaluate(ctx, "step1"), true);
 });
 
 Deno.test("succeeded condition evaluates to true when step succeeded", () => {
-  const cond = TriggerCondition.succeeded("step1");
+  const cond = TriggerCondition.succeeded();
   const ctx = createContext({ step1: "succeeded" });
-  assertEquals(cond.evaluate(ctx), true);
+  assertEquals(cond.evaluate(ctx, "step1"), true);
 });
 
 Deno.test("succeeded condition evaluates to false when step failed", () => {
-  const cond = TriggerCondition.succeeded("step1");
+  const cond = TriggerCondition.succeeded();
   const ctx = createContext({ step1: "failed" });
-  assertEquals(cond.evaluate(ctx), false);
+  assertEquals(cond.evaluate(ctx, "step1"), false);
 });
 
 Deno.test("failed condition evaluates to true when step failed", () => {
-  const cond = TriggerCondition.failed("step1");
+  const cond = TriggerCondition.failed();
   const ctx = createContext({ step1: "failed" });
-  assertEquals(cond.evaluate(ctx), true);
+  assertEquals(cond.evaluate(ctx, "step1"), true);
 });
 
 Deno.test("failed condition evaluates to false when step succeeded", () => {
-  const cond = TriggerCondition.failed("step1");
+  const cond = TriggerCondition.failed();
   const ctx = createContext({ step1: "succeeded" });
-  assertEquals(cond.evaluate(ctx), false);
+  assertEquals(cond.evaluate(ctx, "step1"), false);
 });
 
 Deno.test("completed condition evaluates to true when step succeeded", () => {
-  const cond = TriggerCondition.completed("step1");
+  const cond = TriggerCondition.completed();
   const ctx = createContext({ step1: "succeeded" });
-  assertEquals(cond.evaluate(ctx), true);
+  assertEquals(cond.evaluate(ctx, "step1"), true);
 });
 
 Deno.test("completed condition evaluates to true when step failed", () => {
-  const cond = TriggerCondition.completed("step1");
+  const cond = TriggerCondition.completed();
   const ctx = createContext({ step1: "failed" });
-  assertEquals(cond.evaluate(ctx), true);
+  assertEquals(cond.evaluate(ctx, "step1"), true);
 });
 
 Deno.test("completed condition evaluates to false when step is pending", () => {
-  const cond = TriggerCondition.completed("step1");
+  const cond = TriggerCondition.completed();
   const ctx = createContext({ step1: "pending" });
-  assertEquals(cond.evaluate(ctx), false);
+  assertEquals(cond.evaluate(ctx, "step1"), false);
 });
 
 Deno.test("skipped condition evaluates to true when step skipped", () => {
-  const cond = TriggerCondition.skipped("step1");
+  const cond = TriggerCondition.skipped();
   const ctx = createContext({ step1: "skipped" });
-  assertEquals(cond.evaluate(ctx), true);
+  assertEquals(cond.evaluate(ctx, "step1"), true);
 });
 
 Deno.test("skipped condition evaluates to false when step succeeded", () => {
-  const cond = TriggerCondition.skipped("step1");
+  const cond = TriggerCondition.skipped();
   const ctx = createContext({ step1: "succeeded" });
-  assertEquals(cond.evaluate(ctx), false);
+  assertEquals(cond.evaluate(ctx, "step1"), false);
 });
 
 Deno.test("and condition evaluates to true when all conditions are true", () => {
   const cond = TriggerCondition.and([
-    TriggerCondition.succeeded("step1"),
-    TriggerCondition.succeeded("step2"),
+    TriggerCondition.succeeded(),
+    TriggerCondition.not(TriggerCondition.failed()),
   ]);
-  const ctx = createContext({ step1: "succeeded", step2: "succeeded" });
-  assertEquals(cond.evaluate(ctx), true);
+  const ctx = createContext({ step1: "succeeded" });
+  assertEquals(cond.evaluate(ctx, "step1"), true);
 });
 
 Deno.test("and condition evaluates to false when any condition is false", () => {
   const cond = TriggerCondition.and([
-    TriggerCondition.succeeded("step1"),
-    TriggerCondition.succeeded("step2"),
+    TriggerCondition.succeeded(),
+    TriggerCondition.not(TriggerCondition.skipped()),
   ]);
-  const ctx = createContext({ step1: "succeeded", step2: "failed" });
-  assertEquals(cond.evaluate(ctx), false);
+  const ctx = createContext({ step1: "failed" });
+  assertEquals(cond.evaluate(ctx, "step1"), false);
 });
 
 Deno.test("or condition evaluates to true when any condition is true", () => {
   const cond = TriggerCondition.or([
-    TriggerCondition.succeeded("step1"),
-    TriggerCondition.succeeded("step2"),
+    TriggerCondition.succeeded(),
+    TriggerCondition.failed(),
   ]);
-  const ctx = createContext({ step1: "failed", step2: "succeeded" });
-  assertEquals(cond.evaluate(ctx), true);
+  const ctx = createContext({ step1: "failed" });
+  assertEquals(cond.evaluate(ctx, "step1"), true);
 });
 
 Deno.test("or condition evaluates to false when all conditions are false", () => {
   const cond = TriggerCondition.or([
-    TriggerCondition.succeeded("step1"),
-    TriggerCondition.succeeded("step2"),
+    TriggerCondition.succeeded(),
+    TriggerCondition.skipped(),
   ]);
-  const ctx = createContext({ step1: "failed", step2: "failed" });
-  assertEquals(cond.evaluate(ctx), false);
+  const ctx = createContext({ step1: "failed" });
+  assertEquals(cond.evaluate(ctx, "step1"), false);
 });
 
 Deno.test("not condition inverts the result", () => {
-  const cond = TriggerCondition.not(TriggerCondition.failed("step1"));
+  const cond = TriggerCondition.not(TriggerCondition.failed());
   const ctxFailed = createContext({ step1: "failed" });
   const ctxSucceeded = createContext({ step1: "succeeded" });
-  assertEquals(cond.evaluate(ctxFailed), false);
-  assertEquals(cond.evaluate(ctxSucceeded), true);
+  assertEquals(cond.evaluate(ctxFailed, "step1"), false);
+  assertEquals(cond.evaluate(ctxSucceeded, "step1"), true);
 });
 
-Deno.test("complex nested condition evaluates correctly", () => {
-  // (step1 succeeded AND step2 succeeded) OR step3 failed
+Deno.test("compound condition evaluates correctly", () => {
+  // succeeded OR failed (i.e. completed)
   const cond = TriggerCondition.or([
-    TriggerCondition.and([
-      TriggerCondition.succeeded("step1"),
-      TriggerCondition.succeeded("step2"),
-    ]),
-    TriggerCondition.failed("step3"),
+    TriggerCondition.succeeded(),
+    TriggerCondition.failed(),
   ]);
 
-  // Test case: step1 and step2 succeeded
+  // Test case: step succeeded
   assertEquals(
-    cond.evaluate(
-      createContext({
-        step1: "succeeded",
-        step2: "succeeded",
-        step3: "succeeded",
-      }),
-    ),
+    cond.evaluate(createContext({ step1: "succeeded" }), "step1"),
     true,
   );
 
-  // Test case: step3 failed
+  // Test case: step failed
   assertEquals(
-    cond.evaluate(
-      createContext({ step1: "failed", step2: "failed", step3: "failed" }),
-    ),
+    cond.evaluate(createContext({ step1: "failed" }), "step1"),
     true,
   );
 
-  // Test case: neither condition met
+  // Test case: step pending (neither succeeded nor failed)
   assertEquals(
-    cond.evaluate(
-      createContext({
-        step1: "succeeded",
-        step2: "failed",
-        step3: "succeeded",
-      }),
-    ),
+    cond.evaluate(createContext({ step1: "pending" }), "step1"),
     false,
   );
-});
-
-// getRefs tests
-
-Deno.test("getRefs returns empty array for always condition", () => {
-  const cond = TriggerCondition.always();
-  assertEquals(cond.getRefs(), []);
-});
-
-Deno.test("getRefs returns ref for simple conditions", () => {
-  assertEquals(TriggerCondition.succeeded("step1").getRefs(), ["step1"]);
-  assertEquals(TriggerCondition.failed("step2").getRefs(), ["step2"]);
-  assertEquals(TriggerCondition.completed("step3").getRefs(), ["step3"]);
-  assertEquals(TriggerCondition.skipped("step4").getRefs(), ["step4"]);
-});
-
-Deno.test("getRefs collects all refs from nested conditions", () => {
-  const cond = TriggerCondition.and([
-    TriggerCondition.succeeded("step1"),
-    TriggerCondition.or([
-      TriggerCondition.failed("step2"),
-      TriggerCondition.completed("step3"),
-    ]),
-  ]);
-  assertEquals(cond.getRefs().sort(), ["step1", "step2", "step3"]);
 });
 
 // equals tests
 
 Deno.test("equals returns true for identical conditions", () => {
-  const cond1 = TriggerCondition.succeeded("step1");
-  const cond2 = TriggerCondition.succeeded("step1");
+  const cond1 = TriggerCondition.succeeded();
+  const cond2 = TriggerCondition.succeeded();
   assertEquals(cond1.equals(cond2), true);
 });
 
 Deno.test("equals returns false for different conditions", () => {
-  const cond1 = TriggerCondition.succeeded("step1");
-  const cond2 = TriggerCondition.failed("step1");
+  const cond1 = TriggerCondition.succeeded();
+  const cond2 = TriggerCondition.failed();
   assertEquals(cond1.equals(cond2), false);
 });
 
@@ -257,8 +215,8 @@ Deno.test("equals returns false for different conditions", () => {
 
 Deno.test("fromData and toData roundtrip correctly", () => {
   const original = TriggerCondition.and([
-    TriggerCondition.succeeded("step1"),
-    TriggerCondition.not(TriggerCondition.failed("step2")),
+    TriggerCondition.succeeded(),
+    TriggerCondition.not(TriggerCondition.failed()),
   ]);
   const data = original.toData();
   const restored = TriggerCondition.fromData(data);
@@ -266,12 +224,6 @@ Deno.test("fromData and toData roundtrip correctly", () => {
 });
 
 // Schema validation tests
-
-Deno.test("TriggerConditionSchema rejects empty ref", () => {
-  assertThrows(() => {
-    TriggerConditionSchema.parse({ type: "succeeded", ref: "" });
-  });
-});
 
 Deno.test("TriggerConditionSchema rejects and with less than 2 conditions", () => {
   assertThrows(() => {

--- a/src/domain/workflows/validation_service_test.ts
+++ b/src/domain/workflows/validation_service_test.ts
@@ -59,7 +59,7 @@ Deno.test("validates workflow with job dependencies", async () => {
           }),
         ],
         dependsOn: [
-          { job: "build", condition: TriggerCondition.succeeded("build") },
+          { job: "build", condition: TriggerCondition.succeeded() },
         ],
       }),
     ],
@@ -85,7 +85,7 @@ Deno.test("validates workflow with step dependencies", async () => {
             name: "compile",
             task: StepTask.shell("echo", { args: ["compile"] }),
             dependsOn: [
-              { step: "setup", condition: TriggerCondition.succeeded("setup") },
+              { step: "setup", condition: TriggerCondition.succeeded() },
             ],
           }),
         ],
@@ -304,7 +304,7 @@ Deno.test("passes all validations for complex valid workflow", async () => {
             dependsOn: [
               {
                 step: "checkout",
-                condition: TriggerCondition.succeeded("checkout"),
+                condition: TriggerCondition.succeeded(),
               },
             ],
           }),
@@ -319,7 +319,7 @@ Deno.test("passes all validations for complex valid workflow", async () => {
           }),
         ],
         dependsOn: [
-          { job: "setup", condition: TriggerCondition.succeeded("setup") },
+          { job: "setup", condition: TriggerCondition.succeeded() },
         ],
       }),
       Job.create({
@@ -333,12 +333,12 @@ Deno.test("passes all validations for complex valid workflow", async () => {
             name: "integration",
             task: StepTask.shell("npm", { args: ["run", "test:integration"] }),
             dependsOn: [
-              { step: "unit", condition: TriggerCondition.succeeded("unit") },
+              { step: "unit", condition: TriggerCondition.succeeded() },
             ],
           }),
         ],
         dependsOn: [
-          { job: "build", condition: TriggerCondition.succeeded("build") },
+          { job: "build", condition: TriggerCondition.succeeded() },
         ],
       }),
       Job.create({
@@ -350,7 +350,7 @@ Deno.test("passes all validations for complex valid workflow", async () => {
           }),
         ],
         dependsOn: [
-          { job: "test", condition: TriggerCondition.succeeded("test") },
+          { job: "test", condition: TriggerCondition.succeeded() },
         ],
       }),
     ],

--- a/src/domain/workflows/workflow_test.ts
+++ b/src/domain/workflows/workflow_test.ts
@@ -179,7 +179,7 @@ Deno.test("Workflow.fromData and toData roundtrip correctly", () => {
           }),
         ],
         dependsOn: [
-          { job: "build", condition: TriggerCondition.succeeded("build") },
+          { job: "build", condition: TriggerCondition.succeeded() },
         ],
       }),
     ],


### PR DESCRIPTION
## Summary

- Remove redundant `ref` field from `TriggerCondition` simple variants (`succeeded`, `failed`, `completed`, `skipped`) — the ref always duplicated the parent dependency's `step`/`job` name
- `evaluate()` now accepts a `ref` parameter, sourced from `dep.step` or `dep.job` at the call site
- Remove `getRefs()` / `getRefsFromData()` which were only used in tests
- Update Mermaid diagram schema and swamp-workflow skill docs to match

## Test Plan

- All 1248 unit tests pass
- `deno check` passes (no new type errors)
- `deno lint` and `deno fmt` pass
- `deno run compile` produces a valid binary
- Backwards compatible: Zod strip mode silently drops old `ref` fields from persisted data

🤖 Generated with [Claude Code](https://claude.com/claude-code)