### PR TITLE
fix: Defer env expressions to runtime, add globalArguments validation

### DIFF
--- a/integration/cel_data_access_test.ts
+++ b/integration/cel_data_access_test.ts
@@ -589,10 +589,25 @@ Deno.test("CEL Data Access: access environment variables", async () => {
         repoDir,
       );
 
+      // evaluateDefinition defers env expressions to runtime (leaves raw)
       const result = await evalService.evaluateDefinition(model, type);
 
-      assertEquals(result.definition.globalArguments.from_env, "test-value");
-      assertEquals(result.definition.globalArguments.number_as_string, "42");
+      assertEquals(
+        result.definition.globalArguments.from_env,
+        "${{ env.CEL_TEST_VAR }}",
+      );
+      assertEquals(
+        result.definition.globalArguments.number_as_string,
+        "${{ env.CEL_TEST_NUMBER }}",
+      );
+
+      // Resolve runtime expressions (env + vault) — this is the runtime phase
+      const resolved = await evalService.resolveRuntimeExpressionsInDefinition(
+        result.definition,
+      );
+
+      assertEquals(resolved.globalArguments.from_env, "test-value");
+      assertEquals(resolved.globalArguments.number_as_string, "42");
     } finally {
       Deno.env.delete("CEL_TEST_VAR");
       Deno.env.delete("CEL_TEST_NUMBER");

--- a/integration/definition_lifecycle_test.ts
+++ b/integration/definition_lifecycle_test.ts
@@ -769,12 +769,23 @@ Deno.test("Definition Lifecycle: environment variable expressions", async () => 
         repoDir,
       );
 
+      // evaluateDefinition defers env expressions to runtime (leaves raw)
       const result = await evalService.evaluateDefinition(
         definition,
         modelType,
       );
 
-      assertEquals(result.definition.globalArguments.from_env, "env-value-123");
+      assertEquals(
+        result.definition.globalArguments.from_env,
+        "${{ env.TEST_ENV_VAR }}",
+      );
+
+      // Resolve runtime expressions (env + vault) — this is the runtime phase
+      const resolved = await evalService.resolveRuntimeExpressionsInDefinition(
+        result.definition,
+      );
+
+      assertEquals(resolved.globalArguments.from_env, "env-value-123");
     } finally {
       Deno.env.delete("TEST_ENV_VAR");
     }

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -235,9 +235,9 @@ export const modelMethodRunCommand = new Command()
         }
       }
 
-      // Resolve vault expressions at runtime (never persisted)
+      // Resolve runtime expressions (vault and env) at runtime (never persisted)
       evaluatedDefinition = await evaluationService
-        .resolveVaultExpressionsInDefinition(evaluatedDefinition);
+        .resolveRuntimeExpressionsInDefinition(evaluatedDefinition);
 
       runLogger.info("Executing method {method}", { method: methodName });
 

--- a/src/cli/commands/workflow_evaluate.ts
+++ b/src/cli/commands/workflow_evaluate.ts
@@ -28,7 +28,7 @@ import { createContext, type GlobalOptions } from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { parseInputs } from "../input_parser.ts";
 import { InputValidationService } from "../../domain/inputs/mod.ts";
-import { containsVaultExpression } from "../../domain/expressions/expression_evaluation_service.ts";
+import { containsRuntimeExpression } from "../../domain/expressions/expression_evaluation_service.ts";
 import { YamlEvaluatedWorkflowRepository } from "../../infrastructure/persistence/yaml_evaluated_workflow_repository.ts";
 import {
   extractExpressions,
@@ -206,7 +206,7 @@ async function evaluateWorkflow(
   // Evaluate CEL-only expressions; skip vault, self.*, and forEach.in expressions
   const evaluatedValues = new Map<string, unknown>();
   for (const expr of expressions) {
-    if (containsVaultExpression(expr.celExpression)) {
+    if (containsRuntimeExpression(expr.celExpression)) {
       continue;
     }
     // Skip self.* expressions — they reference forEach variables resolved at runtime
@@ -381,7 +381,7 @@ function resolveForEachTaskExpressions(
     for (const [key, val] of Object.entries(expandedTask.inputs)) {
       if (typeof val === "string") {
         const exprMatch = (val as string).match(/\$\{\{\s*(.+?)\s*\}\}/);
-        if (exprMatch && !containsVaultExpression(exprMatch[1])) {
+        if (exprMatch && !containsRuntimeExpression(exprMatch[1])) {
           try {
             expandedTask.inputs[key] = celEvaluator.evaluate(
               exprMatch[1],
@@ -402,7 +402,7 @@ function resolveForEachTaskExpressions(
       return (arg as string).replace(
         /\$\{\{\s*(.+?)\s*\}\}/g,
         (_match: string, expr: string) => {
-          if (containsVaultExpression(expr)) return _match;
+          if (containsRuntimeExpression(expr)) return _match;
           try {
             return String(celEvaluator.evaluate(expr, stepContext));
           } catch {

--- a/src/domain/expressions/expression_evaluation_service.ts
+++ b/src/domain/expressions/expression_evaluation_service.ts
@@ -30,6 +30,7 @@ import {
 import type { ExpressionLocation } from "./expression.ts";
 import { extractModelRefs } from "./dependency_extractor.ts";
 import {
+  buildEnvContext,
   type ExpressionContext,
   ModelResolver,
   type ModelResolverRepositories,
@@ -47,12 +48,36 @@ import {
 const VAULT_GET_PATTERN = /vault\.get\s*\(/;
 
 /**
+ * Pattern to detect env.* references inside a CEL expression.
+ */
+const ENV_PATTERN = /\benv\./;
+
+/**
  * Checks whether a CEL expression references vault.get().
  * Expressions containing vault references must NOT be evaluated during
  * the persist phase — they are resolved at runtime only.
  */
 export function containsVaultExpression(celExpression: string): boolean {
   return VAULT_GET_PATTERN.test(celExpression);
+}
+
+/**
+ * Checks whether a CEL expression references env.* variables.
+ * Expressions containing env references must NOT be evaluated during
+ * the persist phase — they are resolved at runtime only.
+ */
+export function containsEnvExpression(celExpression: string): boolean {
+  return ENV_PATTERN.test(celExpression);
+}
+
+/**
+ * Checks whether a CEL expression contains any runtime-only references
+ * (vault or env). Expressions matching this check are deferred to runtime
+ * and skipped during the persist phase.
+ */
+export function containsRuntimeExpression(celExpression: string): boolean {
+  return containsVaultExpression(celExpression) ||
+    containsEnvExpression(celExpression);
 }
 
 /**
@@ -118,10 +143,10 @@ export class ExpressionEvaluationService {
       return data;
     }
 
-    // Evaluate CEL-only expressions; skip vault-containing expressions
+    // Evaluate CEL-only expressions; skip runtime expressions (vault, env)
     const evaluatedValues = new Map<string, unknown>();
     for (const expr of expressions) {
-      if (containsVaultExpression(expr.celExpression)) {
+      if (containsRuntimeExpression(expr.celExpression)) {
         continue;
       }
 
@@ -172,12 +197,12 @@ export class ExpressionEvaluationService {
       return { definition, type, hadExpressions: false };
     }
 
-    // Evaluate CEL-only expressions; skip vault-containing expressions
-    // Vault expressions are resolved at runtime only, never persisted
+    // Evaluate CEL-only expressions; skip runtime expressions (vault, env)
+    // Runtime expressions are resolved at runtime only, never persisted
     const evaluatedValues = new Map<string, unknown>();
     for (const expr of expressions) {
-      if (containsVaultExpression(expr.celExpression)) {
-        // Leave vault-containing expressions (vault-only and mixed) as raw
+      if (containsRuntimeExpression(expr.celExpression)) {
+        // Leave runtime expressions (vault, env, and mixed) as raw
         continue;
       }
 
@@ -334,59 +359,62 @@ export class ExpressionEvaluationService {
   }
 
   /**
-   * Resolves remaining vault expressions in an already-evaluated definition.
-   * This is the runtime phase — vault secrets are resolved here and never persisted.
+   * Resolves remaining runtime expressions (vault and env) in an already-evaluated definition.
+   * This is the runtime phase — vault secrets and env variables are resolved here and never persisted.
    *
-   * @param definition - The definition (may contain remaining ${{ vault.get(...) }} expressions)
-   * @returns A new definition with vault expressions resolved to actual secret values
+   * @param definition - The definition (may contain remaining ${{ vault.get(...) }} or ${{ env.* }} expressions)
+   * @returns A new definition with all runtime expressions resolved
    */
-  async resolveVaultExpressionsInDefinition(
+  async resolveRuntimeExpressionsInDefinition(
     definition: Definition,
   ): Promise<Definition> {
     const definitionData = definition.toData();
     const expressions = extractExpressions(definitionData);
 
-    // Filter to only vault-containing expressions
-    const vaultExpressions = expressions.filter((expr) =>
-      containsVaultExpression(expr.celExpression)
+    // Filter to only runtime expressions (vault or env)
+    const runtimeExpressions = expressions.filter((expr) =>
+      containsRuntimeExpression(expr.celExpression)
     );
 
-    if (vaultExpressions.length === 0) {
+    if (runtimeExpressions.length === 0) {
       return definition;
     }
 
-    return await this.resolveVaultInExpressions(
+    return await this.resolveRuntimeInExpressions(
       definitionData,
-      vaultExpressions,
+      runtimeExpressions,
     );
   }
 
   /**
-   * Resolves remaining vault expressions in arbitrary data.
-   * This is the runtime phase — vault secrets are resolved here and never persisted.
+   * Resolves remaining runtime expressions (vault and env) in arbitrary data.
+   * This is the runtime phase — vault secrets and env variables are resolved here and never persisted.
    *
-   * @param data - The data (may contain remaining ${{ vault.get(...) }} expressions)
-   * @returns The data with vault expressions resolved
+   * @param data - The data (may contain remaining runtime expressions)
+   * @returns The data with all runtime expressions resolved
    */
-  async resolveVaultExpressionsInData(data: unknown): Promise<unknown> {
+  async resolveRuntimeExpressionsInData(data: unknown): Promise<unknown> {
     const expressions = extractExpressions(data);
-    const vaultExpressions = expressions.filter((expr) =>
-      containsVaultExpression(expr.celExpression)
+    const runtimeExpressions = expressions.filter((expr) =>
+      containsRuntimeExpression(expr.celExpression)
     );
 
-    if (vaultExpressions.length === 0) {
+    if (runtimeExpressions.length === 0) {
       return data;
     }
 
     const evaluatedValues = new Map<string, unknown>();
-    for (const expr of vaultExpressions) {
-      // Resolve vault expressions first, then evaluate the full CEL
-      const resolvedCelExpr = await this.modelResolver.resolveVaultExpressions(
-        expr.celExpression,
-      );
+    for (const expr of runtimeExpressions) {
+      // Resolve vault references first (if any), then evaluate the full CEL
+      let resolvedCelExpr = expr.celExpression;
+      if (containsVaultExpression(expr.celExpression)) {
+        resolvedCelExpr = await this.modelResolver.resolveVaultExpressions(
+          expr.celExpression,
+        );
+      }
       const value = this.celEvaluator.evaluate(resolvedCelExpr, {
         model: {},
-        env: {},
+        env: buildEnvContext(),
       });
       evaluatedValues.set(expr.raw, value);
     }
@@ -395,21 +423,40 @@ export class ExpressionEvaluationService {
   }
 
   /**
-   * Internal: resolves vault expressions in definition data and returns a new Definition.
+   * @deprecated Use resolveRuntimeExpressionsInDefinition instead.
    */
-  private async resolveVaultInExpressions(
+  resolveVaultExpressionsInDefinition(
+    definition: Definition,
+  ): Promise<Definition> {
+    return this.resolveRuntimeExpressionsInDefinition(definition);
+  }
+
+  /**
+   * @deprecated Use resolveRuntimeExpressionsInData instead.
+   */
+  resolveVaultExpressionsInData(data: unknown): Promise<unknown> {
+    return this.resolveRuntimeExpressionsInData(data);
+  }
+
+  /**
+   * Internal: resolves runtime expressions in definition data and returns a new Definition.
+   */
+  private async resolveRuntimeInExpressions(
     definitionData: ReturnType<Definition["toData"]>,
-    vaultExpressions: ExpressionLocation[],
+    runtimeExpressions: ExpressionLocation[],
   ): Promise<Definition> {
     const evaluatedValues = new Map<string, unknown>();
-    for (const expr of vaultExpressions) {
-      // Resolve vault references, then evaluate the CEL expression
-      const resolvedCelExpr = await this.modelResolver.resolveVaultExpressions(
-        expr.celExpression,
-      );
+    for (const expr of runtimeExpressions) {
+      // Resolve vault references first (if any), then evaluate the CEL expression
+      let resolvedCelExpr = expr.celExpression;
+      if (containsVaultExpression(expr.celExpression)) {
+        resolvedCelExpr = await this.modelResolver.resolveVaultExpressions(
+          expr.celExpression,
+        );
+      }
       const value = this.celEvaluator.evaluate(resolvedCelExpr, {
         model: {},
-        env: {},
+        env: buildEnvContext(),
       });
       evaluatedValues.set(expr.raw, value);
     }

--- a/src/domain/expressions/expression_evaluation_service_test.ts
+++ b/src/domain/expressions/expression_evaluation_service_test.ts
@@ -18,7 +18,15 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { containsVaultExpression } from "./expression_evaluation_service.ts";
+import {
+  containsEnvExpression,
+  containsRuntimeExpression,
+  containsVaultExpression,
+} from "./expression_evaluation_service.ts";
+
+// ============================================================================
+// containsVaultExpression
+// ============================================================================
 
 Deno.test("containsVaultExpression returns true for vault-only expressions", () => {
   assertEquals(containsVaultExpression("vault.get(aws, myKey)"), true);
@@ -54,4 +62,67 @@ Deno.test("containsVaultExpression returns false for CEL-only expressions", () =
 Deno.test("containsVaultExpression returns false for vault-like but not vault.get", () => {
   assertEquals(containsVaultExpression("vault.name"), false);
   assertEquals(containsVaultExpression("vault_get(foo)"), false);
+});
+
+// ============================================================================
+// containsEnvExpression
+// ============================================================================
+
+Deno.test("containsEnvExpression returns true for env references", () => {
+  assertEquals(containsEnvExpression("env.FOO"), true);
+  assertEquals(containsEnvExpression("env.HOME"), true);
+  assertEquals(containsEnvExpression("env.AWS_REGION"), true);
+});
+
+Deno.test("containsEnvExpression returns true for mixed expressions with env", () => {
+  assertEquals(
+    containsEnvExpression("model.foo.input.name + env.SUFFIX"),
+    true,
+  );
+});
+
+Deno.test("containsEnvExpression returns false for non-env expressions", () => {
+  assertEquals(containsEnvExpression("vault.get(aws, key)"), false);
+  assertEquals(containsEnvExpression("model.x.input.name"), false);
+  assertEquals(containsEnvExpression("self.name"), false);
+  assertEquals(containsEnvExpression("inputs.param"), false);
+});
+
+Deno.test("containsEnvExpression returns false for env-like but not env.*", () => {
+  // "environment" should not match because \b word boundary prevents it
+  assertEquals(containsEnvExpression("environment.X"), false);
+  assertEquals(containsEnvExpression("myenv.FOO"), false);
+});
+
+// ============================================================================
+// containsRuntimeExpression
+// ============================================================================
+
+Deno.test("containsRuntimeExpression returns true for vault expressions", () => {
+  assertEquals(
+    containsRuntimeExpression("vault.get(aws, myKey)"),
+    true,
+  );
+});
+
+Deno.test("containsRuntimeExpression returns true for env expressions", () => {
+  assertEquals(containsRuntimeExpression("env.HOME"), true);
+});
+
+Deno.test("containsRuntimeExpression returns true for mixed vault+env", () => {
+  assertEquals(
+    containsRuntimeExpression(
+      'vault.get(main, key) + "-" + env.SUFFIX',
+    ),
+    true,
+  );
+});
+
+Deno.test("containsRuntimeExpression returns false for model/self/inputs", () => {
+  assertEquals(
+    containsRuntimeExpression("model.foo.input.name"),
+    false,
+  );
+  assertEquals(containsRuntimeExpression("self.name"), false);
+  assertEquals(containsRuntimeExpression("inputs.param"), false);
 });

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -178,6 +178,20 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
       );
     }
 
+    // Validate globalArguments against schema (after upgrade and runtime resolution)
+    if (modelDef.globalArguments) {
+      const globalArgsResult = modelDef.globalArguments.safeParse(
+        currentDefinition.globalArguments,
+      );
+      if (!globalArgsResult.success) {
+        throw new Error(
+          `Global arguments validation failed: ${
+            formatZodError(globalArgsResult.error)
+          }`,
+        );
+      }
+    }
+
     // Create writeResource and createFileWriter for this execution
     const definitionHash = await currentDefinition.computeHash();
     const resources = modelDef.resources ?? {};

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -919,3 +919,109 @@ Deno.test("execute passes logger in context to method", async () => {
   assertEquals(capturedLogger !== undefined, true);
   assertEquals(typeof (capturedLogger as { info: unknown }).info, "function");
 });
+
+// ---------- globalArguments Validation Tests ----------
+
+Deno.test("executeWorkflow - rejects invalid globalArguments after resolution", async () => {
+  const service = new DefaultMethodExecutionService();
+
+  const schema = z.object({
+    host: z.string(),
+    port: z.number(),
+  });
+
+  const model: ModelDefinition = {
+    type: ModelType.create("test/global-args-validation"),
+    version: "1",
+    globalArguments: schema,
+    methods: {
+      run: {
+        description: "Test method",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({}),
+      },
+    },
+  };
+
+  // Port is a string instead of a number — should fail validation
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: { host: "localhost", port: "not-a-number" },
+  });
+
+  const { context } = createTestContext({ modelType: model.type });
+  await assertRejects(
+    () => service.executeWorkflow(definition, model, "run", context),
+    Error,
+    "Global arguments validation failed",
+  );
+});
+
+Deno.test("executeWorkflow - passes with valid globalArguments", async () => {
+  const service = new DefaultMethodExecutionService();
+
+  const schema = z.object({
+    host: z.string(),
+    port: z.number(),
+  });
+
+  const model: ModelDefinition = {
+    type: ModelType.create("test/global-args-valid"),
+    version: "1",
+    globalArguments: schema,
+    methods: {
+      run: {
+        description: "Test method",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({}),
+      },
+    },
+  };
+
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: { host: "localhost", port: 5432 },
+  });
+
+  const { context } = createTestContext({ modelType: model.type });
+  const result = await service.executeWorkflow(
+    definition,
+    model,
+    "run",
+    context,
+  );
+  // Should succeed without error
+  assertEquals(result !== undefined, true);
+});
+
+Deno.test("executeWorkflow - skips validation when model has no globalArguments schema", async () => {
+  const service = new DefaultMethodExecutionService();
+
+  const model: ModelDefinition = {
+    type: ModelType.create("test/no-global-args"),
+    version: "1",
+    // No globalArguments schema
+    methods: {
+      run: {
+        description: "Test method",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({}),
+      },
+    },
+  };
+
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: { anything: "goes" },
+  });
+
+  const { context } = createTestContext({ modelType: model.type });
+  const result = await service.executeWorkflow(
+    definition,
+    model,
+    "run",
+    context,
+  );
+  // Should succeed without error
+  assertEquals(result !== undefined, true);
+});

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -48,7 +48,7 @@ import {
   replaceExpressions,
 } from "../expressions/expression_parser.ts";
 import {
-  containsVaultExpression,
+  containsRuntimeExpression,
   ExpressionEvaluationService,
 } from "../expressions/expression_evaluation_service.ts";
 import {
@@ -394,14 +394,15 @@ export class DefaultStepExecutor implements StepExecutor {
     const evaluatedDefRepo = new YamlEvaluatedDefinitionRepository(ctx.repoDir);
     await evaluatedDefRepo.save(modelType, evaluatedDefinition);
 
-    // Resolve vault expressions at runtime (never persisted)
+    // Resolve runtime expressions (vault and env) at runtime (never persisted)
     const evalService = new ExpressionEvaluationService(
       new YamlDefinitionRepository(ctx.repoDir),
       ctx.repoDir,
     );
-    evaluatedDefinition = await evalService.resolveVaultExpressionsInDefinition(
-      evaluatedDefinition,
-    );
+    evaluatedDefinition = await evalService
+      .resolveRuntimeExpressionsInDefinition(
+        evaluatedDefinition,
+      );
 
     // Validate method exists on the model
     const method = modelDef.methods[task.methodName];
@@ -628,10 +629,10 @@ export class DefaultStepExecutor implements StepExecutor {
       return definition;
     }
 
-    // Evaluate CEL-only expressions; skip vault-containing expressions
+    // Evaluate CEL-only expressions; skip runtime expressions (vault, env)
     const evaluatedValues = new Map<string, unknown>();
     for (const expr of expressions) {
-      if (containsVaultExpression(expr.celExpression)) {
+      if (containsRuntimeExpression(expr.celExpression)) {
         continue;
       }
 
@@ -1471,10 +1472,10 @@ export class WorkflowExecutionService {
       }
     }
 
-    // Evaluate CEL-only expressions; skip vault, self.*, and forEach.in expressions
+    // Evaluate CEL-only expressions; skip runtime (vault, env), self.*, and forEach.in expressions
     const evaluatedValues = new Map<string, unknown>();
     for (const expr of expressions) {
-      if (containsVaultExpression(expr.celExpression)) {
+      if (containsRuntimeExpression(expr.celExpression)) {
         continue;
       }
       // Skip self.* expressions — they reference forEach variables resolved at runtime


### PR DESCRIPTION
## Summary

Closes #323 and #329.

**Problem:** Environment variable expressions (`${{ env.* }}`) were resolved at persist time, unlike vault expressions which are deferred to runtime. This caused two issues:

1. **Secret leakage (#323):** Sensitive environment variables (e.g., `AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`) referenced via `${{ env.* }}` were resolved during expression evaluation and written as plaintext YAML to `.swamp/definitions-evaluated/` on disk.

2. **Schema validation bypass (#329):** When ANY field in a definition contained a CEL expression, validation of ALL static fields was completely skipped. Because env expressions were resolved at persist time but the validation gap existed, there was no point where a fully-resolved definition could be schema-validated.

**Fix:** Defer env expressions to runtime (matching vault behavior), then add runtime `globalArguments` schema validation after all expressions are resolved. This fixes both issues by design — at runtime, the definition is fully resolved and can be completely validated.

### What changes for users

- **Env expressions are no longer persisted as plaintext.** Evaluated definition files (`.swamp/definitions-evaluated/`) will now contain the raw `${{ env.HOST }}` template instead of the resolved value. This means sensitive env vars are never written to disk.
- **Runtime validation catches invalid globalArguments.** If a model's `globalArguments` schema requires `port` to be a number but the resolved value is a string, execution will now fail with a clear validation error instead of silently proceeding.
- **No breaking changes to workflow behavior.** Env expressions still resolve correctly — just at runtime instead of persist time. The resolved values are identical.

### Changes

- **Expression detection:** Added `containsEnvExpression()` and `containsRuntimeExpression()` as a unified check for vault OR env references
- **Persist-time skip:** Replaced `containsVaultExpression` with `containsRuntimeExpression` at all 7 persist-time skip checks across `expression_evaluation_service.ts`, `execution_service.ts`, and `workflow_evaluate.ts`
- **Runtime resolution:** Added `resolveRuntimeExpressionsInDefinition()` and `resolveRuntimeExpressionsInData()` that handle both vault AND env resolution in a single pass. Old `resolveVaultExpressionsIn*` methods kept as deprecated aliases for backward compatibility.
- **Schema validation:** Added `globalArguments` schema validation in `executeWorkflow()` after definition upgrade and runtime expression resolution
- **Tests:** Added unit tests for new detection functions and globalArguments validation. Updated 2 integration tests to verify env expressions are left raw at persist time and resolved at runtime.

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — no lint errors
- [x] `deno fmt` — formatting clean
- [x] `deno run test` — all 1697 tests pass (0 failures)
- [ ] Verify env expressions in definitions are not persisted as plaintext
- [ ] Verify models with invalid globalArguments after resolution are rejected

Co-authored-by: Magistr <umag@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)