### PR TITLE
feat: configurable default log level via .swamp.yaml and SWAMP_LOG_LEVEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,36 @@ This means you get the feature you asked for, maintained over time, without
 having to worry about keeping a fork in sync. See
 [CONTRIBUTING.md](CONTRIBUTING.md) for the full details.
 
+## Log Level
+
+By default, swamp outputs at the `info` level. You can change this once rather
+than repeating a flag on every command.
+
+Per-invocation flags (highest priority):
+
+```bash
+swamp -q workflow run my-workflow               # error level only
+swamp --log-level debug workflow run my-workflow
+```
+
+Via environment variable (useful for CI/CD):
+
+```bash
+export SWAMP_LOG_LEVEL=warning
+swamp workflow run my-workflow
+```
+
+Permanently for a repository — add to `.swamp.yaml`:
+
+```yaml
+logLevel: error
+```
+
+Valid levels: `trace`, `debug`, `info`, `warning`, `error`, `fatal`.
+
+Priority order (highest to lowest): `-q` / `--log-level` flag →
+`SWAMP_LOG_LEVEL` env var → `.swamp.yaml` `logLevel` → default (`info`).
+
 ## Telemetry
 
 Swamp collects anonymous usage telemetry to help us understand which commands

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -80,6 +80,21 @@ export function resolveModelsDir(marker: RepoMarkerData | null): string {
 }
 
 /**
+ * Resolves the log level.
+ * Priority: SWAMP_LOG_LEVEL env var > .swamp.yaml config > undefined (caller uses default)
+ *
+ * @internal Exported for testing
+ */
+export function resolveLogLevel(
+  marker: RepoMarkerData | null,
+): string | undefined {
+  const envVal = Deno.env.get("SWAMP_LOG_LEVEL");
+  if (envVal) return envVal;
+  if (marker?.logLevel) return marker.logLevel;
+  return undefined;
+}
+
+/**
  * Checks whether telemetry is disabled via .swamp.yaml config.
  *
  * @internal Exported for testing
@@ -219,6 +234,16 @@ export async function runCli(args: string[]): Promise<void> {
   // Load user models before setting up CLI
   await loadUserModels();
 
+  // Read marker for resolveLogLevel (used in globalAction closure)
+  let marker: RepoMarkerData | null = null;
+  try {
+    const markerRepo = new RepoMarkerRepository();
+    const repoPath = RepoPath.create(Deno.cwd());
+    marker = await markerRepo.read(repoPath);
+  } catch {
+    // Not in a swamp repo - marker stays null
+  }
+
   const cli = new Command()
     .name("swamp")
     .version(VERSION)
@@ -248,13 +273,17 @@ export async function runCli(args: string[]): Promise<void> {
       }
       const prettyOutput = !noColor && isStdinTty();
 
-      // Derive log level: --quiet → error, --log-level → parsed, default → info
+      // Derive log level: --quiet → error, --log-level → parsed,
+      // SWAMP_LOG_LEVEL env var / .swamp.yaml logLevel → parsed, default → info
       let logLevel: "trace" | "debug" | "info" | "warning" | "error" | "fatal" =
         "info";
       if (options.quiet) {
         logLevel = "error";
       } else if (options.logLevel) {
         logLevel = parseLogLevel(options.logLevel);
+      } else {
+        const resolved = resolveLogLevel(marker);
+        if (resolved) logLevel = parseLogLevel(resolved);
       }
 
       await initializeLogging({

--- a/src/cli/mod_test.ts
+++ b/src/cli/mod_test.ts
@@ -21,6 +21,7 @@ import { assertEquals } from "@std/assert";
 import {
   isTelemetryDisabledByConfig,
   isTelemetryDisabledByEnv,
+  resolveLogLevel,
   resolveModelsDir,
 } from "./mod.ts";
 
@@ -109,6 +110,94 @@ Deno.test("resolveModelsDir env var takes priority over default", () => {
       Deno.env.set("SWAMP_MODELS_DIR", original);
     } else {
       Deno.env.delete("SWAMP_MODELS_DIR");
+    }
+  }
+});
+
+Deno.test("resolveLogLevel returns undefined when no env var and no config", () => {
+  const original = Deno.env.get("SWAMP_LOG_LEVEL");
+  try {
+    Deno.env.delete("SWAMP_LOG_LEVEL");
+
+    const result = resolveLogLevel(null);
+    assertEquals(result, undefined);
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_LOG_LEVEL", original);
+    }
+  }
+});
+
+Deno.test("resolveLogLevel returns undefined when marker has no logLevel", () => {
+  const original = Deno.env.get("SWAMP_LOG_LEVEL");
+  try {
+    Deno.env.delete("SWAMP_LOG_LEVEL");
+
+    const marker = {
+      swampVersion: "0.1.0",
+      initializedAt: "2024-01-01T00:00:00Z",
+    };
+    const result = resolveLogLevel(marker);
+    assertEquals(result, undefined);
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_LOG_LEVEL", original);
+    }
+  }
+});
+
+Deno.test("resolveLogLevel returns marker.logLevel when only config is set", () => {
+  const original = Deno.env.get("SWAMP_LOG_LEVEL");
+  try {
+    Deno.env.delete("SWAMP_LOG_LEVEL");
+
+    const marker = {
+      swampVersion: "0.1.0",
+      initializedAt: "2024-01-01T00:00:00Z",
+      logLevel: "warning",
+    };
+    const result = resolveLogLevel(marker);
+    assertEquals(result, "warning");
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_LOG_LEVEL", original);
+    }
+  }
+});
+
+Deno.test("resolveLogLevel returns env var when set, even if config also has logLevel", () => {
+  const original = Deno.env.get("SWAMP_LOG_LEVEL");
+  try {
+    Deno.env.set("SWAMP_LOG_LEVEL", "debug");
+
+    const marker = {
+      swampVersion: "0.1.0",
+      initializedAt: "2024-01-01T00:00:00Z",
+      logLevel: "error",
+    };
+    const result = resolveLogLevel(marker);
+    assertEquals(result, "debug");
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_LOG_LEVEL", original);
+    } else {
+      Deno.env.delete("SWAMP_LOG_LEVEL");
+    }
+  }
+});
+
+Deno.test("resolveLogLevel returns env var when set with no marker", () => {
+  const original = Deno.env.get("SWAMP_LOG_LEVEL");
+  try {
+    Deno.env.set("SWAMP_LOG_LEVEL", "error");
+
+    const result = resolveLogLevel(null);
+    assertEquals(result, "error");
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_LOG_LEVEL", original);
+    } else {
+      Deno.env.delete("SWAMP_LOG_LEVEL");
     }
   }
 });

--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -41,6 +41,7 @@ export interface RepoMarkerData {
   telemetryDisabled?: boolean;
   telemetryKeepFlushed?: boolean;
   tool?: AiTool;
+  logLevel?: string;
 }
 
 /**


### PR DESCRIPTION
Closes #372.

Users in audit/reporting workflows had no way to set a persistent log
verbosity preference — they had to pass `-q` or `--log-level` on every
command. This PR adds two new configuration mechanisms so a default can
be set once and forgotten.

## What changed

Three complementary mechanisms now control log verbosity, applied in
priority order (highest → lowest):

| Priority | Source | Example |
|----------|--------|---------|
| 1 | `-q` flag | `-q` → `error` |
| 2 | `--log-level` flag | `--log-level debug` |
| 3 | `SWAMP_LOG_LEVEL` env var | CI/CD pipeline config |
| 4 | `.swamp.yaml` logLevel | per-repo default |
| 5 | Built-in default | `info` |

**Files changed:**

- `src/infrastructure/persistence/repo_marker_repository.ts` — added
`logLevel?: string` to `RepoMarkerData`
- `src/cli/mod.ts` — added `resolveLogLevel()` helper (exported for
testing); reads marker once before CLI setup and captures it via
closure into `globalAction`; updated `globalAction` branching to call
`resolveLogLevel()` between CLI flags and the hardcoded default
- `src/cli/mod_test.ts` — 5 new unit tests for `resolveLogLevel()`
- `README.md` — new "Log Level" section documenting all three mechanisms

## Plan vs. implementation

The implementation matched the plan exactly except for one incorrect
assumption: the plan stated that `this.marker` would be available on the
Cliffy `Command` `this` context inside `globalAction` (by analogy with
telemetry). In practice, the marker is read independently inside
`initTelemetryService()` and `loadUserModels()` and is not attached to
the command object.

**Resolution:** the marker is read once in `runCli()` just before
`new Command()` and captured via closure into `globalAction`. This is
functionally correct and keeps the change self-contained, at the cost of
reading the `.swamp.yaml` file a third time on every invocation (it's
already read by `loadUserModels` and `initTelemetryService`). This is
acceptable — the file is tiny and local.

The plan also called for a 5th unit test asserting that CLI flags
override the env var/config at integration level. This was not
implemented; a structurally equivalent but different 5th unit test
("env var with null marker") was written instead. The CLI-flag-wins
behaviour is covered implicitly by the `if`/`else if`/`else` structure
in `globalAction`, which is unit-tested by the existing command parsing
tests.

## Why this is a good change

- **Zero breaking change** — existing behaviour is identical when
neither `SWAMP_LOG_LEVEL` nor `logLevel` is set
- **Follows existing patterns** — `resolveLogLevel()` is modelled
directly on `resolveModelsDir()`; the `.swamp.yaml` field follows
`telemetryDisabled`; the README section follows the Telemetry section
structure
- **CI/CD friendly** — env var override means pipelines can suppress
noise without touching config files
- **Repo-level default** — teams running swamp in operational contexts
(fleet audits, credential rotation) can ship a quiet default in their
repo rather than documenting a flag for every user

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] `deno task test` — 1779 passed, 0 failed
- [x] `deno task compile` passes
- [x] `.swamp.yaml` `logLevel: debug` — debug lines appear
- [x] `SWAMP_LOG_LEVEL=debug` — debug lines appear
- [x] `SWAMP_LOG_LEVEL=error` overrides `.swamp.yaml` `logLevel: debug` — debug lines suppressed
- [x] `--log-level debug` — debug lines appear
- [x] `SWAMP_LOG_LEVEL=error` + `--log-level debug` — debug lines appear (CLI flag wins)