### PR TITLE
fix: Use relative paths in .swamp data files for multi-user repos

### DIFF
--- a/src/cli/commands/model_method_history_logs.ts
+++ b/src/cli/commands/model_method_history_logs.ts
@@ -32,6 +32,7 @@ import {
   readLogFile,
   renderLogFile,
 } from "../../presentation/output/log_file_reader.ts";
+import { toRelativePath } from "../../infrastructure/persistence/paths.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -51,7 +52,7 @@ export const modelMethodHistoryLogsCommand = new Command()
     ]);
     ctx.logger.debug`Getting logs for method run: ${outputIdOrModelName}`;
 
-    const { repoContext } = await requireInitializedRepo({
+    const { repoDir, repoContext } = await requireInitializedRepo({
       repoDir: options.repoDir ?? ".",
       outputMode: ctx.outputMode,
     });
@@ -145,13 +146,17 @@ export const modelMethodHistoryLogsCommand = new Command()
     const tail = options.tail as number | undefined;
     const logData = await readLogFile(output.logFile, { tail });
 
+    // Use relative path for display
+    const displayPath = toRelativePath(repoDir, output.logFile);
+    const logDataWithRelativePath = { ...logData, path: displayPath };
+
     if (logData.lines.length === 0) {
       if (ctx.outputMode === "json") {
         console.log(JSON.stringify(
           {
             outputId: output.id,
             methodName: output.methodName,
-            path: output.logFile,
+            path: displayPath,
             lines: [],
             lineCount: 0,
           },
@@ -159,12 +164,12 @@ export const modelMethodHistoryLogsCommand = new Command()
           2,
         ));
       } else {
-        console.log(`Log file not found or empty: ${output.logFile}`);
+        console.log(`Log file not found or empty: ${displayPath}`);
       }
       return;
     }
 
-    renderLogFile(logData, ctx.outputMode);
+    renderLogFile(logDataWithRelativePath, ctx.outputMode);
 
     ctx.logger.debug("Model method history logs command completed");
   });

--- a/src/cli/commands/workflow_history_logs.ts
+++ b/src/cli/commands/workflow_history_logs.ts
@@ -31,6 +31,7 @@ import {
   readLogFile,
   renderLogFile,
 } from "../../presentation/output/log_file_reader.ts";
+import { toRelativePath } from "../../infrastructure/persistence/paths.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -51,7 +52,7 @@ export const workflowHistoryLogsCommand = new Command()
     );
     ctx.logger.debug`Getting logs for workflow run: ${runIdOrWorkflow}`;
 
-    const { repoContext } = await requireInitializedRepo({
+    const { repoDir, repoContext } = await requireInitializedRepo({
       repoDir: options.repoDir ?? ".",
       outputMode: ctx.outputMode,
     });
@@ -126,13 +127,17 @@ export const workflowHistoryLogsCommand = new Command()
     const tail = options.tail as number | undefined;
     const logData = await readLogFile(run.logFile, { tail });
 
+    // Use relative path for display
+    const displayPath = toRelativePath(repoDir, run.logFile);
+    const logDataWithRelativePath = { ...logData, path: displayPath };
+
     if (logData.lines.length === 0) {
       if (ctx.outputMode === "json") {
         console.log(JSON.stringify(
           {
             runId: run.id,
             workflowName: run.workflowName,
-            path: run.logFile,
+            path: displayPath,
             lines: [],
             lineCount: 0,
           },
@@ -140,12 +145,12 @@ export const workflowHistoryLogsCommand = new Command()
           2,
         ));
       } else {
-        console.log(`Log file not found or empty: ${run.logFile}`);
+        console.log(`Log file not found or empty: ${displayPath}`);
       }
       return;
     }
 
-    renderLogFile(logData, ctx.outputMode);
+    renderLogFile(logDataWithRelativePath, ctx.outputMode);
 
     ctx.logger.debug("Workflow history logs command completed");
   });

--- a/src/infrastructure/persistence/paths.ts
+++ b/src/infrastructure/persistence/paths.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { join } from "@std/path";
+import { isAbsolute, join, relative } from "@std/path";
 
 /**
  * Central constants for swamp data storage paths.
@@ -91,4 +91,39 @@ export function swampPath(repoDir: string, ...segments: string[]): string {
  */
 export function swampMarkerPath(repoDir: string): string {
   return join(repoDir, SWAMP_MARKER_FILE);
+}
+
+/**
+ * Converts an absolute path to a relative path from the repository root.
+ *
+ * Used when persisting paths to YAML files so they work across different
+ * users and machines. If the path is already relative, returns it unchanged.
+ *
+ * @param repoDir - The repository root directory
+ * @param absolutePath - The absolute path to convert
+ * @returns The relative path from repoDir
+ */
+export function toRelativePath(repoDir: string, absolutePath: string): string {
+  if (!isAbsolute(absolutePath)) {
+    return absolutePath; // Already relative
+  }
+  return relative(repoDir, absolutePath);
+}
+
+/**
+ * Converts a relative path to an absolute path from the repository root.
+ *
+ * Used when loading paths from YAML files to reconstruct the full path
+ * for the current machine. If the path is already absolute, returns it
+ * unchanged for backwards compatibility with existing data.
+ *
+ * @param repoDir - The repository root directory
+ * @param relativePath - The relative path to convert
+ * @returns The absolute path
+ */
+export function toAbsolutePath(repoDir: string, relativePath: string): string {
+  if (isAbsolute(relativePath)) {
+    return relativePath; // Backwards compat: already absolute
+  }
+  return join(repoDir, relativePath);
 }

--- a/src/infrastructure/persistence/paths_test.ts
+++ b/src/infrastructure/persistence/paths_test.ts
@@ -24,6 +24,8 @@ import {
   SWAMP_SUBDIRS,
   swampMarkerPath,
   swampPath,
+  toAbsolutePath,
+  toRelativePath,
 } from "./paths.ts";
 
 Deno.test("SWAMP_DATA_DIR is .swamp", () => {
@@ -80,4 +82,71 @@ Deno.test("swampPath with SWAMP_SUBDIRS constants", () => {
     swampPath("/repo", SWAMP_SUBDIRS.workflowRuns, "workflow-123"),
     "/repo/.swamp/workflow-runs/workflow-123",
   );
+});
+
+Deno.test("toRelativePath - converts absolute path inside repo to relative", () => {
+  const repoDir = "/Users/john/repo";
+  const absolutePath = "/Users/john/repo/.swamp/outputs/aws/cli/run.log";
+
+  const result = toRelativePath(repoDir, absolutePath);
+
+  assertEquals(result, ".swamp/outputs/aws/cli/run.log");
+});
+
+Deno.test("toRelativePath - returns already relative path unchanged", () => {
+  const repoDir = "/Users/john/repo";
+  const relativePath = ".swamp/outputs/aws/cli/run.log";
+
+  const result = toRelativePath(repoDir, relativePath);
+
+  assertEquals(result, ".swamp/outputs/aws/cli/run.log");
+});
+
+Deno.test("toRelativePath - handles path at repo root", () => {
+  const repoDir = "/Users/john/repo";
+  const absolutePath = "/Users/john/repo/file.txt";
+
+  const result = toRelativePath(repoDir, absolutePath);
+
+  assertEquals(result, "file.txt");
+});
+
+Deno.test("toAbsolutePath - converts relative path to absolute", () => {
+  const repoDir = "/Users/john/repo";
+  const relativePath = ".swamp/outputs/aws/cli/run.log";
+
+  const result = toAbsolutePath(repoDir, relativePath);
+
+  assertEquals(result, "/Users/john/repo/.swamp/outputs/aws/cli/run.log");
+});
+
+Deno.test("toAbsolutePath - returns already absolute path unchanged (backwards compat)", () => {
+  const repoDir = "/Users/john/repo";
+  const absolutePath = "/Users/john/repo/.swamp/outputs/aws/cli/run.log";
+
+  const result = toAbsolutePath(repoDir, absolutePath);
+
+  assertEquals(result, "/Users/john/repo/.swamp/outputs/aws/cli/run.log");
+});
+
+Deno.test("toAbsolutePath - handles different repo directory", () => {
+  const repoDir = "/home/alice/projects/infra";
+  const relativePath = ".swamp/workflow-runs/my-workflow/run.yaml";
+
+  const result = toAbsolutePath(repoDir, relativePath);
+
+  assertEquals(
+    result,
+    "/home/alice/projects/infra/.swamp/workflow-runs/my-workflow/run.yaml",
+  );
+});
+
+Deno.test("toRelativePath and toAbsolutePath - round trip", () => {
+  const repoDir = "/Users/john/repo";
+  const originalAbsolute = "/Users/john/repo/.swamp/outputs/test.log";
+
+  const relative = toRelativePath(repoDir, originalAbsolute);
+  const backToAbsolute = toAbsolutePath(repoDir, relative);
+
+  assertEquals(backToAbsolute, originalAbsolute);
 });

--- a/src/infrastructure/persistence/yaml_output_repository.ts
+++ b/src/infrastructure/persistence/yaml_output_repository.ts
@@ -21,7 +21,12 @@ import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
-import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
+import {
+  SWAMP_SUBDIRS,
+  swampPath,
+  toAbsolutePath,
+  toRelativePath,
+} from "./paths.ts";
 import type { OutputRepository } from "../../domain/models/repositories.ts";
 import type { DefinitionId } from "../../domain/definitions/definition.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
@@ -56,6 +61,10 @@ export class YamlOutputRepository implements OutputRepository {
           const content = await Deno.readTextFile(path);
           const data = parseYaml(content) as ModelOutputData;
           if (data.id === id) {
+            // Convert logFile back to absolute path
+            if (data.logFile) {
+              data.logFile = toAbsolutePath(this.repoDir, data.logFile);
+            }
             return ModelOutput.fromData(data);
           }
         }
@@ -106,6 +115,10 @@ export class YamlOutputRepository implements OutputRepository {
               const path = join(methodDir, entry.name);
               const content = await Deno.readTextFile(path);
               const data = parseYaml(content) as ModelOutputData;
+              // Convert logFile back to absolute path
+              if (data.logFile) {
+                data.logFile = toAbsolutePath(this.repoDir, data.logFile);
+              }
               outputs.push(ModelOutput.fromData(data));
             }
           }
@@ -152,6 +165,10 @@ export class YamlOutputRepository implements OutputRepository {
 
     const path = this.getPath(type, method, output);
     const data = output.toData();
+    // Convert logFile to relative path for storage
+    if (data.logFile) {
+      data.logFile = toRelativePath(this.repoDir, data.logFile);
+    }
     // Remove undefined values since YAML can't stringify them
     const cleanData = JSON.parse(JSON.stringify(data));
     const content = stringifyYaml(cleanData as Record<string, unknown>);

--- a/src/infrastructure/persistence/yaml_workflow_run_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository.ts
@@ -21,7 +21,12 @@ import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import type { WorkflowRunRepository } from "../../domain/workflows/repositories.ts";
-import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
+import {
+  SWAMP_SUBDIRS,
+  swampPath,
+  toAbsolutePath,
+  toRelativePath,
+} from "./paths.ts";
 import {
   createWorkflowRunId,
   type WorkflowId,
@@ -66,6 +71,10 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
           const content = await Deno.readTextFile(path);
           const data = parseYaml(content) as WorkflowRunData;
           if (data.id === runId) {
+            // Convert logFile back to absolute path
+            if (data.logFile) {
+              data.logFile = toAbsolutePath(this.repoDir, data.logFile);
+            }
             return WorkflowRun.fromData(data);
           }
         }
@@ -93,6 +102,10 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
           const path = join(dir, entry.name);
           const content = await Deno.readTextFile(path);
           const data = parseYaml(content) as WorkflowRunData;
+          // Convert logFile back to absolute path
+          if (data.logFile) {
+            data.logFile = toAbsolutePath(this.repoDir, data.logFile);
+          }
           runs.push(WorkflowRun.fromData(data));
         }
       }
@@ -168,6 +181,10 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
     }
 
     const data = run.toData();
+    // Convert logFile to relative path for storage
+    if (data.logFile) {
+      data.logFile = toRelativePath(this.repoDir, data.logFile);
+    }
     // Remove undefined values since YAML can't stringify them
     const cleanData = JSON.parse(JSON.stringify(data));
     const content = stringifyYaml(cleanData as Record<string, unknown>);


### PR DESCRIPTION
- Store `logFile` paths as relative paths in YAML data files instead of absolute paths
- Convert paths at the serialization boundary (repositories) to maintain runtime behavior
- Display relative paths in CLI output for `workflow history logs` and `model method history logs`

## Test plan
- [x] Unit tests for `toRelativePath()` and `toAbsolutePath()` utilities
- [x] All 1781 existing tests pass
- [x] Backwards compatible: absolute paths in existing data are handled correctly on load

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)