### PR TITLE
docs: require skill-creator guidelines for swamp skill maintenance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,11 @@ service integrations.
 When planning new features, always use the `ddd` skill to inform the
 architecture.
 
+## Skills
+
+When creating or updating `swamp-*` skills in `.claude/skills/`, follow the
+`skill-creator` skill guidelines to ensure consistent structure and quality.
+
 ## Code Style
 
 - TypeScript strict mode, no `any` types


### PR DESCRIPTION
## Summary

- Adds a note to CLAUDE.md requiring that all `swamp-*` skill changes follow
  the `skill-creator` skill guidelines

## Why

Without a shared standard, skills drift in structure and quality as different
authors (human or Claude) update them independently. This one-liner keeps the
`skill-creator` guidelines front of mind and ensures consistency across all
swamp skills.

## Test plan

- [ ] Verify CLAUDE.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)