### PR TITLE
fix: Prevent path traversal via data names in unified data repository (#325)

### DIFF
--- a/src/domain/data/data_metadata.ts
+++ b/src/domain/data/data_metadata.ts
@@ -81,7 +81,15 @@ export type OwnerDefinition = z.infer<typeof OwnerDefinitionSchema>;
  * Tags must include a 'type' key for categorization.
  */
 export const DataMetadataSchema = z.object({
-  name: z.string().min(1),
+  name: z.string().min(1).refine(
+    (name) =>
+      !name.includes("..") && !name.includes("/") && !name.includes("\\") &&
+      !name.includes("\0"),
+    {
+      message:
+        "Data name must not contain '..', '/', '\\', or null bytes (path traversal)",
+    },
+  ),
   id: z.string().uuid(),
   version: z.number().int().positive(),
   contentType: z.string().min(1),

--- a/src/domain/data/data_test.ts
+++ b/src/domain/data/data_test.ts
@@ -362,6 +362,87 @@ Deno.test("Data.create with garbage collection as duration", () => {
   assertEquals(data.garbageCollection, "30d");
 });
 
+Deno.test("Data.create rejects name with '..'", () => {
+  const owner = createTestOwner();
+  assertThrows(
+    () =>
+      Data.create({
+        name: "../escape",
+        contentType: "text/plain",
+        lifetime: "infinite",
+        garbageCollection: 5,
+        tags: { type: "test" },
+        ownerDefinition: owner,
+      }),
+    Error,
+    "path traversal",
+  );
+});
+
+Deno.test("Data.create rejects name with '/'", () => {
+  const owner = createTestOwner();
+  assertThrows(
+    () =>
+      Data.create({
+        name: "foo/bar",
+        contentType: "text/plain",
+        lifetime: "infinite",
+        garbageCollection: 5,
+        tags: { type: "test" },
+        ownerDefinition: owner,
+      }),
+    Error,
+    "path traversal",
+  );
+});
+
+Deno.test("Data.create rejects name with '\\'", () => {
+  const owner = createTestOwner();
+  assertThrows(
+    () =>
+      Data.create({
+        name: "foo\\bar",
+        contentType: "text/plain",
+        lifetime: "infinite",
+        garbageCollection: 5,
+        tags: { type: "test" },
+        ownerDefinition: owner,
+      }),
+    Error,
+    "path traversal",
+  );
+});
+
+Deno.test("Data.create rejects name with null byte", () => {
+  const owner = createTestOwner();
+  assertThrows(
+    () =>
+      Data.create({
+        name: "foo\0bar",
+        contentType: "text/plain",
+        lifetime: "infinite",
+        garbageCollection: 5,
+        tags: { type: "test" },
+        ownerDefinition: owner,
+      }),
+    Error,
+    "path traversal",
+  );
+});
+
+Deno.test("Data.create accepts valid names with hyphens, dots, and underscores", () => {
+  const owner = createTestOwner();
+  const data = Data.create({
+    name: "my-data.v2_final",
+    contentType: "text/plain",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: { type: "test" },
+    ownerDefinition: owner,
+  });
+  assertEquals(data.name, "my-data.v2_final");
+});
+
 Deno.test("Data.create defaults streaming to false", () => {
   const owner = createTestOwner();
   const data = Data.create({

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { ensureDir } from "@std/fs";
-import { join, relative } from "@std/path";
+import { join, relative, resolve } from "@std/path";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import { atomicWriteFile, atomicWriteTextFile } from "./atomic_write.ts";
 import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
@@ -938,7 +938,10 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
   }
 
   private getModelDataDir(type: ModelType, modelId: string): string {
-    return join(this.getTypeDir(type), modelId);
+    const typeDir = this.getTypeDir(type);
+    const result = join(typeDir, modelId);
+    this.assertPathContained(result, typeDir, `modelId "${modelId}"`);
+    return result;
   }
 
   private getDataNameDir(
@@ -946,7 +949,27 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     modelId: string,
     dataName: string,
   ): string {
-    return join(this.getModelDataDir(type, modelId), dataName);
+    const modelDir = this.getModelDataDir(type, modelId);
+    const result = join(modelDir, dataName);
+    this.assertPathContained(result, modelDir, `dataName "${dataName}"`);
+    return result;
+  }
+
+  private assertPathContained(
+    path: string,
+    expectedParent: string,
+    context: string,
+  ): void {
+    const resolvedPath = resolve(path);
+    const resolvedParent = resolve(expectedParent);
+    if (
+      resolvedPath !== resolvedParent &&
+      !resolvedPath.startsWith(resolvedParent + "/")
+    ) {
+      throw new Error(
+        `Path traversal detected: ${context} resolves outside expected directory`,
+      );
+    }
   }
 
   private getMetadataPath(

--- a/src/infrastructure/persistence/unified_data_repository_test.ts
+++ b/src/infrastructure/persistence/unified_data_repository_test.ts
@@ -1,0 +1,66 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertRejects, assertStringIncludes } from "@std/assert";
+import { FileSystemUnifiedDataRepository } from "./unified_data_repository.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
+
+const testType = ModelType.create("test/model");
+
+Deno.test("getPath rejects dataName with path traversal", () => {
+  const repo = new FileSystemUnifiedDataRepository("/tmp/test-repo");
+  try {
+    repo.getPath(testType, "valid-model", "../escape", 1);
+    throw new Error("Expected path traversal error");
+  } catch (e) {
+    assertStringIncludes(
+      (e as Error).message,
+      "Path traversal detected",
+    );
+  }
+});
+
+Deno.test("getPath rejects modelId with path traversal", () => {
+  const repo = new FileSystemUnifiedDataRepository("/tmp/test-repo");
+  try {
+    repo.getPath(testType, "../escape", "valid-data", 1);
+    throw new Error("Expected path traversal error");
+  } catch (e) {
+    assertStringIncludes(
+      (e as Error).message,
+      "Path traversal detected",
+    );
+  }
+});
+
+Deno.test("getPath accepts valid modelId and dataName", () => {
+  const repo = new FileSystemUnifiedDataRepository("/tmp/test-repo");
+  const path = repo.getPath(testType, "my-model-id", "my-data-name", 1);
+  assertStringIncludes(path, "my-model-id");
+  assertStringIncludes(path, "my-data-name");
+});
+
+Deno.test("listVersions rejects dataName with path traversal", async () => {
+  const repo = new FileSystemUnifiedDataRepository("/tmp/test-repo");
+  await assertRejects(
+    () => repo.listVersions(testType, "valid-model", "../escape"),
+    Error,
+    "Path traversal detected",
+  );
+});


### PR DESCRIPTION
Fixes: #325

- Add Zod validation rejecting `..`, `/`, `\`, and null bytes in data names at the domain layer
- Add resolved-path containment guard in `FileSystemUnifiedDataRepository` to catch traversal at the infrastructure
boundary
- Defense-in-depth: Layer 1 (schema) catches names flowing through `Data.create()`/`Data.fromData()`, Layer 2 (repository)
catches raw strings passed directly to repository methods (e.g. CLI commands like `data get`, `data versions`)

## Comparison to plan

| Planned | Implemented | Notes |
|---------|-------------|-------|
| `.refine()` on `DataMetadataSchema.name` | Exact match | Rejects `..`, `/`, `\`, null bytes |
| `resolve` added to `@std/path` import | Exact match | |
| `assertPathContained` private method | Exact match | Mirrors `http_source_downloader.ts` pattern |
| Wired into `getModelDataDir` + `getDataNameDir` | Exact match | Both chokepoints guarded |
| Domain tests in `data_test.ts` | Exact match | 5 new tests (4 rejection + 1 acceptance) |
| Repository tests in `unified_data_repository_test.ts` | Exact match | 4 new tests (new file) |
| No changes to `data_writer.ts`, CLI commands, no `DataName` value object | Confirmed | |

Zero deviations from plan.

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] `deno run test` — 1685 tests pass, 0 failures
- [x] `deno run compile` — binary compiles

## Files changed

| File | Change |
|------|--------|
| `src/domain/data/data_metadata.ts` | Added `.refine()` to `name` field |
| `src/domain/data/data_test.ts` | 5 new traversal rejection/acceptance tests |
| `src/infrastructure/persistence/unified_data_repository.ts` | Added `resolve` import, `assertPathContained` method,
guarded `getModelDataDir` and `getDataNameDir` |
| `src/infrastructure/persistence/unified_data_repository_test.ts` | New file — 4 repository-level guard tests |