### PR TITLE
fix: path traversal in yaml_vault_config_repository via assertPathContained (#393)

### DIFF
--- a/src/infrastructure/persistence/yaml_vault_config_repository.ts
+++ b/src/infrastructure/persistence/yaml_vault_config_repository.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { ensureDir } from "@std/fs";
-import { join } from "@std/path";
+import { join, resolve } from "@std/path";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import { atomicWriteTextFile } from "./atomic_write.ts";
 import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
@@ -234,7 +234,27 @@ export class YamlVaultConfigRepository {
    * Gets the directory for a specific vault type.
    */
   private getTypeDir(vaultType: string): string {
-    return join(this.getVaultDir(), vaultType);
+    const vaultDir = this.getVaultDir();
+    const result = join(vaultDir, vaultType);
+    this.assertPathContained(result, vaultDir, `vaultType "${vaultType}"`);
+    return result;
+  }
+
+  private assertPathContained(
+    path: string,
+    expectedParent: string,
+    context: string,
+  ): void {
+    const resolvedPath = resolve(path);
+    const resolvedParent = resolve(expectedParent);
+    if (
+      resolvedPath !== resolvedParent &&
+      !resolvedPath.startsWith(resolvedParent + "/")
+    ) {
+      throw new Error(
+        `Path traversal detected: ${context} resolves outside expected directory`,
+      );
+    }
   }
 
   /**

--- a/src/infrastructure/persistence/yaml_vault_config_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_vault_config_repository_test.ts
@@ -1,0 +1,67 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertRejects } from "@std/assert";
+import { YamlVaultConfigRepository } from "./yaml_vault_config_repository.ts";
+
+Deno.test("YamlVaultConfigRepository - normal vault types resolve correctly", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const repo = new YamlVaultConfigRepository(dir);
+    // These should not throw - normal vault types
+    const resultAws = await repo.findAllByType("aws");
+    const resultLocal = await repo.findAllByType("local_encryption");
+    // Both return empty arrays since the vault dir doesn't exist yet
+    if (
+      !Array.isArray(resultAws) || !Array.isArray(resultLocal)
+    ) {
+      throw new Error("Expected arrays");
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("YamlVaultConfigRepository - path traversal via ../../.ssh throws", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const repo = new YamlVaultConfigRepository(dir);
+    await assertRejects(
+      () => repo.findAllByType("../../.ssh"),
+      Error,
+      "Path traversal detected",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("YamlVaultConfigRepository - path traversal via ../foo throws", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const repo = new YamlVaultConfigRepository(dir);
+    await assertRejects(
+      () => repo.findAllByType("../foo"),
+      Error,
+      "Path traversal detected",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes the path traversal vulnerability reported in #393.

`getTypeDir()` in `YamlVaultConfigRepository` passed the user-supplied `vaultType` string directly to `join()` with no validation, allowing a crafted type like `"../../.ssh"` to escape `.swamp/vault/`.

The fix pattern already existed in `unified_data_repository.ts` via `assertPathContained()`. This change applies the same approach here.

## Plan vs Implementation

The plan (issue #393) identified two possible fix approaches:
1. Add component validation rejecting `..`, `/`, `\`, and null bytes
2. Use `assertPathContained()` from `unified_data_repository.ts`

**Implementation chose option 2** — porting `assertPathContained()` directly — because:
- It is already proven and in use for the same class of problem
- It uses `resolve()` to handle all path normalisation edge cases (not just literal `..` segments)
- It keeps the fix consistent with the existing codebase pattern

## Changes

- Added `resolve` to the `@std/path` import alongside the existing `join`
- Ported `assertPathContained()` from `unified_data_repository.ts` (identical logic: resolves both paths and checks prefix containment)
- Updated `getTypeDir()` to call `assertPathContained()` after constructing the candidate path, throwing before any I/O if the path escapes the vault base directory
- Created `yaml_vault_config_repository_test.ts` with three tests:
  - Normal vault types (`"aws"`, `"local_encryption"`) resolve without error
  - `"../../.ssh"` throws `Error: Path traversal detected`
  - `"../foo"` throws `Error: Path traversal detected`

`getPath()` requires no further change — it already depends on the validated output of `getTypeDir()`.

## Test Plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — no lint errors
- [x] `deno fmt` — code formatted
- [x] New tests pass: `deno run test src/infrastructure/persistence/yaml_vault_config_repository_test.ts` (3/3)
- [x] Full test suite passes: `deno run test` (1792/1792)
- [x] `deno run compile` — binary recompiles cleanly

Reported-by: @umag