### PR TITLE
fix: Use globalThis for modelRegistry to survive Vite bundling

### DIFF
--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -546,8 +546,16 @@ export class ModelRegistry {
 
 /**
  * Global model registry instance.
+ *
+ * Uses globalThis so that the same registry is shared across module
+ * boundaries (e.g., when a Vite bundle has its own copy of this module
+ * but extension models were loaded outside the bundle).
  */
-export const modelRegistry = new ModelRegistry();
+const MODEL_REGISTRY_KEY = "__swampModelRegistry";
+// deno-lint-ignore no-explicit-any
+export const modelRegistry: ModelRegistry = (globalThis as any)[
+  MODEL_REGISTRY_KEY
+] ??= new ModelRegistry();
 
 /**
  * Defines and registers a model with the global registry.


### PR DESCRIPTION
## Summary

- **Fix extension models not appearing in swamp-webapp UI** by storing the
  `modelRegistry` singleton on `globalThis` instead of at module scope

## Problem

When the webapp is built with Vite, `model.ts` gets bundled into
`_fresh/server.js` — creating a **second** `ModelRegistry` instance.
`compile-entry.ts` loads extension models into the runtime's registry, but
the Fresh routes query the bundle's separate empty registry. Result:
extension models load successfully (logged at startup) but never appear
in the UI.

## Fix

Same `globalThis` pattern that `state.ts` already uses for `AppState`:

```typescript
const MODEL_REGISTRY_KEY = "__swampModelRegistry";
export const modelRegistry: ModelRegistry = (globalThis as any)[
  MODEL_REGISTRY_KEY
] ??= new ModelRegistry();
```

The `??=` ensures exactly one `ModelRegistry` instance exists regardless of
how many copies of the module are loaded. Built-in models registered via
side-effect imports and extension models loaded at startup all end up in
the same registry that the bundled routes query.

## Why this matters

Without this fix, **no user-defined extension models are visible** in the
webapp — the entire `/models` page is missing them, and API endpoints like
`/api/v1/types` and `/api/v1/models` only return built-in types. This
completely breaks the webapp's ability to display, inspect, or interact
with extension models.

## Test plan

- [x] `deno check` passes on upstream
- [x] Vendor sync to swamp-webapp passes type-check
- [x] `compile-entry.ts` pointed at a repo with 10 extension models:
  all 19 types (9 built-in + 10 extension) returned by `/api/v1/types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)