### PR TITLE
fix: escape $ and ` in vault secrets to prevent shell command substitution

### DIFF
--- a/design/expressions.md
+++ b/design/expressions.md
@@ -165,6 +165,27 @@ attributes:
   keyData: ${{ vault.get(aws, machineKeyData) }}
 ```
 
+### Shell Safety
+
+When vault secrets are injected into the `run` field of a `command/shell` model via CEL
+string concatenation, shell metacharacters in the secret value are automatically escaped so
+that the value is always treated as **literal data**, never as shell syntax.
+
+Specifically, `$` and `` ` `` are escaped so that `$(cmd)` and `` `cmd` `` in a secret
+value do not trigger command substitution:
+
+```yaml
+# Secret value: $(cat /etc/passwd)
+# Shell receives: \$(cat /etc/passwd)  → outputs literally: $(cat /etc/passwd)
+attributes:
+  run: '"echo " + vault.get(''my-vault'', ''SECRET'') + '' done'''
+```
+
+This means:
+- `$VAR_NAME` in a secret is **not** expanded as a shell variable — it appears literally.
+- `$(cmd)` and `` `cmd` `` in a secret are **not** executed — they appear literally.
+- Prices, connection strings, and other data containing `$` are safe to store and use.
+
 ## Environment Variables
 
 All process environment variables are available in CEL expressions via the `env`

--- a/integration/vault_cel_integration_test.ts
+++ b/integration/vault_cel_integration_test.ts
@@ -726,9 +726,12 @@ Deno.test("Vault CEL: handles secrets with special characters", async () => {
     ]);
 
     // Store secret with special characters
-    // Note: Avoiding characters that require escaping in CEL strings
-    // (backslashes, quotes, newlines) as these are escaped for CEL parsing
+    // Note: $ and ` are escaped with a \\ prefix so that after CEL evaluation
+    // the shell receives \$ and \` (literal characters, no command substitution).
+    // Backslashes, quotes, and newlines are also escaped for CEL string safety.
     const specialSecret = "p@ssw0rd!#$%^&*()_+-=[]{}|;:.<>?/";
+    // After escaping, $ becomes \$ so the resolved CEL value includes the backslash
+    const expectedResolved = "p@ssw0rd!#\\$%^&*()_+-=[]{}|;:.<>?/";
     const vaultServiceForPut = await VaultService.fromRepository(repoDir);
     await vaultServiceForPut.put(
       "special-chars-vault",
@@ -760,7 +763,7 @@ Deno.test("Vault CEL: handles secrets with special characters", async () => {
       result.definition,
     );
 
-    assertEquals(resolved.globalArguments.password, specialSecret);
+    assertEquals(resolved.globalArguments.password, expectedResolved);
   });
 });
 

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -788,12 +788,16 @@ export class ModelResolver {
       const [fullMatch, , vaultName, , secretKey] = match;
       try {
         const secretValue = await vaultService.get(vaultName, secretKey);
-        // Escape special characters to prevent CEL parsing issues and injection attacks
+        // Escape special characters to prevent CEL parsing issues and injection attacks.
+        // For $ and `, we use a \\X prefix (two backslashes + char) so that:
+        //   - CEL sees \\ → produces one \, then the char is a plain literal
+        //   - Shell receives \$ or \` → literal character, no command substitution
         const escapedValue = secretValue
           .replace(/\\/g, "\\\\")
+          .replace(/\$/g, "\\\\$") // $ → \\$ so CEL produces \$, shell treats as literal $
+          .replace(/`/g, "\\\\`") // ` → \\` so CEL produces \`, shell treats as literal `
           .replace(/"/g, '\\"')
           .replace(/'/g, "\\'")
-          .replace(/`/g, "\\`")
           .replace(/\n/g, "\\n")
           .replace(/\r/g, "\\r")
           .replace(/\t/g, "\\t");

--- a/src/domain/vaults/vault_expression_test.ts
+++ b/src/domain/vaults/vault_expression_test.ts
@@ -199,7 +199,7 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
     const result = await resolver.resolveVaultExpressions(
       "vault.get(test-vault, backtick-secret)",
     );
-    assertEquals(result, '"value\\`with\\`backticks"');
+    assertEquals(result, '"value\\\\`with\\\\`backticks"');
   });
 
   await t.step(
@@ -255,7 +255,7 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
   });
 
   await t.step(
-    "should preserve $& pattern in secret values",
+    "should escape $ in secret values to prevent shell variable expansion",
     async () => {
       const resolver = createResolverWithMockVault({
         "dollar-amp": "my$&secret",
@@ -263,12 +263,12 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
       const result = await resolver.resolveVaultExpressions(
         "vault.get(test-vault, dollar-amp)",
       );
-      assertEquals(result, '"my$&secret"');
+      assertEquals(result, '"my\\\\$&secret"');
     },
   );
 
   await t.step(
-    "should preserve $` pattern in secret values",
+    "should escape $` pattern in secret values",
     async () => {
       const resolver = createResolverWithMockVault({
         "dollar-backtick": "prefix$`suffix",
@@ -276,12 +276,12 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
       const result = await resolver.resolveVaultExpressions(
         "vault.get(test-vault, dollar-backtick)",
       );
-      assertEquals(result, '"prefix$\\`suffix"');
+      assertEquals(result, '"prefix\\\\$\\\\`suffix"');
     },
   );
 
   await t.step(
-    "should preserve $' pattern in secret values",
+    "should escape $' pattern in secret values",
     async () => {
       const resolver = createResolverWithMockVault({
         "dollar-quote": "prefix$'suffix",
@@ -289,12 +289,12 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
       const result = await resolver.resolveVaultExpressions(
         "vault.get(test-vault, dollar-quote)",
       );
-      assertEquals(result, '"prefix$\\\'suffix"');
+      assertEquals(result, '"prefix\\\\$\\\'suffix"');
     },
   );
 
   await t.step(
-    "should preserve $$ pattern in secret values",
+    "should escape $$ pattern in secret values",
     async () => {
       const resolver = createResolverWithMockVault({
         "dollar-dollar": "cost: $$100",
@@ -302,12 +302,12 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
       const result = await resolver.resolveVaultExpressions(
         "vault.get(test-vault, dollar-dollar)",
       );
-      assertEquals(result, '"cost: $$100"');
+      assertEquals(result, '"cost: \\\\$\\\\$100"');
     },
   );
 
   await t.step(
-    "should preserve numbered capture group patterns in secret values",
+    "should escape numbered dollar patterns in secret values",
     async () => {
       const resolver = createResolverWithMockVault({
         "dollar-numbers": "$1$2$3",
@@ -315,12 +315,12 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
       const result = await resolver.resolveVaultExpressions(
         "vault.get(test-vault, dollar-numbers)",
       );
-      assertEquals(result, '"$1$2$3"');
+      assertEquals(result, '"\\\\$1\\\\$2\\\\$3"');
     },
   );
 
   await t.step(
-    "should preserve multiple dollar patterns in same secret",
+    "should escape multiple dollar and backtick patterns in same secret",
     async () => {
       const resolver = createResolverWithMockVault({
         "multi-dollar": "a]$&b$`c$'d$$e$1f",
@@ -328,7 +328,36 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
       const result = await resolver.resolveVaultExpressions(
         "vault.get(test-vault, multi-dollar)",
       );
-      assertEquals(result, '"a]$&b$\\`c$\\\'d$$e$1f"');
+      assertEquals(
+        result,
+        '"a]\\\\$&b\\\\$\\\\`c\\\\$\\\'d\\\\$\\\\$e\\\\$1f"',
+      );
+    },
+  );
+
+  await t.step(
+    "should escape $ to prevent shell command substitution",
+    async () => {
+      const resolver = createResolverWithMockVault({
+        "cmd-secret": "$(echo injected)",
+      });
+      const result = await resolver.resolveVaultExpressions(
+        "vault.get(test-vault, cmd-secret)",
+      );
+      assertEquals(result, '"\\\\$(echo injected)"');
+    },
+  );
+
+  await t.step(
+    "should escape backticks to prevent shell command substitution",
+    async () => {
+      const resolver = createResolverWithMockVault({
+        "backtick-cmd": "`echo injected`",
+      });
+      const result = await resolver.resolveVaultExpressions(
+        "vault.get(test-vault, backtick-cmd)",
+      );
+      assertEquals(result, '"\\\\`echo injected\\\\`"');
     },
   );
 


### PR DESCRIPTION
## Summary

Vault secrets containing `$(cmd)` or `` `cmd` `` sequences were passed unescaped through CEL evaluation and executed as shell commands when used in `command/shell` models via `sh -c`. This is a shell injection vulnerability.

## Background

When `vault.get(vault-name, secret-key)` appears in a CEL expression, `resolveVaultExpressions()` fetches the secret value and embeds it as a CEL string literal — for example `"my-secret-value"` — before cel-js evaluates the expression. The existing escaping (from PR #407) handled CEL string breakout for backticks (`\``) but **did not make the value safe at the shell layer**.

### Why PR #407's `\`` fix was incomplete

PR #407 added `.replace(/\`/g, "\\`")`. While `` \` `` is a valid CEL escape sequence (it maps back to `` ` ``), this means cel-js **strips the backslash** during evaluation. The shell then receives an unescaped backtick and executes `` `cmd` `` as command substitution. `$` was not escaped at all.

### Why naive `.replace(/\$/g, "\\$")` is wrong

`\$` is **not** in cel-js's `STRING_ESCAPES` map. Inserting it into a CEL string literal throws `ParseError: Invalid escape sequence: \$`.

## The Fix: `\\X` prefix via `"\\\\X"` replacement

Inserting `\\X` (two backslashes + char) into the escaped value causes a two-layer transformation:

| Layer | `$` example | `` ` `` example |
|-------|-------------|-----------------|
| Secret stored in vault | `$(cat /etc/passwd)` | `` `cmd` `` |
| `escapedValue` string | `\\$(cat /etc/passwd)` | `` \\`cmd\\` `` |
| CEL string literal | `"\\$(cat /etc/passwd)"` | `` "\\`cmd\\`" `` |
| After CEL evaluation | `\$(cat /etc/passwd)` | `` \`cmd\` `` |
| Shell output | `$(cat /etc/passwd)` — **literal** ✓ | `` `cmd` `` — **literal** ✓ |

- CEL sees `\\` → produces one `\`, then treats `$` / `` ` `` as plain literal characters (both are valid after `\\`)
- Shell receives `\$` or `` \` `` → treats them as literal characters, **no substitution**

This also replaces PR #407's broken `` \` `` line — the new `\\\\`` produces the correct shell-safe `\\`` in the CEL string, whereas the old `\\`` caused CEL to silently unescape back to `` ` ``.

## What This Can Break for Users

**Vault secrets containing `$` or `` ` `` will now have a `\` prefix in their CEL-evaluated value.** This is intentional — it is the shell-safe form — but it is a **behaviour change** in one scenario:

> If a user stores a secret like `p@ssw0rd!#$%^&*` and uses it as a model attribute (not in a shell command), the resolved attribute value will be `p@ssw0rd!#\$%^&*` (with a backslash before the `$`).

Practically speaking:
- **`command/shell` model `run` field** — correct and safe: the shell interprets `\$` as a literal `$`, so the command receives the original value.
- **Non-shell attributes** — the value will contain `\$` rather than `$`. If that attribute is then passed to an external API or compared to a stored value, the extra backslash could cause a mismatch.

The fundamental trade-off is that `resolveVaultExpressions()` is a shared function with no knowledge of whether the resolved value will reach a shell. Scoping the escaping to shell models only would require a larger architectural change and is out of scope for this fix.

**Recommendation for users:** Avoid storing secrets with literal `$` or `` ` `` characters if they are used in non-shell model attributes. Secrets used in `command/shell` models are fully safe.

## Files Changed

| File | Change |
|------|--------|
| `src/domain/expressions/model_resolver.ts` | Replace `\$` / `` \` `` escaping with `\\\\$` / `` \\\\` `` double-backslash prefix |
| `src/domain/vaults/vault_expression_test.ts` | Update 7 existing dollar/backtick tests to match new escaping; add 2 new shell-injection-prevention tests |
| `integration/vault_cel_integration_test.ts` | Update special-characters integration test to expect `\$` in CEL-evaluated value |
| `design/expressions.md` | Add Shell Safety subsection documenting the escaping contract |

## Verification

All 1809 tests pass (`deno run test`). Checked against `swamp-uat` — no UAT tests use `$` or `` ` `` in vault secret values, so no UAT impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)