### PR TITLE
docs: Document direct file editing for Claude in model/workflow skills

### DIFF
--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -157,41 +157,16 @@ in attributes using `${{ inputs.<name> }}` expressions.
 
 ## Edit a Model
 
-Open model input file in your editor, or update via stdin in non-interactive
-mode.
+**Recommended:** Use `swamp model get <name> --json` to get the file path, then
+edit directly with the Edit tool, then validate with
+`swamp model validate <name> --json`. Never modify the `id` field.
 
-```bash
-# Interactive: opens in editor
-swamp model edit my-echo
-swamp model edit my-echo --resource  # Edit resource file instead
+**Alternative methods:**
 
-# Non-interactive: update from stdin
-cat updated-model.yaml | swamp model edit my-echo --json
+- Interactive: `swamp model edit my-echo` (opens in system editor)
+- Stdin: `cat updated.yaml | swamp model edit my-echo --json`
 
-# With here-doc (agent-friendly)
-swamp model edit my-echo --json <<EOF
-id: existing-uuid
-name: my-echo
-version: 1
-attributes:
-  message: "Updated message"
-EOF
-```
-
-Without arguments in interactive mode, shows a search interface to select a
-model.
-
-**Output shape (when updating via stdin):**
-
-```json
-{
-  "path": ".swamp/definitions/swamp/echo/abc-123.yaml",
-  "status": "updated",
-  "name": "my-echo",
-  "type": "swamp/echo",
-  "editType": "definition"
-}
-```
+Run `swamp repo index` if search results seem stale after editing.
 
 ## Delete a Model
 

--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -128,44 +128,16 @@ jobs:
 
 ## Edit a Workflow
 
-Open workflow file in your editor, or update via stdin in non-interactive mode.
+**Recommended:** Use `swamp workflow get <name> --json` to get the file path,
+then edit directly with the Edit tool, then validate with
+`swamp workflow validate <name> --json`. Never modify the `id` field.
 
-```bash
-# Interactive: opens in editor
-swamp workflow edit my-workflow
+**Alternative methods:**
 
-# Non-interactive: update from stdin
-cat updated-workflow.yaml | swamp workflow edit my-workflow --json
+- Interactive: `swamp workflow edit my-workflow` (opens in system editor)
+- Stdin: `cat updated.yaml | swamp workflow edit my-workflow --json`
 
-# With here-doc (agent-friendly)
-swamp workflow edit my-workflow --json <<EOF
-id: existing-uuid
-name: my-workflow
-version: 1
-jobs:
-  - name: updated-job
-    steps:
-      - name: step1
-        task:
-          type: shell
-          command: echo
-          args: ["updated"]
-EOF
-```
-
-Without arguments in interactive mode, shows a search interface to select a
-workflow.
-
-**Output shape (when updating via stdin):**
-
-```json
-{
-  "path": ".swamp/workflows/workflow-abc-123.yaml",
-  "status": "updated",
-  "name": "my-workflow",
-  "id": "abc-123"
-}
-```
+Run `swamp repo index` if search results seem stale after editing.
 
 ## Delete a Workflow
 


### PR DESCRIPTION
- Update swamp-model and swamp-workflow skills to recommend direct file editing
- Claude can now use the Edit tool on YAML files instead of piping via stdin
- Workflow: `get` → Edit tool → `validate`

Closes #253