### PR TITLE
feat: add SWAMP_NO_TELEMETRY environment variable to disable telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,11 +227,21 @@ Per-invocation:
 swamp --no-telemetry workflow run my-workflow
 ```
 
+Via environment variable (useful for CI/UAT environments):
+
+```bash
+export SWAMP_NO_TELEMETRY=1
+swamp workflow run my-workflow
+```
+
 Permanently for a repository — add to `.swamp.yaml`:
 
 ```yaml
 telemetryDisabled: true
 ```
+
+Priority order (highest to lowest): `--no-telemetry` flag → `SWAMP_NO_TELEMETRY`
+env var → `.swamp.yaml` `telemetryDisabled: true`.
 
 ## License
 

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -91,6 +91,18 @@ export function isTelemetryDisabledByConfig(
 }
 
 /**
+ * Checks whether telemetry is disabled via SWAMP_NO_TELEMETRY environment variable.
+ * Any value other than "0", "false", or empty string disables telemetry.
+ *
+ * @internal Exported for testing
+ */
+export function isTelemetryDisabledByEnv(): boolean {
+  const val = Deno.env.get("SWAMP_NO_TELEMETRY");
+  if (val === undefined) return false;
+  return val !== "0" && val !== "false" && val !== "";
+}
+
+/**
  * Load user models from configured directory.
  */
 async function loadUserModels(): Promise<void> {
@@ -192,7 +204,8 @@ export async function runCli(args: string[]): Promise<void> {
   const startTime = new Date();
 
   // Pre-parse check for telemetry disable flag
-  const telemetryDisabled = isTelemetryDisabled(args);
+  const telemetryDisabled = isTelemetryDisabled(args) ||
+    isTelemetryDisabledByEnv();
 
   // Extract command info for telemetry (before parsing)
   const commandInfo = extractCommandInfo(args);

--- a/src/cli/mod_test.ts
+++ b/src/cli/mod_test.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { isTelemetryDisabledByConfig, resolveModelsDir } from "./mod.ts";
+import {
+  isTelemetryDisabledByConfig,
+  isTelemetryDisabledByEnv,
+  resolveModelsDir,
+} from "./mod.ts";
 
 Deno.test("resolveModelsDir returns default 'extensions/models' when no config", () => {
   // Ensure env var is not set
@@ -137,4 +141,86 @@ Deno.test("isTelemetryDisabledByConfig returns true when field is true", () => {
     telemetryDisabled: true,
   };
   assertEquals(isTelemetryDisabledByConfig(marker), true);
+});
+
+Deno.test("isTelemetryDisabledByEnv returns false when env var is not set", () => {
+  const original = Deno.env.get("SWAMP_NO_TELEMETRY");
+  try {
+    Deno.env.delete("SWAMP_NO_TELEMETRY");
+    assertEquals(isTelemetryDisabledByEnv(), false);
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_NO_TELEMETRY", original);
+    }
+  }
+});
+
+Deno.test("isTelemetryDisabledByEnv returns true when env var is '1'", () => {
+  const original = Deno.env.get("SWAMP_NO_TELEMETRY");
+  try {
+    Deno.env.set("SWAMP_NO_TELEMETRY", "1");
+    assertEquals(isTelemetryDisabledByEnv(), true);
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_NO_TELEMETRY", original);
+    } else {
+      Deno.env.delete("SWAMP_NO_TELEMETRY");
+    }
+  }
+});
+
+Deno.test("isTelemetryDisabledByEnv returns true when env var is 'true'", () => {
+  const original = Deno.env.get("SWAMP_NO_TELEMETRY");
+  try {
+    Deno.env.set("SWAMP_NO_TELEMETRY", "true");
+    assertEquals(isTelemetryDisabledByEnv(), true);
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_NO_TELEMETRY", original);
+    } else {
+      Deno.env.delete("SWAMP_NO_TELEMETRY");
+    }
+  }
+});
+
+Deno.test("isTelemetryDisabledByEnv returns false when env var is '0'", () => {
+  const original = Deno.env.get("SWAMP_NO_TELEMETRY");
+  try {
+    Deno.env.set("SWAMP_NO_TELEMETRY", "0");
+    assertEquals(isTelemetryDisabledByEnv(), false);
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_NO_TELEMETRY", original);
+    } else {
+      Deno.env.delete("SWAMP_NO_TELEMETRY");
+    }
+  }
+});
+
+Deno.test("isTelemetryDisabledByEnv returns false when env var is 'false'", () => {
+  const original = Deno.env.get("SWAMP_NO_TELEMETRY");
+  try {
+    Deno.env.set("SWAMP_NO_TELEMETRY", "false");
+    assertEquals(isTelemetryDisabledByEnv(), false);
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_NO_TELEMETRY", original);
+    } else {
+      Deno.env.delete("SWAMP_NO_TELEMETRY");
+    }
+  }
+});
+
+Deno.test("isTelemetryDisabledByEnv returns false when env var is ''", () => {
+  const original = Deno.env.get("SWAMP_NO_TELEMETRY");
+  try {
+    Deno.env.set("SWAMP_NO_TELEMETRY", "");
+    assertEquals(isTelemetryDisabledByEnv(), false);
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_NO_TELEMETRY", original);
+    } else {
+      Deno.env.delete("SWAMP_NO_TELEMETRY");
+    }
+  }
 });


### PR DESCRIPTION
Fixes: #375 

Implements the SWAMP_NO_TELEMETRY environment variable mechanism proposed in issue #362. PR #364 added
.swamp.yaml telemetryDisabled: true but left out the env var approach, which is the missing piece for CI/UAT
environments where editing .swamp.yaml per-run isn't practical.

### Changes

src/cli/mod.ts

- Added isTelemetryDisabledByEnv() (exported for testing) after isTelemetryDisabledByConfig(), following the
same pattern as resolveModelsDir() which already reads SWAMP_MODELS_DIR
- Updated runCli() to OR the env var check with the existing flag check: isTelemetryDisabled(args) ||
isTelemetryDisabledByEnv()

src/cli/mod_test.ts

- Added 6 tests for isTelemetryDisabledByEnv() covering: not set, "1", "true" (disabled); "0", "false", ""
(enabled/explicit opt-in)
- Updated import line to include isTelemetryDisabledByEnv

README.md

- Extended the "Disabling Telemetry" section with the env var usage example and the full priority order

### Precedence (highest to lowest)

1. --no-telemetry CLI flag
2. SWAMP_NO_TELEMETRY env var  ← this PR
3. .swamp.yaml telemetryDisabled: true
4. Default (telemetry enabled)

The flag and env var checks are evaluated before initTelemetryService() is called, so they short-circuit the
config file read entirely.

### Plan vs Implementation

The implementation follows the plan exactly with one minor cosmetic difference: deno fmt reflowed the priority
sentence in README.md to fit within the line limit. No functional deviation from the plan.

### Verification

- deno check — passes
- deno lint — passes
- deno fmt — passes
- deno run test src/cli/mod_test.ts — 15/15 tests pass