### PR TITLE
fix: write encrypted .enc files with 0600 permissions

### DIFF
--- a/src/domain/vaults/local_encryption_vault_provider.ts
+++ b/src/domain/vaults/local_encryption_vault_provider.ts
@@ -117,6 +117,7 @@ export class LocalEncryptionVaultProvider implements VaultProvider {
     await atomicWriteTextFile(
       encryptedFilePath,
       JSON.stringify(encryptedData, null, 2),
+      { mode: 0o600 },
     );
   }
 

--- a/src/domain/vaults/local_encryption_vault_provider_test.ts
+++ b/src/domain/vaults/local_encryption_vault_provider_test.ts
@@ -378,6 +378,29 @@ Deno.test("LocalEncryptionVaultProvider - error handling", async (t) => {
   });
 });
 
+Deno.test("LocalEncryptionVaultProvider - file permissions", async (t) => {
+  await t.step(
+    "should create .enc files with 0o600 permissions",
+    async () => {
+      await withTempDir(async (dir) => {
+        await Deno.writeTextFile("test_ssh_key", MOCK_SSH_PRIVATE_KEY);
+
+        const vaultSecretsDir = secretsDir(dir, "perms-vault");
+        const config: LocalEncryptionConfig = {
+          ssh_key_path: "test_ssh_key",
+          base_dir: dir,
+        };
+        const vault = new LocalEncryptionVaultProvider("perms-vault", config);
+
+        await vault.put("secret-key", "secret-value");
+
+        const stat = await Deno.stat(join(vaultSecretsDir, "secret-key.enc"));
+        assertEquals(stat.mode! & 0o777, 0o600);
+      });
+    },
+  );
+});
+
 Deno.test("LocalEncryptionVaultProvider - security properties", async (t) => {
   await t.step("should use different salts for different secrets", async () => {
     await withTempDir(async (dir) => {


### PR DESCRIPTION
## Summary
- Add `mode: 0o600` to `.enc` file writes in `LocalEncryptionVaultProvider.put()`, matching the existing `.key` file behavior
- Add test verifying `.enc` files are created with restrictive permissions
- Closes #395

## Test plan
- [x] New test: "should create .enc files with 0o600 permissions" passes
- [x] All existing vault provider tests pass
- [x] `deno check`, `deno lint`, `deno fmt` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)