### PR TITLE
fix: escape single quotes and backticks in vault secret values

### DIFF
--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -775,6 +775,8 @@ export class ModelResolver {
         const escapedValue = secretValue
           .replace(/\\/g, "\\\\")
           .replace(/"/g, '\\"')
+          .replace(/'/g, "\\'")
+          .replace(/`/g, "\\`")
           .replace(/\n/g, "\\n")
           .replace(/\r/g, "\\r")
           .replace(/\t/g, "\\t");

--- a/src/domain/vaults/vault_expression_test.ts
+++ b/src/domain/vaults/vault_expression_test.ts
@@ -182,6 +182,26 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
     assertEquals(result, '"col1\\tcol2\\tcol3"');
   });
 
+  await t.step("should escape single quotes in secret values", async () => {
+    const resolver = createResolverWithMockVault({
+      "quote-secret": "p@ss'w0rd",
+    });
+    const result = await resolver.resolveVaultExpressions(
+      "vault.get(test-vault, quote-secret)",
+    );
+    assertEquals(result, '"p@ss\\\'w0rd"');
+  });
+
+  await t.step("should escape backticks in secret values", async () => {
+    const resolver = createResolverWithMockVault({
+      "backtick-secret": "value`with`backticks",
+    });
+    const result = await resolver.resolveVaultExpressions(
+      "vault.get(test-vault, backtick-secret)",
+    );
+    assertEquals(result, '"value\\`with\\`backticks"');
+  });
+
   await t.step(
     "should handle complex secret with multiple special characters",
     async () => {
@@ -256,7 +276,7 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
       const result = await resolver.resolveVaultExpressions(
         "vault.get(test-vault, dollar-backtick)",
       );
-      assertEquals(result, '"prefix$`suffix"');
+      assertEquals(result, '"prefix$\\`suffix"');
     },
   );
 
@@ -269,7 +289,7 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
       const result = await resolver.resolveVaultExpressions(
         "vault.get(test-vault, dollar-quote)",
       );
-      assertEquals(result, '"prefix$\'suffix"');
+      assertEquals(result, '"prefix$\\\'suffix"');
     },
   );
 
@@ -308,7 +328,7 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
       const result = await resolver.resolveVaultExpressions(
         "vault.get(test-vault, multi-dollar)",
       );
-      assertEquals(result, '"a]$&b$`c$\'d$$e$1f"');
+      assertEquals(result, '"a]$&b$\\`c$\\\'d$$e$1f"');
     },
   );
 


### PR DESCRIPTION
Closes #394

## Summary

- Add single quote (`'`) and backtick (`` ` ``) escaping to the vault secret value escape chain in `model_resolver.ts`
- Add dedicated test cases for both characters and update existing tests that contain them

## Problem

The `vault.get()` regex accepts three quote styles as argument delimiters (`'`, `"`, `` ` ``), but the escaping logic only handled double quotes, backslashes, and whitespace characters (`\n`, `\r`, `\t`). While the current double-quote wrapping (`"${escapedValue}"`) means unescaped single quotes and backticks can't break out of the string today, this is an incomplete defense-in-depth.

## Plan vs Implementation

The plan called for:
1. Adding `.replace(/'/g, "\\'")` and `.replace(/`/g, "\\`")` after the double-quote escape — **implemented exactly as planned**
2. Adding two new test cases for single quotes and backticks — **implemented as planned**

One aspect not anticipated in the plan: three existing tests (`$'` pattern, `` $` `` pattern, and multi-dollar pattern) contained single quotes or backticks in their secret values and needed their expected outputs updated to reflect the new escaping. This was a straightforward consequence of the change.

## Changes

### `src/domain/expressions/model_resolver.ts`
Added two `.replace()` calls to the escape chain:
```typescript
.replace(/'/g, "\\'")   // NEW — escape single quotes
.replace(/`/g, "\\`")   // NEW — escape backticks
```

### `src/domain/vaults/vault_expression_test.ts`
- **Added:** "should escape single quotes in secret values" — `p@ss'w0rd` → `"p@ss\\'w0rd"`
- **Added:** "should escape backticks in secret values" — `` value`with`backticks `` → `` "value\`with\`backticks" ``
- **Updated:** 3 existing dollar-pattern tests to expect escaped single quotes/backticks

## Verification

- `deno check` — passes
- `deno lint` — passes
- `deno fmt` — passes
- `deno run test src/domain/vaults/vault_expression_test.ts` — all 24 steps pass

## Note on user impact

The practical user impact today is **none** — the double-quote wrapping already prevents these characters from causing issues. This is a **defense-in-depth** fix that ensures safety if the quoting strategy is ever changed. Confirmed that cel-js v7.3.1 supports both `\'` and `` \` `` as valid escape sequences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)