### PR TITLE
fix: resolve CEL resource expressions after model delete and recreate

### DIFF
--- a/integration/cel_data_access_test.ts
+++ b/integration/cel_data_access_test.ts
@@ -934,3 +934,147 @@ Deno.test(
     });
   },
 );
+
+// ============================================================================
+// Cross-Model Type Resource References (Issue #370)
+// ============================================================================
+
+Deno.test("CEL Data Access: cross-type resource with specName tag via ExpressionEvaluationService (#370)", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const owner = createOwner("user/s3-inventory:create");
+
+    // Two distinct model types — mirrors the real-world scenario from issue #370
+    // Uses @-prefixed types as in the actual user report
+    const inventoryType = ModelType.create("@user/s3-inventory");
+    const reportType = ModelType.create("@user/s3-report");
+
+    // Source model under inventory type — uses hyphenated name like issue #370
+    const sourceModel = Definition.create({
+      name: "s3-infra",
+      globalArguments: { region: "us-east-1" },
+    });
+    await definitionRepo.save(inventoryType, sourceModel);
+
+    // Write resource data the way createResourceWriter does:
+    //   name = "latest" (instance name), specName tag = "summary"
+    const resourceData = Data.create({
+      name: "latest",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { type: "resource", specName: "summary" },
+      ownerDefinition: owner,
+    });
+
+    await dataRepo.save(
+      inventoryType,
+      sourceModel.id,
+      resourceData,
+      new TextEncoder().encode(JSON.stringify({ totalBuckets: 42 })),
+    );
+
+    // Dependent model under a *different* type referencing the source's resource
+    // Uses bracket notation for hyphenated name, matching the error from issue #370:
+    //   model["s3-infra"].resource.summary.latest.attributes.totalBuckets
+    const reportModel = Definition.create({
+      name: "s3-report",
+      globalArguments: {
+        bucket_count:
+          '${{ model["s3-infra"].resource.summary.latest.attributes.totalBuckets }}',
+      },
+    });
+    await definitionRepo.save(reportType, reportModel);
+
+    // Evaluate via ExpressionEvaluationService — the code path used by
+    // `swamp model method run` and `swamp model evaluate`
+    const evalService = new ExpressionEvaluationService(
+      definitionRepo,
+      repoDir,
+      { dataRepo },
+    );
+
+    const result = await evalService.evaluateDefinition(
+      reportModel,
+      reportType,
+    );
+
+    assertEquals(result.hadExpressions, true);
+    assertEquals(result.definition.globalArguments.bucket_count, 42);
+  });
+});
+
+Deno.test("CEL Data Access: resource resolves after model delete and recreate with new UUID (#370)", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const inventoryType = ModelType.create("@user/s3-inventory");
+    const reportType = ModelType.create("@user/s3-report");
+    const owner = createOwner("user/s3-inventory:create");
+
+    // Step 1: Create source model and save resource data under its UUID
+    const originalModel = Definition.create({
+      name: "s3-infra",
+      globalArguments: { region: "us-east-1" },
+    });
+    await definitionRepo.save(inventoryType, originalModel);
+
+    const resourceData = Data.create({
+      name: "latest",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { type: "resource", specName: "summary", modelName: "s3-infra" },
+      ownerDefinition: owner,
+    });
+
+    await dataRepo.save(
+      inventoryType,
+      originalModel.id,
+      resourceData,
+      new TextEncoder().encode(JSON.stringify({ totalBuckets: 42 })),
+    );
+
+    // Step 2: Delete the definition and recreate with a NEW UUID
+    // (simulates `swamp model delete` + `swamp model create`)
+    await definitionRepo.delete(inventoryType, originalModel.id);
+    const recreatedModel = Definition.create({
+      name: "s3-infra",
+      globalArguments: { region: "us-east-1" },
+    });
+    await definitionRepo.save(inventoryType, recreatedModel);
+
+    // Sanity check: the UUIDs are different
+    const uuidsDiffer = originalModel.id !== recreatedModel.id;
+    assertEquals(uuidsDiffer, true);
+
+    // Step 3: Create dependent model referencing the source's resource
+    const reportModel = Definition.create({
+      name: "s3-report",
+      globalArguments: {
+        bucket_count:
+          '${{ model["s3-infra"].resource.summary.latest.attributes.totalBuckets }}',
+      },
+    });
+    await definitionRepo.save(reportType, reportModel);
+
+    // Step 4: Evaluate — this used to fail with "No such key: resource"
+    // because data lived under the old UUID and the new UUID had no data.
+    const evalService = new ExpressionEvaluationService(
+      definitionRepo,
+      repoDir,
+      { dataRepo },
+    );
+
+    const result = await evalService.evaluateDefinition(
+      reportModel,
+      reportType,
+    );
+
+    assertEquals(result.hadExpressions, true);
+    assertEquals(result.definition.globalArguments.bucket_count, 42);
+  });
+});

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -23,6 +23,7 @@ import type { Definition, InputsSchema } from "../definitions/definition.ts";
 import type { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
 import type { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import type { Data } from "../data/data.ts";
 import { ModelNotFoundError } from "./errors.ts";
 import { VaultService } from "../vaults/vault_service.ts";
 
@@ -433,31 +434,91 @@ export class ModelResolver {
       context.model[definition.id] = modelData;
     }
 
-    // Build data cache if dataRepo is available
+    // Build data cache if dataRepo is available.
+    // Uses findAllGlobal() to discover data from disk first, then matches
+    // to definitions. This handles the case where a model was deleted and
+    // recreated (new UUID) — data under the old UUID is still found.
     const dataCache = new DataCache();
     if (this.dataRepo) {
-      for (const { definition, type: defType } of allDefinitions) {
-        const modelType = typeResolver?.(definition.id) ?? defType;
-        const modelName = definition.name;
+      // Build definition lookup maps
+      const defById = new Map<
+        string,
+        { definition: Definition; type: ModelType }
+      >();
+      const defsByType = new Map<
+        string,
+        Array<{ definition: Definition; type: ModelType }>
+      >();
 
-        // Load all data for this model
-        const allData = await this.dataRepo.findAllForModel(
-          modelType,
-          definition.id,
-        );
+      for (const { definition: def, type: defType } of allDefinitions) {
+        defById.set(def.id, { definition: def, type: defType });
+        const typeKey = defType.normalized;
+        if (!defsByType.has(typeKey)) defsByType.set(typeKey, []);
+        defsByType.get(typeKey)!.push({ definition: def, type: defType });
+      }
 
-        for (const data of allData) {
-          // Get all versions for this data item
+      // Discover all data on disk
+      const allGlobalData = await this.dataRepo.findAllGlobal();
+
+      // Group data items by (modelType, modelId) — the disk coordinates
+      const groupKey = (mt: ModelType, mid: string) =>
+        `${mt.normalized}::${mid}`;
+      const groupedData = new Map<
+        string,
+        { modelType: ModelType; modelId: string; items: Data[] }
+      >();
+      for (const { data, modelType, modelId } of allGlobalData) {
+        const key = groupKey(modelType, modelId);
+        if (!groupedData.has(key)) {
+          groupedData.set(key, { modelType, modelId, items: [] });
+        }
+        groupedData.get(key)!.items.push(data);
+      }
+
+      // Match each group to a definition and load data
+      for (const [_key, group] of groupedData) {
+        const { modelType, modelId, items } = group;
+
+        // 1. Direct match: modelId matches a definition's UUID
+        let matchedDef = defById.get(modelId);
+
+        // 2. Orphan recovery by modelName tag
+        if (!matchedDef) {
+          const modelNameTag = items.find((d) => d.tags["modelName"])
+            ?.tags["modelName"];
+          if (modelNameTag) {
+            const defsOfType = defsByType.get(modelType.normalized) ?? [];
+            const nameMatch = defsOfType.find(
+              (d) => d.definition.name === modelNameTag,
+            );
+            if (nameMatch) matchedDef = nameMatch;
+          }
+        }
+
+        // 3. Orphan recovery by heuristic: only one definition of this type
+        if (!matchedDef) {
+          const defsOfType = defsByType.get(modelType.normalized) ?? [];
+          if (defsOfType.length === 1) {
+            matchedDef = defsOfType[0];
+          }
+        }
+
+        if (!matchedDef) continue;
+
+        const modelName = matchedDef.definition.name;
+
+        // Process data items — use disk modelId for all repo calls
+        for (const data of items) {
           const versions = await this.dataRepo.listVersions(
             modelType,
-            definition.id,
+            modelId,
             data.name,
           );
 
           for (const version of versions) {
             const versionData = await this.dataRepo.findByName(
               modelType,
-              definition.id,
+              modelId,
               data.name,
               version,
             );
@@ -468,7 +529,7 @@ export class ModelResolver {
               if (versionData.contentType === "application/json") {
                 const content = await this.dataRepo.getContent(
                   modelType,
-                  definition.id,
+                  modelId,
                   data.name,
                   version,
                 );
@@ -520,9 +581,10 @@ export class ModelResolver {
               if (!modelData.file) modelData.file = {};
               const specName = latestRecord.tags["specName"] ?? dataName;
               if (!modelData.file[specName]) modelData.file[specName] = {};
+              // Use disk modelId for content path lookup
               const contentPath = this.dataRepo.getContentPath(
                 modelType,
-                definition.id,
+                modelId,
                 dataName,
                 latestRecord.version as number,
               );

--- a/src/domain/models/data_writer.ts
+++ b/src/domain/models/data_writer.ts
@@ -301,6 +301,7 @@ export function createResourceWriter(
   }>,
   definitionTags?: Record<string, string>,
   runtimeTags?: Record<string, string>,
+  definitionName?: string,
 ): {
   writeResource: (
     specName: string,
@@ -364,6 +365,11 @@ export function createResourceWriter(
 
     // Auto-inject specName tag for findBySpec discovery
     resolvedTags["specName"] = specName;
+
+    // Auto-inject modelName tag for orphan data recovery (issue #370)
+    if (definitionName) {
+      resolvedTags["modelName"] = definitionName;
+    }
 
     // Apply global tag overrides (workflow step tags)
     if (tagOverrides) {
@@ -453,6 +459,7 @@ export function createFileWriterFactory(
   callbacks?: DataWriterCallbacks,
   definitionTags?: Record<string, string>,
   runtimeTags?: Record<string, string>,
+  definitionName?: string,
 ): {
   createFileWriter: (
     specName: string,
@@ -501,6 +508,11 @@ export function createFileWriterFactory(
 
     // Auto-inject specName tag for findBySpec discovery
     resolvedTags["specName"] = specName;
+
+    // Auto-inject modelName tag for orphan data recovery (issue #370)
+    if (definitionName) {
+      resolvedTags["modelName"] = definitionName;
+    }
 
     // Apply global tag overrides (workflow step tags)
     if (tagOverrides) {

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -209,6 +209,7 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
       context.dataOutputOverrides,
       currentDefinition.tags,
       context.runtimeTags,
+      currentDefinition.name,
     );
 
     const {
@@ -224,6 +225,7 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
       undefined, // callbacks
       currentDefinition.tags,
       context.runtimeTags,
+      currentDefinition.name,
     );
 
     // Inject into context

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -397,12 +397,15 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
       for await (const entry of Deno.readDir(dir)) {
         if (!entry.isDirectory && !entry.isSymlink) continue;
 
-        // Check if this child is a data-name directory
+        // Check if this child is a data-name directory by looking for
+        // numeric version subdirectories (1/, 2/, 3/, ...).
+        // We intentionally skip checking for "latest" here because a data
+        // item could be literally named "latest", which would cause a
+        // type directory to be misidentified as a model-ID directory.
         const childPath = join(dir, entry.name);
         try {
           for await (const subEntry of Deno.readDir(childPath)) {
-            // If we find a "latest" symlink or a numeric directory, this is a data dir
-            if (subEntry.name === "latest" || /^\d+$/.test(subEntry.name)) {
+            if (subEntry.isDirectory && /^\d+$/.test(subEntry.name)) {
               return true;
             }
           }


### PR DESCRIPTION
## Summary

Fixes #370 — CEL expressions like `model["s3-infra"].resource.summary.latest.attributes.totalBuckets` fail with **"No such key: resource"** when running `swamp model method run` or `swamp model evaluate` standalone after a model has been deleted and recreated.

## The Problem

### What users see

A user creates a model (e.g. `@user/s3-inventory` with definition name `s3-infra`), runs it to produce resource data, then later deletes and recreates the model — perhaps to change configuration, fix a typo, or start fresh. After recreation, any CEL expression referencing that model's resource data from another model breaks:

```
Invalid expression: No such key: resource

>    1 | model["s3-infra"].resource.summary.latest.attributes.totalBuckets
                           ^
```

This is especially frustrating because:
- The data **still exists on disk** at `.swamp/data/@user/s3-inventory/<old-uuid>/latest/<version>/raw`
- The expression **passes `swamp model validate`**
- The expression **works inside workflows** (which bypass this code path entirely)
- There is no indication that the data is "orphaned" or how to fix it
- The only workaround is to re-run the entire upstream pipeline

### Why it happens

Every swamp definition gets a random UUID when created. Data written by a model method is stored on disk under that UUID:

```
.swamp/data/@user/s3-inventory/<definition-uuid>/latest/1/raw
```

When a definition is deleted and recreated, it gets a **new UUID**. But the data on disk still lives under the **old UUID's** directory.

The bug is in `ModelResolver.buildContext()`, which builds the CEL evaluation context for standalone commands. It iterates all current definitions and calls `dataRepo.findAllForModel(type, definition.id)` — using the definition's **current UUID** to look up data. Since the UUID changed, the lookup finds nothing, and `model.X.resource` is never populated in the context.

### Why workflows aren't affected

Workflows inject resource data in-memory via `taskOutput.resources` after each step completes (in `execution_service.ts`), completely bypassing the disk-based data lookup in `buildContext()`. This is why the same CEL expression works in a workflow but fails in standalone `model method run` / `model evaluate`.

## The Fix

### Part 1: Filesystem-first data discovery (model_resolver.ts)

Instead of iterating definitions and looking up data by each definition's current UUID, the new approach:

1. **Scans all data from disk first** via `dataRepo.findAllGlobal()`, which returns every data item with its `(modelType, modelId)` disk coordinates — where `modelId` is whatever UUID directory the data lives under
2. **Groups data items** by `(modelType, modelId)`
3. **Matches each group to a definition** using a 3-tier strategy:
   - **Direct match**: the disk `modelId` matches a current definition's UUID (the common case — no delete/recreate)
   - **Tag-based match**: the data has a `modelName` tag (see Part 2) → find the definition of the same type with that name
   - **Heuristic match**: only one definition exists for that model type → use it (covers most single-model-per-type scenarios, and handles pre-existing data that doesn't have the `modelName` tag yet)
4. **Uses the disk `modelId`** (not the definition's current UUID) for all subsequent data repo calls (`listVersions`, `findByName`, `getContent`, `getContentPath`)

This eliminates the root cause: data is discovered from the filesystem regardless of which UUID directory it lives under.

### Part 2: `modelName` tag for reliable orphan matching (data_writer.ts, method_execution_service.ts)

Both `createResourceWriter()` and `createFileWriterFactory()` now accept an optional `definitionName` parameter and auto-inject a `modelName` tag into every data item's metadata. This tag records the human-readable definition name at write time, enabling the tag-based matching in Part 1.

`DefaultMethodExecutionService.executeWorkflow()` passes `currentDefinition.name` to both factories.

**Backward compatibility**: The `modelName` tag is only written on new data going forward. For existing data without it, the resolver falls back to the single-definition heuristic (which covers most real-world cases where there's only one definition per model type). Over time, as models are re-run, data naturally gains the tag.

### Part 3: Fix `isModelIdDirectory()` heuristic (unified_data_repository.ts)

During implementation, we discovered a pre-existing bug in `FileSystemUnifiedDataRepository.findAllGlobal()`. Its recursive directory walker uses `isModelIdDirectory()` to distinguish model-ID directories from type directories. The old check looked for a "latest" entry in grandchild directories — but if a data item is literally named "latest" (a valid name used in the issue's reproduction case), the check misidentifies a type directory as a model-ID directory, causing the entire subtree to be incorrectly parsed.

Fixed by only checking for **numeric version subdirectories** (1/, 2/, 3/, ...) which are unambiguous markers of the version directory structure.

## Files Changed

| File | What changed |
|------|-------------|
| `src/domain/expressions/model_resolver.ts` | Refactored `buildContext()` data loading: filesystem-first discovery via `findAllGlobal()` with 3-tier definition matching |
| `src/domain/models/data_writer.ts` | Added `definitionName` param to `createResourceWriter()` and `createFileWriterFactory()`; auto-injects `modelName` tag |
| `src/domain/models/method_execution_service.ts` | Passes `currentDefinition.name` to both data writer factories |
| `src/infrastructure/persistence/unified_data_repository.ts` | Fixed `isModelIdDirectory()` to only check numeric version dirs (not "latest") |
| `integration/cel_data_access_test.ts` | Added 2 regression tests: cross-type resource resolution, and UUID-mismatch after delete+recreate |

## Test plan

- [x] New test: cross-type resource with `specName` tag resolves via `ExpressionEvaluationService`
- [x] New test: resource resolves after model delete and recreate with new UUID (the exact reproduction from #370)
- [x] All 19 CEL data access integration tests pass
- [x] Full test suite: 1768 tests pass, 0 failures
- [x] `deno check` — no type errors
- [x] `deno lint` — no lint issues
- [x] `deno fmt --check` — formatting clean