### PR TITLE
fix: resolve TOCTOU race in vault encryption key auto-generation

### DIFF
--- a/src/domain/vaults/local_encryption_vault_provider.ts
+++ b/src/domain/vaults/local_encryption_vault_provider.ts
@@ -266,19 +266,42 @@ export class LocalEncryptionVaultProvider implements VaultProvider {
           false,
           ["deriveKey"],
         );
-      } catch {
-        // Generate new key if it doesn't exist
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          throw error;
+        }
+        // Key file doesn't exist — generate a new one with exclusive creation
         await this.ensureVaultDirectory();
         const generatedKey = crypto.randomUUID() + crypto.randomUUID(); // 72 chars
-        await atomicWriteTextFile(keyFile, generatedKey, { mode: 0o600 });
 
-        return await crypto.subtle.importKey(
-          "raw",
-          new TextEncoder().encode(generatedKey),
-          { name: "PBKDF2" },
-          false,
-          ["deriveKey"],
-        );
+        try {
+          // createNew: true uses O_CREAT | O_EXCL — atomic exclusive creation
+          // prevents TOCTOU race where two processes both generate different keys
+          await Deno.writeTextFile(keyFile, generatedKey, {
+            createNew: true,
+            mode: 0o600,
+          });
+          return await crypto.subtle.importKey(
+            "raw",
+            new TextEncoder().encode(generatedKey),
+            { name: "PBKDF2" },
+            false,
+            ["deriveKey"],
+          );
+        } catch (writeError) {
+          if (!(writeError instanceof Deno.errors.AlreadyExists)) {
+            throw writeError;
+          }
+          // Another process won the race — read back their key
+          const winnerKey = await Deno.readTextFile(keyFile);
+          return await crypto.subtle.importKey(
+            "raw",
+            new TextEncoder().encode(winnerKey),
+            { name: "PBKDF2" },
+            false,
+            ["deriveKey"],
+          );
+        }
       }
     }
 

--- a/src/domain/vaults/local_encryption_vault_provider_test.ts
+++ b/src/domain/vaults/local_encryption_vault_provider_test.ts
@@ -271,6 +271,49 @@ Deno.test("LocalEncryptionVaultProvider - auto-generated keys", async (t) => {
   });
 
   await t.step(
+    "should handle concurrent key generation safely",
+    async () => {
+      await withTempDir(async (dir) => {
+        const vaultSecretsDir = secretsDir(dir, "concurrent-vault");
+        const config: LocalEncryptionConfig = {
+          auto_generate: true,
+          base_dir: dir,
+        };
+
+        // Create two vault instances pointing at the same vault directory
+        const vault1 = new LocalEncryptionVaultProvider(
+          "concurrent-vault",
+          config,
+        );
+        const vault2 = new LocalEncryptionVaultProvider(
+          "concurrent-vault",
+          config,
+        );
+
+        // Concurrently put secrets from both instances
+        await Promise.all([
+          vault1.put("secret-from-1", "value1"),
+          vault2.put("secret-from-2", "value2"),
+        ]);
+
+        // Both vaults should be able to read each other's secrets,
+        // proving they share the same encryption key
+        assertEquals(await vault1.get("secret-from-2"), "value2");
+        assertEquals(await vault2.get("secret-from-1"), "value1");
+
+        // Only one .key file should exist on disk
+        const keyEntries: string[] = [];
+        for await (const entry of Deno.readDir(vaultSecretsDir)) {
+          if (entry.name === ".key") {
+            keyEntries.push(entry.name);
+          }
+        }
+        assertEquals(keyEntries.length, 1);
+      });
+    },
+  );
+
+  await t.step(
     "should fall back to auto-generate when SSH key fails",
     async () => {
       await withTempDir(async (dir) => {


### PR DESCRIPTION
Closes #391

## Summary

`loadKeyMaterial()` in `LocalEncryptionVaultProvider` had a time-of-check-time-of-use (TOCTOU) race condition. Two concurrent processes could both fail the `readTextFile()` check, generate different encryption keys, and the second `atomicWriteTextFile()` (which uses rename internally) would silently overwrite the first. Secrets encrypted by the losing process would become **permanently unrecoverable**.

## Fix

Replace the read-then-write pattern with exclusive file creation:

1. **`Deno.writeTextFile(keyFile, generatedKey, { createNew: true, mode: 0o600 })`** — `createNew: true` maps to `O_CREAT | O_EXCL` at the OS level, guaranteeing exactly one process wins the creation. No application-level lock needed.

2. **Catch `Deno.errors.AlreadyExists`** on the write — the losing process reads back the winner's key instead of overwriting it.

3. **Catch `Deno.errors.NotFound` specifically** (not bare `catch`) on the initial read — real errors like permission denied now propagate instead of being silently swallowed.

## Plan vs Implementation

The implementation matches the plan exactly:

| Aspect | Plan | Implementation | Match |
|--------|------|----------------|-------|
| Replace `atomicWriteTextFile` with `Deno.writeTextFile` + `createNew: true` | ✅ | ✅ | Exact |
| Catch `Deno.errors.NotFound` specifically on initial read | ✅ | ✅ | Exact |
| Catch `Deno.errors.AlreadyExists` on write | ✅ | ✅ | Exact |
| Read back winner's key on `AlreadyExists` | ✅ | ✅ | Exact |
| Call `ensureVaultDirectory()` before write | ✅ | ✅ | Exact |
| Concurrency test: two vault instances, same dir | ✅ | ✅ | Exact |
| Concurrency test: `Promise.all()` on `put()` | ✅ | ✅ | Exact |
| Concurrency test: cross-read verification | ✅ | ✅ | Exact |
| Concurrency test: single `.key` file assertion | ✅ | ✅ | Exact |

No deviations from the plan. The only additions are the `crypto.subtle.importKey` calls in each branch, which the plan's pseudocode intentionally omitted for brevity.

### Test caveat

The concurrency test runs two vault instances in the same Deno process. Async interleaving at `await` points *can* exercise the race, but doesn't guarantee it every run. The real safety comes from the OS-level `O_EXCL` guarantee, which holds regardless of test coverage.

## User impact

- **Existing users**: Zero — if a `.key` file already exists, the code reads it on the first try and never hits the changed path
- **New users**: No observable difference in behavior
- **The fix**: Prevents silent, permanent data loss when two processes initialize the same vault concurrently

## Test plan

- [x] All existing tests pass (29 steps)
- [x] New "should handle concurrent key generation safely" test passes
- [x] `deno check` — type checking clean
- [x] `deno lint` — no lint errors
- [x] `deno fmt` — formatting clean