### PR TITLE
fix: Await waitUntilExit() in ink interactive renders to prevent WouldBlock crash

### DIFF
--- a/src/presentation/output/data_search_output.tsx
+++ b/src/presentation/output/data_search_output.tsx
@@ -127,15 +127,21 @@ function renderInteractiveDataSearch(
   data: DataSearchData,
 ): Promise<DataSearchItem | undefined> {
   return new Promise<DataSearchItem | undefined>((resolve) => {
+    let result: DataSearchItem | undefined;
     const { waitUntilExit } = render(
       <DataSearchUI
         items={data.results}
         initialQuery={data.query}
-        onSelect={(item) => resolve(item)}
-        onCancel={() => resolve(undefined)}
+        onSelect={(item) => {
+          result = item;
+        }}
+        onCancel={() => {}}
       />,
     );
-    waitUntilExit();
+    waitUntilExit().then(
+      () => resolve(result),
+      () => resolve(result),
+    );
   });
 }
 

--- a/src/presentation/output/input_file_select_output.tsx
+++ b/src/presentation/output/input_file_select_output.tsx
@@ -77,17 +77,23 @@ function renderInteractiveInputFileSelect(
   data: InputFileSelectData,
 ): Promise<InputFileSelection | undefined> {
   return new Promise<InputFileSelection | undefined>((resolve) => {
+    let result: InputFileSelection | undefined;
     const { waitUntilExit } = render(
       <InputFileSelectUI
         workflowName={data.workflowName}
         requiredInputs={data.requiredInputs}
         hasDefaults={data.hasDefaults}
         searchDir={data.searchDir}
-        onSelect={(selection) => resolve(selection)}
-        onCancel={() => resolve(undefined)}
+        onSelect={(selection) => {
+          result = selection;
+        }}
+        onCancel={() => {}}
       />,
     );
-    waitUntilExit();
+    waitUntilExit().then(
+      () => resolve(result),
+      () => resolve(result),
+    );
   });
 }
 

--- a/src/presentation/output/model_output_search_output.tsx
+++ b/src/presentation/output/model_output_search_output.tsx
@@ -82,15 +82,21 @@ export function renderInteractiveModelOutputSearch(
   data: ModelOutputSearchData,
 ): Promise<ModelOutputSearchItem | undefined> {
   return new Promise<ModelOutputSearchItem | undefined>((resolve) => {
+    let result: ModelOutputSearchItem | undefined;
     const { waitUntilExit } = render(
       <ModelOutputSearchUI
         outputs={data.results}
         initialQuery={data.query}
-        onSelect={(item) => resolve(item)}
-        onCancel={() => resolve(undefined)}
+        onSelect={(item) => {
+          result = item;
+        }}
+        onCancel={() => {}}
       />,
     );
-    waitUntilExit();
+    waitUntilExit().then(
+      () => resolve(result),
+      () => resolve(result),
+    );
   });
 }
 

--- a/src/presentation/output/model_search_output.tsx
+++ b/src/presentation/output/model_search_output.tsx
@@ -77,15 +77,21 @@ export function renderInteractiveModelSearch(
   data: ModelSearchData,
 ): Promise<ModelSearchItem | undefined> {
   return new Promise<ModelSearchItem | undefined>((resolve) => {
+    let result: ModelSearchItem | undefined;
     const { waitUntilExit } = render(
       <ModelSearchUI
         models={data.results}
         initialQuery={data.query}
-        onSelect={(item) => resolve(item)}
-        onCancel={() => resolve(undefined)}
+        onSelect={(item) => {
+          result = item;
+        }}
+        onCancel={() => {}}
       />,
     );
-    waitUntilExit();
+    waitUntilExit().then(
+      () => resolve(result),
+      () => resolve(result),
+    );
   });
 }
 

--- a/src/presentation/output/type_search_output.tsx
+++ b/src/presentation/output/type_search_output.tsx
@@ -76,15 +76,21 @@ export function renderInteractiveTypeSearch(
   data: TypeSearchData,
 ): Promise<TypeSearchItem | undefined> {
   return new Promise<TypeSearchItem | undefined>((resolve) => {
+    let result: TypeSearchItem | undefined;
     const { waitUntilExit } = render(
       <TypeSearchUI
         types={data.results}
         initialQuery={data.query}
-        onSelect={(item) => resolve(item)}
-        onCancel={() => resolve(undefined)}
+        onSelect={(item) => {
+          result = item;
+        }}
+        onCancel={() => {}}
       />,
     );
-    waitUntilExit();
+    waitUntilExit().then(
+      () => resolve(result),
+      () => resolve(result),
+    );
   });
 }
 

--- a/src/presentation/output/vault_search_output.tsx
+++ b/src/presentation/output/vault_search_output.tsx
@@ -91,15 +91,21 @@ export function renderInteractiveVaultSearch(
   data: VaultSearchData,
 ): Promise<VaultSearchItem | undefined> {
   return new Promise<VaultSearchItem | undefined>((resolve) => {
+    let result: VaultSearchItem | undefined;
     const { waitUntilExit } = render(
       <VaultSearchUI
         vaults={data.results}
         initialQuery={data.query}
-        onSelect={(item) => resolve(item)}
-        onCancel={() => resolve(undefined)}
+        onSelect={(item) => {
+          result = item;
+        }}
+        onCancel={() => {}}
       />,
     );
-    waitUntilExit();
+    waitUntilExit().then(
+      () => resolve(result),
+      () => resolve(result),
+    );
   });
 }
 

--- a/src/presentation/output/vault_type_search_output.tsx
+++ b/src/presentation/output/vault_type_search_output.tsx
@@ -91,15 +91,21 @@ export function renderInteractiveVaultTypeSearch(
   data: VaultTypeSearchData,
 ): Promise<VaultTypeSearchItem | undefined> {
   return new Promise<VaultTypeSearchItem | undefined>((resolve) => {
+    let result: VaultTypeSearchItem | undefined;
     const { waitUntilExit } = render(
       <VaultTypeSearchUI
         vaultTypes={data.results}
         initialQuery={data.query}
-        onSelect={(item) => resolve(item)}
-        onCancel={() => resolve(undefined)}
+        onSelect={(item) => {
+          result = item;
+        }}
+        onCancel={() => {}}
       />,
     );
-    waitUntilExit();
+    waitUntilExit().then(
+      () => resolve(result),
+      () => resolve(result),
+    );
   });
 }
 

--- a/src/presentation/output/workflow_action_select_output.tsx
+++ b/src/presentation/output/workflow_action_select_output.tsx
@@ -81,16 +81,22 @@ function renderInteractiveWorkflowActionSelect(
   data: WorkflowActionSelectData,
 ): Promise<WorkflowAction | undefined> {
   return new Promise<WorkflowAction | undefined>((resolve) => {
+    let result: WorkflowAction | undefined;
     const { waitUntilExit } = render(
       <WorkflowActionSelectUI
         workflowName={data.workflowName}
         workflowDescription={data.workflowDescription}
         hasInputs={data.hasInputs}
-        onSelect={(action) => resolve(action)}
-        onCancel={() => resolve(undefined)}
+        onSelect={(action) => {
+          result = action;
+        }}
+        onCancel={() => {}}
       />,
     );
-    waitUntilExit();
+    waitUntilExit().then(
+      () => resolve(result),
+      () => resolve(result),
+    );
   });
 }
 

--- a/src/presentation/output/workflow_history_search_output.tsx
+++ b/src/presentation/output/workflow_history_search_output.tsx
@@ -83,15 +83,21 @@ export function renderInteractiveWorkflowHistorySearch(
   data: WorkflowHistorySearchData,
 ): Promise<WorkflowHistorySearchItem | undefined> {
   return new Promise<WorkflowHistorySearchItem | undefined>((resolve) => {
+    let result: WorkflowHistorySearchItem | undefined;
     const { waitUntilExit } = render(
       <WorkflowHistorySearchUI
         runs={data.results}
         initialQuery={data.query}
-        onSelect={(item) => resolve(item)}
-        onCancel={() => resolve(undefined)}
+        onSelect={(item) => {
+          result = item;
+        }}
+        onCancel={() => {}}
       />,
     );
-    waitUntilExit();
+    waitUntilExit().then(
+      () => resolve(result),
+      () => resolve(result),
+    );
   });
 }
 

--- a/src/presentation/output/workflow_search_output.tsx
+++ b/src/presentation/output/workflow_search_output.tsx
@@ -78,15 +78,21 @@ export function renderInteractiveWorkflowSearch(
   data: WorkflowSearchData,
 ): Promise<WorkflowSearchItem | undefined> {
   return new Promise<WorkflowSearchItem | undefined>((resolve) => {
+    let result: WorkflowSearchItem | undefined;
     const { waitUntilExit } = render(
       <WorkflowSearchUI
         workflows={data.results}
         initialQuery={data.query}
-        onSelect={(item) => resolve(item)}
-        onCancel={() => resolve(undefined)}
+        onSelect={(item) => {
+          result = item;
+        }}
+        onCancel={() => {}}
       />,
     );
-    waitUntilExit();
+    waitUntilExit().then(
+      () => resolve(result),
+      () => resolve(result),
+    );
   });
 }
 


### PR DESCRIPTION
## Summary

- All 10 interactive render functions (model search, workflow search, data search, vault search, etc.) called `waitUntilExit()` without awaiting it, leaving a floating promise
- The `onSelect`/`onCancel` callbacks resolved the outer promise immediately, before ink finished cleaning up the TTY
- During ink's async teardown, a pending `TTY.#read` in Deno's Node.js compat layer hits EAGAIN, surfacing as `Uncaught WouldBlock: Resource temporarily unavailable (os error 11)` that crashes the process
- Fix: store callback result in a local variable and resolve only after `waitUntilExit()` completes, with a rejection handler to gracefully handle TTY cleanup errors

## Test plan

- [x] `deno check` passes on all 10 modified files
- [x] All 36 existing tests pass (`deno task test` on model_search and type_search test files)
- [ ] `swamp model edit` → select a model → opens editor without WouldBlock crash
- [ ] `swamp model edit` → press Esc → exits cleanly
- [ ] `swamp workflow edit` → select a workflow → opens editor without crash
- [ ] `echo "yaml" | swamp model edit mymodel` → stdin pipe still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)