### PR TITLE
feat: Add multi-tool support (Claude, Cursor, OpenCode, Codex)

### DIFF
--- a/src/cli/commands/repo_init.ts
+++ b/src/cli/commands/repo_init.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { Command } from "@cliffy/command";
+import { Command, EnumType } from "@cliffy/command";
 import {
   renderRepoInit,
   renderRepoUpgrade,
@@ -26,12 +26,14 @@ import {
 } from "../../presentation/output/repo_output.ts";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
-import { RepoService } from "../../domain/repo/repo_service.ts";
+import { type AiTool, RepoService } from "../../domain/repo/repo_service.ts";
 import { VERSION } from "./version.ts";
 import { repoIndexCommand } from "./repo_index.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
+
+const aiToolType = new EnumType(["claude", "cursor", "opencode", "codex"]);
 
 // Exported for reuse by repoCommand default action
 export async function repoInitAction(
@@ -43,8 +45,9 @@ export async function repoInitAction(
 
   const repoPath = RepoPath.create(pathArg ?? ".");
   const service = new RepoService(VERSION);
+  const tool = (options.tool as AiTool) ?? "claude";
 
-  const result = await service.init(repoPath, { force: options.force });
+  const result = await service.init(repoPath, { force: options.force, tool });
 
   ctx.logger.debug`Repository initialized: ${result.path}`;
 
@@ -53,9 +56,10 @@ export async function repoInitAction(
     version: result.version,
     initializedAt: result.initializedAt,
     skillsCopied: result.skillsCopied,
-    claudeMdCreated: result.claudeMdCreated,
-    claudeSettingsCreated: result.claudeSettingsCreated,
+    instructionsFileCreated: result.instructionsFileCreated,
+    settingsCreated: result.settingsCreated,
     gitignoreCreated: result.gitignoreCreated,
+    tool: result.tool,
   };
 
   renderRepoInit(data, ctx.outputMode);
@@ -66,19 +70,31 @@ export const repoInitCommand = new Command()
   .description("Initialize a new swamp repository")
   .arguments("[path:string]")
   .option("-f, --force", "Reinitialize if already exists")
+  .type("aiTool", aiToolType)
+  .option(
+    "-t, --tool <tool:aiTool>",
+    "AI coding tool to configure for (claude, cursor, opencode, codex)",
+    { default: "claude" },
+  )
   .action(repoInitAction);
 
 export const repoUpgradeCommand = new Command()
   .description("Upgrade an existing swamp repository")
   .arguments("[path:string]")
+  .type("aiTool", aiToolType)
+  .option(
+    "-t, --tool <tool:aiTool>",
+    "Switch to a different AI coding tool",
+  )
   .action(async function (options: AnyOptions, pathArg?: string) {
     const ctx = createContext(options as GlobalOptions, ["repo", "upgrade"]);
     ctx.logger.debug`Upgrading repository at: ${pathArg ?? "."}`;
 
     const repoPath = RepoPath.create(pathArg ?? ".");
     const service = new RepoService(VERSION);
+    const tool = options.tool as AiTool | undefined;
 
-    const result = await service.upgrade(repoPath);
+    const result = await service.upgrade(repoPath, { tool });
 
     ctx.logger.debug`Repository upgraded: ${result.path}`;
 
@@ -88,7 +104,8 @@ export const repoUpgradeCommand = new Command()
       newVersion: result.newVersion,
       upgradedAt: result.upgradedAt,
       skillsUpdated: result.skillsUpdated,
-      claudeSettingsUpdated: result.claudeSettingsUpdated,
+      settingsUpdated: result.settingsUpdated,
+      tool: result.tool,
     };
 
     renderRepoUpgrade(data, ctx.outputMode);
@@ -100,6 +117,12 @@ export const repoCommand = new Command()
   .description("Initialize a swamp repository (or manage existing ones)")
   .arguments("[path:string]")
   .option("-f, --force", "Reinitialize if already exists")
+  .type("aiTool", aiToolType)
+  .option(
+    "-t, --tool <tool:aiTool>",
+    "AI coding tool to configure for (claude, cursor, opencode, codex)",
+    { default: "claude" },
+  )
   .action(repoInitAction)
   .command(
     "init",
@@ -108,6 +131,12 @@ export const repoCommand = new Command()
       .hidden()
       .arguments("[path:string]")
       .option("-f, --force", "Reinitialize if already exists")
+      .type("aiTool", aiToolType)
+      .option(
+        "-t, --tool <tool:aiTool>",
+        "AI coding tool to configure for (claude, cursor, opencode, codex)",
+        { default: "claude" },
+      )
       .action(repoInitAction),
   )
   .command("upgrade", repoUpgradeCommand)

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -27,14 +27,37 @@ import {
 } from "../../infrastructure/persistence/paths.ts";
 import { SwampVersion } from "./swamp_version.ts";
 import {
+  type AiTool,
   type RepoMarkerData,
   RepoMarkerRepository,
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { SkillAssets } from "../../infrastructure/assets/skill_assets.ts";
 import { UserError } from "../errors.ts";
 
-const CLAUDE_MD_FILENAME = "CLAUDE.md";
+export type { AiTool } from "../../infrastructure/persistence/repo_marker_repository.ts";
+
 const GITIGNORE_FILENAME = ".gitignore";
+
+const SKILL_DIRS: Record<AiTool, string> = {
+  claude: ".claude/skills",
+  cursor: ".cursor/skills",
+  opencode: ".agents/skills",
+  codex: ".agents/skills",
+};
+
+const INSTRUCTIONS_FILES: Record<AiTool, string> = {
+  claude: "CLAUDE.md",
+  cursor: ".cursor/rules/swamp.mdc",
+  opencode: "AGENTS.md",
+  codex: "AGENTS.md",
+};
+
+const GITIGNORE_TOOL_ENTRIES: Record<AiTool, string> = {
+  claude: "# Claude Code configuration (managed by swamp)\n.claude/",
+  cursor: "# Cursor skills (managed by swamp)\n.cursor/skills/",
+  opencode: "# Agent skills (managed by swamp)\n.agents/skills/",
+  codex: "# Agent skills (managed by swamp)\n.agents/skills/",
+};
 
 /**
  * Result of a repository initialization operation.
@@ -44,9 +67,10 @@ export interface RepoInitResult {
   version: string;
   initializedAt: string;
   skillsCopied: string[];
-  claudeMdCreated: boolean;
-  claudeSettingsCreated: boolean;
+  instructionsFileCreated: boolean;
+  settingsCreated: boolean;
   gitignoreCreated: boolean;
+  tool: AiTool;
 }
 
 /**
@@ -58,7 +82,8 @@ export interface RepoUpgradeResult {
   newVersion: string;
   upgradedAt: string;
   skillsUpdated: string[];
-  claudeSettingsUpdated: boolean;
+  settingsUpdated: boolean;
+  tool: AiTool;
 }
 
 /**
@@ -66,6 +91,14 @@ export interface RepoUpgradeResult {
  */
 export interface RepoInitOptions {
   force?: boolean;
+  tool?: AiTool;
+}
+
+/**
+ * Options for upgrade.
+ */
+export interface RepoUpgradeOptions {
+  tool?: AiTool;
 }
 
 /**
@@ -100,6 +133,7 @@ export class RepoService {
     repoPath: RepoPath,
     options: RepoInitOptions = {},
   ): Promise<RepoInitResult> {
+    const tool = options.tool ?? "claude";
     const isAlreadyInit = await this.isInitialized(repoPath);
 
     if (isAlreadyInit && !options.force) {
@@ -111,37 +145,44 @@ export class RepoService {
     // Ensure the directory exists
     await ensureDir(repoPath.value);
 
-    // Create marker file
+    // Create marker file with tool choice
     const markerData = this.markerRepo.createInitMarker(this.currentVersion);
+    markerData.tool = tool;
     await this.markerRepo.write(repoPath, markerData);
 
     // Create data directory structure
     await this.createDataDirectoryStructure(repoPath);
 
-    // Copy skills
-    const skillsDir = join(repoPath.value, ".claude", "skills");
+    // Copy skills to tool-appropriate directory
+    const skillsDir = join(repoPath.value, SKILL_DIRS[tool]);
     await this.skillAssets.copySkillsTo(skillsDir);
     const skillsCopied = this.skillAssets.getSkillNames();
 
-    // Create CLAUDE.md if it doesn't exist
-    const claudeMdCreated = await this.createClaudeMdIfNotExists(repoPath);
+    // Create instructions file if it doesn't exist
+    const instructionsFileCreated = await this
+      .createInstructionsFileIfNotExists(repoPath, tool);
 
-    // Create Claude settings.local.json if it doesn't exist
-    const claudeSettingsCreated = await this.createClaudeSettingsIfNotExists(
-      repoPath,
-    );
+    // Create Claude settings.local.json only for Claude
+    let settingsCreated = false;
+    if (tool === "claude") {
+      settingsCreated = await this.createClaudeSettingsIfNotExists(repoPath);
+    }
 
     // Create .gitignore if it doesn't exist
-    const gitignoreCreated = await this.createGitignoreIfNotExists(repoPath);
+    const gitignoreCreated = await this.createGitignoreIfNotExists(
+      repoPath,
+      tool,
+    );
 
     return {
       path: repoPath.value,
       version: this.currentVersion.toString(),
       initializedAt: markerData.initializedAt,
       skillsCopied,
-      claudeMdCreated,
-      claudeSettingsCreated,
+      instructionsFileCreated,
+      settingsCreated,
       gitignoreCreated,
+      tool,
     };
   }
 
@@ -149,9 +190,13 @@ export class RepoService {
    * Upgrades an existing swamp repository.
    *
    * @param repoPath - The path to upgrade
+   * @param options - Upgrade options
    * @throws Error if not initialized
    */
-  async upgrade(repoPath: RepoPath): Promise<RepoUpgradeResult> {
+  async upgrade(
+    repoPath: RepoPath,
+    options: RepoUpgradeOptions = {},
+  ): Promise<RepoUpgradeResult> {
     const existingMarker = await this.markerRepo.read(repoPath);
 
     if (!existingMarker) {
@@ -160,22 +205,31 @@ export class RepoService {
       );
     }
 
+    // Determine tool: CLI override > stored marker > default "claude"
+    const tool = options.tool ?? existingMarker.tool ?? "claude";
     const previousVersion = existingMarker.swampVersion;
 
-    // Update marker with new version
+    // Update marker with new version and tool
     const updatedMarker = this.markerRepo.createUpgradeMarker(
       existingMarker,
       this.currentVersion,
     );
+    updatedMarker.tool = tool;
     await this.markerRepo.write(repoPath, updatedMarker);
 
-    // Update skills
-    const skillsDir = join(repoPath.value, ".claude", "skills");
+    // Update skills in tool-appropriate directory
+    const skillsDir = join(repoPath.value, SKILL_DIRS[tool]);
     await this.skillAssets.copySkillsTo(skillsDir);
     const skillsUpdated = this.skillAssets.getSkillNames();
 
-    // Update Claude settings.local.json (merge new permissions)
-    const claudeSettingsUpdated = await this.updateClaudeSettings(repoPath);
+    // Create instructions file if it doesn't exist (e.g., when switching tools)
+    await this.createInstructionsFileIfNotExists(repoPath, tool);
+
+    // Update Claude settings only for Claude tool
+    let settingsUpdated = false;
+    if (tool === "claude") {
+      settingsUpdated = await this.updateClaudeSettings(repoPath);
+    }
 
     // createUpgradeMarker always sets upgradedAt, but TypeScript doesn't know this
     if (!updatedMarker.upgradedAt) {
@@ -190,7 +244,8 @@ export class RepoService {
       newVersion: this.currentVersion.toString(),
       upgradedAt: updatedMarker.upgradedAt,
       skillsUpdated,
-      claudeSettingsUpdated,
+      settingsUpdated,
+      tool,
     };
   }
 
@@ -202,22 +257,26 @@ export class RepoService {
   }
 
   /**
-   * Creates CLAUDE.md if it doesn't already exist.
+   * Creates the tool-appropriate instructions file if it doesn't already exist.
    */
-  private async createClaudeMdIfNotExists(
+  private async createInstructionsFileIfNotExists(
     repoPath: RepoPath,
+    tool: AiTool,
   ): Promise<boolean> {
-    const claudeMdPath = join(repoPath.value, CLAUDE_MD_FILENAME);
+    const filePath = join(repoPath.value, INSTRUCTIONS_FILES[tool]);
 
     try {
-      await Deno.stat(claudeMdPath);
+      await Deno.stat(filePath);
       // File exists, don't overwrite
       return false;
     } catch (error) {
       if (error instanceof Deno.errors.NotFound) {
-        // Create the file
-        const content = this.generateClaudeMdContent();
-        await Deno.writeTextFile(claudeMdPath, content);
+        // Ensure parent directory exists (for cursor: .cursor/rules/)
+        const parentDir = join(filePath, "..");
+        await ensureDir(parentDir);
+
+        const content = this.generateInstructionsContent(tool);
+        await Deno.writeTextFile(filePath, content);
         return true;
       }
       throw error;
@@ -225,10 +284,10 @@ export class RepoService {
   }
 
   /**
-   * Generates the content for CLAUDE.md.
+   * Generates the instructions content for the given tool.
    */
-  private generateClaudeMdContent(): string {
-    return `# Project
+  private generateInstructionsContent(tool: AiTool): string {
+    const body = `# Project
 
 This repository is managed with [swamp](https://github.com/systeminit/swamp).
 
@@ -262,6 +321,16 @@ Always start by using the \`swamp-model\` skill to work with swamp models.
 
 Use \`swamp --help\` to see available commands.
 `;
+
+    if (tool === "cursor") {
+      return `---
+description: Swamp automation rules
+alwaysApply: true
+---
+${body}`;
+    }
+
+    return body;
   }
 
   /**
@@ -269,6 +338,7 @@ Use \`swamp --help\` to see available commands.
    */
   private async createGitignoreIfNotExists(
     repoPath: RepoPath,
+    tool: AiTool,
   ): Promise<boolean> {
     const gitignorePath = join(repoPath.value, GITIGNORE_FILENAME);
 
@@ -279,7 +349,7 @@ Use \`swamp --help\` to see available commands.
     } catch (error) {
       if (error instanceof Deno.errors.NotFound) {
         // Create the file
-        const content = this.generateGitignoreContent();
+        const content = this.generateGitignoreContent(tool);
         await Deno.writeTextFile(gitignorePath, content);
         return true;
       }
@@ -290,7 +360,7 @@ Use \`swamp --help\` to see available commands.
   /**
    * Generates the content for .gitignore.
    */
-  private generateGitignoreContent(): string {
+  private generateGitignoreContent(tool: AiTool): string {
     return `# Swamp managed defaults
 # Feel free to modify this file to suit your needs
 
@@ -300,8 +370,7 @@ Use \`swamp --help\` to see available commands.
 # Encryption keyfile (NEVER commit - allows decrypting secrets)
 .swamp/secrets/keyfile
 
-# Claude Code configuration (managed by swamp)
-.claude/
+${GITIGNORE_TOOL_ENTRIES[tool]}
 `;
   }
 

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -21,6 +21,7 @@ import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import { join } from "@std/path";
 import { RepoService } from "./repo_service.ts";
 import { RepoPath } from "./repo_path.ts";
+import type { AiTool } from "../../infrastructure/persistence/repo_marker_repository.ts";
 
 // Helper to create a temp directory for testing
 async function withTempDir(
@@ -43,6 +44,7 @@ Deno.test("RepoService.init creates marker file", async () => {
 
     assertEquals(result.version, "0.1.0");
     assertEquals(result.path, tempDir);
+    assertEquals(result.tool, "claude");
 
     // Check marker file exists
     const markerPath = join(tempDir, ".swamp.yaml");
@@ -51,14 +53,14 @@ Deno.test("RepoService.init creates marker file", async () => {
   });
 });
 
-Deno.test("RepoService.init creates CLAUDE.md", async () => {
+Deno.test("RepoService.init creates CLAUDE.md by default", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
     const result = await service.init(repoPath);
 
-    assertEquals(result.claudeMdCreated, true);
+    assertEquals(result.instructionsFileCreated, true);
 
     // Check CLAUDE.md exists
     const claudeMdPath = join(tempDir, "CLAUDE.md");
@@ -78,7 +80,7 @@ Deno.test("RepoService.init does not overwrite existing CLAUDE.md", async () => 
 
     const result = await service.init(repoPath);
 
-    assertEquals(result.claudeMdCreated, false);
+    assertEquals(result.instructionsFileCreated, false);
 
     // Check content is unchanged
     const content = await Deno.readTextFile(claudeMdPath);
@@ -253,14 +255,14 @@ Deno.test("RepoService.getMarker returns data after init", async () => {
   });
 });
 
-Deno.test("RepoService.init creates settings.local.json", async () => {
+Deno.test("RepoService.init creates settings.local.json for claude", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
     const result = await service.init(repoPath);
 
-    assertEquals(result.claudeSettingsCreated, true);
+    assertEquals(result.settingsCreated, true);
 
     // Check settings.local.json exists and has expected content
     const settingsPath = join(tempDir, ".claude", "settings.local.json");
@@ -294,7 +296,7 @@ Deno.test("RepoService.init does not overwrite existing settings.local.json", as
 
     const result = await service.init(repoPath);
 
-    assertEquals(result.claudeSettingsCreated, false);
+    assertEquals(result.settingsCreated, false);
 
     // Check content is unchanged
     const content = await Deno.readTextFile(settingsPath);
@@ -326,7 +328,7 @@ Deno.test("RepoService.upgrade merges new permissions into existing settings", a
     const newService = new RepoService("0.2.0");
     const result = await newService.upgrade(repoPath);
 
-    assertEquals(result.claudeSettingsUpdated, true);
+    assertEquals(result.settingsUpdated, true);
 
     // Check that custom permission is preserved and new ones are added
     const content = await Deno.readTextFile(settingsPath);
@@ -360,7 +362,7 @@ Deno.test("RepoService.upgrade creates settings if they do not exist", async () 
     const newService = new RepoService("0.2.0");
     const result = await newService.upgrade(repoPath);
 
-    assertEquals(result.claudeSettingsUpdated, true);
+    assertEquals(result.settingsUpdated, true);
 
     // Check settings created
     const content = await Deno.readTextFile(settingsPath);
@@ -380,7 +382,7 @@ Deno.test("RepoService.upgrade returns false if settings unchanged", async () =>
     const newService = new RepoService("0.2.0");
     const result = await newService.upgrade(repoPath);
 
-    assertEquals(result.claudeSettingsUpdated, false);
+    assertEquals(result.settingsUpdated, false);
   });
 });
 
@@ -465,4 +467,307 @@ Deno.test("RepoService.init with force does not overwrite existing .gitignore", 
     const content = await Deno.readTextFile(gitignorePath);
     assertEquals(content, "# Custom gitignore\nmy-custom-file.txt\n");
   });
+});
+
+// Multi-tool tests
+
+Deno.test("RepoService.init with cursor creates .cursor/skills/ and .cursor/rules/swamp.mdc", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    const result = await service.init(repoPath, { tool: "cursor" });
+
+    assertEquals(result.tool, "cursor");
+    assertEquals(result.instructionsFileCreated, true);
+    assertEquals(result.settingsCreated, false);
+
+    // Check skills copied to .cursor/skills/
+    const skillsDir = join(tempDir, ".cursor", "skills");
+    const stat = await Deno.stat(skillsDir);
+    assertEquals(stat.isDirectory, true);
+
+    // Check instructions file is .cursor/rules/swamp.mdc with MDC frontmatter
+    const mdcPath = join(tempDir, ".cursor", "rules", "swamp.mdc");
+    const content = await Deno.readTextFile(mdcPath);
+    assertStringIncludes(content, "alwaysApply: true");
+    assertStringIncludes(content, "swamp");
+    assertStringIncludes(content, "## Skills");
+
+    // Check .gitignore has cursor-specific entries
+    const gitignorePath = join(tempDir, ".gitignore");
+    const gitignoreContent = await Deno.readTextFile(gitignorePath);
+    assertStringIncludes(gitignoreContent, ".cursor/skills/");
+
+    // Check no .claude/ settings created
+    const claudeSettingsPath = join(
+      tempDir,
+      ".claude",
+      "settings.local.json",
+    );
+    let settingsExist = false;
+    try {
+      await Deno.stat(claudeSettingsPath);
+      settingsExist = true;
+    } catch {
+      // expected
+    }
+    assertEquals(settingsExist, false);
+  });
+});
+
+Deno.test("RepoService.init with opencode creates .agents/skills/ and AGENTS.md", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    const result = await service.init(repoPath, { tool: "opencode" });
+
+    assertEquals(result.tool, "opencode");
+    assertEquals(result.instructionsFileCreated, true);
+    assertEquals(result.settingsCreated, false);
+
+    // Check skills copied to .agents/skills/
+    const skillsDir = join(tempDir, ".agents", "skills");
+    const stat = await Deno.stat(skillsDir);
+    assertEquals(stat.isDirectory, true);
+
+    // Check AGENTS.md created
+    const agentsMdPath = join(tempDir, "AGENTS.md");
+    const content = await Deno.readTextFile(agentsMdPath);
+    assertStringIncludes(content, "swamp");
+    assertStringIncludes(content, "## Skills");
+
+    // Check .gitignore has agents-specific entries
+    const gitignorePath = join(tempDir, ".gitignore");
+    const gitignoreContent = await Deno.readTextFile(gitignorePath);
+    assertStringIncludes(gitignoreContent, ".agents/skills/");
+  });
+});
+
+Deno.test("RepoService.init with codex creates .agents/skills/ and AGENTS.md", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    const result = await service.init(repoPath, { tool: "codex" });
+
+    assertEquals(result.tool, "codex");
+    assertEquals(result.instructionsFileCreated, true);
+    assertEquals(result.settingsCreated, false);
+
+    // Check skills copied to .agents/skills/
+    const skillsDir = join(tempDir, ".agents", "skills");
+    const stat = await Deno.stat(skillsDir);
+    assertEquals(stat.isDirectory, true);
+
+    // Check AGENTS.md created
+    const agentsMdPath = join(tempDir, "AGENTS.md");
+    const content = await Deno.readTextFile(agentsMdPath);
+    assertStringIncludes(content, "swamp");
+
+    // Check .gitignore has agents-specific entries
+    const gitignorePath = join(tempDir, ".gitignore");
+    const gitignoreContent = await Deno.readTextFile(gitignorePath);
+    assertStringIncludes(gitignoreContent, ".agents/skills/");
+  });
+});
+
+Deno.test("RepoService.init stores tool in marker", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath, { tool: "cursor" });
+
+    const marker = await service.getMarker(repoPath);
+    assertEquals(marker!.tool, "cursor");
+  });
+});
+
+Deno.test("RepoService.upgrade reads tool from marker", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    // Init with cursor
+    await service.init(repoPath, { tool: "cursor" });
+
+    // Upgrade without specifying tool
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath);
+
+    assertEquals(result.tool, "cursor");
+
+    // Verify skills updated in cursor dir
+    const skillsDir = join(tempDir, ".cursor", "skills");
+    const stat = await Deno.stat(skillsDir);
+    assertEquals(stat.isDirectory, true);
+  });
+});
+
+Deno.test("RepoService.upgrade allows switching tool via --tool", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    // Init with claude (default)
+    await service.init(repoPath);
+
+    // Upgrade with tool switch to cursor
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath, { tool: "cursor" });
+
+    assertEquals(result.tool, "cursor");
+
+    // Verify skills exist in cursor dir
+    const skillsDir = join(tempDir, ".cursor", "skills");
+    const stat = await Deno.stat(skillsDir);
+    assertEquals(stat.isDirectory, true);
+
+    // Verify marker updated with new tool
+    const marker = await upgradeService.getMarker(repoPath);
+    assertEquals(marker!.tool, "cursor");
+
+    // Verify instructions file created for cursor
+    const instructionsPath = join(tempDir, ".cursor", "rules", "swamp.mdc");
+    const instructionsStat = await Deno.stat(instructionsPath);
+    assertEquals(instructionsStat.isFile, true);
+    const content = await Deno.readTextFile(instructionsPath);
+    assertStringIncludes(content, "---");
+    assertStringIncludes(content, "alwaysApply: true");
+  });
+});
+
+Deno.test("RepoService.upgrade creates AGENTS.md when switching to codex", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    // Init with claude (default)
+    await service.init(repoPath);
+
+    // Upgrade with tool switch to codex
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath, { tool: "codex" });
+
+    assertEquals(result.tool, "codex");
+
+    // Verify AGENTS.md created
+    const instructionsPath = join(tempDir, "AGENTS.md");
+    const instructionsStat = await Deno.stat(instructionsPath);
+    assertEquals(instructionsStat.isFile, true);
+    const content = await Deno.readTextFile(instructionsPath);
+    assertStringIncludes(content, "# Project");
+    assertStringIncludes(content, "swamp");
+  });
+});
+
+Deno.test("RepoService.upgrade does not overwrite existing instructions file", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    // Init with claude
+    await service.init(repoPath);
+
+    // Create custom AGENTS.md before switching
+    const instructionsPath = join(tempDir, "AGENTS.md");
+    const customContent = "# My Custom Instructions\nDo not overwrite me!";
+    await Deno.writeTextFile(instructionsPath, customContent);
+
+    // Upgrade with tool switch to codex
+    const upgradeService = new RepoService("0.2.0");
+    await upgradeService.upgrade(repoPath, { tool: "codex" });
+
+    // Verify AGENTS.md was NOT overwritten
+    const content = await Deno.readTextFile(instructionsPath);
+    assertEquals(content, customContent);
+  });
+});
+
+Deno.test("RepoService.upgrade defaults to claude for pre-existing repos without tool", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    // Init with default (claude) - simulate old marker without tool field
+    await service.init(repoPath);
+
+    // Manually remove tool from marker to simulate old repo
+    const markerPath = join(tempDir, ".swamp.yaml");
+    const markerContent = await Deno.readTextFile(markerPath);
+    const updatedMarker = markerContent.replace(/tool:.*\n/, "");
+    await Deno.writeTextFile(markerPath, updatedMarker);
+
+    // Upgrade without specifying tool
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath);
+
+    assertEquals(result.tool, "claude");
+  });
+});
+
+Deno.test("RepoService.upgrade skips settings for non-claude tools", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath, { tool: "cursor" });
+
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath);
+
+    assertEquals(result.settingsUpdated, false);
+  });
+});
+
+Deno.test("RepoService.init cursor instructions have MDC frontmatter", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath, { tool: "cursor" });
+
+    const mdcPath = join(tempDir, ".cursor", "rules", "swamp.mdc");
+    const content = await Deno.readTextFile(mdcPath);
+
+    // Check MDC frontmatter
+    assertStringIncludes(content, "---\n");
+    assertStringIncludes(content, "description: Swamp automation rules");
+    assertStringIncludes(content, "alwaysApply: true");
+  });
+});
+
+Deno.test("RepoService.init tool-specific gitignore entries", async () => {
+  const toolGitignoreEntries: Record<AiTool, string> = {
+    claude: ".claude/",
+    cursor: ".cursor/skills/",
+    opencode: ".agents/skills/",
+    codex: ".agents/skills/",
+  };
+
+  for (
+    const [tool, expectedEntry] of Object.entries(
+      toolGitignoreEntries,
+    ) as [AiTool, string][]
+  ) {
+    await withTempDir(async (tempDir) => {
+      const service = new RepoService("0.1.0");
+      const repoPath = RepoPath.create(tempDir);
+
+      await service.init(repoPath, { tool });
+
+      const gitignorePath = join(tempDir, ".gitignore");
+      const content = await Deno.readTextFile(gitignorePath);
+      assertStringIncludes(
+        content,
+        expectedEntry,
+        `${tool} gitignore should include ${expectedEntry}`,
+      );
+      // All tools should have common entries
+      assertStringIncludes(content, ".swamp/telemetry/");
+      assertStringIncludes(content, ".swamp/secrets/keyfile");
+    });
+  }
 });

--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -24,6 +24,11 @@ import type { RepoPath } from "../../domain/repo/repo_path.ts";
 import { swampMarkerPath } from "./paths.ts";
 
 /**
+ * The AI coding tool to configure skills and instructions for.
+ */
+export type AiTool = "claude" | "cursor" | "opencode" | "codex";
+
+/**
  * Data structure for the .swamp.yaml marker file.
  */
 export interface RepoMarkerData {
@@ -34,6 +39,7 @@ export interface RepoMarkerData {
   repoId?: string;
   telemetryEndpoint?: string;
   telemetryKeepFlushed?: boolean;
+  tool?: AiTool;
 }
 
 /**

--- a/src/presentation/output/repo_output.ts
+++ b/src/presentation/output/repo_output.ts
@@ -30,9 +30,10 @@ export interface RepoInitData {
   version: string;
   initializedAt: string;
   skillsCopied: string[];
-  claudeMdCreated: boolean;
-  claudeSettingsCreated: boolean;
+  instructionsFileCreated: boolean;
+  settingsCreated: boolean;
   gitignoreCreated: boolean;
+  tool: string;
 }
 
 /**
@@ -44,7 +45,8 @@ export interface RepoUpgradeData {
   newVersion: string;
   upgradedAt: string;
   skillsUpdated: string[];
-  claudeSettingsUpdated: boolean;
+  settingsUpdated: boolean;
+  tool: string;
 }
 
 /**
@@ -93,7 +95,8 @@ export function renderRepoInit(data: RepoInitData, mode: OutputMode): void {
     console.log("    ║  for hackers, by hackers                  ║");
     console.log("    ╚═══════════════════════════════════════════╝");
     console.log("");
-    logger.info`Initialized swamp repository at ${data.path}`;
+    logger
+      .info`Initialized swamp repository at ${data.path} (tool: ${data.tool})`;
   }
 }
 
@@ -105,7 +108,7 @@ export function renderRepoUpgrade(
     console.log(JSON.stringify(data, null, 2));
   } else {
     logger
-      .info`Upgraded swamp repository: ${data.previousVersion} \u2192 ${data.newVersion}`;
+      .info`Upgraded swamp repository: ${data.previousVersion} \u2192 ${data.newVersion} (tool: ${data.tool})`;
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #355

Adds `--tool` flag to `swamp repo init` and `swamp repo upgrade` so users of Cursor, OpenCode, and Codex get first-class support alongside Claude Code. Default remains `claude` for full backward compatibility.

- `swamp repo init --tool cursor` creates `.cursor/skills/` + `.cursor/rules/swamp.mdc`
- `swamp repo init --tool opencode` creates `.agents/skills/` + `AGENTS.md`
- `swamp repo init --tool codex` creates `.agents/skills/` + `AGENTS.md`
- `swamp repo init` (default) behaves exactly as before
- `swamp repo upgrade` reads the stored tool from `.swamp.yaml` marker
- `swamp repo upgrade --tool cursor` switches an existing repo to a different tool

## What Each Tool Gets

| Artifact | Claude Code | Cursor | OpenCode | Codex |
|----------|------------|--------|----------|-------|
| Skills dir | `.claude/skills/` | `.cursor/skills/` | `.agents/skills/` | `.agents/skills/` |
| Instructions file | `CLAUDE.md` | `.cursor/rules/swamp.mdc` | `AGENTS.md` | `AGENTS.md` |
| Permissions | `.claude/settings.local.json` | N/A | N/A | N/A |
| Gitignore entry | `.claude/` | `.cursor/skills/` | `.agents/skills/` | `.agents/skills/` |

## Files Changed

| File | Change |
|------|--------|
| `src/infrastructure/persistence/repo_marker_repository.ts` | Added `AiTool` type, `tool?` field to `RepoMarkerData` |
| `src/domain/repo/repo_service.ts` | Core multi-tool logic: skill dirs, instructions files, gitignore, settings gating |
| `src/cli/commands/repo_init.ts` | `--tool` flag on init, upgrade, and repo commands |
| `src/presentation/output/repo_output.ts` | Renamed fields, added `tool` to output data |
| `src/domain/repo/repo_service_test.ts` | Updated existing tests + 10 new multi-tool tests (33 total) |

## Plan vs Implementation

The implementation follows the plan from #355 with one deliberate deviation:

| Plan Item | Status | Notes |
|-----------|--------|-------|
| 1. `AiTool` type + `SKILL_DIRS` | Done | Type defined in marker repo, re-exported from service |
| 2. `--tool` flag on CLI | Done | Uses Cliffy `EnumType` for validation |
| 3. Updated options/result types | Done | Renamed `claudeMdCreated` → `instructionsFileCreated`, `claudeSettingsCreated` → `settingsCreated` |
| 4. Tool-aware `init()` | Done | Skills, instructions, settings, gitignore all tool-aware |
| 5. Tool-specific instructions | Done | Cursor gets MDC frontmatter, opencode/codex get AGENTS.md |
| 6. Tool-aware gitignore | Done | Each tool gets appropriate entries + common swamp entries |
| 7. No changes to `SkillAssets` | Done | Already generic |
| 8. Updated output types | Done | Renamed fields, added tool, updated log rendering |
| 9. Tool in `.swamp.yaml` marker | Done | Stored on init, read on upgrade |
| 10. Tool-aware `upgrade()` | Done | CLI override > marker > "claude" fallback works. Old tool directories are intentionally preserved (see below) |
| 11. Updated tests | Done | 33 tests, 10 new multi-tool tests |
| 12. No compile script changes | Done | N/A |

### Why old tool directories are preserved on switch

The plan suggested cleaning up the old tool's skill directory when switching tools via `swamp repo upgrade --tool <new>`. This was intentionally **not** implemented because users may want multiple tools active in the same repo — e.g. running both Claude Code and Cursor side by side. Each tool's skills directory is independent and gitignored, so having multiple coexist is harmless and supports real multi-tool workflows.

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] `deno run test` — all 1711 tests pass (33 repo service tests, 10 new)
- [x] Manual: `swamp repo init` (default claude behavior unchanged)
- [x] Manual: `swamp repo init --tool cursor`
- [x] Manual: `swamp repo init --tool opencode`
- [x] Manual: `swamp repo init --tool codex`
- [x] Manual: `swamp repo upgrade` (reads tool from marker)
- [x] Manual: `swamp repo upgrade --tool cursor` (switches tool)

🤖 Generated with [Claude Code](https://claude.com/claude-code)