### PR TITLE
feat: Add workflow run search command

### DIFF
--- a/integration/workflow_run_search_test.ts
+++ b/integration/workflow_run_search_test.ts
@@ -1,0 +1,416 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Integration tests for the `workflow run search` command.
+ */
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+import { stringify as stringifyYaml } from "@std/yaml";
+import { Workflow } from "../src/domain/workflows/workflow.ts";
+import { Job } from "../src/domain/workflows/job.ts";
+import { Step } from "../src/domain/workflows/step.ts";
+import { StepTask } from "../src/domain/workflows/step_task.ts";
+import { YamlWorkflowRepository } from "../src/infrastructure/persistence/yaml_workflow_repository.ts";
+import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
+import { Definition } from "../src/domain/definitions/definition.ts";
+import { SHELL_MODEL_TYPE } from "../src/domain/models/command/shell/shell_model.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-run-search-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+async function initializeTestRepo(repoDir: string): Promise<void> {
+  const subdirs = [
+    ".swamp/definitions",
+    ".swamp/outputs",
+    ".swamp/data",
+    ".swamp/logs",
+    ".swamp/workflows",
+    ".swamp/workflow-runs",
+    ".swamp/vault",
+    ".swamp/secrets",
+  ];
+  for (const subdir of subdirs) {
+    await ensureDir(join(repoDir, subdir));
+  }
+
+  const markerData = {
+    swampVersion: "0.0.0",
+    initializedAt: new Date().toISOString(),
+  };
+  await Deno.writeTextFile(
+    join(repoDir, ".swamp.yaml"),
+    stringifyYaml(markerData as Record<string, unknown>),
+  );
+}
+
+async function runCliCommand(
+  args: string[],
+  cwd: string,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["task", "dev", ...args],
+    stdout: "piped",
+    stderr: "piped",
+    cwd,
+  });
+
+  const { code, stdout, stderr } = await command.output();
+  return {
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+    code,
+  };
+}
+
+/**
+ * Creates a shell model definition and a simple workflow that uses it.
+ */
+async function createModelAndWorkflow(
+  repoDir: string,
+  modelName: string,
+  workflowName: string,
+): Promise<void> {
+  const definitionRepo = new YamlDefinitionRepository(repoDir);
+  const model = Definition.create({
+    name: modelName,
+    methods: { execute: { arguments: { run: "echo test" } } },
+  });
+  await definitionRepo.save(SHELL_MODEL_TYPE, model);
+
+  const workflowRepo = new YamlWorkflowRepository(repoDir);
+  const workflow = Workflow.create({
+    name: workflowName,
+    jobs: [
+      Job.create({
+        name: "test-job",
+        steps: [
+          Step.create({
+            name: "test-step",
+            task: StepTask.model(modelName, "execute"),
+          }),
+        ],
+      }),
+    ],
+  });
+  await workflowRepo.save(workflow);
+}
+
+/**
+ * Runs a workflow and returns the CLI result.
+ */
+async function executeWorkflow(
+  repoDir: string,
+  workflowName: string,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  return await runCliCommand(
+    ["workflow", "run", workflowName, "--repo-dir", repoDir, "--json"],
+    Deno.cwd(),
+  );
+}
+
+// Tests
+
+Deno.test("CLI: workflow run search returns all runs", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+    await createModelAndWorkflow(repoDir, "search-model", "search-workflow");
+
+    // Run the workflow twice
+    const run1 = await executeWorkflow(repoDir, "search-workflow");
+    assertEquals(
+      run1.code,
+      0,
+      `First run should succeed. stderr: ${run1.stderr}`,
+    );
+    const run2 = await executeWorkflow(repoDir, "search-workflow");
+    assertEquals(
+      run2.code,
+      0,
+      `Second run should succeed. stderr: ${run2.stderr}`,
+    );
+
+    // Search for all runs
+    const result = await runCliCommand(
+      ["workflow", "run", "search", "--repo-dir", repoDir, "--json"],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Search should succeed. stderr: ${result.stderr}`,
+    );
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.results.length, 2);
+    assertEquals(output.results[0].workflowName, "search-workflow");
+    assertEquals(output.results[0].status, "succeeded");
+  });
+});
+
+Deno.test("CLI: workflow run search filters by --status", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+    await createModelAndWorkflow(repoDir, "status-model", "status-workflow");
+
+    // Run the workflow (it should succeed)
+    const run = await executeWorkflow(repoDir, "status-workflow");
+    assertEquals(run.code, 0, `Run should succeed. stderr: ${run.stderr}`);
+
+    // Search with --status succeeded
+    const succeededResult = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "search",
+        "--status",
+        "succeeded",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+    assertEquals(
+      succeededResult.code,
+      0,
+      `Search should succeed. stderr: ${succeededResult.stderr}`,
+    );
+    const succeededOutput = JSON.parse(succeededResult.stdout);
+    assertEquals(succeededOutput.results.length, 1);
+    assertEquals(succeededOutput.results[0].status, "succeeded");
+
+    // Search with --status failed (should return no results)
+    const failedResult = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "search",
+        "--status",
+        "failed",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+    assertEquals(
+      failedResult.code,
+      0,
+      `Search should succeed. stderr: ${failedResult.stderr}`,
+    );
+    const failedOutput = JSON.parse(failedResult.stdout);
+    assertEquals(failedOutput.results.length, 0);
+  });
+});
+
+Deno.test("CLI: workflow run search filters by --workflow", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    // Create two different workflows
+    await createModelAndWorkflow(repoDir, "alpha-model", "alpha-workflow");
+    await createModelAndWorkflow(repoDir, "beta-model", "beta-workflow");
+
+    // Run each workflow
+    const runAlpha = await executeWorkflow(repoDir, "alpha-workflow");
+    assertEquals(
+      runAlpha.code,
+      0,
+      `Alpha run should succeed. stderr: ${runAlpha.stderr}`,
+    );
+    const runBeta = await executeWorkflow(repoDir, "beta-workflow");
+    assertEquals(
+      runBeta.code,
+      0,
+      `Beta run should succeed. stderr: ${runBeta.stderr}`,
+    );
+
+    // Search for alpha only
+    const result = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "search",
+        "--workflow",
+        "alpha-workflow",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Search should succeed. stderr: ${result.stderr}`,
+    );
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.results.length, 1);
+    assertEquals(output.results[0].workflowName, "alpha-workflow");
+  });
+});
+
+Deno.test("CLI: workflow run search filters by --since", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+    await createModelAndWorkflow(repoDir, "since-model", "since-workflow");
+
+    // Run the workflow (just ran, so it's within --since 1h)
+    const run = await executeWorkflow(repoDir, "since-workflow");
+    assertEquals(run.code, 0, `Run should succeed. stderr: ${run.stderr}`);
+
+    // Search with --since 1h (should include the recent run)
+    const result = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "search",
+        "--since",
+        "1h",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Search should succeed. stderr: ${result.stderr}`,
+    );
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.results.length, 1);
+    assertEquals(output.results[0].workflowName, "since-workflow");
+  });
+});
+
+Deno.test("CLI: workflow run search with query filters by text", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+    await createModelAndWorkflow(repoDir, "query-model-a", "query-wf-alpha");
+    await createModelAndWorkflow(repoDir, "query-model-b", "query-wf-beta");
+
+    const runAlpha = await executeWorkflow(repoDir, "query-wf-alpha");
+    assertEquals(
+      runAlpha.code,
+      0,
+      `Alpha run should succeed. stderr: ${runAlpha.stderr}`,
+    );
+    const runBeta = await executeWorkflow(repoDir, "query-wf-beta");
+    assertEquals(
+      runBeta.code,
+      0,
+      `Beta run should succeed. stderr: ${runBeta.stderr}`,
+    );
+
+    // Search with query "alpha"
+    const result = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "search",
+        "alpha",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Search should succeed. stderr: ${result.stderr}`,
+    );
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.results.length, 1);
+    assertEquals(output.results[0].workflowName, "query-wf-alpha");
+  });
+});
+
+Deno.test("CLI: workflow run search with no runs returns empty", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    const result = await runCliCommand(
+      ["workflow", "run", "search", "--repo-dir", repoDir, "--json"],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Search should succeed. stderr: ${result.stderr}`,
+    );
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.results.length, 0);
+    assertEquals(output.query, "");
+  });
+});
+
+Deno.test("CLI: workflow run search respects --limit", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+    await createModelAndWorkflow(repoDir, "limit-model", "limit-workflow");
+
+    // Run the workflow 3 times
+    for (let i = 0; i < 3; i++) {
+      const run = await executeWorkflow(repoDir, "limit-workflow");
+      assertEquals(
+        run.code,
+        0,
+        `Run ${i + 1} should succeed. stderr: ${run.stderr}`,
+      );
+    }
+
+    // Search with --limit 2
+    const result = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "search",
+        "--limit",
+        "2",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Search should succeed. stderr: ${result.stderr}`,
+    );
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.results.length, 2);
+  });
+});

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -41,6 +41,7 @@ import { createLogProgressCallback } from "../../presentation/output/log_progres
 import { parseInputs } from "../input_parser.ts";
 import { parseTags } from "./data_search.ts";
 import { InputValidationService } from "../../domain/inputs/mod.ts";
+import { workflowRunSearchCommand } from "./workflow_run_search.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -287,4 +288,5 @@ export const workflowRunCommand = new Command()
       const message = error instanceof Error ? error.message : String(error);
       throw new UserError(`Workflow execution failed: ${message}`);
     }
-  });
+  })
+  .command("search", workflowRunSearchCommand);

--- a/src/cli/commands/workflow_run_search.ts
+++ b/src/cli/commands/workflow_run_search.ts
@@ -1,0 +1,267 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  type JobRunData,
+  renderWorkflowRun,
+  type StepRunData,
+  type WorkflowRunData,
+} from "../../presentation/output/workflow_run_output.ts";
+import {
+  renderWorkflowHistorySearch,
+  type WorkflowHistorySearchData,
+  type WorkflowHistorySearchItem,
+} from "../../presentation/output/workflow_history_search_output.tsx";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
+import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
+import {
+  createWorkflowId,
+  createWorkflowRunId,
+} from "../../domain/workflows/workflow_id.ts";
+import { parseDuration } from "./data_search.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+/**
+ * Converts a WorkflowRun to WorkflowRunData for presentation.
+ */
+function toRunData(run: WorkflowRun, path?: string): WorkflowRunData {
+  const startTime = run.startedAt?.getTime();
+  const endTime = run.completedAt?.getTime();
+
+  return {
+    id: run.id,
+    workflowId: run.workflowId,
+    workflowName: run.workflowName,
+    status: run.status,
+    jobs: run.jobs.map((job): JobRunData => {
+      const jobStart = job.startedAt?.getTime();
+      const jobEnd = job.completedAt?.getTime();
+
+      return {
+        name: job.jobName,
+        status: job.status,
+        steps: job.steps.map((step): StepRunData => {
+          const stepStart = step.startedAt?.getTime();
+          const stepEnd = step.completedAt?.getTime();
+
+          return {
+            name: step.stepName,
+            status: step.status,
+            error: step.error,
+            duration: stepStart && stepEnd ? stepEnd - stepStart : undefined,
+          };
+        }),
+        duration: jobStart && jobEnd ? jobEnd - jobStart : undefined,
+      };
+    }),
+    duration: startTime && endTime ? endTime - startTime : undefined,
+    path,
+  };
+}
+
+/**
+ * Converts a WorkflowRun to WorkflowHistorySearchItem.
+ */
+function toSearchItem(run: WorkflowRun): WorkflowHistorySearchItem {
+  const startTime = run.startedAt?.getTime();
+  const endTime = run.completedAt?.getTime();
+
+  return {
+    runId: run.id,
+    workflowId: run.workflowId,
+    workflowName: run.workflowName,
+    status: run.status,
+    startedAt: run.startedAt?.toISOString(),
+    completedAt: run.completedAt?.toISOString(),
+    duration: startTime && endTime ? endTime - startTime : undefined,
+  };
+}
+
+/**
+ * Filters runs by a query string (case-insensitive match on workflow name, run id, or status).
+ */
+function filterByQuery(
+  runs: WorkflowHistorySearchItem[],
+  query: string,
+): WorkflowHistorySearchItem[] {
+  if (!query) {
+    return runs;
+  }
+  const lowerQuery = query.toLowerCase();
+  return runs.filter(
+    (r) =>
+      r.workflowName.toLowerCase().includes(lowerQuery) ||
+      r.runId.toLowerCase().includes(lowerQuery) ||
+      r.status.toLowerCase().includes(lowerQuery),
+  );
+}
+
+/**
+ * Options for filtering workflow run search results.
+ */
+interface RunSearchFilterOptions {
+  since?: string;
+  status?: string;
+  workflow?: string;
+  limit?: number;
+}
+
+/**
+ * Applies structured filters to workflow run search items.
+ */
+function applyFilters(
+  runs: WorkflowHistorySearchItem[],
+  options: RunSearchFilterOptions,
+): WorkflowHistorySearchItem[] {
+  let filtered = runs;
+
+  if (options.since) {
+    const durationMs = parseDuration(options.since);
+    const cutoff = Date.now() - durationMs;
+    filtered = filtered.filter((r) => {
+      if (!r.startedAt) return false;
+      return new Date(r.startedAt).getTime() >= cutoff;
+    });
+  }
+
+  if (options.status) {
+    const status = options.status.toLowerCase();
+    filtered = filtered.filter((r) => r.status === status);
+  }
+
+  if (options.workflow) {
+    const name = options.workflow.toLowerCase();
+    filtered = filtered.filter(
+      (r) => r.workflowName.toLowerCase() === name,
+    );
+  }
+
+  if (options.limit !== undefined) {
+    filtered = filtered.slice(0, options.limit);
+  }
+
+  return filtered;
+}
+
+export async function workflowRunSearchAction(
+  options: AnyOptions,
+  query?: string,
+): Promise<void> {
+  const ctx = createContext(
+    options as GlobalOptions,
+    ["workflow", "run", "search"],
+  );
+  ctx.logger.debug`Searching workflow runs with query: ${query ?? "(none)"}`;
+
+  const { repoContext } = await requireInitializedRepo({
+    repoDir: options.repoDir ?? ".",
+    outputMode: ctx.outputMode,
+  });
+  const workflowRepo = repoContext.workflowRepo;
+  const runRepo = repoContext.workflowRunRepo;
+
+  // Get all workflows
+  const allWorkflows = await workflowRepo.findAll();
+
+  // Get all runs for all workflows
+  const allRuns: WorkflowRun[] = [];
+  for (const workflow of allWorkflows) {
+    const runs = await runRepo.findAllByWorkflowId(workflow.id);
+    allRuns.push(...runs);
+  }
+
+  // Sort by startedAt descending (most recent first)
+  allRuns.sort((a, b) => {
+    const aTime = a.startedAt?.getTime() ?? 0;
+    const bTime = b.startedAt?.getTime() ?? 0;
+    return bTime - aTime;
+  });
+
+  // Convert to search items and apply structured filters
+  let searchItems = allRuns.map(toSearchItem);
+  searchItems = applyFilters(searchItems, {
+    since: options.since as string | undefined,
+    status: options.status as string | undefined,
+    workflow: options.workflow as string | undefined,
+    limit: options.limit as number | undefined,
+  });
+
+  if (ctx.outputMode === "json") {
+    // Non-interactive: also apply query text filter
+    const filteredRuns = filterByQuery(searchItems, query ?? "");
+    const data: WorkflowHistorySearchData = {
+      query: query ?? "",
+      results: filteredRuns,
+    };
+    await renderWorkflowHistorySearch(data, ctx.outputMode);
+  } else {
+    // Interactive: show fuzzy search UI
+    const data: WorkflowHistorySearchData = {
+      query: query ?? "",
+      results: searchItems,
+    };
+
+    const selected = await renderWorkflowHistorySearch(data, ctx.outputMode);
+
+    if (selected) {
+      ctx.logger.debug`Selected run: ${selected.runId}`;
+      // Display the run details
+      const run = await runRepo.findById(
+        createWorkflowId(selected.workflowId),
+        createWorkflowRunId(selected.runId),
+      );
+      if (run) {
+        const path = runRepo.getPath(
+          createWorkflowId(selected.workflowId),
+          createWorkflowRunId(selected.runId),
+        );
+        const runData = toRunData(run, path);
+        renderWorkflowRun(runData, ctx.outputMode);
+      }
+    } else {
+      ctx.logger.debug`Search cancelled`;
+    }
+  }
+
+  ctx.logger.debug("Workflow run search command completed");
+}
+
+export const workflowRunSearchCommand = new Command()
+  .name("search")
+  .description("Search workflow run history")
+  .arguments("[query:string]")
+  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--since <duration:string>",
+    "Only runs started within duration (1h, 1d, 7d, 1w, 1mo)",
+  )
+  .option(
+    "--status <status:string>",
+    "Filter by run status (pending, running, succeeded, failed)",
+  )
+  .option(
+    "--workflow <name:string>",
+    "Filter by workflow name",
+  )
+  .option("--limit <n:number>", "Max results", { default: 50 })
+  .action(workflowRunSearchAction);


### PR DESCRIPTION
## Summary

- Adds `swamp workflow run search` as a new subcommand with data search-style
  filter options: `--since`, `--status`, `--workflow`, `--limit`
- Reuses the existing workflow history search TUI and presentation layer
- Registered as a subcommand on `workflow run` (Cliffy resolves subcommands
  before arguments, so `workflow run <name>` still works)
- Includes 7 integration tests covering all filter options

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] All 1623 tests pass (including 7 new integration tests)
- [x] `deno run compile` succeeds
- [x] `workflow run search --json` returns structured results
- [x] `workflow run <name>` still executes workflows as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)