### PR TITLE
docs: Document expression scoping rules and add integration tests for model.* vs data.latest()

### DIFF
--- a/.claude/skills/swamp-data/SKILL.md
+++ b/.claude/skills/swamp-data/SKILL.md
@@ -283,7 +283,12 @@ swamp data gc -f --json  # Skip confirmation prompt
 
 ## Accessing Data in Expressions
 
-Use CEL expressions to access model data in workflows and model inputs:
+Use CEL expressions to access model data in workflows and model inputs.
+
+**Note:** `model.<name>.resource.<spec>` requires the model to have previously
+produced data (a method was run that called `writeResource`). If no data exists
+yet, accessing `.resource` will fail with "No such key". Use
+`swamp data list <model-name>` to verify data exists.
 
 ```yaml
 # Access latest resource data via dot notation
@@ -347,12 +352,21 @@ subnets: ${{ data.findBySpec("my-scanner", "subnet") }}
 
 **Key rules:**
 
-- `model.<name>.resource.<specName>` accesses the latest version of a resource
+- `model.<name>.resource.<specName>` — **intra-workflow only**. Sees data
+  written by earlier steps in the current run (in-memory context updates). Does
+  NOT see data from prior workflow runs (filtered by `type: "resource"` tag,
+  missing workflow-produced `step-output` data). Creates implicit step
+  dependencies in workflows.
 - `model.<name>.file.<specName>` accesses file metadata (path, size,
-  contentType)
+  contentType). Same intra-workflow scope as `model.*.resource.*`.
+- `data.latest(modelName, dataName)` — **cross-workflow only**. Reads persisted
+  data regardless of tags. Does NOT see data written earlier in the same
+  workflow run. Does not create implicit step dependencies.
 - Use `data.version()` function for specific versions
 - Use `data.findByTag()` to query across models
-- Resource/file expressions create implicit step dependencies in workflows
+- Use separate model instances for different lifecycle phases: `model.*` for
+  create workflows, `data.latest()` for tag/delete workflows. See the
+  `swamp-workflow` skill's data-chaining reference for full details.
 
 ## Data Ownership
 

--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -190,6 +190,27 @@ resources: {
 | `garbageCollection` | Yes      | Version retention policy                      |
 | `tags`              | No       | Extra tags (auto-includes `type: "resource"`) |
 
+**Spec naming:** Resource spec keys must not contain hyphens (`-`). CEL
+expressions use dot-notation to access resources
+(`model.<m>.resource.<specName>.attributes.<field>`), and hyphens in spec names
+are interpreted as the subtraction operator. Use camelCase or single words
+instead (e.g., `igw` not `internet-gateway`, `routeTable` not `route-table`).
+
+**Schema and expression validation:** If your resource will be referenced by
+other models via CEL expressions, you must declare the referenced properties
+explicitly in the Zod schema. Using `z.object({}).passthrough()` allows any data
+to be stored, but the expression path validator cannot resolve attribute
+references against an empty schema. Always declare the key properties you need
+to reference:
+
+```typescript
+// Wrong — expression validator can't resolve attributes.VpcId
+schema: z.object({}).passthrough(),
+
+// Correct — VpcId is declared so expressions can reference it
+schema: z.object({ VpcId: z.string() }).passthrough(),
+```
+
 ### File Specs
 
 Files are binary or text content (including logs):
@@ -233,10 +254,12 @@ execute: (async (definition, context) => {
   // definition.attributes - Validated input data (expressions already resolved)
   // context.repoDir       - Repository root path
   // context.logger        - LogTape Logger for emitting log messages
-  // context.dataRepository - For advanced data operations
-  // context.writeResource  - Write structured JSON data (validates against schema)
+  // context.dataRepository   - For advanced data operations
+  // context.modelType        - The ModelType for this execution
+  // context.modelId          - The model instance ID (definition ID)
+  // context.writeResource    - Write structured JSON data (validates against schema)
   // context.createFileWriter - Create a writer for binary/text files
-  // context.inputs        - Runtime inputs (if inputsSchema defined)
+  // context.inputs           - Runtime inputs (if inputsSchema defined)
 
   // 1. Write a resource — specName must match a key in `resources`
   const handle = await context.writeResource!("result", {
@@ -264,6 +287,16 @@ against the resource's Zod schema (warns on mismatch, doesn't throw).
 | `lifetime`          | Override lifetime (default from spec)          |
 | `garbageCollection` | Override version retention (default from spec) |
 | `tags`              | Additional tags                                |
+
+**Important: `name` override and CEL resolution.** By default, the resource
+instance name matches the spec name, so
+`model.<m>.resource.<specName>.attributes.X` resolves correctly. If you pass a
+`name` override, the resource is stored under that custom name instead — the CEL
+expression `model.<m>.resource.<specName>` will fail with "No such key" because
+the instance name no longer matches. Only use `name` overrides for factory
+models that produce multiple resources from one spec (see Factory Models below).
+For single-resource models, omit the `name` override so the default spec name is
+used and CEL chaining works as expected.
 
 ### createFileWriter API
 
@@ -310,6 +343,38 @@ for binary/streaming content.
 **UserMethodResult:**
 
 The execute function returns `{ dataHandles?: DataHandle[] }`.
+
+### Reading Stored Data
+
+Delete and update methods need to read back previously stored resource data
+(e.g., to get a resource ID for cleanup). Use `context.dataRepository` with
+`context.modelType` and `context.modelId`:
+
+```typescript
+const content = await context.dataRepository.getContent(
+  context.modelType,
+  context.modelId,
+  "<specName>", // matches a key in resources
+);
+// Returns Uint8Array | null
+```
+
+To parse the content:
+
+```typescript
+if (!content) {
+  throw new Error("No data found - nothing to delete");
+}
+const data = JSON.parse(new TextDecoder().decode(content));
+```
+
+**Key dataRepository methods for model authors:**
+
+| Method                                          | Returns              | Description                            |
+| ----------------------------------------------- | -------------------- | -------------------------------------- |
+| `getContent(type, modelId, dataName, version?)` | `Uint8Array \| null` | Get raw content bytes                  |
+| `findByName(type, modelId, dataName, version?)` | `Data \| null`       | Get data metadata (tags, version, etc) |
+| `findAllForModel(type, modelId)`                | `Data[]`             | List all data for this model instance  |
 
 ### Lifetime Values
 
@@ -819,6 +884,25 @@ methods: {
 },
 ```
 
+### CRUD Lifecycle Model
+
+Models that manage real resources typically have `create`, `update`, and
+`delete` methods. See
+[references/examples.md](references/examples.md#crud-lifecycle-model-vpc) for a
+complete VPC example with all three methods.
+
+**Pattern summary:**
+
+- **`create`** — run a command, store the result via `writeResource()`
+- **`update`** — read stored data via `context.dataRepository.getContent()`,
+  modify the resource, write updated state via `writeResource()`
+- **`delete`** — read stored data, clean up, return `{ dataHandles: [] }`
+
+**Expression scoping:** `model.*` is intra-workflow only; `data.latest()` is
+cross-workflow only. They are not interchangeable. See the `swamp-workflow`
+skill's [data-chaining reference](../swamp-workflow/references/data-chaining.md)
+for full scoping rules.
+
 ## Verify
 
 After creating your model:
@@ -840,6 +924,11 @@ swamp model type describe @myorg/my-model   # Check schema
 
 ## References
 
+- **Examples**: See [references/examples.md](references/examples.md) for
+  complete model examples (CRUD lifecycle, data chaining, extensions, etc.)
+- **Troubleshooting**: See
+  [references/troubleshooting.md](references/troubleshooting.md) for common
+  errors and fixes
 - **Built-in example**: See `src/domain/models/echo/echo_model.ts` for reference
 - **Model loader**: See `src/domain/models/user_model_loader.ts` for API details
 - **Model design**: See [design/models.md](design/models.md) for concepts

--- a/.claude/skills/swamp-extension-model/references/examples.md
+++ b/.claude/skills/swamp-extension-model/references/examples.md
@@ -1,5 +1,196 @@
 # Extension Model Examples
 
+## Table of Contents
+
+- [CRUD Lifecycle Model (VPC)](#crud-lifecycle-model-vpc)
+- [Text Processor Model](#text-processor-model)
+- [Deployment Model](#deployment-model)
+- [Minimal Echo Model](#minimal-echo-model)
+- [Data Chaining Model](#data-chaining-model)
+- [Shell Command with Streamed Logging](#shell-command-with-streamed-logging)
+- [Extending Existing Model Types](#extending-existing-model-types)
+
+## CRUD Lifecycle Model (VPC)
+
+Models that manage real resources typically have `create`, `update`, and
+`delete` methods. Each method follows a distinct pattern:
+
+- **`create`** — runs a command, stores the result via `writeResource()`
+- **`update`** — reads stored data to get the resource ID, modifies the
+  resource, writes updated state via `writeResource()` (creates a new version)
+- **`delete`** — reads stored data to get the resource ID, cleans up, returns
+  `{ dataHandles: [] }`
+
+```typescript
+// extensions/models/vpc.ts
+import { z } from "npm:zod@4";
+
+const InputSchema = z.object({
+  cidrBlock: z.string(),
+  region: z.string().default("us-east-1"),
+});
+
+const VpcSchema = z.object({
+  VpcId: z.string(),
+}).passthrough();
+
+export const model = {
+  type: "@user/vpc",
+  version: "2026.02.10.1",
+  inputAttributesSchema: InputSchema,
+  resources: {
+    "vpc": {
+      description: "VPC resource state",
+      schema: VpcSchema,
+      lifetime: "infinite",
+      garbageCollection: 10,
+    },
+  },
+  methods: {
+    create: {
+      description: "Create a VPC",
+      execute: async (definition, context) => {
+        const { cidrBlock, region } = definition.attributes;
+
+        const cmd = new Deno.Command("aws", {
+          args: [
+            "ec2",
+            "create-vpc",
+            "--cidr-block",
+            cidrBlock,
+            "--region",
+            region,
+            "--output",
+            "json",
+          ],
+          stdout: "piped",
+          stderr: "piped",
+        });
+        const output = await cmd.output();
+        const vpcData = JSON.parse(new TextDecoder().decode(output.stdout)).Vpc;
+
+        const handle = await context.writeResource!("vpc", vpcData);
+        return { dataHandles: [handle] };
+      },
+    },
+    update: {
+      description: "Update VPC attributes (e.g., enable DNS support)",
+      execute: async (definition, context) => {
+        const region = definition.attributes.region;
+
+        // 1. Read stored data to get the resource ID
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          "vpc",
+        );
+
+        if (!content) {
+          throw new Error("No VPC data found - run create first");
+        }
+
+        const existingData = JSON.parse(new TextDecoder().decode(content));
+        const vpcId = existingData.VpcId;
+
+        // 2. Modify the resource
+        const modifyCmd = new Deno.Command("aws", {
+          args: [
+            "ec2",
+            "modify-vpc-attribute",
+            "--vpc-id",
+            vpcId,
+            "--enable-dns-support",
+            '{"Value": true}',
+            "--region",
+            region,
+          ],
+          stdout: "piped",
+          stderr: "piped",
+        });
+        await modifyCmd.output();
+
+        // 3. Describe to get current state
+        const describeCmd = new Deno.Command("aws", {
+          args: [
+            "ec2",
+            "describe-vpcs",
+            "--vpc-ids",
+            vpcId,
+            "--region",
+            region,
+            "--output",
+            "json",
+          ],
+          stdout: "piped",
+          stderr: "piped",
+        });
+        const describeOutput = await describeCmd.output();
+        const updatedData = JSON.parse(
+          new TextDecoder().decode(describeOutput.stdout),
+        ).Vpcs[0];
+
+        // 4. Write updated state — creates a new version of the resource
+        const handle = await context.writeResource!("vpc", updatedData);
+        return { dataHandles: [handle] };
+      },
+    },
+    delete: {
+      description: "Delete the VPC",
+      execute: async (definition, context) => {
+        const region = definition.attributes.region;
+
+        // Read back stored data to get the VPC ID
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          "vpc",
+        );
+
+        if (!content) {
+          throw new Error("No VPC data found - nothing to delete");
+        }
+
+        const vpcData = JSON.parse(new TextDecoder().decode(content));
+        const vpcId = vpcData.VpcId;
+
+        const cmd = new Deno.Command("aws", {
+          args: [
+            "ec2",
+            "delete-vpc",
+            "--vpc-id",
+            vpcId,
+            "--region",
+            region,
+          ],
+          stdout: "piped",
+          stderr: "piped",
+        });
+        await cmd.output();
+
+        // Return empty dataHandles — resource is gone
+        return { dataHandles: [] };
+      },
+    },
+  },
+};
+```
+
+**Key points:**
+
+- `create` stores data via `writeResource` — makes it available to other models
+  via CEL expressions and to update/delete methods via `dataRepository`
+- `update` reads stored data, modifies the resource, writes updated state via
+  `writeResource` (creates a new version)
+- `delete` reads stored data via `context.dataRepository.getContent()` using
+  `context.modelType` and `context.modelId` to locate the model's own data
+- `delete` returns `{ dataHandles: [] }` since no new data is produced
+- Always check for `null` content — the model may not have been created yet
+
+**Expression scoping:** `model.*` is intra-workflow only; `data.latest()` is
+cross-workflow only. See the `swamp-workflow` skill's
+[data-chaining reference](../swamp-workflow/references/data-chaining.md) for
+full scoping rules.
+
 ## Text Processor Model
 
 ```typescript

--- a/.claude/skills/swamp-extension-model/references/troubleshooting.md
+++ b/.claude/skills/swamp-extension-model/references/troubleshooting.md
@@ -1,5 +1,22 @@
 # Troubleshooting Extension Models
 
+## Table of Contents
+
+- [Common Errors](#common-errors)
+  - [No 'model' or 'extension' export found](#no-model-or-extension-export-found)
+  - [Unknown resource spec / Unknown file spec](#unknown-resource-spec-or-unknown-file-spec)
+  - [Model type already registered](#model-type-already-registered)
+  - [Model type must use '@' prefix](#model-type-must-use--prefix)
+  - [Uses a reserved namespace](#uses-a-reserved-namespace)
+  - [Cannot extend unregistered model type](#cannot-extend-unregistered-model-type)
+  - [Method already exists](#method-x-already-exists-on-model-type-y)
+  - [Duplicate method name](#duplicate-method-name-x-within-extension-methods-array)
+  - [No such key in CEL expressions](#no-such-key-specname-in-cel-expressions)
+  - [Property not found in expression path validation](#property-not-found-in-expression-path-validation)
+  - [Syntax errors on load](#syntax-errors-on-load)
+- [Configuration](#configuration)
+- [Verification Commands](#verification-commands)
+
 ## Common Errors
 
 ### "No 'model' or 'extension' export found"
@@ -100,6 +117,62 @@ method name.
 The same method name appears in multiple elements of the `methods` array within
 a single extension file. Each method name must be unique across all array
 elements.
+
+### "No such key: &lt;specName&gt;" in CEL expressions
+
+This occurs when a CEL expression like
+`model.<m>.resource.<specName>.attributes.X` can't find the resource. Common
+causes:
+
+**1. `writeResource` used a `name` override.** When you pass
+`{ name: "custom-name" }` to `writeResource`, the resource is stored under
+`"custom-name"` instead of the spec name. The CEL expression must then use the
+instance name: `model.<m>.resource.custom-name.attributes.X`. For
+single-resource models, omit the `name` override so the instance name defaults
+to the spec name.
+
+```typescript
+// Wrong — stores as "vpc-abc123", breaks model.<m>.resource.vpc
+await context.writeResource("vpc", data, { name: vpcId });
+
+// Correct — stores as "vpc", model.<m>.resource.vpc works
+await context.writeResource("vpc", data);
+```
+
+**2. Resource spec name contains hyphens.** CEL interprets hyphens as
+subtraction, so `model.<m>.resource.internet-gateway` is parsed as
+`resource.internet` minus `gateway`. Use camelCase or single words for spec
+names (e.g., `igw`, `routeTable`).
+
+**3. Model has never been executed.** The `resource` key on `model.<name>` is
+only populated if the model has produced data (a method was run that called
+`writeResource`). If no data exists, `model.<name>` has `input` and `definition`
+keys but no `resource` key. Run the create method or workflow first, or check
+with `swamp data list <model-name>` to verify data exists.
+
+**4. Cross-workflow `model.*` reference (tag mismatch).** Data written via a
+workflow step is tagged `type: "step-output"`. When a _different_ workflow run
+starts, `buildContext()` only populates `model.*.resource.*` for data tagged
+`type: "resource"` — so workflow-produced data is invisible to `model.*`
+expressions. Use `data.latest("<model-name>", "<spec>")` instead, which reads
+persisted data regardless of tags. This is the most common cause when `model.*`
+works in a create workflow but fails in a subsequent delete or tag workflow. See
+the `swamp-workflow` skill's data-chaining reference for details.
+
+### "Property not found" in expression path validation
+
+The expression path validator checks that referenced attributes exist in the
+resource's Zod schema. If you use `z.object({}).passthrough()`, the schema has
+no declared properties and the validator can't resolve paths like
+`attributes.VpcId`. Declare the properties you need to reference:
+
+```typescript
+// Wrong — validator can't resolve attributes.VpcId
+schema: z.object({}).passthrough(),
+
+// Correct — VpcId is declared, .passthrough() allows additional fields
+schema: z.object({ VpcId: z.string() }).passthrough(),
+```
 
 ### Syntax errors on load
 

--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -432,6 +432,7 @@ End-to-end workflow creation:
   [references/expressions-and-foreach.md](references/expressions-and-foreach.md)
   for forEach iteration patterns, CEL expressions, implicit dependency
   resolution, environment variables, and data artifact tagging
-- **Data chaining**: See
-  [references/data-chaining.md](references/data-chaining.md) for aws/cli model
-  workflow examples and chaining patterns
+- **Data chaining and expression choice**: See
+  [references/data-chaining.md](references/data-chaining.md) for `model.*` vs
+  `data.latest()` expression guidance, delete workflow ordering, sub-workflow
+  data patterns, and aws/cli chaining examples

--- a/.claude/skills/swamp-workflow/references/data-chaining.md
+++ b/.claude/skills/swamp-workflow/references/data-chaining.md
@@ -1,5 +1,20 @@
 # Data Chaining in Workflows
 
+## Table of Contents
+
+- [Implicit Dependency Resolution](#implicit-dependency-resolution)
+- [Example: Dynamic AMI Lookup Workflow](#example-dynamic-ami-lookup-workflow)
+- [Example: Multi-Step Infrastructure Workflow](#example-multi-step-infrastructure-workflow)
+- [Choosing model.* vs data.latest() Expressions](#choosing-model-vs-datalatest-expressions)
+  - [Why model.* is intra-workflow only](#why-model-is-intra-workflow-only)
+  - [Why data.latest() is cross-workflow only](#why-datalatest-is-cross-workflow-only)
+  - [Practical guidance](#practical-guidance)
+  - [Example: Sub-workflow referencing parent data](#example-sub-workflow-referencing-parent-workflow-data)
+  - [Summary](#summary)
+- [Resource References](#resource-references)
+- [Delete Workflow Ordering](#delete-workflow-ordering)
+- [Update Workflow Ordering](#update-workflow-ordering)
+
 The `aws/cli` model enables powerful data chaining in workflows by running AWS
 CLI commands and making the output available to other models. This is useful for
 dynamic lookups like finding the latest AMI, checking resource state, or
@@ -146,6 +161,144 @@ attributes:
   instanceType: t3.micro
 ```
 
+## Choosing `model.*` vs `data.latest()` Expressions
+
+Model instance definitions use CEL expressions to reference other models' data.
+The two forms have **different resolution scopes** — they are not
+interchangeable.
+
+| Expression                        | Sees current-run data?                              | Sees prior-run data?                                                                                     | Implicit deps? |
+| --------------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | -------------- |
+| `model.<name>.resource.<spec>`    | **Yes** — in-memory context updated after each step | **No** — `buildContext()` filters by `type: "resource"` tag, misses workflow-produced `step-output` data | **Yes**        |
+| `data.latest("<name>", "<spec>")` | **No** — data functions reflect pre-run state only  | **Yes** — reads persisted data regardless of tags                                                        | **No**         |
+
+**Neither expression type works for both intra-workflow and cross-workflow
+simultaneously.** They serve different lifecycle phases.
+
+### Why `model.*` is intra-workflow only
+
+When data is written via a workflow step, the workflow engine tags it with
+`type: "step-output"` (not `type: "resource"`). At the start of a new workflow
+run, `buildContext()` populates `model.*.resource.*` only for data tagged
+`type: "resource"` — so data produced by a previous workflow run is invisible to
+`model.*` expressions.
+
+Within the same workflow run, `model.*` works because the execution service
+updates the in-memory context directly after each step, bypassing the tag
+filter.
+
+`model.*` also creates **implicit step dependencies** — Swamp detects
+`model.<name>.resource` references and automatically orders the referencing step
+after the step that writes that model's data. This is helpful for create
+workflows but causes **cyclic dependency errors** when the execution order is
+reversed:
+
+1. Explicit `dependsOn` says: delete subnet first, then delete VPC
+2. Implicit dependency (from `model.networking-vpc` in subnet's definition)
+   says: VPC step must run before subnet step
+3. These two constraints conflict → **cycle detected**
+
+### Why `data.latest()` is cross-workflow only
+
+`data.latest()` resolves from persisted data loaded at workflow start,
+regardless of tags. However, the data functions are **not updated** as steps
+execute during the current run — they reflect the pre-run state. Data written by
+a previous workflow run is visible; data written earlier in the same run is not.
+
+`data.latest()` does **not** create implicit step dependencies, so execution
+ordering is fully controlled by explicit `dependsOn`.
+
+### Practical guidance
+
+**Use separate model instances for different lifecycle phases.** The demo
+demonstrates this pattern:
+
+- **Create workflow** — model instances use `model.*` for intra-workflow
+  chaining (implicit dependencies automatically order VPC → subnets → route
+  tables)
+- **Tag/delete workflows** — separate model instances use `data.latest()` to
+  reference data persisted by the create workflow
+
+```yaml
+# networking model instances — used in create-networking workflow
+# Uses model.* for intra-workflow chaining with implicit deps
+name: public-subnet
+attributes:
+  vpcId: ${{ model.networking-vpc.resource.vpc.attributes.VpcId }}
+  cidrBlock: "10.0.1.0/24"
+```
+
+```yaml
+# tagger model instances — used in tag-networking workflow
+# Uses data.latest() to read data persisted by a prior create run
+name: tag-vpc
+attributes:
+  resourceId: ${{ data.latest("networking-vpc", "vpc").attributes.VpcId }}
+  tagKey: ManagedBy
+  tagValue: Swamp
+```
+
+```yaml
+# delete workflow — uses job-level dependsOn for ordering
+# Delete methods read their own stored data via context.dataRepository,
+# not via CEL expressions, so no cross-model expressions are needed
+```
+
+### Example: Sub-workflow referencing parent workflow data
+
+A workflow can invoke another workflow using `task: type: workflow`. The
+sub-workflow's model instances must use `data.latest()` to reference data
+produced by the parent workflow's steps — `model.*` cannot see that data because
+of the `step-output` tag filtering.
+
+```yaml
+# create-networking workflow
+jobs:
+  - name: create
+    description: Create VPC, subnets, IGW, and route tables
+    steps:
+      - name: create-vpc
+        task:
+          type: model_method
+          modelIdOrName: networking-vpc
+          methodName: create
+      # ... more create steps ...
+    dependsOn: []
+  - name: tag
+    description: Tag all created resources
+    steps:
+      - name: tag-resources
+        task:
+          type: workflow
+          workflowIdOrName: tag-networking
+    dependsOn:
+      - job: create
+        condition:
+          type: succeeded
+```
+
+The `tag-networking` sub-workflow's model instances use `data.latest()`:
+
+```yaml
+# tag-vpc model instance — uses data.latest() to reference VPC data
+# from the create workflow
+name: tag-vpc
+attributes:
+  region: us-east-1
+  resourceId: ${{ data.latest("networking-vpc", "vpc").attributes.VpcId }}
+  tagKey: ManagedBy
+  tagValue: Swamp
+```
+
+### Summary
+
+| Scenario                                                        | Expression               | Why                                                    |
+| --------------------------------------------------------------- | ------------------------ | ------------------------------------------------------ |
+| Intra-workflow chaining (create VPC → create subnet)            | `model.*`                | Sees current-run data, implicit deps handle ordering   |
+| Cross-workflow reference (tag/delete/update reading prior data) | `data.latest()`          | Sees persisted data regardless of tags                 |
+| Sub-workflow reading parent data                                | `data.latest()`          | `model.*` can't see `step-output` tagged data          |
+| Update/delete methods reading own stored data                   | `context.dataRepository` | Direct API access in model code, no expressions needed |
+
 ## Resource References
 
 All model data outputs are accessed via
@@ -156,3 +309,166 @@ All model data outputs are accessed via
 | aws/cli       | `data`     | `model.ami-lookup.resource.data.attributes.json.ImageId` |
 | Cloud Control | `resource` | `model.my-vpc.resource.resource.attributes.VpcId`        |
 | Custom models | (varies)   | `model.my-deploy.resource.state.attributes.endpoint`     |
+
+## Delete Workflow Ordering
+
+Delete workflows require **explicit `dependsOn`** in reverse dependency order.
+Unlike create workflows where CEL expressions (e.g.,
+`${{ model.vpc.resource.vpc.attributes.VpcId }}`) create implicit dependencies,
+delete methods read their own stored data via `context.dataRepository` — not
+other models' data via expressions. There are no expression-based references to
+trigger implicit dependency detection, so you must declare the ordering
+explicitly.
+
+The dependency graph for a delete workflow is the **reverse** of the create
+workflow.
+
+### Example: Delete Networking
+
+```yaml
+id: delete-networking
+name: delete-networking
+description: Delete all networking resources in reverse dependency order
+version: 1
+jobs:
+  - name: delete-route-tables
+    description: Disassociate and delete route tables first
+    steps:
+      - name: delete-public-route-table
+        task:
+          type: model_method
+          modelIdOrName: public-route-table
+          methodName: delete
+      - name: delete-private-route-table
+        task:
+          type: model_method
+          modelIdOrName: private-route-table
+          methodName: delete
+    dependsOn: []
+
+  - name: delete-subnets-and-igw
+    description: Delete subnets and internet gateway
+    steps:
+      - name: delete-public-subnet
+        task:
+          type: model_method
+          modelIdOrName: public-subnet
+          methodName: delete
+      - name: delete-private-subnet
+        task:
+          type: model_method
+          modelIdOrName: private-subnet
+          methodName: delete
+      - name: delete-igw
+        task:
+          type: model_method
+          modelIdOrName: networking-igw
+          methodName: delete
+    dependsOn:
+      - job: delete-route-tables
+        condition:
+          type: succeeded
+
+  - name: delete-vpc
+    description: Delete the VPC last
+    steps:
+      - name: delete-vpc
+        task:
+          type: model_method
+          modelIdOrName: networking-vpc
+          methodName: delete
+    dependsOn:
+      - job: delete-subnets-and-igw
+        condition:
+          type: succeeded
+```
+
+**Ordering rationale** (reverse of create):
+
+| Create order (first → last) | Delete order (first → last) |
+| --------------------------- | --------------------------- |
+| 1. VPC                      | 1. Route tables             |
+| 2. Subnets, IGW             | 2. Subnets, IGW             |
+| 3. Route tables             | 3. VPC                      |
+
+**Key points:**
+
+- Use **job-level `dependsOn`** to enforce ordering between groups of deletions
+- Each delete method reads its own stored data — no cross-model CEL references
+- Steps within a job can run in parallel (e.g., public and private subnets
+  delete concurrently)
+- Always delete dependent resources before the resources they depend on (e.g.,
+  route tables before subnets, subnets before VPC)
+
+## Update Workflow Ordering
+
+Update workflows follow the **same dependency order as create** — update the
+foundation first, then dependents. Like delete workflows, update methods read
+their own stored data via `context.dataRepository` and don't reference other
+models via CEL expressions, so you need **explicit `dependsOn`**.
+
+The key difference from delete: update methods call `writeResource()` to persist
+the updated state (creating a new version), so the stored data stays current for
+subsequent workflows.
+
+```yaml
+id: update-networking
+name: update-networking
+description: Update networking resources (e.g., enable DNS, modify tags)
+version: 1
+jobs:
+  - name: update-vpc
+    description: Update VPC attributes first
+    steps:
+      - name: update-vpc
+        task:
+          type: model_method
+          modelIdOrName: networking-vpc
+          methodName: update
+    dependsOn: []
+
+  - name: update-subnets-and-igw
+    description: Update subnets and internet gateway
+    steps:
+      - name: update-public-subnet
+        task:
+          type: model_method
+          modelIdOrName: public-subnet
+          methodName: update
+      - name: update-private-subnet
+        task:
+          type: model_method
+          modelIdOrName: private-subnet
+          methodName: update
+    dependsOn:
+      - job: update-vpc
+        condition:
+          type: succeeded
+
+  - name: update-route-tables
+    description: Update route tables last
+    steps:
+      - name: update-public-route-table
+        task:
+          type: model_method
+          modelIdOrName: public-route-table
+          methodName: update
+      - name: update-private-route-table
+        task:
+          type: model_method
+          modelIdOrName: private-route-table
+          methodName: update
+    dependsOn:
+      - job: update-subnets-and-igw
+        condition:
+          type: succeeded
+```
+
+**Ordering across lifecycle phases:**
+
+| Phase  | Dependency order             | Method pattern                                        |
+| ------ | ---------------------------- | ----------------------------------------------------- |
+| Create | Forward (VPC → subnets → RT) | Write new data via `writeResource()`                  |
+| Update | Forward (VPC → subnets → RT) | Read stored data, modify, write via `writeResource()` |
+| Tag    | Any order (parallel OK)      | Read persisted data via `data.latest()`               |
+| Delete | Reverse (RT → subnets → VPC) | Read stored data, clean up, return empty handles      |

--- a/.claude/skills/swamp-workflow/references/expressions-and-foreach.md
+++ b/.claude/skills/swamp-workflow/references/expressions-and-foreach.md
@@ -1,5 +1,19 @@
 # Expressions, forEach, and Data Tracking
 
+## Table of Contents
+
+- [forEach Iteration](#foreach-iteration)
+  - [Iterate Over Array](#iterate-over-array)
+  - [Iterate Over Object](#iterate-over-object)
+  - [forEach Variables](#foreach-variables)
+- [Step Task Inputs](#step-task-inputs)
+- [Expressions in Workflows](#expressions-in-workflows)
+  - [Automatic Dependency Resolution](#automatic-dependency-resolution)
+  - [Environment Variables](#environment-variables)
+- [Data Artifact Tracking](#data-artifact-tracking)
+  - [Automatic Tagging](#automatic-tagging)
+  - [Querying Workflow Data](#querying-workflow-data)
+
 ## forEach Iteration
 
 Steps can iterate over arrays or objects using `forEach`. Each iteration creates
@@ -121,6 +135,14 @@ jobs:
 # If subnet-input has: vpcId: ${{ model.vpc-input.resource.resource.attributes.vpcId }}
 # create-vpc runs first due to implicit dependency
 ```
+
+**Important:** `model.*` is **intra-workflow only** — it sees data from earlier
+steps in the current run but NOT data from prior workflow runs
+(workflow-produced data is tagged `step-output`, which `buildContext()` filters
+out). For cross-workflow references (tag, delete, or sub-workflows), use
+`data.latest()`. `model.*` also creates implicit dependencies that cause cyclic
+errors if reused in reversed-order workflows. See
+[data-chaining.md](data-chaining.md) for the full scoping rules.
 
 ### Environment Variables
 

--- a/.claude/skills/swamp-workflow/references/nested-workflows.md
+++ b/.claude/skills/swamp-workflow/references/nested-workflows.md
@@ -1,5 +1,13 @@
 # Calling Workflows from Workflows
 
+## Table of Contents
+
+- [Basic Nested Workflow](#basic-nested-workflow)
+- [Workflow Task Fields](#workflow-task-fields)
+- [Nested Workflow with forEach](#nested-workflow-with-foreach)
+- [Expression Choice for Sub-Workflows](#expression-choice-for-sub-workflows)
+- [Limitations](#limitations)
+
 Steps can invoke another workflow using `type: workflow`. The parent step waits
 for the child workflow to complete before continuing.
 
@@ -95,6 +103,16 @@ jobs:
           inputs:
             environment: ${{ self.env }}
 ```
+
+## Expression Choice for Sub-Workflows
+
+Sub-workflow model instances **must** use `data.latest()` instead of `model.*`
+to reference data produced by the parent workflow. `model.*` cannot see data
+from prior workflow steps because workflow-produced data is tagged
+`step-output`, which `buildContext()` filters out when populating
+`model.*.resource.*`. Only `data.latest()` reads persisted data regardless of
+tags. See [data-chaining.md](data-chaining.md) for the full scoping rules and a
+concrete example using a tag-networking sub-workflow.
 
 ## Limitations
 

--- a/integration/expression_scoping_test.ts
+++ b/integration/expression_scoping_test.ts
@@ -1,0 +1,501 @@
+/**
+ * Integration tests for expression scoping rules.
+ *
+ * Tests the contract between model.*.resource (tag-filtered) and data.latest()
+ * (tag-agnostic), and verifies dependency extraction behavior.
+ *
+ * Key scoping rules:
+ * - model.*.resource is populated ONLY for data tagged type: "resource"
+ * - Workflow execution tags data as type: "step-output", so it is excluded
+ * - data.latest() reads from DataCache which contains ALL data regardless of tag
+ * - extractResourceDependencies() only detects model.X.resource patterns
+ * - extractDataFunctionDependencies() detects data.latest/version/etc patterns
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+import { Data } from "../src/domain/data/data.ts";
+import type { OwnerDefinition } from "../src/domain/data/data_metadata.ts";
+import { ModelType } from "../src/domain/models/model_type.ts";
+import { Definition } from "../src/domain/definitions/definition.ts";
+import { FileSystemUnifiedDataRepository } from "../src/infrastructure/persistence/unified_data_repository.ts";
+import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
+import { ModelResolver } from "../src/domain/expressions/model_resolver.ts";
+import type { DataRecord } from "../src/domain/expressions/model_resolver.ts";
+import { CelEvaluator } from "../src/infrastructure/cel/cel_evaluator.ts";
+import {
+  extractDataFunctionDependencies,
+  extractResourceDependencies,
+} from "../src/domain/expressions/dependency_extractor.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-expr-scope-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+async function setupRepoDir(dir: string): Promise<void> {
+  await ensureDir(join(dir, ".swamp", "data"));
+  await ensureDir(join(dir, ".swamp", "definitions"));
+}
+
+function createOwner(ref: string): OwnerDefinition {
+  return {
+    ownerType: "model-method",
+    ownerRef: ref,
+  };
+}
+
+// ============================================================================
+// Section 1: model.*.resource Tag-Based Population
+// ============================================================================
+
+Deno.test("Integration: model.*.resource populated for type=resource data", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const type = ModelType.create("test/model");
+
+    const definition = Definition.create({
+      name: "my-vpc",
+      tags: {},
+      attributes: { cidr: "10.0.0.0/16" },
+    });
+    await definitionRepo.save(type, definition);
+
+    const owner = createOwner("test/model:create");
+    const dataEntity = Data.create({
+      name: "vpc-info",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { type: "resource" },
+      ownerDefinition: owner,
+    });
+
+    await dataRepo.save(
+      type,
+      definition.id,
+      dataEntity,
+      new TextEncoder().encode(JSON.stringify({ vpcId: "vpc-123" })),
+    );
+
+    const modelResolver = new ModelResolver(definitionRepo, {
+      repoDir,
+      dataRepo,
+    });
+    const context = await modelResolver.buildContext();
+
+    // model.my-vpc.resource should be populated
+    const modelData = context.model["my-vpc"];
+    assertExists(modelData);
+    assertExists(modelData.resource);
+    const resourceRecord = modelData.resource!["vpc-info"];
+    assertExists(resourceRecord);
+    assertEquals(resourceRecord.attributes.vpcId, "vpc-123");
+
+    // CEL expression should resolve
+    const celEvaluator = new CelEvaluator();
+    const result = celEvaluator.evaluate(
+      'model["my-vpc"].resource["vpc-info"].attributes.vpcId',
+      context,
+    );
+    assertEquals(result, "vpc-123");
+  });
+});
+
+Deno.test("Integration: model.*.resource NOT populated for type=step-output data", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const type = ModelType.create("test/model");
+
+    const definition = Definition.create({
+      name: "my-vpc",
+      tags: {},
+      attributes: { cidr: "10.0.0.0/16" },
+    });
+    await definitionRepo.save(type, definition);
+
+    const owner = createOwner("test/model:create");
+    const dataEntity = Data.create({
+      name: "vpc-state",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: {
+        type: "step-output",
+        workflow: "deploy",
+        step: "create-vpc",
+      },
+      ownerDefinition: owner,
+    });
+
+    await dataRepo.save(
+      type,
+      definition.id,
+      dataEntity,
+      new TextEncoder().encode(JSON.stringify({ vpcId: "vpc-456" })),
+    );
+
+    const modelResolver = new ModelResolver(definitionRepo, {
+      repoDir,
+      dataRepo,
+    });
+    const context = await modelResolver.buildContext();
+
+    // model.my-vpc.resource should NOT be populated for step-output tagged data
+    const modelData = context.model["my-vpc"];
+    assertExists(modelData);
+    assertEquals(modelData.resource, undefined);
+  });
+});
+
+Deno.test("Integration: same model with both tag types — only resource populates model.*.resource", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const type = ModelType.create("test/model");
+
+    const definition = Definition.create({
+      name: "my-vpc",
+      tags: {},
+      attributes: {},
+    });
+    await definitionRepo.save(type, definition);
+
+    const owner = createOwner("test/model:create");
+
+    // Resource-tagged data
+    const resourceData = Data.create({
+      name: "vpc-info",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { type: "resource" },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      definition.id,
+      resourceData,
+      new TextEncoder().encode(JSON.stringify({ vpcId: "vpc-789" })),
+    );
+
+    // Step-output-tagged data
+    const stepOutputData = Data.create({
+      name: "deploy-log",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: {
+        type: "step-output",
+        workflow: "deploy",
+        step: "create-vpc",
+      },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      definition.id,
+      stepOutputData,
+      new TextEncoder().encode(JSON.stringify({ status: "created" })),
+    );
+
+    const modelResolver = new ModelResolver(definitionRepo, {
+      repoDir,
+      dataRepo,
+    });
+    const context = await modelResolver.buildContext();
+
+    const modelData = context.model["my-vpc"];
+    assertExists(modelData);
+    assertExists(modelData.resource);
+
+    // Resource-tagged data IS in model.*.resource
+    assertExists(modelData.resource!["vpc-info"]);
+    assertEquals(modelData.resource!["vpc-info"].attributes.vpcId, "vpc-789");
+
+    // Step-output-tagged data is NOT in model.*.resource
+    assertEquals(modelData.resource!["deploy-log"], undefined);
+  });
+});
+
+// ============================================================================
+// Section 2: data.latest() Tag-Agnostic Access
+// ============================================================================
+
+Deno.test("Integration: data.latest() sees step-output tagged data", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const type = ModelType.create("test/model");
+
+    const definition = Definition.create({
+      name: "my-vpc",
+      tags: {},
+      attributes: {},
+    });
+    await definitionRepo.save(type, definition);
+
+    const owner = createOwner("test/model:create");
+    const dataEntity = Data.create({
+      name: "vpc-state",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: {
+        type: "step-output",
+        workflow: "deploy",
+        step: "create-vpc",
+      },
+      ownerDefinition: owner,
+    });
+
+    await dataRepo.save(
+      type,
+      definition.id,
+      dataEntity,
+      new TextEncoder().encode(JSON.stringify({ vpcId: "vpc-abc" })),
+    );
+
+    const modelResolver = new ModelResolver(definitionRepo, {
+      repoDir,
+      dataRepo,
+    });
+    const context = await modelResolver.buildContext();
+
+    // data.latest() bypasses the type tag filter
+    assertExists(context.data);
+    const latest = context.data.latest("my-vpc", "vpc-state");
+    assertExists(latest);
+    assertEquals(latest.attributes.vpcId, "vpc-abc");
+    assertEquals(latest.tags.type, "step-output");
+    assertEquals(latest.tags.workflow, "deploy");
+  });
+});
+
+Deno.test("Integration: data.latest() is a snapshot at build time", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const type = ModelType.create("test/model");
+
+    const definition = Definition.create({
+      name: "my-model",
+      tags: {},
+      attributes: {},
+    });
+    await definitionRepo.save(type, definition);
+
+    const owner = createOwner("test/model:create");
+    const dataEntity = Data.create({
+      name: "state",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { type: "resource" },
+      ownerDefinition: owner,
+    });
+
+    // Save version 1 and build context1
+    await dataRepo.save(
+      type,
+      definition.id,
+      dataEntity,
+      new TextEncoder().encode(JSON.stringify({ value: "before" })),
+    );
+
+    const resolver1 = new ModelResolver(definitionRepo, {
+      repoDir,
+      dataRepo,
+    });
+    const context1 = await resolver1.buildContext();
+
+    // Save version 2 and build context2
+    await dataRepo.save(
+      type,
+      definition.id,
+      dataEntity,
+      new TextEncoder().encode(JSON.stringify({ value: "after" })),
+    );
+
+    const resolver2 = new ModelResolver(definitionRepo, {
+      repoDir,
+      dataRepo,
+    });
+    const context2 = await resolver2.buildContext();
+
+    // context1 snapshot has version 1
+    assertExists(context1.data);
+    const snap1 = context1.data.latest("my-model", "state");
+    assertExists(snap1);
+    assertEquals(snap1.attributes.value, "before");
+    assertEquals(snap1.version, 1);
+
+    // context2 snapshot has version 2
+    assertExists(context2.data);
+    const snap2 = context2.data.latest("my-model", "state");
+    assertExists(snap2);
+    assertEquals(snap2.attributes.value, "after");
+    assertEquals(snap2.version, 2);
+  });
+});
+
+// ============================================================================
+// Section 3: Cross-Workflow Scoping (the critical scenario)
+// ============================================================================
+
+Deno.test("Integration: cross-workflow model.* fails, data.latest() succeeds", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const type = ModelType.create("test/model");
+
+    const definition = Definition.create({
+      name: "vpc-model",
+      tags: {},
+      attributes: {},
+    });
+    await definitionRepo.save(type, definition);
+
+    const owner = createOwner("test/model:create");
+
+    // Simulate workflow A output: data tagged as step-output
+    const dataEntity = Data.create({
+      name: "vpc-state",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: {
+        type: "step-output",
+        workflow: "create-vpc",
+        step: "create.create-vpc",
+      },
+      ownerDefinition: owner,
+    });
+
+    await dataRepo.save(
+      type,
+      definition.id,
+      dataEntity,
+      new TextEncoder().encode(
+        JSON.stringify({ vpcId: "vpc-cross", cidr: "10.0.0.0/16" }),
+      ),
+    );
+
+    // Build fresh context (simulating workflow B starting)
+    const modelResolver = new ModelResolver(definitionRepo, {
+      repoDir,
+      dataRepo,
+    });
+    const context = await modelResolver.buildContext();
+
+    // model.*.resource is undefined — step-output data excluded from model context
+    const modelData = context.model["vpc-model"];
+    assertExists(modelData);
+    assertEquals(modelData.resource, undefined);
+
+    // data.latest() succeeds — DataCache contains ALL data regardless of tag
+    assertExists(context.data);
+    const latest = context.data.latest("vpc-model", "vpc-state");
+    assertExists(latest);
+    assertEquals(latest.attributes.vpcId, "vpc-cross");
+    assertEquals(latest.attributes.cidr, "10.0.0.0/16");
+    assertEquals(latest.tags.type, "step-output");
+    assertEquals(latest.tags.workflow, "create-vpc");
+  });
+});
+
+// ============================================================================
+// Section 4: Implicit Dependency Extraction
+// ============================================================================
+
+Deno.test("Integration: extractResourceDependencies detects model.X.resource patterns", () => {
+  const expr = 'model.other-model.resource["vpc-state"].attributes.vpcId';
+  const deps = extractResourceDependencies(expr);
+  assertEquals(deps, ["other-model"]);
+});
+
+Deno.test("Integration: extractResourceDependencies does NOT detect data.latest()", () => {
+  const expr = 'data.latest("other-model", "vpc-state").attributes.vpcId';
+
+  // extractResourceDependencies only sees model.X.resource patterns
+  const resourceDeps = extractResourceDependencies(expr);
+  assertEquals(resourceDeps, []);
+
+  // extractDataFunctionDependencies DOES detect it
+  const dataDeps = extractDataFunctionDependencies(expr);
+  assertEquals(dataDeps, ["other-model"]);
+});
+
+Deno.test("Integration: multiple model.* refs in one expression detected", () => {
+  const expr =
+    'model.vpc-model.resource["vpc-state"].attributes.vpcId + "-" + model.subnet-model.resource["subnet-info"].attributes.subnetId';
+  const deps = extractResourceDependencies(expr);
+  assertEquals(deps.sort(), ["subnet-model", "vpc-model"]);
+});
+
+// ============================================================================
+// Section 5: In-Memory Context Update (intra-workflow model.*)
+// ============================================================================
+
+Deno.test("Integration: direct context mutation makes step-output visible via model.*", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const type = ModelType.create("test/model");
+
+    const definition = Definition.create({
+      name: "vpc-model",
+      tags: {},
+      attributes: {},
+    });
+    await definitionRepo.save(type, definition);
+
+    // Build context with no data — resource is undefined
+    const modelResolver = new ModelResolver(definitionRepo, {
+      repoDir,
+      dataRepo,
+    });
+    const context = await modelResolver.buildContext();
+
+    const modelData = context.model["vpc-model"];
+    assertExists(modelData);
+    assertEquals(modelData.resource, undefined);
+
+    // Simulate what execution_service.ts does: mutate context in-memory
+    // This is how intra-workflow model.* access works — the execution service
+    // directly populates the resource record after each step completes
+    const record: DataRecord = {
+      id: crypto.randomUUID(),
+      name: "vpc-state",
+      version: 1,
+      createdAt: new Date().toISOString(),
+      attributes: { vpcId: "vpc-inmem", cidr: "10.0.0.0/16" },
+      tags: { type: "step-output", workflow: "deploy", step: "create-vpc" },
+    };
+
+    if (!modelData.resource) modelData.resource = {};
+    modelData.resource["vpc-state"] = record;
+
+    // Now CEL can access it via model.* despite the step-output tag
+    const celEvaluator = new CelEvaluator();
+    const result = celEvaluator.evaluate(
+      'model["vpc-model"].resource["vpc-state"].attributes.vpcId',
+      context,
+    );
+    assertEquals(result, "vpc-inmem");
+  });
+});


### PR DESCRIPTION
- Document the critical scoping boundary between model.* and data.latest() CEL expressions across all relevant skill files
- Add 10 integration tests that verify the documented behaviors against the actual codebase
- Add troubleshooting guidance for the most common expression failure mode (cross-workflow model.* returning "No such key")

## Problem

model.<name>.resource.<spec> and data.latest("<name>", "<spec>") look like interchangeable ways to access the same data. They are not. They have fundamentally different resolution scopes, and using the wrong one is a silent failure — the expression evaluates to undefined or throws "No such key" with no indication of why.

The root cause is a tag-based filter in model_resolver.ts:489-494. When buildContext() populates model.*.resource, it only includes data tagged type: "resource". But when data is written via a workflow step, execution_service.ts:450-455 overrides the tag to type: "step-output". This means:

- model.* is intra-workflow only. Within the same run, it works because execution_service.ts:1293-1327 updates the in-memory context directly after each step, bypassing the tag filter. But across workflow runs, the persisted step-output data is invisible to model.*.
- data.latest() is cross-workflow only. It reads from DataCache, which loads ALL data regardless of tags. But it's a snapshot taken at buildContext() time and is not updated as steps execute during the current run.

This distinction matters most when users build CRUD lifecycle workflows: create works with model.*, then they copy the same expressions into a delete workflow and everything silently breaks. It also causes cyclic dependency errors when model.* expressions are used in reversed-order workflows, because model.* creates implicit step dependencies that conflict with the explicit reverse ordering.

None of this was documented. The skill files described model.* and data.latest() as if they were equivalent. There were no tests validating the scoping boundary.

### Documentation changes

Seven skill files updated to document the scoping rules consistently:

File: swamp-data/SKILL.md
Change: Updated "Accessing Data in Expressions" section: marked model.* as intra-workflow only, data.latest() as cross-workflow only, added prerequisite note about data existence
────────────────────────────────────────
File: swamp-extension-model/SKILL.md
Change: Added expression scoping guidance to the new CRUD Lifecycle Model section, spec naming rules (no hyphens in CEL), schema declaration requirements for expression validation, name override impact on CEL resolution, Reading Stored Data section for delete/update methods
────────────────────────────────────────
File: swamp-extension-model/references/troubleshooting.md
Change: Added "No such key" troubleshooting (4 causes: name override, hyphenated spec name, unexecuted model, cross-workflow tag mismatch) and "Property not found" schema validation guidance
────────────────────────────────────────
File: swamp-workflow/SKILL.md
Change: Updated references section to describe data-chaining.md as covering expression choice, not just chaining patterns 
────────────────────────────────────────
File: swamp-workflow/references/data-chaining.md
Change: Added ~300 lines: model.* vs data.latest() comparison table, explanation of why each is scoped the way it is, practical guidance with create/tag/delete examples, sub-workflow data access patterns, summary table, delete workflow ordering with full example, update workflow ordering with full example, lifecycle phase ordering table
────────────────────────────────────────
File: swamp-workflow/references/expressions-and-foreach.md
Change: Added scoping warning in the expressions section with cross-reference to data-chaining.md
────────────────────────────────────────
File: swamp-workflow/references/nested-workflows.md
Change: Added "Expression Choice for Sub-Workflows" section explaining why sub-workflows must use data.latest()


## Integration tests

New file: integration/expression_scoping_test.ts — 10 tests in 5 sections:

Section 1: Tag-based population of model.*.resource
- type=resource data populates model.*.resource (confirms the filter accepts it)
- type=step-output data does NOT populate model.*.resource (confirms the filter rejects it)
- Same model with both tag types — only resource-tagged data appears in model.*.resource

Section 2: data.latest() tag-agnostic access
- data.latest() returns step-output-tagged data (proves it bypasses the tag filter)
- data.latest() is a snapshot at buildContext() time (separate contexts see separate versions)

Section 3: Cross-workflow scoping (the critical scenario)
- Simulates workflow B reading workflow A's output: model.*.resource is undefined, data.latest() succeeds — this is THE core test for the documented contract

Section 4: Implicit dependency extraction
- extractResourceDependencies detects model.X.resource patterns
- extractResourceDependencies does NOT detect data.latest() (and extractDataFunctionDependencies does)
- Multiple model.* refs in one expression are all detected

Section 5: In-memory context update (intra-workflow)
- Direct context mutation (simulating what execution_service.ts does after each step) makes step-output-tagged data accessible via model.* and CEL evaluation — proves intra-workflow model.* works by bypassing the tag filter

## Test plan

- deno check — type checking passes
- deno lint — linting passes
- deno fmt — formatting passes
- deno run test integration/expression_scoping_test.ts — all 10 tests pass
- deno run test — full test suite passes (1741 tests, 0 failures)
- deno run compile — binary recompiles successfully