### PR TITLE
feat: add automated triage workflow for community issues

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,50 @@
+name: Issue Triage
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  triage:
+    name: Triage New Issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if author is a maintainer
+        id: check-role
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const association = context.payload.issue.author_association;
+            const isMaintainer = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(association);
+            core.setOutput('is_maintainer', isMaintainer.toString());
+
+      - name: Add needs-triage label
+        if: steps.check-role.outputs.is_maintainer == 'false'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              labels: ['needs-triage'],
+            });
+
+      - name: Post welcome comment
+        if: steps.check-role.outputs.is_maintainer == 'false'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const author = context.payload.issue.user.login;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: `Hi @${author}, thanks for opening this issue!\n\nWe appreciate you taking the time to report it. A maintainer will review it as soon as possible.\n\nIn the meantime, please make sure you've included all relevant details (steps to reproduce, expected vs actual behaviour, swamp version, etc.) to help us triage it quickly.`,
+            });


### PR DESCRIPTION
- Adds a GitHub Actions workflow that fires when an issue is opened
- Checks `author_association` from the webhook payload to determine if the author is an `OWNER`, `MEMBER`, or
`COLLABORATOR`
- For external contributors: adds a `needs-triage` label and posts a welcome comment thanking them and asking
for reproduction details
- Maintainers/owners/collaborators opening issues are unaffected