### PR TITLE
fix: Human-readable output for model type describe (#249)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -12,6 +12,7 @@
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@1",
+    "@std/fmt": "jsr:@std/fmt@1",
     "@std/cli": "jsr:@std/cli@1",
     "@std/fs": "jsr:@std/fs@1",
     "@std/path": "jsr:@std/path@1",

--- a/deno.lock
+++ b/deno.lock
@@ -11,6 +11,7 @@
     "jsr:@std/assert@1": "1.0.16",
     "jsr:@std/assert@^1.0.17": "1.0.18",
     "jsr:@std/cli@1": "1.0.27",
+    "jsr:@std/fmt@1": "1.0.9",
     "jsr:@std/fmt@~1.0.2": "1.0.9",
     "jsr:@std/fs@1": "1.0.22",
     "jsr:@std/internal@^1.0.12": "1.0.12",
@@ -38,7 +39,7 @@
         "jsr:@cliffy/flags",
         "jsr:@cliffy/internal",
         "jsr:@cliffy/table",
-        "jsr:@std/fmt",
+        "jsr:@std/fmt@~1.0.2",
         "jsr:@std/text"
       ]
     },
@@ -54,7 +55,7 @@
     "@cliffy/table@1.0.0-rc.8": {
       "integrity": "8bbcdc2ba5e0061b4b13810a24e6f5c6ab19c09f0cce9eb691ccd76c7c6c9db5",
       "dependencies": [
-        "jsr:@std/fmt"
+        "jsr:@std/fmt@~1.0.2"
       ]
     },
     "@logtape/logtape@2.0.2": {
@@ -1281,6 +1282,7 @@
       "jsr:@logtape/pretty@2",
       "jsr:@std/assert@1",
       "jsr:@std/cli@1",
+      "jsr:@std/fmt@1",
       "jsr:@std/fs@1",
       "jsr:@std/path@1",
       "jsr:@std/yaml@1",

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1,4 +1,5 @@
 import { Command } from "@cliffy/command";
+import { setColorEnabled } from "@std/fmt/colors";
 import { isAbsolute, resolve } from "@std/path";
 import { parseLogLevel } from "@logtape/logtape";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
@@ -162,6 +163,7 @@ export async function runCli(args: string[]): Promise<void> {
         Deno.env.get("NO_COLOR") !== undefined;
       if (noColor) {
         Deno.env.set("NO_COLOR", "1");
+        setColorEnabled(false);
       }
       const prettyOutput = !noColor && isStdinTty();
 

--- a/src/infrastructure/logging/logger.ts
+++ b/src/infrastructure/logging/logger.ts
@@ -160,6 +160,16 @@ export function getSwampLogger(category: string[]) {
   return getLogger(category);
 }
 
+/**
+ * Writes plain text to stdout with no decoration (no timestamp, level,
+ * or category prefix). Use for human-readable CLI "log" mode output
+ * that should read like a document rather than a log stream.
+ */
+export function writeOutput(message: string): void {
+  // deno-lint-ignore no-console
+  console.log(message);
+}
+
 export function getRunLogger(modelName: string, methodName: string) {
   return getLogger([
     "model",

--- a/src/presentation/output/type_describe_output.ts
+++ b/src/presentation/output/type_describe_output.ts
@@ -1,4 +1,5 @@
-import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import { bold, cyan, dim } from "@std/fmt/colors";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import type { OutputMode } from "./output.ts";
 
 /**
@@ -32,9 +33,15 @@ export interface TypeDescribeData {
   methods: MethodDescribeData[];
 }
 
+interface JsonSchemaProperty {
+  type?: string;
+  enum?: string[];
+  description?: string;
+}
+
 interface JsonSchemaObject {
   type?: string;
-  properties?: Record<string, { type?: string }>;
+  properties?: Record<string, JsonSchemaProperty>;
   required?: string[];
 }
 
@@ -51,8 +58,9 @@ function formatSchemaAttributes(
   const required = new Set(s.required ?? []);
   return Object.entries(s.properties).map(([name, prop]) => {
     const parts = [name];
-    if (prop.type) parts.push(`(${prop.type})`);
-    if (required.has(name)) parts.push("*required");
+    if (prop.type) parts.push(dim(`(${prop.type})`));
+    if (prop.enum) parts.push(dim(`[${prop.enum.join(", ")}]`));
+    if (required.has(name)) parts.push(dim("*required"));
     return `${indent}${parts.join(" ")}`;
   });
 }
@@ -69,54 +77,52 @@ export function renderTypeDescribe(
     return;
   }
 
-  const logger = getSwampLogger(["type", "describe"]);
+  const lines: string[] = [];
 
   const typeName = data.type.raw !== data.type.normalized
-    ? `${data.type.normalized} (${data.type.raw})`
+    ? `${data.type.normalized} ${dim(`(${data.type.raw})`)}`
     : data.type.normalized;
 
-  logger.info("Type: {typeName}", { typeName });
-  logger.info("Version: {version}", { version: data.version });
+  lines.push(`${bold(cyan("Type:"))} ${typeName}`);
+  lines.push(`${bold(cyan("Version:"))} ${data.version}`);
 
   const attrs = formatSchemaAttributes(data.inputAttributesSchema, "  ");
   if (attrs.length > 0) {
-    logger.info("");
-    logger.info("Input Attributes:");
-    for (const attr of attrs) {
-      logger.info(attr);
-    }
+    lines.push("");
+    lines.push(bold(cyan("Input Attributes:")));
+    lines.push(...attrs);
   }
 
   if (data.methods.length > 0) {
-    logger.info("");
-    logger.info("Methods:");
-    for (const method of data.methods) {
-      logger.info("  {name} - {description}", {
-        name: method.name,
-        description: method.description,
-      });
+    lines.push("");
+    lines.push(bold(cyan("Methods:")));
+    for (let i = 0; i < data.methods.length; i++) {
+      const method = data.methods[i];
+      lines.push(
+        `  ${bold(cyan(method.name))} ${dim("-")} ${method.description}`,
+      );
 
       const methodAttrs = formatSchemaAttributes(
         method.inputAttributesSchema,
         "      ",
       );
       if (methodAttrs.length > 0) {
-        logger.info("    Input Attributes:");
-        for (const attr of methodAttrs) {
-          logger.info(attr);
-        }
+        lines.push(`    ${cyan("Input Attributes:")}`);
+        lines.push(...methodAttrs);
       }
 
       if (method.dataOutputSpecs && method.dataOutputSpecs.length > 0) {
-        logger.info("    Data Outputs:");
+        lines.push(`    ${cyan("Data Outputs:")}`);
         for (const spec of method.dataOutputSpecs) {
           const parts = [spec.specType];
-          if (spec.description) parts.push(`- ${spec.description}`);
+          if (spec.description) parts.push(`${dim("-")} ${spec.description}`);
           const meta = [spec.contentType, spec.lifetime].filter(Boolean);
-          if (meta.length > 0) parts.push(`(${meta.join(", ")})`);
-          logger.info(`      ${parts.join(" ")}`);
+          if (meta.length > 0) parts.push(dim(`(${meta.join(", ")})`));
+          lines.push(`      ${parts.join(" ")}`);
         }
       }
     }
   }
+
+  writeOutput(lines.join("\n"));
 }

--- a/src/presentation/output/type_describe_output_test.ts
+++ b/src/presentation/output/type_describe_output_test.ts
@@ -1,4 +1,5 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
+import { stripAnsiCode } from "@std/fmt/colors";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 import {
   renderTypeDescribe,
@@ -92,15 +93,20 @@ Deno.test("renderTypeDescribe with json mode outputs valid JSON", () => {
   }
 });
 
-Deno.test("renderTypeDescribe with log mode does not output JSON", () => {
+Deno.test("renderTypeDescribe with log mode outputs plain text, not JSON", () => {
   const logs: string[] = [];
   const originalLog = console.log;
   console.log = (msg: string) => logs.push(msg);
 
   try {
     renderTypeDescribe(testData, "log");
-    // Log mode should use the logger, not console.log
-    assertEquals(logs.length, 0);
+    const combined = stripAnsiCode(logs.join("\n"));
+    assertStringIncludes(combined, "Type:");
+    assertStringIncludes(combined, "swamp/echo");
+    assertStringIncludes(combined, "Version:");
+    assertStringIncludes(combined, "Methods:");
+    assertStringIncludes(combined, "write");
+    assertThrows(() => JSON.parse(combined), SyntaxError);
   } finally {
     console.log = originalLog;
   }


### PR DESCRIPTION
## Summary

- `renderTypeDescribe()` was outputting JSON in both `log` and `json` modes, making `swamp model type search` and `swamp model type describe` unreadable without `--json`
- Added `writeOutput()` to the logger module as a reusable plain-text output function that bypasses LogTape decoration (no timestamps, levels, or category prefixes)
- Added colored output using `@std/fmt/colors`: bold cyan section headers, dim metadata (types, enums, required markers), bold cyan method names for clear hierarchy
- Wired `setColorEnabled(false)` on `--no-color` so `@std/fmt/colors` respects the flag at runtime
- Shows enum values inline: `InstanceTenancy (string) [default, dedicated, host]`

Closes #249

## Test Plan

- `deno run dev model type describe swamp/echo` — colored human-readable output
- `deno run dev model type describe "AWS::EC2::VPC"` — complex model with enums, 3 methods
- `deno run dev model type describe swamp/echo --json` — JSON unchanged
- `deno run dev model type describe swamp/echo --no-color` — no ANSI codes
- `NO_COLOR=1 deno run dev model type describe swamp/echo` — env var respected
- `deno run dev model type search` — interactive select shows formatted output
- All 1630 tests pass