### PR TITLE
fix: Validate vault secret keys to prevent path traversal

### DIFF
--- a/src/domain/vaults/local_encryption_vault_provider.ts
+++ b/src/domain/vaults/local_encryption_vault_provider.ts
@@ -80,6 +80,7 @@ export class LocalEncryptionVaultProvider implements VaultProvider {
   }
 
   async get(secretKey: string): Promise<string> {
+    this.validateSecretKey(secretKey);
     const encryptedFilePath = join(this.vaultDir, `${secretKey}.enc`);
 
     try {
@@ -105,6 +106,7 @@ export class LocalEncryptionVaultProvider implements VaultProvider {
   }
 
   async put(secretKey: string, secretValue: string): Promise<void> {
+    this.validateSecretKey(secretKey);
     await this.ensureVaultDirectory();
 
     const salt = crypto.getRandomValues(new Uint8Array(16));
@@ -334,6 +336,24 @@ export class LocalEncryptionVaultProvider implements VaultProvider {
     );
 
     return new TextDecoder().decode(decrypted);
+  }
+
+  /**
+   * Validates that a secret key does not contain path traversal characters.
+   * Rejects keys containing '..', '/', '\', or null bytes to prevent
+   * file operations outside the vault directory.
+   */
+  private validateSecretKey(secretKey: string): void {
+    if (
+      secretKey.includes("..") ||
+      secretKey.includes("/") ||
+      secretKey.includes("\\") ||
+      secretKey.includes("\0")
+    ) {
+      throw new Error(
+        `Invalid secret key '${secretKey}': must not contain '..', '/', '\\', or null bytes`,
+      );
+    }
   }
 
   /**

--- a/src/domain/vaults/local_encryption_vault_provider_test.ts
+++ b/src/domain/vaults/local_encryption_vault_provider_test.ts
@@ -589,3 +589,118 @@ Deno.test("LocalEncryptionVaultProvider - list secrets", async (t) => {
     });
   });
 });
+
+Deno.test("LocalEncryptionVaultProvider - path traversal prevention", async (t) => {
+  await t.step("should reject key with ../ in put()", async () => {
+    await withTempDir(async (dir) => {
+      const config: LocalEncryptionConfig = {
+        auto_generate: true,
+        base_dir: dir,
+      };
+      const vault = new LocalEncryptionVaultProvider("traversal-vault", config);
+
+      const error = await assertRejects(
+        () => vault.put("../../escaped/pwned", "malicious"),
+        Error,
+      );
+
+      assertStringIncludes(error.message, "Invalid secret key");
+      assertStringIncludes(error.message, "..");
+    });
+  });
+
+  await t.step("should reject key with ../ in get()", async () => {
+    await withTempDir(async (dir) => {
+      const config: LocalEncryptionConfig = {
+        auto_generate: true,
+        base_dir: dir,
+      };
+      const vault = new LocalEncryptionVaultProvider("traversal-vault", config);
+
+      const error = await assertRejects(
+        () => vault.get("../../escaped/pwned"),
+        Error,
+      );
+
+      assertStringIncludes(error.message, "Invalid secret key");
+      assertStringIncludes(error.message, "..");
+    });
+  });
+
+  await t.step("should reject key with forward slash", async () => {
+    await withTempDir(async (dir) => {
+      const config: LocalEncryptionConfig = {
+        auto_generate: true,
+        base_dir: dir,
+      };
+      const vault = new LocalEncryptionVaultProvider("traversal-vault", config);
+
+      const error = await assertRejects(
+        () => vault.put("path/to/secret", "value"),
+        Error,
+      );
+
+      assertStringIncludes(error.message, "Invalid secret key");
+    });
+  });
+
+  await t.step("should reject key with backslash", async () => {
+    await withTempDir(async (dir) => {
+      const config: LocalEncryptionConfig = {
+        auto_generate: true,
+        base_dir: dir,
+      };
+      const vault = new LocalEncryptionVaultProvider("traversal-vault", config);
+
+      const error = await assertRejects(
+        () => vault.put("path\\to\\secret", "value"),
+        Error,
+      );
+
+      assertStringIncludes(error.message, "Invalid secret key");
+    });
+  });
+
+  await t.step("should reject key with null byte", async () => {
+    await withTempDir(async (dir) => {
+      const config: LocalEncryptionConfig = {
+        auto_generate: true,
+        base_dir: dir,
+      };
+      const vault = new LocalEncryptionVaultProvider("traversal-vault", config);
+
+      const error = await assertRejects(
+        () => vault.put("secret\0key", "value"),
+        Error,
+      );
+
+      assertStringIncludes(error.message, "Invalid secret key");
+    });
+  });
+
+  await t.step(
+    "should allow valid keys with hyphens, underscores, and dots",
+    async () => {
+      await withTempDir(async (dir) => {
+        const config: LocalEncryptionConfig = {
+          auto_generate: true,
+          base_dir: dir,
+        };
+        const vault = new LocalEncryptionVaultProvider(
+          "valid-keys-vault",
+          config,
+        );
+
+        await vault.put("api-key", "value1");
+        await vault.put("db_password", "value2");
+        await vault.put("config.prod", "value3");
+        await vault.put("MySecret123", "value4");
+
+        assertEquals(await vault.get("api-key"), "value1");
+        assertEquals(await vault.get("db_password"), "value2");
+        assertEquals(await vault.get("config.prod"), "value3");
+        assertEquals(await vault.get("MySecret123"), "value4");
+      });
+    },
+  );
+});


### PR DESCRIPTION
- Adds secret key validation in `LocalEncryptionVaultProvider` to reject keys containing `..`, `/`, `\`, or null bytes
- Prevents path traversal attacks where a key like `../../escaped/pwned` could write/read encrypted files outside the vault
directory
- Adds 6 test cases covering all rejection paths and valid key acceptance

Fixes: #324

## Plan comparison

The implementation matches the plan posted on #324 exactly:

| Planned | Implemented |
|---------|-------------|
| Add `validateSecretKey()` private method | Done — rejects `..`, `/`, `\`, `\0` |
| Call at top of `get()` and `put()` | Done — lines 83 and 109 |
| Add path traversal prevention tests | Done — 6 test cases |

No deviations from the plan.

## Why this approach

**Why validate in the provider, not `VaultService`?** The vulnerability is specific to providers that map keys to file
paths. The AWS provider sends keys over an API where path characters are harmless. Validating at `VaultService` would
over-constrain providers that don't need it.

**Why a character blocklist, not path resolution?** The codebase already uses this exact pattern in `data_metadata.ts` (Zod
schema rejects `..`, `/`, `\`, `\0` for data names) and `skill_assets.ts` (rejects `..` in skill paths). A `resolve()` +
prefix check approach is more complex and introduces subtle edge cases (symlinks, TOCTOU). The blocklist is simpler,
stricter, and consistent.

**Why not validate at the CLI layer?** Defense-in-depth says validate at the boundary where the dangerous operation
happens. The provider constructs the file path, so the provider should validate the input. Other callers (workflows, CEL
expressions) also reach the provider without going through CLI argument parsing.

## Test plan

- [x] Keys with `../` rejected in `put()` and `get()`
- [x] Keys with `/` rejected
- [x] Keys with `\` rejected
- [x] Keys with null bytes rejected
- [x] Valid keys (hyphens, underscores, dots, alphanumeric) still work
- [x] All 1686 existing tests pass
- [x] `deno check`, `deno lint`, `deno fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)