### PR TITLE
Use PAT for auto-merge to trigger release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,4 +115,4 @@ jobs:
         run: gh pr merge --auto --squash --delete-branch "$PR_NUMBER"
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.UAT_TRIGGER_TOKEN }}


### PR DESCRIPTION
- Use `UAT_TRIGGER_TOKEN` instead of `GITHUB_TOKEN` for the auto-merge step

## Problem
When PRs are merged using the default `GITHUB_TOKEN`, GitHub does not trigger subsequent workflows (security feature to prevent infinite loops). This meant the release workflow never ran automatically on merge to main.

## Solution
Using a PAT for the merge operation ensures the `pull_request: closed` event properly triggers the release workflow.

## Test plan
- [ ] Merge this PR and verify the release workflow triggers automatically