### PR TITLE
fix: Resolve TOCTOU race condition in data version allocation

### DIFF
--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -17,7 +17,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { ensureDir } from "@std/fs";
 import { join, relative, resolve } from "@std/path";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import { atomicWriteFile, atomicWriteTextFile } from "./atomic_write.ts";
@@ -546,13 +545,12 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
       }
     }
 
-    // Determine the new version
-    const versions = await this.listVersions(type, modelId, data.name);
-    const newVersion = versions.length > 0 ? Math.max(...versions) + 1 : 1;
-
-    // Create the version directory
-    const versionDir = this.getPath(type, modelId, data.name, newVersion);
-    await ensureDir(versionDir);
+    // Atomically allocate a new version directory
+    const { version: newVersion } = await this.atomicAllocateVersionDir(
+      type,
+      modelId,
+      data.name,
+    );
 
     // Create the data with updated version and size
     const dataToSave = data.withNewVersion({
@@ -780,13 +778,12 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
       }
     }
 
-    // Determine the new version
-    const versions = await this.listVersions(type, modelId, data.name);
-    const newVersion = versions.length > 0 ? Math.max(...versions) + 1 : 1;
-
-    // Create the version directory
-    const versionDir = this.getPath(type, modelId, data.name, newVersion);
-    await ensureDir(versionDir);
+    // Atomically allocate a new version directory
+    const { version: newVersion } = await this.atomicAllocateVersionDir(
+      type,
+      modelId,
+      data.name,
+    );
 
     const contentPath = this.getContentPath(
       type,
@@ -955,6 +952,41 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     const result = join(modelDir, dataName);
     this.assertPathContained(result, modelDir, `dataName "${dataName}"`);
     return result;
+  }
+
+  /**
+   * Atomically allocates a new version directory using mkdir as a claim mechanism.
+   * On collision (AlreadyExists), increments the version and retries.
+   */
+  private async atomicAllocateVersionDir(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+  ): Promise<{ version: number; versionDir: string }> {
+    const dataNameDir = this.getDataNameDir(type, modelId, dataName);
+    await Deno.mkdir(dataNameDir, { recursive: true });
+
+    const versions = await this.listVersions(type, modelId, dataName);
+    let nextVersion = versions.length > 0 ? Math.max(...versions) + 1 : 1;
+
+    const maxRetries = 100;
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      const versionDir = this.getPath(type, modelId, dataName, nextVersion);
+      try {
+        await Deno.mkdir(versionDir);
+        return { version: nextVersion, versionDir };
+      } catch (error) {
+        if (error instanceof Deno.errors.AlreadyExists) {
+          nextVersion++;
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    throw new Error(
+      `Failed to allocate version for "${dataName}" after ${maxRetries} retries`,
+    );
   }
 
   private assertPathContained(

--- a/src/infrastructure/persistence/unified_data_repository_test.ts
+++ b/src/infrastructure/persistence/unified_data_repository_test.ts
@@ -17,8 +17,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertRejects, assertStringIncludes } from "@std/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import { FileSystemUnifiedDataRepository } from "./unified_data_repository.ts";
+import { Data } from "../../domain/data/mod.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 
 const testType = ModelType.create("test/model");
@@ -63,4 +64,88 @@ Deno.test("listVersions rejects dataName with path traversal", async () => {
     Error,
     "Path traversal detected",
   );
+});
+
+const owner = {
+  ownerType: "model-method" as const,
+  ownerRef: "test/model:test-method",
+};
+
+function makeData(name: string): Data {
+  return Data.create({
+    name,
+    contentType: "text/plain",
+    lifetime: "infinite",
+    garbageCollection: 100,
+    tags: { type: "test" },
+    ownerDefinition: owner,
+  });
+}
+
+Deno.test("concurrent allocateVersion returns unique versions", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new FileSystemUnifiedDataRepository(tmpDir);
+    const data = makeData("concurrent-alloc");
+    const concurrency = 10;
+
+    const results = await Promise.all(
+      Array.from(
+        { length: concurrency },
+        () => repo.allocateVersion(testType, "model-1", data),
+      ),
+    );
+
+    const versions = results.map((r) => r.version);
+    const uniqueVersions = new Set(versions);
+    assertEquals(
+      uniqueVersions.size,
+      concurrency,
+      `Expected ${concurrency} unique versions, got ${uniqueVersions.size}: [${
+        versions.join(", ")
+      }]`,
+    );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("concurrent save returns unique versions with distinct content", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new FileSystemUnifiedDataRepository(tmpDir);
+    const data = makeData("concurrent-save");
+    const concurrency = 10;
+
+    const results = await Promise.all(
+      Array.from({ length: concurrency }, (_, i) => {
+        const content = new TextEncoder().encode(`content-${i}`);
+        return repo.save(testType, "model-1", data, content);
+      }),
+    );
+
+    // All versions must be unique
+    const versions = results.map((r) => r.version);
+    const uniqueVersions = new Set(versions);
+    assertEquals(
+      uniqueVersions.size,
+      concurrency,
+      `Expected ${concurrency} unique versions, got ${uniqueVersions.size}: [${
+        versions.join(", ")
+      }]`,
+    );
+
+    // All content must be preserved
+    for (const version of versions) {
+      const saved = await repo.getContent(
+        testType,
+        "model-1",
+        "concurrent-save",
+        version,
+      );
+      assertEquals(saved !== null, true, `Version ${version} content is null`);
+    }
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
 });


### PR DESCRIPTION
## Summary

Fixes #327 — TOCTOU race condition in `unified_data_repository.ts` where concurrent `allocateVersion()` and `save()` calls could compute the same version number, causing silent data loss.

## Reasoning

Both `allocateVersion()` and `save()` followed a read-then-create pattern: read existing version directories, compute `max + 1`, then create the directory with `ensureDir()`. Because `ensureDir()` uses `recursive: true`, it silently succeeds even if the directory already exists — so two concurrent calls that both compute version N would both "succeed", with the last writer silently overwriting the first.

This is a real risk because workflow steps execute in parallel via `Promise.allSettled()` and jobs execute in parallel via `Promise.all()`.

The fix uses `Deno.mkdir()` **without** `recursive: true` as an atomic claim mechanism. `mkdir` is an atomic kernel-level operation — it either creates the directory or throws `AlreadyExists`. On collision, we increment the version and retry. This avoids introducing any locking infrastructure; the directory creation itself is the lock.

## Plan vs Implementation

| Plan Step | Status | Notes |
|---|---|---|
| **Step 1:** Add failing concurrent tests | Done | Two tests: concurrent `allocateVersion()` (10 parallel calls, assert unique versions) and concurrent `save()` (10 parallel calls with distinct content, assert unique versions + content preserved). Uses `Deno.makeTempDir()`, `Data.create()`, `Promise.all()`. |
| **Step 2:** Add `atomicAllocateVersionDir()` private method | Done | Added after `getDataNameDir()`. Ensures parent dir with `recursive: true`, reads starting version via `listVersions()`, loops with non-recursive `Deno.mkdir()`, catches `AlreadyExists` to retry with incremented version, rethrows other errors, caps at 100 retries. |
| **Step 3:** Update `allocateVersion()` | Done | Replaced racy `listVersions` + `ensureDir` block with `atomicAllocateVersionDir()` call. Ownership validation unchanged. |
| **Step 4:** Update `save()` | Done | Same replacement. Metadata write, content write, symlink update all unchanged. |
| **Step 5:** Run tests and confirm pass | Done | All 1713 tests pass including the 2 new concurrent tests. |
| **Step 6:** Remove unused `ensureDir` import | Done | `import { ensureDir } from "@std/fs"` removed — no other usages in the file. |

No deviations from the plan. All steps implemented exactly as specified.

## Files Changed

- `src/infrastructure/persistence/unified_data_repository.ts` — core fix (atomic version allocation)
- `src/infrastructure/persistence/unified_data_repository_test.ts` — concurrent race condition tests

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt` — formatting passes
- [x] `deno run test` — all 1713 tests pass
- [x] `deno run compile` — binary compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)