### PR TITLE
fix: harden vary dimensions with path safety and bigint regression test

### DIFF
--- a/src/domain/data/composite_name.ts
+++ b/src/domain/data/composite_name.ts
@@ -47,6 +47,20 @@ export function composeDataName(
         `Vary value at index ${i} must be a non-empty string`,
       );
     }
+    if (/[\/\\]/.test(varyValues[i])) {
+      throw new Error(
+        `Vary value at index ${i} contains path separator characters: ${
+          varyValues[i]
+        }`,
+      );
+    }
+    if (varyValues[i] === "." || varyValues[i] === "..") {
+      throw new Error(
+        `Vary value at index ${i} must not be a relative path component: ${
+          varyValues[i]
+        }`,
+      );
+    }
   }
 
   return `${baseName}-${varyValues.join("-")}`;

--- a/src/domain/data/composite_name_test.ts
+++ b/src/domain/data/composite_name_test.ts
@@ -70,3 +70,35 @@ Deno.test("composeDataName: throws on whitespace-only vary value", () => {
 Deno.test("composeDataName: handles numeric-like vary values", () => {
   assertEquals(composeDataName("result", ["42"]), "result-42");
 });
+
+Deno.test("composeDataName: throws on vary value with forward slash", () => {
+  assertThrows(
+    () => composeDataName("result", ["../../etc"]),
+    Error,
+    "Vary value at index 0 contains path separator characters",
+  );
+});
+
+Deno.test("composeDataName: throws on vary value with backslash", () => {
+  assertThrows(
+    () => composeDataName("result", ["foo\\bar"]),
+    Error,
+    "Vary value at index 0 contains path separator characters",
+  );
+});
+
+Deno.test("composeDataName: throws on dot-dot vary value", () => {
+  assertThrows(
+    () => composeDataName("result", [".."]),
+    Error,
+    "Vary value at index 0 must not be a relative path component",
+  );
+});
+
+Deno.test("composeDataName: throws on single-dot vary value", () => {
+  assertThrows(
+    () => composeDataName("result", ["."]),
+    Error,
+    "Vary value at index 0 must not be a relative path component",
+  );
+});

--- a/src/infrastructure/cel/cel_evaluator_test.ts
+++ b/src/infrastructure/cel/cel_evaluator_test.ts
@@ -776,3 +776,63 @@ Deno.test("CelEvaluator data.listVersions() with vary dimensions", () => {
   );
   assertEquals(result, [1, 2, 3]);
 });
+
+Deno.test("CelEvaluator data.version() converts CEL int (bigint) to number for cache lookup", () => {
+  // Regression test: CEL represents integers as bigint, but DataCache uses
+  // number keys. Map.get(1n) !== Map.get(1), so the CelDataNamespace must
+  // convert to Number() before delegating.
+  const evaluator = new CelEvaluator();
+
+  // Simulate a DataCache-like delegate that uses strict number equality
+  const versionStore = new Map<number, Record<string, unknown>>();
+  versionStore.set(1, { id: "d1", attributes: { value: "first" } });
+  versionStore.set(2, { id: "d2", attributes: { value: "second" } });
+
+  const context = {
+    data: {
+      version: (
+        _modelName: string,
+        _dataName: string,
+        version: number,
+      ) => {
+        // This mirrors DataCache.getVersion() — uses Map.get with number keys
+        return versionStore.get(version) ?? null;
+      },
+    },
+  };
+
+  // 3-arg form: data.version(model, name, version)
+  const v1 = evaluator.evaluate(
+    'data.version("scanner", "result", 1).attributes.value',
+    context,
+  );
+  assertEquals(v1, "first");
+
+  const v2 = evaluator.evaluate(
+    'data.version("scanner", "result", 2).attributes.value',
+    context,
+  );
+  assertEquals(v2, "second");
+
+  // 4-arg form with vary: data.version(model, name, [vary], version)
+  const varyContext = {
+    data: {
+      version: (
+        _modelName: string,
+        dataName: string,
+        version: number,
+      ) => {
+        if (dataName === "result-prod") {
+          return versionStore.get(version) ?? null;
+        }
+        return null;
+      },
+    },
+  };
+
+  const v1Vary = evaluator.evaluate(
+    'data.version("scanner", "result", ["prod"], 1).attributes.value',
+    varyContext,
+  );
+  assertEquals(v1Vary, "first");
+});


### PR DESCRIPTION
## Summary

Addresses review feedback from #435 (vary dimensions for environment-isolated
data storage). Two non-blocking suggestions were made during review — this PR
implements both.

## Changes

### 1. Path safety validation in `composeDataName()`

`composeDataName()` now rejects vary values containing path-unsafe characters:

- **Path separators** (`/`, `\`) — prevents values like `../../etc` from
  creating data outside the expected directory
- **Relative path components** (`.`, `..`) — prevents directory traversal

Current usage is safe since vary values come from controlled workflow inputs,
but this hardens the function against future use cases where values may come
from less trusted sources.

**Error messages are clear and actionable:**
```
Vary value at index 0 contains path separator characters: ../../etc
Vary value at index 0 must not be a relative path component: ..
```

### 2. Explicit bigint regression test for `data.version()`

Added a test that simulates the real `DataCache` behavior — a `Map` with
`number` keys — to verify that CEL `int` values (which JavaScript represents
as `bigint`) are correctly converted to `Number()` before cache lookup.

This test would have caught the latent bug fixed in #435 where
`Map.get(1n)` silently returned `undefined` when the key was `1` (number),
causing `data.version()` to return null.

The test covers both:
- **3-arg form:** `data.version("scanner", "result", 1)`
- **4-arg form with vary:** `data.version("scanner", "result", ["prod"], 1)`

## Test coverage

- 4 new unit tests for path safety validation
- 1 new regression test for bigint-to-number conversion
- All 1867 tests pass

## Verification

- `deno check` — pass
- `deno lint` — pass
- `deno fmt` — pass
- `deno run test` — 1867 passed, 0 failed
- `deno run compile` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>