### PR TITLE
docs: add co-author attribution instructions for external contributors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,13 @@ Use `deno run` to get a complete list of custom tasks.
   add the `hold` label to the PR.
 - After completing work (finishing tasks, merging PRs), run `deno run compile`
   to recompile swamp.
+- When a PR fixes a GitHub issue filed by an external contributor (not a repo
+  collaborator), add them as a co-author to the commit. Check with
+  `gh api /repos/systeminit/swamp/collaborators --jq '.[].login'` to determine
+  if the issue author is a team member. If they are not, add
+  `Co-authored-by: Name <email>` to the commit. Use `gh api /users/<username>`
+  to look up their name, and use `<username>@users.noreply.github.com` as the
+  email unless a public email is available from the API response.
 
 ## Verification
 


### PR DESCRIPTION
## Summary

- Adds instructions to CLAUDE.md's `Source Control & Pull Requests` section
  encoding the co-author attribution policy from CONTRIBUTING.md
- When a PR fixes a GitHub issue filed by an external contributor (not a repo
  collaborator), the commit should include a `Co-authored-by` trailer
- Claude checks `gh api /repos/systeminit/swamp/collaborators` to distinguish
  team members from external contributors before adding the trailer
- Uses `gh api /users/<username>` to look up the contributor's name and falls
  back to `<username>@users.noreply.github.com` for the email

## Why

Our [CONTRIBUTING.md](./CONTRIBUTING.md#attribution) promises external
contributors who file issues that we will include them as a co-author on
the resulting PR. This change encodes that promise directly into Claude's
workflow instructions so it happens automatically — no manual reminder
needed.

## Test plan

- [x] Verify `deno fmt` passes (no code changes, only markdown)
- [x] Confirm the new instructions are clear and actionable by reviewing the
  diff in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)