### PR TITLE
Fix forEach workflow execution with model methods and improve error handling

### DIFF
--- a/src/cli/commands/workflow_evaluate.ts
+++ b/src/cli/commands/workflow_evaluate.ts
@@ -141,6 +141,8 @@ export const workflowEvaluateCommand = new Command()
 /**
  * Evaluates a single workflow, replacing CEL expressions with values.
  * Vault expressions are left as-is for runtime resolution.
+ * forEach-related expressions (self.* and forEach.in) are left raw for
+ * runtime expansion.
  */
 async function evaluateWorkflow(
   workflow: Workflow,
@@ -167,10 +169,31 @@ async function evaluateWorkflow(
   const context = await modelResolver.buildContext();
   context.inputs = inputs;
 
-  // Evaluate CEL-only expressions; skip vault-containing expressions
+  // Collect forEach.in expressions to skip during evaluation
+  const forEachInExpressions = new Set<string>();
+  for (const job of workflow.jobs) {
+    for (const step of job.steps) {
+      if (step.forEach) {
+        const match = step.forEach.in.match(/\$\{\{\s*(.+?)\s*\}\}/);
+        if (match) {
+          forEachInExpressions.add(step.forEach.in);
+        }
+      }
+    }
+  }
+
+  // Evaluate CEL-only expressions; skip vault, self.*, and forEach.in expressions
   const evaluatedValues = new Map<string, unknown>();
   for (const expr of expressions) {
     if (containsVaultExpression(expr.celExpression)) {
+      continue;
+    }
+    // Skip self.* expressions — they reference forEach variables resolved at runtime
+    if (expr.celExpression.match(/\bself\./)) {
+      continue;
+    }
+    // Skip forEach.in expressions — they must remain as strings for forEach expansion
+    if (forEachInExpressions.has(expr.raw)) {
       continue;
     }
 

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -304,6 +304,6 @@ export const workflowRunCommand = new Command()
         throw error;
       }
       const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`Workflow execution failed: ${message}`);
+      throw new UserError(`Workflow execution failed: ${message}`);
     }
   });

--- a/src/domain/models/validation_service.ts
+++ b/src/domain/models/validation_service.ts
@@ -309,9 +309,13 @@ export class DefaultModelValidationService implements ModelValidationService {
       // Extract env references (these are always valid - resolved at runtime)
       const envRefs = extractEnvReferences(celExpression);
 
+      // Check for inputs references (valid when model defines an inputs schema)
+      const hasInputsRef = /\binputs\./.test(celExpression);
+
       // Check for expressions with valid ${{...}} syntax but no valid references
       if (
-        pathRefs.length === 0 && selfRefs.length === 0 && envRefs.length === 0
+        pathRefs.length === 0 && selfRefs.length === 0 &&
+        envRefs.length === 0 && !hasInputsRef
       ) {
         const error = this.validateExpressionContent(celExpression, raw, path);
         if (error) errors.push(error);

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -334,12 +334,18 @@ export class DefaultStepExecutor implements StepExecutor {
     } else if (ctx.expressionContext) {
       runLogger.info("Evaluating expressions");
       // Set self context for this specific model before evaluating
+      // Preserve any forEach variables that were set by the workflow engine
+      const forEachVars: Record<string, unknown> = {};
+      if (ctx.forEachVariable && ctx.forEachVariable.name) {
+        forEachVars[ctx.forEachVariable.name] = ctx.forEachVariable.value;
+      }
       ctx.expressionContext.self = {
         id: originalDefinition.id,
         name: originalDefinition.name,
         version: originalDefinition.version,
         tags: originalDefinition.tags,
         attributes: originalDefinition.attributes,
+        ...forEachVars,
       };
 
       // Evaluate step task inputs and merge into context
@@ -1090,8 +1096,8 @@ export class WorkflowExecutionService {
       // Extract the CEL expression (remove ${{ }})
       const match = inExpression.match(/\$\{\{\s*(.+?)\s*\}\}/);
       if (!match) {
-        throw new Error(
-          `Invalid forEach.in expression: ${inExpression}. Must be in ${{}} format.`,
+        throw new UserError(
+          `Invalid forEach.in expression: ${inExpression}. Must be in $\{{ }} format.`,
         );
       }
 
@@ -1100,6 +1106,8 @@ export class WorkflowExecutionService {
 
       // Handle both arrays and objects
       const expandedSteps: ExpandedStep[] = [];
+
+      const nameHasExpression = /\$\{\{.+?\}\}/.test(step.name);
 
       if (Array.isArray(items)) {
         // Array iteration: self.{item} = item value
@@ -1119,6 +1127,9 @@ export class WorkflowExecutionService {
           if (nameMatch) {
             const value = celEvaluator.evaluate(nameMatch[1], stepContext);
             expandedName = step.name.replace(nameMatch[0], String(value));
+          } else if (!nameHasExpression) {
+            // Step name has no expression template — append item value for uniqueness
+            expandedName = `${step.name}-${String(item)}`;
           }
 
           expandedSteps.push({
@@ -1147,6 +1158,9 @@ export class WorkflowExecutionService {
           if (nameMatch) {
             const evalValue = celEvaluator.evaluate(nameMatch[1], stepContext);
             expandedName = step.name.replace(nameMatch[0], String(evalValue));
+          } else if (!nameHasExpression) {
+            // Step name has no expression template — append key for uniqueness
+            expandedName = `${step.name}-${key}`;
           }
 
           expandedSteps.push({
@@ -1156,7 +1170,7 @@ export class WorkflowExecutionService {
           });
         }
       } else {
-        throw new Error(
+        throw new UserError(
           `forEach.in must evaluate to an array or object, got: ${typeof items}`,
         );
       }
@@ -1591,6 +1605,8 @@ export class WorkflowExecutionService {
   /**
    * Evaluates CEL expressions in a workflow, leaving vault expressions raw.
    * Vault expressions are resolved at runtime only.
+   * forEach-related expressions (self.* and forEach.in) are left raw for
+   * runtime expansion.
    */
   private evaluateWorkflow(
     workflow: Workflow,
@@ -1604,10 +1620,31 @@ export class WorkflowExecutionService {
       return workflow;
     }
 
-    // Evaluate CEL-only expressions; skip vault-containing expressions
+    // Collect forEach.in expressions to skip during evaluation
+    const forEachInExpressions = new Set<string>();
+    for (const job of workflow.jobs) {
+      for (const step of job.steps) {
+        if (step.forEach) {
+          const match = step.forEach.in.match(/\$\{\{\s*(.+?)\s*\}\}/);
+          if (match) {
+            forEachInExpressions.add(step.forEach.in);
+          }
+        }
+      }
+    }
+
+    // Evaluate CEL-only expressions; skip vault, self.*, and forEach.in expressions
     const evaluatedValues = new Map<string, unknown>();
     for (const expr of expressions) {
       if (containsVaultExpression(expr.celExpression)) {
+        continue;
+      }
+      // Skip self.* expressions — they reference forEach variables resolved at runtime
+      if (expr.celExpression.match(/\bself\./)) {
+        continue;
+      }
+      // Skip forEach.in expressions — they must remain as strings for forEach expansion
+      if (forEachInExpressions.has(expr.raw)) {
         continue;
       }
 


### PR DESCRIPTION
- Fix forEach step expansion failing when used with model_method tasks
- Fix forEach variables being lost during model method execution
- Fix duplicate step names causing false cyclic dependency errors
- Accept inputs.* as a valid expression reference in model validation
- Wrap workflow execution errors as UserError to suppress stack traces

## Problem

Running a workflow with forEach over an array and a model_method task failed with multiple errors:

1. "Identifier 'self' not found" — During the evaluate phase, ${{ self.env }} expressions were evaluated before forEach
expansion, but self isn't available until runtime.
2. "expected string, received array" — The forEach.in expression ${{ inputs.environments }} was resolved to an actual array
during evaluation, but the ForEachSchema requires it to remain a string until runtime expansion.
3. "Cyclic dependency detected" — When a forEach step name doesn't contain a ${{ self.env }} template, all expanded steps
got the same name, creating duplicates in the topological sort.
4. "Missing model. prefix" — Model definitions using ${{ inputs.environment }} were rejected by the expression validator,
which only recognized model.*, self.*, and env.* references.
5. Stack traces on user errors — Workflow execution failures (e.g., missing required inputs, invalid forEach expressions)
showed full stack traces instead of clean error messages.

## Changes

src/domain/workflows/execution_service.ts
- Skip self.* and forEach.in expressions during the workflow evaluate phase — they're runtime-only constructs
- Preserve forEach variables when building the model's self context in executeModelMethod(), so self.env isn't overwritten
by the model identity
- Auto-append item value to step names when no ${{ }} template is present, ensuring unique names per forEach iteration
- Wrap forEach validation errors as UserError

src/cli/commands/workflow_evaluate.ts
- Same evaluate-phase fix: skip self.* and forEach.in expressions

src/domain/models/validation_service.ts
- Recognize inputs.* as a valid expression reference type

src/cli/commands/workflow_run.ts
- Wrap workflow execution errors as UserError to suppress stack traces

## Test plan

- All 1323 existing unit tests pass
- Workflow with forEach over array + model_method task runs successfully
- Expanded steps produce unique names (echo-env-dev, echo-env-staging, echo-env-production)
- forEach variables correctly passed through to model method execution
- Model with inputs schema validates, runs standalone, and works with default values
- Missing required inputs produces clean error without stack trace
- Run existing forEach integration tests (integration/foreach_test.ts)