### PR TITLE
feat: Generate Claude settings.local.json during repo init/upgrade

### DIFF
--- a/src/cli/commands/repo_init.ts
+++ b/src/cli/commands/repo_init.ts
@@ -35,6 +35,7 @@ export const repoInitCommand = new Command()
       initializedAt: result.initializedAt,
       skillsCopied: result.skillsCopied,
       claudeMdCreated: result.claudeMdCreated,
+      claudeSettingsCreated: result.claudeSettingsCreated,
     };
 
     renderRepoInit(data, ctx.outputMode);
@@ -61,6 +62,7 @@ export const repoUpgradeCommand = new Command()
       newVersion: result.newVersion,
       upgradedAt: result.upgradedAt,
       skillsUpdated: result.skillsUpdated,
+      claudeSettingsUpdated: result.claudeSettingsUpdated,
     };
 
     renderRepoUpgrade(data, ctx.outputMode);

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -24,6 +24,7 @@ export interface RepoInitResult {
   initializedAt: string;
   skillsCopied: string[];
   claudeMdCreated: boolean;
+  claudeSettingsCreated: boolean;
 }
 
 /**
@@ -35,6 +36,7 @@ export interface RepoUpgradeResult {
   newVersion: string;
   upgradedAt: string;
   skillsUpdated: string[];
+  claudeSettingsUpdated: boolean;
 }
 
 /**
@@ -102,12 +104,18 @@ export class RepoService {
     // Create CLAUDE.md if it doesn't exist
     const claudeMdCreated = await this.createClaudeMdIfNotExists(repoPath);
 
+    // Create Claude settings.local.json if it doesn't exist
+    const claudeSettingsCreated = await this.createClaudeSettingsIfNotExists(
+      repoPath,
+    );
+
     return {
       path: repoPath.value,
       version: this.currentVersion.toString(),
       initializedAt: markerData.initializedAt,
       skillsCopied,
       claudeMdCreated,
+      claudeSettingsCreated,
     };
   }
 
@@ -140,6 +148,9 @@ export class RepoService {
     await this.skillAssets.copySkillsTo(skillsDir);
     const skillsUpdated = this.skillAssets.getSkillNames();
 
+    // Update Claude settings.local.json (merge new permissions)
+    const claudeSettingsUpdated = await this.updateClaudeSettings(repoPath);
+
     // createUpgradeMarker always sets upgradedAt, but TypeScript doesn't know this
     if (!updatedMarker.upgradedAt) {
       throw new Error(
@@ -153,6 +164,7 @@ export class RepoService {
       newVersion: this.currentVersion.toString(),
       upgradedAt: updatedMarker.upgradedAt,
       skillsUpdated,
+      claudeSettingsUpdated,
     };
   }
 
@@ -194,6 +206,17 @@ export class RepoService {
 
 This repository is managed with [swamp](https://github.com/systeminit/swamp).
 
+## Skills
+
+**IMPORTANT:** Always load swamp skills, even when in plan mode. The skills provide
+essential context for working with this repository.
+
+- \`swamp-model\` - Work with swamp models (creating, editing, validating)
+- \`swamp-workflow\` - Work with workflows (creating, editing, running)
+- \`swamp-vault\` - Manage secrets and credentials
+- \`swamp-data\` - Manage model data lifecycle
+- \`swamp-repo\` - Repository management
+
 ## Getting Started
 
 Always start by using the \`swamp-model\` skill to work with swamp models.
@@ -202,6 +225,132 @@ Always start by using the \`swamp-model\` skill to work with swamp models.
 
 Use \`swamp --help\` to see available commands.
 `;
+  }
+
+  /**
+   * Gets the list of allowed swamp commands for Claude settings.
+   */
+  private getClaudeAllowedCommands(): string[] {
+    return [
+      "Bash(swamp model type search:*)",
+      "Bash(swamp model type describe:*)",
+      "Bash(swamp model search:*)",
+      "Bash(swamp model create:*)",
+      "Bash(swamp model edit:*)",
+      "Bash(swamp model delete:*)",
+      "Bash(swamp model get:*)",
+      "Bash(swamp model validate:*)",
+      "Bash(swamp model output:*)",
+      "Bash(swamp model method history:*)",
+      "Bash(swamp workflow search:*)",
+      "Bash(swamp workflow create:*)",
+      "Bash(swamp workflow edit:*)",
+      "Bash(swamp workflow delete:*)",
+      "Bash(swamp workflow get:*)",
+      "Bash(swamp workflow validate:*)",
+      "Bash(swamp workflow schema:*)",
+      "Bash(swamp workflow history:*)",
+      "Bash(swamp vault:*)",
+      "Bash(swamp data:*)",
+      "Bash(swamp repo:*)",
+      "Bash(swamp telemetry:*)",
+      "Bash(swamp init:*)",
+      "Bash(swamp version:*)",
+      "Bash(swamp completions:*)",
+    ];
+  }
+
+  /**
+   * Generates the content for settings.local.json.
+   */
+  private generateClaudeSettingsContent(): string {
+    const settings = {
+      permissions: {
+        allow: this.getClaudeAllowedCommands(),
+      },
+    };
+    return JSON.stringify(settings, null, 2) + "\n";
+  }
+
+  /**
+   * Creates settings.local.json if it doesn't already exist.
+   */
+  private async createClaudeSettingsIfNotExists(
+    repoPath: RepoPath,
+  ): Promise<boolean> {
+    const claudeDir = join(repoPath.value, ".claude");
+    const settingsPath = join(claudeDir, "settings.local.json");
+
+    try {
+      await Deno.stat(settingsPath);
+      // File exists, don't overwrite
+      return false;
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        // Ensure .claude directory exists
+        await ensureDir(claudeDir);
+        // Create the file
+        const content = this.generateClaudeSettingsContent();
+        await Deno.writeTextFile(settingsPath, content);
+        return true;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Updates settings.local.json, merging new permissions with existing ones.
+   * If the file doesn't exist, it creates it.
+   */
+  private async updateClaudeSettings(repoPath: RepoPath): Promise<boolean> {
+    const claudeDir = join(repoPath.value, ".claude");
+    const settingsPath = join(claudeDir, "settings.local.json");
+
+    // Ensure .claude directory exists
+    await ensureDir(claudeDir);
+
+    let existingSettings: { permissions?: { allow?: string[] } } = {};
+    let settingsExisted = false;
+
+    try {
+      const content = await Deno.readTextFile(settingsPath);
+      existingSettings = JSON.parse(content);
+      settingsExisted = true;
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+      // File doesn't exist, will create new
+    }
+
+    // Get our allowed commands
+    const ourCommands = this.getClaudeAllowedCommands();
+
+    // Merge with existing permissions
+    const existingAllow = existingSettings.permissions?.allow ?? [];
+    const mergedAllow = [...new Set([...existingAllow, ...ourCommands])];
+
+    // Check if anything changed
+    const hasChanges = mergedAllow.length !== existingAllow.length ||
+      !ourCommands.every((cmd) => existingAllow.includes(cmd));
+
+    if (!hasChanges && settingsExisted) {
+      return false;
+    }
+
+    // Write merged settings
+    const newSettings = {
+      ...existingSettings,
+      permissions: {
+        ...existingSettings.permissions,
+        allow: mergedAllow,
+      },
+    };
+    await Deno.writeTextFile(
+      settingsPath,
+      JSON.stringify(newSettings, null, 2) + "\n",
+    );
+    return true;
   }
 
   /**

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -233,3 +233,151 @@ Deno.test("RepoService.getMarker returns data after init", async () => {
     assertEquals(marker!.swampVersion, "0.1.0");
   });
 });
+
+Deno.test("RepoService.init creates settings.local.json", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    const result = await service.init(repoPath);
+
+    assertEquals(result.claudeSettingsCreated, true);
+
+    // Check settings.local.json exists and has expected content
+    const settingsPath = join(tempDir, ".claude", "settings.local.json");
+    const content = await Deno.readTextFile(settingsPath);
+    const settings = JSON.parse(content);
+
+    assertEquals(Array.isArray(settings.permissions?.allow), true);
+    assertStringIncludes(
+      JSON.stringify(settings.permissions.allow),
+      "swamp model",
+    );
+  });
+});
+
+Deno.test("RepoService.init does not overwrite existing settings.local.json", async () => {
+  await withTempDir(async (tempDir) => {
+    // Create existing settings
+    const claudeDir = join(tempDir, ".claude");
+    await Deno.mkdir(claudeDir, { recursive: true });
+    const settingsPath = join(claudeDir, "settings.local.json");
+    const existingSettings = {
+      permissions: { allow: ["Bash(custom command:*)"] },
+    };
+    await Deno.writeTextFile(
+      settingsPath,
+      JSON.stringify(existingSettings, null, 2),
+    );
+
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    const result = await service.init(repoPath);
+
+    assertEquals(result.claudeSettingsCreated, false);
+
+    // Check content is unchanged
+    const content = await Deno.readTextFile(settingsPath);
+    const settings = JSON.parse(content);
+    assertEquals(settings.permissions.allow, ["Bash(custom command:*)"]);
+  });
+});
+
+Deno.test("RepoService.upgrade merges new permissions into existing settings", async () => {
+  await withTempDir(async (tempDir) => {
+    // Init first
+    const oldService = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+    await oldService.init(repoPath);
+
+    // Modify settings to add custom permission and remove some default ones
+    const settingsPath = join(tempDir, ".claude", "settings.local.json");
+    const customSettings = {
+      permissions: {
+        allow: ["Bash(custom command:*)", "Bash(swamp model search:*)"],
+      },
+    };
+    await Deno.writeTextFile(
+      settingsPath,
+      JSON.stringify(customSettings, null, 2),
+    );
+
+    // Upgrade
+    const newService = new RepoService("0.2.0");
+    const result = await newService.upgrade(repoPath);
+
+    assertEquals(result.claudeSettingsUpdated, true);
+
+    // Check that custom permission is preserved and new ones are added
+    const content = await Deno.readTextFile(settingsPath);
+    const settings = JSON.parse(content);
+
+    // Custom permission preserved
+    assertStringIncludes(
+      JSON.stringify(settings.permissions.allow),
+      "Bash(custom command:*)",
+    );
+    // Default permissions added
+    assertStringIncludes(
+      JSON.stringify(settings.permissions.allow),
+      "Bash(swamp vault:*)",
+    );
+  });
+});
+
+Deno.test("RepoService.upgrade creates settings if they do not exist", async () => {
+  await withTempDir(async (tempDir) => {
+    // Init first
+    const oldService = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+    await oldService.init(repoPath);
+
+    // Remove settings file
+    const settingsPath = join(tempDir, ".claude", "settings.local.json");
+    await Deno.remove(settingsPath);
+
+    // Upgrade
+    const newService = new RepoService("0.2.0");
+    const result = await newService.upgrade(repoPath);
+
+    assertEquals(result.claudeSettingsUpdated, true);
+
+    // Check settings created
+    const content = await Deno.readTextFile(settingsPath);
+    const settings = JSON.parse(content);
+    assertEquals(Array.isArray(settings.permissions?.allow), true);
+  });
+});
+
+Deno.test("RepoService.upgrade returns false if settings unchanged", async () => {
+  await withTempDir(async (tempDir) => {
+    // Init first
+    const oldService = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+    await oldService.init(repoPath);
+
+    // Upgrade immediately (settings already have all permissions)
+    const newService = new RepoService("0.2.0");
+    const result = await newService.upgrade(repoPath);
+
+    assertEquals(result.claudeSettingsUpdated, false);
+  });
+});
+
+Deno.test("RepoService.init generates CLAUDE.md with skills section", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath);
+
+    const claudeMdPath = join(tempDir, "CLAUDE.md");
+    const content = await Deno.readTextFile(claudeMdPath);
+
+    assertStringIncludes(content, "## Skills");
+    assertStringIncludes(content, "swamp-model");
+    assertStringIncludes(content, "swamp-workflow");
+    assertStringIncludes(content, "plan mode");
+  });
+});

--- a/src/presentation/output/repo_output.ts
+++ b/src/presentation/output/repo_output.ts
@@ -12,6 +12,7 @@ export interface RepoInitData {
   initializedAt: string;
   skillsCopied: string[];
   claudeMdCreated: boolean;
+  claudeSettingsCreated: boolean;
 }
 
 /**
@@ -23,6 +24,7 @@ export interface RepoUpgradeData {
   newVersion: string;
   upgradedAt: string;
   skillsUpdated: string[];
+  claudeSettingsUpdated: boolean;
 }
 
 /**


### PR DESCRIPTION
Fixes: #254

- Add `.claude/settings.local.json` generation during `swamp repo init` and `swamp repo upgrade`
- Allowed commands enable common swamp operations without prompting while execution commands require approval
- Update `CLAUDE.md` template to include skills section with plan mode instructions

## Details

### Claude Settings Generation

During `repo init`, creates `.claude/settings.local.json` with pre-approved permissions for:
- Model operations: `search`, `create`, `edit`, `delete`, `get`, `validate`, `output`, `method history`
- Workflow operations: `search`, `create`, `edit`, `delete`, `get`, `validate`, `schema`, `history`
- All `vault`, `data`, `repo`, and `telemetry` commands

Execution commands (`workflow run`, `workflow evaluate`, `model method run`, `model evaluate`) are intentionally excluded
to require user approval.

During `repo upgrade`, merges new permissions into existing settings while preserving user-added permissions.

### CLAUDE.md Enhancement

Updated the generated `CLAUDE.md` to include a Skills section instructing Claude to load swamp skills even in plan mode.

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] All 1675 tests pass
- [x] Binary compiles successfully
- [ ] Manual test: Run `swamp repo init` in new directory, verify `.claude/settings.local.json` created
- [ ] Manual test: Run `swamp repo upgrade`, verify settings preserved/merged