### PR TITLE
fix: Improve skill documentation clarity and progressive disclosure

### DIFF
--- a/.claude/skills/swamp-data/SKILL.md
+++ b/.claude/skills/swamp-data/SKILL.md
@@ -292,14 +292,14 @@ yet, accessing `.resource` will fail with "No such key". Use
 
 ```yaml
 # Access latest resource data via dot notation
-value: ${{ model.my-model.resource.output.output.attributes.result }}
+value: ${{ model.my-model.resource.output.main.attributes.result }}
 
 # Access specific version
-value: ${{ data.version("my-model", "output", 2).attributes.result }}
+value: ${{ data.version("my-model", "main", 2).attributes.result }}
 
 # Access file metadata
-path: ${{ model.my-model.file.content.content.path }}
-size: ${{ model.my-model.file.content.content.size }}
+path: ${{ model.my-model.file.content.primary.path }}
+size: ${{ model.my-model.file.content.primary.size }}
 
 # Lazy-load file contents
 body: ${{ file.contents("my-model", "content") }}

--- a/.claude/skills/swamp-data/references/examples.md
+++ b/.claude/skills/swamp-data/references/examples.md
@@ -15,7 +15,7 @@
 | Expression Pattern                                           | Description                                 |
 | ------------------------------------------------------------ | ------------------------------------------- |
 | `model.<name>.resource.<spec>.<instance>.attributes.<field>` | Cross-model resource reference (PREFERRED)  |
-| `model.<name>.resource.data.data.attributes.json.<field>`    | aws/cli with parseJson: true                |
+| `model.<name>.resource.data.output.attributes.json.<field>`  | aws/cli with parseJson: true                |
 | `model.<name>.file.<spec>.<instance>.path`                   | File path reference                         |
 | `self.name`                                                  | Current model's name                        |
 | `inputs.<name>`                                              | Workflow or model runtime input             |
@@ -28,12 +28,12 @@
 
 ## CEL Path Patterns by Model Type
 
-| Model Type      | CEL Path                                                             |
-| --------------- | -------------------------------------------------------------------- |
-| `command/shell` | `model.<name>.resource.result.result.attributes.stdout`              |
-| `aws/cli`       | `model.<name>.resource.data.data.attributes.json.<field>`            |
-| `@user/custom`  | `model.<name>.resource.<spec>.<instance>.attributes.<field>`         |
-| Factory models  | `model.<name>.resource.<spec>.<dynamic-instance>.attributes.<field>` |
+| Model Type      | CEL Path                                                             | Notes                              |
+| --------------- | -------------------------------------------------------------------- | ---------------------------------- |
+| `command/shell` | `model.<name>.resource.result.result.attributes.stdout`              | Built-in uses `result` for both    |
+| `aws/cli`       | `model.<name>.resource.data.output.attributes.json.<field>`          | spec=`data`, instance=`output`     |
+| `@user/custom`  | `model.<name>.resource.<spec>.<instance>.attributes.<field>`         | You choose both names              |
+| Factory models  | `model.<name>.resource.<spec>.<dynamic-instance>.attributes.<field>` | Instance varies (e.g., `vpc-1234`) |
 
 ## Cross-Model Data References
 
@@ -49,12 +49,12 @@ models' data. The `model.*` expression provides:
 ```yaml
 # PREFERRED: Cross-model resource reference
 globalArguments:
-  vpcId: ${{ model.my-vpc.resource.vpc.vpc.attributes.VpcId }}
-  subnetId: ${{ model.public-subnet.resource.subnet.subnet.attributes.SubnetId }}
+  vpcId: ${{ model.my-vpc.resource.vpc.main.attributes.VpcId }}
+  subnetId: ${{ model.public-subnet.resource.subnet.primary.attributes.SubnetId }}
 
 # For aws/cli models with parseJson: true
 globalArguments:
-  imageId: ${{ model.ami-lookup.resource.data.data.attributes.json.ImageId }}
+  imageId: ${{ model.ami-lookup.resource.data.output.attributes.json.ImageId }}
 ```
 
 ### When to Use data.latest()
@@ -118,8 +118,8 @@ jobs:
 # Known instance name from factory model
 subnetA: ${{ model.subnet-scanner.resource.subnet.subnet-aaa.attributes.cidr }}
 
-# Single-instance model (specName == instanceName convention)
-vpcId: ${{ model.my-vpc.resource.vpc.vpc.attributes.VpcId }}
+# Single-instance model — use descriptive instance name
+vpcId: ${{ model.my-vpc.resource.vpc.main.attributes.VpcId }}
 ```
 
 ## Version Management
@@ -272,7 +272,7 @@ jobs:
 # Model used by sub-workflow (tag-networking)
 name: tag-vpc
 globalArguments:
-  resourceId: ${{ model.networking-vpc.resource.vpc.vpc.attributes.VpcId }}
+  resourceId: ${{ model.networking-vpc.resource.vpc.main.attributes.VpcId }}
   tagKey: ManagedBy
   tagValue: Swamp
 ```

--- a/.claude/skills/swamp-data/references/troubleshooting.md
+++ b/.claude/skills/swamp-data/references/troubleshooting.md
@@ -45,7 +45,7 @@ swamp model method run <model-name> create --json
 **CEL path anatomy**:
 
 ```
-model.my-vpc.resource.vpc.vpc.attributes.VpcId
+model.my-vpc.resource.vpc.main.attributes.VpcId
       ──────         ─── ───
       model name     |   └── instanceName (from writeResource 2nd arg)
                      └── specName (from writeResource 1st arg)
@@ -168,7 +168,7 @@ swamp data get <model-name> <data-name> --json
 
 ### Step 2: Verify Path Components
 
-For expression `model.my-vpc.resource.vpc.vpc.attributes.VpcId`:
+For expression `model.my-vpc.resource.vpc.main.attributes.VpcId`:
 
 | Component | Check Command                                           |
 | --------- | ------------------------------------------------------- |
@@ -191,7 +191,7 @@ Create a test model that uses the expression and run validate:
 ```yaml
 name: test-expression
 globalArguments:
-  testValue: ${{ model.my-vpc.resource.vpc.vpc.attributes.VpcId }}
+  testValue: ${{ model.my-vpc.resource.vpc.main.attributes.VpcId }}
 ```
 
 ```bash

--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -31,16 +31,7 @@ doesn't exist. Extension models let you:
 **Important:** Do not default to generic CLI types (like `aws/cli`) for specific
 service integrations. If the user wants to manage S3 buckets, EC2 instances, or
 other resources, create a dedicated model for that service rather than wrapping
-CLI commands. Dedicated models provide:
-
-- Typed input validation with Zod schemas
-- Structured output data for use in workflows
-- Better error handling and resource tracking
-- Reusable automation components
-
-Extension models have the same capabilities as built-in models - they can make
-HTTP requests, run shell commands, interact with cloud APIs, and produce data
-outputs.
+CLI commands.
 
 ## Quick Reference
 
@@ -82,8 +73,7 @@ export const model = {
       description: "Process the input message",
       arguments: z.object({}),
       execute: async (args, context) => {
-        // writeResource(specName, instanceName, data) — for single-instance, use specName as instanceName
-        const handle = await context.writeResource!("result", "result", {
+        const handle = await context.writeResource!("result", "main", {
           message: context.globalArgs.message.toUpperCase(),
           timestamp: new Date().toISOString(),
         });
@@ -96,76 +86,19 @@ export const model = {
 
 ## Model Structure
 
-| Field             | Required | Description                                                              |
-| ----------------- | -------- | ------------------------------------------------------------------------ |
-| `type`            | Yes      | Unique identifier (`namespace/name`)                                     |
-| `version`         | Yes      | CalVer version (`YYYY.MM.DD.MICRO`)                                      |
-| `globalArguments` | No       | Zod schema for global arguments validation                               |
-| `resources`       | No       | Resource output specs — JSON data with Zod schema                        |
-| `files`           | No       | File output specs — binary/text with content type                        |
-| `inputsSchema`    | No       | Zod schema for runtime inputs                                            |
-| `methods`         | Yes      | Object of method definitions (each with required `arguments` Zod schema) |
-
-### Model-Level Inputs
-
-Models can define an `inputsSchema` for runtime parameterization. These inputs
-are provided via `--input` or `--input-file` when running methods:
-
-```typescript
-export const model = {
-  type: "@user/deploy",
-  version: 1,
-  globalArguments: z.object({
-    serviceName: z.string(),
-    target: z.string(), // Will use ${{ inputs.environment }}
-  }),
-  resources: {
-    "state": {
-      description: "Deployment resource state",
-      schema: z.object({
-        deployed: z.boolean(),
-        target: z.string(),
-      }),
-      lifetime: "infinite",
-      garbageCollection: 10,
-    },
-  },
-  inputsSchema: z.object({
-    environment: z.enum(["dev", "staging", "production"]),
-    dryRun: z.boolean().optional().default(false),
-  }),
-  methods: {
-    deploy: {
-      description: "Deploy the service",
-      arguments: z.object({}),
-      execute: async (args, context) => {
-        // Inputs are evaluated before execution, so context.globalArgs
-        // contains the resolved values (e.g., target = "production")
-        const handle = await context.writeResource!("state", "state", {
-          deployed: true,
-          target: context.globalArgs.target,
-        });
-        return { dataHandles: [handle] };
-      },
-    },
-  },
-};
-```
-
-**Usage:**
-
-```bash
-swamp model method run my-deploy deploy --input '{"environment": "production"}' --json
-```
-
-The `inputsSchema` defines what runtime inputs are accepted. These inputs are
-available in CEL expressions via `${{ inputs.<name> }}`.
+| Field             | Required | Description                                       |
+| ----------------- | -------- | ------------------------------------------------- |
+| `type`            | Yes      | Unique identifier (`@namespace/name`)             |
+| `version`         | Yes      | CalVer version (`YYYY.MM.DD.MICRO`)               |
+| `globalArguments` | No       | Zod schema for global arguments                   |
+| `resources`       | No       | Resource output specs (JSON data with Zod schema) |
+| `files`           | No       | File output specs (binary/text with content type) |
+| `inputsSchema`    | No       | Zod schema for runtime inputs                     |
+| `methods`         | Yes      | Object of method definitions with `arguments` Zod |
 
 ## Resources & Files
 
-Models declare their data outputs using `resources` and/or `files` on the model
-definition. These are model-level — shared across all methods. Any method can
-write to any declared spec.
+Models declare their data outputs using `resources` and/or `files`.
 
 ### Resource Specs
 
@@ -185,27 +118,11 @@ resources: {
 },
 ```
 
-| Field               | Required | Description                                   |
-| ------------------- | -------- | --------------------------------------------- |
-| `description`       | No       | Human-readable description                    |
-| `schema`            | Yes      | Zod schema for validation                     |
-| `lifetime`          | Yes      | How long data persists                        |
-| `garbageCollection` | Yes      | Version retention policy                      |
-| `tags`              | No       | Extra tags (auto-includes `type: "resource"`) |
+**Spec naming:** Resource spec keys must not contain hyphens (`-`). Use
+camelCase or single words (e.g., `igw` not `internet-gateway`).
 
-**Spec naming:** Resource spec keys must not contain hyphens (`-`). CEL
-expressions use dot-notation to access resources
-(`model.<m>.resource.<specName>.<instanceName>.attributes.<field>`), and hyphens
-in spec names are interpreted as the subtraction operator. Use camelCase or
-single words instead (e.g., `igw` not `internet-gateway`, `routeTable` not
-`route-table`).
-
-**Schema and expression validation:** If your resource will be referenced by
-other models via CEL expressions, you must declare the referenced properties
-explicitly in the Zod schema. Using `z.object({}).passthrough()` allows any data
-to be stored, but the expression path validator cannot resolve attribute
-references against an empty schema. Always declare the key properties you need
-to reference:
+**Schema requirement:** If your resource will be referenced by other models via
+CEL expressions, declare the referenced properties explicitly in the Zod schema:
 
 ```typescript
 // Wrong — expression validator can't resolve attributes.VpcId
@@ -228,272 +145,76 @@ files: {
     garbageCollection: 5,
     streaming: true,
   },
-  "download": {
-    description: "Downloaded file",
-    contentType: "application/octet-stream",
-    lifetime: "infinite",
-    garbageCollection: 10,
-  },
 },
 ```
 
-| Field               | Required | Description                               |
-| ------------------- | -------- | ----------------------------------------- |
-| `description`       | No       | Human-readable description                |
-| `contentType`       | Yes      | MIME type                                 |
-| `lifetime`          | Yes      | How long data persists                    |
-| `garbageCollection` | Yes      | Version retention policy                  |
-| `streaming`         | No       | True for line-oriented streaming          |
-| `tags`              | No       | Extra tags (auto-includes `type: "file"`) |
-
 ## Execute Function
 
-The execute function receives pre-validated `args` (from the method's
-`arguments` Zod schema) and a `context` object. It uses `writeResource` for JSON
-data and `createFileWriter` for binary/text content.
+The execute function receives pre-validated `args` and a `context` object:
 
 ```typescript
 execute: (async (args, context) => {
-  // args                   - Pre-validated against the method's `arguments` Zod schema
-  // context.globalArgs     - Global arguments (validated against model's `globalArguments` schema)
-  // context.definition     - { id, name, version, tags } of the current definition
+  // args                   - Pre-validated method arguments
+  // context.globalArgs     - Global arguments
+  // context.definition     - { id, name, version, tags }
   // context.methodName     - Name of the executing method
   // context.repoDir        - Repository root path
-  // context.logger         - LogTape Logger for emitting log messages
+  // context.logger         - LogTape Logger
   // context.dataRepository - For advanced data operations
-  // context.writeResource  - Write structured JSON data (validates against schema)
-  // context.createFileWriter - Create a writer for binary/text files
-  // context.inputs         - Runtime inputs (if inputsSchema defined)
+  // context.writeResource  - Write structured JSON data
+  // context.createFileWriter - Create a writer for files
 
-  // 1. Write a resource — specName must match a key in `resources`
-  const handle = await context.writeResource!("result", "result", {
+  const handle = await context.writeResource!("result", "main", {
     value: "processed",
     timestamp: new Date().toISOString(),
   });
 
-  // 2. Return the data handles
   return { dataHandles: [handle] };
 });
 ```
 
-### writeResource API
-
-Write structured JSON data:
-`context.writeResource(specName, name, data, overrides?)`.
-
-- `specName` — must match a key in the model's `resources`
-- `name` — the instance name (any non-empty string; use specName for
-  single-instance resources)
-
-Data is validated against the resource's Zod schema (warns on mismatch, doesn't
-throw). The `name` you pass here is the `<instanceName>` used in CEL:
-`model.<defName>.resource.<specName>.<instanceName>.attributes.<field>`.
-
-**ResourceWriteOverrides** (optional):
-
-| Field               | Description                                    |
-| ------------------- | ---------------------------------------------- |
-| `lifetime`          | Override lifetime (default from spec)          |
-| `garbageCollection` | Override version retention (default from spec) |
-| `tags`              | Additional tags                                |
-
-### createFileWriter API
-
-Create a file writer: `context.createFileWriter(specName, name, overrides?)`.
-
-- `specName` — must match a key in the model's `files`
-- `name` — the instance name (any non-empty string; use specName for
-  single-instance files)
-
-Returns a `DataWriter` for binary/streaming content. The `name` you pass here is
-the `<instanceName>` used in CEL:
-`model.<defName>.file.<specName>.<instanceName>.path`.
-
-**FileWriterOverrides** (optional):
-
-| Field               | Description                                    |
-| ------------------- | ---------------------------------------------- |
-| `contentType`       | Override MIME type (default from spec)         |
-| `lifetime`          | Override lifetime (default from spec)          |
-| `garbageCollection` | Override version retention (default from spec) |
-| `streaming`         | True for line-oriented streaming               |
-| `tags`              | Additional tags                                |
-
-**DataWriter Methods:**
-
-| Method                      | Description                                      |
-| --------------------------- | ------------------------------------------------ |
-| `writeAll(content)`         | Write complete binary content (`Uint8Array`)     |
-| `writeText(text)`           | Write text content (encoded as UTF-8)            |
-| `writeLine(line)`           | Append a single line (for streaming/incremental) |
-| `writeStream(stream, opts)` | Pipe a `ReadableStream<Uint8Array>`              |
-| `getFilePath()`             | Get the file path for direct I/O                 |
-| `finalize()`                | Finalize after using `writeLine`/`getFilePath`   |
-
-**DataHandle** (returned by `writeResource` and writer methods):
-
-| Field      | Description                          |
-| ---------- | ------------------------------------ |
-| `name`     | Data artifact name                   |
-| `specName` | The declared spec name               |
-| `kind`     | `"resource"` or `"file"`             |
-| `dataId`   | Unique ID for this data              |
-| `version`  | Version number of this write         |
-| `size`     | Size of the written content in bytes |
-| `tags`     | Tags from the writer options         |
-| `metadata` | Full metadata for the data artifact  |
-
-**UserMethodResult:**
-
-The execute function returns `{ dataHandles?: DataHandle[] }`.
-
-### Reading Stored Data
-
-Delete and update methods need to read back previously stored resource data
-(e.g., to get a resource ID for cleanup). Use `context.dataRepository` with
-`context.modelType` and `context.modelId`:
-
-```typescript
-const content = await context.dataRepository.getContent(
-  context.modelType,
-  context.modelId,
-  "<specName>", // matches a key in resources
-  "<instanceName>", // instance name used when writing
-);
-// Returns Uint8Array | null
-```
-
-To parse the content:
-
-```typescript
-if (!content) {
-  throw new Error("No data found - nothing to delete");
-}
-const data = JSON.parse(new TextDecoder().decode(content));
-```
-
-**Key dataRepository methods for model authors:**
-
-| Method                                                    | Returns              | Description                            |
-| --------------------------------------------------------- | -------------------- | -------------------------------------- |
-| `getContent(type, modelId, dataName, instanceName, ver?)` | `Uint8Array \| null` | Get raw content bytes                  |
-| `findByName(type, modelId, dataName, instanceName, ver?)` | `Data \| null`       | Get data metadata (tags, version, etc) |
-| `findAllForModel(type, modelId)`                          | `Data[]`             | List all data for this model instance  |
-
-### Lifetime Values
-
-| Value       | Behavior                                     |
-| ----------- | -------------------------------------------- |
-| `ephemeral` | Deleted after method/workflow completes      |
-| `job`       | Persists while creating job runs             |
-| `workflow`  | Persists while creating workflow runs        |
-| Duration    | Expires after time (e.g., `1h`, `7d`, `1mo`) |
-| `infinite`  | Never expires (default)                      |
-
-### Standard Tags
-
-Tags are auto-applied based on the spec kind:
-
-| Tag                  | Applied to | Description                              |
-| -------------------- | ---------- | ---------------------------------------- |
-| `type: "resource"`   | resources  | Auto-added to all resource data outputs  |
-| `type: "file"`       | files      | Auto-added to all file data outputs      |
-| `specName: "<name>"` | both       | Auto-added with the output spec key name |
+For detailed API documentation on `writeResource`, `createFileWriter`,
+`DataWriter`, `DataHandle`, and `dataRepository`, see
+[references/api.md](references/api.md).
 
 ## Instance Names
 
-The `name` parameter (second argument) on `writeResource` and `createFileWriter`
-sets the **instance name** — this is the same identifier used in CEL expressions
-to access the data:
+The `instanceName` parameter on `writeResource` and `createFileWriter` sets the
+identifier used in CEL expressions:
 
 ```
-writeResource("state", "my-deploy", data)
-  → accessible as: model.<defName>.resource.state.my-deploy.attributes.<field>
-                                          ─────  ─────────
-                                        specName instanceName
+writeResource("state", "current", data)
+  → model.<name>.resource.state.current.attributes.<field>
+                          ─────  ───────
+                        specName instanceName
 ```
 
-**Convention:** For single-instance resources (most models), pass the specName
-as both arguments: `writeResource("state", "state", data)`. This produces the
-CEL path `model.<name>.resource.state.state.attributes.<field>`.
+**Convention:** For single-instance resources (most models), use a descriptive
+instance name like `main`, `current`, or `primary`.
 
 **Factory models** use distinct instance names to produce multiple outputs from
-one spec — see [Factory Models](#factory-models-dynamic-instance-names) below.
+one spec — see [Factory Models](#factory-models) below.
 
-> **Both `specName` and `name` are required.** If you omit the `name` argument
-> (old 2-arg form), the `data` object is silently treated as the name string,
-> causing a runtime error.
-
-## Factory Models (Dynamic Instance Names)
+## Factory Models
 
 A single method execution can produce multiple dynamically-named resources from
-the same output spec by passing a `name` override. This is useful when a model
-discovers N items and needs to emit each as a separately-addressable resource.
+the same output spec. This is useful when a model discovers N items and needs to
+emit each as a separately-addressable resource.
 
 ```typescript
-// extensions/models/subnet_scanner.ts
-import { z } from "npm:zod@4";
-
-const GlobalArgsSchema = z.object({ vpcId: z.string() });
-
-const SubnetSchema = z.object({
-  subnetId: z.string(),
-  cidr: z.string(),
-  az: z.string(),
-});
-
-export const model = {
-  type: "@user/subnet-scanner",
-  version: "2026.02.10.1",
-  globalArguments: GlobalArgsSchema,
-  resources: {
-    "subnet": {
-      description: "Discovered subnet",
-      schema: SubnetSchema,
-      lifetime: "infinite",
-      garbageCollection: 10,
-    },
-  },
-  methods: {
-    scan: {
-      description: "Scan VPC and emit each subnet as a named resource",
-      arguments: z.object({}),
-      execute: async (args, context) => {
-        // Simulated discovery — real model would call AWS API
-        const subnets = [
-          { subnetId: "subnet-aaa", cidr: "10.0.1.0/24", az: "us-east-1a" },
-          { subnetId: "subnet-bbb", cidr: "10.0.2.0/24", az: "us-east-1b" },
-        ];
-
-        const handles = [];
-        for (const subnet of subnets) {
-          // Each call uses the same "subnet" spec but a unique instance name
-          const handle = await context.writeResource!(
-            "subnet",
-            subnet.subnetId,
-            subnet,
-          );
-          handles.push(handle);
-        }
-        return { dataHandles: handles };
-      },
-    },
-  },
-};
+const handles = [];
+for (const subnet of subnets) {
+  const handle = await context.writeResource!(
+    "subnet",
+    subnet.subnetId, // Dynamic instance name
+    subnet,
+  );
+  handles.push(handle);
+}
+return { dataHandles: handles };
 ```
 
-### How it works
-
-- The `name` parameter (second argument) on `writeResource` / `createFileWriter`
-  sets the instance name.
-- Each write produces a distinct data artifact — validation passes because
-  instance names are unique.
-- A `specName` tag is auto-injected so all instances from the same spec can be
-  discovered with `data.findBySpec("model-name", "subnet")`.
-- Individual instances are addressable in CEL as
-  `model.<name>.resource.<specName>.<instanceName>.attributes.<field>`.
-
-### Discovering factory outputs in CEL
+**Discovering factory outputs in CEL:**
 
 ```yaml
 # Get all subnets produced by the scanner
@@ -503,42 +224,27 @@ allSubnets: ${{ data.findBySpec("my-scanner", "subnet") }}
 subnetA: ${{ model.my-scanner.resource.subnet.subnet-aaa.attributes.cidr }}
 ```
 
-### Factory vs forEach
-
-| Pattern            | Use when                                         |
-| ------------------ | ------------------------------------------------ |
-| Factory model      | One execution discovers/creates N outputs        |
-| forEach (workflow) | Run the same model N times with different inputs |
+See [references/scenarios.md](references/scenarios.md) for complete factory
+model examples.
 
 ## CRUD Lifecycle Models
 
 Models that manage real resources typically have `create`, `update`, and
-`delete` methods. See
-[references/examples.md](references/examples.md#crud-lifecycle-model-vpc) for a
-complete VPC example with all three methods.
-
-**Pattern summary:**
+`delete` methods:
 
 - **`create`** — run a command/API call, store the result via `writeResource()`
 - **`update`** — read stored data via `context.dataRepository.getContent()`,
-  modify the resource, write updated state via `writeResource()` (new version)
+  modify the resource, write updated state
 - **`delete`** — read stored data, clean up the resource, return
   `{ dataHandles: [] }`
 
-**Delete workflow ordering:** Delete workflows require **explicit `dependsOn`**
-in reverse dependency order. Delete methods read their own stored data via
-`context.dataRepository` — not other models' data via expressions. See the
-`swamp-workflow` skill's
-[data-chaining reference](../swamp-workflow/references/data-chaining.md) for
-delete workflow examples.
+See [references/examples.md](references/examples.md#crud-lifecycle-model-vpc)
+for a complete VPC example with all three methods.
 
 ## Extending Existing Model Types
 
-You can add new methods to existing model types (built-in or user-defined)
-without changing their schema. Use `export const extension` instead of
-`export const model`.
-
-### Extension Structure
+Add new methods to existing model types without changing their schema. Use
+`export const extension` instead of `export const model`:
 
 ```typescript
 // extensions/models/shell_audit.ts
@@ -549,7 +255,6 @@ export const extension = {
       description: "Audit the shell command execution",
       arguments: z.object({}),
       execute: async (args, context) => {
-        // Extensions use the target model's resources/files
         const handle = await context.writeResource!("result", "result", {
           exitCode: 0,
           command: `audit: ${context.definition.name}`,
@@ -562,392 +267,42 @@ export const extension = {
 };
 ```
 
-| Field     | Required | Description                           |
-| --------- | -------- | ------------------------------------- |
-| `type`    | Yes      | Target model type to extend           |
-| `methods` | Yes      | Array of method record objects to add |
-
-### Extension Rules
+**Extension rules:**
 
 - Extensions **cannot** change the target model's Zod schema
 - Extensions **only** add new methods — no overriding existing methods
 - `methods` is always an array of `Record<string, MethodDef>` objects
-- One file can contain one method or many methods
-- Multiple extension files can target the same type
-- Extension methods must define their own `arguments` Zod schema
-- Models are loaded first, then extensions (two-pass loading)
 
 ## Model Discovery
 
 Swamp discovers models and extensions recursively:
 
-1. **Repository extensions**: `{repo}/extensions/models/**/*.ts` (nested dirs
-   supported)
+1. **Repository extensions**: `{repo}/extensions/models/**/*.ts`
 2. **Built-in models**: Bundled with swamp binary
 
 Files are classified by export name: `export const model` defines new types,
-`export const extension` adds methods to existing types. Files can live in
-subdirectories for organization (e.g., `extensions/models/aws/s3_audit.ts`).
-
-Repository models take precedence, allowing you to override built-in types.
+`export const extension` adds methods to existing types.
 
 ## Key Rules
 
 1. **Export**: Use `export const model = { ... }` for new types or
    `export const extension = { ... }` for extending existing types
 2. **Import**: Only `import { z } from "npm:zod@4";` is needed
-3. **Type naming**: Use `@<namespace>/<name>` format (e.g., `@keeb/my-model`,
-   `@stack72/deploy`). Reserved namespaces (`swamp`, `si`) are for built-in
-   types only.
+3. **Type naming**: Use `@<namespace>/<name>` format (e.g., `@user/my-model`)
 4. **No type annotations**: Avoid TypeScript types in execute parameters
-5. **File naming**: Use snake_case (`my_model.ts`), test files excluded
-6. **Nesting**: Files can live in subdirectories for organization
+5. **File naming**: Use snake_case (`my_model.ts`)
 
 ## Namespace Rules
 
 User-defined models can use any namespace except reserved ones (`swamp`, `si`):
 
-| Type                  | Valid? | Notes                       |
-| --------------------- | ------ | --------------------------- |
-| `@user/my-model`      | ✅     | Valid namespace             |
-| `@stack72/my-model`   | ✅     | Custom namespace allowed    |
-| `@keeb/keyboard`      | ✅     | Custom namespace allowed    |
-| `@myorg/deploy`       | ✅     | Custom namespace allowed    |
-| `@user/aws/s3-bucket` | ✅     | Nested paths allowed        |
-| `@stack72/aws/s3`     | ✅     | Nested paths allowed        |
-| `mycompany/model`     | ❌     | Missing `@` prefix          |
-| `@user`               | ❌     | Needs 2+ segments           |
-| `swamp/my-model`      | ❌     | Reserved for built-in types |
-| `@swamp/my-model`     | ❌     | Reserved namespace          |
-| `si/auth`             | ❌     | Reserved namespace          |
-| `@si/auth`            | ❌     | Reserved namespace          |
-
-## Data Ownership
-
-Data artifacts are tracked with ownership information. This prevents other
-models from accidentally overwriting data.
-
-- Each model "owns" the data it creates
-- Multiple models can read the same data via CEL expressions
-- Only the creating model can update its own data
-- Use unique data names to avoid conflicts
-
-## Logging
-
-Model methods have access to a pre-configured LogTape logger via
-`context.logger`. The logger category is set automatically based on the model
-type and method name — no configuration needed.
-
-### Log Levels
-
-From low to high severity: `trace`, `debug`, `info`, `warning`, `error`,
-`fatal`.
-
-### Structured Placeholders (Preferred)
-
-Use named `{placeholder}` tokens with a properties object:
-
-```typescript
-context.logger.info("Processing {name}", { name: context.definition.name });
-context.logger.error("Request failed: {error}", { error: err.message });
-```
-
-Use `{*}` to inline all properties from the object:
-
-```typescript
-context.logger.info("Bucket created: {*}", {
-  bucket: "my-bucket",
-  region: "us-east-1",
-});
-// Output: Bucket created: bucket=my-bucket region=us-east-1
-```
-
-### Additional Features
-
-- `context.logger.with({ requestId: "abc" })` — returns a logger with extra
-  properties on all messages
-- `context.logger.getChild("subsystem")` — creates a child logger with a
-  sub-category
-- Logger respects `--log-level`, `--verbose`, `--quiet`, and `--json` flags
-  automatically
-- In JSON mode, non-fatal messages are suppressed; fatal goes to stderr as JSON
-
-## Examples
-
-### Shell Command Model
-
-Use `executeProcess` from `src/infrastructure/process/process_executor.ts` for
-shell commands. Pass `context.logger` to stream output through LogTape (console
-display + file persistence via RunFileSink).
-
-```typescript
-import { z } from "npm:zod@4";
-import { executeProcess } from "../../../../src/infrastructure/process/process_executor.ts";
-
-const GlobalArgsSchema = z.object({
-  command: z.string(),
-  args: z.array(z.string()).optional(),
-});
-
-export const model = {
-  type: "@user/shell",
-  version: "2026.02.09.1",
-  globalArguments: GlobalArgsSchema,
-  resources: {
-    "output": {
-      description: "Command output",
-      schema: z.object({
-        stdout: z.string(),
-        stderr: z.string(),
-        exitCode: z.number(),
-      }),
-      lifetime: "infinite",
-      garbageCollection: 10,
-    },
-  },
-  methods: {
-    run: {
-      description: "Execute shell command",
-      arguments: z.object({}),
-      execute: async (args, context) => {
-        const result = await executeProcess({
-          command: context.globalArgs.command,
-          args: context.globalArgs.args,
-          logger: context.logger,
-        });
-
-        const handle = await context.writeResource!("output", "output", {
-          stdout: result.stdout,
-          stderr: result.stderr,
-          exitCode: result.exitCode,
-        });
-        return { dataHandles: [handle] };
-      },
-    },
-  },
-};
-```
-
-### Model with Resources and Files
-
-```typescript
-import { z } from "npm:zod@4";
-
-const GlobalArgsSchema = z.object({ query: z.string() });
-
-export const model = {
-  type: "@user/search",
-  version: "2026.02.09.1",
-  globalArguments: GlobalArgsSchema,
-  resources: {
-    "results": {
-      description: "Search results",
-      schema: z.object({ results: z.array(z.string()) }),
-      lifetime: "infinite",
-      garbageCollection: 10,
-    },
-  },
-  files: {
-    "log": {
-      description: "Search execution log",
-      contentType: "application/json",
-      lifetime: "7d",
-      garbageCollection: 10,
-      streaming: true,
-    },
-  },
-  methods: {
-    search: {
-      description: "Search and store results with log",
-      arguments: z.object({}),
-      execute: async (args, context) => {
-        const results = ["result1", "result2"];
-
-        // Primary result data (resource)
-        const resultsHandle = await context.writeResource!(
-          "results",
-          "results",
-          {
-            results,
-          },
-        );
-
-        // Execution log (file)
-        const logWriter = context.createFileWriter!("log", "log");
-        const logHandle = await logWriter.writeText(JSON.stringify({
-          query: context.globalArgs.query,
-          timestamp: new Date().toISOString(),
-          resultCount: results.length,
-        }));
-
-        return { dataHandles: [resultsHandle, logHandle] };
-      },
-    },
-  },
-};
-```
-
-### API Integration Model
-
-```typescript
-import { z } from "npm:zod@4";
-
-const GlobalArgsSchema = z.object({
-  endpoint: z.string().url(),
-  apiKey: z.string(), // Use vault expression: ${{ vault.get(my-vault, API_KEY) }}
-});
-
-export const model = {
-  type: "@user/api-resource",
-  version: "2026.02.09.1",
-  globalArguments: GlobalArgsSchema,
-  resources: {
-    "state": {
-      description: "API resource state",
-      schema: z.object({
-        resourceId: z.string(),
-        status: z.string(),
-        createdAt: z.string(),
-      }),
-      lifetime: "infinite",
-      garbageCollection: 10,
-    },
-  },
-  methods: {
-    create: {
-      description: "Create resource via API",
-      arguments: z.object({}),
-      execute: async (args, context) => {
-        const response = await fetch(context.globalArgs.endpoint, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${context.globalArgs.apiKey}`,
-          },
-        });
-        const data = await response.json();
-
-        const handle = await context.writeResource!("state", "state", {
-          resourceId: data.id,
-          status: data.status,
-          createdAt: new Date().toISOString(),
-        });
-        return { dataHandles: [handle] };
-      },
-    },
-  },
-};
-```
-
-### Cloud Service Model (e.g., AWS S3)
-
-When a built-in type doesn't exist, create your own:
-
-```typescript
-// extensions/models/s3_bucket.ts
-import { z } from "npm:zod@4";
-
-const GlobalArgsSchema = z.object({
-  bucketName: z.string(),
-  region: z.string().default("us-east-1"),
-  accessKeyId: z.string(), // Use: ${{ vault.get(aws-vault, ACCESS_KEY_ID) }}
-  secretAccessKey: z.string(), // Use: ${{ vault.get(aws-vault, SECRET_ACCESS_KEY) }}
-});
-
-export const model = {
-  type: "@user/s3-bucket",
-  version: "2026.02.09.1",
-  globalArguments: GlobalArgsSchema,
-  resources: {
-    "bucket": {
-      description: "S3 bucket resource state",
-      schema: z.object({
-        bucketName: z.string(),
-        region: z.string(),
-        arn: z.string(),
-        createdAt: z.string(),
-      }),
-      lifetime: "infinite",
-      garbageCollection: 10,
-    },
-    "objects": {
-      description: "S3 object listing",
-      schema: z.object({
-        objects: z.array(z.any()),
-      }),
-      lifetime: "infinite",
-      garbageCollection: 10,
-    },
-  },
-  methods: {
-    create: {
-      description: "Create an S3 bucket",
-      arguments: z.object({}),
-      execute: async (args, context) => {
-        const { bucketName, region, accessKeyId, secretAccessKey } =
-          context.globalArgs;
-
-        // Use AWS SDK or direct API calls
-        const response = await fetch(
-          `https://s3.${region}.amazonaws.com/${bucketName}`,
-          {
-            method: "PUT",
-            headers: {
-              // Add AWS Signature V4 authentication
-              Authorization: `...`, // Implement AWS signing
-            },
-          },
-        );
-
-        const handle = await context.writeResource!("bucket", "bucket", {
-          bucketName,
-          region,
-          arn: `arn:aws:s3:::${bucketName}`,
-          createdAt: new Date().toISOString(),
-        });
-        return { dataHandles: [handle] };
-      },
-    },
-    list: {
-      description: "List objects in the bucket",
-      arguments: z.object({}),
-      execute: async (args, context) => {
-        // Implement S3 ListObjects API call
-        const handle = await context.writeResource!("objects", "objects", {
-          objects: [], // Populate from API response
-        });
-        return { dataHandles: [handle] };
-      },
-    },
-  },
-};
-```
-
-### Method with Arguments
-
-Each method defines its own `arguments` Zod schema for per-method parameters.
-These are pre-validated and passed as the first argument to `execute`:
-
-```typescript
-methods: {
-  deploy: {
-    description: "Deploy with environment-specific config",
-    arguments: z.object({
-      environment: z.enum(["dev", "staging", "prod"]),
-      dryRun: z.boolean().optional(),
-    }),
-    execute: async (args, context) => {
-      const env = args.environment;
-      // Use env for deployment logic...
-
-      const handle = await context.writeResource!("state", "state", {
-        environment: env,
-        status: "deployed",
-      });
-      return { dataHandles: [handle] };
-    },
-  },
-},
-```
+| Type              | Valid? | Notes                    |
+| ----------------- | ------ | ------------------------ |
+| `@user/my-model`  | ✅     | Valid namespace          |
+| `@myorg/deploy`   | ✅     | Custom namespace allowed |
+| `@user/aws/s3`    | ✅     | Nested paths allowed     |
+| `mycompany/model` | ❌     | Missing `@` prefix       |
+| `@swamp/my-model` | ❌     | Reserved namespace       |
 
 ## Verify
 
@@ -970,11 +325,14 @@ swamp model type describe @myorg/my-model   # Check schema
 
 ## References
 
+- **API Reference**: See [references/api.md](references/api.md) for detailed
+  `writeResource`, `createFileWriter`, `DataWriter`, and logging API docs
 - **Examples**: See [references/examples.md](references/examples.md) for
   complete model examples (CRUD lifecycle, data chaining, extensions, etc.)
+- **Scenarios**: See [references/scenarios.md](references/scenarios.md) for
+  end-to-end scenarios (custom API, cloud CRUD, factory models)
 - **Troubleshooting**: See
   [references/troubleshooting.md](references/troubleshooting.md) for common
   errors and fixes
 - **Built-in example**: See `src/domain/models/echo/echo_model.ts` for reference
-- **Model loader**: See `src/domain/models/user_model_loader.ts` for API details
 - **Model design**: See [design/models.md](design/models.md) for concepts

--- a/.claude/skills/swamp-extension-model/references/api.md
+++ b/.claude/skills/swamp-extension-model/references/api.md
@@ -1,0 +1,239 @@
+# Extension Model API Reference
+
+Detailed API documentation for extension model development.
+
+## Table of Contents
+
+- [writeResource API](#writeresource-api)
+- [createFileWriter API](#createfilewriter-api)
+- [DataWriter Methods](#datawriter-methods)
+- [DataHandle Structure](#datahandle-structure)
+- [Reading Stored Data](#reading-stored-data)
+- [Lifetime Values](#lifetime-values)
+- [Standard Tags](#standard-tags)
+- [Logging API](#logging-api)
+
+---
+
+## writeResource API
+
+Write structured JSON data:
+`context.writeResource(specName, instanceName, data, overrides?)`.
+
+**Parameters:**
+
+| Parameter      | Description                                                     |
+| -------------- | --------------------------------------------------------------- |
+| `specName`     | Must match a key in the model's `resources`                     |
+| `instanceName` | The instance name (any non-empty string)                        |
+| `data`         | JSON data to write (validated against the resource's Zod schema |
+| `overrides`    | Optional overrides (see below)                                  |
+
+Data is validated against the resource's Zod schema (warns on mismatch, doesn't
+throw). The `instanceName` you pass here is used in CEL:
+`model.<defName>.resource.<specName>.<instanceName>.attributes.<field>`.
+
+**ResourceWriteOverrides** (optional):
+
+| Field               | Description                                    |
+| ------------------- | ---------------------------------------------- |
+| `lifetime`          | Override lifetime (default from spec)          |
+| `garbageCollection` | Override version retention (default from spec) |
+| `tags`              | Additional tags                                |
+
+**Example:**
+
+```typescript
+// Single-instance resource (use descriptive instance name)
+const handle = await context.writeResource!("state", "current", {
+  status: "active",
+  updatedAt: new Date().toISOString(),
+});
+
+// Factory model (use dynamic instance names)
+for (const item of items) {
+  await context.writeResource!("item", item.id, item);
+}
+```
+
+---
+
+## createFileWriter API
+
+Create a file writer:
+`context.createFileWriter(specName, instanceName, overrides?)`.
+
+**Parameters:**
+
+| Parameter      | Description                              |
+| -------------- | ---------------------------------------- |
+| `specName`     | Must match a key in the model's `files`  |
+| `instanceName` | The instance name (any non-empty string) |
+| `overrides`    | Optional overrides (see below)           |
+
+Returns a `DataWriter` for binary/streaming content. The `instanceName` you pass
+here is used in CEL: `model.<defName>.file.<specName>.<instanceName>.path`.
+
+**FileWriterOverrides** (optional):
+
+| Field               | Description                                    |
+| ------------------- | ---------------------------------------------- |
+| `contentType`       | Override MIME type (default from spec)         |
+| `lifetime`          | Override lifetime (default from spec)          |
+| `garbageCollection` | Override version retention (default from spec) |
+| `streaming`         | True for line-oriented streaming               |
+| `tags`              | Additional tags                                |
+
+---
+
+## DataWriter Methods
+
+| Method                      | Description                                      |
+| --------------------------- | ------------------------------------------------ |
+| `writeAll(content)`         | Write complete binary content (`Uint8Array`)     |
+| `writeText(text)`           | Write text content (encoded as UTF-8)            |
+| `writeLine(line)`           | Append a single line (for streaming/incremental) |
+| `writeStream(stream, opts)` | Pipe a `ReadableStream<Uint8Array>`              |
+| `getFilePath()`             | Get the file path for direct I/O                 |
+| `finalize()`                | Finalize after using `writeLine`/`getFilePath`   |
+
+**Example:**
+
+```typescript
+// Write text file
+const logWriter = context.createFileWriter!("log", "execution");
+const handle = await logWriter.writeText(JSON.stringify({
+  timestamp: new Date().toISOString(),
+  message: "Operation completed",
+}));
+
+// Streaming log (line by line)
+const streamWriter = context.createFileWriter!("log", "stream", {
+  streaming: true,
+});
+await streamWriter.writeLine("Starting process...");
+await streamWriter.writeLine("Step 1 complete");
+await streamWriter.writeLine("Done");
+const handle = await streamWriter.finalize();
+```
+
+---
+
+## DataHandle Structure
+
+Returned by `writeResource` and writer methods:
+
+| Field      | Description                          |
+| ---------- | ------------------------------------ |
+| `name`     | Data artifact name                   |
+| `specName` | The declared spec name               |
+| `kind`     | `"resource"` or `"file"`             |
+| `dataId`   | Unique ID for this data              |
+| `version`  | Version number of this write         |
+| `size`     | Size of the written content in bytes |
+| `tags`     | Tags from the writer options         |
+| `metadata` | Full metadata for the data artifact  |
+
+**UserMethodResult:**
+
+The execute function returns `{ dataHandles?: DataHandle[] }`.
+
+---
+
+## Reading Stored Data
+
+Delete and update methods need to read back previously stored resource data
+(e.g., to get a resource ID for cleanup). Use `context.dataRepository` with
+`context.modelType` and `context.modelId`:
+
+```typescript
+const content = await context.dataRepository.getContent(
+  context.modelType,
+  context.modelId,
+  "<specName>", // matches a key in resources
+  "<instanceName>", // instance name used when writing
+);
+// Returns Uint8Array | null
+```
+
+To parse the content:
+
+```typescript
+if (!content) {
+  throw new Error("No data found - nothing to delete");
+}
+const data = JSON.parse(new TextDecoder().decode(content));
+```
+
+**Key dataRepository methods for model authors:**
+
+| Method                                                    | Returns              | Description                            |
+| --------------------------------------------------------- | -------------------- | -------------------------------------- |
+| `getContent(type, modelId, dataName, instanceName, ver?)` | `Uint8Array \| null` | Get raw content bytes                  |
+| `findByName(type, modelId, dataName, instanceName, ver?)` | `Data \| null`       | Get data metadata (tags, version, etc) |
+| `findAllForModel(type, modelId)`                          | `Data[]`             | List all data for this model instance  |
+
+---
+
+## Lifetime Values
+
+| Value       | Behavior                                     |
+| ----------- | -------------------------------------------- |
+| `ephemeral` | Deleted after method/workflow completes      |
+| `job`       | Persists while creating job runs             |
+| `workflow`  | Persists while creating workflow runs        |
+| Duration    | Expires after time (e.g., `1h`, `7d`, `1mo`) |
+| `infinite`  | Never expires (default)                      |
+
+---
+
+## Standard Tags
+
+Tags are auto-applied based on the spec kind:
+
+| Tag                  | Applied to | Description                              |
+| -------------------- | ---------- | ---------------------------------------- |
+| `type: "resource"`   | resources  | Auto-added to all resource data outputs  |
+| `type: "file"`       | files      | Auto-added to all file data outputs      |
+| `specName: "<name>"` | both       | Auto-added with the output spec key name |
+
+---
+
+## Logging API
+
+Model methods have access to a pre-configured LogTape logger via
+`context.logger`. The logger category is set automatically based on the model
+type and method name.
+
+### Log Levels
+
+From low to high severity: `trace`, `debug`, `info`, `warning`, `error`,
+`fatal`.
+
+### Structured Placeholders (Preferred)
+
+Use named `{placeholder}` tokens with a properties object:
+
+```typescript
+context.logger.info("Processing {name}", { name: context.definition.name });
+context.logger.error("Request failed: {error}", { error: err.message });
+```
+
+Use `{*}` to inline all properties from the object:
+
+```typescript
+context.logger.info("Bucket created: {*}", {
+  bucket: "my-bucket",
+  region: "us-east-1",
+});
+// Output: Bucket created: bucket=my-bucket region=us-east-1
+```
+
+### Additional Features
+
+| Method/Feature                    | Description                                    |
+| --------------------------------- | ---------------------------------------------- |
+| `context.logger.with({ ... })`    | Returns logger with extra properties           |
+| `context.logger.getChild("name")` | Creates child logger with sub-category         |
+| Flag handling                     | Respects `--log-level`, `--verbose`, `--quiet` |
+| JSON mode                         | Non-fatal suppressed; fatal goes to stderr     |

--- a/.claude/skills/swamp-extension-model/references/scenarios.md
+++ b/.claude/skills/swamp-extension-model/references/scenarios.md
@@ -95,7 +95,7 @@ export const model = {
 
         const handle = await context.writeResource!(
           "customer",
-          "customer",
+          "primary",
           customer,
         );
         return { dataHandles: [handle] };
@@ -110,7 +110,7 @@ export const model = {
           context.modelType,
           context.modelId,
           "customer",
-          "customer",
+          "primary",
         );
 
         if (!content) {
@@ -133,7 +133,7 @@ export const model = {
 
         const handle = await context.writeResource!(
           "customer",
-          "customer",
+          "primary",
           customer,
         );
         return { dataHandles: [handle] };
@@ -173,16 +173,16 @@ swamp model method run my-customer create --json
 ```yaml
 # Another model referencing the customer
 globalArguments:
-  customerId: ${{ model.my-customer.resource.customer.customer.attributes.id }}
+  customerId: ${{ model.my-customer.resource.customer.primary.attributes.id }}
 ```
 
 ### CEL Paths Used
 
-| Field       | CEL Path                                                          |
-| ----------- | ----------------------------------------------------------------- |
-| Customer ID | `model.my-customer.resource.customer.customer.attributes.id`      |
-| Email       | `model.my-customer.resource.customer.customer.attributes.email`   |
-| Created     | `model.my-customer.resource.customer.customer.attributes.created` |
+| Field       | CEL Path                                                         |
+| ----------- | ---------------------------------------------------------------- |
+| Customer ID | `model.my-customer.resource.customer.primary.attributes.id`      |
+| Email       | `model.my-customer.resource.customer.primary.attributes.email`   |
+| Created     | `model.my-customer.resource.customer.primary.attributes.created` |
 
 ---
 
@@ -281,7 +281,7 @@ export const model = {
 
         const handle = await context.writeResource!(
           "bucket",
-          "bucket",
+          "main",
           bucketData,
         );
         return { dataHandles: [handle] };
@@ -298,7 +298,7 @@ export const model = {
           context.modelType,
           context.modelId,
           "bucket",
-          "bucket",
+          "main",
         );
 
         if (!content) {
@@ -331,7 +331,7 @@ export const model = {
 
         const handle = await context.writeResource!(
           "bucket",
-          "bucket",
+          "main",
           updatedData,
         );
         return { dataHandles: [handle] };
@@ -346,7 +346,7 @@ export const model = {
           context.modelType,
           context.modelId,
           "bucket",
-          "bucket",
+          "main",
         );
 
         if (!content) {

--- a/.claude/skills/swamp-extension-model/references/troubleshooting.md
+++ b/.claude/skills/swamp-extension-model/references/troubleshooting.md
@@ -137,9 +137,9 @@ resource. Common causes:
 name.
 
 ```typescript
-// Writes to instance name "vpc"
-await context.writeResource("vpc", "vpc", data);
-// CEL: model.<name>.resource.vpc.vpc.attributes.X
+// Writes to spec "vpc" with instance name "main"
+await context.writeResource("vpc", "main", data);
+// CEL: model.<name>.resource.vpc.main.attributes.X
 ```
 
 **2. Resource spec name contains hyphens.** CEL interprets hyphens as

--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -313,7 +313,7 @@ name: my-subnet
 version: 1
 tags: {}
 globalArguments:
-  vpcId: ${{ model.my-vpc.resource.state.state.attributes.VpcId }}
+  vpcId: ${{ model.my-vpc.resource.state.current.attributes.VpcId }}
   cidrBlock: "10.0.1.0/24"
   tags:
     Name: ${{ self.name + "-subnet" }}

--- a/.claude/skills/swamp-model/references/data-chaining.md
+++ b/.claude/skills/swamp-model/references/data-chaining.md
@@ -2,7 +2,7 @@
 
 The `aws/cli` model enables data chaining by running AWS CLI commands and
 capturing output for use in other models. Use `parseJson: true` to parse JSON
-output and access it via `resource.data.data.attributes.json`.
+output and access it via `resource.data.output.attributes.json`.
 
 ## aws/cli Data Attributes
 
@@ -50,11 +50,11 @@ version: 1
 tags: {}
 attributes:
   # Reference parsed JSON fields from the aws/cli model's data output
-  imageId: \${{ model.latest-ami.resource.data.data.attributes.json.ImageId }}
+  imageId: \${{ model.latest-ami.resource.data.output.attributes.json.ImageId }}
   instanceType: t3.micro
   tags:
     Name: \${{ self.name }}
-    AmiName: \${{ model.latest-ami.resource.data.data.attributes.json.Name }}
+    AmiName: \${{ model.latest-ami.resource.data.output.attributes.json.Name }}
 EOF
 ```
 
@@ -83,7 +83,7 @@ swamp model edit my-server --json <<EOF
 name: my-server
 attributes:
   securityGroupIds:
-    - \${{ model.default-sg.resource.data.data.attributes.json.GroupId }}
+    - \${{ model.default-sg.resource.data.output.attributes.json.GroupId }}
 EOF
 ```
 
@@ -110,7 +110,7 @@ name: subnet-lookup
 attributes:
   command: >-
     ec2 describe-subnets
-    --filters "Name=vpc-id,Values=\${{ model.vpc-lookup.resource.data.data.attributes.json.VpcId }}"
+    --filters "Name=vpc-id,Values=\${{ model.vpc-lookup.resource.data.output.attributes.json.VpcId }}"
     --query "Subnets[0]"
   parseJson: true
 EOF
@@ -123,7 +123,7 @@ swamp model create @user/ec2-instance my-instance --json
 swamp model edit my-instance --json <<EOF
 name: my-instance
 attributes:
-  subnetId: \${{ model.subnet-lookup.resource.data.data.attributes.json.SubnetId }}
-  vpcId: \${{ model.vpc-lookup.resource.data.data.attributes.json.VpcId }}
+  subnetId: \${{ model.subnet-lookup.resource.data.output.attributes.json.SubnetId }}
+  vpcId: \${{ model.vpc-lookup.resource.data.output.attributes.json.VpcId }}
 EOF
 ```

--- a/.claude/skills/swamp-model/references/examples.md
+++ b/.claude/skills/swamp-model/references/examples.md
@@ -14,7 +14,7 @@
 | Expression Pattern                                           | Description                                | Example Value                 |
 | ------------------------------------------------------------ | ------------------------------------------ | ----------------------------- |
 | `model.<name>.resource.<spec>.<instance>.attributes.<field>` | Cross-model resource reference (PREFERRED) | VPC ID, subnet CIDR, etc.     |
-| `model.<name>.resource.data.data.attributes.json.<field>`    | aws/cli with parseJson: true               | AMI ID from describe-images   |
+| `model.<name>.resource.data.output.attributes.json.<field>`  | aws/cli with parseJson: true               | AMI ID from describe-images   |
 | `model.<name>.file.<spec>.<instance>.path`                   | File path from another model               | `/path/to/file.txt`           |
 | `self.name`                                                  | Current model's name                       | `my-vpc`                      |
 | `self.version`                                               | Current model's version                    | `1`                           |
@@ -29,13 +29,13 @@
 
 ### CEL Path Patterns by Model Type
 
-| Model Type      | Resource Spec | CEL Path Example                                              |
-| --------------- | ------------- | ------------------------------------------------------------- |
-| `command/shell` | `result`      | `model.my-shell.resource.result.result.attributes.stdout`     |
-| `aws/cli`       | `data`        | `model.ami-lookup.resource.data.data.attributes.json.ImageId` |
-| `@user/vpc`     | `vpc`         | `model.my-vpc.resource.vpc.vpc.attributes.VpcId`              |
-| `@user/subnet`  | `subnet`      | `model.my-subnet.resource.subnet.subnet.attributes.SubnetId`  |
-| Factory model   | `<spec>`      | `model.scanner.resource.subnet.subnet-aaa.attributes.cidr`    |
+| Model Type      | Resource Spec | Instance    | CEL Path Example                                                |
+| --------------- | ------------- | ----------- | --------------------------------------------------------------- |
+| `command/shell` | `result`      | `result`    | `model.my-shell.resource.result.result.attributes.stdout`       |
+| `aws/cli`       | `data`        | `output`    | `model.ami-lookup.resource.data.output.attributes.json.ImageId` |
+| `@user/vpc`     | `vpc`         | `main`      | `model.my-vpc.resource.vpc.main.attributes.VpcId`               |
+| `@user/subnet`  | `subnet`      | `primary`   | `model.my-subnet.resource.subnet.primary.attributes.SubnetId`   |
+| Factory model   | `<spec>`      | `<dynamic>` | `model.scanner.resource.subnet.subnet-aaa.attributes.cidr`      |
 
 ## Decision Tree: What to Build
 
@@ -124,7 +124,7 @@ tags: {}
 globalArguments:
   command: >-
     ec2 describe-subnets
-    --filters "Name=vpc-id,Values=${{ model.vpc-lookup.resource.data.data.attributes.json.VpcId }}"
+    --filters "Name=vpc-id,Values=${{ model.vpc-lookup.resource.data.output.attributes.json.VpcId }}"
     --query "Subnets[0]"
   region: us-east-1
   parseJson: true
@@ -142,8 +142,8 @@ name: my-instance
 version: 1
 tags: {}
 globalArguments:
-  vpcId: ${{ model.vpc-lookup.resource.data.data.attributes.json.VpcId }}
-  subnetId: ${{ model.subnet-lookup.resource.data.data.attributes.json.SubnetId }}
+  vpcId: ${{ model.vpc-lookup.resource.data.output.attributes.json.VpcId }}
+  subnetId: ${{ model.subnet-lookup.resource.data.output.attributes.json.SubnetId }}
   instanceType: t3.micro
   tags:
     Name: ${{ self.name }}
@@ -151,11 +151,11 @@ globalArguments:
 
 ### Key CEL Paths Used
 
-| Model         | Expression                                                        | Value             |
-| ------------- | ----------------------------------------------------------------- | ----------------- |
-| vpc-lookup    | `model.vpc-lookup.resource.data.data.attributes.json.VpcId`       | `vpc-12345678`    |
-| subnet-lookup | `model.subnet-lookup.resource.data.data.attributes.json.SubnetId` | `subnet-abcd1234` |
-| my-instance   | `self.name`                                                       | `my-instance`     |
+| Model         | Expression                                                          | Value             |
+| ------------- | ------------------------------------------------------------------- | ----------------- |
+| vpc-lookup    | `model.vpc-lookup.resource.data.output.attributes.json.VpcId`       | `vpc-12345678`    |
+| subnet-lookup | `model.subnet-lookup.resource.data.output.attributes.json.SubnetId` | `subnet-abcd1234` |
+| my-instance   | `self.name`                                                         | `my-instance`     |
 
 ## Model with Runtime Inputs
 
@@ -212,11 +212,11 @@ Always use `model.*` expressions for referencing other models' data:
 ```yaml
 # CORRECT: model.* expression
 globalArguments:
-  vpcId: ${{ model.my-vpc.resource.vpc.vpc.attributes.VpcId }}
+  vpcId: ${{ model.my-vpc.resource.vpc.main.attributes.VpcId }}
 
 # AVOID: data.latest() for cross-model references
 globalArguments:
-  vpcId: ${{ data.latest("my-vpc", "vpc").attributes.VpcId }}
+  vpcId: ${{ data.latest("my-vpc", "main").attributes.VpcId }}
 ```
 
 ### Why model.* is Preferred

--- a/.claude/skills/swamp-model/references/scenarios.md
+++ b/.claude/skills/swamp-model/references/scenarios.md
@@ -150,7 +150,7 @@ tags: {}
 globalArguments:
   command: >-
     ec2 describe-subnets
-    --filters "Name=vpc-id,Values=${{ model.vpc-lookup.resource.data.data.attributes.json.VpcId }}"
+    --filters "Name=vpc-id,Values=${{ model.vpc-lookup.resource.data.output.attributes.json.VpcId }}"
     --query "Subnets[0]"
   region: us-east-1
   parseJson: true
@@ -176,8 +176,8 @@ name: my-instance
 version: 1
 tags: {}
 globalArguments:
-  vpcId: ${{ model.vpc-lookup.resource.data.data.attributes.json.VpcId }}
-  subnetId: ${{ model.subnet-lookup.resource.data.data.attributes.json.SubnetId }}
+  vpcId: ${{ model.vpc-lookup.resource.data.output.attributes.json.VpcId }}
+  subnetId: ${{ model.subnet-lookup.resource.data.output.attributes.json.SubnetId }}
   instanceType: t3.micro
   tags:
     Name: ${{ self.name }}
@@ -192,13 +192,13 @@ swamp model validate my-instance --json
 
 ### CEL Paths Used
 
-| Model         | Expression                                                                | Description |
-| ------------- | ------------------------------------------------------------------------- | ----------- |
-| vpc-lookup    | `model.vpc-lookup.resource.data.data.attributes.json.VpcId`               | VPC ID      |
-| vpc-lookup    | `model.vpc-lookup.resource.data.data.attributes.json.CidrBlock`           | VPC CIDR    |
-| subnet-lookup | `model.subnet-lookup.resource.data.data.attributes.json.SubnetId`         | Subnet ID   |
-| subnet-lookup | `model.subnet-lookup.resource.data.data.attributes.json.AvailabilityZone` | AZ          |
-| my-instance   | `self.name`                                                               | Model name  |
+| Model         | Expression                                                                  | Description |
+| ------------- | --------------------------------------------------------------------------- | ----------- |
+| vpc-lookup    | `model.vpc-lookup.resource.data.output.attributes.json.VpcId`               | VPC ID      |
+| vpc-lookup    | `model.vpc-lookup.resource.data.output.attributes.json.CidrBlock`           | VPC CIDR    |
+| subnet-lookup | `model.subnet-lookup.resource.data.output.attributes.json.SubnetId`         | Subnet ID   |
+| subnet-lookup | `model.subnet-lookup.resource.data.output.attributes.json.AvailabilityZone` | AZ          |
+| my-instance   | `self.name`                                                                 | Model name  |
 
 ---
 

--- a/.claude/skills/swamp-model/references/troubleshooting.md
+++ b/.claude/skills/swamp-model/references/troubleshooting.md
@@ -112,11 +112,11 @@ swamp model validate my-model --json
 3. **Syntax error in expression**:
 
    ```yaml
-   # Wrong
-   value: ${{ model.my-vpc.resource.vpc.attributes.VpcId }} # Missing instance name
+   # Wrong — missing instance name
+   value: ${{ model.my-vpc.resource.vpc.attributes.VpcId }}
 
-   # Correct
-   value: ${{ model.my-vpc.resource.vpc.vpc.attributes.VpcId }}
+   # Correct — spec="vpc", instance="main"
+   value: ${{ model.my-vpc.resource.vpc.main.attributes.VpcId }}
    ```
 
 ### "No such key" in CEL expressions
@@ -131,8 +131,8 @@ swamp model validate my-model --json
    # Wrong — missing instance name
    vpcId: ${{ model.my-vpc.resource.vpc.attributes.VpcId }}
 
-   # Correct — include instance name (usually same as spec name)
-   vpcId: ${{ model.my-vpc.resource.vpc.vpc.attributes.VpcId }}
+   # Correct — include instance name (spec="vpc", instance="main")
+   vpcId: ${{ model.my-vpc.resource.vpc.main.attributes.VpcId }}
    ```
 
 2. **Model never executed**:
@@ -213,20 +213,20 @@ swamp data get <referenced-model> <data-name> --json
 model.<model-name>.resource.<specName>.<instanceName>.attributes.<field>
 
 Example:
-model.my-vpc.resource.vpc.vpc.attributes.VpcId
-      └─────┘         └─┘ └─┘            └───┘
-      model name      |   |              attribute
-                      |   └── instanceName (from writeResource 2nd arg)
+model.my-vpc.resource.vpc.main.attributes.VpcId
+      └─────┘         └─┘ └──┘            └───┘
+      model name      |    |              attribute
+                      |    └── instanceName (from writeResource 2nd arg)
                       └── specName (from writeResource 1st arg)
 ```
 
 ### Common Expression Patterns
 
-| Model Type    | Spec     | Expression Pattern                                        |
-| ------------- | -------- | --------------------------------------------------------- |
-| command/shell | result   | `model.<name>.resource.result.result.attributes.stdout`   |
-| aws/cli       | data     | `model.<name>.resource.data.data.attributes.json.<field>` |
-| Custom model  | (varies) | `model.<name>.resource.<spec>.<spec>.attributes.<field>`  |
+| Model Type    | Spec     | Instance | Expression Pattern                                           |
+| ------------- | -------- | -------- | ------------------------------------------------------------ |
+| command/shell | result   | result   | `model.<name>.resource.result.result.attributes.stdout`      |
+| aws/cli       | data     | output   | `model.<name>.resource.data.output.attributes.json.<field>`  |
+| Custom model  | (varies) | (varies) | `model.<name>.resource.<spec>.<instance>.attributes.<field>` |
 
 ## Method Execution Issues
 

--- a/.claude/skills/swamp-workflow/references/data-chaining.md
+++ b/.claude/skills/swamp-workflow/references/data-chaining.md
@@ -57,7 +57,7 @@ attributes:
 # my-instance input (references aws/cli output)
 name: my-instance
 attributes:
-  imageId: ${{ model.latest-ami.resource.data.data.attributes.json.ImageId }}
+  imageId: ${{ model.latest-ami.resource.data.output.attributes.json.ImageId }}
   instanceType: t3.micro
 ```
 
@@ -145,7 +145,7 @@ name: subnet-lookup
 attributes:
   command: >-
     ec2 describe-subnets
-    --filters "Name=vpc-id,Values=${{ model.vpc-lookup.resource.data.data.attributes.json.VpcId }}"
+    --filters "Name=vpc-id,Values=${{ model.vpc-lookup.resource.data.output.attributes.json.VpcId }}"
     --query "Subnets[0]"
   parseJson: true
 ```
@@ -154,7 +154,7 @@ attributes:
 # app-security-group - chains from vpc-lookup
 name: app-security-group
 attributes:
-  vpcId: ${{ model.vpc-lookup.resource.data.data.attributes.json.VpcId }}
+  vpcId: ${{ model.vpc-lookup.resource.data.output.attributes.json.VpcId }}
   groupName: app-sg
   description: Security group for application
 ```
@@ -163,10 +163,10 @@ attributes:
 # app-server - chains from multiple lookups
 name: app-server
 attributes:
-  imageId: ${{ model.latest-ami.resource.data.data.attributes.json.ImageId }}
-  subnetId: ${{ model.subnet-lookup.resource.data.data.attributes.json.SubnetId }}
+  imageId: ${{ model.latest-ami.resource.data.output.attributes.json.ImageId }}
+  subnetId: ${{ model.subnet-lookup.resource.data.output.attributes.json.SubnetId }}
   securityGroupIds:
-    - ${{ model.app-security-group.resource.resource.resource.attributes.groupId }}
+    - ${{ model.app-security-group.resource.resource.main.attributes.groupId }}
   instanceType: t3.micro
 ```
 
@@ -175,11 +175,11 @@ attributes:
 All model data outputs are accessed via
 `model.<name>.resource.<specName>.<instanceName>.attributes.<field>`:
 
-| Model Type    | Spec Name  | Example                                                       |
-| ------------- | ---------- | ------------------------------------------------------------- |
-| aws/cli       | `data`     | `model.ami-lookup.resource.data.data.attributes.json.ImageId` |
-| Cloud Control | `resource` | `model.my-vpc.resource.resource.resource.attributes.VpcId`    |
-| Custom models | (varies)   | `model.my-deploy.resource.state.state.attributes.endpoint`    |
+| Model Type    | Spec Name  | Example                                                         |
+| ------------- | ---------- | --------------------------------------------------------------- |
+| aws/cli       | `data`     | `model.ami-lookup.resource.data.output.attributes.json.ImageId` |
+| Cloud Control | `resource` | `model.my-vpc.resource.resource.main.attributes.VpcId`          |
+| Custom models | (varies)   | `model.my-deploy.resource.state.current.attributes.endpoint`    |
 
 ## Delete Workflow Ordering
 

--- a/.claude/skills/swamp-workflow/references/nested-workflows.md
+++ b/.claude/skills/swamp-workflow/references/nested-workflows.md
@@ -142,7 +142,7 @@ The `tag-networking` sub-workflow's model instances can reference the VPC data:
 name: tag-vpc
 attributes:
   region: us-east-1
-  resourceId: ${{ model.networking-vpc.resource.vpc.vpc.attributes.VpcId }}
+  resourceId: ${{ model.networking-vpc.resource.vpc.main.attributes.VpcId }}
   tagKey: ManagedBy
   tagValue: Swamp
 ```

--- a/.claude/skills/swamp-workflow/references/scenarios.md
+++ b/.claude/skills/swamp-workflow/references/scenarios.md
@@ -48,7 +48,7 @@ Configure each model to reference the previous:
 name: public-subnet
 version: 1
 globalArguments:
-  vpcId: ${{ model.networking-vpc.resource.vpc.vpc.attributes.VpcId }}
+  vpcId: ${{ model.networking-vpc.resource.vpc.main.attributes.VpcId }}
   cidrBlock: "10.0.1.0/24"
 ```
 
@@ -57,8 +57,8 @@ globalArguments:
 name: app-sg
 version: 1
 globalArguments:
-  vpcId: ${{ model.networking-vpc.resource.vpc.vpc.attributes.VpcId }}
-  subnetId: ${{ model.public-subnet.resource.subnet.subnet.attributes.SubnetId }}
+  vpcId: ${{ model.networking-vpc.resource.vpc.main.attributes.VpcId }}
+  subnetId: ${{ model.public-subnet.resource.subnet.primary.attributes.SubnetId }}
 ```
 
 **2. Create the workflow**
@@ -120,11 +120,11 @@ swamp workflow run provision-networking --json
 
 ### CEL Paths Used
 
-| Model         | Expression                                                       |
-| ------------- | ---------------------------------------------------------------- |
-| public-subnet | `model.networking-vpc.resource.vpc.vpc.attributes.VpcId`         |
-| app-sg        | `model.networking-vpc.resource.vpc.vpc.attributes.VpcId`         |
-| app-sg        | `model.public-subnet.resource.subnet.subnet.attributes.SubnetId` |
+| Model         | Expression                                                        |
+| ------------- | ----------------------------------------------------------------- |
+| public-subnet | `model.networking-vpc.resource.vpc.main.attributes.VpcId`         |
+| app-sg        | `model.networking-vpc.resource.vpc.main.attributes.VpcId`         |
+| app-sg        | `model.public-subnet.resource.subnet.primary.attributes.SubnetId` |
 
 ---
 
@@ -208,9 +208,9 @@ jobs:
 name: my-instance
 version: 1
 globalArguments:
-  imageId: ${{ model.ami-lookup.resource.data.data.attributes.json.ImageId }}
-  vpcId: ${{ model.vpc-lookup.resource.data.data.attributes.json.VpcId }}
-  securityGroupId: ${{ model.sg-lookup.resource.data.data.attributes.json.GroupId }}
+  imageId: ${{ model.ami-lookup.resource.data.output.attributes.json.ImageId }}
+  vpcId: ${{ model.vpc-lookup.resource.data.output.attributes.json.VpcId }}
+  securityGroupId: ${{ model.sg-lookup.resource.data.output.attributes.json.GroupId }}
 ```
 
 ---

--- a/src/infrastructure/assets/skill_assets.ts
+++ b/src/infrastructure/assets/skill_assets.ts
@@ -78,6 +78,14 @@ const BUNDLED_SKILLS: SkillInfo[] = [
     name: "swamp-workflow",
   },
   {
+    relativePath: "swamp-workflow/references/nested-workflows.md",
+    name: "swamp-workflow",
+  },
+  {
+    relativePath: "swamp-workflow/references/expressions-and-foreach.md",
+    name: "swamp-workflow",
+  },
+  {
     relativePath: "swamp-extension-model/SKILL.md",
     name: "swamp-extension-model",
   },
@@ -91,6 +99,10 @@ const BUNDLED_SKILLS: SkillInfo[] = [
   },
   {
     relativePath: "swamp-extension-model/references/scenarios.md",
+    name: "swamp-extension-model",
+  },
+  {
+    relativePath: "swamp-extension-model/references/api.md",
     name: "swamp-extension-model",
   },
   {

--- a/src/infrastructure/assets/skill_assets_test.ts
+++ b/src/infrastructure/assets/skill_assets_test.ts
@@ -295,6 +295,57 @@ Deno.test("SkillAssets includes swamp-troubleshooting skill", () => {
   assertEquals(names.includes("swamp-troubleshooting"), true);
 });
 
+Deno.test("SkillAssets.copySkillsTo copies swamp-extension-model api file", async () => {
+  await withTempDir(async (dir) => {
+    const assets = new SkillAssets();
+    await assets.copySkillsTo(dir);
+
+    const apiPath = join(
+      dir,
+      "swamp-extension-model",
+      "references",
+      "api.md",
+    );
+
+    const apiStat = await Deno.stat(apiPath);
+    assertEquals(apiStat.isFile, true);
+  });
+});
+
+Deno.test("SkillAssets.copySkillsTo copies swamp-workflow nested-workflows file", async () => {
+  await withTempDir(async (dir) => {
+    const assets = new SkillAssets();
+    await assets.copySkillsTo(dir);
+
+    const nestedPath = join(
+      dir,
+      "swamp-workflow",
+      "references",
+      "nested-workflows.md",
+    );
+
+    const nestedStat = await Deno.stat(nestedPath);
+    assertEquals(nestedStat.isFile, true);
+  });
+});
+
+Deno.test("SkillAssets.copySkillsTo copies swamp-workflow expressions-and-foreach file", async () => {
+  await withTempDir(async (dir) => {
+    const assets = new SkillAssets();
+    await assets.copySkillsTo(dir);
+
+    const forEachPath = join(
+      dir,
+      "swamp-workflow",
+      "references",
+      "expressions-and-foreach.md",
+    );
+
+    const forEachStat = await Deno.stat(forEachPath);
+    assertEquals(forEachStat.isFile, true);
+  });
+});
+
 Deno.test("SkillAssets.copySkillsTo copies swamp-troubleshooting skill", async () => {
   await withTempDir(async (dir) => {
     const assets = new SkillAssets();


### PR DESCRIPTION
Follow-up improvements to PR #309 that enhance Claude skill documentation quality:

- **CEL Expression Clarity**: Replace confusing duplicate spec/instance patterns (`vpc.vpc`, `data.data`) with distinct
descriptive names (`vpc.main`, `data.output`, `state.current`)
- **Progressive Disclosure**: Refactor `swamp-extension-model/SKILL.md` from 980 to 338 lines by extracting detailed API
docs to `references/api.md`
- **Missing Assets**: Add missing workflow reference files to skill bundling

## Changes

### CEL Expression Naming (14 files)
Before: `model.my-vpc.resource.vpc.vpc.attributes.VpcId`
After: `model.my-vpc.resource.vpc.main.attributes.VpcId`

This makes the path structure clearer:
model..resource...attributes.
                        ───────    ────────────
                        vpc         main (not vpc again)

### Progressive Disclosure Fix
- `swamp-extension-model/SKILL.md`: 980 → 338 lines (under 500 line guideline)
- New `references/api.md`: Detailed `writeResource`, `createFileWriter`, `DataWriter`, logging API docs
- Removed duplicate examples already present in `references/examples.md`

### Skill Asset Registration
Added missing files to `skill_assets.ts`:
- `swamp-extension-model/references/api.md`
- `swamp-workflow/references/nested-workflows.md`
- `swamp-workflow/references/expressions-and-foreach.md`

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] All 1627 tests pass (3 new tests for added reference files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)