### PR TITLE
fix: add missing boolean flags to telemetry command extraction

### DIFF
--- a/src/cli/telemetry_integration.ts
+++ b/src/cli/telemetry_integration.ts
@@ -38,12 +38,13 @@ const ARG_SCHEMAS: Record<string, readonly ("categorical" | "redact")[]> = {
 /** Global options that are tracked separately */
 const GLOBAL_OPTIONS = new Set([
   "--json",
-  "--stream",
   "-q",
   "--quiet",
   "-v",
   "--verbose",
   "--no-telemetry",
+  "--no-color",
+  "--show-properties",
 ]);
 
 /**
@@ -170,12 +171,13 @@ export function extractCommandInfo(args: string[]): CommandInvocationData {
 function isKnownFlag(option: string): boolean {
   const flags = new Set([
     "--json",
-    "--stream",
     "-q",
     "--quiet",
     "-v",
     "--verbose",
     "--no-telemetry",
+    "--no-color",
+    "--show-properties",
     "--force",
     "-f",
     "--help",
@@ -187,6 +189,11 @@ function isKnownFlag(option: string): boolean {
     "-a",
     "--yes",
     "-y",
+    "--check",
+    "--verify",
+    "--prune",
+    "--streaming",
+    "--last-evaluated",
   ]);
   return flags.has(option);
 }

--- a/src/cli/telemetry_integration_test.ts
+++ b/src/cli/telemetry_integration_test.ts
@@ -210,3 +210,70 @@ Deno.test("extractCommandInfo records categorical arg for vault create", () => {
   assertEquals(info.subcommand, "create");
   assertEquals(info.args, ["aws-sm", "<REDACTED>"]);
 });
+
+Deno.test("extractCommandInfo handles --no-color as boolean flag", () => {
+  const info = extractCommandInfo(["--no-color", "model", "create"]);
+
+  assertEquals(info.command, "model");
+  assertEquals(info.subcommand, "create");
+  assertEquals(info.globalOptions, ["--no-color"]);
+});
+
+Deno.test("extractCommandInfo handles --show-properties as boolean flag", () => {
+  const info = extractCommandInfo(["--show-properties", "workflow", "run"]);
+
+  assertEquals(info.command, "workflow");
+  assertEquals(info.subcommand, "run");
+  assertEquals(info.globalOptions, ["--show-properties"]);
+});
+
+Deno.test("extractCommandInfo handles --no-color with --json", () => {
+  const info = extractCommandInfo([
+    "--no-color",
+    "--json",
+    "model",
+    "search",
+  ]);
+
+  assertEquals(info.command, "model");
+  assertEquals(info.subcommand, "search");
+  assertEquals(info.globalOptions, ["--no-color", "--json"]);
+});
+
+Deno.test("extractCommandInfo handles --last-evaluated as boolean flag", () => {
+  const info = extractCommandInfo([
+    "workflow",
+    "run",
+    "my-workflow",
+    "--last-evaluated",
+  ]);
+
+  assertEquals(info.command, "workflow");
+  assertEquals(info.subcommand, "run");
+  assertEquals(info.args, ["<REDACTED>"]);
+  assertEquals(info.optionKeys, ["--last-evaluated"]);
+});
+
+Deno.test("extractCommandInfo handles --check as boolean flag", () => {
+  const info = extractCommandInfo(["update", "--check"]);
+
+  assertEquals(info.command, "update");
+  assertEquals(info.subcommand, undefined);
+  assertEquals(info.optionKeys, ["--check"]);
+});
+
+Deno.test("extractCommandInfo handles --verify and --prune as boolean flags", () => {
+  const info = extractCommandInfo(["repo", "index", "--verify", "--prune"]);
+
+  assertEquals(info.command, "repo");
+  assertEquals(info.subcommand, "index");
+  assertEquals(info.optionKeys, ["--verify", "--prune"]);
+});
+
+Deno.test("extractCommandInfo handles --streaming as boolean flag", () => {
+  const info = extractCommandInfo(["data", "search", "--streaming"]);
+
+  assertEquals(info.command, "data");
+  assertEquals(info.subcommand, "search");
+  assertEquals(info.optionKeys, ["--streaming"]);
+});


### PR DESCRIPTION
## Summary

- **Fixed telemetry misreporting** caused by missing boolean flags in `extractCommandInfo`'s `isKnownFlag()` function
- Added 7 regression tests covering all previously-missing flags
- Removed stale `--stream` option that doesn't exist in the CLI

## Problem

The telemetry pre-parser (`extractCommandInfo` in `telemetry_integration.ts`) uses `isKnownFlag()` to determine whether a CLI flag is boolean (takes no value) or expects a value argument. When a boolean flag is **not** listed in `isKnownFlag()`, the parser assumes it takes a value and consumes the **next positional argument** as that value — silently swallowing the command or subcommand name from the telemetry record.

### Critical: Global flags

Two global flags were missing from `isKnownFlag()`:
- `--no-color` (global option defined in `mod.ts`)
- `--show-properties` (global option defined in `mod.ts`)

Because global flags appear **before** the command name in the argument list, these caused the command itself to be misidentified:

```
swamp --no-color model create prompt my-thing
```

**Before fix:** `command: "create"`, `subcommand: "prompt"` (wrong — "model" was consumed as `--no-color`'s value)

**After fix:** `command: "model"`, `subcommand: "create"` (correct)

In the worst case (`swamp --no-color model` to view help), the command would be recorded as an empty string with no subcommand — explaining the "swamp with no subcommand" entries seen in Mixpanel.

### Lower impact: Per-command flags

Five per-command boolean flags were also missing. These appear after the command/subcommand are identified, so they don't break command identification, but they cause positional arguments to be swallowed:

- `--check` (`update` command)
- `--verify` (`repo index` command)
- `--prune` (`repo index` command)
- `--streaming` (`data search` command)
- `--last-evaluated` (`workflow run` and `model method run` commands)

### Cleanup

Removed stale `--stream` from both `GLOBAL_OPTIONS` and `isKnownFlag` — it is not an actual CLI option defined anywhere.

## Test plan

- [x] Added regression tests for `--no-color` before command (the critical case)
- [x] Added regression tests for `--show-properties` before command
- [x] Added regression test for `--no-color` combined with `--json`
- [x] Added regression tests for `--last-evaluated`, `--check`, `--verify`, `--prune`, `--streaming`
- [x] All 23 telemetry integration tests pass
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)