### PR TITLE
fix: use getCollaboratorPermissionLevel instead of author_association

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   issues: write
+  contents: read
 
 jobs:
   triage:
@@ -18,16 +19,19 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const payloadAssociation = context.payload.issue.author_association;
-            core.info(`Webhook payload author_association: ${payloadAssociation}`);
-            const { data: issue } = await github.rest.issues.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.issue.number,
-            });
-            const association = issue.author_association;
-            core.info(`REST API author_association: ${association}`);
-            const isMaintainer = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(association);
+            const login = context.payload.issue.user.login;
+            let isMaintainer = false;
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: login,
+              });
+              core.info(`Permission level for ${login}: ${data.permission}`);
+              isMaintainer = ['admin', 'write'].includes(data.permission);
+            } catch (error) {
+              core.info(`Could not fetch permission level for ${login}: ${error.message}`);
+            }
             core.setOutput('is_maintainer', isMaintainer.toString());
 
       - name: Add needs-triage label


### PR DESCRIPTION
## Summary

- Follow-up to #398 — that fix didn't work because `author_association` is computed **lazily** by GitHub
- The logs confirmed both the webhook payload and a fresh REST API call immediately after issue creation return `CONTRIBUTOR` for a maintainer; only after several minutes does it resolve to `MEMBER`
- Fix: switch to `repos.getCollaboratorPermissionLevel` which checks actual real-time repo permissions (`admin`/`write`) rather than the cached `author_association` field
- Add `contents: read` permission required for that API call

## Test plan

- [ ] Merge and open a new issue as a maintainer
- [ ] Confirm `needs-triage` label and welcome comment are **not** added
- [ ] Check run logs for `Permission level for <user>: admin` (or `write`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)