### PR TITLE
fix: path traversal in symlink_repo_index_service (#390)

### DIFF
--- a/src/infrastructure/repo/symlink_repo_index_service.ts
+++ b/src/infrastructure/repo/symlink_repo_index_service.ts
@@ -25,7 +25,7 @@
  */
 
 import { ensureDir } from "@std/fs";
-import { join, relative } from "@std/path";
+import { join, relative, resolve } from "@std/path";
 import { getLogger } from "@logtape/logtape";
 import {
   SWAMP_DATA_DIR,
@@ -126,7 +126,13 @@ export class SymlinkRepoIndexService implements RepoIndexService {
   }
 
   async handleModelDeleted(event: ModelDeleted): Promise<void> {
-    const modelDir = join(this.repoDir, "models", event.modelName);
+    const modelsBaseDir = join(this.repoDir, "models");
+    const modelDir = join(modelsBaseDir, event.modelName);
+    this.assertPathContained(
+      modelDir,
+      modelsBaseDir,
+      `modelName "${event.modelName}"`,
+    );
     await this.removeDirectory(modelDir);
   }
 
@@ -143,7 +149,13 @@ export class SymlinkRepoIndexService implements RepoIndexService {
   }
 
   async handleWorkflowDeleted(event: WorkflowDeleted): Promise<void> {
-    const workflowDir = join(this.repoDir, "workflows", event.workflowName);
+    const workflowsBaseDir = join(this.repoDir, "workflows");
+    const workflowDir = join(workflowsBaseDir, event.workflowName);
+    this.assertPathContained(
+      workflowDir,
+      workflowsBaseDir,
+      `workflowName "${event.workflowName}"`,
+    );
     await this.removeDirectory(workflowDir);
   }
 
@@ -188,7 +200,13 @@ export class SymlinkRepoIndexService implements RepoIndexService {
   }
 
   async handleVaultDeleted(event: VaultDeleted): Promise<void> {
-    const vaultDir = join(this.repoDir, "vaults", event.vaultName);
+    const vaultsBaseDir = join(this.repoDir, "vaults");
+    const vaultDir = join(vaultsBaseDir, event.vaultName);
+    this.assertPathContained(
+      vaultDir,
+      vaultsBaseDir,
+      `vaultName "${event.vaultName}"`,
+    );
     await this.removeDirectory(vaultDir);
   }
 
@@ -393,7 +411,13 @@ export class SymlinkRepoIndexService implements RepoIndexService {
     modelInputId: string,
     modelName: string,
   ): Promise<void> {
-    const modelDir = join(this.repoDir, "models", modelName);
+    const modelsBaseDir = join(this.repoDir, "models");
+    const modelDir = join(modelsBaseDir, modelName);
+    this.assertPathContained(
+      modelDir,
+      modelsBaseDir,
+      `modelName "${modelName}"`,
+    );
     await ensureDir(modelDir);
 
     // Create ModelType for path generation
@@ -518,11 +542,22 @@ export class SymlinkRepoIndexService implements RepoIndexService {
 
       // Create symlinks for custom tags: {tag-key}/{tag-value}/
       for (const [tagKey, valueMap] of customTags) {
-        const tagKeyDir = join(typeDir, "..", tagKey);
+        const modelDir = join(typeDir, "..");
+        const tagKeyDir = join(modelDir, tagKey);
+        this.assertPathContained(
+          tagKeyDir,
+          modelDir,
+          `tagKey "${tagKey}"`,
+        );
         await ensureDir(tagKeyDir);
 
         for (const [tagValue, dataItems] of valueMap) {
           const tagValueDir = join(tagKeyDir, tagValue);
+          this.assertPathContained(
+            tagValueDir,
+            tagKeyDir,
+            `tagValue "${tagValue}"`,
+          );
           await ensureDir(tagValueDir);
 
           for (const data of dataItems) {
@@ -548,6 +583,12 @@ export class SymlinkRepoIndexService implements RepoIndexService {
         }
       }
     } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.startsWith("Path traversal detected")
+      ) {
+        throw error;
+      }
       logger.debug`Failed to index tag-based data: ${error}`;
     }
   }
@@ -579,7 +620,13 @@ export class SymlinkRepoIndexService implements RepoIndexService {
     workflowId: string,
     workflowName: string,
   ): Promise<void> {
-    const workflowDir = join(this.repoDir, "workflows", workflowName);
+    const workflowsBaseDir = join(this.repoDir, "workflows");
+    const workflowDir = join(workflowsBaseDir, workflowName);
+    this.assertPathContained(
+      workflowDir,
+      workflowsBaseDir,
+      `workflowName "${workflowName}"`,
+    );
     await ensureDir(workflowDir);
 
     // Symlink to workflow.yaml
@@ -605,7 +652,13 @@ export class SymlinkRepoIndexService implements RepoIndexService {
     workflowName: string,
     runId: string,
   ): Promise<void> {
-    const workflowDir = join(this.repoDir, "workflows", workflowName);
+    const workflowsBaseDir = join(this.repoDir, "workflows");
+    const workflowDir = join(workflowsBaseDir, workflowName);
+    this.assertPathContained(
+      workflowDir,
+      workflowsBaseDir,
+      `workflowName "${workflowName}"`,
+    );
     const runsDir = join(workflowDir, "runs");
     await ensureDir(runsDir);
 
@@ -647,6 +700,11 @@ export class SymlinkRepoIndexService implements RepoIndexService {
       for (const job of run.jobs) {
         for (const step of job.steps) {
           const stepDir = join(stepsDir, step.stepName);
+          this.assertPathContained(
+            stepDir,
+            stepsDir,
+            `stepName "${step.stepName}"`,
+          );
           await ensureDir(stepDir);
 
           // Note: Step output symlinks would require additional context
@@ -668,7 +726,13 @@ export class SymlinkRepoIndexService implements RepoIndexService {
     vaultType: string,
     vaultName: string,
   ): Promise<void> {
-    const vaultDir = join(this.repoDir, "vaults", vaultName);
+    const vaultsBaseDir = join(this.repoDir, "vaults");
+    const vaultDir = join(vaultsBaseDir, vaultName);
+    this.assertPathContained(
+      vaultDir,
+      vaultsBaseDir,
+      `vaultName "${vaultName}"`,
+    );
     await ensureDir(vaultDir);
 
     // Symlink to vault.yaml
@@ -909,6 +973,27 @@ export class SymlinkRepoIndexService implements RepoIndexService {
       if (!(error instanceof Deno.errors.NotFound)) {
         throw error;
       }
+    }
+  }
+
+  /**
+   * Asserts that a path is contained within an expected parent directory.
+   * Throws if the resolved path escapes the parent, preventing path traversal.
+   */
+  private assertPathContained(
+    path: string,
+    expectedParent: string,
+    context: string,
+  ): void {
+    const resolvedPath = resolve(path);
+    const resolvedParent = resolve(expectedParent);
+    if (
+      resolvedPath !== resolvedParent &&
+      !resolvedPath.startsWith(resolvedParent + "/")
+    ) {
+      throw new Error(
+        `Path traversal detected: ${context} resolves outside expected directory`,
+      );
     }
   }
 

--- a/src/infrastructure/repo/symlink_repo_index_service_test.ts
+++ b/src/infrastructure/repo/symlink_repo_index_service_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import { join } from "@std/path";
 import { ensureDir } from "@std/fs";
 import { SymlinkRepoIndexService } from "./symlink_repo_index_service.ts";
@@ -34,6 +34,11 @@ import { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
 import {
   createModelCreated,
   createModelDeleted,
+  createVaultCreated,
+  createVaultDeleted,
+  createWorkflowCreated,
+  createWorkflowDeleted,
+  createWorkflowRunStarted,
 } from "../../domain/events/types.ts";
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
@@ -430,5 +435,144 @@ Deno.test("SymlinkRepoIndexService indexes workflow runs with latest symlink", a
     const latestPath = join(runsDir, "latest");
     const latestInfo = await Deno.lstat(latestPath);
     assertEquals(latestInfo.isSymlink, true);
+  });
+});
+
+// ============================================================================
+// Path Traversal Protection Tests
+// ============================================================================
+
+Deno.test("path traversal protection: model name in handleModelCreated", async () => {
+  await withTempDir(async (dir) => {
+    await setupRepoDir(dir);
+    const { indexService } = createIndexService(dir);
+    const type = ModelType.create("swamp/echo");
+
+    const event = createModelCreated(
+      type.normalized,
+      "some-id",
+      "../../../malicious",
+    );
+    await assertRejects(
+      () => indexService.handleModelCreated(event),
+      Error,
+      "Path traversal detected",
+    );
+  });
+});
+
+Deno.test("path traversal protection: model name in handleModelDeleted", async () => {
+  await withTempDir(async (dir) => {
+    await setupRepoDir(dir);
+    const { indexService } = createIndexService(dir);
+    const type = ModelType.create("swamp/echo");
+
+    const event = createModelDeleted(
+      type.normalized,
+      "some-id",
+      "../../../malicious",
+    );
+    await assertRejects(
+      () => indexService.handleModelDeleted(event),
+      Error,
+      "Path traversal detected",
+    );
+  });
+});
+
+Deno.test("path traversal protection: workflow name in handleWorkflowCreated", async () => {
+  await withTempDir(async (dir) => {
+    await setupRepoDir(dir);
+    const { indexService } = createIndexService(dir);
+
+    const event = createWorkflowCreated("some-id", "../../../malicious");
+    await assertRejects(
+      () => indexService.handleWorkflowCreated(event),
+      Error,
+      "Path traversal detected",
+    );
+  });
+});
+
+Deno.test("path traversal protection: workflow name in handleWorkflowDeleted", async () => {
+  await withTempDir(async (dir) => {
+    await setupRepoDir(dir);
+    const { indexService } = createIndexService(dir);
+
+    const event = createWorkflowDeleted("some-id", "../../../malicious");
+    await assertRejects(
+      () => indexService.handleWorkflowDeleted(event),
+      Error,
+      "Path traversal detected",
+    );
+  });
+});
+
+Deno.test("path traversal protection: vault name in handleVaultCreated", async () => {
+  await withTempDir(async (dir) => {
+    await setupRepoDir(dir);
+    const { indexService } = createIndexService(dir);
+
+    const event = createVaultCreated(
+      "some-id",
+      "local_encryption",
+      "../../../malicious",
+    );
+    await assertRejects(
+      () => indexService.handleVaultCreated(event),
+      Error,
+      "Path traversal detected",
+    );
+  });
+});
+
+Deno.test("path traversal protection: vault name in handleVaultDeleted", async () => {
+  await withTempDir(async (dir) => {
+    await setupRepoDir(dir);
+    const { indexService } = createIndexService(dir);
+
+    const event = createVaultDeleted(
+      "some-id",
+      "local_encryption",
+      "../../../malicious",
+    );
+    await assertRejects(
+      () => indexService.handleVaultDeleted(event),
+      Error,
+      "Path traversal detected",
+    );
+  });
+});
+
+Deno.test("path traversal protection: step name in handleWorkflowRunStarted", async () => {
+  await withTempDir(async (dir) => {
+    await setupRepoDir(dir);
+    const { indexService, workflowRepo, workflowRunRepo } = createIndexService(
+      dir,
+    );
+
+    // Create a workflow with a step whose name is a path traversal attempt
+    const step = Step.create({
+      name: "../../../malicious",
+      task: StepTask.model("test-model", "run"),
+    });
+    const job = Job.create({ name: "job1", steps: [step] });
+    const workflow = Workflow.create({ name: "my-workflow", jobs: [job] });
+    await workflowRepo.save(workflow);
+
+    const run = WorkflowRun.create(workflow);
+    run.start();
+    await workflowRunRepo.save(workflow.id, run);
+
+    const event = createWorkflowRunStarted(
+      workflow.id,
+      workflow.name,
+      run.id,
+    );
+    await assertRejects(
+      () => indexService.handleWorkflowRunStarted(event),
+      Error,
+      "Path traversal detected",
+    );
   });
 });


### PR DESCRIPTION
Fixes #390, reported by @umag.

## Problem

`symlink_repo_index_service.ts` passed user-controlled names (model names, workflow names, vault names, step names, tag keys, tag values) directly into `join()` path construction without any validation, allowing path traversal outside the index directory. The tag key case was the worst — the source already included `".."` in the join _before_ the user-controlled `tagKey`, amplifying the traversal.

## Fix

Added a private `assertPathContained()` method (mirroring the identical pattern already in `unified_data_repository.ts:995–1010`) and applied it at every vulnerable path-construction site.

### Locations validated

| Method | Component validated | Bounded to |
|---|---|---|
| `indexModel()` | `modelName` | `models/` |
| `handleModelDeleted()` | `event.modelName` | `models/` |
| `indexWorkflow()` | `workflowName` | `workflows/` |
| `handleWorkflowDeleted()` | `event.workflowName` | `workflows/` |
| `indexWorkflowRun()` | `workflowName` | `workflows/` |
| `indexWorkflowRun()` | `step.stepName` | `steps/` |
| `indexVault()` | `vaultName` | `vaults/` |
| `handleVaultDeleted()` | `event.vaultName` | `vaults/` |
| `indexTagBasedData()` | `tagKey` | `modelDir` |
| `indexTagBasedData()` | `tagValue` | `tagKeyDir` |

### Extra fix beyond the original plan

The `try-catch` in `indexTagBasedData()` previously swallowed all errors via `logger.debug`. Without fixing this, the new `assertPathContained()` calls inside that block would be dead code from a security standpoint. Added a re-throw guard so path traversal errors propagate:

```ts
if (
  error instanceof Error &&
  error.message.startsWith("Path traversal detected")
) {
  throw error;
}
```

## Tests added

7 of the 9 planned traversal vectors covered with `assertRejects` in `symlink_repo_index_service_test.ts`:

- ✅ model name `../../../malicious` → `handleModelCreated`
- ✅ model name `../../../malicious` → `handleModelDeleted`
- ✅ workflow name `../../../malicious` → `handleWorkflowCreated`
- ✅ workflow name `../../../malicious` → `handleWorkflowDeleted`
- ✅ vault name `../../../malicious` → `handleVaultCreated`
- ✅ vault name `../../../malicious` → `handleVaultDeleted`
- ✅ step name `../../../malicious` → `handleWorkflowRunStarted`

The 2 remaining planned vectors (tag key / tag value traversal) were not tested. They require a `unifiedDataRepo` stub; the existing `createIndexService` test helper does not wire one up, and building a full `UnifiedDataRepository` stub is out of scope for this fix.

## Plan vs implementation

| Area | Plan | Implemented |
|---|---|---|
| Add `resolve` to import | ✅ | ✅ |
| `assertPathContained()` method | ✅ | ✅ |
| `indexModel` validation | ✅ | ✅ |
| `handleModelDeleted` validation | ✅ | ✅ |
| `indexWorkflow` validation | ✅ | ✅ |
| `handleWorkflowDeleted` validation | ✅ | ✅ |
| `indexWorkflowRun` validation | ✅ | ✅ |
| `indexVault` validation | ✅ | ✅ |
| `handleVaultDeleted` validation | ✅ | ✅ |
| `indexTagBasedData` tag key/value validation | ✅ | ✅ |
| Fix try-catch swallowing traversal error | ✗ not planned | ✅ added |
| 7 path traversal tests | ✅ | ✅ |
| Tag key/value traversal tests | ✅ planned | ✗ omitted |