### PR TITLE
fix: Use split/join for vault secret replacement to preserve $ patterns

### DIFF
--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -717,7 +717,9 @@ export class ModelResolver {
           .replace(/\r/g, "\\r")
           .replace(/\t/g, "\\t");
         // Replace the entire vault.get(...) call with the escaped secret value wrapped in quotes for CEL
-        resolvedValue = resolvedValue.replace(fullMatch, `"${escapedValue}"`);
+        resolvedValue = resolvedValue.split(fullMatch).join(
+          `"${escapedValue}"`,
+        );
       } catch (error) {
         throw new Error(
           `Failed to resolve vault expression ${fullMatch}: ${

--- a/src/domain/vaults/vault_expression_test.ts
+++ b/src/domain/vaults/vault_expression_test.ts
@@ -234,6 +234,84 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
     assertStringIncludes(error.message, "vault.get(test-vault, missing-key)");
   });
 
+  await t.step(
+    "should preserve $& pattern in secret values",
+    async () => {
+      const resolver = createResolverWithMockVault({
+        "dollar-amp": "my$&secret",
+      });
+      const result = await resolver.resolveVaultExpressions(
+        "vault.get(test-vault, dollar-amp)",
+      );
+      assertEquals(result, '"my$&secret"');
+    },
+  );
+
+  await t.step(
+    "should preserve $` pattern in secret values",
+    async () => {
+      const resolver = createResolverWithMockVault({
+        "dollar-backtick": "prefix$`suffix",
+      });
+      const result = await resolver.resolveVaultExpressions(
+        "vault.get(test-vault, dollar-backtick)",
+      );
+      assertEquals(result, '"prefix$`suffix"');
+    },
+  );
+
+  await t.step(
+    "should preserve $' pattern in secret values",
+    async () => {
+      const resolver = createResolverWithMockVault({
+        "dollar-quote": "prefix$'suffix",
+      });
+      const result = await resolver.resolveVaultExpressions(
+        "vault.get(test-vault, dollar-quote)",
+      );
+      assertEquals(result, '"prefix$\'suffix"');
+    },
+  );
+
+  await t.step(
+    "should preserve $$ pattern in secret values",
+    async () => {
+      const resolver = createResolverWithMockVault({
+        "dollar-dollar": "cost: $$100",
+      });
+      const result = await resolver.resolveVaultExpressions(
+        "vault.get(test-vault, dollar-dollar)",
+      );
+      assertEquals(result, '"cost: $$100"');
+    },
+  );
+
+  await t.step(
+    "should preserve numbered capture group patterns in secret values",
+    async () => {
+      const resolver = createResolverWithMockVault({
+        "dollar-numbers": "$1$2$3",
+      });
+      const result = await resolver.resolveVaultExpressions(
+        "vault.get(test-vault, dollar-numbers)",
+      );
+      assertEquals(result, '"$1$2$3"');
+    },
+  );
+
+  await t.step(
+    "should preserve multiple dollar patterns in same secret",
+    async () => {
+      const resolver = createResolverWithMockVault({
+        "multi-dollar": "a]$&b$`c$'d$$e$1f",
+      });
+      const result = await resolver.resolveVaultExpressions(
+        "vault.get(test-vault, multi-dollar)",
+      );
+      assertEquals(result, '"a]$&b$`c$\'d$$e$1f"');
+    },
+  );
+
   // Cleanup
   await Deno.remove(tempDir, { recursive: true });
 });


### PR DESCRIPTION
## Summary

- Fixes vault secret value corruption caused by `String.replace()` interpreting special replacement patterns (`$&`, `` $` ``, `$'`, `$$`, `$1`-`$9`) in secret values
- Replaces `.replace(fullMatch, replacement)` with `.split(fullMatch).join(replacement)` in `ModelResolver.resolveVaultExpressions()` for literal string replacement
- Adds 6 new test cases covering all special `$` patterns

Closes #331

## Test Plan

- Added unit tests for each special replacement pattern (`$&`, `` $` ``, `$'`, `$$`, `$1$2$3`, and combined)
- Verified tests fail before the fix and pass after
- Full test suite passes (1658 tests)
- `deno check`, `deno lint`, `deno fmt` all pass