### PR TITLE
Extract shared useScrollableList hook to reduce duplication in search components

### DIFF
--- a/src/presentation/output/hooks/mod.ts
+++ b/src/presentation/output/hooks/mod.ts
@@ -1,2 +1,7 @@
-export { calculateScrollWindow } from "./useScrollableList.ts";
+export {
+  calculateScrollWindow,
+  type ScrollMetrics,
+  useScrollableList,
+  type UseScrollableListResult,
+} from "./useScrollableList.ts";
 export { useTerminalSize } from "./useTerminalSize.ts";

--- a/src/presentation/output/hooks/useScrollableList.ts
+++ b/src/presentation/output/hooks/useScrollableList.ts
@@ -1,3 +1,5 @@
+import { useEffect, useState } from "react";
+
 /**
  * Calculates visible window for a scrollable list.
  * Keeps the selected item visible by auto-scrolling.
@@ -30,4 +32,104 @@ export function calculateScrollWindow(
   const end = Math.min(start + visibleHeight, totalItems);
 
   return { start, end };
+}
+
+/**
+ * Scroll metrics for displaying "more above/below" indicators.
+ */
+export interface ScrollMetrics {
+  /** Whether there are items above the visible window */
+  hasMoreAbove: boolean;
+  /** Whether there are items below the visible window */
+  hasMoreBelow: boolean;
+  /** Number of items hidden above */
+  moreAboveCount: number;
+  /** Number of items hidden below */
+  moreBelowCount: number;
+}
+
+/**
+ * Return type for the useScrollableList hook.
+ */
+export interface UseScrollableListResult<T> {
+  /** Currently selected index in the full list */
+  selectedIndex: number;
+  /** Function to update the selected index */
+  setSelectedIndex: React.Dispatch<React.SetStateAction<number>>;
+  /** Current scroll offset */
+  scrollOffset: number;
+  /** Items visible in the current window */
+  visibleItems: T[];
+  /** Scroll metrics for "more above/below" indicators */
+  scrollMetrics: ScrollMetrics;
+}
+
+/**
+ * React hook for managing a scrollable list with selection.
+ *
+ * This hook handles:
+ * - Selected index state
+ * - Scroll offset state
+ * - Auto-scrolling to keep selected item visible
+ * - Resetting selection/scroll when items change
+ * - Calculating visible window and scroll metrics
+ *
+ * @param items - The full list of items
+ * @param maxVisible - Maximum number of items visible at once (default: 10)
+ * @param resetDeps - Additional dependencies that trigger selection reset
+ * @returns Selection state, visible items, and scroll metrics
+ *
+ * @example
+ * ```tsx
+ * const { selectedIndex, setSelectedIndex, visibleItems, scrollMetrics } =
+ *   useScrollableList(results, 10, [query]);
+ *
+ * // In render:
+ * {scrollMetrics.hasMoreAbove && <Text>... {scrollMetrics.moreAboveCount} more above</Text>}
+ * {visibleItems.map((item, index) => (
+ *   <Item key={item.id} isSelected={index + scrollMetrics.moreAboveCount === selectedIndex} />
+ * ))}
+ * {scrollMetrics.hasMoreBelow && <Text>... {scrollMetrics.moreBelowCount} more below</Text>}
+ * ```
+ */
+export function useScrollableList<T>(
+  items: T[],
+  maxVisible: number = 10,
+  resetDeps: unknown[] = [],
+): UseScrollableListResult<T> {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [scrollOffset, setScrollOffset] = useState(0);
+
+  // Adjust scroll offset to keep selected item visible
+  useEffect(() => {
+    if (selectedIndex < scrollOffset) {
+      setScrollOffset(selectedIndex);
+    } else if (selectedIndex >= scrollOffset + maxVisible) {
+      setScrollOffset(selectedIndex - maxVisible + 1);
+    }
+  }, [selectedIndex, scrollOffset, maxVisible]);
+
+  // Reset selection and scroll when dependencies change (e.g., query)
+  useEffect(() => {
+    setSelectedIndex(0);
+    setScrollOffset(0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, resetDeps);
+
+  const visibleItems = items.slice(scrollOffset, scrollOffset + maxVisible);
+
+  const scrollMetrics: ScrollMetrics = {
+    hasMoreAbove: scrollOffset > 0,
+    hasMoreBelow: scrollOffset + maxVisible < items.length,
+    moreAboveCount: scrollOffset,
+    moreBelowCount: Math.max(0, items.length - scrollOffset - maxVisible),
+  };
+
+  return {
+    selectedIndex,
+    setSelectedIndex,
+    scrollOffset,
+    visibleItems,
+    scrollMetrics,
+  };
 }

--- a/src/presentation/output/model_output_search_output.tsx
+++ b/src/presentation/output/model_output_search_output.tsx
@@ -1,8 +1,9 @@
 // deno-lint-ignore verbatim-module-syntax
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { Box, render, Text, useApp, useInput } from "ink";
 import type { OutputMode } from "./output.ts";
 import { Fzf, type FzfResultItem } from "fzf";
+import { useScrollableList } from "./hooks/mod.ts";
 
 /**
  * Represents a single model output search item.
@@ -126,8 +127,6 @@ export function ModelOutputSearchUI(
   const { exit } = useApp();
 
   const [query, setQuery] = useState(initialQuery);
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const [scrollOffset, setScrollOffset] = useState(0);
 
   // Create fzf instance for fuzzy searching (memoized to avoid recreation on every render)
   const fzf = useMemo(
@@ -143,24 +142,14 @@ export function ModelOutputSearchUI(
 
   // Get filtered results
   const results: FzfResultItem<ModelOutputSearchItem>[] = fzf.find(query);
-  const maxVisible = 10;
 
-  // Adjust scroll offset to keep selected item visible
-  useEffect(() => {
-    if (selectedIndex < scrollOffset) {
-      setScrollOffset(selectedIndex);
-    } else if (selectedIndex >= scrollOffset + maxVisible) {
-      setScrollOffset(selectedIndex - maxVisible + 1);
-    }
-  }, [selectedIndex, scrollOffset]);
-
-  const visibleResults = results.slice(scrollOffset, scrollOffset + maxVisible);
-
-  // Reset selection and scroll when query changes
-  useEffect(() => {
-    setSelectedIndex(0);
-    setScrollOffset(0);
-  }, [query]);
+  // Use shared scrollable list hook
+  const {
+    selectedIndex,
+    setSelectedIndex,
+    visibleItems: visibleResults,
+    scrollMetrics,
+  } = useScrollableList(results, 10, [query]);
 
   const handleSelect = useCallback(() => {
     if (results.length > 0 && selectedIndex < results.length) {
@@ -227,18 +216,19 @@ export function ModelOutputSearchUI(
 
       {/* Results list */}
       <Box flexDirection="column" marginTop={1}>
-        {scrollOffset > 0 && <Text dimColor>... {scrollOffset} more above
-        </Text>}
+        {scrollMetrics.hasMoreAbove && (
+          <Text dimColor>... {scrollMetrics.moreAboveCount} more above</Text>
+        )}
         {visibleResults.map((result, index) => (
           <ModelOutputSearchResultItem
             key={result.item.id}
             item={result.item}
-            isSelected={index + scrollOffset === selectedIndex}
+            isSelected={index + scrollMetrics.moreAboveCount === selectedIndex}
           />
         ))}
-        {scrollOffset + maxVisible < results.length && (
+        {scrollMetrics.hasMoreBelow && (
           <Text dimColor>
-            ... {results.length - scrollOffset - maxVisible} more below
+            ... {scrollMetrics.moreBelowCount} more below
           </Text>
         )}
         {results.length === 0 && (

--- a/src/presentation/output/model_search_output.tsx
+++ b/src/presentation/output/model_search_output.tsx
@@ -1,8 +1,9 @@
 // deno-lint-ignore verbatim-module-syntax
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { Box, render, Text, useApp, useInput } from "ink";
 import type { OutputMode } from "./output.ts";
 import { Fzf, type FzfResultItem } from "fzf";
+import { useScrollableList } from "./hooks/mod.ts";
 
 /**
  * Represents a single model search item.
@@ -86,8 +87,6 @@ export function ModelSearchUI(
   const { exit } = useApp();
 
   const [query, setQuery] = useState(initialQuery);
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const [scrollOffset, setScrollOffset] = useState(0);
 
   // Create fzf instance for fuzzy searching (memoized to avoid recreation on every render)
   const fzf = useMemo(
@@ -100,24 +99,14 @@ export function ModelSearchUI(
 
   // Get filtered results
   const results: FzfResultItem<ModelSearchItem>[] = fzf.find(query);
-  const maxVisible = 10;
 
-  // Adjust scroll offset to keep selected item visible
-  useEffect(() => {
-    if (selectedIndex < scrollOffset) {
-      setScrollOffset(selectedIndex);
-    } else if (selectedIndex >= scrollOffset + maxVisible) {
-      setScrollOffset(selectedIndex - maxVisible + 1);
-    }
-  }, [selectedIndex, scrollOffset]);
-
-  const visibleResults = results.slice(scrollOffset, scrollOffset + maxVisible);
-
-  // Reset selection and scroll when query changes
-  useEffect(() => {
-    setSelectedIndex(0);
-    setScrollOffset(0);
-  }, [query]);
+  // Use shared scrollable list hook
+  const {
+    selectedIndex,
+    setSelectedIndex,
+    visibleItems: visibleResults,
+    scrollMetrics,
+  } = useScrollableList(results, 10, [query]);
 
   const handleSelect = useCallback(() => {
     if (results.length > 0 && selectedIndex < results.length) {
@@ -184,18 +173,19 @@ export function ModelSearchUI(
 
       {/* Results list */}
       <Box flexDirection="column" marginTop={1}>
-        {scrollOffset > 0 && <Text dimColor>... {scrollOffset} more above
-        </Text>}
+        {scrollMetrics.hasMoreAbove && (
+          <Text dimColor>... {scrollMetrics.moreAboveCount} more above</Text>
+        )}
         {visibleResults.map((result, index) => (
           <ModelSearchResultItem
             key={result.item.id}
             item={result.item}
-            isSelected={index + scrollOffset === selectedIndex}
+            isSelected={index + scrollMetrics.moreAboveCount === selectedIndex}
           />
         ))}
-        {scrollOffset + maxVisible < results.length && (
+        {scrollMetrics.hasMoreBelow && (
           <Text dimColor>
-            ... {results.length - scrollOffset - maxVisible} more below
+            ... {scrollMetrics.moreBelowCount} more below
           </Text>
         )}
         {results.length === 0 && (

--- a/src/presentation/output/type_search_output.tsx
+++ b/src/presentation/output/type_search_output.tsx
@@ -1,8 +1,9 @@
 // deno-lint-ignore verbatim-module-syntax
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { Box, render, Text, useApp, useInput } from "ink";
 import type { OutputMode } from "./output.ts";
 import { Fzf, type FzfResultItem } from "fzf";
+import { useScrollableList } from "./hooks/mod.ts";
 
 /**
  * Represents a single type search result item.
@@ -85,8 +86,6 @@ export function TypeSearchUI(
   const { exit } = useApp();
 
   const [query, setQuery] = useState(initialQuery);
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const [scrollOffset, setScrollOffset] = useState(0);
 
   // Create fzf instance for fuzzy searching (memoized to avoid recreation on every render)
   const fzf = useMemo(
@@ -99,24 +98,14 @@ export function TypeSearchUI(
 
   // Get filtered results
   const results: FzfResultItem<TypeSearchItem>[] = fzf.find(query);
-  const maxVisible = 10;
 
-  // Adjust scroll offset to keep selected item visible
-  useEffect(() => {
-    if (selectedIndex < scrollOffset) {
-      setScrollOffset(selectedIndex);
-    } else if (selectedIndex >= scrollOffset + maxVisible) {
-      setScrollOffset(selectedIndex - maxVisible + 1);
-    }
-  }, [selectedIndex, scrollOffset]);
-
-  const visibleResults = results.slice(scrollOffset, scrollOffset + maxVisible);
-
-  // Reset selection and scroll when query changes
-  useEffect(() => {
-    setSelectedIndex(0);
-    setScrollOffset(0);
-  }, [query]);
+  // Use shared scrollable list hook
+  const {
+    selectedIndex,
+    setSelectedIndex,
+    visibleItems: visibleResults,
+    scrollMetrics,
+  } = useScrollableList(results, 10, [query]);
 
   const handleSelect = useCallback(() => {
     if (results.length > 0 && selectedIndex < results.length) {
@@ -183,18 +172,19 @@ export function TypeSearchUI(
 
       {/* Results list */}
       <Box flexDirection="column" marginTop={1}>
-        {scrollOffset > 0 && <Text dimColor>... {scrollOffset} more above
-        </Text>}
+        {scrollMetrics.hasMoreAbove && (
+          <Text dimColor>... {scrollMetrics.moreAboveCount} more above</Text>
+        )}
         {visibleResults.map((result, index) => (
           <TypeSearchResultItem
             key={result.item.normalized}
             item={result.item}
-            isSelected={index + scrollOffset === selectedIndex}
+            isSelected={index + scrollMetrics.moreAboveCount === selectedIndex}
           />
         ))}
-        {scrollOffset + maxVisible < results.length && (
+        {scrollMetrics.hasMoreBelow && (
           <Text dimColor>
-            ... {results.length - scrollOffset - maxVisible} more below
+            ... {scrollMetrics.moreBelowCount} more below
           </Text>
         )}
         {results.length === 0 && (

--- a/src/presentation/output/type_search_output_test.tsx
+++ b/src/presentation/output/type_search_output_test.tsx
@@ -359,3 +359,140 @@ Deno.test({
     assertStringIncludes(output, "1 / 3 types");
   },
 });
+
+// Scrolling behavior tests
+Deno.test({
+  name: "TypeSearchUI does not show scroll indicators when all items visible",
+  ...inkTestOptions,
+  fn: () => {
+    const fewTypes: TypeSearchItem[] = Array.from({ length: 5 }, (_, i) => ({
+      raw: `type-${i}`,
+      normalized: `type-${i}`,
+    }));
+
+    const { lastFrame } = render(
+      <TypeSearchUI
+        types={fewTypes}
+        initialQuery=""
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    const output = lastFrame() ?? "";
+    // Should not show "more above" or "more below"
+    assertEquals(output.includes("more above"), false);
+    assertEquals(output.includes("more below"), false);
+  },
+});
+
+Deno.test({
+  name: "TypeSearchUI shows correct count for items below visible window",
+  ...inkTestOptions,
+  fn: () => {
+    // Create 15 types, window shows 10, so 5 should be "more below"
+    const manyTypes: TypeSearchItem[] = Array.from({ length: 15 }, (_, i) => ({
+      raw: `type-${String(i).padStart(2, "0")}`,
+      normalized: `type-${String(i).padStart(2, "0")}`,
+    }));
+
+    const { lastFrame } = render(
+      <TypeSearchUI
+        types={manyTypes}
+        initialQuery=""
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    const output = lastFrame() ?? "";
+    // Should show "5 more below" (15 total - 10 visible = 5)
+    assertStringIncludes(output, "5 more below");
+    // Should not show "more above" when at start
+    assertEquals(output.includes("more above"), false);
+  },
+});
+
+Deno.test({
+  name: "TypeSearchUI shows first 10 items when list exceeds limit",
+  ...inkTestOptions,
+  fn: () => {
+    const manyTypes: TypeSearchItem[] = Array.from({ length: 15 }, (_, i) => ({
+      raw: `type-${String(i).padStart(2, "0")}`,
+      normalized: `type-${String(i).padStart(2, "0")}`,
+    }));
+
+    const { lastFrame } = render(
+      <TypeSearchUI
+        types={manyTypes}
+        initialQuery=""
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    const output = lastFrame() ?? "";
+    // First item should be visible and selected
+    assertStringIncludes(output, "type-00");
+    // Item 9 (index 9) should be visible
+    assertStringIncludes(output, "type-09");
+    // Item 10 (index 10) should NOT be visible (it's hidden)
+    assertEquals(output.includes("type-10"), false);
+  },
+});
+
+Deno.test({
+  name: "TypeSearchUI handles exactly 10 items without scroll indicators",
+  ...inkTestOptions,
+  fn: () => {
+    const exactTypes: TypeSearchItem[] = Array.from({ length: 10 }, (_, i) => ({
+      raw: `type-${i}`,
+      normalized: `type-${i}`,
+    }));
+
+    const { lastFrame } = render(
+      <TypeSearchUI
+        types={exactTypes}
+        initialQuery=""
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    const output = lastFrame() ?? "";
+    // All 10 items should be visible
+    assertStringIncludes(output, "10 / 10 types");
+    // No scroll indicators needed
+    assertEquals(output.includes("more above"), false);
+    assertEquals(output.includes("more below"), false);
+  },
+});
+
+Deno.test({
+  name: "TypeSearchUI handles exactly 11 items with scroll indicator",
+  ...inkTestOptions,
+  fn: () => {
+    const elevenTypes: TypeSearchItem[] = Array.from(
+      { length: 11 },
+      (_, i) => ({
+        raw: `type-${String(i).padStart(2, "0")}`,
+        normalized: `type-${String(i).padStart(2, "0")}`,
+      }),
+    );
+
+    const { lastFrame } = render(
+      <TypeSearchUI
+        types={elevenTypes}
+        initialQuery=""
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    const output = lastFrame() ?? "";
+    // Should show 11 total types
+    assertStringIncludes(output, "11 / 11 types");
+    // Should show "1 more below"
+    assertStringIncludes(output, "1 more below");
+  },
+});

--- a/src/presentation/output/vault_search_output.tsx
+++ b/src/presentation/output/vault_search_output.tsx
@@ -1,9 +1,10 @@
 // deno-lint-ignore verbatim-module-syntax
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { Box, render, Text, useApp, useInput } from "ink";
 import type { OutputMode } from "./output.ts";
 import { Fzf, type FzfResultItem } from "fzf";
 import type { VaultConfig } from "../../domain/vaults/vault_config.ts";
+import { useScrollableList } from "./hooks/mod.ts";
 
 /**
  * Represents a single vault search result item.
@@ -98,8 +99,6 @@ export function VaultSearchUI(props: VaultSearchUIProps): React.ReactElement {
   const { exit } = useApp();
 
   const [query, setQuery] = useState(initialQuery);
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const [scrollOffset, setScrollOffset] = useState(0);
 
   // Create fzf instance for fuzzy searching (memoized to avoid recreation on every render)
   const fzf = useMemo(
@@ -112,24 +111,14 @@ export function VaultSearchUI(props: VaultSearchUIProps): React.ReactElement {
 
   // Get filtered results
   const results: FzfResultItem<VaultSearchItem>[] = fzf.find(query);
-  const maxVisible = 10;
 
-  // Adjust scroll offset to keep selected item visible
-  useEffect(() => {
-    if (selectedIndex < scrollOffset) {
-      setScrollOffset(selectedIndex);
-    } else if (selectedIndex >= scrollOffset + maxVisible) {
-      setScrollOffset(selectedIndex - maxVisible + 1);
-    }
-  }, [selectedIndex, scrollOffset]);
-
-  const visibleResults = results.slice(scrollOffset, scrollOffset + maxVisible);
-
-  // Reset selection and scroll when query changes
-  useEffect(() => {
-    setSelectedIndex(0);
-    setScrollOffset(0);
-  }, [query]);
+  // Use shared scrollable list hook
+  const {
+    selectedIndex,
+    setSelectedIndex,
+    visibleItems: visibleResults,
+    scrollMetrics,
+  } = useScrollableList(results, 10, [query]);
 
   const handleSelect = useCallback(() => {
     if (results.length > 0 && selectedIndex < results.length) {
@@ -196,18 +185,19 @@ export function VaultSearchUI(props: VaultSearchUIProps): React.ReactElement {
 
       {/* Results list */}
       <Box flexDirection="column" marginTop={1}>
-        {scrollOffset > 0 && <Text dimColor>... {scrollOffset} more above
-        </Text>}
+        {scrollMetrics.hasMoreAbove && (
+          <Text dimColor>... {scrollMetrics.moreAboveCount} more above</Text>
+        )}
         {visibleResults.map((result, index) => (
           <VaultSearchResultItem
             key={result.item.id}
             item={result.item}
-            isSelected={index + scrollOffset === selectedIndex}
+            isSelected={index + scrollMetrics.moreAboveCount === selectedIndex}
           />
         ))}
-        {scrollOffset + maxVisible < results.length && (
+        {scrollMetrics.hasMoreBelow && (
           <Text dimColor>
-            ... {results.length - scrollOffset - maxVisible} more below
+            ... {scrollMetrics.moreBelowCount} more below
           </Text>
         )}
         {results.length === 0 && (

--- a/src/presentation/output/vault_type_search_output.tsx
+++ b/src/presentation/output/vault_type_search_output.tsx
@@ -1,9 +1,10 @@
 // deno-lint-ignore verbatim-module-syntax
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { Box, render, Text, useApp, useInput } from "ink";
 import type { OutputMode } from "./output.ts";
 import { Fzf, type FzfResultItem } from "fzf";
 import type { VaultTypeInfo } from "../../domain/vaults/vault_types.ts";
+import { useScrollableList } from "./hooks/mod.ts";
 
 /**
  * Represents a single vault type search result item.
@@ -100,8 +101,6 @@ export function VaultTypeSearchUI(
   const { exit } = useApp();
 
   const [query, setQuery] = useState(initialQuery);
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const [scrollOffset, setScrollOffset] = useState(0);
 
   // Create fzf instance for fuzzy searching (memoized to avoid recreation on every render)
   const fzf = useMemo(
@@ -114,24 +113,14 @@ export function VaultTypeSearchUI(
 
   // Get filtered results
   const results: FzfResultItem<VaultTypeSearchItem>[] = fzf.find(query);
-  const maxVisible = 10;
 
-  // Adjust scroll offset to keep selected item visible
-  useEffect(() => {
-    if (selectedIndex < scrollOffset) {
-      setScrollOffset(selectedIndex);
-    } else if (selectedIndex >= scrollOffset + maxVisible) {
-      setScrollOffset(selectedIndex - maxVisible + 1);
-    }
-  }, [selectedIndex, scrollOffset]);
-
-  const visibleResults = results.slice(scrollOffset, scrollOffset + maxVisible);
-
-  // Reset selection and scroll when query changes
-  useEffect(() => {
-    setSelectedIndex(0);
-    setScrollOffset(0);
-  }, [query]);
+  // Use shared scrollable list hook
+  const {
+    selectedIndex,
+    setSelectedIndex,
+    visibleItems: visibleResults,
+    scrollMetrics,
+  } = useScrollableList(results, 10, [query]);
 
   const handleSelect = useCallback(() => {
     if (results.length > 0 && selectedIndex < results.length) {
@@ -198,18 +187,19 @@ export function VaultTypeSearchUI(
 
       {/* Results list */}
       <Box flexDirection="column" marginTop={1}>
-        {scrollOffset > 0 && <Text dimColor>... {scrollOffset} more above
-        </Text>}
+        {scrollMetrics.hasMoreAbove && (
+          <Text dimColor>... {scrollMetrics.moreAboveCount} more above</Text>
+        )}
         {visibleResults.map((result, index) => (
           <VaultTypeSearchResultItem
             key={result.item.type}
             item={result.item}
-            isSelected={index + scrollOffset === selectedIndex}
+            isSelected={index + scrollMetrics.moreAboveCount === selectedIndex}
           />
         ))}
-        {scrollOffset + maxVisible < results.length && (
+        {scrollMetrics.hasMoreBelow && (
           <Text dimColor>
-            ... {results.length - scrollOffset - maxVisible} more below
+            ... {scrollMetrics.moreBelowCount} more below
           </Text>
         )}
         {results.length === 0 && (

--- a/src/presentation/output/workflow_history_search_output.tsx
+++ b/src/presentation/output/workflow_history_search_output.tsx
@@ -1,8 +1,9 @@
 // deno-lint-ignore verbatim-module-syntax
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { Box, render, Text, useApp, useInput } from "ink";
 import type { OutputMode } from "./output.ts";
 import { Fzf, type FzfResultItem } from "fzf";
+import { useScrollableList } from "./hooks/mod.ts";
 
 /**
  * Represents a single workflow run search result item.
@@ -92,37 +93,29 @@ export function WorkflowHistorySearchUI(
   const { exit } = useApp();
 
   const [query, setQuery] = useState(initialQuery);
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const [scrollOffset, setScrollOffset] = useState(0);
 
-  // Create fzf instance for fuzzy searching
-  const fzf = new Fzf(runs, {
-    selector: (item) =>
-      `${item.workflowName} ${item.runId} ${item.status} ${
-        item.startedAt ?? ""
-      }`,
-  });
+  // Create fzf instance for fuzzy searching (memoized to avoid recreation on every render)
+  const fzf = useMemo(
+    () =>
+      new Fzf(runs, {
+        selector: (item) =>
+          `${item.workflowName} ${item.runId} ${item.status} ${
+            item.startedAt ?? ""
+          }`,
+      }),
+    [runs],
+  );
 
   // Get filtered results
   const results: FzfResultItem<WorkflowHistorySearchItem>[] = fzf.find(query);
-  const maxVisible = 10;
 
-  // Adjust scroll offset to keep selected item visible
-  useEffect(() => {
-    if (selectedIndex < scrollOffset) {
-      setScrollOffset(selectedIndex);
-    } else if (selectedIndex >= scrollOffset + maxVisible) {
-      setScrollOffset(selectedIndex - maxVisible + 1);
-    }
-  }, [selectedIndex, scrollOffset]);
-
-  const visibleResults = results.slice(scrollOffset, scrollOffset + maxVisible);
-
-  // Reset selection and scroll when query changes
-  useEffect(() => {
-    setSelectedIndex(0);
-    setScrollOffset(0);
-  }, [query]);
+  // Use shared scrollable list hook
+  const {
+    selectedIndex,
+    setSelectedIndex,
+    visibleItems: visibleResults,
+    scrollMetrics,
+  } = useScrollableList(results, 10, [query]);
 
   const handleSelect = useCallback(() => {
     if (results.length > 0 && selectedIndex < results.length) {
@@ -189,18 +182,19 @@ export function WorkflowHistorySearchUI(
 
       {/* Results list */}
       <Box flexDirection="column" marginTop={1}>
-        {scrollOffset > 0 && <Text dimColor>... {scrollOffset} more above
-        </Text>}
+        {scrollMetrics.hasMoreAbove && (
+          <Text dimColor>... {scrollMetrics.moreAboveCount} more above</Text>
+        )}
         {visibleResults.map((result, index) => (
           <WorkflowHistorySearchResultItem
             key={result.item.runId}
             item={result.item}
-            isSelected={index + scrollOffset === selectedIndex}
+            isSelected={index + scrollMetrics.moreAboveCount === selectedIndex}
           />
         ))}
-        {scrollOffset + maxVisible < results.length && (
+        {scrollMetrics.hasMoreBelow && (
           <Text dimColor>
-            ... {results.length - scrollOffset - maxVisible} more below
+            ... {scrollMetrics.moreBelowCount} more below
           </Text>
         )}
         {results.length === 0 && (

--- a/src/presentation/output/workflow_search_output.tsx
+++ b/src/presentation/output/workflow_search_output.tsx
@@ -1,8 +1,9 @@
 // deno-lint-ignore verbatim-module-syntax
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { Box, render, Text, useApp, useInput } from "ink";
 import type { OutputMode } from "./output.ts";
 import { Fzf, type FzfResultItem } from "fzf";
+import { useScrollableList } from "./hooks/mod.ts";
 
 /**
  * Represents a single workflow search result item.
@@ -87,34 +88,26 @@ export function WorkflowSearchUI(
   const { exit } = useApp();
 
   const [query, setQuery] = useState(initialQuery);
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const [scrollOffset, setScrollOffset] = useState(0);
 
-  // Create fzf instance for fuzzy searching
-  const fzf = new Fzf(workflows, {
-    selector: (item) => `${item.name} ${item.id} ${item.description ?? ""}`,
-  });
+  // Create fzf instance for fuzzy searching (memoized to avoid recreation on every render)
+  const fzf = useMemo(
+    () =>
+      new Fzf(workflows, {
+        selector: (item) => `${item.name} ${item.id} ${item.description ?? ""}`,
+      }),
+    [workflows],
+  );
 
   // Get filtered results
   const results: FzfResultItem<WorkflowSearchItem>[] = fzf.find(query);
-  const maxVisible = 10;
 
-  // Adjust scroll offset to keep selected item visible
-  useEffect(() => {
-    if (selectedIndex < scrollOffset) {
-      setScrollOffset(selectedIndex);
-    } else if (selectedIndex >= scrollOffset + maxVisible) {
-      setScrollOffset(selectedIndex - maxVisible + 1);
-    }
-  }, [selectedIndex, scrollOffset]);
-
-  const visibleResults = results.slice(scrollOffset, scrollOffset + maxVisible);
-
-  // Reset selection and scroll when query changes
-  useEffect(() => {
-    setSelectedIndex(0);
-    setScrollOffset(0);
-  }, [query]);
+  // Use shared scrollable list hook
+  const {
+    selectedIndex,
+    setSelectedIndex,
+    visibleItems: visibleResults,
+    scrollMetrics,
+  } = useScrollableList(results, 10, [query]);
 
   const handleSelect = useCallback(() => {
     if (results.length > 0 && selectedIndex < results.length) {
@@ -181,18 +174,19 @@ export function WorkflowSearchUI(
 
       {/* Results list */}
       <Box flexDirection="column" marginTop={1}>
-        {scrollOffset > 0 && <Text dimColor>... {scrollOffset} more above
-        </Text>}
+        {scrollMetrics.hasMoreAbove && (
+          <Text dimColor>... {scrollMetrics.moreAboveCount} more above</Text>
+        )}
         {visibleResults.map((result, index) => (
           <WorkflowSearchResultItem
             key={result.item.id}
             item={result.item}
-            isSelected={index + scrollOffset === selectedIndex}
+            isSelected={index + scrollMetrics.moreAboveCount === selectedIndex}
           />
         ))}
-        {scrollOffset + maxVisible < results.length && (
+        {scrollMetrics.hasMoreBelow && (
           <Text dimColor>
-            ... {results.length - scrollOffset - maxVisible} more below
+            ... {scrollMetrics.moreBelowCount} more below
           </Text>
         )}
         {results.length === 0 && (


### PR DESCRIPTION
- Extracts duplicated scrolling logic from 7 search components into a shared `useScrollableList` hook
- The hook manages selection state, scroll offset, visible window calculation, and scroll metrics
- Updates all search components to use the new hook: type_search, model_search, workflow_search, vault_search, vault_type_search, workflow_history_search, model_output_search
- Adds memoization for fzf instances in workflow_search and workflow_history_search (previously missing)
- Adds comprehensive tests for scrolling behavior in type_search_output_test.tsx

## Test Plan

- All 1346 existing tests pass
- Added 5 new tests for scrolling behavior:
    - Does not show scroll indicators when all items visible
    - Shows correct count for items below visible window
    - Shows first 10 items when list exceeds limit
    - Handles exactly 10 items without scroll indicators
    - Handles exactly 11 items with scroll indicator