### PR TITLE
Fix model output search result display formatting

### DIFF
--- a/src/presentation/output/model_output_search_output.tsx
+++ b/src/presentation/output/model_output_search_output.tsx
@@ -265,13 +265,10 @@ function ModelOutputSearchResultItem(
         {isSelected ? "> " : "  "}
         {item.modelName ?? item.definitionId.slice(0, 8)}
       </Text>
-      <Text dimColor></Text>
-      <Text color="cyan">{item.methodName}</Text>
-      <Text dimColor></Text>
-      <Text color={getStatusColor(item.status)}>{item.status}</Text>
-      <Text dimColor></Text>
+      <Text color="cyan">{` ${item.methodName}`}</Text>
+      <Text color={getStatusColor(item.status)}>{` [${item.status}]`}</Text>
       {item.durationMs !== undefined && (
-        <Text dimColor>({formatDuration(item.durationMs)})</Text>
+        <Text dimColor>{` (${formatDuration(item.durationMs)})`}</Text>
       )}
     </Box>
   );


### PR DESCRIPTION
Fixes: #187

- Fix missing separators in model output search results that caused fields to concatenate together
- Add spaces between model name, method name, status, and duration
- Wrap status in brackets for visual distinction, matching the workflow history search pattern

## Before
`systeminit-artifacts-fetcherfetchsucceeded(185ms)`

## After
`systeminit-artifacts-fetcher fetch [succeeded] (185ms)`

## Test plan
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] All 1346 tests pass
- [ ] Manually verify `swamp model output search <query>` displays results with proper spacing

<img width="582" height="355" alt="Screenshot 2026-02-10 at 01 45 28" src="https://github.com/user-attachments/assets/3a5d4173-1aed-46d9-ad12-be6df5625a83" />
