### PR TITLE
fix: Atomic file writes to prevent repository corruption on crash

### DIFF
--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -19,6 +19,7 @@
 
 import { join } from "@std/path";
 import { ensureDir } from "@std/fs";
+import { atomicWriteTextFile } from "../../infrastructure/persistence/atomic_write.ts";
 import type { RepoPath } from "./repo_path.ts";
 import {
   SWAMP_SUBDIRS,
@@ -424,7 +425,7 @@ Use \`swamp --help\` to see available commands.
         allow: mergedAllow,
       },
     };
-    await Deno.writeTextFile(
+    await atomicWriteTextFile(
       settingsPath,
       JSON.stringify(newSettings, null, 2) + "\n",
     );

--- a/src/domain/vaults/local_encryption_vault_provider.ts
+++ b/src/domain/vaults/local_encryption_vault_provider.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { join } from "@std/path";
+import { atomicWriteTextFile } from "../../infrastructure/persistence/atomic_write.ts";
 import type { VaultProvider } from "./vault_provider.ts";
 import {
   SWAMP_SUBDIRS,
@@ -111,7 +112,7 @@ export class LocalEncryptionVaultProvider implements VaultProvider {
     const encryptedData = await this.encrypt(secretValue, masterKey, salt);
 
     const encryptedFilePath = join(this.vaultDir, `${secretKey}.enc`);
-    await Deno.writeTextFile(
+    await atomicWriteTextFile(
       encryptedFilePath,
       JSON.stringify(encryptedData, null, 2),
     );
@@ -267,7 +268,7 @@ export class LocalEncryptionVaultProvider implements VaultProvider {
         // Generate new key if it doesn't exist
         await this.ensureVaultDirectory();
         const generatedKey = crypto.randomUUID() + crypto.randomUUID(); // 72 chars
-        await Deno.writeTextFile(keyFile, generatedKey, { mode: 0o600 });
+        await atomicWriteTextFile(keyFile, generatedKey, { mode: 0o600 });
 
         return await crypto.subtle.importKey(
           "raw",

--- a/src/infrastructure/persistence/atomic_write.ts
+++ b/src/infrastructure/persistence/atomic_write.ts
@@ -1,0 +1,81 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { dirname, join } from "@std/path";
+
+/**
+ * Writes text content to a file atomically.
+ *
+ * Writes to a temporary file in the same directory, then renames to the
+ * target path. This ensures the file is never left in a partially-written
+ * state if the process crashes mid-write.
+ *
+ * @param path The target file path
+ * @param content The text content to write
+ */
+export async function atomicWriteTextFile(
+  path: string,
+  content: string,
+  options?: Deno.WriteFileOptions,
+): Promise<void> {
+  const dir = dirname(path);
+  const tmpPath = join(dir, `.${crypto.randomUUID()}.tmp`);
+
+  try {
+    await Deno.writeTextFile(tmpPath, content, options);
+    await Deno.rename(tmpPath, path);
+  } catch (error) {
+    try {
+      await Deno.remove(tmpPath);
+    } catch {
+      // Temp file may not exist if writeTextFile failed before creating it
+    }
+    throw error;
+  }
+}
+
+/**
+ * Writes binary content to a file atomically.
+ *
+ * Writes to a temporary file in the same directory, then renames to the
+ * target path. This ensures the file is never left in a partially-written
+ * state if the process crashes mid-write.
+ *
+ * @param path The target file path
+ * @param content The binary content to write
+ */
+export async function atomicWriteFile(
+  path: string,
+  content: Uint8Array,
+): Promise<void> {
+  const dir = dirname(path);
+  const tmpPath = join(dir, `.${crypto.randomUUID()}.tmp`);
+
+  try {
+    await Deno.writeFile(tmpPath, content);
+    await Deno.rename(tmpPath, path);
+  } catch (error) {
+    try {
+      await Deno.remove(tmpPath);
+    } catch {
+      // Temp file may not exist if writeFile failed before creating it
+    }
+    throw error;
+  }
+}

--- a/src/infrastructure/persistence/atomic_write_test.ts
+++ b/src/infrastructure/persistence/atomic_write_test.ts
@@ -1,0 +1,120 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects } from "@std/assert";
+import { join } from "@std/path";
+import { atomicWriteFile, atomicWriteTextFile } from "./atomic_write.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-atomic-write-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+async function listTmpFiles(dir: string): Promise<string[]> {
+  const tmpFiles: string[] = [];
+  for await (const entry of Deno.readDir(dir)) {
+    if (entry.name.endsWith(".tmp")) {
+      tmpFiles.push(entry.name);
+    }
+  }
+  return tmpFiles;
+}
+
+Deno.test("atomicWriteTextFile writes text content correctly", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "test.yaml");
+    const content = "hello: world\nfoo: bar\n";
+
+    await atomicWriteTextFile(filePath, content);
+
+    const result = await Deno.readTextFile(filePath);
+    assertEquals(result, content);
+  });
+});
+
+Deno.test("atomicWriteFile writes binary content correctly", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "test.bin");
+    const content = new Uint8Array([0, 1, 2, 255, 128, 64]);
+
+    await atomicWriteFile(filePath, content);
+
+    const result = await Deno.readFile(filePath);
+    assertEquals(result, content);
+  });
+});
+
+Deno.test("atomicWriteTextFile overwrites existing file", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "test.yaml");
+
+    await Deno.writeTextFile(filePath, "original content");
+    await atomicWriteTextFile(filePath, "new content");
+
+    const result = await Deno.readTextFile(filePath);
+    assertEquals(result, "new content");
+  });
+});
+
+Deno.test("atomicWriteTextFile leaves no temp files on success", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "test.yaml");
+
+    await atomicWriteTextFile(filePath, "content");
+
+    const tmpFiles = await listTmpFiles(dir);
+    assertEquals(tmpFiles.length, 0);
+  });
+});
+
+Deno.test("atomicWriteFile leaves no temp files on success", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "test.bin");
+
+    await atomicWriteFile(filePath, new Uint8Array([1, 2, 3]));
+
+    const tmpFiles = await listTmpFiles(dir);
+    assertEquals(tmpFiles.length, 0);
+  });
+});
+
+Deno.test("atomicWriteTextFile preserves original on directory error", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "test.yaml");
+    await Deno.writeTextFile(filePath, "original");
+
+    // Try to write to a non-existent directory — the temp file creation will fail
+    const badPath = join(dir, "nonexistent", "subdir", "test.yaml");
+    await assertRejects(
+      () => atomicWriteTextFile(badPath, "new content"),
+    );
+
+    // Original file is untouched
+    const result = await Deno.readTextFile(filePath);
+    assertEquals(result, "original");
+
+    // No temp files left behind
+    const tmpFiles = await listTmpFiles(dir);
+    assertEquals(tmpFiles.length, 0);
+  });
+});

--- a/src/infrastructure/persistence/json_telemetry_repository.ts
+++ b/src/infrastructure/persistence/json_telemetry_repository.ts
@@ -19,6 +19,7 @@
 
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
+import { atomicWriteTextFile } from "./atomic_write.ts";
 import type { TelemetryRepository } from "../../domain/telemetry/repositories.ts";
 import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
 import {
@@ -52,7 +53,7 @@ export class JsonTelemetryRepository implements TelemetryRepository {
       const path = join(telemetryDir, filename);
 
       const json = JSON.stringify(entry.toData(), null, 2);
-      await Deno.writeTextFile(path, json);
+      await atomicWriteTextFile(path, json);
     } catch (error) {
       // Silent failure - log only if SWAMP_DEBUG
       if (Deno.env.get("SWAMP_DEBUG")) {

--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import { atomicWriteTextFile } from "./atomic_write.ts";
 import type { SwampVersion } from "../../domain/repo/swamp_version.ts";
 import type { RepoPath } from "../../domain/repo/repo_path.ts";
 import { swampMarkerPath } from "./paths.ts";
@@ -88,7 +89,7 @@ export class RepoMarkerRepository {
     // Remove undefined values since YAML can't stringify them
     const cleanData = JSON.parse(JSON.stringify(data));
     const content = stringifyYaml(cleanData as Record<string, unknown>);
-    await Deno.writeTextFile(path, content);
+    await atomicWriteTextFile(path, content);
   }
 
   /**

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -20,6 +20,7 @@
 import { ensureDir } from "@std/fs";
 import { join, relative } from "@std/path";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import { atomicWriteFile, atomicWriteTextFile } from "./atomic_write.ts";
 import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
 import {
   Data,
@@ -571,7 +572,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     // Remove undefined values
     const cleanData = JSON.parse(JSON.stringify(metadata));
     const metadataContent = stringifyYaml(cleanData as Record<string, unknown>);
-    await Deno.writeTextFile(metadataPath, metadataContent);
+    await atomicWriteTextFile(metadataPath, metadataContent);
 
     // Save content
     const contentPath = this.getContentPath(
@@ -580,7 +581,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
       data.name,
       newVersion,
     );
-    await Deno.writeFile(contentPath, content);
+    await atomicWriteFile(contentPath, content);
 
     // Update latest symlink
     await this.updateLatestSymlink(type, modelId, data.name, newVersion);
@@ -629,7 +630,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     metadata.size = currentContent.length;
     metadata.checksum = await this.computeChecksum(currentContent);
     const cleanData = JSON.parse(JSON.stringify(metadata));
-    await Deno.writeTextFile(
+    await atomicWriteTextFile(
       metadataPath,
       stringifyYaml(cleanData as Record<string, unknown>),
     );
@@ -830,7 +831,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     const metadata = dataToSave.toData();
     const cleanData = JSON.parse(JSON.stringify(metadata));
     const metadataContent = stringifyYaml(cleanData as Record<string, unknown>);
-    await Deno.writeTextFile(metadataPath, metadataContent);
+    await atomicWriteTextFile(metadataPath, metadataContent);
 
     // Update latest symlink
     await this.updateLatestSymlink(type, modelId, data.name, version);

--- a/src/infrastructure/persistence/user_identity_repository.ts
+++ b/src/infrastructure/persistence/user_identity_repository.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { join } from "@std/path";
+import { atomicWriteTextFile } from "./atomic_write.ts";
 import {
   createUserIdentity,
   type UserIdentityData,
@@ -58,7 +59,7 @@ export class UserIdentityRepository {
       // Create new identity
       const identity = createUserIdentity();
       await Deno.mkdir(configDir, { recursive: true });
-      await Deno.writeTextFile(
+      await atomicWriteTextFile(
         identityPath,
         JSON.stringify(identity, null, 2) + "\n",
       );

--- a/src/infrastructure/persistence/yaml_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository.ts
@@ -20,6 +20,7 @@
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { getLogger } from "@logtape/logtape";
+import { atomicWriteTextFile } from "./atomic_write.ts";
 import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
@@ -232,7 +233,7 @@ export class YamlDefinitionRepository implements DefinitionRepository {
     // Remove undefined values since YAML can't stringify them
     const cleanData = JSON.parse(JSON.stringify(data));
     const content = stringifyYaml(cleanData as Record<string, unknown>);
-    await Deno.writeTextFile(path, content);
+    await atomicWriteTextFile(path, content);
 
     // Emit event
     if (this.eventBus) {

--- a/src/infrastructure/persistence/yaml_evaluated_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_definition_repository.ts
@@ -19,6 +19,7 @@
 
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
+import { atomicWriteTextFile } from "./atomic_write.ts";
 import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import { ModelType } from "../../domain/models/model_type.ts";
@@ -245,7 +246,7 @@ export class YamlEvaluatedDefinitionRepository {
     // Remove undefined values since YAML can't stringify them
     const cleanData = JSON.parse(JSON.stringify(data));
     const content = stringifyYaml(cleanData as Record<string, unknown>);
-    await Deno.writeTextFile(path, content);
+    await atomicWriteTextFile(path, content);
   }
 
   /**

--- a/src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts
@@ -20,6 +20,7 @@
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import { atomicWriteTextFile } from "./atomic_write.ts";
 import type { WorkflowId } from "../../domain/workflows/workflow_id.ts";
 import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
 import {
@@ -96,7 +97,7 @@ export class YamlEvaluatedWorkflowRepository {
     // Remove undefined values since YAML can't stringify them
     const cleanData = JSON.parse(JSON.stringify(data));
     const content = stringifyYaml(cleanData as Record<string, unknown>);
-    await Deno.writeTextFile(path, content);
+    await atomicWriteTextFile(path, content);
   }
 
   async delete(id: WorkflowId): Promise<void> {

--- a/src/infrastructure/persistence/yaml_output_repository.ts
+++ b/src/infrastructure/persistence/yaml_output_repository.ts
@@ -19,6 +19,7 @@
 
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
+import { atomicWriteTextFile } from "./atomic_write.ts";
 import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import {
@@ -172,7 +173,7 @@ export class YamlOutputRepository implements OutputRepository {
     // Remove undefined values since YAML can't stringify them
     const cleanData = JSON.parse(JSON.stringify(data));
     const content = stringifyYaml(cleanData as Record<string, unknown>);
-    await Deno.writeTextFile(path, content);
+    await atomicWriteTextFile(path, content);
   }
 
   async delete(

--- a/src/infrastructure/persistence/yaml_vault_config_repository.ts
+++ b/src/infrastructure/persistence/yaml_vault_config_repository.ts
@@ -20,6 +20,7 @@
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import { atomicWriteTextFile } from "./atomic_write.ts";
 import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
 import {
   VaultConfig,
@@ -168,7 +169,7 @@ export class YamlVaultConfigRepository {
 
     const data = config.toData();
     const content = stringifyYaml(data as unknown as Record<string, unknown>);
-    await Deno.writeTextFile(path, content);
+    await atomicWriteTextFile(path, content);
 
     // Emit event
     if (this.eventBus) {

--- a/src/infrastructure/persistence/yaml_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_repository.ts
@@ -20,6 +20,7 @@
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { getLogger } from "@logtape/logtape";
+import { atomicWriteTextFile } from "./atomic_write.ts";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
@@ -125,7 +126,7 @@ export class YamlWorkflowRepository implements WorkflowRepository {
     // Remove undefined values since YAML can't stringify them
     const cleanData = JSON.parse(JSON.stringify(data));
     const content = stringifyYaml(cleanData as Record<string, unknown>);
-    await Deno.writeTextFile(path, content);
+    await atomicWriteTextFile(path, content);
 
     // Emit event
     if (this.eventBus) {

--- a/src/infrastructure/persistence/yaml_workflow_run_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository.ts
@@ -20,6 +20,7 @@
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import { atomicWriteTextFile } from "./atomic_write.ts";
 import type { WorkflowRunRepository } from "../../domain/workflows/repositories.ts";
 import {
   SWAMP_SUBDIRS,
@@ -188,7 +189,7 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
     // Remove undefined values since YAML can't stringify them
     const cleanData = JSON.parse(JSON.stringify(data));
     const content = stringifyYaml(cleanData as Record<string, unknown>);
-    await Deno.writeTextFile(path, content);
+    await atomicWriteTextFile(path, content);
 
     // Emit events based on status changes
     if (this.eventBus) {

--- a/src/infrastructure/source/json_source_metadata_repository.ts
+++ b/src/infrastructure/source/json_source_metadata_repository.ts
@@ -19,6 +19,7 @@
 
 import { ensureDir } from "@std/fs";
 import { dirname } from "@std/path";
+import { atomicWriteTextFile } from "../persistence/atomic_write.ts";
 import type {
   SourceMetadata,
   SourceMetadataRepository,
@@ -71,7 +72,7 @@ export class JsonSourceMetadataRepository implements SourceMetadataRepository {
   async write(metadata: SourceMetadata): Promise<void> {
     await ensureDir(dirname(this.metaPath));
     const content = JSON.stringify(metadata, null, 2);
-    await Deno.writeTextFile(this.metaPath, content);
+    await atomicWriteTextFile(this.metaPath, content);
   }
 
   /**


### PR DESCRIPTION
Closes #328

All YAML/JSON repository files previously used `Deno.writeTextFile()` directly. If the process crashes mid-write (Ctrl+C,
OOM kill, power loss), files are left truncated or corrupted — silently destroying definitions, workflows, vault secrets,
data metadata, and the repo marker. This is especially dangerous because YAML parse errors on next read surface as
confusing failures far removed from the original crash.

This PR introduces `atomicWriteTextFile()` and `atomicWriteFile()` utilities that write to a temporary file first
(`.{uuid}.tmp` in the same directory), then `Deno.rename()` to the target path. On POSIX, `rename(2)` is atomic — the file
is either the old version or the new version, never a partial write.

## Changes vs plan

The original plan in #328 scoped the change to 12 repository files in `src/infrastructure/persistence/` and
`src/infrastructure/source/`. During implementation review, we identified 3 additional write sites with corruption risk:

- `local_encryption_vault_provider.ts` — encrypted vault secrets (2 write sites, including one with `mode: 0o600`)
- `repo_service.ts` — `settings.local.json` read-modify-write

To support the `{ mode: 0o600 }` vault key file, `atomicWriteTextFile` accepts an optional `Deno.WriteFileOptions`
parameter.

**Final total: 2 new files, 14 modified files, 17 write sites converted.**

Write sites intentionally left unchanged:
- `unified_data_repository.ts` append-mode streaming (`Deno.open({ append: true })`) — non-atomic by design
- `repo_service.ts` one-time init writes (CLAUDE.md, .gitignore, settings) — idempotent, re-running init recovers
- `data_writer.ts` empty file creation — nothing to corrupt
- `issue_bug/feature.ts` temp files for editor — ephemeral
- `skill_assets.ts` — extracted from embedded assets, re-extractable

## Why this is safe

1. **Drop-in replacement**: `atomicWriteTextFile` has identical semantics to `Deno.writeTextFile` — creates new files,
overwrites existing files, passes through options. The only difference is the write goes through a temp file + rename.
2. **No symlink risk**: All write targets are canonical paths constructed via `join()` from the repo root. The symlink
index is a separate read-only layer that points *to* these files — repositories never write through symlinks.
3. **No architectural violations**: The two domain-layer files (`local_encryption_vault_provider.ts`, `repo_service.ts`)
already imported from `infrastructure/persistence/` before this change.
4. **Same-directory temp files**: UUID-named `.tmp` files in the same directory ensure same-filesystem rename (required for
atomicity) and won't be picked up by `findAll()` methods that scan for `.yaml`/`.json` files.
5. **Error cleanup**: If the write or rename fails, the temp file is removed and the original error is re-thrown. The
original file is never touched until the rename succeeds.

## Test plan

- [x] 6 new unit tests for atomic write (text/binary correctness, overwrite, no leftover tmp files, error preservation)
- [x] All 1673 existing tests pass
- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt` — formatting passes
- [x] `deno run compile` — binary compiles