### PR TITLE
fix: Silence warnings for library files without model exports

### DIFF
--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -303,13 +303,8 @@ export class UserModelLoader {
       }
     }
 
-    // Files with neither export
-    for (const file of unknownFiles) {
-      result.failed.push({
-        file,
-        error: "No 'model' or 'extension' export found",
-      });
-    }
+    // Files with neither 'model' nor 'extension' export are silently skipped
+    // (they are likely library/utility files imported by actual model files)
 
     return result;
   }

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -285,7 +285,7 @@ export const model = {
   });
 });
 
-Deno.test("UserModelLoader handles missing model export", async () => {
+Deno.test("UserModelLoader silently skips files without model or extension export", async () => {
   const modelCode = `
 export const notAModel = { foo: "bar" };
 `;
@@ -294,13 +294,10 @@ export const notAModel = { foo: "bar" };
     const loader = new UserModelLoader();
     const result = await loader.loadModels(dir);
 
+    // Files without model/extension exports are now silently skipped
     assertEquals(result.loaded.length, 0);
-    assertEquals(result.failed.length, 1);
-    assertEquals(result.failed[0].file, "no_export.ts");
-    assertEquals(
-      result.failed[0].error,
-      "No 'model' or 'extension' export found",
-    );
+    assertEquals(result.extended.length, 0);
+    assertEquals(result.failed.length, 0);
   });
 });
 
@@ -1933,5 +1930,51 @@ export const model = {
     assertEquals(result.loaded.length, 0);
     assertEquals(result.failed.length, 1);
     assertStringIncludes(result.failed[0].error, "reserved namespace");
+  });
+});
+
+Deno.test("UserModelLoader silently skips library files without model exports", async () => {
+  const validModelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "@test/skip-test-${Date.now()}",
+  version: "2026.02.11.1",
+  methods: {
+    run: {
+      description: "Run",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+  const libCode = `
+// Library file with no model or extension export
+export function sshConnect(host: string) {
+  return \`ssh \${host}\`;
+}
+
+export class ProxmoxClient {
+  constructor(public url: string) {}
+}
+`;
+
+  await withTempModels({
+    "models/server.ts": validModelCode,
+    "lib/ssh.ts": libCode,
+    "lib/proxmox.ts": libCode,
+    "utils/helpers.ts": libCode,
+  }, async (dir) => {
+    const loader = new UserModelLoader();
+    const result = await loader.loadModels(dir);
+
+    // Should load only the valid model
+    assertEquals(result.loaded.length, 1);
+    assertEquals(result.loaded[0], join("models", "server.ts"));
+
+    // Library files should be silently skipped (not in failed list)
+    assertEquals(result.failed.length, 0);
   });
 });


### PR DESCRIPTION
Fixes false warnings when the model loader encounters library/utility files that don't export `model` or `extension` objects.

Previously, users would see warnings like:
```
Warning: Failed to load user model lib/proxmox.ts: No 'model' or 'extension' export found
Warning: Failed to load user model lib/ssh.ts: No 'model' or 'extension' export found
```

These warnings were misleading - library files (like `lib/ssh.ts`,
`utils/helpers.ts`) are meant to be imported by actual model files, not to export models themselves.

**Changes:**
- Modified `UserModelLoader.loadModels()` to silently skip files without `model` or `extension` exports
- Updated test to verify library files are skipped without warnings
- Users can now organize their extensions directory however they want (lib/, utils/, etc.)

## Test Plan

- ✅ All existing tests pass (1741 tests)
- ✅ New test verifies library files are silently skipped
- ✅ Updated test verifies files without exports don't generate warnings
- ✅ Type checking, linting, and formatting all pass

**Manual verification:**
```bash
# Create test structure with library files
mkdir -p extensions/lib extensions/models
echo 'export function helper() {}' > extensions/lib/ssh.ts
echo 'import { z } from "npm:zod@4"; export const model = {...}' >
extensions/models/test.ts

# Run - should only load models/test.ts, no warnings about lib/ssh.ts
swamp model type list
```

🤖 Generated with https://claude.com/claude-code