### PR TITLE
test: add integration tests for CEL resource specName != dataName (issue #370)

### DIFF
--- a/integration/cel_data_access_test.ts
+++ b/integration/cel_data_access_test.ts
@@ -42,6 +42,7 @@ import {
 } from "../src/domain/expressions/model_resolver.ts";
 import { ExpressionEvaluationService } from "../src/domain/expressions/expression_evaluation_service.ts";
 import { CelEvaluator } from "../src/infrastructure/cel/cel_evaluator.ts";
+import { initializeTestRepo, runCliCommand } from "./test_helpers.ts";
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   const dir = await Deno.makeTempDir({ prefix: "swamp-cel-data-" });
@@ -811,3 +812,125 @@ Deno.test("CEL Data Access: multiple resource items from same model", async () =
     }
   });
 });
+
+// ============================================================================
+// specName != dataName (writeResource pattern)
+// ============================================================================
+
+Deno.test(
+  "CEL Data Access: cross-model resource with specName != dataName (writeResource pattern)",
+  async () => {
+    await withTempDir(async (repoDir) => {
+      await setupRepoDir(repoDir);
+      const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+      const definitionRepo = new YamlDefinitionRepository(repoDir);
+      const type = ModelType.create("test/model");
+      const owner = createOwner("test/model:spec-name-test");
+
+      // Create "s3-infra" model
+      const s3InfraModel = Definition.create({
+        name: "s3-infra",
+        globalArguments: {},
+      });
+      await definitionRepo.save(type, s3InfraModel);
+
+      // Write resource data with specName="summary", dataName="latest"
+      // This mirrors what writeResource("summary", "latest", data) produces:
+      //   tags.type = "resource", tags.specName = "summary", data.name = "latest"
+      const resourceData = Data.create({
+        name: "latest",
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 5,
+        tags: { type: "resource", specName: "summary" },
+        ownerDefinition: owner,
+      });
+      await dataRepo.save(
+        type,
+        s3InfraModel.id,
+        resourceData,
+        new TextEncoder().encode(JSON.stringify({ totalBuckets: 42 })),
+      );
+
+      // Create "s3-report" model referencing model.s3-infra.resource.summary.latest
+      const s3ReportModel = Definition.create({
+        name: "s3-report",
+        globalArguments: {
+          bucket_count:
+            "${{ model['s3-infra'].resource.summary.latest.attributes.totalBuckets }}",
+        },
+      });
+      await definitionRepo.save(type, s3ReportModel);
+
+      const evalService = new ExpressionEvaluationService(
+        definitionRepo,
+        repoDir,
+        { dataRepo },
+      );
+
+      const result = await evalService.evaluateDefinition(s3ReportModel, type);
+
+      assertEquals(result.hadExpressions, true);
+      assertEquals(result.definition.globalArguments.bucket_count, 42);
+    });
+  },
+);
+
+Deno.test(
+  "CLI: model evaluate resolves cross-model resource expressions (standalone, specName != dataName)",
+  async () => {
+    await withTempDir(async (repoDir) => {
+      await initializeTestRepo(repoDir);
+      const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+      const definitionRepo = new YamlDefinitionRepository(repoDir);
+      const type = ModelType.create("test/model");
+      const owner = createOwner("test/model:cli-spec-name-test");
+
+      // Create "infra" model with resource data: specName="report", dataName="current"
+      const infraModel = Definition.create({
+        name: "infra",
+        globalArguments: {},
+      });
+      await definitionRepo.save(type, infraModel);
+
+      const resourceData = Data.create({
+        name: "current",
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 5,
+        tags: { type: "resource", specName: "report" },
+        ownerDefinition: owner,
+      });
+      await dataRepo.save(
+        type,
+        infraModel.id,
+        resourceData,
+        new TextEncoder().encode(JSON.stringify({ instanceCount: 7 })),
+      );
+
+      // Create "app" model referencing the infra resource
+      const appModel = Definition.create({
+        name: "app",
+        globalArguments: {
+          count:
+            "${{ model.infra.resource.report.current.attributes.instanceCount }}",
+        },
+      });
+      await definitionRepo.save(type, appModel);
+
+      // Run model evaluate via CLI
+      const { stdout, stderr, code } = await runCliCommand(
+        ["--json", "model", "evaluate", "app", "--repo-dir", repoDir],
+        Deno.cwd(),
+      );
+
+      assertEquals(
+        code,
+        0,
+        `CLI exited with code ${code}. stdout: ${stdout} stderr: ${stderr}`,
+      );
+      const parsed = JSON.parse(stdout);
+      assertEquals(parsed.globalArguments.count, 7);
+    });
+  },
+);


### PR DESCRIPTION
## Summary

Closes #370 (partially — confirms root cause and adds regression coverage).

The issue reported that `model.X.resource.<spec>.<instance>.attributes.<field>` CEL expressions fail with `No such key: resource` in standalone mode. After tracing through the code, `buildContext()` in `ModelResolver` already handles `specName != dataName` correctly at line 513:

```ts
const specName = latestRecord.tags["specName"] ?? dataName;
```

The root cause was a **test coverage gap**: no existing test exercised the case where `specName` differs from `dataName` (the pattern produced by `writeResource("summary", "latest", data)`).

## Changes

Adds two new tests to `integration/cel_data_access_test.ts`:

1. **Service-level test** — exercises `ExpressionEvaluationService.evaluateDefinition` with data written using `specName="summary"`, `dataName="latest"` tags, asserting the CEL expression `model['s3-infra'].resource.summary.latest.attributes.totalBuckets` resolves correctly.

2. **CLI-level test** — exercises the full `model evaluate` CLI command path end-to-end with the same `specName != dataName` pattern, asserting the JSON output contains the resolved value.

Both tests pass, confirming the existing code is correct and providing regression coverage going forward.

## Test Plan

- [x] `deno task test integration/cel_data_access_test.ts` — all 17 tests pass
- [x] `deno task test` — full suite: 1774 passed, 0 failed
- [x] `deno check integration/cel_data_access_test.ts` — clean
- [x] `deno lint integration/cel_data_access_test.ts` — clean
- [x] `deno fmt integration/cel_data_access_test.ts` — no changes needed