### PR TITLE
feat: Add CLI commands for submitting bug reports and feature requests

### DIFF
--- a/.claude/skills/swamp-issue/SKILL.md
+++ b/.claude/skills/swamp-issue/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: swamp-issue
+description: Submit bug reports and feature requests for swamp. Use when the user wants to report a bug, request a feature, or provide feedback about swamp. Triggers on "bug report", "feature request", "report bug", "request feature", "file bug", "submit bug", "swamp bug", "swamp feature", "feedback", "report issue", "file issue".
+---
+
+# Swamp Issue Submission Skill
+
+Submit bug reports and feature requests through the swamp CLI. Issues are
+submitted directly to GitHub with appropriate labels.
+
+## Quick Reference
+
+| Task                  | Command                                                |
+| --------------------- | ------------------------------------------------------ |
+| Report a bug          | `swamp issue bug`                                      |
+| Request a feature     | `swamp issue feature`                                  |
+| Submit bug (CLI args) | `swamp issue bug --title "Title" --body "Description"` |
+| Submit feature (args) | `swamp issue feature --title "Title" --body "Desc"`    |
+
+## Submitting a Bug Report
+
+Report bugs you've encountered while using swamp. The interactive mode opens
+your editor with a template to guide your bug report.
+
+**Interactive mode (recommended):**
+
+```bash
+swamp issue bug
+```
+
+This opens your configured `$EDITOR` with a template containing:
+
+- Title section for a brief description
+- Description section for details
+- Steps to reproduce
+- Environment information
+- Additional context
+
+**Non-interactive mode:**
+
+```bash
+swamp issue bug --title "CLI crashes on empty input" --body "When running..."
+swamp issue bug -t "Title" -b "Body" --json
+```
+
+**Labels applied:** `bug`, `external`
+
+## Submitting a Feature Request
+
+Request new features or improvements to swamp.
+
+**Interactive mode (recommended):**
+
+```bash
+swamp issue feature
+```
+
+This opens your editor with a template containing:
+
+- Title section for a brief description
+- Problem statement (what pain point this solves)
+- Proposed solution
+- Alternatives considered
+- Additional context
+
+**Non-interactive mode:**
+
+```bash
+swamp issue feature --title "Add dark mode" --body "I'd like..."
+swamp issue feature -t "Title" -b "Body" --json
+```
+
+**Labels applied:** `enhancement`, `external`
+
+## JSON Output
+
+Both commands support `--json` for machine-readable output:
+
+```bash
+swamp issue bug --title "My Bug" --body "Details" --json
+```
+
+**Output shape:**
+
+```json
+{
+  "url": "https://github.com/systeminit/swamp/issues/123",
+  "number": 123,
+  "type": "bug",
+  "title": "My Bug"
+}
+```
+
+## Requirements
+
+- **GitHub CLI (`gh`)**: Must be installed and authenticated
+  - Install: https://cli.github.com/
+  - Authenticate: `gh auth login`
+
+## Best Practices for Bug Reports
+
+When submitting a bug report, include:
+
+1. **Clear title**: Summarize the bug in one line
+2. **Steps to reproduce**: Numbered list of actions that trigger the bug
+3. **Expected vs actual behavior**: What should happen vs what does happen
+4. **Environment details**: swamp version, OS, shell
+5. **Error messages**: Include any error output (use code blocks)
+
+**Example bug title:**
+
+- Good: "CLI crashes when running workflow with missing input file"
+- Bad: "It doesn't work"
+
+## Best Practices for Feature Requests
+
+When submitting a feature request, include:
+
+1. **Clear title**: Summarize the feature in one line
+2. **Problem statement**: What pain point this addresses
+3. **Proposed solution**: How the feature would work
+4. **Alternatives**: Other approaches you've considered
+
+**Example feature title:**
+
+- Good: "Add --dry-run flag to workflow run command"
+- Bad: "Make it better"
+
+## For AI Agents: Formatting Issue Content
+
+When helping users create issues, follow these guidelines:
+
+### Bug Reports
+
+Provide a summary of the work involved to fix the bug:
+
+- Describe what component is affected
+- Outline the expected fix approach at a high level
+- Do NOT include specific code implementations
+
+**Example summary:**
+
+> This bug affects the workflow execution service when input files are missing.
+> The fix would involve adding validation in the input resolution phase before
+> job execution begins, with a clear error message pointing to the missing file.
+
+### Feature Requests
+
+Provide a summary of the implementation plan:
+
+- Describe the scope of changes needed
+- List affected components
+- Outline the high-level approach
+- Do NOT include specific code implementations
+
+**Example summary:**
+
+> This feature would add a `--dry-run` flag to the `workflow run` command.
+> Changes would be needed in:
+>
+> - Command option parsing (workflow_run.ts)
+> - Execution service to skip actual method calls
+> - Output rendering to show what would be executed
+>
+> The approach would intercept execution at the method call boundary and display
+> the planned actions without making external calls.
+
+## Troubleshooting
+
+**"GitHub CLI (gh) is not installed"** Install the GitHub CLI from
+https://cli.github.com/
+
+**"GitHub CLI is not authenticated"** Run `gh auth login` and follow the prompts
+to authenticate.
+
+**Editor doesn't wait for input (GUI editors)** The CLI auto-detects terminal vs
+GUI editors. For GUI editors like VS Code, the `--wait` flag is automatically
+added. If your editor doesn't wait, set `$EDITOR` to a terminal-based editor
+like `vim` or `nano`.
+
+## Related Skills
+
+| Need                   | Use Skill             |
+| ---------------------- | --------------------- |
+| Debug swamp issues     | swamp-troubleshooting |
+| View swamp source code | swamp-troubleshooting |

--- a/src/cli/commands/issue.ts
+++ b/src/cli/commands/issue.ts
@@ -1,0 +1,31 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { issueBugCommand } from "./issue_bug.ts";
+import { issueFeatureCommand } from "./issue_feature.ts";
+
+export const issueCommand = new Command()
+  .name("issue")
+  .description("Submit bug reports and feature requests")
+  .action(function () {
+    this.showHelp();
+  })
+  .command("bug", issueBugCommand)
+  .command("feature", issueFeatureCommand);

--- a/src/cli/commands/issue_bug.ts
+++ b/src/cli/commands/issue_bug.ts
@@ -1,0 +1,196 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  type IssueCreateData,
+  renderIssueCancelled,
+  renderIssueCreate,
+} from "../../presentation/output/issue_output.ts";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { EditorService } from "../../infrastructure/editor/editor_service.ts";
+import { GitHubIssueService } from "../../infrastructure/github/github_issue_service.ts";
+import { UserError } from "../../domain/errors.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+/**
+ * Template for bug reports.
+ */
+const BUG_TEMPLATE = `
+# Bug Report
+
+## Title
+<!-- Enter a brief, descriptive title for the bug on the line below -->
+
+
+## Description
+<!-- Describe the bug in detail. What did you expect to happen? What actually happened? -->
+
+
+## Steps to Reproduce
+<!-- List the steps to reproduce the bug -->
+1.
+2.
+3.
+
+## Environment
+<!-- Include relevant environment information -->
+- swamp version:
+- OS:
+- Shell:
+
+## Additional Context
+<!-- Add any other context about the problem here -->
+
+`.trimStart();
+
+/**
+ * Parses the bug report content from the editor.
+ * Returns null if the content is empty or unchanged from the template.
+ */
+function parseBugContent(
+  content: string,
+): { title: string; body: string } | null {
+  // Check if content is essentially empty or unchanged
+  const trimmedContent = content.trim();
+  if (!trimmedContent || trimmedContent === BUG_TEMPLATE.trim()) {
+    return null;
+  }
+
+  // Extract title from the "## Title" section
+  // Title must be a single line that doesn't start with # or <!--
+  const titleMatch = content.match(
+    /## Title\s*\n(?:<!--[^>]*-->\s*\n)?([^\n#<][^\n]*)/,
+  );
+  const title = titleMatch?.[1]?.trim();
+
+  if (!title) {
+    return null;
+  }
+
+  // Build body from remaining sections (everything after ## Description)
+  const descriptionIndex = content.indexOf("## Description");
+  if (descriptionIndex === -1) {
+    return { title, body: "" };
+  }
+
+  const body = content.substring(descriptionIndex);
+
+  // Clean up the body by removing HTML comment lines
+  const cleanedBody = body
+    .split("\n")
+    .filter((line) => !line.match(/^\s*<!--.*-->\s*$/))
+    .join("\n")
+    .trim();
+
+  return { title, body: cleanedBody };
+}
+
+export const issueBugCommand = new Command()
+  .name("bug")
+  .description("Submit a bug report")
+  .option("-t, --title <title:string>", "Bug title (skips editor for title)")
+  .option(
+    "-b, --body <body:string>",
+    "Bug description (requires --title, skips editor entirely)",
+  )
+  .action(async function (options: AnyOptions) {
+    const ctx = createContext(options as GlobalOptions, ["issue", "bug"]);
+    ctx.logger.debug`Submitting bug report`;
+
+    const editorService = new EditorService();
+    const githubService = new GitHubIssueService();
+
+    let title: string;
+    let body: string;
+
+    if (options.title && options.body) {
+      // Non-interactive mode: both title and body provided
+      title = options.title;
+      body = options.body;
+    } else if (options.body && !options.title) {
+      throw new UserError("--body requires --title to be specified");
+    } else {
+      // Interactive mode: open editor
+      if (ctx.outputMode === "json") {
+        throw new UserError(
+          "Interactive mode is not available with --json. Use --title and --body options.",
+        );
+      }
+
+      // Create temp file with template
+      const tempFile = await Deno.makeTempFile({
+        prefix: "swamp-bug-",
+        suffix: ".md",
+      });
+
+      try {
+        // Write template to temp file
+        await Deno.writeTextFile(tempFile, BUG_TEMPLATE);
+
+        // Open editor and wait for it to close
+        ctx.logger.debug`Opening editor for bug report`;
+        await editorService.openFile(tempFile, { wait: true });
+
+        // Read the edited content
+        const content = await Deno.readTextFile(tempFile);
+
+        // Parse the content
+        const parsed = parseBugContent(content);
+        if (!parsed) {
+          renderIssueCancelled(
+            { type: "bug", reason: "empty" },
+            ctx.outputMode,
+          );
+          return;
+        }
+
+        title = parsed.title;
+        body = parsed.body;
+      } finally {
+        // Clean up temp file
+        try {
+          await Deno.remove(tempFile);
+        } catch {
+          // Ignore cleanup errors
+        }
+      }
+    }
+
+    ctx.logger.debug`Creating GitHub issue with title: ${title}`;
+
+    // Create the GitHub issue
+    const result = await githubService.createIssue({
+      title,
+      body,
+      labels: ["bug", "external"],
+    });
+
+    const data: IssueCreateData = {
+      url: result.url,
+      number: result.number,
+      type: "bug",
+      title,
+    };
+
+    renderIssueCreate(data, ctx.outputMode);
+    ctx.logger.debug("Bug report submitted successfully");
+  });

--- a/src/cli/commands/issue_bug_test.ts
+++ b/src/cli/commands/issue_bug_test.ts
@@ -1,0 +1,172 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+
+// Re-export the parse function for testing by copying the logic
+// (since the original is not exported)
+
+/**
+ * Template for bug reports (copied from issue_bug.ts for testing).
+ */
+const BUG_TEMPLATE = `
+# Bug Report
+
+## Title
+<!-- Enter a brief, descriptive title for the bug on the line below -->
+
+
+## Description
+<!-- Describe the bug in detail. What did you expect to happen? What actually happened? -->
+
+
+## Steps to Reproduce
+<!-- List the steps to reproduce the bug -->
+1.
+2.
+3.
+
+## Environment
+<!-- Include relevant environment information -->
+- swamp version:
+- OS:
+- Shell:
+
+## Additional Context
+<!-- Add any other context about the problem here -->
+
+`.trimStart();
+
+/**
+ * Parses the bug report content from the editor.
+ * Returns null if the content is empty or unchanged from the template.
+ */
+function parseBugContent(
+  content: string,
+): { title: string; body: string } | null {
+  // Check if content is essentially empty or unchanged
+  const trimmedContent = content.trim();
+  if (!trimmedContent || trimmedContent === BUG_TEMPLATE.trim()) {
+    return null;
+  }
+
+  // Extract title from the "## Title" section
+  // Title must be a single line that doesn't start with # or <!--
+  const titleMatch = content.match(
+    /## Title\s*\n(?:<!--[^>]*-->\s*\n)?([^\n#<][^\n]*)/,
+  );
+  const title = titleMatch?.[1]?.trim();
+
+  if (!title) {
+    return null;
+  }
+
+  // Build body from remaining sections (everything after ## Description)
+  const descriptionIndex = content.indexOf("## Description");
+  if (descriptionIndex === -1) {
+    return { title, body: "" };
+  }
+
+  const body = content.substring(descriptionIndex);
+
+  // Clean up the body by removing HTML comment lines
+  const cleanedBody = body
+    .split("\n")
+    .filter((line) => !line.match(/^\s*<!--.*-->\s*$/))
+    .join("\n")
+    .trim();
+
+  return { title, body: cleanedBody };
+}
+
+Deno.test("parseBugContent returns null for empty content", () => {
+  const result = parseBugContent("");
+  assertEquals(result, null);
+});
+
+Deno.test("parseBugContent returns null for unchanged template", () => {
+  const result = parseBugContent(BUG_TEMPLATE);
+  assertEquals(result, null);
+});
+
+Deno.test("parseBugContent extracts title and body", () => {
+  const content = `
+# Bug Report
+
+## Title
+<!-- Enter a brief, descriptive title for the bug on the line below -->
+CLI crashes when running without arguments
+
+## Description
+<!-- Describe the bug in detail. What did you expect to happen? What actually happened? -->
+When I run swamp without any arguments, it crashes.
+
+## Steps to Reproduce
+<!-- List the steps to reproduce the bug -->
+1. Run swamp
+2. See crash
+
+## Environment
+<!-- Include relevant environment information -->
+- swamp version: 1.0.0
+- OS: macOS
+- Shell: zsh
+
+## Additional Context
+<!-- Add any other context about the problem here -->
+None
+`.trimStart();
+
+  const result = parseBugContent(content);
+  assertEquals(result?.title, "CLI crashes when running without arguments");
+  assertEquals(result?.body.includes("When I run swamp"), true);
+  assertEquals(result?.body.startsWith("## Description"), true);
+});
+
+Deno.test("parseBugContent returns null when no title provided", () => {
+  const content = `
+# Bug Report
+
+## Title
+<!-- Enter a brief, descriptive title for the bug on the line below -->
+
+
+## Description
+Some description here
+`.trimStart();
+
+  const result = parseBugContent(content);
+  assertEquals(result, null);
+});
+
+Deno.test("parseBugContent handles title with only whitespace after", () => {
+  const content = `
+# Bug Report
+
+## Title
+My bug title
+
+## Description
+Bug description
+`.trimStart();
+
+  const result = parseBugContent(content);
+  assertEquals(result?.title, "My bug title");
+  assertEquals(result?.body.includes("Bug description"), true);
+});

--- a/src/cli/commands/issue_feature.ts
+++ b/src/cli/commands/issue_feature.ts
@@ -1,0 +1,195 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  type IssueCreateData,
+  renderIssueCancelled,
+  renderIssueCreate,
+} from "../../presentation/output/issue_output.ts";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { EditorService } from "../../infrastructure/editor/editor_service.ts";
+import { GitHubIssueService } from "../../infrastructure/github/github_issue_service.ts";
+import { UserError } from "../../domain/errors.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+/**
+ * Template for feature requests.
+ */
+const FEATURE_TEMPLATE = `
+# Feature Request
+
+## Title
+<!-- Enter a brief, descriptive title for the feature on the line below -->
+
+
+## Problem Statement
+<!-- What problem does this feature solve? What pain point are you experiencing? -->
+
+
+## Proposed Solution
+<!-- Describe the solution you'd like to see -->
+
+
+## Alternatives Considered
+<!-- Have you considered any alternative solutions or workarounds? -->
+
+
+## Additional Context
+<!-- Add any other context, mockups, or examples about the feature request here -->
+
+`.trimStart();
+
+/**
+ * Parses the feature request content from the editor.
+ * Returns null if the content is empty or unchanged from the template.
+ */
+function parseFeatureContent(
+  content: string,
+): { title: string; body: string } | null {
+  // Check if content is essentially empty or unchanged
+  const trimmedContent = content.trim();
+  if (!trimmedContent || trimmedContent === FEATURE_TEMPLATE.trim()) {
+    return null;
+  }
+
+  // Extract title from the "## Title" section
+  // Title must be a single line that doesn't start with # or <!--
+  const titleMatch = content.match(
+    /## Title\s*\n(?:<!--[^>]*-->\s*\n)?([^\n#<][^\n]*)/,
+  );
+  const title = titleMatch?.[1]?.trim();
+
+  if (!title) {
+    return null;
+  }
+
+  // Build body from remaining sections (everything after ## Problem Statement)
+  const problemIndex = content.indexOf("## Problem Statement");
+  if (problemIndex === -1) {
+    return { title, body: "" };
+  }
+
+  const body = content.substring(problemIndex);
+
+  // Clean up the body by removing HTML comment lines
+  const cleanedBody = body
+    .split("\n")
+    .filter((line) => !line.match(/^\s*<!--.*-->\s*$/))
+    .join("\n")
+    .trim();
+
+  return { title, body: cleanedBody };
+}
+
+export const issueFeatureCommand = new Command()
+  .name("feature")
+  .description("Submit a feature request")
+  .option(
+    "-t, --title <title:string>",
+    "Feature title (skips editor for title)",
+  )
+  .option(
+    "-b, --body <body:string>",
+    "Feature description (requires --title, skips editor entirely)",
+  )
+  .action(async function (options: AnyOptions) {
+    const ctx = createContext(options as GlobalOptions, ["issue", "feature"]);
+    ctx.logger.debug`Submitting feature request`;
+
+    const editorService = new EditorService();
+    const githubService = new GitHubIssueService();
+
+    let title: string;
+    let body: string;
+
+    if (options.title && options.body) {
+      // Non-interactive mode: both title and body provided
+      title = options.title;
+      body = options.body;
+    } else if (options.body && !options.title) {
+      throw new UserError("--body requires --title to be specified");
+    } else {
+      // Interactive mode: open editor
+      if (ctx.outputMode === "json") {
+        throw new UserError(
+          "Interactive mode is not available with --json. Use --title and --body options.",
+        );
+      }
+
+      // Create temp file with template
+      const tempFile = await Deno.makeTempFile({
+        prefix: "swamp-feature-",
+        suffix: ".md",
+      });
+
+      try {
+        // Write template to temp file
+        await Deno.writeTextFile(tempFile, FEATURE_TEMPLATE);
+
+        // Open editor and wait for it to close
+        ctx.logger.debug`Opening editor for feature request`;
+        await editorService.openFile(tempFile, { wait: true });
+
+        // Read the edited content
+        const content = await Deno.readTextFile(tempFile);
+
+        // Parse the content
+        const parsed = parseFeatureContent(content);
+        if (!parsed) {
+          renderIssueCancelled(
+            { type: "feature", reason: "empty" },
+            ctx.outputMode,
+          );
+          return;
+        }
+
+        title = parsed.title;
+        body = parsed.body;
+      } finally {
+        // Clean up temp file
+        try {
+          await Deno.remove(tempFile);
+        } catch {
+          // Ignore cleanup errors
+        }
+      }
+    }
+
+    ctx.logger.debug`Creating GitHub issue with title: ${title}`;
+
+    // Create the GitHub issue
+    const result = await githubService.createIssue({
+      title,
+      body,
+      labels: ["enhancement", "external"],
+    });
+
+    const data: IssueCreateData = {
+      url: result.url,
+      number: result.number,
+      type: "feature",
+      title,
+    };
+
+    renderIssueCreate(data, ctx.outputMode);
+    ctx.logger.debug("Feature request submitted successfully");
+  });

--- a/src/cli/commands/issue_feature_test.ts
+++ b/src/cli/commands/issue_feature_test.ts
@@ -1,0 +1,165 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+
+// Re-export the parse function for testing by copying the logic
+// (since the original is not exported)
+
+/**
+ * Template for feature requests (copied from issue_feature.ts for testing).
+ */
+const FEATURE_TEMPLATE = `
+# Feature Request
+
+## Title
+<!-- Enter a brief, descriptive title for the feature on the line below -->
+
+
+## Problem Statement
+<!-- What problem does this feature solve? What pain point are you experiencing? -->
+
+
+## Proposed Solution
+<!-- Describe the solution you'd like to see -->
+
+
+## Alternatives Considered
+<!-- Have you considered any alternative solutions or workarounds? -->
+
+
+## Additional Context
+<!-- Add any other context, mockups, or examples about the feature request here -->
+
+`.trimStart();
+
+/**
+ * Parses the feature request content from the editor.
+ * Returns null if the content is empty or unchanged from the template.
+ */
+function parseFeatureContent(
+  content: string,
+): { title: string; body: string } | null {
+  // Check if content is essentially empty or unchanged
+  const trimmedContent = content.trim();
+  if (!trimmedContent || trimmedContent === FEATURE_TEMPLATE.trim()) {
+    return null;
+  }
+
+  // Extract title from the "## Title" section
+  // Title must be a single line that doesn't start with # or <!--
+  const titleMatch = content.match(
+    /## Title\s*\n(?:<!--[^>]*-->\s*\n)?([^\n#<][^\n]*)/,
+  );
+  const title = titleMatch?.[1]?.trim();
+
+  if (!title) {
+    return null;
+  }
+
+  // Build body from remaining sections (everything after ## Problem Statement)
+  const problemIndex = content.indexOf("## Problem Statement");
+  if (problemIndex === -1) {
+    return { title, body: "" };
+  }
+
+  const body = content.substring(problemIndex);
+
+  // Clean up the body by removing HTML comment lines
+  const cleanedBody = body
+    .split("\n")
+    .filter((line) => !line.match(/^\s*<!--.*-->\s*$/))
+    .join("\n")
+    .trim();
+
+  return { title, body: cleanedBody };
+}
+
+Deno.test("parseFeatureContent returns null for empty content", () => {
+  const result = parseFeatureContent("");
+  assertEquals(result, null);
+});
+
+Deno.test("parseFeatureContent returns null for unchanged template", () => {
+  const result = parseFeatureContent(FEATURE_TEMPLATE);
+  assertEquals(result, null);
+});
+
+Deno.test("parseFeatureContent extracts title and body", () => {
+  const content = `
+# Feature Request
+
+## Title
+<!-- Enter a brief, descriptive title for the feature on the line below -->
+Add dark mode support
+
+## Problem Statement
+<!-- What problem does this feature solve? What pain point are you experiencing? -->
+The current light theme is hard on the eyes at night.
+
+## Proposed Solution
+<!-- Describe the solution you'd like to see -->
+Add a --dark-mode flag or automatic detection.
+
+## Alternatives Considered
+<!-- Have you considered any alternative solutions or workarounds? -->
+Using terminal dark mode, but it doesn't affect output colors.
+
+## Additional Context
+<!-- Add any other context, mockups, or examples about the feature request here -->
+None
+`.trimStart();
+
+  const result = parseFeatureContent(content);
+  assertEquals(result?.title, "Add dark mode support");
+  assertEquals(result?.body.includes("hard on the eyes"), true);
+  assertEquals(result?.body.startsWith("## Problem Statement"), true);
+});
+
+Deno.test("parseFeatureContent returns null when no title provided", () => {
+  const content = `
+# Feature Request
+
+## Title
+<!-- Enter a brief, descriptive title for the feature on the line below -->
+
+
+## Problem Statement
+Some problem here
+`.trimStart();
+
+  const result = parseFeatureContent(content);
+  assertEquals(result, null);
+});
+
+Deno.test("parseFeatureContent handles title with only whitespace after", () => {
+  const content = `
+# Feature Request
+
+## Title
+My feature title
+
+## Problem Statement
+Problem description
+`.trimStart();
+
+  const result = parseFeatureContent(content);
+  assertEquals(result?.title, "My feature title");
+  assertEquals(result?.body.includes("Problem description"), true);
+});

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -29,6 +29,7 @@ import { workflowCommand } from "./commands/workflow.ts";
 import { completionCommand } from "./commands/completion.ts";
 import { vaultCommand } from "./commands/vault.ts";
 import { dataCommand } from "./commands/data.ts";
+import { issueCommand } from "./commands/issue.ts";
 import { telemetryCommand } from "./commands/telemetry_stats.ts";
 import { updateCommand } from "./commands/update.ts";
 import { sourceCommand } from "./commands/source.ts";
@@ -243,7 +244,8 @@ export async function runCli(args: string[]): Promise<void> {
     .command("telemetry", telemetryCommand)
     .command("update", updateCommand)
     .command("source", sourceCommand)
-    .command("completions", completionCommand);
+    .command("completions", completionCommand)
+    .command("issue", issueCommand);
 
   try {
     await cli.parse(args);

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -235,6 +235,7 @@ essential context for working with this repository.
 - \`swamp-vault\` - Manage secrets and credentials
 - \`swamp-data\` - Manage model data lifecycle
 - \`swamp-repo\` - Repository management
+- \`swamp-issue\` - Submit bug reports and feature requests
 
 ## Getting Started
 
@@ -276,6 +277,7 @@ Use \`swamp --help\` to see available commands.
       "Bash(swamp init:*)",
       "Bash(swamp version:*)",
       "Bash(swamp completions:*)",
+      "Bash(swamp issue:*)",
     ];
   }
 

--- a/src/infrastructure/assets/skill_assets.ts
+++ b/src/infrastructure/assets/skill_assets.ts
@@ -69,6 +69,10 @@ const BUNDLED_SKILLS: SkillInfo[] = [
     relativePath: "swamp-vault/references/troubleshooting.md",
     name: "swamp-vault",
   },
+  {
+    relativePath: "swamp-issue/SKILL.md",
+    name: "swamp-issue",
+  },
 ];
 
 /**

--- a/src/infrastructure/github/github_issue_service.ts
+++ b/src/infrastructure/github/github_issue_service.ts
@@ -1,0 +1,126 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { UserError } from "../../domain/errors.ts";
+
+/**
+ * Result of creating a GitHub issue.
+ */
+export interface GitHubIssueResult {
+  url: string;
+  number: number;
+}
+
+/**
+ * Options for creating a GitHub issue.
+ */
+export interface CreateIssueOptions {
+  title: string;
+  body: string;
+  labels: string[];
+  repo?: string;
+}
+
+/**
+ * Service for interacting with GitHub issues via the gh CLI.
+ */
+export class GitHubIssueService {
+  private readonly defaultRepo = "systeminit/swamp";
+
+  /**
+   * Checks if the gh CLI is installed and authenticated.
+   */
+  async checkGhCli(): Promise<void> {
+    // Check if gh is installed
+    const whichCommand = new Deno.Command("which", {
+      args: ["gh"],
+      stdout: "null",
+      stderr: "null",
+    });
+    const { success: ghInstalled } = await whichCommand.output();
+    if (!ghInstalled) {
+      throw new UserError(
+        "GitHub CLI (gh) is not installed. Install it from https://cli.github.com/",
+      );
+    }
+
+    // Check if gh is authenticated
+    const authCommand = new Deno.Command("gh", {
+      args: ["auth", "status"],
+      stdout: "null",
+      stderr: "null",
+    });
+    const { success: ghAuthenticated } = await authCommand.output();
+    if (!ghAuthenticated) {
+      throw new UserError(
+        "GitHub CLI is not authenticated. Run 'gh auth login' to authenticate.",
+      );
+    }
+  }
+
+  /**
+   * Creates a GitHub issue using the gh CLI.
+   *
+   * @param options - The issue creation options
+   * @returns The URL and number of the created issue
+   */
+  async createIssue(options: CreateIssueOptions): Promise<GitHubIssueResult> {
+    await this.checkGhCli();
+
+    const repo = options.repo ?? this.defaultRepo;
+
+    const args = [
+      "issue",
+      "create",
+      "--repo",
+      repo,
+      "--title",
+      options.title,
+      "--body",
+      options.body,
+    ];
+
+    // Add labels
+    for (const label of options.labels) {
+      args.push("--label", label);
+    }
+
+    const command = new Deno.Command("gh", {
+      args,
+      stdout: "piped",
+      stderr: "piped",
+    });
+
+    const { success, stdout, stderr } = await command.output();
+
+    if (!success) {
+      const errorMessage = new TextDecoder().decode(stderr);
+      throw new UserError(`Failed to create GitHub issue: ${errorMessage}`);
+    }
+
+    // gh issue create returns the URL of the created issue
+    const url = new TextDecoder().decode(stdout).trim();
+
+    // Extract issue number from URL (e.g., https://github.com/owner/repo/issues/123)
+    const match = url.match(/\/issues\/(\d+)$/);
+    const number = match ? parseInt(match[1], 10) : 0;
+
+    return { url, number };
+  }
+}

--- a/src/infrastructure/github/github_issue_service_test.ts
+++ b/src/infrastructure/github/github_issue_service_test.ts
@@ -1,0 +1,41 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+
+Deno.test("issue URL parsing extracts issue number", () => {
+  const url = "https://github.com/systeminit/swamp/issues/123";
+  const match = url.match(/\/issues\/(\d+)$/);
+  const number = match ? parseInt(match[1], 10) : 0;
+  assertEquals(number, 123);
+});
+
+Deno.test("issue URL parsing handles different repos", () => {
+  const url = "https://github.com/owner/repo/issues/456";
+  const match = url.match(/\/issues\/(\d+)$/);
+  const number = match ? parseInt(match[1], 10) : 0;
+  assertEquals(number, 456);
+});
+
+Deno.test("issue URL parsing returns 0 for invalid URL", () => {
+  const url = "not-a-valid-url";
+  const match = url.match(/\/issues\/(\d+)$/);
+  const number = match ? parseInt(match[1], 10) : 0;
+  assertEquals(number, 0);
+});

--- a/src/presentation/output/issue_output.ts
+++ b/src/presentation/output/issue_output.ts
@@ -1,0 +1,77 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { OutputMode } from "./output.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+
+/**
+ * Data structure for issue creation output.
+ */
+export interface IssueCreateData {
+  url: string;
+  number: number;
+  type: "bug" | "feature";
+  title: string;
+}
+
+/**
+ * Renders issue creation output in either log or JSON mode.
+ */
+export function renderIssueCreate(
+  data: IssueCreateData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    const logger = getSwampLogger(["issue", "create"]);
+    logger.info(
+      "Created {type} report #{number}: {title}",
+      { type: data.type, number: data.number, title: data.title },
+    );
+    logger.info("View at: {url}", { url: data.url });
+  }
+}
+
+/**
+ * Data structure for issue editor cancelled output.
+ */
+export interface IssueCancelledData {
+  type: "bug" | "feature";
+  reason: "empty" | "cancelled";
+}
+
+/**
+ * Renders issue cancelled output in either log or JSON mode.
+ */
+export function renderIssueCancelled(
+  data: IssueCancelledData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify({ status: "cancelled", ...data }, null, 2));
+  } else {
+    const logger = getSwampLogger(["issue", "create"]);
+    if (data.reason === "empty") {
+      logger.info("Issue creation cancelled: no content provided");
+    } else {
+      logger.info("Issue creation cancelled");
+    }
+  }
+}


### PR DESCRIPTION
- Add `swamp issue bug` and `swamp issue feature` commands for submitting issues via CLI
- Opens editor with structured template for title and description
- Creates GitHub issues using `gh` CLI with appropriate labels (`bug`/`enhancement` + `external`)
- Add skill documentation explaining how to file bugs and feature requests

Closes #165

## Plan vs Implementation

| Plan Requirement | Status | Implementation |
|-----------------|--------|----------------|
| CLI support for bugs/features | ✅ | `swamp issue bug` and `swamp issue feature` commands |
| Pop editor for title/description | ✅ | Opens `$EDITOR` with markdown template |
| Send to GitHub issues | ✅ | Uses `gh` CLI to create issues on `systeminit/swamp` |
| Skill explaining how to file issues | ✅ | `.claude/skills/swamp-issue/SKILL.md` |
| "external" label on issues | ✅ | Both bug and feature issues get `external` label |

## Additional Features

- Non-interactive mode via `--title` and `--body` flags
- JSON output support via `--json` flag
- Structured templates (Steps to Reproduce, Environment, Problem Statement, etc.)
- GitHub CLI validation (checks `gh` is installed and authenticated)

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] `deno run test` passes (1782 tests)
- [x] `deno run compile` succeeds
- [x] `swamp issue --help` shows bug and feature subcommands
- [ ] Manual test: `swamp issue bug` opens editor and creates issue
- [ ] Manual test: `swamp issue feature --title "Test" --body "Test" --json` creates issue

🤖 Generated with [Claude Code](https://claude.ai/code)