### PR TITLE
Fix cursor getting lost in search TUI when navigating down

### DIFF
--- a/src/presentation/output/hooks/useScrollableList.ts
+++ b/src/presentation/output/hooks/useScrollableList.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 /**
  * Calculates visible window for a scrollable list.
@@ -98,37 +98,56 @@ export function useScrollableList<T>(
   resetDeps: unknown[] = [],
 ): UseScrollableListResult<T> {
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const [scrollOffset, setScrollOffset] = useState(0);
-
-  // Adjust scroll offset to keep selected item visible
-  useEffect(() => {
-    if (selectedIndex < scrollOffset) {
-      setScrollOffset(selectedIndex);
-    } else if (selectedIndex >= scrollOffset + maxVisible) {
-      setScrollOffset(selectedIndex - maxVisible + 1);
-    }
-  }, [selectedIndex, scrollOffset, maxVisible]);
+  // Use ref to track scroll offset for "sticky" scrolling behavior
+  // (viewport only moves when selected item would go off-screen)
+  const scrollOffsetRef = useRef(0);
 
   // Reset selection and scroll when dependencies change (e.g., query)
   useEffect(() => {
     setSelectedIndex(0);
-    setScrollOffset(0);
+    scrollOffsetRef.current = 0;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, resetDeps);
 
-  const visibleItems = items.slice(scrollOffset, scrollOffset + maxVisible);
+  // Compute effective scroll offset synchronously during render
+  // This ensures the selected item is always visible without render lag
+  let effectiveScrollOffset = scrollOffsetRef.current;
+
+  // If selected item is above the visible window, scroll up
+  if (selectedIndex < effectiveScrollOffset) {
+    effectiveScrollOffset = selectedIndex;
+  } // If selected item is below the visible window, scroll down
+  else if (selectedIndex >= effectiveScrollOffset + maxVisible) {
+    effectiveScrollOffset = selectedIndex - maxVisible + 1;
+  }
+
+  // Clamp scroll offset to valid bounds (handles case where items array shrinks)
+  const maxScrollOffset = Math.max(0, items.length - maxVisible);
+  effectiveScrollOffset = Math.min(effectiveScrollOffset, maxScrollOffset);
+  effectiveScrollOffset = Math.max(0, effectiveScrollOffset);
+
+  // Update ref for next render's "sticky" behavior
+  scrollOffsetRef.current = effectiveScrollOffset;
+
+  const visibleItems = items.slice(
+    effectiveScrollOffset,
+    effectiveScrollOffset + maxVisible,
+  );
 
   const scrollMetrics: ScrollMetrics = {
-    hasMoreAbove: scrollOffset > 0,
-    hasMoreBelow: scrollOffset + maxVisible < items.length,
-    moreAboveCount: scrollOffset,
-    moreBelowCount: Math.max(0, items.length - scrollOffset - maxVisible),
+    hasMoreAbove: effectiveScrollOffset > 0,
+    hasMoreBelow: effectiveScrollOffset + maxVisible < items.length,
+    moreAboveCount: effectiveScrollOffset,
+    moreBelowCount: Math.max(
+      0,
+      items.length - effectiveScrollOffset - maxVisible,
+    ),
   };
 
   return {
     selectedIndex,
     setSelectedIndex,
-    scrollOffset,
+    scrollOffset: effectiveScrollOffset,
     visibleItems,
     scrollMetrics,
   };


### PR DESCRIPTION
- Fixes the scroll offset computation in `useScrollableList` hook to be synchronous instead of async via `useEffect`
- The cursor would disappear for one render frame when navigating past the visible window because `scrollOffset` was
updated after render
- Now uses a `useRef` to track scroll offset and computes the effective offset synchronously during render

## Problem

When pressing down arrow at the edge of the visible window (e.g., from item 9 to 10 with 10 items visible):

1. `selectedIndex` updates immediately
2. Component re-renders with old `scrollOffset` (not yet updated)
3. The selected item is outside `visibleItems` - cursor appears "lost"
4. `useEffect` runs after render, updates `scrollOffset`
5. Second render shows cursor correctly

This one-frame lag caused the cursor to visually disappear.

## Solution

Compute the scroll offset synchronously during render before slicing `visibleItems`. This ensures the selected item is
always within the visible window on every render.

Closes #272

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] All 1646 tests pass
- [ ] Manual testing: navigate up/down in search TUI with more items than visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)