### PR TITLE
Improve error messages for deprecated workflows and invalid user models

### DIFF
--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -78,6 +78,98 @@ const UserModelSchema = z.object({
 });
 
 /**
+ * Formats a Zod error into a clear, actionable message.
+ */
+function formatUserModelError(error: z.ZodError): string {
+  const issues = error.issues;
+
+  // Check for missing dataOutputSpecs
+  const dataOutputSpecsIssue = issues.find(
+    (i) => i.path[0] === "dataOutputSpecs" && i.code === "invalid_type",
+  );
+  if (dataOutputSpecsIssue) {
+    return (
+      "Missing required 'dataOutputSpecs' field. " +
+      "Add dataOutputSpecs to declare what data your model produces.\n\n" +
+      "Example:\n" +
+      "  dataOutputSpecs: {\n" +
+      "    result: {\n" +
+      '      specType: "result",\n' +
+      '      contentType: "application/json",\n' +
+      '      lifetime: { type: "persistent" },\n' +
+      '      garbageCollection: { type: "keep_latest", count: 10 },\n' +
+      "      tags: {},\n" +
+      "    },\n" +
+      "  },"
+    );
+  }
+
+  // Check for missing inputAttributesSchema
+  const inputSchemaIssue = issues.find(
+    (i) => i.path[0] === "inputAttributesSchema",
+  );
+  if (inputSchemaIssue) {
+    return (
+      "Missing or invalid 'inputAttributesSchema'. " +
+      "Add a Zod schema to validate model inputs.\n\n" +
+      "Example:\n" +
+      "  inputAttributesSchema: z.object({\n" +
+      '    name: z.string().describe("Resource name"),\n' +
+      "  }),"
+    );
+  }
+
+  // Check for missing type
+  const typeIssue = issues.find((i) => i.path[0] === "type");
+  if (typeIssue) {
+    return (
+      "Missing required 'type' field. " +
+      "Add a namespaced type identifier.\n\n" +
+      "Example:\n" +
+      '  type: "@myorg/my-model",'
+    );
+  }
+
+  // Check for missing version
+  const versionIssue = issues.find((i) => i.path[0] === "version");
+  if (versionIssue) {
+    return (
+      "Missing or invalid 'version' field. " +
+      "Use CalVer format: YYYY.MM.DD.MICRO.\n\n" +
+      "Example:\n" +
+      '  version: "2026.02.10.1",'
+    );
+  }
+
+  // Check for missing methods
+  const methodsIssue = issues.find((i) => i.path[0] === "methods");
+  if (methodsIssue) {
+    return (
+      "Missing required 'methods' field. " +
+      "Add at least one method to your model.\n\n" +
+      "Example:\n" +
+      "  methods: {\n" +
+      "    run: {\n" +
+      '      description: "Execute the model",\n' +
+      "      execute: async (definition, context) => {\n" +
+      "        // Your logic here\n" +
+      "        return { dataHandles: [] };\n" +
+      "      },\n" +
+      "    },\n" +
+      "  },"
+    );
+  }
+
+  // Fallback: format all issues concisely
+  return issues
+    .map((i) => {
+      const path = i.path.join(".");
+      return `${path}: ${i.message}`;
+    })
+    .join("; ");
+}
+
+/**
  * Schema for validating user extension exports.
  */
 const UserExtensionSchema = z.object({
@@ -154,7 +246,10 @@ export class UserModelLoader {
       try {
         const parsed = UserModelSchema.safeParse(module.model);
         if (!parsed.success) {
-          result.failed.push({ file, error: parsed.error.message });
+          result.failed.push({
+            file,
+            error: formatUserModelError(parsed.error),
+          });
           continue;
         }
 

--- a/src/infrastructure/persistence/yaml_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_repository.ts
@@ -68,7 +68,18 @@ export class YamlWorkflowRepository implements WorkflowRepository {
             const data = parseYaml(content) as WorkflowData;
             workflows.push(Workflow.fromData(data));
           } catch (parseError) {
-            logger.warn`Skipping broken workflow file ${path}: ${parseError}`;
+            const errorMsg = parseError instanceof Error
+              ? parseError.message
+              : String(parseError);
+            const workflowName = this.tryExtractName(path);
+
+            if (errorMsg.includes('type "shell" is no longer supported')) {
+              logger
+                .warn`Skipping workflow "${workflowName}": uses deprecated 'shell' task. Delete or update to 'type: model_method' with 'keeb/shell'. File: ${path}`;
+            } else {
+              logger
+                .warn`Skipping broken workflow "${workflowName}": ${errorMsg}. File: ${path}`;
+            }
           }
         }
       }
@@ -156,5 +167,24 @@ export class YamlWorkflowRepository implements WorkflowRepository {
 
   private getWorkflowsDir(): string {
     return swampPath(this.repoDir, SWAMP_SUBDIRS.workflows);
+  }
+
+  /**
+   * Attempts to extract workflow name from a YAML file path.
+   * Falls back to the filename if parsing fails.
+   */
+  private tryExtractName(path: string): string {
+    try {
+      const content = Deno.readTextFileSync(path);
+      const data = parseYaml(content) as { name?: string };
+      if (data?.name) {
+        return data.name;
+      }
+    } catch {
+      // Ignore - fall through to filename
+    }
+    // Extract filename without extension as fallback
+    const filename = path.split("/").pop() ?? path;
+    return filename.replace(/\.yaml$/, "");
   }
 }


### PR DESCRIPTION
- Improve warning message when loading workflows with deprecated 'shell' task type to be concise and actionable
- Add clear, actionable error messages for user model schema validation failures with examples

## Changes

### Workflow Repository
When a workflow with the deprecated `type: shell` is encountered, the warning now shows:
Skipping workflow "name": uses deprecated 'shell' task. Delete or update to 'type: model_method' with 'keeb/shell'. File:
/path/to/file.yaml

### User Model Loader
Schema validation errors now provide specific guidance based on what field is missing/invalid:
- Missing `dataOutputSpecs` - explains what it is with a complete example
- Missing `inputAttributesSchema` - shows how to add a Zod schema
- Missing `type` - shows the required namespace format
- Missing `version` - explains CalVer format
- Missing `methods` - shows method structure with execute function

## Test plan
- [x] All existing tests pass (1640 tests)
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes