### PR TITLE
Add hidden list aliases for common LLM hallucinations

### DIFF
--- a/src/cli/commands/hidden_aliases_test.ts
+++ b/src/cli/commands/hidden_aliases_test.ts
@@ -1,0 +1,47 @@
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Initialize logging for tests
+await initializeLogging({});
+
+Deno.test("model list is registered as a hidden subcommand", async () => {
+  const { modelCommand } = await import("./model_create.ts");
+
+  // getCommand with second arg true includes hidden commands
+  const listCmd = modelCommand.getCommand("list", true);
+  assertEquals(
+    listCmd !== undefined,
+    true,
+    "list command should be registered",
+  );
+
+  // Verify it's hidden: not in getCommands() (which excludes hidden)
+  const visibleCommands = modelCommand.getCommands();
+  const visibleList = visibleCommands.find((c) => c.getName() === "list");
+  assertEquals(
+    visibleList,
+    undefined,
+    "list should not appear in visible commands",
+  );
+});
+
+Deno.test("workflow history list is registered as a hidden subcommand", async () => {
+  const { workflowHistoryCommand } = await import("./workflow_history.ts");
+
+  // getCommand with second arg true includes hidden commands
+  const listCmd = workflowHistoryCommand.getCommand("list", true);
+  assertEquals(
+    listCmd !== undefined,
+    true,
+    "list command should be registered",
+  );
+
+  // Verify it's hidden: not in getCommands() (which excludes hidden)
+  const visibleCommands = workflowHistoryCommand.getCommands();
+  const visibleList = visibleCommands.find((c) => c.getName() === "list");
+  assertEquals(
+    visibleList,
+    undefined,
+    "list should not appear in visible commands",
+  );
+});

--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -11,7 +11,7 @@ import { Definition } from "../../domain/definitions/definition.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 import { modelValidateCommand } from "./model_validate.ts";
 import { modelMethodCommand } from "./model_method_run.ts";
-import { modelSearchCommand } from "./model_search.ts";
+import { modelSearchAction, modelSearchCommand } from "./model_search.ts";
 import { modelGetCommand } from "./model_get.ts";
 import { modelDeleteCommand } from "./model_delete.ts";
 import { modelEditCommand } from "./model_edit.ts";
@@ -96,4 +96,15 @@ export const modelCommand = new Command()
   .command("search", modelSearchCommand)
   .command("validate", modelValidateCommand)
   .command("method", modelMethodCommand)
-  .command("output", modelOutputCommand);
+  .command("output", modelOutputCommand)
+  .command(
+    "list",
+    new Command()
+      .description("Alias for model search")
+      .hidden()
+      .arguments("[query:string]")
+      .option("--repo-dir <dir:string>", "Repository directory", {
+        default: ".",
+      })
+      .action(modelSearchAction),
+  );

--- a/src/cli/commands/model_search.ts
+++ b/src/cli/commands/model_search.ts
@@ -86,60 +86,65 @@ async function displayModelGet(
   renderModelGet(data, outputMode);
 }
 
+export async function modelSearchAction(
+  options: AnyOptions,
+  query?: string,
+): Promise<void> {
+  const ctx = createContext(options as GlobalOptions, ["model", "search"]);
+  ctx.logger.debug`Searching models with query: ${query ?? "(none)"}`;
+
+  const { repoContext } = await requireInitializedRepo({
+    repoDir: options.repoDir ?? ".",
+    outputMode: ctx.outputMode,
+  });
+  const definitionRepo = repoContext.definitionRepo;
+
+  // Get all models from repository
+  const allResults = await definitionRepo.findAllGlobal();
+  const allModels = toModelSearchItems(allResults);
+
+  if (ctx.outputMode === "json") {
+    // Non-interactive: filter and output JSON
+    const filteredModels = filterModels(allModels, query ?? "");
+
+    // If query matches exactly one model, show full details (same as interactive selection)
+    if (query && filteredModels.length === 1) {
+      await displayModelGet(
+        filteredModels[0],
+        definitionRepo,
+        ctx.outputMode,
+      );
+    } else {
+      const data: ModelSearchData = {
+        query: query ?? "",
+        results: filteredModels,
+      };
+      await renderModelSearch(data, ctx.outputMode);
+    }
+  } else {
+    // Interactive: show fuzzy search UI
+    const data: ModelSearchData = {
+      query: query ?? "",
+      results: allModels,
+    };
+
+    const selected = await renderModelSearch(data, ctx.outputMode);
+
+    if (selected) {
+      ctx.logger.debug`Selected model: ${selected.name} (${selected.id})`;
+      // Display the full model details
+      await displayModelGet(selected, definitionRepo, ctx.outputMode);
+    } else {
+      ctx.logger.debug`Search cancelled`;
+    }
+  }
+
+  ctx.logger.debug("Model search command completed");
+}
+
 export const modelSearchCommand = new Command()
   .name("search")
   .description("Search for model definitions")
   .arguments("[query:string]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
-  .action(async function (options: AnyOptions, query?: string) {
-    const ctx = createContext(options as GlobalOptions, ["model", "search"]);
-    ctx.logger.debug`Searching models with query: ${query ?? "(none)"}`;
-
-    const { repoContext } = await requireInitializedRepo({
-      repoDir: options.repoDir ?? ".",
-      outputMode: ctx.outputMode,
-    });
-    const definitionRepo = repoContext.definitionRepo;
-
-    // Get all models from repository
-    const allResults = await definitionRepo.findAllGlobal();
-    const allModels = toModelSearchItems(allResults);
-
-    if (ctx.outputMode === "json") {
-      // Non-interactive: filter and output JSON
-      const filteredModels = filterModels(allModels, query ?? "");
-
-      // If query matches exactly one model, show full details (same as interactive selection)
-      if (query && filteredModels.length === 1) {
-        await displayModelGet(
-          filteredModels[0],
-          definitionRepo,
-          ctx.outputMode,
-        );
-      } else {
-        const data: ModelSearchData = {
-          query: query ?? "",
-          results: filteredModels,
-        };
-        await renderModelSearch(data, ctx.outputMode);
-      }
-    } else {
-      // Interactive: show fuzzy search UI
-      const data: ModelSearchData = {
-        query: query ?? "",
-        results: allModels,
-      };
-
-      const selected = await renderModelSearch(data, ctx.outputMode);
-
-      if (selected) {
-        ctx.logger.debug`Selected model: ${selected.name} (${selected.id})`;
-        // Display the full model details
-        await displayModelGet(selected, definitionRepo, ctx.outputMode);
-      } else {
-        ctx.logger.debug`Search cancelled`;
-      }
-    }
-
-    ctx.logger.debug("Model search command completed");
-  });
+  .action(modelSearchAction);

--- a/src/cli/commands/workflow_history.ts
+++ b/src/cli/commands/workflow_history.ts
@@ -1,6 +1,9 @@
 import { Command } from "@cliffy/command";
 import { workflowHistoryGetCommand } from "./workflow_history_get.ts";
-import { workflowHistorySearchCommand } from "./workflow_history_search.ts";
+import {
+  workflowHistorySearchAction,
+  workflowHistorySearchCommand,
+} from "./workflow_history_search.ts";
 import { workflowHistoryLogsCommand } from "./workflow_history_logs.ts";
 
 export const workflowHistoryCommand = new Command()
@@ -11,4 +14,15 @@ export const workflowHistoryCommand = new Command()
   })
   .command("get", workflowHistoryGetCommand)
   .command("search", workflowHistorySearchCommand)
-  .command("logs", workflowHistoryLogsCommand);
+  .command("logs", workflowHistoryLogsCommand)
+  .command(
+    "list",
+    new Command()
+      .description("Alias for workflow history search")
+      .hidden()
+      .arguments("[query:string]")
+      .option("--repo-dir <dir:string>", "Repository directory", {
+        default: ".",
+      })
+      .action(workflowHistorySearchAction),
+  );

--- a/src/cli/commands/workflow_history_search.ts
+++ b/src/cli/commands/workflow_history_search.ts
@@ -96,82 +96,85 @@ function filterRuns(
   );
 }
 
+export async function workflowHistorySearchAction(
+  options: AnyOptions,
+  query?: string,
+): Promise<void> {
+  const ctx = createContext(
+    options as GlobalOptions,
+    ["workflow", "history", "search"],
+  );
+  ctx.logger.debug`Searching workflow history with query: ${query ?? "(none)"}`;
+
+  const { repoContext } = await requireInitializedRepo({
+    repoDir: options.repoDir ?? ".",
+    outputMode: ctx.outputMode,
+  });
+  const workflowRepo = repoContext.workflowRepo;
+  const runRepo = repoContext.workflowRunRepo;
+
+  // Get all workflows
+  const allWorkflows = await workflowRepo.findAll();
+
+  // Get all runs for all workflows
+  const allRuns: WorkflowRun[] = [];
+  for (const workflow of allWorkflows) {
+    const runs = await runRepo.findAllByWorkflowId(workflow.id);
+    allRuns.push(...runs);
+  }
+
+  // Sort by startedAt descending (most recent first)
+  allRuns.sort((a, b) => {
+    const aTime = a.startedAt?.getTime() ?? 0;
+    const bTime = b.startedAt?.getTime() ?? 0;
+    return bTime - aTime;
+  });
+
+  const searchItems = allRuns.map(toSearchItem);
+
+  if (ctx.outputMode === "json") {
+    // Non-interactive: filter and output JSON
+    const filteredRuns = filterRuns(searchItems, query ?? "");
+    const data: WorkflowHistorySearchData = {
+      query: query ?? "",
+      results: filteredRuns,
+    };
+    await renderWorkflowHistorySearch(data, ctx.outputMode);
+  } else {
+    // Interactive: show fuzzy search UI
+    const data: WorkflowHistorySearchData = {
+      query: query ?? "",
+      results: searchItems,
+    };
+
+    const selected = await renderWorkflowHistorySearch(data, ctx.outputMode);
+
+    if (selected) {
+      ctx.logger.debug`Selected run: ${selected.runId}`;
+      // Display the run details
+      const run = await runRepo.findById(
+        createWorkflowId(selected.workflowId),
+        createWorkflowRunId(selected.runId),
+      );
+      if (run) {
+        const path = runRepo.getPath(
+          createWorkflowId(selected.workflowId),
+          createWorkflowRunId(selected.runId),
+        );
+        const runData = toRunData(run, path);
+        renderWorkflowRun(runData, ctx.outputMode);
+      }
+    } else {
+      ctx.logger.debug`Search cancelled`;
+    }
+  }
+
+  ctx.logger.debug("Workflow history search command completed");
+}
+
 export const workflowHistorySearchCommand = new Command()
   .name("search")
   .description("Search workflow run history")
   .arguments("[query:string]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
-  .action(async function (options: AnyOptions, query?: string) {
-    const ctx = createContext(
-      options as GlobalOptions,
-      ["workflow", "history", "search"],
-    );
-    ctx.logger.debug`Searching workflow history with query: ${
-      query ?? "(none)"
-    }`;
-
-    const { repoContext } = await requireInitializedRepo({
-      repoDir: options.repoDir ?? ".",
-      outputMode: ctx.outputMode,
-    });
-    const workflowRepo = repoContext.workflowRepo;
-    const runRepo = repoContext.workflowRunRepo;
-
-    // Get all workflows
-    const allWorkflows = await workflowRepo.findAll();
-
-    // Get all runs for all workflows
-    const allRuns: WorkflowRun[] = [];
-    for (const workflow of allWorkflows) {
-      const runs = await runRepo.findAllByWorkflowId(workflow.id);
-      allRuns.push(...runs);
-    }
-
-    // Sort by startedAt descending (most recent first)
-    allRuns.sort((a, b) => {
-      const aTime = a.startedAt?.getTime() ?? 0;
-      const bTime = b.startedAt?.getTime() ?? 0;
-      return bTime - aTime;
-    });
-
-    const searchItems = allRuns.map(toSearchItem);
-
-    if (ctx.outputMode === "json") {
-      // Non-interactive: filter and output JSON
-      const filteredRuns = filterRuns(searchItems, query ?? "");
-      const data: WorkflowHistorySearchData = {
-        query: query ?? "",
-        results: filteredRuns,
-      };
-      await renderWorkflowHistorySearch(data, ctx.outputMode);
-    } else {
-      // Interactive: show fuzzy search UI
-      const data: WorkflowHistorySearchData = {
-        query: query ?? "",
-        results: searchItems,
-      };
-
-      const selected = await renderWorkflowHistorySearch(data, ctx.outputMode);
-
-      if (selected) {
-        ctx.logger.debug`Selected run: ${selected.runId}`;
-        // Display the run details
-        const run = await runRepo.findById(
-          createWorkflowId(selected.workflowId),
-          createWorkflowRunId(selected.runId),
-        );
-        if (run) {
-          const path = runRepo.getPath(
-            createWorkflowId(selected.workflowId),
-            createWorkflowRunId(selected.runId),
-          );
-          const runData = toRunData(run, path);
-          renderWorkflowRun(runData, ctx.outputMode);
-        }
-      } else {
-        ctx.logger.debug`Search cancelled`;
-      }
-    }
-
-    ctx.logger.debug("Workflow history search command completed");
-  });
+  .action(workflowHistorySearchAction);


### PR DESCRIPTION
## Summary

Closes #164

- Adds hidden `list` command aliases for `model search` and `workflow history search`
- LLMs commonly hallucinate `list` when they mean `search` — these aliases make those commands work without cluttering help output
- Extracts `modelSearchAction` and `workflowHistorySearchAction` into named exports so the hidden commands can reuse them

## Test Plan

- Added `hidden_aliases_test.ts` verifying both aliases are registered and hidden
- All 1358 existing tests continue to pass
- `model list` invokes the same action as `model search`
- `workflow history list` invokes the same action as `workflow history search`
- Neither alias appears in `--help` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)