### PR TITLE
test: add missing tag key/value path traversal tests (#412)

### DIFF
--- a/src/infrastructure/repo/symlink_repo_index_service_test.ts
+++ b/src/infrastructure/repo/symlink_repo_index_service_test.ts
@@ -24,7 +24,9 @@ import { SymlinkRepoIndexService } from "./symlink_repo_index_service.ts";
 import { YamlDefinitionRepository } from "../persistence/yaml_definition_repository.ts";
 import { YamlWorkflowRepository } from "../persistence/yaml_workflow_repository.ts";
 import { YamlWorkflowRunRepository } from "../persistence/yaml_workflow_run_repository.ts";
+import type { UnifiedDataRepository } from "../persistence/unified_data_repository.ts";
 import { Definition } from "../../domain/definitions/definition.ts";
+import { Data } from "../../domain/data/data.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import { Workflow } from "../../domain/workflows/workflow.ts";
 import { Job } from "../../domain/workflows/job.ts";
@@ -68,7 +70,9 @@ async function setupRepoDir(dir: string): Promise<void> {
   }
 }
 
-function createIndexService(dir: string) {
+function createIndexService(dir: string, opts?: {
+  unifiedDataRepo?: UnifiedDataRepository;
+}) {
   const definitionRepo = new YamlDefinitionRepository(dir);
   const workflowRepo = new YamlWorkflowRepository(dir);
   const workflowRunRepo = new YamlWorkflowRunRepository(dir);
@@ -79,10 +83,38 @@ function createIndexService(dir: string) {
       definitionRepo,
       workflowRepo,
       workflowRunRepo,
+      unifiedDataRepo: opts?.unifiedDataRepo,
     }),
     definitionRepo,
     workflowRepo,
     workflowRunRepo,
+  };
+}
+
+function createStubUnifiedDataRepo(
+  dataItems: Data[],
+): UnifiedDataRepository {
+  const notImplemented = () => {
+    throw new Error("not implemented");
+  };
+  return {
+    findAllGlobal: notImplemented,
+    findByName: notImplemented,
+    findById: notImplemented,
+    listVersions: () => Promise.resolve([]),
+    findAllForModel: () => Promise.resolve(dataItems),
+    save: notImplemented,
+    append: notImplemented,
+    stream: notImplemented,
+    getContent: notImplemented,
+    delete: notImplemented,
+    removeLatestSymlink: notImplemented,
+    allocateVersion: notImplemented,
+    finalizeVersion: notImplemented,
+    nextId: notImplemented,
+    getPath: notImplemented,
+    getContentPath: notImplemented,
+    collectGarbage: notImplemented,
   };
 }
 
@@ -538,6 +570,82 @@ Deno.test("path traversal protection: vault name in handleVaultDeleted", async (
     );
     await assertRejects(
       () => indexService.handleVaultDeleted(event),
+      Error,
+      "Path traversal detected",
+    );
+  });
+});
+
+Deno.test("path traversal protection: tag key in indexTagBasedData", async () => {
+  await withTempDir(async (dir) => {
+    await setupRepoDir(dir);
+    const maliciousData = Data.create({
+      name: "test-data",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { "type": "resource", "../../../malicious": "value" },
+      ownerDefinition: { ownerType: "manual", ownerRef: "test" },
+    });
+    const stubRepo = createStubUnifiedDataRepo([maliciousData]);
+    const { indexService, definitionRepo } = createIndexService(dir, {
+      unifiedDataRepo: stubRepo,
+    });
+
+    const type = ModelType.create("swamp/echo");
+    const definition = Definition.create({
+      name: "tag-key-model",
+      version: 1,
+      tags: {},
+      globalArguments: {},
+    });
+    await definitionRepo.save(type, definition);
+
+    const event = createModelCreated(
+      type.normalized,
+      definition.id,
+      definition.name,
+    );
+    await assertRejects(
+      () => indexService.handleModelCreated(event),
+      Error,
+      "Path traversal detected",
+    );
+  });
+});
+
+Deno.test("path traversal protection: tag value in indexTagBasedData", async () => {
+  await withTempDir(async (dir) => {
+    await setupRepoDir(dir);
+    const maliciousData = Data.create({
+      name: "test-data",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { "type": "resource", "safe-key": "../../../malicious" },
+      ownerDefinition: { ownerType: "manual", ownerRef: "test" },
+    });
+    const stubRepo = createStubUnifiedDataRepo([maliciousData]);
+    const { indexService, definitionRepo } = createIndexService(dir, {
+      unifiedDataRepo: stubRepo,
+    });
+
+    const type = ModelType.create("swamp/echo");
+    const definition = Definition.create({
+      name: "tag-value-model",
+      version: 1,
+      tags: {},
+      globalArguments: {},
+    });
+    await definitionRepo.save(type, definition);
+
+    const event = createModelCreated(
+      type.normalized,
+      definition.id,
+      definition.name,
+    );
+    await assertRejects(
+      () => indexService.handleModelCreated(event),
       Error,
       "Path traversal detected",
     );


### PR DESCRIPTION
## Summary

- Adds two missing path traversal tests for `tagKey` and `tagValue` validation in `indexTagBasedData()`, closing the test coverage gap identified in #412
- Extends `createIndexService()` test helper to accept an optional `UnifiedDataRepository` stub
- Adds `createStubUnifiedDataRepo()` helper that returns controlled `Data` items for testing tag-based indexing

## Context

PR #403 added `assertPathContained()` checks for custom tag keys and tag values inside `indexTagBasedData()`, but explicitly skipped writing tests because the test helper had no way to inject a `UnifiedDataRepository`. Without tests, regressions in these security checks (e.g., accidentally removing the re-throw guard in the `catch` block, or removing the `assertPathContained` calls) would be completely silent.

## What the tests verify

**Test 1 — malicious tag key:** Creates a `Data` item with tag `{ "type": "resource", "../../../malicious": "value" }`. Asserts that `handleModelCreated` → `indexModel` → `indexTagBasedData` rejects with `"Path traversal detected"` when the tag key would escape the model directory.

**Test 2 — malicious tag value:** Creates a `Data` item with tag `{ "type": "resource", "safe-key": "../../../malicious" }`. Asserts the same rejection when the tag value would escape the tag key directory.

Both tests also implicitly verify the re-throw guard in the `catch` block of `indexTagBasedData()`, since the error must propagate through `try-catch` to reach `assertRejects`.

## Test plan

- [x] `deno run test src/infrastructure/repo/symlink_repo_index_service_test.ts` — 19/19 pass
- [x] `deno run test` — full suite 1809/1809 pass
- [x] `deno check` — passes
- [x] `deno lint` — passes
- [x] `deno fmt --check` — passes

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)