### PR TITLE
fix: preserve leading zeros in SwampVersion calver time component

### DIFF
--- a/src/domain/repo/swamp_version.ts
+++ b/src/domain/repo/swamp_version.ts
@@ -29,6 +29,7 @@ export class SwampVersion {
     readonly major: number,
     readonly minor: number,
     readonly patch: number,
+    private readonly rawVersion: string,
   ) {}
 
   /**
@@ -58,7 +59,8 @@ export class SwampVersion {
     const minor = parseInt(match[2], 10);
     const patch = parseInt(match[3], 10);
 
-    return new SwampVersion(major, minor, patch);
+    const rawVersion = `${match[1]}.${match[2]}.${match[3]}`;
+    return new SwampVersion(major, minor, patch, rawVersion);
   }
 
   /**
@@ -104,6 +106,6 @@ export class SwampVersion {
    * Returns the version as a string (e.g., "1.0.0").
    */
   toString(): string {
-    return `${this.major}.${this.minor}.${this.patch}`;
+    return this.rawVersion;
   }
 }

--- a/src/domain/repo/swamp_version_test.ts
+++ b/src/domain/repo/swamp_version_test.ts
@@ -94,6 +94,17 @@ Deno.test("SwampVersion.create accepts calver format with sha suffix", () => {
   assertEquals(v.patch, 0);
 });
 
+Deno.test("SwampVersion.create preserves leading zeros in calver time component", () => {
+  const v = SwampVersion.create("20260224.003901.0");
+  assertEquals(v.toString(), "20260224.003901.0");
+  assertEquals(v.minor, 3901);
+});
+
+Deno.test("SwampVersion.create preserves leading zeros with sha suffix", () => {
+  const v = SwampVersion.create("20260224.003901.0-sha.abc123");
+  assertEquals(v.toString(), "20260224.003901.0");
+});
+
 Deno.test("SwampVersion.create accepts dev version", () => {
   const v = SwampVersion.create("0.0.0-dev");
   assertEquals(v.major, 0);


### PR DESCRIPTION
## Summary

Fixes #439

`SwampVersion.create()` uses `parseInt()` to parse calver version segments into integers for comparison. However, `toString()` was reconstructing the version string from those integers, which strips leading zeros. This is a problem for builds between midnight and ~09:59:59 UTC, where the `HHMMSS` time component has leading zeros (e.g. `003901`).

**Example of the bug:**
```
Input:    "20260224.003901.0"
Parsed:   major=20260224, minor=3901, patch=0
Output:   "20260224.3901.0"  ← leading zeros lost
Expected: "20260224.003901.0"
```

This caused `.swamp.yaml` version round-tripping to fail — the version written back after parsing didn't match the original, breaking UAT validation for early-morning builds.

## Fix

Store the original string segments (`rawVersion`) alongside the parsed integer values. `toString()` now returns the preserved raw string instead of reconstructing from integers. The integer fields (`major`, `minor`, `patch`) remain unchanged and continue to be used for `compareTo`, `equals`, `isNewerThan`, and `isOlderThan`.

This approach preserves exact round-tripping for all version formats:
- Calver: `"20260224.003901.0"` → `toString()` → `"20260224.003901.0"`
- Semver: `"1.2.3"` → `toString()` → `"1.2.3"`
- With suffix: `"20260224.003901.0-sha.abc123"` → `toString()` → `"20260224.003901.0"` (suffix correctly stripped, zeros preserved)

## Test plan

- [x] Added regression test: `create("20260224.003901.0").toString()` returns `"20260224.003901.0"`
- [x] Added regression test: leading zeros preserved when suffix is stripped
- [x] All 28 existing `SwampVersion` tests pass (including `create("1.2.3").toString() === "1.2.3"`)
- [x] Full test suite passes (1877 tests)
- [x] `deno check`, `deno lint`, `deno fmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)