### PR TITLE
fix: Fall back to browser URL when gh CLI is unavailable

### DIFF
--- a/src/cli/commands/issue_bug.ts
+++ b/src/cli/commands/issue_bug.ts
@@ -184,12 +184,22 @@ export const issueBugCommand = new Command()
       labels: ["bug", "external"],
     });
 
-    const data: IssueCreateData = {
-      url: result.url,
-      number: result.number,
-      type: "bug",
-      title,
-    };
+    const data: IssueCreateData = result.method === "created"
+      ? {
+        method: "created",
+        url: result.url,
+        number: result.number,
+        type: "bug",
+        title,
+      }
+      : {
+        method: "url",
+        url: result.url,
+        type: "bug",
+        title,
+        body: result.body,
+        labels: result.labels,
+      };
 
     renderIssueCreate(data, ctx.outputMode);
     ctx.logger.debug("Bug report submitted successfully");

--- a/src/cli/commands/issue_feature.ts
+++ b/src/cli/commands/issue_feature.ts
@@ -183,12 +183,22 @@ export const issueFeatureCommand = new Command()
       labels: ["enhancement", "external"],
     });
 
-    const data: IssueCreateData = {
-      url: result.url,
-      number: result.number,
-      type: "feature",
-      title,
-    };
+    const data: IssueCreateData = result.method === "created"
+      ? {
+        method: "created",
+        url: result.url,
+        number: result.number,
+        type: "feature",
+        title,
+      }
+      : {
+        method: "url",
+        url: result.url,
+        type: "feature",
+        title,
+        body: result.body,
+        labels: result.labels,
+      };
 
     renderIssueCreate(data, ctx.outputMode);
     ctx.logger.debug("Feature request submitted successfully");

--- a/src/infrastructure/github/github_issue_service.ts
+++ b/src/infrastructure/github/github_issue_service.ts
@@ -21,11 +21,17 @@ import { UserError } from "../../domain/errors.ts";
 
 /**
  * Result of creating a GitHub issue.
+ * Discriminated union: "created" when gh CLI was used, "url" when falling back to a browser URL.
  */
-export interface GitHubIssueResult {
-  url: string;
-  number: number;
-}
+export type GitHubIssueResult =
+  | { method: "created"; url: string; number: number }
+  | {
+    method: "url";
+    url: string;
+    title: string;
+    body: string;
+    labels: string[];
+  };
 
 /**
  * Options for creating a GitHub issue.
@@ -45,9 +51,9 @@ export class GitHubIssueService {
 
   /**
    * Checks if the gh CLI is installed and authenticated.
+   * Returns true if available, false otherwise.
    */
-  async checkGhCli(): Promise<void> {
-    // Check if gh is installed
+  async isAvailable(): Promise<boolean> {
     const whichCommand = new Deno.Command("which", {
       args: ["gh"],
       stdout: "null",
@@ -55,33 +61,54 @@ export class GitHubIssueService {
     });
     const { success: ghInstalled } = await whichCommand.output();
     if (!ghInstalled) {
-      throw new UserError(
-        "GitHub CLI (gh) is not installed. Install it from https://cli.github.com/",
-      );
+      return false;
     }
 
-    // Check if gh is authenticated
     const authCommand = new Deno.Command("gh", {
       args: ["auth", "status"],
       stdout: "null",
       stderr: "null",
     });
     const { success: ghAuthenticated } = await authCommand.output();
-    if (!ghAuthenticated) {
-      throw new UserError(
-        "GitHub CLI is not authenticated. Run 'gh auth login' to authenticate.",
-      );
+    return ghAuthenticated;
+  }
+
+  /**
+   * Returns a GitHub "new issue" URL with labels pre-filled.
+   */
+  getNewIssueUrl(options: { repo?: string; labels: string[] }): string {
+    const repo = options.repo ?? this.defaultRepo;
+    const params = new URLSearchParams();
+    if (options.labels.length > 0) {
+      params.set("labels", options.labels.join(","));
     }
+    const query = params.toString();
+    return query
+      ? `https://github.com/${repo}/issues/new?${query}`
+      : `https://github.com/${repo}/issues/new`;
   }
 
   /**
    * Creates a GitHub issue using the gh CLI.
+   * Falls back to returning a pre-filled URL if the gh CLI is unavailable.
    *
    * @param options - The issue creation options
-   * @returns The URL and number of the created issue
+   * @returns The result, either a created issue or a fallback URL
    */
   async createIssue(options: CreateIssueOptions): Promise<GitHubIssueResult> {
-    await this.checkGhCli();
+    const available = await this.isAvailable();
+    if (!available) {
+      return {
+        method: "url",
+        url: this.getNewIssueUrl({
+          repo: options.repo,
+          labels: options.labels,
+        }),
+        title: options.title,
+        body: options.body,
+        labels: options.labels,
+      };
+    }
 
     const repo = options.repo ?? this.defaultRepo;
 
@@ -121,6 +148,6 @@ export class GitHubIssueService {
     const match = url.match(/\/issues\/(\d+)$/);
     const number = match ? parseInt(match[1], 10) : 0;
 
-    return { url, number };
+    return { method: "created", url, number };
   }
 }

--- a/src/infrastructure/github/github_issue_service_test.ts
+++ b/src/infrastructure/github/github_issue_service_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
+import { GitHubIssueService } from "./github_issue_service.ts";
 
 Deno.test("issue URL parsing extracts issue number", () => {
   const url = "https://github.com/systeminit/swamp/issues/123";
@@ -38,4 +39,31 @@ Deno.test("issue URL parsing returns 0 for invalid URL", () => {
   const match = url.match(/\/issues\/(\d+)$/);
   const number = match ? parseInt(match[1], 10) : 0;
   assertEquals(number, 0);
+});
+
+Deno.test("getNewIssueUrl uses default repo with labels", () => {
+  const service = new GitHubIssueService();
+  const url = service.getNewIssueUrl({ labels: ["bug", "external"] });
+  assertEquals(
+    url,
+    "https://github.com/systeminit/swamp/issues/new?labels=bug%2Cexternal",
+  );
+});
+
+Deno.test("getNewIssueUrl uses custom repo", () => {
+  const service = new GitHubIssueService();
+  const url = service.getNewIssueUrl({
+    repo: "owner/other-repo",
+    labels: ["enhancement"],
+  });
+  assertEquals(
+    url,
+    "https://github.com/owner/other-repo/issues/new?labels=enhancement",
+  );
+});
+
+Deno.test("getNewIssueUrl with no labels omits query string", () => {
+  const service = new GitHubIssueService();
+  const url = service.getNewIssueUrl({ labels: [] });
+  assertEquals(url, "https://github.com/systeminit/swamp/issues/new");
 });

--- a/src/presentation/output/issue_output.ts
+++ b/src/presentation/output/issue_output.ts
@@ -22,13 +22,24 @@ import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 
 /**
  * Data structure for issue creation output.
+ * Discriminated union: "created" when issue was created via gh CLI, "url" when falling back to a browser URL.
  */
-export interface IssueCreateData {
-  url: string;
-  number: number;
-  type: "bug" | "feature";
-  title: string;
-}
+export type IssueCreateData =
+  | {
+    method: "created";
+    url: string;
+    number: number;
+    type: "bug" | "feature";
+    title: string;
+  }
+  | {
+    method: "url";
+    url: string;
+    type: "bug" | "feature";
+    title: string;
+    body: string;
+    labels: string[];
+  };
 
 /**
  * Renders issue creation output in either log or JSON mode.
@@ -41,11 +52,23 @@ export function renderIssueCreate(
     console.log(JSON.stringify(data, null, 2));
   } else {
     const logger = getSwampLogger(["issue", "create"]);
-    logger.info(
-      "Created {type} report #{number}: {title}",
-      { type: data.type, number: data.number, title: data.title },
-    );
-    logger.info("View at: {url}", { url: data.url });
+    if (data.method === "created") {
+      logger.info(
+        "Created {type} report #{number}: {title}",
+        { type: data.type, number: data.number, title: data.title },
+      );
+      logger.info("View at: {url}", { url: data.url });
+    } else {
+      logger.info(
+        "GitHub CLI is not available. Open this URL to submit your {type} report:",
+        { type: data.type },
+      );
+      logger.info("{url}", { url: data.url });
+      logger.info("");
+      logger.info("Title: {title}", { title: data.title });
+      logger.info("");
+      logger.info("{body}", { body: data.body });
+    }
   }
 }
 

--- a/src/presentation/output/issue_output_test.ts
+++ b/src/presentation/output/issue_output_test.ts
@@ -1,0 +1,146 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import { type IssueCreateData, renderIssueCreate } from "./issue_output.ts";
+
+await initializeLogging({});
+
+// --- JSON output tests ---
+
+Deno.test("renderIssueCreate json mode: created variant", () => {
+  const data: IssueCreateData = {
+    method: "created",
+    url: "https://github.com/systeminit/swamp/issues/42",
+    number: 42,
+    type: "bug",
+    title: "Test bug",
+  };
+
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderIssueCreate(data, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.method, "created");
+    assertEquals(parsed.url, "https://github.com/systeminit/swamp/issues/42");
+    assertEquals(parsed.number, 42);
+    assertEquals(parsed.type, "bug");
+    assertEquals(parsed.title, "Test bug");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderIssueCreate json mode: url variant includes body and labels", () => {
+  const data: IssueCreateData = {
+    method: "url",
+    url: "https://github.com/systeminit/swamp/issues/new",
+    type: "bug",
+    title: "Test bug",
+    body: "Bug description here",
+    labels: ["bug", "external"],
+  };
+
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderIssueCreate(data, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.method, "url");
+    assertEquals(
+      parsed.url,
+      "https://github.com/systeminit/swamp/issues/new",
+    );
+    assertEquals(parsed.type, "bug");
+    assertEquals(parsed.title, "Test bug");
+    assertEquals(parsed.body, "Bug description here");
+    assertEquals(parsed.labels, ["bug", "external"]);
+    assertEquals(parsed.number, undefined);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderIssueCreate json mode: feature created variant", () => {
+  const data: IssueCreateData = {
+    method: "created",
+    url: "https://github.com/systeminit/swamp/issues/99",
+    number: 99,
+    type: "feature",
+    title: "New feature",
+  };
+
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderIssueCreate(data, "json");
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.method, "created");
+    assertEquals(parsed.type, "feature");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+// --- Log mode tests ---
+
+Deno.test("renderIssueCreate log mode: created variant does not throw", () => {
+  const data: IssueCreateData = {
+    method: "created",
+    url: "https://github.com/systeminit/swamp/issues/42",
+    number: 42,
+    type: "bug",
+    title: "Test bug",
+  };
+  renderIssueCreate(data, "log");
+});
+
+Deno.test("renderIssueCreate log mode: url variant does not throw", () => {
+  const data: IssueCreateData = {
+    method: "url",
+    url: "https://github.com/systeminit/swamp/issues/new",
+    type: "bug",
+    title: "Test bug",
+    body: "Bug description",
+    labels: ["bug", "external"],
+  };
+  renderIssueCreate(data, "log");
+});
+
+Deno.test("renderIssueCreate log mode: feature url variant does not throw", () => {
+  const data: IssueCreateData = {
+    method: "url",
+    url: "https://github.com/systeminit/swamp/issues/new",
+    type: "feature",
+    title: "New feature",
+    body: "Feature description",
+    labels: ["enhancement", "external"],
+  };
+  renderIssueCreate(data, "log");
+});


### PR DESCRIPTION
- When gh CLI is not installed or authenticated, swamp issue bug and swamp issue feature now gracefully fall back instead
of throwing a hard error
- Prints the GitHub new-issue URL for the user to open, plus the full issue title and body for copy/paste
- In JSON mode, the output includes method: "url" with the URL, title, body, and labels
- GitHubIssueResult and IssueCreateData are now discriminated unions (method: "created" | "url")

## Test plan

- getNewIssueUrl() tests: default repo and custom repo
- renderIssueCreate() tests: both "created" and "url" variants in JSON and log modes
- All 1663 tests pass
- Manual: swamp issue bug --title "test" --body "test" with gh authenticated — creates issue via gh CLI
- Manual: with gh unauthenticated — prints URL + issue details for copy/paste