### PR TITLE
feat: add human-friendly key=value syntax for --input flag

### DIFF
--- a/design/inputs.md
+++ b/design/inputs.md
@@ -190,11 +190,70 @@ Workflows and Models must be able to have their inputs and CEL expressions evalu
 
 Workflow run and model method run both should support a --last-evaluated flag, which will skip evaluating the definitions inputs or CEL expressions, and instead run directly from the last evaluated version of the models and workflows.
 
-## Model Method Run
+## CLI Input Syntax
 
-When executing a model with `swamp model method run`, inputs are specified on the command line as --input '{..}' with JSON, or via --input-file, where the file will be yaml.
+There are three ways to provide inputs on the command line. These apply to both
+`swamp model method run` and `swamp workflow run`.
 
-## Workflow run
+### 1. Key=value pairs (recommended for humans)
 
-When executing a workflow with `swamp workflow run`, inputs are specified on the command line as --input '{..}' with JSON, or via --input-file, where the file will be yaml.
+The `--input` flag accepts repeatable `key=value` pairs:
+
+```bash
+swamp workflow run deploy --input environment=production --input replicas=3
+```
+
+Dot notation creates nested objects:
+
+```bash
+swamp workflow run deploy --input server.host=localhost --input server.port=8080
+# → { server: { host: "localhost", port: "8080" } }
+```
+
+Values starting with `@` read file contents (like curl):
+
+```bash
+swamp workflow run deploy --input sshKey=@~/.ssh/id_rsa.pub
+```
+
+To pass a literal `@` as the start of a value, escape it with `\@`:
+
+```bash
+swamp workflow run deploy --input handle=\@username
+```
+
+### 2. JSON (backward compatible)
+
+A single `--input` value starting with `{` is treated as JSON:
+
+```bash
+swamp workflow run deploy --input '{"environment": "production"}'
+```
+
+### 3. YAML file
+
+```bash
+swamp workflow run deploy --input-file inputs.yaml
+```
+
+### Combining file + key=value overrides
+
+When both `--input-file` and key=value `--input` are provided, the file supplies
+base values and key=value pairs act as overrides (deep merged):
+
+```bash
+swamp workflow run deploy --input-file base.yaml --input environment=production
+```
+
+### Type coercion
+
+Key=value inputs are always parsed as strings. When the workflow or model
+declares an `InputsSchema`, string values are automatically coerced to match
+the schema's declared types (`number`, `integer`, `boolean`) before validation.
+Without a schema, values remain as strings.
+
+### Arrays
+
+Array inputs are not supported via key=value syntax. Use `--input-file` or JSON
+for array values.
 

--- a/integration/inputs_test.ts
+++ b/integration/inputs_test.ts
@@ -547,3 +547,257 @@ Deno.test("CLI: input validation reports multiple errors", async () => {
     assertStringIncludes(result.stderr, "count");
   });
 });
+
+// Test: Key-value input for model method run
+
+Deno.test("CLI: model method run with key=value input succeeds", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+    await createShellModelWithInputs(repoDir, "shell-env-kv");
+
+    const result = await runCliCommand(
+      [
+        "model",
+        "method",
+        "run",
+        "shell-env-kv",
+        "execute",
+        "--repo-dir",
+        repoDir,
+        "--input",
+        "environment=dev",
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(result.code, 0, `Should succeed. stderr: ${result.stderr}`);
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.modelName, "shell-env-kv");
+  });
+});
+
+// Test: Key-value input for workflow run
+
+Deno.test("CLI: workflow run with key=value input succeeds", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+    await createShellModelWithInputs(repoDir, "echo-model-kv");
+
+    // Create workflow with inputs
+    const workflowData = {
+      id: crypto.randomUUID(),
+      name: "test-workflow-kv",
+      version: 1,
+      inputs: {
+        properties: {
+          "environment-one": {
+            type: "string",
+            enum: ["dev", "staging", "production"],
+            description: "Target environment",
+          },
+        },
+        required: ["environment-one"],
+      },
+      jobs: [
+        {
+          name: "echo-job",
+          steps: [
+            {
+              name: "first-env",
+              task: {
+                type: "model_method",
+                modelIdOrName: "echo-model-kv",
+                methodName: "execute",
+                inputs: {
+                  environment: '${{ inputs["environment-one"] }}',
+                },
+              },
+              dependsOn: [],
+              weight: 0,
+            },
+          ],
+          dependsOn: [],
+          weight: 0,
+        },
+      ],
+    };
+
+    const workflowDir = join(repoDir, ".swamp/workflows");
+    await ensureDir(workflowDir);
+    await Deno.writeTextFile(
+      join(workflowDir, `workflow-${workflowData.id}.yaml`),
+      stringifyYaml(workflowData as Record<string, unknown>),
+    );
+
+    const result = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "test-workflow-kv",
+        "--repo-dir",
+        repoDir,
+        "--input",
+        "environment-one=dev",
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(result.code, 0, `Should succeed. stderr: ${result.stderr}`);
+  });
+});
+
+// Test: Multiple key=value inputs with schema coercion
+
+Deno.test("CLI: model method run with multiple k=v and type coercion", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    // Create model with number and string inputs
+    const modelData = {
+      type: "command/shell",
+      typeVersion: 1,
+      id: crypto.randomUUID(),
+      name: "coerce-model",
+      version: 1,
+      tags: {},
+      inputs: {
+        properties: {
+          name: { type: "string" },
+          count: { type: "integer" },
+        },
+        required: ["name", "count"],
+      },
+      globalArguments: {},
+      methods: {
+        execute: {
+          arguments: {
+            run: "echo '${{ inputs.name }} ${{ inputs.count }}'",
+          },
+        },
+      },
+    };
+
+    const modelDir = join(repoDir, ".swamp/definitions/command/shell");
+    await ensureDir(modelDir);
+    await Deno.writeTextFile(
+      join(modelDir, `${modelData.id}.yaml`),
+      stringifyYaml(modelData as Record<string, unknown>),
+    );
+
+    const result = await runCliCommand(
+      [
+        "model",
+        "method",
+        "run",
+        "coerce-model",
+        "execute",
+        "--repo-dir",
+        repoDir,
+        "--input",
+        "name=alice",
+        "--input",
+        "count=5",
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(result.code, 0, `Should succeed. stderr: ${result.stderr}`);
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.modelName, "coerce-model");
+  });
+});
+
+// Test: @file input reads file contents
+
+Deno.test("CLI: model method run with @file input", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    // Create model that takes a string input
+    const modelData = {
+      type: "command/shell",
+      typeVersion: 1,
+      id: crypto.randomUUID(),
+      name: "file-input-model",
+      version: 1,
+      tags: {},
+      inputs: {
+        properties: {
+          message: { type: "string" },
+        },
+        required: ["message"],
+      },
+      globalArguments: {},
+      methods: {
+        execute: {
+          arguments: {
+            run: "echo '${{ inputs.message }}'",
+          },
+        },
+      },
+    };
+
+    const modelDir = join(repoDir, ".swamp/definitions/command/shell");
+    await ensureDir(modelDir);
+    await Deno.writeTextFile(
+      join(modelDir, `${modelData.id}.yaml`),
+      stringifyYaml(modelData as Record<string, unknown>),
+    );
+
+    // Create a file to read
+    const contentFile = join(repoDir, "message.txt");
+    await Deno.writeTextFile(contentFile, "hello from file");
+
+    const result = await runCliCommand(
+      [
+        "model",
+        "method",
+        "run",
+        "file-input-model",
+        "execute",
+        "--repo-dir",
+        repoDir,
+        "--input",
+        `message=@${contentFile}`,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(result.code, 0, `Should succeed. stderr: ${result.stderr}`);
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.modelName, "file-input-model");
+  });
+});
+
+// Test: Existing JSON tests still pass (backward compat explicitly verified)
+
+Deno.test("CLI: model method run with JSON input still works", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+    await createShellModelWithInputs(repoDir, "shell-env-json-compat");
+
+    const result = await runCliCommand(
+      [
+        "model",
+        "method",
+        "run",
+        "shell-env-json-compat",
+        "execute",
+        "--repo-dir",
+        repoDir,
+        "--input",
+        '{"environment": "production"}',
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(result.code, 0, `Should succeed. stderr: ${result.stderr}`);
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.modelName, "shell-env-json-compat");
+  });
+});

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -35,7 +35,7 @@ import {
   getRunLogger,
   runFileSink,
 } from "../../infrastructure/logging/logger.ts";
-import { parseInputs } from "../input_parser.ts";
+import { coerceInputTypes, parseInputs } from "../input_parser.ts";
 import { parseTags } from "./data_search.ts";
 import { InputValidationService } from "../../domain/inputs/mod.ts";
 import { join } from "@std/path";
@@ -61,7 +61,9 @@ export const modelMethodRunCommand = new Command()
     "Skip CEL evaluation, use previously evaluated definition",
     { default: false },
   )
-  .option("--input <json:string>", "Input values as JSON")
+  .option("--input <value:string>", "Input values (key=value or JSON)", {
+    collect: true,
+  })
   .option("--input-file <file:string>", "Input values from YAML file")
   .option(
     "--tag <tag:string>",
@@ -94,7 +96,7 @@ export const modelMethodRunCommand = new Command()
 
       // Parse input values
       const { inputs } = await parseInputs({
-        input: options.input as string | undefined,
+        input: options.input as string[] | undefined,
         inputFile: options.inputFile as string | undefined,
       });
 
@@ -113,6 +115,12 @@ export const modelMethodRunCommand = new Command()
         throw new UserError(`Model not found: ${modelIdOrName}`);
       }
       const { definition, type: modelType } = result;
+
+      // Coerce k=v string inputs to match schema types before validation
+      const coercedInputs = definition.inputs
+        ? coerceInputTypes(inputs, definition.inputs)
+        : inputs;
+      Object.assign(inputs, coercedInputs);
 
       // Validate inputs against model's input schema if provided
       if (definition.inputs) {

--- a/src/cli/commands/workflow_evaluate.ts
+++ b/src/cli/commands/workflow_evaluate.ts
@@ -53,7 +53,9 @@ export const workflowEvaluateCommand = new Command()
   .arguments("[workflow_id_or_name:string]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("--all", "Evaluate all workflow definitions")
-  .option("--input <json:string>", "Input values as JSON")
+  .option("--input <value:string>", "Input values (key=value or JSON)", {
+    collect: true,
+  })
   .option("--input-file <file:string>", "Input values from YAML file")
   .action(
     async function (options: AnyOptions, workflowIdOrName?: string) {
@@ -71,7 +73,7 @@ export const workflowEvaluateCommand = new Command()
 
       // Parse input values
       const { inputs } = await parseInputs({
-        input: options.input as string | undefined,
+        input: options.input as string[] | undefined,
         inputFile: options.inputFile as string | undefined,
       });
 

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -38,7 +38,7 @@ import type {
 } from "../../domain/workflows/workflow_run.ts";
 import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
 import { createLogProgressCallback } from "../../presentation/output/log_progress_callback.ts";
-import { parseInputs } from "../input_parser.ts";
+import { coerceInputTypes, parseInputs } from "../input_parser.ts";
 import { parseTags } from "./data_search.ts";
 import { InputValidationService } from "../../domain/inputs/mod.ts";
 import { workflowRunSearchCommand } from "./workflow_run_search.ts";
@@ -159,7 +159,9 @@ export const workflowRunCommand = new Command()
     "Skip CEL evaluation, use previously evaluated workflow and definitions",
     { default: false },
   )
-  .option("--input <json:string>", "Input values as JSON")
+  .option("--input <value:string>", "Input values (key=value or JSON)", {
+    collect: true,
+  })
   .option("--input-file <file:string>", "Input values from YAML file")
   .option(
     "--tag <tag:string>",
@@ -188,7 +190,7 @@ export const workflowRunCommand = new Command()
 
     // Parse input values
     const { inputs } = await parseInputs({
-      input: options.input as string | undefined,
+      input: options.input as string[] | undefined,
       inputFile: options.inputFile as string | undefined,
     });
 
@@ -205,6 +207,12 @@ export const workflowRunCommand = new Command()
       if (!workflow) {
         throw new UserError(`Workflow not found: ${workflowIdOrName}`);
       }
+
+      // Coerce k=v string inputs to match schema types before validation
+      const coercedInputs = workflow.inputs
+        ? coerceInputTypes(inputs, workflow.inputs)
+        : inputs;
+      Object.assign(inputs, coercedInputs);
 
       // Validate inputs against workflow schema if provided
       // Skip validation when using --last-evaluated since inputs are already baked in

--- a/src/cli/input_parser.ts
+++ b/src/cli/input_parser.ts
@@ -18,29 +18,248 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { parse as parseYaml } from "@std/yaml";
+import type { InputsSchema } from "../domain/definitions/definition.ts";
 
 /**
  * Result of parsing inputs.
  */
 export interface ParsedInputs {
   inputs: Record<string, unknown>;
-  source: "json" | "yaml-file" | "none";
+  source: "json" | "yaml-file" | "key-value" | "combined" | "none";
+}
+
+/**
+ * Sets a value at a dot-separated key path in an object.
+ * Creates intermediate objects as needed.
+ *
+ * @example
+ * setNestedValue({}, "server.host", "localhost")
+ * // → { server: { host: "localhost" } }
+ */
+export function setNestedValue(
+  obj: Record<string, unknown>,
+  keyPath: string,
+  value: unknown,
+): void {
+  const parts = keyPath.split(".");
+  // deno-lint-ignore no-explicit-any
+  let current: any = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i];
+    if (
+      current[part] === undefined || current[part] === null ||
+      typeof current[part] !== "object" || Array.isArray(current[part])
+    ) {
+      current[part] = {};
+    }
+    current = current[part];
+  }
+  current[parts[parts.length - 1]] = value;
+}
+
+/**
+ * Resolves a file reference value (prefixed with @) to its file contents.
+ * Supports tilde expansion for home directory paths.
+ */
+async function resolveFileValue(
+  key: string,
+  filePath: string,
+): Promise<string> {
+  let resolvedPath = filePath;
+  if (resolvedPath.startsWith("~/")) {
+    const home = Deno.env.get("HOME");
+    if (home) {
+      resolvedPath = home + resolvedPath.slice(1);
+    }
+  }
+  try {
+    return await Deno.readTextFile(resolvedPath);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      throw new Error(
+        `Input file not found for key "${key}": ${resolvedPath}`,
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Parses an array of key=value strings into a nested object.
+ *
+ * - Dot notation creates nested objects: `server.host=localhost`
+ * - Values starting with `@` read file contents: `key=@path/to/file`
+ * - Escaped `@` with `\@` produces a literal `@`: `key=\@literal`
+ * - Splits on first `=` only, so values can contain `=`
+ */
+export async function parseKeyValueInputs(
+  entries: string[],
+): Promise<Record<string, unknown>> {
+  const result: Record<string, unknown> = {};
+
+  for (const entry of entries) {
+    const eqIndex = entry.indexOf("=");
+    if (eqIndex === -1) {
+      throw new Error(
+        `Invalid input format: "${entry}". Expected key=value format.`,
+      );
+    }
+
+    const key = entry.slice(0, eqIndex);
+    if (key === "") {
+      throw new Error(`Invalid input: empty key in "${entry}".`);
+    }
+
+    let value: string = entry.slice(eqIndex + 1);
+
+    if (value.startsWith("\\@")) {
+      // Escaped @ — use literal value without the backslash
+      value = value.slice(1);
+    } else if (value.startsWith("@")) {
+      // File reference — read file contents
+      const filePath = value.slice(1);
+      value = await resolveFileValue(key, filePath);
+    }
+
+    setNestedValue(result, key, value);
+  }
+
+  return result;
+}
+
+/**
+ * Deep merges two objects. Override values take precedence.
+ * Only merges plain objects recursively; arrays and primitives are replaced.
+ */
+export function deepMerge(
+  base: Record<string, unknown>,
+  overrides: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...base };
+
+  for (const [key, overrideValue] of Object.entries(overrides)) {
+    const baseValue = result[key];
+    if (
+      isPlainObject(baseValue) && isPlainObject(overrideValue)
+    ) {
+      result[key] = deepMerge(
+        baseValue as Record<string, unknown>,
+        overrideValue as Record<string, unknown>,
+      );
+    } else {
+      result[key] = overrideValue;
+    }
+  }
+
+  return result;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Coerces string input values to match their declared types in an InputsSchema.
+ * Only coerces values that are strings and have a declared type in the schema.
+ * Without a schema, values are returned unchanged.
+ */
+export function coerceInputTypes(
+  inputs: Record<string, unknown>,
+  schema?: InputsSchema,
+): Record<string, unknown> {
+  if (!schema?.properties) {
+    return inputs;
+  }
+
+  const result: Record<string, unknown> = { ...inputs };
+
+  for (const [key, value] of Object.entries(result)) {
+    if (typeof value !== "string") {
+      continue;
+    }
+
+    const propSchema = schema.properties[key];
+    if (!propSchema?.type) {
+      continue;
+    }
+
+    switch (propSchema.type) {
+      case "number":
+      case "integer": {
+        const num = Number(value);
+        if (!Number.isNaN(num)) {
+          result[key] = propSchema.type === "integer" ? Math.trunc(num) : num;
+        }
+        break;
+      }
+      case "boolean": {
+        if (value === "true") {
+          result[key] = true;
+        } else if (value === "false") {
+          result[key] = false;
+        }
+        break;
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Detects whether input strings represent JSON (backward compat) or key=value pairs.
+ */
+function isJsonInput(entries: string[]): boolean {
+  return entries.length === 1 && entries[0].trimStart().startsWith("{");
+}
+
+/**
+ * Parses a YAML input file and returns the parsed object.
+ */
+async function parseInputFile(
+  inputFile: string,
+): Promise<Record<string, unknown>> {
+  try {
+    const content = await Deno.readTextFile(inputFile);
+    const parsed = parseYaml(content);
+    if (
+      typeof parsed !== "object" || parsed === null || Array.isArray(parsed)
+    ) {
+      throw new Error("Input file must contain a YAML object");
+    }
+    return parsed as Record<string, unknown>;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      throw new Error(`Input file not found: ${inputFile}`);
+    }
+    throw error;
+  }
 }
 
 /**
  * Parses input values from CLI options.
  *
+ * Supports three input methods:
+ * - `--input '{"key": "value"}'` — JSON object (backward compat, detected by leading `{`)
+ * - `--input key=value` — repeatable key=value pairs with dot-notation nesting
+ * - `--input-file file.yaml` — YAML file
+ *
+ * When both `--input-file` and key=value `--input` are provided, the file
+ * provides base values and key=value pairs act as overrides (deep merged).
+ *
  * @param options - CLI options containing input or inputFile
  * @returns Parsed inputs and their source
  */
 export async function parseInputs(options: {
-  input?: string;
+  input?: string | string[];
   inputFile?: string;
 }): Promise<ParsedInputs> {
-  // --input takes precedence over --input-file
-  if (options.input) {
+  const inputEntries = normalizeInputOption(options.input);
+
+  // JSON mode: single string starting with `{` — backward compat
+  if (inputEntries.length > 0 && isJsonInput(inputEntries)) {
     try {
-      const parsed = JSON.parse(options.input);
+      const parsed = JSON.parse(inputEntries[0]);
       if (
         typeof parsed !== "object" || parsed === null || Array.isArray(parsed)
       ) {
@@ -58,29 +277,51 @@ export async function parseInputs(options: {
     }
   }
 
-  if (options.inputFile) {
-    try {
-      const content = await Deno.readTextFile(options.inputFile);
-      const parsed = parseYaml(content);
-      if (
-        typeof parsed !== "object" || parsed === null || Array.isArray(parsed)
-      ) {
-        throw new Error("Input file must contain a YAML object");
-      }
+  // Key-value mode (possibly combined with --input-file)
+  if (inputEntries.length > 0) {
+    const kvInputs = await parseKeyValueInputs(inputEntries);
+
+    if (options.inputFile) {
+      const fileInputs = await parseInputFile(options.inputFile);
       return {
-        inputs: parsed as Record<string, unknown>,
-        source: "yaml-file",
+        inputs: deepMerge(fileInputs, kvInputs),
+        source: "combined",
       };
-    } catch (error) {
-      if (error instanceof Deno.errors.NotFound) {
-        throw new Error(`Input file not found: ${options.inputFile}`);
-      }
-      throw error;
     }
+
+    return {
+      inputs: kvInputs,
+      source: "key-value",
+    };
+  }
+
+  // --input-file only
+  if (options.inputFile) {
+    const fileInputs = await parseInputFile(options.inputFile);
+    return {
+      inputs: fileInputs,
+      source: "yaml-file",
+    };
   }
 
   return {
     inputs: {},
     source: "none",
   };
+}
+
+/**
+ * Normalizes the --input option value to an array of strings.
+ * Handles both the old single-string form and the new collected array form.
+ */
+function normalizeInputOption(
+  input: string | string[] | undefined,
+): string[] {
+  if (input === undefined) {
+    return [];
+  }
+  if (Array.isArray(input)) {
+    return input;
+  }
+  return [input];
 }

--- a/src/cli/input_parser_test.ts
+++ b/src/cli/input_parser_test.ts
@@ -1,0 +1,389 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import {
+  coerceInputTypes,
+  deepMerge,
+  parseInputs,
+  parseKeyValueInputs,
+  setNestedValue,
+} from "./input_parser.ts";
+import type { InputsSchema } from "../domain/definitions/definition.ts";
+import { stringify as stringifyYaml } from "@std/yaml";
+
+// --- setNestedValue ---
+
+Deno.test("setNestedValue: sets a simple key", () => {
+  const obj: Record<string, unknown> = {};
+  setNestedValue(obj, "name", "alice");
+  assertEquals(obj, { name: "alice" });
+});
+
+Deno.test("setNestedValue: sets a dot-notation nested key", () => {
+  const obj: Record<string, unknown> = {};
+  setNestedValue(obj, "server.host", "localhost");
+  assertEquals(obj, { server: { host: "localhost" } });
+});
+
+Deno.test("setNestedValue: sets deeply nested key", () => {
+  const obj: Record<string, unknown> = {};
+  setNestedValue(obj, "a.b.c", "deep");
+  assertEquals(obj, { a: { b: { c: "deep" } } });
+});
+
+Deno.test("setNestedValue: merges into existing nested object", () => {
+  const obj: Record<string, unknown> = { server: { host: "localhost" } };
+  setNestedValue(obj, "server.port", "8080");
+  assertEquals(obj, { server: { host: "localhost", port: "8080" } });
+});
+
+// --- parseKeyValueInputs ---
+
+Deno.test("parseKeyValueInputs: single key=value", async () => {
+  const result = await parseKeyValueInputs(["environment=production"]);
+  assertEquals(result, { environment: "production" });
+});
+
+Deno.test("parseKeyValueInputs: multiple key=value pairs", async () => {
+  const result = await parseKeyValueInputs([
+    "environment=production",
+    "replicas=3",
+  ]);
+  assertEquals(result, { environment: "production", replicas: "3" });
+});
+
+Deno.test("parseKeyValueInputs: dot notation nesting", async () => {
+  const result = await parseKeyValueInputs([
+    "server.host=localhost",
+    "server.port=8080",
+  ]);
+  assertEquals(result, { server: { host: "localhost", port: "8080" } });
+});
+
+Deno.test("parseKeyValueInputs: value containing equals sign", async () => {
+  const result = await parseKeyValueInputs(["query=SELECT * WHERE id=1"]);
+  assertEquals(result, { query: "SELECT * WHERE id=1" });
+});
+
+Deno.test("parseKeyValueInputs: empty value", async () => {
+  const result = await parseKeyValueInputs(["key="]);
+  assertEquals(result, { key: "" });
+});
+
+Deno.test("parseKeyValueInputs: missing equals sign throws", async () => {
+  await assertRejects(
+    () => parseKeyValueInputs(["noequals"]),
+    Error,
+    "Expected key=value format",
+  );
+});
+
+Deno.test("parseKeyValueInputs: empty key throws", async () => {
+  await assertRejects(
+    () => parseKeyValueInputs(["=value"]),
+    Error,
+    "empty key",
+  );
+});
+
+Deno.test("parseKeyValueInputs: escaped @ produces literal @", async () => {
+  const result = await parseKeyValueInputs(["key=\\@notafile"]);
+  assertEquals(result, { key: "@notafile" });
+});
+
+Deno.test("parseKeyValueInputs: @file reads file contents", async () => {
+  const tempFile = await Deno.makeTempFile();
+  try {
+    await Deno.writeTextFile(tempFile, "file-contents-here");
+    const result = await parseKeyValueInputs([`key=@${tempFile}`]);
+    assertEquals(result, { key: "file-contents-here" });
+  } finally {
+    await Deno.remove(tempFile);
+  }
+});
+
+Deno.test("parseKeyValueInputs: @file with missing file throws", async () => {
+  const err = await assertRejects(
+    () => parseKeyValueInputs(["key=@/nonexistent/path/file.txt"]),
+    Error,
+  );
+  assertStringIncludes(
+    (err as Error).message,
+    'Input file not found for key "key"',
+  );
+});
+
+Deno.test("parseKeyValueInputs: @file with dot notation", async () => {
+  const tempFile = await Deno.makeTempFile();
+  try {
+    await Deno.writeTextFile(tempFile, "cert-data");
+    const result = await parseKeyValueInputs([`server.cert=@${tempFile}`]);
+    assertEquals(result, { server: { cert: "cert-data" } });
+  } finally {
+    await Deno.remove(tempFile);
+  }
+});
+
+// --- deepMerge ---
+
+Deno.test("deepMerge: flat objects", () => {
+  const result = deepMerge({ a: 1, b: 2 }, { b: 3, c: 4 });
+  assertEquals(result, { a: 1, b: 3, c: 4 });
+});
+
+Deno.test("deepMerge: nested objects", () => {
+  const result = deepMerge(
+    { server: { host: "base", port: 80 } },
+    { server: { host: "override" } },
+  );
+  assertEquals(result, { server: { host: "override", port: 80 } });
+});
+
+Deno.test("deepMerge: override replaces non-object with object", () => {
+  const result = deepMerge({ server: "old" }, { server: { host: "new" } });
+  assertEquals(result, { server: { host: "new" } });
+});
+
+Deno.test("deepMerge: does not mutate base", () => {
+  const base = { a: 1 };
+  deepMerge(base, { b: 2 });
+  assertEquals(base, { a: 1 });
+});
+
+// --- coerceInputTypes ---
+
+Deno.test("coerceInputTypes: coerces string to number", () => {
+  const schema: InputsSchema = {
+    properties: {
+      replicas: { type: "number" },
+    },
+  };
+  const result = coerceInputTypes({ replicas: "3.5" }, schema);
+  assertEquals(result, { replicas: 3.5 });
+});
+
+Deno.test("coerceInputTypes: coerces string to integer (truncates)", () => {
+  const schema: InputsSchema = {
+    properties: {
+      count: { type: "integer" },
+    },
+  };
+  const result = coerceInputTypes({ count: "7" }, schema);
+  assertEquals(result, { count: 7 });
+});
+
+Deno.test("coerceInputTypes: coerces string to boolean", () => {
+  const schema: InputsSchema = {
+    properties: {
+      enabled: { type: "boolean" },
+      verbose: { type: "boolean" },
+    },
+  };
+  const result = coerceInputTypes(
+    { enabled: "true", verbose: "false" },
+    schema,
+  );
+  assertEquals(result, { enabled: true, verbose: false });
+});
+
+Deno.test("coerceInputTypes: non-boolean string stays as string", () => {
+  const schema: InputsSchema = {
+    properties: {
+      flag: { type: "boolean" },
+    },
+  };
+  const result = coerceInputTypes({ flag: "yes" }, schema);
+  assertEquals(result, { flag: "yes" });
+});
+
+Deno.test("coerceInputTypes: NaN stays as string", () => {
+  const schema: InputsSchema = {
+    properties: {
+      count: { type: "number" },
+    },
+  };
+  const result = coerceInputTypes({ count: "not-a-number" }, schema);
+  assertEquals(result, { count: "not-a-number" });
+});
+
+Deno.test("coerceInputTypes: no schema returns inputs unchanged", () => {
+  const result = coerceInputTypes({ replicas: "3" });
+  assertEquals(result, { replicas: "3" });
+});
+
+Deno.test("coerceInputTypes: non-string values are untouched", () => {
+  const schema: InputsSchema = {
+    properties: {
+      count: { type: "number" },
+    },
+  };
+  const result = coerceInputTypes({ count: 42 }, schema);
+  assertEquals(result, { count: 42 });
+});
+
+Deno.test("coerceInputTypes: keys not in schema stay as strings", () => {
+  const schema: InputsSchema = {
+    properties: {
+      known: { type: "number" },
+    },
+  };
+  const result = coerceInputTypes({ known: "5", unknown: "hello" }, schema);
+  assertEquals(result, { known: 5, unknown: "hello" });
+});
+
+// --- parseInputs (backward compat) ---
+
+Deno.test("parseInputs: JSON string backward compat", async () => {
+  const result = await parseInputs({
+    input: '{"environment": "production"}',
+  });
+  assertEquals(result.source, "json");
+  assertEquals(result.inputs, { environment: "production" });
+});
+
+Deno.test("parseInputs: JSON array form backward compat", async () => {
+  const result = await parseInputs({
+    input: ['{"environment": "production"}'],
+  });
+  assertEquals(result.source, "json");
+  assertEquals(result.inputs, { environment: "production" });
+});
+
+Deno.test("parseInputs: invalid JSON throws", async () => {
+  await assertRejects(
+    () => parseInputs({ input: "{bad json" }),
+    Error,
+    "Invalid JSON in --input",
+  );
+});
+
+Deno.test("parseInputs: JSON array throws", async () => {
+  // A JSON array starts with { after stringify won't, but we can test
+  // invalid JSON object like {"key": [1]} parsed as non-object via a trick:
+  // only `{` triggers JSON mode, and `{` always yields an object or syntax error.
+  // Test that a JSON array wrapped to start with `{` but being invalid still errors.
+  await assertRejects(
+    () => parseInputs({ input: "{ invalid json" }),
+    Error,
+    "Invalid JSON in --input",
+  );
+});
+
+// --- parseInputs (key-value) ---
+
+Deno.test("parseInputs: single key=value", async () => {
+  const result = await parseInputs({
+    input: ["environment=production"],
+  });
+  assertEquals(result.source, "key-value");
+  assertEquals(result.inputs, { environment: "production" });
+});
+
+Deno.test("parseInputs: multiple key=value", async () => {
+  const result = await parseInputs({
+    input: ["environment=production", "replicas=3"],
+  });
+  assertEquals(result.source, "key-value");
+  assertEquals(result.inputs, { environment: "production", replicas: "3" });
+});
+
+Deno.test("parseInputs: key=value with dot notation", async () => {
+  const result = await parseInputs({
+    input: ["server.host=localhost", "server.port=8080"],
+  });
+  assertEquals(result.source, "key-value");
+  assertEquals(result.inputs, {
+    server: { host: "localhost", port: "8080" },
+  });
+});
+
+// --- parseInputs (YAML file) ---
+
+Deno.test("parseInputs: YAML file", async () => {
+  const tempFile = await Deno.makeTempFile({ suffix: ".yaml" });
+  try {
+    await Deno.writeTextFile(
+      tempFile,
+      stringifyYaml({ environment: "staging" } as Record<string, unknown>),
+    );
+    const result = await parseInputs({ inputFile: tempFile });
+    assertEquals(result.source, "yaml-file");
+    assertEquals(result.inputs, { environment: "staging" });
+  } finally {
+    await Deno.remove(tempFile);
+  }
+});
+
+Deno.test("parseInputs: missing YAML file throws", async () => {
+  await assertRejects(
+    () => parseInputs({ inputFile: "/nonexistent/file.yaml" }),
+    Error,
+    "Input file not found",
+  );
+});
+
+// --- parseInputs (combined) ---
+
+Deno.test("parseInputs: combined file + k=v overrides", async () => {
+  const tempFile = await Deno.makeTempFile({ suffix: ".yaml" });
+  try {
+    await Deno.writeTextFile(
+      tempFile,
+      stringifyYaml(
+        { environment: "staging", replicas: 2 } as Record<string, unknown>,
+      ),
+    );
+    const result = await parseInputs({
+      input: ["environment=production"],
+      inputFile: tempFile,
+    });
+    assertEquals(result.source, "combined");
+    assertEquals(result.inputs.environment, "production"); // override
+    assertEquals(result.inputs.replicas, 2); // from file
+  } finally {
+    await Deno.remove(tempFile);
+  }
+});
+
+Deno.test("parseInputs: JSON input ignores input-file", async () => {
+  const tempFile = await Deno.makeTempFile({ suffix: ".yaml" });
+  try {
+    await Deno.writeTextFile(
+      tempFile,
+      stringifyYaml({ fromFile: true } as Record<string, unknown>),
+    );
+    const result = await parseInputs({
+      input: ['{"fromJson": true}'],
+      inputFile: tempFile,
+    });
+    assertEquals(result.source, "json");
+    assertEquals(result.inputs, { fromJson: true });
+  } finally {
+    await Deno.remove(tempFile);
+  }
+});
+
+// --- parseInputs (none) ---
+
+Deno.test("parseInputs: no options returns none", async () => {
+  const result = await parseInputs({});
+  assertEquals(result.source, "none");
+  assertEquals(result.inputs, {});
+});


### PR DESCRIPTION
Fixes: #353 

## Summary

- Makes `--input` accept repeatable `key=value` pairs (`--input environment=production --input replicas=3`) alongside existing JSON mode
- Supports dot-notation for nested objects (`server.host=localhost`), `@file` references for reading values from files, and combining `--input-file` with k=v overrides (deep merge)
- Adds schema-aware type coercion so string k=v values are automatically coerced to `number`/`integer`/`boolean` when an InputsSchema declares those types
- Full backward compatibility: a single `--input` starting with `{` is still treated as JSON

## Test Plan

- 39 new unit tests in `src/cli/input_parser_test.ts` covering all parser functions, edge cases, coercion, and backward compat
- 5 new integration tests in `integration/inputs_test.ts` for k=v model method run, k=v workflow run, type coercion, @file input, and JSON backward compat
- All 1766 existing tests pass with 0 failures
- `deno check`, `deno lint`, `deno fmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)