### PR TITLE
feat: Display raw content in data get command

### DIFF
--- a/src/cli/commands/data_get.ts
+++ b/src/cli/commands/data_get.ts
@@ -27,6 +27,10 @@ export const dataGetCommand = new Command()
     "--run <run_id:string>",
     "Specific workflow run ID (defaults to latest)",
   )
+  .option(
+    "--no-content",
+    "Show metadata only, without content",
+  )
   .action(
     // @ts-expect-error - Cliffy custom type returns unknown instead of string
     async function (
@@ -138,6 +142,18 @@ export const dataGetCommand = new Command()
           contentPath: item.contentPath,
         };
 
+        if (options.content !== false) {
+          const rawContent = await dataRepo.getContent(
+            item.modelType,
+            item.modelId,
+            item.data.name,
+            item.data.version,
+          );
+          if (rawContent) {
+            output.content = new TextDecoder().decode(rawContent);
+          }
+        }
+
         renderDataGet(output, ctx.outputMode);
       } else {
         // Model-scoped data get (original behavior)
@@ -205,6 +221,18 @@ export const dataGetCommand = new Command()
           checksum: data.checksum,
           contentPath,
         };
+
+        if (options.content !== false) {
+          const rawContent = await dataRepo.getContent(
+            modelType,
+            definition.id,
+            dataName,
+            data.version,
+          );
+          if (rawContent) {
+            output.content = new TextDecoder().decode(rawContent);
+          }
+        }
 
         renderDataGet(output, ctx.outputMode);
       }

--- a/src/cli/commands/data_get_test.ts
+++ b/src/cli/commands/data_get_test.ts
@@ -46,3 +46,10 @@ Deno.test("dataGetCommand accepts optional model argument", async () => {
   const args = dataGetCommand.getArguments();
   assertEquals(args.length > 0, true);
 });
+
+Deno.test("dataGetCommand has --no-content option", async () => {
+  const { dataGetCommand } = await import("./data_get.ts");
+  const options = dataGetCommand.getOptions();
+  const contentOpt = options.find((o) => o.name === "no-content");
+  assertEquals(contentOpt !== undefined, true);
+});

--- a/src/cli/commands/data_search.ts
+++ b/src/cli/commands/data_search.ts
@@ -249,30 +249,18 @@ async function displayDataDetail(
     contentPath,
   };
 
-  renderDataGet(output, outputMode);
-
-  // Display raw content
-  const content = await dataRepo.getContent(
+  // Fetch raw content for display
+  const rawContent = await dataRepo.getContent(
     modelType,
     item.modelId,
     item.name,
     data.version,
   );
-
-  if (content) {
-    console.log();
-    if (data.contentType === "application/json") {
-      try {
-        const text = new TextDecoder().decode(content);
-        const parsed = JSON.parse(text);
-        console.log(JSON.stringify(parsed, null, 2));
-      } catch {
-        console.log(new TextDecoder().decode(content));
-      }
-    } else {
-      console.log(new TextDecoder().decode(content));
-    }
+  if (rawContent) {
+    output.content = new TextDecoder().decode(rawContent);
   }
+
+  renderDataGet(output, outputMode);
 }
 
 export const dataSearchCommand = new Command()

--- a/src/presentation/output/data_get_output.ts
+++ b/src/presentation/output/data_get_output.ts
@@ -26,6 +26,7 @@ export interface DataGetData {
   size?: number;
   checksum?: string;
   contentPath: string;
+  content?: string;
 }
 
 /**
@@ -43,7 +44,16 @@ function formatSize(bytes?: number): string {
  */
 export function renderDataGet(data: DataGetData, mode: OutputMode): void {
   if (mode === "json") {
-    console.log(JSON.stringify(data, null, 2));
+    const jsonOutput: Record<string, unknown> = { ...data };
+    // Parse JSON content inline for structured output
+    if (data.content && data.contentType === "application/json") {
+      try {
+        jsonOutput.content = JSON.parse(data.content);
+      } catch {
+        // Leave as string if not valid JSON
+      }
+    }
+    console.log(JSON.stringify(jsonOutput, null, 2));
   } else {
     console.log(`Data: ${data.name} (v${data.version})`);
     console.log(`Model: ${data.modelName} (${data.modelType})`);
@@ -61,5 +71,19 @@ export function renderDataGet(data: DataGetData, mode: OutputMode): void {
     );
     console.log(`Created: ${data.createdAt}`);
     console.log(`Path: ${data.contentPath}`);
+
+    if (data.content !== undefined) {
+      console.log();
+      if (data.contentType === "application/json") {
+        try {
+          const parsed = JSON.parse(data.content);
+          console.log(JSON.stringify(parsed, null, 2));
+        } catch {
+          console.log(data.content);
+        }
+      } else {
+        console.log(data.content);
+      }
+    }
   }
 }


### PR DESCRIPTION
- `data get` now fetches and displays the actual data content after
  metadata, matching the behavior of the `data search` TUI detail view
- Added `--no-content` flag to show metadata only when content isn't
  needed
- JSON mode (`--json`) includes a `content` field (parsed inline for
  JSON content types)
- Refactored `data search` TUI's `displayDataDetail()` to reuse the
  shared renderer from `data_get_output.ts` instead of duplicating
  content display logic

## Test plan
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] `deno run test` passes (1731 tests, 0 failures)
- [x] `swamp data get <model> <name>` shows metadata + content
- [x] `swamp data get --no-content <model> <name>` shows metadata only
- [x] `swamp data get --json <model> <name>` includes `content` field
- [x] `swamp data search` TUI selection still displays content
  identically

Before:

```
swamp data get discover-subnets subnet-048206583caad69ec
Data: subnet-048206583caad69ec (v1)Model: discover-subnets
(@stack72/subnet)Content: application/json, 707BLifetime: infinite | GC:
10Tags: type=step-output, specName=subnet, workflow=discover-subnets,
step=find-subnetsOwner: model-method
(94570b4e-40db-4c53-98ef-20444f6bf151)Created:
2026-02-11T06:25:48.949ZPath:
/Users/stack72/code/swamp-demo/.swamp/data/@stack72/subnet/94570b4e-40db-4c53-98ef-20444f6bf151/subnet-048206583caad69ec/1/raw
```

After:

```
Data: subnet-048206583caad69ec (v1)
Model: discover-subnets (@stack72/subnet)
Content: application/json, 707B
Lifetime: infinite | GC: 10
Tags: type=step-output, specName=subnet, workflow=discover-subnets, step=find-subnets
Owner: model-method (94570b4e-40db-4c53-98ef-20444f6bf151)
Created: 2026-02-11T06:25:48.949Z
Path: /Users/stack72/code/swamp-demo/.swamp/data/@stack72/subnet/94570b4e-40db-4c53-98ef-20444f6bf151/subnet-048206583caad69ec/1/raw

{
  "AvailabilityZoneId": "use1-az1",
  "MapCustomerOwnedIpOnLaunch": false,
  "OwnerId": "439803112369",
  "AssignIpv6AddressOnCreation": false,
  "Ipv6CidrBlockAssociationSet": [],
  "SubnetArn": "arn:aws:ec2:us-east-1:439803112369:subnet/subnet-048206583caad69ec",
  "EnableDns64": false,
  "Ipv6Native": false,
  "PrivateDnsNameOptionsOnLaunch": {
    "HostnameType": "ip-name",
    "EnableResourceNameDnsARecord": false,
    "EnableResourceNameDnsAAAARecord": false
  },
  "BlockPublicAccessStates": {
    "InternetGatewayBlockMode": "off"
  },
  "SubnetId": "subnet-048206583caad69ec",
  "State": "available",
  "VpcId": "vpc-0025265f7d7b4de3c",
  "CidrBlock": "172.31.0.0/20",
  "AvailableIpAddressCount": 4091,
  "AvailabilityZone": "us-east-1a",
  "DefaultForAz": true,
  "MapPublicIpOnLaunch": true
}
```