### PR TITLE
fix: Validate actual days-in-month for CalVer dates

### DIFF
--- a/src/domain/models/calver.ts
+++ b/src/domain/models/calver.ts
@@ -49,14 +49,18 @@ export class CalVer {
    * Checks whether a string is a valid CalVer version.
    *
    * Validates both format (YYYY.MM.DD.MICRO) and semantic date
-   * ranges (month 01–12, day 01–31).
+   * ranges (month 01–12, day valid for the given month/year
+   * including leap year handling).
    */
   static isValid(version: string): boolean {
     if (!CalVer.PATTERN.test(version)) return false;
     const parts = version.split(".");
+    const year = Number(parts[0]);
     const month = Number(parts[1]);
     const day = Number(parts[2]);
-    return month >= 1 && month <= 12 && day >= 1 && day <= 31;
+    if (month < 1 || month > 12 || day < 1) return false;
+    const daysInMonth = new Date(year, month, 0).getDate();
+    return day <= daysInMonth;
   }
 
   /**

--- a/src/domain/models/calver_test.ts
+++ b/src/domain/models/calver_test.ts
@@ -52,6 +52,29 @@ Deno.test("CalVer.isValid rejects invalid date ranges", () => {
   assertEquals(CalVer.isValid("2025.13.45.1"), false); // month 13, day 45
 });
 
+Deno.test("CalVer.isValid rejects impossible days for the month", () => {
+  assertEquals(CalVer.isValid("2026.02.31.1"), false); // Feb 31
+  assertEquals(CalVer.isValid("2026.02.30.1"), false); // Feb 30
+  assertEquals(CalVer.isValid("2026.02.29.1"), false); // Feb 29 non-leap year
+  assertEquals(CalVer.isValid("2026.04.31.1"), false); // Apr has 30 days
+  assertEquals(CalVer.isValid("2026.06.31.1"), false); // Jun has 30 days
+  assertEquals(CalVer.isValid("2026.09.31.1"), false); // Sep has 30 days
+  assertEquals(CalVer.isValid("2026.11.31.1"), false); // Nov has 30 days
+});
+
+Deno.test("CalVer.isValid accepts leap year Feb 29", () => {
+  assertEquals(CalVer.isValid("2024.02.29.1"), true); // 2024 is a leap year
+  assertEquals(CalVer.isValid("2028.02.29.1"), true); // 2028 is a leap year
+});
+
+Deno.test("CalVer.isValid accepts valid last days of months", () => {
+  assertEquals(CalVer.isValid("2026.01.31.1"), true); // Jan 31
+  assertEquals(CalVer.isValid("2026.02.28.1"), true); // Feb 28 non-leap
+  assertEquals(CalVer.isValid("2026.03.31.1"), true); // Mar 31
+  assertEquals(CalVer.isValid("2026.04.30.1"), true); // Apr 30
+  assertEquals(CalVer.isValid("2026.06.30.1"), true); // Jun 30
+});
+
 Deno.test("CalVer.create returns instance for valid version", () => {
   const cv = CalVer.create("2025.01.15.1");
   assertEquals(cv.value, "2025.01.15.1");


### PR DESCRIPTION
## Summary

- Fixes `CalVer.isValid()` to validate the actual number of days in the given month/year instead of blindly accepting days 1-31 for all months
- Uses `new Date(year, month, 0).getDate()` to get the correct days-in-month, which handles leap years automatically
- Adds tests for impossible dates (Feb 31, Apr 31, Feb 29 in non-leap years) and valid edge cases (leap year Feb 29, last days of months)

Closes #340

## Test plan

- [x] Existing CalVer tests continue to pass
- [x] New tests verify rejection of impossible dates (Feb 31, Apr 31, Jun 31, Sep 31, Nov 31)
- [x] New tests verify Feb 29 rejected in non-leap years (2026) but accepted in leap years (2024, 2028)
- [x] New tests verify valid last-day-of-month values are still accepted
- [x] `deno check`, `deno lint`, `deno fmt` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)