### PR TITLE
fix: validate version string in HttpSourceDownloader

### DIFF
--- a/src/infrastructure/source/http_source_downloader.ts
+++ b/src/infrastructure/source/http_source_downloader.ts
@@ -35,6 +35,12 @@ export class HttpSourceDownloader implements SourceDownloader {
    * For version tags, uses tags/{version}.tar.gz
    */
   protected getArchiveUrl(version: string): string {
+    if (!/^[a-zA-Z0-9._-]+$/.test(version)) {
+      throw new UserError(
+        `Invalid version string "${version}": must contain only alphanumeric characters, dots, hyphens, and underscores.`,
+      );
+    }
+
     if (version === "main") {
       return `${HttpSourceDownloader.GITHUB_BASE}/heads/main.tar.gz`;
     }

--- a/src/infrastructure/source/http_source_downloader_test.ts
+++ b/src/infrastructure/source/http_source_downloader_test.ts
@@ -317,6 +317,76 @@ Deno.test("downloadAndExtract skips symlinks escaping via relative path", async 
   }
 });
 
+Deno.test("downloadAndExtract rejects version with path traversal", async () => {
+  const downloader = new HttpSourceDownloader();
+  const tempDir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await assertRejects(
+      () => downloader.downloadAndExtract("../malicious", tempDir),
+      UserError,
+      "Invalid version string",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("downloadAndExtract rejects version with nested path traversal", async () => {
+  const downloader = new HttpSourceDownloader();
+  const tempDir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await assertRejects(
+      () => downloader.downloadAndExtract("foo/../../heads/main", tempDir),
+      UserError,
+      "Invalid version string",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("downloadAndExtract rejects version with URL-encoded characters", async () => {
+  const downloader = new HttpSourceDownloader();
+  const tempDir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await assertRejects(
+      () => downloader.downloadAndExtract("version%2F..", tempDir),
+      UserError,
+      "Invalid version string",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("downloadAndExtract rejects version with query string", async () => {
+  const downloader = new HttpSourceDownloader();
+  const tempDir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await assertRejects(
+      () => downloader.downloadAndExtract("v1.0?ref=main", tempDir),
+      UserError,
+      "Invalid version string",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("downloadAndExtract rejects version with fragment", async () => {
+  const downloader = new HttpSourceDownloader();
+  const tempDir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await assertRejects(
+      () => downloader.downloadAndExtract("v1.0#fragment", tempDir),
+      UserError,
+      "Invalid version string",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
 Deno.test("downloadAndExtract skips symlinks escaping via absolute path", async () => {
   const tempDir = await Deno.makeTempDir({ prefix: "swamp-test-" });
   try {


### PR DESCRIPTION
## Summary

Closes #413.

Adds a regex allowlist (`/^[a-zA-Z0-9._-]+$/`) to `getArchiveUrl()` in `HttpSourceDownloader` that rejects version strings containing unsafe URL characters (slashes, `..`, `%`, `?`, `#`) before they are interpolated into the GitHub archive URL.

**This is defense-in-depth input validation, not a security patch.** The actual risk is minimal because:

- The version string is self-supplied by the user via the `--version` CLI flag — the "attacker" and "victim" are the same person
- The base URL is hardcoded to `https://github.com/systeminit/swamp/archive/refs` — no SSRF to arbitrary hosts is possible
- The worst case without this fix is a confusing GitHub 404 or downloading a different ref from the same repo (e.g., `heads/main` instead of a tagged release)

The practical benefit is **better error messages**: users who mistype a version string now get a clear `UserError` instead of a cryptic GitHub 404. The guard also provides insurance if the version source ever changes to come from an untrusted input (e.g., a shared workflow file or remote config).

## Test Plan

- Added 5 test cases to `http_source_downloader_test.ts` covering:
  - `../malicious` — path traversal with `..`
  - `foo/../../heads/main` — nested path traversal escaping `/tags/`
  - `version%2F..` — URL-encoded slash
  - `v1.0?ref=main` — query string injection
  - `v1.0#fragment` — fragment injection
- All validation fires before any network request is made
- All 1802 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)