### PR TITLE
feat: Add --last-evaluated option to workflow run and model method run

### DIFF
--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -11,6 +11,7 @@ import { ModelOutput } from "../../domain/models/model_output.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 import { DefaultMethodExecutionService } from "../../domain/models/method_execution_service.ts";
 import { ExpressionEvaluationService } from "../../domain/expressions/expression_evaluation_service.ts";
+import { UserError } from "../../domain/errors.ts";
 import { getRunLogger } from "../../infrastructure/logging/logger.ts";
 
 // Cliffy's custom type system returns `unknown` for custom types like `model_name`,
@@ -24,6 +25,11 @@ export const modelMethodRunCommand = new Command()
   .description("Execute a method on a model")
   .arguments("<model_id_or_name:model_name> <method_name:string>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--last-evaluated",
+    "Skip CEL evaluation, use previously evaluated definition",
+    { default: false },
+  )
   .action(
     // @ts-expect-error - Cliffy custom type returns unknown instead of string
     async function (
@@ -84,22 +90,50 @@ export const modelMethodRunCommand = new Command()
         );
       }
 
-      // Evaluate expressions (including vault expressions) before execution
       const evaluationService = new ExpressionEvaluationService(
         definitionRepo,
         repoDir,
         { dataRepo: unifiedDataRepo },
       );
 
+      const lastEvaluated = options.lastEvaluated as boolean;
       let evaluatedDefinition = definition;
-      if (evaluationService.hasDefinitionExpressions(definition)) {
-        runLogger.info("Evaluating expressions");
-        const evalResult = await evaluationService.evaluateDefinition(
-          definition,
+
+      if (lastEvaluated) {
+        // Load previously-evaluated definition from cache
+        runLogger.info("Loading last evaluated definition");
+        const evaluatedDefRepo = repoContext.evaluatedDefinitionRepo;
+        const lastEval = await evaluatedDefRepo.findByName(
           modelType,
+          definition.name,
         );
-        evaluatedDefinition = evalResult.definition;
+        if (!lastEval) {
+          throw new UserError(
+            `No previously evaluated definition found for "${definition.name}".\n\n` +
+              `Run the method without --last-evaluated first to generate evaluated data:\n` +
+              `  swamp model method run ${definition.name} ${methodName}`,
+          );
+        }
+        evaluatedDefinition = lastEval;
+      } else {
+        // Evaluate CEL expressions (vault expressions left raw for persistence)
+        if (evaluationService.hasDefinitionExpressions(definition)) {
+          runLogger.info("Evaluating expressions");
+          const evalResult = await evaluationService.evaluateDefinition(
+            definition,
+            modelType,
+          );
+          evaluatedDefinition = evalResult.definition;
+        }
+
+        // Save evaluated definition (with vault expressions still raw) for --last-evaluated
+        const evaluatedDefRepo = repoContext.evaluatedDefinitionRepo;
+        await evaluatedDefRepo.save(modelType, evaluatedDefinition);
       }
+
+      // Resolve vault expressions at runtime (never persisted)
+      evaluatedDefinition = await evaluationService
+        .resolveVaultExpressionsInDefinition(evaluatedDefinition);
 
       runLogger.info("Executing method {method}", { method: methodName });
 

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -141,6 +141,11 @@ export const workflowRunCommand = new Command()
   .arguments("<workflow_id_or_name:workflow_name>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("--tui", "Use interactive TUI dashboard", { default: false })
+  .option(
+    "--last-evaluated",
+    "Skip CEL evaluation, use previously evaluated workflow and definitions",
+    { default: false },
+  )
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(async function (options: AnyOptions, workflowIdOrName: string) {
     const ctx = createContext(options as GlobalOptions, ["workflow", "run"]);
@@ -160,6 +165,7 @@ export const workflowRunCommand = new Command()
     );
 
     const tui = options.tui as boolean;
+    const lastEvaluated = options.lastEvaluated as boolean;
 
     try {
       // Look up workflow first to get its data
@@ -189,7 +195,9 @@ export const workflowRunCommand = new Command()
           },
         };
 
-        const run = await executionService.execute(workflow.name, progress);
+        const run = await executionService.execute(workflow.name, progress, {
+          lastEvaluated,
+        });
 
         // Get the path for the run
         const path = runRepo.getPath(workflow.id, run.id);
@@ -220,7 +228,9 @@ export const workflowRunCommand = new Command()
         const executeWorkflow = async (
           progress: ExecutionProgressCallback,
         ): Promise<WorkflowRun> => {
-          return await executionService.execute(workflow.name, progress);
+          return await executionService.execute(workflow.name, progress, {
+            lastEvaluated,
+          });
         };
 
         const data = await renderWorkflowExecution(
@@ -244,6 +254,7 @@ export const workflowRunCommand = new Command()
         const progress = createLogProgressCallback(workflow.name);
         const run = await executionService.execute(workflow.name, progress, {
           enableStepLogging: true,
+          lastEvaluated,
         });
 
         ctx.logger.debug`Workflow run completed: status=${run.status}`;

--- a/src/domain/expressions/expression_evaluation_service.ts
+++ b/src/domain/expressions/expression_evaluation_service.ts
@@ -8,6 +8,7 @@ import {
   extractExpressions,
   replaceExpressions,
 } from "./expression_parser.ts";
+import type { ExpressionLocation } from "./expression.ts";
 import { extractModelRefs } from "./dependency_extractor.ts";
 import {
   type ExpressionContext,
@@ -20,6 +21,20 @@ import {
   type GraphNode,
   TopologicalSortService,
 } from "../workflows/topological_sort_service.ts";
+
+/**
+ * Pattern to detect vault.get() references inside a CEL expression.
+ */
+const VAULT_GET_PATTERN = /vault\.get\s*\(/;
+
+/**
+ * Checks whether a CEL expression references vault.get().
+ * Expressions containing vault references must NOT be evaluated during
+ * the persist phase — they are resolved at runtime only.
+ */
+export function containsVaultExpression(celExpression: string): boolean {
+  return VAULT_GET_PATTERN.test(celExpression);
+}
 
 /**
  * Result of evaluating a single definition.
@@ -75,24 +90,23 @@ export class ExpressionEvaluationService {
    * @param context - The evaluation context
    * @returns The data with expressions replaced
    */
-  async evaluateData(
+  evaluateData(
     data: unknown,
     context: ExpressionContext,
-  ): Promise<unknown> {
+  ): unknown {
     const expressions = extractExpressions(data);
     if (expressions.length === 0) {
       return data;
     }
 
+    // Evaluate CEL-only expressions; skip vault-containing expressions
     const evaluatedValues = new Map<string, unknown>();
     for (const expr of expressions) {
-      // First resolve any vault expressions in the CEL expression
-      const resolvedCelExpr = await this.modelResolver.resolveVaultExpressions(
-        expr.celExpression,
-      );
+      if (containsVaultExpression(expr.celExpression)) {
+        continue;
+      }
 
-      // Then evaluate the CEL expression
-      const value = this.celEvaluator.evaluate(resolvedCelExpr, context);
+      const value = this.celEvaluator.evaluate(expr.celExpression, context);
       evaluatedValues.set(expr.raw, value);
     }
 
@@ -139,20 +153,20 @@ export class ExpressionEvaluationService {
       return { definition, type, hadExpressions: false };
     }
 
-    // Evaluate each expression
+    // Evaluate CEL-only expressions; skip vault-containing expressions
+    // Vault expressions are resolved at runtime only, never persisted
     const evaluatedValues = new Map<string, unknown>();
     for (const expr of expressions) {
-      // First resolve any vault expressions in the CEL expression
-      const resolvedCelExpr = await this.modelResolver.resolveVaultExpressions(
-        expr.celExpression,
-      );
+      if (containsVaultExpression(expr.celExpression)) {
+        // Leave vault-containing expressions (vault-only and mixed) as raw
+        continue;
+      }
 
-      // Then evaluate the CEL expression
-      const value = this.celEvaluator.evaluate(resolvedCelExpr, ctx);
+      const value = this.celEvaluator.evaluate(expr.celExpression, ctx);
       evaluatedValues.set(expr.raw, value);
     }
 
-    // Replace expressions with evaluated values
+    // Replace only the CEL-only expressions with evaluated values
     const evaluatedData = replaceExpressions(definitionData, evaluatedValues);
 
     // Create new Definition from evaluated data
@@ -298,5 +312,92 @@ export class ExpressionEvaluationService {
   hasDefinitionExpressions(definition: Definition): boolean {
     const data = definition.toData();
     return this.checkForExpressions(data);
+  }
+
+  /**
+   * Resolves remaining vault expressions in an already-evaluated definition.
+   * This is the runtime phase — vault secrets are resolved here and never persisted.
+   *
+   * @param definition - The definition (may contain remaining ${{ vault.get(...) }} expressions)
+   * @returns A new definition with vault expressions resolved to actual secret values
+   */
+  async resolveVaultExpressionsInDefinition(
+    definition: Definition,
+  ): Promise<Definition> {
+    const definitionData = definition.toData();
+    const expressions = extractExpressions(definitionData);
+
+    // Filter to only vault-containing expressions
+    const vaultExpressions = expressions.filter((expr) =>
+      containsVaultExpression(expr.celExpression)
+    );
+
+    if (vaultExpressions.length === 0) {
+      return definition;
+    }
+
+    return await this.resolveVaultInExpressions(
+      definitionData,
+      vaultExpressions,
+    );
+  }
+
+  /**
+   * Resolves remaining vault expressions in arbitrary data.
+   * This is the runtime phase — vault secrets are resolved here and never persisted.
+   *
+   * @param data - The data (may contain remaining ${{ vault.get(...) }} expressions)
+   * @returns The data with vault expressions resolved
+   */
+  async resolveVaultExpressionsInData(data: unknown): Promise<unknown> {
+    const expressions = extractExpressions(data);
+    const vaultExpressions = expressions.filter((expr) =>
+      containsVaultExpression(expr.celExpression)
+    );
+
+    if (vaultExpressions.length === 0) {
+      return data;
+    }
+
+    const evaluatedValues = new Map<string, unknown>();
+    for (const expr of vaultExpressions) {
+      // Resolve vault expressions first, then evaluate the full CEL
+      const resolvedCelExpr = await this.modelResolver.resolveVaultExpressions(
+        expr.celExpression,
+      );
+      const value = this.celEvaluator.evaluate(resolvedCelExpr, {
+        model: {},
+        env: {},
+      });
+      evaluatedValues.set(expr.raw, value);
+    }
+
+    return replaceExpressions(data, evaluatedValues);
+  }
+
+  /**
+   * Internal: resolves vault expressions in definition data and returns a new Definition.
+   */
+  private async resolveVaultInExpressions(
+    definitionData: ReturnType<Definition["toData"]>,
+    vaultExpressions: ExpressionLocation[],
+  ): Promise<Definition> {
+    const evaluatedValues = new Map<string, unknown>();
+    for (const expr of vaultExpressions) {
+      // Resolve vault references, then evaluate the CEL expression
+      const resolvedCelExpr = await this.modelResolver.resolveVaultExpressions(
+        expr.celExpression,
+      );
+      const value = this.celEvaluator.evaluate(resolvedCelExpr, {
+        model: {},
+        env: {},
+      });
+      evaluatedValues.set(expr.raw, value);
+    }
+
+    const resolvedData = replaceExpressions(definitionData, evaluatedValues);
+    return DefinitionClass.fromData(
+      resolvedData as ReturnType<Definition["toData"]>,
+    );
   }
 }

--- a/src/domain/expressions/expression_evaluation_service_test.ts
+++ b/src/domain/expressions/expression_evaluation_service_test.ts
@@ -1,0 +1,38 @@
+import { assertEquals } from "@std/assert";
+import { containsVaultExpression } from "./expression_evaluation_service.ts";
+
+Deno.test("containsVaultExpression returns true for vault-only expressions", () => {
+  assertEquals(containsVaultExpression("vault.get(aws, myKey)"), true);
+  assertEquals(
+    containsVaultExpression("vault.get('aws', 'myKey')"),
+    true,
+  );
+  assertEquals(
+    containsVaultExpression('vault.get("aws", "myKey")'),
+    true,
+  );
+});
+
+Deno.test("containsVaultExpression returns true for mixed CEL+vault expressions", () => {
+  assertEquals(
+    containsVaultExpression(
+      "model.foo.data.attributes.x + vault.get(aws, key)",
+    ),
+    true,
+  );
+});
+
+Deno.test("containsVaultExpression returns false for CEL-only expressions", () => {
+  assertEquals(
+    containsVaultExpression("model.foo.data.attributes.message"),
+    false,
+  );
+  assertEquals(containsVaultExpression("self.name"), false);
+  assertEquals(containsVaultExpression("inputs.param"), false);
+  assertEquals(containsVaultExpression("env.HOME"), false);
+});
+
+Deno.test("containsVaultExpression returns false for vault-like but not vault.get", () => {
+  assertEquals(containsVaultExpression("vault.name"), false);
+  assertEquals(containsVaultExpression("vault_get(foo)"), false);
+});

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -13,6 +13,7 @@ import type {
   WorkflowRunRepository,
 } from "./repositories.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import { YamlEvaluatedDefinitionRepository } from "../../infrastructure/persistence/yaml_evaluated_definition_repository.ts";
 import { YamlEvaluatedWorkflowRepository } from "../../infrastructure/persistence/yaml_evaluated_workflow_repository.ts";
 import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
@@ -26,6 +27,10 @@ import {
   extractExpressions,
   replaceExpressions,
 } from "../expressions/expression_parser.ts";
+import {
+  containsVaultExpression,
+  ExpressionEvaluationService,
+} from "../expressions/expression_evaluation_service.ts";
 import { extractResourceDependencies } from "../expressions/dependency_extractor.ts";
 import {
   type DataRecord,
@@ -36,6 +41,7 @@ import { CelEvaluator } from "../../infrastructure/cel/cel_evaluator.ts";
 import {
   DataOutputValidationService,
 } from "../models/data_output_validation_service.ts";
+import { UserError } from "../errors.ts";
 import {
   getRunLogger,
   getWorkflowRunLogger,
@@ -61,6 +67,8 @@ export interface StepExecutionContext {
   step?: Step;
   /** Whether step executors should log execution details via LogTape */
   enableStepLogging?: boolean;
+  /** When true, load previously-evaluated definitions instead of evaluating CEL */
+  useLastEvaluated?: boolean;
 }
 
 /**
@@ -287,9 +295,26 @@ export class DefaultStepExecutor implements StepExecutor {
       );
     }
 
-    // Evaluate expressions for execution (after validation passes)
+    // Evaluate CEL expressions (vault left raw for persistence)
     let evaluatedDefinition = originalDefinition;
-    if (ctx.expressionContext) {
+    if (ctx.useLastEvaluated) {
+      // Load previously-evaluated definition from cache
+      runLogger?.info("Loading last evaluated definition");
+      const evaluatedDefRepo = new YamlEvaluatedDefinitionRepository(
+        ctx.repoDir,
+      );
+      const lastEvaluated = await evaluatedDefRepo.findByName(
+        modelType,
+        originalDefinition.name,
+      );
+      if (!lastEvaluated) {
+        throw new Error(
+          `No previously evaluated definition found for "${originalDefinition.name}". ` +
+            `Run the workflow without --last-evaluated first.`,
+        );
+      }
+      evaluatedDefinition = lastEvaluated;
+    } else if (ctx.expressionContext) {
       runLogger?.info("Evaluating expressions");
       // Set self context for this specific model before evaluating
       ctx.expressionContext.self = {
@@ -306,6 +331,19 @@ export class DefaultStepExecutor implements StepExecutor {
         ctx.repoDir,
       );
     }
+
+    // Save evaluated definition (with vault expressions still raw) for --last-evaluated
+    const evaluatedDefRepo = new YamlEvaluatedDefinitionRepository(ctx.repoDir);
+    await evaluatedDefRepo.save(modelType, evaluatedDefinition);
+
+    // Resolve vault expressions at runtime (never persisted)
+    const evalService = new ExpressionEvaluationService(
+      new YamlDefinitionRepository(ctx.repoDir),
+      ctx.repoDir,
+    );
+    evaluatedDefinition = await evalService.resolveVaultExpressionsInDefinition(
+      evaluatedDefinition,
+    );
 
     // Validate method exists on the model
     const method = modelDef.methods[task.methodName];
@@ -522,12 +560,13 @@ export class DefaultStepExecutor implements StepExecutor {
   }
 
   /**
-   * Evaluates expressions in a definition.
+   * Evaluates CEL expressions in a definition, leaving vault expressions raw.
+   * Vault expressions are resolved at runtime only.
    */
   private async evaluateDefinitionExpressions(
     definition: Definition,
     context: ExpressionContext,
-    repoDir: string,
+    _repoDir: string,
   ): Promise<Definition> {
     const celEvaluator = new CelEvaluator();
     const definitionData = definition.toData();
@@ -537,26 +576,18 @@ export class DefaultStepExecutor implements StepExecutor {
       return definition;
     }
 
-    // Create ModelResolver for vault expression handling
-    const definitionRepoForResolver = new YamlDefinitionRepository(repoDir);
-    const modelResolver = new ModelResolver(definitionRepoForResolver, {
-      repoDir,
-    });
-
-    // Evaluate each expression
+    // Evaluate CEL-only expressions; skip vault-containing expressions
     const evaluatedValues = new Map<string, unknown>();
     for (const expr of expressions) {
-      // First resolve any vault expressions in the CEL expression
-      const resolvedCelExpr = await modelResolver.resolveVaultExpressions(
-        expr.celExpression,
-      );
+      if (containsVaultExpression(expr.celExpression)) {
+        continue;
+      }
 
-      // Then evaluate the CEL expression
-      const value = celEvaluator.evaluate(resolvedCelExpr, context);
+      const value = celEvaluator.evaluate(expr.celExpression, context);
       evaluatedValues.set(expr.raw, value);
     }
 
-    // Replace expressions with evaluated values
+    // Replace only CEL-only expressions with evaluated values
     const evaluatedData = replaceExpressions(definitionData, evaluatedValues);
 
     // Create new Definition from evaluated data
@@ -645,7 +676,7 @@ export class WorkflowExecutionService {
   async execute(
     idOrName: string,
     progress?: ExecutionProgressCallback,
-    options?: { enableStepLogging?: boolean },
+    options?: { enableStepLogging?: boolean; lastEvaluated?: boolean },
   ): Promise<WorkflowRun> {
     // Look up workflow
     const workflow = await this.lookupWorkflow(idOrName);
@@ -653,18 +684,37 @@ export class WorkflowExecutionService {
       throw new Error(`Workflow not found: ${idOrName}`);
     }
 
-    // Build expression context for the workflow
-    const expressionContext = await this.modelResolver.buildContext();
+    let expressionContext: ExpressionContext | undefined;
 
-    // Evaluate workflow and save to workflows-evaluated/
-    const evaluatedWorkflow = await this.evaluateWorkflow(
-      workflow,
-      expressionContext,
-    );
-    const evaluatedWorkflowRepo = new YamlEvaluatedWorkflowRepository(
-      this.repoDir,
-    );
-    await evaluatedWorkflowRepo.save(evaluatedWorkflow);
+    if (options?.lastEvaluated) {
+      // Load previously evaluated workflow from cache
+      const evaluatedWorkflowRepo = new YamlEvaluatedWorkflowRepository(
+        this.repoDir,
+      );
+      const lastEvaluated = await evaluatedWorkflowRepo.findByName(
+        workflow.name,
+      );
+      if (!lastEvaluated) {
+        throw new UserError(
+          `No previously evaluated workflow found for "${workflow.name}".\n\n` +
+            `Run the workflow without --last-evaluated first to generate evaluated data:\n` +
+            `  swamp workflow run ${workflow.name}`,
+        );
+      }
+      // No expression context needed — we use pre-evaluated definitions per-step
+    } else {
+      // Build expression context and evaluate workflow
+      expressionContext = await this.modelResolver.buildContext();
+
+      const evaluatedWorkflow = await this.evaluateWorkflow(
+        workflow,
+        expressionContext,
+      );
+      const evaluatedWorkflowRepo = new YamlEvaluatedWorkflowRepository(
+        this.repoDir,
+      );
+      await evaluatedWorkflowRepo.save(evaluatedWorkflow);
+    }
 
     // Create workflow run
     const run = WorkflowRun.create(workflow);
@@ -712,6 +762,7 @@ export class WorkflowExecutionService {
             expressionContext,
             progress,
             options?.enableStepLogging,
+            options?.lastEvaluated,
           )
         ),
       );
@@ -730,9 +781,10 @@ export class WorkflowExecutionService {
     workflow: Workflow,
     run: WorkflowRun,
     jobName: string,
-    expressionContext: ExpressionContext,
+    expressionContext: ExpressionContext | undefined,
     progress?: ExecutionProgressCallback,
     enableStepLogging?: boolean,
+    lastEvaluated?: boolean,
   ): Promise<void> {
     const job = workflow.getJob(jobName);
     if (!job) {
@@ -809,6 +861,7 @@ export class WorkflowExecutionService {
               expressionContext,
               streamingCallbacks,
               enableStepLogging,
+              lastEvaluated,
             )
           ),
         );
@@ -915,9 +968,10 @@ export class WorkflowExecutionService {
     job: Job,
     jobRun: JobRun,
     stepName: string,
-    expressionContext: ExpressionContext,
+    expressionContext: ExpressionContext | undefined,
     progress?: ExecutionProgressCallback,
     enableStepLogging?: boolean,
+    lastEvaluated?: boolean,
   ): Promise<void> {
     const step = job.getStep(stepName);
     if (!step) {
@@ -949,16 +1003,17 @@ export class WorkflowExecutionService {
         jobName: job.name,
         stepName,
         repoDir: this.repoDir,
-        expressionContext,
+        expressionContext: lastEvaluated ? undefined : expressionContext,
         progress,
         workflowRun: run,
         step, // Include step for accessing data output overrides
         enableStepLogging,
+        useLastEvaluated: lastEvaluated,
       };
 
       const output = await this.executor.execute(step, ctx);
 
-      // Update expression context with new resource and data if this was a model method
+      // Track data artifacts and update expression context if this was a model method
       if (step.task.isModelMethod() && output && typeof output === "object") {
         const taskOutput = output as {
           model?: string;
@@ -981,7 +1036,9 @@ export class WorkflowExecutionService {
             stepRun.addDataArtifact(artifact);
           }
         }
-        if (taskOutput.model) {
+
+        // Update expression context for subsequent steps (only when not using --last-evaluated)
+        if (expressionContext && taskOutput.model) {
           // Create model entry if it doesn't exist
           if (!expressionContext.model[taskOutput.model]) {
             expressionContext.model[taskOutput.model] = {
@@ -1143,12 +1200,13 @@ export class WorkflowExecutionService {
   }
 
   /**
-   * Evaluates expressions in a workflow.
+   * Evaluates CEL expressions in a workflow, leaving vault expressions raw.
+   * Vault expressions are resolved at runtime only.
    */
-  private async evaluateWorkflow(
+  private evaluateWorkflow(
     workflow: Workflow,
     context: ExpressionContext,
-  ): Promise<Workflow> {
+  ): Workflow {
     const celEvaluator = new CelEvaluator();
     const workflowData = workflow.toData();
     const expressions = extractExpressions(workflowData);
@@ -1157,20 +1215,18 @@ export class WorkflowExecutionService {
       return workflow;
     }
 
-    // Evaluate each expression
+    // Evaluate CEL-only expressions; skip vault-containing expressions
     const evaluatedValues = new Map<string, unknown>();
     for (const expr of expressions) {
-      // First resolve any vault expressions in the CEL expression
-      const resolvedCelExpr = await this.modelResolver.resolveVaultExpressions(
-        expr.celExpression,
-      );
+      if (containsVaultExpression(expr.celExpression)) {
+        continue;
+      }
 
-      // Then evaluate the CEL expression
-      const value = celEvaluator.evaluate(resolvedCelExpr, context);
+      const value = celEvaluator.evaluate(expr.celExpression, context);
       evaluatedValues.set(expr.raw, value);
     }
 
-    // Replace expressions with evaluated values
+    // Replace only CEL-only expressions with evaluated values
     const evaluatedData = replaceExpressions(workflowData, evaluatedValues);
 
     // Create new Workflow from evaluated data

--- a/src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts
@@ -57,6 +57,17 @@ export class YamlEvaluatedWorkflowRepository {
     return workflows;
   }
 
+  /**
+   * Finds an evaluated workflow by its name.
+   *
+   * @param name - The workflow name
+   * @returns The evaluated workflow if found, or null
+   */
+  async findByName(name: string): Promise<Workflow | null> {
+    const workflows = await this.findAll();
+    return workflows.find((w) => w.name === name) ?? null;
+  }
+
   async save(workflow: Workflow): Promise<void> {
     const dir = this.getWorkflowsDir();
     await ensureDir(dir);

--- a/src/infrastructure/persistence/yaml_evaluated_workflow_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_workflow_repository_test.ts
@@ -1,0 +1,55 @@
+import { assertEquals } from "@std/assert";
+import { YamlEvaluatedWorkflowRepository } from "./yaml_evaluated_workflow_repository.ts";
+import { Workflow } from "../../domain/workflows/workflow.ts";
+
+Deno.test("findByName returns workflow with matching name", async () => {
+  const tempDir = await Deno.makeTempDir();
+
+  try {
+    const repo = new YamlEvaluatedWorkflowRepository(tempDir);
+
+    const workflow = Workflow.fromData({
+      id: "a1b2c3d4-e5f6-1a2b-9c3d-4e5f6a7b8c9d",
+      name: "test-workflow",
+      version: 1,
+      jobs: [
+        {
+          name: "test-job",
+          dependsOn: [],
+          weight: 0,
+          steps: [
+            {
+              name: "test-step",
+              dependsOn: [],
+              weight: 0,
+              task: {
+                type: "shell",
+                command: "echo hello",
+                args: [],
+              },
+            },
+          ],
+        },
+      ],
+    });
+    await repo.save(workflow);
+
+    const found = await repo.findByName("test-workflow");
+    assertEquals(found?.name, "test-workflow");
+    assertEquals(found?.id, "a1b2c3d4-e5f6-1a2b-9c3d-4e5f6a7b8c9d");
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("findByName returns null for non-existent workflow", async () => {
+  const tempDir = await Deno.makeTempDir();
+
+  try {
+    const repo = new YamlEvaluatedWorkflowRepository(tempDir);
+    const found = await repo.findByName("non-existent");
+    assertEquals(found, null);
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Add `--last-evaluated` flag to `swamp model method run` and `swamp workflow run` that skips CEL expression evaluation and reuses previously evaluated definitions/workflows
- Separate vault and CEL evaluation into two phases: CEL is evaluated and persisted to disk, vault expressions are **always resolved at runtime only** and never written to evaluated YAML files
- Add `findByName()` to `YamlEvaluatedWorkflowRepository` for looking up cached evaluated workflows

Closes #220

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] `deno run test` — 1254 tests pass, 0 failures
- [x] `deno run compile` — binary compiles
- [x] Verified `definitions-evaluated/` YAML files do NOT contain resolved vault secrets
- [x] Verified `workflows-evaluated/` YAML files do NOT contain resolved vault secrets
- [x] `swamp model method run <model> <method>` — vault resolved at runtime, CEL persisted
- [x] `swamp model method run --last-evaluated <model> <method>` — loads cached CEL, vault resolved at runtime
- [x] `swamp workflow run <workflow>` — vault resolved at runtime, CEL persisted
- [x] `swamp workflow run --last-evaluated <workflow>` — loads cached workflow, vault resolved at runtime
- [x] `--last-evaluated` with no prior run produces `UserError` with helpful guidance message

🤖 Generated with [Claude Code](https://claude.com/claude-code)