### PR TITLE
fix: Product usage fixes from real-world testing

### DIFF
--- a/.claude/skills/swamp-data/references/examples.md
+++ b/.claude/skills/swamp-data/references/examples.md
@@ -15,7 +15,7 @@
 | Expression Pattern                                           | Description                                 |
 | ------------------------------------------------------------ | ------------------------------------------- |
 | `model.<name>.resource.<spec>.<instance>.attributes.<field>` | Cross-model resource reference (PREFERRED)  |
-| `model.<name>.resource.data.output.attributes.json.<field>`  | aws/cli with parseJson: true                |
+| `model.<name>.resource.result.result.attributes.stdout`      | command/shell stdout                        |
 | `model.<name>.file.<spec>.<instance>.path`                   | File path reference                         |
 | `self.name`                                                  | Current model's name                        |
 | `inputs.<name>`                                              | Workflow or model runtime input             |
@@ -31,7 +31,6 @@
 | Model Type      | CEL Path                                                             | Notes                              |
 | --------------- | -------------------------------------------------------------------- | ---------------------------------- |
 | `command/shell` | `model.<name>.resource.result.result.attributes.stdout`              | Built-in uses `result` for both    |
-| `aws/cli`       | `model.<name>.resource.data.output.attributes.json.<field>`          | spec=`data`, instance=`output`     |
 | `@user/custom`  | `model.<name>.resource.<spec>.<instance>.attributes.<field>`         | You choose both names              |
 | Factory models  | `model.<name>.resource.<spec>.<dynamic-instance>.attributes.<field>` | Instance varies (e.g., `vpc-1234`) |
 
@@ -52,9 +51,9 @@ globalArguments:
   vpcId: ${{ model.my-vpc.resource.vpc.main.attributes.VpcId }}
   subnetId: ${{ model.public-subnet.resource.subnet.primary.attributes.SubnetId }}
 
-# For aws/cli models with parseJson: true
+# For command/shell models
 globalArguments:
-  imageId: ${{ model.ami-lookup.resource.data.output.attributes.json.ImageId }}
+  imageId: ${{ model.ami-lookup.resource.result.result.attributes.stdout }}
 ```
 
 ### When to Use data.latest()

--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -28,10 +28,10 @@ doesn't exist. Extension models let you:
 3. Solution: Create extensions/models/s3_bucket.ts with the S3 logic you need
 ```
 
-**Important:** Do not default to generic CLI types (like `aws/cli`) for specific
-service integrations. If the user wants to manage S3 buckets, EC2 instances, or
-other resources, create a dedicated model for that service rather than wrapping
-CLI commands.
+**Important:** Do not default to generic CLI types (like `command/shell`) for
+specific service integrations. If the user wants to manage S3 buckets, EC2
+instances, or other resources, create a dedicated model for that service rather
+than wrapping CLI commands.
 
 ## Quick Reference
 

--- a/.claude/skills/swamp-extension-model/references/api.md
+++ b/.claude/skills/swamp-extension-model/references/api.md
@@ -150,7 +150,6 @@ Delete and update methods need to read back previously stored resource data
 const content = await context.dataRepository.getContent(
   context.modelType,
   context.modelId,
-  "<specName>", // matches a key in resources
   "<instanceName>", // instance name used when writing
 );
 // Returns Uint8Array | null
@@ -167,11 +166,11 @@ const data = JSON.parse(new TextDecoder().decode(content));
 
 **Key dataRepository methods for model authors:**
 
-| Method                                                    | Returns              | Description                            |
-| --------------------------------------------------------- | -------------------- | -------------------------------------- |
-| `getContent(type, modelId, dataName, instanceName, ver?)` | `Uint8Array \| null` | Get raw content bytes                  |
-| `findByName(type, modelId, dataName, instanceName, ver?)` | `Data \| null`       | Get data metadata (tags, version, etc) |
-| `findAllForModel(type, modelId)`                          | `Data[]`             | List all data for this model instance  |
+| Method                                      | Returns              | Description                            |
+| ------------------------------------------- | -------------------- | -------------------------------------- |
+| `getContent(type, modelId, dataName, ver?)` | `Uint8Array \| null` | Get raw content bytes                  |
+| `findByName(type, modelId, dataName, ver?)` | `Data \| null`       | Get data metadata (tags, version, etc) |
+| `findAllForModel(type, modelId)`            | `Data[]`             | List all data for this model instance  |
 
 ---
 

--- a/.claude/skills/swamp-extension-model/references/examples.md
+++ b/.claude/skills/swamp-extension-model/references/examples.md
@@ -85,7 +85,6 @@ export const model = {
           context.modelType,
           context.modelId,
           "vpc",
-          "vpc",
         );
 
         if (!content) {
@@ -147,7 +146,6 @@ export const model = {
         const content = await context.dataRepository.getContent(
           context.modelType,
           context.modelId,
-          "vpc",
           "vpc",
         );
 

--- a/.claude/skills/swamp-extension-model/references/scenarios.md
+++ b/.claude/skills/swamp-extension-model/references/scenarios.md
@@ -46,7 +46,7 @@ const GlobalArgsSchema = z.object({
 const CreateArgsSchema = z.object({
   email: z.string().email(),
   name: z.string(),
-  metadata: z.record(z.string()).optional(),
+  metadata: z.record(z.string(), z.string()).optional(),
 });
 
 const CustomerSchema = z.object({
@@ -109,7 +109,6 @@ export const model = {
         const content = await context.dataRepository.getContent(
           context.modelType,
           context.modelId,
-          "customer",
           "primary",
         );
 
@@ -297,7 +296,6 @@ export const model = {
         const content = await context.dataRepository.getContent(
           context.modelType,
           context.modelId,
-          "bucket",
           "main",
         );
 
@@ -345,7 +343,6 @@ export const model = {
         const content = await context.dataRepository.getContent(
           context.modelType,
           context.modelId,
-          "bucket",
           "main",
         );
 

--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -528,7 +528,7 @@ This ensures data integrity when multiple models reference the same data names.
 - **Scenarios**: See [references/scenarios.md](references/scenarios.md) for
   end-to-end scenarios (shell commands, chained lookups, runtime inputs)
 - **Data chaining**: See
-  [references/data-chaining.md](references/data-chaining.md) for aws/cli model
-  examples and chaining patterns
+  [references/data-chaining.md](references/data-chaining.md) for command/shell
+  model examples and chaining patterns
 - **Model design**: See [design/models.md](design/models.md) for data structures
   and concepts

--- a/.claude/skills/swamp-model/references/data-chaining.md
+++ b/.claude/skills/swamp-model/references/data-chaining.md
@@ -1,129 +1,158 @@
-# Data Chaining with aws/cli Model
+# Data Chaining with command/shell Model
 
-The `aws/cli` model enables data chaining by running AWS CLI commands and
-capturing output for use in other models. Use `parseJson: true` to parse JSON
-output and access it via `resource.data.output.attributes.json`.
+The `command/shell` model enables data chaining by running shell commands and
+capturing output for use in other models. For JSON output, use `jq` in the
+command to extract specific fields, then access the result via
+`resource.result.result.attributes.stdout`.
 
-## aws/cli Data Attributes
+## command/shell Data Attributes
 
 | Attribute    | Description                                   |
 | ------------ | --------------------------------------------- |
-| `output`     | Raw stdout from the command                   |
-| `json`       | Parsed JSON output (when `parseJson: true`)   |
+| `stdout`     | Raw stdout from the command                   |
+| `stderr`     | Raw stderr from the command                   |
 | `exitCode`   | Command exit code                             |
 | `executedAt` | ISO timestamp when command was executed       |
 | `durationMs` | Duration of command execution in milliseconds |
 
 ## Example: Dynamic AMI Lookup
 
-**Step 1: Create an aws/cli model to look up an AMI:**
+**Step 1: Create a command/shell model to look up an AMI:**
 
 ```bash
 # Create the model
-swamp model create aws/cli latest-ami --json
+swamp model create command/shell latest-ami --json
+```
 
-# Configure the model with stdin
-swamp model edit latest-ami --json <<EOF
+Edit `models/latest-ami/input.yaml`:
+
+```yaml
 name: latest-ami
 version: 1
 tags: {}
-attributes:
-  command: >-
-    ec2 describe-images --owners amazon
-    --filters "Name=name,Values=amzn2-ami-hvm-*-x86_64-gp2"
-    --query "sort_by(Images,&CreationDate)[-1]"
-  region: us-east-1
-  parseJson: true
-EOF
+methods:
+  execute:
+    arguments:
+      run: >-
+        aws ec2 describe-images --owners amazon
+        --filters "Name=name,Values=amzn2-ami-hvm-*-x86_64-gp2"
+        --query "sort_by(Images,&CreationDate)[-1].ImageId"
+        --output text
 ```
 
-**Step 2: Create another model that references the CLI output:**
+**Step 2: Create another model that references the shell output:**
 
 ```bash
 # Create the EC2 instance model
 swamp model create @user/ec2-instance my-instance --json
+```
 
-# Configure with references to the aws/cli model's data output
-swamp model edit my-instance --json <<EOF
+Edit `models/my-instance/input.yaml`:
+
+```yaml
 name: my-instance
 version: 1
 tags: {}
-attributes:
-  # Reference parsed JSON fields from the aws/cli model's data output
-  imageId: \${{ model.latest-ami.resource.data.output.attributes.json.ImageId }}
+globalArguments:
+  # Reference stdout from the command/shell model
+  imageId: ${{ model.latest-ami.resource.result.result.attributes.stdout }}
   instanceType: t3.micro
   tags:
-    Name: \${{ self.name }}
-    AmiName: \${{ model.latest-ami.resource.data.output.attributes.json.Name }}
-EOF
+    Name: ${{ self.name }}
 ```
 
 ## Example: Security Group Lookup
 
 ```bash
 # Create and configure the security group lookup model
-swamp model create aws/cli default-sg --json
+swamp model create command/shell default-sg --json
+```
 
-swamp model edit default-sg --json <<EOF
+Edit `models/default-sg/input.yaml`:
+
+```yaml
 name: default-sg
-attributes:
-  command: >-
-    ec2 describe-security-groups
-    --filters "Name=group-name,Values=default"
-    --query "SecurityGroups[0]"
-  parseJson: true
-EOF
+version: 1
+tags: {}
+methods:
+  execute:
+    arguments:
+      run: >-
+        aws ec2 describe-security-groups
+        --filters "Name=group-name,Values=default"
+        --query "SecurityGroups[0].GroupId"
+        --output text
 ```
 
 ```bash
 # Create an EC2 instance that references the security group
 swamp model create @user/ec2 my-server --json
+```
 
-swamp model edit my-server --json <<EOF
+Edit `models/my-server/input.yaml`:
+
+```yaml
 name: my-server
-attributes:
+version: 1
+tags: {}
+globalArguments:
   securityGroupIds:
-    - \${{ model.default-sg.resource.data.output.attributes.json.GroupId }}
-EOF
+    - ${{ model.default-sg.resource.result.result.attributes.stdout }}
 ```
 
 ## Example: Chaining Multiple Lookups
 
 ```bash
 # Step 1: Create VPC lookup model
-swamp model create aws/cli vpc-lookup --json
+swamp model create command/shell vpc-lookup --json
+```
 
-swamp model edit vpc-lookup --json <<EOF
+Edit `models/vpc-lookup/input.yaml`:
+
+```yaml
 name: vpc-lookup
-attributes:
-  command: ec2 describe-vpcs --filters "Name=isDefault,Values=true" --query "Vpcs[0]"
-  parseJson: true
-EOF
+version: 1
+tags: {}
+methods:
+  execute:
+    arguments:
+      run: >-
+        aws ec2 describe-vpcs --filters "Name=isDefault,Values=true"
+        --query "Vpcs[0].VpcId" --output text
 ```
 
 ```bash
 # Step 2: Create subnet lookup that references the VPC
-swamp model create aws/cli subnet-lookup --json
+swamp model create command/shell subnet-lookup --json
+```
 
-swamp model edit subnet-lookup --json <<EOF
+Edit `models/subnet-lookup/input.yaml`:
+
+```yaml
 name: subnet-lookup
-attributes:
-  command: >-
-    ec2 describe-subnets
-    --filters "Name=vpc-id,Values=\${{ model.vpc-lookup.resource.data.output.attributes.json.VpcId }}"
-    --query "Subnets[0]"
-  parseJson: true
-EOF
+version: 1
+tags: {}
+methods:
+  execute:
+    arguments:
+      run: >-
+        aws ec2 describe-subnets
+        --filters "Name=vpc-id,Values=${{ model.vpc-lookup.resource.result.result.attributes.stdout }}"
+        --query "Subnets[0].SubnetId" --output text
 ```
 
 ```bash
 # Step 3: Create instance model that uses both lookups
 swamp model create @user/ec2-instance my-instance --json
+```
 
-swamp model edit my-instance --json <<EOF
+Edit `models/my-instance/input.yaml`:
+
+```yaml
 name: my-instance
-attributes:
-  subnetId: \${{ model.subnet-lookup.resource.data.output.attributes.json.SubnetId }}
-  vpcId: \${{ model.vpc-lookup.resource.data.output.attributes.json.VpcId }}
-EOF
+version: 1
+tags: {}
+globalArguments:
+  subnetId: ${{ model.subnet-lookup.resource.result.result.attributes.stdout }}
+  vpcId: ${{ model.vpc-lookup.resource.result.result.attributes.stdout }}
 ```

--- a/.claude/skills/swamp-model/references/examples.md
+++ b/.claude/skills/swamp-model/references/examples.md
@@ -14,7 +14,7 @@
 | Expression Pattern                                           | Description                                | Example Value                 |
 | ------------------------------------------------------------ | ------------------------------------------ | ----------------------------- |
 | `model.<name>.resource.<spec>.<instance>.attributes.<field>` | Cross-model resource reference (PREFERRED) | VPC ID, subnet CIDR, etc.     |
-| `model.<name>.resource.data.output.attributes.json.<field>`  | aws/cli with parseJson: true               | AMI ID from describe-images   |
+| `model.<name>.resource.result.result.attributes.stdout`      | command/shell stdout                       | AMI ID from aws cli command   |
 | `model.<name>.file.<spec>.<instance>.path`                   | File path from another model               | `/path/to/file.txt`           |
 | `self.name`                                                  | Current model's name                       | `my-vpc`                      |
 | `self.version`                                               | Current model's version                    | `1`                           |
@@ -29,13 +29,12 @@
 
 ### CEL Path Patterns by Model Type
 
-| Model Type      | Resource Spec | Instance    | CEL Path Example                                                |
-| --------------- | ------------- | ----------- | --------------------------------------------------------------- |
-| `command/shell` | `result`      | `result`    | `model.my-shell.resource.result.result.attributes.stdout`       |
-| `aws/cli`       | `data`        | `output`    | `model.ami-lookup.resource.data.output.attributes.json.ImageId` |
-| `@user/vpc`     | `vpc`         | `main`      | `model.my-vpc.resource.vpc.main.attributes.VpcId`               |
-| `@user/subnet`  | `subnet`      | `primary`   | `model.my-subnet.resource.subnet.primary.attributes.SubnetId`   |
-| Factory model   | `<spec>`      | `<dynamic>` | `model.scanner.resource.subnet.subnet-aaa.attributes.cidr`      |
+| Model Type      | Resource Spec | Instance    | CEL Path Example                                              |
+| --------------- | ------------- | ----------- | ------------------------------------------------------------- |
+| `command/shell` | `result`      | `result`    | `model.my-shell.resource.result.result.attributes.stdout`     |
+| `@user/vpc`     | `vpc`         | `main`      | `model.my-vpc.resource.vpc.main.attributes.VpcId`             |
+| `@user/subnet`  | `subnet`      | `primary`   | `model.my-subnet.resource.subnet.primary.attributes.SubnetId` |
+| Factory model   | `<spec>`      | `<dynamic>` | `model.scanner.resource.subnet.subnet-aaa.attributes.cidr`    |
 
 ## Decision Tree: What to Build
 
@@ -43,7 +42,7 @@
 What does the user want to accomplish?
 │
 ├── Run a single command or API call
-│   └── Create a swamp model (command/shell, aws/cli, or @user/custom)
+│   └── Create a swamp model (command/shell or @user/custom)
 │
 ├── Orchestrate multiple steps in order
 │   └── Create a swamp workflow with jobs and steps
@@ -91,7 +90,7 @@ swamp model method run my-shell execute --json
 **Step 1: VPC Lookup**
 
 ```bash
-swamp model create aws/cli vpc-lookup --json
+swamp model create command/shell vpc-lookup --json
 ```
 
 ```yaml
@@ -99,21 +98,22 @@ swamp model create aws/cli vpc-lookup --json
 name: vpc-lookup
 version: 1
 tags: {}
-globalArguments:
-  command: >-
-    ec2 describe-vpcs --filters "Name=isDefault,Values=true" --query "Vpcs[0]"
-  region: us-east-1
-  parseJson: true
+methods:
+  execute:
+    arguments:
+      run: >-
+        aws ec2 describe-vpcs --filters "Name=isDefault,Values=true"
+        --query "Vpcs[0].VpcId" --output text
 ```
 
 ```bash
-swamp model method run vpc-lookup run --json
+swamp model method run vpc-lookup execute --json
 ```
 
 **Step 2: Subnet Lookup (references VPC)**
 
 ```bash
-swamp model create aws/cli subnet-lookup --json
+swamp model create command/shell subnet-lookup --json
 ```
 
 ```yaml
@@ -121,13 +121,13 @@ swamp model create aws/cli subnet-lookup --json
 name: subnet-lookup
 version: 1
 tags: {}
-globalArguments:
-  command: >-
-    ec2 describe-subnets
-    --filters "Name=vpc-id,Values=${{ model.vpc-lookup.resource.data.output.attributes.json.VpcId }}"
-    --query "Subnets[0]"
-  region: us-east-1
-  parseJson: true
+methods:
+  execute:
+    arguments:
+      run: >-
+        aws ec2 describe-subnets
+        --filters "Name=vpc-id,Values=${{ model.vpc-lookup.resource.result.result.attributes.stdout }}"
+        --query "Subnets[0].SubnetId" --output text
 ```
 
 **Step 3: Instance (references both)**
@@ -142,8 +142,8 @@ name: my-instance
 version: 1
 tags: {}
 globalArguments:
-  vpcId: ${{ model.vpc-lookup.resource.data.output.attributes.json.VpcId }}
-  subnetId: ${{ model.subnet-lookup.resource.data.output.attributes.json.SubnetId }}
+  vpcId: ${{ model.vpc-lookup.resource.result.result.attributes.stdout }}
+  subnetId: ${{ model.subnet-lookup.resource.result.result.attributes.stdout }}
   instanceType: t3.micro
   tags:
     Name: ${{ self.name }}
@@ -151,11 +151,11 @@ globalArguments:
 
 ### Key CEL Paths Used
 
-| Model         | Expression                                                          | Value             |
-| ------------- | ------------------------------------------------------------------- | ----------------- |
-| vpc-lookup    | `model.vpc-lookup.resource.data.output.attributes.json.VpcId`       | `vpc-12345678`    |
-| subnet-lookup | `model.subnet-lookup.resource.data.output.attributes.json.SubnetId` | `subnet-abcd1234` |
-| my-instance   | `self.name`                                                         | `my-instance`     |
+| Model         | Expression                                                     | Value             |
+| ------------- | -------------------------------------------------------------- | ----------------- |
+| vpc-lookup    | `model.vpc-lookup.resource.result.result.attributes.stdout`    | `vpc-12345678`    |
+| subnet-lookup | `model.subnet-lookup.resource.result.result.attributes.stdout` | `subnet-abcd1234` |
+| my-instance   | `self.name`                                                    | `my-instance`     |
 
 ## Model with Runtime Inputs
 

--- a/.claude/skills/swamp-model/references/scenarios.md
+++ b/.claude/skills/swamp-model/references/scenarios.md
@@ -94,15 +94,15 @@ swamp data get my-shell result --json
 ### What You'll Build
 
 - 3 models:
-  - `vpc-lookup` (aws/cli) — find the default VPC
-  - `subnet-lookup` (aws/cli) — find a subnet in that VPC
+  - `vpc-lookup` (command/shell) — find the default VPC
+  - `subnet-lookup` (command/shell) — find a subnet in that VPC
   - `my-instance` (@user/ec2-instance or similar) — uses both
 
 ### Decision Tree
 
 ```
 User wants to chain multiple lookups → Multiple models with CEL references
-Each lookup is a command → aws/cli model
+Each lookup is a command → command/shell model
 Final resource needs custom logic → Extension model (or use existing type)
 ```
 
@@ -111,7 +111,7 @@ Final resource needs custom logic → Extension model (or use existing type)
 **1. Create VPC lookup model**
 
 ```bash
-swamp model create aws/cli vpc-lookup --json
+swamp model create command/shell vpc-lookup --json
 ```
 
 Edit `models/vpc-lookup/input.yaml`:
@@ -120,25 +120,25 @@ Edit `models/vpc-lookup/input.yaml`:
 name: vpc-lookup
 version: 1
 tags: {}
-globalArguments:
-  command: >-
-    ec2 describe-vpcs
-    --filters "Name=isDefault,Values=true"
-    --query "Vpcs[0]"
-  region: us-east-1
-  parseJson: true
+methods:
+  execute:
+    arguments:
+      run: >-
+        aws ec2 describe-vpcs
+        --filters "Name=isDefault,Values=true"
+        --query "Vpcs[0].VpcId" --output text
 ```
 
 Run it:
 
 ```bash
-swamp model method run vpc-lookup run --json
+swamp model method run vpc-lookup execute --json
 ```
 
 **2. Create subnet lookup model (references VPC)**
 
 ```bash
-swamp model create aws/cli subnet-lookup --json
+swamp model create command/shell subnet-lookup --json
 ```
 
 Edit `models/subnet-lookup/input.yaml`:
@@ -147,20 +147,20 @@ Edit `models/subnet-lookup/input.yaml`:
 name: subnet-lookup
 version: 1
 tags: {}
-globalArguments:
-  command: >-
-    ec2 describe-subnets
-    --filters "Name=vpc-id,Values=${{ model.vpc-lookup.resource.data.output.attributes.json.VpcId }}"
-    --query "Subnets[0]"
-  region: us-east-1
-  parseJson: true
+methods:
+  execute:
+    arguments:
+      run: >-
+        aws ec2 describe-subnets
+        --filters "Name=vpc-id,Values=${{ model.vpc-lookup.resource.result.result.attributes.stdout }}"
+        --query "Subnets[0].SubnetId" --output text
 ```
 
 Validate and run:
 
 ```bash
 swamp model validate subnet-lookup --json
-swamp model method run subnet-lookup run --json
+swamp model method run subnet-lookup execute --json
 ```
 
 **3. Create instance model (references both)**
@@ -176,8 +176,8 @@ name: my-instance
 version: 1
 tags: {}
 globalArguments:
-  vpcId: ${{ model.vpc-lookup.resource.data.output.attributes.json.VpcId }}
-  subnetId: ${{ model.subnet-lookup.resource.data.output.attributes.json.SubnetId }}
+  vpcId: ${{ model.vpc-lookup.resource.result.result.attributes.stdout }}
+  subnetId: ${{ model.subnet-lookup.resource.result.result.attributes.stdout }}
   instanceType: t3.micro
   tags:
     Name: ${{ self.name }}
@@ -192,13 +192,11 @@ swamp model validate my-instance --json
 
 ### CEL Paths Used
 
-| Model         | Expression                                                                  | Description |
-| ------------- | --------------------------------------------------------------------------- | ----------- |
-| vpc-lookup    | `model.vpc-lookup.resource.data.output.attributes.json.VpcId`               | VPC ID      |
-| vpc-lookup    | `model.vpc-lookup.resource.data.output.attributes.json.CidrBlock`           | VPC CIDR    |
-| subnet-lookup | `model.subnet-lookup.resource.data.output.attributes.json.SubnetId`         | Subnet ID   |
-| subnet-lookup | `model.subnet-lookup.resource.data.output.attributes.json.AvailabilityZone` | AZ          |
-| my-instance   | `self.name`                                                                 | Model name  |
+| Model         | Expression                                                     | Description |
+| ------------- | -------------------------------------------------------------- | ----------- |
+| vpc-lookup    | `model.vpc-lookup.resource.result.result.attributes.stdout`    | VPC ID      |
+| subnet-lookup | `model.subnet-lookup.resource.result.result.attributes.stdout` | Subnet ID   |
+| my-instance   | `self.name`                                                    | Model name  |
 
 ---
 

--- a/.claude/skills/swamp-model/references/troubleshooting.md
+++ b/.claude/skills/swamp-model/references/troubleshooting.md
@@ -225,7 +225,6 @@ model.my-vpc.resource.vpc.main.attributes.VpcId
 | Model Type    | Spec     | Instance | Expression Pattern                                           |
 | ------------- | -------- | -------- | ------------------------------------------------------------ |
 | command/shell | result   | result   | `model.<name>.resource.result.result.attributes.stdout`      |
-| aws/cli       | data     | output   | `model.<name>.resource.data.output.attributes.json.<field>`  |
 | Custom model  | (varies) | (varies) | `model.<name>.resource.<spec>.<instance>.attributes.<field>` |
 
 ## Method Execution Issues

--- a/.claude/skills/swamp-repo/references/structure.md
+++ b/.claude/skills/swamp-repo/references/structure.md
@@ -17,9 +17,6 @@ my-swamp-repo/
 │   │   ├── command/
 │   │   │   └── shell/
 │   │   │       └── {model-id}.yaml
-│   │   ├── aws/
-│   │   │   └── cli/
-│   │   │       └── {model-id}.yaml
 │   │   └── @user/
 │   │       └── my-type/
 │   │           └── {model-id}.yaml
@@ -165,7 +162,7 @@ methods:
 
 **Path pattern**: `.swamp/definitions/{normalized-type}/{model-id}.yaml`
 
-- `normalized-type`: e.g., `command/shell`, `aws/cli`, `@user/my-type`
+- `normalized-type`: e.g., `command/shell`, `@user/my-type`
 - `model-id`: UUID assigned at creation
 
 ### Model Data (.swamp/data/)

--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -435,4 +435,4 @@ End-to-end workflow creation:
 - **Data chaining and lifecycle workflows**: See
   [references/data-chaining.md](references/data-chaining.md) for `model.*` vs
   `data.latest()` expression guidance, delete/update workflow ordering, and
-  aws/cli chaining examples
+  command/shell chaining examples

--- a/.claude/skills/swamp-workflow/references/data-chaining.md
+++ b/.claude/skills/swamp-workflow/references/data-chaining.md
@@ -9,9 +9,9 @@
 - [Delete Workflow Ordering](#delete-workflow-ordering)
 - [Update Workflow Ordering](#update-workflow-ordering)
 
-The `aws/cli` model enables powerful data chaining in workflows by running AWS
-CLI commands and making the output available to other models. This is useful for
-dynamic lookups like finding the latest AMI, checking resource state, or
+The `command/shell` model enables powerful data chaining in workflows by running
+shell commands and making the output available to other models. This is useful
+for dynamic lookups like finding the latest AMI, checking resource state, or
 querying AWS for configuration values.
 
 ## Example: Dynamic AMI Lookup Workflow
@@ -30,7 +30,7 @@ jobs:
         task:
           type: model_method
           modelIdOrName: latest-ami
-          methodName: run
+          methodName: execute
       - name: create-instance
         description: Create EC2 instance using looked-up AMI
         task:
@@ -42,22 +42,27 @@ jobs:
 ### Model Inputs
 
 ```yaml
-# latest-ami input (aws/cli model)
+# latest-ami input (command/shell model)
 name: latest-ami
-attributes:
-  command: >-
-    ec2 describe-images --owners amazon
-    --filters "Name=name,Values=amzn2-ami-hvm-*-x86_64-gp2"
-    --query "sort_by(Images,&CreationDate)[-1]"
-  region: us-east-1
-  parseJson: true
+version: 1
+tags: {}
+methods:
+  execute:
+    arguments:
+      run: >-
+        aws ec2 describe-images --owners amazon
+        --filters "Name=name,Values=amzn2-ami-hvm-*-x86_64-gp2"
+        --query "sort_by(Images,&CreationDate)[-1].ImageId"
+        --output text
 ```
 
 ```yaml
-# my-instance input (references aws/cli output)
+# my-instance input (references command/shell output)
 name: my-instance
-attributes:
-  imageId: ${{ model.latest-ami.resource.data.output.attributes.json.ImageId }}
+version: 1
+tags: {}
+globalArguments:
+  imageId: ${{ model.latest-ami.resource.result.result.attributes.stdout }}
   instanceType: t3.micro
 ```
 
@@ -104,12 +109,12 @@ jobs:
         task:
           type: model_method
           modelIdOrName: vpc-lookup
-          methodName: run
+          methodName: execute
       - name: find-subnet
         task:
           type: model_method
           modelIdOrName: subnet-lookup
-          methodName: run
+          methodName: execute
   - name: provision
     description: Create resources using lookup results
     dependsOn:
@@ -132,29 +137,39 @@ jobs:
 ### Model Inputs for Multi-Step Workflow
 
 ```yaml
-# vpc-lookup (aws/cli)
+# vpc-lookup (command/shell)
 name: vpc-lookup
-attributes:
-  command: ec2 describe-vpcs --filters "Name=isDefault,Values=true" --query "Vpcs[0]"
-  parseJson: true
+version: 1
+tags: {}
+methods:
+  execute:
+    arguments:
+      run: >-
+        aws ec2 describe-vpcs --filters "Name=isDefault,Values=true"
+        --query "Vpcs[0].VpcId" --output text
 ```
 
 ```yaml
-# subnet-lookup (aws/cli) - chains from vpc-lookup
+# subnet-lookup (command/shell) - chains from vpc-lookup
 name: subnet-lookup
-attributes:
-  command: >-
-    ec2 describe-subnets
-    --filters "Name=vpc-id,Values=${{ model.vpc-lookup.resource.data.output.attributes.json.VpcId }}"
-    --query "Subnets[0]"
-  parseJson: true
+version: 1
+tags: {}
+methods:
+  execute:
+    arguments:
+      run: >-
+        aws ec2 describe-subnets
+        --filters "Name=vpc-id,Values=${{ model.vpc-lookup.resource.result.result.attributes.stdout }}"
+        --query "Subnets[0].SubnetId" --output text
 ```
 
 ```yaml
 # app-security-group - chains from vpc-lookup
 name: app-security-group
-attributes:
-  vpcId: ${{ model.vpc-lookup.resource.data.output.attributes.json.VpcId }}
+version: 1
+tags: {}
+globalArguments:
+  vpcId: ${{ model.vpc-lookup.resource.result.result.attributes.stdout }}
   groupName: app-sg
   description: Security group for application
 ```
@@ -162,9 +177,11 @@ attributes:
 ```yaml
 # app-server - chains from multiple lookups
 name: app-server
-attributes:
-  imageId: ${{ model.latest-ami.resource.data.output.attributes.json.ImageId }}
-  subnetId: ${{ model.subnet-lookup.resource.data.output.attributes.json.SubnetId }}
+version: 1
+tags: {}
+globalArguments:
+  imageId: ${{ model.latest-ami.resource.result.result.attributes.stdout }}
+  subnetId: ${{ model.subnet-lookup.resource.result.result.attributes.stdout }}
   securityGroupIds:
     - ${{ model.app-security-group.resource.resource.main.attributes.groupId }}
   instanceType: t3.micro
@@ -175,11 +192,11 @@ attributes:
 All model data outputs are accessed via
 `model.<name>.resource.<specName>.<instanceName>.attributes.<field>`:
 
-| Model Type    | Spec Name  | Example                                                         |
-| ------------- | ---------- | --------------------------------------------------------------- |
-| aws/cli       | `data`     | `model.ami-lookup.resource.data.output.attributes.json.ImageId` |
-| Cloud Control | `resource` | `model.my-vpc.resource.resource.main.attributes.VpcId`          |
-| Custom models | (varies)   | `model.my-deploy.resource.state.current.attributes.endpoint`    |
+| Model Type    | Spec Name  | Example                                                      |
+| ------------- | ---------- | ------------------------------------------------------------ |
+| command/shell | `result`   | `model.ami-lookup.resource.result.result.attributes.stdout`  |
+| Cloud Control | `resource` | `model.my-vpc.resource.resource.main.attributes.VpcId`       |
+| Custom models | (varies)   | `model.my-deploy.resource.state.current.attributes.endpoint` |
 
 ## Delete Workflow Ordering
 

--- a/.claude/skills/swamp-workflow/references/scenarios.md
+++ b/.claude/skills/swamp-workflow/references/scenarios.md
@@ -152,9 +152,9 @@ No data dependencies between them → Run in parallel automatically
 **1. Create independent lookup models**
 
 ```bash
-swamp model create aws/cli ami-lookup --json
-swamp model create aws/cli vpc-lookup --json
-swamp model create aws/cli sg-lookup --json
+swamp model create command/shell ami-lookup --json
+swamp model create command/shell vpc-lookup --json
+swamp model create command/shell sg-lookup --json
 ```
 
 **2. Create parallel workflow**
@@ -173,19 +173,19 @@ jobs:
         task:
           type: model_method
           modelIdOrName: ami-lookup
-          methodName: run
+          methodName: execute
 
       - name: vpc
         task:
           type: model_method
           modelIdOrName: vpc-lookup
-          methodName: run
+          methodName: execute
 
       - name: sg
         task:
           type: model_method
           modelIdOrName: sg-lookup
-          methodName: run
+          methodName: execute
 
   - name: use-results
     description: Use all lookup results
@@ -208,9 +208,9 @@ jobs:
 name: my-instance
 version: 1
 globalArguments:
-  imageId: ${{ model.ami-lookup.resource.data.output.attributes.json.ImageId }}
-  vpcId: ${{ model.vpc-lookup.resource.data.output.attributes.json.VpcId }}
-  securityGroupId: ${{ model.sg-lookup.resource.data.output.attributes.json.GroupId }}
+  imageId: ${{ model.ami-lookup.resource.result.result.attributes.stdout }}
+  vpcId: ${{ model.vpc-lookup.resource.result.result.attributes.stdout }}
+  securityGroupId: ${{ model.sg-lookup.resource.result.result.attributes.stdout }}
 ```
 
 ---
@@ -403,7 +403,6 @@ methods: {
       const content = await context.dataRepository.getContent(
         context.modelType,
         context.modelId,
-        "vpc",
         "vpc",
       );
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,19 @@
 
 Deno based CLI for doing AI Native Automation.
 
+## Building Automation with Swamp
+
+When users ask you to build automation for specific services (AWS, APIs, etc.):
+
+1. **Always create extension models** in `extensions/models/` - do NOT use
+   `command/shell` to wrap CLI commands
+2. Search for existing model types first: `swamp model type search <query>`
+3. If no type exists, create a dedicated extension model for that service
+4. Use the `swamp-extension-model` skill for guidance on creating models
+
+The `command/shell` model is only for ad-hoc shell commands, NOT for building
+service integrations.
+
 ## Planning
 
 When planning new features, always use the `ddd` skill to inform the

--- a/integration/data_output_flow_test.ts
+++ b/integration/data_output_flow_test.ts
@@ -329,8 +329,10 @@ Deno.test("Integration: data commands work with model data artifacts", async () 
     assertEquals(typeof getOutput.contentPath, "string");
     assertEquals(getOutput.contentType, "application/json");
 
-    // Read the content file to verify the data
-    const content = await Deno.readTextFile(getOutput.contentPath);
+    // Read the content file to verify the data (contentPath is now relative)
+    const content = await Deno.readTextFile(
+      join(repoDir, getOutput.contentPath),
+    );
     const parsedContent = JSON.parse(content);
     // Shell model produces result with exitCode and command
     assertEquals(parsedContent.exitCode, 0);
@@ -715,8 +717,10 @@ Deno.test("Integration: data versioning across multiple runs", async () => {
     const v1Output = JSON.parse(v1Result.stdout);
     assertEquals(v1Output.version, 1);
 
-    // Read content from file path - shell model produces exitCode
-    const v1Content = await Deno.readTextFile(v1Output.contentPath);
+    // Read content from file path - shell model produces exitCode (contentPath is relative)
+    const v1Content = await Deno.readTextFile(
+      join(repoDir, v1Output.contentPath),
+    );
     const v1Parsed = JSON.parse(v1Content);
     assertEquals(v1Parsed.exitCode, 0);
 
@@ -747,8 +751,10 @@ Deno.test("Integration: data versioning across multiple runs", async () => {
       "Latest should be version 2 or higher",
     );
 
-    // Read content from file path - shell model produces exitCode
-    const latestContent = await Deno.readTextFile(latestOutput.contentPath);
+    // Read content from file path - shell model produces exitCode (contentPath is relative)
+    const latestContent = await Deno.readTextFile(
+      join(repoDir, latestOutput.contentPath),
+    );
     const latestParsed = JSON.parse(latestContent);
     assertEquals(latestParsed.exitCode, 0);
   });

--- a/src/cli/commands/data_get.ts
+++ b/src/cli/commands/data_get.ts
@@ -28,6 +28,7 @@ import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { UserError } from "../../domain/errors.ts";
 import { WorkflowDataService } from "../../domain/data/workflow_data_service.ts";
 import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
+import { toRelativePath } from "../../infrastructure/persistence/paths.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -142,6 +143,7 @@ export const dataGetCommand = new Command()
           );
         }
 
+        const repoDir = options.repoDir ?? ".";
         const output: DataGetData = {
           id: item.data.id,
           name: item.data.name,
@@ -158,7 +160,7 @@ export const dataGetCommand = new Command()
           createdAt: item.data.createdAt.toISOString(),
           size: item.data.size,
           checksum: item.data.checksum,
-          contentPath: item.contentPath,
+          contentPath: toRelativePath(repoDir, item.contentPath),
         };
 
         if (options.content !== false) {
@@ -215,7 +217,8 @@ export const dataGetCommand = new Command()
           );
         }
 
-        const contentPath = dataRepo.getContentPath(
+        const repoDir = options.repoDir ?? ".";
+        const absoluteContentPath = dataRepo.getContentPath(
           modelType,
           definition.id,
           dataName,
@@ -238,7 +241,7 @@ export const dataGetCommand = new Command()
           createdAt: data.createdAt.toISOString(),
           size: data.size,
           checksum: data.checksum,
-          contentPath,
+          contentPath: toRelativePath(repoDir, absoluteContentPath),
         };
 
         if (options.content !== false) {

--- a/src/cli/commands/data_search.ts
+++ b/src/cli/commands/data_search.ts
@@ -37,6 +37,7 @@ import { ModelType } from "../../domain/models/model_type.ts";
 import type { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import type { OutputMode } from "../../presentation/output/output.ts";
 import { UserError } from "../../domain/errors.ts";
+import { toRelativePath } from "../../infrastructure/persistence/paths.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -224,6 +225,7 @@ export function filterData(
 async function displayDataDetail(
   item: DataSearchItem,
   dataRepo: FileSystemUnifiedDataRepository,
+  repoDir: string,
   outputMode: OutputMode,
 ): Promise<void> {
   const modelType = ModelType.create(item.modelType);
@@ -241,7 +243,7 @@ async function displayDataDetail(
     );
   }
 
-  const contentPath = dataRepo.getContentPath(
+  const absoluteContentPath = dataRepo.getContentPath(
     modelType,
     item.modelId,
     item.name,
@@ -265,7 +267,7 @@ async function displayDataDetail(
     createdAt: data.createdAt.toISOString(),
     size: data.size,
     checksum: data.checksum,
-    contentPath,
+    contentPath: toRelativePath(repoDir, absoluteContentPath),
   };
 
   // Fetch raw content for display
@@ -420,7 +422,8 @@ export const dataSearchCommand = new Command()
     const selected = await renderDataSearch(data, ctx.outputMode);
 
     if (selected) {
-      await displayDataDetail(selected, dataRepo, ctx.outputMode);
+      const repoDir = options.repoDir ?? ".";
+      await displayDataDetail(selected, dataRepo, repoDir, ctx.outputMode);
     }
 
     ctx.logger.debug("Data search command completed");

--- a/src/cli/commands/hidden_aliases_test.ts
+++ b/src/cli/commands/hidden_aliases_test.ts
@@ -64,3 +64,24 @@ Deno.test("workflow history list is registered as a hidden subcommand", async ()
     "list should not appear in visible commands",
   );
 });
+
+Deno.test("repo init is registered as a hidden subcommand", async () => {
+  const { repoCommand } = await import("./repo_init.ts");
+
+  // getCommand with second arg true includes hidden commands
+  const initCmd = repoCommand.getCommand("init", true);
+  assertEquals(
+    initCmd !== undefined,
+    true,
+    "init command should be registered",
+  );
+
+  // Verify it's hidden: not in getCommands() (which excludes hidden)
+  const visibleCommands = repoCommand.getCommands();
+  const visibleInit = visibleCommands.find((c) => c.getName() === "init");
+  assertEquals(
+    visibleInit,
+    undefined,
+    "init should not appear in visible commands",
+  );
+});

--- a/src/cli/commands/repo_init.ts
+++ b/src/cli/commands/repo_init.ts
@@ -33,34 +33,40 @@ import { repoIndexCommand } from "./repo_index.ts";
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
+// Exported for reuse by repoCommand default action
+export async function repoInitAction(
+  options: AnyOptions,
+  pathArg?: string,
+): Promise<void> {
+  const ctx = createContext(options as GlobalOptions, ["repo", "init"]);
+  ctx.logger.debug`Initializing repository at: ${pathArg ?? "."}`;
+
+  const repoPath = RepoPath.create(pathArg ?? ".");
+  const service = new RepoService(VERSION);
+
+  const result = await service.init(repoPath, { force: options.force });
+
+  ctx.logger.debug`Repository initialized: ${result.path}`;
+
+  const data: RepoInitData = {
+    path: result.path,
+    version: result.version,
+    initializedAt: result.initializedAt,
+    skillsCopied: result.skillsCopied,
+    claudeMdCreated: result.claudeMdCreated,
+    claudeSettingsCreated: result.claudeSettingsCreated,
+    gitignoreCreated: result.gitignoreCreated,
+  };
+
+  renderRepoInit(data, ctx.outputMode);
+  ctx.logger.debug("Repo init command completed");
+}
+
 export const repoInitCommand = new Command()
   .description("Initialize a new swamp repository")
   .arguments("[path:string]")
   .option("-f, --force", "Reinitialize if already exists")
-  .action(async function (options: AnyOptions, pathArg?: string) {
-    const ctx = createContext(options as GlobalOptions, ["repo", "init"]);
-    ctx.logger.debug`Initializing repository at: ${pathArg ?? "."}`;
-
-    const repoPath = RepoPath.create(pathArg ?? ".");
-    const service = new RepoService(VERSION);
-
-    const result = await service.init(repoPath, { force: options.force });
-
-    ctx.logger.debug`Repository initialized: ${result.path}`;
-
-    const data: RepoInitData = {
-      path: result.path,
-      version: result.version,
-      initializedAt: result.initializedAt,
-      skillsCopied: result.skillsCopied,
-      claudeMdCreated: result.claudeMdCreated,
-      claudeSettingsCreated: result.claudeSettingsCreated,
-      gitignoreCreated: result.gitignoreCreated,
-    };
-
-    renderRepoInit(data, ctx.outputMode);
-    ctx.logger.debug("Repo init command completed");
-  });
+  .action(repoInitAction);
 
 export const repoUpgradeCommand = new Command()
   .description("Upgrade an existing swamp repository")
@@ -91,10 +97,18 @@ export const repoUpgradeCommand = new Command()
 
 export const repoCommand = new Command()
   .name("repo")
-  .description("Manage swamp repositories")
-  .action(function () {
-    this.showHelp();
-  })
-  .command("init", repoInitCommand)
+  .description("Initialize a swamp repository (or manage existing ones)")
+  .arguments("[path:string]")
+  .option("-f, --force", "Reinitialize if already exists")
+  .action(repoInitAction)
+  .command(
+    "init",
+    new Command()
+      .description("Initialize a new swamp repository")
+      .hidden()
+      .arguments("[path:string]")
+      .option("-f, --force", "Reinitialize if already exists")
+      .action(repoInitAction),
+  )
   .command("upgrade", repoUpgradeCommand)
   .command("index", repoIndexCommand);

--- a/src/cli/commands/repo_init_test.ts
+++ b/src/cli/commands/repo_init_test.ts
@@ -28,11 +28,23 @@ Deno.test("repoCommand module loads", async () => {
   assertEquals(repoCommand.getName(), "repo");
 });
 
-Deno.test("repoInitCommand is registered as subcommand", async () => {
+Deno.test("repoInitCommand is registered as hidden subcommand", async () => {
   const { repoCommand } = await import("./repo_init.ts");
-  const commands = repoCommand.getCommands();
-  const initCmd = commands.find((c) => c.getName() === "init");
-  assertEquals(initCmd !== undefined, true);
+  // getCommand with second arg true includes hidden commands
+  const initCmd = repoCommand.getCommand("init", true);
+  assertEquals(
+    initCmd !== undefined,
+    true,
+    "init command should be registered",
+  );
+  // Verify it's hidden: not in getCommands() (which excludes hidden)
+  const visibleCommands = repoCommand.getCommands();
+  const visibleInit = visibleCommands.find((c) => c.getName() === "init");
+  assertEquals(
+    visibleInit,
+    undefined,
+    "init should not appear in visible commands",
+  );
 });
 
 Deno.test("repoUpgradeCommand is registered as subcommand", async () => {

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -231,9 +231,9 @@ export class RepoService {
 
 This repository is managed with [swamp](https://github.com/systeminit/swamp).
 
-## The Commandments
+## Rules
 
-1. **Models over shell commands.** Never drop to \`curl\`, \`ssh\`, or raw API calls. If the model doesn't have the method you need, add it to the extension.
+1. **Extension models for service integrations.** When automating AWS, APIs, or any external service, ALWAYS create an extension model in \`extensions/models/\`. Use the \`swamp-extension-model\` skill for guidance. The \`command/shell\` model is ONLY for ad-hoc one-off shell commands, NEVER for wrapping CLI tools or building integrations.
 2. **Extend, don't be clever.** Don't work around a missing capability with shell scripts or multi-step hacks. Add a method to the extension model. One method, one purpose.
 3. **Use the data model.** Once data exists in a model (via \`lookup\`, \`start\`, \`sync\`, etc.), reference it with CEL expressions. Don't re-fetch data that's already available.
 4. **CEL expressions everywhere.** Wire models together with \`model.*\` expressions. Always prefer \`model.<name>.resource.<spec>.<instance>.attributes.<field>\` over \`data.latest()\`.


### PR DESCRIPTION
A collection of fixes discovered while using swamp in real-world scenarios:

- **Fix CLAUDE.md template to prevent command/shell misuse**: Updated the first commandment in the generated CLAUDE.md
template to be explicit:
- OLD: "Models over shell commands. Never drop to curl, ssh, or raw API calls..."
- NEW: "Extension models for service integrations. When automating AWS, APIs, or any external service, ALWAYS create an
extension model in `extensions/models/`. Use the `swamp-extension-model` skill for guidance. The `command/shell` model is
ONLY for ad-hoc one-off shell commands, NEVER for wrapping CLI tools or building integrations."

- **Update skill documentation to use `command/shell`**: Replace all `aws/cli` model references with `command/shell` since
`aws/cli` was removed. Updated 11 skill files with correct model type, method names (`execute`), and CEL paths
(`resource.result.result.attributes.stdout`)

- **Add CLAUDE.md guidance for swamp development**: Added explicit guidance in the swamp source repo's CLAUDE.md about
creating extension models

- **Fix relative paths in data commands**: `swamp data get` and `swamp data search` now return relative `contentPath`
instead of absolute paths, consistent with PR #299 pattern for multi-user repos

- **Fix Zod v4 schema example**: Corrected `z.record(z.string())` to `z.record(z.string(), z.string())` in extension model
documentation (Zod v4 requires two arguments)

- **Make `swamp repo` an alias for `swamp repo init`**: Running `swamp repo` now initializes a repository directly. The
`init` subcommand is hidden but still functional for backwards compatibility

## Test plan

- [x] All tests pass
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] Binary compiles successfully
- [x] Verified `swamp repo --help` shows init behavior
- [x] Verified `swamp repo init` still works as hidden command

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
The key fix is in src/domain/repo/repo_service.ts - the CLAUDE.md template that gets generated for all new repos now
explicitly tells agents:
1. ALWAYS create extension models for service integrations (AWS, APIs, etc.)
2. command/shell is ONLY for ad-hoc one-off commands
3. Points to swamp-extension-model skill for guidance