### PR TITLE
fix: Handle symlinks and version prefix in source fetch

### DIFF
--- a/integration/source_fetch_test.ts
+++ b/integration/source_fetch_test.ts
@@ -1,0 +1,162 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+import { HttpSourceDownloader } from "../src/infrastructure/source/http_source_downloader.ts";
+
+Deno.test({
+  name: "HttpSourceDownloader fetches swamp source from GitHub",
+  // This test downloads from GitHub and may be slow
+  sanitizeResources: false,
+  sanitizeOps: false,
+  async fn() {
+    const downloader = new HttpSourceDownloader();
+    const tempDir = await Deno.makeTempDir({ prefix: "swamp-integration-" });
+
+    try {
+      const targetDir = join(tempDir, "source");
+      await ensureDir(targetDir);
+
+      const fileCount = await downloader.downloadAndExtract("main", targetDir);
+
+      // Should have extracted a non-trivial number of files
+      assert(fileCount > 0, `Expected files to be extracted, got ${fileCount}`);
+
+      // Verify key files exist
+      const denoJson = await Deno.stat(join(targetDir, "deno.json"));
+      assert(denoJson.isFile, "deno.json should exist");
+
+      const mainTs = await Deno.stat(join(targetDir, "main.ts"));
+      assert(mainTs.isFile, "main.ts should exist");
+
+      // Verify symlinks are preserved (the repo has symlinks in .claude/skills/)
+      const skillsDir = join(targetDir, ".claude", "skills");
+      try {
+        for await (const entry of Deno.readDir(skillsDir)) {
+          if (entry.isSymlink) {
+            // If we find any symlink, verify it was preserved correctly
+            const linkPath = join(skillsDir, entry.name);
+            const linkTarget = await Deno.readLink(linkPath);
+            assert(
+              linkTarget.length > 0,
+              `Symlink ${entry.name} should have a target`,
+            );
+
+            // The symlink target should be a relative path
+            assert(
+              !linkTarget.startsWith("/"),
+              `Symlink ${entry.name} should have a relative target, got: ${linkTarget}`,
+            );
+          }
+        }
+      } catch (e) {
+        if (!(e instanceof Deno.errors.NotFound)) {
+          throw e;
+        }
+        // Skills directory may not exist in all versions, that's OK
+      }
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  },
+});
+
+async function checkSymlinks(dir: string): Promise<number> {
+  let symlinkCount = 0;
+  for await (const entry of Deno.readDir(dir)) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isSymlink) {
+      symlinkCount++;
+      // Verify the symlink was preserved (not dereferenced)
+      const stat = await Deno.lstat(fullPath);
+      assert(stat.isSymlink, `${fullPath} should be a symlink`);
+
+      const target = await Deno.readLink(fullPath);
+      assert(target.length > 0, `${fullPath} should have a link target`);
+    } else if (entry.isDirectory) {
+      symlinkCount += await checkSymlinks(fullPath);
+    }
+  }
+  return symlinkCount;
+}
+
+Deno.test({
+  name: "HttpSourceDownloader preserves symlinks that point to directories",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  async fn() {
+    const downloader = new HttpSourceDownloader();
+    const tempDir = await Deno.makeTempDir({ prefix: "swamp-integration-" });
+
+    try {
+      const targetDir = join(tempDir, "source");
+      await ensureDir(targetDir);
+
+      await downloader.downloadAndExtract("main", targetDir);
+
+      const totalSymlinks = await checkSymlinks(targetDir);
+      // The swamp repo is known to have symlinks; verify at least one was found
+      assert(
+        totalSymlinks > 0,
+        `Expected at least one symlink in extracted source, found ${totalSymlinks}`,
+      );
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "HttpSourceDownloader returns 404 error for non-existent version",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  async fn() {
+    const downloader = new HttpSourceDownloader();
+    const tempDir = await Deno.makeTempDir({
+      prefix: "swamp-integration-404-",
+    });
+
+    try {
+      const targetDir = join(tempDir, "source");
+      await ensureDir(targetDir);
+
+      let errorThrown = false;
+      try {
+        await downloader.downloadAndExtract(
+          "nonexistent-version-xyz-12345",
+          targetDir,
+        );
+      } catch (e) {
+        errorThrown = true;
+        assertEquals(
+          (e as Error).message,
+          `Source version "nonexistent-version-xyz-12345" not found. Check that the version tag exists.`,
+        );
+      }
+      assert(
+        errorThrown,
+        "Should have thrown an error for non-existent version",
+      );
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  },
+});

--- a/src/infrastructure/source/http_source_downloader.ts
+++ b/src/infrastructure/source/http_source_downloader.ts
@@ -34,12 +34,13 @@ export class HttpSourceDownloader implements SourceDownloader {
    * For "main", uses heads/main.tar.gz
    * For version tags, uses tags/{version}.tar.gz
    */
-  private getArchiveUrl(version: string): string {
+  protected getArchiveUrl(version: string): string {
     if (version === "main") {
       return `${HttpSourceDownloader.GITHUB_BASE}/heads/main.tar.gz`;
     }
-    // For version tags (e.g., "v1.2.3" or "20260101.123456.0-sha.abc123")
-    return `${HttpSourceDownloader.GITHUB_BASE}/tags/${version}.tar.gz`;
+    // GitHub tags have a "v" prefix; add it if not already present
+    const tag = version.startsWith("v") ? version : `v${version}`;
+    return `${HttpSourceDownloader.GITHUB_BASE}/tags/${tag}.tar.gz`;
   }
 
   /**
@@ -144,7 +145,10 @@ export class HttpSourceDownloader implements SourceDownloader {
       const sourcePath = join(sourceDir, entry.name);
       const targetPath = join(targetDir, entry.name);
 
-      if (entry.isDirectory) {
+      if (entry.isSymlink) {
+        const linkTarget = await Deno.readLink(sourcePath);
+        await Deno.symlink(linkTarget, targetPath);
+      } else if (entry.isDirectory) {
         await ensureDir(targetPath);
         fileCount += await this.moveContents(sourcePath, targetPath);
       } else {

--- a/src/infrastructure/source/http_source_downloader_test.ts
+++ b/src/infrastructure/source/http_source_downloader_test.ts
@@ -1,0 +1,208 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+import { HttpSourceDownloader } from "./http_source_downloader.ts";
+
+Deno.test("downloadAndExtract copies regular files", async () => {
+  const tempDir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    // Create a fake archive structure: top-level dir with files
+    const archiveRoot = join(tempDir, "archive");
+    const innerDir = join(archiveRoot, "swamp-main");
+    await ensureDir(innerDir);
+    await Deno.writeTextFile(join(innerDir, "file1.txt"), "hello");
+    await Deno.writeTextFile(join(innerDir, "file2.txt"), "world");
+
+    // Create a tarball from the archive
+    const tarball = join(tempDir, "test.tar.gz");
+    const tar = new Deno.Command("tar", {
+      args: ["-czf", tarball, "-C", archiveRoot, "swamp-main"],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const tarResult = await tar.output();
+    assert(tarResult.success, "tar creation should succeed");
+
+    // Serve the tarball via a local HTTP server
+    const server = Deno.serve({ port: 0, onListen: () => {} }, (_req) => {
+      const body = Deno.readFileSync(tarball);
+      return new Response(body, {
+        headers: { "content-type": "application/gzip" },
+      });
+    });
+
+    const port = server.addr.port;
+
+    const targetDir = join(tempDir, "target");
+    await ensureDir(targetDir);
+
+    // Bypass URL construction by subclassing to point to our test server
+    const TestDownloader = class extends HttpSourceDownloader {
+      protected override getArchiveUrl(_version: string): string {
+        return `http://localhost:${port}/test.tar.gz`;
+      }
+    };
+
+    const testDownloader = new TestDownloader();
+    const fileCount = await testDownloader.downloadAndExtract(
+      "main",
+      targetDir,
+    );
+
+    assertEquals(fileCount, 2);
+    assertEquals(
+      await Deno.readTextFile(join(targetDir, "file1.txt")),
+      "hello",
+    );
+    assertEquals(
+      await Deno.readTextFile(join(targetDir, "file2.txt")),
+      "world",
+    );
+
+    await server.shutdown();
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("downloadAndExtract preserves symlinks", async () => {
+  const tempDir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    // Create archive structure with a symlink
+    const archiveRoot = join(tempDir, "archive");
+    const innerDir = join(archiveRoot, "swamp-main");
+    const subDir = join(innerDir, "target-dir");
+    await ensureDir(subDir);
+    await Deno.writeTextFile(join(subDir, "content.txt"), "linked content");
+    await Deno.symlink("target-dir", join(innerDir, "link-to-dir"));
+
+    // Create tarball (with -h omitted so symlinks are preserved)
+    const tarball = join(tempDir, "test.tar.gz");
+    const tar = new Deno.Command("tar", {
+      args: ["-czf", tarball, "-C", archiveRoot, "swamp-main"],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const tarResult = await tar.output();
+    assert(tarResult.success, "tar creation should succeed");
+
+    // Serve tarball
+    const server = Deno.serve({ port: 0, onListen: () => {} }, (_req) => {
+      const body = Deno.readFileSync(tarball);
+      return new Response(body, {
+        headers: { "content-type": "application/gzip" },
+      });
+    });
+
+    const port = server.addr.port;
+
+    const TestDownloader = class extends HttpSourceDownloader {
+      protected override getArchiveUrl(_version: string): string {
+        return `http://localhost:${port}/test.tar.gz`;
+      }
+    };
+
+    const testDownloader = new TestDownloader();
+    const targetDir = join(tempDir, "target");
+    await ensureDir(targetDir);
+
+    const fileCount = await testDownloader.downloadAndExtract(
+      "main",
+      targetDir,
+    );
+
+    // The symlink should be preserved, not dereferenced
+    const linkPath = join(targetDir, "link-to-dir");
+    const linkStat = await Deno.lstat(linkPath);
+    assert(linkStat.isSymlink, "link-to-dir should be a symlink");
+
+    const linkTarget = await Deno.readLink(linkPath);
+    assertEquals(linkTarget, "target-dir");
+
+    // The symlink should still work (resolve to the target directory)
+    const resolvedContent = await Deno.readTextFile(
+      join(linkPath, "content.txt"),
+    );
+    assertEquals(resolvedContent, "linked content");
+
+    // fileCount should only count regular files, not symlinks or directories
+    assertEquals(fileCount, 1);
+
+    await server.shutdown();
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("downloadAndExtract copies nested directories", async () => {
+  const tempDir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    const archiveRoot = join(tempDir, "archive");
+    const innerDir = join(archiveRoot, "swamp-main");
+    const nested = join(innerDir, "a", "b");
+    await ensureDir(nested);
+    await Deno.writeTextFile(join(nested, "deep.txt"), "deep content");
+
+    const tarball = join(tempDir, "test.tar.gz");
+    const tar = new Deno.Command("tar", {
+      args: ["-czf", tarball, "-C", archiveRoot, "swamp-main"],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const tarResult = await tar.output();
+    assert(tarResult.success, "tar creation should succeed");
+
+    const server = Deno.serve({ port: 0, onListen: () => {} }, (_req) => {
+      const body = Deno.readFileSync(tarball);
+      return new Response(body, {
+        headers: { "content-type": "application/gzip" },
+      });
+    });
+
+    const port = server.addr.port;
+
+    const TestDownloader = class extends HttpSourceDownloader {
+      protected override getArchiveUrl(_version: string): string {
+        return `http://localhost:${port}/test.tar.gz`;
+      }
+    };
+
+    const testDownloader = new TestDownloader();
+    const targetDir = join(tempDir, "target");
+    await ensureDir(targetDir);
+
+    const fileCount = await testDownloader.downloadAndExtract(
+      "main",
+      targetDir,
+    );
+
+    assertEquals(fileCount, 1);
+    assertEquals(
+      await Deno.readTextFile(join(targetDir, "a", "b", "deep.txt")),
+      "deep content",
+    );
+
+    await server.shutdown();
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});


### PR DESCRIPTION
- Fix `swamp source fetch` failing with EISDIR when the GitHub tarball
contains symlinks to directories. The `moveContents` method now detects
symlinks via `entry.isSymlink` and recreates them with `Deno.symlink()`
instead of falling through to `Deno.copyFile()`.
- Fix version tag URL construction to prepend the `v` prefix that GitHub
release tags use (e.g., `v20260213.182136.0-sha.a3fa6360`), since the
`VERSION` constant doesn't include it.

## Test plan

- [x] Unit tests for `moveContents` via `downloadAndExtract` (regular files,
symlinks, nested directories) using a local HTTP server
- [x] Integration test that fetches from the real GitHub archive and verifies
symlinks are preserved
- [x] Integration test for 404 error on non-existent version
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] Full test suite (1655 tests) passes

Closes #318