### PR TITLE
feat: Move `swamp type` to `swamp model type` (#247 #246)

### DIFF
--- a/design/models.md
+++ b/design/models.md
@@ -343,7 +343,7 @@ directory.
 
 ## CLI Commands
 
-### type describe <type>
+### model type describe <type>
 
 This command describes the model as a markdown document, will all of its
 details, using code blocks as neccessary. it should syntax highlight the
@@ -351,7 +351,7 @@ markdown.
 
 when specifying json, it should have the same content.
 
-### type search <string>
+### model type search <string>
 
 When run interactively, it should show a text box that says "type to search",
 and then use the npm:fzf package to search the list of available types (by

--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -17,6 +17,7 @@ import { modelDeleteCommand } from "./model_delete.ts";
 import { modelEditCommand } from "./model_edit.ts";
 import { modelEvaluateCommand } from "./model_evaluate.ts";
 import { modelOutputCommand } from "./model_output.ts";
+import { modelTypeCommand } from "./model_type.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -97,6 +98,7 @@ export const modelCommand = new Command()
   .command("validate", modelValidateCommand)
   .command("method", modelMethodCommand)
   .command("output", modelOutputCommand)
+  .command("type", modelTypeCommand)
   .command(
     "list",
     new Command()

--- a/src/cli/commands/model_type.ts
+++ b/src/cli/commands/model_type.ts
@@ -1,0 +1,15 @@
+import { Command } from "@cliffy/command";
+import { typeDescribeCommand } from "./type_describe.ts";
+import { typeSearchCommand } from "./type_search.ts";
+
+/**
+ * Parent command for model type operations.
+ */
+export const modelTypeCommand = new Command()
+  .name("type")
+  .description("Inspect model types")
+  .action(function () {
+    this.showHelp();
+  })
+  .command("describe", typeDescribeCommand)
+  .command("search", typeSearchCommand);

--- a/src/cli/commands/type_describe.ts
+++ b/src/cli/commands/type_describe.ts
@@ -12,7 +12,6 @@ import {
   type MethodDefinition,
   modelRegistry,
 } from "../../domain/models/model.ts";
-import { typeSearchCommand } from "./type_search.ts";
 import { UserError } from "../../domain/errors.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -110,12 +109,3 @@ export const typeDescribeCommand = new Command()
   .arguments("<type:model_type>")
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(typeDescribeAction);
-
-export const typeCommand = new Command()
-  .name("type")
-  .description("Inspect model types")
-  .action(function () {
-    this.showHelp();
-  })
-  .command("describe", typeDescribeCommand)
-  .command("search", typeSearchCommand);

--- a/src/cli/commands/type_describe_test.ts
+++ b/src/cli/commands/type_describe_test.ts
@@ -1,4 +1,5 @@
 import { assertEquals } from "@std/assert";
+import type { Command } from "@cliffy/command";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 
 // Import models barrel to trigger self-registration
@@ -7,15 +8,15 @@ import "../../domain/models/models.ts";
 // Initialize logging for tests
 await initializeLogging({});
 
-Deno.test("typeCommand module loads", async () => {
-  const { typeCommand } = await import("./type_describe.ts");
-  assertEquals(typeCommand.getName(), "type");
+Deno.test("modelTypeCommand module loads", async () => {
+  const { modelTypeCommand } = await import("./model_type.ts");
+  assertEquals(modelTypeCommand.getName(), "type");
 });
 
-Deno.test("typeDescribeCommand is registered as subcommand", async () => {
-  const { typeCommand } = await import("./type_describe.ts");
-  const commands = typeCommand.getCommands();
-  const describeCmd = commands.find((c) => c.getName() === "describe");
+Deno.test("typeDescribeCommand is registered as subcommand of modelTypeCommand", async () => {
+  const { modelTypeCommand } = await import("./model_type.ts");
+  const commands = modelTypeCommand.getCommands();
+  const describeCmd = commands.find((c: Command) => c.getName() === "describe");
   assertEquals(describeCmd !== undefined, true);
 });
 

--- a/src/cli/commands/type_search_test.ts
+++ b/src/cli/commands/type_search_test.ts
@@ -1,4 +1,5 @@
 import { assertEquals } from "@std/assert";
+import type { Command } from "@cliffy/command";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 
 // Import models barrel to trigger self-registration
@@ -20,9 +21,9 @@ Deno.test("typeSearchCommand has correct description", async () => {
   );
 });
 
-Deno.test("typeSearchCommand is registered as subcommand of typeCommand", async () => {
-  const { typeCommand } = await import("./type_describe.ts");
-  const commands = typeCommand.getCommands();
-  const searchCmd = commands.find((c) => c.getName() === "search");
+Deno.test("typeSearchCommand is registered as subcommand of modelTypeCommand", async () => {
+  const { modelTypeCommand } = await import("./model_type.ts");
+  const commands = modelTypeCommand.getCommands();
+  const searchCmd = commands.find((c: Command) => c.getName() === "search");
   assertEquals(searchCmd !== undefined, true);
 });

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -4,7 +4,6 @@ import { parseLogLevel } from "@logtape/logtape";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
 import { VERSION, versionCommand } from "./commands/version.ts";
 import { modelCommand } from "./commands/model_create.ts";
-import { typeCommand } from "./commands/type_describe.ts";
 import { repoCommand, repoInitCommand } from "./commands/repo_init.ts";
 import { workflowCommand } from "./commands/workflow.ts";
 import { completionCommand } from "./commands/completion.ts";
@@ -188,7 +187,6 @@ export async function runCli(args: string[]): Promise<void> {
     })
     .command("version", versionCommand)
     .command("model", modelCommand)
-    .command("type", typeCommand)
     .command("init", repoInitCommand)
     .command("repo", repoCommand)
     .command("workflow", workflowCommand)


### PR DESCRIPTION
Moves the `swamp type` commands under `swamp model type` for clarity and consistency. Users were confused about the difference between "types" and "models" in the CLI - grouping type inspection commands under `model` makes the relationship clearer.

Fixes: #246
Fixes: #247

## Changes

- `swamp type describe` → `swamp model type describe`
- `swamp type search` → `swamp model type search`
- `swamp type get` alias preserved as `swamp model type get`

## Files Changed

- **New:** `src/cli/commands/model_type.ts` - parent command for model type ops
- **Modified:** `src/cli/commands/type_describe.ts` - removed `typeCommand`
- **Modified:** `src/cli/commands/model_create.ts` - added `modelTypeCommand`
- **Modified:** `src/cli/mod.ts` - removed standalone `type` command
- **Modified:** `design/models.md` - updated documentation
- **Modified:** `src/cli/commands/type_describe_test.ts` - updated tests
- **Modified:** `src/cli/commands/type_search_test.ts` - updated tests

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] All 1669 tests pass
- [x] `swamp model type describe swamp/echo` works
- [x] `swamp model type get swamp/echo` works (alias)
- [x] `swamp model type search` works
- [x] `swamp type` correctly fails as unknown command