### PR TITLE
feat: Add logger to MethodContext for model method logging

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -153,6 +153,7 @@ execute: (async (definition, context) => {
   // definition.name       - User-provided name
   // definition.attributes - Validated input data (expressions already resolved)
   // context.repoDir       - Repository root path
+  // context.logger        - LogTape Logger for emitting log messages
   // context.dataRepository - For advanced data operations
   // context.inputs        - Runtime inputs (if inputsSchema defined)
 
@@ -321,6 +322,46 @@ models from accidentally overwriting data.
 - Multiple models can read the same data via CEL expressions
 - Only the creating model can update its own data
 - Use unique data names to avoid conflicts
+
+## Logging
+
+Model methods have access to a pre-configured LogTape logger via
+`context.logger`. The logger category is set automatically based on the model
+type and method name — no configuration needed.
+
+### Log Levels
+
+From low to high severity: `trace`, `debug`, `info`, `warning`, `error`,
+`fatal`.
+
+### Structured Placeholders (Preferred)
+
+Use named `{placeholder}` tokens with a properties object:
+
+```typescript
+context.logger.info("Processing {name}", { name: definition.name });
+context.logger.error("Request failed: {error}", { error: err.message });
+```
+
+Use `{*}` to inline all properties from the object:
+
+```typescript
+context.logger.info("Bucket created: {*}", {
+  bucket: "my-bucket",
+  region: "us-east-1",
+});
+// Output: Bucket created: bucket=my-bucket region=us-east-1
+```
+
+### Additional Features
+
+- `context.logger.with({ requestId: "abc" })` — returns a logger with extra
+  properties on all messages
+- `context.logger.getChild("subsystem")` — creates a child logger with a
+  sub-category
+- Logger respects `--log-level`, `--verbose`, `--quiet`, and `--json` flags
+  automatically
+- In JSON mode, non-fatal messages are suppressed; fatal goes to stderr as JSON
 
 ## Examples
 

--- a/integration/echo_model_test.ts
+++ b/integration/echo_model_test.ts
@@ -19,6 +19,7 @@ import {
   echoModel,
 } from "../src/domain/models/echo/echo_model.ts";
 import type { MethodContext } from "../src/domain/models/model.ts";
+import { getLogger } from "@logtape/logtape";
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   const dir = await Deno.makeTempDir({ prefix: "swamp-integration-" });
@@ -106,6 +107,7 @@ Deno.test("Echo model: full flow - create definition, execute write, verify data
       repoDir,
       modelType,
       modelId: definition.id,
+      logger: getLogger(["test"]),
       dataRepository: dataRepo,
       definitionRepository: definitionRepo,
     };

--- a/integration/simple_return_format_test.ts
+++ b/integration/simple_return_format_test.ts
@@ -19,6 +19,7 @@ import { modelRegistry } from "../src/domain/models/model.ts";
 import type { MethodContext } from "../src/domain/models/model.ts";
 import { ModelType } from "../src/domain/models/model_type.ts";
 import { FileSystemUnifiedDataRepository } from "../src/infrastructure/persistence/unified_data_repository.ts";
+import { getLogger } from "@logtape/logtape";
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   const dir = await Deno.makeTempDir({ prefix: "swamp-simple-return-" });
@@ -56,6 +57,7 @@ function createTestContext(
     repoDir,
     modelType,
     modelId,
+    logger: getLogger(["test"]),
     dataRepository: new FileSystemUnifiedDataRepository(repoDir),
     definitionRepository: new YamlDefinitionRepository(repoDir),
   };

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -202,6 +202,7 @@ export const modelMethodRunCommand = new Command()
             repoDir,
             modelType,
             modelId: evaluatedDefinition.id,
+            logger: runLogger,
             dataRepository: unifiedDataRepo,
             definitionRepository: definitionRepo,
           },

--- a/src/domain/models/aws/cli/aws_cli_model_test.ts
+++ b/src/domain/models/aws/cli/aws_cli_model_test.ts
@@ -14,6 +14,7 @@ import type { MethodContext } from "../../model.ts";
 import type { UnifiedDataRepository } from "../../../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../../../definitions/repositories.ts";
 import { generateDataId } from "../../../data/data_id.ts";
+import { getLogger } from "@logtape/logtape";
 
 /**
  * Creates a mock UnifiedDataRepository for testing.
@@ -63,6 +64,7 @@ function createTestContext(): MethodContext {
     repoDir: "/tmp",
     modelType: AWS_CLI_MODEL_TYPE,
     modelId: crypto.randomUUID(),
+    logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
   };

--- a/src/domain/models/aws/ec2/instance/ec2_instance_model_test.ts
+++ b/src/domain/models/aws/ec2/instance/ec2_instance_model_test.ts
@@ -14,6 +14,7 @@ import type { MethodContext } from "../../../../models/model.ts";
 import type { UnifiedDataRepository } from "../../../../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../../../../definitions/repositories.ts";
 import { generateDataId } from "../../../../data/data_id.ts";
+import { getLogger } from "@logtape/logtape";
 
 /**
  * Creates a mock UnifiedDataRepository for testing.
@@ -72,6 +73,7 @@ function createTestContext(
     repoDir: "/tmp/test-repo",
     modelType: EC2_INSTANCE_MODEL_TYPE,
     modelId: crypto.randomUUID(),
+    logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
     ...overrides,

--- a/src/domain/models/aws/ec2/subnet/ec2_subnet_model_test.ts
+++ b/src/domain/models/aws/ec2/subnet/ec2_subnet_model_test.ts
@@ -14,6 +14,7 @@ import type { MethodContext } from "../../../../models/model.ts";
 import type { UnifiedDataRepository } from "../../../../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../../../../definitions/repositories.ts";
 import { generateDataId } from "../../../../data/data_id.ts";
+import { getLogger } from "@logtape/logtape";
 
 /**
  * Creates a mock UnifiedDataRepository for testing.
@@ -72,6 +73,7 @@ function createTestContext(
     repoDir: "/tmp/test-repo",
     modelType: EC2_SUBNET_MODEL_TYPE,
     modelId: crypto.randomUUID(),
+    logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
     ...overrides,

--- a/src/domain/models/aws/ec2/vpc/ec2_vpc_model_test.ts
+++ b/src/domain/models/aws/ec2/vpc/ec2_vpc_model_test.ts
@@ -14,6 +14,7 @@ import type { MethodContext } from "../../../../models/model.ts";
 import type { UnifiedDataRepository } from "../../../../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../../../../definitions/repositories.ts";
 import { generateDataId } from "../../../../data/data_id.ts";
+import { getLogger } from "@logtape/logtape";
 
 /**
  * Creates a mock UnifiedDataRepository for testing.
@@ -72,6 +73,7 @@ function createTestContext(
     repoDir: "/tmp/test-repo",
     modelType: EC2_VPC_MODEL_TYPE,
     modelId: crypto.randomUUID(),
+    logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
     ...overrides,

--- a/src/domain/models/command/curl/curl_model_test.ts
+++ b/src/domain/models/command/curl/curl_model_test.ts
@@ -13,6 +13,7 @@ import type { MethodContext } from "../../model.ts";
 import type { UnifiedDataRepository } from "../../../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../../../definitions/repositories.ts";
 import { generateDataId } from "../../../data/data_id.ts";
+import { getLogger } from "@logtape/logtape";
 
 // Check if we have network permission for integration tests
 const hasNetworkPermission = await (async () => {
@@ -71,6 +72,7 @@ function createTestContext(): MethodContext {
     repoDir: "/tmp",
     modelType: CURL_MODEL_TYPE,
     modelId: crypto.randomUUID(),
+    logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
   };

--- a/src/domain/models/echo/echo_model_test.ts
+++ b/src/domain/models/echo/echo_model_test.ts
@@ -13,6 +13,7 @@ import type { MethodContext } from "../model.ts";
 import type { UnifiedDataRepository } from "../../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../../definitions/repositories.ts";
 import { generateDataId } from "../../data/data_id.ts";
+import { getLogger } from "@logtape/logtape";
 
 /**
  * Creates a mock UnifiedDataRepository for testing.
@@ -62,6 +63,7 @@ function createTestContext(): MethodContext {
     repoDir: "/tmp",
     modelType: ECHO_MODEL_TYPE,
     modelId: crypto.randomUUID(),
+    logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
   };

--- a/src/domain/models/keeb/shell/shell_model_test.ts
+++ b/src/domain/models/keeb/shell/shell_model_test.ts
@@ -13,6 +13,7 @@ import type { MethodContext } from "../../model.ts";
 import type { UnifiedDataRepository } from "../../../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../../../definitions/repositories.ts";
 import { generateDataId } from "../../../data/data_id.ts";
+import { getLogger } from "@logtape/logtape";
 
 /**
  * Creates a mock UnifiedDataRepository for testing.
@@ -64,6 +65,7 @@ function createTestContext(
     repoDir: "/tmp",
     modelType: SHELL_MODEL_TYPE,
     modelId: crypto.randomUUID(),
+    logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
     ...overrides,

--- a/src/domain/models/lets-get-sensitive/vault_model_test.ts
+++ b/src/domain/models/lets-get-sensitive/vault_model_test.ts
@@ -12,6 +12,7 @@ import type { MethodContext } from "../model.ts";
 import type { UnifiedDataRepository } from "../../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../../definitions/repositories.ts";
 import { generateDataId } from "../../data/data_id.ts";
+import { getLogger } from "@logtape/logtape";
 
 /**
  * Creates a mock UnifiedDataRepository for testing.
@@ -61,6 +62,7 @@ function createTestContext(repoDir: string): MethodContext {
     repoDir,
     modelType: VAULT_MODEL_TYPE,
     modelId: crypto.randomUUID(),
+    logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
   };

--- a/src/domain/models/mermaid/workflow_diagram/workflow_diagram_model_test.ts
+++ b/src/domain/models/mermaid/workflow_diagram/workflow_diagram_model_test.ts
@@ -12,6 +12,7 @@ import type { MethodContext } from "../../model.ts";
 import type { UnifiedDataRepository } from "../../../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../../../definitions/repositories.ts";
 import { generateDataId } from "../../../data/data_id.ts";
+import { getLogger } from "@logtape/logtape";
 
 /**
  * Creates a mock UnifiedDataRepository for testing.
@@ -61,6 +62,7 @@ function createTestContext(): MethodContext {
     repoDir: "/tmp",
     modelType: MERMAID_WORKFLOW_MODEL_TYPE,
     modelId: crypto.randomUUID(),
+    logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
   };

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../definitions/repositories.ts";
 import { generateDataId } from "../data/data_id.ts";
+import { getLogger } from "@logtape/logtape";
 
 /**
  * Creates a mock UnifiedDataRepository for testing.
@@ -63,6 +64,7 @@ function createTestContext(overrides?: Partial<MethodContext>): MethodContext {
     repoDir: ".",
     modelType: ModelType.create("swamp/echo"),
     modelId: crypto.randomUUID(),
+    logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
     ...overrides,
@@ -673,3 +675,44 @@ Deno.test(
     assertEquals(finalAttrs?.OperationStatus, "SUCCESS");
   },
 );
+
+Deno.test("execute passes logger in context to method", async () => {
+  const service = new DefaultMethodExecutionService();
+  let capturedLogger: unknown = undefined;
+
+  const schema = z.object({ value: z.string().optional() });
+  const model: ModelDefinition = {
+    type: ModelType.create("test/logger-check"),
+    version: "1",
+    inputAttributesSchema: schema,
+    dataOutputSpecs: {},
+    methods: {
+      run: {
+        description: "Method that captures the logger from context",
+        inputAttributesSchema: schema,
+        execute: (_definition, context) => {
+          capturedLogger = context.logger;
+          // Verify logger methods are callable (no-op in test env)
+          context.logger.trace`trace message`;
+          context.logger.debug`debug message`;
+          context.logger.info`info message`;
+          context.logger.warning`warning message`;
+          context.logger.error`error message`;
+          context.logger.fatal`fatal message`;
+          return Promise.resolve({});
+        },
+      },
+    },
+  };
+
+  const definition = Definition.create({
+    name: "test-definition",
+    attributes: { value: "test" },
+  });
+
+  const context = createTestContext({ modelType: model.type });
+  await service.executeWorkflow(definition, model, "run", context);
+
+  assertEquals(capturedLogger !== undefined, true);
+  assertEquals(typeof (capturedLogger as { info: unknown }).info, "function");
+});

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { CloudControlClient } from "@aws-sdk/client-cloudcontrol";
+import type { Logger } from "@logtape/logtape";
 import { ModelType } from "./model_type.ts";
 import { CalVer } from "./calver.ts";
 import type { Definition } from "../definitions/definition.ts";
@@ -131,6 +132,11 @@ export interface MethodContext {
    * Repository for tracking execution history.
    */
   outputRepository?: OutputRepository;
+
+  /**
+   * Logger for emitting log messages. Category is set automatically.
+   */
+  logger: Logger;
 
   /**
    * Optional callbacks for streaming stdout/stderr output.

--- a/src/domain/models/model_test.ts
+++ b/src/domain/models/model_test.ts
@@ -12,6 +12,7 @@ import { createDefinitionId, Definition } from "../definitions/definition.ts";
 import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../definitions/repositories.ts";
 import { generateDataId } from "../data/data_id.ts";
+import { getLogger } from "@logtape/logtape";
 
 /**
  * Creates a mock UnifiedDataRepository for testing.
@@ -61,6 +62,7 @@ function createTestContext(modelType: ModelType): MethodContext {
     repoDir: "/tmp",
     modelType,
     modelId: crypto.randomUUID(),
+    logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
   };

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -9,6 +9,7 @@ import type { UnifiedDataRepository } from "../../infrastructure/persistence/uni
 import type { DefinitionRepository } from "../definitions/repositories.ts";
 import { generateDataId } from "../data/data_id.ts";
 import { createDefinitionId } from "../definitions/definition.ts";
+import { getLogger } from "@logtape/logtape";
 
 // Import models barrel to ensure swamp/echo is registered for duplicate test
 import "./models.ts";
@@ -61,6 +62,7 @@ function createTestContext(modelType: ModelType): MethodContext {
     repoDir: "/tmp",
     modelType,
     modelId: crypto.randomUUID(),
+    logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
   };

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -165,9 +165,11 @@ export class DefaultStepExecutor implements StepExecutor {
     command: Deno.Command,
     ctx: StepExecutionContext,
   ): Promise<unknown> {
-    const stepLogger = ctx.enableStepLogging
-      ? getWorkflowRunLogger(ctx.workflowName, ctx.jobName, ctx.stepName)
-      : undefined;
+    const stepLogger = getWorkflowRunLogger(
+      ctx.workflowName,
+      ctx.jobName,
+      ctx.stepName,
+    );
 
     const process = command.spawn();
 
@@ -179,7 +181,7 @@ export class DefaultStepExecutor implements StepExecutor {
       process.stdout,
       (line) => {
         stdoutLines.push(line);
-        stepLogger?.info(line);
+        stepLogger.info(line);
         if (ctx.progress?.onStepStdout && ctx.workflowRun) {
           ctx.progress.onStepStdout(
             ctx.workflowRun,
@@ -195,7 +197,7 @@ export class DefaultStepExecutor implements StepExecutor {
       process.stderr,
       (line) => {
         stderrLines.push(line);
-        stepLogger?.warn(line);
+        stepLogger.warn(line);
         if (ctx.progress?.onStepStderr && ctx.workflowRun) {
           ctx.progress.onStepStderr(
             ctx.workflowRun,
@@ -281,11 +283,9 @@ export class DefaultStepExecutor implements StepExecutor {
     const { definition: originalDefinition, type: modelType } = lookupResult;
 
     // Log via model method run logger (same categories as standalone)
-    const runLogger = ctx.enableStepLogging
-      ? getRunLogger(originalDefinition.name, task.methodName)
-      : undefined;
+    const runLogger = getRunLogger(originalDefinition.name, task.methodName);
 
-    runLogger?.info("Found model {name} ({type})", {
+    runLogger.info("Found model {name} ({type})", {
       name: originalDefinition.name,
       type: modelType.normalized,
     });
@@ -332,7 +332,7 @@ export class DefaultStepExecutor implements StepExecutor {
       }
       evaluatedDefinition = lastEvaluated;
     } else if (ctx.expressionContext) {
-      runLogger?.info("Evaluating expressions");
+      runLogger.info("Evaluating expressions");
       // Set self context for this specific model before evaluating
       ctx.expressionContext.self = {
         id: originalDefinition.id,
@@ -416,40 +416,36 @@ export class DefaultStepExecutor implements StepExecutor {
     let dataName: string | undefined;
 
     try {
-      runLogger?.info("Executing method {method}", {
+      runLogger.info("Executing method {method}", {
         method: task.methodName,
       });
 
-      // Build streaming callbacks — log via runLogger when enabled,
-      // and always call progress callback for persistence
-      const hasProgressStreaming = ctx.progress?.onStepStdout ||
-        ctx.progress?.onStepStderr;
-      const streaming = (runLogger || hasProgressStreaming)
-        ? {
-          onStdout: (line: string) => {
-            runLogger?.info(line);
-            if (ctx.progress?.onStepStdout && ctx.workflowRun) {
-              ctx.progress.onStepStdout(
-                ctx.workflowRun,
-                ctx.jobName,
-                ctx.stepName,
-                line,
-              );
-            }
-          },
-          onStderr: (line: string) => {
-            runLogger?.warn(line);
-            if (ctx.progress?.onStepStderr && ctx.workflowRun) {
-              ctx.progress.onStepStderr(
-                ctx.workflowRun,
-                ctx.jobName,
-                ctx.stepName,
-                line,
-              );
-            }
-          },
-        }
-        : undefined;
+      // Build streaming callbacks — log via runLogger,
+      // and call progress callback for persistence
+      const streaming = {
+        onStdout: (line: string) => {
+          runLogger.info(line);
+          if (ctx.progress?.onStepStdout && ctx.workflowRun) {
+            ctx.progress.onStepStdout(
+              ctx.workflowRun,
+              ctx.jobName,
+              ctx.stepName,
+              line,
+            );
+          }
+        },
+        onStderr: (line: string) => {
+          runLogger.warn(line);
+          if (ctx.progress?.onStepStderr && ctx.workflowRun) {
+            ctx.progress.onStepStderr(
+              ctx.workflowRun,
+              ctx.jobName,
+              ctx.stepName,
+              line,
+            );
+          }
+        },
+      };
 
       // Execute the method with EVALUATED definition
       const result = await executionService.executeWorkflow(
@@ -460,6 +456,7 @@ export class DefaultStepExecutor implements StepExecutor {
           repoDir: ctx.repoDir,
           modelType,
           modelId: evaluatedDefinition.id,
+          logger: runLogger,
           dataRepository: unifiedDataRepo,
           definitionRepository: definitionRepo,
           streaming,
@@ -528,15 +525,13 @@ export class DefaultStepExecutor implements StepExecutor {
           output.addDataArtifact(artifactRef);
           savedArtifacts.push(artifactRef);
 
-          if (runLogger) {
-            const dataPath = unifiedDataRepo.getPath(
-              modelType,
-              evaluatedDefinition.id,
-              dataOutput.name,
-              saveResult.version,
-            );
-            runLogger.info("Data saved to {path}", { path: dataPath });
-          }
+          const dataPath = unifiedDataRepo.getPath(
+            modelType,
+            evaluatedDefinition.id,
+            dataOutput.name,
+            saveResult.version,
+          );
+          runLogger.info("Data saved to {path}", { path: dataPath });
 
           // Use first JSON data output for context refresh
           if (
@@ -558,7 +553,7 @@ export class DefaultStepExecutor implements StepExecutor {
       output.markSucceeded();
       await outputRepo.save(modelType, task.methodName, output);
 
-      runLogger?.with({ summary: true }).info(
+      runLogger.with({ summary: true }).info(
         "Method {method} completed on {model}",
         { method: task.methodName, model: originalDefinition.name },
       );
@@ -584,7 +579,7 @@ export class DefaultStepExecutor implements StepExecutor {
       output.markFailed({ message: errorMessage, stack: errorStack });
       await outputRepo.save(modelType, task.methodName, output);
 
-      runLogger?.error("Method {method} failed: {error}", {
+      runLogger.error("Method {method} failed: {error}", {
         method: task.methodName,
         model: originalDefinition.name,
         error: errorMessage,


### PR DESCRIPTION
## Summary

Closes #222

Inject a pre-configured LogTape logger into `MethodContext` so model authors can emit log messages via `context.logger` with zero setup. The logger category is set automatically based on model type + method name.

- Add required `logger: Logger` field to `MethodContext` interface
- Wire logger in both CLI (`model_method_run`) and workflow (`execution_service`) execution paths
- Always create run/step loggers — remove conditional gating (LogTape sink configuration already handles suppression)
- Update all 14 test helpers with `getLogger(["test"])`
- Add test verifying logger is present in context and all log level methods are callable
- Document `context.logger` in the extension model skill docs (structured placeholders, `{*}`, log levels)

## Test Plan

- All 1249 tests pass
- New test in `method_execution_service_test.ts` verifies logger is injected and callable
- `deno check`, `deno lint`, `deno fmt` all pass