### PR TITLE
Fix concurrent release workflow race condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 permissions:
   contents: write
 


### PR DESCRIPTION
- Add concurrency control to the release workflow to prevent race conditions when multiple PRs merge simultaneously

## Problem
When multiple PRs merge to main at the same time, multiple release workflow runs would start concurrently. This could cause
race conditions when creating tags and releases.

## Solution
Added a `concurrency` group with `cancel-in-progress: false` to queue release runs. Now if multiple PRs merge
simultaneously:
1. The first release runs to completion
2. Subsequent releases queue and run sequentially
3. Each queued run checks out the latest `main`, so it includes all previously merged changes