### PR TITLE
Expand forEach steps during workflow evaluate and support --last-evaluated without inputs

### DIFF
--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -222,11 +222,11 @@ swamp workflow run my-workflow --last-evaluated --json  # Use pre-evaluated work
 
 **Options:**
 
-| Flag               | Description                                   |
-| ------------------ | --------------------------------------------- |
-| `--input <json>`   | Input values as JSON string                   |
-| `--input-file <f>` | Input values from YAML file                   |
-| `--last-evaluated` | Use previously evaluated workflow (skip eval) |
+| Flag               | Description                                                        |
+| ------------------ | ------------------------------------------------------------------ |
+| `--input <json>`   | Input values as JSON string                                        |
+| `--input-file <f>` | Input values from YAML file                                        |
+| `--last-evaluated` | Use previously evaluated workflow (skip eval and input validation) |
 
 **Output shape:**
 
@@ -439,8 +439,11 @@ swamp workflow evaluate --all --json
 **Key behaviors:**
 
 - CEL expressions (`${{ inputs.X }}`, `${{ model.X.resource... }}`) are resolved
+- forEach steps are expanded into concrete steps with resolved inputs
 - Vault expressions (`${{ vault.get(...) }}`) remain raw for runtime resolution
 - Output saved to `.swamp/workflows-evaluated/` for `--last-evaluated` use
+- After evaluating with inputs, `--last-evaluated` can run without re-providing
+  inputs
 
 ## forEach Iteration
 

--- a/src/cli/commands/workflow_evaluate.ts
+++ b/src/cli/commands/workflow_evaluate.ts
@@ -215,14 +215,174 @@ async function evaluateWorkflow(
   // Create new Workflow from evaluated data
   const evaluatedWorkflow = Workflow.fromData(evaluatedData as WorkflowData);
 
-  // Save evaluated workflow
-  await evaluatedWorkflowRepo.save(evaluatedWorkflow);
+  // Expand forEach steps
+  const expandedWorkflowData = evaluatedWorkflow.toData();
+  for (const jobData of expandedWorkflowData.jobs) {
+    const expandedSteps: typeof jobData.steps = [];
+
+    for (const stepData of jobData.steps) {
+      if (!stepData.forEach) {
+        expandedSteps.push(stepData);
+        continue;
+      }
+
+      // Evaluate the forEach.in expression
+      const inMatch = stepData.forEach.in.match(/\$\{\{\s*(.+?)\s*\}\}/);
+      if (!inMatch) {
+        expandedSteps.push(stepData);
+        continue;
+      }
+
+      const items = celEvaluator.evaluate(inMatch[1], context);
+      const itemName = stepData.forEach.item;
+      const nameHasExpression = /\$\{\{.+?\}\}/.test(stepData.name);
+
+      if (Array.isArray(items)) {
+        for (const item of items) {
+          const stepContext = {
+            ...context,
+            self: { ...context.self, [itemName]: item },
+          };
+
+          // Resolve step name
+          let expandedName = stepData.name;
+          const nameMatch = stepData.name.match(/\$\{\{\s*(.+?)\s*\}\}/);
+          if (nameMatch) {
+            const value = celEvaluator.evaluate(nameMatch[1], stepContext);
+            expandedName = stepData.name.replace(nameMatch[0], String(value));
+          } else if (!nameHasExpression) {
+            expandedName = `${stepData.name}-${String(item)}`;
+          }
+
+          const expandedTask = resolveForEachTaskExpressions(
+            stepData.task,
+            stepContext,
+            celEvaluator,
+          );
+
+          expandedSteps.push({
+            ...stepData,
+            name: expandedName,
+            task: expandedTask,
+            forEach: undefined,
+          });
+        }
+      } else if (items && typeof items === "object") {
+        for (const [key, value] of Object.entries(items)) {
+          const objItem = { key, value };
+          const stepContext = {
+            ...context,
+            self: { ...context.self, [itemName]: objItem },
+          };
+
+          // Resolve step name
+          let expandedName = stepData.name;
+          const nameMatch = stepData.name.match(/\$\{\{\s*(.+?)\s*\}\}/);
+          if (nameMatch) {
+            const evalValue = celEvaluator.evaluate(nameMatch[1], stepContext);
+            expandedName = stepData.name.replace(
+              nameMatch[0],
+              String(evalValue),
+            );
+          } else if (!nameHasExpression) {
+            expandedName = `${stepData.name}-${key}`;
+          }
+
+          const expandedTask = resolveForEachTaskExpressions(
+            stepData.task,
+            stepContext,
+            celEvaluator,
+          );
+
+          expandedSteps.push({
+            ...stepData,
+            name: expandedName,
+            task: expandedTask,
+            forEach: undefined,
+          });
+        }
+      } else {
+        // Not iterable — keep original step
+        expandedSteps.push(stepData);
+      }
+    }
+
+    jobData.steps = expandedSteps;
+  }
+
+  const forEachExpanded = expandedWorkflowData.jobs.some(
+    (j) =>
+      j.steps.length !==
+        workflowData.jobs.find((wj) => wj.name === j.name)?.steps.length,
+  );
+
+  // Save the expanded workflow (forEach resolved, expressions evaluated)
+  // so --last-evaluated can run without inputs or further expansion
+  const workflowToSave = forEachExpanded
+    ? Workflow.fromData(expandedWorkflowData as WorkflowData)
+    : evaluatedWorkflow;
+  await evaluatedWorkflowRepo.save(workflowToSave);
 
   return {
     id: workflow.id,
     name: workflow.name,
-    hadExpressions: evaluatedValues.size > 0,
+    hadExpressions: evaluatedValues.size > 0 || forEachExpanded,
+    forEachExpanded,
     outputPath: evaluatedWorkflowRepo.getPath(workflow.id),
-    jobs: evaluatedWorkflow.toData().jobs,
+    jobs: expandedWorkflowData.jobs,
   };
+}
+
+/**
+ * Resolves forEach self.* expressions in a task's inputs and args.
+ * Vault expressions are left raw for runtime resolution.
+ */
+function resolveForEachTaskExpressions(
+  // deno-lint-ignore no-explicit-any
+  taskData: any,
+  // deno-lint-ignore no-explicit-any
+  stepContext: any,
+  celEvaluator: CelEvaluator,
+  // deno-lint-ignore no-explicit-any
+): any {
+  const expandedTask = JSON.parse(JSON.stringify(taskData));
+
+  // Resolve expressions in task inputs (model_method tasks)
+  if (expandedTask.inputs) {
+    for (const [key, val] of Object.entries(expandedTask.inputs)) {
+      if (typeof val === "string") {
+        const exprMatch = (val as string).match(/\$\{\{\s*(.+?)\s*\}\}/);
+        if (exprMatch && !containsVaultExpression(exprMatch[1])) {
+          try {
+            expandedTask.inputs[key] = celEvaluator.evaluate(
+              exprMatch[1],
+              stepContext,
+            );
+          } catch {
+            // Leave as-is if evaluation fails
+          }
+        }
+      }
+    }
+  }
+
+  // Resolve expressions in shell args
+  if (expandedTask.args && Array.isArray(expandedTask.args)) {
+    expandedTask.args = expandedTask.args.map((arg: unknown) => {
+      if (typeof arg !== "string") return arg;
+      return (arg as string).replace(
+        /\$\{\{\s*(.+?)\s*\}\}/g,
+        (_match: string, expr: string) => {
+          if (containsVaultExpression(expr)) return _match;
+          try {
+            return String(celEvaluator.evaluate(expr, stepContext));
+          } catch {
+            return _match;
+          }
+        },
+      );
+    });
+  }
+
+  return expandedTask;
 }

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -188,7 +188,8 @@ export const workflowRunCommand = new Command()
       }
 
       // Validate inputs against workflow schema if provided
-      if (workflow.inputs) {
+      // Skip validation when using --last-evaluated since inputs are already baked in
+      if (workflow.inputs && !lastEvaluated) {
         const validationService = new InputValidationService();
         const inputsWithDefaults = validationService.applyDefaults(
           inputs,

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -719,7 +719,7 @@ export class WorkflowExecutionService {
     },
   ): Promise<WorkflowRun> {
     // Look up workflow
-    const workflow = await this.lookupWorkflow(idOrName);
+    let workflow = await this.lookupWorkflow(idOrName);
     if (!workflow) {
       throw new Error(`Workflow not found: ${idOrName}`);
     }
@@ -737,11 +737,12 @@ export class WorkflowExecutionService {
       if (!lastEvaluated) {
         throw new UserError(
           `No previously evaluated workflow found for "${workflow.name}".\n\n` +
-            `Run the workflow without --last-evaluated first to generate evaluated data:\n` +
-            `  swamp workflow run ${workflow.name}`,
+            `Evaluate the workflow first to generate evaluated data:\n` +
+            `  swamp workflow evaluate ${workflow.name}`,
         );
       }
-      // No expression context needed — we use pre-evaluated definitions per-step
+      // Use the fully evaluated workflow (forEach expanded, expressions resolved)
+      workflow = lastEvaluated;
     } else {
       // Build expression context and evaluate workflow
       expressionContext = await this.modelResolver.buildContext();

--- a/src/presentation/output/workflow_evaluate_output.ts
+++ b/src/presentation/output/workflow_evaluate_output.ts
@@ -6,6 +6,7 @@ export interface WorkflowEvaluateItemData {
   id: string;
   name: string;
   hadExpressions: boolean;
+  forEachExpanded?: boolean;
   outputPath?: string;
   jobs?: JobData[];
 }
@@ -60,8 +61,17 @@ export function renderWorkflowEvaluateSingle(
 
     if (item.hadExpressions) {
       logger.info("  Expressions evaluated");
-    } else {
+    } else if (!item.forEachExpanded) {
       logger.info("  No expressions to evaluate");
+    }
+
+    if (item.forEachExpanded && item.jobs) {
+      logger.info("  forEach steps expanded:");
+      for (const job of item.jobs) {
+        for (const step of job.steps) {
+          logger.info("    - {step}", { step: step.name });
+        }
+      }
     }
 
     if (item.outputPath) {


### PR DESCRIPTION
- Expand forEach steps during `workflow evaluate`, resolving iteration variables and task inputs into concrete steps
- Save the fully expanded workflow to the evaluated file so `--last-evaluated` can run without re-providing inputs
- Use the evaluated workflow directly when running with `--last-evaluated` instead of the original definition
- Skip input validation when `--last-evaluated` is used since inputs are already baked into the evaluated workflow
- Show expanded forEach steps in the evaluate log output

## Problem

`swamp workflow evaluate` resolved CEL expressions but did not expand forEach steps. The evaluated output file still
contained raw `forEach` blocks with `${{ self.env }}` expressions, meaning:

1. The evaluated file didn't reflect what would actually execute at runtime
2. `--last-evaluated` still required `--input` to be passed because forEach expansion and input resolution happened at
runtime
3. The evaluate log output said "No expressions to evaluate" even when forEach expansion was needed

## Changes

**src/cli/commands/workflow_evaluate.ts**
- Add forEach step expansion after CEL expression evaluation
- Support both array and object iteration, resolving step names and task inputs per iteration
- Add `resolveForEachTaskExpressions()` helper that resolves `self.*` expressions in task inputs and shell args while
preserving vault expressions for runtime
- Save the fully expanded workflow for `--last-evaluated` compatibility

**src/cli/commands/workflow_run.ts**
- Skip input validation when `--last-evaluated` is used (inputs are already resolved)

**src/domain/workflows/execution_service.ts**
- Use the evaluated workflow directly when `--last-evaluated` is set instead of the original definition
- Update error message to reference `swamp workflow evaluate` instead of `swamp workflow run`

**src/presentation/output/workflow_evaluate_output.ts**
- Add `forEachExpanded` flag and `jobs` data to the output interface
- Show expanded step names in log output when forEach expansion occurs

## Test plan

- [x] All 1323 existing tests pass
- [x] `swamp workflow evaluate <name> --input '{...}'` expands forEach steps in output
- [x] Evaluated file contains concrete expanded steps (no forEach blocks)
- [x] `swamp workflow run <name> --last-evaluated` works without `--input`
- [x] `swamp workflow run <name> --input '{...}'` still works (non-last-evaluated path)
- [x] Vault expressions remain unresolved in expanded steps
- [x] Object iteration (key/value) expands correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)