### PR TITLE
fix: separate data kind from provenance for cross-workflow model expressions

### DIFF
--- a/.claude/skills/swamp-workflow/references/expressions-and-foreach.md
+++ b/.claude/skills/swamp-workflow/references/expressions-and-foreach.md
@@ -143,16 +143,22 @@ Data created during workflow execution receives automatic tags:
 
 | Tag        | Value               | Description                       |
 | ---------- | ------------------- | --------------------------------- |
-| `type`     | `step-output`       | Identifies workflow-created data  |
+| `source`   | `step-output`       | Identifies workflow-created data  |
 | `workflow` | `{workflow-name}`   | Source workflow name              |
 | `step`     | `{job-name}.{step}` | Full step path                    |
 | `specName` | `{spec-key}`        | Output spec name for `findBySpec` |
+
+Note: The original `type` tag (`resource` or `file`) is preserved so that
+`model.*` expressions can resolve workflow-produced data across workflows.
 
 ### Querying Workflow Data
 
 Use CEL expressions to find data from workflows:
 
 ```yaml
+# Find all workflow-produced data
+allStepOutputs: ${{ data.findByTag("source", "step-output") }}
+
 # Find all data from a specific workflow
 workflowOutputs: ${{ data.findByTag("workflow", "my-deploy") }}
 

--- a/integration/data_ownership_test.ts
+++ b/integration/data_ownership_test.ts
@@ -104,7 +104,7 @@ Deno.test("Data Ownership: create data with workflow-step owner", async () => {
       contentType: "application/json",
       lifetime: "workflow",
       garbageCollection: 5,
-      tags: { type: "step-output" },
+      tags: { type: "resource", source: "step-output" },
       ownerDefinition: owner,
     });
 
@@ -415,7 +415,7 @@ Deno.test("Data Ownership: multiple data items can have different owners", async
       contentType: "text/plain",
       lifetime: "infinite",
       garbageCollection: 5,
-      tags: { type: "step-output" },
+      tags: { type: "resource", source: "step-output" },
       ownerDefinition: owner3,
     });
 

--- a/integration/data_tagging_test.ts
+++ b/integration/data_tagging_test.ts
@@ -360,7 +360,6 @@ Deno.test("Data Tagging: different type categories", async () => {
       { name: "state", description: "State data" },
       { name: "config", description: "Configuration" },
       { name: "output", description: "Model outputs" },
-      { name: "step-output", description: "Workflow step outputs" },
     ];
 
     for (const category of categories) {
@@ -434,7 +433,8 @@ Deno.test("Data Tagging: workflow and step tags", async () => {
           lifetime: "infinite",
           garbageCollection: 5,
           tags: {
-            type: "step-output",
+            type: "resource",
+            source: "step-output",
             workflow: wf.workflow,
             step: step,
           },
@@ -461,7 +461,7 @@ Deno.test("Data Tagging: workflow and step tags", async () => {
     assertExists(context.data);
 
     // Find all step outputs
-    const allStepOutputs = context.data.findByTag("type", "step-output");
+    const allStepOutputs = context.data.findByTag("source", "step-output");
     assertEquals(allStepOutputs.length, 5);
 
     // Find by workflow

--- a/integration/workflow_new_architecture_test.ts
+++ b/integration/workflow_new_architecture_test.ts
@@ -262,7 +262,7 @@ Deno.test("Workflow Architecture: step creates Data artifact", async () => {
     assertExists(artifact.dataId);
     assertExists(artifact.version);
     assertExists(artifact.tags);
-    assertEquals(artifact.tags.type, "step-output");
+    assertEquals(artifact.tags.source, "step-output");
     assertEquals(artifact.tags.workflow, "data-artifact-workflow");
     assertEquals(artifact.tags.step, "write-data");
   });

--- a/integration/workflow_test.ts
+++ b/integration/workflow_test.ts
@@ -1677,9 +1677,9 @@ Deno.test("CLI: workflow run creates Data with step-output tags", async () => {
     // Verify tags on the data artifact
     const artifact = stepOutput.dataArtifacts[0];
     assertEquals(
-      artifact.tags.type,
+      artifact.tags.source,
       "step-output",
-      "Tag type should be step-output",
+      "Tag source should be step-output",
     );
     assertEquals(
       artifact.tags.workflow,
@@ -1757,9 +1757,9 @@ Deno.test("CLI: workflow run persists data artifacts in workflow run record", as
 
     // Verify tags are correct
     assertEquals(
-      stepData.dataArtifacts[0].tags.type,
+      stepData.dataArtifacts[0].tags.source,
       "step-output",
-      "Tag type should be step-output",
+      "Tag source should be step-output",
     );
     assertEquals(
       stepData.dataArtifacts[0].tags.workflow,

--- a/src/cli/commands/data_search.ts
+++ b/src/cli/commands/data_search.ts
@@ -270,7 +270,7 @@ export const dataSearchCommand = new Command()
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option(
     "--type <type:string>",
-    "Filter by data type tag (log, file, resource, data, step-output)",
+    "Filter by data type tag (log, file, resource, data, output)",
   )
   .option(
     "--lifetime <lifetime:string>",

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -448,8 +448,10 @@ export class DefaultStepExecutor implements StepExecutor {
       });
 
       // Build workflow-specific tag overrides
+      // Use "source" instead of "type" to preserve the original data type
+      // (resource/file) while tracking provenance for cross-workflow resolution
       const workflowTagOverrides: Record<string, string> = {
-        type: "step-output",
+        source: "step-output",
         workflow: ctx.workflowName,
         step: ctx.stepName,
       };


### PR DESCRIPTION
## Summary

`model.<name>.resource.<spec>.attributes.<field>` CEL expressions could not resolve data produced by a previous workflow run, making it impossible to chain model instances across workflows (e.g., a create workflow followed by a delete workflow).

### Root Cause

When a workflow step writes data via `writeResource()`, the workflow engine applied tag overrides that **replaced** `type: "resource"` with `type: "step-output"`. Since `ModelResolver.buildContext()` only populates `model.*.resource.*` for data tagged `type: "resource"`, cross-workflow resolution failed — the data existed but was invisible to model expressions.

Intra-workflow worked because `execution_service.ts` updates the in-memory expression context directly after each step, bypassing the tag filter.

### Fix

Separated data **kind** (`type: "resource"` / `type: "file"`) from **provenance** (`source: "step-output"`) by changing the workflow tag override from `type` to `source`. This preserves the original `type` tag so `buildContext()` correctly populates model expression contexts for workflow-produced data.

### Changes

| File | Change |
|---|---|
| `src/domain/workflows/execution_service.ts` | Changed `type: "step-output"` → `source: "step-output"` in `workflowTagOverrides` |
| `src/domain/expressions/model_resolver.ts` | No changes needed — existing `type === "resource"` filter now correctly matches |
| `integration/workflow_test.ts` | Updated assertions: `tags.type` → `tags.source` |
| `integration/workflow_new_architecture_test.ts` | Updated assertion: `tags.type` → `tags.source` |
| `integration/data_tagging_test.ts` | Updated test data to use `source: "step-output"` alongside `type: "resource"`, query via `findByTag("source", ...)` |
| `integration/data_ownership_test.ts` | Updated test data to use `type: "resource", source: "step-output"` |
| `src/cli/commands/data_search.ts` | Removed `step-output` from `--type` filter help text (users can use `--tag source=step-output`) |
| `.claude/skills/swamp-workflow/references/expressions-and-foreach.md` | Updated tag table (`type` → `source`), added note on `type` preservation, added `findByTag("source", ...)` example |

### Comparison Against Plan (Issue #278)

| Plan Item | Status |
|---|---|
| `execution_service.ts` — use `source: "step-output"` instead of `type` | Done |
| `model_resolver.ts` — no changes needed | Confirmed, no changes |
| `workflow_test.ts` (lines 1681, 1761) | Done |
| `workflow_new_architecture_test.ts` (line 265) | Done |
| `data_tagging_test.ts` (lines 437, 464) | Done |
| `data_ownership_test.ts` (lines 107, 418) | Done |
| `execution_service_test.ts` (line 1174) | No change needed — `step-output` only appears in test name, not assertions |
| `data_search.ts` — remove `step-output` from `--type` help | Done |
| `data_search.ts` — add `--source` filter | Covered by existing `--tag source=step-output` option |
| Skill documentation update | Done |

### Result

| Expression | Intra-workflow | Cross-workflow |
|---|---|---|
| `model.*` | Works (in-memory update) | **Works** (`type: "resource"` now preserved) |
| `data.latest()` | Doesn't work (cache built at start) | Works (reads from persisted data) |

Fixes #278

## Test Plan

- All 1731 existing tests pass with 0 failures
- Updated integration tests verify `source: "step-output"` tagging
- Verified `Data.create()` Zod validation still enforces `type` key in tags