### PR TITLE
docs: Add expression guidance, CRUD lifecycle patterns, and troubleshooting for extension models

### DIFF
--- a/.claude/skills/swamp-data/SKILL.md
+++ b/.claude/skills/swamp-data/SKILL.md
@@ -283,7 +283,12 @@ swamp data gc -f --json  # Skip confirmation prompt
 
 ## Accessing Data in Expressions
 
-Use CEL expressions to access model data in workflows and model inputs:
+Use CEL expressions to access model data in workflows and model inputs.
+
+**Note:** `model.<name>.resource.<spec>` requires the model to have previously
+produced data (a method was run that called `writeResource`). If no data exists
+yet, accessing `.resource` will fail with "No such key". Use
+`swamp data list <model-name>` to verify data exists.
 
 ```yaml
 # Access latest resource data via dot notation
@@ -347,13 +352,20 @@ subnets: ${{ data.findBySpec("my-scanner", "subnet") }}
 
 **Key rules:**
 
-- `model.<name>.resource.<specName>.<instanceName>` accesses the latest version
-  of a resource
-- `model.<name>.file.<specName>.<instanceName>` accesses file metadata (path,
-  size, contentType)
+- `model.<name>.resource.<specName>.<instanceName>` — accesses the latest
+  version of a resource. Works both within a workflow run (in-memory updates)
+  and across workflow runs (persisted data). Creates implicit step dependencies
+  in workflows.
+- `model.<name>.file.<specName>.<instanceName>` — accesses file metadata (path,
+  size, contentType). Same behavior as resource expressions.
+- `data.latest(modelName, dataName)` — reads persisted data snapshot taken at
+  workflow start. Does not create implicit step dependencies. Useful when you
+  want explicit control over execution ordering.
 - Use `data.version()` function for specific versions
 - Use `data.findByTag()` to query across models
-- Resource/file expressions create implicit step dependencies in workflows
+- See the `swamp-workflow` skill's
+  [data-chaining reference](../swamp-workflow/references/data-chaining.md) for
+  detailed guidance on expression choice in workflows.
 
 ## Data Ownership
 

--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -193,6 +193,28 @@ resources: {
 | `garbageCollection` | Yes      | Version retention policy                      |
 | `tags`              | No       | Extra tags (auto-includes `type: "resource"`) |
 
+**Spec naming:** Resource spec keys must not contain hyphens (`-`). CEL
+expressions use dot-notation to access resources
+(`model.<m>.resource.<specName>.<instanceName>.attributes.<field>`), and hyphens
+in spec names are interpreted as the subtraction operator. Use camelCase or
+single words instead (e.g., `igw` not `internet-gateway`, `routeTable` not
+`route-table`).
+
+**Schema and expression validation:** If your resource will be referenced by
+other models via CEL expressions, you must declare the referenced properties
+explicitly in the Zod schema. Using `z.object({}).passthrough()` allows any data
+to be stored, but the expression path validator cannot resolve attribute
+references against an empty schema. Always declare the key properties you need
+to reference:
+
+```typescript
+// Wrong — expression validator can't resolve attributes.VpcId
+schema: z.object({}).passthrough(),
+
+// Correct — VpcId is declared so expressions can reference it
+schema: z.object({ VpcId: z.string() }).passthrough(),
+```
+
 ### File Specs
 
 Files are binary or text content (including logs):
@@ -325,6 +347,39 @@ the `<instanceName>` used in CEL:
 
 The execute function returns `{ dataHandles?: DataHandle[] }`.
 
+### Reading Stored Data
+
+Delete and update methods need to read back previously stored resource data
+(e.g., to get a resource ID for cleanup). Use `context.dataRepository` with
+`context.modelType` and `context.modelId`:
+
+```typescript
+const content = await context.dataRepository.getContent(
+  context.modelType,
+  context.modelId,
+  "<specName>", // matches a key in resources
+  "<instanceName>", // instance name used when writing
+);
+// Returns Uint8Array | null
+```
+
+To parse the content:
+
+```typescript
+if (!content) {
+  throw new Error("No data found - nothing to delete");
+}
+const data = JSON.parse(new TextDecoder().decode(content));
+```
+
+**Key dataRepository methods for model authors:**
+
+| Method                                                    | Returns              | Description                            |
+| --------------------------------------------------------- | -------------------- | -------------------------------------- |
+| `getContent(type, modelId, dataName, instanceName, ver?)` | `Uint8Array \| null` | Get raw content bytes                  |
+| `findByName(type, modelId, dataName, instanceName, ver?)` | `Data \| null`       | Get data metadata (tags, version, etc) |
+| `findAllForModel(type, modelId)`                          | `Data[]`             | List all data for this model instance  |
+
 ### Lifetime Values
 
 | Value       | Behavior                                     |
@@ -454,6 +509,29 @@ subnetA: ${{ model.my-scanner.resource.subnet.subnet-aaa.attributes.cidr }}
 | ------------------ | ------------------------------------------------ |
 | Factory model      | One execution discovers/creates N outputs        |
 | forEach (workflow) | Run the same model N times with different inputs |
+
+## CRUD Lifecycle Models
+
+Models that manage real resources typically have `create`, `update`, and
+`delete` methods. See
+[references/examples.md](references/examples.md#crud-lifecycle-model-vpc) for a
+complete VPC example with all three methods.
+
+**Pattern summary:**
+
+- **`create`** — run a command/API call, store the result via `writeResource()`
+- **`update`** — read stored data via `context.dataRepository.getContent()`,
+  modify the resource, write updated state via `writeResource()` (new version)
+- **`delete`** — read stored data, clean up the resource, return
+  `{ dataHandles: [] }`
+
+**Delete workflow ordering:** Delete workflows require **explicit `dependsOn`**
+in reverse dependency order. Unlike create workflows where CEL expressions
+create implicit dependencies, delete methods read their own stored data via
+`context.dataRepository` — not other models' data via expressions. See the
+`swamp-workflow` skill's
+[data-chaining reference](../swamp-workflow/references/data-chaining.md) for
+delete workflow examples.
 
 ## Extending Existing Model Types
 
@@ -892,6 +970,11 @@ swamp model type describe @myorg/my-model   # Check schema
 
 ## References
 
+- **Examples**: See [references/examples.md](references/examples.md) for
+  complete model examples (CRUD lifecycle, data chaining, extensions, etc.)
+- **Troubleshooting**: See
+  [references/troubleshooting.md](references/troubleshooting.md) for common
+  errors and fixes
 - **Built-in example**: See `src/domain/models/echo/echo_model.ts` for reference
 - **Model loader**: See `src/domain/models/user_model_loader.ts` for API details
 - **Model design**: See [design/models.md](design/models.md) for concepts

--- a/.claude/skills/swamp-extension-model/references/examples.md
+++ b/.claude/skills/swamp-extension-model/references/examples.md
@@ -1,5 +1,196 @@
 # Extension Model Examples
 
+## Table of Contents
+
+- [CRUD Lifecycle Model (VPC)](#crud-lifecycle-model-vpc)
+- [Text Processor Model](#text-processor-model)
+- [Deployment Model](#deployment-model)
+- [Minimal Echo Model](#minimal-echo-model)
+- [Data Chaining Model](#data-chaining-model)
+- [Shell Command with Streamed Logging](#shell-command-with-streamed-logging)
+- [Extending Existing Model Types](#extending-existing-model-types)
+
+## CRUD Lifecycle Model (VPC)
+
+Models that manage real resources typically have `create`, `update`, and
+`delete` methods. Each method follows a distinct pattern:
+
+- **`create`** — runs a command, stores the result via `writeResource()`
+- **`update`** — reads stored data to get the resource ID, modifies the
+  resource, writes updated state via `writeResource()` (creates a new version)
+- **`delete`** — reads stored data to get the resource ID, cleans up, returns
+  `{ dataHandles: [] }`
+
+```typescript
+// extensions/models/vpc.ts
+import { z } from "npm:zod@4";
+
+const GlobalArgsSchema = z.object({
+  cidrBlock: z.string(),
+  region: z.string().default("us-east-1"),
+});
+
+const VpcSchema = z.object({
+  VpcId: z.string(),
+}).passthrough();
+
+export const model = {
+  type: "@user/vpc",
+  version: "2026.02.10.1",
+  globalArguments: GlobalArgsSchema,
+  resources: {
+    "vpc": {
+      description: "VPC resource state",
+      schema: VpcSchema,
+      lifetime: "infinite",
+      garbageCollection: 10,
+    },
+  },
+  methods: {
+    create: {
+      description: "Create a VPC",
+      arguments: z.object({}),
+      execute: async (_args, context) => {
+        const { cidrBlock, region } = context.globalArgs;
+
+        const cmd = new Deno.Command("aws", {
+          args: [
+            "ec2",
+            "create-vpc",
+            "--cidr-block",
+            cidrBlock,
+            "--region",
+            region,
+            "--output",
+            "json",
+          ],
+          stdout: "piped",
+          stderr: "piped",
+        });
+        const output = await cmd.output();
+        const vpcData = JSON.parse(new TextDecoder().decode(output.stdout)).Vpc;
+
+        const handle = await context.writeResource!("vpc", "vpc", vpcData);
+        return { dataHandles: [handle] };
+      },
+    },
+    update: {
+      description: "Update VPC attributes (e.g., enable DNS support)",
+      arguments: z.object({}),
+      execute: async (_args, context) => {
+        const region = context.globalArgs.region;
+
+        // 1. Read stored data to get the resource ID
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          "vpc",
+          "vpc",
+        );
+
+        if (!content) {
+          throw new Error("No VPC data found - run create first");
+        }
+
+        const existingData = JSON.parse(new TextDecoder().decode(content));
+        const vpcId = existingData.VpcId;
+
+        // 2. Modify the resource
+        const modifyCmd = new Deno.Command("aws", {
+          args: [
+            "ec2",
+            "modify-vpc-attribute",
+            "--vpc-id",
+            vpcId,
+            "--enable-dns-support",
+            '{"Value": true}',
+            "--region",
+            region,
+          ],
+          stdout: "piped",
+          stderr: "piped",
+        });
+        await modifyCmd.output();
+
+        // 3. Describe to get current state
+        const describeCmd = new Deno.Command("aws", {
+          args: [
+            "ec2",
+            "describe-vpcs",
+            "--vpc-ids",
+            vpcId,
+            "--region",
+            region,
+            "--output",
+            "json",
+          ],
+          stdout: "piped",
+          stderr: "piped",
+        });
+        const describeOutput = await describeCmd.output();
+        const updatedData = JSON.parse(
+          new TextDecoder().decode(describeOutput.stdout),
+        ).Vpcs[0];
+
+        // 4. Write updated state — creates a new version of the resource
+        const handle = await context.writeResource!("vpc", "vpc", updatedData);
+        return { dataHandles: [handle] };
+      },
+    },
+    delete: {
+      description: "Delete the VPC",
+      arguments: z.object({}),
+      execute: async (_args, context) => {
+        const region = context.globalArgs.region;
+
+        // Read back stored data to get the VPC ID
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          "vpc",
+          "vpc",
+        );
+
+        if (!content) {
+          throw new Error("No VPC data found - nothing to delete");
+        }
+
+        const vpcData = JSON.parse(new TextDecoder().decode(content));
+        const vpcId = vpcData.VpcId;
+
+        const cmd = new Deno.Command("aws", {
+          args: [
+            "ec2",
+            "delete-vpc",
+            "--vpc-id",
+            vpcId,
+            "--region",
+            region,
+          ],
+          stdout: "piped",
+          stderr: "piped",
+        });
+        await cmd.output();
+
+        // Return empty dataHandles — resource is gone
+        return { dataHandles: [] };
+      },
+    },
+  },
+};
+```
+
+**Key points:**
+
+- `create` stores data via `writeResource` — makes it available to other models
+  via CEL expressions and to update/delete methods via `dataRepository`
+- `update` reads stored data, modifies the resource, writes updated state via
+  `writeResource` (creates a new version)
+- `delete` reads stored data via `context.dataRepository.getContent()` using
+  `context.modelType` and `context.modelId` to locate the model's own data
+- `delete` returns `{ dataHandles: [] }` since no new data is produced
+- Always check for `null` content — the model may not have been created yet
+
 ## Text Processor Model
 
 ```typescript

--- a/.claude/skills/swamp-extension-model/references/troubleshooting.md
+++ b/.claude/skills/swamp-extension-model/references/troubleshooting.md
@@ -1,5 +1,22 @@
 # Troubleshooting Extension Models
 
+## Table of Contents
+
+- [Common Errors](#common-errors)
+  - [No 'model' or 'extension' export found](#no-model-or-extension-export-found)
+  - [Unknown resource spec / Unknown file spec](#unknown-resource-spec-or-unknown-file-spec)
+  - [Model type already registered](#model-type-already-registered)
+  - [Model type must use '@' prefix](#model-type-must-use--prefix)
+  - [Uses a reserved namespace](#uses-a-reserved-namespace)
+  - [Cannot extend unregistered model type](#cannot-extend-unregistered-model-type)
+  - [Method already exists](#method-x-already-exists-on-model-type-y)
+  - [Duplicate method name](#duplicate-method-name-x-within-extension-methods-array)
+  - [No such key in CEL expressions](#no-such-key-specname-in-cel-expressions)
+  - [Property not found in expression path validation](#property-not-found-in-expression-path-validation)
+  - [Syntax errors on load](#syntax-errors-on-load)
+- [Configuration](#configuration)
+- [Verification Commands](#verification-commands)
+
 ## Common Errors
 
 ### "No 'model' or 'extension' export found"
@@ -105,6 +122,51 @@ method name.
 The same method name appears in multiple elements of the `methods` array within
 a single extension file. Each method name must be unique across all array
 elements.
+
+### "No such key: &lt;specName&gt;" in CEL expressions
+
+This occurs when a CEL expression like
+`model.<m>.resource.<specName>.<instanceName>.attributes.X` can't find the
+resource. Common causes:
+
+**1. Instance name mismatch.** The `name` parameter (second argument) passed to
+`writeResource` determines the instance name. If you wrote
+`writeResource("vpc", "my-vpc", data)`, the CEL path is
+`model.<m>.resource.vpc.my-vpc.attributes.X`. Using just
+`model.<m>.resource.vpc` won't work — you need the full path including instance
+name.
+
+```typescript
+// Writes to instance name "vpc"
+await context.writeResource("vpc", "vpc", data);
+// CEL: model.<name>.resource.vpc.vpc.attributes.X
+```
+
+**2. Resource spec name contains hyphens.** CEL interprets hyphens as
+subtraction, so `model.<m>.resource.internet-gateway` is parsed as
+`resource.internet` minus `gateway`. Use camelCase or single words for spec
+names (e.g., `igw`, `routeTable`).
+
+**3. Model has never been executed.** The `resource` key on `model.<name>` is
+only populated if the model has produced data (a method was run that called
+`writeResource`). If no data exists, `model.<name>` has `input` and `definition`
+keys but no `resource` key. Run the create method or workflow first, or check
+with `swamp data list <model-name>` to verify data exists.
+
+### "Property not found" in expression path validation
+
+The expression path validator checks that referenced attributes exist in the
+resource's Zod schema. If you use `z.object({}).passthrough()`, the schema has
+no declared properties and the validator can't resolve paths like
+`attributes.VpcId`. Declare the properties you need to reference:
+
+```typescript
+// Wrong — validator can't resolve attributes.VpcId
+schema: z.object({}).passthrough(),
+
+// Correct — VpcId is declared, .passthrough() allows additional fields
+schema: z.object({ VpcId: z.string() }).passthrough(),
+```
 
 ### Syntax errors on load
 

--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -432,6 +432,7 @@ End-to-end workflow creation:
   [references/expressions-and-foreach.md](references/expressions-and-foreach.md)
   for forEach iteration patterns, CEL expressions, implicit dependency
   resolution, environment variables, and data artifact tagging
-- **Data chaining**: See
-  [references/data-chaining.md](references/data-chaining.md) for aws/cli model
-  workflow examples and chaining patterns
+- **Data chaining and lifecycle workflows**: See
+  [references/data-chaining.md](references/data-chaining.md) for `model.*` vs
+  `data.latest()` expression guidance, delete/update workflow ordering, and
+  aws/cli chaining examples

--- a/.claude/skills/swamp-workflow/references/data-chaining.md
+++ b/.claude/skills/swamp-workflow/references/data-chaining.md
@@ -1,5 +1,15 @@
 # Data Chaining in Workflows
 
+## Table of Contents
+
+- [Implicit Dependency Resolution](#implicit-dependency-resolution)
+- [Example: Dynamic AMI Lookup Workflow](#example-dynamic-ami-lookup-workflow)
+- [Example: Multi-Step Infrastructure Workflow](#example-multi-step-infrastructure-workflow)
+- [Choosing model.\* vs data.latest() Expressions](#choosing-model-vs-datalatest-expressions)
+- [Resource References](#resource-references)
+- [Delete Workflow Ordering](#delete-workflow-ordering)
+- [Update Workflow Ordering](#update-workflow-ordering)
+
 The `aws/cli` model enables powerful data chaining in workflows by running AWS
 CLI commands and making the output available to other models. This is useful for
 dynamic lookups like finding the latest AMI, checking resource state, or
@@ -64,6 +74,48 @@ attributes:
 
 The workflow engine detects that `my-instance` references
 `latest-ami.resource.data.data.attributes`, creating an implicit dependency.
+
+## Choosing `model.*` vs `data.latest()` Expressions
+
+Model instance definitions use CEL expressions to reference other models' data.
+Both expression forms work for cross-workflow data access, but they have
+different characteristics:
+
+| Expression                        | Sees current-run data?                              | Sees prior-run data?                              | Implicit deps? |
+| --------------------------------- | --------------------------------------------------- | ------------------------------------------------- | -------------- |
+| `model.<name>.resource.<spec>`    | **Yes** — in-memory context updated after each step | **Yes** — reads persisted data with `type` intact | **Yes**        |
+| `data.latest("<name>", "<spec>")` | **No** — snapshot taken at workflow start           | **Yes** — reads persisted data regardless of tags | **No**         |
+
+### When to use each
+
+**Use `model.*`** for most cases:
+
+- Intra-workflow chaining (step B reads step A's output in the same run)
+- Cross-workflow chaining (workflow B reads data from prior workflow A run)
+- When you want automatic step dependency ordering
+
+**Use `data.latest()`** when:
+
+- You explicitly don't want implicit dependencies created
+- You need to query data by model name dynamically
+- You're building advanced patterns where automatic ordering would cause cycles
+
+### Implicit dependency ordering
+
+`model.*` expressions create **implicit step dependencies** — Swamp detects
+`model.<name>.resource` references and automatically orders the referencing step
+after the step that writes that model's data. This is helpful for create
+workflows but can cause **cyclic dependency errors** in delete workflows:
+
+1. Explicit `dependsOn` says: delete subnet first, then delete VPC
+2. If subnet's definition still has `model.vpc` expression, implicit dependency
+   says: VPC step must run before subnet step
+3. These two constraints conflict → **cycle detected**
+
+**Solution for delete workflows:** Use `context.dataRepository` in the model's
+delete method to read its own stored data, rather than CEL expressions that
+reference other models. See
+[Delete Workflow Ordering](#delete-workflow-ordering) below.
 
 ## Example: Multi-Step Infrastructure Workflow
 
@@ -156,3 +208,165 @@ All model data outputs are accessed via
 | aws/cli       | `data`     | `model.ami-lookup.resource.data.data.attributes.json.ImageId` |
 | Cloud Control | `resource` | `model.my-vpc.resource.resource.resource.attributes.VpcId`    |
 | Custom models | (varies)   | `model.my-deploy.resource.state.state.attributes.endpoint`    |
+
+## Delete Workflow Ordering
+
+Delete workflows require **explicit `dependsOn`** in reverse dependency order.
+Unlike create workflows where CEL expressions (e.g.,
+`${{ model.vpc.resource.vpc.vpc.attributes.VpcId }}`) create implicit
+dependencies, delete methods read their own stored data via
+`context.dataRepository` — not other models' data via expressions. There are no
+expression-based references to trigger implicit dependency detection, so you
+must declare the ordering explicitly.
+
+The dependency graph for a delete workflow is the **reverse** of the create
+workflow.
+
+### Example: Delete Networking
+
+```yaml
+id: delete-networking
+name: delete-networking
+description: Delete all networking resources in reverse dependency order
+version: 1
+jobs:
+  - name: delete-route-tables
+    description: Disassociate and delete route tables first
+    steps:
+      - name: delete-public-route-table
+        task:
+          type: model_method
+          modelIdOrName: public-route-table
+          methodName: delete
+      - name: delete-private-route-table
+        task:
+          type: model_method
+          modelIdOrName: private-route-table
+          methodName: delete
+    dependsOn: []
+
+  - name: delete-subnets-and-igw
+    description: Delete subnets and internet gateway
+    steps:
+      - name: delete-public-subnet
+        task:
+          type: model_method
+          modelIdOrName: public-subnet
+          methodName: delete
+      - name: delete-private-subnet
+        task:
+          type: model_method
+          modelIdOrName: private-subnet
+          methodName: delete
+      - name: delete-igw
+        task:
+          type: model_method
+          modelIdOrName: networking-igw
+          methodName: delete
+    dependsOn:
+      - job: delete-route-tables
+        condition:
+          type: succeeded
+
+  - name: delete-vpc
+    description: Delete the VPC last
+    steps:
+      - name: delete-vpc
+        task:
+          type: model_method
+          modelIdOrName: networking-vpc
+          methodName: delete
+    dependsOn:
+      - job: delete-subnets-and-igw
+        condition:
+          type: succeeded
+```
+
+**Ordering rationale** (reverse of create):
+
+| Create order (first → last) | Delete order (first → last) |
+| --------------------------- | --------------------------- |
+| 1. VPC                      | 1. Route tables             |
+| 2. Subnets, IGW             | 2. Subnets, IGW             |
+| 3. Route tables             | 3. VPC                      |
+
+**Key points:**
+
+- Use **job-level `dependsOn`** to enforce ordering between groups of deletions
+- Each delete method reads its own stored data — no cross-model CEL references
+- Steps within a job can run in parallel (e.g., public and private subnets
+  delete concurrently)
+- Always delete dependent resources before the resources they depend on (e.g.,
+  route tables before subnets, subnets before VPC)
+
+## Update Workflow Ordering
+
+Update workflows follow the **same dependency order as create** — update the
+foundation first, then dependents. Like delete workflows, update methods read
+their own stored data via `context.dataRepository` and don't reference other
+models via CEL expressions, so you need **explicit `dependsOn`**.
+
+The key difference from delete: update methods call `writeResource()` to persist
+the updated state (creating a new version), so the stored data stays current for
+subsequent workflows.
+
+```yaml
+id: update-networking
+name: update-networking
+description: Update networking resources (e.g., enable DNS, modify tags)
+version: 1
+jobs:
+  - name: update-vpc
+    description: Update VPC attributes first
+    steps:
+      - name: update-vpc
+        task:
+          type: model_method
+          modelIdOrName: networking-vpc
+          methodName: update
+    dependsOn: []
+
+  - name: update-subnets-and-igw
+    description: Update subnets and internet gateway
+    steps:
+      - name: update-public-subnet
+        task:
+          type: model_method
+          modelIdOrName: public-subnet
+          methodName: update
+      - name: update-private-subnet
+        task:
+          type: model_method
+          modelIdOrName: private-subnet
+          methodName: update
+    dependsOn:
+      - job: update-vpc
+        condition:
+          type: succeeded
+
+  - name: update-route-tables
+    description: Update route tables last
+    steps:
+      - name: update-public-route-table
+        task:
+          type: model_method
+          modelIdOrName: public-route-table
+          methodName: update
+      - name: update-private-route-table
+        task:
+          type: model_method
+          modelIdOrName: private-route-table
+          methodName: update
+    dependsOn:
+      - job: update-subnets-and-igw
+        condition:
+          type: succeeded
+```
+
+**Ordering across lifecycle phases:**
+
+| Phase  | Dependency order             | Method pattern                                        |
+| ------ | ---------------------------- | ----------------------------------------------------- |
+| Create | Forward (VPC → subnets → RT) | Write new data via `writeResource()`                  |
+| Update | Forward (VPC → subnets → RT) | Read stored data, modify, write via `writeResource()` |
+| Delete | Reverse (RT → subnets → VPC) | Read stored data, clean up, return empty handles      |

--- a/.claude/skills/swamp-workflow/references/nested-workflows.md
+++ b/.claude/skills/swamp-workflow/references/nested-workflows.md
@@ -1,5 +1,13 @@
 # Calling Workflows from Workflows
 
+## Table of Contents
+
+- [Basic Nested Workflow](#basic-nested-workflow)
+- [Workflow Task Fields](#workflow-task-fields)
+- [Nested Workflow with forEach](#nested-workflow-with-foreach)
+- [Data Access in Sub-Workflows](#data-access-in-sub-workflows)
+- [Limitations](#limitations)
+
 Steps can invoke another workflow using `type: workflow`. The parent step waits
 for the child workflow to complete before continuing.
 
@@ -95,6 +103,52 @@ jobs:
           inputs:
             environment: ${{ self.env }}
 ```
+
+## Data Access in Sub-Workflows
+
+Sub-workflow model instances can access data produced by the parent workflow
+using either `model.*` or `data.latest()` expressions. Both work for
+cross-workflow data access since `type: "resource"` is preserved on
+workflow-produced data.
+
+**Example: Parent workflow creates resources, sub-workflow tags them**
+
+```yaml
+# create-networking workflow (parent)
+jobs:
+  - name: create
+    steps:
+      - name: create-vpc
+        task:
+          type: model_method
+          modelIdOrName: networking-vpc
+          methodName: create
+  - name: tag
+    dependsOn:
+      - job: create
+        condition:
+          type: succeeded
+    steps:
+      - name: tag-resources
+        task:
+          type: workflow
+          workflowIdOrName: tag-networking
+```
+
+The `tag-networking` sub-workflow's model instances can reference the VPC data:
+
+```yaml
+# tag-vpc model instance (used by tag-networking workflow)
+name: tag-vpc
+attributes:
+  region: us-east-1
+  resourceId: ${{ model.networking-vpc.resource.vpc.vpc.attributes.VpcId }}
+  tagKey: ManagedBy
+  tagValue: Swamp
+```
+
+See [data-chaining.md](data-chaining.md) for more details on expression choice
+and implicit dependency behavior.
 
 ## Limitations
 


### PR DESCRIPTION
- Add comprehensive documentation for CRUD lifecycle model patterns (create/update/delete methods)
- Document `model.*` vs `data.latest()` expression characteristics and when to use each
- Add troubleshooting guidance for common CEL expression errors
- Document delete and update workflow ordering requirements

## Background

PR #279 attempted to document expression scoping rules, but was based on the assumption that `model.*` expressions only
worked intra-workflow due to tag filtering. PR #280 subsequently fixed the underlying issue by changing workflow tagging
from `type: "step-output"` to `source: "step-output"`, preserving `type: "resource"` so that `model.*` expressions now
correctly resolve cross-workflow data.

This PR salvages the valuable documentation from #279 while correcting the technical guidance to reflect the current
(fixed) behavior:

| Expression | Behavior |
|------------|----------|
| `model.*` | Works both intra-workflow (in-memory updates) AND cross-workflow (persisted data). Creates implicit step
dependencies. |
| `data.latest()` | Snapshot taken at workflow start. Does not create implicit dependencies. |

The key distinction is now about **dependency control**, not scoping limitations.

## Changes

### swamp-extension-model/SKILL.md
- Spec naming guidance (no hyphens in CEL — interpreted as subtraction)
- Schema declaration requirements for expression path validation
- Reading Stored Data section for delete/update methods using `context.dataRepository`
- CRUD Lifecycle Models section with pattern summary
- Updated References section

### swamp-extension-model/references/examples.md
- Added Table of Contents
- Complete CRUD Lifecycle Model (VPC) example with create/update/delete methods

### swamp-extension-model/references/troubleshooting.md
- Added Table of Contents
- "No such key" troubleshooting (instance name mismatch, hyphens, model never executed)
- "Property not found" schema validation troubleshooting

### swamp-workflow/references/data-chaining.md
- Added Table of Contents
- Expression choice guidance (`model.*` vs `data.latest()`) with corrected behavior
- Delete Workflow Ordering section with complete example
- Update Workflow Ordering section with complete example

### swamp-workflow/references/nested-workflows.md
- Added Table of Contents
- Data Access in Sub-Workflows section

### swamp-data/SKILL.md
- Note about data existence requirement for `model.*` expressions
- Clarified Key rules with expression characteristics

### swamp-workflow/SKILL.md
- Updated References section description

## Why These Changes Are Needed

1. **CRUD lifecycle patterns are undocumented** — Users building models that manage real resources need guidance on how
delete/update methods should read their own stored data via `context.dataRepository`

2. **Delete workflow ordering is non-obvious** — Unlike create workflows where CEL expressions create implicit
dependencies, delete methods don't reference other models via expressions, requiring explicit `dependsOn` in reverse order

3. **Common errors lack troubleshooting guidance** — "No such key" errors from instance name mismatches or hyphenated spec
names are common but not documented

4. **Expression characteristics need clarification** — Users need to understand when `model.*` creates implicit
dependencies vs when to use `data.latest()` for explicit ordering control

## Test Plan

- Documentation only — no code changes
- Verified technical accuracy against implementation in `model_resolver.ts` and `execution_service.ts`