### PR TITLE
fix: Validate symlink targets to prevent path traversal in archive extraction

### DIFF
--- a/src/infrastructure/source/http_source_downloader.ts
+++ b/src/infrastructure/source/http_source_downloader.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { ensureDir } from "@std/fs";
-import { join } from "@std/path";
+import { dirname, join, resolve } from "@std/path";
 import type { SourceDownloader } from "../../domain/source/mod.ts";
 import { UserError } from "../../domain/errors.ts";
 
@@ -147,11 +147,16 @@ export class HttpSourceDownloader implements SourceDownloader {
   /**
    * Recursively move contents from source to target directory.
    * Returns the count of files moved.
+   *
+   * @param rootTargetDir The root extraction directory used to validate symlink
+   *   targets. Defaults to `targetDir` on the first (non-recursive) call.
    */
   private async moveContents(
     sourceDir: string,
     targetDir: string,
+    rootTargetDir?: string,
   ): Promise<number> {
+    const effectiveRoot = resolve(rootTargetDir ?? targetDir);
     let fileCount = 0;
 
     for await (const entry of Deno.readDir(sourceDir)) {
@@ -160,10 +165,20 @@ export class HttpSourceDownloader implements SourceDownloader {
 
       if (entry.isSymlink) {
         const linkTarget = await Deno.readLink(sourcePath);
-        await Deno.symlink(linkTarget, targetPath);
+        const resolvedTarget = resolve(dirname(targetPath), linkTarget);
+        if (
+          resolvedTarget === effectiveRoot ||
+          resolvedTarget.startsWith(effectiveRoot + "/")
+        ) {
+          await Deno.symlink(linkTarget, targetPath);
+        }
       } else if (entry.isDirectory) {
         await ensureDir(targetPath);
-        fileCount += await this.moveContents(sourcePath, targetPath);
+        fileCount += await this.moveContents(
+          sourcePath,
+          targetPath,
+          effectiveRoot,
+        );
       } else {
         await Deno.copyFile(sourcePath, targetPath);
         fileCount++;

--- a/src/infrastructure/source/http_source_downloader_test.ts
+++ b/src/infrastructure/source/http_source_downloader_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assert, assertEquals, assertRejects } from "@std/assert";
+import { assert, assertEquals, assertFalse, assertRejects } from "@std/assert";
 import { join } from "@std/path";
 import { ensureDir } from "@std/fs";
 import { HttpSourceDownloader } from "./http_source_downloader.ts";
@@ -243,6 +243,141 @@ Deno.test("downloadAndExtract throws on download failure", async () => {
       () => testDownloader.downloadAndExtract("main", targetDir),
       UserError,
       "Download failed:",
+    );
+
+    await server.shutdown();
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("downloadAndExtract skips symlinks escaping via relative path", async () => {
+  const tempDir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    const archiveRoot = join(tempDir, "archive");
+    const innerDir = join(archiveRoot, "swamp-main");
+    await ensureDir(innerDir);
+    await Deno.writeTextFile(join(innerDir, "safe.txt"), "safe");
+    // Create a symlink that escapes via relative path
+    await Deno.symlink("../../etc/passwd", join(innerDir, "escape-link"));
+
+    const tarball = join(tempDir, "test.tar.gz");
+    const tar = new Deno.Command("tar", {
+      args: ["-czf", tarball, "-C", archiveRoot, "swamp-main"],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const tarResult = await tar.output();
+    assert(tarResult.success, "tar creation should succeed");
+
+    const server = Deno.serve({ port: 0, onListen: () => {} }, (_req) => {
+      const body = Deno.readFileSync(tarball);
+      return new Response(body, {
+        headers: { "content-type": "application/gzip" },
+      });
+    });
+
+    const port = server.addr.port;
+
+    const TestDownloader = class extends HttpSourceDownloader {
+      protected override getArchiveUrl(_version: string): string {
+        return `http://localhost:${port}/test.tar.gz`;
+      }
+    };
+
+    const testDownloader = new TestDownloader();
+    const targetDir = join(tempDir, "target");
+    await ensureDir(targetDir);
+
+    const fileCount = await testDownloader.downloadAndExtract(
+      "main",
+      targetDir,
+    );
+
+    assertEquals(fileCount, 1);
+    assertEquals(
+      await Deno.readTextFile(join(targetDir, "safe.txt")),
+      "safe",
+    );
+
+    // The escaping symlink should NOT have been created
+    let exists = true;
+    try {
+      await Deno.lstat(join(targetDir, "escape-link"));
+    } catch (e) {
+      if (e instanceof Deno.errors.NotFound) {
+        exists = false;
+      }
+    }
+    assertFalse(exists, "symlink escaping via relative path should be skipped");
+
+    await server.shutdown();
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("downloadAndExtract skips symlinks escaping via absolute path", async () => {
+  const tempDir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    const archiveRoot = join(tempDir, "archive");
+    const innerDir = join(archiveRoot, "swamp-main");
+    await ensureDir(innerDir);
+    await Deno.writeTextFile(join(innerDir, "safe.txt"), "safe");
+    // Create a symlink with an absolute path outside the target
+    await Deno.symlink("/etc/passwd", join(innerDir, "abs-escape-link"));
+
+    const tarball = join(tempDir, "test.tar.gz");
+    const tar = new Deno.Command("tar", {
+      args: ["-czf", tarball, "-C", archiveRoot, "swamp-main"],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const tarResult = await tar.output();
+    assert(tarResult.success, "tar creation should succeed");
+
+    const server = Deno.serve({ port: 0, onListen: () => {} }, (_req) => {
+      const body = Deno.readFileSync(tarball);
+      return new Response(body, {
+        headers: { "content-type": "application/gzip" },
+      });
+    });
+
+    const port = server.addr.port;
+
+    const TestDownloader = class extends HttpSourceDownloader {
+      protected override getArchiveUrl(_version: string): string {
+        return `http://localhost:${port}/test.tar.gz`;
+      }
+    };
+
+    const testDownloader = new TestDownloader();
+    const targetDir = join(tempDir, "target");
+    await ensureDir(targetDir);
+
+    const fileCount = await testDownloader.downloadAndExtract(
+      "main",
+      targetDir,
+    );
+
+    assertEquals(fileCount, 1);
+    assertEquals(
+      await Deno.readTextFile(join(targetDir, "safe.txt")),
+      "safe",
+    );
+
+    // The escaping symlink should NOT have been created
+    let exists = true;
+    try {
+      await Deno.lstat(join(targetDir, "abs-escape-link"));
+    } catch (e) {
+      if (e instanceof Deno.errors.NotFound) {
+        exists = false;
+      }
+    }
+    assertFalse(
+      exists,
+      "symlink escaping via absolute path should be skipped",
     );
 
     await server.shutdown();


### PR DESCRIPTION
Fixes: #336

- Symlinks from downloaded tar archives are now validated before being recreated, preventing path traversal attacks
- Symlinks targeting paths outside the extraction directory (via relative ../../ or absolute paths) are silently skipped
- Two new test cases verify rejection of both relative and absolute escaping symlinks

## Plan comparison

The implementation matches the plan exactly:

Plan item: Import resolve, dirname from @std/path
Status: Done
Notes: Matches plan
────────────────────────────────────────
Plan item: Add rootTargetDir parameter to moveContents()
Status: Done
Notes: Used rootTargetDir?: string optional param as planned
────────────────────────────────────────
Plan item: Default rootTargetDir to targetDir on first call
Status: Done
Notes: Via resolve(rootTargetDir ?? targetDir) — slightly different from plan's undefined default + early assignment, but
equivalent
────────────────────────────────────────
Plan item: Resolve symlink target relative to dirname(targetPath)
Status: Done
Notes: Matches plan snippet exactly
────────────────────────────────────────
Plan item: Check resolvedTarget starts with normalizedRoot + "/"
Status: Done
Notes: Used effectiveRoot instead of normalizedRoot as the variable name — no behavioral difference
────────────────────────────────────────
Plan item: Pass rootTargetDir through recursive calls
Status: Done
Notes: Passes effectiveRoot (already resolved) to avoid redundant resolve() calls
────────────────────────────────────────
Plan item: Skip symlinks that fail validation (no error thrown)
Status: Done
Notes: Matches plan
────────────────────────────────────────
Plan item: Test: relative path escape (../../etc/passwd)
Status: Done
Notes: Follows existing test pattern as planned
────────────────────────────────────────
Plan item: Test: absolute path escape (/etc/passwd)
Status: Done
Notes: Follows existing test pattern as planned

No deviations from the plan. The only cosmetic differences are variable naming (effectiveRoot vs normalizedRoot) and
computing the resolved root once upfront rather than on each iteration.

## Test plan

- New test: symlinks escaping via relative path are skipped
- New test: symlinks escaping via absolute path are skipped
- Existing test: safe symlinks are still preserved
- Full test suite passes (1676 tests, 0 failures)
- deno check, deno lint, deno fmt all clean
- deno run compile succeeds