### PR TITLE
feat: Add CalVer versioning with upgrade functions for models

### DIFF
--- a/design/models.md
+++ b/design/models.md
@@ -32,14 +32,101 @@ Each instance of a model has a unique ID that is a uuidv4.
 
 ## Version
 
-Each model has a version number, starting with 1. Models must support data
-written by all earlier versions, but not later versions.
+Each model has a version using **CalVer** format `YYYY.MM.DD.MICRO` (e.g.,
+`"2025.01.15.1"`, `"2025.06.01.3"`). The micro counter allows multiple version
+bumps per day and resets for each new date.
 
-For example, a model '4' can read data from version 1-4, but not '5'.
+Version comparison splits on `.`, compares the first three segments as
+zero-padded strings, and the fourth as a number. This is implemented as the
+`CalVer` value object in `src/domain/models/calver.ts`.
+
+Models must support data written by all earlier versions, but not later
+versions.
 
 ## Migration
 
-A model can migrate its definitions and data from one version to the next.
+A model can migrate its definitions from one version to the next using **upgrade
+functions**. Each model declares an ordered list of `VersionUpgrade` entries,
+one per version transition. When a definition's `typeVersion` is behind the
+model's current `version`, the upgrade chain runs all applicable upgrades in
+order, transforming attributes at each step.
+
+Upgrades are **lazy** — they run at method execution time in
+`executeWorkflow()`, not at load time. The upgraded definition is persisted so
+the upgrade only runs once.
+
+### Upgrade Rules
+
+- Upgrades must be ordered chronologically by `toVersion`
+- The last upgrade's `toVersion` must equal the model's current `version`
+- Upgrade functions are pure attribute transforms (old attrs → new attrs)
+- Upgrades are forward-only; there is no downgrade path
+
+### Example
+
+A model starts at version `"2025.01.15.1"` with just a `message` attribute. On
+`"2025.06.01.1"`, a `priority` field is added with a default. On
+`"2026.02.09.1"`, the `message` field is renamed to `content`:
+
+```typescript
+import { z } from "zod";
+
+export const model = {
+  type: "acme/notifier",
+  version: "2026.02.09.1",
+  inputAttributesSchema: z.object({
+    content: z.string().min(1),
+    priority: z.enum(["low", "medium", "high"]),
+  }),
+  upgrades: [
+    {
+      toVersion: "2025.06.01.1",
+      description: "Add priority field with default 'medium'",
+      upgradeAttributes: (old) => ({ ...old, priority: "medium" }),
+    },
+    {
+      toVersion: "2026.02.09.1",
+      description: "Rename 'message' to 'content'",
+      upgradeAttributes: (old) => {
+        const { message, ...rest } = old;
+        return { ...rest, content: message };
+      },
+    },
+  ],
+  methods: {
+    send: {
+      description: "Send a notification",
+      execute: async (definition, _context) => {
+        const attrs = definition.attributes;
+        return {
+          data: {
+            attributes: {
+              sent: true,
+              content: attrs.content,
+              priority: attrs.priority,
+            },
+          },
+        };
+      },
+    },
+  },
+};
+```
+
+If a definition was created at `"2025.01.15.1"` with `{ message: "hello" }`, and
+the model is now at `"2026.02.09.1"`, running a method will:
+
+1. Apply upgrade to `"2025.06.01.1"`: `{ message: "hello", priority: "medium" }`
+2. Apply upgrade to `"2026.02.09.1"`: `{ content: "hello", priority: "medium" }`
+3. Persist the definition with `typeVersion: "2026.02.09.1"` and new attributes
+4. Execute the method with the upgraded definition
+
+### Backwards Compatibility
+
+Existing definitions on disk with numeric `typeVersion` (e.g., `typeVersion: 1`)
+are automatically coerced to `undefined` by the `DefinitionSchema`, meaning
+"pre-CalVer, needs upgrade from earliest version". They will be upgraded on
+first method execution and persisted with the new CalVer `typeVersion`.
 
 ## Definitions
 

--- a/experiments/extensions/models/anthropic_claude.ts
+++ b/experiments/extensions/models/anthropic_claude.ts
@@ -138,7 +138,7 @@ async function executeGenerate(
  */
 export const anthropicClaudeModel = defineModel({
   type: ModelType.create("anthropic/claude"),
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputAttributesSchema,
   methods: {
     generate: {

--- a/experiments/extensions/models/digitalocean_app.ts
+++ b/experiments/extensions/models/digitalocean_app.ts
@@ -651,7 +651,7 @@ async function executeSync(
  */
 export const digitaloceanAppModel = defineModel({
   type: ModelType.create("digitalocean/app"),
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputAttributesSchema,
   methods: {
     create: {

--- a/experiments/extensions/models/digitalocean_droplet.ts
+++ b/experiments/extensions/models/digitalocean_droplet.ts
@@ -398,7 +398,7 @@ function executeReboot(
  */
 export const digitaloceanDropletModel = defineModel({
   type: ModelType.create("digitalocean/droplet"),
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputAttributesSchema,
   methods: {
     create: {

--- a/experiments/extensions/models/digitalocean_ssh_key.ts
+++ b/experiments/extensions/models/digitalocean_ssh_key.ts
@@ -298,7 +298,7 @@ async function executeSync(
  */
 export const digitaloceanSshKeyModel = defineModel({
   type: ModelType.create("digitalocean/ssh-key"),
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputAttributesSchema,
   methods: {
     create: {

--- a/experiments/extensions/models/discord_webhook.ts
+++ b/experiments/extensions/models/discord_webhook.ts
@@ -114,7 +114,7 @@ async function executeSend(
  */
 export const discordWebhookModel = defineModel({
   type: ModelType.create("discord/webhook"),
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputAttributesSchema,
   methods: {
     send: {

--- a/experiments/extensions/models/docker_image.ts
+++ b/experiments/extensions/models/docker_image.ts
@@ -190,7 +190,7 @@ async function executeBuildPush(
  */
 export const dockerImageModel = defineModel({
   type: ModelType.create("docker/image"),
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputAttributesSchema,
   methods: {
     build: {

--- a/experiments/extensions/models/github_pr_list.ts
+++ b/experiments/extensions/models/github_pr_list.ts
@@ -154,7 +154,7 @@ async function executeList(
  */
 export const githubPrListModel = defineModel({
   type: ModelType.create("github/pr-list"),
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputAttributesSchema,
   methods: {
     list: {

--- a/experiments/extensions/models/ssh_remote.ts
+++ b/experiments/extensions/models/ssh_remote.ts
@@ -199,7 +199,7 @@ export const sshRemoteModel: ModelDefinition<
   typeof SshRemoteInputAttributesSchema
 > = defineModel({
   type: SSH_REMOTE_MODEL_TYPE,
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: SshRemoteInputAttributesSchema,
   methods: {
     execute: {

--- a/integration/data_output_specs_test.ts
+++ b/integration/data_output_specs_test.ts
@@ -421,7 +421,7 @@ import { z } from "npm:zod@4";
 
 export const model = {
   type: "${typeId}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   methods: {
     process: {
@@ -488,7 +488,7 @@ import { z } from "npm:zod@4";
 
 export const model = {
   type: "${typeId}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: z.object({ name: z.string() }),
   methods: {
     create: {

--- a/integration/definition_test.ts
+++ b/integration/definition_test.ts
@@ -52,7 +52,7 @@ Deno.test("Definition: create and save definition with static attributes", async
     const content = await Deno.readTextFile(path);
     const data = parseYaml(content) as Record<string, unknown>;
     assertEquals(data.type, "swamp/echo");
-    assertEquals(data.typeVersion, 1);
+    assertEquals(data.typeVersion, undefined);
     assertEquals(data.name, "my-echo");
     assertEquals(data.version, 1);
     assertEquals((data.tags as Record<string, string>).env, "test");

--- a/integration/echo_model_test.ts
+++ b/integration/echo_model_test.ts
@@ -94,7 +94,7 @@ Deno.test("Echo model: full flow - create definition, execute write, verify data
       unknown
     >;
     assertEquals(definitionData.type, "swamp/echo");
-    assertEquals(definitionData.typeVersion, 1);
+    assertEquals(definitionData.typeVersion, "2026.02.09.1");
     assertEquals(definitionData.name, "test-echo-definition");
     assertEquals(
       (definitionData.attributes as Record<string, unknown>).message,

--- a/integration/simple_return_format_test.ts
+++ b/integration/simple_return_format_test.ts
@@ -75,7 +75,7 @@ const InputSchema = z.object({
 
 export const model = {
   type: "test/resource-model",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
     provision: {
@@ -189,7 +189,7 @@ const InputSchema = z.object({
 
 export const model = {
   type: "test/data-model",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
     fetch: {
@@ -318,7 +318,7 @@ const InputSchema = z.object({
 
 export const model = {
   type: "test/expression-model",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
     deploy: {
@@ -406,7 +406,7 @@ const InputSchema = z.object({
 
 export const model = {
   type: "test/simple-data",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
     process: {
@@ -480,7 +480,7 @@ const InputSchema = z.object({
 
 export const model = {
   type: "test/legacy-format",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
     run: {
@@ -517,7 +517,7 @@ const InputSchema = z.object({
 
 export const model = {
   type: "test/simple-format",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
     run: {

--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -64,7 +64,7 @@ export const modelCreateCommand = new Command()
     const definition = Definition.create({
       name,
       type: modelType.normalized,
-      typeVersion: modelDef?.version ?? 1,
+      typeVersion: modelDef?.version,
     });
     await definitionRepo.save(modelType, definition);
 

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -144,7 +144,7 @@ export const modelMethodRunCommand = new Command()
         methodName,
         provenance: {
           definitionHash,
-          modelVersion: definition.version,
+          modelVersion: modelDef.version,
           triggeredBy: "manual",
         },
       });

--- a/src/domain/definitions/definition.ts
+++ b/src/domain/definitions/definition.ts
@@ -86,10 +86,17 @@ export const InputsSchemaSchema: z.ZodType<InputsSchema | undefined> = z
 
 /**
  * Zod schema for the core properties of a Definition.
+ *
+ * `typeVersion` accepts CalVer strings.  Legacy numeric values (from
+ * pre-CalVer definitions stored on disk) are coerced to `undefined` so
+ * the upgrade chain treats them as "oldest version, needs full upgrade".
  */
 export const DefinitionSchema = z.object({
   type: z.string().optional(),
-  typeVersion: z.number().int().positive().optional(),
+  typeVersion: z.preprocess(
+    (val) => (typeof val === "number" ? undefined : val),
+    z.string().optional(),
+  ),
   id: z.string().uuid(),
   name: z.string().min(1),
   version: z.number().int().positive(),
@@ -108,7 +115,7 @@ export type DefinitionData = z.infer<typeof DefinitionSchema>;
  */
 export interface CreateDefinitionProps {
   type?: string;
-  typeVersion?: number;
+  typeVersion?: string;
   id?: string;
   name: string;
   version?: number;
@@ -129,7 +136,7 @@ export interface CreateDefinitionProps {
 export class Definition {
   private constructor(
     readonly type: string | undefined,
-    readonly typeVersion: number | undefined,
+    readonly typeVersion: string | undefined,
     readonly id: DefinitionId,
     readonly name: string,
     readonly version: number,
@@ -188,6 +195,32 @@ export class Definition {
       validated.tags,
       validated.attributes,
       validated.inputs,
+    );
+  }
+
+  /**
+   * Creates a new Definition with upgraded attributes and an updated typeVersion.
+   * Preserves the same id, name, version, tags, and inputs.
+   *
+   * @param original - The original definition to upgrade
+   * @param newAttributes - The upgraded attributes
+   * @param newTypeVersion - The CalVer version after upgrade
+   * @returns A new Definition with upgraded attributes
+   */
+  static withUpgradedAttributes(
+    original: Definition,
+    newAttributes: Record<string, unknown>,
+    newTypeVersion: string,
+  ): Definition {
+    return new Definition(
+      original.type,
+      newTypeVersion,
+      original.id,
+      original.name,
+      original.version,
+      { ...original._tags },
+      structuredClone(newAttributes),
+      original._inputs ? structuredClone(original._inputs) : undefined,
     );
   }
 

--- a/src/domain/definitions/definition_test.ts
+++ b/src/domain/definitions/definition_test.ts
@@ -305,10 +305,10 @@ Deno.test("Definition.create with type and typeVersion", () => {
   const definition = Definition.create({
     name: "test-definition",
     type: "swamp/echo",
-    typeVersion: 1,
+    typeVersion: "2026.02.09.1",
   });
   assertEquals(definition.type, "swamp/echo");
-  assertEquals(definition.typeVersion, 1);
+  assertEquals(definition.typeVersion, "2026.02.09.1");
 });
 
 Deno.test("Definition.create without type and typeVersion defaults to undefined", () => {
@@ -321,11 +321,11 @@ Deno.test("Definition.toData includes type and typeVersion", () => {
   const definition = Definition.create({
     name: "test-definition",
     type: "swamp/echo",
-    typeVersion: 2,
+    typeVersion: "2026.02.09.2",
   });
   const data = definition.toData();
   assertEquals(data.type, "swamp/echo");
-  assertEquals(data.typeVersion, 2);
+  assertEquals(data.typeVersion, "2026.02.09.2");
 });
 
 Deno.test("Definition.fromData round-trips type and typeVersion", () => {
@@ -333,12 +333,12 @@ Deno.test("Definition.fromData round-trips type and typeVersion", () => {
     id: "550e8400-e29b-41d4-a716-446655440000",
     name: "test-definition",
     type: "aws/ec2/vpc",
-    typeVersion: 3,
+    typeVersion: "2026.02.09.3",
   });
   const data = definition.toData();
   const restored = Definition.fromData(data);
   assertEquals(restored.type, "aws/ec2/vpc");
-  assertEquals(restored.typeVersion, 3);
+  assertEquals(restored.typeVersion, "2026.02.09.3");
   assertEquals(restored.id, definition.id);
   assertEquals(restored.name, definition.name);
 });
@@ -358,11 +358,72 @@ Deno.test("Definition.computeHash is stable regardless of type/typeVersion", asy
     version: 1,
     attributes: { message: "hello" },
     type: "swamp/echo",
-    typeVersion: 1,
+    typeVersion: "2026.02.09.1",
   });
 
   const hash1 = await defWithout.computeHash();
   const hash2 = await defWith.computeHash();
 
   assertEquals(hash1, hash2);
+});
+
+// --- withUpgradedAttributes tests ---
+
+Deno.test("Definition.withUpgradedAttributes preserves id, name, tags", () => {
+  const original = Definition.create({
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "my-definition",
+    type: "swamp/echo",
+    typeVersion: "2025.01.15.1",
+    tags: { env: "prod" },
+    attributes: { message: "hello" },
+  });
+
+  const upgraded = Definition.withUpgradedAttributes(
+    original,
+    { content: "hello", priority: "medium" },
+    "2026.02.09.1",
+  );
+
+  assertEquals(upgraded.id, "550e8400-e29b-41d4-a716-446655440000");
+  assertEquals(upgraded.name, "my-definition");
+  assertEquals(upgraded.type, "swamp/echo");
+  assertEquals(upgraded.tags, { env: "prod" });
+  assertEquals(upgraded.version, 1);
+});
+
+Deno.test("Definition.withUpgradedAttributes updates attributes and typeVersion", () => {
+  const original = Definition.create({
+    name: "test-def",
+    type: "swamp/echo",
+    typeVersion: "2025.01.15.1",
+    attributes: { message: "old" },
+  });
+
+  const upgraded = Definition.withUpgradedAttributes(
+    original,
+    { content: "new", priority: "high" },
+    "2026.02.09.1",
+  );
+
+  assertEquals(upgraded.attributes, { content: "new", priority: "high" });
+  assertEquals(upgraded.typeVersion, "2026.02.09.1");
+  // Original should be unchanged
+  assertEquals(original.attributes, { message: "old" });
+  assertEquals(original.typeVersion, "2025.01.15.1");
+});
+
+Deno.test("Legacy numeric typeVersion coerced to undefined", () => {
+  const definition = Definition.fromData({
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "legacy-def",
+    version: 1,
+    type: "swamp/echo",
+    typeVersion: 1 as unknown as string,
+    tags: {},
+    attributes: { message: "hello" },
+    inputs: undefined,
+  });
+
+  assertEquals(definition.typeVersion, undefined);
 });

--- a/src/domain/models/aws/cli/aws_cli_model.ts
+++ b/src/domain/models/aws/cli/aws_cli_model.ts
@@ -223,7 +223,7 @@ export const awsCliModel: ModelDefinition<
   typeof AwsCliInputAttributesSchema
 > = defineModel({
   type: AWS_CLI_MODEL_TYPE,
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: AwsCliInputAttributesSchema,
   dataOutputSpecs: {
     "data": {

--- a/src/domain/models/aws/cli/aws_cli_model_test.ts
+++ b/src/domain/models/aws/cli/aws_cli_model_test.ts
@@ -73,7 +73,7 @@ Deno.test("AWS_CLI_MODEL_TYPE has correct normalized type", () => {
 });
 
 Deno.test("awsCliModel has correct version", () => {
-  assertEquals(awsCliModel.version, 1);
+  assertEquals(awsCliModel.version, "2026.02.09.1");
 });
 
 Deno.test("awsCliModel.type equals AWS_CLI_MODEL_TYPE", () => {

--- a/src/domain/models/aws/cloud_control_model.ts
+++ b/src/domain/models/aws/cloud_control_model.ts
@@ -574,7 +574,7 @@ export abstract class AWSCloudControlModel<
 
     return {
       type: this.modelType,
-      version: 1,
+      version: "2026.02.09.1",
       inputAttributesSchema: this.config.inputAttributesSchema,
       dataOutputSpecs: {
         "resource": {

--- a/src/domain/models/aws/cloud_control_model_test.ts
+++ b/src/domain/models/aws/cloud_control_model_test.ts
@@ -44,7 +44,7 @@ Deno.test("AWSCloudControlModel.defineAndRegister returns valid ModelDefinition"
   const definition = model.defineAndRegister();
 
   // Verify the definition has the expected structure
-  assertEquals(definition.version, 1);
+  assertEquals(definition.version, "2026.02.09.1");
   assertEquals(typeof definition.methods.create, "object");
   assertEquals(typeof definition.methods.delete, "object");
   assertEquals(typeof definition.methods.sync, "object");

--- a/src/domain/models/aws/ec2/instance/ec2_instance_model_test.ts
+++ b/src/domain/models/aws/ec2/instance/ec2_instance_model_test.ts
@@ -101,7 +101,7 @@ Deno.test("EC2InstanceModel - model type", () => {
 });
 
 Deno.test("EC2InstanceModel - version", () => {
-  assertEquals(ec2InstanceModel.version, 1);
+  assertEquals(ec2InstanceModel.version, "2026.02.09.1");
 });
 
 Deno.test("EC2InstanceModel - has required methods", () => {

--- a/src/domain/models/aws/ec2/subnet/ec2_subnet_model_test.ts
+++ b/src/domain/models/aws/ec2/subnet/ec2_subnet_model_test.ts
@@ -101,7 +101,7 @@ Deno.test("EC2SubnetModel - model type", () => {
 });
 
 Deno.test("EC2SubnetModel - version", () => {
-  assertEquals(ec2SubnetModel.version, 1);
+  assertEquals(ec2SubnetModel.version, "2026.02.09.1");
 });
 
 Deno.test("EC2SubnetModel - has required methods", () => {

--- a/src/domain/models/aws/ec2/vpc/ec2_vpc_model_test.ts
+++ b/src/domain/models/aws/ec2/vpc/ec2_vpc_model_test.ts
@@ -101,7 +101,7 @@ Deno.test("EC2VpcModel - model type", () => {
 });
 
 Deno.test("EC2VpcModel - version", () => {
-  assertEquals(ec2VpcModel.version, 1);
+  assertEquals(ec2VpcModel.version, "2026.02.09.1");
 });
 
 Deno.test("EC2VpcModel - has required methods", () => {

--- a/src/domain/models/calver.ts
+++ b/src/domain/models/calver.ts
@@ -1,0 +1,73 @@
+/**
+ * CalVer version string in the format YYYY.MM.DD.MICRO.
+ *
+ * Value object — equality by value.
+ *
+ * The micro counter allows multiple version bumps per day and resets
+ * for each new date.  Comparison splits on `.`, compares the first
+ * three segments as zero-padded strings, and the fourth as a number.
+ */
+export class CalVer {
+  private static readonly PATTERN = /^\d{4}\.\d{2}\.\d{2}\.\d+$/;
+
+  private constructor(readonly value: string) {}
+
+  /**
+   * Creates a CalVer instance after validating the format.
+   *
+   * @throws Error if the version string is not valid CalVer
+   */
+  static create(version: string): CalVer {
+    if (!CalVer.isValid(version)) {
+      throw new Error(
+        `Invalid CalVer version: "${version}". Expected format YYYY.MM.DD.MICRO (e.g., "2025.01.15.1")`,
+      );
+    }
+    return new CalVer(version);
+  }
+
+  /**
+   * Checks whether a string is a valid CalVer version.
+   */
+  static isValid(version: string): boolean {
+    return CalVer.PATTERN.test(version);
+  }
+
+  /**
+   * Compares two CalVer values.
+   *
+   * @returns -1 if a < b, 0 if equal, 1 if a > b
+   */
+  static compare(a: CalVer, b: CalVer): -1 | 0 | 1 {
+    const aParts = a.value.split(".");
+    const bParts = b.value.split(".");
+
+    // Compare first three segments as strings (zero-padded)
+    for (let i = 0; i < 3; i++) {
+      if (aParts[i] < bParts[i]) return -1;
+      if (aParts[i] > bParts[i]) return 1;
+    }
+
+    // Compare micro segment as numbers
+    const aMicro = Number(aParts[3]);
+    const bMicro = Number(bParts[3]);
+    if (aMicro < bMicro) return -1;
+    if (aMicro > bMicro) return 1;
+
+    return 0;
+  }
+
+  /**
+   * Returns the raw version string.
+   */
+  toString(): string {
+    return this.value;
+  }
+
+  /**
+   * Value equality.
+   */
+  equals(other: CalVer): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/domain/models/calver_test.ts
+++ b/src/domain/models/calver_test.ts
@@ -1,0 +1,104 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { CalVer } from "./calver.ts";
+
+// --- Validation ---
+
+Deno.test("CalVer.isValid accepts valid CalVer strings", () => {
+  assertEquals(CalVer.isValid("2025.01.15.1"), true);
+  assertEquals(CalVer.isValid("2025.06.01.3"), true);
+  assertEquals(CalVer.isValid("2026.02.09.1"), true);
+  assertEquals(CalVer.isValid("2025.12.31.100"), true);
+  assertEquals(CalVer.isValid("2025.01.01.0"), true);
+});
+
+Deno.test("CalVer.isValid rejects invalid formats", () => {
+  assertEquals(CalVer.isValid("1"), false);
+  assertEquals(CalVer.isValid("2025"), false);
+  assertEquals(CalVer.isValid("2025.01"), false);
+  assertEquals(CalVer.isValid("2025.01.15"), false);
+  assertEquals(CalVer.isValid("2025.1.15.1"), false); // month not zero-padded
+  assertEquals(CalVer.isValid("2025.01.1.1"), false); // day not zero-padded
+  assertEquals(CalVer.isValid("25.01.15.1"), false); // year not 4 digits
+  assertEquals(CalVer.isValid("v2025.01.15.1"), false); // leading v
+  assertEquals(CalVer.isValid("2025.01.15.1.extra"), false); // too many segments
+  assertEquals(CalVer.isValid(""), false);
+  assertEquals(CalVer.isValid("abc"), false);
+});
+
+Deno.test("CalVer.create returns instance for valid version", () => {
+  const cv = CalVer.create("2025.01.15.1");
+  assertEquals(cv.value, "2025.01.15.1");
+});
+
+Deno.test("CalVer.create throws for invalid version", () => {
+  assertThrows(
+    () => CalVer.create("not-a-version"),
+    Error,
+    'Invalid CalVer version: "not-a-version"',
+  );
+});
+
+// --- Comparison ---
+
+Deno.test("CalVer.compare returns 0 for equal versions", () => {
+  const a = CalVer.create("2025.01.15.1");
+  const b = CalVer.create("2025.01.15.1");
+  assertEquals(CalVer.compare(a, b), 0);
+});
+
+Deno.test("CalVer.compare handles different years", () => {
+  const a = CalVer.create("2024.06.01.1");
+  const b = CalVer.create("2025.06.01.1");
+  assertEquals(CalVer.compare(a, b), -1);
+  assertEquals(CalVer.compare(b, a), 1);
+});
+
+Deno.test("CalVer.compare handles different months", () => {
+  const a = CalVer.create("2025.01.15.1");
+  const b = CalVer.create("2025.06.15.1");
+  assertEquals(CalVer.compare(a, b), -1);
+  assertEquals(CalVer.compare(b, a), 1);
+});
+
+Deno.test("CalVer.compare handles different days", () => {
+  const a = CalVer.create("2025.06.01.1");
+  const b = CalVer.create("2025.06.15.1");
+  assertEquals(CalVer.compare(a, b), -1);
+  assertEquals(CalVer.compare(b, a), 1);
+});
+
+Deno.test("CalVer.compare handles micro segment as numeric (not string)", () => {
+  const a = CalVer.create("2025.01.15.2");
+  const b = CalVer.create("2025.01.15.10");
+  assertEquals(CalVer.compare(a, b), -1);
+  assertEquals(CalVer.compare(b, a), 1);
+});
+
+Deno.test("CalVer.compare same date different micro", () => {
+  const a = CalVer.create("2025.01.15.1");
+  const b = CalVer.create("2025.01.15.3");
+  assertEquals(CalVer.compare(a, b), -1);
+  assertEquals(CalVer.compare(b, a), 1);
+});
+
+// --- Equality ---
+
+Deno.test("CalVer.equals returns true for same value", () => {
+  const a = CalVer.create("2025.01.15.1");
+  const b = CalVer.create("2025.01.15.1");
+  assertEquals(a.equals(b), true);
+});
+
+Deno.test("CalVer.equals returns false for different values", () => {
+  const a = CalVer.create("2025.01.15.1");
+  const b = CalVer.create("2025.01.15.2");
+  assertEquals(a.equals(b), false);
+});
+
+// --- toString ---
+
+Deno.test("CalVer.toString returns the raw string", () => {
+  const cv = CalVer.create("2025.06.01.3");
+  assertEquals(cv.toString(), "2025.06.01.3");
+  assertEquals(`${cv}`, "2025.06.01.3");
+});

--- a/src/domain/models/command/curl/curl_model.ts
+++ b/src/domain/models/command/curl/curl_model.ts
@@ -226,7 +226,7 @@ export const curlModel: ModelDefinition<
   typeof CurlInputAttributesSchema
 > = defineModel({
   type: CURL_MODEL_TYPE,
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: CurlInputAttributesSchema,
   dataOutputSpecs: {
     "metadata": {

--- a/src/domain/models/command/curl/curl_model_test.ts
+++ b/src/domain/models/command/curl/curl_model_test.ts
@@ -104,7 +104,7 @@ Deno.test("CURL_MODEL_TYPE has correct normalized type", () => {
 });
 
 Deno.test("curlModel has correct version", () => {
-  assertEquals(curlModel.version, 1);
+  assertEquals(curlModel.version, "2026.02.09.1");
 });
 
 Deno.test("curlModel.type equals CURL_MODEL_TYPE", () => {

--- a/src/domain/models/definition_upgrade_service.ts
+++ b/src/domain/models/definition_upgrade_service.ts
@@ -1,0 +1,86 @@
+import { CalVer } from "./calver.ts";
+import { Definition } from "../definitions/definition.ts";
+import type { ModelDefinition } from "./model.ts";
+
+/**
+ * Result of an upgrade attempt.
+ */
+export interface UpgradeResult {
+  /** Whether the definition was upgraded */
+  upgraded: boolean;
+  /** The (possibly upgraded) definition */
+  definition: Definition;
+  /** The original typeVersion (may be undefined for legacy definitions) */
+  fromVersion: string | undefined;
+  /** The target version (always the model's current version) */
+  toVersion: string;
+}
+
+/**
+ * Domain service that applies version upgrades to definitions.
+ *
+ * When a definition's `typeVersion` is behind the model's current `version`,
+ * the upgrade chain runs all applicable upgrades in order, transforming
+ * attributes at each step.
+ */
+export class DefinitionUpgradeService {
+  /**
+   * Upgrades a definition to the model's current version by applying
+   * all applicable upgrade functions in order.
+   *
+   * @param definition - The definition to potentially upgrade
+   * @param modelDef - The model definition with the upgrade chain
+   * @returns The upgrade result
+   */
+  upgrade(definition: Definition, modelDef: ModelDefinition): UpgradeResult {
+    const fromVersion = definition.typeVersion;
+    const toVersion = modelDef.version;
+
+    // No upgrades defined — nothing to do
+    if (!modelDef.upgrades || modelDef.upgrades.length === 0) {
+      return { upgraded: false, definition, fromVersion, toVersion };
+    }
+
+    // If typeVersion is defined and >= model version, no upgrade needed
+    if (fromVersion !== undefined) {
+      const fromCv = CalVer.create(fromVersion);
+      const toCv = CalVer.create(toVersion);
+      if (CalVer.compare(fromCv, toCv) >= 0) {
+        return { upgraded: false, definition, fromVersion, toVersion };
+      }
+    }
+
+    // Filter upgrades to those with toVersion > definition.typeVersion
+    const applicableUpgrades = fromVersion === undefined
+      ? modelDef.upgrades // undefined typeVersion → apply all upgrades
+      : modelDef.upgrades.filter((upgrade) => {
+        const upgradeCv = CalVer.create(upgrade.toVersion);
+        const fromCv = CalVer.create(fromVersion);
+        return CalVer.compare(upgradeCv, fromCv) > 0;
+      });
+
+    if (applicableUpgrades.length === 0) {
+      return { upgraded: false, definition, fromVersion, toVersion };
+    }
+
+    // Apply upgrades in order
+    let currentAttributes = definition.attributes;
+    for (const upgrade of applicableUpgrades) {
+      currentAttributes = upgrade.upgradeAttributes(currentAttributes);
+    }
+
+    // Create a new definition with the upgraded attributes
+    const upgradedDefinition = Definition.withUpgradedAttributes(
+      definition,
+      currentAttributes,
+      toVersion,
+    );
+
+    return {
+      upgraded: true,
+      definition: upgradedDefinition,
+      fromVersion,
+      toVersion,
+    };
+  }
+}

--- a/src/domain/models/definition_upgrade_service_test.ts
+++ b/src/domain/models/definition_upgrade_service_test.ts
@@ -1,0 +1,252 @@
+import { assertEquals } from "@std/assert";
+import { z } from "zod";
+import { DefinitionUpgradeService } from "./definition_upgrade_service.ts";
+import { Definition } from "../definitions/definition.ts";
+import type { ModelDefinition, VersionUpgrade } from "./model.ts";
+import { ModelType } from "./model_type.ts";
+
+function createModelDef(
+  version: string,
+  upgrades?: VersionUpgrade[],
+): ModelDefinition {
+  return {
+    type: ModelType.create("test/upgradeable"),
+    version,
+    inputAttributesSchema: z.object({}),
+    dataOutputSpecs: {},
+    methods: {},
+    upgrades,
+  };
+}
+
+Deno.test("DefinitionUpgradeService - no upgrade needed when versions match", () => {
+  const service = new DefinitionUpgradeService();
+  const definition = Definition.create({
+    name: "test-def",
+    type: "test/upgradeable",
+    typeVersion: "2025.06.01.1",
+    attributes: { message: "hello" },
+  });
+
+  const modelDef = createModelDef("2025.06.01.1", [
+    {
+      toVersion: "2025.06.01.1",
+      description: "Initial version",
+      upgradeAttributes: (old) => ({ ...old, added: true }),
+    },
+  ]);
+
+  const result = service.upgrade(definition, modelDef);
+
+  assertEquals(result.upgraded, false);
+  assertEquals(result.definition.attributes.message, "hello");
+  assertEquals(result.definition.attributes.added, undefined);
+});
+
+Deno.test("DefinitionUpgradeService - no upgrade needed when no upgrades defined", () => {
+  const service = new DefinitionUpgradeService();
+  const definition = Definition.create({
+    name: "test-def",
+    type: "test/upgradeable",
+    typeVersion: "2025.01.15.1",
+    attributes: { message: "hello" },
+  });
+
+  const modelDef = createModelDef("2025.06.01.1");
+
+  const result = service.upgrade(definition, modelDef);
+
+  assertEquals(result.upgraded, false);
+});
+
+Deno.test("DefinitionUpgradeService - single-step upgrade", () => {
+  const service = new DefinitionUpgradeService();
+  const definition = Definition.create({
+    name: "test-def",
+    type: "test/upgradeable",
+    typeVersion: "2025.01.15.1",
+    attributes: { message: "hello" },
+  });
+
+  const modelDef = createModelDef("2025.06.01.1", [
+    {
+      toVersion: "2025.06.01.1",
+      description: "Add priority field",
+      upgradeAttributes: (old) => ({ ...old, priority: "medium" }),
+    },
+  ]);
+
+  const result = service.upgrade(definition, modelDef);
+
+  assertEquals(result.upgraded, true);
+  assertEquals(result.definition.attributes.message, "hello");
+  assertEquals(result.definition.attributes.priority, "medium");
+  assertEquals(result.definition.typeVersion, "2025.06.01.1");
+  assertEquals(result.fromVersion, "2025.01.15.1");
+  assertEquals(result.toVersion, "2025.06.01.1");
+});
+
+Deno.test("DefinitionUpgradeService - multi-step upgrade chain", () => {
+  const service = new DefinitionUpgradeService();
+  const definition = Definition.create({
+    name: "test-def",
+    type: "test/upgradeable",
+    typeVersion: "2025.01.15.1",
+    attributes: { message: "hello" },
+  });
+
+  const modelDef = createModelDef("2026.02.09.1", [
+    {
+      toVersion: "2025.06.01.1",
+      description: "Add priority field",
+      upgradeAttributes: (old) => ({ ...old, priority: "medium" }),
+    },
+    {
+      toVersion: "2026.02.09.1",
+      description: "Rename message to content",
+      upgradeAttributes: (old) => {
+        const { message, ...rest } = old;
+        return { ...rest, content: message };
+      },
+    },
+  ]);
+
+  const result = service.upgrade(definition, modelDef);
+
+  assertEquals(result.upgraded, true);
+  assertEquals(result.definition.attributes.content, "hello");
+  assertEquals(result.definition.attributes.priority, "medium");
+  assertEquals(result.definition.attributes.message, undefined);
+  assertEquals(result.definition.typeVersion, "2026.02.09.1");
+});
+
+Deno.test("DefinitionUpgradeService - undefined typeVersion triggers full upgrade chain", () => {
+  const service = new DefinitionUpgradeService();
+  const definition = Definition.create({
+    name: "test-def",
+    type: "test/upgradeable",
+    attributes: { message: "hello" },
+  });
+
+  // typeVersion is undefined (legacy pre-CalVer definition)
+  assertEquals(definition.typeVersion, undefined);
+
+  const modelDef = createModelDef("2026.02.09.1", [
+    {
+      toVersion: "2025.06.01.1",
+      description: "Add priority field",
+      upgradeAttributes: (old) => ({ ...old, priority: "medium" }),
+    },
+    {
+      toVersion: "2026.02.09.1",
+      description: "Rename message to content",
+      upgradeAttributes: (old) => {
+        const { message, ...rest } = old;
+        return { ...rest, content: message };
+      },
+    },
+  ]);
+
+  const result = service.upgrade(definition, modelDef);
+
+  assertEquals(result.upgraded, true);
+  assertEquals(result.definition.attributes.content, "hello");
+  assertEquals(result.definition.attributes.priority, "medium");
+  assertEquals(result.definition.typeVersion, "2026.02.09.1");
+  assertEquals(result.fromVersion, undefined);
+});
+
+Deno.test("DefinitionUpgradeService - partial upgrade (skip already applied)", () => {
+  const service = new DefinitionUpgradeService();
+  const definition = Definition.create({
+    name: "test-def",
+    type: "test/upgradeable",
+    typeVersion: "2025.06.01.1",
+    attributes: { message: "hello", priority: "medium" },
+  });
+
+  const modelDef = createModelDef("2026.02.09.1", [
+    {
+      toVersion: "2025.06.01.1",
+      description: "Add priority field",
+      upgradeAttributes: (old) => ({ ...old, priority: "medium" }),
+    },
+    {
+      toVersion: "2026.02.09.1",
+      description: "Rename message to content",
+      upgradeAttributes: (old) => {
+        const { message, ...rest } = old;
+        return { ...rest, content: message };
+      },
+    },
+  ]);
+
+  const result = service.upgrade(definition, modelDef);
+
+  assertEquals(result.upgraded, true);
+  // Only the second upgrade should have been applied
+  assertEquals(result.definition.attributes.content, "hello");
+  assertEquals(result.definition.attributes.priority, "medium");
+  assertEquals(result.definition.attributes.message, undefined);
+  assertEquals(result.definition.typeVersion, "2026.02.09.1");
+});
+
+Deno.test("DefinitionUpgradeService - preserves id, name, tags", () => {
+  const service = new DefinitionUpgradeService();
+  const definition = Definition.create({
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "my-definition",
+    type: "test/upgradeable",
+    typeVersion: "2025.01.15.1",
+    tags: { env: "prod", team: "platform" },
+    attributes: { message: "hello" },
+  });
+
+  const modelDef = createModelDef("2025.06.01.1", [
+    {
+      toVersion: "2025.06.01.1",
+      description: "Add priority",
+      upgradeAttributes: (old) => ({ ...old, priority: "high" }),
+    },
+  ]);
+
+  const result = service.upgrade(definition, modelDef);
+
+  assertEquals(result.upgraded, true);
+  assertEquals(result.definition.id, "550e8400-e29b-41d4-a716-446655440000");
+  assertEquals(result.definition.name, "my-definition");
+  assertEquals(result.definition.tags, { env: "prod", team: "platform" });
+  assertEquals(result.definition.type, "test/upgradeable");
+});
+
+Deno.test("DefinitionUpgradeService - legacy numeric typeVersion coerced to undefined", () => {
+  const service = new DefinitionUpgradeService();
+  // Simulate a definition loaded from disk with numeric typeVersion
+  const definition = Definition.fromData({
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "legacy-def",
+    version: 1,
+    type: "test/upgradeable",
+    typeVersion: 1 as unknown as string, // numeric typeVersion from disk
+    tags: {},
+    attributes: { message: "old" },
+    inputs: undefined,
+  });
+
+  // After preprocess, typeVersion should be undefined
+  assertEquals(definition.typeVersion, undefined);
+
+  const modelDef = createModelDef("2025.06.01.1", [
+    {
+      toVersion: "2025.06.01.1",
+      description: "Add priority",
+      upgradeAttributes: (old) => ({ ...old, priority: "low" }),
+    },
+  ]);
+
+  const result = service.upgrade(definition, modelDef);
+
+  assertEquals(result.upgraded, true);
+  assertEquals(result.definition.attributes.priority, "low");
+  assertEquals(result.definition.typeVersion, "2025.06.01.1");
+});

--- a/src/domain/models/echo/echo_model.ts
+++ b/src/domain/models/echo/echo_model.ts
@@ -93,7 +93,7 @@ export const echoModel: ModelDefinition<
   typeof EchoInputAttributesSchema
 > = defineModel({
   type: ECHO_MODEL_TYPE,
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: EchoInputAttributesSchema,
   dataOutputSpecs: {
     "message": {

--- a/src/domain/models/echo/echo_model_test.ts
+++ b/src/domain/models/echo/echo_model_test.ts
@@ -88,7 +88,7 @@ Deno.test("ECHO_MODEL_TYPE has correct normalized type", () => {
 });
 
 Deno.test("echoModel has correct version", () => {
-  assertEquals(echoModel.version, 1);
+  assertEquals(echoModel.version, "2026.02.09.1");
 });
 
 Deno.test("echoModel.type equals ECHO_MODEL_TYPE", () => {

--- a/src/domain/models/keeb/shell/shell_model.ts
+++ b/src/domain/models/keeb/shell/shell_model.ts
@@ -267,7 +267,7 @@ export const shellModel: ModelDefinition<
   typeof ShellInputAttributesSchema
 > = defineModel({
   type: SHELL_MODEL_TYPE,
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: ShellInputAttributesSchema,
   dataOutputSpecs: {
     "result": {

--- a/src/domain/models/keeb/shell/shell_model_test.ts
+++ b/src/domain/models/keeb/shell/shell_model_test.ts
@@ -101,7 +101,7 @@ Deno.test("SHELL_MODEL_TYPE has correct normalized type", () => {
 });
 
 Deno.test("shellModel has correct version", () => {
-  assertEquals(shellModel.version, 1);
+  assertEquals(shellModel.version, "2026.02.09.1");
 });
 
 Deno.test("shellModel.type equals SHELL_MODEL_TYPE", () => {

--- a/src/domain/models/lets-get-sensitive/vault_model.ts
+++ b/src/domain/models/lets-get-sensitive/vault_model.ts
@@ -317,7 +317,7 @@ export const vaultModel: ModelDefinition<
   typeof VaultInputAttributesSchema
 > = defineModel({
   type: VAULT_MODEL_TYPE,
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: VaultInputAttributesSchema,
   dataOutputSpecs: {
     "result": {

--- a/src/domain/models/lets-get-sensitive/vault_model_test.ts
+++ b/src/domain/models/lets-get-sensitive/vault_model_test.ts
@@ -85,7 +85,7 @@ Deno.test("VAULT_MODEL_TYPE has correct normalized type", () => {
 });
 
 Deno.test("vaultModel has correct version", () => {
-  assertEquals(vaultModel.version, 1);
+  assertEquals(vaultModel.version, "2026.02.09.1");
 });
 
 Deno.test("vaultModel.type equals VAULT_MODEL_TYPE", () => {

--- a/src/domain/models/mermaid/workflow_diagram/workflow_diagram_model.ts
+++ b/src/domain/models/mermaid/workflow_diagram/workflow_diagram_model.ts
@@ -364,7 +364,7 @@ export const mermaidWorkflowModel: ModelDefinition<
   typeof MermaidWorkflowInputAttributesSchema
 > = defineModel({
   type: MERMAID_WORKFLOW_MODEL_TYPE,
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: MermaidWorkflowInputAttributesSchema,
   dataOutputSpecs: {
     "metadata": {

--- a/src/domain/models/mermaid/workflow_diagram/workflow_diagram_model_test.ts
+++ b/src/domain/models/mermaid/workflow_diagram/workflow_diagram_model_test.ts
@@ -361,5 +361,5 @@ Deno.test("mermaidWorkflowModel: model type is correctly defined", () => {
     "mermaid/workflow-diagram",
   );
   assertEquals(mermaidWorkflowModel.type, MERMAID_WORKFLOW_MODEL_TYPE);
-  assertEquals(mermaidWorkflowModel.version, 1);
+  assertEquals(mermaidWorkflowModel.version, "2026.02.09.1");
 });

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -12,6 +12,7 @@ import { Data } from "../data/mod.ts";
 import type { DataArtifactRef } from "./model_output.ts";
 import { ModelOutput } from "./model_output.ts";
 import { DataOutputValidationService } from "./data_output_validation_service.ts";
+import { DefinitionUpgradeService } from "./definition_upgrade_service.ts";
 
 /**
  * Maximum depth for recursive follow-up action processing.
@@ -147,14 +148,27 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
       throw new Error(`Method '${methodName}' not found in model`);
     }
 
-    // Execute the initial method
-    const result = await this.execute(definition, method, context);
+    // Upgrade definition if needed
+    const upgradeService = new DefinitionUpgradeService();
+    const upgradeResult = upgradeService.upgrade(definition, modelDef);
+    const currentDefinition = upgradeResult.definition;
+
+    // Persist upgraded definition if it was upgraded
+    if (upgradeResult.upgraded && context.definitionRepository) {
+      await context.definitionRepository.save(
+        context.modelType,
+        currentDefinition,
+      );
+    }
+
+    // Execute the initial method with the (possibly upgraded) definition
+    const result = await this.execute(currentDefinition, method, context);
     let currentDataOutputs = result.dataOutputs ?? [];
 
     // Store data outputs
     const storedArtifacts: DataArtifactRef[] = [];
     if (currentDataOutputs.length > 0) {
-      const definitionHash = await definition.computeHash();
+      const definitionHash = await currentDefinition.computeHash();
       for (const output of currentDataOutputs) {
         const artifact = await this.storeDataOutput(
           output,
@@ -168,9 +182,9 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
 
     // Create ModelOutput if output repository is available
     if (context.outputRepository) {
-      const definitionHash = await definition.computeHash();
+      const definitionHash = await currentDefinition.computeHash();
       const output = ModelOutput.create({
-        definitionId: definition.id,
+        definitionId: currentDefinition.id,
         methodName,
         status: "running",
         provenance: {
@@ -187,7 +201,7 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
     // Process follow-up actions
     if (result.followUpActions && currentDataOutputs.length > 0) {
       const finalResult = await this.processFollowUpActions(
-        definition,
+        currentDefinition,
         modelDef,
         context,
         result.followUpActions,

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -204,7 +204,7 @@ function createTestModel(options: {
 
   return {
     type: ModelType.create("test/workflow"),
-    version: 1,
+    version: "2026.02.09.1",
     inputAttributesSchema: schema,
     dataOutputSpecs: {},
     methods: {
@@ -470,7 +470,7 @@ Deno.test("executeWorkflow - handles recursive follow-up actions", async () => {
 
   const model: ModelDefinition = {
     type: ModelType.create("test/recursive"),
-    version: 1,
+    version: "2026.02.09.1",
     inputAttributesSchema: schema,
     dataOutputSpecs: {},
     methods: {
@@ -541,7 +541,7 @@ Deno.test("executeWorkflow - throws on max depth exceeded", async () => {
 
   const model: ModelDefinition = {
     type: ModelType.create("test/infinite"),
-    version: 1,
+    version: "2026.02.09.1",
     inputAttributesSchema: schema,
     dataOutputSpecs: {},
     methods: {
@@ -593,7 +593,7 @@ Deno.test(
 
     const model: ModelDefinition = {
       type: ModelType.create("test/token-passing"),
-      version: 1,
+      version: "2026.02.09.1",
       inputAttributesSchema: schema,
       dataOutputSpecs: {},
       methods: {

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { CloudControlClient } from "@aws-sdk/client-cloudcontrol";
 import { ModelType } from "./model_type.ts";
+import { CalVer } from "./calver.ts";
 import type { Definition } from "../definitions/definition.ts";
 import type { DefinitionRepository } from "../definitions/repositories.ts";
 import {
@@ -244,14 +245,30 @@ export interface MethodDefinition<
 }
 
 /**
+ * A version upgrade step that transforms definition attributes from one
+ * version to the next.
+ */
+export interface VersionUpgrade {
+  /** The CalVer version this upgrade produces (e.g., "2025.06.01.1") */
+  toVersion: string;
+  /** Human-readable description of what changed */
+  description: string;
+  /** Transform old attributes into new attributes */
+  upgradeAttributes: (
+    oldAttributes: Record<string, unknown>,
+  ) => Record<string, unknown>;
+}
+
+/**
  * Definition of a model type (the aggregate root).
  *
  * A model defines:
  * - Its type identifier
- * - Current version
+ * - Current version (CalVer format: YYYY.MM.DD.MICRO)
  * - Schema for validating definition attributes
  * - Data output specifications
  * - Available methods
+ * - Optional upgrade chain for migrating definitions between versions
  */
 export interface ModelDefinition<
   TInputAttrs extends z.ZodTypeAny = z.ZodTypeAny,
@@ -263,8 +280,9 @@ export interface ModelDefinition<
 
   /**
    * Current version of this model definition.
+   * CalVer format: YYYY.MM.DD.MICRO (e.g., "2025.01.15.1")
    */
-  version: number;
+  version: string;
 
   /**
    * Zod schema for validating definition attributes.
@@ -282,6 +300,14 @@ export interface ModelDefinition<
    * Available methods on this model.
    */
   methods: Record<string, MethodDefinition>;
+
+  /**
+   * Ordered list of upgrade functions for migrating definitions between versions.
+   * Each entry transforms attributes from the previous version to `toVersion`.
+   * Must be ordered chronologically by `toVersion`.
+   * The last entry's `toVersion` must equal `version`.
+   */
+  upgrades?: VersionUpgrade[];
 }
 
 /**
@@ -293,6 +319,8 @@ export class ModelRegistry {
   /**
    * Registers a model definition.
    *
+   * Validates CalVer version format and upgrade chain ordering.
+   *
    * @param model - The model definition to register
    */
   register(model: ModelDefinition): void {
@@ -300,6 +328,51 @@ export class ModelRegistry {
     if (this.models.has(key)) {
       throw new Error(`Model type already registered: ${key}`);
     }
+
+    // Validate CalVer version
+    if (!CalVer.isValid(model.version)) {
+      throw new Error(
+        `Invalid CalVer version "${model.version}" for model type "${key}". ` +
+          `Expected format YYYY.MM.DD.MICRO (e.g., "2025.01.15.1")`,
+      );
+    }
+
+    // Validate upgrades if provided
+    if (model.upgrades && model.upgrades.length > 0) {
+      for (let i = 0; i < model.upgrades.length; i++) {
+        const upgrade = model.upgrades[i];
+
+        // Validate each toVersion is valid CalVer
+        if (!CalVer.isValid(upgrade.toVersion)) {
+          throw new Error(
+            `Invalid CalVer version "${upgrade.toVersion}" in upgrade at index ${i} ` +
+              `for model type "${key}"`,
+          );
+        }
+
+        // Validate chronological ordering
+        if (i > 0) {
+          const prev = CalVer.create(model.upgrades[i - 1].toVersion);
+          const curr = CalVer.create(upgrade.toVersion);
+          if (CalVer.compare(prev, curr) >= 0) {
+            throw new Error(
+              `Upgrades for model type "${key}" are not in chronological order: ` +
+                `"${prev.value}" must be before "${curr.value}"`,
+            );
+          }
+        }
+      }
+
+      // Validate last upgrade's toVersion matches model version
+      const lastUpgrade = model.upgrades[model.upgrades.length - 1];
+      if (lastUpgrade.toVersion !== model.version) {
+        throw new Error(
+          `Last upgrade toVersion "${lastUpgrade.toVersion}" does not match model ` +
+            `version "${model.version}" for model type "${key}"`,
+        );
+      }
+    }
+
     this.models.set(key, model);
   }
 

--- a/src/domain/models/model_output.ts
+++ b/src/domain/models/model_output.ts
@@ -48,7 +48,10 @@ export type ExecutionError = z.infer<typeof ExecutionErrorSchema>;
  */
 export const ExecutionProvenanceSchema = z.object({
   definitionHash: z.string(),
-  modelVersion: z.number().int().positive(),
+  modelVersion: z.preprocess(
+    (val) => (typeof val === "number" ? String(val) : val),
+    z.string(),
+  ),
   triggeredBy: z.enum(TriggerTypes),
   workflowId: z.string().optional(),
   workflowRunId: z.string().optional(),

--- a/src/domain/models/model_output_test.ts
+++ b/src/domain/models/model_output_test.ts
@@ -8,7 +8,7 @@ import { createDefinitionId } from "../definitions/definition.ts";
 
 const defaultProvenance: ExecutionProvenance = {
   definitionHash: "abc123",
-  modelVersion: 1,
+  modelVersion: "2026.02.09.1",
   triggeredBy: "manual",
 };
 
@@ -88,7 +88,7 @@ Deno.test("ModelOutput.create stores method name", () => {
 Deno.test("ModelOutput.create stores provenance", () => {
   const provenance: ExecutionProvenance = {
     definitionHash: "xyz789",
-    modelVersion: 2,
+    modelVersion: "2026.02.09.2",
     triggeredBy: "workflow",
     workflowId: "wf-123",
     workflowRunId: "run-456",
@@ -305,7 +305,7 @@ Deno.test("ModelOutput toData/fromData roundtrip", () => {
     status: "running",
     provenance: {
       definitionHash: "hash123",
-      modelVersion: 3,
+      modelVersion: "2026.02.09.3",
       triggeredBy: "workflow",
       workflowId: "wf-1",
     },
@@ -364,7 +364,7 @@ Deno.test("ModelOutput fromData with explicit data", () => {
     retryCount: 2,
     provenance: {
       definitionHash: "hash",
-      modelVersion: 1,
+      modelVersion: "2026.02.09.1",
       triggeredBy: "manual" as const,
     },
     artifacts: {

--- a/src/domain/models/model_test.ts
+++ b/src/domain/models/model_test.ts
@@ -84,7 +84,7 @@ function createTestModel(typeString: string): ModelDefinition {
   const type = ModelType.create(typeString);
   return {
     type,
-    version: 1,
+    version: "2026.02.09.1",
     inputAttributesSchema: z.object({ message: z.string() }),
     dataOutputSpecs: {},
     methods: {
@@ -153,7 +153,7 @@ Deno.test("ModelRegistry.get returns registered model", () => {
 
   const retrieved = registry.get("swamp/echo");
   assertEquals(retrieved?.type.normalized, "swamp/echo");
-  assertEquals(retrieved?.version, 1);
+  assertEquals(retrieved?.version, "2026.02.09.1");
 });
 
 Deno.test("ModelRegistry.get accepts ModelType", () => {
@@ -341,7 +341,7 @@ Deno.test("ModelRegistry.extend preserves original methods and schema", () => {
 
   const extended = registry.get("swamp/preserve-test");
   assertEquals(extended!.inputAttributesSchema, originalSchema);
-  assertEquals(extended!.version, 1);
+  assertEquals(extended!.version, "2026.02.09.1");
   assertEquals(extended!.methods.write.description, "Write message to data");
 });
 
@@ -393,4 +393,116 @@ Deno.test("ModelRegistry.extend - extended methods are callable", async () => {
   const result = await extended.methods.greet.execute(definition, context);
   const attrs = getDataOutputAttributes(result.dataOutputs);
   assertEquals(attrs?.greeting, "Hello, world");
+});
+
+// --- CalVer validation tests ---
+
+Deno.test("ModelRegistry.register rejects non-CalVer version string", () => {
+  const registry = new ModelRegistry();
+  const model: ModelDefinition = {
+    type: ModelType.create("test/invalid-version"),
+    version: "not-a-calver",
+    inputAttributesSchema: z.object({}),
+    dataOutputSpecs: {},
+    methods: {},
+  };
+
+  assertThrows(
+    () => registry.register(model),
+    Error,
+    'Invalid CalVer version "not-a-calver"',
+  );
+});
+
+Deno.test("ModelRegistry.register accepts model with CalVer version and valid upgrade chain", () => {
+  const registry = new ModelRegistry();
+  const model: ModelDefinition = {
+    type: ModelType.create("test/with-upgrades"),
+    version: "2026.02.09.1",
+    inputAttributesSchema: z.object({}),
+    dataOutputSpecs: {},
+    methods: {},
+    upgrades: [
+      {
+        toVersion: "2025.06.01.1",
+        description: "Add field",
+        upgradeAttributes: (old) => ({ ...old, added: true }),
+      },
+      {
+        toVersion: "2026.02.09.1",
+        description: "Rename field",
+        upgradeAttributes: (old) => old,
+      },
+    ],
+  };
+
+  registry.register(model);
+  assertEquals(registry.has("test/with-upgrades"), true);
+});
+
+Deno.test("ModelRegistry.register rejects upgrades not in chronological order", () => {
+  const registry = new ModelRegistry();
+  const model: ModelDefinition = {
+    type: ModelType.create("test/bad-order"),
+    version: "2026.02.09.1",
+    inputAttributesSchema: z.object({}),
+    dataOutputSpecs: {},
+    methods: {},
+    upgrades: [
+      {
+        toVersion: "2026.02.09.1",
+        description: "Later",
+        upgradeAttributes: (old) => old,
+      },
+      {
+        toVersion: "2025.06.01.1",
+        description: "Earlier",
+        upgradeAttributes: (old) => old,
+      },
+    ],
+  };
+
+  assertThrows(
+    () => registry.register(model),
+    Error,
+    "not in chronological order",
+  );
+});
+
+Deno.test("ModelRegistry.register rejects when last upgrade toVersion doesn't match model version", () => {
+  const registry = new ModelRegistry();
+  const model: ModelDefinition = {
+    type: ModelType.create("test/mismatch-version"),
+    version: "2026.02.09.1",
+    inputAttributesSchema: z.object({}),
+    dataOutputSpecs: {},
+    methods: {},
+    upgrades: [
+      {
+        toVersion: "2025.06.01.1",
+        description: "Only upgrade",
+        upgradeAttributes: (old) => old,
+      },
+    ],
+  };
+
+  assertThrows(
+    () => registry.register(model),
+    Error,
+    'Last upgrade toVersion "2025.06.01.1" does not match model version "2026.02.09.1"',
+  );
+});
+
+Deno.test("ModelRegistry.register accepts model with no upgrades", () => {
+  const registry = new ModelRegistry();
+  const model: ModelDefinition = {
+    type: ModelType.create("test/no-upgrades"),
+    version: "2026.02.09.1",
+    inputAttributesSchema: z.object({}),
+    dataOutputSpecs: {},
+    methods: {},
+  };
+
+  registry.register(model);
+  assertEquals(registry.has("test/no-upgrades"), true);
 });

--- a/src/domain/models/systemd/journalctl/journalctl_model.ts
+++ b/src/domain/models/systemd/journalctl/journalctl_model.ts
@@ -209,7 +209,7 @@ export const journalctlModel: ModelDefinition<
   typeof JournalctlInputAttributesSchema
 > = defineModel({
   type: JOURNALCTL_MODEL_TYPE,
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: JournalctlInputAttributesSchema,
   dataOutputSpecs: {
     "log": {

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { join, resolve } from "@std/path";
 import { ModelType } from "./model_type.ts";
+import { CalVer } from "./calver.ts";
 import type { Definition } from "../definitions/definition.ts";
 import {
   type DataOutput,
@@ -12,6 +13,7 @@ import {
   type MethodResult,
   type ModelDefinition,
   modelRegistry,
+  type VersionUpgrade,
 } from "./model.ts";
 
 /**
@@ -74,17 +76,33 @@ const UserMethodSchema = z.object({
 }).passthrough();
 
 /**
+ * Schema for validating a user-supplied upgrade step.
+ */
+const UserUpgradeSchema = z.object({
+  toVersion: z.string().refine(CalVer.isValid, {
+    message: "toVersion must be valid CalVer (YYYY.MM.DD.MICRO)",
+  }),
+  description: z.string(),
+  upgradeAttributes: z.custom<
+    (old: Record<string, unknown>) => Record<string, unknown>
+  >((val) => typeof val === "function"),
+});
+
+/**
  * Schema for validating user model exports.
  */
 const UserModelSchema = z.object({
   type: z.string(),
-  version: z.number(),
+  version: z.string().refine(CalVer.isValid, {
+    message: "version must be valid CalVer (YYYY.MM.DD.MICRO)",
+  }),
   inputAttributesSchema: z.custom<z.ZodTypeAny>((val) =>
     val instanceof z.ZodType
   ),
   dataOutputSpecs: z.record(z.string(), DataOutputSpecificationSchema)
     .optional(),
   methods: z.record(z.string(), UserMethodSchema),
+  upgrades: z.array(UserUpgradeSchema).optional(),
 });
 
 /**
@@ -410,12 +428,22 @@ export class UserModelLoader {
       }
     }
 
+    // Convert user upgrades to VersionUpgrade[]
+    const upgrades: VersionUpgrade[] | undefined = userModel.upgrades?.map(
+      (u) => ({
+        toVersion: u.toVersion,
+        description: u.description,
+        upgradeAttributes: u.upgradeAttributes,
+      }),
+    );
+
     return {
       type: modelType,
       version: userModel.version,
       inputAttributesSchema: userModel.inputAttributesSchema,
       dataOutputSpecs: { ...defaultSpecs, ...userSpecs },
       methods,
+      ...(upgrades && upgrades.length > 0 ? { upgrades } : {}),
     };
   }
 

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -96,7 +96,7 @@ const InputSchema = z.object({
 
 export const model = {
   type: "test/data-model-${Date.now()}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
     process: {
@@ -181,7 +181,7 @@ import { z } from "npm:zod@4";
 
 export const model = {
   type: "test/regular-${Date.now()}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: z.object({ msg: z.string() }),
   methods: {
     run: {
@@ -218,7 +218,7 @@ import { z } from "npm:zod@4";
 
 export const model = {
   type: "swamp/echo",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   methods: {
     write: {
@@ -251,7 +251,7 @@ const InputSchema = z.object({
 
 export const model = {
   type: "${typeId}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
     create: {
@@ -325,7 +325,7 @@ const InputSchema = z.object({
 
 export const model = {
   type: "${typeId}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
     run: {
@@ -366,7 +366,7 @@ Deno.test("UserModelLoader loads multiple models from directory", async () => {
 import { z } from "npm:zod@4";
 export const model = {
   type: "test/multi-a-${Date.now()}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: z.object({ a: z.string() }),
   methods: {
     run: {
@@ -381,7 +381,7 @@ export const model = {
 import { z } from "npm:zod@4";
 export const model = {
   type: "test/multi-b-${Date.now()}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: z.object({ b: z.string() }),
   methods: {
     run: {
@@ -418,7 +418,7 @@ const InputSchema = z.object({
 
 export const model = {
   type: "${typeId}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
     execute: {
@@ -486,7 +486,7 @@ const InputSchema = z.object({
 
 export const model = {
   type: "${typeId}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
     fetch: {
@@ -552,7 +552,7 @@ Deno.test("UserModelLoader discovers nested files with correct relative paths", 
 import { z } from "npm:zod@4";
 export const model = {
   type: "test/nested-a-${ts}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: z.object({ a: z.string() }),
   methods: {
     run: {
@@ -566,7 +566,7 @@ export const model = {
 import { z } from "npm:zod@4";
 export const model = {
   type: "test/nested-b-${ts}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: z.object({ b: z.string() }),
   methods: {
     run: {
@@ -598,7 +598,7 @@ Deno.test("UserModelLoader excludes _test.ts in subdirectories", async () => {
 import { z } from "npm:zod@4";
 export const model = {
   type: "test/subdir-notest-${ts}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: z.object({ x: z.string() }),
   methods: {
     run: { description: "Run", execute: async () => ({ dataOutputs: [] }) },
@@ -626,7 +626,7 @@ Deno.test("UserModelLoader handles deeply nested directories (3+ levels)", async
 import { z } from "npm:zod@4";
 export const model = {
   type: "test/deep-nested-${ts}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: z.object({ x: z.string() }),
   methods: {
     run: { description: "Run", execute: async () => ({ dataOutputs: [] }) },
@@ -657,7 +657,7 @@ Deno.test("UserModelLoader loads extension with single method in array", async (
 import { z } from "npm:zod@4";
 export const model = {
   type: "test/ext-single-${ts}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   methods: {
     write: {
@@ -710,7 +710,7 @@ Deno.test("UserModelLoader loads extension with multiple methods in array", asyn
 import { z } from "npm:zod@4";
 export const model = {
   type: "test/ext-multi-${ts}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   methods: {
     write: {
@@ -784,7 +784,7 @@ Deno.test("UserModelLoader extension with method name conflict fails gracefully"
 import { z } from "npm:zod@4";
 export const model = {
   type: "test/ext-conflict-${ts}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   methods: {
     write: {
@@ -826,7 +826,7 @@ Deno.test("UserModelLoader extension with duplicate method names within array fa
 import { z } from "npm:zod@4";
 export const model = {
   type: "test/ext-dup-methods-${ts}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   methods: {
     write: {
@@ -880,7 +880,7 @@ Deno.test("UserModelLoader extension methods inherit target model's inputAttribu
 import { z } from "npm:zod@4";
 export const model = {
   type: "test/ext-inherit-schema-${ts}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   methods: {
     write: {
@@ -956,7 +956,7 @@ Deno.test("UserModelLoader multiple extensions targeting same type", async () =>
 import { z } from "npm:zod@4";
 export const model = {
   type: "test/multi-ext-${ts}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   methods: {
     write: {
@@ -1015,7 +1015,7 @@ Deno.test("UserModelLoader two-pass ordering: user model registered before exten
 import { z } from "npm:zod@4";
 export const model = {
   type: "test/two-pass-${ts}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   methods: {
     write: {
@@ -1061,7 +1061,7 @@ Deno.test("UserModelLoader extension method execute produces proper DataOutput",
 import { z } from "npm:zod@4";
 export const model = {
   type: "test/ext-execute-${ts}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   methods: {
     write: {
@@ -1134,7 +1134,7 @@ import { z } from "npm:zod@4";
 
 export const model = {
   type: "${typeId}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   methods: {
     run: {
@@ -1181,7 +1181,7 @@ import { z } from "npm:zod@4";
 
 export const model = {
   type: "${typeId}",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   dataOutputSpecs: {
     "data": {

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -363,7 +363,7 @@ export class DefaultStepExecutor implements StepExecutor {
       methodName: task.methodName,
       provenance: {
         definitionHash,
-        modelVersion: originalDefinition.version,
+        modelVersion: modelDef.version,
         triggeredBy: "workflow",
         workflowId: ctx.workflowId,
         workflowRunId: ctx.workflowRunId,

--- a/src/infrastructure/persistence/yaml_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository.ts
@@ -209,7 +209,7 @@ export class YamlDefinitionRepository implements DefinitionRepository {
     // Ensure type metadata is always present in persisted YAML
     data.type = type.normalized;
     const modelDef = modelRegistry.get(type);
-    data.typeVersion = modelDef?.version ?? data.typeVersion ?? 1;
+    data.typeVersion = modelDef?.version ?? data.typeVersion;
     // Remove undefined values since YAML can't stringify them
     const cleanData = JSON.parse(JSON.stringify(data));
     const content = stringifyYaml(cleanData as Record<string, unknown>);

--- a/src/infrastructure/persistence/yaml_evaluated_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_definition_repository.ts
@@ -222,7 +222,7 @@ export class YamlEvaluatedDefinitionRepository {
     // Ensure type metadata is always present in persisted YAML
     data.type = type.normalized;
     const modelDef = modelRegistry.get(type);
-    data.typeVersion = modelDef?.version ?? data.typeVersion ?? 1;
+    data.typeVersion = modelDef?.version ?? data.typeVersion;
     // Remove undefined values since YAML can't stringify them
     const cleanData = JSON.parse(JSON.stringify(data));
     const content = stringifyYaml(cleanData as Record<string, unknown>);

--- a/src/infrastructure/persistence/yaml_output_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_output_repository_test.ts
@@ -20,7 +20,7 @@ async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
 
 const defaultProvenance: ExecutionProvenance = {
   definitionHash: "abc123",
-  modelVersion: 1,
+  modelVersion: "2026.02.09.1",
   triggeredBy: "manual",
 };
 
@@ -58,7 +58,7 @@ Deno.test("YamlOutputRepository.save creates yaml file with correct path structu
       methodName: "deploy",
       provenance: {
         definitionHash: "xyz789",
-        modelVersion: 2,
+        modelVersion: "2026.02.09.2",
         triggeredBy: "workflow",
         workflowId: "wf-123",
       },

--- a/src/presentation/output/model_output_get_output.ts
+++ b/src/presentation/output/model_output_get_output.ts
@@ -5,7 +5,7 @@ import type { OutputMode } from "./output.ts";
  */
 export interface ProvenanceData {
   definitionHash: string;
-  modelVersion: number;
+  modelVersion: string;
   triggeredBy: string;
   workflowId?: string;
   workflowRunId?: string;

--- a/src/presentation/output/type_describe_output.ts
+++ b/src/presentation/output/type_describe_output.ts
@@ -26,7 +26,7 @@ export interface TypeDescribeData {
     raw: string;
     normalized: string;
   };
-  version: number;
+  version: string;
   inputAttributesSchema: object;
   methods: MethodDescribeData[];
 }

--- a/src/presentation/output/type_describe_output_test.ts
+++ b/src/presentation/output/type_describe_output_test.ts
@@ -12,7 +12,7 @@ const testData: TypeDescribeData = {
     raw: "swamp/echo",
     normalized: "swamp/echo",
   },
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: {
     type: "object",
     properties: {


### PR DESCRIPTION
## Summary

Implements #171 — adds CalVer (`YYYY.MM.DD.MICRO`) versioning to models with forward-compatible upgrade functions that lazily migrate definitions at method execution time.

- **CalVer value object** (`calver.ts`) — validates format, compares versions with numeric micro segment ordering
- **VersionUpgrade interface** — ordered upgrade functions that transform definition attributes between model versions
- **DefinitionUpgradeService** — filters applicable upgrades by comparing definition's `typeVersion` against the model's current version, applies them in order, returns upgraded definition
- **Lazy upgrade integration** — upgrades run in `executeWorkflow()` before method execution; upgraded definitions are persisted so they only run once
- **Backwards compatibility** — legacy numeric `typeVersion` values (e.g. `typeVersion: 1`) are coerced to `undefined` via `z.preprocess`, triggering the full upgrade chain on first method execution
- **Registration gate** — `modelRegistry.register()` rejects models without valid CalVer versions, so they never appear in `type describe` or `type search`
- **All built-in and experiment models** updated to CalVer `"2026.02.09.1"`

## Plan Validation

This implementation was built from a detailed plan. Here is the step-by-step comparison:

| Plan Step | Description | Status |
|-----------|-------------|--------|
| 1 | Create `CalVer` value object (`calver.ts`) with `create()`, `isValid()`, `compare()`, `toString()`, `equals()` | Done — 13 unit tests |
| 2 | Change `version` from `number` to CalVer `string` across domain, infrastructure, CLI, and presentation layers | Done — 15+ files updated |
| 3 | Add `Definition.withUpgradedAttributes()` immutable factory method | Done — preserves id, name, tags, inputs |
| 4 | Create `DefinitionUpgradeService` domain service | Done — 8 unit tests covering no-op, single-step, multi-step, undefined typeVersion, partial upgrade, metadata preservation, legacy coercion |
| 5 | Integrate upgrades into `executeWorkflow()` | Done — upgrades before execution, persists if upgraded |
| 6 | Update `design/models.md` documentation | Done — CalVer format, migration rules, acme/notifier example, backwards compatibility |

### Files changed (54 total)

**New files (4):**
- `src/domain/models/calver.ts` — CalVer value object
- `src/domain/models/calver_test.ts` — CalVer tests
- `src/domain/models/definition_upgrade_service.ts` — Upgrade chain logic
- `src/domain/models/definition_upgrade_service_test.ts` — Upgrade service tests

**Domain layer:**
- `src/domain/models/model.ts` — `VersionUpgrade` interface, `upgrades` field, CalVer validation in `register()`
- `src/domain/definitions/definition.ts` — `typeVersion` as CalVer string with legacy number coercion, `withUpgradedAttributes()`
- `src/domain/models/method_execution_service.ts` — Upgrade integration in `executeWorkflow()`
- `src/domain/models/user_model_loader.ts` — CalVer schema validation, upgrade support
- `src/domain/models/model_output.ts` — `modelVersion` as string with preprocess
- `src/domain/workflows/execution_service.ts` — `modelVersion` from model definition

**Built-in models (11 models updated `version: 1` → `version: "2026.02.09.1"`):**
- echo, aws/cli, aws/cloud_control (inherited by ec2/vpc, ec2/instance, ec2/subnet), command/curl, keeb/shell, lets-get-sensitive/vault, mermaid/workflow_diagram, systemd/journalctl

**Experiment models (8 models):**
- anthropic_claude, docker_image, digitalocean_ssh_key, digitalocean_droplet, digitalocean_app, github_pr_list, ssh_remote, discord_webhook

**Infrastructure & presentation:**
- `yaml_definition_repository.ts`, `yaml_evaluated_definition_repository.ts` — removed `?? 1` fallback
- `model_create.ts`, `model_method_run.ts` — version references updated
- `type_describe_output.ts`, `model_output_get_output.ts` — version type to string

**Tests (20+ test files updated):**
- All model test files updated version assertions from `1` to `"2026.02.09.1"`
- New tests for CalVer validation, upgrade chain ordering, registry rejection of invalid versions
- New tests for `withUpgradedAttributes()`, legacy numeric coercion
- Integration tests updated for CalVer

## Test plan

- [x] `deno check` — 0 type errors
- [x] `deno lint` — clean
- [x] `deno fmt` — clean
- [x] `deno run test` — 1283 tests pass, 0 failures
- [x] `deno run compile` — binary compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)