### PR TITLE
fix: Simplify UserError message in repo_context

### DIFF
--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -57,11 +57,7 @@ export async function requireInitializedRepo(
 
   if (!isInit) {
     throw new UserError(
-      `Not a swamp repository: ${repoPath.value}\n\n` +
-        `To initialize a new repository, run:\n` +
-        `  swamp repo init\n\n` +
-        `Or specify an existing repository with --repo-dir:\n` +
-        `  swamp <command> --repo-dir /path/to/repo`,
+      `Not a swamp repository: ${repoPath.value}. To initialize a new repository, run 'swamp repo init', or specify an existing repository with 'swamp <command> --repo-dir /path/to/repo'.`,
     );
   }
 


### PR DESCRIPTION
## Summary

- Consolidates the multi-line `UserError` message in `repo_context.ts` into a single-line format for consistency with other error messages in the codebase.

## Test Plan

- All 1323 existing tests pass
- `deno fmt`, `deno lint` checks pass