### PR TITLE
fix: Use Deno.stat() instead of Deno.readFile() in append()

### DIFF
--- a/integration/unified_data_test.ts
+++ b/integration/unified_data_test.ts
@@ -443,6 +443,13 @@ Deno.test("Integration: append works for streaming data", async () => {
     // Verify content
     const content = await repo.getContent(type, modelId, "append-test");
     assertEquals(new TextDecoder().decode(content!), "line1\nline2\nline3\n");
+
+    // Verify size is correct after appends
+    const found = await repo.findByName(type, modelId, "append-test");
+    assertEquals(found?.size, "line1\nline2\nline3\n".length);
+
+    // Checksum should be removed after append (content changed, old checksum is stale)
+    assertEquals(found?.checksum, undefined);
   });
 });
 

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -618,8 +618,8 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
       file.close();
     }
 
-    // Update metadata with new size
-    const currentContent = await Deno.readFile(contentPath);
+    // Update metadata with new size (O(1) via stat, no file read)
+    const stat = await Deno.stat(contentPath);
     const metadataPath = this.getMetadataPath(
       type,
       modelId,
@@ -627,8 +627,10 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
       latestVersion,
     );
     const metadata = data.toData();
-    metadata.size = currentContent.length;
-    metadata.checksum = await this.computeChecksum(currentContent);
+    metadata.size = stat.size;
+    // Remove stale checksum — content has changed and recomputing
+    // would require reading the entire file into memory
+    delete metadata.checksum;
     const cleanData = JSON.parse(JSON.stringify(metadata));
     await atomicWriteTextFile(
       metadataPath,


### PR DESCRIPTION
## Summary

- Replace `Deno.readFile()` with `Deno.stat()` in `FileSystemUnifiedDataRepository.append()` to get file size in O(1) with zero memory overhead, instead of reading the entire file into memory
- Remove stale checksum after append — the content has changed so the old checksum is wrong, and recomputing it would require the same O(n) file read we're eliminating
- Non-streaming data is unaffected (checksum is still computed on `save()`)

Closes #332

## Deviation from Original Plan

The original plan proposed three steps: a streaming checksum utility, the `append()` fix, and a `finalizeVersion()` fix with a 10MB threshold. This PR only implements the `append()` fix because:

1. **The streaming checksum utility was unnecessary** — the plan itself noted that Web Crypto doesn't support true streaming digest in Deno, and the proposed `computeChecksumFromFile()` still loaded all chunks into memory before hashing, offering no improvement over `Deno.readFile()`
2. **`finalizeVersion()` doesn't need fixing here** — it's called once per version, not per-append, so it doesn't cause the O(n²) behavior described in the issue. If it becomes a problem for very large files, that's a separate concern
3. **The 10MB threshold was arbitrary** — silently skipping checksums above a magic number is a behavioral change that could surprise callers. Better to leave `finalizeVersion()` alone than introduce that

The core fix is two lines: `Deno.stat()` for size and `delete metadata.checksum` for the stale checksum.

## Test Plan

- Extended existing "Integration: append works for streaming data" test to verify `size` is correct after appends and `checksum` is `undefined`
- All 1686 tests passing, `deno check`, `deno lint`, `deno fmt` clean