### PR TITLE
feat: Add telemetryDisabled config to .swamp.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,60 @@ This means you get the feature you asked for, maintained over time, without
 having to worry about keeping a fork in sync. See
 [CONTRIBUTING.md](CONTRIBUTING.md) for the full details.
 
+## Telemetry
+
+Swamp collects anonymous usage telemetry to help us understand which commands
+are used, how long they take, and what errors occur. All user-identifiable
+values are redacted before transmission — nothing sensitive is ever sent.
+
+Here is a complete example of a telemetry event:
+
+```json
+{
+  "event": "cli_invocation",
+  "distinct_id": "a3f1b2c4-5678-9abc-def0-1234567890ab",
+  "properties": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "invocation": {
+      "command": "model",
+      "subcommand": "create",
+      "args": ["prompt", "<REDACTED>"],
+      "optionKeys": ["--force"],
+      "globalOptions": ["--json"]
+    },
+    "result": {
+      "status": "success",
+      "exitCode": 0
+    },
+    "startedAt": "2026-02-16T10:00:00.000Z",
+    "completedAt": "2026-02-16T10:00:01.234Z",
+    "durationMs": 1234,
+    "swampVersion": "0.13.0",
+    "denoVersion": "2.1.0",
+    "platform": "linux"
+  }
+}
+```
+
+Note that positional arguments containing user data (model names, file paths,
+queries) are replaced with `<REDACTED>`. Only categorical values defined by
+swamp itself (like model types) are recorded. Option values are never recorded —
+only the option keys.
+
+### Disabling Telemetry
+
+Per-invocation:
+
+```bash
+swamp --no-telemetry workflow run my-workflow
+```
+
+Permanently for a repository — add to `.swamp.yaml`:
+
+```yaml
+telemetryDisabled: true
+```
+
 ## License
 
 Swamp is licensed under the [GNU Affero General Public License v3.0](COPYING)

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -80,6 +80,17 @@ export function resolveModelsDir(marker: RepoMarkerData | null): string {
 }
 
 /**
+ * Checks whether telemetry is disabled via .swamp.yaml config.
+ *
+ * @internal Exported for testing
+ */
+export function isTelemetryDisabledByConfig(
+  marker: RepoMarkerData | null,
+): boolean {
+  return marker?.telemetryDisabled === true;
+}
+
+/**
  * Load user models from configured directory.
  */
 async function loadUserModels(): Promise<void> {
@@ -144,6 +155,10 @@ async function initTelemetryService(): Promise<TelemetryContext | null> {
     const marker = await markerRepo.read(repoPath);
     if (!marker) {
       return null; // Not in a swamp repo
+    }
+
+    if (isTelemetryDisabledByConfig(marker)) {
+      return null;
     }
 
     // Lazy-migrate repoId if missing

--- a/src/cli/mod_test.ts
+++ b/src/cli/mod_test.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { resolveModelsDir } from "./mod.ts";
+import { isTelemetryDisabledByConfig, resolveModelsDir } from "./mod.ts";
 
 Deno.test("resolveModelsDir returns default 'extensions/models' when no config", () => {
   // Ensure env var is not set
@@ -107,4 +107,34 @@ Deno.test("resolveModelsDir env var takes priority over default", () => {
       Deno.env.delete("SWAMP_MODELS_DIR");
     }
   }
+});
+
+Deno.test("isTelemetryDisabledByConfig returns false for null marker", () => {
+  assertEquals(isTelemetryDisabledByConfig(null), false);
+});
+
+Deno.test("isTelemetryDisabledByConfig returns false when field is absent", () => {
+  const marker = {
+    swampVersion: "0.1.0",
+    initializedAt: "2024-01-01T00:00:00Z",
+  };
+  assertEquals(isTelemetryDisabledByConfig(marker), false);
+});
+
+Deno.test("isTelemetryDisabledByConfig returns false when field is false", () => {
+  const marker = {
+    swampVersion: "0.1.0",
+    initializedAt: "2024-01-01T00:00:00Z",
+    telemetryDisabled: false,
+  };
+  assertEquals(isTelemetryDisabledByConfig(marker), false);
+});
+
+Deno.test("isTelemetryDisabledByConfig returns true when field is true", () => {
+  const marker = {
+    swampVersion: "0.1.0",
+    initializedAt: "2024-01-01T00:00:00Z",
+    telemetryDisabled: true,
+  };
+  assertEquals(isTelemetryDisabledByConfig(marker), true);
 });

--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -38,6 +38,7 @@ export interface RepoMarkerData {
   modelsDir?: string;
   repoId?: string;
   telemetryEndpoint?: string;
+  telemetryDisabled?: boolean;
   telemetryKeepFlushed?: boolean;
   tool?: AiTool;
 }

--- a/src/infrastructure/persistence/repo_marker_repository_test.ts
+++ b/src/infrastructure/persistence/repo_marker_repository_test.ts
@@ -225,6 +225,24 @@ Deno.test("RepoMarkerRepository.createUpgradeMarker preserves existing data", ()
   assertEquals(isNaN(date.getTime()), false);
 });
 
+Deno.test("RepoMarkerRepository.write and read roundtrip with telemetryDisabled", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new RepoMarkerRepository();
+    const repoPath = RepoPath.create(dir);
+
+    const original = {
+      swampVersion: "1.2.3",
+      initializedAt: "2024-01-15T10:30:00.000Z",
+      telemetryDisabled: true,
+    };
+
+    await repo.write(repoPath, original);
+    const result = await repo.read(repoPath);
+
+    assertEquals(result, original);
+  });
+});
+
 Deno.test("RepoMarkerRepository.createUpgradeMarker always sets upgradedAt", () => {
   const repo = new RepoMarkerRepository();
   const existing = {


### PR DESCRIPTION
## Summary

- Add `telemetryDisabled?: boolean` to `RepoMarkerData` so users can persistently opt out of telemetry via `.swamp.yaml` instead of passing `--no-telemetry` on every invocation
- Add `isTelemetryDisabledByConfig()` helper in `src/cli/mod.ts` and check it in `initTelemetryService()` before creating any telemetry infrastructure
- Add Telemetry section to README.md documenting the exact payload shape, redaction policy, and both opt-out methods

Closes #362

## Test Plan

- Added YAML roundtrip test for `telemetryDisabled: true` in `repo_marker_repository_test.ts`
- Added 4 unit tests for `isTelemetryDisabledByConfig()` covering: null marker, field absent, field false, field true
- All 1722 tests pass, `deno check`, `deno lint`, `deno fmt` clean