### PR TITLE
fix: Propagate HTTP download errors instead of silently swallowing them

### DIFF
--- a/src/infrastructure/source/http_source_downloader.ts
+++ b/src/infrastructure/source/http_source_downloader.ts
@@ -61,7 +61,13 @@ export class HttpSourceDownloader implements SourceDownloader {
       const tarballPath = join(tempDir, "source.tar.gz");
 
       // Download the tarball
-      const response = await fetch(url);
+      let response: Response;
+      try {
+        response = await fetch(url);
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new UserError(`Download failed: ${message}`);
+      }
       if (!response.ok) {
         if (response.status === 404) {
           throw new UserError(
@@ -82,8 +88,15 @@ export class HttpSourceDownloader implements SourceDownloader {
       });
       try {
         await response.body.pipeTo(file.writable);
-      } catch {
-        // writable stream may already be closed by pipeTo, that's fine
+      } catch (error: unknown) {
+        // Clean up partial download
+        try {
+          await Deno.remove(tarballPath);
+        } catch {
+          // Best-effort cleanup
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        throw new UserError(`Download failed: ${message}`);
       }
 
       // Extract the tarball to temp directory first

--- a/src/infrastructure/source/http_source_downloader_test.ts
+++ b/src/infrastructure/source/http_source_downloader_test.ts
@@ -17,10 +17,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertRejects } from "@std/assert";
 import { join } from "@std/path";
 import { ensureDir } from "@std/fs";
 import { HttpSourceDownloader } from "./http_source_downloader.ts";
+import { UserError } from "../../domain/errors.ts";
 
 Deno.test("downloadAndExtract copies regular files", async () => {
   const tempDir = await Deno.makeTempDir({ prefix: "swamp-test-" });
@@ -199,6 +200,49 @@ Deno.test("downloadAndExtract copies nested directories", async () => {
     assertEquals(
       await Deno.readTextFile(join(targetDir, "a", "b", "deep.txt")),
       "deep content",
+    );
+
+    await server.shutdown();
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("downloadAndExtract throws on download failure", async () => {
+  const tempDir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    // Serve a response that aborts mid-stream
+    const server = Deno.serve({ port: 0, onListen: () => {} }, (_req) => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(4096));
+        },
+        async pull(controller) {
+          await new Promise((resolve) => setTimeout(resolve, 50));
+          controller.error(new Error("Connection reset"));
+        },
+      });
+      return new Response(stream, {
+        headers: { "content-type": "application/gzip" },
+      });
+    });
+
+    const port = server.addr.port;
+
+    const TestDownloader = class extends HttpSourceDownloader {
+      protected override getArchiveUrl(_version: string): string {
+        return `http://localhost:${port}/test.tar.gz`;
+      }
+    };
+
+    const testDownloader = new TestDownloader();
+    const targetDir = join(tempDir, "target");
+    await ensureDir(targetDir);
+
+    await assertRejects(
+      () => testDownloader.downloadAndExtract("main", targetDir),
+      UserError,
+      "Download failed:",
     );
 
     await server.shutdown();

--- a/src/infrastructure/update/http_update_checker.ts
+++ b/src/infrastructure/update/http_update_checker.ts
@@ -91,7 +91,13 @@ export class HttpUpdateChecker implements UpdateChecker {
       const tarballPath = `${tempDir}/swamp.tar.gz`;
 
       // Download the tarball
-      const response = await fetch(url);
+      let response: Response;
+      try {
+        response = await fetch(url);
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new UserError(`Download failed: ${message}`);
+      }
       if (!response.ok) {
         throw new UserError(
           `Failed to download update: HTTP ${response.status}`,
@@ -107,8 +113,15 @@ export class HttpUpdateChecker implements UpdateChecker {
       });
       try {
         await response.body.pipeTo(file.writable);
-      } catch {
-        // writable stream may already be closed by pipeTo, that's fine
+      } catch (error: unknown) {
+        // Clean up partial download
+        try {
+          await Deno.remove(tarballPath);
+        } catch {
+          // Best-effort cleanup
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        throw new UserError(`Download failed: ${message}`);
       }
 
       // Extract the tarball


### PR DESCRIPTION
## Summary

- Fix silent error swallowing in `HttpSourceDownloader` and `HttpUpdateChecker` where `response.body.pipeTo()` failures were caught with an empty catch block, causing partial/corrupt downloads to produce confusing "unexpected EOF" errors during tar extraction
- Wrap `fetch()` calls to catch network-level errors (connection reset, DNS failure, timeout) and propagate them as clear `UserError` messages
- Clean up partial downloads on failure before propagating the error

Closes #335

## Test Plan

- Added test for download failure mid-stream (server aborts with "Connection reset")
- Verified existing download tests still pass (regular files, symlinks, nested directories)
- All 1659 tests passing, `deno check`, `deno lint`, `deno fmt` clean