### PR TITLE
fix: Detect cycles from implicit CEL dependencies in workflow validate

### DIFF
--- a/integration/workflow_test.ts
+++ b/integration/workflow_test.ts
@@ -1995,3 +1995,98 @@ Deno.test("CLI: workflow run detects direct workflow cycle", async () => {
     );
   });
 });
+
+// Implicit CEL dependency cycle detection in workflow validate
+
+Deno.test("CLI: workflow validate detects cycle from implicit CEL dependencies", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+
+    // networking-vpc has no expressions — it's clean
+    const vpcModel = Definition.create({
+      name: "networking-vpc",
+      methods: {
+        write: { arguments: { cidr: "10.0.0.0/16" } },
+      },
+    });
+    await definitionRepo.save(ECHO_MODEL_TYPE, vpcModel);
+
+    // public-route-table references networking-vpc's resource (implicit dep)
+    const routeTableModel = Definition.create({
+      name: "public-route-table",
+      methods: {
+        write: {
+          arguments: {
+            vpcId:
+              "${{ model.networking-vpc.resource.aws_vpc.main.attributes.VpcId }}",
+          },
+        },
+      },
+    });
+    await definitionRepo.save(ECHO_MODEL_TYPE, routeTableModel);
+
+    // Workflow has explicit dep: vpc depends on route-table (reversed order)
+    // Implicit dep: route-table depends on vpc (from CEL expression)
+    // This creates a cycle: vpc -> route-table -> vpc
+    const workflowRepo = new YamlWorkflowRepository(repoDir);
+    const workflow = Workflow.create({
+      name: "implicit-cycle-workflow",
+      jobs: [
+        Job.create({
+          name: "infra-job",
+          steps: [
+            Step.create({
+              name: "create-route-table",
+              task: StepTask.model("public-route-table", "write"),
+            }),
+            Step.create({
+              name: "create-vpc",
+              task: StepTask.model("networking-vpc", "write"),
+              dependsOn: [
+                {
+                  step: "create-route-table",
+                  condition: TriggerCondition.succeeded(),
+                },
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    const result = await runCliCommand(
+      [
+        "workflow",
+        "validate",
+        "implicit-cycle-workflow",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      1,
+      `Command should fail with exit code 1. stderr: ${result.stderr}, stdout: ${result.stdout}`,
+    );
+
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.passed, false);
+
+    // Find the implicit cycle validation result
+    const implicitValidation = output.validations.find(
+      (v: { name: string }) => v.name.includes("including implicit"),
+    );
+    assertEquals(implicitValidation?.passed, false);
+    assertStringIncludes(implicitValidation?.error ?? "", "Cyclic");
+    assertStringIncludes(
+      implicitValidation?.error ?? "",
+      "implicit dependencies from CEL",
+    );
+  });
+});

--- a/src/cli/commands/workflow_validate.ts
+++ b/src/cli/commands/workflow_validate.ts
@@ -81,7 +81,9 @@ export const workflowValidateCommand = new Command()
       outputMode: ctx.outputMode,
     });
     const repo = repoContext.workflowRepo;
-    const validationService = new DefaultWorkflowValidationService();
+    const validationService = new DefaultWorkflowValidationService(
+      repoContext.definitionRepo,
+    );
 
     // If no argument provided, validate all workflows
     if (!workflowIdOrName) {
@@ -94,7 +96,7 @@ export const workflowValidateCommand = new Command()
 
       const results: WorkflowValidateData[] = [];
       for (const workflow of allWorkflows) {
-        const validationResults = validationService.validate(workflow);
+        const validationResults = await validationService.validate(workflow);
         const validations = toValidationItemData(validationResults);
         const allPassed = validationResults.every((r) => r.passed);
 
@@ -139,7 +141,7 @@ export const workflowValidateCommand = new Command()
     ctx.logger.debug`Found workflow: id=${workflow.id}, name=${workflow.name}`;
 
     // Run validations
-    const results = validationService.validate(workflow);
+    const results = await validationService.validate(workflow);
     const validations = toValidationItemData(results);
     const allPassed = results.every((r) => r.passed);
 

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -52,8 +52,6 @@ import {
   ExpressionEvaluationService,
 } from "../expressions/expression_evaluation_service.ts";
 import {
-  extractFileContentsDependencies,
-  extractResourceDependencies,
   hasStepOutputDependency,
 } from "../expressions/dependency_extractor.ts";
 import {
@@ -73,6 +71,7 @@ import {
   swampPath,
 } from "../../infrastructure/persistence/paths.ts";
 import { join } from "@std/path";
+import { buildStepNodesWithImplicitDeps } from "./implicit_dependency_service.ts";
 
 /**
  * Context for step execution.
@@ -770,9 +769,9 @@ export class WorkflowExecutionService {
     // Build implicit dependencies for all jobs upfront
     const allImplicitDeps: ImplicitDependencyMap = new Map();
     for (const job of workflow.jobs) {
-      const { implicitDeps } = await this.buildStepNodesWithImplicitDeps(
+      const { implicitDeps } = await buildStepNodesWithImplicitDeps(
         job,
-        workflow,
+        this.definitionRepo,
       );
       if (implicitDeps.size > 0) {
         allImplicitDeps.set(job.name, implicitDeps);
@@ -881,9 +880,9 @@ export class WorkflowExecutionService {
     }
 
     // Build step nodes with implicit dependencies from expressions
-    const { nodes: stepNodes } = await this.buildStepNodesWithImplicitDeps(
+    const { nodes: stepNodes } = await buildStepNodesWithImplicitDeps(
       job,
-      workflow,
+      this.definitionRepo,
     );
 
     // If we have expanded steps, update the graph nodes
@@ -976,134 +975,6 @@ export class WorkflowExecutionService {
       jobRun.succeed();
     }
     progress?.onJobComplete?.(run, jobName);
-  }
-
-  /**
-   * Builds step graph nodes including implicit dependencies from expressions.
-   * If a step's model input has ${{ model.X.resource.attributes.Y }}, then
-   * that step implicitly depends on the step that creates model X's resource.
-   *
-   * Returns both the nodes and a mapping of step names to their implicit dependencies.
-   */
-  private async buildStepNodesWithImplicitDeps(
-    job: Job,
-    _workflow: Workflow,
-  ): Promise<{ nodes: GraphNode[]; implicitDeps: Map<string, string[]> }> {
-    // Build a map from model name/id to step name
-    const modelToStep = new Map<string, string>();
-    for (const step of job.steps) {
-      if (step.task.isModelMethod()) {
-        const task = step.task.data as { modelIdOrName: string };
-        modelToStep.set(task.modelIdOrName, step.name);
-      }
-    }
-
-    const nodes: GraphNode[] = [];
-    const implicitDepsMap = new Map<string, string[]>();
-
-    for (const step of job.steps) {
-      const explicitDeps = step.getDependencyNames();
-      const implicitDeps: string[] = [];
-
-      // Check for implicit dependencies from expressions
-      if (step.task.isModelMethod()) {
-        const task = step.task.data as { modelIdOrName: string };
-
-        // Look up the model definition to check for expressions
-        const lookupResult = await findDefinitionByIdOrName(
-          this.definitionRepo,
-          task.modelIdOrName,
-        );
-        if (lookupResult) {
-          const definitionData = lookupResult.definition.toData();
-          const expressions = extractExpressions(definitionData);
-
-          // Extract resource dependencies from expressions
-          for (const expr of expressions) {
-            const resourceRefs = extractResourceDependencies(
-              expr.celExpression,
-            );
-            for (const modelRef of resourceRefs) {
-              const dependsOnStep = modelToStep.get(modelRef);
-              if (dependsOnStep && dependsOnStep !== step.name) {
-                if (
-                  !explicitDeps.includes(dependsOnStep) &&
-                  !implicitDeps.includes(dependsOnStep)
-                ) {
-                  implicitDeps.push(dependsOnStep);
-                }
-              }
-            }
-
-            // Extract file.contents() dependencies from expressions
-            const fileContentsRefs = extractFileContentsDependencies(
-              expr.celExpression,
-            );
-            for (const modelRef of fileContentsRefs) {
-              const dependsOnStep = modelToStep.get(modelRef);
-              if (dependsOnStep && dependsOnStep !== step.name) {
-                if (
-                  !explicitDeps.includes(dependsOnStep) &&
-                  !implicitDeps.includes(dependsOnStep)
-                ) {
-                  implicitDeps.push(dependsOnStep);
-                }
-              }
-            }
-          }
-        }
-      }
-
-      // Also scan task.inputs for implicit dependencies
-      const taskInputs = step.task.data.inputs;
-      if (taskInputs) {
-        const inputExpressions = extractExpressions(taskInputs);
-        for (const expr of inputExpressions) {
-          const resourceRefs = extractResourceDependencies(
-            expr.celExpression,
-          );
-          for (const modelRef of resourceRefs) {
-            const dependsOnStep = modelToStep.get(modelRef);
-            if (dependsOnStep && dependsOnStep !== step.name) {
-              if (
-                !explicitDeps.includes(dependsOnStep) &&
-                !implicitDeps.includes(dependsOnStep)
-              ) {
-                implicitDeps.push(dependsOnStep);
-              }
-            }
-          }
-
-          const fileContentsRefs = extractFileContentsDependencies(
-            expr.celExpression,
-          );
-          for (const modelRef of fileContentsRefs) {
-            const dependsOnStep = modelToStep.get(modelRef);
-            if (dependsOnStep && dependsOnStep !== step.name) {
-              if (
-                !explicitDeps.includes(dependsOnStep) &&
-                !implicitDeps.includes(dependsOnStep)
-              ) {
-                implicitDeps.push(dependsOnStep);
-              }
-            }
-          }
-        }
-      }
-
-      // Store implicit deps for this step
-      if (implicitDeps.length > 0) {
-        implicitDepsMap.set(step.name, implicitDeps);
-      }
-
-      nodes.push({
-        name: step.name,
-        weight: step.weight,
-        dependencies: [...explicitDeps, ...implicitDeps],
-      });
-    }
-
-    return { nodes, implicitDeps: implicitDepsMap };
   }
 
   /**

--- a/src/domain/workflows/implicit_dependency_service.ts
+++ b/src/domain/workflows/implicit_dependency_service.ts
@@ -1,0 +1,162 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { Job } from "./job.ts";
+import type { GraphNode } from "./topological_sort_service.ts";
+import type { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import { findDefinitionByIdOrName } from "../models/model_lookup.ts";
+import { extractExpressions } from "../expressions/expression_parser.ts";
+import {
+  extractFileContentsDependencies,
+  extractResourceDependencies,
+} from "../expressions/dependency_extractor.ts";
+
+/**
+ * Builds step graph nodes including implicit dependencies from CEL expressions.
+ *
+ * If a step's model definition has `${{ model.X.resource.attributes.Y }}`, then
+ * that step implicitly depends on the step that creates model X's resource.
+ * Similarly for `file.contents('model', ...)` references.
+ *
+ * Also scans task.inputs for implicit dependencies.
+ *
+ * @param job - The job containing steps to analyze
+ * @param definitionRepo - Repository for looking up model definitions
+ * @returns The graph nodes and a mapping of step names to their implicit dependencies
+ */
+export async function buildStepNodesWithImplicitDeps(
+  job: Job,
+  definitionRepo: YamlDefinitionRepository,
+): Promise<{ nodes: GraphNode[]; implicitDeps: Map<string, string[]> }> {
+  // Build a map from model name/id to step name
+  const modelToStep = new Map<string, string>();
+  for (const step of job.steps) {
+    if (step.task.isModelMethod()) {
+      const task = step.task.data as { modelIdOrName: string };
+      modelToStep.set(task.modelIdOrName, step.name);
+    }
+  }
+
+  const nodes: GraphNode[] = [];
+  const implicitDepsMap = new Map<string, string[]>();
+
+  for (const step of job.steps) {
+    const explicitDeps = step.getDependencyNames();
+    const implicitDeps: string[] = [];
+
+    // Check for implicit dependencies from expressions
+    if (step.task.isModelMethod()) {
+      const task = step.task.data as { modelIdOrName: string };
+
+      // Look up the model definition to check for expressions
+      const lookupResult = await findDefinitionByIdOrName(
+        definitionRepo,
+        task.modelIdOrName,
+      );
+      if (lookupResult) {
+        const definitionData = lookupResult.definition.toData();
+        const expressions = extractExpressions(definitionData);
+
+        // Extract resource dependencies from expressions
+        for (const expr of expressions) {
+          const resourceRefs = extractResourceDependencies(
+            expr.celExpression,
+          );
+          for (const modelRef of resourceRefs) {
+            const dependsOnStep = modelToStep.get(modelRef);
+            if (dependsOnStep && dependsOnStep !== step.name) {
+              if (
+                !explicitDeps.includes(dependsOnStep) &&
+                !implicitDeps.includes(dependsOnStep)
+              ) {
+                implicitDeps.push(dependsOnStep);
+              }
+            }
+          }
+
+          // Extract file.contents() dependencies from expressions
+          const fileContentsRefs = extractFileContentsDependencies(
+            expr.celExpression,
+          );
+          for (const modelRef of fileContentsRefs) {
+            const dependsOnStep = modelToStep.get(modelRef);
+            if (dependsOnStep && dependsOnStep !== step.name) {
+              if (
+                !explicitDeps.includes(dependsOnStep) &&
+                !implicitDeps.includes(dependsOnStep)
+              ) {
+                implicitDeps.push(dependsOnStep);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Also scan task.inputs for implicit dependencies
+    const taskInputs = step.task.data.inputs;
+    if (taskInputs) {
+      const inputExpressions = extractExpressions(taskInputs);
+      for (const expr of inputExpressions) {
+        const resourceRefs = extractResourceDependencies(
+          expr.celExpression,
+        );
+        for (const modelRef of resourceRefs) {
+          const dependsOnStep = modelToStep.get(modelRef);
+          if (dependsOnStep && dependsOnStep !== step.name) {
+            if (
+              !explicitDeps.includes(dependsOnStep) &&
+              !implicitDeps.includes(dependsOnStep)
+            ) {
+              implicitDeps.push(dependsOnStep);
+            }
+          }
+        }
+
+        const fileContentsRefs = extractFileContentsDependencies(
+          expr.celExpression,
+        );
+        for (const modelRef of fileContentsRefs) {
+          const dependsOnStep = modelToStep.get(modelRef);
+          if (dependsOnStep && dependsOnStep !== step.name) {
+            if (
+              !explicitDeps.includes(dependsOnStep) &&
+              !implicitDeps.includes(dependsOnStep)
+            ) {
+              implicitDeps.push(dependsOnStep);
+            }
+          }
+        }
+      }
+    }
+
+    // Store implicit deps for this step
+    if (implicitDeps.length > 0) {
+      implicitDepsMap.set(step.name, implicitDeps);
+    }
+
+    nodes.push({
+      name: step.name,
+      weight: step.weight,
+      dependencies: [...explicitDeps, ...implicitDeps],
+    });
+  }
+
+  return { nodes, implicitDeps: implicitDepsMap };
+}

--- a/src/domain/workflows/implicit_dependency_service_test.ts
+++ b/src/domain/workflows/implicit_dependency_service_test.ts
@@ -1,0 +1,275 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { buildStepNodesWithImplicitDeps } from "./implicit_dependency_service.ts";
+import { Job } from "./job.ts";
+import { Step } from "./step.ts";
+import { StepTask } from "./step_task.ts";
+import { Definition } from "../definitions/definition.ts";
+import { ECHO_MODEL_TYPE } from "../models/echo/echo_model.ts";
+import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+
+async function withTempRepo(
+  fn: (repo: YamlDefinitionRepository) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-implicit-deps-" });
+  try {
+    await ensureDir(join(dir, ".swamp/definitions"));
+    const repo = new YamlDefinitionRepository(dir);
+    await fn(repo);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("no implicit deps when steps have no model references", async () => {
+  await withTempRepo(async (repo) => {
+    const modelA = Definition.create({
+      name: "model-a",
+      methods: { write: { arguments: { message: "hello" } } },
+    });
+    const modelB = Definition.create({
+      name: "model-b",
+      methods: { write: { arguments: { message: "world" } } },
+    });
+    await repo.save(ECHO_MODEL_TYPE, modelA);
+    await repo.save(ECHO_MODEL_TYPE, modelB);
+
+    const job = Job.create({
+      name: "test-job",
+      steps: [
+        Step.create({
+          name: "step-a",
+          task: StepTask.model("model-a", "write"),
+        }),
+        Step.create({
+          name: "step-b",
+          task: StepTask.model("model-b", "write"),
+        }),
+      ],
+    });
+
+    const { nodes, implicitDeps } = await buildStepNodesWithImplicitDeps(
+      job,
+      repo,
+    );
+
+    assertEquals(nodes.length, 2);
+    assertEquals(implicitDeps.size, 0);
+    assertEquals(nodes[0].dependencies, []);
+    assertEquals(nodes[1].dependencies, []);
+  });
+});
+
+Deno.test("extracts resource deps from model definition CEL expressions", async () => {
+  await withTempRepo(async (repo) => {
+    const vpcModel = Definition.create({
+      name: "networking-vpc",
+      methods: { write: { arguments: { cidr: "10.0.0.0/16" } } },
+    });
+    const routeTableModel = Definition.create({
+      name: "public-route-table",
+      methods: {
+        write: {
+          arguments: {
+            vpcId:
+              "${{ model.networking-vpc.resource.aws_vpc.main.attributes.VpcId }}",
+          },
+        },
+      },
+    });
+    await repo.save(ECHO_MODEL_TYPE, vpcModel);
+    await repo.save(ECHO_MODEL_TYPE, routeTableModel);
+
+    const job = Job.create({
+      name: "infra-job",
+      steps: [
+        Step.create({
+          name: "create-vpc",
+          task: StepTask.model("networking-vpc", "write"),
+        }),
+        Step.create({
+          name: "create-route-table",
+          task: StepTask.model("public-route-table", "write"),
+        }),
+      ],
+    });
+
+    const { nodes, implicitDeps } = await buildStepNodesWithImplicitDeps(
+      job,
+      repo,
+    );
+
+    assertEquals(nodes.length, 2);
+    assertEquals(implicitDeps.size, 1);
+    assertEquals(implicitDeps.get("create-route-table"), ["create-vpc"]);
+    assertEquals(nodes[1].dependencies, ["create-vpc"]);
+  });
+});
+
+Deno.test("extracts file.contents deps from model definition", async () => {
+  await withTempRepo(async (repo) => {
+    const sourceModel = Definition.create({
+      name: "source-model",
+      methods: { write: { arguments: { data: "source data" } } },
+    });
+    const consumerModel = Definition.create({
+      name: "consumer-model",
+      methods: {
+        write: {
+          arguments: {
+            content: "${{ file.contents('source-model', 'config') }}",
+          },
+        },
+      },
+    });
+    await repo.save(ECHO_MODEL_TYPE, sourceModel);
+    await repo.save(ECHO_MODEL_TYPE, consumerModel);
+
+    const job = Job.create({
+      name: "file-job",
+      steps: [
+        Step.create({
+          name: "write-source",
+          task: StepTask.model("source-model", "write"),
+        }),
+        Step.create({
+          name: "read-consumer",
+          task: StepTask.model("consumer-model", "write"),
+        }),
+      ],
+    });
+
+    const { implicitDeps } = await buildStepNodesWithImplicitDeps(job, repo);
+
+    assertEquals(implicitDeps.size, 1);
+    assertEquals(implicitDeps.get("read-consumer"), ["write-source"]);
+  });
+});
+
+Deno.test("extracts deps from task.inputs", async () => {
+  await withTempRepo(async (repo) => {
+    const vpcModel = Definition.create({
+      name: "networking-vpc",
+      methods: { write: { arguments: { cidr: "10.0.0.0/16" } } },
+    });
+    const subnetModel = Definition.create({
+      name: "subnet-model",
+      methods: { write: { arguments: {} } },
+    });
+    await repo.save(ECHO_MODEL_TYPE, vpcModel);
+    await repo.save(ECHO_MODEL_TYPE, subnetModel);
+
+    const job = Job.create({
+      name: "infra-job",
+      steps: [
+        Step.create({
+          name: "create-vpc",
+          task: StepTask.model("networking-vpc", "write"),
+        }),
+        Step.create({
+          name: "create-subnet",
+          task: StepTask.model("subnet-model", "write", {
+            vpcId:
+              "${{ model.networking-vpc.resource.aws_vpc.main.attributes.VpcId }}",
+          }),
+        }),
+      ],
+    });
+
+    const { implicitDeps } = await buildStepNodesWithImplicitDeps(job, repo);
+
+    assertEquals(implicitDeps.size, 1);
+    assertEquals(implicitDeps.get("create-subnet"), ["create-vpc"]);
+  });
+});
+
+Deno.test("gracefully skips when model definition not found", async () => {
+  await withTempRepo(async (repo) => {
+    // Don't save any definitions - they won't be found
+    const job = Job.create({
+      name: "test-job",
+      steps: [
+        Step.create({
+          name: "step-a",
+          task: StepTask.model("nonexistent-model", "write"),
+        }),
+        Step.create({
+          name: "step-b",
+          task: StepTask.model("also-nonexistent", "write"),
+        }),
+      ],
+    });
+
+    const { nodes, implicitDeps } = await buildStepNodesWithImplicitDeps(
+      job,
+      repo,
+    );
+
+    assertEquals(nodes.length, 2);
+    assertEquals(implicitDeps.size, 0);
+  });
+});
+
+Deno.test("deduplicates repeated references to the same model", async () => {
+  await withTempRepo(async (repo) => {
+    const vpcModel = Definition.create({
+      name: "networking-vpc",
+      methods: { write: { arguments: { cidr: "10.0.0.0/16" } } },
+    });
+    const multiRefModel = Definition.create({
+      name: "multi-ref-model",
+      methods: {
+        write: {
+          arguments: {
+            vpcId:
+              "${{ model.networking-vpc.resource.aws_vpc.main.attributes.VpcId }}",
+            subnetCidr:
+              "${{ model.networking-vpc.resource.aws_vpc.main.attributes.CidrBlock }}",
+          },
+        },
+      },
+    });
+    await repo.save(ECHO_MODEL_TYPE, vpcModel);
+    await repo.save(ECHO_MODEL_TYPE, multiRefModel);
+
+    const job = Job.create({
+      name: "test-job",
+      steps: [
+        Step.create({
+          name: "create-vpc",
+          task: StepTask.model("networking-vpc", "write"),
+        }),
+        Step.create({
+          name: "create-multi",
+          task: StepTask.model("multi-ref-model", "write"),
+        }),
+      ],
+    });
+
+    const { implicitDeps } = await buildStepNodesWithImplicitDeps(job, repo);
+
+    assertEquals(implicitDeps.size, 1);
+    // Should only appear once despite two references
+    assertEquals(implicitDeps.get("create-multi"), ["create-vpc"]);
+  });
+});

--- a/src/domain/workflows/validation_service.ts
+++ b/src/domain/workflows/validation_service.ts
@@ -24,6 +24,8 @@ import {
   type GraphNode,
   TopologicalSortService,
 } from "./topological_sort_service.ts";
+import type { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import { buildStepNodesWithImplicitDeps } from "./implicit_dependency_service.ts";
 
 /**
  * Value object representing the result of a single validation.
@@ -72,6 +74,7 @@ export class WorkflowValidationResult {
  * 5. Valid step dependency references
  * 6. No cyclic dependencies between jobs
  * 7. No cyclic dependencies between steps within jobs
+ * 8. No cyclic dependencies between steps (including implicit CEL deps)
  */
 export interface WorkflowValidationService {
   /**
@@ -80,17 +83,25 @@ export interface WorkflowValidationService {
    * @param workflow The workflow to validate
    * @returns Array of validation results
    */
-  validate(workflow: Workflow): WorkflowValidationResult[];
+  validate(workflow: Workflow): Promise<WorkflowValidationResult[]>;
 }
 
 /**
  * Default implementation of workflow validation service.
+ *
+ * Optionally accepts a DefinitionRepository to detect implicit CEL
+ * dependencies when checking for step cycles.
  */
 export class DefaultWorkflowValidationService
   implements WorkflowValidationService {
   private readonly sortService = new TopologicalSortService();
+  private readonly definitionRepo?: YamlDefinitionRepository;
 
-  validate(workflow: Workflow): WorkflowValidationResult[] {
+  constructor(definitionRepo?: YamlDefinitionRepository) {
+    this.definitionRepo = definitionRepo;
+  }
+
+  async validate(workflow: Workflow): Promise<WorkflowValidationResult[]> {
     const results: WorkflowValidationResult[] = [];
 
     // 1. Schema validation
@@ -113,6 +124,13 @@ export class DefaultWorkflowValidationService
 
     // 7. No cyclic step dependencies within jobs
     results.push(...this.validateNoStepCycles(workflow));
+
+    // 8. No cyclic step dependencies (including implicit CEL deps)
+    if (this.definitionRepo) {
+      results.push(
+        ...await this.validateNoStepCyclesWithImplicit(workflow),
+      );
+    }
 
     return results;
   }
@@ -305,6 +323,75 @@ export class DefaultWorkflowValidationService
         } else {
           throw error;
         }
+      }
+    }
+
+    return results;
+  }
+
+  private async validateNoStepCyclesWithImplicit(
+    workflow: Workflow,
+  ): Promise<WorkflowValidationResult[]> {
+    const results: WorkflowValidationResult[] = [];
+
+    for (const job of workflow.jobs) {
+      if (job.steps.length === 0) {
+        results.push(
+          WorkflowValidationResult.pass(
+            `No cyclic step dependencies (including implicit) in job '${job.name}'`,
+          ),
+        );
+        continue;
+      }
+
+      try {
+        const { nodes, implicitDeps } = await buildStepNodesWithImplicitDeps(
+          job,
+          this.definitionRepo!,
+        );
+
+        try {
+          this.sortService.sort(nodes);
+          results.push(
+            WorkflowValidationResult.pass(
+              `No cyclic step dependencies (including implicit) in job '${job.name}'`,
+            ),
+          );
+        } catch (error) {
+          if (error instanceof CyclicDependencyError) {
+            // Annotate the error message with which edges are implicit
+            const implicitEdges: string[] = [];
+            for (const [step, deps] of implicitDeps) {
+              for (const dep of deps) {
+                implicitEdges.push(`${step} -> ${dep}`);
+              }
+            }
+            const implicitNote = implicitEdges.length > 0
+              ? ` (implicit dependencies from CEL expressions: ${
+                implicitEdges.join(", ")
+              })`
+              : "";
+
+            results.push(
+              WorkflowValidationResult.fail(
+                `No cyclic step dependencies (including implicit) in job '${job.name}'`,
+                `${error.message}${implicitNote}`,
+              ),
+            );
+          } else {
+            throw error;
+          }
+        }
+      } catch (error) {
+        if (error instanceof CyclicDependencyError) {
+          throw error;
+        }
+        // If we fail to resolve definitions (e.g., missing models), skip gracefully
+        results.push(
+          WorkflowValidationResult.pass(
+            `No cyclic step dependencies (including implicit) in job '${job.name}'`,
+          ),
+        );
       }
     }
 

--- a/src/domain/workflows/validation_service_test.ts
+++ b/src/domain/workflows/validation_service_test.ts
@@ -18,12 +18,17 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
 import { DefaultWorkflowValidationService } from "./validation_service.ts";
 import { Workflow } from "./workflow.ts";
 import { Job } from "./job.ts";
 import { Step } from "./step.ts";
 import { StepTask } from "./step_task.ts";
 import { TriggerCondition } from "./trigger_condition.ts";
+import { Definition } from "../definitions/definition.ts";
+import { ECHO_MODEL_TYPE } from "../models/echo/echo_model.ts";
+import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 
 const service = new DefaultWorkflowValidationService();
 
@@ -399,4 +404,178 @@ Deno.test("validation results have equals method", async () => {
   const result1 = results[0];
   const result2 = results[0];
   assertEquals(result1.equals(result2), true);
+});
+
+// Implicit CEL dependency tests
+
+async function withTempRepo(
+  fn: (repo: YamlDefinitionRepository) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-validation-" });
+  try {
+    await ensureDir(join(dir, ".swamp/definitions"));
+    const repo = new YamlDefinitionRepository(dir);
+    await fn(repo);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("detects cycle from implicit CEL deps", async () => {
+  await withTempRepo(async (repo) => {
+    // model-a references model-b's resource
+    const modelA = Definition.create({
+      name: "model-a",
+      methods: {
+        write: {
+          arguments: {
+            value: "${{ model.model-b.resource.aws_thing.main.attributes.Id }}",
+          },
+        },
+      },
+    });
+    // model-b is clean
+    const modelB = Definition.create({
+      name: "model-b",
+      methods: { write: { arguments: { value: "hello" } } },
+    });
+    await repo.save(ECHO_MODEL_TYPE, modelA);
+    await repo.save(ECHO_MODEL_TYPE, modelB);
+
+    // Workflow has explicit dep: step-b depends on step-a
+    // Implicit dep: step-a depends on step-b (from CEL expression)
+    // This creates a cycle: step-a -> step-b -> step-a
+    const workflow = Workflow.create({
+      name: "cycle-workflow",
+      jobs: [
+        Job.create({
+          name: "infra-job",
+          steps: [
+            Step.create({
+              name: "step-a",
+              task: StepTask.model("model-a", "write"),
+            }),
+            Step.create({
+              name: "step-b",
+              task: StepTask.model("model-b", "write"),
+              dependsOn: [
+                { step: "step-a", condition: TriggerCondition.succeeded() },
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const implicitService = new DefaultWorkflowValidationService(repo);
+    const results = await implicitService.validate(workflow);
+
+    const implicitCycleResult = results.find((r) =>
+      r.name.includes("including implicit")
+    );
+    assertEquals(implicitCycleResult?.passed, false);
+    assertEquals(implicitCycleResult?.error?.includes("Cyclic"), true);
+    assertEquals(
+      implicitCycleResult?.error?.includes("implicit dependencies from CEL"),
+      true,
+    );
+  });
+});
+
+Deno.test("passes when implicit deps exist but no cycle", async () => {
+  await withTempRepo(async (repo) => {
+    const vpcModel = Definition.create({
+      name: "networking-vpc",
+      methods: { write: { arguments: { cidr: "10.0.0.0/16" } } },
+    });
+    const routeTableModel = Definition.create({
+      name: "route-table",
+      methods: {
+        write: {
+          arguments: {
+            vpcId:
+              "${{ model.networking-vpc.resource.aws_vpc.main.attributes.VpcId }}",
+          },
+        },
+      },
+    });
+    await repo.save(ECHO_MODEL_TYPE, vpcModel);
+    await repo.save(ECHO_MODEL_TYPE, routeTableModel);
+
+    // Implicit dep: route-table -> vpc (same direction, no cycle)
+    const workflow = Workflow.create({
+      name: "no-cycle-workflow",
+      jobs: [
+        Job.create({
+          name: "infra-job",
+          steps: [
+            Step.create({
+              name: "create-vpc",
+              task: StepTask.model("networking-vpc", "write"),
+            }),
+            Step.create({
+              name: "create-route-table",
+              task: StepTask.model("route-table", "write"),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const implicitService = new DefaultWorkflowValidationService(repo);
+    const results = await implicitService.validate(workflow);
+
+    const implicitResult = results.find((r) =>
+      r.name.includes("including implicit")
+    );
+    assertEquals(implicitResult?.passed, true);
+  });
+});
+
+Deno.test("graceful when no definition repo provided (skips implicit check)", async () => {
+  const workflow = createSimpleWorkflow();
+  const noRepoService = new DefaultWorkflowValidationService();
+  const results = await noRepoService.validate(workflow);
+
+  // Should not have any implicit cycle check results
+  const implicitResults = results.filter((r) =>
+    r.name.includes("including implicit")
+  );
+  assertEquals(implicitResults.length, 0);
+});
+
+Deno.test("graceful when model definitions are missing", async () => {
+  await withTempRepo(async (repo) => {
+    // Don't save any definitions — models won't be found
+    const workflow = Workflow.create({
+      name: "missing-models-workflow",
+      jobs: [
+        Job.create({
+          name: "test-job",
+          steps: [
+            Step.create({
+              name: "step-a",
+              task: StepTask.model("nonexistent-a", "write"),
+            }),
+            Step.create({
+              name: "step-b",
+              task: StepTask.model("nonexistent-b", "write"),
+              dependsOn: [
+                { step: "step-a", condition: TriggerCondition.succeeded() },
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const implicitService = new DefaultWorkflowValidationService(repo);
+    const results = await implicitService.validate(workflow);
+
+    // Should still pass — missing models just means no implicit deps found
+    const implicitResult = results.find((r) =>
+      r.name.includes("including implicit")
+    );
+    assertEquals(implicitResult?.passed, true);
+  });
 });


### PR DESCRIPTION
Fixes #277

## Summary

`swamp workflow validate` only checked explicit `dependsOn` for step cycle
detection. Implicit dependencies from CEL expressions (e.g.,
`${{ model.vpc.resource.* }}`) were only discovered at runtime by
`workflow run`, causing surprise cycle errors.

This PR extracts the implicit dependency resolution logic from
`execution_service.ts` into a reusable function, then calls it from the
validation service when a `DefinitionRepository` is available.

### Changes

- **New `src/domain/workflows/implicit_dependency_service.ts`** — Extracted
  `buildStepNodesWithImplicitDeps()` (~120 lines) from `execution_service.ts`
  into a standalone async function that scans model definitions and task.inputs
  for CEL expressions referencing other models' resources and file.contents.

- **Updated `src/domain/workflows/validation_service.ts`** — `validate()` is
  now async (returns `Promise<WorkflowValidationResult[]>`). Constructor accepts
  optional `YamlDefinitionRepository`. Added
  `validateNoStepCyclesWithImplicit()` that runs implicit dep resolution +
  topological sort. Error messages annotate which edges are implicit.

- **Refactored `src/domain/workflows/execution_service.ts`** — Replaced
  inline `buildStepNodesWithImplicitDeps` method with a call to the extracted
  function. Removed unused imports.

- **Updated `src/cli/commands/workflow_validate.ts`** — Passes
  `repoContext.definitionRepo` to the validation service constructor.

## Plan Conformance

All 7 items from the implementation plan were completed as specified:

| Plan Item | Status |
|---|---|
| 1. New `implicit_dependency_service.ts` | ✅ Line-for-line extraction |
| 2. Update `validation_service.ts` (async, optional repo, implicit check) | ✅ |
| 3. Refactor `execution_service.ts` to use extracted function | ✅ ~120 lines removed |
| 4. Update `workflow_validate.ts` to pass definitionRepo | ✅ |
| 5. New `implicit_dependency_service_test.ts` (6 unit tests) | ✅ |
| 6. Update `validation_service_test.ts` (4 new tests) | ✅ |
| 7. Integration test in `integration/workflow_test.ts` | ✅ |

One intentional deviation: uses `YamlDefinitionRepository` (concrete type)
instead of plan's `DefinitionRepository` (interface) because
`findDefinitionByIdOrName` requires the concrete type.

## Safety Analysis

**This is safe for normal operations:**

- **Backward-compatible constructor** — `new DefaultWorkflowValidationService()`
  without args still works, skipping the implicit check entirely (same as before).
- **`validate()` going async** — Only 3 consumers (service, test, CLI command).
  All callers already used `await` in tests. CLI command updated.
- **Execution service refactor** — Line-for-line extraction, behavior identical.
- **Graceful degradation** — If model definitions can't be found, the check
  silently passes (no worse than status quo).

**One behavioral change:** Workflows that previously passed `validate` may now
fail if they have implicit CEL dependencies that create a cycle with explicit
`dependsOn`. This is the intended fix — catching cycles at validation time rather
than at runtime.

## Test Plan

- 6 new unit tests for `implicit_dependency_service.ts` (no deps, resource deps,
  file.contents deps, task.inputs deps, missing model, deduplication)
- 4 new unit tests for `validation_service.ts` (cycle detected, no cycle, no
  repo, missing models)
- 1 new integration test (end-to-end CLI cycle detection with two model
  definitions and reverse-order explicit deps)
- All 1752 existing tests continue to pass
- `deno check`, `deno lint`, `deno fmt`, `deno run compile` all pass