### PR TITLE
fix: Remove non-null assertions from extension model skill docs

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -73,7 +73,7 @@ export const model = {
       description: "Process the input message",
       arguments: z.object({}),
       execute: async (args, context) => {
-        const handle = await context.writeResource!("result", "main", {
+        const handle = await context.writeResource("result", "main", {
           message: context.globalArgs.message.toUpperCase(),
           timestamp: new Date().toISOString(),
         });
@@ -164,7 +164,7 @@ execute: (async (args, context) => {
   // context.writeResource  - Write structured JSON data
   // context.createFileWriter - Create a writer for files
 
-  const handle = await context.writeResource!("result", "main", {
+  const handle = await context.writeResource("result", "main", {
     value: "processed",
     timestamp: new Date().toISOString(),
   });
@@ -204,7 +204,7 @@ emit each as a separately-addressable resource.
 ```typescript
 const handles = [];
 for (const subnet of subnets) {
-  const handle = await context.writeResource!(
+  const handle = await context.writeResource(
     "subnet",
     subnet.subnetId, // Dynamic instance name
     subnet,
@@ -255,7 +255,7 @@ export const extension = {
       description: "Audit the shell command execution",
       arguments: z.object({}),
       execute: async (args, context) => {
-        const handle = await context.writeResource!("result", "result", {
+        const handle = await context.writeResource("result", "result", {
           exitCode: 0,
           command: `audit: ${context.definition.name}`,
           executedAt: new Date().toISOString(),

--- a/.claude/skills/swamp-extension-model/references/api.md
+++ b/.claude/skills/swamp-extension-model/references/api.md
@@ -45,14 +45,14 @@ throw). The `instanceName` you pass here is used in CEL:
 
 ```typescript
 // Single-instance resource (use descriptive instance name)
-const handle = await context.writeResource!("state", "current", {
+const handle = await context.writeResource("state", "current", {
   status: "active",
   updatedAt: new Date().toISOString(),
 });
 
 // Factory model (use dynamic instance names)
 for (const item of items) {
-  await context.writeResource!("item", item.id, item);
+  await context.writeResource("item", item.id, item);
 }
 ```
 
@@ -101,14 +101,14 @@ here is used in CEL: `model.<defName>.file.<specName>.<instanceName>.path`.
 
 ```typescript
 // Write text file
-const logWriter = context.createFileWriter!("log", "execution");
+const logWriter = context.createFileWriter("log", "execution");
 const handle = await logWriter.writeText(JSON.stringify({
   timestamp: new Date().toISOString(),
   message: "Operation completed",
 }));
 
 // Streaming log (line by line)
-const streamWriter = context.createFileWriter!("log", "stream", {
+const streamWriter = context.createFileWriter("log", "stream", {
   streaming: true,
 });
 await streamWriter.writeLine("Starting process...");

--- a/.claude/skills/swamp-extension-model/references/examples.md
+++ b/.claude/skills/swamp-extension-model/references/examples.md
@@ -70,7 +70,7 @@ export const model = {
         const output = await cmd.output();
         const vpcData = JSON.parse(new TextDecoder().decode(output.stdout)).Vpc;
 
-        const handle = await context.writeResource!("vpc", "vpc", vpcData);
+        const handle = await context.writeResource("vpc", "vpc", vpcData);
         return { dataHandles: [handle] };
       },
     },
@@ -132,7 +132,7 @@ export const model = {
         ).Vpcs[0];
 
         // 4. Write updated state — creates a new version of the resource
-        const handle = await context.writeResource!("vpc", "vpc", updatedData);
+        const handle = await context.writeResource("vpc", "vpc", updatedData);
         return { dataHandles: [handle] };
       },
     },
@@ -238,7 +238,7 @@ export const model = {
             break;
         }
 
-        const handle = await context.writeResource!("result", "result", {
+        const handle = await context.writeResource("result", "result", {
           originalText: text,
           processedText,
           operation,
@@ -294,7 +294,7 @@ export const model = {
         const attrs = context.globalArgs;
         const deploymentId = `deploy-${attrs.appName}-${Date.now()}`;
 
-        const handle = await context.writeResource!("state", "state", {
+        const handle = await context.writeResource("state", "state", {
           deploymentId,
           appName: attrs.appName,
           version: attrs.version,
@@ -312,7 +312,7 @@ export const model = {
       execute: async (args, context) => {
         const attrs = context.globalArgs;
 
-        const handle = await context.writeResource!("state", "state", {
+        const handle = await context.writeResource("state", "state", {
           deploymentId: `deploy-${attrs.appName}-scaled`,
           appName: attrs.appName,
           version: attrs.version,
@@ -358,7 +358,7 @@ export const model = {
       description: "Echo the message with timestamp",
       arguments: z.object({}),
       execute: async (args, context) => {
-        const handle = await context.writeResource!("data", "data", {
+        const handle = await context.writeResource("data", "data", {
           message: context.globalArgs.message,
           timestamp: new Date().toISOString(),
         });
@@ -422,7 +422,7 @@ export const model = {
         const endpoint =
           `https://${serviceName}.${environment}.example.com/api`;
 
-        const handle = await context.writeResource!("config", "config", {
+        const handle = await context.writeResource("config", "config", {
           configJson: {
             endpoint,
             timeout: envConfig.timeout,
@@ -509,7 +509,7 @@ export const model = {
           );
         }
 
-        const handle = await context.writeResource!("output", "output", {
+        const handle = await context.writeResource("output", "output", {
           stdout: result.stdout,
           exitCode: result.exitCode,
           durationMs: result.durationMs,
@@ -537,7 +537,7 @@ export const extension = {
       arguments: z.object({}),
       execute: async (args, context) => {
         // Extensions use the target model's resources/files
-        const handle = await context.writeResource!("result", "result", {
+        const handle = await context.writeResource("result", "result", {
           exitCode: 0,
           command: `audit: ${context.definition.name}`,
           executedAt: new Date().toISOString(),
@@ -562,7 +562,7 @@ export const extension = {
       description: "Audit the shell command execution",
       arguments: z.object({}),
       execute: async (args, context) => {
-        const handle = await context.writeResource!("result", "result", {
+        const handle = await context.writeResource("result", "result", {
           exitCode: 0,
           command: `audit: ${context.definition.name}`,
           executedAt: new Date().toISOString(),
@@ -574,7 +574,7 @@ export const extension = {
       description: "Validate the shell command format",
       arguments: z.object({}),
       execute: async (args, context) => {
-        const handle = await context.writeResource!("result", "result", {
+        const handle = await context.writeResource("result", "result", {
           exitCode: 0,
           command: `valid: ${context.globalArgs.run?.length > 0}`,
           executedAt: new Date().toISOString(),

--- a/.claude/skills/swamp-extension-model/references/scenarios.md
+++ b/.claude/skills/swamp-extension-model/references/scenarios.md
@@ -93,7 +93,7 @@ export const model = {
 
         const customer = await response.json();
 
-        const handle = await context.writeResource!(
+        const handle = await context.writeResource(
           "customer",
           "primary",
           customer,
@@ -130,7 +130,7 @@ export const model = {
 
         const customer = await response.json();
 
-        const handle = await context.writeResource!(
+        const handle = await context.writeResource(
           "customer",
           "primary",
           customer,
@@ -278,7 +278,7 @@ export const model = {
           CreationDate: new Date().toISOString(),
         };
 
-        const handle = await context.writeResource!(
+        const handle = await context.writeResource(
           "bucket",
           "main",
           bucketData,
@@ -327,7 +327,7 @@ export const model = {
           UpdatedAt: new Date().toISOString(),
         };
 
-        const handle = await context.writeResource!(
+        const handle = await context.writeResource(
           "bucket",
           "main",
           updatedData,
@@ -504,7 +504,7 @@ export const model = {
         const handles = [];
         for (const vpc of vpcs) {
           // Each VPC gets its own instance name based on VpcId
-          const handle = await context.writeResource!(
+          const handle = await context.writeResource(
             "vpc",
             vpc.VpcId, // Dynamic instance name!
             vpc,
@@ -618,7 +618,7 @@ export const extension = {
         context.logger.info("Audit: {*}", auditEntry);
 
         // Write to the shell model's result spec
-        const handle = await context.writeResource!("result", "result", {
+        const handle = await context.writeResource("result", "result", {
           exitCode: 0,
           command: `audit: ${JSON.stringify(auditEntry)}`,
           executedAt: auditEntry.timestamp,
@@ -635,7 +635,7 @@ export const extension = {
 
         context.logger.info("Would execute: {command}", { command });
 
-        const handle = await context.writeResource!("result", "result", {
+        const handle = await context.writeResource("result", "result", {
           exitCode: 0,
           command: `dry-run: ${command}`,
           executedAt: new Date().toISOString(),

--- a/.claude/skills/swamp-extension-model/references/troubleshooting.md
+++ b/.claude/skills/swamp-extension-model/references/troubleshooting.md
@@ -170,10 +170,17 @@ schema: z.object({ VpcId: z.string() }).passthrough(),
 
 ### Syntax errors on load
 
-Avoid inline TypeScript type annotations in execute parameters:
+Extension models are loaded as JavaScript at runtime. Avoid TypeScript-only
+syntax:
 
 ```typescript
-// Wrong - causes syntax error
+// Wrong - non-null assertion (!) causes SyntaxError
+const handle = await context.writeResource!("state", "main", data);
+
+// Correct - call without !
+const handle = await context.writeResource("state", "main", data);
+
+// Wrong - type annotations cause syntax error
 execute: async (args: { id: string }, context: any) => { ... }
 
 // Correct


### PR DESCRIPTION
- Remove TypeScript non-null assertion operator (`!`) from all `context.writeResource!()` and `context.createFileWriter!()`
calls in the extension model skill documentation
- Add the `!` syntax as a documented pitfall in the troubleshooting guide

## Context
Extension model `.ts` files are loaded as JavaScript at runtime by the compiled swamp binary. The `!` non-null assertion is
TypeScript-only syntax that causes `SyntaxError: Unexpected token '!'` when models are loaded. Since Claude uses these
skill docs as guidance when generating extension models, the generated code inherits the bug.

## Test plan
- [ ] Verify skill docs no longer contain `context.writeResource!()` or `context.createFileWriter!()`
- [ ] Verify troubleshooting guide documents the `!` pitfall
- [ ] Generate a new extension model using the skill and confirm no `!` in output