### PR TITLE
docs: Update README license section for AGPLv3

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,6 @@ deno fmt
 
 ## License
 
-Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE),
-[COPYRIGHT](COPYRIGHT), [CONTRIBUTORS.md](CONTRIBUTORS.md), and [NOTICE](NOTICE)
-for details.
+Swamp is licensed under the [GNU Affero General Public License v3.0](COPYING)
+with the [Swamp Extension and Definition Exception](COPYING-EXCEPTION). See
+[COPYRIGHT](COPYRIGHT) and [CONTRIBUTING.md](CONTRIBUTING.md) for details.


### PR DESCRIPTION
## Summary

- Update the License section of README.md to reference AGPLv3 with the Swamp Extension and Definition Exception
- Link to `COPYING`, `COPYING-EXCEPTION`, `COPYRIGHT`, and `CONTRIBUTING.md`
- Remove outdated Apache 2.0 references

## Test plan

- [x] Verified links point to correct files

🤖 Generated with [Claude Code](https://claude.com/claude-code)