### PR TITLE
fix: use recursive key sorting in computeHash to include nested data

### DIFF
--- a/src/domain/definitions/definition.ts
+++ b/src/domain/definitions/definition.ts
@@ -384,11 +384,19 @@ export class Definition {
    */
   async computeHash(): Promise<string> {
     const { type: _type, typeVersion: _tv, ...contentData } = this.toData();
-    // Sort keys for consistent hashing
-    const sortedData = JSON.stringify(
-      contentData,
-      Object.keys(contentData).sort(),
-    );
+    // Recursively sort keys for consistent hashing
+    const sortedData = JSON.stringify(contentData, (_key, value) => {
+      if (
+        value !== null && typeof value === "object" && !Array.isArray(value)
+      ) {
+        const sorted: Record<string, unknown> = {};
+        for (const k of Object.keys(value).sort()) {
+          sorted[k] = value[k];
+        }
+        return sorted;
+      }
+      return value;
+    });
     const encoder = new TextEncoder();
     const dataBuffer = encoder.encode(sortedData);
     const hashBuffer = await crypto.subtle.digest("SHA-256", dataBuffer);

--- a/src/domain/definitions/definition_test.ts
+++ b/src/domain/definitions/definition_test.ts
@@ -309,13 +309,17 @@ Deno.test("Definition.computeHash returns consistent hash", async () => {
   assertEquals(hash1.length, 64); // SHA-256 hex string length
 });
 
-Deno.test("Definition.computeHash returns different hash for different content", async () => {
+Deno.test("Definition.computeHash returns different hash for different nested content", async () => {
+  const fixedId = "550e8400-e29b-41d4-a716-446655440000";
+
   const definition1 = Definition.create({
+    id: fixedId,
     name: "test-definition",
     globalArguments: { message: "hello" },
   });
 
   const definition2 = Definition.create({
+    id: fixedId,
     name: "test-definition",
     globalArguments: { message: "world" },
   });
@@ -323,8 +327,7 @@ Deno.test("Definition.computeHash returns different hash for different content",
   const hash1 = await definition1.computeHash();
   const hash2 = await definition2.computeHash();
 
-  // Different content should produce different hashes
-  // Note: IDs will be different, so hashes will definitely differ
+  // Different nested content should produce different hashes
   assertEquals(hash1 !== hash2, true);
 });
 


### PR DESCRIPTION
## Summary

Fixes #337 — reported by @umag.

`Definition.computeHash()` used `JSON.stringify(data, Object.keys(data).sort())` to produce deterministic hashes. The second argument to `JSON.stringify` is a **replacer array** that acts as a key whitelist applied at **all nesting levels**. This means any nested object keys not present in the top-level key list (e.g., `message` inside `globalArguments: { message: "hello" }`) were **silently dropped** from serialization. The hash was effectively computed over only scalar top-level fields while nested structures like `tags`, `globalArguments`, `methods`, and `inputs` all serialized as `{}`.

The fix replaces the replacer array with a **replacer function** that recursively sorts keys at every depth. `JSON.stringify` calls the replacer for every value in the object tree, so nested objects at any depth get their keys sorted and fully serialized. Arrays pass through unchanged (preserving element order).

The existing test didn't catch this because it relied on auto-generated UUIDs to differentiate hashes (`Definition.create()` generates a new `crypto.randomUUID()` each time), meaning hashes would always differ regardless of whether nested content was included. The test has been updated to use a fixed ID so it actually validates that different nested content produces different hashes.

## Why this has no risk to existing workflows

`definitionHash` is used in exactly two places, neither of which involves decision-making logic:

1. **Provenance metadata in `ModelOutput`** — purely informational, stored alongside execution results for audit purposes. New runs will produce new hashes; old data on disk retains its old hashes untouched. Nothing compares old hashes to new ones.

2. **Backward compatibility in `OwnerDefinition`** — the `definitionHash` field is retained for compatibility with existing data on disk, but **ownership is determined solely by `ownerType + ownerRef`**, as confirmed by `Data.isOwnedBy()` and its tests.

No cache invalidation, no `--last-evaluated` behavior (which loads cached YAML directly from disk), and no conditional logic anywhere in the codebase depends on this hash value. Changing the hash output has zero functional impact on existing workflows or stored data.

## Test plan

- Updated `Definition.computeHash returns different hash for different nested content` test to use a fixed ID, confirming nested content differences produce different hashes
- All 36 definition tests pass
- `deno fmt`, `deno lint`, `deno check` all pass

Generated with [Claude Code](https://claude.com/claude-code)