### PR TITLE
Enforce @user namespace for user-defined extensions (#173)

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -48,8 +48,8 @@ outputs.
 | ------------------- | ------------------------------------------------------ |
 | Create model file   | Create `extensions/models/my_model.ts`                 |
 | Verify registration | `swamp type search --json`                             |
-| Check schema        | `swamp type describe myorg/my-model --json`            |
-| Create instance     | `swamp model create myorg/my-model my-instance --json` |
+| Check schema        | `swamp type describe @user/my-model --json`            |
+| Create instance     | `swamp model create @user/my-model my-instance --json` |
 | Run method          | `swamp model method run my-instance run --json`        |
 
 ## Quick Start
@@ -61,7 +61,7 @@ import { z } from "npm:zod@4";
 const InputSchema = z.object({ message: z.string() });
 
 export const model = {
-  type: "myorg/my-model",
+  type: "@user/my-model",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
@@ -100,7 +100,7 @@ are provided via `--input` or `--input-file` when running methods:
 
 ```typescript
 export const model = {
-  type: "myorg/deploy",
+  type: "@user/deploy",
   version: 1,
   inputAttributesSchema: z.object({
     serviceName: z.string(),
@@ -308,10 +308,28 @@ Repository models take precedence, allowing you to override built-in types.
 1. **Export**: Use `export const model = { ... }` for new types or
    `export const extension = { ... }` for extending existing types
 2. **Import**: Only `import { z } from "npm:zod@4";` is needed
-3. **Type naming**: Use `namespace/name` format to avoid conflicts
+3. **Type naming**: Use `@user/<name>` format (e.g., `@user/my-model`,
+   `@user/aws/s3-bucket`). Reserved namespaces (`swamp`, `si`) are for built-in
+   types only.
 4. **No type annotations**: Avoid TypeScript types in execute parameters
 5. **File naming**: Use snake_case (`my_model.ts`), test files excluded
 6. **Nesting**: Files can live in subdirectories for organization
+
+## Namespace Rules
+
+User-defined models **must** use the `@user` namespace:
+
+| Type                  | Valid? | Notes                          |
+| --------------------- | ------ | ------------------------------ |
+| `@user/my-model`      | ✅     | Required format                |
+| `@user/aws/s3-bucket` | ✅     | Nested namespaces allowed      |
+| `mycompany/model`     | ❌     | Missing `@` prefix             |
+| `@mycompany/model`    | ❌     | Only `@user` namespace allowed |
+| `swamp/my-model`      | ❌     | Reserved for built-in types    |
+| `@swamp/my-model`     | ❌     | Reserved namespace             |
+
+When authentication is added, users will be able to use their username as the
+namespace (e.g., `@adam/my-model`).
 
 ## Data Ownership
 
@@ -376,7 +394,7 @@ const InputSchema = z.object({
 });
 
 export const model = {
-  type: "myorg/shell",
+  type: "@user/shell",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
@@ -412,7 +430,7 @@ import { z } from "npm:zod@4";
 const InputSchema = z.object({ query: z.string() });
 
 export const model = {
-  type: "myorg/search",
+  type: "@user/search",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
@@ -466,7 +484,7 @@ const InputSchema = z.object({
 });
 
 export const model = {
-  type: "myorg/api-resource",
+  type: "@user/api-resource",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
@@ -512,7 +530,7 @@ const InputSchema = z.object({
 });
 
 export const model = {
-  type: "myorg/s3-bucket",
+  type: "@user/s3-bucket",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
@@ -599,7 +617,7 @@ After creating your model:
 
 ```bash
 swamp type search --json              # Model should appear
-swamp type describe myorg/my-model    # Check schema
+swamp type describe @user/my-model    # Check schema
 ```
 
 ## When to Use Other Skills

--- a/.claude/skills/swamp-extension-model/references/examples.md
+++ b/.claude/skills/swamp-extension-model/references/examples.md
@@ -19,7 +19,7 @@ const DataSchema = z.object({
 });
 
 export const model = {
-  type: "myorg/text-processor",
+  type: "@user/text-processor",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   dataAttributesSchema: DataSchema,
@@ -83,7 +83,7 @@ const ResourceSchema = z.object({
 });
 
 export const model = {
-  type: "myorg/deployment",
+  type: "@user/deployment",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   resourceAttributesSchema: ResourceSchema,
@@ -145,7 +145,7 @@ const InputSchema = z.object({ message: z.string() });
 const DataSchema = z.object({ message: z.string(), timestamp: z.string() });
 
 export const model = {
-  type: "myorg/echo",
+  type: "@user/echo",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   dataAttributesSchema: DataSchema,
@@ -190,7 +190,7 @@ const DataSchema = z.object({
 });
 
 export const model = {
-  type: "myorg/config-generator",
+  type: "@user/config-generator",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   dataAttributesSchema: DataSchema,

--- a/.claude/skills/swamp-extension-model/references/troubleshooting.md
+++ b/.claude/skills/swamp-extension-model/references/troubleshooting.md
@@ -34,14 +34,45 @@ export const model = {
 
 ### "Model type already registered"
 
-Type name conflicts with built-in or another user model. Use namespaced names:
+Type name conflicts with built-in or another user model. Use unique names within
+the `@user` namespace:
 
 ```typescript
 // Avoid
-type: "echo"; // May conflict
+type: "@user/echo"; // May conflict with other users
 
 // Use
-type: "mycompany/echo"; // Unique
+type: "@user/mycompany/echo"; // More unique
+```
+
+### "Model type must use '@' prefix"
+
+User-defined models must use the `@user` namespace:
+
+```typescript
+// Wrong - missing @user namespace
+type: "mycompany/echo";
+
+// Correct
+type: "@user/echo";
+type: "@user/mycompany/echo";
+```
+
+### "Namespace 'X' is not allowed"
+
+Only the `@user` namespace is currently allowed for user models. Reserved
+namespaces (`swamp`, `si`) are for built-in types:
+
+```typescript
+// Wrong - reserved namespace
+type: "swamp/my-model";
+type: "@swamp/my-model";
+
+// Wrong - custom namespace not allowed yet
+type: "@mycompany/echo";
+
+// Correct
+type: "@user/my-model";
 ```
 
 ### "Cannot extend unregistered model type: ..."
@@ -92,9 +123,9 @@ Models directory priority:
 swamp type search --json
 
 # Check model schema
-swamp type describe myorg/my-model --json
+swamp type describe @user/my-model --json
 
 # Test the model
-swamp model create myorg/my-model test --set fieldName="test"
+swamp model create @user/my-model test --set fieldName="test"
 swamp model method run test methodName --json
 ```

--- a/.claude/skills/swamp-model/references/data-chaining.md
+++ b/.claude/skills/swamp-model/references/data-chaining.md
@@ -41,7 +41,7 @@ EOF
 
 ```bash
 # Create the EC2 instance model
-swamp model create myorg/ec2-instance my-instance --json
+swamp model create @user/ec2-instance my-instance --json
 
 # Configure with references to the aws/cli model's data output
 swamp model edit my-instance --json <<EOF
@@ -77,7 +77,7 @@ EOF
 
 ```bash
 # Create an EC2 instance that references the security group
-swamp model create myorg/ec2 my-server --json
+swamp model create @user/ec2 my-server --json
 
 swamp model edit my-server --json <<EOF
 name: my-server
@@ -118,7 +118,7 @@ EOF
 
 ```bash
 # Step 3: Create instance model that uses both lookups
-swamp model create myorg/ec2-instance my-instance --json
+swamp model create @user/ec2-instance my-instance --json
 
 swamp model edit my-instance --json <<EOF
 name: my-instance

--- a/src/domain/models/model_type.ts
+++ b/src/domain/models/model_type.ts
@@ -88,4 +88,68 @@ export class ModelType {
   toString(): string {
     return this.raw;
   }
+
+  /**
+   * Checks if a normalized type string starts with '@' (user namespace).
+   */
+  static isUserNamespace(normalized: string): boolean {
+    return normalized.startsWith("@");
+  }
+
+  /**
+   * Extracts the namespace from a user namespace type.
+   * Returns the segment after '@' (e.g., "@user/foo/bar" → "user").
+   * Returns undefined if not a user namespace.
+   */
+  static getUserNamespace(normalized: string): string | undefined {
+    if (!ModelType.isUserNamespace(normalized)) {
+      return undefined;
+    }
+    const withoutAt = normalized.slice(1);
+    const slashIndex = withoutAt.indexOf("/");
+    if (slashIndex === -1) {
+      return withoutAt;
+    }
+    return withoutAt.slice(0, slashIndex);
+  }
+
+  /**
+   * Returns the number of path segments in a normalized type.
+   * For user namespaces, treats "@namespace" as segment 1.
+   * Examples:
+   * - "swamp/echo" → 2
+   * - "@user/echo" → 2
+   * - "@user/foo/bar" → 3
+   */
+  static getSegmentCount(normalized: string): number {
+    if (ModelType.isUserNamespace(normalized)) {
+      const withoutAt = normalized.slice(1);
+      return withoutAt.split("/").filter((s) => s.length > 0).length;
+    }
+    return normalized.split("/").filter((s) => s.length > 0).length;
+  }
+
+  /**
+   * Reserved built-in namespaces that user extensions cannot use.
+   */
+  private static readonly RESERVED_NAMESPACES = ["swamp", "si"];
+
+  /**
+   * Checks if a normalized type uses a reserved namespace.
+   * Reserved namespaces are: swamp, si (with or without @ prefix).
+   */
+  static isReservedNamespace(normalized: string): boolean {
+    // Check for @swamp/*, @si/*
+    if (ModelType.isUserNamespace(normalized)) {
+      const namespace = ModelType.getUserNamespace(normalized);
+      return namespace !== undefined &&
+        ModelType.RESERVED_NAMESPACES.includes(namespace);
+    }
+    // Check for swamp/*, si/*
+    const firstSlash = normalized.indexOf("/");
+    const firstSegment = firstSlash === -1
+      ? normalized
+      : normalized.slice(0, firstSlash);
+    return ModelType.RESERVED_NAMESPACES.includes(firstSegment);
+  }
 }

--- a/src/domain/models/model_type_test.ts
+++ b/src/domain/models/model_type_test.ts
@@ -74,3 +74,67 @@ Deno.test("ModelType.toString returns raw type", () => {
   const type = ModelType.create("AWS::EC2::VPC");
   assertEquals(type.toString(), "AWS::EC2::VPC");
 });
+
+// --- User namespace helper tests ---
+
+Deno.test("ModelType.isUserNamespace returns true for @ prefixed types", () => {
+  assertEquals(ModelType.isUserNamespace("@user/foo"), true);
+  assertEquals(ModelType.isUserNamespace("@adam/bar"), true);
+  assertEquals(ModelType.isUserNamespace("@user/foo/bar"), true);
+});
+
+Deno.test("ModelType.isUserNamespace returns false for non-@ types", () => {
+  assertEquals(ModelType.isUserNamespace("swamp/echo"), false);
+  assertEquals(ModelType.isUserNamespace("aws/ec2/vpc"), false);
+  assertEquals(ModelType.isUserNamespace("user/foo"), false);
+});
+
+Deno.test("ModelType.getUserNamespace extracts namespace correctly", () => {
+  assertEquals(ModelType.getUserNamespace("@user/foo"), "user");
+  assertEquals(ModelType.getUserNamespace("@adam/bar"), "adam");
+  assertEquals(ModelType.getUserNamespace("@mycompany/cloud/aws"), "mycompany");
+  assertEquals(ModelType.getUserNamespace("@user"), "user");
+});
+
+Deno.test("ModelType.getUserNamespace returns undefined for non-@ types", () => {
+  assertEquals(ModelType.getUserNamespace("swamp/echo"), undefined);
+  assertEquals(ModelType.getUserNamespace("user/foo"), undefined);
+});
+
+Deno.test("ModelType.getSegmentCount returns correct counts", () => {
+  // Built-in types
+  assertEquals(ModelType.getSegmentCount("swamp/echo"), 2);
+  assertEquals(ModelType.getSegmentCount("aws/ec2/vpc"), 3);
+  // User namespace types
+  assertEquals(ModelType.getSegmentCount("@user/echo"), 2);
+  assertEquals(ModelType.getSegmentCount("@user/foo/bar"), 3);
+  assertEquals(ModelType.getSegmentCount("@user/a/b/c/d"), 5);
+  // Edge cases
+  assertEquals(ModelType.getSegmentCount("@user"), 1);
+  assertEquals(ModelType.getSegmentCount("single"), 1);
+});
+
+Deno.test("ModelType.isReservedNamespace identifies swamp as reserved", () => {
+  assertEquals(ModelType.isReservedNamespace("swamp/echo"), true);
+  assertEquals(ModelType.isReservedNamespace("swamp/foo/bar"), true);
+  assertEquals(ModelType.isReservedNamespace("@swamp/echo"), true);
+  assertEquals(ModelType.isReservedNamespace("@swamp/foo/bar"), true);
+});
+
+Deno.test("ModelType.isReservedNamespace identifies si as reserved", () => {
+  assertEquals(ModelType.isReservedNamespace("si/auth"), true);
+  assertEquals(ModelType.isReservedNamespace("si/foo/bar"), true);
+  assertEquals(ModelType.isReservedNamespace("@si/auth"), true);
+  assertEquals(ModelType.isReservedNamespace("@si/foo/bar"), true);
+});
+
+Deno.test("ModelType.isReservedNamespace returns false for user namespaces", () => {
+  assertEquals(ModelType.isReservedNamespace("@user/echo"), false);
+  assertEquals(ModelType.isReservedNamespace("@adam/foo"), false);
+  assertEquals(ModelType.isReservedNamespace("@mycompany/model"), false);
+});
+
+Deno.test("ModelType.isReservedNamespace returns false for non-reserved built-in", () => {
+  assertEquals(ModelType.isReservedNamespace("aws/ec2/vpc"), false);
+  assertEquals(ModelType.isReservedNamespace("docker/run"), false);
+});

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -123,6 +123,13 @@ export interface LoadResult {
 }
 
 /**
+ * Allowed namespaces for user-defined models.
+ * Currently only "user" is allowed. When authentication is added,
+ * the authenticated username will be added to this list.
+ */
+const ALLOWED_NAMESPACES = ["user"];
+
+/**
  * Loader for user-defined TypeScript models and extensions.
  *
  * Users export a plain `model` object to define new types, or an `extension`
@@ -187,6 +194,14 @@ export class UserModelLoader {
         }
 
         const userModel = parsed.data;
+
+        // Validate namespace before registration
+        const namespaceError = this.validateUserNamespace(userModel.type);
+        if (namespaceError) {
+          result.failed.push({ file, error: namespaceError });
+          continue;
+        }
+
         const modelDef = this.convertToModelDefinition(userModel);
 
         if (!modelRegistry.has(modelDef.type)) {
@@ -221,6 +236,46 @@ export class UserModelLoader {
     }
 
     return result;
+  }
+
+  /**
+   * Validates that a user-defined model type follows the required namespace conventions.
+   *
+   * Requirements:
+   * - Must start with '@' (user namespace prefix)
+   * - Must use an allowed namespace (currently only "user")
+   * - Must have at least 2 segments (e.g., "@user/echo")
+   * - Must not use reserved namespaces (swamp, si)
+   *
+   * @param rawType - The raw type string from the user model
+   * @returns Error message if validation fails, undefined if valid
+   */
+  private validateUserNamespace(rawType: string): string | undefined {
+    const normalized = ModelType.create(rawType).normalized;
+
+    // Check for reserved built-in namespaces
+    if (ModelType.isReservedNamespace(normalized)) {
+      return `Model type '${rawType}' uses a reserved namespace. User models cannot use 'swamp' or 'si' namespaces.`;
+    }
+
+    // Must start with '@'
+    if (!ModelType.isUserNamespace(normalized)) {
+      return `Model type '${rawType}' must use '@' prefix. Expected format: @user/<name> (e.g., @user/my-model)`;
+    }
+
+    // Must use an allowed namespace
+    const namespace = ModelType.getUserNamespace(normalized);
+    if (!namespace || !ALLOWED_NAMESPACES.includes(namespace)) {
+      return `Model type '${rawType}' uses namespace '${namespace}' which is not allowed. Currently only '@user' namespace is allowed.`;
+    }
+
+    // Must have at least 2 segments
+    const segmentCount = ModelType.getSegmentCount(normalized);
+    if (segmentCount < 2) {
+      return `Model type '${rawType}' must have at least 2 segments. Expected format: @user/<name> (e.g., @user/my-model)`;
+    }
+
+    return undefined;
   }
 
   /**

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -97,7 +97,7 @@ const InputSchema = z.object({
 });
 
 export const model = {
-  type: "test/data-model-${Date.now()}",
+  type: "@user/data-model-${Date.now()}",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {
@@ -151,7 +151,7 @@ export const notAModel = { foo: "bar" };
 Deno.test("UserModelLoader handles invalid model structure", async () => {
   const modelCode = `
 export const model = {
-  type: "test/invalid",
+  type: "@user/invalid",
   // Missing required fields
 };
 `;
@@ -182,7 +182,7 @@ export const model = { type: "test/should-skip" };
 import { z } from "npm:zod@4";
 
 export const model = {
-  type: "test/regular-${Date.now()}",
+  type: "@user/regular-${Date.now()}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ msg: z.string() }),
   methods: {
@@ -214,12 +214,14 @@ export const model = {
 });
 
 Deno.test("UserModelLoader prevents duplicate type registration", async () => {
-  // First, ensure swamp/echo is registered (it's already in the global registry)
-  const modelCode = `
+  // Test that two models with the same type fail on the second one
+  const ts = Date.now();
+  const typeId = `@user/duplicate-${ts}`;
+  const model1 = `
 import { z } from "npm:zod@4";
 
 export const model = {
-  type: "swamp/echo",
+  type: "${typeId}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   methods: {
@@ -230,20 +232,39 @@ export const model = {
   },
 };
 `;
+  const model2 = `
+import { z } from "npm:zod@4";
 
-  await withTempModels({ "duplicate.ts": modelCode }, async (dir) => {
-    const loader = new UserModelLoader();
-    const result = await loader.loadModels(dir);
+export const model = {
+  type: "${typeId}",
+  version: "2026.02.09.2",
+  inputAttributesSchema: z.object({ message: z.string() }),
+  methods: {
+    run: {
+      description: "Run",
+      execute: async () => ({ dataOutputs: [] }),
+    },
+  },
+};
+`;
 
-    assertEquals(result.loaded.length, 0);
-    assertEquals(result.failed.length, 1);
-    assertEquals(result.failed[0].file, "duplicate.ts");
-    assertStringIncludes(result.failed[0].error, "already registered");
-  });
+  await withTempModels(
+    { "aaa_first.ts": model1, "zzz_second.ts": model2 },
+    async (dir) => {
+      const loader = new UserModelLoader();
+      const result = await loader.loadModels(dir);
+
+      // First model should load, second should fail as duplicate
+      assertEquals(result.loaded.length, 1);
+      assertEquals(result.failed.length, 1);
+      assertEquals(result.failed[0].file, "zzz_second.ts");
+      assertStringIncludes(result.failed[0].error, "already registered");
+    },
+  );
 });
 
 Deno.test("UserModelLoader converts plain dataOutputs to proper DataOutput format", async () => {
-  const typeId = `test/convert-data-${Date.now()}`;
+  const typeId = `@user/convert-data-${Date.now()}`;
   const modelCode = `
 import { z } from "npm:zod@4";
 
@@ -317,7 +338,7 @@ export const model = {
 });
 
 Deno.test("UserModelLoader uses model inputAttributesSchema when method lacks one", async () => {
-  const typeId = `test/method-inherits-schema-${Date.now()}`;
+  const typeId = `@user/method-inherits-schema-${Date.now()}`;
   const modelCode = `
 import { z } from "npm:zod@4";
 
@@ -367,7 +388,7 @@ Deno.test("UserModelLoader loads multiple models from directory", async () => {
   const model1 = `
 import { z } from "npm:zod@4";
 export const model = {
-  type: "test/multi-a-${Date.now()}",
+  type: "@user/multi-a-${Date.now()}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ a: z.string() }),
   methods: {
@@ -382,7 +403,7 @@ export const model = {
   const model2 = `
 import { z } from "npm:zod@4";
 export const model = {
-  type: "test/multi-b-${Date.now()}",
+  type: "@user/multi-b-${Date.now()}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ b: z.string() }),
   methods: {
@@ -410,7 +431,7 @@ export const model = {
 });
 
 Deno.test("UserModelLoader converts resource return format to dataOutputs", async () => {
-  const typeId = `test/resource-format-${Date.now()}`;
+  const typeId = `@user/resource-format-${Date.now()}`;
   const modelCode = `
 import { z } from "npm:zod@4";
 
@@ -478,7 +499,7 @@ export const model = {
 });
 
 Deno.test("UserModelLoader converts data return format to dataOutputs", async () => {
-  const typeId = `test/data-format-${Date.now()}`;
+  const typeId = `@user/data-format-${Date.now()}`;
   const modelCode = `
 import { z } from "npm:zod@4";
 
@@ -553,7 +574,7 @@ Deno.test("UserModelLoader discovers nested files with correct relative paths", 
   const modelA = `
 import { z } from "npm:zod@4";
 export const model = {
-  type: "test/nested-a-${ts}",
+  type: "@user/nested-a-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ a: z.string() }),
   methods: {
@@ -567,7 +588,7 @@ export const model = {
   const modelB = `
 import { z } from "npm:zod@4";
 export const model = {
-  type: "test/nested-b-${ts}",
+  type: "@user/nested-b-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ b: z.string() }),
   methods: {
@@ -599,7 +620,7 @@ Deno.test("UserModelLoader excludes _test.ts in subdirectories", async () => {
   const modelCode = `
 import { z } from "npm:zod@4";
 export const model = {
-  type: "test/subdir-notest-${ts}",
+  type: "@user/subdir-notest-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ x: z.string() }),
   methods: {
@@ -627,7 +648,7 @@ Deno.test("UserModelLoader handles deeply nested directories (3+ levels)", async
   const modelCode = `
 import { z } from "npm:zod@4";
 export const model = {
-  type: "test/deep-nested-${ts}",
+  type: "@user/deep-nested-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ x: z.string() }),
   methods: {
@@ -658,7 +679,7 @@ Deno.test("UserModelLoader loads extension with single method in array", async (
   const modelCode = `
 import { z } from "npm:zod@4";
 export const model = {
-  type: "test/ext-single-${ts}",
+  type: "@user/ext-single-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   methods: {
@@ -671,7 +692,7 @@ export const model = {
 `;
   const extCode = `
 export const extension = {
-  type: "test/ext-single-${ts}",
+  type: "@user/ext-single-${ts}",
   methods: [{
     audit: {
       description: "Audit the echo message",
@@ -698,7 +719,7 @@ export const extension = {
       assertEquals(result.failed.length, 0);
 
       // Verify the method was added
-      const modelDef = modelRegistry.get(`test/ext-single-${ts}`);
+      const modelDef = modelRegistry.get(`@user/ext-single-${ts}`);
       assertEquals(modelDef !== undefined, true);
       assertEquals("write" in modelDef!.methods, true);
       assertEquals("audit" in modelDef!.methods, true);
@@ -711,7 +732,7 @@ Deno.test("UserModelLoader loads extension with multiple methods in array", asyn
   const modelCode = `
 import { z } from "npm:zod@4";
 export const model = {
-  type: "test/ext-multi-${ts}",
+  type: "@user/ext-multi-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   methods: {
@@ -724,7 +745,7 @@ export const model = {
 `;
   const extCode = `
 export const extension = {
-  type: "test/ext-multi-${ts}",
+  type: "@user/ext-multi-${ts}",
   methods: [{
     audit: {
       description: "Audit",
@@ -747,7 +768,7 @@ export const extension = {
       assertEquals(result.loaded.length, 1);
       assertEquals(result.extended.length, 1);
 
-      const modelDef = modelRegistry.get(`test/ext-multi-${ts}`);
+      const modelDef = modelRegistry.get(`@user/ext-multi-${ts}`);
       assertEquals("write" in modelDef!.methods, true);
       assertEquals("audit" in modelDef!.methods, true);
       assertEquals("verify" in modelDef!.methods, true);
@@ -759,7 +780,7 @@ Deno.test("UserModelLoader extension targeting unregistered type fails gracefull
   const ts = Date.now();
   const extCode = `
 export const extension = {
-  type: "test/nonexistent-${ts}",
+  type: "@user/nonexistent-${ts}",
   methods: [{
     audit: {
       description: "Audit",
@@ -785,7 +806,7 @@ Deno.test("UserModelLoader extension with method name conflict fails gracefully"
   const modelCode = `
 import { z } from "npm:zod@4";
 export const model = {
-  type: "test/ext-conflict-${ts}",
+  type: "@user/ext-conflict-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   methods: {
@@ -798,7 +819,7 @@ export const model = {
 `;
   const extCode = `
 export const extension = {
-  type: "test/ext-conflict-${ts}",
+  type: "@user/ext-conflict-${ts}",
   methods: [{
     write: {
       description: "Duplicate write",
@@ -827,7 +848,7 @@ Deno.test("UserModelLoader extension with duplicate method names within array fa
   const modelCode = `
 import { z } from "npm:zod@4";
 export const model = {
-  type: "test/ext-dup-methods-${ts}",
+  type: "@user/ext-dup-methods-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   methods: {
@@ -841,7 +862,7 @@ export const model = {
   // Two array elements with same method name
   const extCode = `
 export const extension = {
-  type: "test/ext-dup-methods-${ts}",
+  type: "@user/ext-dup-methods-${ts}",
   methods: [
     {
       audit: {
@@ -881,7 +902,7 @@ Deno.test("UserModelLoader extension methods inherit target model's inputAttribu
   const modelCode = `
 import { z } from "npm:zod@4";
 export const model = {
-  type: "test/ext-inherit-schema-${ts}",
+  type: "@user/ext-inherit-schema-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   methods: {
@@ -894,7 +915,7 @@ export const model = {
 `;
   const extCode = `
 export const extension = {
-  type: "test/ext-inherit-schema-${ts}",
+  type: "@user/ext-inherit-schema-${ts}",
   methods: [{
     audit: {
       description: "Audit without own schema",
@@ -912,7 +933,7 @@ export const extension = {
 
       assertEquals(result.extended.length, 1);
 
-      const modelDef = modelRegistry.get(`test/ext-inherit-schema-${ts}`);
+      const modelDef = modelRegistry.get(`@user/ext-inherit-schema-${ts}`);
       // Extension method should have inputAttributesSchema inherited from target model
       assertEquals(
         modelDef!.methods.audit.inputAttributesSchema !== undefined,
@@ -957,7 +978,7 @@ Deno.test("UserModelLoader multiple extensions targeting same type", async () =>
   const modelCode = `
 import { z } from "npm:zod@4";
 export const model = {
-  type: "test/multi-ext-${ts}",
+  type: "@user/multi-ext-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   methods: {
@@ -970,7 +991,7 @@ export const model = {
 `;
   const ext1 = `
 export const extension = {
-  type: "test/multi-ext-${ts}",
+  type: "@user/multi-ext-${ts}",
   methods: [{
     audit: {
       description: "Audit",
@@ -981,7 +1002,7 @@ export const extension = {
 `;
   const ext2 = `
 export const extension = {
-  type: "test/multi-ext-${ts}",
+  type: "@user/multi-ext-${ts}",
   methods: [{
     verify: {
       description: "Verify",
@@ -1001,7 +1022,7 @@ export const extension = {
       assertEquals(result.extended.length, 2);
       assertEquals(result.failed.length, 0);
 
-      const modelDef = modelRegistry.get(`test/multi-ext-${ts}`);
+      const modelDef = modelRegistry.get(`@user/multi-ext-${ts}`);
       assertEquals("write" in modelDef!.methods, true);
       assertEquals("audit" in modelDef!.methods, true);
       assertEquals("verify" in modelDef!.methods, true);
@@ -1016,7 +1037,7 @@ Deno.test("UserModelLoader two-pass ordering: user model registered before exten
   const modelCode = `
 import { z } from "npm:zod@4";
 export const model = {
-  type: "test/two-pass-${ts}",
+  type: "@user/two-pass-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   methods: {
@@ -1029,7 +1050,7 @@ export const model = {
 `;
   const extCode = `
 export const extension = {
-  type: "test/two-pass-${ts}",
+  type: "@user/two-pass-${ts}",
   methods: [{
     audit: {
       description: "Audit",
@@ -1050,7 +1071,7 @@ export const extension = {
       assertEquals(result.extended.length, 1);
       assertEquals(result.failed.length, 0);
 
-      const modelDef = modelRegistry.get(`test/two-pass-${ts}`);
+      const modelDef = modelRegistry.get(`@user/two-pass-${ts}`);
       assertEquals("write" in modelDef!.methods, true);
       assertEquals("audit" in modelDef!.methods, true);
     },
@@ -1062,7 +1083,7 @@ Deno.test("UserModelLoader extension method execute produces proper DataOutput",
   const modelCode = `
 import { z } from "npm:zod@4";
 export const model = {
-  type: "test/ext-execute-${ts}",
+  type: "@user/ext-execute-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   methods: {
@@ -1075,7 +1096,7 @@ export const model = {
 `;
   const extCode = `
 export const extension = {
-  type: "test/ext-execute-${ts}",
+  type: "@user/ext-execute-${ts}",
   methods: [{
     audit: {
       description: "Audit",
@@ -1098,7 +1119,7 @@ export const extension = {
 
       assertEquals(result.extended.length, 1);
 
-      const modelDef = modelRegistry.get(`test/ext-execute-${ts}`);
+      const modelDef = modelRegistry.get(`@user/ext-execute-${ts}`);
       const definition = Definition.create({
         name: "test-audit",
         attributes: { message: "hello" },
@@ -1130,7 +1151,7 @@ export const extension = {
 // --- Default dataOutputSpecs tests ---
 
 Deno.test("UserModelLoader provides default data and resource spec types", async () => {
-  const typeId = `test/default-specs-${Date.now()}`;
+  const typeId = `@user/default-specs-${Date.now()}`;
   const modelCode = `
 import { z } from "npm:zod@4";
 
@@ -1177,7 +1198,7 @@ export const model = {
 });
 
 Deno.test("UserModelLoader user-declared dataOutputSpecs override defaults", async () => {
-  const typeId = `test/custom-specs-${Date.now()}`;
+  const typeId = `@user/custom-specs-${Date.now()}`;
   const modelCode = `
 import { z } from "npm:zod@4";
 
@@ -1233,5 +1254,254 @@ export const model = {
       modelDef!.dataOutputSpecs["metrics"].specType.value,
       "metrics",
     );
+  });
+});
+
+// --- Namespace validation tests ---
+
+Deno.test("UserModelLoader rejects model without @ prefix", async () => {
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "mycompany/mymodel",
+  version: "2026.02.09.1",
+  inputAttributesSchema: z.object({ message: z.string() }),
+  methods: {
+    run: {
+      description: "Run",
+      execute: async () => ({ dataOutputs: [] }),
+    },
+  },
+};
+`;
+
+  await withTempModels({ "no_at_prefix.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 0);
+    assertEquals(result.failed.length, 1);
+    assertStringIncludes(result.failed[0].error, "must use '@' prefix");
+  });
+});
+
+Deno.test("UserModelLoader rejects model with only namespace segment", async () => {
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "@user",
+  version: "2026.02.09.1",
+  inputAttributesSchema: z.object({ message: z.string() }),
+  methods: {
+    run: {
+      description: "Run",
+      execute: async () => ({ dataOutputs: [] }),
+    },
+  },
+};
+`;
+
+  await withTempModels({ "only_namespace.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 0);
+    assertEquals(result.failed.length, 1);
+    assertStringIncludes(result.failed[0].error, "at least 2 segments");
+  });
+});
+
+Deno.test("UserModelLoader rejects model with non-user namespace", async () => {
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "@adam/mymodel",
+  version: "2026.02.09.1",
+  inputAttributesSchema: z.object({ message: z.string() }),
+  methods: {
+    run: {
+      description: "Run",
+      execute: async () => ({ dataOutputs: [] }),
+    },
+  },
+};
+`;
+
+  await withTempModels({ "wrong_namespace.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 0);
+    assertEquals(result.failed.length, 1);
+    assertStringIncludes(result.failed[0].error, "namespace 'adam'");
+    assertStringIncludes(result.failed[0].error, "not allowed");
+  });
+});
+
+Deno.test("UserModelLoader accepts valid @user/name format", async () => {
+  const typeId = `@user/valid-model-${Date.now()}`;
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "${typeId}",
+  version: "2026.02.09.1",
+  inputAttributesSchema: z.object({ message: z.string() }),
+  methods: {
+    run: {
+      description: "Run",
+      execute: async () => ({ dataOutputs: [] }),
+    },
+  },
+};
+`;
+
+  await withTempModels({ "valid_user_model.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 1);
+    assertEquals(result.failed.length, 0);
+
+    const modelDef = modelRegistry.get(typeId);
+    assertEquals(modelDef !== undefined, true);
+  });
+});
+
+Deno.test("UserModelLoader accepts valid @user/foo/bar format with 3 segments", async () => {
+  const typeId = `@user/category/model-${Date.now()}`;
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "${typeId}",
+  version: "2026.02.09.1",
+  inputAttributesSchema: z.object({ message: z.string() }),
+  methods: {
+    run: {
+      description: "Run",
+      execute: async () => ({ dataOutputs: [] }),
+    },
+  },
+};
+`;
+
+  await withTempModels({ "valid_nested.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 1);
+    assertEquals(result.failed.length, 0);
+  });
+});
+
+Deno.test("UserModelLoader rejects reserved namespace swamp/*", async () => {
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "swamp/mymodel",
+  version: "2026.02.09.1",
+  inputAttributesSchema: z.object({ message: z.string() }),
+  methods: {
+    run: {
+      description: "Run",
+      execute: async () => ({ dataOutputs: [] }),
+    },
+  },
+};
+`;
+
+  await withTempModels({ "reserved_swamp.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 0);
+    assertEquals(result.failed.length, 1);
+    assertStringIncludes(result.failed[0].error, "reserved namespace");
+  });
+});
+
+Deno.test("UserModelLoader rejects reserved namespace si/*", async () => {
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "si/mymodel",
+  version: "2026.02.09.1",
+  inputAttributesSchema: z.object({ message: z.string() }),
+  methods: {
+    run: {
+      description: "Run",
+      execute: async () => ({ dataOutputs: [] }),
+    },
+  },
+};
+`;
+
+  await withTempModels({ "reserved_si.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 0);
+    assertEquals(result.failed.length, 1);
+    assertStringIncludes(result.failed[0].error, "reserved namespace");
+  });
+});
+
+Deno.test("UserModelLoader rejects reserved namespace @swamp/*", async () => {
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "@swamp/mymodel",
+  version: "2026.02.09.1",
+  inputAttributesSchema: z.object({ message: z.string() }),
+  methods: {
+    run: {
+      description: "Run",
+      execute: async () => ({ dataOutputs: [] }),
+    },
+  },
+};
+`;
+
+  await withTempModels({ "reserved_at_swamp.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 0);
+    assertEquals(result.failed.length, 1);
+    assertStringIncludes(result.failed[0].error, "reserved namespace");
+  });
+});
+
+Deno.test("UserModelLoader rejects reserved namespace @si/*", async () => {
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "@si/mymodel",
+  version: "2026.02.09.1",
+  inputAttributesSchema: z.object({ message: z.string() }),
+  methods: {
+    run: {
+      description: "Run",
+      execute: async () => ({ dataOutputs: [] }),
+    },
+  },
+};
+`;
+
+  await withTempModels({ "reserved_at_si.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 0);
+    assertEquals(result.failed.length, 1);
+    assertStringIncludes(result.failed[0].error, "reserved namespace");
   });
 });

--- a/src/presentation/output/model_output_search_output.tsx
+++ b/src/presentation/output/model_output_search_output.tsx
@@ -127,6 +127,7 @@ export function ModelOutputSearchUI(
 
   const [query, setQuery] = useState(initialQuery);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [scrollOffset, setScrollOffset] = useState(0);
 
   // Create fzf instance for fuzzy searching (memoized to avoid recreation on every render)
   const fzf = useMemo(
@@ -143,11 +144,22 @@ export function ModelOutputSearchUI(
   // Get filtered results
   const results: FzfResultItem<ModelOutputSearchItem>[] = fzf.find(query);
   const maxVisible = 10;
-  const visibleResults = results.slice(0, maxVisible);
 
-  // Reset selection when query changes
+  // Adjust scroll offset to keep selected item visible
+  useEffect(() => {
+    if (selectedIndex < scrollOffset) {
+      setScrollOffset(selectedIndex);
+    } else if (selectedIndex >= scrollOffset + maxVisible) {
+      setScrollOffset(selectedIndex - maxVisible + 1);
+    }
+  }, [selectedIndex, scrollOffset]);
+
+  const visibleResults = results.slice(scrollOffset, scrollOffset + maxVisible);
+
+  // Reset selection and scroll when query changes
   useEffect(() => {
     setSelectedIndex(0);
+    setScrollOffset(0);
   }, [query]);
 
   const handleSelect = useCallback(() => {
@@ -215,15 +227,19 @@ export function ModelOutputSearchUI(
 
       {/* Results list */}
       <Box flexDirection="column" marginTop={1}>
+        {scrollOffset > 0 && <Text dimColor>... {scrollOffset} more above
+        </Text>}
         {visibleResults.map((result, index) => (
           <ModelOutputSearchResultItem
             key={result.item.id}
             item={result.item}
-            isSelected={index === selectedIndex}
+            isSelected={index + scrollOffset === selectedIndex}
           />
         ))}
-        {results.length > maxVisible && (
-          <Text dimColor>... {results.length - maxVisible} more results</Text>
+        {scrollOffset + maxVisible < results.length && (
+          <Text dimColor>
+            ... {results.length - scrollOffset - maxVisible} more below
+          </Text>
         )}
         {results.length === 0 && (
           <Text color="yellow">No matching outputs found</Text>

--- a/src/presentation/output/model_search_output.tsx
+++ b/src/presentation/output/model_search_output.tsx
@@ -87,6 +87,7 @@ export function ModelSearchUI(
 
   const [query, setQuery] = useState(initialQuery);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [scrollOffset, setScrollOffset] = useState(0);
 
   // Create fzf instance for fuzzy searching (memoized to avoid recreation on every render)
   const fzf = useMemo(
@@ -100,11 +101,22 @@ export function ModelSearchUI(
   // Get filtered results
   const results: FzfResultItem<ModelSearchItem>[] = fzf.find(query);
   const maxVisible = 10;
-  const visibleResults = results.slice(0, maxVisible);
 
-  // Reset selection when query changes
+  // Adjust scroll offset to keep selected item visible
+  useEffect(() => {
+    if (selectedIndex < scrollOffset) {
+      setScrollOffset(selectedIndex);
+    } else if (selectedIndex >= scrollOffset + maxVisible) {
+      setScrollOffset(selectedIndex - maxVisible + 1);
+    }
+  }, [selectedIndex, scrollOffset]);
+
+  const visibleResults = results.slice(scrollOffset, scrollOffset + maxVisible);
+
+  // Reset selection and scroll when query changes
   useEffect(() => {
     setSelectedIndex(0);
+    setScrollOffset(0);
   }, [query]);
 
   const handleSelect = useCallback(() => {
@@ -172,15 +184,19 @@ export function ModelSearchUI(
 
       {/* Results list */}
       <Box flexDirection="column" marginTop={1}>
+        {scrollOffset > 0 && <Text dimColor>... {scrollOffset} more above
+        </Text>}
         {visibleResults.map((result, index) => (
           <ModelSearchResultItem
             key={result.item.id}
             item={result.item}
-            isSelected={index === selectedIndex}
+            isSelected={index + scrollOffset === selectedIndex}
           />
         ))}
-        {results.length > maxVisible && (
-          <Text dimColor>... {results.length - maxVisible} more results</Text>
+        {scrollOffset + maxVisible < results.length && (
+          <Text dimColor>
+            ... {results.length - scrollOffset - maxVisible} more below
+          </Text>
         )}
         {results.length === 0 && (
           <Text color="yellow">No matching models found</Text>

--- a/src/presentation/output/type_search_output.tsx
+++ b/src/presentation/output/type_search_output.tsx
@@ -86,6 +86,7 @@ export function TypeSearchUI(
 
   const [query, setQuery] = useState(initialQuery);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [scrollOffset, setScrollOffset] = useState(0);
 
   // Create fzf instance for fuzzy searching (memoized to avoid recreation on every render)
   const fzf = useMemo(
@@ -99,11 +100,22 @@ export function TypeSearchUI(
   // Get filtered results
   const results: FzfResultItem<TypeSearchItem>[] = fzf.find(query);
   const maxVisible = 10;
-  const visibleResults = results.slice(0, maxVisible);
 
-  // Reset selection when query changes
+  // Adjust scroll offset to keep selected item visible
+  useEffect(() => {
+    if (selectedIndex < scrollOffset) {
+      setScrollOffset(selectedIndex);
+    } else if (selectedIndex >= scrollOffset + maxVisible) {
+      setScrollOffset(selectedIndex - maxVisible + 1);
+    }
+  }, [selectedIndex, scrollOffset]);
+
+  const visibleResults = results.slice(scrollOffset, scrollOffset + maxVisible);
+
+  // Reset selection and scroll when query changes
   useEffect(() => {
     setSelectedIndex(0);
+    setScrollOffset(0);
   }, [query]);
 
   const handleSelect = useCallback(() => {
@@ -171,15 +183,19 @@ export function TypeSearchUI(
 
       {/* Results list */}
       <Box flexDirection="column" marginTop={1}>
+        {scrollOffset > 0 && <Text dimColor>... {scrollOffset} more above
+        </Text>}
         {visibleResults.map((result, index) => (
           <TypeSearchResultItem
             key={result.item.normalized}
             item={result.item}
-            isSelected={index === selectedIndex}
+            isSelected={index + scrollOffset === selectedIndex}
           />
         ))}
-        {results.length > maxVisible && (
-          <Text dimColor>... {results.length - maxVisible} more results</Text>
+        {scrollOffset + maxVisible < results.length && (
+          <Text dimColor>
+            ... {results.length - scrollOffset - maxVisible} more below
+          </Text>
         )}
         {results.length === 0 && (
           <Text color="yellow">No matching types found</Text>

--- a/src/presentation/output/type_search_output_test.tsx
+++ b/src/presentation/output/type_search_output_test.tsx
@@ -335,9 +335,9 @@ Deno.test({
     );
 
     const output = lastFrame() ?? "";
-    // Should show "more results" message
+    // Should show "more below" message when there are hidden results
     assertStringIncludes(output, "15 / 15 types");
-    assertStringIncludes(output, "more results");
+    assertStringIncludes(output, "more below");
   },
 });
 

--- a/src/presentation/output/vault_search_output.tsx
+++ b/src/presentation/output/vault_search_output.tsx
@@ -99,6 +99,7 @@ export function VaultSearchUI(props: VaultSearchUIProps): React.ReactElement {
 
   const [query, setQuery] = useState(initialQuery);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [scrollOffset, setScrollOffset] = useState(0);
 
   // Create fzf instance for fuzzy searching (memoized to avoid recreation on every render)
   const fzf = useMemo(
@@ -112,11 +113,22 @@ export function VaultSearchUI(props: VaultSearchUIProps): React.ReactElement {
   // Get filtered results
   const results: FzfResultItem<VaultSearchItem>[] = fzf.find(query);
   const maxVisible = 10;
-  const visibleResults = results.slice(0, maxVisible);
 
-  // Reset selection when query changes
+  // Adjust scroll offset to keep selected item visible
+  useEffect(() => {
+    if (selectedIndex < scrollOffset) {
+      setScrollOffset(selectedIndex);
+    } else if (selectedIndex >= scrollOffset + maxVisible) {
+      setScrollOffset(selectedIndex - maxVisible + 1);
+    }
+  }, [selectedIndex, scrollOffset]);
+
+  const visibleResults = results.slice(scrollOffset, scrollOffset + maxVisible);
+
+  // Reset selection and scroll when query changes
   useEffect(() => {
     setSelectedIndex(0);
+    setScrollOffset(0);
   }, [query]);
 
   const handleSelect = useCallback(() => {
@@ -184,15 +196,19 @@ export function VaultSearchUI(props: VaultSearchUIProps): React.ReactElement {
 
       {/* Results list */}
       <Box flexDirection="column" marginTop={1}>
+        {scrollOffset > 0 && <Text dimColor>... {scrollOffset} more above
+        </Text>}
         {visibleResults.map((result, index) => (
           <VaultSearchResultItem
             key={result.item.id}
             item={result.item}
-            isSelected={index === selectedIndex}
+            isSelected={index + scrollOffset === selectedIndex}
           />
         ))}
-        {results.length > maxVisible && (
-          <Text dimColor>... {results.length - maxVisible} more results</Text>
+        {scrollOffset + maxVisible < results.length && (
+          <Text dimColor>
+            ... {results.length - scrollOffset - maxVisible} more below
+          </Text>
         )}
         {results.length === 0 && (
           <Text color="yellow">No matching vaults found</Text>

--- a/src/presentation/output/vault_type_search_output.tsx
+++ b/src/presentation/output/vault_type_search_output.tsx
@@ -101,6 +101,7 @@ export function VaultTypeSearchUI(
 
   const [query, setQuery] = useState(initialQuery);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [scrollOffset, setScrollOffset] = useState(0);
 
   // Create fzf instance for fuzzy searching (memoized to avoid recreation on every render)
   const fzf = useMemo(
@@ -114,11 +115,22 @@ export function VaultTypeSearchUI(
   // Get filtered results
   const results: FzfResultItem<VaultTypeSearchItem>[] = fzf.find(query);
   const maxVisible = 10;
-  const visibleResults = results.slice(0, maxVisible);
 
-  // Reset selection when query changes
+  // Adjust scroll offset to keep selected item visible
+  useEffect(() => {
+    if (selectedIndex < scrollOffset) {
+      setScrollOffset(selectedIndex);
+    } else if (selectedIndex >= scrollOffset + maxVisible) {
+      setScrollOffset(selectedIndex - maxVisible + 1);
+    }
+  }, [selectedIndex, scrollOffset]);
+
+  const visibleResults = results.slice(scrollOffset, scrollOffset + maxVisible);
+
+  // Reset selection and scroll when query changes
   useEffect(() => {
     setSelectedIndex(0);
+    setScrollOffset(0);
   }, [query]);
 
   const handleSelect = useCallback(() => {
@@ -186,15 +198,19 @@ export function VaultTypeSearchUI(
 
       {/* Results list */}
       <Box flexDirection="column" marginTop={1}>
+        {scrollOffset > 0 && <Text dimColor>... {scrollOffset} more above
+        </Text>}
         {visibleResults.map((result, index) => (
           <VaultTypeSearchResultItem
             key={result.item.type}
             item={result.item}
-            isSelected={index === selectedIndex}
+            isSelected={index + scrollOffset === selectedIndex}
           />
         ))}
-        {results.length > maxVisible && (
-          <Text dimColor>... {results.length - maxVisible} more results</Text>
+        {scrollOffset + maxVisible < results.length && (
+          <Text dimColor>
+            ... {results.length - scrollOffset - maxVisible} more below
+          </Text>
         )}
         {results.length === 0 && (
           <Text color="yellow">No matching vault types found</Text>

--- a/src/presentation/output/workflow_history_search_output.tsx
+++ b/src/presentation/output/workflow_history_search_output.tsx
@@ -93,6 +93,7 @@ export function WorkflowHistorySearchUI(
 
   const [query, setQuery] = useState(initialQuery);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [scrollOffset, setScrollOffset] = useState(0);
 
   // Create fzf instance for fuzzy searching
   const fzf = new Fzf(runs, {
@@ -105,11 +106,22 @@ export function WorkflowHistorySearchUI(
   // Get filtered results
   const results: FzfResultItem<WorkflowHistorySearchItem>[] = fzf.find(query);
   const maxVisible = 10;
-  const visibleResults = results.slice(0, maxVisible);
 
-  // Reset selection when query changes
+  // Adjust scroll offset to keep selected item visible
+  useEffect(() => {
+    if (selectedIndex < scrollOffset) {
+      setScrollOffset(selectedIndex);
+    } else if (selectedIndex >= scrollOffset + maxVisible) {
+      setScrollOffset(selectedIndex - maxVisible + 1);
+    }
+  }, [selectedIndex, scrollOffset]);
+
+  const visibleResults = results.slice(scrollOffset, scrollOffset + maxVisible);
+
+  // Reset selection and scroll when query changes
   useEffect(() => {
     setSelectedIndex(0);
+    setScrollOffset(0);
   }, [query]);
 
   const handleSelect = useCallback(() => {
@@ -177,15 +189,19 @@ export function WorkflowHistorySearchUI(
 
       {/* Results list */}
       <Box flexDirection="column" marginTop={1}>
+        {scrollOffset > 0 && <Text dimColor>... {scrollOffset} more above
+        </Text>}
         {visibleResults.map((result, index) => (
           <WorkflowHistorySearchResultItem
             key={result.item.runId}
             item={result.item}
-            isSelected={index === selectedIndex}
+            isSelected={index + scrollOffset === selectedIndex}
           />
         ))}
-        {results.length > maxVisible && (
-          <Text dimColor>... {results.length - maxVisible} more results</Text>
+        {scrollOffset + maxVisible < results.length && (
+          <Text dimColor>
+            ... {results.length - scrollOffset - maxVisible} more below
+          </Text>
         )}
         {results.length === 0 && (
           <Text color="yellow">No matching runs found</Text>

--- a/src/presentation/output/workflow_search_output.tsx
+++ b/src/presentation/output/workflow_search_output.tsx
@@ -88,6 +88,7 @@ export function WorkflowSearchUI(
 
   const [query, setQuery] = useState(initialQuery);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [scrollOffset, setScrollOffset] = useState(0);
 
   // Create fzf instance for fuzzy searching
   const fzf = new Fzf(workflows, {
@@ -97,11 +98,22 @@ export function WorkflowSearchUI(
   // Get filtered results
   const results: FzfResultItem<WorkflowSearchItem>[] = fzf.find(query);
   const maxVisible = 10;
-  const visibleResults = results.slice(0, maxVisible);
 
-  // Reset selection when query changes
+  // Adjust scroll offset to keep selected item visible
+  useEffect(() => {
+    if (selectedIndex < scrollOffset) {
+      setScrollOffset(selectedIndex);
+    } else if (selectedIndex >= scrollOffset + maxVisible) {
+      setScrollOffset(selectedIndex - maxVisible + 1);
+    }
+  }, [selectedIndex, scrollOffset]);
+
+  const visibleResults = results.slice(scrollOffset, scrollOffset + maxVisible);
+
+  // Reset selection and scroll when query changes
   useEffect(() => {
     setSelectedIndex(0);
+    setScrollOffset(0);
   }, [query]);
 
   const handleSelect = useCallback(() => {
@@ -169,15 +181,19 @@ export function WorkflowSearchUI(
 
       {/* Results list */}
       <Box flexDirection="column" marginTop={1}>
+        {scrollOffset > 0 && <Text dimColor>... {scrollOffset} more above
+        </Text>}
         {visibleResults.map((result, index) => (
           <WorkflowSearchResultItem
             key={result.item.id}
             item={result.item}
-            isSelected={index === selectedIndex}
+            isSelected={index + scrollOffset === selectedIndex}
           />
         ))}
-        {results.length > maxVisible && (
-          <Text dimColor>... {results.length - maxVisible} more results</Text>
+        {scrollOffset + maxVisible < results.length && (
+          <Text dimColor>
+            ... {results.length - scrollOffset - maxVisible} more below
+          </Text>
         )}
         {results.length === 0 && (
           <Text color="yellow">No matching workflows found</Text>


### PR DESCRIPTION
Implements namespace validation for user-defined extensions as specified in #173. User models must now use the @user/<name> format, ensuring they won't conflict with built-in models. The implementation is designed to be extensible for future authentication support.

## Changes

- Added helper methods to ModelType for namespace validation
- Added namespace validation to UserModelLoader with clear error messages
- Updated all existing tests to use valid @user/* namespaces
- Added comprehensive tests for namespace validation
- Updated skill documentation to reflect new namespace requirements
- Bonus fix: Fixed interactive search scrolling in all 7 search components (users can now scroll past 10 items)

## Implementation vs Plan

| Plan Item                                      | Status |
|-----------------------------------------------|--------|
| 1. Add Helper Methods to ModelType             | ✅ |
| isUserNamespace(), check if starts with @     | ✅ |
| getUserNamespace(), extract namespace after @ | ✅ |
| getSegmentCount(), count path segments        | ✅ |
| isReservedNamespace(), check for swamp, si    | ✅ |
| 2. Add Namespace Validation to UserModelLoader | ✅ |
| ALLOWED_NAMESPACES = ["user"] constant        | ✅ |
| Check reserved namespaces, swamp, si          | ✅ |
| Check @ prefix required                       | ✅ |
| Check namespace in allowed list               | ✅ |
| Check minimum 2 segments                      | ✅ |
| Descriptive error messages                    | ✅ |
| 3. Add Tests for Helper Methods               | ✅ |
| 4. Add Tests for Namespace Validation         | ✅ |
| Rejects mycompany/mymodel, no @ prefix        | ✅ |
| Rejects @user, only 1 segment                 | ✅ |
| Rejects @adam/foo, non-user namespace         | ✅ |
| Accepts @user/name, 2 segments                | ✅ |
| Accepts @user/foo/bar, 3+ segments            | ✅ |
| Rejects swamp/*, si/*, @swamp/*, @si/*        | ✅ |
| 5. Update Existing Tests                      | ✅ |

## Validation Examples

| Type            | Valid? | Reason |
|-----------------|--------|--------|
| @user/echo      | ✅     | Correct format |
| @user/foo/bar   | ✅     | 3 segments allowed |
| @user           | ❌     | Needs 2+ segments |
| @adam/foo       | ❌     | Namespace not allowed, until auth |
| mycompany/echo  | ❌     | Missing @ prefix |
| swamp/echo      | ❌     | Reserved namespace |

## Future Extensibility

When CLI authentication is added, the ALLOWED_NAMESPACES array can be extended to include the authenticated username, enabling @<username>/* patterns.

## Test Plan

- deno check passes
- deno lint passes
- deno fmt --check passes
- All 1341 tests pass

Closes #173