### PR TITLE
fix: Add CalVer semantic date validation and update skill docs

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -62,7 +62,7 @@ const InputSchema = z.object({ message: z.string() });
 
 export const model = {
   type: "myorg/my-model",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
     run: {
@@ -88,7 +88,7 @@ export const model = {
 | Field                   | Required | Description                          |
 | ----------------------- | -------- | ------------------------------------ |
 | `type`                  | Yes      | Unique identifier (`namespace/name`) |
-| `version`               | Yes      | Schema version number                |
+| `version`               | Yes      | CalVer version (`YYYY.MM.DD.MICRO`)  |
 | `inputAttributesSchema` | Yes      | Zod schema for input validation      |
 | `methods`               | Yes      | Object of method definitions         |
 
@@ -288,7 +288,7 @@ const InputSchema = z.object({
 
 export const model = {
   type: "myorg/shell",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
     run: {
@@ -324,7 +324,7 @@ const InputSchema = z.object({ query: z.string() });
 
 export const model = {
   type: "myorg/search",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
     search: {
@@ -378,7 +378,7 @@ const InputSchema = z.object({
 
 export const model = {
   type: "myorg/api-resource",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
     create: {
@@ -424,7 +424,7 @@ const InputSchema = z.object({
 
 export const model = {
   type: "myorg/s3-bucket",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
     create: {

--- a/.claude/skills/swamp-extension-model/references/examples.md
+++ b/.claude/skills/swamp-extension-model/references/examples.md
@@ -20,7 +20,7 @@ const DataSchema = z.object({
 
 export const model = {
   type: "myorg/text-processor",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   dataAttributesSchema: DataSchema,
   methods: {
@@ -84,7 +84,7 @@ const ResourceSchema = z.object({
 
 export const model = {
   type: "myorg/deployment",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   resourceAttributesSchema: ResourceSchema,
   methods: {
@@ -146,7 +146,7 @@ const DataSchema = z.object({ message: z.string(), timestamp: z.string() });
 
 export const model = {
   type: "myorg/echo",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   dataAttributesSchema: DataSchema,
   methods: {
@@ -191,7 +191,7 @@ const DataSchema = z.object({
 
 export const model = {
   type: "myorg/config-generator",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   dataAttributesSchema: DataSchema,
   methods: {

--- a/.claude/skills/swamp-extension-model/references/troubleshooting.md
+++ b/.claude/skills/swamp-extension-model/references/troubleshooting.md
@@ -25,7 +25,7 @@ Add either `dataAttributesSchema` (ephemeral) or `resourceAttributesSchema`
 ```typescript
 export const model = {
   type: "...",
-  version: 1,
+  version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   dataAttributesSchema: DataSchema,  // Add this
   methods: { ... },

--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -79,7 +79,7 @@ swamp type describe swamp/echo --json
 ```json
 {
   "type": { "raw": "swamp/echo", "normalized": "swamp/echo" },
-  "version": 1,
+  "version": "2026.02.09.1",
   "inputAttributesSchema": {/* JSON Schema */},
   "resourceAttributesSchema": {/* JSON Schema */},
   "methods": [

--- a/src/domain/models/calver.ts
+++ b/src/domain/models/calver.ts
@@ -28,9 +28,16 @@ export class CalVer {
 
   /**
    * Checks whether a string is a valid CalVer version.
+   *
+   * Validates both format (YYYY.MM.DD.MICRO) and semantic date
+   * ranges (month 01–12, day 01–31).
    */
   static isValid(version: string): boolean {
-    return CalVer.PATTERN.test(version);
+    if (!CalVer.PATTERN.test(version)) return false;
+    const parts = version.split(".");
+    const month = Number(parts[1]);
+    const day = Number(parts[2]);
+    return month >= 1 && month <= 12 && day >= 1 && day <= 31;
   }
 
   /**

--- a/src/domain/models/calver_test.ts
+++ b/src/domain/models/calver_test.ts
@@ -25,6 +25,14 @@ Deno.test("CalVer.isValid rejects invalid formats", () => {
   assertEquals(CalVer.isValid("abc"), false);
 });
 
+Deno.test("CalVer.isValid rejects invalid date ranges", () => {
+  assertEquals(CalVer.isValid("2025.13.01.1"), false); // month 13
+  assertEquals(CalVer.isValid("2025.00.01.1"), false); // month 0
+  assertEquals(CalVer.isValid("2025.01.00.1"), false); // day 0
+  assertEquals(CalVer.isValid("2025.01.32.1"), false); // day 32
+  assertEquals(CalVer.isValid("2025.13.45.1"), false); // month 13, day 45
+});
+
 Deno.test("CalVer.create returns instance for valid version", () => {
   const cv = CalVer.create("2025.01.15.1");
   assertEquals(cv.value, "2025.01.15.1");


### PR DESCRIPTION
## Summary

Follow-up to #230 (CalVer versioning for models):

- **CalVer date validation**: `CalVer.isValid()` now rejects semantically invalid dates like `2025.13.45.1` (month 13, day 45) beyond the regex pattern match. Validates month 01-12 and day 01-31.
- **Skill documentation updates**: All `version: 1` references in model code examples across skill files updated to CalVer `version: "2026.02.09.1"` format, matching the new API.

### Files changed

| File | Change |
|------|--------|
| `src/domain/models/calver.ts` | Added semantic date range validation (month/day bounds) |
| `src/domain/models/calver_test.ts` | Added test for invalid date ranges (month 0/13, day 0/32) |
| `.claude/skills/swamp-extension-model/SKILL.md` | Updated 5 model examples + version table description |
| `.claude/skills/swamp-extension-model/references/examples.md` | Updated 4 model examples |
| `.claude/skills/swamp-extension-model/references/troubleshooting.md` | Updated 1 model example |
| `.claude/skills/swamp-model/SKILL.md` | Updated type describe JSON output example |

## Test plan

- [x] `deno check` passes on modified files
- [x] CalVer tests pass (14/14 including new date range test)
- [x] No functional code changes beyond CalVer validation — skill files are documentation only