### PR TITLE
Fix ink interactive TUI crash from Deno TTY WouldBlock error

### DIFF
--- a/src/presentation/output/data_search_output.tsx
+++ b/src/presentation/output/data_search_output.tsx
@@ -22,6 +22,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Box, render, Text, useApp, useInput } from "ink";
 import type { OutputMode } from "./output.ts";
 import { Fzf, type FzfResultItem } from "fzf";
+import { suppressInkTtyErrors } from "./ink_lifecycle.ts";
 
 /**
  * Represents a single data search result item.
@@ -127,21 +128,22 @@ function renderInteractiveDataSearch(
   data: DataSearchData,
 ): Promise<DataSearchItem | undefined> {
   return new Promise<DataSearchItem | undefined>((resolve) => {
-    let result: DataSearchItem | undefined;
+    const cleanupTty = suppressInkTtyErrors();
     const { waitUntilExit } = render(
       <DataSearchUI
         items={data.results}
         initialQuery={data.query}
         onSelect={(item) => {
-          result = item;
+          cleanupTty();
+          resolve(item);
         }}
-        onCancel={() => {}}
+        onCancel={() => {
+          cleanupTty();
+          resolve(undefined);
+        }}
       />,
     );
-    waitUntilExit().then(
-      () => resolve(result),
-      () => resolve(result),
-    );
+    waitUntilExit().catch(() => {});
   });
 }
 

--- a/src/presentation/output/ink_lifecycle.ts
+++ b/src/presentation/output/ink_lifecycle.ts
@@ -1,0 +1,70 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import process from "node:process";
+
+function isWouldBlock(err: unknown): boolean {
+  if (err == null || typeof err !== "object") return false;
+  const e = err as Record<string, unknown>;
+  return (
+    e.name === "WouldBlock" ||
+    (typeof e.message === "string" && e.message.includes("os error 11"))
+  );
+}
+
+/**
+ * Suppresses WouldBlock errors from Deno's Node.js compat TTY layer
+ * that occur during ink's stdin cleanup. This works around a Deno bug
+ * where EAGAIN on non-blocking TTY reads crashes the process instead
+ * of being retried.
+ *
+ * Installs handlers on three error surfaces:
+ * - process.stdin "error" event (Node.js stream errors)
+ * - globalThis "unhandledrejection" (async function rejections)
+ * - globalThis "error" (uncaught exceptions)
+ *
+ * Call before `render()`, and call the returned cleanup function
+ * after the ink selection callback fires.
+ */
+export function suppressInkTtyErrors(): () => void {
+  const onStdinError = (err: Error) => {
+    if (!isWouldBlock(err)) throw err;
+  };
+
+  const onRejection = (event: PromiseRejectionEvent) => {
+    if (isWouldBlock(event.reason)) event.preventDefault();
+  };
+
+  const onError = (event: ErrorEvent) => {
+    if (isWouldBlock(event.error)) event.preventDefault();
+  };
+
+  process.stdin.on("error", onStdinError);
+  globalThis.addEventListener("unhandledrejection", onRejection);
+  globalThis.addEventListener("error", onError);
+
+  return () => {
+    // Delay removal to catch late-firing errors from ink's async cleanup
+    setTimeout(() => {
+      process.stdin.removeListener("error", onStdinError);
+      globalThis.removeEventListener("unhandledrejection", onRejection);
+      globalThis.removeEventListener("error", onError);
+    }, 100);
+  };
+}

--- a/src/presentation/output/input_file_select_output.tsx
+++ b/src/presentation/output/input_file_select_output.tsx
@@ -22,6 +22,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Box, render, Text, useApp, useInput } from "ink";
 import type { OutputMode } from "./output.ts";
 import { Fzf, type FzfResultItem } from "fzf";
+import { suppressInkTtyErrors } from "./ink_lifecycle.ts";
 import { useScrollableList } from "./hooks/mod.ts";
 import { join, relative } from "@std/path";
 
@@ -77,7 +78,7 @@ function renderInteractiveInputFileSelect(
   data: InputFileSelectData,
 ): Promise<InputFileSelection | undefined> {
   return new Promise<InputFileSelection | undefined>((resolve) => {
-    let result: InputFileSelection | undefined;
+    const cleanupTty = suppressInkTtyErrors();
     const { waitUntilExit } = render(
       <InputFileSelectUI
         workflowName={data.workflowName}
@@ -85,15 +86,16 @@ function renderInteractiveInputFileSelect(
         hasDefaults={data.hasDefaults}
         searchDir={data.searchDir}
         onSelect={(selection) => {
-          result = selection;
+          cleanupTty();
+          resolve(selection);
         }}
-        onCancel={() => {}}
+        onCancel={() => {
+          cleanupTty();
+          resolve(undefined);
+        }}
       />,
     );
-    waitUntilExit().then(
-      () => resolve(result),
-      () => resolve(result),
-    );
+    waitUntilExit().catch(() => {});
   });
 }
 

--- a/src/presentation/output/model_output_search_output.tsx
+++ b/src/presentation/output/model_output_search_output.tsx
@@ -22,6 +22,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import { Box, render, Text, useApp, useInput } from "ink";
 import type { OutputMode } from "./output.ts";
 import { Fzf, type FzfResultItem } from "fzf";
+import { suppressInkTtyErrors } from "./ink_lifecycle.ts";
 import { useScrollableList } from "./hooks/mod.ts";
 
 /**
@@ -82,21 +83,22 @@ export function renderInteractiveModelOutputSearch(
   data: ModelOutputSearchData,
 ): Promise<ModelOutputSearchItem | undefined> {
   return new Promise<ModelOutputSearchItem | undefined>((resolve) => {
-    let result: ModelOutputSearchItem | undefined;
+    const cleanupTty = suppressInkTtyErrors();
     const { waitUntilExit } = render(
       <ModelOutputSearchUI
         outputs={data.results}
         initialQuery={data.query}
         onSelect={(item) => {
-          result = item;
+          cleanupTty();
+          resolve(item);
         }}
-        onCancel={() => {}}
+        onCancel={() => {
+          cleanupTty();
+          resolve(undefined);
+        }}
       />,
     );
-    waitUntilExit().then(
-      () => resolve(result),
-      () => resolve(result),
-    );
+    waitUntilExit().catch(() => {});
   });
 }
 

--- a/src/presentation/output/model_search_output.tsx
+++ b/src/presentation/output/model_search_output.tsx
@@ -22,6 +22,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import { Box, render, Text, useApp, useInput } from "ink";
 import type { OutputMode } from "./output.ts";
 import { Fzf, type FzfResultItem } from "fzf";
+import { suppressInkTtyErrors } from "./ink_lifecycle.ts";
 import { useScrollableList } from "./hooks/mod.ts";
 
 /**
@@ -77,21 +78,22 @@ export function renderInteractiveModelSearch(
   data: ModelSearchData,
 ): Promise<ModelSearchItem | undefined> {
   return new Promise<ModelSearchItem | undefined>((resolve) => {
-    let result: ModelSearchItem | undefined;
+    const cleanupTty = suppressInkTtyErrors();
     const { waitUntilExit } = render(
       <ModelSearchUI
         models={data.results}
         initialQuery={data.query}
         onSelect={(item) => {
-          result = item;
+          cleanupTty();
+          resolve(item);
         }}
-        onCancel={() => {}}
+        onCancel={() => {
+          cleanupTty();
+          resolve(undefined);
+        }}
       />,
     );
-    waitUntilExit().then(
-      () => resolve(result),
-      () => resolve(result),
-    );
+    waitUntilExit().catch(() => {});
   });
 }
 

--- a/src/presentation/output/type_search_output.tsx
+++ b/src/presentation/output/type_search_output.tsx
@@ -22,6 +22,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import { Box, render, Text, useApp, useInput } from "ink";
 import type { OutputMode } from "./output.ts";
 import { Fzf, type FzfResultItem } from "fzf";
+import { suppressInkTtyErrors } from "./ink_lifecycle.ts";
 import { useScrollableList } from "./hooks/mod.ts";
 
 /**
@@ -76,21 +77,22 @@ export function renderInteractiveTypeSearch(
   data: TypeSearchData,
 ): Promise<TypeSearchItem | undefined> {
   return new Promise<TypeSearchItem | undefined>((resolve) => {
-    let result: TypeSearchItem | undefined;
+    const cleanupTty = suppressInkTtyErrors();
     const { waitUntilExit } = render(
       <TypeSearchUI
         types={data.results}
         initialQuery={data.query}
         onSelect={(item) => {
-          result = item;
+          cleanupTty();
+          resolve(item);
         }}
-        onCancel={() => {}}
+        onCancel={() => {
+          cleanupTty();
+          resolve(undefined);
+        }}
       />,
     );
-    waitUntilExit().then(
-      () => resolve(result),
-      () => resolve(result),
-    );
+    waitUntilExit().catch(() => {});
   });
 }
 

--- a/src/presentation/output/vault_search_output.tsx
+++ b/src/presentation/output/vault_search_output.tsx
@@ -22,6 +22,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import { Box, render, Text, useApp, useInput } from "ink";
 import type { OutputMode } from "./output.ts";
 import { Fzf, type FzfResultItem } from "fzf";
+import { suppressInkTtyErrors } from "./ink_lifecycle.ts";
 import type { VaultConfig } from "../../domain/vaults/vault_config.ts";
 import { useScrollableList } from "./hooks/mod.ts";
 
@@ -91,21 +92,22 @@ export function renderInteractiveVaultSearch(
   data: VaultSearchData,
 ): Promise<VaultSearchItem | undefined> {
   return new Promise<VaultSearchItem | undefined>((resolve) => {
-    let result: VaultSearchItem | undefined;
+    const cleanupTty = suppressInkTtyErrors();
     const { waitUntilExit } = render(
       <VaultSearchUI
         vaults={data.results}
         initialQuery={data.query}
         onSelect={(item) => {
-          result = item;
+          cleanupTty();
+          resolve(item);
         }}
-        onCancel={() => {}}
+        onCancel={() => {
+          cleanupTty();
+          resolve(undefined);
+        }}
       />,
     );
-    waitUntilExit().then(
-      () => resolve(result),
-      () => resolve(result),
-    );
+    waitUntilExit().catch(() => {});
   });
 }
 

--- a/src/presentation/output/vault_type_search_output.tsx
+++ b/src/presentation/output/vault_type_search_output.tsx
@@ -22,6 +22,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import { Box, render, Text, useApp, useInput } from "ink";
 import type { OutputMode } from "./output.ts";
 import { Fzf, type FzfResultItem } from "fzf";
+import { suppressInkTtyErrors } from "./ink_lifecycle.ts";
 import type { VaultTypeInfo } from "../../domain/vaults/vault_types.ts";
 import { useScrollableList } from "./hooks/mod.ts";
 
@@ -91,21 +92,22 @@ export function renderInteractiveVaultTypeSearch(
   data: VaultTypeSearchData,
 ): Promise<VaultTypeSearchItem | undefined> {
   return new Promise<VaultTypeSearchItem | undefined>((resolve) => {
-    let result: VaultTypeSearchItem | undefined;
+    const cleanupTty = suppressInkTtyErrors();
     const { waitUntilExit } = render(
       <VaultTypeSearchUI
         vaultTypes={data.results}
         initialQuery={data.query}
         onSelect={(item) => {
-          result = item;
+          cleanupTty();
+          resolve(item);
         }}
-        onCancel={() => {}}
+        onCancel={() => {
+          cleanupTty();
+          resolve(undefined);
+        }}
       />,
     );
-    waitUntilExit().then(
-      () => resolve(result),
-      () => resolve(result),
-    );
+    waitUntilExit().catch(() => {});
   });
 }
 

--- a/src/presentation/output/workflow_action_select_output.tsx
+++ b/src/presentation/output/workflow_action_select_output.tsx
@@ -21,6 +21,7 @@
 import React, { useState } from "react";
 import { Box, render, Text, useApp, useInput } from "ink";
 import type { OutputMode } from "./output.ts";
+import { suppressInkTtyErrors } from "./ink_lifecycle.ts";
 
 /**
  * Available actions after selecting a workflow from search.
@@ -81,22 +82,23 @@ function renderInteractiveWorkflowActionSelect(
   data: WorkflowActionSelectData,
 ): Promise<WorkflowAction | undefined> {
   return new Promise<WorkflowAction | undefined>((resolve) => {
-    let result: WorkflowAction | undefined;
+    const cleanupTty = suppressInkTtyErrors();
     const { waitUntilExit } = render(
       <WorkflowActionSelectUI
         workflowName={data.workflowName}
         workflowDescription={data.workflowDescription}
         hasInputs={data.hasInputs}
         onSelect={(action) => {
-          result = action;
+          cleanupTty();
+          resolve(action);
         }}
-        onCancel={() => {}}
+        onCancel={() => {
+          cleanupTty();
+          resolve(undefined);
+        }}
       />,
     );
-    waitUntilExit().then(
-      () => resolve(result),
-      () => resolve(result),
-    );
+    waitUntilExit().catch(() => {});
   });
 }
 

--- a/src/presentation/output/workflow_history_search_output.tsx
+++ b/src/presentation/output/workflow_history_search_output.tsx
@@ -22,6 +22,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import { Box, render, Text, useApp, useInput } from "ink";
 import type { OutputMode } from "./output.ts";
 import { Fzf, type FzfResultItem } from "fzf";
+import { suppressInkTtyErrors } from "./ink_lifecycle.ts";
 import { useScrollableList } from "./hooks/mod.ts";
 
 /**
@@ -83,21 +84,22 @@ export function renderInteractiveWorkflowHistorySearch(
   data: WorkflowHistorySearchData,
 ): Promise<WorkflowHistorySearchItem | undefined> {
   return new Promise<WorkflowHistorySearchItem | undefined>((resolve) => {
-    let result: WorkflowHistorySearchItem | undefined;
+    const cleanupTty = suppressInkTtyErrors();
     const { waitUntilExit } = render(
       <WorkflowHistorySearchUI
         runs={data.results}
         initialQuery={data.query}
         onSelect={(item) => {
-          result = item;
+          cleanupTty();
+          resolve(item);
         }}
-        onCancel={() => {}}
+        onCancel={() => {
+          cleanupTty();
+          resolve(undefined);
+        }}
       />,
     );
-    waitUntilExit().then(
-      () => resolve(result),
-      () => resolve(result),
-    );
+    waitUntilExit().catch(() => {});
   });
 }
 

--- a/src/presentation/output/workflow_search_output.tsx
+++ b/src/presentation/output/workflow_search_output.tsx
@@ -22,6 +22,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import { Box, render, Text, useApp, useInput } from "ink";
 import type { OutputMode } from "./output.ts";
 import { Fzf, type FzfResultItem } from "fzf";
+import { suppressInkTtyErrors } from "./ink_lifecycle.ts";
 import { useScrollableList } from "./hooks/mod.ts";
 
 /**
@@ -78,21 +79,22 @@ export function renderInteractiveWorkflowSearch(
   data: WorkflowSearchData,
 ): Promise<WorkflowSearchItem | undefined> {
   return new Promise<WorkflowSearchItem | undefined>((resolve) => {
-    let result: WorkflowSearchItem | undefined;
+    const cleanupTty = suppressInkTtyErrors();
     const { waitUntilExit } = render(
       <WorkflowSearchUI
         workflows={data.results}
         initialQuery={data.query}
         onSelect={(item) => {
-          result = item;
+          cleanupTty();
+          resolve(item);
         }}
-        onCancel={() => {}}
+        onCancel={() => {
+          cleanupTty();
+          resolve(undefined);
+        }}
       />,
     );
-    waitUntilExit().then(
-      () => resolve(result),
-      () => resolve(result),
-    );
+    waitUntilExit().catch(() => {});
   });
 }
 


### PR DESCRIPTION
## Summary

- Fixes `Uncaught WouldBlock: Resource temporarily unavailable (os error 11)` crash when selecting an item in any interactive TUI (model edit, workflow edit, search, etc.)
- Deno's Node.js compat layer doesn't handle EAGAIN on non-blocking TTY reads during ink's stdin teardown — it throws instead of retrying
- Adds `suppressInkTtyErrors()` utility that installs temporary error handlers on `process.stdin`, `unhandledrejection`, and `globalThis error` to catch WouldBlock during ink's lifecycle
- Resolves the render promise directly from `onSelect`/`onCancel` callbacks instead of waiting on `waitUntilExit()`, which hangs when ink's cleanup is broken by the TTY error

## Test plan

- [ ] `swamp model edit` → select a model → editor opens (was crashing with WouldBlock)
- [ ] `swamp model edit` → press Esc → exits cleanly
- [ ] `swamp workflow edit` → select a workflow → editor opens
- [ ] `swamp model edit <name>` → still works (non-interactive path)
- [ ] `echo "yaml" | swamp model edit <name>` → stdin pipe still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)