### PR TITLE
feat: create .gitignore during repo upgrade if missing

### DIFF
--- a/src/cli/commands/repo_init.ts
+++ b/src/cli/commands/repo_init.ts
@@ -105,6 +105,7 @@ export const repoUpgradeCommand = new Command()
       upgradedAt: result.upgradedAt,
       skillsUpdated: result.skillsUpdated,
       settingsUpdated: result.settingsUpdated,
+      gitignoreCreated: result.gitignoreCreated,
       tool: result.tool,
     };
 

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -83,6 +83,7 @@ export interface RepoUpgradeResult {
   upgradedAt: string;
   skillsUpdated: string[];
   settingsUpdated: boolean;
+  gitignoreCreated: boolean;
   tool: AiTool;
 }
 
@@ -231,6 +232,12 @@ export class RepoService {
       settingsUpdated = await this.updateClaudeSettings(repoPath);
     }
 
+    // Create .gitignore if it doesn't exist
+    const gitignoreCreated = await this.createGitignoreIfNotExists(
+      repoPath,
+      tool,
+    );
+
     // createUpgradeMarker always sets upgradedAt, but TypeScript doesn't know this
     if (!updatedMarker.upgradedAt) {
       throw new Error(
@@ -245,6 +252,7 @@ export class RepoService {
       upgradedAt: updatedMarker.upgradedAt,
       skillsUpdated,
       settingsUpdated,
+      gitignoreCreated,
       tool,
     };
   }

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -722,6 +722,45 @@ Deno.test("RepoService.upgrade skips settings for non-claude tools", async () =>
   });
 });
 
+Deno.test("RepoService.upgrade creates .gitignore if missing", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    // Init (creates .gitignore), then delete it
+    await service.init(repoPath);
+    const gitignorePath = join(tempDir, ".gitignore");
+    await Deno.remove(gitignorePath);
+
+    // Upgrade should recreate .gitignore
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath);
+
+    assertEquals(result.gitignoreCreated, true);
+
+    const content = await Deno.readTextFile(gitignorePath);
+    assertStringIncludes(content, ".swamp/telemetry/");
+    assertStringIncludes(content, ".swamp/secrets/keyfile");
+    assertStringIncludes(content, ".claude/");
+  });
+});
+
+Deno.test("RepoService.upgrade does not overwrite existing .gitignore", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    // Init creates .gitignore
+    await service.init(repoPath);
+
+    // Upgrade should leave .gitignore unchanged
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath);
+
+    assertEquals(result.gitignoreCreated, false);
+  });
+});
+
 Deno.test("RepoService.init cursor instructions have MDC frontmatter", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");

--- a/src/presentation/output/repo_output.ts
+++ b/src/presentation/output/repo_output.ts
@@ -46,6 +46,7 @@ export interface RepoUpgradeData {
   upgradedAt: string;
   skillsUpdated: string[];
   settingsUpdated: boolean;
+  gitignoreCreated: boolean;
   tool: string;
 }
 


### PR DESCRIPTION
## Summary

`swamp repo upgrade` did not check for or create a `.gitignore` file, unlike `swamp repo init` which calls `createGitignoreIfNotExists`. This meant repos initialised before gitignore support was added, or repos where the file was accidentally deleted, would not get a `.gitignore` on upgrade.

This PR mirrors the same _create-if-not-exists_ pattern already used for the instructions file during upgrade.

## Changes

### `src/domain/repo/repo_service.ts`
- Added `gitignoreCreated: boolean` to the `RepoUpgradeResult` interface.
- Called `createGitignoreIfNotExists(repoPath, tool)` inside `upgrade()` after the Claude-settings block, before the return statement.
- Included `gitignoreCreated` in the return value.

### `src/presentation/output/repo_output.ts`
- Added `gitignoreCreated: boolean` to the `RepoUpgradeData` interface so the field is included in `--json` output.
- The log-mode `renderRepoUpgrade` function is unchanged — it deliberately omits fine-grained details and only logs the version transition.

### `src/cli/commands/repo_init.ts`
- Added `gitignoreCreated: result.gitignoreCreated` to the manually-constructed `RepoUpgradeData` object in the upgrade command handler. This file was not called out in the original plan but is required for the TypeScript compiler to accept the updated interface.

### `src/domain/repo/repo_service_test.ts`
- **`RepoService.upgrade creates .gitignore if missing`** — inits a repo, deletes the `.gitignore`, runs `upgrade()`, and asserts the file is recreated with the expected content and that `gitignoreCreated === true`.
- **`RepoService.upgrade does not overwrite existing .gitignore`** — inits a repo (which creates `.gitignore`), runs `upgrade()`, and asserts `gitignoreCreated === false`.

## Test plan

- [x] `deno check` — no type errors
- [x] `deno lint` — no lint warnings
- [x] `deno fmt` — no formatting changes
- [x] `deno run test src/domain/repo/repo_service_test.ts` — all 37 repo-service tests pass (including 2 new ones)
- [x] `deno run test` — full suite of 1795 tests passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)