### PR TITLE
feat: Allow any non-reserved namespace for user models

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -44,13 +44,13 @@ outputs.
 
 ## Quick Reference
 
-| Task                | Command/Action                                         |
-| ------------------- | ------------------------------------------------------ |
-| Create model file   | Create `extensions/models/my_model.ts`                 |
-| Verify registration | `swamp type search --json`                             |
-| Check schema        | `swamp type describe @user/my-model --json`            |
-| Create instance     | `swamp model create @user/my-model my-instance --json` |
-| Run method          | `swamp model method run my-instance run --json`        |
+| Task                | Command/Action                                          |
+| ------------------- | ------------------------------------------------------- |
+| Create model file   | Create `extensions/models/my_model.ts`                  |
+| Verify registration | `swamp type search --json`                              |
+| Check schema        | `swamp type describe @myorg/my-model --json`            |
+| Create instance     | `swamp model create @myorg/my-model my-instance --json` |
+| Run method          | `swamp model method run my-instance run --json`         |
 
 ## Quick Start
 
@@ -61,7 +61,7 @@ import { z } from "npm:zod@4";
 const InputSchema = z.object({ message: z.string() });
 
 export const model = {
-  type: "@user/my-model",
+  type: "@myorg/my-model",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   dataOutputSpecs: {
@@ -361,8 +361,8 @@ Repository models take precedence, allowing you to override built-in types.
 1. **Export**: Use `export const model = { ... }` for new types or
    `export const extension = { ... }` for extending existing types
 2. **Import**: Only `import { z } from "npm:zod@4";` is needed
-3. **Type naming**: Use `@user/<name>` format (e.g., `@user/my-model`,
-   `@user/aws/s3-bucket`). Reserved namespaces (`swamp`, `si`) are for built-in
+3. **Type naming**: Use `@<namespace>/<name>` format (e.g., `@keeb/my-model`,
+   `@stack72/deploy`). Reserved namespaces (`swamp`, `si`) are for built-in
    types only.
 4. **No type annotations**: Avoid TypeScript types in execute parameters
 5. **File naming**: Use snake_case (`my_model.ts`), test files excluded
@@ -370,19 +370,22 @@ Repository models take precedence, allowing you to override built-in types.
 
 ## Namespace Rules
 
-User-defined models **must** use the `@user` namespace:
+User-defined models can use any namespace except reserved ones (`swamp`, `si`):
 
-| Type                  | Valid? | Notes                          |
-| --------------------- | ------ | ------------------------------ |
-| `@user/my-model`      | ✅     | Required format                |
-| `@user/aws/s3-bucket` | ✅     | Nested namespaces allowed      |
-| `mycompany/model`     | ❌     | Missing `@` prefix             |
-| `@mycompany/model`    | ❌     | Only `@user` namespace allowed |
-| `swamp/my-model`      | ❌     | Reserved for built-in types    |
-| `@swamp/my-model`     | ❌     | Reserved namespace             |
-
-When authentication is added, users will be able to use their username as the
-namespace (e.g., `@adam/my-model`).
+| Type                  | Valid? | Notes                       |
+| --------------------- | ------ | --------------------------- |
+| `@user/my-model`      | ✅     | Valid namespace             |
+| `@stack72/my-model`   | ✅     | Custom namespace allowed    |
+| `@keeb/keyboard`      | ✅     | Custom namespace allowed    |
+| `@myorg/deploy`       | ✅     | Custom namespace allowed    |
+| `@user/aws/s3-bucket` | ✅     | Nested paths allowed        |
+| `@stack72/aws/s3`     | ✅     | Nested paths allowed        |
+| `mycompany/model`     | ❌     | Missing `@` prefix          |
+| `@user`               | ❌     | Needs 2+ segments           |
+| `swamp/my-model`      | ❌     | Reserved for built-in types |
+| `@swamp/my-model`     | ❌     | Reserved namespace          |
+| `si/auth`             | ❌     | Reserved namespace          |
+| `@si/auth`            | ❌     | Reserved namespace          |
 
 ## Data Ownership
 
@@ -728,7 +731,7 @@ After creating your model:
 
 ```bash
 swamp type search --json              # Model should appear
-swamp type describe @user/my-model    # Check schema
+swamp type describe @myorg/my-model   # Check schema
 ```
 
 ## When to Use Other Skills

--- a/.claude/skills/swamp-extension-model/references/examples.md
+++ b/.claude/skills/swamp-extension-model/references/examples.md
@@ -274,7 +274,7 @@ const InputSchema = z.object({
 });
 
 export const model = {
-  type: "myorg/system-info",
+  type: "@myorg/system-info",
   version: "2026.02.09.1",
   inputAttributesSchema: InputSchema,
   methods: {

--- a/.claude/skills/swamp-extension-model/references/troubleshooting.md
+++ b/.claude/skills/swamp-extension-model/references/troubleshooting.md
@@ -44,44 +44,43 @@ export const model = {
 
 ### "Model type already registered"
 
-Type name conflicts with built-in or another user model. Use unique names within
-the `@user` namespace:
+Type name conflicts with built-in or another user model. Use unique namespaced
+names:
 
 ```typescript
 // Avoid
 type: "@user/echo"; // May conflict with other users
 
 // Use
-type: "@user/mycompany/echo"; // More unique
+type: "@myorg/echo"; // Use your own namespace
 ```
 
 ### "Model type must use '@' prefix"
 
-User-defined models must use the `@user` namespace:
+User-defined models must start with `@`:
 
 ```typescript
-// Wrong - missing @user namespace
+// Wrong - missing @ prefix
 type: "mycompany/echo";
 
 // Correct
+type: "@mycompany/echo";
 type: "@user/echo";
-type: "@user/mycompany/echo";
 ```
 
-### "Namespace 'X' is not allowed"
+### "Uses a reserved namespace"
 
-Only the `@user` namespace is currently allowed for user models. Reserved
-namespaces (`swamp`, `si`) are for built-in types:
+Reserved namespaces (`swamp`, `si`) are for built-in types only:
 
 ```typescript
 // Wrong - reserved namespace
 type: "swamp/my-model";
 type: "@swamp/my-model";
+type: "si/auth";
+type: "@si/auth";
 
-// Wrong - custom namespace not allowed yet
-type: "@mycompany/echo";
-
-// Correct
+// Correct - use any other namespace
+type: "@myorg/my-model";
 type: "@user/my-model";
 ```
 
@@ -133,9 +132,9 @@ Models directory priority:
 swamp type search --json
 
 # Check model schema
-swamp type describe @user/my-model --json
+swamp type describe @myorg/my-model --json
 
 # Test the model
-swamp model create @user/my-model test --set fieldName="test"
+swamp model create @myorg/my-model test --set fieldName="test"
 swamp model method run test methodName --json
 ```

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -95,13 +95,6 @@ export interface LoadResult {
 }
 
 /**
- * Allowed namespaces for user-defined models.
- * Currently only "user" is allowed. When authentication is added,
- * the authenticated username will be added to this list.
- */
-const ALLOWED_NAMESPACES = ["user"];
-
-/**
  * Loader for user-defined TypeScript models and extensions.
  *
  * Users export a plain `model` object to define new types, or an `extension`
@@ -214,10 +207,9 @@ export class UserModelLoader {
    * Validates that a user-defined model type follows the required namespace conventions.
    *
    * Requirements:
-   * - Must start with '@' (user namespace prefix)
-   * - Must use an allowed namespace (currently only "user")
-   * - Must have at least 2 segments (e.g., "@user/echo")
    * - Must not use reserved namespaces (swamp, si)
+   * - Must start with '@' (user namespace prefix)
+   * - Must have at least 2 segments (e.g., "@myorg/echo")
    *
    * @param rawType - The raw type string from the user model
    * @returns Error message if validation fails, undefined if valid
@@ -232,19 +224,13 @@ export class UserModelLoader {
 
     // Must start with '@'
     if (!ModelType.isUserNamespace(normalized)) {
-      return `Model type '${rawType}' must use '@' prefix. Expected format: @user/<name> (e.g., @user/my-model)`;
-    }
-
-    // Must use an allowed namespace
-    const namespace = ModelType.getUserNamespace(normalized);
-    if (!namespace || !ALLOWED_NAMESPACES.includes(namespace)) {
-      return `Model type '${rawType}' uses namespace '${namespace}' which is not allowed. Currently only '@user' namespace is allowed.`;
+      return `Model type '${rawType}' must use '@' prefix. Expected format: @<namespace>/<name> (e.g., @myorg/my-model)`;
     }
 
     // Must have at least 2 segments
     const segmentCount = ModelType.getSegmentCount(normalized);
     if (segmentCount < 2) {
-      return `Model type '${rawType}' must have at least 2 segments. Expected format: @user/<name> (e.g., @user/my-model)`;
+      return `Model type '${rawType}' must have at least 2 segments. Expected format: @<namespace>/<name> (e.g., @myorg/my-model)`;
     }
 
     return undefined;

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -1556,7 +1556,7 @@ export const model = {
   });
 });
 
-Deno.test("UserModelLoader rejects model with only namespace segment", async () => {
+Deno.test("UserModelLoader rejects model with only namespace segment (@user)", async () => {
   const modelCode = `
 import { z } from "npm:zod@4";
 
@@ -1593,12 +1593,12 @@ export const model = {
   });
 });
 
-Deno.test("UserModelLoader rejects model with non-user namespace", async () => {
+Deno.test("UserModelLoader rejects model with only namespace segment (@myorg)", async () => {
   const modelCode = `
 import { z } from "npm:zod@4";
 
 export const model = {
-  type: "@adam/mymodel",
+  type: "@myorg",
   version: "2026.02.09.1",
   inputAttributesSchema: z.object({ message: z.string() }),
   dataOutputSpecs: {
@@ -1620,14 +1620,133 @@ export const model = {
 };
 `;
 
-  await withTempModels({ "wrong_namespace.ts": modelCode }, async (dir) => {
+  await withTempModels({ "only_myorg.ts": modelCode }, async (dir) => {
     const loader = new UserModelLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.loaded.length, 0);
     assertEquals(result.failed.length, 1);
-    assertStringIncludes(result.failed[0].error, "namespace 'adam'");
-    assertStringIncludes(result.failed[0].error, "not allowed");
+    assertStringIncludes(result.failed[0].error, "at least 2 segments");
+  });
+});
+
+Deno.test("UserModelLoader accepts model with custom namespace @adam/mymodel", async () => {
+  const typeId = `@adam/mymodel-${Date.now()}`;
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "${typeId}",
+  version: "2026.02.09.1",
+  inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
+  methods: {
+    run: {
+      description: "Run",
+      execute: async () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+  await withTempModels({ "custom_namespace.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 1);
+    assertEquals(result.failed.length, 0);
+
+    const modelDef = modelRegistry.get(typeId);
+    assertEquals(modelDef !== undefined, true);
+  });
+});
+
+Deno.test("UserModelLoader accepts model with custom namespace @stack72/name", async () => {
+  const typeId = `@stack72/my-model-${Date.now()}`;
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "${typeId}",
+  version: "2026.02.09.1",
+  inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
+  methods: {
+    run: {
+      description: "Run",
+      execute: async () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+  await withTempModels({ "stack72_model.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 1);
+    assertEquals(result.failed.length, 0);
+
+    const modelDef = modelRegistry.get(typeId);
+    assertEquals(modelDef !== undefined, true);
+  });
+});
+
+Deno.test("UserModelLoader accepts model with custom namespace @keeb/name", async () => {
+  const typeId = `@keeb/keyboard-${Date.now()}`;
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "${typeId}",
+  version: "2026.02.09.1",
+  inputAttributesSchema: z.object({ message: z.string() }),
+  dataOutputSpecs: {
+    "data": {
+      specType: "data",
+      description: "Data output",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "data" },
+    },
+  },
+  methods: {
+    run: {
+      description: "Run",
+      execute: async () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+  await withTempModels({ "keeb_model.ts": modelCode }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 1);
+    assertEquals(result.failed.length, 0);
+
+    const modelDef = modelRegistry.get(typeId);
+    assertEquals(modelDef !== undefined, true);
   });
 });
 


### PR DESCRIPTION
- Removed the `@user`-only allowlist for user model namespaces, replacing it with a blocklist approach
- User models can now use any `@<namespace>/<name>` format except reserved namespaces (`swamp`, `si`)
- The `@user`-only restriction will move to a future publish service instead

## Changes

- Removed `ALLOWED_NAMESPACES` constant and allowlist check from `UserModelLoader.validateUserNamespace()`
- Validation now only enforces: no reserved namespaces, `@` prefix required, 2+ segments required
- Updated tests: `@adam/mymodel`, `@stack72/name`, `@keeb/name` now accepted
- Updated skill documentation to reflect open namespaces

## Validation

| Type                | Valid? | Reason                    |
| ------------------- | ------ | ------------------------- |
| `@user/echo`        | Yes    | Valid namespace            |
| `@stack72/my-model` | Yes    | Custom namespace allowed   |
| `@keeb/keyboard`    | Yes    | Custom namespace allowed   |
| `@myorg/deploy`     | Yes    | Custom namespace allowed   |
| `mycompany/echo`    | No     | Missing `@` prefix         |
| `@user`             | No     | Needs 2+ segments          |
| `swamp/echo`        | No     | Reserved namespace         |
| `@swamp/echo`       | No     | Reserved namespace         |
| `si/auth`           | No     | Reserved namespace         |
| `@si/auth`          | No     | Reserved namespace         |

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] All 1672 tests pass