### PR TITLE
feat: Add DataWriter API for direct-to-disk model data persistence

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -64,19 +64,29 @@ export const model = {
   type: "@user/my-model",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Model output data",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     run: {
       description: "Process the input message",
-      execute: async (definition, _context) => {
-        return {
-          data: {
-            attributes: {
-              message: definition.attributes.message.toUpperCase(),
-              timestamp: new Date().toISOString(),
-            },
-            name: "result",
-          },
-        };
+      execute: async (definition, context) => {
+        const writer = context.createDataWriter!({
+          name: "result",
+          specType: "data",
+        });
+        const handle = await writer.writeText(JSON.stringify({
+          message: definition.attributes.message.toUpperCase(),
+          timestamp: new Date().toISOString(),
+        }));
+        return { dataHandles: [handle] };
       },
     },
   },
@@ -85,13 +95,14 @@ export const model = {
 
 ## Model Structure
 
-| Field                   | Required | Description                          |
-| ----------------------- | -------- | ------------------------------------ |
-| `type`                  | Yes      | Unique identifier (`namespace/name`) |
-| `version`               | Yes      | CalVer version (`YYYY.MM.DD.MICRO`)  |
-| `inputAttributesSchema` | Yes      | Zod schema for input validation      |
-| `inputsSchema`          | No       | Zod schema for runtime inputs        |
-| `methods`               | Yes      | Object of method definitions         |
+| Field                   | Required | Description                               |
+| ----------------------- | -------- | ----------------------------------------- |
+| `type`                  | Yes      | Unique identifier (`namespace/name`)      |
+| `version`               | Yes      | CalVer version (`YYYY.MM.DD.MICRO`)       |
+| `inputAttributesSchema` | Yes      | Zod schema for input validation           |
+| `dataOutputSpecs`       | Yes      | Data output spec declarations (see below) |
+| `inputsSchema`          | No       | Zod schema for runtime inputs             |
+| `methods`               | Yes      | Object of method definitions              |
 
 ### Model-Level Inputs
 
@@ -106,6 +117,16 @@ export const model = {
     serviceName: z.string(),
     target: z.string(), // Will use ${{ inputs.environment }}
   }),
+  dataOutputSpecs: {
+    "resource": {
+      specType: "resource",
+      description: "Deployment resource state",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource" },
+    },
+  },
   inputsSchema: z.object({
     environment: z.enum(["dev", "staging", "production"]),
     dryRun: z.boolean().optional().default(false),
@@ -116,14 +137,15 @@ export const model = {
       execute: async (definition, context) => {
         // Inputs are evaluated before execution, so definition.attributes
         // contains the resolved values (e.g., target = "production")
-        return {
-          resource: {
-            attributes: {
-              deployed: true,
-              target: definition.attributes.target,
-            },
-          },
-        };
+        const writer = context.createDataWriter!({
+          name: "resource",
+          specType: "resource",
+        });
+        const handle = await writer.writeText(JSON.stringify({
+          deployed: true,
+          target: definition.attributes.target,
+        }));
+        return { dataHandles: [handle] };
       },
     },
   },
@@ -139,13 +161,45 @@ swamp model method run my-deploy deploy --input '{"environment": "production"}' 
 The `inputsSchema` defines what runtime inputs are accepted. These inputs are
 available in CEL expressions via `${{ inputs.<name> }}`.
 
+## Data Output Specs
+
+Every model must declare its data output specifications in `dataOutputSpecs`.
+This is the single source of truth for what spec types a model can produce. When
+`createDataWriter` is called with a `specType`, it must match a key in
+`dataOutputSpecs` — otherwise the factory fails fast with an "undeclared spec
+type" error.
+
+Each spec entry defines defaults for `contentType`, `lifetime`,
+`garbageCollection`, and `tags`. The `createDataWriter` call only needs `name`
+and `specType`; all other fields are inherited from the spec and can be
+overridden per-write if needed.
+
+```typescript
+dataOutputSpecs: {
+  "data": {
+    specType: "data",
+    description: "Model output data",
+    contentType: "application/json",
+    lifetime: "infinite",
+    garbageCollection: 10,
+    tags: { type: "data" },
+  },
+  "log": {
+    specType: "log",
+    description: "Execution log",
+    contentType: "text/plain",
+    lifetime: "7d",
+    garbageCollection: 5,
+    tags: { type: "log" },
+  },
+},
+```
+
 ## Execute Function
 
-The execute function receives the definition and context, and returns data
-outputs. There are three return formats: the preferred simpler formats
-(`resource` and `data`) and the explicit `dataOutputs` array.
-
-### Preferred: Simple Return Formats
+The execute function receives the definition and context. It uses the
+`DataWriter` API to write data directly to disk and returns `DataHandle`
+references.
 
 ```typescript
 execute: (async (definition, context) => {
@@ -155,79 +209,72 @@ execute: (async (definition, context) => {
   // context.repoDir       - Repository root path
   // context.logger        - LogTape Logger for emitting log messages
   // context.dataRepository - For advanced data operations
+  // context.createDataWriter - Factory for creating DataWriter instances
   // context.inputs        - Runtime inputs (if inputsSchema defined)
 
-  // For external resources (APIs, cloud services, etc.)
-  return {
-    resource: {
-      attributes: {
-        id: "resource-123",
-        status: "created",
-        endpoint: "https://api.example.com/resource/123",
-      },
-    },
-  };
+  // 1. Create a DataWriter — specType must match a key in dataOutputSpecs
+  const writer = context.createDataWriter!({
+    name: "my-data",
+    specType: "data", // references "data" entry in dataOutputSpecs
+  });
 
-  // OR for general data output
-  return {
-    data: {
-      attributes: {
-        result: "processed value",
-        timestamp: new Date().toISOString(),
-      },
-      name: "result", // optional, defaults to "data"
-      tags: { category: "output" }, // optional custom tags
-    },
-  };
+  // 2. Write content using one of the writer methods
+  const handle = await writer.writeText(JSON.stringify({
+    result: "processed value",
+    timestamp: new Date().toISOString(),
+  }));
+
+  // 3. Return the data handles
+  return { dataHandles: [handle] };
 });
 ```
 
-| Format     | Use Case                                 | Default Name | Default Tags       |
-| ---------- | ---------------------------------------- | ------------ | ------------------ |
-| `resource` | External resource state (APIs, services) | `"resource"` | `type: "resource"` |
-| `data`     | General data output                      | `"data"`     | `type: "data"`     |
+### DataWriter API
 
-Both formats automatically:
+Create a writer with `context.createDataWriter(options)`:
 
-- Serialize `attributes` as JSON with `application/json` content type
-- Set lifetime to `"infinite"`
-- Track ownership for data integrity
+**SpecBasedWriterOptions:**
 
-### Explicit: dataOutputs Array
+| Field               | Required | Description                                    |
+| ------------------- | -------- | ---------------------------------------------- |
+| `name`              | Yes      | Unique name for this data artifact             |
+| `specType`          | Yes      | Must match a key in `dataOutputSpecs`          |
+| `contentType`       | No       | Override MIME type (default from spec)         |
+| `lifetime`          | No       | Override lifetime (default from spec)          |
+| `garbageCollection` | No       | Override version retention (default from spec) |
+| `streaming`         | No       | True for line-oriented streaming data          |
+| `tags`              | No       | Override tags (default from spec)              |
 
-For advanced use cases requiring multiple outputs, custom content types, or
-streaming:
+**Writer Methods:**
 
-```typescript
-execute: (async (definition, context) => {
-  return {
-    dataOutputs: [
-      {
-        name: "output-name",
-        content: "string or Uint8Array",
-        metadata: {
-          contentType: "application/json",
-          lifetime: "infinite",
-          tags: { type: "data" },
-        },
-      },
-    ],
-  };
-});
-```
+| Method                      | Description                                      |
+| --------------------------- | ------------------------------------------------ |
+| `writeAll(content)`         | Write complete binary content (`Uint8Array`)     |
+| `writeText(text)`           | Write text content (encoded as UTF-8)            |
+| `writeLine(line)`           | Append a single line (for streaming/incremental) |
+| `writeStream(stream, opts)` | Pipe a `ReadableStream<Uint8Array>`              |
+| `getFilePath()`             | Get the file path for direct I/O                 |
+| `finalize()`                | Finalize after using `writeLine`/`getFilePath`   |
 
-## Data Output Structure
+All write methods that complete a data artifact return a `Promise<DataHandle>`.
+Use `writeLine` for incremental writes, then call `finalize()` to get the
+handle.
 
-Each data output in the `dataOutputs` array has:
+**DataHandle** (returned by write methods):
 
-| Field                  | Required | Description                                  |
-| ---------------------- | -------- | -------------------------------------------- |
-| `name`                 | Yes      | Unique name for this data artifact           |
-| `content`              | Yes      | Data as `string` or `Uint8Array`             |
-| `metadata.contentType` | No       | MIME type (default: `application/json`)      |
-| `metadata.lifetime`    | No       | How long data persists (default: `infinite`) |
-| `metadata.tags`        | No       | Key-value pairs for categorization           |
-| `metadata.streaming`   | No       | True for line-oriented log data              |
+| Field      | Description                          |
+| ---------- | ------------------------------------ |
+| `name`     | Data artifact name                   |
+| `specType` | Data spec type                       |
+| `dataId`   | Unique ID for this data              |
+| `version`  | Version number of this write         |
+| `size`     | Size of the written content in bytes |
+| `tags`     | Tags from the writer options         |
+| `metadata` | Full metadata for the data artifact  |
+
+**UserMethodResult:**
+
+The execute function returns `{ dataHandles?: DataHandle[] }`.
 
 ### Lifetime Values
 
@@ -263,12 +310,18 @@ export const extension = {
   methods: [{
     audit: {
       description: "Audit the echo message",
-      execute: async (definition, _context) => ({
-        data: {
-          attributes: { audited: true, name: definition.name },
+      execute: async (definition, context) => {
+        // Extensions use the target model's dataOutputSpecs
+        const writer = context.createDataWriter!({
           name: "audit-result",
-        },
-      }),
+          specType: "data",
+        });
+        const handle = await writer.writeText(JSON.stringify({
+          audited: true,
+          name: definition.name,
+        }));
+        return { dataHandles: [handle] };
+      },
     },
   }],
 };
@@ -402,6 +455,16 @@ export const model = {
   type: "@user/shell",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Command output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     run: {
       description: "Execute shell command",
@@ -412,16 +475,16 @@ export const model = {
           logger: context.logger,
         });
 
-        return {
-          data: {
-            attributes: {
-              stdout: result.stdout,
-              stderr: result.stderr,
-              exitCode: result.exitCode,
-            },
-            name: "output",
-          },
-        };
+        const writer = context.createDataWriter!({
+          name: "output",
+          specType: "data",
+        });
+        const handle = await writer.writeText(JSON.stringify({
+          stdout: result.stdout,
+          stderr: result.stderr,
+          exitCode: result.exitCode,
+        }));
+        return { dataHandles: [handle] };
       },
     },
   },
@@ -439,40 +502,51 @@ export const model = {
   type: "@user/search",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Search results",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+    "log": {
+      specType: "log",
+      description: "Search execution log",
+      contentType: "application/json",
+      lifetime: "7d",
+      garbageCollection: 10,
+      tags: { type: "log" },
+    },
+  },
   methods: {
     search: {
       description: "Search and store results with log",
-      execute: async (definition, _context) => {
+      execute: async (definition, context) => {
         const results = ["result1", "result2"];
 
-        return {
-          dataOutputs: [
-            // Primary result data
-            {
-              name: "results",
-              content: JSON.stringify({ results }),
-              metadata: {
-                contentType: "application/json",
-                lifetime: "infinite",
-                tags: { type: "data" },
-              },
-            },
-            // Execution log
-            {
-              name: "search-log",
-              content: JSON.stringify({
-                query: definition.attributes.query,
-                timestamp: new Date().toISOString(),
-                resultCount: results.length,
-              }),
-              metadata: {
-                contentType: "application/json",
-                lifetime: "7d",
-                tags: { type: "log" },
-              },
-            },
-          ],
-        };
+        // Primary result data
+        const resultsWriter = context.createDataWriter!({
+          name: "results",
+          specType: "data",
+        });
+        const resultsHandle = await resultsWriter.writeText(
+          JSON.stringify({ results }),
+        );
+
+        // Execution log
+        const logWriter = context.createDataWriter!({
+          name: "search-log",
+          specType: "log",
+        });
+        const logHandle = await logWriter.writeText(JSON.stringify({
+          query: definition.attributes.query,
+          timestamp: new Date().toISOString(),
+          resultCount: results.length,
+        }));
+
+        return { dataHandles: [resultsHandle, logHandle] };
       },
     },
   },
@@ -493,10 +567,20 @@ export const model = {
   type: "@user/api-resource",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
+  dataOutputSpecs: {
+    "resource": {
+      specType: "resource",
+      description: "API resource state",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource" },
+    },
+  },
   methods: {
     create: {
       description: "Create resource via API",
-      execute: async (definition, _context) => {
+      execute: async (definition, context) => {
         const response = await fetch(definition.attributes.endpoint, {
           method: "POST",
           headers: {
@@ -505,15 +589,16 @@ export const model = {
         });
         const data = await response.json();
 
-        return {
-          resource: {
-            attributes: {
-              resourceId: data.id,
-              status: data.status,
-              createdAt: new Date().toISOString(),
-            },
-          },
-        };
+        const writer = context.createDataWriter!({
+          name: "resource",
+          specType: "resource",
+        });
+        const handle = await writer.writeText(JSON.stringify({
+          resourceId: data.id,
+          status: data.status,
+          createdAt: new Date().toISOString(),
+        }));
+        return { dataHandles: [handle] };
       },
     },
   },
@@ -539,10 +624,28 @@ export const model = {
   type: "@user/s3-bucket",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
+  dataOutputSpecs: {
+    "resource": {
+      specType: "resource",
+      description: "S3 bucket resource state",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource" },
+    },
+    "data": {
+      specType: "data",
+      description: "S3 object listing",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     create: {
       description: "Create an S3 bucket",
-      execute: async (definition, _context) => {
+      execute: async (definition, context) => {
         const { bucketName, region, accessKeyId, secretAccessKey } =
           definition.attributes;
 
@@ -558,30 +661,31 @@ export const model = {
           },
         );
 
-        return {
-          resource: {
-            attributes: {
-              bucketName,
-              region,
-              arn: `arn:aws:s3:::${bucketName}`,
-              createdAt: new Date().toISOString(),
-            },
-          },
-        };
+        const writer = context.createDataWriter!({
+          name: "resource",
+          specType: "resource",
+        });
+        const handle = await writer.writeText(JSON.stringify({
+          bucketName,
+          region,
+          arn: `arn:aws:s3:::${bucketName}`,
+          createdAt: new Date().toISOString(),
+        }));
+        return { dataHandles: [handle] };
       },
     },
     list: {
       description: "List objects in the bucket",
-      execute: async (definition, _context) => {
+      execute: async (definition, context) => {
         // Implement S3 ListObjects API call
-        return {
-          data: {
-            attributes: {
-              objects: [], // Populate from API response
-            },
-            name: "objects",
-          },
-        };
+        const writer = context.createDataWriter!({
+          name: "objects",
+          specType: "data",
+        });
+        const handle = await writer.writeText(JSON.stringify({
+          objects: [], // Populate from API response
+        }));
+        return { dataHandles: [handle] };
       },
     },
   },
@@ -604,14 +708,15 @@ methods: {
       const env = methodInput?.environment ?? "dev";
       // Use env for deployment logic...
 
-      return {
-        resource: {
-          attributes: {
-            environment: env,
-            status: "deployed",
-          },
-        },
-      };
+      const writer = context.createDataWriter!({
+        name: "resource",
+        specType: "resource",
+      });
+      const handle = await writer.writeText(JSON.stringify({
+        environment: env,
+        status: "deployed",
+      }));
+      return { dataHandles: [handle] };
     },
   },
 },

--- a/.claude/skills/swamp-extension-model/references/examples.md
+++ b/.claude/skills/swamp-extension-model/references/examples.md
@@ -1,6 +1,6 @@
 # Extension Model Examples
 
-## Data Model (Ephemeral Output)
+## Text Processor Model
 
 ```typescript
 // extensions/models/text_processor.ts
@@ -11,22 +11,24 @@ const InputSchema = z.object({
   operation: z.enum(["uppercase", "lowercase", "reverse"]),
 });
 
-const DataSchema = z.object({
-  originalText: z.string(),
-  processedText: z.string(),
-  operation: z.string(),
-  processedAt: z.string(),
-});
-
 export const model = {
   type: "@user/text-processor",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
-  dataAttributesSchema: DataSchema,
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Processed text output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     process: {
       description: "Process text according to the specified operation",
-      execute: async (input, _context) => {
+      execute: async (input, context) => {
         const { text, operation } = input.attributes;
 
         let processedText: string;
@@ -42,24 +44,24 @@ export const model = {
             break;
         }
 
-        return {
-          data: {
-            id: input.id,
-            attributes: {
-              originalText: text,
-              processedText,
-              operation,
-              processedAt: new Date().toISOString(),
-            },
-          },
-        };
+        const writer = context.createDataWriter!({
+          name: "result",
+          specType: "data",
+        });
+        const handle = await writer.writeText(JSON.stringify({
+          originalText: text,
+          processedText,
+          operation,
+          processedAt: new Date().toISOString(),
+        }));
+        return { dataHandles: [handle] };
       },
     },
   },
 };
 ```
 
-## Resource Model (Persistent Output)
+## Deployment Model
 
 ```typescript
 // extensions/models/deployment.ts
@@ -72,95 +74,104 @@ const InputSchema = z.object({
   replicas: z.number().min(1).max(10).default(1),
 });
 
-const ResourceSchema = z.object({
-  deploymentId: z.string(),
-  appName: z.string(),
-  version: z.string(),
-  environment: z.string(),
-  replicas: z.number(),
-  status: z.enum(["pending", "deployed", "failed"]),
-  deployedAt: z.string(),
-});
-
 export const model = {
   type: "@user/deployment",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
-  resourceAttributesSchema: ResourceSchema,
+  dataOutputSpecs: {
+    "resource": {
+      specType: "resource",
+      description: "Deployment resource state",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource" },
+    },
+  },
   methods: {
     deploy: {
       description: "Deploy the application",
-      execute: async (input, _context) => {
+      execute: async (input, context) => {
         const attrs = input.attributes;
         const deploymentId = `deploy-${attrs.appName}-${Date.now()}`;
 
-        return {
-          resource: {
-            id: input.id,
-            attributes: {
-              deploymentId,
-              appName: attrs.appName,
-              version: attrs.version,
-              environment: attrs.environment ?? "dev",
-              replicas: attrs.replicas ?? 1,
-              status: "deployed",
-              deployedAt: new Date().toISOString(),
-            },
-          },
-        };
+        const writer = context.createDataWriter!({
+          name: "resource",
+          specType: "resource",
+        });
+        const handle = await writer.writeText(JSON.stringify({
+          deploymentId,
+          appName: attrs.appName,
+          version: attrs.version,
+          environment: attrs.environment ?? "dev",
+          replicas: attrs.replicas ?? 1,
+          status: "deployed",
+          deployedAt: new Date().toISOString(),
+        }));
+        return { dataHandles: [handle] };
       },
     },
     scale: {
       description: "Scale the deployment replicas",
-      execute: async (input, _context) => {
+      execute: async (input, context) => {
         const attrs = input.attributes;
 
-        return {
-          resource: {
-            id: input.id,
-            attributes: {
-              deploymentId: `deploy-${attrs.appName}-scaled`,
-              appName: attrs.appName,
-              version: attrs.version,
-              environment: attrs.environment ?? "dev",
-              replicas: attrs.replicas ?? 1,
-              status: "deployed",
-              deployedAt: new Date().toISOString(),
-            },
-          },
-        };
+        const writer = context.createDataWriter!({
+          name: "resource",
+          specType: "resource",
+        });
+        const handle = await writer.writeText(JSON.stringify({
+          deploymentId: `deploy-${attrs.appName}-scaled`,
+          appName: attrs.appName,
+          version: attrs.version,
+          environment: attrs.environment ?? "dev",
+          replicas: attrs.replicas ?? 1,
+          status: "deployed",
+          deployedAt: new Date().toISOString(),
+        }));
+        return { dataHandles: [handle] };
       },
     },
   },
 };
 ```
 
-## Minimal Data Model
+## Minimal Echo Model
 
 ```typescript
 // extensions/models/echo.ts
 import { z } from "npm:zod@4";
 
 const InputSchema = z.object({ message: z.string() });
-const DataSchema = z.object({ message: z.string(), timestamp: z.string() });
 
 export const model = {
   type: "@user/echo",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
-  dataAttributesSchema: DataSchema,
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Echo output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     run: {
       description: "Echo the message with timestamp",
-      execute: async (input, _context) => ({
-        data: {
-          id: input.id,
-          attributes: {
-            message: input.attributes.message,
-            timestamp: new Date().toISOString(),
-          },
-        },
-      }),
+      execute: async (input, context) => {
+        const writer = context.createDataWriter!({
+          name: "data",
+          specType: "data",
+        });
+        const handle = await writer.writeText(JSON.stringify({
+          message: input.attributes.message,
+          timestamp: new Date().toISOString(),
+        }));
+        return { dataHandles: [handle] };
+      },
     },
   },
 };
@@ -169,7 +180,7 @@ export const model = {
 ## Data Chaining Model
 
 Models that produce data can be chained together using CEL expressions. The
-output from one model's `data.attributes` can be referenced by another model.
+output from one model's data can be referenced by another model.
 
 ```typescript
 // extensions/models/config_generator.ts
@@ -180,24 +191,24 @@ const InputSchema = z.object({
   serviceName: z.string(),
 });
 
-const DataSchema = z.object({
-  configJson: z.object({
-    endpoint: z.string(),
-    timeout: z.number(),
-    retries: z.number(),
-  }),
-  generatedAt: z.string(),
-});
-
 export const model = {
   type: "@user/config-generator",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
-  dataAttributesSchema: DataSchema,
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Generated configuration",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     generate: {
       description: "Generate service configuration based on environment",
-      execute: async (input, _context) => {
+      execute: async (input, context) => {
         const { environment, serviceName } = input.attributes;
 
         // Generate environment-specific configuration
@@ -211,19 +222,19 @@ export const model = {
         const endpoint =
           `https://${serviceName}.${environment}.example.com/api`;
 
-        return {
-          data: {
-            id: input.id,
-            attributes: {
-              configJson: {
-                endpoint,
-                timeout: envConfig.timeout,
-                retries: envConfig.retries,
-              },
-              generatedAt: new Date().toISOString(),
-            },
+        const writer = context.createDataWriter!({
+          name: "config",
+          specType: "data",
+        });
+        const handle = await writer.writeText(JSON.stringify({
+          configJson: {
+            endpoint,
+            timeout: envConfig.timeout,
+            retries: envConfig.retries,
           },
-        };
+          generatedAt: new Date().toISOString(),
+        }));
+        return { dataHandles: [handle] };
       },
     },
   },
@@ -314,16 +325,19 @@ export const extension = {
   methods: [{
     audit: {
       description: "Audit the echo message",
-      execute: async (definition, _context) => ({
-        data: {
-          attributes: {
-            audited: true,
-            name: definition.name,
-            auditedAt: new Date().toISOString(),
-          },
+      execute: async (definition, context) => {
+        // Extensions use the target model's dataOutputSpecs
+        const writer = context.createDataWriter!({
           name: "audit-result",
-        },
-      }),
+          specType: "data",
+        });
+        const handle = await writer.writeText(JSON.stringify({
+          audited: true,
+          name: definition.name,
+          auditedAt: new Date().toISOString(),
+        }));
+        return { dataHandles: [handle] };
+      },
     },
   }],
 };
@@ -338,24 +352,31 @@ export const extension = {
   methods: [{
     audit: {
       description: "Audit the echo message",
-      execute: async (definition, _context) => ({
-        data: {
-          attributes: { audited: true, name: definition.name },
+      execute: async (definition, context) => {
+        const writer = context.createDataWriter!({
           name: "audit-result",
-        },
-      }),
+          specType: "data",
+        });
+        const handle = await writer.writeText(JSON.stringify({
+          audited: true,
+          name: definition.name,
+        }));
+        return { dataHandles: [handle] };
+      },
     },
     validate: {
       description: "Validate the echo message format",
-      execute: async (definition, _context) => ({
-        data: {
-          attributes: {
-            valid: definition.attributes.message.length > 0,
-            length: definition.attributes.message.length,
-          },
+      execute: async (definition, context) => {
+        const writer = context.createDataWriter!({
           name: "validation-result",
-        },
-      }),
+          specType: "data",
+        });
+        const handle = await writer.writeText(JSON.stringify({
+          valid: definition.attributes.message.length > 0,
+          length: definition.attributes.message.length,
+        }));
+        return { dataHandles: [handle] };
+      },
     },
   }],
 };

--- a/.claude/skills/swamp-extension-model/references/troubleshooting.md
+++ b/.claude/skills/swamp-extension-model/references/troubleshooting.md
@@ -17,17 +17,27 @@ export const model = { ... };
 export const extension = { ... };
 ```
 
-### "Model must have at least one of resourceAttributesSchema or dataAttributesSchema"
+### "Undeclared spec type" or "dataOutputSpecs is required"
 
-Add either `dataAttributesSchema` (ephemeral) or `resourceAttributesSchema`
-(persistent):
+Every model must declare `dataOutputSpecs` listing each spec type used by
+`createDataWriter`. If a method calls `createDataWriter({ specType: "data" })`,
+the model must include a `"data"` entry in `dataOutputSpecs`:
 
 ```typescript
 export const model = {
-  type: "...",
+  type: "@user/my-model",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
-  dataAttributesSchema: DataSchema,  // Add this
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Model output data",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: { ... },
 };
 ```

--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -96,7 +96,6 @@ swamp type describe swamp/echo --json
 **Key fields:**
 
 - `inputAttributesSchema` - JSON Schema for input YAML `attributes` section
-- `resourceAttributesSchema` - JSON Schema for resulting resource
 - `methods` - Available operations with their input schemas
 
 ## Create Model Inputs

--- a/design/models.md
+++ b/design/models.md
@@ -96,17 +96,22 @@ export const model = {
   methods: {
     send: {
       description: "Send a notification",
-      execute: async (definition, _context) => {
+      execute: async (definition, context) => {
         const attrs = definition.attributes;
-        return {
-          data: {
-            attributes: {
-              sent: true,
-              content: attrs.content,
-              priority: attrs.priority,
-            },
-          },
-        };
+        const writer = context.createDataWriter!({
+          name: "result",
+          specType: "data",
+          contentType: "application/json",
+          lifetime: "infinite",
+          garbageCollection: 10,
+          tags: { type: "data" },
+        });
+        const handle = await writer.writeText(JSON.stringify({
+          sent: true,
+          content: attrs.content,
+          priority: attrs.priority,
+        }));
+        return { dataHandles: [handle] };
       },
     },
   },
@@ -246,76 +251,55 @@ Files will have a data tag of 'type=file'.
 
 Files that represent external resource data will be tagged with 'type=resource'.
 
-## Method Return Formats
+## DataWriter API
 
-Methods return data through three formats. The simpler `resource` and `data`
-formats are preferred for most use cases.
+Methods write data during execution using the `DataWriter` domain service,
+accessed through `context.createDataWriter()`. Data is written directly to disk
+and the method returns lightweight `DataHandle` references.
 
-### Preferred: Simple Return Formats
-
-**Resource format** - Use for external resource state (APIs, cloud services):
+### Writing Data
 
 ```typescript
-return {
-  resource: {
-    attributes: {
-      id: "resource-123",
-      status: "created",
-    },
-  },
+execute: async (definition, context) => {
+  const writer = context.createDataWriter!({
+    name: "result",
+    specType: "data",
+    contentType: "application/json",
+    lifetime: "infinite",
+    garbageCollection: 10,
+    tags: { type: "data" },
+  });
+  const handle = await writer.writeText(JSON.stringify({
+    result: "processed value",
+  }));
+  return { dataHandles: [handle] };
 };
 ```
 
-**Data format** - Use for general data output:
+### Writer Methods
 
-```typescript
-return {
-  data: {
-    attributes: {
-      result: "processed value",
-    },
-    name: "result", // optional, defaults to "data"
-    tags: { category: "output" }, // optional custom tags
-  },
-};
-```
+| Method                      | Description                                      |
+| --------------------------- | ------------------------------------------------ |
+| `writeAll(content)`         | Write complete binary content (`Uint8Array`)     |
+| `writeText(text)`           | Write text content (encoded as UTF-8)            |
+| `writeLine(line)`           | Append a single line (for streaming/incremental) |
+| `writeStream(stream, opts)` | Pipe a `ReadableStream<Uint8Array>`              |
+| `getFilePath()`             | Get the file path for direct I/O                 |
+| `finalize()`                | Finalize after using `writeLine`/`getFilePath`   |
 
-Both formats automatically:
+### DataHandle
 
-- Serialize `attributes` as JSON
-- Set content type to `application/json`
-- Set lifetime to `infinite`
-- Track ownership via definition hash
+Lightweight reference to data already persisted by a `DataWriter`:
 
-### Explicit: dataOutputs Array
-
-Use `dataOutputs` for advanced cases: multiple outputs, custom content types,
-streaming, or custom lifetimes.
-
-```typescript
-return {
-  dataOutputs: [
-    {
-      name: "output-name",
-      content: "string or Uint8Array",
-      metadata: {
-        contentType: "application/json",
-        lifetime: "7d",
-        streaming: true,
-        tags: { type: "log" },
-      },
-    },
-  ],
-};
-```
-
-### When to Use Each Format
-
-| Format        | Use Case                                           |
-| ------------- | -------------------------------------------------- |
-| `resource`    | External resource state (APIs, cloud, deployments) |
-| `data`        | General data output, computation results           |
-| `dataOutputs` | Multiple outputs, custom metadata, streaming       |
+| Field      | Description                          |
+| ---------- | ------------------------------------ |
+| `name`     | Data artifact name                   |
+| `specType` | Data spec type                       |
+| `dataId`   | Unique ID for this data              |
+| `version`  | Version number of this write         |
+| `size`     | Size of the written content in bytes |
+| `tags`     | Tags from the writer options         |
+| `metadata` | Full metadata for the data artifact  |
 
 ## Output
 

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -231,64 +231,50 @@ export const modelMethodRunCommand = new Command()
 
         runLogger.info("Method executed");
 
-        // Handle data output persistence
-        if (execResult.dataOutputs && execResult.dataOutputs.length > 0) {
-          for (const dataOutput of execResult.dataOutputs) {
-            ctx.logger.debug`Saving data output: ${dataOutput.name}`;
-
-            // Create Data entity from DataOutput
-            const { Data } = await import("../../domain/data/mod.ts");
-            const data = Data.create({
-              name: dataOutput.name,
-              contentType: dataOutput.metadata.contentType,
-              lifetime: dataOutput.metadata.lifetime,
-              garbageCollection: dataOutput.metadata.garbageCollection,
-              streaming: dataOutput.metadata.streaming,
-              tags: dataOutput.metadata.tags,
-              ownerDefinition: dataOutput.metadata.ownerDefinition,
-            });
-
-            // Save the data
-            const saveResult = await unifiedDataRepo.save(
-              modelType,
-              definition.id,
-              data,
-              dataOutput.content,
-            );
-
+        // Data is already persisted by DataWriter — extract artifact info from handles
+        if (execResult.dataHandles && execResult.dataHandles.length > 0) {
+          for (const handle of execResult.dataHandles) {
             const dataPath = unifiedDataRepo.getPath(
               modelType,
               definition.id,
-              dataOutput.name,
-              saveResult.version,
+              handle.name,
+              handle.version,
             );
 
             runLogger.info("Data saved to {path}", {
               path: dataPath,
-              name: dataOutput.name,
+              name: handle.name,
             });
 
             // Track artifact in output
             output.addDataArtifact({
-              dataId: data.id,
-              name: dataOutput.name,
-              version: saveResult.version,
-              tags: dataOutput.metadata.tags,
+              dataId: handle.dataId,
+              name: handle.name,
+              version: handle.version,
+              tags: handle.tags,
             });
 
             // Parse content if JSON for display purposes
             let attributes: Record<string, unknown> | undefined;
-            if (dataOutput.metadata.contentType === "application/json") {
+            if (handle.metadata.contentType === "application/json") {
               try {
-                const text = new TextDecoder().decode(dataOutput.content);
-                attributes = JSON.parse(text) as Record<string, unknown>;
+                const content = await unifiedDataRepo.getContent(
+                  modelType,
+                  evaluatedDefinition.id,
+                  handle.name,
+                  handle.version,
+                );
+                if (content) {
+                  const text = new TextDecoder().decode(content);
+                  attributes = JSON.parse(text) as Record<string, unknown>;
+                }
               } catch {
                 // Not valid JSON, skip attributes
               }
             }
 
             dataArtifacts.push({
-              id: data.id,
+              id: handle.dataId,
               path: dataPath,
               attributes,
             });

--- a/src/domain/models/aws/cli/aws_cli_model.ts
+++ b/src/domain/models/aws/cli/aws_cli_model.ts
@@ -168,29 +168,14 @@ async function executeRun(
     durationMs: result.durationMs,
   };
 
-  const definitionHash = await definition.computeHash();
+  const writer = context.createDataWriter!({
+    name: `${definition.name}-data`,
+    specType: "data",
+  });
 
-  return {
-    dataOutputs: [
-      {
-        name: `${definition.name}-data`,
-        specType: DataSpecType.create("data"),
-        content: new TextEncoder().encode(JSON.stringify(dataAttributes)),
-        metadata: {
-          contentType: "application/json",
-          lifetime: "infinite",
-          garbageCollection: 10,
-          streaming: false,
-          tags: { type: "data" },
-          ownerDefinition: {
-            definitionHash,
-            ownerType: "model-method",
-            ownerRef: "run",
-          },
-        },
-      },
-    ],
-  };
+  const handle = await writer.writeText(JSON.stringify(dataAttributes));
+
+  return { dataHandles: [handle] };
 }
 
 /**

--- a/src/domain/models/aws/cli/aws_cli_model_test.ts
+++ b/src/domain/models/aws/cli/aws_cli_model_test.ts
@@ -36,6 +36,10 @@ function createMockDataRepo(): UnifiedDataRepository {
     getContentPath: () => "",
     collectGarbage: () =>
       Promise.resolve({ versionsRemoved: 0, bytesReclaimed: 0 }),
+    allocateVersion: () =>
+      Promise.resolve({ version: 1, contentPath: "/tmp/mock" }),
+    finalizeVersion: () =>
+      Promise.resolve({ size: 0, checksum: "mock-checksum" }),
   };
 }
 

--- a/src/domain/models/aws/cloud_control_model.ts
+++ b/src/domain/models/aws/cloud_control_model.ts
@@ -8,7 +8,7 @@ import {
 } from "@aws-sdk/client-cloudcontrol";
 import type { ModelType } from "../model_type.ts";
 import {
-  type DataOutput,
+  type DataHandle,
   DataSpecType,
   defineModel,
   type FollowUpAction,
@@ -151,7 +151,8 @@ export abstract class AWSCloudControlModel<
    */
   protected async createDeletedResult(
     definition: Definition,
-    methodName: string,
+    _methodName: string,
+    context: MethodContext,
   ): Promise<MethodResult> {
     const attributes = {
       OperationStatus: "SUCCESS",
@@ -160,58 +161,29 @@ export abstract class AWSCloudControlModel<
       DeletionCompleted: true,
     };
 
-    const definitionHash = await definition.computeHash();
+    const handle = await this.writeDataHandle(
+      definition,
+      attributes,
+      context,
+    );
 
-    return {
-      dataOutputs: [
-        {
-          name: `${definition.name}-data`,
-          specType: DataSpecType.create("resource"),
-          content: new TextEncoder().encode(JSON.stringify(attributes)),
-          metadata: {
-            contentType: "application/json",
-            lifetime: "infinite",
-            garbageCollection: 10,
-            streaming: false,
-            tags: { type: "resource" },
-            ownerDefinition: {
-              definitionHash,
-              ownerType: "model-method",
-              ownerRef: methodName,
-            },
-          },
-        },
-      ],
-    };
+    return { dataHandles: [handle] };
   }
 
   /**
-   * Creates a DataOutput from attributes.
+   * Writes attributes as a DataHandle via DataWriter.
    */
-  protected async createDataOutput(
+  protected async writeDataHandle(
     definition: Definition,
-    methodName: string,
     attributes: Record<string, unknown>,
-  ): Promise<DataOutput> {
-    const definitionHash = await definition.computeHash();
-
-    return {
+    context: MethodContext,
+  ): Promise<DataHandle> {
+    const writer = context.createDataWriter!({
       name: `${definition.name}-data`,
-      specType: DataSpecType.create("resource"),
-      content: new TextEncoder().encode(JSON.stringify(attributes)),
-      metadata: {
-        contentType: "application/json",
-        lifetime: "infinite",
-        garbageCollection: 10,
-        streaming: false,
-        tags: { type: "resource" },
-        ownerDefinition: {
-          definitionHash,
-          ownerType: "model-method",
-          ownerRef: methodName,
-        },
-      },
-    };
+      specType: "resource",
+    });
+
+    return await writer.writeText(JSON.stringify(attributes));
   }
 
   /**
@@ -253,10 +225,10 @@ export abstract class AWSCloudControlModel<
       ResourceIdentifier: response.ProgressEvent.Identifier,
     };
 
-    const dataOutput = await this.createDataOutput(
+    const handle = await this.writeDataHandle(
       definition,
-      "create",
       attributes,
+      context,
     );
 
     const followUpActions: FollowUpAction[] = [
@@ -264,14 +236,13 @@ export abstract class AWSCloudControlModel<
         methodName: "sync",
         delayMs: 5000,
         maxRetries: 3,
-        continueCondition: (dataOutputs: DataOutput[]) => {
-          // Continue if we have data outputs
-          return dataOutputs.length > 0;
+        continueCondition: (dataHandles: DataHandle[]) => {
+          return dataHandles.length > 0;
         },
       },
     ];
 
-    return { dataOutputs: [dataOutput], followUpActions };
+    return { dataHandles: [handle], followUpActions };
   }
 
   /**
@@ -313,7 +284,7 @@ export abstract class AWSCloudControlModel<
 
     if (!awsResourceId) {
       // No resource exists - nothing to delete
-      return this.createDeletedResult(definition, "delete");
+      return this.createDeletedResult(definition, "delete", context);
     }
 
     const client = this.createClient(context);
@@ -346,10 +317,10 @@ export abstract class AWSCloudControlModel<
         DeletionInitiated: true,
       };
 
-      const dataOutput = await this.createDataOutput(
+      const handle = await this.writeDataHandle(
         definition,
-        "delete",
         attributes,
+        context,
       );
 
       const followUpActions: FollowUpAction[] = [
@@ -357,16 +328,16 @@ export abstract class AWSCloudControlModel<
           methodName: "sync",
           delayMs: 5000,
           maxRetries: 3,
-          continueCondition: (dataOutputs: DataOutput[]) => {
-            return dataOutputs.length > 0;
+          continueCondition: (dataHandles: DataHandle[]) => {
+            return dataHandles.length > 0;
           },
         },
       ];
 
-      return { dataOutputs: [dataOutput], followUpActions };
+      return { dataHandles: [handle], followUpActions };
     } catch (error: unknown) {
       if (isResourceNotFoundError(error)) {
-        return this.createDeletedResult(definition, "delete");
+        return this.createDeletedResult(definition, "delete", context);
       }
       throw error;
     }
@@ -443,7 +414,7 @@ export abstract class AWSCloudControlModel<
       statusResponse = await client.send(statusCommand);
     } catch (error: unknown) {
       if (isResourceNotFoundError(error)) {
-        return this.createDeletedResult(definition, "sync");
+        return this.createDeletedResult(definition, "sync", context);
       }
       throw error;
     }
@@ -463,10 +434,10 @@ export abstract class AWSCloudControlModel<
         DeletionInitiated: isDeletionContext || undefined,
       };
 
-      const dataOutput = await this.createDataOutput(
+      const handle = await this.writeDataHandle(
         definition,
-        "sync",
         attributes,
+        context,
       );
 
       const followUpActions: FollowUpAction[] = [
@@ -474,13 +445,13 @@ export abstract class AWSCloudControlModel<
           methodName: "sync",
           delayMs: 10000,
           maxRetries: 30,
-          continueCondition: (dataOutputs: DataOutput[]) => {
-            return dataOutputs.length > 0;
+          continueCondition: (dataHandles: DataHandle[]) => {
+            return dataHandles.length > 0;
           },
         },
       ];
 
-      return { dataOutputs: [dataOutput], followUpActions };
+      return { dataHandles: [handle], followUpActions };
     }
 
     if (currentStatus === "FAILED") {
@@ -488,7 +459,7 @@ export abstract class AWSCloudControlModel<
         statusMessage.includes("was not found") ||
         statusMessage.includes("does not exist")
       ) {
-        return this.createDeletedResult(definition, "sync");
+        return this.createDeletedResult(definition, "sync", context);
       }
       throw new Error(
         `CloudControl operation failed: ${statusMessage || "Unknown error"}`,
@@ -496,7 +467,7 @@ export abstract class AWSCloudControlModel<
     }
 
     if (isDeletionContext) {
-      return this.createDeletedResult(definition, "sync");
+      return this.createDeletedResult(definition, "sync", context);
     }
 
     if (!resourceIdentifier) {
@@ -531,16 +502,16 @@ export abstract class AWSCloudControlModel<
         RawProperties: rawProperties,
       };
 
-      const dataOutput = await this.createDataOutput(
+      const handle = await this.writeDataHandle(
         definition,
-        "sync",
         attributes,
+        context,
       );
 
-      return { dataOutputs: [dataOutput] };
+      return { dataHandles: [handle] };
     } catch (error: unknown) {
       if (isResourceNotFoundError(error)) {
-        return this.createDeletedResult(definition, "sync");
+        return this.createDeletedResult(definition, "sync", context);
       }
       throw error;
     }

--- a/src/domain/models/aws/ec2/instance/ec2_instance_model_test.ts
+++ b/src/domain/models/aws/ec2/instance/ec2_instance_model_test.ts
@@ -10,11 +10,103 @@ import {
   createDefinitionId,
   Definition,
 } from "../../../../definitions/definition.ts";
-import type { MethodContext } from "../../../../models/model.ts";
+import { normalizeSpecType } from "../../../../models/model.ts";
+import type {
+  DataHandle,
+  DataWriter,
+  DataWriterFactory,
+  MethodContext,
+  SpecBasedWriterOptions,
+} from "../../../../models/model.ts";
 import type { UnifiedDataRepository } from "../../../../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../../../../definitions/repositories.ts";
-import { generateDataId } from "../../../../data/data_id.ts";
+import { type DataId, generateDataId } from "../../../../data/data_id.ts";
 import { getLogger } from "@logtape/logtape";
+
+/**
+ * Stored result from mock data writer.
+ */
+interface MockWriterResult {
+  handle: DataHandle;
+  content: Uint8Array;
+}
+
+/**
+ * Creates a mock DataWriterFactory that stores written content in memory.
+ */
+function createMockDataWriterFactory(): {
+  factory: DataWriterFactory;
+  getResults: () => MockWriterResult[];
+} {
+  const results: MockWriterResult[] = [];
+  const getResults = (): MockWriterResult[] => results;
+  let nextId = 1;
+
+  const factory: DataWriterFactory = (
+    options: SpecBasedWriterOptions,
+  ): DataWriter => {
+    const dataId = `mock-data-${nextId++}` as DataId;
+
+    const buildHandle = (content: Uint8Array): DataHandle => ({
+      name: options.name,
+      specType: normalizeSpecType(options.specType),
+      dataId,
+      version: 1,
+      size: content.length,
+      tags: options.tags ?? {},
+      metadata: {
+        contentType: options.contentType ?? "application/json",
+        lifetime: options.lifetime ?? "infinite",
+        garbageCollection: options.garbageCollection ?? 10,
+        streaming: options.streaming ?? false,
+        tags: options.tags ?? {},
+        ownerDefinition: {
+          definitionHash: "test-hash",
+          ownerType: "model-method",
+          ownerRef: "test",
+        },
+      },
+    });
+
+    return {
+      dataId,
+      name: options.name,
+      writeAll(content: Uint8Array): Promise<DataHandle> {
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeText(text: string): Promise<DataHandle> {
+        const content = new TextEncoder().encode(text);
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeLine(_line: string): Promise<void> {
+        return Promise.resolve();
+      },
+      writeStream(
+        _stream: ReadableStream<Uint8Array>,
+      ): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      getFilePath(): Promise<string> {
+        return Promise.resolve("/tmp/mock");
+      },
+      finalize(): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+    } as DataWriter;
+  };
+
+  return { factory, getResults };
+}
 
 /**
  * Creates a mock UnifiedDataRepository for testing.
@@ -43,6 +135,10 @@ function createMockDataRepo(
     getContentPath: () => "",
     collectGarbage: () =>
       Promise.resolve({ versionsRemoved: 0, bytesReclaimed: 0 }),
+    allocateVersion: () =>
+      Promise.resolve({ version: 1, contentPath: "/tmp/mock" }),
+    finalizeVersion: () =>
+      Promise.resolve({ size: 0, checksum: "mock-checksum" }),
   };
 }
 
@@ -68,29 +164,32 @@ function createMockDefinitionRepo(): DefinitionRepository {
  */
 function createTestContext(
   overrides?: Partial<MethodContext>,
-): MethodContext {
-  return {
+): { context: MethodContext; getResults: () => MockWriterResult[] } {
+  const { factory, getResults } = createMockDataWriterFactory();
+  const context: MethodContext = {
     repoDir: "/tmp/test-repo",
     modelType: EC2_INSTANCE_MODEL_TYPE,
     modelId: crypto.randomUUID(),
     logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
+    createDataWriter: factory,
     ...overrides,
   };
+  return { context, getResults };
 }
 
 /**
- * Helper to get attributes from a DataOutput.
+ * Helper to get attributes from mock writer results.
  */
-function getDataOutputAttributes(
-  dataOutputs: { content: Uint8Array }[] | undefined,
+function getDataHandleAttributes(
+  results: MockWriterResult[],
   index = 0,
 ): Record<string, unknown> | undefined {
-  if (!dataOutputs || dataOutputs.length <= index) {
+  if (results.length <= index) {
     return undefined;
   }
-  const content = new TextDecoder().decode(dataOutputs[index].content);
+  const content = new TextDecoder().decode(results[index].content);
   const parsed = JSON.parse(content);
   // CloudControl resources wrap in {attributes: {...}}
   return parsed.attributes ?? parsed;
@@ -192,7 +291,7 @@ Deno.test("EC2InstanceModel - sync method without RequestToken fails", async () 
     },
   });
 
-  const context = createTestContext();
+  const { context } = createTestContext();
 
   await assertRejects(
     () => ec2InstanceModel.methods.sync.execute(definition, context),
@@ -210,15 +309,15 @@ Deno.test("EC2InstanceModel - delete method without data returns deleted result"
     },
   });
 
-  const context = createTestContext();
+  const { context, getResults } = createTestContext();
 
-  const result = await ec2InstanceModel.methods.delete.execute(
+  await ec2InstanceModel.methods.delete.execute(
     definition,
     context,
   );
 
-  // Should return success data output since no data exists
-  const attrs = getDataOutputAttributes(result.dataOutputs);
+  // Should return success data handle since no data exists
+  const attrs = getDataHandleAttributes(getResults());
   assertEquals(attrs?.OperationStatus, "SUCCESS");
   assertEquals(attrs?.DeletionCompleted, true);
 });
@@ -244,7 +343,7 @@ Deno.test("EC2InstanceModel - create method uses injected CloudControl client", 
       }),
   };
 
-  const context = createTestContext({
+  const { context, getResults } = createTestContext({
     cloudControlClientFactory: () =>
       mockClient as unknown as CloudControlClient,
   });
@@ -254,7 +353,7 @@ Deno.test("EC2InstanceModel - create method uses injected CloudControl client", 
     context,
   );
 
-  const attrs = getDataOutputAttributes(result.dataOutputs);
+  const attrs = getDataHandleAttributes(getResults());
   assertEquals(attrs?.RequestToken, "request-123");
   assertEquals(attrs?.OperationStatus, "IN_PROGRESS");
   assertEquals(result.followUpActions?.length, 1);
@@ -282,7 +381,7 @@ Deno.test("EC2InstanceModel - sync method treats 'not found' as deleted", async 
       }),
   };
 
-  const context = createTestContext({
+  const { context, getResults } = createTestContext({
     cloudControlClientFactory: () =>
       mockClient as unknown as CloudControlClient,
   });
@@ -292,8 +391,8 @@ Deno.test("EC2InstanceModel - sync method treats 'not found' as deleted", async 
     context,
   );
 
-  // Should return success data output
-  const attrs = getDataOutputAttributes(result.dataOutputs);
+  // Should return success data handle
+  const attrs = getDataHandleAttributes(getResults());
   assertEquals(attrs?.OperationStatus, "SUCCESS");
   assertEquals(attrs?.DeletionCompleted, true);
   assertEquals(result.followUpActions, undefined);
@@ -333,7 +432,7 @@ Deno.test("EC2InstanceModel - delete method treats 'not found' as success", asyn
     },
   };
 
-  const context = createTestContext({
+  const { context, getResults } = createTestContext({
     dataRepository: mockDataRepo,
     cloudControlClientFactory: () =>
       mockClient as unknown as CloudControlClient,
@@ -344,8 +443,8 @@ Deno.test("EC2InstanceModel - delete method treats 'not found' as success", asyn
     context,
   );
 
-  // Should return success data output
-  const attrs = getDataOutputAttributes(result.dataOutputs);
+  // Should return success data handle
+  const attrs = getDataHandleAttributes(getResults());
   assertEquals(attrs?.OperationStatus, "SUCCESS");
   assertEquals(attrs?.DeletionCompleted, true);
   assertEquals(result.followUpActions, undefined);

--- a/src/domain/models/aws/ec2/subnet/ec2_subnet_model_test.ts
+++ b/src/domain/models/aws/ec2/subnet/ec2_subnet_model_test.ts
@@ -10,11 +10,103 @@ import {
   createDefinitionId,
   Definition,
 } from "../../../../definitions/definition.ts";
-import type { MethodContext } from "../../../../models/model.ts";
+import { normalizeSpecType } from "../../../../models/model.ts";
+import type {
+  DataHandle,
+  DataWriter,
+  DataWriterFactory,
+  MethodContext,
+  SpecBasedWriterOptions,
+} from "../../../../models/model.ts";
 import type { UnifiedDataRepository } from "../../../../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../../../../definitions/repositories.ts";
-import { generateDataId } from "../../../../data/data_id.ts";
+import { type DataId, generateDataId } from "../../../../data/data_id.ts";
 import { getLogger } from "@logtape/logtape";
+
+/**
+ * Stored result from mock data writer.
+ */
+interface MockWriterResult {
+  handle: DataHandle;
+  content: Uint8Array;
+}
+
+/**
+ * Creates a mock DataWriterFactory that stores written content in memory.
+ */
+function createMockDataWriterFactory(): {
+  factory: DataWriterFactory;
+  getResults: () => MockWriterResult[];
+} {
+  const results: MockWriterResult[] = [];
+  const getResults = (): MockWriterResult[] => results;
+  let nextId = 1;
+
+  const factory: DataWriterFactory = (
+    options: SpecBasedWriterOptions,
+  ): DataWriter => {
+    const dataId = `mock-data-${nextId++}` as DataId;
+
+    const buildHandle = (content: Uint8Array): DataHandle => ({
+      name: options.name,
+      specType: normalizeSpecType(options.specType),
+      dataId,
+      version: 1,
+      size: content.length,
+      tags: options.tags ?? {},
+      metadata: {
+        contentType: options.contentType ?? "application/json",
+        lifetime: options.lifetime ?? "infinite",
+        garbageCollection: options.garbageCollection ?? 10,
+        streaming: options.streaming ?? false,
+        tags: options.tags ?? {},
+        ownerDefinition: {
+          definitionHash: "test-hash",
+          ownerType: "model-method",
+          ownerRef: "test",
+        },
+      },
+    });
+
+    return {
+      dataId,
+      name: options.name,
+      writeAll(content: Uint8Array): Promise<DataHandle> {
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeText(text: string): Promise<DataHandle> {
+        const content = new TextEncoder().encode(text);
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeLine(_line: string): Promise<void> {
+        return Promise.resolve();
+      },
+      writeStream(
+        _stream: ReadableStream<Uint8Array>,
+      ): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      getFilePath(): Promise<string> {
+        return Promise.resolve("/tmp/mock");
+      },
+      finalize(): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+    } as DataWriter;
+  };
+
+  return { factory, getResults };
+}
 
 /**
  * Creates a mock UnifiedDataRepository for testing.
@@ -43,6 +135,10 @@ function createMockDataRepo(
     getContentPath: () => "",
     collectGarbage: () =>
       Promise.resolve({ versionsRemoved: 0, bytesReclaimed: 0 }),
+    allocateVersion: () =>
+      Promise.resolve({ version: 1, contentPath: "/tmp/mock" }),
+    finalizeVersion: () =>
+      Promise.resolve({ size: 0, checksum: "mock-checksum" }),
   };
 }
 
@@ -68,29 +164,32 @@ function createMockDefinitionRepo(): DefinitionRepository {
  */
 function createTestContext(
   overrides?: Partial<MethodContext>,
-): MethodContext {
-  return {
+): { context: MethodContext; getResults: () => MockWriterResult[] } {
+  const { factory, getResults } = createMockDataWriterFactory();
+  const context: MethodContext = {
     repoDir: "/tmp/test-repo",
     modelType: EC2_SUBNET_MODEL_TYPE,
     modelId: crypto.randomUUID(),
     logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
+    createDataWriter: factory,
     ...overrides,
   };
+  return { context, getResults };
 }
 
 /**
- * Helper to get attributes from a DataOutput.
+ * Helper to get attributes from mock writer results.
  */
-function getDataOutputAttributes(
-  dataOutputs: { content: Uint8Array }[] | undefined,
+function getDataHandleAttributes(
+  results: MockWriterResult[],
   index = 0,
 ): Record<string, unknown> | undefined {
-  if (!dataOutputs || dataOutputs.length <= index) {
+  if (results.length <= index) {
     return undefined;
   }
-  const content = new TextDecoder().decode(dataOutputs[index].content);
+  const content = new TextDecoder().decode(results[index].content);
   const parsed = JSON.parse(content);
   // CloudControl resources wrap in {attributes: {...}}
   return parsed.attributes ?? parsed;
@@ -258,7 +357,7 @@ Deno.test("EC2SubnetModel - sync method without RequestToken fails", async () =>
     },
   });
 
-  const context = createTestContext();
+  const { context } = createTestContext();
 
   await assertRejects(
     () => ec2SubnetModel.methods.sync.execute(definition, context),
@@ -276,15 +375,15 @@ Deno.test("EC2SubnetModel - delete method without data returns deleted result", 
     },
   });
 
-  const context = createTestContext();
+  const { context, getResults } = createTestContext();
 
-  const result = await ec2SubnetModel.methods.delete.execute(
+  await ec2SubnetModel.methods.delete.execute(
     definition,
     context,
   );
 
-  // Should return success data output since no data exists
-  const attrs = getDataOutputAttributes(result.dataOutputs);
+  // Should return success data handle since no data exists
+  const attrs = getDataHandleAttributes(getResults());
   assertEquals(attrs?.OperationStatus, "SUCCESS");
   assertEquals(attrs?.DeletionCompleted, true);
 });
@@ -310,7 +409,7 @@ Deno.test("EC2SubnetModel - create method uses injected CloudControl client", as
       }),
   };
 
-  const context = createTestContext({
+  const { context, getResults } = createTestContext({
     cloudControlClientFactory: () =>
       mockClient as unknown as CloudControlClient,
   });
@@ -320,7 +419,7 @@ Deno.test("EC2SubnetModel - create method uses injected CloudControl client", as
     context,
   );
 
-  const attrs = getDataOutputAttributes(result.dataOutputs);
+  const attrs = getDataHandleAttributes(getResults());
   assertEquals(attrs?.RequestToken, "request-123");
   assertEquals(attrs?.OperationStatus, "IN_PROGRESS");
   assertEquals(result.followUpActions?.length, 1);
@@ -347,14 +446,14 @@ Deno.test("EC2SubnetModel - sync method treats 'not found' as deleted", async ()
       }),
   };
 
-  const context = createTestContext({
+  const { context, getResults } = createTestContext({
     cloudControlClientFactory: () =>
       mockClient as unknown as CloudControlClient,
   });
 
   const result = await ec2SubnetModel.methods.sync.execute(definition, context);
 
-  const attrs = getDataOutputAttributes(result.dataOutputs);
+  const attrs = getDataHandleAttributes(getResults());
   assertEquals(attrs?.OperationStatus, "SUCCESS");
   assertEquals(attrs?.DeletionCompleted, true);
   assertEquals(result.followUpActions, undefined);
@@ -394,7 +493,7 @@ Deno.test("EC2SubnetModel - delete method treats 'not found' as success", async 
     },
   };
 
-  const context = createTestContext({
+  const { context, getResults } = createTestContext({
     dataRepository: mockDataRepo,
     cloudControlClientFactory: () =>
       mockClient as unknown as CloudControlClient,
@@ -405,7 +504,7 @@ Deno.test("EC2SubnetModel - delete method treats 'not found' as success", async 
     context,
   );
 
-  const attrs = getDataOutputAttributes(result.dataOutputs);
+  const attrs = getDataHandleAttributes(getResults());
   assertEquals(attrs?.OperationStatus, "SUCCESS");
   assertEquals(attrs?.DeletionCompleted, true);
   assertEquals(result.followUpActions, undefined);

--- a/src/domain/models/aws/ec2/vpc/ec2_vpc_model_test.ts
+++ b/src/domain/models/aws/ec2/vpc/ec2_vpc_model_test.ts
@@ -10,11 +10,103 @@ import {
   createDefinitionId,
   Definition,
 } from "../../../../definitions/definition.ts";
-import type { MethodContext } from "../../../../models/model.ts";
+import { normalizeSpecType } from "../../../../models/model.ts";
+import type {
+  DataHandle,
+  DataWriter,
+  DataWriterFactory,
+  MethodContext,
+  SpecBasedWriterOptions,
+} from "../../../../models/model.ts";
 import type { UnifiedDataRepository } from "../../../../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../../../../definitions/repositories.ts";
-import { generateDataId } from "../../../../data/data_id.ts";
+import { type DataId, generateDataId } from "../../../../data/data_id.ts";
 import { getLogger } from "@logtape/logtape";
+
+/**
+ * Stored result from mock data writer.
+ */
+interface MockWriterResult {
+  handle: DataHandle;
+  content: Uint8Array;
+}
+
+/**
+ * Creates a mock DataWriterFactory that stores written content in memory.
+ */
+function createMockDataWriterFactory(): {
+  factory: DataWriterFactory;
+  getResults: () => MockWriterResult[];
+} {
+  const results: MockWriterResult[] = [];
+  const getResults = (): MockWriterResult[] => results;
+  let nextId = 1;
+
+  const factory: DataWriterFactory = (
+    options: SpecBasedWriterOptions,
+  ): DataWriter => {
+    const dataId = `mock-data-${nextId++}` as DataId;
+
+    const buildHandle = (content: Uint8Array): DataHandle => ({
+      name: options.name,
+      specType: normalizeSpecType(options.specType),
+      dataId,
+      version: 1,
+      size: content.length,
+      tags: options.tags ?? {},
+      metadata: {
+        contentType: options.contentType ?? "application/json",
+        lifetime: options.lifetime ?? "infinite",
+        garbageCollection: options.garbageCollection ?? 10,
+        streaming: options.streaming ?? false,
+        tags: options.tags ?? {},
+        ownerDefinition: {
+          definitionHash: "test-hash",
+          ownerType: "model-method",
+          ownerRef: "test",
+        },
+      },
+    });
+
+    return {
+      dataId,
+      name: options.name,
+      writeAll(content: Uint8Array): Promise<DataHandle> {
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeText(text: string): Promise<DataHandle> {
+        const content = new TextEncoder().encode(text);
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeLine(_line: string): Promise<void> {
+        return Promise.resolve();
+      },
+      writeStream(
+        _stream: ReadableStream<Uint8Array>,
+      ): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      getFilePath(): Promise<string> {
+        return Promise.resolve("/tmp/mock");
+      },
+      finalize(): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+    } as DataWriter;
+  };
+
+  return { factory, getResults };
+}
 
 /**
  * Creates a mock UnifiedDataRepository for testing.
@@ -43,6 +135,10 @@ function createMockDataRepo(
     getContentPath: () => "",
     collectGarbage: () =>
       Promise.resolve({ versionsRemoved: 0, bytesReclaimed: 0 }),
+    allocateVersion: () =>
+      Promise.resolve({ version: 1, contentPath: "/tmp/mock" }),
+    finalizeVersion: () =>
+      Promise.resolve({ size: 0, checksum: "mock-checksum" }),
   };
 }
 
@@ -68,29 +164,32 @@ function createMockDefinitionRepo(): DefinitionRepository {
  */
 function createTestContext(
   overrides?: Partial<MethodContext>,
-): MethodContext {
-  return {
+): { context: MethodContext; getResults: () => MockWriterResult[] } {
+  const { factory, getResults } = createMockDataWriterFactory();
+  const context: MethodContext = {
     repoDir: "/tmp/test-repo",
     modelType: EC2_VPC_MODEL_TYPE,
     modelId: crypto.randomUUID(),
     logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
+    createDataWriter: factory,
     ...overrides,
   };
+  return { context, getResults };
 }
 
 /**
- * Helper to get attributes from a DataOutput.
+ * Helper to get attributes from mock writer results.
  */
-function getDataOutputAttributes(
-  dataOutputs: { content: Uint8Array }[] | undefined,
+function getDataHandleAttributes(
+  results: MockWriterResult[],
   index = 0,
 ): Record<string, unknown> | undefined {
-  if (!dataOutputs || dataOutputs.length <= index) {
+  if (results.length <= index) {
     return undefined;
   }
-  const content = new TextDecoder().decode(dataOutputs[index].content);
+  const content = new TextDecoder().decode(results[index].content);
   const parsed = JSON.parse(content);
   // CloudControl resources wrap in {attributes: {...}}
   return parsed.attributes ?? parsed;
@@ -193,7 +292,7 @@ Deno.test("EC2VpcModel - sync method without RequestToken fails", async () => {
     },
   });
 
-  const context = createTestContext();
+  const { context } = createTestContext();
 
   await assertRejects(
     () => ec2VpcModel.methods.sync.execute(definition, context),
@@ -210,12 +309,12 @@ Deno.test("EC2VpcModel - delete method without data returns deleted result", asy
     },
   });
 
-  const context = createTestContext();
+  const { context, getResults } = createTestContext();
 
-  const result = await ec2VpcModel.methods.delete.execute(definition, context);
+  await ec2VpcModel.methods.delete.execute(definition, context);
 
-  // Should return success data output since no data exists
-  const attrs = getDataOutputAttributes(result.dataOutputs);
+  // Should return success data handle since no data exists
+  const attrs = getDataHandleAttributes(getResults());
   assertEquals(attrs?.OperationStatus, "SUCCESS");
   assertEquals(attrs?.DeletionCompleted, true);
 });
@@ -241,14 +340,14 @@ Deno.test("EC2VpcModel - create method uses injected CloudControl client", async
       }),
   };
 
-  const context = createTestContext({
+  const { context, getResults } = createTestContext({
     cloudControlClientFactory: () =>
       mockClient as unknown as CloudControlClient,
   });
 
   const result = await ec2VpcModel.methods.create.execute(definition, context);
 
-  const attrs = getDataOutputAttributes(result.dataOutputs);
+  const attrs = getDataHandleAttributes(getResults());
   assertEquals(attrs?.RequestToken, "request-123");
   assertEquals(attrs?.OperationStatus, "IN_PROGRESS");
   assertEquals(result.followUpActions?.length, 1);
@@ -275,14 +374,14 @@ Deno.test("EC2VpcModel - sync method treats 'not found' as deleted", async () =>
       }),
   };
 
-  const context = createTestContext({
+  const { context, getResults } = createTestContext({
     cloudControlClientFactory: () =>
       mockClient as unknown as CloudControlClient,
   });
 
   const result = await ec2VpcModel.methods.sync.execute(definition, context);
 
-  const attrs = getDataOutputAttributes(result.dataOutputs);
+  const attrs = getDataHandleAttributes(getResults());
   assertEquals(attrs?.OperationStatus, "SUCCESS");
   assertEquals(attrs?.DeletionCompleted, true);
   assertEquals(result.followUpActions, undefined);
@@ -321,7 +420,7 @@ Deno.test("EC2VpcModel - delete method treats 'not found' as success", async () 
     },
   };
 
-  const context = createTestContext({
+  const { context, getResults } = createTestContext({
     dataRepository: mockDataRepo,
     cloudControlClientFactory: () =>
       mockClient as unknown as CloudControlClient,
@@ -329,7 +428,7 @@ Deno.test("EC2VpcModel - delete method treats 'not found' as success", async () 
 
   const result = await ec2VpcModel.methods.delete.execute(definition, context);
 
-  const attrs = getDataOutputAttributes(result.dataOutputs);
+  const attrs = getDataHandleAttributes(getResults());
   assertEquals(attrs?.OperationStatus, "SUCCESS");
   assertEquals(attrs?.DeletionCompleted, true);
   assertEquals(result.followUpActions, undefined);

--- a/src/domain/models/command/curl/curl_model.ts
+++ b/src/domain/models/command/curl/curl_model.ts
@@ -107,7 +107,7 @@ function extractFilename(url: string, headers: Headers): string {
  */
 async function executeDownload(
   definition: Definition,
-  _context: MethodContext,
+  context: MethodContext,
 ): Promise<MethodResult> {
   const attrs = CurlInputAttributesSchema.parse(definition.attributes);
   const startTime = Date.now();
@@ -160,8 +160,6 @@ async function executeDownload(
   // Compute checksum
   const checksum = await computeChecksum(content);
 
-  const definitionHash = await definition.computeHash();
-
   // Create metadata attributes
   const metadataAttributes = {
     url: attrs.url,
@@ -174,44 +172,24 @@ async function executeDownload(
     checksum,
   };
 
-  return {
-    dataOutputs: [
-      {
-        name: `${definition.name}-metadata`,
-        specType: DataSpecType.create("metadata"),
-        content: new TextEncoder().encode(JSON.stringify(metadataAttributes)),
-        metadata: {
-          contentType: "application/json",
-          lifetime: "infinite",
-          garbageCollection: 10,
-          streaming: false,
-          tags: { type: "data" },
-          ownerDefinition: {
-            definitionHash,
-            ownerType: "model-method",
-            ownerRef: "download",
-          },
-        },
-      },
-      {
-        name: `${definition.name}-file`,
-        specType: DataSpecType.create("file"),
-        content,
-        metadata: {
-          contentType,
-          lifetime: "infinite",
-          garbageCollection: 10,
-          streaming: false,
-          tags: { type: "file", filename },
-          ownerDefinition: {
-            definitionHash,
-            ownerType: "model-method",
-            ownerRef: "download",
-          },
-        },
-      },
-    ],
-  };
+  const metadataWriter = context.createDataWriter!({
+    name: `${definition.name}-metadata`,
+    specType: "metadata",
+  });
+
+  const fileWriter = context.createDataWriter!({
+    name: `${definition.name}-file`,
+    specType: "file",
+    contentType,
+    tags: { filename },
+  });
+
+  const metadataHandle = await metadataWriter.writeText(
+    JSON.stringify(metadataAttributes),
+  );
+  const fileHandle = await fileWriter.writeAll(content);
+
+  return { dataHandles: [metadataHandle, fileHandle] };
 }
 
 /**

--- a/src/domain/models/command/curl/curl_model_test.ts
+++ b/src/domain/models/command/curl/curl_model_test.ts
@@ -9,20 +9,123 @@ import {
   curlModel,
   CurlResourceAttributesSchema,
 } from "./curl_model.ts";
-import type { MethodContext } from "../../model.ts";
+import { normalizeSpecType } from "../../model.ts";
+import type {
+  DataHandle,
+  DataWriter,
+  DataWriterFactory,
+  MethodContext,
+  SpecBasedWriterOptions,
+} from "../../model.ts";
 import type { UnifiedDataRepository } from "../../../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../../../definitions/repositories.ts";
-import { generateDataId } from "../../../data/data_id.ts";
+import { type DataId, generateDataId } from "../../../data/data_id.ts";
 import { getLogger } from "@logtape/logtape";
 
-// Check if we have network permission for integration tests
-const hasNetworkPermission = await (async () => {
-  const status = await Deno.permissions.query({
-    name: "net",
-    host: "httpbin.org",
-  });
-  return status.state === "granted";
-})();
+/**
+ * Stored result from mock data writer.
+ */
+interface MockWriterResult {
+  handle: DataHandle;
+  content: Uint8Array;
+}
+
+/**
+ * Creates a mock DataWriterFactory that stores written content in memory.
+ */
+function createMockDataWriterFactory(): {
+  factory: DataWriterFactory;
+  getResults: () => MockWriterResult[];
+} {
+  const results: MockWriterResult[] = [];
+  const getResults = (): MockWriterResult[] => results;
+  let nextId = 1;
+
+  const factory: DataWriterFactory = (
+    options: SpecBasedWriterOptions,
+  ): DataWriter => {
+    const dataId = `mock-data-${nextId++}` as DataId;
+
+    const buildHandle = (content: Uint8Array): DataHandle => ({
+      name: options.name,
+      specType: normalizeSpecType(options.specType),
+      dataId,
+      version: 1,
+      size: content.length,
+      tags: { ...(options.tags ?? {}) },
+      metadata: {
+        contentType: options.contentType ?? "application/json",
+        lifetime: options.lifetime ?? "infinite",
+        garbageCollection: options.garbageCollection ?? 10,
+        streaming: options.streaming ?? false,
+        tags: { ...(options.tags ?? {}) },
+        ownerDefinition: {
+          definitionHash: "test-hash",
+          ownerType: "model-method",
+          ownerRef: "test",
+        },
+      },
+    });
+
+    return {
+      dataId,
+      name: options.name,
+      writeAll(content: Uint8Array): Promise<DataHandle> {
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeText(text: string): Promise<DataHandle> {
+        const content = new TextEncoder().encode(text);
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeLine(_line: string): Promise<void> {
+        return Promise.resolve();
+      },
+      writeStream(
+        _stream: ReadableStream<Uint8Array>,
+      ): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      getFilePath(): Promise<string> {
+        return Promise.resolve("/tmp/mock");
+      },
+      finalize(): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+    } as DataWriter;
+  };
+
+  return { factory, getResults };
+}
+
+/**
+ * Helper to get parsed JSON content from mock results by name pattern.
+ */
+function getResultAttributes(
+  results: MockWriterResult[],
+  namePattern: string,
+): Record<string, unknown> | undefined {
+  const result = results.find((r) => r.handle.name.includes(namePattern));
+  if (!result) return undefined;
+  return JSON.parse(new TextDecoder().decode(result.content));
+}
+
+/**
+ * Helper to get file content from mock results.
+ */
+function getFileContent(results: MockWriterResult[]): Uint8Array | undefined {
+  const fileResult = results.find((r) => r.handle.name.includes("file"));
+  return fileResult?.content;
+}
 
 /**
  * Creates a mock UnifiedDataRepository for testing.
@@ -44,6 +147,10 @@ function createMockDataRepo(): UnifiedDataRepository {
     getContentPath: () => "",
     collectGarbage: () =>
       Promise.resolve({ versionsRemoved: 0, bytesReclaimed: 0 }),
+    allocateVersion: () =>
+      Promise.resolve({ version: 1, contentPath: "/tmp/mock" }),
+    finalizeVersion: () =>
+      Promise.resolve({ size: 0, checksum: "mock-checksum" }),
   };
 }
 
@@ -67,38 +174,21 @@ function createMockDefinitionRepo(): DefinitionRepository {
 /**
  * Creates a test MethodContext with mocked repositories.
  */
-function createTestContext(): MethodContext {
-  return {
+function createTestContext(): {
+  context: MethodContext;
+  getResults: () => MockWriterResult[];
+} {
+  const { factory, getResults } = createMockDataWriterFactory();
+  const context: MethodContext = {
     repoDir: "/tmp",
     modelType: CURL_MODEL_TYPE,
     modelId: crypto.randomUUID(),
     logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
+    createDataWriter: factory,
   };
-}
-
-/**
- * Helper to get attributes from a DataOutput by name pattern.
- */
-function getDataOutputAttributes(
-  dataOutputs: { name: string; content: Uint8Array }[] | undefined,
-  namePattern: string,
-): Record<string, unknown> | undefined {
-  const dataOutput = dataOutputs?.find((d) => d.name.includes(namePattern));
-  if (!dataOutput) return undefined;
-  const content = new TextDecoder().decode(dataOutput.content);
-  return JSON.parse(content);
-}
-
-/**
- * Helper to get file content from DataOutputs.
- */
-function getFileContent(
-  dataOutputs: { name: string; content: Uint8Array }[] | undefined,
-): Uint8Array | undefined {
-  const fileOutput = dataOutputs?.find((d) => d.name.includes("file"));
-  return fileOutput?.content;
+  return { context, getResults };
 }
 
 Deno.test("CURL_MODEL_TYPE has correct normalized type", () => {
@@ -213,7 +303,7 @@ Deno.test("curlModel.methods.download validates input attributes", async () => {
     attributes: { notAUrl: "value" },
   });
 
-  const context = createTestContext();
+  const { context } = createTestContext();
   let error: Error | null = null;
   try {
     await curlModel.methods.download.execute(definition, context);
@@ -224,27 +314,34 @@ Deno.test("curlModel.methods.download validates input attributes", async () => {
   assertEquals(error !== null, true);
 });
 
-Deno.test({
-  name: "curlModel.methods.download executes correctly",
-  ignore: !hasNetworkPermission,
-  fn: async () => {
+Deno.test("curlModel.methods.download executes correctly", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (_input: string | URL | Request, _init?: RequestInit) => {
+    return Promise.resolve(
+      new Response(JSON.stringify({ slideshow: { title: "Sample" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  };
+  try {
     const definition = Definition.create({
       name: "test-curl",
       attributes: { url: "https://httpbin.org/json" },
     });
 
-    const context = createTestContext();
+    const { context, getResults } = createTestContext();
     const result = await curlModel.methods.download.execute(
       definition,
       context,
     );
 
-    // Check data outputs were created
-    assertExists(result.dataOutputs);
-    assertEquals(result.dataOutputs.length >= 1, true);
+    // Check data handles were created
+    assertExists(result.dataHandles);
+    assertEquals(result.dataHandles.length >= 1, true);
 
     // Check metadata output
-    const metadata = getDataOutputAttributes(result.dataOutputs, "metadata");
+    const metadata = getResultAttributes(getResults(), "metadata");
     assertExists(metadata);
     assertEquals(metadata.url, "https://httpbin.org/json");
     assertEquals(metadata.statusCode, 200);
@@ -258,16 +355,25 @@ Deno.test({
     assertEquals(isNaN(downloadedAt.getTime()), false);
 
     // Check file content was included
-    const fileContent = getFileContent(result.dataOutputs);
+    const fileContent = getFileContent(getResults());
     assertExists(fileContent);
     assertEquals(fileContent.length > 0, true);
-  },
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
-Deno.test({
-  name: "curlModel.methods.download handles custom filename",
-  ignore: !hasNetworkPermission,
-  fn: async () => {
+Deno.test("curlModel.methods.download handles custom filename", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (_input: string | URL | Request, _init?: RequestInit) => {
+    return Promise.resolve(
+      new Response(JSON.stringify({ data: "test" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  };
+  try {
     const definition = Definition.create({
       name: "test-curl-filename",
       attributes: {
@@ -276,34 +382,43 @@ Deno.test({
       },
     });
 
-    const context = createTestContext();
+    const { context, getResults } = createTestContext();
     const result = await curlModel.methods.download.execute(
       definition,
       context,
     );
 
-    assertExists(result.dataOutputs);
-    // The file output should exist
-    const fileOutput = result.dataOutputs.find((d) => d.name.endsWith("-file"));
-    assertExists(fileOutput);
+    assertExists(result.dataHandles);
+    // The file handle should exist
+    const fileHandle = result.dataHandles.find((h) => h.name.endsWith("-file"));
+    assertExists(fileHandle);
 
     // The metadata should contain the custom filename
-    const metadata = getDataOutputAttributes(result.dataOutputs, "metadata");
+    const metadata = getResultAttributes(getResults(), "metadata");
     assertExists(metadata);
     assertEquals(metadata.filename, "custom-response.json");
-  },
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
-Deno.test({
-  name: "curlModel.methods.download handles HTTP errors",
-  ignore: !hasNetworkPermission,
-  fn: async () => {
+Deno.test("curlModel.methods.download handles HTTP errors", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (_input: string | URL | Request, _init?: RequestInit) => {
+    return Promise.resolve(
+      new Response(null, {
+        status: 404,
+        statusText: "Not Found",
+      }),
+    );
+  };
+  try {
     const definition = Definition.create({
       name: "test-curl-error",
       attributes: { url: "https://httpbin.org/status/404" },
     });
 
-    const context = createTestContext();
+    const { context } = createTestContext();
     let error: Error | null = null;
     try {
       await curlModel.methods.download.execute(definition, context);
@@ -313,5 +428,7 @@ Deno.test({
 
     assertEquals(error !== null, true);
     assertEquals(error!.message.includes("404"), true);
-  },
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });

--- a/src/domain/models/data_output_validation_service.ts
+++ b/src/domain/models/data_output_validation_service.ts
@@ -1,5 +1,4 @@
-import type { DataOutput, DataOutputSpecification } from "./model.ts";
-import type { DataOutputOverride } from "./data_output_override.ts";
+import type { DataHandle } from "./model.ts";
 
 export interface DataOutputValidationResult {
   valid: boolean;
@@ -7,88 +6,37 @@ export interface DataOutputValidationResult {
 }
 
 /**
- * Domain service for validating and enhancing data outputs.
+ * Domain service for validating data handles produced by method execution.
+ *
+ * Spec type validation is now enforced at writer creation time by the
+ * DataWriterFactory. This service focuses on detecting duplicate instance
+ * names within a single method execution.
  */
 export class DataOutputValidationService {
   /**
-   * Validates that all data outputs reference declared spec types.
+   * Validates data handles for duplicate instance names.
    */
   validate(
-    dataOutputs: DataOutput[],
-    specs: Record<string, DataOutputSpecification>,
+    dataHandles: DataHandle[],
+    _specs: Record<string, unknown>,
     methodName: string,
   ): DataOutputValidationResult {
     const errors: string[] = [];
-    const declaredSpecTypes = new Set(Object.keys(specs));
-
-    // Check that all outputs reference declared spec types
-    for (const output of dataOutputs) {
-      const specTypeValue = output.specType.value;
-
-      if (!declaredSpecTypes.has(specTypeValue)) {
-        errors.push(
-          `Data output '${output.name}' references undeclared spec type '${specTypeValue}' ` +
-            `in method '${methodName}'. Declared spec types: ${
-              Array.from(declaredSpecTypes).join(", ")
-            }`,
-        );
-      }
-    }
 
     // Check for duplicate instance names
     const names = new Set<string>();
-    for (const output of dataOutputs) {
-      if (names.has(output.name)) {
+    for (const handle of dataHandles) {
+      if (names.has(handle.name)) {
         errors.push(
-          `Duplicate data instance name '${output.name}' in method '${methodName}'`,
+          `Duplicate data instance name '${handle.name}' in method '${methodName}'`,
         );
       }
-      names.add(output.name);
+      names.add(handle.name);
     }
 
     return {
       valid: errors.length === 0,
       errors,
-    };
-  }
-
-  /**
-   * Applies defaults from spec and merges overrides.
-   */
-  applyDefaultsAndOverrides(
-    dataOutput: DataOutput,
-    spec: DataOutputSpecification,
-    overrides?: DataOutputOverride[],
-  ): DataOutput {
-    // Find override for this spec type
-    const override = overrides?.find((o) =>
-      o.specType.equals(dataOutput.specType)
-    );
-
-    return {
-      ...dataOutput,
-      metadata: {
-        ...dataOutput.metadata,
-        contentType: dataOutput.metadata.contentType ??
-          spec.contentType ??
-          "application/json",
-        lifetime: override?.lifetime ??
-          dataOutput.metadata.lifetime ??
-          spec.lifetime ??
-          "infinite",
-        garbageCollection: override?.garbageCollection ??
-          dataOutput.metadata.garbageCollection ??
-          spec.garbageCollection ??
-          10,
-        streaming: dataOutput.metadata.streaming ??
-          spec.streaming ??
-          false,
-        tags: {
-          ...(spec.tags ?? {}),
-          ...(dataOutput.metadata.tags ?? {}),
-          ...(override?.tags ?? {}),
-        },
-      },
     };
   }
 }

--- a/src/domain/models/data_output_validation_service_test.ts
+++ b/src/domain/models/data_output_validation_service_test.ts
@@ -1,11 +1,40 @@
 import { assertEquals } from "@std/assert";
 import { DataOutputValidationService } from "./data_output_validation_service.ts";
 import {
-  type DataOutput,
+  type DataHandle,
   type DataOutputSpecification,
   DataSpecType,
 } from "./model.ts";
-import type { DataOutputOverride } from "./data_output_override.ts";
+import type { DataId } from "../data/data_id.ts";
+
+/**
+ * Creates a test DataHandle with the given spec type and name.
+ */
+function createTestHandle(
+  name: string,
+  specTypeValue: string,
+): DataHandle {
+  return {
+    name,
+    specType: DataSpecType.create(specTypeValue),
+    dataId: `mock-data-${name}` as DataId,
+    version: 1,
+    size: 0,
+    tags: { type: "data" },
+    metadata: {
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      streaming: false,
+      tags: { type: "data" },
+      ownerDefinition: {
+        definitionHash: "hash",
+        ownerType: "model-method",
+        ownerRef: "test",
+      },
+    },
+  };
+}
 
 Deno.test("DataOutputValidationService - validate - accepts valid spec types", () => {
   const service = new DataOutputValidationService();
@@ -14,94 +43,54 @@ Deno.test("DataOutputValidationService - validate - accepts valid spec types", (
     "message": {
       specType: DataSpecType.create("message"),
       description: "Test message",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
     },
     "log": {
       specType: DataSpecType.create("log"),
       description: "Test log",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "log" },
     },
   };
 
-  const dataOutputs: DataOutput[] = [
-    {
-      name: "foo-message",
-      specType: DataSpecType.create("message"),
-      content: new Uint8Array(),
-      metadata: {
-        contentType: "application/json",
-        lifetime: "infinite",
-        garbageCollection: 10,
-        streaming: false,
-        tags: { type: "data" },
-        ownerDefinition: {
-          definitionHash: "hash",
-          ownerType: "model-method",
-          ownerRef: "test",
-        },
-      },
-    },
-    {
-      name: "bar-log",
-      specType: DataSpecType.create("log"),
-      content: new Uint8Array(),
-      metadata: {
-        contentType: "text/plain",
-        lifetime: "ephemeral",
-        garbageCollection: 5,
-        streaming: false,
-        tags: { type: "log" },
-        ownerDefinition: {
-          definitionHash: "hash",
-          ownerType: "model-method",
-          ownerRef: "test",
-        },
-      },
-    },
+  const dataHandles: DataHandle[] = [
+    createTestHandle("foo-message", "message"),
+    createTestHandle("bar-log", "log"),
   ];
 
-  const result = service.validate(dataOutputs, specs, "testMethod");
+  const result = service.validate(dataHandles, specs, "testMethod");
 
   assertEquals(result.valid, true);
   assertEquals(result.errors, []);
 });
 
-Deno.test("DataOutputValidationService - validate - detects undeclared spec type", () => {
+Deno.test("DataOutputValidationService - validate - passes for spec types not in specs (checked at writer creation)", () => {
   const service = new DataOutputValidationService();
 
   const specs: Record<string, DataOutputSpecification> = {
     "message": {
       specType: DataSpecType.create("message"),
       description: "Test message",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
     },
   };
 
-  const dataOutputs: DataOutput[] = [
-    {
-      name: "foo-unknown",
-      specType: DataSpecType.create("unknown"),
-      content: new Uint8Array(),
-      metadata: {
-        contentType: "application/json",
-        lifetime: "infinite",
-        garbageCollection: 10,
-        streaming: false,
-        tags: { type: "data" },
-        ownerDefinition: {
-          definitionHash: "hash",
-          ownerType: "model-method",
-          ownerRef: "test",
-        },
-      },
-    },
+  const dataHandles: DataHandle[] = [
+    createTestHandle("foo-unknown", "unknown"),
   ];
 
-  const result = service.validate(dataOutputs, specs, "testMethod");
+  const result = service.validate(dataHandles, specs, "testMethod");
 
-  assertEquals(result.valid, false);
-  assertEquals(result.errors.length, 1);
-  assertEquals(
-    result.errors[0],
-    "Data output 'foo-unknown' references undeclared spec type 'unknown' in method 'testMethod'. Declared spec types: message",
-  );
+  assertEquals(result.valid, true);
+  assertEquals(result.errors, []);
 });
 
 Deno.test("DataOutputValidationService - validate - detects duplicate instance names", () => {
@@ -111,47 +100,19 @@ Deno.test("DataOutputValidationService - validate - detects duplicate instance n
     "message": {
       specType: DataSpecType.create("message"),
       description: "Test message",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
     },
   };
 
-  const dataOutputs: DataOutput[] = [
-    {
-      name: "duplicate",
-      specType: DataSpecType.create("message"),
-      content: new Uint8Array(),
-      metadata: {
-        contentType: "application/json",
-        lifetime: "infinite",
-        garbageCollection: 10,
-        streaming: false,
-        tags: { type: "data" },
-        ownerDefinition: {
-          definitionHash: "hash",
-          ownerType: "model-method",
-          ownerRef: "test",
-        },
-      },
-    },
-    {
-      name: "duplicate",
-      specType: DataSpecType.create("message"),
-      content: new Uint8Array(),
-      metadata: {
-        contentType: "application/json",
-        lifetime: "infinite",
-        garbageCollection: 10,
-        streaming: false,
-        tags: { type: "data" },
-        ownerDefinition: {
-          definitionHash: "hash",
-          ownerType: "model-method",
-          ownerRef: "test",
-        },
-      },
-    },
+  const dataHandles: DataHandle[] = [
+    createTestHandle("duplicate", "message"),
+    createTestHandle("duplicate", "message"),
   ];
 
-  const result = service.validate(dataOutputs, specs, "testMethod");
+  const result = service.validate(dataHandles, specs, "testMethod");
 
   assertEquals(result.valid, false);
   assertEquals(result.errors.length, 1);
@@ -159,184 +120,4 @@ Deno.test("DataOutputValidationService - validate - detects duplicate instance n
     result.errors[0],
     "Duplicate data instance name 'duplicate' in method 'testMethod'",
   );
-});
-
-Deno.test("DataOutputValidationService - applyDefaultsAndOverrides - applies spec defaults", () => {
-  const service = new DataOutputValidationService();
-
-  const spec: DataOutputSpecification = {
-    specType: DataSpecType.create("message"),
-    contentType: "text/plain",
-    lifetime: "ephemeral",
-    garbageCollection: 5,
-    streaming: true,
-    tags: { specTag: "specValue" },
-  };
-
-  const dataOutput: DataOutput = {
-    name: "test-message",
-    specType: DataSpecType.create("message"),
-    content: new Uint8Array(),
-    metadata: {
-      contentType: "application/json",
-      lifetime: "infinite",
-      garbageCollection: 10,
-      streaming: false,
-      tags: { type: "data" },
-      ownerDefinition: {
-        definitionHash: "hash",
-        ownerType: "model-method",
-        ownerRef: "test",
-      },
-    },
-  };
-
-  const result = service.applyDefaultsAndOverrides(dataOutput, spec);
-
-  // Existing values should be preserved
-  assertEquals(result.metadata.contentType, "application/json");
-  assertEquals(result.metadata.lifetime, "infinite");
-  assertEquals(result.metadata.garbageCollection, 10);
-  assertEquals(result.metadata.streaming, false);
-
-  // Tags should be merged (spec tags + metadata tags)
-  assertEquals(result.metadata.tags, {
-    specTag: "specValue",
-    type: "data",
-  });
-});
-
-Deno.test("DataOutputValidationService - applyDefaultsAndOverrides - fills missing values from spec", () => {
-  const service = new DataOutputValidationService();
-
-  const spec: DataOutputSpecification = {
-    specType: DataSpecType.create("message"),
-    contentType: "text/plain",
-    lifetime: "ephemeral",
-    garbageCollection: 5,
-    streaming: true,
-    tags: { specTag: "specValue" },
-  };
-
-  const dataOutput: DataOutput = {
-    name: "test-message",
-    specType: DataSpecType.create("message"),
-    content: new Uint8Array(),
-    metadata: {
-      contentType: "application/json",
-      lifetime: "infinite",
-      garbageCollection: 10,
-      streaming: false,
-      tags: { type: "data" },
-      ownerDefinition: {
-        definitionHash: "hash",
-        ownerType: "model-method",
-        ownerRef: "test",
-      },
-    },
-  };
-
-  // Remove some metadata to test defaults
-  delete (dataOutput.metadata as { contentType?: string }).contentType;
-  delete (dataOutput.metadata as { lifetime?: string }).lifetime;
-
-  const result = service.applyDefaultsAndOverrides(dataOutput, spec);
-
-  // Should use spec defaults
-  assertEquals(result.metadata.contentType, "text/plain");
-  assertEquals(result.metadata.lifetime, "ephemeral");
-});
-
-Deno.test("DataOutputValidationService - applyDefaultsAndOverrides - applies overrides", () => {
-  const service = new DataOutputValidationService();
-
-  const spec: DataOutputSpecification = {
-    specType: DataSpecType.create("message"),
-    contentType: "text/plain",
-    lifetime: "ephemeral",
-    garbageCollection: 5,
-    tags: { specTag: "specValue" },
-  };
-
-  const dataOutput: DataOutput = {
-    name: "test-message",
-    specType: DataSpecType.create("message"),
-    content: new Uint8Array(),
-    metadata: {
-      contentType: "application/json",
-      lifetime: "infinite",
-      garbageCollection: 10,
-      streaming: false,
-      tags: { type: "data" },
-      ownerDefinition: {
-        definitionHash: "hash",
-        ownerType: "model-method",
-        ownerRef: "test",
-      },
-    },
-  };
-
-  const overrides: DataOutputOverride[] = [
-    {
-      specType: DataSpecType.create("message"),
-      lifetime: "7d",
-      garbageCollection: 20,
-      tags: { overrideTag: "overrideValue" },
-    },
-  ];
-
-  const result = service.applyDefaultsAndOverrides(dataOutput, spec, overrides);
-
-  // Overrides should take precedence
-  assertEquals(result.metadata.lifetime, "7d");
-  assertEquals(result.metadata.garbageCollection, 20);
-
-  // Tags should be merged (spec + metadata + override)
-  assertEquals(result.metadata.tags, {
-    specTag: "specValue",
-    type: "data",
-    overrideTag: "overrideValue",
-  });
-});
-
-Deno.test("DataOutputValidationService - applyDefaultsAndOverrides - uses hardcoded defaults when spec has no defaults", () => {
-  const service = new DataOutputValidationService();
-
-  const spec: DataOutputSpecification = {
-    specType: DataSpecType.create("message"),
-    // No defaults provided
-  };
-
-  const dataOutput: DataOutput = {
-    name: "test-message",
-    specType: DataSpecType.create("message"),
-    content: new Uint8Array(),
-    metadata: {
-      contentType: "application/json",
-      lifetime: "infinite",
-      garbageCollection: 10,
-      streaming: false,
-      tags: { type: "data" },
-      ownerDefinition: {
-        definitionHash: "hash",
-        ownerType: "model-method",
-        ownerRef: "test",
-      },
-    },
-  };
-
-  // Remove metadata to test hardcoded defaults
-  delete (dataOutput.metadata as { contentType?: string }).contentType;
-  delete (dataOutput.metadata as { lifetime?: string }).lifetime;
-  delete (dataOutput.metadata as { garbageCollection?: number })
-    .garbageCollection;
-  delete (dataOutput.metadata as { streaming?: boolean }).streaming;
-
-  const result = service.applyDefaultsAndOverrides(dataOutput, spec);
-
-  // Should use hardcoded defaults
-  assertEquals(result.metadata.contentType, "application/json");
-  assertEquals(result.metadata.lifetime, "infinite");
-  assertEquals(result.metadata.garbageCollection, 10);
-  assertEquals(result.metadata.streaming, false);
 });

--- a/src/domain/models/data_spec_type_test.ts
+++ b/src/domain/models/data_spec_type_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertThrows } from "@std/assert";
-import { DataSpecType } from "./model.ts";
+import { DataSpecType, normalizeSpecType } from "./model.ts";
 
 Deno.test("DataSpecType - create - trims whitespace", () => {
   const specType = DataSpecType.create("  message  ");
@@ -37,4 +37,36 @@ Deno.test("DataSpecType - equals - returns false for different value", () => {
 Deno.test("DataSpecType - toString - returns value", () => {
   const specType = DataSpecType.create("message");
   assertEquals(specType.toString(), "message");
+});
+
+Deno.test("normalizeSpecType - converts string to DataSpecType", () => {
+  const result = normalizeSpecType("data");
+  assertEquals(result.value, "data");
+});
+
+Deno.test("normalizeSpecType - passes through existing DataSpecType", () => {
+  const original = DataSpecType.create("resource");
+  const result = normalizeSpecType(original);
+  assertEquals(result, original);
+});
+
+Deno.test("normalizeSpecType - trims whitespace from string", () => {
+  const result = normalizeSpecType("  data  ");
+  assertEquals(result.value, "data");
+});
+
+Deno.test("normalizeSpecType - throws on empty string", () => {
+  assertThrows(
+    () => normalizeSpecType(""),
+    Error,
+    "Data spec type cannot be empty",
+  );
+});
+
+Deno.test("normalizeSpecType - throws on whitespace-only string", () => {
+  assertThrows(
+    () => normalizeSpecType("   "),
+    Error,
+    "Data spec type cannot be empty",
+  );
 });

--- a/src/domain/models/data_writer.ts
+++ b/src/domain/models/data_writer.ts
@@ -1,0 +1,401 @@
+import { Data } from "../data/mod.ts";
+import type { DataId, OwnerDefinition } from "../data/mod.ts";
+import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import type { ModelType } from "./model_type.ts";
+import {
+  type DataHandle,
+  type DataOutputSpecification,
+  type DataWriter,
+  type DataWriterCallbacks,
+  type DataWriterFactory,
+  normalizeSpecType,
+  type ResolvedDataWriterOptions,
+  type SpecBasedWriterOptions,
+} from "./model.ts";
+import type { DataSpecType } from "./model.ts";
+
+/**
+ * Default implementation of the DataWriter domain service.
+ *
+ * Writes data directly to disk during method execution, returning
+ * lightweight DataHandle references instead of buffering full content.
+ */
+export class DefaultDataWriter implements DataWriter {
+  readonly dataId: DataId;
+  readonly name: string;
+
+  private readonly repo: UnifiedDataRepository;
+  private readonly modelType: ModelType;
+  private readonly modelId: string;
+  private readonly options: ResolvedDataWriterOptions;
+  private readonly normalizedSpecType: DataSpecType;
+  private readonly callbacks: DataWriterCallbacks;
+
+  private allocated: { version: number; contentPath: string } | null = null;
+  private data: Data | null = null;
+  private lineBuffer: string[] | null = null;
+  private finalized = false;
+
+  constructor(
+    repo: UnifiedDataRepository,
+    modelType: ModelType,
+    modelId: string,
+    options: ResolvedDataWriterOptions,
+    callbacks: DataWriterCallbacks = {},
+  ) {
+    this.repo = repo;
+    this.modelType = modelType;
+    this.modelId = modelId;
+    this.options = options;
+    this.normalizedSpecType = normalizeSpecType(options.specType);
+    this.callbacks = callbacks;
+    this.dataId = repo.nextId();
+    this.name = options.name;
+  }
+
+  async writeAll(content: Uint8Array): Promise<DataHandle> {
+    this.ensureNotFinalized();
+    const data = this.createDataEntity();
+
+    const saveResult = await this.repo.save(
+      this.modelType,
+      this.modelId,
+      data,
+      content,
+    );
+
+    this.finalized = true;
+    return this.buildHandle(saveResult.version, content.length);
+  }
+
+  writeText(text: string): Promise<DataHandle> {
+    return this.writeAll(new TextEncoder().encode(text));
+  }
+
+  async writeLine(line: string): Promise<void> {
+    this.ensureNotFinalized();
+
+    if (!this.allocated) {
+      // First call: allocate version and create initial empty file
+      const data = this.createDataEntity();
+      this.data = data;
+      this.allocated = await this.repo.allocateVersion(
+        this.modelType,
+        this.modelId,
+        data,
+      );
+      // Write empty file to create it
+      await Deno.writeFile(this.allocated.contentPath, new Uint8Array());
+      this.lineBuffer = [];
+    }
+
+    // Append line
+    const lineContent = line + "\n";
+    const file = await Deno.open(this.allocated.contentPath, { append: true });
+    try {
+      await file.write(new TextEncoder().encode(lineContent));
+    } finally {
+      file.close();
+    }
+
+    this.lineBuffer!.push(line);
+
+    // Invoke callback
+    if (this.callbacks.onLine) {
+      this.callbacks.onLine(this.name, line);
+    }
+  }
+
+  async writeStream(
+    stream: ReadableStream<Uint8Array>,
+    options?: { onLine?: (line: string) => void },
+  ): Promise<DataHandle> {
+    this.ensureNotFinalized();
+
+    const data = this.createDataEntity();
+    this.data = data;
+    this.allocated = await this.repo.allocateVersion(
+      this.modelType,
+      this.modelId,
+      data,
+    );
+
+    // Open file for writing
+    const file = await Deno.open(this.allocated.contentPath, {
+      write: true,
+      create: true,
+      truncate: true,
+    });
+
+    try {
+      const reader = stream.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        // Write raw bytes to file
+        await file.write(value);
+
+        // Decode for line callbacks if needed
+        if (options?.onLine || this.callbacks.onLine) {
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+
+          for (let i = 0; i < lines.length - 1; i++) {
+            const line = lines[i];
+            options?.onLine?.(line);
+            this.callbacks.onLine?.(this.name, line);
+          }
+
+          buffer = lines[lines.length - 1];
+        }
+      }
+
+      // Process remaining buffer
+      if (buffer && (options?.onLine || this.callbacks.onLine)) {
+        options?.onLine?.(buffer);
+        this.callbacks.onLine?.(this.name, buffer);
+      }
+    } finally {
+      file.close();
+    }
+
+    return this.finalize();
+  }
+
+  async getFilePath(): Promise<string> {
+    this.ensureNotFinalized();
+
+    if (!this.allocated) {
+      const data = this.createDataEntity();
+      this.data = data;
+      this.allocated = await this.repo.allocateVersion(
+        this.modelType,
+        this.modelId,
+        data,
+      );
+    }
+
+    return this.allocated.contentPath;
+  }
+
+  async finalize(): Promise<DataHandle> {
+    this.ensureNotFinalized();
+
+    if (!this.allocated || !this.data) {
+      throw new Error(
+        `DataWriter "${this.name}" has not been used — nothing to finalize`,
+      );
+    }
+
+    const { size, checksum: _checksum } = await this.repo.finalizeVersion(
+      this.modelType,
+      this.modelId,
+      this.data,
+      this.allocated.version,
+    );
+
+    this.finalized = true;
+    return this.buildHandle(this.allocated.version, size);
+  }
+
+  private get ownerDefinition(): OwnerDefinition {
+    return this.options.ownerDefinition ?? {
+      definitionHash: "",
+      ownerType: "model-method",
+      ownerRef: this.modelId,
+    };
+  }
+
+  private createDataEntity(): Data {
+    return Data.create({
+      id: this.dataId,
+      name: this.options.name,
+      version: 1, // Will be updated by repo operations
+      contentType: this.options.contentType,
+      lifetime: this.options.lifetime,
+      garbageCollection: this.options.garbageCollection,
+      streaming: this.options.streaming ?? false,
+      tags: this.options.tags,
+      ownerDefinition: this.ownerDefinition,
+    });
+  }
+
+  private buildHandle(version: number, size: number): DataHandle {
+    return {
+      name: this.options.name,
+      specType: this.normalizedSpecType,
+      dataId: this.dataId,
+      version,
+      size,
+      tags: { ...this.options.tags },
+      metadata: {
+        contentType: this.options.contentType,
+        lifetime: this.options.lifetime,
+        garbageCollection: this.options.garbageCollection,
+        streaming: this.options.streaming ?? false,
+        tags: { ...this.options.tags },
+        ownerDefinition: { ...this.ownerDefinition },
+      },
+    };
+  }
+
+  private ensureNotFinalized(): void {
+    if (this.finalized) {
+      throw new Error(
+        `DataWriter "${this.name}" has already been finalized`,
+      );
+    }
+  }
+}
+
+/**
+ * Creates a DataWriterFactory bound to a specific execution context.
+ *
+ * The factory resolves spec-based options against the model's declared
+ * DataOutputSpecifications, merges workflow overrides, and produces
+ * fully-resolved DefaultDataWriter instances.
+ *
+ * @param repo - The unified data repository
+ * @param modelType - The model type
+ * @param modelId - The model ID (definition ID)
+ * @param definitionHash - The definition hash for ownership
+ * @param dataOutputSpecs - The model's declared data output specifications
+ * @param tagOverrides - Tags merged into every writer (e.g., workflow step tags)
+ * @param dataOutputOverrides - Overrides merged into every writer's options
+ * @param callbacks - Optional callbacks for streaming events
+ * @returns A tuple of [factory, getHandles] where getHandles returns all completed handles
+ */
+export function createDataWriterFactory(
+  repo: UnifiedDataRepository,
+  modelType: ModelType,
+  modelId: string,
+  definitionHash: string,
+  dataOutputSpecs: Record<string, DataOutputSpecification>,
+  tagOverrides?: Record<string, string>,
+  dataOutputOverrides?: Array<{
+    specType: string;
+    lifetime?: string;
+    garbageCollection?: string | number;
+    tags?: Record<string, string>;
+  }>,
+  callbacks?: DataWriterCallbacks,
+): { factory: DataWriterFactory; getHandles: () => DataHandle[] } {
+  const handles: DataHandle[] = [];
+  const writers: DefaultDataWriter[] = [];
+
+  const factory: DataWriterFactory = (options: SpecBasedWriterOptions) => {
+    // Look up the spec — fail fast if not declared
+    const spec = dataOutputSpecs[options.specType];
+    if (!spec) {
+      const declared = Object.keys(dataOutputSpecs).join(", ");
+      throw new Error(
+        `Undeclared spec type '${options.specType}' in model '${modelType.normalized}'. ` +
+          `Declared spec types: ${declared || "(none)"}`,
+      );
+    }
+
+    // Resolve: spec defaults -> call-site overrides
+    const resolvedTags = {
+      ...spec.tags,
+      ...(options.tags ?? {}),
+    };
+
+    let resolvedOptions: ResolvedDataWriterOptions = {
+      name: options.name,
+      specType: spec.specType,
+      contentType: options.contentType ?? spec.contentType,
+      lifetime: options.lifetime ?? spec.lifetime,
+      garbageCollection: options.garbageCollection ?? spec.garbageCollection,
+      streaming: options.streaming ?? spec.streaming,
+      tags: resolvedTags,
+    };
+
+    // Apply workflow tag overrides
+    if (tagOverrides) {
+      resolvedOptions = {
+        ...resolvedOptions,
+        tags: {
+          ...resolvedOptions.tags,
+          ...tagOverrides,
+        },
+      };
+    }
+
+    // Apply data output overrides for this spec type
+    if (dataOutputOverrides) {
+      const normalizedSpec = normalizeSpecType(resolvedOptions.specType);
+      const override = dataOutputOverrides.find(
+        (o) => o.specType === normalizedSpec.value,
+      );
+      if (override) {
+        resolvedOptions = {
+          ...resolvedOptions,
+          lifetime: override.lifetime ?? resolvedOptions.lifetime,
+          garbageCollection: override.garbageCollection ??
+            resolvedOptions.garbageCollection,
+          tags: {
+            ...resolvedOptions.tags,
+            ...(override.tags ?? {}),
+          },
+        };
+      }
+    }
+
+    // Set ownership from definitionHash
+    resolvedOptions.ownerDefinition = {
+      ownerType: "model-method",
+      ownerRef: modelId,
+      definitionHash,
+    };
+
+    const writer = new DefaultDataWriter(
+      repo,
+      modelType,
+      modelId,
+      resolvedOptions,
+      callbacks,
+    );
+    writers.push(writer);
+
+    // Wrap write methods to track handles
+    const originalWriteAll = writer.writeAll.bind(writer);
+    const originalWriteText = writer.writeText.bind(writer);
+    const originalWriteStream = writer.writeStream.bind(writer);
+    const originalFinalize = writer.finalize.bind(writer);
+
+    writer.writeAll = async (content: Uint8Array) => {
+      const handle = await originalWriteAll(content);
+      handles.push(handle);
+      return handle;
+    };
+
+    writer.writeText = async (text: string) => {
+      const handle = await originalWriteText(text);
+      handles.push(handle);
+      return handle;
+    };
+
+    writer.writeStream = async (
+      stream: ReadableStream<Uint8Array>,
+      opts?: { onLine?: (line: string) => void },
+    ) => {
+      const handle = await originalWriteStream(stream, opts);
+      handles.push(handle);
+      return handle;
+    };
+
+    writer.finalize = async () => {
+      const handle = await originalFinalize();
+      handles.push(handle);
+      return handle;
+    };
+
+    return writer;
+  };
+
+  return { factory, getHandles: () => [...handles] };
+}

--- a/src/domain/models/echo/echo_model.ts
+++ b/src/domain/models/echo/echo_model.ts
@@ -47,7 +47,7 @@ export const ECHO_MODEL_TYPE = ModelType.create("swamp/echo");
  */
 async function executeWrite(
   definition: Definition,
-  _context: MethodContext,
+  context: MethodContext,
 ): Promise<MethodResult> {
   // Validate definition attributes
   const attrs = EchoInputAttributesSchema.parse(definition.attributes);
@@ -58,27 +58,14 @@ async function executeWrite(
     timestamp: new Date().toISOString(),
   };
 
-  const definitionHash = await definition.computeHash();
+  const writer = context.createDataWriter!({
+    name: `${definition.name}-message`,
+    specType: "message",
+  });
 
-  return {
-    dataOutputs: [{
-      name: `${definition.name}-message`,
-      specType: DataSpecType.create("message"),
-      content: new TextEncoder().encode(JSON.stringify(dataAttributes)),
-      metadata: {
-        contentType: "application/json",
-        lifetime: "ephemeral",
-        garbageCollection: 10,
-        streaming: false,
-        tags: { type: "data" },
-        ownerDefinition: {
-          definitionHash,
-          ownerType: "model-method",
-          ownerRef: "write",
-        },
-      },
-    }],
-  };
+  const handle = await writer.writeText(JSON.stringify(dataAttributes));
+
+  return { dataHandles: [handle] };
 }
 
 /**

--- a/src/domain/models/echo/echo_model_test.ts
+++ b/src/domain/models/echo/echo_model_test.ts
@@ -9,11 +9,117 @@ import {
   EchoInputAttributesSchema,
   echoModel,
 } from "./echo_model.ts";
-import type { MethodContext } from "../model.ts";
+import { normalizeSpecType } from "../model.ts";
+import type {
+  DataHandle,
+  DataWriter,
+  DataWriterFactory,
+  MethodContext,
+  SpecBasedWriterOptions,
+} from "../model.ts";
 import type { UnifiedDataRepository } from "../../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../../definitions/repositories.ts";
-import { generateDataId } from "../../data/data_id.ts";
+import { type DataId, generateDataId } from "../../data/data_id.ts";
 import { getLogger } from "@logtape/logtape";
+
+/**
+ * Stored result from mock data writer.
+ */
+interface MockWriterResult {
+  handle: DataHandle;
+  content: Uint8Array;
+}
+
+/**
+ * Creates a mock DataWriterFactory that stores written content in memory.
+ */
+function createMockDataWriterFactory(): {
+  factory: DataWriterFactory;
+  getResults: () => MockWriterResult[];
+} {
+  const results: MockWriterResult[] = [];
+  const getResults = (): MockWriterResult[] => results;
+  let nextId = 1;
+
+  const factory: DataWriterFactory = (
+    options: SpecBasedWriterOptions,
+  ): DataWriter => {
+    const dataId = `mock-data-${nextId++}` as DataId;
+
+    const buildHandle = (content: Uint8Array): DataHandle => ({
+      name: options.name,
+      specType: normalizeSpecType(options.specType),
+      dataId,
+      version: 1,
+      size: content.length,
+      tags: { ...(options.tags ?? {}) },
+      metadata: {
+        contentType: options.contentType ?? "application/json",
+        lifetime: options.lifetime ?? "infinite",
+        garbageCollection: options.garbageCollection ?? 10,
+        streaming: options.streaming ?? false,
+        tags: { ...(options.tags ?? {}) },
+        ownerDefinition: {
+          definitionHash: "test-hash",
+          ownerType: "model-method",
+          ownerRef: "test",
+        },
+      },
+    });
+
+    return {
+      dataId,
+      name: options.name,
+      writeAll(content: Uint8Array): Promise<DataHandle> {
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeText(text: string): Promise<DataHandle> {
+        const content = new TextEncoder().encode(text);
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeLine(_line: string): Promise<void> {
+        return Promise.resolve();
+      },
+      writeStream(
+        _stream: ReadableStream<Uint8Array>,
+      ): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      getFilePath(): Promise<string> {
+        return Promise.resolve("/tmp/mock");
+      },
+      finalize(): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+    } as DataWriter;
+  };
+
+  return { factory, getResults };
+}
+
+/**
+ * Helper to get parsed JSON content from mock results by name.
+ */
+function getResultAttributes(
+  results: MockWriterResult[],
+  namePart: string,
+): Record<string, unknown> {
+  const result = results.find((r) => r.handle.name.includes(namePart));
+  if (!result) {
+    throw new Error(`No result found with name containing "${namePart}"`);
+  }
+  return JSON.parse(new TextDecoder().decode(result.content));
+}
 
 /**
  * Creates a mock UnifiedDataRepository for testing.
@@ -35,6 +141,10 @@ function createMockDataRepo(): UnifiedDataRepository {
     getContentPath: () => "",
     collectGarbage: () =>
       Promise.resolve({ versionsRemoved: 0, bytesReclaimed: 0 }),
+    allocateVersion: () =>
+      Promise.resolve({ version: 1, contentPath: "/tmp/mock" }),
+    finalizeVersion: () =>
+      Promise.resolve({ size: 0, checksum: "mock-checksum" }),
   };
 }
 
@@ -58,31 +168,21 @@ function createMockDefinitionRepo(): DefinitionRepository {
 /**
  * Creates a test MethodContext with mocked repositories.
  */
-function createTestContext(): MethodContext {
-  return {
+function createTestContext(): {
+  context: MethodContext;
+  getResults: () => MockWriterResult[];
+} {
+  const { factory, getResults } = createMockDataWriterFactory();
+  const context: MethodContext = {
     repoDir: "/tmp",
     modelType: ECHO_MODEL_TYPE,
     modelId: crypto.randomUUID(),
     logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
+    createDataWriter: factory,
   };
-}
-
-/**
- * Helper to get attributes from a DataOutput.
- */
-function getDataOutputAttributes(
-  dataOutputs: { content: Uint8Array }[] | undefined,
-  index = 0,
-): Record<string, unknown> | undefined {
-  if (!dataOutputs || dataOutputs.length <= index) {
-    return undefined;
-  }
-  const content = new TextDecoder().decode(dataOutputs[index].content);
-  const parsed = JSON.parse(content);
-  // Handle wrapped attributes format
-  return parsed.attributes ?? parsed;
+  return { context, getResults };
 }
 
 Deno.test("ECHO_MODEL_TYPE has correct normalized type", () => {
@@ -145,10 +245,13 @@ Deno.test("echoModel.methods.write executes correctly", async () => {
     attributes: { message: "hello world" },
   });
 
-  const context = createTestContext();
+  const { context, getResults } = createTestContext();
   const result = await echoModel.methods.write.execute(definition, context);
 
-  const attrs = getDataOutputAttributes(result.dataOutputs);
+  assertEquals(result.dataHandles !== undefined, true);
+  assertEquals(result.dataHandles!.length, 1);
+
+  const attrs = getResultAttributes(getResults(), "message");
   assertEquals(attrs?.message, "hello world");
   assertEquals(typeof attrs?.timestamp, "string");
 
@@ -163,7 +266,7 @@ Deno.test("echoModel.methods.write validates input attributes", async () => {
     attributes: { notAMessage: "value" },
   });
 
-  const context = createTestContext();
+  const { context } = createTestContext();
   let error: Error | null = null;
   try {
     await echoModel.methods.write.execute(definition, context);
@@ -180,7 +283,7 @@ Deno.test("echoModel.methods.write rejects empty message", async () => {
     attributes: { message: "" },
   });
 
-  const context = createTestContext();
+  const { context } = createTestContext();
   let error: Error | null = null;
   try {
     await echoModel.methods.write.execute(definition, context);

--- a/src/domain/models/keeb/shell/shell_model.ts
+++ b/src/domain/models/keeb/shell/shell_model.ts
@@ -94,8 +94,6 @@ async function executeCommand(
     exitCode = -1;
   }
 
-  const definitionHash = await definition.computeHash();
-
   // Create data attributes for the result
   const resultAttributes = {
     exitCode,
@@ -116,44 +114,22 @@ async function executeCommand(
   }
   const outputLogContent = outputLogParts.join("\n");
 
-  return {
-    dataOutputs: [
-      {
-        name: `${definition.name}-result`,
-        specType: DataSpecType.create("result"),
-        content: new TextEncoder().encode(JSON.stringify(resultAttributes)),
-        metadata: {
-          contentType: "application/json",
-          lifetime: "infinite",
-          garbageCollection: 10,
-          streaming: false,
-          tags: { type: "data" },
-          ownerDefinition: {
-            definitionHash,
-            ownerType: "model-method",
-            ownerRef: "execute",
-          },
-        },
-      },
-      {
-        name: `${definition.name}-output`,
-        specType: DataSpecType.create("log"),
-        content: new TextEncoder().encode(outputLogContent),
-        metadata: {
-          contentType: "text/plain",
-          lifetime: "infinite",
-          garbageCollection: 10,
-          streaming: true,
-          tags: { type: "log" },
-          ownerDefinition: {
-            definitionHash,
-            ownerType: "model-method",
-            ownerRef: "execute",
-          },
-        },
-      },
-    ],
-  };
+  const resultWriter = context.createDataWriter!({
+    name: `${definition.name}-result`,
+    specType: "result",
+  });
+
+  const logWriter = context.createDataWriter!({
+    name: `${definition.name}-output`,
+    specType: "log",
+  });
+
+  const resultHandle = await resultWriter.writeText(
+    JSON.stringify(resultAttributes),
+  );
+  const logHandle = await logWriter.writeText(outputLogContent);
+
+  return { dataHandles: [resultHandle, logHandle] };
 }
 
 /**
@@ -186,6 +162,7 @@ export const shellModel: ModelDefinition<
       contentType: "text/plain",
       lifetime: "infinite",
       garbageCollection: 10,
+      streaming: true,
       tags: { type: "log" },
     },
   },

--- a/src/domain/models/keeb/shell/shell_model_test.ts
+++ b/src/domain/models/keeb/shell/shell_model_test.ts
@@ -9,11 +9,124 @@ import {
   ShellInputAttributesSchema,
   shellModel,
 } from "./shell_model.ts";
-import type { MethodContext } from "../../model.ts";
+import { normalizeSpecType } from "../../model.ts";
+import type {
+  DataHandle,
+  DataWriter,
+  DataWriterFactory,
+  MethodContext,
+  SpecBasedWriterOptions,
+} from "../../model.ts";
 import type { UnifiedDataRepository } from "../../../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../../../definitions/repositories.ts";
-import { generateDataId } from "../../../data/data_id.ts";
+import { type DataId, generateDataId } from "../../../data/data_id.ts";
 import { getLogger } from "@logtape/logtape";
+
+/**
+ * Stored result from mock data writer.
+ */
+interface MockWriterResult {
+  handle: DataHandle;
+  content: Uint8Array;
+}
+
+/**
+ * Creates a mock DataWriterFactory that stores written content in memory.
+ */
+function createMockDataWriterFactory(): {
+  factory: DataWriterFactory;
+  getResults: () => MockWriterResult[];
+} {
+  const results: MockWriterResult[] = [];
+  const getResults = (): MockWriterResult[] => results;
+  let nextId = 1;
+
+  const factory: DataWriterFactory = (
+    options: SpecBasedWriterOptions,
+  ): DataWriter => {
+    const dataId = `mock-data-${nextId++}` as DataId;
+
+    const buildHandle = (content: Uint8Array): DataHandle => ({
+      name: options.name,
+      specType: normalizeSpecType(options.specType),
+      dataId,
+      version: 1,
+      size: content.length,
+      tags: { ...(options.tags ?? {}) },
+      metadata: {
+        contentType: options.contentType ?? "application/json",
+        lifetime: options.lifetime ?? "infinite",
+        garbageCollection: options.garbageCollection ?? 10,
+        streaming: options.streaming ?? false,
+        tags: { ...(options.tags ?? {}) },
+        ownerDefinition: {
+          definitionHash: "test-hash",
+          ownerType: "model-method",
+          ownerRef: "test",
+        },
+      },
+    });
+
+    return {
+      dataId,
+      name: options.name,
+      writeAll(content: Uint8Array): Promise<DataHandle> {
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeText(text: string): Promise<DataHandle> {
+        const content = new TextEncoder().encode(text);
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeLine(_line: string): Promise<void> {
+        return Promise.resolve();
+      },
+      writeStream(
+        _stream: ReadableStream<Uint8Array>,
+      ): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      getFilePath(): Promise<string> {
+        return Promise.resolve("/tmp/mock");
+      },
+      finalize(): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+    } as DataWriter;
+  };
+
+  return { factory, getResults };
+}
+
+/**
+ * Helper to get parsed JSON content from mock results by name.
+ */
+function getResultAttributes(
+  results: MockWriterResult[],
+  namePart: string,
+): Record<string, unknown> | undefined {
+  const result = results.find((r) => r.handle.name.includes(namePart));
+  if (!result) return undefined;
+  return JSON.parse(new TextDecoder().decode(result.content));
+}
+
+/**
+ * Helper to get output log content as string.
+ */
+function getOutputLogContent(results: MockWriterResult[]): string {
+  const logResult = results.find((r) => r.handle.name.includes("output"));
+  if (!logResult) return "";
+  return new TextDecoder().decode(logResult.content);
+}
 
 /**
  * Creates a mock UnifiedDataRepository for testing.
@@ -35,6 +148,10 @@ function createMockDataRepo(): UnifiedDataRepository {
     getContentPath: () => "",
     collectGarbage: () =>
       Promise.resolve({ versionsRemoved: 0, bytesReclaimed: 0 }),
+    allocateVersion: () =>
+      Promise.resolve({ version: 1, contentPath: "/tmp/mock" }),
+    finalizeVersion: () =>
+      Promise.resolve({ size: 0, checksum: "mock-checksum" }),
   };
 }
 
@@ -60,42 +177,22 @@ function createMockDefinitionRepo(): DefinitionRepository {
  */
 function createTestContext(
   overrides?: Partial<MethodContext>,
-): MethodContext {
-  return {
+): {
+  context: MethodContext;
+  getResults: () => MockWriterResult[];
+} {
+  const { factory, getResults } = createMockDataWriterFactory();
+  const context: MethodContext = {
     repoDir: "/tmp",
     modelType: SHELL_MODEL_TYPE,
     modelId: crypto.randomUUID(),
     logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
+    createDataWriter: factory,
     ...overrides,
   };
-}
-
-/**
- * Helper to get attributes from a DataOutput by name.
- */
-function getDataOutputAttributes(
-  dataOutputs: { name: string; content: Uint8Array }[] | undefined,
-  name: string,
-): Record<string, unknown> | undefined {
-  const dataOutput = dataOutputs?.find((d) => d.name.includes(name));
-  if (!dataOutput) return undefined;
-  const content = new TextDecoder().decode(dataOutput.content);
-  const parsed = JSON.parse(content);
-  // Handle wrapped attributes format
-  return parsed.attributes ?? parsed;
-}
-
-/**
- * Helper to get output log content as string.
- */
-function getOutputLogContent(
-  dataOutputs: { name: string; content: Uint8Array }[] | undefined,
-): string {
-  const logOutput = dataOutputs?.find((d) => d.name.includes("output"));
-  if (!logOutput) return "";
-  return new TextDecoder().decode(logOutput.content);
+  return { context, getResults };
 }
 
 Deno.test("SHELL_MODEL_TYPE has correct normalized type", () => {
@@ -208,18 +305,18 @@ Deno.test("shellModel.methods.execute runs simple command", async () => {
     attributes: { run: "echo hello" },
   });
 
-  const context = createTestContext();
-  const result = await shellModel.methods.execute.execute(definition, context);
+  const { context, getResults } = createTestContext();
+  await shellModel.methods.execute.execute(definition, context);
 
   // Check data attributes
-  const attrs = getDataOutputAttributes(result.dataOutputs, "result");
+  const attrs = getResultAttributes(getResults(), "result");
   assertEquals(attrs?.exitCode, 0);
   assertEquals(attrs?.command, "echo hello");
   assertEquals(typeof attrs?.executedAt, "string");
   assertEquals(typeof attrs?.durationMs, "number");
 
   // Check output contains stdout
-  const logContent = getOutputLogContent(result.dataOutputs);
+  const logContent = getOutputLogContent(getResults());
   assertStringIncludes(logContent, "hello");
 });
 
@@ -229,14 +326,14 @@ Deno.test("shellModel.methods.execute captures stderr", async () => {
     attributes: { run: "echo error >&2" },
   });
 
-  const context = createTestContext();
-  const result = await shellModel.methods.execute.execute(definition, context);
+  const { context, getResults } = createTestContext();
+  await shellModel.methods.execute.execute(definition, context);
 
-  const attrs = getDataOutputAttributes(result.dataOutputs, "result");
+  const attrs = getResultAttributes(getResults(), "result");
   assertEquals(attrs?.exitCode, 0);
 
   // Check output contains stderr
-  const logContent = getOutputLogContent(result.dataOutputs);
+  const logContent = getOutputLogContent(getResults());
   assertStringIncludes(logContent, "error");
 });
 
@@ -246,10 +343,10 @@ Deno.test("shellModel.methods.execute captures exit code", async () => {
     attributes: { run: "exit 42" },
   });
 
-  const context = createTestContext();
-  const result = await shellModel.methods.execute.execute(definition, context);
+  const { context, getResults } = createTestContext();
+  await shellModel.methods.execute.execute(definition, context);
 
-  const attrs = getDataOutputAttributes(result.dataOutputs, "result");
+  const attrs = getResultAttributes(getResults(), "result");
   assertEquals(attrs?.exitCode, 42);
 });
 
@@ -259,10 +356,10 @@ Deno.test("shellModel.methods.execute handles command failure gracefully", async
     attributes: { run: "false" },
   });
 
-  const context = createTestContext();
-  const result = await shellModel.methods.execute.execute(definition, context);
+  const { context, getResults } = createTestContext();
+  await shellModel.methods.execute.execute(definition, context);
 
-  const attrs = getDataOutputAttributes(result.dataOutputs, "result");
+  const attrs = getResultAttributes(getResults(), "result");
   assertEquals(attrs?.exitCode, 1);
 });
 
@@ -275,16 +372,16 @@ Deno.test("shellModel.methods.execute respects workingDir", async () => {
     },
   });
 
-  const context = createTestContext();
-  const result = await shellModel.methods.execute.execute(definition, context);
+  const { context, getResults } = createTestContext();
+  await shellModel.methods.execute.execute(definition, context);
 
   // Use realPathSync to handle symlinks (e.g., /tmp -> /private/tmp on macOS)
   const expectedPath = Deno.realPathSync("/tmp");
-  const attrs = getDataOutputAttributes(result.dataOutputs, "result");
+  const attrs = getResultAttributes(getResults(), "result");
   assertEquals(attrs?.exitCode, 0);
 
   // Check output contains the working directory
-  const logContent = getOutputLogContent(result.dataOutputs);
+  const logContent = getOutputLogContent(getResults());
   assertStringIncludes(logContent, expectedPath);
 });
 
@@ -297,14 +394,14 @@ Deno.test("shellModel.methods.execute respects env variables", async () => {
     },
   });
 
-  const context = createTestContext();
-  const result = await shellModel.methods.execute.execute(definition, context);
+  const { context, getResults } = createTestContext();
+  await shellModel.methods.execute.execute(definition, context);
 
-  const attrs = getDataOutputAttributes(result.dataOutputs, "result");
+  const attrs = getResultAttributes(getResults(), "result");
   assertEquals(attrs?.exitCode, 0);
 
   // Check output contains the env variable value
-  const logContent = getOutputLogContent(result.dataOutputs);
+  const logContent = getOutputLogContent(getResults());
   assertStringIncludes(logContent, "test_value");
 });
 
@@ -314,14 +411,14 @@ Deno.test("shellModel.methods.execute handles pipes", async () => {
     attributes: { run: "echo 'hello world' | tr 'h' 'H'" },
   });
 
-  const context = createTestContext();
-  const result = await shellModel.methods.execute.execute(definition, context);
+  const { context, getResults } = createTestContext();
+  await shellModel.methods.execute.execute(definition, context);
 
-  const attrs = getDataOutputAttributes(result.dataOutputs, "result");
+  const attrs = getResultAttributes(getResults(), "result");
   assertEquals(attrs?.exitCode, 0);
 
   // Check output contains the piped output
-  const logContent = getOutputLogContent(result.dataOutputs);
+  const logContent = getOutputLogContent(getResults());
   assertStringIncludes(logContent, "Hello world");
 });
 
@@ -331,14 +428,14 @@ Deno.test("shellModel.methods.execute handles complex commands", async () => {
     attributes: { run: "cd /tmp && pwd" },
   });
 
-  const context = createTestContext();
-  const result = await shellModel.methods.execute.execute(definition, context);
+  const { context, getResults } = createTestContext();
+  await shellModel.methods.execute.execute(definition, context);
 
-  const attrs = getDataOutputAttributes(result.dataOutputs, "result");
+  const attrs = getResultAttributes(getResults(), "result");
   assertEquals(attrs?.exitCode, 0);
 
   // Check output contains /tmp (cd /tmp && pwd outputs the logical path)
-  const logContent = getOutputLogContent(result.dataOutputs);
+  const logContent = getOutputLogContent(getResults());
   assertStringIncludes(logContent, "/tmp");
 });
 
@@ -348,7 +445,7 @@ Deno.test("shellModel.methods.execute validates input attributes", async () => {
     attributes: { notRun: "value" },
   });
 
-  const context = createTestContext();
+  const { context } = createTestContext();
   let error: Error | null = null;
   try {
     await shellModel.methods.execute.execute(definition, context);
@@ -365,7 +462,7 @@ Deno.test("shellModel.methods.execute rejects empty run command", async () => {
     attributes: { run: "" },
   });
 
-  const context = createTestContext();
+  const { context } = createTestContext();
   let error: Error | null = null;
   try {
     await shellModel.methods.execute.execute(definition, context);
@@ -382,15 +479,15 @@ Deno.test("shellModel.methods.execute handles nonexistent command", async () => 
     attributes: { run: "nonexistent_command_12345" },
   });
 
-  const context = createTestContext();
-  const result = await shellModel.methods.execute.execute(definition, context);
+  const { context, getResults } = createTestContext();
+  await shellModel.methods.execute.execute(definition, context);
 
   // Should return non-zero exit code and error in output
-  const attrs = getDataOutputAttributes(result.dataOutputs, "result");
+  const attrs = getResultAttributes(getResults(), "result");
   assertEquals(attrs?.exitCode !== 0, true);
 
   // Check output contains error about nonexistent command
-  const logContent = getOutputLogContent(result.dataOutputs);
+  const logContent = getOutputLogContent(getResults());
   assertStringIncludes(logContent, "nonexistent_command_12345");
 });
 
@@ -400,30 +497,30 @@ Deno.test("shellModel.methods.execute records execution duration", async () => {
     attributes: { run: "sleep 0.1" },
   });
 
-  const context = createTestContext();
-  const result = await shellModel.methods.execute.execute(definition, context);
+  const { context, getResults } = createTestContext();
+  await shellModel.methods.execute.execute(definition, context);
 
-  const attrs = getDataOutputAttributes(result.dataOutputs, "result");
+  const attrs = getResultAttributes(getResults(), "result");
   const durationMs = attrs?.durationMs as number;
   // Should be at least 100ms (sleep 0.1 seconds)
   assertEquals(durationMs >= 100, true);
 });
 
-Deno.test("shellModel.methods.execute returns dataOutputs", async () => {
+Deno.test("shellModel.methods.execute returns dataHandles", async () => {
   const definition = Definition.create({
     name: "test-shell",
     attributes: { run: "echo hello && echo error >&2" },
   });
 
-  const context = createTestContext();
+  const { context, getResults } = createTestContext();
   const result = await shellModel.methods.execute.execute(definition, context);
 
-  // Should have data outputs (data and output)
-  assertEquals(result.dataOutputs !== undefined, true);
-  assertEquals(result.dataOutputs!.length >= 1, true);
+  // Should have data handles (result and output)
+  assertEquals(result.dataHandles !== undefined, true);
+  assertEquals(result.dataHandles!.length >= 1, true);
 
   // Output should contain both stdout and stderr
-  const logContent = getOutputLogContent(result.dataOutputs);
+  const logContent = getOutputLogContent(getResults());
   assertStringIncludes(logContent, "hello");
   assertStringIncludes(logContent, "error");
 });
@@ -434,9 +531,9 @@ Deno.test("shellModel.methods.execute returns output for no output command", asy
     attributes: { run: "true" }, // Command with no output
   });
 
-  const context = createTestContext();
+  const { context } = createTestContext();
   const result = await shellModel.methods.execute.execute(definition, context);
 
-  // Should still have data outputs
-  assertEquals(result.dataOutputs !== undefined, true);
+  // Should still have data handles
+  assertEquals(result.dataHandles !== undefined, true);
 });

--- a/src/domain/models/lets-get-sensitive/vault_model.ts
+++ b/src/domain/models/lets-get-sensitive/vault_model.ts
@@ -151,46 +151,22 @@ async function executeGet(
       success: true,
     };
 
-    const definitionHash = await definition.computeHash();
+    const resultWriter = context.createDataWriter!({
+      name: `${definition.name}-result`,
+      specType: "result",
+    });
 
-    return {
-      dataOutputs: [
-        {
-          name: `${definition.name}-result`,
-          specType: DataSpecType.create("result"),
-          content: new TextEncoder().encode(JSON.stringify(dataAttributes)),
-          metadata: {
-            contentType: "application/json",
-            lifetime: "infinite",
-            garbageCollection: 10,
-            streaming: false,
-            tags: { type: "data" },
-            ownerDefinition: {
-              definitionHash,
-              ownerType: "model-method",
-              ownerRef: "get",
-            },
-          },
-        },
-        {
-          name: `${definition.name}-audit-log`,
-          specType: DataSpecType.create("log"),
-          content: new TextEncoder().encode(logLines.join("\n")),
-          metadata: {
-            contentType: "text/plain",
-            lifetime: "infinite",
-            garbageCollection: 10,
-            streaming: true,
-            tags: { type: "log" },
-            ownerDefinition: {
-              definitionHash,
-              ownerType: "model-method",
-              ownerRef: "get",
-            },
-          },
-        },
-      ],
-    };
+    const logWriter = context.createDataWriter!({
+      name: `${definition.name}-audit-log`,
+      specType: "log",
+    });
+
+    const resultHandle = await resultWriter.writeText(
+      JSON.stringify(dataAttributes),
+    );
+    const logHandle = await logWriter.writeText(logLines.join("\n"));
+
+    return { dataHandles: [resultHandle, logHandle] };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     logLines.push(`[vault] ❌ Failed to retrieve secret: ${errorMessage}`);
@@ -250,46 +226,22 @@ async function executePut(
       success: true,
     };
 
-    const definitionHash = await definition.computeHash();
+    const resultWriter = context.createDataWriter!({
+      name: `${definition.name}-result`,
+      specType: "result",
+    });
 
-    return {
-      dataOutputs: [
-        {
-          name: `${definition.name}-result`,
-          specType: DataSpecType.create("result"),
-          content: new TextEncoder().encode(JSON.stringify(dataAttributes)),
-          metadata: {
-            contentType: "application/json",
-            lifetime: "infinite",
-            garbageCollection: 10,
-            streaming: false,
-            tags: { type: "data" },
-            ownerDefinition: {
-              definitionHash,
-              ownerType: "model-method",
-              ownerRef: "put",
-            },
-          },
-        },
-        {
-          name: `${definition.name}-audit-log`,
-          specType: DataSpecType.create("log"),
-          content: new TextEncoder().encode(logLines.join("\n")),
-          metadata: {
-            contentType: "text/plain",
-            lifetime: "infinite",
-            garbageCollection: 10,
-            streaming: true,
-            tags: { type: "log" },
-            ownerDefinition: {
-              definitionHash,
-              ownerType: "model-method",
-              ownerRef: "put",
-            },
-          },
-        },
-      ],
-    };
+    const logWriter = context.createDataWriter!({
+      name: `${definition.name}-audit-log`,
+      specType: "log",
+    });
+
+    const resultHandle = await resultWriter.writeText(
+      JSON.stringify(dataAttributes),
+    );
+    const logHandle = await logWriter.writeText(logLines.join("\n"));
+
+    return { dataHandles: [resultHandle, logHandle] };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     logLines.push(`[vault] ❌ Failed to store secret: ${errorMessage}`);
@@ -334,6 +286,7 @@ export const vaultModel: ModelDefinition<
       contentType: "text/plain",
       lifetime: "infinite",
       garbageCollection: 10,
+      streaming: true,
       tags: { type: "log" },
     },
   },

--- a/src/domain/models/lets-get-sensitive/vault_model_test.ts
+++ b/src/domain/models/lets-get-sensitive/vault_model_test.ts
@@ -8,11 +8,114 @@ import {
   VaultInputAttributesSchema,
   vaultModel,
 } from "./vault_model.ts";
-import type { MethodContext } from "../model.ts";
+import { normalizeSpecType } from "../model.ts";
+import type {
+  DataHandle,
+  DataWriter,
+  DataWriterFactory,
+  MethodContext,
+  SpecBasedWriterOptions,
+} from "../model.ts";
 import type { UnifiedDataRepository } from "../../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../../definitions/repositories.ts";
-import { generateDataId } from "../../data/data_id.ts";
+import { type DataId, generateDataId } from "../../data/data_id.ts";
 import { getLogger } from "@logtape/logtape";
+
+/**
+ * Stored result from mock data writer.
+ */
+interface MockWriterResult {
+  handle: DataHandle;
+  content: Uint8Array;
+}
+
+/**
+ * Creates a mock DataWriterFactory that stores written content in memory.
+ */
+function createMockDataWriterFactory(): {
+  factory: DataWriterFactory;
+  getResults: () => MockWriterResult[];
+} {
+  const results: MockWriterResult[] = [];
+  const getResults = (): MockWriterResult[] => results;
+  let nextId = 1;
+
+  const factory: DataWriterFactory = (
+    options: SpecBasedWriterOptions,
+  ): DataWriter => {
+    const dataId = `mock-data-${nextId++}` as DataId;
+
+    const buildHandle = (content: Uint8Array): DataHandle => ({
+      name: options.name,
+      specType: normalizeSpecType(options.specType),
+      dataId,
+      version: 1,
+      size: content.length,
+      tags: { ...(options.tags ?? {}) },
+      metadata: {
+        contentType: options.contentType ?? "application/json",
+        lifetime: options.lifetime ?? "infinite",
+        garbageCollection: options.garbageCollection ?? 10,
+        streaming: options.streaming ?? false,
+        tags: { ...(options.tags ?? {}) },
+        ownerDefinition: {
+          definitionHash: "test-hash",
+          ownerType: "model-method",
+          ownerRef: "test",
+        },
+      },
+    });
+
+    return {
+      dataId,
+      name: options.name,
+      writeAll(content: Uint8Array): Promise<DataHandle> {
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeText(text: string): Promise<DataHandle> {
+        const content = new TextEncoder().encode(text);
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeLine(_line: string): Promise<void> {
+        return Promise.resolve();
+      },
+      writeStream(
+        _stream: ReadableStream<Uint8Array>,
+      ): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      getFilePath(): Promise<string> {
+        return Promise.resolve("/tmp/mock");
+      },
+      finalize(): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+    } as DataWriter;
+  };
+
+  return { factory, getResults };
+}
+
+/**
+ * Helper to get parsed JSON content from the first mock result.
+ */
+function getResultAttributes(
+  results: MockWriterResult[],
+  index = 0,
+): Record<string, unknown> | undefined {
+  if (results.length <= index) return undefined;
+  return JSON.parse(new TextDecoder().decode(results[index].content));
+}
 
 /**
  * Creates a mock UnifiedDataRepository for testing.
@@ -34,6 +137,10 @@ function createMockDataRepo(): UnifiedDataRepository {
     getContentPath: () => "",
     collectGarbage: () =>
       Promise.resolve({ versionsRemoved: 0, bytesReclaimed: 0 }),
+    allocateVersion: () =>
+      Promise.resolve({ version: 1, contentPath: "/tmp/mock" }),
+    finalizeVersion: () =>
+      Promise.resolve({ size: 0, checksum: "mock-checksum" }),
   };
 }
 
@@ -57,29 +164,21 @@ function createMockDefinitionRepo(): DefinitionRepository {
 /**
  * Creates a test MethodContext with mocked repositories.
  */
-function createTestContext(repoDir: string): MethodContext {
-  return {
+function createTestContext(repoDir: string): {
+  context: MethodContext;
+  getResults: () => MockWriterResult[];
+} {
+  const { factory, getResults } = createMockDataWriterFactory();
+  const context: MethodContext = {
     repoDir,
     modelType: VAULT_MODEL_TYPE,
     modelId: crypto.randomUUID(),
     logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
+    createDataWriter: factory,
   };
-}
-
-/**
- * Helper to get attributes from a DataOutput.
- */
-function getDataOutputAttributes(
-  dataOutputs: { content: Uint8Array }[] | undefined,
-  index = 0,
-): Record<string, unknown> | undefined {
-  if (!dataOutputs || dataOutputs.length <= index) {
-    return undefined;
-  }
-  const content = new TextDecoder().decode(dataOutputs[index].content);
-  return JSON.parse(content);
+  return { context, getResults };
 }
 
 Deno.test("VAULT_MODEL_TYPE has correct normalized type", () => {
@@ -151,8 +250,8 @@ Deno.test("Vault Model - Get Operation", async () => {
       },
     });
 
-    const context = createTestContext(repoDir);
-    await vaultModel.methods.put.execute(putDefinition, context);
+    const { context: putContext } = createTestContext(repoDir);
+    await vaultModel.methods.put.execute(putDefinition, putContext);
 
     // Now test getting the secret
     const getDefinition = Definition.create({
@@ -164,9 +263,10 @@ Deno.test("Vault Model - Get Operation", async () => {
       },
     });
 
-    const result = await vaultModel.methods.get.execute(getDefinition, context);
+    const { context, getResults } = createTestContext(repoDir);
+    await vaultModel.methods.get.execute(getDefinition, context);
 
-    const attrs = getDataOutputAttributes(result.dataOutputs);
+    const attrs = getResultAttributes(getResults());
     assertEquals(attrs !== undefined, true);
     assertEquals(attrs?.vaultName, "test-vault");
     assertEquals(attrs?.secretKey, "test-secret-key");
@@ -188,10 +288,10 @@ Deno.test("Vault Model - Put Operation", async () => {
       },
     });
 
-    const context = createTestContext(repoDir);
-    const result = await vaultModel.methods.put.execute(definition, context);
+    const { context, getResults } = createTestContext(repoDir);
+    await vaultModel.methods.put.execute(definition, context);
 
-    const attrs = getDataOutputAttributes(result.dataOutputs);
+    const attrs = getResultAttributes(getResults());
     assertEquals(attrs !== undefined, true);
     assertEquals(attrs?.vaultName, "test-vault");
     assertEquals(attrs?.secretKey, "test-secret-key");
@@ -211,7 +311,7 @@ Deno.test("Vault Model - Get with wrong operation fails", async () => {
     },
   });
 
-  const context = createTestContext("/tmp/test");
+  const { context } = createTestContext("/tmp/test");
 
   try {
     await vaultModel.methods.get.execute(definition, context);
@@ -235,7 +335,7 @@ Deno.test("Vault Model - Put without secretValue fails", async () => {
     },
   });
 
-  const context = createTestContext("/tmp/test");
+  const { context } = createTestContext("/tmp/test");
 
   try {
     await vaultModel.methods.put.execute(definition, context);

--- a/src/domain/models/mermaid/workflow_diagram/workflow_diagram_model.ts
+++ b/src/domain/models/mermaid/workflow_diagram/workflow_diagram_model.ts
@@ -273,7 +273,7 @@ function generateMermaidDiagram(
  */
 async function executeGenerate(
   definition: Definition,
-  _context: MethodContext,
+  context: MethodContext,
 ): Promise<MethodResult> {
   const attrs = MermaidWorkflowInputAttributesSchema.parse(
     definition.attributes,
@@ -310,46 +310,23 @@ async function executeGenerate(
     checksum,
   };
 
-  const definitionHash = await definition.computeHash();
+  const metadataWriter = context.createDataWriter!({
+    name: `${definition.name}-metadata`,
+    specType: "metadata",
+  });
 
-  return {
-    dataOutputs: [
-      {
-        name: `${definition.name}-metadata`,
-        specType: DataSpecType.create("metadata"),
-        content: new TextEncoder().encode(JSON.stringify(metadataAttributes)),
-        metadata: {
-          contentType: "application/json",
-          lifetime: "infinite",
-          garbageCollection: 10,
-          streaming: false,
-          tags: { type: "data" },
-          ownerDefinition: {
-            definitionHash,
-            ownerType: "model-method",
-            ownerRef: "generate",
-          },
-        },
-      },
-      {
-        name: `${definition.name}-diagram`,
-        specType: DataSpecType.create("file"),
-        content,
-        metadata: {
-          contentType: "text/plain",
-          lifetime: "infinite",
-          garbageCollection: 10,
-          streaming: false,
-          tags: { type: "file", filename },
-          ownerDefinition: {
-            definitionHash,
-            ownerType: "model-method",
-            ownerRef: "generate",
-          },
-        },
-      },
-    ],
-  };
+  const diagramWriter = context.createDataWriter!({
+    name: `${definition.name}-diagram`,
+    specType: "file",
+    tags: { filename },
+  });
+
+  const metadataHandle = await metadataWriter.writeText(
+    JSON.stringify(metadataAttributes),
+  );
+  const diagramHandle = await diagramWriter.writeAll(content);
+
+  return { dataHandles: [metadataHandle, diagramHandle] };
 }
 
 /**

--- a/src/domain/models/mermaid/workflow_diagram/workflow_diagram_model_test.ts
+++ b/src/domain/models/mermaid/workflow_diagram/workflow_diagram_model_test.ts
@@ -8,11 +8,124 @@ import {
   type MermaidWorkflowInputAttributes,
   mermaidWorkflowModel,
 } from "./workflow_diagram_model.ts";
-import type { MethodContext } from "../../model.ts";
+import { normalizeSpecType } from "../../model.ts";
+import type {
+  DataHandle,
+  DataWriter,
+  DataWriterFactory,
+  MethodContext,
+  SpecBasedWriterOptions,
+} from "../../model.ts";
 import type { UnifiedDataRepository } from "../../../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../../../definitions/repositories.ts";
-import { generateDataId } from "../../../data/data_id.ts";
+import { type DataId, generateDataId } from "../../../data/data_id.ts";
 import { getLogger } from "@logtape/logtape";
+
+/**
+ * Stored result from mock data writer.
+ */
+interface MockWriterResult {
+  handle: DataHandle;
+  content: Uint8Array;
+}
+
+/**
+ * Creates a mock DataWriterFactory that stores written content in memory.
+ */
+function createMockDataWriterFactory(): {
+  factory: DataWriterFactory;
+  getResults: () => MockWriterResult[];
+} {
+  const results: MockWriterResult[] = [];
+  const getResults = (): MockWriterResult[] => results;
+  let nextId = 1;
+
+  const factory: DataWriterFactory = (
+    options: SpecBasedWriterOptions,
+  ): DataWriter => {
+    const dataId = `mock-data-${nextId++}` as DataId;
+
+    const buildHandle = (content: Uint8Array): DataHandle => ({
+      name: options.name,
+      specType: normalizeSpecType(options.specType),
+      dataId,
+      version: 1,
+      size: content.length,
+      tags: { ...(options.tags ?? {}) },
+      metadata: {
+        contentType: options.contentType ?? "application/json",
+        lifetime: options.lifetime ?? "infinite",
+        garbageCollection: options.garbageCollection ?? 10,
+        streaming: options.streaming ?? false,
+        tags: { ...(options.tags ?? {}) },
+        ownerDefinition: {
+          definitionHash: "test-hash",
+          ownerType: "model-method",
+          ownerRef: "test",
+        },
+      },
+    });
+
+    return {
+      dataId,
+      name: options.name,
+      writeAll(content: Uint8Array): Promise<DataHandle> {
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeText(text: string): Promise<DataHandle> {
+        const content = new TextEncoder().encode(text);
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeLine(_line: string): Promise<void> {
+        return Promise.resolve();
+      },
+      writeStream(
+        _stream: ReadableStream<Uint8Array>,
+      ): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      getFilePath(): Promise<string> {
+        return Promise.resolve("/tmp/mock");
+      },
+      finalize(): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+    } as DataWriter;
+  };
+
+  return { factory, getResults };
+}
+
+/**
+ * Helper to get parsed JSON content from mock results by name.
+ */
+function getResultAttributes(
+  results: MockWriterResult[],
+  namePart: string,
+): Record<string, unknown> | undefined {
+  const result = results.find((r) => r.handle.name.includes(namePart));
+  if (!result) return undefined;
+  return JSON.parse(new TextDecoder().decode(result.content));
+}
+
+/**
+ * Helper to get diagram content as string.
+ */
+function getDiagramContent(results: MockWriterResult[]): string {
+  const diagramResult = results.find((r) => r.handle.name.endsWith("-diagram"));
+  if (!diagramResult) return "";
+  return new TextDecoder().decode(diagramResult.content);
+}
 
 /**
  * Creates a mock UnifiedDataRepository for testing.
@@ -34,6 +147,10 @@ function createMockDataRepo(): UnifiedDataRepository {
     getContentPath: () => "",
     collectGarbage: () =>
       Promise.resolve({ versionsRemoved: 0, bytesReclaimed: 0 }),
+    allocateVersion: () =>
+      Promise.resolve({ version: 1, contentPath: "/tmp/mock" }),
+    finalizeVersion: () =>
+      Promise.resolve({ size: 0, checksum: "mock-checksum" }),
   };
 }
 
@@ -57,39 +174,21 @@ function createMockDefinitionRepo(): DefinitionRepository {
 /**
  * Creates a test MethodContext with mocked repositories.
  */
-function createTestContext(): MethodContext {
-  return {
+function createTestContext(): {
+  context: MethodContext;
+  getResults: () => MockWriterResult[];
+} {
+  const { factory, getResults } = createMockDataWriterFactory();
+  const context: MethodContext = {
     repoDir: "/tmp",
     modelType: MERMAID_WORKFLOW_MODEL_TYPE,
     modelId: crypto.randomUUID(),
     logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
+    createDataWriter: factory,
   };
-}
-
-/**
- * Helper to get attributes from a DataOutput by name.
- */
-function getDataOutputAttributes(
-  dataOutputs: { name: string; content: Uint8Array }[] | undefined,
-  name: string,
-): Record<string, unknown> | undefined {
-  const dataOutput = dataOutputs?.find((d) => d.name.includes(name));
-  if (!dataOutput) return undefined;
-  const content = new TextDecoder().decode(dataOutput.content);
-  return JSON.parse(content);
-}
-
-/**
- * Helper to get diagram content as string.
- */
-function getDiagramContent(
-  dataOutputs: { name: string; content: Uint8Array }[] | undefined,
-): string {
-  const diagramOutput = dataOutputs?.find((d) => d.name.endsWith("-diagram"));
-  if (!diagramOutput) return "";
-  return new TextDecoder().decode(diagramOutput.content);
+  return { context, getResults };
 }
 
 Deno.test("mermaidWorkflowModel: generate creates Mermaid diagram for simple workflow", async () => {
@@ -154,24 +253,24 @@ Deno.test("mermaidWorkflowModel: generate creates Mermaid diagram for simple wor
     attributes: inputAttributes,
   });
 
-  const context = createTestContext();
+  const { context, getResults } = createTestContext();
   const result = await mermaidWorkflowModel.methods.generate.execute(
     definition,
     context,
   );
 
-  assertEquals(result.dataOutputs !== undefined, true);
-  assertEquals(result.dataOutputs!.length >= 1, true);
+  assertEquals(result.dataHandles !== undefined, true);
+  assertEquals(result.dataHandles!.length >= 1, true);
 
   // Verify metadata attributes
-  const attrs = getDataOutputAttributes(result.dataOutputs, "metadata");
+  const attrs = getResultAttributes(getResults(), "metadata");
   assertEquals(attrs?.workflowName, "test-workflow");
   assertEquals(attrs?.jobCount, 2);
   assertEquals(attrs?.stepCount, 2);
   assertEquals(attrs?.workflowStatus, "succeeded");
 
   // Verify diagram content contains Mermaid syntax
-  const diagramContent = getDiagramContent(result.dataOutputs);
+  const diagramContent = getDiagramContent(getResults());
   assertEquals(diagramContent.includes("graph TD"), true);
   assertEquals(diagramContent.includes("Workflow: test-workflow"), true);
   assertEquals(diagramContent.includes("Job: build"), true);
@@ -218,14 +317,14 @@ Deno.test("mermaidWorkflowModel: generate creates simple diagram without steps",
     attributes: inputAttributes,
   });
 
-  const context = createTestContext();
-  const result = await mermaidWorkflowModel.methods.generate.execute(
+  const { context, getResults } = createTestContext();
+  await mermaidWorkflowModel.methods.generate.execute(
     definition,
     context,
   );
 
   // Verify diagram content is simpler without steps
-  const diagramContent = getDiagramContent(result.dataOutputs);
+  const diagramContent = getDiagramContent(getResults());
   assertEquals(diagramContent.includes("graph TD"), true);
   assertEquals(diagramContent.includes("Job: deploy"), true);
   assertEquals(diagramContent.includes("Status: failed"), true);
@@ -324,13 +423,13 @@ Deno.test("mermaidWorkflowModel: generate handles complex workflow with multiple
     attributes: inputAttributes,
   });
 
-  const context = createTestContext();
-  const result = await mermaidWorkflowModel.methods.generate.execute(
+  const { context, getResults } = createTestContext();
+  await mermaidWorkflowModel.methods.generate.execute(
     definition,
     context,
   );
 
-  const diagramContent = getDiagramContent(result.dataOutputs);
+  const diagramContent = getDiagramContent(getResults());
 
   // Verify all jobs are present
   assertEquals(diagramContent.includes("Job: setup"), true);

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -1,6 +1,6 @@
 import type { z } from "zod";
 import type {
-  DataOutput,
+  DataHandle,
   FollowUpAction,
   MethodContext,
   MethodDefinition,
@@ -8,11 +8,11 @@ import type {
   ModelDefinition,
 } from "./model.ts";
 import type { Definition } from "../definitions/definition.ts";
-import { Data } from "../data/mod.ts";
 import type { DataArtifactRef } from "./model_output.ts";
 import { ModelOutput } from "./model_output.ts";
 import { DataOutputValidationService } from "./data_output_validation_service.ts";
 import { DefinitionUpgradeService } from "./definition_upgrade_service.ts";
+import { createDataWriterFactory } from "./data_writer.ts";
 
 /**
  * Maximum depth for recursive follow-up action processing.
@@ -77,6 +77,8 @@ export interface MethodExecutionService {
  * Default implementation of the method execution service.
  *
  * Validates definition attributes against the method's schema before execution.
+ * Creates DataWriterFactory and injects it into context so methods write
+ * data directly to disk. The result contains DataHandle[] (already persisted).
  */
 export class DefaultMethodExecutionService implements MethodExecutionService {
   private readonly dataOutputValidationService =
@@ -103,8 +105,8 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
     // Execute the method
     const result = await method.execute(definition, context);
 
-    // Validate and enhance data outputs if model definition is provided
-    if (result.dataOutputs && context.modelDefinition) {
+    // Validate data handles if model definition is provided
+    if (result.dataHandles && context.modelDefinition) {
       const specs = context.modelDefinition.dataOutputSpecs;
 
       // Find the method name (for better error messages)
@@ -113,7 +115,7 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
 
       // Validate spec type references
       const validation = this.dataOutputValidationService.validate(
-        result.dataOutputs,
+        result.dataHandles,
         specs,
         methodName,
       );
@@ -123,15 +125,6 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
           `Data output validation failed: ${validation.errors.join("; ")}`,
         );
       }
-
-      // Apply defaults from specs (no overrides at this level)
-      result.dataOutputs = result.dataOutputs.map((output) => {
-        const spec = specs[output.specType.value];
-        return this.dataOutputValidationService.applyDefaultsAndOverrides(
-          output,
-          spec,
-        );
-      });
     }
 
     return result;
@@ -161,28 +154,43 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
       );
     }
 
-    // Execute the initial method with the (possibly upgraded) definition
-    const result = await this.execute(currentDefinition, method, context);
-    let currentDataOutputs = result.dataOutputs ?? [];
+    // Create DataWriterFactory for this execution
+    const definitionHash = await currentDefinition.computeHash();
+    const { factory, getHandles: _getHandles } = createDataWriterFactory(
+      context.dataRepository,
+      context.modelType,
+      context.modelId,
+      definitionHash,
+      modelDef.dataOutputSpecs,
+      context.tagOverrides,
+      context.dataOutputOverrides,
+    );
 
-    // Store data outputs
-    const storedArtifacts: DataArtifactRef[] = [];
-    if (currentDataOutputs.length > 0) {
-      const definitionHash = await currentDefinition.computeHash();
-      for (const output of currentDataOutputs) {
-        const artifact = await this.storeDataOutput(
-          output,
-          definitionHash,
-          methodName,
-          context,
-        );
-        storedArtifacts.push(artifact);
-      }
-    }
+    // Inject factory into context
+    const contextWithWriter: MethodContext = {
+      ...context,
+      createDataWriter: factory,
+      modelDefinition: modelDef,
+    };
+
+    // Execute the initial method
+    const result = await this.execute(
+      currentDefinition,
+      method,
+      contextWithWriter,
+    );
+    let currentHandles = result.dataHandles ?? [];
+
+    // Collect artifact refs from handles (data is already persisted)
+    const storedArtifacts: DataArtifactRef[] = currentHandles.map((h) => ({
+      dataId: h.dataId,
+      name: h.name,
+      version: h.version,
+      tags: h.tags,
+    }));
 
     // Create ModelOutput if output repository is available
     if (context.outputRepository) {
-      const definitionHash = await currentDefinition.computeHash();
       const output = ModelOutput.create({
         definitionId: currentDefinition.id,
         methodName,
@@ -199,80 +207,35 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
     }
 
     // Process follow-up actions
-    if (result.followUpActions && currentDataOutputs.length > 0) {
+    if (result.followUpActions && currentHandles.length > 0) {
       const finalResult = await this.processFollowUpActions(
         currentDefinition,
         modelDef,
-        context,
+        contextWithWriter,
         result.followUpActions,
-        currentDataOutputs,
+        currentHandles,
         0,
       );
-      currentDataOutputs = finalResult.dataOutputs;
+      currentHandles = finalResult.dataHandles;
     }
 
     return {
       ...result,
-      dataOutputs: currentDataOutputs,
+      dataHandles: currentHandles,
     };
   }
 
   /**
-   * Stores a data output and returns a reference to the stored artifact.
-   */
-  private async storeDataOutput(
-    output: DataOutput,
-    definitionHash: string,
-    methodName: string,
-    context: MethodContext,
-  ): Promise<DataArtifactRef> {
-    // Get next version for this data
-    const dataId = context.dataRepository.nextId();
-
-    // Create the Data entity
-    const data = Data.create({
-      id: dataId,
-      name: output.name,
-      version: 1, // Will be updated by save()
-      contentType: output.metadata.contentType,
-      lifetime: output.metadata.lifetime,
-      garbageCollection: output.metadata.garbageCollection,
-      streaming: output.metadata.streaming ?? false,
-      tags: output.metadata.tags,
-      ownerDefinition: {
-        ...output.metadata.ownerDefinition,
-        definitionHash,
-        ownerRef: methodName,
-      },
-    });
-
-    // Save the data with content
-    const saveResult = await context.dataRepository.save(
-      context.modelType,
-      context.modelId,
-      data,
-      output.content,
-    );
-
-    return {
-      dataId: data.id,
-      name: data.name,
-      version: saveResult.version,
-      tags: data.tags,
-    };
-  }
-
-  /**
-   * Process follow-up actions using the data outputs pattern.
+   * Process follow-up actions using the data handles pattern.
    */
   private async processFollowUpActions(
     definition: Definition,
     modelDef: ModelDefinition,
     context: MethodContext,
     followUpActions: FollowUpAction[],
-    currentDataOutputs: DataOutput[],
+    currentHandles: DataHandle[],
     depth: number = 0,
-  ): Promise<{ dataOutputs: DataOutput[] }> {
+  ): Promise<{ dataHandles: DataHandle[] }> {
     if (depth >= DEFAULT_MAX_FOLLOW_UP_DEPTH) {
       throw new Error(
         `Maximum follow-up action depth (${DEFAULT_MAX_FOLLOW_UP_DEPTH}) exceeded. ` +
@@ -292,7 +255,7 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
 
         // Check continue condition
         if (action.continueCondition) {
-          const conditionResult = action.continueCondition(currentDataOutputs);
+          const conditionResult = action.continueCondition(currentHandles);
           if (!conditionResult) {
             break;
           }
@@ -313,9 +276,9 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
             context,
           );
 
-          // Update current data outputs
-          if (result.dataOutputs && result.dataOutputs.length > 0) {
-            currentDataOutputs = result.dataOutputs;
+          // Update current handles
+          if (result.dataHandles && result.dataHandles.length > 0) {
+            currentHandles = result.dataHandles;
           }
 
           // If this follow-up method has its own follow-up actions, process them recursively
@@ -325,10 +288,10 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
               modelDef,
               context,
               result.followUpActions,
-              currentDataOutputs,
+              currentHandles,
               depth + 1,
             );
-            currentDataOutputs = recursiveResult.dataOutputs;
+            currentHandles = recursiveResult.dataHandles;
           }
 
           break; // Success, exit retry loop
@@ -343,7 +306,7 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
       }
     }
 
-    return { dataOutputs: currentDataOutputs };
+    return { dataHandles: currentHandles };
   }
 
   private delay(ms: number): Promise<void> {

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -4,17 +4,106 @@ import { createDefinitionId, Definition } from "../definitions/definition.ts";
 import { ModelType } from "./model_type.ts";
 import { echoModel } from "./echo/echo_model.ts";
 import {
-  type DataOutput,
+  type DataHandle,
   DataSpecType,
+  type DataWriter,
+  type DataWriterFactory,
   type MethodContext,
   type MethodResult,
   type ModelDefinition,
+  normalizeSpecType,
+  type SpecBasedWriterOptions,
 } from "./model.ts";
 import { z } from "zod";
 import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../definitions/repositories.ts";
-import { generateDataId } from "../data/data_id.ts";
+import { type DataId, generateDataId } from "../data/data_id.ts";
 import { getLogger } from "@logtape/logtape";
+
+/**
+ * Stored result from mock data writer.
+ */
+interface MockWriterResult {
+  handle: DataHandle;
+  content: Uint8Array;
+}
+
+/**
+ * Creates a mock DataWriterFactory that stores written content in memory.
+ */
+function createMockDataWriterFactory(): {
+  factory: DataWriterFactory;
+  getResults: () => MockWriterResult[];
+} {
+  const results: MockWriterResult[] = [];
+  const getResults = (): MockWriterResult[] => results;
+  let nextId = 1;
+
+  const factory: DataWriterFactory = (
+    options: SpecBasedWriterOptions,
+  ): DataWriter => {
+    const dataId = `mock-data-${nextId++}` as DataId;
+
+    const buildHandle = (content: Uint8Array): DataHandle => ({
+      name: options.name,
+      specType: normalizeSpecType(options.specType),
+      dataId,
+      version: 1,
+      size: content.length,
+      tags: options.tags ?? {},
+      metadata: {
+        contentType: options.contentType ?? "application/json",
+        lifetime: options.lifetime ?? "infinite",
+        garbageCollection: options.garbageCollection ?? 10,
+        streaming: options.streaming ?? false,
+        tags: options.tags ?? {},
+        ownerDefinition: {
+          definitionHash: "test-hash",
+          ownerType: "model-method",
+          ownerRef: "test",
+        },
+      },
+    });
+
+    return {
+      dataId,
+      name: options.name,
+      writeAll(content: Uint8Array): Promise<DataHandle> {
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeText(text: string): Promise<DataHandle> {
+        const content = new TextEncoder().encode(text);
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeLine(_line: string): Promise<void> {
+        return Promise.resolve();
+      },
+      writeStream(
+        _stream: ReadableStream<Uint8Array>,
+      ): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      getFilePath(): Promise<string> {
+        return Promise.resolve("/tmp/mock");
+      },
+      finalize(): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+    } as DataWriter;
+  };
+
+  return { factory, getResults };
+}
 
 /**
  * Creates a mock UnifiedDataRepository for testing.
@@ -36,6 +125,10 @@ function createMockDataRepo(): UnifiedDataRepository {
     getContentPath: () => "",
     collectGarbage: () =>
       Promise.resolve({ versionsRemoved: 0, bytesReclaimed: 0 }),
+    allocateVersion: () =>
+      Promise.resolve({ version: 1, contentPath: "/tmp/mock" }),
+    finalizeVersion: () =>
+      Promise.resolve({ size: 0, checksum: "mock-checksum" }),
   };
 }
 
@@ -59,16 +152,21 @@ function createMockDefinitionRepo(): DefinitionRepository {
 /**
  * Creates a test MethodContext with mocked repositories.
  */
-function createTestContext(overrides?: Partial<MethodContext>): MethodContext {
-  return {
+function createTestContext(
+  overrides?: Partial<MethodContext>,
+): { context: MethodContext; getResults: () => MockWriterResult[] } {
+  const { factory, getResults } = createMockDataWriterFactory();
+  const context: MethodContext = {
     repoDir: ".",
     modelType: ModelType.create("swamp/echo"),
     modelId: crypto.randomUUID(),
     logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
+    createDataWriter: factory,
     ...overrides,
   };
+  return { context, getResults };
 }
 
 Deno.test("execute with valid definition returns method result", async () => {
@@ -78,17 +176,22 @@ Deno.test("execute with valid definition returns method result", async () => {
     attributes: { message: "Hello, world!" },
   });
 
-  const context = createTestContext();
+  const { context, getResults } = createTestContext();
   const result = await service.execute(
     definition,
     echoModel.methods.write,
     context,
   );
 
-  // Echo model now returns data artifacts
-  assertEquals(result.dataOutputs?.length, 1);
-  const dataOutput = result.dataOutputs![0];
-  const content = JSON.parse(new TextDecoder().decode(dataOutput.content));
+  // Echo model now returns data handles
+  assertEquals(result.dataHandles?.length, 1);
+
+  // Content is in the mock writer results
+  const writerResults = getResults();
+  assertEquals(writerResults.length, 1);
+  const content = JSON.parse(
+    new TextDecoder().decode(writerResults[0].content),
+  );
   assertEquals(content.message, "Hello, world!");
   assertEquals(typeof content.timestamp, "string");
 });
@@ -100,7 +203,7 @@ Deno.test("execute with missing required attribute throws error", async () => {
     attributes: {}, // Missing required 'message'
   });
 
-  const context = createTestContext();
+  const { context } = createTestContext();
   await assertRejects(
     () => service.execute(definition, echoModel.methods.write, context),
     Error,
@@ -115,7 +218,7 @@ Deno.test("execute with invalid attribute type throws error", async () => {
     attributes: { message: 123 }, // Should be string
   });
 
-  const context = createTestContext();
+  const { context } = createTestContext();
   await assertRejects(
     () => service.execute(definition, echoModel.methods.write, context),
     Error,
@@ -130,7 +233,7 @@ Deno.test("execute with empty message throws error", async () => {
     attributes: { message: "" }, // Empty message fails min(1) validation
   });
 
-  const context = createTestContext();
+  const { context } = createTestContext();
   await assertRejects(
     () => service.execute(definition, echoModel.methods.write, context),
     Error,
@@ -145,7 +248,7 @@ Deno.test("execute error message includes Zod details", async () => {
     attributes: { wrongField: "value" },
   });
 
-  const context = createTestContext();
+  const { context } = createTestContext();
   try {
     await service.execute(definition, echoModel.methods.write, context);
     throw new Error("Expected error to be thrown");
@@ -160,33 +263,23 @@ Deno.test("execute error message includes Zod details", async () => {
 // ---------- Workflow Tests ----------
 
 /**
- * Helper to create a DataOutput with given attributes.
+ * Helper to write data via context.createDataWriter and return a DataHandle.
  */
-function createTestDataOutput(
+async function writeTestData(
+  context: MethodContext,
   name: string,
   attributes: Record<string, unknown>,
-): DataOutput {
-  return {
+): Promise<DataHandle> {
+  const writer = context.createDataWriter!({
     name,
-    specType: DataSpecType.create("data"),
-    content: new TextEncoder().encode(JSON.stringify(attributes)),
-    metadata: {
-      contentType: "application/json",
-      lifetime: "infinite",
-      garbageCollection: 10,
-      streaming: false,
-      tags: { type: "data" },
-      ownerDefinition: {
-        definitionHash: "test-hash",
-        ownerType: "model-method",
-        ownerRef: "test",
-      },
-    },
-  };
+    specType: "data",
+  });
+  return await writer.writeText(JSON.stringify(attributes));
 }
 
 /**
  * Creates a test model with configurable behavior for workflow testing.
+ * Mock methods use context.createDataWriter to write data and return dataHandles.
  */
 function createTestModel(options: {
   executeImpl?: (
@@ -208,44 +301,41 @@ function createTestModel(options: {
     type: ModelType.create("test/workflow"),
     version: "2026.02.09.1",
     inputAttributesSchema: schema,
-    dataOutputSpecs: {},
+    dataOutputSpecs: {
+      "data": {
+        specType: DataSpecType.create("data"),
+        description: "Test data",
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        tags: { type: "data" },
+      },
+    },
     methods: {
       start: {
         description: "Start method for testing",
         inputAttributesSchema: schema,
         execute: options.executeImpl ??
-          ((_definition) =>
-            Promise.resolve({
-              dataOutputs: [createTestDataOutput("data", { value: "started" })],
-            })),
+          (async (_definition, context) => {
+            const handle = await writeTestData(context, "data", {
+              value: "started",
+            });
+            return { dataHandles: [handle] };
+          }),
       },
       followUp: {
         description: "Follow-up method for testing",
         inputAttributesSchema: schema,
         execute: options.followUpImpl ??
-          ((_definition) =>
-            Promise.resolve({
-              dataOutputs: [
-                createTestDataOutput("data", { value: "followed-up" }),
-              ],
-            })),
+          (async (_definition, context) => {
+            const handle = await writeTestData(context, "data", {
+              value: "followed-up",
+            });
+            return { dataHandles: [handle] };
+          }),
       },
     },
   };
-}
-
-/**
- * Helper to get attributes from a DataOutput.
- */
-function getDataOutputAttributes(
-  result: MethodResult,
-  index = 0,
-): Record<string, unknown> | undefined {
-  if (!result.dataOutputs || result.dataOutputs.length <= index) {
-    return undefined;
-  }
-  const content = new TextDecoder().decode(result.dataOutputs[index].content);
-  return JSON.parse(content);
 }
 
 Deno.test(
@@ -259,7 +349,7 @@ Deno.test(
       attributes: { value: "test" },
     });
 
-    const context = createTestContext({
+    const { context } = createTestContext({
       modelType: model.type,
     });
     const result = await service.executeWorkflow(
@@ -269,8 +359,8 @@ Deno.test(
       context,
     );
 
-    const attrs = getDataOutputAttributes(result);
-    assertEquals(attrs?.value, "started");
+    assertEquals(result.dataHandles !== undefined, true);
+    assertEquals(result.dataHandles!.length >= 1, true);
   },
 );
 
@@ -283,7 +373,7 @@ Deno.test("executeWorkflow - throws error for unknown method", async () => {
     attributes: { value: "test" },
   });
 
-  const context = createTestContext({
+  const { context } = createTestContext({
     modelType: model.type,
   });
 
@@ -298,19 +388,23 @@ Deno.test("executeWorkflow - processes follow-up actions", async () => {
   const service = new DefaultMethodExecutionService();
 
   const model = createTestModel({
-    executeImpl: (_definition) =>
-      Promise.resolve({
-        dataOutputs: [
-          createTestDataOutput("data", { value: "started", counter: 1 }),
-        ],
+    executeImpl: async (_definition, context) => {
+      const handle = await writeTestData(context, "data", {
+        value: "started",
+        counter: 1,
+      });
+      return {
+        dataHandles: [handle],
         followUpActions: [{ methodName: "followUp" }],
-      }),
-    followUpImpl: (_definition) =>
-      Promise.resolve({
-        dataOutputs: [
-          createTestDataOutput("data", { value: "completed", counter: 2 }),
-        ],
-      }),
+      };
+    },
+    followUpImpl: async (_definition, context) => {
+      const handle = await writeTestData(context, "data", {
+        value: "completed",
+        counter: 2,
+      });
+      return { dataHandles: [handle] };
+    },
   });
 
   const definition = Definition.create({
@@ -318,7 +412,7 @@ Deno.test("executeWorkflow - processes follow-up actions", async () => {
     attributes: { value: "test" },
   });
 
-  const context = createTestContext({
+  const { context } = createTestContext({
     modelType: model.type,
   });
   const result = await service.executeWorkflow(
@@ -328,9 +422,8 @@ Deno.test("executeWorkflow - processes follow-up actions", async () => {
     context,
   );
 
-  const attrs = getDataOutputAttributes(result);
-  assertEquals(attrs?.value, "completed");
-  assertEquals(attrs?.counter, 2);
+  assertEquals(result.dataHandles !== undefined, true);
+  assertEquals(result.dataHandles!.length >= 1, true);
 });
 
 Deno.test("executeWorkflow - respects continueCondition", async () => {
@@ -338,31 +431,30 @@ Deno.test("executeWorkflow - respects continueCondition", async () => {
   let followUpCallCount = 0;
 
   const model = createTestModel({
-    executeImpl: (_definition) =>
-      Promise.resolve({
-        dataOutputs: [
-          createTestDataOutput("data", { value: "started", counter: 0 }),
-        ],
+    executeImpl: async (_definition, context) => {
+      const handle = await writeTestData(context, "data", {
+        value: "started",
+        counter: 0,
+      });
+      return {
+        dataHandles: [handle],
         followUpActions: [
           {
             methodName: "followUp",
             // Only continue if counter is less than 0 (never true after start)
-            continueCondition: (dataOutputs: DataOutput[]) => {
-              const attrs = JSON.parse(
-                new TextDecoder().decode(dataOutputs[0].content),
-              );
-              return (attrs.counter as number) < 0;
+            continueCondition: (_dataHandles: DataHandle[]) => {
+              return false; // Never continue
             },
           },
         ],
-      }),
-    followUpImpl: (_definition) => {
+      };
+    },
+    followUpImpl: async (_definition, context) => {
       followUpCallCount++;
-      return Promise.resolve({
-        dataOutputs: [
-          createTestDataOutput("data", { value: "should-not-reach" }),
-        ],
+      const handle = await writeTestData(context, "data", {
+        value: "should-not-reach",
       });
+      return { dataHandles: [handle] };
     },
   });
 
@@ -371,7 +463,7 @@ Deno.test("executeWorkflow - respects continueCondition", async () => {
     attributes: { value: "test" },
   });
 
-  const context = createTestContext({
+  const { context } = createTestContext({
     modelType: model.type,
   });
   const result = await service.executeWorkflow(
@@ -383,8 +475,7 @@ Deno.test("executeWorkflow - respects continueCondition", async () => {
 
   // Follow-up should not be called because condition was false
   assertEquals(followUpCallCount, 0);
-  const attrs = getDataOutputAttributes(result);
-  assertEquals(attrs?.value, "started");
+  assertEquals(result.dataHandles !== undefined, true);
 });
 
 Deno.test("executeWorkflow - retries on failure with maxRetries", async () => {
@@ -392,21 +483,24 @@ Deno.test("executeWorkflow - retries on failure with maxRetries", async () => {
   let attemptCount = 0;
 
   const model = createTestModel({
-    executeImpl: (_definition) =>
-      Promise.resolve({
-        dataOutputs: [createTestDataOutput("data", { value: "started" })],
+    executeImpl: async (_definition, context) => {
+      const handle = await writeTestData(context, "data", {
+        value: "started",
+      });
+      return {
+        dataHandles: [handle],
         followUpActions: [{ methodName: "followUp", maxRetries: 2 }],
-      }),
-    followUpImpl: (_definition) => {
+      };
+    },
+    followUpImpl: async (_definition, context) => {
       attemptCount++;
       if (attemptCount < 3) {
         return Promise.reject(new Error("Simulated failure"));
       }
-      return Promise.resolve({
-        dataOutputs: [
-          createTestDataOutput("data", { value: "succeeded-on-retry" }),
-        ],
+      const handle = await writeTestData(context, "data", {
+        value: "succeeded-on-retry",
       });
+      return { dataHandles: [handle] };
     },
   });
 
@@ -415,7 +509,7 @@ Deno.test("executeWorkflow - retries on failure with maxRetries", async () => {
     attributes: { value: "test" },
   });
 
-  const context = createTestContext({
+  const { context } = createTestContext({
     modelType: model.type,
   });
   const result = await service.executeWorkflow(
@@ -427,19 +521,22 @@ Deno.test("executeWorkflow - retries on failure with maxRetries", async () => {
 
   // Should have succeeded on the 3rd attempt (1 initial + 2 retries)
   assertEquals(attemptCount, 3);
-  const attrs = getDataOutputAttributes(result);
-  assertEquals(attrs?.value, "succeeded-on-retry");
+  assertEquals(result.dataHandles !== undefined, true);
 });
 
 Deno.test("executeWorkflow - fails after exhausting maxRetries", async () => {
   const service = new DefaultMethodExecutionService();
 
   const model = createTestModel({
-    executeImpl: (_definition) =>
-      Promise.resolve({
-        dataOutputs: [createTestDataOutput("data", { value: "started" })],
+    executeImpl: async (_definition, context) => {
+      const handle = await writeTestData(context, "data", {
+        value: "started",
+      });
+      return {
+        dataHandles: [handle],
         followUpActions: [{ methodName: "followUp", maxRetries: 1 }],
-      }),
+      };
+    },
     followUpImpl: () => Promise.reject(new Error("Always fails")),
   });
 
@@ -448,7 +545,7 @@ Deno.test("executeWorkflow - fails after exhausting maxRetries", async () => {
     attributes: { value: "test" },
   });
 
-  const context = createTestContext({
+  const { context } = createTestContext({
     modelType: model.type,
   });
 
@@ -474,41 +571,53 @@ Deno.test("executeWorkflow - handles recursive follow-up actions", async () => {
     type: ModelType.create("test/recursive"),
     version: "2026.02.09.1",
     inputAttributesSchema: schema,
-    dataOutputSpecs: {},
+    dataOutputSpecs: {
+      "data": {
+        specType: DataSpecType.create("data"),
+        description: "Test data",
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        tags: { type: "data" },
+      },
+    },
     methods: {
       start: {
         description: "Start method",
         inputAttributesSchema: schema,
-        execute: (_definition) => {
+        execute: async (_definition, context) => {
           callSequence.push("start");
           currentStep = 1;
-          return Promise.resolve({
-            dataOutputs: [createTestDataOutput("data", { step: 1 })],
+          const handle = await writeTestData(context, "data", { step: 1 });
+          return {
+            dataHandles: [handle],
             followUpActions: [{ methodName: "increment" }],
-          });
+          };
         },
       },
       increment: {
         description: "Increment method that may recurse",
         inputAttributesSchema: schema,
-        execute: (_definition) => {
+        execute: async (_definition, context) => {
           callSequence.push(`increment-${currentStep}`);
 
           currentStep++;
 
           // Only recurse if step < 3
           if (currentStep < 3) {
-            return Promise.resolve({
-              dataOutputs: [
-                createTestDataOutput("data", { step: currentStep }),
-              ],
-              followUpActions: [{ methodName: "increment" }],
+            const handle = await writeTestData(context, "data", {
+              step: currentStep,
             });
+            return {
+              dataHandles: [handle],
+              followUpActions: [{ methodName: "increment" }],
+            };
           }
 
-          return Promise.resolve({
-            dataOutputs: [createTestDataOutput("data", { step: currentStep })],
+          const handle = await writeTestData(context, "data", {
+            step: currentStep,
           });
+          return { dataHandles: [handle] };
         },
       },
     },
@@ -519,7 +628,7 @@ Deno.test("executeWorkflow - handles recursive follow-up actions", async () => {
     attributes: { step: 0 },
   });
 
-  const context = createTestContext({
+  const { context } = createTestContext({
     modelType: model.type,
   });
   const result = await service.executeWorkflow(
@@ -530,8 +639,7 @@ Deno.test("executeWorkflow - handles recursive follow-up actions", async () => {
   );
 
   assertEquals(callSequence, ["start", "increment-1", "increment-2"]);
-  const attrs = getDataOutputAttributes(result);
-  assertEquals(attrs?.step, 3);
+  assertEquals(result.dataHandles !== undefined, true);
 });
 
 Deno.test("executeWorkflow - throws on max depth exceeded", async () => {
@@ -545,17 +653,27 @@ Deno.test("executeWorkflow - throws on max depth exceeded", async () => {
     type: ModelType.create("test/infinite"),
     version: "2026.02.09.1",
     inputAttributesSchema: schema,
-    dataOutputSpecs: {},
+    dataOutputSpecs: {
+      "data": {
+        specType: DataSpecType.create("data"),
+        description: "Test data",
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        tags: { type: "data" },
+      },
+    },
     methods: {
       start: {
         description: "Start infinite loop",
         inputAttributesSchema: schema,
-        execute: (_definition) => {
+        execute: async (_definition, context) => {
           counter++;
-          return Promise.resolve({
-            dataOutputs: [createTestDataOutput("data", { counter })],
+          const handle = await writeTestData(context, "data", { counter });
+          return {
+            dataHandles: [handle],
             followUpActions: [{ methodName: "start" }],
-          });
+          };
         },
       },
     },
@@ -566,7 +684,7 @@ Deno.test("executeWorkflow - throws on max depth exceeded", async () => {
     attributes: { counter: 0 },
   });
 
-  const context = createTestContext({
+  const { context } = createTestContext({
     modelType: model.type,
   });
 
@@ -582,11 +700,11 @@ Deno.test(
   async () => {
     const service = new DefaultMethodExecutionService();
     let receivedDefinitionName = "";
-    let previousDataOutputsInCondition: DataOutput[] | undefined = undefined;
+    let previousDataHandlesInCondition: DataHandle[] | undefined = undefined;
 
     // This test demonstrates that:
     // - Follow-up methods receive the same definition
-    // - continueCondition receives the dataOutputs from the previous method
+    // - continueCondition receives the dataHandles from the previous method
     const schema = z.object({
       RequestToken: z.string().optional(),
       OperationStatus: z.string().optional(),
@@ -597,46 +715,51 @@ Deno.test(
       type: ModelType.create("test/token-passing"),
       version: "2026.02.09.1",
       inputAttributesSchema: schema,
-      dataOutputSpecs: {},
+      dataOutputSpecs: {
+        "data": {
+          specType: DataSpecType.create("data"),
+          description: "Test data",
+          contentType: "application/json",
+          lifetime: "infinite",
+          garbageCollection: 10,
+          tags: { type: "data" },
+        },
+      },
       methods: {
         create: {
-          description: "Create method that returns RequestToken in data output",
+          description: "Create method that returns RequestToken in data handle",
           inputAttributesSchema: schema,
-          execute: (_definition) => {
-            return Promise.resolve({
-              dataOutputs: [
-                createTestDataOutput("data", {
-                  RequestToken: "test-request-token-123",
-                  OperationStatus: "IN_PROGRESS",
-                }),
-              ],
+          execute: async (_definition, context) => {
+            const handle = await writeTestData(context, "data", {
+              RequestToken: "test-request-token-123",
+              OperationStatus: "IN_PROGRESS",
+            });
+            return {
+              dataHandles: [handle],
               followUpActions: [
                 {
                   methodName: "sync",
-                  continueCondition: (dataOutputs: DataOutput[]) => {
-                    previousDataOutputsInCondition = dataOutputs;
+                  continueCondition: (dataHandles: DataHandle[]) => {
+                    previousDataHandlesInCondition = dataHandles;
                     return true;
                   },
                 },
               ],
-            });
+            };
           },
         },
         sync: {
           description: "Sync method that uses definition",
           inputAttributesSchema: schema,
-          execute: (definition) => {
+          execute: async (definition, context) => {
             // Capture the definition name to verify it's the same definition
             receivedDefinitionName = definition.name;
 
-            return Promise.resolve({
-              dataOutputs: [
-                createTestDataOutput("data", {
-                  RequestToken: "test-request-token-123",
-                  OperationStatus: "SUCCESS",
-                }),
-              ],
+            const handle = await writeTestData(context, "data", {
+              RequestToken: "test-request-token-123",
+              OperationStatus: "SUCCESS",
             });
+            return { dataHandles: [handle] };
           },
         },
       },
@@ -647,7 +770,7 @@ Deno.test(
       attributes: { OriginalValue: "from-yaml" },
     });
 
-    const context = createTestContext({
+    const { context } = createTestContext({
       modelType: model.type,
     });
     const result = await service.executeWorkflow(
@@ -660,19 +783,14 @@ Deno.test(
     // Verify sync received the same definition
     assertEquals(receivedDefinitionName, "test-definition");
 
-    // Verify continueCondition received the data outputs from create
-    assertEquals(previousDataOutputsInCondition !== undefined, true);
-    const conditionDataOutputs = previousDataOutputsInCondition!;
-    assertEquals(conditionDataOutputs.length, 1);
-    const conditionAttrs = JSON.parse(
-      new TextDecoder().decode(conditionDataOutputs[0].content),
-    );
-    assertEquals(conditionAttrs.RequestToken, "test-request-token-123");
-    assertEquals(conditionAttrs.OperationStatus, "IN_PROGRESS");
+    // Verify continueCondition received the data handles from create
+    assertEquals(previousDataHandlesInCondition !== undefined, true);
+    const conditionHandles = previousDataHandlesInCondition!;
+    assertEquals(conditionHandles.length, 1);
 
-    // Verify final result
-    const finalAttrs = getDataOutputAttributes(result);
-    assertEquals(finalAttrs?.OperationStatus, "SUCCESS");
+    // Verify final result has data handles
+    assertEquals(result.dataHandles !== undefined, true);
+    assertEquals(result.dataHandles!.length >= 1, true);
   },
 );
 
@@ -710,7 +828,7 @@ Deno.test("execute passes logger in context to method", async () => {
     attributes: { value: "test" },
   });
 
-  const context = createTestContext({ modelType: model.type });
+  const { context } = createTestContext({ modelType: model.type });
   await service.executeWorkflow(definition, model, "run", context);
 
   assertEquals(capturedLogger !== undefined, true);

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -6,29 +6,16 @@ import { CalVer } from "./calver.ts";
 import type { Definition } from "../definitions/definition.ts";
 import type { DefinitionRepository } from "../definitions/repositories.ts";
 import {
+  type DataId,
   type DataMetadata,
   type GarbageCollectionPolicy,
   GarbageCollectionSchema,
   type Lifetime,
   LifetimeSchema,
+  type OwnerDefinition,
 } from "../data/mod.ts";
 import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import type { OutputRepository } from "./repositories.ts";
-
-/**
- * Callbacks for streaming output from method execution.
- */
-export interface MethodStreamingCallbacks {
-  /**
-   * Called for each line of stdout.
-   */
-  onStdout?: (line: string) => void;
-
-  /**
-   * Called for each line of stderr.
-   */
-  onStderr?: (line: string) => void;
-}
 
 /**
  * Data spec type - identifies a category of data output.
@@ -55,8 +42,22 @@ export class DataSpecType {
 }
 
 /**
+ * Normalizes a specType value to a DataSpecType instance.
+ * Accepts either an existing DataSpecType or a plain string.
+ */
+export function normalizeSpecType(
+  specType: DataSpecType | string,
+): DataSpecType {
+  if (specType instanceof DataSpecType) {
+    return specType;
+  }
+  return DataSpecType.create(specType);
+}
+
+/**
  * Specification for a data output spec type.
- * Value object - immutable.
+ * Value object - immutable. This is the single source of truth for how
+ * a particular category of data output should be stored.
  */
 export interface DataOutputSpecification {
   /** The spec type identifier */
@@ -65,20 +66,20 @@ export interface DataOutputSpecification {
   /** Human-readable description */
   description?: string;
 
-  /** Default content type */
-  contentType?: string;
+  /** Content type for this data output */
+  contentType: string;
 
-  /** Default lifetime policy */
-  lifetime?: Lifetime;
+  /** Lifetime policy */
+  lifetime: Lifetime;
 
-  /** Default garbage collection policy */
-  garbageCollection?: GarbageCollectionPolicy;
+  /** Garbage collection policy */
+  garbageCollection: GarbageCollectionPolicy;
 
   /** Whether this supports streaming */
   streaming?: boolean;
 
-  /** Default tags */
-  tags?: Record<string, string>;
+  /** Tags applied to this data output */
+  tags: Record<string, string>;
 }
 
 /**
@@ -87,11 +88,11 @@ export interface DataOutputSpecification {
 export const DataOutputSpecificationSchema = z.object({
   specType: z.string().min(1),
   description: z.string().optional(),
-  contentType: z.string().optional(),
-  lifetime: LifetimeSchema.optional(),
-  garbageCollection: GarbageCollectionSchema.optional(),
+  contentType: z.string(),
+  lifetime: LifetimeSchema,
+  garbageCollection: GarbageCollectionSchema,
   streaming: z.boolean().optional(),
-  tags: z.record(z.string(), z.string()).optional(),
+  tags: z.record(z.string(), z.string()),
 });
 
 /**
@@ -139,43 +140,136 @@ export interface MethodContext {
   logger: Logger;
 
   /**
-   * Optional callbacks for streaming stdout/stderr output.
-   */
-  streaming?: MethodStreamingCallbacks;
-
-  /**
    * The model definition for validation and defaults.
    */
   modelDefinition?: ModelDefinition;
+
+  /**
+   * Factory for creating DataWriter instances to write data during execution.
+   */
+  createDataWriter?: DataWriterFactory;
+
+  /**
+   * Tags merged into every DataWriter created during execution.
+   * Used by workflow steps to inject workflow-specific tags.
+   */
+  tagOverrides?: Record<string, string>;
+
+  /**
+   * Data output overrides merged into every DataWriter's options.
+   * Used by workflow steps to override lifetime, gc, and tags per spec type.
+   */
+  dataOutputOverrides?: Array<{
+    specType: string;
+    lifetime?: Lifetime;
+    garbageCollection?: GarbageCollectionPolicy;
+    tags?: Record<string, string>;
+  }>;
 }
 
 /**
- * Data output from a method execution.
+ * Lightweight reference to data already written during method execution.
+ * Value object — the content has already been persisted by a DataWriter.
  */
-export interface DataOutput {
-  /**
-   * Unique name for this data instance.
-   */
+export interface DataHandle {
+  /** Human-readable name of this data artifact. */
   name: string;
-
-  /**
-   * Reference to the declared spec type.
-   */
+  /** Reference to the declared spec type. */
   specType: DataSpecType;
-
-  /**
-   * Content of the data artifact.
-   */
-  content: Uint8Array;
-
-  /**
-   * Metadata for the data artifact (can override spec defaults).
-   */
+  /** Unique data ID. */
+  dataId: DataId;
+  /** Version number on disk. */
+  version: number;
+  /** Size in bytes. */
+  size: number;
+  /** Tags applied to the data. */
+  tags: Record<string, string>;
+  /** Metadata excluding auto-generated fields. */
   metadata: Omit<
     DataMetadata,
     "id" | "name" | "version" | "createdAt" | "size" | "checksum"
   >;
 }
+
+/**
+ * Options for creating a DataWriter from a spec-based call site.
+ * Only `name` and `specType` are required — defaults come from the
+ * model's DataOutputSpecification. Optional fields override spec defaults.
+ */
+export interface SpecBasedWriterOptions {
+  /** Unique instance name for this data artifact */
+  name: string;
+  /** Key into dataOutputSpecs — must match a declared spec type */
+  specType: string;
+  /** Override the spec's default content type */
+  contentType?: string;
+  /** Override the spec's default lifetime */
+  lifetime?: Lifetime;
+  /** Override the spec's default garbage collection policy */
+  garbageCollection?: GarbageCollectionPolicy;
+  /** Override the spec's default streaming flag */
+  streaming?: boolean;
+  /** Merged on top of spec's default tags */
+  tags?: Record<string, string>;
+}
+
+/**
+ * Fully resolved options used internally by DefaultDataWriter.
+ * All fields are required (resolved from spec + overrides).
+ */
+export interface ResolvedDataWriterOptions {
+  name: string;
+  specType: DataSpecType | string;
+  contentType: string;
+  lifetime: Lifetime;
+  garbageCollection: GarbageCollectionPolicy;
+  streaming?: boolean;
+  tags: Record<string, string>;
+  ownerDefinition?: OwnerDefinition;
+}
+
+/**
+ * Domain service interface for writing data directly to disk during method execution.
+ */
+export interface DataWriter {
+  /** The data ID assigned to this writer. */
+  readonly dataId: DataId;
+  /** The data name. */
+  readonly name: string;
+
+  /** Write all content at once. */
+  writeAll(content: Uint8Array): Promise<DataHandle>;
+  /** Write text content (encodes to UTF-8). */
+  writeText(text: string): Promise<DataHandle>;
+  /** Append a single line (streaming). */
+  writeLine(line: string): Promise<void>;
+  /** Pipe a stream to disk with optional line-by-line callbacks. */
+  writeStream(
+    stream: ReadableStream<Uint8Array>,
+    options?: { onLine?: (line: string) => void },
+  ): Promise<DataHandle>;
+  /** Get the file path for direct I/O. */
+  getFilePath(): Promise<string>;
+  /** Finalize a writer that used writeLine/getFilePath and return the handle. */
+  finalize(): Promise<DataHandle>;
+}
+
+/**
+ * Callbacks for DataWriter events.
+ */
+export interface DataWriterCallbacks {
+  /** Called for each line written by writeLine or writeStream. */
+  onLine?: (dataName: string, line: string) => void;
+}
+
+/**
+ * Factory function for creating DataWriter instances.
+ * Accepts spec-based options — the factory resolves defaults from
+ * the model's DataOutputSpecification.
+ */
+export type DataWriterFactory = (
+  options: SpecBasedWriterOptions,
+) => DataWriter;
 
 /**
  * Follow-up action to be executed after a method completes.
@@ -199,9 +293,9 @@ export interface FollowUpAction {
   /**
    * Condition that must be met to continue with follow-up actions.
    * If this returns false, the workflow stops.
-   * Receives the data outputs from the previous method execution.
+   * Receives the data handles from the previous method execution.
    */
-  continueCondition?: (dataOutputs: DataOutput[]) => boolean;
+  continueCondition?: (dataHandles: DataHandle[]) => boolean;
 }
 
 /**
@@ -209,10 +303,9 @@ export interface FollowUpAction {
  */
 export interface MethodResult {
   /**
-   * Data outputs produced by the method.
-   * Each output will be stored as a versioned Data artifact.
+   * Data handles referencing artifacts already persisted by DataWriter.
    */
-  dataOutputs?: DataOutput[];
+  dataHandles?: DataHandle[];
 
   /**
    * Optional follow-up actions to execute.

--- a/src/domain/models/model_test.ts
+++ b/src/domain/models/model_test.ts
@@ -1,18 +1,108 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import { z } from "zod";
 import {
+  type DataHandle,
   DataSpecType,
+  type DataWriter,
+  type DataWriterFactory,
   defineModel,
   type MethodContext,
   type ModelDefinition,
   ModelRegistry,
+  normalizeSpecType,
+  type SpecBasedWriterOptions,
 } from "./model.ts";
 import { ModelType } from "./model_type.ts";
 import { createDefinitionId, Definition } from "../definitions/definition.ts";
 import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../definitions/repositories.ts";
-import { generateDataId } from "../data/data_id.ts";
+import { type DataId, generateDataId } from "../data/data_id.ts";
 import { getLogger } from "@logtape/logtape";
+
+/**
+ * Stored result from mock data writer.
+ */
+interface MockWriterResult {
+  handle: DataHandle;
+  content: Uint8Array;
+}
+
+/**
+ * Creates a mock DataWriterFactory that stores written content in memory.
+ */
+function createMockDataWriterFactory(): {
+  factory: DataWriterFactory;
+  getResults: () => MockWriterResult[];
+} {
+  const results: MockWriterResult[] = [];
+  const getResults = (): MockWriterResult[] => results;
+  let nextId = 1;
+
+  const factory: DataWriterFactory = (
+    options: SpecBasedWriterOptions,
+  ): DataWriter => {
+    const dataId = `mock-data-${nextId++}` as DataId;
+
+    const buildHandle = (content: Uint8Array): DataHandle => ({
+      name: options.name,
+      specType: normalizeSpecType(options.specType),
+      dataId,
+      version: 1,
+      size: content.length,
+      tags: options.tags ?? {},
+      metadata: {
+        contentType: options.contentType ?? "application/json",
+        lifetime: options.lifetime ?? "infinite",
+        garbageCollection: options.garbageCollection ?? 10,
+        streaming: options.streaming ?? false,
+        tags: options.tags ?? {},
+        ownerDefinition: {
+          definitionHash: "test-hash",
+          ownerType: "model-method",
+          ownerRef: "test",
+        },
+      },
+    });
+
+    return {
+      dataId,
+      name: options.name,
+      writeAll(content: Uint8Array): Promise<DataHandle> {
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeText(text: string): Promise<DataHandle> {
+        const content = new TextEncoder().encode(text);
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeLine(_line: string): Promise<void> {
+        return Promise.resolve();
+      },
+      writeStream(
+        _stream: ReadableStream<Uint8Array>,
+      ): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      getFilePath(): Promise<string> {
+        return Promise.resolve("/tmp/mock");
+      },
+      finalize(): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+    } as DataWriter;
+  };
+
+  return { factory, getResults };
+}
 
 /**
  * Creates a mock UnifiedDataRepository for testing.
@@ -34,6 +124,10 @@ function createMockDataRepo(): UnifiedDataRepository {
     getContentPath: () => "",
     collectGarbage: () =>
       Promise.resolve({ versionsRemoved: 0, bytesReclaimed: 0 }),
+    allocateVersion: () =>
+      Promise.resolve({ version: 1, contentPath: "/tmp/mock" }),
+    finalizeVersion: () =>
+      Promise.resolve({ size: 0, checksum: "mock-checksum" }),
   };
 }
 
@@ -57,28 +151,34 @@ function createMockDefinitionRepo(): DefinitionRepository {
 /**
  * Creates a test MethodContext with mocked repositories.
  */
-function createTestContext(modelType: ModelType): MethodContext {
-  return {
+function createTestContext(modelType: ModelType): {
+  context: MethodContext;
+  getResults: () => MockWriterResult[];
+} {
+  const { factory, getResults } = createMockDataWriterFactory();
+  const context: MethodContext = {
     repoDir: "/tmp",
     modelType,
     modelId: crypto.randomUUID(),
     logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
+    createDataWriter: factory,
   };
+  return { context, getResults };
 }
 
 /**
- * Helper to get attributes from a DataOutput.
+ * Helper to get parsed JSON content from mock results.
  */
-function getDataOutputAttributes(
-  dataOutputs: { content: Uint8Array }[] | undefined,
+function getResultAttributes(
+  results: MockWriterResult[],
   index = 0,
 ): Record<string, unknown> | undefined {
-  if (!dataOutputs || dataOutputs.length <= index) {
+  if (results.length <= index) {
     return undefined;
   }
-  const content = new TextDecoder().decode(dataOutputs[index].content);
+  const content = new TextDecoder().decode(results[index].content);
   return JSON.parse(content);
 }
 
@@ -88,39 +188,32 @@ function createTestModel(typeString: string): ModelDefinition {
     type,
     version: "2026.02.09.1",
     inputAttributesSchema: z.object({ message: z.string() }),
-    dataOutputSpecs: {},
+    dataOutputSpecs: {
+      "data": {
+        specType: DataSpecType.create("data"),
+        description: "Test data",
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        tags: { type: "data" },
+      },
+    },
     methods: {
       write: {
         description: "Write message to data",
         inputAttributesSchema: z.object({ message: z.string() }),
-        execute: (definition: Definition, _context: MethodContext) => {
-          const content = new TextEncoder().encode(
+        execute: async (definition: Definition, context: MethodContext) => {
+          const writer = context.createDataWriter!({
+            name: `${definition.name}-data`,
+            specType: "data",
+          });
+          const handle = await writer.writeText(
             JSON.stringify({
               message: definition.attributes.message,
               timestamp: new Date().toISOString(),
             }),
           );
-          return Promise.resolve({
-            dataOutputs: [
-              {
-                name: `${definition.name}-data`,
-                specType: DataSpecType.create("data"),
-                content,
-                metadata: {
-                  contentType: "application/json",
-                  lifetime: "infinite" as const,
-                  garbageCollection: 10,
-                  streaming: false,
-                  tags: { type: "data" },
-                  ownerDefinition: {
-                    definitionHash: "test-hash",
-                    ownerType: "model-method" as const,
-                    ownerRef: "write",
-                  },
-                },
-              },
-            ],
-          });
+          return { dataHandles: [handle] };
         },
       },
     },
@@ -230,9 +323,13 @@ Deno.test("ModelDefinition method can execute", async () => {
     attributes: { message: "hello world" },
   });
 
-  const context = createTestContext(model.type);
+  const { context, getResults } = createTestContext(model.type);
   const result = await model.methods.write.execute(definition, context);
-  const attrs = getDataOutputAttributes(result.dataOutputs);
+
+  assertEquals(result.dataHandles !== undefined, true);
+  assertEquals(result.dataHandles!.length, 1);
+
+  const attrs = getResultAttributes(getResults());
   assertEquals(attrs?.message, "hello world");
   assertEquals(typeof attrs?.timestamp, "string");
 });
@@ -280,7 +377,7 @@ Deno.test("ModelRegistry.extend adds methods to existing model", () => {
     read: {
       description: "Read the data",
       inputAttributesSchema: z.object({ message: z.string() }),
-      execute: () => Promise.resolve({ dataOutputs: [] }),
+      execute: () => Promise.resolve({ dataHandles: [] }),
     },
   });
 
@@ -299,7 +396,7 @@ Deno.test("ModelRegistry.extend throws on unregistered type", () => {
         read: {
           description: "Read",
           inputAttributesSchema: z.object({}),
-          execute: () => Promise.resolve({ dataOutputs: [] }),
+          execute: () => Promise.resolve({ dataHandles: [] }),
         },
       }),
     Error,
@@ -318,7 +415,7 @@ Deno.test("ModelRegistry.extend throws on method name conflict", () => {
         write: {
           description: "Duplicate write",
           inputAttributesSchema: z.object({}),
-          execute: () => Promise.resolve({ dataOutputs: [] }),
+          execute: () => Promise.resolve({ dataHandles: [] }),
         },
       }),
     Error,
@@ -337,7 +434,7 @@ Deno.test("ModelRegistry.extend preserves original methods and schema", () => {
     read: {
       description: "Read the data",
       inputAttributesSchema: z.object({}),
-      execute: () => Promise.resolve({ dataOutputs: [] }),
+      execute: () => Promise.resolve({ dataHandles: [] }),
     },
   });
 
@@ -356,31 +453,17 @@ Deno.test("ModelRegistry.extend - extended methods are callable", async () => {
     greet: {
       description: "Greet",
       inputAttributesSchema: z.object({ message: z.string() }),
-      execute: (definition: Definition, _context: MethodContext) => {
-        const content = new TextEncoder().encode(
+      execute: async (definition: Definition, context: MethodContext) => {
+        const writer = context.createDataWriter!({
+          name: "greeting",
+          specType: "data",
+        });
+        const handle = await writer.writeText(
           JSON.stringify({
             greeting: `Hello, ${definition.attributes.message}`,
           }),
         );
-        return Promise.resolve({
-          dataOutputs: [{
-            name: "greeting",
-            specType: DataSpecType.create("data"),
-            content,
-            metadata: {
-              contentType: "application/json",
-              lifetime: "infinite" as const,
-              garbageCollection: 10,
-              streaming: false,
-              tags: { type: "data" },
-              ownerDefinition: {
-                definitionHash: "test-hash",
-                ownerType: "model-method" as const,
-                ownerRef: "greet",
-              },
-            },
-          }],
-        });
+        return { dataHandles: [handle] };
       },
     },
   });
@@ -390,10 +473,13 @@ Deno.test("ModelRegistry.extend - extended methods are callable", async () => {
     name: "test",
     attributes: { message: "world" },
   });
-  const context = createTestContext(extended.type);
+  const { context, getResults } = createTestContext(extended.type);
 
   const result = await extended.methods.greet.execute(definition, context);
-  const attrs = getDataOutputAttributes(result.dataOutputs);
+  assertEquals(result.dataHandles !== undefined, true);
+  assertEquals(result.dataHandles!.length, 1);
+
+  const attrs = getResultAttributes(getResults());
   assertEquals(attrs?.greeting, "Hello, world");
 });
 

--- a/src/domain/models/systemd/journalctl/journalctl_model.ts
+++ b/src/domain/models/systemd/journalctl/journalctl_model.ts
@@ -123,29 +123,14 @@ async function readLogs(
 
   const logLines = result.stdout.split("\n").filter((line) => line.length > 0);
 
-  const definitionHash = await definition.computeHash();
+  const writer = context.createDataWriter!({
+    name: `${definition.name}-logs`,
+    specType: "log",
+  });
 
-  return {
-    dataOutputs: [
-      {
-        name: `${definition.name}-logs`,
-        specType: DataSpecType.create("log"),
-        content: new TextEncoder().encode(logLines.join("\n")),
-        metadata: {
-          contentType: "text/plain",
-          lifetime: "infinite",
-          garbageCollection: 10,
-          streaming: true,
-          tags: { type: "log" },
-          ownerDefinition: {
-            definitionHash,
-            ownerType: "model-method",
-            ownerRef: "read",
-          },
-        },
-      },
-    ],
-  };
+  const handle = await writer.writeText(logLines.join("\n"));
+
+  return { dataHandles: [handle] };
 }
 
 /**
@@ -170,6 +155,7 @@ export const journalctlModel: ModelDefinition<
       contentType: "text/plain",
       lifetime: "infinite",
       garbageCollection: 10,
+      streaming: true,
       tags: { type: "log" },
     },
   },

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -4,7 +4,7 @@ import { ModelType } from "./model_type.ts";
 import { CalVer } from "./calver.ts";
 import type { Definition } from "../definitions/definition.ts";
 import {
-  type DataOutput,
+  type DataHandle,
   type DataOutputSpecification,
   DataOutputSpecificationSchema,
   DataSpecType,
@@ -18,40 +18,13 @@ import {
 
 /**
  * Plain object result returned by user methods before conversion.
+ * User models must use context.createDataWriter() to produce data.
  */
 interface UserMethodResult {
   /**
-   * Direct data outputs with explicit content and metadata.
+   * Handles for data written via context.createDataWriter() during execution.
    */
-  dataOutputs?: Array<{
-    name: string;
-    specType?: string;
-    content: Uint8Array | string;
-    metadata?: {
-      contentType?: string;
-      lifetime?: string;
-      garbageCollection?: number;
-      streaming?: boolean;
-      tags?: Record<string, string>;
-    };
-  }>;
-  /**
-   * Resource output - a simpler format that gets converted to dataOutputs.
-   * The resource attributes are serialized as JSON and tagged with type=resource.
-   */
-  resource?: {
-    id?: string;
-    attributes: Record<string, unknown>;
-  };
-  /**
-   * Data output - a simpler format that gets converted to dataOutputs.
-   * The data attributes are serialized as JSON.
-   */
-  data?: {
-    attributes: Record<string, unknown>;
-    name?: string;
-    tags?: Record<string, string>;
-  };
+  dataHandles?: DataHandle[];
   [key: string]: unknown;
 }
 
@@ -99,8 +72,7 @@ const UserModelSchema = z.object({
   inputAttributesSchema: z.custom<z.ZodTypeAny>((val) =>
     val instanceof z.ZodType
   ),
-  dataOutputSpecs: z.record(z.string(), DataOutputSpecificationSchema)
-    .optional(),
+  dataOutputSpecs: z.record(z.string(), DataOutputSpecificationSchema),
   methods: z.record(z.string(), UserMethodSchema),
   upgrades: z.array(UserUpgradeSchema).optional(),
 });
@@ -330,7 +302,7 @@ export class UserModelLoader {
         description: method.description,
         inputAttributesSchema: method.inputAttributesSchema ??
           targetModel.inputAttributesSchema,
-        execute: this.wrapUserExecute(name, method.execute),
+        execute: this.wrapUserExecute(method.execute),
       };
     }
 
@@ -344,93 +316,16 @@ export class UserModelLoader {
   }
 
   /**
-   * Wraps a user execute function to convert UserMethodResult to MethodResult
-   * with proper DataOutput format.
+   * Wraps a user execute function to pass through dataHandles from the result.
+   * User models write data via context.createDataWriter() and return handles.
    */
   private wrapUserExecute(
-    methodName: string,
     userExecuteFn: UserExecuteFn,
   ): (definition: Definition, context: MethodContext) => Promise<MethodResult> {
     return async (definition, context): Promise<MethodResult> => {
       const userResult = await userExecuteFn(definition, context);
-      const definitionHash = await definition.computeHash();
 
-      // Convert user data outputs to proper DataOutput format
-      const dataOutputs: DataOutput[] = [];
-
-      // Handle resource output (simpler format)
-      if (userResult.resource && userResult.resource.attributes) {
-        const resourceJson = JSON.stringify(userResult.resource.attributes);
-        dataOutputs.push({
-          name: "resource",
-          specType: DataSpecType.create("resource"),
-          content: new TextEncoder().encode(resourceJson),
-          metadata: {
-            contentType: "application/json",
-            lifetime: "infinite",
-            garbageCollection: 10,
-            streaming: false,
-            tags: { type: "resource" },
-            ownerDefinition: {
-              definitionHash,
-              ownerType: "model-method",
-              ownerRef: methodName,
-            },
-          },
-        });
-      }
-
-      // Handle data output (simpler format)
-      if (userResult.data && userResult.data.attributes) {
-        const dataJson = JSON.stringify(userResult.data.attributes);
-        dataOutputs.push({
-          name: userResult.data.name ?? "data",
-          specType: DataSpecType.create("data"),
-          content: new TextEncoder().encode(dataJson),
-          metadata: {
-            contentType: "application/json",
-            lifetime: "infinite",
-            garbageCollection: 10,
-            streaming: false,
-            tags: userResult.data.tags ?? { type: "data" },
-            ownerDefinition: {
-              definitionHash,
-              ownerType: "model-method",
-              ownerRef: methodName,
-            },
-          },
-        });
-      }
-
-      // Handle explicit dataOutputs
-      if (userResult.dataOutputs) {
-        for (const output of userResult.dataOutputs) {
-          const content = typeof output.content === "string"
-            ? new TextEncoder().encode(output.content)
-            : output.content;
-
-          dataOutputs.push({
-            name: output.name,
-            specType: DataSpecType.create(output.specType ?? "data"),
-            content,
-            metadata: {
-              contentType: output.metadata?.contentType ??
-                "application/octet-stream",
-              lifetime: output.metadata?.lifetime ?? "infinite",
-              garbageCollection: output.metadata?.garbageCollection ?? 10,
-              streaming: output.metadata?.streaming ?? false,
-              tags: output.metadata?.tags ?? { type: "data" },
-              ownerDefinition: {
-                definitionHash,
-                ownerType: "model-method",
-                ownerRef: methodName,
-              },
-            },
-          });
-        }
-      }
-
-      return { dataOutputs };
+      return { dataHandles: userResult.dataHandles };
     };
   }
 
@@ -449,38 +344,17 @@ export class UserModelLoader {
         description: method.description,
         inputAttributesSchema: method.inputAttributesSchema ??
           userModel.inputAttributesSchema,
-        execute: this.wrapUserExecute(name, method.execute),
+        execute: this.wrapUserExecute(method.execute),
       };
     }
 
-    const defaultSpecs: Record<string, DataOutputSpecification> = {
-      "data": {
-        specType: DataSpecType.create("data"),
-        description: "Data output",
-        contentType: "application/json",
-        lifetime: "infinite",
-        garbageCollection: 10,
-        tags: { type: "data" },
-      },
-      "resource": {
-        specType: DataSpecType.create("resource"),
-        description: "Resource output",
-        contentType: "application/json",
-        lifetime: "infinite",
-        garbageCollection: 10,
-        tags: { type: "resource" },
-      },
-    };
-
     // User-declared specs need specType converted from string to DataSpecType
     const userSpecs: Record<string, DataOutputSpecification> = {};
-    if (userModel.dataOutputSpecs) {
-      for (const [key, spec] of Object.entries(userModel.dataOutputSpecs)) {
-        userSpecs[key] = {
-          ...spec,
-          specType: DataSpecType.create(String(spec.specType)),
-        };
-      }
+    for (const [key, spec] of Object.entries(userModel.dataOutputSpecs)) {
+      userSpecs[key] = {
+        ...spec,
+        specType: DataSpecType.create(String(spec.specType)),
+      };
     }
 
     // Convert user upgrades to VersionUpgrade[]
@@ -496,7 +370,7 @@ export class UserModelLoader {
       type: modelType,
       version: userModel.version,
       inputAttributesSchema: userModel.inputAttributesSchema,
-      dataOutputSpecs: { ...defaultSpecs, ...userSpecs },
+      dataOutputSpecs: { ...userSpecs },
       methods,
       ...(upgrades && upgrades.length > 0 ? { upgrades } : {}),
     };

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -3,16 +3,108 @@ import { dirname, join } from "@std/path";
 import { UserModelLoader } from "./user_model_loader.ts";
 import { modelRegistry } from "./model.ts";
 import { Definition } from "../definitions/definition.ts";
-import type { MethodContext } from "./model.ts";
+import { normalizeSpecType } from "./model.ts";
+import type {
+  DataHandle,
+  DataWriter,
+  DataWriterFactory,
+  MethodContext,
+  SpecBasedWriterOptions,
+} from "./model.ts";
 import type { ModelType } from "./model_type.ts";
 import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../definitions/repositories.ts";
-import { generateDataId } from "../data/data_id.ts";
+import { type DataId, generateDataId } from "../data/data_id.ts";
 import { createDefinitionId } from "../definitions/definition.ts";
 import { getLogger } from "@logtape/logtape";
 
 // Import models barrel to ensure swamp/echo is registered for duplicate test
 import "./models.ts";
+
+/**
+ * Stored result from mock data writer.
+ */
+interface MockWriterResult {
+  handle: DataHandle;
+  content: Uint8Array;
+}
+
+/**
+ * Creates a mock DataWriterFactory that stores written content in memory.
+ */
+function createMockDataWriterFactory(): {
+  factory: DataWriterFactory;
+  getResults: () => MockWriterResult[];
+} {
+  const results: MockWriterResult[] = [];
+  const getResults = (): MockWriterResult[] => results;
+  let nextId = 1;
+
+  const factory: DataWriterFactory = (
+    options: SpecBasedWriterOptions,
+  ): DataWriter => {
+    const dataId = `mock-data-${nextId++}` as DataId;
+
+    const buildHandle = (content: Uint8Array): DataHandle => ({
+      name: options.name,
+      specType: normalizeSpecType(options.specType),
+      dataId,
+      version: 1,
+      size: content.length,
+      tags: { ...(options.tags ?? {}) },
+      metadata: {
+        contentType: options.contentType ?? "application/json",
+        lifetime: options.lifetime ?? "infinite",
+        garbageCollection: options.garbageCollection ?? 10,
+        streaming: options.streaming ?? false,
+        tags: { ...(options.tags ?? {}) },
+        ownerDefinition: {
+          definitionHash: "test-hash",
+          ownerType: "model-method",
+          ownerRef: "test",
+        },
+      },
+    });
+
+    return {
+      dataId,
+      name: options.name,
+      writeAll(content: Uint8Array): Promise<DataHandle> {
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeText(text: string): Promise<DataHandle> {
+        const content = new TextEncoder().encode(text);
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      writeLine(_line: string): Promise<void> {
+        return Promise.resolve();
+      },
+      writeStream(
+        _stream: ReadableStream<Uint8Array>,
+      ): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+      getFilePath(): Promise<string> {
+        return Promise.resolve("/tmp/mock");
+      },
+      finalize(): Promise<DataHandle> {
+        const content = new Uint8Array();
+        const handle = buildHandle(content);
+        results.push({ handle, content });
+        return Promise.resolve(handle);
+      },
+    } as DataWriter;
+  };
+
+  return { factory, getResults };
+}
 
 /**
  * Creates a mock UnifiedDataRepository for testing.
@@ -34,6 +126,10 @@ function createMockDataRepo(): UnifiedDataRepository {
     getContentPath: () => "",
     collectGarbage: () =>
       Promise.resolve({ versionsRemoved: 0, bytesReclaimed: 0 }),
+    allocateVersion: () =>
+      Promise.resolve({ version: 1, contentPath: "/tmp/mock" }),
+    finalizeVersion: () =>
+      Promise.resolve({ size: 0, checksum: "mock-checksum" }),
   };
 }
 
@@ -57,15 +153,20 @@ function createMockDefinitionRepo(): DefinitionRepository {
 /**
  * Creates a test MethodContext with mocked repositories.
  */
-function createTestContext(modelType: ModelType): MethodContext {
-  return {
+function createTestContext(
+  modelType: ModelType,
+): { context: MethodContext; getResults: () => MockWriterResult[] } {
+  const { factory, getResults } = createMockDataWriterFactory();
+  const context: MethodContext = {
     repoDir: "/tmp",
     modelType,
     modelId: crypto.randomUUID(),
     logger: getLogger(["test"]),
     dataRepository: createMockDataRepo(),
     definitionRepository: createMockDefinitionRepo(),
+    createDataWriter: factory,
   };
+  return { context, getResults };
 }
 
 // Helper to create a temporary directory with model files.
@@ -88,7 +189,7 @@ async function withTempModels(
   }
 }
 
-Deno.test("UserModelLoader loads valid model with dataOutputs", async () => {
+Deno.test("UserModelLoader loads valid model with dataHandles", async () => {
   const modelCode = `
 import { z } from "npm:zod@4";
 
@@ -100,19 +201,33 @@ export const model = {
   type: "@user/data-model-${Date.now()}",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     process: {
       description: "Process the message",
-      execute: async (definition, _context) => {
-        return {
-          dataOutputs: [{
-            name: definition.name + "-data",
-            content: JSON.stringify({
-              message: definition.attributes.message,
-              processedAt: new Date().toISOString(),
-            }),
-          }],
-        };
+      execute: async (definition, context) => {
+        const writer = context.createDataWriter({
+          name: definition.name + "-data",
+          specType: "data",
+          contentType: "application/json",
+          lifetime: "infinite",
+          garbageCollection: 10,
+          tags: { type: "data" },
+        });
+        const handle = await writer.writeText(JSON.stringify({
+          message: definition.attributes.message,
+          processedAt: new Date().toISOString(),
+        }));
+        return { dataHandles: [handle] };
       },
     },
   },
@@ -185,15 +300,20 @@ export const model = {
   type: "@user/regular-${Date.now()}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ msg: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     run: {
       description: "Run",
-      execute: async (definition) => ({
-        dataOutputs: [{
-          name: definition.name + "-result",
-          content: JSON.stringify({ result: "ok" }),
-        }],
-      }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -224,10 +344,20 @@ export const model = {
   type: "${typeId}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     write: {
       description: "Write message",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -239,10 +369,20 @@ export const model = {
   type: "${typeId}",
   version: "2026.02.09.2",
   inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     run: {
       description: "Run",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -263,8 +403,8 @@ export const model = {
   );
 });
 
-Deno.test("UserModelLoader converts plain dataOutputs to proper DataOutput format", async () => {
-  const typeId = `@user/convert-data-${Date.now()}`;
+Deno.test("UserModelLoader passes through dataHandles from user execute", async () => {
+  const typeId = `@user/passthrough-handles-${Date.now()}`;
   const modelCode = `
 import { z } from "npm:zod@4";
 
@@ -276,27 +416,41 @@ export const model = {
   type: "${typeId}",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     create: {
       description: "Create a resource",
-      execute: async (definition, _context) => {
-        // Return plain objects - the loader should add proper metadata
-        return {
-          dataOutputs: [{
-            name: definition.name + "-data",
-            content: JSON.stringify({
-              id: "resource-123",
-              status: "created",
-            }),
-          }],
-        };
+      execute: async (definition, context) => {
+        // Use context.createDataWriter to write data
+        const writer = context.createDataWriter({
+          name: definition.name + "-data",
+          specType: "data",
+          contentType: "application/json",
+          lifetime: "infinite",
+          garbageCollection: 10,
+          tags: { type: "data" },
+        });
+        const handle = await writer.writeText(JSON.stringify({
+          id: "resource-123",
+          status: "created",
+        }));
+        return { dataHandles: [handle] };
       },
     },
   },
 };
 `;
 
-  await withTempModels({ "convert_data.ts": modelCode }, async (dir) => {
+  await withTempModels({ "passthrough_data.ts": modelCode }, async (dir) => {
     const loader = new UserModelLoader();
     const result = await loader.loadModels(dir);
 
@@ -311,27 +465,23 @@ export const model = {
       attributes: { name: "test" },
     });
 
-    const context = createTestContext(modelDef!.type);
+    const { context, getResults } = createTestContext(modelDef!.type);
     const methodResult = await modelDef!.methods.create.execute(
       definition,
       context,
     );
 
-    // Verify the dataOutputs have proper structure
-    assertEquals(methodResult.dataOutputs !== undefined, true);
-    assertEquals(methodResult.dataOutputs!.length, 1);
+    // Verify the dataHandles are passed through
+    assertEquals(methodResult.dataHandles !== undefined, true);
+    assertEquals(methodResult.dataHandles!.length, 1);
 
-    const dataOutput = methodResult.dataOutputs![0];
-    assertEquals(dataOutput.name, "test-input-data");
-    assertEquals(dataOutput.metadata !== undefined, true);
-    assertEquals(dataOutput.metadata.contentType, "application/octet-stream");
-    assertEquals(dataOutput.metadata.lifetime, "infinite");
-    assertEquals(dataOutput.metadata.ownerDefinition !== undefined, true);
-    assertEquals(dataOutput.metadata.ownerDefinition.ownerType, "model-method");
-    assertEquals(dataOutput.metadata.ownerDefinition.ownerRef, "create");
+    const handle = methodResult.dataHandles![0];
+    assertEquals(handle.name, "test-input-data");
 
-    // Verify the content
-    const content = JSON.parse(new TextDecoder().decode(dataOutput.content));
+    // Verify content was written via mock writer
+    const results = getResults();
+    assertEquals(results.length, 1);
+    const content = JSON.parse(new TextDecoder().decode(results[0].content));
     assertEquals(content.id, "resource-123");
     assertEquals(content.status, "created");
   });
@@ -350,18 +500,21 @@ export const model = {
   type: "${typeId}",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     run: {
       description: "Run without own schema",
       // No inputAttributesSchema here - should inherit from model
-      execute: async (definition, _context) => {
-        return {
-          dataOutputs: [{
-            name: definition.name + "-result",
-            content: JSON.stringify({ result: "processed" }),
-          }],
-        };
-      },
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -391,10 +544,20 @@ export const model = {
   type: "@user/multi-a-${Date.now()}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ a: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     run: {
       description: "Run A",
-      execute: async (d) => ({ dataOutputs: [{ name: d.name + "-a", content: JSON.stringify({ a: "a" }) }] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -406,10 +569,20 @@ export const model = {
   type: "@user/multi-b-${Date.now()}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ b: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     run: {
       description: "Run B",
-      execute: async (d) => ({ dataOutputs: [{ name: d.name + "-b", content: JSON.stringify({ b: "b" }) }] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -430,8 +603,8 @@ export const model = {
   );
 });
 
-Deno.test("UserModelLoader converts resource return format to dataOutputs", async () => {
-  const typeId = `@user/resource-format-${Date.now()}`;
+Deno.test("UserModelLoader user method returns empty dataHandles", async () => {
+  const typeId = `@user/empty-handles-${Date.now()}`;
   const modelCode = `
 import { z } from "npm:zod@4";
 
@@ -443,26 +616,28 @@ export const model = {
   type: "${typeId}",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     execute: {
-      description: "Test method that returns resource format",
-      execute: async (definition, _context) => {
-        return {
-          resource: {
-            id: definition.id,
-            attributes: {
-              testOutput: "Processed: " + definition.attributes.testInput,
-              executedAt: "2024-01-01T00:00:00Z",
-            },
-          },
-        };
+      description: "Test method that returns empty dataHandles",
+      execute: async (_definition, _context) => {
+        return { dataHandles: [] };
       },
     },
   },
 };
 `;
 
-  await withTempModels({ "resource_format.ts": modelCode }, async (dir) => {
+  await withTempModels({ "empty_handles.ts": modelCode }, async (dir) => {
     const loader = new UserModelLoader();
     const result = await loader.loadModels(dir);
 
@@ -476,30 +651,20 @@ export const model = {
       attributes: { testInput: "Hello World" },
     });
 
-    const context = createTestContext(modelDef!.type);
+    const { context } = createTestContext(modelDef!.type);
     const methodResult = await modelDef!.methods.execute.execute(
       definition,
       context,
     );
 
-    // Verify resource was converted to dataOutputs
-    assertEquals(methodResult.dataOutputs !== undefined, true);
-    assertEquals(methodResult.dataOutputs!.length, 1);
-
-    const dataOutput = methodResult.dataOutputs![0];
-    assertEquals(dataOutput.name, "resource");
-    assertEquals(dataOutput.metadata.contentType, "application/json");
-    assertEquals(dataOutput.metadata.tags.type, "resource");
-
-    // Verify the content contains the resource attributes
-    const content = JSON.parse(new TextDecoder().decode(dataOutput.content));
-    assertEquals(content.testOutput, "Processed: Hello World");
-    assertEquals(content.executedAt, "2024-01-01T00:00:00Z");
+    // Verify empty dataHandles are passed through
+    assertEquals(methodResult.dataHandles !== undefined, true);
+    assertEquals(methodResult.dataHandles!.length, 0);
   });
 });
 
-Deno.test("UserModelLoader converts data return format to dataOutputs", async () => {
-  const typeId = `@user/data-format-${Date.now()}`;
+Deno.test("UserModelLoader user method without dataHandles returns undefined", async () => {
+  const typeId = `@user/no-handles-${Date.now()}`;
   const modelCode = `
 import { z } from "npm:zod@4";
 
@@ -511,27 +676,28 @@ export const model = {
   type: "${typeId}",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     fetch: {
-      description: "Test method that returns data format",
-      execute: async (definition, _context) => {
-        return {
-          data: {
-            attributes: {
-              result: "Query result for: " + definition.attributes.query,
-              count: 42,
-            },
-            name: "query-result",
-            tags: { source: "test" },
-          },
-        };
+      description: "Test method that returns no dataHandles",
+      execute: async (_definition, _context) => {
+        return {};
       },
     },
   },
 };
 `;
 
-  await withTempModels({ "data_format.ts": modelCode }, async (dir) => {
+  await withTempModels({ "no_handles.ts": modelCode }, async (dir) => {
     const loader = new UserModelLoader();
     const result = await loader.loadModels(dir);
 
@@ -545,25 +711,14 @@ export const model = {
       attributes: { query: "SELECT *" },
     });
 
-    const context = createTestContext(modelDef!.type);
+    const { context } = createTestContext(modelDef!.type);
     const methodResult = await modelDef!.methods.fetch.execute(
       definition,
       context,
     );
 
-    // Verify data was converted to dataOutputs
-    assertEquals(methodResult.dataOutputs !== undefined, true);
-    assertEquals(methodResult.dataOutputs!.length, 1);
-
-    const dataOutput = methodResult.dataOutputs![0];
-    assertEquals(dataOutput.name, "query-result");
-    assertEquals(dataOutput.metadata.contentType, "application/json");
-    assertEquals(dataOutput.metadata.tags.source, "test");
-
-    // Verify the content contains the data attributes
-    const content = JSON.parse(new TextDecoder().decode(dataOutput.content));
-    assertEquals(content.result, "Query result for: SELECT *");
-    assertEquals(content.count, 42);
+    // Verify dataHandles is undefined when not provided
+    assertEquals(methodResult.dataHandles, undefined);
   });
 });
 
@@ -577,10 +732,20 @@ export const model = {
   type: "@user/nested-a-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ a: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     run: {
       description: "Run A",
-      execute: async (d) => ({ dataOutputs: [{ name: d.name + "-a", content: JSON.stringify({ a: "a" }) }] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -591,10 +756,20 @@ export const model = {
   type: "@user/nested-b-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ b: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     run: {
       description: "Run B",
-      execute: async (d) => ({ dataOutputs: [{ name: d.name + "-b", content: JSON.stringify({ b: "b" }) }] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -623,8 +798,18 @@ export const model = {
   type: "@user/subdir-notest-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ x: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
-    run: { description: "Run", execute: async () => ({ dataOutputs: [] }) },
+    run: { description: "Run", execute: async () => ({ dataHandles: [] }) },
   },
 };
 `;
@@ -651,8 +836,18 @@ export const model = {
   type: "@user/deep-nested-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ x: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
-    run: { description: "Run", execute: async () => ({ dataOutputs: [] }) },
+    run: { description: "Run", execute: async () => ({ dataHandles: [] }) },
   },
 };
 `;
@@ -682,10 +877,20 @@ export const model = {
   type: "@user/ext-single-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     write: {
       description: "Write",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -696,12 +901,7 @@ export const extension = {
   methods: [{
     audit: {
       description: "Audit the echo message",
-      execute: async (definition, _context) => ({
-        data: {
-          attributes: { audited: true, name: definition.name },
-          name: "audit-result",
-        },
-      }),
+      execute: async () => ({ dataHandles: [] }),
     },
   }],
 };
@@ -735,10 +935,20 @@ export const model = {
   type: "@user/ext-multi-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     write: {
       description: "Write",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -749,11 +959,11 @@ export const extension = {
   methods: [{
     audit: {
       description: "Audit",
-      execute: async () => ({ data: { attributes: { audited: true } } }),
+      execute: async () => ({ dataHandles: [] }),
     },
     verify: {
       description: "Verify",
-      execute: async () => ({ data: { attributes: { verified: true } } }),
+      execute: async () => ({ dataHandles: [] }),
     },
   }],
 };
@@ -784,7 +994,7 @@ export const extension = {
   methods: [{
     audit: {
       description: "Audit",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   }],
 };
@@ -809,10 +1019,20 @@ export const model = {
   type: "@user/ext-conflict-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     write: {
       description: "Write",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -823,7 +1043,7 @@ export const extension = {
   methods: [{
     write: {
       description: "Duplicate write",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   }],
 };
@@ -851,10 +1071,20 @@ export const model = {
   type: "@user/ext-dup-methods-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     write: {
       description: "Write",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -867,13 +1097,13 @@ export const extension = {
     {
       audit: {
         description: "Audit v1",
-        execute: async () => ({ dataOutputs: [] }),
+        execute: async () => ({ dataHandles: [] }),
       },
     },
     {
       audit: {
         description: "Audit v2",
-        execute: async () => ({ dataOutputs: [] }),
+        execute: async () => ({ dataHandles: [] }),
       },
     },
   ],
@@ -905,10 +1135,20 @@ export const model = {
   type: "@user/ext-inherit-schema-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     write: {
       description: "Write",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -919,7 +1159,7 @@ export const extension = {
   methods: [{
     audit: {
       description: "Audit without own schema",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   }],
 };
@@ -951,9 +1191,7 @@ export const extension = {
   methods: [{
     audit_ext_test_${Date.now()}: {
       description: "Audit the echo",
-      execute: async (definition, _context) => ({
-        data: { attributes: { audited: true, name: definition.name } },
-      }),
+      execute: async () => ({ dataHandles: [] }),
     },
   }],
 };
@@ -981,10 +1219,20 @@ export const model = {
   type: "@user/multi-ext-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     write: {
       description: "Write",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -995,7 +1243,7 @@ export const extension = {
   methods: [{
     audit: {
       description: "Audit",
-      execute: async () => ({ data: { attributes: { audited: true } } }),
+      execute: async () => ({ dataHandles: [] }),
     },
   }],
 };
@@ -1006,7 +1254,7 @@ export const extension = {
   methods: [{
     verify: {
       description: "Verify",
-      execute: async () => ({ data: { attributes: { verified: true } } }),
+      execute: async () => ({ dataHandles: [] }),
     },
   }],
 };
@@ -1040,10 +1288,20 @@ export const model = {
   type: "@user/two-pass-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     write: {
       description: "Write",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -1054,7 +1312,7 @@ export const extension = {
   methods: [{
     audit: {
       description: "Audit",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   }],
 };
@@ -1078,7 +1336,7 @@ export const extension = {
   );
 });
 
-Deno.test("UserModelLoader extension method execute produces proper DataOutput", async () => {
+Deno.test("UserModelLoader extension method execute passes through dataHandles", async () => {
   const ts = Date.now();
   const modelCode = `
 import { z } from "npm:zod@4";
@@ -1086,10 +1344,20 @@ export const model = {
   type: "@user/ext-execute-${ts}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     write: {
       description: "Write",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -1100,12 +1368,21 @@ export const extension = {
   methods: [{
     audit: {
       description: "Audit",
-      execute: async (definition, _context) => ({
-        data: {
-          attributes: { audited: true, msg: definition.attributes.message },
+      execute: async (definition, context) => {
+        const writer = context.createDataWriter({
           name: "audit-result",
-        },
-      }),
+          specType: "data",
+          contentType: "application/json",
+          lifetime: "infinite",
+          garbageCollection: 10,
+          tags: { type: "data" },
+        });
+        const handle = await writer.writeText(JSON.stringify({
+          audited: true,
+          msg: definition.attributes.message,
+        }));
+        return { dataHandles: [handle] };
+      },
     },
   }],
 };
@@ -1124,23 +1401,24 @@ export const extension = {
         name: "test-audit",
         attributes: { message: "hello" },
       });
-      const context = createTestContext(modelDef!.type);
+      const { context, getResults } = createTestContext(modelDef!.type);
 
       const methodResult = await modelDef!.methods.audit.execute(
         definition,
         context,
       );
 
-      assertEquals(methodResult.dataOutputs !== undefined, true);
-      assertEquals(methodResult.dataOutputs!.length, 1);
+      assertEquals(methodResult.dataHandles !== undefined, true);
+      assertEquals(methodResult.dataHandles!.length, 1);
 
-      const dataOutput = methodResult.dataOutputs![0];
-      assertEquals(dataOutput.name, "audit-result");
-      assertEquals(dataOutput.metadata.contentType, "application/json");
-      assertEquals(dataOutput.metadata.ownerDefinition.ownerRef, "audit");
+      const handle = methodResult.dataHandles![0];
+      assertEquals(handle.name, "audit-result");
 
+      // Verify content written via mock writer
+      const results = getResults();
+      assertEquals(results.length, 1);
       const content = JSON.parse(
-        new TextDecoder().decode(dataOutput.content),
+        new TextDecoder().decode(results[0].content),
       );
       assertEquals(content.audited, true);
       assertEquals(content.msg, "hello");
@@ -1148,10 +1426,10 @@ export const extension = {
   );
 });
 
-// --- Default dataOutputSpecs tests ---
+// --- dataOutputSpecs validation tests ---
 
-Deno.test("UserModelLoader provides default data and resource spec types", async () => {
-  const typeId = `@user/default-specs-${Date.now()}`;
+Deno.test("UserModelLoader rejects model without dataOutputSpecs", async () => {
+  const typeId = `@user/no-specs-${Date.now()}`;
   const modelCode = `
 import { z } from "npm:zod@4";
 
@@ -1162,42 +1440,23 @@ export const model = {
   methods: {
     run: {
       description: "Run",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
 `;
 
-  await withTempModels({ "default_specs.ts": modelCode }, async (dir) => {
+  await withTempModels({ "no_specs.ts": modelCode }, async (dir) => {
     const loader = new UserModelLoader();
     const result = await loader.loadModels(dir);
 
-    assertEquals(result.loaded.length, 1);
-
-    const modelDef = modelRegistry.get(typeId);
-    assertEquals(modelDef !== undefined, true);
-
-    // Verify default "data" and "resource" spec types are present
-    assertEquals(Object.keys(modelDef!.dataOutputSpecs).length, 2);
-    assertEquals(modelDef!.dataOutputSpecs["data"] !== undefined, true);
-    assertEquals(modelDef!.dataOutputSpecs["resource"] !== undefined, true);
-    assertEquals(modelDef!.dataOutputSpecs["data"].specType.value, "data");
-    assertEquals(
-      modelDef!.dataOutputSpecs["resource"].specType.value,
-      "resource",
-    );
-    assertEquals(
-      modelDef!.dataOutputSpecs["data"].contentType,
-      "application/json",
-    );
-    assertEquals(
-      modelDef!.dataOutputSpecs["resource"].contentType,
-      "application/json",
-    );
+    assertEquals(result.loaded.length, 0);
+    assertEquals(result.failed.length, 1);
+    assertStringIncludes(result.failed[0].error, "dataOutputSpecs");
   });
 });
 
-Deno.test("UserModelLoader user-declared dataOutputSpecs override defaults", async () => {
+Deno.test("UserModelLoader registers user-declared dataOutputSpecs", async () => {
   const typeId = `@user/custom-specs-${Date.now()}`;
   const modelCode = `
 import { z } from "npm:zod@4";
@@ -1211,17 +1470,23 @@ export const model = {
       specType: "data",
       description: "Custom data spec",
       contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
     },
     "metrics": {
       specType: "metrics",
       description: "Metrics output",
       contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { type: "metrics" },
     },
   },
   methods: {
     run: {
       description: "Run",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -1236,8 +1501,7 @@ export const model = {
     const modelDef = modelRegistry.get(typeId);
     assertEquals(modelDef !== undefined, true);
 
-    // User "data" spec overrides default, "resource" default preserved, "metrics" added
-    assertEquals(Object.keys(modelDef!.dataOutputSpecs).length, 3);
+    // User "data" spec overrides default, "metrics" added
     assertEquals(
       modelDef!.dataOutputSpecs["data"].description,
       "Custom data spec",
@@ -1245,10 +1509,6 @@ export const model = {
     assertEquals(
       modelDef!.dataOutputSpecs["data"].contentType,
       "text/plain",
-    );
-    assertEquals(
-      modelDef!.dataOutputSpecs["resource"].specType.value,
-      "resource",
     );
     assertEquals(
       modelDef!.dataOutputSpecs["metrics"].specType.value,
@@ -1267,10 +1527,20 @@ export const model = {
   type: "mycompany/mymodel",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     run: {
       description: "Run",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -1294,10 +1564,20 @@ export const model = {
   type: "@user",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     run: {
       description: "Run",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -1321,10 +1601,20 @@ export const model = {
   type: "@adam/mymodel",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     run: {
       description: "Run",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -1350,10 +1640,20 @@ export const model = {
   type: "${typeId}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     run: {
       description: "Run",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -1380,10 +1680,20 @@ export const model = {
   type: "${typeId}",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     run: {
       description: "Run",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -1406,10 +1716,20 @@ export const model = {
   type: "swamp/mymodel",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     run: {
       description: "Run",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -1433,10 +1753,20 @@ export const model = {
   type: "si/mymodel",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     run: {
       description: "Run",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -1460,10 +1790,20 @@ export const model = {
   type: "@swamp/mymodel",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     run: {
       description: "Run",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };
@@ -1487,10 +1827,20 @@ export const model = {
   type: "@si/mymodel",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
   methods: {
     run: {
       description: "Run",
-      execute: async () => ({ dataOutputs: [] }),
+      execute: async () => ({ dataHandles: [] }),
     },
   },
 };

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -38,9 +38,6 @@ import {
   ModelResolver,
 } from "../expressions/model_resolver.ts";
 import { CelEvaluator } from "../../infrastructure/cel/cel_evaluator.ts";
-import {
-  DataOutputValidationService,
-} from "../models/data_output_validation_service.ts";
 import { UserError } from "../errors.ts";
 import {
   getRunLogger,
@@ -328,8 +325,26 @@ export class DefaultStepExecutor implements StepExecutor {
         method: task.methodName,
       });
 
+      // Build workflow-specific tag overrides
+      const workflowTagOverrides: Record<string, string> = {
+        type: "step-output",
+        workflow: ctx.workflowName,
+        step: ctx.stepName,
+      };
+
+      // Convert step's dataOutputOverrides to the format expected by createDataWriterFactory
+      const stepDataOutputOverrides = ctx.step?.dataOutputOverrides
+        ? Array.from(ctx.step.dataOutputOverrides).map((override) => ({
+          specType: override.specType.value,
+          lifetime: override.lifetime,
+          garbageCollection: override.garbageCollection,
+          tags: override.tags,
+        }))
+        : undefined;
+
       // Execute the method with EVALUATED definition
       // Logger handles both console and file persistence via RunFileSink
+      // Data is persisted by DataWriter during execution — no double-save
       const result = await executionService.executeWorkflow(
         evaluatedDefinition,
         modelDef,
@@ -342,66 +357,25 @@ export class DefaultStepExecutor implements StepExecutor {
           dataRepository: unifiedDataRepo,
           definitionRepository: definitionRepo,
           modelDefinition: modelDef,
+          tagOverrides: workflowTagOverrides,
+          dataOutputOverrides: stepDataOutputOverrides,
         },
       );
 
-      // Apply workflow step overrides (on top of definition overrides)
-      if (ctx.step?.dataOutputOverrides && result.dataOutputs) {
-        const validationService = new DataOutputValidationService();
-        result.dataOutputs = result.dataOutputs.map((output) => {
-          const spec = modelDef.dataOutputSpecs[output.specType.value];
-          return validationService.applyDefaultsAndOverrides(
-            output,
-            spec,
-            Array.from(ctx.step!.dataOutputOverrides),
-          );
-        });
-      }
-
-      // Handle data output persistence
+      // Extract artifact info from dataHandles (already persisted by DataWriter)
       const savedArtifacts: Array<{
         dataId: string;
         name: string;
         version: number;
         tags: Record<string, string>;
       }> = [];
-      if (result.dataOutputs && result.dataOutputs.length > 0) {
-        for (const dataOutput of result.dataOutputs) {
-          // Create Data entity from DataOutput with workflow-specific tags
-          const { Data } = await import("../data/mod.ts");
-
-          // Merge workflow-specific tags with model output tags
-          const workflowTags: Record<string, string> = {
-            ...dataOutput.metadata.tags,
-            type: "step-output",
-            workflow: ctx.workflowName,
-            step: ctx.stepName,
-          };
-
-          const data = Data.create({
-            name: dataOutput.name,
-            contentType: dataOutput.metadata.contentType,
-            lifetime: dataOutput.metadata.lifetime,
-            garbageCollection: dataOutput.metadata.garbageCollection,
-            streaming: dataOutput.metadata.streaming,
-            tags: workflowTags,
-            ownerDefinition: dataOutput.metadata.ownerDefinition,
-          });
-
-          // Save the data
-          const saveResult = await unifiedDataRepo.save(
-            modelType,
-            evaluatedDefinition.id,
-            data,
-            dataOutput.content,
-          );
-
-          // Track artifact in output and for returning to step run
+      if (result.dataHandles && result.dataHandles.length > 0) {
+        for (const handle of result.dataHandles) {
           const artifactRef = {
-            dataId: data.id,
-            name: dataOutput.name,
-            version: saveResult.version,
-            tags: workflowTags,
+            dataId: handle.dataId,
+            name: handle.name,
+            version: handle.version,
+            tags: handle.tags,
           };
           output.addDataArtifact(artifactRef);
           savedArtifacts.push(artifactRef);
@@ -409,20 +383,28 @@ export class DefaultStepExecutor implements StepExecutor {
           const dataPath = unifiedDataRepo.getPath(
             modelType,
             evaluatedDefinition.id,
-            dataOutput.name,
-            saveResult.version,
+            handle.name,
+            handle.version,
           );
           runLogger.info("Data saved to {path}", { path: dataPath });
 
-          // Use first JSON data output for context refresh
+          // Use first JSON data handle for context refresh
           if (
-            !dataId && dataOutput.metadata.contentType === "application/json"
+            !dataId && handle.metadata.contentType === "application/json"
           ) {
-            dataId = data.id;
-            dataName = dataOutput.name;
+            dataId = handle.dataId;
+            dataName = handle.name;
             try {
-              const text = new TextDecoder().decode(dataOutput.content);
-              dataAttributes = JSON.parse(text) as Record<string, unknown>;
+              const content = await unifiedDataRepo.getContent(
+                modelType,
+                evaluatedDefinition.id,
+                handle.name,
+                handle.version,
+              );
+              if (content) {
+                const text = new TextDecoder().decode(content);
+                dataAttributes = JSON.parse(text) as Record<string, unknown>;
+              }
             } catch {
               // Not valid JSON, skip attributes
             }

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -191,6 +191,38 @@ export interface UnifiedDataRepository {
   ): Promise<void>;
 
   /**
+   * Allocates a new version directory without writing content.
+   * Used by DataWriter for direct file I/O.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param data - The data entity (for ownership validation)
+   * @returns The allocated version number and content file path
+   */
+  allocateVersion(
+    type: ModelType,
+    modelId: string,
+    data: Data,
+  ): Promise<{ version: number; contentPath: string }>;
+
+  /**
+   * Finalizes a previously allocated version by writing metadata and updating symlinks.
+   * Content must already exist on disk at the content path.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param data - The data entity
+   * @param version - The version number to finalize
+   * @returns Size and checksum of the content
+   */
+  finalizeVersion(
+    type: ModelType,
+    modelId: string,
+    data: Data,
+    version: number,
+  ): Promise<{ size: number; checksum: string }>;
+
+  /**
    * Generates a new unique ID.
    */
   nextId(): DataId;
@@ -598,6 +630,84 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
       }
       // Symlink already missing is OK
     }
+  }
+
+  async allocateVersion(
+    type: ModelType,
+    modelId: string,
+    data: Data,
+  ): Promise<{ version: number; contentPath: string }> {
+    // Validate ownership if data with this name already exists
+    const existing = await this.findByName(type, modelId, data.name);
+    if (existing) {
+      if (!existing.isOwnedBy(data.ownerDefinition)) {
+        throw new OwnershipValidationError(
+          data.name,
+          existing.ownerDefinition.definitionHash,
+          data.ownerDefinition.definitionHash,
+        );
+      }
+    }
+
+    // Determine the new version
+    const versions = await this.listVersions(type, modelId, data.name);
+    const newVersion = versions.length > 0 ? Math.max(...versions) + 1 : 1;
+
+    // Create the version directory
+    const versionDir = this.getPath(type, modelId, data.name, newVersion);
+    await ensureDir(versionDir);
+
+    const contentPath = this.getContentPath(
+      type,
+      modelId,
+      data.name,
+      newVersion,
+    );
+
+    return { version: newVersion, contentPath };
+  }
+
+  async finalizeVersion(
+    type: ModelType,
+    modelId: string,
+    data: Data,
+    version: number,
+  ): Promise<{ size: number; checksum: string }> {
+    const contentPath = this.getContentPath(
+      type,
+      modelId,
+      data.name,
+      version,
+    );
+
+    // Read content to compute size and checksum
+    const content = await Deno.readFile(contentPath);
+    const size = content.length;
+    const checksum = await this.computeChecksum(content);
+
+    // Create the data with updated version, size, and checksum
+    const dataToSave = data.withNewVersion({
+      version,
+      size,
+      checksum,
+    });
+
+    // Save metadata
+    const metadataPath = this.getMetadataPath(
+      type,
+      modelId,
+      data.name,
+      version,
+    );
+    const metadata = dataToSave.toData();
+    const cleanData = JSON.parse(JSON.stringify(metadata));
+    const metadataContent = stringifyYaml(cleanData as Record<string, unknown>);
+    await Deno.writeTextFile(metadataPath, metadataContent);
+
+    // Update latest symlink
+    await this.updateLatestSymlink(type, modelId, data.name, version);
+
+    return { size, checksum };
   }
 
   nextId(): DataId {


### PR DESCRIPTION
## Summary

Replace the pull-based `DataOutput` model (methods return content in memory) with a push-based `DataWriter` API where methods write data directly to disk during execution. This simplifies model implementations by ~50-60% while strengthening separation of concerns and data ownership guarantees.

- **New `DataWriter` service** with factory pattern that resolves spec-based options against model `DataOutputSpecifications`, handling defaults, overrides, and ownership enforcement
- **Type system refactor**: `DataOutput`/`dataOutputs` replaced with lightweight `DataHandle`/`dataHandles` references to already-persisted data
- **`DataWriterFactory` injected into `MethodContext`** so models write data during execution rather than buffering content for post-execution persistence
- **`DataOutputValidationService` simplified** to only check duplicate instance names; spec validation moved to factory creation for fail-fast behavior
- **`UnifiedDataRepository` extended** with `allocateVersion`/`finalizeVersion` for streaming-friendly two-phase writes
- **All model implementations updated** (echo, curl, shell, vault, aws_cli, cloud_control, ec2 instance/subnet/vpc, journalctl, mermaid workflow diagram) to use the DataWriter pattern
- **CLI command simplified** — data already persisted by DataWriter, no manual storage needed
- **Design docs and skill references updated**

Closes #225

## Test Plan

- All 1356 existing tests pass
- Updated tests for all modified models verify DataHandle returns and spec validation
- Method execution service tests validate factory creation, ownership enforcement, and handle tracking
- Data output validation service tests updated for simplified responsibilities
- User model loader tests verify DataWriter integration with extension models