### PR TITLE
fix: use synchronous writes in RunFileSink

### DIFF
--- a/src/infrastructure/logging/run_file_sink.ts
+++ b/src/infrastructure/logging/run_file_sink.ts
@@ -112,7 +112,12 @@ export class RunFileSink {
 
       for (const writer of this.writers.values()) {
         if (categoryMatchesPrefix(record.category, writer.prefix)) {
-          writer.fd.write(writer.encoder.encode(line)).catch(() => {});
+          try {
+            writer.fd.writeSync(writer.encoder.encode(line));
+          } catch {
+            // Logging infrastructure must not throw — a broken log file
+            // should never crash a running workflow.
+          }
         }
       }
     };

--- a/src/infrastructure/logging/run_file_sink_test.ts
+++ b/src/infrastructure/logging/run_file_sink_test.ts
@@ -60,9 +60,6 @@ Deno.test("RunFileSink writes log records to registered file", async () => {
       ),
     );
 
-    // Allow async write to complete
-    await new Promise((r) => setTimeout(r, 50));
-
     const content = await Deno.readTextFile(logPath);
     assertStringIncludes(content, "hello world");
 
@@ -79,8 +76,6 @@ Deno.test("RunFileSink ignores records that don't match any prefix", async () =>
 
     const sinkFn = sink.sink;
     sinkFn(makeRecord(["workflow", "run", "wf1"], "should not appear"));
-
-    await new Promise((r) => setTimeout(r, 50));
 
     const content = await Deno.readTextFile(logPath);
     assertEquals(content, "");
@@ -104,8 +99,6 @@ Deno.test("RunFileSink writes to all matching prefixes", async () => {
     );
     sinkFn(makeRecord(["model", "method", "run", "other-model"], "broad"));
 
-    await new Promise((r) => setTimeout(r, 50));
-
     const specificContent = await Deno.readTextFile(specificPath);
     assertStringIncludes(specificContent, "specific");
 
@@ -128,13 +121,11 @@ Deno.test("RunFileSink unregister closes file and stops writing", async () => {
 
     const sinkFn = sink.sink;
     sinkFn(makeRecord(["model", "method", "run", "my-model"], "before"));
-    await new Promise((r) => setTimeout(r, 50));
 
     sink.unregister(["model", "method", "run", "my-model"]);
 
     // After unregister, records should not be written
     sinkFn(makeRecord(["model", "method", "run", "my-model"], "after"));
-    await new Promise((r) => setTimeout(r, 50));
 
     const content = await Deno.readTextFile(logPath);
     assertStringIncludes(content, "before");
@@ -151,7 +142,6 @@ Deno.test("RunFileSink creates parent directories", async () => {
 
     const sinkFn = sink.sink;
     sinkFn(makeRecord(["workflow", "run", "wf1"], "nested dir test"));
-    await new Promise((r) => setTimeout(r, 50));
 
     const content = await Deno.readTextFile(logPath);
     assertStringIncludes(content, "nested dir test");
@@ -177,8 +167,6 @@ Deno.test("RunFileSink empty prefix matches all categories", async () => {
     );
     sinkFn(makeRecord(["something", "else"], "other log"));
 
-    await new Promise((r) => setTimeout(r, 50));
-
     const content = await Deno.readTextFile(logPath);
     assertStringIncludes(content, "workflow log");
     assertStringIncludes(content, "model log");
@@ -200,7 +188,6 @@ Deno.test("RunFileSink dispose closes all writers", async () => {
     // After dispose, writing should silently fail (no match)
     const sinkFn = sink.sink;
     sinkFn(makeRecord(["a"], "should not write"));
-    await new Promise((r) => setTimeout(r, 50));
 
     // Files should be empty since no records matched after dispose
     const contentA = await Deno.readTextFile(join(dir, "a.log"));


### PR DESCRIPTION
## Summary

Fixes #333 — reported by @umag.

`RunFileSink` used async `fd.write()` in a fire-and-forget pattern with `.catch(() => {})`, which could theoretically produce out-of-order log lines and silently swallowed all write errors.

## Plan

As noted in the [issue discussion](https://github.com/systeminit/swamp/issues/333#issuecomment-2838558685), the fix is straightforward: swap `fd.write()` to `fd.writeSync()`. This works because:

- **LogTape's `Sink` type is synchronous** (`(record: LogRecord) => void`) — async writes were a mismatch with the API contract
- **`writeSync` guarantees ordering** — each write completes before the sink returns, eliminating any possibility of interleaving
- **Performance impact is negligible** — log lines are small and OS-level sync writes to a single fd are fast
- **Error handling should be silent but present** — logging infrastructure must not crash workflows, so a try-catch is appropriate (but not a silent `.catch(() => {})` on a detached promise)

## Implementation

**`src/infrastructure/logging/run_file_sink.ts`**
- Replaced `writer.fd.write(writer.encoder.encode(line)).catch(() => {})` with `writer.fd.writeSync(writer.encoder.encode(line))` wrapped in a try-catch
- The try-catch preserves the "don't crash on write failure" behavior without silently swallowing errors from detached promises

**`src/infrastructure/logging/run_file_sink_test.ts`**
- Removed all `await new Promise((r) => setTimeout(r, 50))` delays from 7 tests — these existed solely to wait for the async writes to settle. With synchronous writes, data is on disk by the time `sinkFn()` returns.

## Test Plan

- [x] All 7 existing `RunFileSink` tests pass
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes