### PR TITLE
feat: Add source fetch commands for troubleshooting (Issue #177)

### DIFF
--- a/.claude/skills/swamp-troubleshooting/SKILL.md
+++ b/.claude/skills/swamp-troubleshooting/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: swamp-troubleshooting
+description: Debug and diagnose swamp issues using source code. Use when troubleshooting swamp bugs, unexpected behavior, or errors. Triggers on "debug swamp", "swamp bug", "swamp error", "unexpected behavior", "swamp issue", "troubleshoot swamp", "diagnose swamp", "swamp not working", "swamp broken", "fix swamp", "swamp problem", "swamp crash", "source code", "read swamp source".
+---
+
+# Swamp Troubleshooting Skill
+
+Diagnose and troubleshoot swamp issues by fetching and reading the swamp source
+code. All commands support `--json` for machine-readable output.
+
+## Quick Reference
+
+| Task                | Command                                      |
+| ------------------- | -------------------------------------------- |
+| Check source status | `swamp source path --json`                   |
+| Fetch source        | `swamp source fetch --json`                  |
+| Fetch specific ver  | `swamp source fetch --version v1.0.0 --json` |
+| Fetch main branch   | `swamp source fetch --version main --json`   |
+| Clean source        | `swamp source clean --json`                  |
+
+## Troubleshooting Workflow
+
+When a user reports a swamp issue:
+
+### 1. Check Current Source Status
+
+```bash
+swamp source path --json
+```
+
+**Output shape (found):**
+
+```json
+{
+  "status": "found",
+  "version": "20260206.200442.0-sha.abc123",
+  "path": "/Users/user/.swamp/source",
+  "fileCount": 245,
+  "fetchedAt": "2026-02-06T20:04:42.000Z"
+}
+```
+
+**Output shape (not found):**
+
+```json
+{
+  "status": "not_found"
+}
+```
+
+### 2. Fetch Source If Needed
+
+If source is missing or the version doesn't match the user's swamp version:
+
+```bash
+swamp source fetch --json
+```
+
+This fetches source for the current CLI version. To fetch a specific version:
+
+```bash
+swamp source fetch --version 20260206.200442.0-sha.abc123 --json
+```
+
+**Output shape:**
+
+```json
+{
+  "status": "fetched",
+  "version": "20260206.200442.0-sha.abc123",
+  "path": "/Users/user/.swamp/source",
+  "fileCount": 245,
+  "fetchedAt": "2026-02-06T20:04:42.000Z",
+  "previousVersion": "20260205.100000.0-sha.xyz789"
+}
+```
+
+### 3. Read Source Files
+
+Once source is fetched, read files from `~/.swamp/source/`:
+
+**Key directories:**
+
+- `src/cli/` - CLI commands and entry point
+- `src/domain/` - Domain logic (models, workflows, vaults, etc.)
+- `src/infrastructure/` - Infrastructure adapters (persistence, HTTP, etc.)
+- `src/presentation/` - Output rendering
+
+**Example: Read the CLI entry point**
+
+```
+Read ~/.swamp/source/src/cli/mod.ts
+```
+
+**Example: Read model service**
+
+```
+Read ~/.swamp/source/src/domain/models/model_service.ts
+```
+
+### 4. Diagnose the Issue
+
+Based on the error message or symptoms:
+
+1. **Command not working**: Check `src/cli/commands/{command}.ts`
+2. **Model issues**: Check `src/domain/models/`
+3. **Workflow issues**: Check `src/domain/workflows/`
+4. **Vault/secret issues**: Check `src/domain/vaults/`
+5. **Data persistence issues**: Check `src/infrastructure/persistence/`
+6. **Output formatting issues**: Check `src/presentation/output/`
+
+### 5. Explain and Suggest Fixes
+
+After diagnosing:
+
+1. Explain what the code is doing
+2. Identify the root cause
+3. Suggest a workaround if available
+4. If it's a bug, summarize the issue and potential fix
+
+## Source Directory Structure
+
+```
+~/.swamp/source/
+├── src/
+│   ├── cli/
+│   │   ├── commands/        # CLI command implementations
+│   │   ├── context.ts       # Command context and options
+│   │   └── mod.ts           # CLI entry point
+│   ├── domain/
+│   │   ├── errors.ts        # User-facing errors
+│   │   ├── models/          # Model types and services
+│   │   ├── workflows/       # Workflow execution
+│   │   ├── vaults/          # Secret management
+│   │   ├── data/            # Data lifecycle
+│   │   └── events/          # Domain events
+│   ├── infrastructure/
+│   │   ├── persistence/     # File-based storage
+│   │   ├── logging/         # LogTape configuration
+│   │   └── update/          # Self-update mechanism
+│   └── presentation/
+│       └── output/          # Terminal output rendering
+├── integration/             # Integration tests
+├── design/                  # Design documents
+└── deno.json                # Deno configuration
+```
+
+## Clean Up Source
+
+When done troubleshooting:
+
+```bash
+swamp source clean --json
+```
+
+**Output shape:**
+
+```json
+{
+  "status": "cleaned",
+  "path": "/Users/user/.swamp/source"
+}
+```
+
+## Version Matching
+
+- By default, `swamp source fetch` downloads source matching the current CLI
+  version
+- Use `--version main` to get the latest unreleased code
+- Use `--version <tag>` to get a specific release
+
+## When to Use Other Skills
+
+| Need                    | Use Skill               |
+| ----------------------- | ----------------------- |
+| Run/create models       | `swamp-model`           |
+| Run/create workflows    | `swamp-workflow`        |
+| Manage secrets          | `swamp-vault`           |
+| Manage repository       | `swamp-repo`            |
+| Create extension models | `swamp-extension-model` |

--- a/src/cli/commands/source.ts
+++ b/src/cli/commands/source.ts
@@ -1,0 +1,33 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { sourceFetchCommand } from "./source_fetch.ts";
+import { sourcePathCommand } from "./source_path.ts";
+import { sourceCleanCommand } from "./source_clean.ts";
+
+export const sourceCommand = new Command()
+  .name("source")
+  .description("Manage swamp source code for troubleshooting")
+  .action(function () {
+    this.showHelp();
+  })
+  .command("fetch", sourceFetchCommand)
+  .command("path", sourcePathCommand)
+  .command("clean", sourceCleanCommand);

--- a/src/cli/commands/source_clean.ts
+++ b/src/cli/commands/source_clean.ts
@@ -1,0 +1,45 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { SourceService } from "../../domain/source/mod.ts";
+import { HttpSourceDownloader } from "../../infrastructure/source/http_source_downloader.ts";
+import { JsonSourceMetadataRepository } from "../../infrastructure/source/json_source_metadata_repository.ts";
+import { renderSourceClean } from "../../presentation/output/source_output.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const sourceCleanCommand = new Command()
+  .description("Remove downloaded swamp source")
+  .action(async function (options: AnyOptions) {
+    const ctx = createContext(options as GlobalOptions, ["source", "clean"]);
+    ctx.logger.debug("Executing source clean command");
+
+    const downloader = new HttpSourceDownloader();
+    const repository = new JsonSourceMetadataRepository();
+    const service = new SourceService(downloader, repository);
+
+    const result = await service.clean();
+
+    renderSourceClean(result, ctx.outputMode);
+
+    ctx.logger.debug("Source clean command completed");
+  });

--- a/src/cli/commands/source_fetch.ts
+++ b/src/cli/commands/source_fetch.ts
@@ -1,0 +1,54 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { VERSION } from "./version.ts";
+import { SourceService } from "../../domain/source/mod.ts";
+import { HttpSourceDownloader } from "../../infrastructure/source/http_source_downloader.ts";
+import { JsonSourceMetadataRepository } from "../../infrastructure/source/json_source_metadata_repository.ts";
+import { renderSourceFetch } from "../../presentation/output/source_output.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const sourceFetchCommand = new Command()
+  .description("Download swamp source code from GitHub")
+  .option(
+    "--version <version:string>",
+    "Version to fetch (tag or 'main')",
+  )
+  .action(async function (options: AnyOptions) {
+    const ctx = createContext(options as GlobalOptions, ["source", "fetch"]);
+    ctx.logger.debug("Executing source fetch command");
+
+    // Use current CLI version if no version specified
+    const version = options.version ?? VERSION;
+    ctx.logger.debug`Fetching source version: ${version}`;
+
+    const downloader = new HttpSourceDownloader();
+    const repository = new JsonSourceMetadataRepository();
+    const service = new SourceService(downloader, repository);
+
+    const result = await service.fetch(version);
+
+    renderSourceFetch(result, ctx.outputMode);
+
+    ctx.logger.debug("Source fetch command completed");
+  });

--- a/src/cli/commands/source_path.ts
+++ b/src/cli/commands/source_path.ts
@@ -1,0 +1,45 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { SourceService } from "../../domain/source/mod.ts";
+import { HttpSourceDownloader } from "../../infrastructure/source/http_source_downloader.ts";
+import { JsonSourceMetadataRepository } from "../../infrastructure/source/json_source_metadata_repository.ts";
+import { renderSourcePath } from "../../presentation/output/source_output.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const sourcePathCommand = new Command()
+  .description("Show swamp source location and version")
+  .action(async function (options: AnyOptions) {
+    const ctx = createContext(options as GlobalOptions, ["source", "path"]);
+    ctx.logger.debug("Executing source path command");
+
+    const downloader = new HttpSourceDownloader();
+    const repository = new JsonSourceMetadataRepository();
+    const service = new SourceService(downloader, repository);
+
+    const result = await service.getInfo();
+
+    renderSourcePath(result, ctx.outputMode);
+
+    ctx.logger.debug("Source path command completed");
+  });

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -31,6 +31,7 @@ import { vaultCommand } from "./commands/vault.ts";
 import { dataCommand } from "./commands/data.ts";
 import { telemetryCommand } from "./commands/telemetry_stats.ts";
 import { updateCommand } from "./commands/update.ts";
+import { sourceCommand } from "./commands/source.ts";
 import { type GlobalOptions, isStdinTty } from "./context.ts";
 import {
   ModelNameType,
@@ -241,6 +242,7 @@ export async function runCli(args: string[]): Promise<void> {
     .command("data", dataCommand)
     .command("telemetry", telemetryCommand)
     .command("update", updateCommand)
+    .command("source", sourceCommand)
     .command("completions", completionCommand);
 
   try {

--- a/src/domain/source/mod.ts
+++ b/src/domain/source/mod.ts
@@ -1,0 +1,32 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+export {
+  type SourceMetadata,
+  SourceMetadataSchema,
+} from "./source_metadata.ts";
+
+export {
+  type SourceCleanResult,
+  type SourceDownloader,
+  type SourceFetchResult,
+  type SourceInfoResult,
+  type SourceMetadataRepository,
+  SourceService,
+} from "./source_service.ts";

--- a/src/domain/source/source_metadata.ts
+++ b/src/domain/source/source_metadata.ts
@@ -1,0 +1,45 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { z } from "zod";
+
+/**
+ * Metadata about fetched swamp source code.
+ * Stored as .swamp-source-meta.json in the source directory.
+ */
+export interface SourceMetadata {
+  /** Version tag or branch name (e.g., "v1.2.3" or "main") */
+  version: string;
+  /** Absolute path to the extracted source directory */
+  path: string;
+  /** Number of files in the extracted source */
+  fileCount: number;
+  /** ISO timestamp when the source was fetched */
+  fetchedAt: string;
+}
+
+/**
+ * Zod schema for validating SourceMetadata from JSON.
+ */
+export const SourceMetadataSchema = z.object({
+  version: z.string(),
+  path: z.string(),
+  fileCount: z.number().int().nonnegative(),
+  fetchedAt: z.string().datetime(),
+});

--- a/src/domain/source/source_service.ts
+++ b/src/domain/source/source_service.ts
@@ -1,0 +1,205 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { SourceMetadata } from "./source_metadata.ts";
+
+/**
+ * Port interface for downloading source archives.
+ * Implemented by infrastructure adapters.
+ */
+export interface SourceDownloader {
+  /**
+   * Download and extract source archive for the given version.
+   * @param version Version tag (e.g., "v1.2.3") or "main" for the main branch
+   * @param targetDir Directory to extract source into
+   * @returns Number of files extracted
+   */
+  downloadAndExtract(version: string, targetDir: string): Promise<number>;
+}
+
+/**
+ * Port interface for source metadata persistence.
+ * Implemented by infrastructure adapters.
+ */
+export interface SourceMetadataRepository {
+  /**
+   * Read source metadata from disk.
+   * @returns Metadata if it exists, null otherwise
+   */
+  read(): Promise<SourceMetadata | null>;
+
+  /**
+   * Write source metadata to disk.
+   */
+  write(metadata: SourceMetadata): Promise<void>;
+
+  /**
+   * Delete source metadata file.
+   */
+  delete(): Promise<void>;
+
+  /**
+   * Get the source directory path.
+   */
+  getSourceDir(): string;
+}
+
+/**
+ * Result types for source operations.
+ */
+export type SourceFetchResult =
+  | {
+    status: "fetched";
+    version: string;
+    path: string;
+    fileCount: number;
+    fetchedAt: string;
+    previousVersion?: string;
+  }
+  | {
+    status: "already_fetched";
+    version: string;
+    path: string;
+    fileCount: number;
+    fetchedAt: string;
+  };
+
+export type SourceInfoResult =
+  | {
+    status: "found";
+    version: string;
+    path: string;
+    fileCount: number;
+    fetchedAt: string;
+  }
+  | { status: "not_found" };
+
+export type SourceCleanResult =
+  | { status: "cleaned"; path: string }
+  | { status: "not_found"; path: string };
+
+/**
+ * Domain service for managing swamp source code.
+ */
+export class SourceService {
+  constructor(
+    private readonly downloader: SourceDownloader,
+    private readonly repository: SourceMetadataRepository,
+  ) {}
+
+  /**
+   * Fetch source code for the given version.
+   * If the same version is already fetched, returns early.
+   */
+  async fetch(version: string): Promise<SourceFetchResult> {
+    const existing = await this.repository.read();
+
+    // Check if we already have this version
+    if (existing && existing.version === version) {
+      return {
+        status: "already_fetched",
+        version: existing.version,
+        path: existing.path,
+        fileCount: existing.fileCount,
+        fetchedAt: existing.fetchedAt,
+      };
+    }
+
+    const previousVersion = existing?.version;
+    const sourceDir = this.repository.getSourceDir();
+
+    // Clean existing source before downloading new version
+    if (existing) {
+      await this.cleanSourceDir(sourceDir);
+    }
+
+    // Download and extract
+    const fileCount = await this.downloader.downloadAndExtract(
+      version,
+      sourceDir,
+    );
+    const fetchedAt = new Date().toISOString();
+
+    // Save metadata
+    const metadata: SourceMetadata = {
+      version,
+      path: sourceDir,
+      fileCount,
+      fetchedAt,
+    };
+    await this.repository.write(metadata);
+
+    return {
+      status: "fetched",
+      version,
+      path: sourceDir,
+      fileCount,
+      fetchedAt,
+      previousVersion,
+    };
+  }
+
+  /**
+   * Get information about currently fetched source.
+   */
+  async getInfo(): Promise<SourceInfoResult> {
+    const metadata = await this.repository.read();
+    if (!metadata) {
+      return { status: "not_found" };
+    }
+
+    return {
+      status: "found",
+      version: metadata.version,
+      path: metadata.path,
+      fileCount: metadata.fileCount,
+      fetchedAt: metadata.fetchedAt,
+    };
+  }
+
+  /**
+   * Remove downloaded source and metadata.
+   */
+  async clean(): Promise<SourceCleanResult> {
+    const sourceDir = this.repository.getSourceDir();
+    const metadata = await this.repository.read();
+
+    if (!metadata) {
+      return { status: "not_found", path: sourceDir };
+    }
+
+    await this.cleanSourceDir(sourceDir);
+    await this.repository.delete();
+
+    return { status: "cleaned", path: sourceDir };
+  }
+
+  /**
+   * Remove source directory contents.
+   */
+  private async cleanSourceDir(sourceDir: string): Promise<void> {
+    try {
+      await Deno.remove(sourceDir, { recursive: true });
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+  }
+}

--- a/src/domain/source/source_service_test.ts
+++ b/src/domain/source/source_service_test.ts
@@ -1,0 +1,208 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import type { SourceMetadata } from "./source_metadata.ts";
+import {
+  type SourceDownloader,
+  type SourceMetadataRepository,
+  SourceService,
+} from "./source_service.ts";
+
+/**
+ * Mock implementation of SourceDownloader for testing.
+ */
+class MockSourceDownloader implements SourceDownloader {
+  downloadCalls: Array<{ version: string; targetDir: string }> = [];
+  fileCountToReturn = 100;
+
+  async downloadAndExtract(
+    version: string,
+    targetDir: string,
+  ): Promise<number> {
+    this.downloadCalls.push({ version, targetDir });
+    return await Promise.resolve(this.fileCountToReturn);
+  }
+}
+
+/**
+ * Mock implementation of SourceMetadataRepository for testing.
+ */
+class MockSourceMetadataRepository implements SourceMetadataRepository {
+  private metadata: SourceMetadata | null = null;
+  private readonly sourceDir: string;
+
+  constructor(sourceDir = "/test/.swamp/source") {
+    this.sourceDir = sourceDir;
+  }
+
+  getSourceDir(): string {
+    return this.sourceDir;
+  }
+
+  async read(): Promise<SourceMetadata | null> {
+    return await Promise.resolve(this.metadata);
+  }
+
+  async write(metadata: SourceMetadata): Promise<void> {
+    this.metadata = metadata;
+    await Promise.resolve();
+  }
+
+  async delete(): Promise<void> {
+    this.metadata = null;
+    await Promise.resolve();
+  }
+
+  // Test helper to set initial metadata
+  setMetadata(metadata: SourceMetadata): void {
+    this.metadata = metadata;
+  }
+}
+
+Deno.test("SourceService.fetch - downloads and saves metadata for new version", async () => {
+  const downloader = new MockSourceDownloader();
+  downloader.fileCountToReturn = 245;
+  const repository = new MockSourceMetadataRepository();
+  const service = new SourceService(downloader, repository);
+
+  const result = await service.fetch("v1.0.0");
+
+  assertEquals(result.status, "fetched");
+  if (result.status === "fetched") {
+    assertEquals(result.version, "v1.0.0");
+    assertEquals(result.fileCount, 245);
+    assertEquals(result.path, "/test/.swamp/source");
+    assertEquals(result.previousVersion, undefined);
+  }
+
+  assertEquals(downloader.downloadCalls.length, 1);
+  assertEquals(downloader.downloadCalls[0].version, "v1.0.0");
+});
+
+Deno.test("SourceService.fetch - returns already_fetched for same version", async () => {
+  const downloader = new MockSourceDownloader();
+  const repository = new MockSourceMetadataRepository();
+  repository.setMetadata({
+    version: "v1.0.0",
+    path: "/test/.swamp/source",
+    fileCount: 200,
+    fetchedAt: "2026-01-01T00:00:00.000Z",
+  });
+  const service = new SourceService(downloader, repository);
+
+  const result = await service.fetch("v1.0.0");
+
+  assertEquals(result.status, "already_fetched");
+  if (result.status === "already_fetched") {
+    assertEquals(result.version, "v1.0.0");
+    assertEquals(result.fileCount, 200);
+  }
+
+  // Should not have downloaded
+  assertEquals(downloader.downloadCalls.length, 0);
+});
+
+Deno.test("SourceService.fetch - replaces existing version with new one", async () => {
+  const downloader = new MockSourceDownloader();
+  downloader.fileCountToReturn = 300;
+  const repository = new MockSourceMetadataRepository();
+  repository.setMetadata({
+    version: "v1.0.0",
+    path: "/test/.swamp/source",
+    fileCount: 200,
+    fetchedAt: "2026-01-01T00:00:00.000Z",
+  });
+  const service = new SourceService(downloader, repository);
+
+  const result = await service.fetch("v2.0.0");
+
+  assertEquals(result.status, "fetched");
+  if (result.status === "fetched") {
+    assertEquals(result.version, "v2.0.0");
+    assertEquals(result.previousVersion, "v1.0.0");
+    assertEquals(result.fileCount, 300);
+  }
+
+  assertEquals(downloader.downloadCalls.length, 1);
+});
+
+Deno.test("SourceService.getInfo - returns not_found when no source", async () => {
+  const downloader = new MockSourceDownloader();
+  const repository = new MockSourceMetadataRepository();
+  const service = new SourceService(downloader, repository);
+
+  const result = await service.getInfo();
+
+  assertEquals(result.status, "not_found");
+});
+
+Deno.test("SourceService.getInfo - returns metadata when source exists", async () => {
+  const downloader = new MockSourceDownloader();
+  const repository = new MockSourceMetadataRepository();
+  repository.setMetadata({
+    version: "v1.0.0",
+    path: "/test/.swamp/source",
+    fileCount: 200,
+    fetchedAt: "2026-01-01T00:00:00.000Z",
+  });
+  const service = new SourceService(downloader, repository);
+
+  const result = await service.getInfo();
+
+  assertEquals(result.status, "found");
+  if (result.status === "found") {
+    assertEquals(result.version, "v1.0.0");
+    assertEquals(result.path, "/test/.swamp/source");
+    assertEquals(result.fileCount, 200);
+    assertEquals(result.fetchedAt, "2026-01-01T00:00:00.000Z");
+  }
+});
+
+Deno.test("SourceService.clean - returns not_found when no source", async () => {
+  const downloader = new MockSourceDownloader();
+  const repository = new MockSourceMetadataRepository();
+  const service = new SourceService(downloader, repository);
+
+  const result = await service.clean();
+
+  assertEquals(result.status, "not_found");
+  assertEquals(result.path, "/test/.swamp/source");
+});
+
+Deno.test("SourceService.clean - removes metadata when source exists", async () => {
+  const downloader = new MockSourceDownloader();
+  const repository = new MockSourceMetadataRepository();
+  repository.setMetadata({
+    version: "v1.0.0",
+    path: "/test/.swamp/source",
+    fileCount: 200,
+    fetchedAt: "2026-01-01T00:00:00.000Z",
+  });
+  const service = new SourceService(downloader, repository);
+
+  const result = await service.clean();
+
+  assertEquals(result.status, "cleaned");
+  assertEquals(result.path, "/test/.swamp/source");
+
+  // Verify metadata was deleted
+  const info = await service.getInfo();
+  assertEquals(info.status, "not_found");
+});

--- a/src/infrastructure/source/http_source_downloader.ts
+++ b/src/infrastructure/source/http_source_downloader.ts
@@ -1,0 +1,158 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import type { SourceDownloader } from "../../domain/source/mod.ts";
+import { UserError } from "../../domain/errors.ts";
+
+/**
+ * HTTP adapter for downloading swamp source archives from GitHub.
+ */
+export class HttpSourceDownloader implements SourceDownloader {
+  private static readonly GITHUB_BASE =
+    "https://github.com/systeminit/swamp/archive/refs";
+
+  /**
+   * Get the GitHub archive URL for a version.
+   * For "main", uses heads/main.tar.gz
+   * For version tags, uses tags/{version}.tar.gz
+   */
+  private getArchiveUrl(version: string): string {
+    if (version === "main") {
+      return `${HttpSourceDownloader.GITHUB_BASE}/heads/main.tar.gz`;
+    }
+    // For version tags (e.g., "v1.2.3" or "20260101.123456.0-sha.abc123")
+    return `${HttpSourceDownloader.GITHUB_BASE}/tags/${version}.tar.gz`;
+  }
+
+  /**
+   * Download and extract source archive for the given version.
+   */
+  async downloadAndExtract(
+    version: string,
+    targetDir: string,
+  ): Promise<number> {
+    const url = this.getArchiveUrl(version);
+
+    // Ensure target directory exists
+    await ensureDir(targetDir);
+
+    const tempDir = await Deno.makeTempDir({ prefix: "swamp-source-" });
+
+    try {
+      const tarballPath = join(tempDir, "source.tar.gz");
+
+      // Download the tarball
+      const response = await fetch(url);
+      if (!response.ok) {
+        if (response.status === 404) {
+          throw new UserError(
+            `Source version "${version}" not found. Check that the version tag exists.`,
+          );
+        }
+        throw new UserError(
+          `Failed to download source: HTTP ${response.status}`,
+        );
+      }
+      if (!response.body) {
+        throw new UserError("Failed to download source: empty response body");
+      }
+
+      const file = await Deno.open(tarballPath, {
+        write: true,
+        create: true,
+      });
+      try {
+        await response.body.pipeTo(file.writable);
+      } catch {
+        // writable stream may already be closed by pipeTo, that's fine
+      }
+
+      // Extract the tarball to temp directory first
+      const extractDir = join(tempDir, "extracted");
+      await ensureDir(extractDir);
+
+      const extract = new Deno.Command("tar", {
+        args: ["-xzf", tarballPath, "-C", extractDir],
+        stdout: "piped",
+        stderr: "piped",
+      });
+      const extractResult = await extract.output();
+      if (!extractResult.success) {
+        const stderr = new TextDecoder().decode(extractResult.stderr);
+        throw new UserError(`Failed to extract source archive: ${stderr}`);
+      }
+
+      // GitHub archives have a top-level directory like "swamp-main" or "swamp-v1.2.3"
+      // Move contents to target directory
+      const entries = [];
+      for await (const entry of Deno.readDir(extractDir)) {
+        entries.push(entry);
+      }
+
+      if (entries.length !== 1 || !entries[0].isDirectory) {
+        throw new UserError(
+          "Unexpected archive structure: expected single top-level directory",
+        );
+      }
+
+      const sourceRoot = join(extractDir, entries[0].name);
+
+      // Move all contents from the extracted directory to the target
+      let fileCount = 0;
+      fileCount = await this.moveContents(sourceRoot, targetDir);
+
+      return fileCount;
+    } finally {
+      // Cleanup temp directory
+      try {
+        await Deno.remove(tempDir, { recursive: true });
+      } catch {
+        // Best-effort cleanup
+      }
+    }
+  }
+
+  /**
+   * Recursively move contents from source to target directory.
+   * Returns the count of files moved.
+   */
+  private async moveContents(
+    sourceDir: string,
+    targetDir: string,
+  ): Promise<number> {
+    let fileCount = 0;
+
+    for await (const entry of Deno.readDir(sourceDir)) {
+      const sourcePath = join(sourceDir, entry.name);
+      const targetPath = join(targetDir, entry.name);
+
+      if (entry.isDirectory) {
+        await ensureDir(targetPath);
+        fileCount += await this.moveContents(sourcePath, targetPath);
+      } else {
+        await Deno.copyFile(sourcePath, targetPath);
+        fileCount++;
+      }
+    }
+
+    return fileCount;
+  }
+}

--- a/src/infrastructure/source/json_source_metadata_repository.ts
+++ b/src/infrastructure/source/json_source_metadata_repository.ts
@@ -1,0 +1,89 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { ensureDir } from "@std/fs";
+import { dirname } from "@std/path";
+import type {
+  SourceMetadata,
+  SourceMetadataRepository,
+} from "../../domain/source/mod.ts";
+import { SourceMetadataSchema } from "../../domain/source/mod.ts";
+import { getSourceMetaPath, getSwampSourceDir } from "./source_paths.ts";
+
+/**
+ * JSON file-based implementation of SourceMetadataRepository.
+ */
+export class JsonSourceMetadataRepository implements SourceMetadataRepository {
+  private readonly metaPath: string;
+  private readonly sourceDir: string;
+
+  constructor() {
+    this.metaPath = getSourceMetaPath();
+    this.sourceDir = getSwampSourceDir();
+  }
+
+  /**
+   * Get the source directory path.
+   */
+  getSourceDir(): string {
+    return this.sourceDir;
+  }
+
+  /**
+   * Read source metadata from disk.
+   */
+  async read(): Promise<SourceMetadata | null> {
+    try {
+      const content = await Deno.readTextFile(this.metaPath);
+      const data = JSON.parse(content);
+      const result = SourceMetadataSchema.safeParse(data);
+      if (!result.success) {
+        return null;
+      }
+      return result.data;
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Write source metadata to disk.
+   */
+  async write(metadata: SourceMetadata): Promise<void> {
+    await ensureDir(dirname(this.metaPath));
+    const content = JSON.stringify(metadata, null, 2);
+    await Deno.writeTextFile(this.metaPath, content);
+  }
+
+  /**
+   * Delete source metadata file.
+   */
+  async delete(): Promise<void> {
+    try {
+      await Deno.remove(this.metaPath);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+  }
+}

--- a/src/infrastructure/source/source_paths.ts
+++ b/src/infrastructure/source/source_paths.ts
@@ -1,0 +1,47 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join } from "@std/path";
+
+/**
+ * Get the home directory path.
+ */
+function getHomeDir(): string {
+  const home = Deno.env.get("HOME");
+  if (!home) {
+    throw new Error("HOME environment variable is not set");
+  }
+  return home;
+}
+
+/**
+ * Get the swamp source directory path.
+ * Located at ~/.swamp/source/
+ */
+export function getSwampSourceDir(): string {
+  return join(getHomeDir(), ".swamp", "source");
+}
+
+/**
+ * Get the path to the source metadata file.
+ * Located at ~/.swamp/source/.swamp-source-meta.json
+ */
+export function getSourceMetaPath(): string {
+  return join(getSwampSourceDir(), ".swamp-source-meta.json");
+}

--- a/src/presentation/output/source_output.ts
+++ b/src/presentation/output/source_output.ts
@@ -1,0 +1,125 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { OutputMode } from "./output.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import type {
+  SourceCleanResult,
+  SourceFetchResult,
+  SourceInfoResult,
+} from "../../domain/source/mod.ts";
+
+const logger = getSwampLogger(["source"]);
+
+/**
+ * Data for source fetch output.
+ */
+export interface SourceFetchData {
+  status: "fetched" | "already_fetched";
+  version: string;
+  path: string;
+  fileCount: number;
+  fetchedAt: string;
+  previousVersion?: string;
+}
+
+/**
+ * Data for source path output.
+ */
+export interface SourcePathData {
+  status: "found" | "not_found";
+  version?: string;
+  path?: string;
+  fileCount?: number;
+  fetchedAt?: string;
+}
+
+/**
+ * Data for source clean output.
+ */
+export interface SourceCleanData {
+  status: "cleaned" | "not_found";
+  path: string;
+}
+
+/**
+ * Renders the source fetch result.
+ */
+export function renderSourceFetch(
+  result: SourceFetchResult,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    if (result.status === "already_fetched") {
+      logger.info`Source already fetched: ${result.version}`;
+      logger.info`Path: ${result.path}`;
+      logger.info`Files: ${result.fileCount}`;
+    } else {
+      if (result.previousVersion) {
+        logger
+          .info`Replaced version ${result.previousVersion} with ${result.version}`;
+      } else {
+        logger.info`Fetched source: ${result.version}`;
+      }
+      logger.info`Path: ${result.path}`;
+      logger.info`Files: ${result.fileCount}`;
+    }
+  }
+}
+
+/**
+ * Renders the source path/info result.
+ */
+export function renderSourcePath(
+  result: SourceInfoResult,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    if (result.status === "not_found") {
+      logger.info("No source fetched. Run `swamp source fetch` first.");
+    } else {
+      logger.info`Version: ${result.version}`;
+      logger.info`Path: ${result.path}`;
+      logger.info`Files: ${result.fileCount}`;
+      logger.info`Fetched: ${result.fetchedAt}`;
+    }
+  }
+}
+
+/**
+ * Renders the source clean result.
+ */
+export function renderSourceClean(
+  result: SourceCleanResult,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    if (result.status === "not_found") {
+      logger.info`No source to clean at ${result.path}`;
+    } else {
+      logger.info`Cleaned source at ${result.path}`;
+    }
+  }
+}

--- a/src/presentation/output/source_output_test.ts
+++ b/src/presentation/output/source_output_test.ts
@@ -1,0 +1,165 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertStringIncludes } from "@std/assert";
+import type {
+  SourceCleanResult,
+  SourceFetchResult,
+  SourceInfoResult,
+} from "../../domain/source/mod.ts";
+import {
+  renderSourceClean,
+  renderSourceFetch,
+  renderSourcePath,
+} from "./source_output.ts";
+
+// Helper to capture console.log output
+function captureOutput(fn: () => void): string {
+  const originalLog = console.log;
+  let output = "";
+  console.log = (...args: unknown[]) => {
+    output += args.map((a) => String(a)).join(" ") + "\n";
+  };
+  try {
+    fn();
+  } finally {
+    console.log = originalLog;
+  }
+  return output;
+}
+
+Deno.test("renderSourceFetch with json mode outputs valid JSON for fetched status", () => {
+  const result: SourceFetchResult = {
+    status: "fetched",
+    version: "v1.0.0",
+    path: "/home/user/.swamp/source",
+    fileCount: 245,
+    fetchedAt: "2026-01-01T00:00:00.000Z",
+  };
+
+  const output = captureOutput(() => renderSourceFetch(result, "json"));
+  const parsed = JSON.parse(output);
+
+  assertStringIncludes(parsed.status, "fetched");
+  assertStringIncludes(parsed.version, "v1.0.0");
+});
+
+Deno.test("renderSourceFetch with json mode includes previousVersion when present", () => {
+  const result: SourceFetchResult = {
+    status: "fetched",
+    version: "v2.0.0",
+    path: "/home/user/.swamp/source",
+    fileCount: 245,
+    fetchedAt: "2026-01-01T00:00:00.000Z",
+    previousVersion: "v1.0.0",
+  };
+
+  const output = captureOutput(() => renderSourceFetch(result, "json"));
+  const parsed = JSON.parse(output);
+
+  assertStringIncludes(parsed.previousVersion, "v1.0.0");
+});
+
+Deno.test("renderSourceFetch with log mode does not throw", () => {
+  const result: SourceFetchResult = {
+    status: "fetched",
+    version: "v1.0.0",
+    path: "/home/user/.swamp/source",
+    fileCount: 245,
+    fetchedAt: "2026-01-01T00:00:00.000Z",
+  };
+
+  // Should not throw
+  renderSourceFetch(result, "log");
+});
+
+Deno.test("renderSourcePath with json mode outputs valid JSON for found status", () => {
+  const result: SourceInfoResult = {
+    status: "found",
+    version: "v1.0.0",
+    path: "/home/user/.swamp/source",
+    fileCount: 245,
+    fetchedAt: "2026-01-01T00:00:00.000Z",
+  };
+
+  const output = captureOutput(() => renderSourcePath(result, "json"));
+  const parsed = JSON.parse(output);
+
+  assertStringIncludes(parsed.status, "found");
+  assertStringIncludes(parsed.version, "v1.0.0");
+});
+
+Deno.test("renderSourcePath with json mode outputs valid JSON for not_found status", () => {
+  const result: SourceInfoResult = {
+    status: "not_found",
+  };
+
+  const output = captureOutput(() => renderSourcePath(result, "json"));
+  const parsed = JSON.parse(output);
+
+  assertStringIncludes(parsed.status, "not_found");
+});
+
+Deno.test("renderSourcePath with log mode does not throw", () => {
+  const result: SourceInfoResult = {
+    status: "found",
+    version: "v1.0.0",
+    path: "/home/user/.swamp/source",
+    fileCount: 245,
+    fetchedAt: "2026-01-01T00:00:00.000Z",
+  };
+
+  // Should not throw
+  renderSourcePath(result, "log");
+});
+
+Deno.test("renderSourceClean with json mode outputs valid JSON for cleaned status", () => {
+  const result: SourceCleanResult = {
+    status: "cleaned",
+    path: "/home/user/.swamp/source",
+  };
+
+  const output = captureOutput(() => renderSourceClean(result, "json"));
+  const parsed = JSON.parse(output);
+
+  assertStringIncludes(parsed.status, "cleaned");
+  assertStringIncludes(parsed.path, ".swamp/source");
+});
+
+Deno.test("renderSourceClean with json mode outputs valid JSON for not_found status", () => {
+  const result: SourceCleanResult = {
+    status: "not_found",
+    path: "/home/user/.swamp/source",
+  };
+
+  const output = captureOutput(() => renderSourceClean(result, "json"));
+  const parsed = JSON.parse(output);
+
+  assertStringIncludes(parsed.status, "not_found");
+});
+
+Deno.test("renderSourceClean with log mode does not throw", () => {
+  const result: SourceCleanResult = {
+    status: "cleaned",
+    path: "/home/user/.swamp/source",
+  };
+
+  // Should not throw
+  renderSourceClean(result, "log");
+});


### PR DESCRIPTION
Adds CLI commands that allow the AI agent to fetch swamp source code for troubleshooting and diagnosis. The source is
downloaded as a tar.gz archive from GitHub (no git dependency required).

- `swamp source fetch [--version <v>]` - Download source archive from GitHub
- `swamp source path` - Show source location and version
- `swamp source clean` - Remove downloaded source

Also adds a `swamp-troubleshooting` skill that guides the agent through fetching and reading source code to diagnose
issues.

## Plan vs Implementation

| Item | Plan | Implementation | Notes |
|------|------|----------------|-------|
| **Commands** | 3 subcommands | ✅ Match | fetch, path, clean |
| **Domain Layer** | `SourceService` with `fetch()`, `getInfo()`, `clean()` | ✅ Match | Uses port interfaces,
discriminated unions |
| **SourceMetadata** | `{ version, path, fileCount, fetchedAt }` | ✅ Match | |
| **Infrastructure** | `HttpSourceDownloader`, path helpers | ✅ Match | Downloads from GitHub archive URLs |
| **CLI** | Parent + 3 subcommands, `--version` option | ✅ Match | Defaults to current CLI version |
| **Presentation** | Render functions for log/json modes | ✅ Match | |
| **SourceCleanData** | `{ path, removed: boolean }` | ⚠️ Deviation | Uses `{ status, path }` discriminated union instead
|
| **Skill** | Troubleshooting workflow | ✅ Match | |
| **Extra** | — | Added | `JsonSourceMetadataRepository`, unit tests (16 new) |

The `SourceCleanData` deviation uses a discriminated union (`status: "cleaned" | "not_found"`) for consistency with other
result types in the codebase.

## Files Created

- `src/domain/source/source_metadata.ts`
- `src/domain/source/source_service.ts`
- `src/domain/source/source_service_test.ts`
- `src/domain/source/mod.ts`
- `src/infrastructure/source/source_paths.ts`
- `src/infrastructure/source/http_source_downloader.ts`
- `src/infrastructure/source/json_source_metadata_repository.ts`
- `src/cli/commands/source.ts`
- `src/cli/commands/source_fetch.ts`
- `src/cli/commands/source_path.ts`
- `src/cli/commands/source_clean.ts`
- `src/presentation/output/source_output.ts`
- `src/presentation/output/source_output_test.ts`
- `.claude/skills/swamp-troubleshooting/SKILL.md`

## Files Modified

- `src/cli/mod.ts` - Added source command

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] `deno run test` passes (1769 tests, including 16 new)
- [x] Manual test: `swamp source path --json` returns `{"status":"not_found"}`
- [x] Manual test: `swamp source clean --json` returns `{"status":"not_found","path":"..."}`
- [ ] Manual test: `swamp source fetch --json` (requires public repo)

Note: The fetch command will work once the repository is public. Currently returns 404 for private repo archives.

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)