### PR TITLE
fix: GC scanning now handles nested/namespaced model types

### DIFF
--- a/src/cli/commands/data_gc.ts
+++ b/src/cli/commands/data_gc.ts
@@ -58,7 +58,7 @@ export const dataGcCommand = new Command()
   .option("-f, --force", "Skip confirmation prompt")
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, ["data", "gc"]);
-    const { repoDir, repoContext } = await requireInitializedRepo({
+    const { repoContext } = await requireInitializedRepo({
       repoDir: options.repoDir ?? ".",
       outputMode: ctx.outputMode,
     });
@@ -66,7 +66,6 @@ export const dataGcCommand = new Command()
     const service = new DefaultDataLifecycleService(
       repoContext.unifiedDataRepo,
       repoContext.workflowRunRepo,
-      repoDir,
     );
 
     // If interactive and no force, prompt for confirmation

--- a/src/domain/data/data_lifecycle_service.ts
+++ b/src/domain/data/data_lifecycle_service.ts
@@ -17,16 +17,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { join } from "@std/path";
 import type { Data } from "./data.ts";
 import type { Lifetime } from "./data_metadata.ts";
-import {
-  SWAMP_SUBDIRS,
-  swampPath,
-} from "../../infrastructure/persistence/paths.ts";
 import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import type { WorkflowRunRepository } from "../workflows/repositories.ts";
-import { ModelType } from "../models/model_type.ts";
+import type { ModelType } from "../models/model_type.ts";
 import {
   createWorkflowId,
   createWorkflowRunId,
@@ -109,7 +104,6 @@ export class DefaultDataLifecycleService implements DataLifecycleService {
   constructor(
     private readonly dataRepo: UnifiedDataRepository,
     private readonly workflowRunRepo: WorkflowRunRepository,
-    private readonly repoDir: string,
   ) {}
 
   calculateExpiration(lifetime: Lifetime, createdAt: Date): Date | null {
@@ -180,75 +174,36 @@ export class DefaultDataLifecycleService implements DataLifecycleService {
 
   async findExpiredData(): Promise<ExpiredDataInfo[]> {
     const expired: ExpiredDataInfo[] = [];
-    const dataDir = swampPath(this.repoDir, SWAMP_SUBDIRS.data);
 
-    try {
-      // Scan model types
-      for await (const typeEntry of Deno.readDir(dataDir)) {
-        if (!typeEntry.isDirectory) continue;
-        const type = ModelType.create(typeEntry.name);
-
-        const typeDir = join(dataDir, type.toDirectoryPath());
-
-        // Scan model IDs
-        for await (const modelEntry of Deno.readDir(typeDir)) {
-          if (!modelEntry.isDirectory) continue;
-          const modelId = modelEntry.name;
-
-          const modelDir = join(typeDir, modelId);
-
-          // Scan data names
-          for await (const dataEntry of Deno.readDir(modelDir)) {
-            if (!dataEntry.isDirectory) continue;
-            const dataName = dataEntry.name;
-
-            // Load the latest version metadata
-            try {
-              const data = await this.dataRepo.findByName(
-                type,
-                modelId,
-                dataName,
-              );
-              if (!data) continue;
-
-              const isExpired = await this.isExpired(data);
-              if (isExpired) {
-                let reason: ExpiredDataInfo["reason"];
-                if (
-                  data.lifetime === "workflow" ||
-                  data.lifetime === "job"
-                ) {
-                  reason = data.lifetime === "workflow"
-                    ? "workflow-deleted"
-                    : "job-deleted";
-                } else {
-                  reason = "duration-expired";
-                }
-
-                expired.push({
-                  type,
-                  modelId,
-                  dataName,
-                  data,
-                  reason,
-                });
-              }
-            } catch (error) {
-              console.error(
-                `Error checking data ${type}/${modelId}/${dataName}:`,
-                error,
-              );
-              // Continue with other data
-            }
+    const allData = await this.dataRepo.findAllGlobal();
+    for (const { data, modelType, modelId } of allData) {
+      try {
+        const isExpired = await this.isExpired(data);
+        if (isExpired) {
+          let reason: ExpiredDataInfo["reason"];
+          if (data.lifetime === "workflow" || data.lifetime === "job") {
+            reason = data.lifetime === "workflow"
+              ? "workflow-deleted"
+              : "job-deleted";
+          } else {
+            reason = "duration-expired";
           }
+
+          expired.push({
+            type: modelType,
+            modelId,
+            dataName: data.name,
+            data,
+            reason,
+          });
         }
+      } catch (error) {
+        console.error(
+          `Error checking data ${modelType.toDirectoryPath()}/${modelId}/${data.name}:`,
+          error,
+        );
+        // Continue with other data
       }
-    } catch (error) {
-      if (error instanceof Deno.errors.NotFound) {
-        // Data directory doesn't exist yet
-        return [];
-      }
-      throw error;
     }
 
     return expired;
@@ -291,35 +246,25 @@ export class DefaultDataLifecycleService implements DataLifecycleService {
     // Now run version-based garbage collection on all models
     // This hard-deletes old versions based on garbageCollection policy
     if (!dryRun) {
-      const dataDir = swampPath(this.repoDir, SWAMP_SUBDIRS.data);
-      try {
-        for await (const typeEntry of Deno.readDir(dataDir)) {
-          if (!typeEntry.isDirectory) continue;
-          const type = ModelType.create(typeEntry.name);
-          const typeDir = join(dataDir, type.toDirectoryPath());
+      const allData = await this.dataRepo.findAllGlobal();
+      const seen = new Set<string>();
+      for (const { modelType, modelId } of allData) {
+        const key = `${modelType.toDirectoryPath()}/${modelId}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
 
-          for await (const modelEntry of Deno.readDir(typeDir)) {
-            if (!modelEntry.isDirectory) continue;
-            const modelId = modelEntry.name;
-
-            try {
-              const result = await this.dataRepo.collectGarbage(
-                type,
-                modelId,
-              );
-              versionsDeleted += result.versionsRemoved;
-              bytesReclaimed += result.bytesReclaimed;
-            } catch (error) {
-              console.error(
-                `Error running GC on ${type.toDirectoryPath()}/${modelId}:`,
-                error,
-              );
-            }
-          }
-        }
-      } catch (error) {
-        if (!(error instanceof Deno.errors.NotFound)) {
-          console.error("Error during version GC:", error);
+        try {
+          const result = await this.dataRepo.collectGarbage(
+            modelType,
+            modelId,
+          );
+          versionsDeleted += result.versionsRemoved;
+          bytesReclaimed += result.bytesReclaimed;
+        } catch (error) {
+          console.error(
+            `Error running GC on ${modelType.toDirectoryPath()}/${modelId}:`,
+            error,
+          );
         }
       }
     }

--- a/src/domain/data/data_lifecycle_service_test.ts
+++ b/src/domain/data/data_lifecycle_service_test.ts
@@ -19,10 +19,15 @@
 
 import { assertEquals } from "@std/assert";
 import { DefaultDataLifecycleService } from "./data_lifecycle_service.ts";
+import { Data } from "./data.ts";
+import { ModelType } from "../models/model_type.ts";
 
 // Mock repositories for testing
 class MockDataRepository {
   findByName = () => Promise.resolve(null);
+  findAllGlobal: () => Promise<
+    Array<{ data: Data; modelType: ModelType; modelId: string }>
+  > = () => Promise.resolve([]);
   listVersions = () => Promise.resolve([]);
   removeLatestSymlink = () => Promise.resolve();
   collectGarbage = () =>
@@ -37,7 +42,6 @@ Deno.test("calculateExpiration - returns null for infinite lifetime", () => {
   const service = new DefaultDataLifecycleService(
     new MockDataRepository() as never,
     new MockWorkflowRunRepository() as never,
-    "/tmp/test",
   );
 
   const createdAt = new Date("2025-01-01T00:00:00Z");
@@ -50,7 +54,6 @@ Deno.test("calculateExpiration - returns null for ephemeral lifetime", () => {
   const service = new DefaultDataLifecycleService(
     new MockDataRepository() as never,
     new MockWorkflowRunRepository() as never,
-    "/tmp/test",
   );
 
   const createdAt = new Date("2025-01-01T00:00:00Z");
@@ -63,7 +66,6 @@ Deno.test("calculateExpiration - returns null for workflow lifetime", () => {
   const service = new DefaultDataLifecycleService(
     new MockDataRepository() as never,
     new MockWorkflowRunRepository() as never,
-    "/tmp/test",
   );
 
   const createdAt = new Date("2025-01-01T00:00:00Z");
@@ -76,7 +78,6 @@ Deno.test("calculateExpiration - returns null for job lifetime", () => {
   const service = new DefaultDataLifecycleService(
     new MockDataRepository() as never,
     new MockWorkflowRunRepository() as never,
-    "/tmp/test",
   );
 
   const createdAt = new Date("2025-01-01T00:00:00Z");
@@ -89,7 +90,6 @@ Deno.test("calculateExpiration - calculates expiration for 1h duration", () => {
   const service = new DefaultDataLifecycleService(
     new MockDataRepository() as never,
     new MockWorkflowRunRepository() as never,
-    "/tmp/test",
   );
 
   const createdAt = new Date("2025-01-01T00:00:00Z");
@@ -102,7 +102,6 @@ Deno.test("calculateExpiration - calculates expiration for 5m duration", () => {
   const service = new DefaultDataLifecycleService(
     new MockDataRepository() as never,
     new MockWorkflowRunRepository() as never,
-    "/tmp/test",
   );
 
   const createdAt = new Date("2025-01-01T00:00:00Z");
@@ -115,7 +114,6 @@ Deno.test("calculateExpiration - calculates expiration for 10d duration", () => 
   const service = new DefaultDataLifecycleService(
     new MockDataRepository() as never,
     new MockWorkflowRunRepository() as never,
-    "/tmp/test",
   );
 
   const createdAt = new Date("2025-01-01T00:00:00Z");
@@ -128,7 +126,6 @@ Deno.test("calculateExpiration - calculates expiration for 2w duration", () => {
   const service = new DefaultDataLifecycleService(
     new MockDataRepository() as never,
     new MockWorkflowRunRepository() as never,
-    "/tmp/test",
   );
 
   const createdAt = new Date("2025-01-01T00:00:00Z");
@@ -141,7 +138,6 @@ Deno.test("calculateExpiration - calculates expiration for 1mo duration", () => 
   const service = new DefaultDataLifecycleService(
     new MockDataRepository() as never,
     new MockWorkflowRunRepository() as never,
-    "/tmp/test",
   );
 
   const createdAt = new Date("2025-01-01T00:00:00Z");
@@ -158,7 +154,6 @@ Deno.test("calculateExpiration - calculates expiration for 1y duration", () => {
   const service = new DefaultDataLifecycleService(
     new MockDataRepository() as never,
     new MockWorkflowRunRepository() as never,
-    "/tmp/test",
   );
 
   const createdAt = new Date("2025-01-01T00:00:00Z");
@@ -169,4 +164,108 @@ Deno.test("calculateExpiration - calculates expiration for 1y duration", () => {
     createdAt.getTime() + 365 * 24 * 60 * 60 * 1000,
   );
   assertEquals(expiration, expected);
+});
+
+function createMockData(overrides: {
+  name: string;
+  lifetime?: string;
+  createdAt?: Date;
+}): Data {
+  return Data.create({
+    name: overrides.name,
+    contentType: "application/json",
+    lifetime: overrides.lifetime ?? "1h",
+    garbageCollection: 5,
+    tags: { type: "test" },
+    ownerDefinition: { ownerType: "model-method", ownerRef: "test-ref" },
+    createdAt: overrides.createdAt ?? new Date("2020-01-01T00:00:00Z"),
+  });
+}
+
+Deno.test("findExpiredData - finds expired data for nested model types", async () => {
+  const mockRepo = new MockDataRepository();
+  const expiredData = createMockData({ name: "vpc-data" });
+  const nestedType = ModelType.create("aws/ec2/vpc");
+
+  mockRepo.findAllGlobal = () =>
+    Promise.resolve([
+      { data: expiredData, modelType: nestedType, modelId: "my-vpc" },
+    ]);
+
+  const service = new DefaultDataLifecycleService(
+    mockRepo as never,
+    new MockWorkflowRunRepository() as never,
+  );
+
+  const expired = await service.findExpiredData();
+
+  assertEquals(expired.length, 1);
+  assertEquals(expired[0].type, nestedType);
+  assertEquals(expired[0].modelId, "my-vpc");
+  assertEquals(expired[0].dataName, "vpc-data");
+  assertEquals(expired[0].reason, "duration-expired");
+});
+
+Deno.test("findExpiredData - finds expired data for two-level nested type", async () => {
+  const mockRepo = new MockDataRepository();
+  const expiredData = createMockData({ name: "shell-output" });
+  const nestedType = ModelType.create("command/shell");
+
+  mockRepo.findAllGlobal = () =>
+    Promise.resolve([
+      {
+        data: expiredData,
+        modelType: nestedType,
+        modelId: "my-shell",
+      },
+    ]);
+
+  const service = new DefaultDataLifecycleService(
+    mockRepo as never,
+    new MockWorkflowRunRepository() as never,
+  );
+
+  const expired = await service.findExpiredData();
+
+  assertEquals(expired.length, 1);
+  assertEquals(expired[0].type.toDirectoryPath(), "command/shell");
+  assertEquals(expired[0].modelId, "my-shell");
+});
+
+Deno.test("findExpiredData - skips non-expired data", async () => {
+  const mockRepo = new MockDataRepository();
+  const freshData = createMockData({
+    name: "fresh",
+    lifetime: "infinite",
+  });
+
+  mockRepo.findAllGlobal = () =>
+    Promise.resolve([
+      {
+        data: freshData,
+        modelType: ModelType.create("test"),
+        modelId: "m1",
+      },
+    ]);
+
+  const service = new DefaultDataLifecycleService(
+    mockRepo as never,
+    new MockWorkflowRunRepository() as never,
+  );
+
+  const expired = await service.findExpiredData();
+  assertEquals(expired.length, 0);
+});
+
+Deno.test("findExpiredData - returns empty array when no data exists", async () => {
+  const mockRepo = new MockDataRepository();
+  mockRepo.findAllGlobal = () => Promise.resolve([]);
+
+  const service = new DefaultDataLifecycleService(
+    mockRepo as never,
+    new MockWorkflowRunRepository() as never,
+  );
+
+  const expired = await service.findExpiredData();
+  assertEquals(expired.length, 0);
 });


### PR DESCRIPTION
## Summary

Fixes #330.

Garbage collection (`swamp data gc`) was silently failing to find and clean up
expired data for any model with a nested or namespaced type — including built-in
types like `command/shell` and user-defined types like `aws/ec2/vpc` or
`@docker/host`.

The root cause was that `DefaultDataLifecycleService.findExpiredData()` and the
version GC loop in `deleteExpiredData()` both scanned `.swamp/data/` using a
flat 3-level `readDir()` loop (`type → modelId → dataName`). For a type like
`command/shell`, the scanner would read `command` as the full type and `shell`
as a model ID, producing completely wrong lookups. Expired data for all
nested/namespaced types was never garbage collected.

## What changed

- **`findExpiredData()`** — replaced the manual 3-level directory scan with a
  call to the repository's `findAllGlobal()` method, which already correctly
  handles arbitrary nesting depth using recursive directory walking with
  `isModelIdDirectory()` detection.
- **`deleteExpiredData()` version GC loop** — replaced the second manual
  directory scan with unique type+modelId pairs derived from `findAllGlobal()`.
- **Removed `repoDir` constructor parameter** from `DefaultDataLifecycleService`
  since the service no longer does its own filesystem path construction.
- **Removed unused imports** (`join`, `SWAMP_SUBDIRS`, `swampPath`) and changed
  `ModelType` to a type-only import.
- **Added tests** for `findExpiredData` covering nested types (`aws/ec2/vpc`,
  `command/shell`), non-expired data, and empty repositories.

## What this means for users

If you use models with nested types (like `command/shell`, custom extension
models under namespaces like `aws/ec2/vpc`, or scoped types like
`@docker/host`), `swamp data gc` will now correctly identify and clean up
expired data and old versions for those models. Previously this data would
accumulate indefinitely regardless of lifetime or garbage collection policies.

## Files changed

| File | Change |
|------|--------|
| `src/domain/data/data_lifecycle_service.ts` | Replace manual dir scanning with `findAllGlobal()`, remove `repoDir` param |
| `src/cli/commands/data_gc.ts` | Remove `repoDir` from constructor call |
| `src/domain/data/data_lifecycle_service_test.ts` | Add `findAllGlobal` to mock, add nested type tests |

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — no lint errors
- [x] `deno fmt` — formatting correct
- [x] `deno run test` — all 1701 tests pass
- [x] `deno run compile` — binary compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)