### PR TITLE
docs: Update skills to use new `swamp model type` commands

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -12,9 +12,9 @@ startup.
 
 **Create an extension model when no built-in type exists for your use case.**
 
-If you search for a type with `swamp type search <query>` and get no results,
-you should create a custom model rather than assuming the functionality doesn't
-exist. Extension models let you:
+If you search for a type with `swamp model type search <query>` and get no
+results, you should create a custom model rather than assuming the functionality
+doesn't exist. Extension models let you:
 
 - Integrate with any API or service (AWS S3, Stripe, custom APIs, etc.)
 - Define any automation logic you need
@@ -24,7 +24,7 @@ exist. Extension models let you:
 
 ```
 1. User wants to work with S3 buckets
-2. Run: swamp type search S3 → no results
+2. Run: swamp model type search S3 → no results
 3. Solution: Create extensions/models/s3_bucket.ts with the S3 logic you need
 ```
 
@@ -47,8 +47,8 @@ outputs.
 | Task                | Command/Action                                          |
 | ------------------- | ------------------------------------------------------- |
 | Create model file   | Create `extensions/models/my_model.ts`                  |
-| Verify registration | `swamp type search --json`                              |
-| Check schema        | `swamp type describe @myorg/my-model --json`            |
+| Verify registration | `swamp model type search --json`                        |
+| Check schema        | `swamp model type describe @myorg/my-model --json`      |
 | Create instance     | `swamp model create @myorg/my-model my-instance --json` |
 | Run method          | `swamp model method run my-instance run --json`         |
 
@@ -730,8 +730,8 @@ methods: {
 After creating your model:
 
 ```bash
-swamp type search --json              # Model should appear
-swamp type describe @myorg/my-model   # Check schema
+swamp model type search --json              # Model should appear
+swamp model type describe @myorg/my-model   # Check schema
 ```
 
 ## When to Use Other Skills

--- a/.claude/skills/swamp-extension-model/references/troubleshooting.md
+++ b/.claude/skills/swamp-extension-model/references/troubleshooting.md
@@ -129,10 +129,10 @@ Models directory priority:
 
 ```bash
 # Verify model loads
-swamp type search --json
+swamp model type search --json
 
 # Check model schema
-swamp type describe @myorg/my-model --json
+swamp model type describe @myorg/my-model --json
 
 # Test the model
 swamp model create @myorg/my-model test --set fieldName="test"

--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -12,8 +12,8 @@ machine-readable output.
 
 | Task               | Command                                                  |
 | ------------------ | -------------------------------------------------------- |
-| Search model types | `swamp type search [query] --json`                       |
-| Describe a type    | `swamp type describe <type> --json`                      |
+| Search model types | `swamp model type search [query] --json`                 |
+| Describe a type    | `swamp model type describe <type> --json`                |
 | Create model input | `swamp model create <type> <name> --json`                |
 | Search models      | `swamp model search [query] --json`                      |
 | Get model details  | `swamp model get <id_or_name> --json`                    |
@@ -52,8 +52,8 @@ Use `swamp repo index` to rebuild if symlinks become out of sync.
 Find available model types in the system.
 
 ```bash
-swamp type search --json
-swamp type search "echo" --json
+swamp model type search --json
+swamp model type search "echo" --json
 ```
 
 **Output shape:**
@@ -72,7 +72,7 @@ swamp type search "echo" --json
 Get the full schema and available methods for a type.
 
 ```bash
-swamp type describe swamp/echo --json
+swamp model type describe swamp/echo --json
 ```
 
 **Output shape:**
@@ -483,9 +483,9 @@ swamp model output data output-789 --json
 
 ## Workflow Example
 
-1. **Search** for the right type: `swamp type search "echo" --json`
+1. **Search** for the right type: `swamp model type search "echo" --json`
 2. **Describe** to understand the schema:
-   `swamp type describe swamp/echo --json`
+   `swamp model type describe swamp/echo --json`
 3. **Create** an input file: `swamp model create swamp/echo my-message --json`
 4. **Edit** the YAML file to set `attributes.message`
 5. **Validate** the model: `swamp model validate my-message --json`


### PR DESCRIPTION
Updates skill documentation to reflect the command restructuring from #257, where `swamp type` commands were moved under `swamp model type`.

- Update `swamp-model` skill with new command paths
- Update `swamp-extension-model` skill with new command paths
- Update troubleshooting docs with new verification commands

## Changes

| Old Command | New Command |
|-------------|-------------|
| `swamp type search` | `swamp model type search` |
| `swamp type describe` | `swamp model type describe` |
| `swamp type get` | `swamp model type get` |

## Files Changed

- `.claude/skills/swamp-model/SKILL.md`
- `.claude/skills/swamp-extension-model/SKILL.md`
- `.claude/skills/swamp-extension-model/references/troubleshooting.md`

## Test Plan

- [x] Verify no remaining `swamp type search/describe/get` references in skills
- [x] `swamp vault type search` left unchanged (separate command)

🤖 Generated with [Claude Code](https://claude.com/claude-code)