### PR TITLE
feat: auto-store sensitive output fields in vault before persistence

### DIFF
--- a/design/vaults.md
+++ b/design/vaults.md
@@ -85,66 +85,107 @@ The expression syntax is:
 - `key` - The secret identifier within that vault
 - `value` - The value to store (for put operations)
 
-## Sensitive Field Marking
+## Sensitive Field Marking (Implemented)
 
-Model schemas can mark fields as sensitive using Zod's `.meta()` method:
+Model schemas mark fields as sensitive using Zod's `.meta()` method. When a
+method executes, sensitive output fields are automatically stored in a vault and
+replaced with vault reference expressions before persistence.
+
+### Schema Metadata
+
+Mark individual fields as sensitive:
 
 ```typescript
-// Input schema with sensitive field
-export const ApiKeyInputAttributesSchema = z.object({
-  serviceName: z.string().min(1),
-  keyData: z.string().meta({
-    description: "Private key data for API authentication",
-    sensitive: true,
-    vault: true, // Indicates this should come from vault
-  }),
-});
-
-// Data/Resource schema with sensitive output
-export const ApiKeyDataAttributesSchema = z.object({
-  serviceName: z.string(),
-  apiKey: z.string().meta({
-    description: "Generated API key",
-    sensitive: true,
-    vault: true, // Indicates this should be stored in vault
-    vaultKey: "generated-api-key", // Optional: specify vault key name
-  }),
+export const DataAttributesSchema = z.object({
   keyId: z.string(),
-  createdAt: z.string().datetime(),
+  keyMaterial: z.string().meta({ sensitive: true }),
+  publicKey: z.string(),
 });
 ```
 
-### Sensitive Field Metadata
+Supported metadata properties on `.meta()`:
 
-Fields marked as sensitive support these metadata properties:
+- `sensitive: boolean` - Marks the field as containing sensitive data (required)
+- `vaultKey?: string` - Custom vault key (defaults to auto-generated path)
+- `vaultName?: string` - Specific vault to use (overrides method/default vault)
 
-- `sensitive: boolean` - Marks the field as containing sensitive data
-- `vault: boolean` - Indicates the field should interact with vault storage
-- `vaultKey?: string` - Optional custom key name for vault storage (defaults to
-  field name)
-- `vaultName?: string` - Optional specific vault to use (defaults to repository
-  default)
+### Method-Level `sensitiveOutput`
 
-### Automatic Vault Integration
+When a method's entire output is sensitive, set `sensitiveOutput: true` on the
+`MethodDefinition` instead of marking each field individually:
 
-When a field is marked with `sensitive: true` and `vault: true`:
+```typescript
+const methods = {
+  createKeyPair: {
+    description: "Create a key pair",
+    sensitiveOutput: true, // All output fields treated as sensitive
+    vaultName: "my-vault", // Optional: override vault for this method
+    inputAttributesSchema: InputSchema,
+    execute: async (input, context) => { ... },
+  },
+};
+```
 
-**Input Fields**: The swamp runtime automatically resolves vault expressions:
+### Vault Key Naming
+
+Auto-generated vault keys follow the pattern:
+
+```
+{modelType}/{modelId}/{methodName}/{fieldPath}
+```
+
+For example: `aws/ec2/key-pair/abc-123/createKeyPair/keyMaterial`
+
+Custom keys can be specified via `vaultKey` in field metadata:
+
+```typescript
+apiKey: z.string().meta({ sensitive: true, vaultKey: "my-api-key" }),
+```
+
+### Vault Reference Format
+
+Sensitive values are replaced with CEL-compatible vault reference expressions
+using single-quoted string arguments:
+
+```
+${{ vault.get('vault-name', 'vault-key') }}
+```
+
+### Vault Resolution Order
+
+The vault used for storing a sensitive field is resolved in this order:
+
+1. Field-level `vaultName` from `.meta()` metadata
+2. Method-level `vaultName` from `MethodDefinition`
+3. `defaultVaultName` from `MethodContext`
+4. First available vault from `VaultService`
+
+### Processing Behavior
+
+- Values are **snapshotted** before processing to prevent cross-contamination
+  when multiple fields are sensitive
+- Both `ModelData` and `ModelResource` attributes are processed
+- Non-string values are JSON-stringified before vault storage
+- Fields with `null` or `undefined` values are skipped
+- If sensitive fields exist but no vault is configured, an error is thrown with
+  guidance to create a vault
+
+### Implementation
+
+Processing is handled by `processSensitiveFields()` and
+`processSensitiveResourceFields()` in `src/domain/models/data_writer.ts`. Schema
+introspection is performed by `extractSensitiveFields()` in
+`src/domain/models/sensitive_field_extractor.ts`.
+
+### Input Fields
+
+Input fields use vault expressions directly in YAML:
 
 ```yaml
-# User writes this
-keyData: ${{ vault.get(aws, machineKeyData) }}
-
-# Runtime validates against schema and retrieves from vault
+keyData: ${{ vault.get('aws', 'machineKeyData') }}
 ```
 
-**Output Fields**: The swamp runtime automatically stores sensitive output:
-
-```typescript
-// After method execution, sensitive fields are automatically stored
-// Field: apiKey with meta { sensitive: true, vault: true, vaultKey: "generated-api-key" }
-// Result: vault.put(default-vault, "generated-api-key", resultData.attributes.apiKey)
-```
+The expression evaluation system resolves these at runtime.
 
 ## AWS Secrets Manager Provider
 

--- a/integration/sensitive_field_vault_test.ts
+++ b/integration/sensitive_field_vault_test.ts
@@ -1,0 +1,199 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Integration tests for sensitive field vault storage.
+ *
+ * Tests the full flow: model data with sensitive fields → processSensitiveFields →
+ * vault storage → persisted data has vault references instead of plaintext.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { z } from "zod";
+import { ModelData } from "../src/domain/models/model_data.ts";
+import { ModelType } from "../src/domain/models/model_type.ts";
+import { VaultService } from "../src/domain/vaults/vault_service.ts";
+import { processSensitiveFields } from "../src/domain/models/data_writer.ts";
+
+Deno.test("Integration: sensitive output fields stored in vault with references in persisted data", async () => {
+  const modelType = ModelType.create("test/sensitive-output");
+  const modelId = crypto.randomUUID();
+  const methodName = "createKeyPair";
+
+  const dataSchema = z.object({
+    keyId: z.string(),
+    keyMaterial: z.string().meta({ sensitive: true }),
+    publicKey: z.string(),
+  });
+
+  // Create model data with sensitive field
+  const data = ModelData.create({
+    id: modelId,
+    attributes: {
+      keyId: "key-12345",
+      keyMaterial:
+        "-----BEGIN RSA PRIVATE KEY-----\nSECRET\n-----END RSA PRIVATE KEY-----",
+      publicKey: "ssh-rsa AAAAB3... user@host",
+    },
+  });
+
+  // Create a mock vault
+  const vaultService = new VaultService();
+  vaultService.registerVault({
+    name: "test-vault",
+    type: "mock",
+    config: {},
+  });
+
+  // Process sensitive fields
+  await processSensitiveFields({
+    data,
+    schema: dataSchema,
+    vaultService,
+    modelType,
+    modelId,
+    methodName,
+    defaultVaultName: "test-vault",
+  });
+
+  // keyId should be plaintext (not sensitive)
+  assertEquals(data.attributes.keyId, "key-12345");
+
+  // publicKey should be plaintext (not sensitive)
+  assertEquals(data.attributes.publicKey, "ssh-rsa AAAAB3... user@host");
+
+  // keyMaterial should be a vault reference (sensitive field)
+  const keyMaterialRef = data.attributes.keyMaterial as string;
+  assertStringIncludes(keyMaterialRef, "vault.get");
+  assertStringIncludes(keyMaterialRef, "'test-vault'");
+  // Verify quoted strings for CEL compatibility
+  assertStringIncludes(keyMaterialRef, "${{ vault.get('test-vault'");
+
+  // Verify the actual secret was stored in the vault
+  const vaultKey = `test/sensitive-output/${modelId}/${methodName}/keyMaterial`;
+  const storedSecret = await vaultService.get("test-vault", vaultKey);
+  assertEquals(
+    storedSecret,
+    "-----BEGIN RSA PRIVATE KEY-----\nSECRET\n-----END RSA PRIVATE KEY-----",
+  );
+
+  // Verify data can be serialized to JSON (simulates persistence)
+  const persistedJson = JSON.stringify(data.toData());
+  const parsed = JSON.parse(persistedJson);
+  assertEquals(parsed.attributes.keyId, "key-12345");
+  assertStringIncludes(parsed.attributes.keyMaterial, "vault.get");
+  assertEquals(parsed.attributes.publicKey, "ssh-rsa AAAAB3... user@host");
+});
+
+Deno.test("Integration: sensitiveOutput flag vaults all fields", async () => {
+  const modelType = ModelType.create("test/all-sensitive");
+  const modelId = crypto.randomUUID();
+  const methodName = "generate";
+
+  const dataSchema = z.object({
+    field1: z.string(),
+    field2: z.string(),
+  });
+
+  const data = ModelData.create({
+    id: modelId,
+    attributes: { field1: "secret-value-1", field2: "secret-value-2" },
+  });
+
+  const vaultService = new VaultService();
+  vaultService.registerVault({
+    name: "test-vault",
+    type: "mock",
+    config: {},
+  });
+
+  await processSensitiveFields({
+    data,
+    schema: dataSchema,
+    vaultService,
+    modelType,
+    modelId,
+    methodName,
+    sensitiveOutput: true,
+    defaultVaultName: "test-vault",
+  });
+
+  // Both fields should be vault references
+  assertStringIncludes(data.attributes.field1 as string, "vault.get");
+  assertStringIncludes(data.attributes.field2 as string, "vault.get");
+
+  // Verify values stored in vault
+  const key1 = `test/all-sensitive/${modelId}/${methodName}/field1`;
+  const key2 = `test/all-sensitive/${modelId}/${methodName}/field2`;
+  assertEquals(
+    await vaultService.get("test-vault", key1),
+    "secret-value-1",
+  );
+  assertEquals(
+    await vaultService.get("test-vault", key2),
+    "secret-value-2",
+  );
+});
+
+Deno.test("Integration: custom vaultKey from schema metadata", async () => {
+  const modelType = ModelType.create("test/custom-key");
+  const modelId = crypto.randomUUID();
+  const methodName = "generate";
+
+  const dataSchema = z.object({
+    apiKey: z.string().meta({
+      sensitive: true,
+      vaultKey: "generated-api-key",
+    }),
+  });
+
+  const data = ModelData.create({
+    id: modelId,
+    attributes: { apiKey: "sk-live-abc123def456" },
+  });
+
+  const vaultService = new VaultService();
+  vaultService.registerVault({
+    name: "test-vault",
+    type: "mock",
+    config: {},
+  });
+
+  await processSensitiveFields({
+    data,
+    schema: dataSchema,
+    vaultService,
+    modelType,
+    modelId,
+    methodName,
+    defaultVaultName: "test-vault",
+  });
+
+  // Verify vault reference uses custom key with quoted strings
+  assertEquals(
+    data.attributes.apiKey,
+    "${{ vault.get('test-vault', 'generated-api-key') }}",
+  );
+
+  // Verify stored with custom key
+  assertEquals(
+    await vaultService.get("test-vault", "generated-api-key"),
+    "sk-live-abc123def456",
+  );
+});

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -18,6 +18,11 @@ import { StreamingLogRepository } from "../../infrastructure/persistence/streami
 import { FileSystemFileRepository } from "../../infrastructure/persistence/fs_file_repository.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 import { DefaultMethodExecutionService } from "../../domain/models/method_execution_service.ts";
+import { VaultService } from "../../domain/vaults/vault_service.ts";
+import {
+  processSensitiveFields,
+  processSensitiveResourceFields,
+} from "../../domain/models/data_writer.ts";
 
 // Cliffy's custom type system returns `unknown` for custom types like `model_name`,
 // but we need to pass `options` to functions expecting specific types. Using `any`
@@ -46,6 +51,7 @@ export const modelMethodRunCommand = new Command()
       const logRepo = new StreamingLogRepository(repoDir);
       const fileRepo = new FileSystemFileRepository(repoDir);
       const executionService = new DefaultMethodExecutionService();
+      const vaultService = VaultService.fromConfig(repoDir);
 
       ctx.logger
         .debug`Running method '${methodName}' on model: ${modelIdOrName}`;
@@ -113,6 +119,7 @@ export const modelMethodRunCommand = new Command()
             resourceRepository: resourceRepo,
             logRepository: logRepo,
             fileRepository: fileRepo,
+            vaultService,
           },
         );
 
@@ -126,6 +133,19 @@ export const modelMethodRunCommand = new Command()
             await resourceRepo.delete(modelType, result.resource.id);
             ctx.logger.debug`Resource deleted: ${result.resource.id}`;
           } else {
+            // Process sensitive fields in resource before saving
+            if (definition.resourceAttributesSchema) {
+              await processSensitiveResourceFields({
+                resource: result.resource,
+                schema: definition.resourceAttributesSchema,
+                vaultService,
+                modelType,
+                modelId: input.id,
+                methodName,
+                sensitiveOutput: method.sensitiveOutput,
+                methodVaultName: method.vaultName,
+              });
+            }
             // Save the resource
             await resourceRepo.save(modelType, result.resource);
             const resourcePath = resourceRepo.getPath(
@@ -151,6 +171,19 @@ export const modelMethodRunCommand = new Command()
             await dataRepo.delete(modelType, result.data.id);
             ctx.logger.debug`Data deleted: ${result.data.id}`;
           } else {
+            // Process sensitive fields before saving
+            if (definition.dataAttributesSchema) {
+              await processSensitiveFields({
+                data: result.data,
+                schema: definition.dataAttributesSchema,
+                vaultService,
+                modelType,
+                modelId: input.id,
+                methodName,
+                sensitiveOutput: method.sensitiveOutput,
+                methodVaultName: method.vaultName,
+              });
+            }
             await dataRepo.save(modelType, result.data);
             const dataPath = dataRepo.getPath(modelType, result.data.id);
             ctx.logger.debug`Data saved to: ${dataPath}`;

--- a/src/domain/models/data_writer.ts
+++ b/src/domain/models/data_writer.ts
@@ -1,0 +1,289 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { z } from "zod";
+import type { ModelData } from "./model_data.ts";
+import type { ModelResource } from "./model_resource.ts";
+import type { ModelType } from "./model_type.ts";
+import type { VaultService } from "../vaults/vault_service.ts";
+import {
+  extractSensitiveFields,
+  getNestedValue,
+  type SensitiveFieldInfo,
+  setNestedValue,
+} from "./sensitive_field_extractor.ts";
+
+/**
+ * Common options for sensitive field processing.
+ */
+interface SensitiveFieldsBaseOptions {
+  /** The Zod schema for the attributes (used to find sensitive fields) */
+  schema: z.ZodTypeAny;
+  /** The vault service for storing sensitive values */
+  vaultService: VaultService;
+  /** The model type (used for vault key generation) */
+  modelType: ModelType;
+  /** The model input ID (used for vault key generation) */
+  modelId: string;
+  /** The method name (used for vault key generation) */
+  methodName: string;
+  /** When true, all top-level fields are treated as sensitive */
+  sensitiveOutput?: boolean;
+  /** Method-level vault name override */
+  methodVaultName?: string;
+  /** Default vault name from context */
+  defaultVaultName?: string;
+}
+
+/**
+ * Options for processing sensitive fields in model data.
+ */
+export interface ProcessSensitiveFieldsOptions
+  extends SensitiveFieldsBaseOptions {
+  /** The model data to process */
+  data: ModelData;
+}
+
+/**
+ * Options for processing sensitive fields in model resources.
+ */
+export interface ProcessSensitiveResourceFieldsOptions
+  extends SensitiveFieldsBaseOptions {
+  /** The model resource to process */
+  resource: ModelResource;
+}
+
+/**
+ * Resolves the list of sensitive fields to process, including sensitiveOutput expansion.
+ * Snapshots values from the original attributes before any mutation.
+ *
+ * Returns fields paired with their original values.
+ */
+function resolveSensitiveFields(
+  schema: z.ZodTypeAny,
+  attributes: Record<string, unknown>,
+  sensitiveOutput?: boolean,
+): { field: SensitiveFieldInfo; originalValue: unknown }[] {
+  const sensitiveFields = extractSensitiveFields(schema);
+
+  if (sensitiveOutput) {
+    const existingPaths = new Set(sensitiveFields.map((f) => f.path));
+    for (const key of Object.keys(attributes)) {
+      if (!existingPaths.has(key)) {
+        sensitiveFields.push({ path: key });
+      }
+    }
+  }
+
+  // Snapshot original values and filter out undefined/null.
+  // Deep clone so we capture values before any mutation.
+  const snapshot = structuredClone(attributes);
+  const result: { field: SensitiveFieldInfo; originalValue: unknown }[] = [];
+  for (const field of sensitiveFields) {
+    const value = getNestedValue(snapshot, field.path);
+    if (value !== undefined && value !== null) {
+      result.push({ field, originalValue: value });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Validates vault availability and throws a clear error if no vaults are configured.
+ */
+function validateVaultAvailability(
+  vaultService: VaultService,
+  sensitiveFields: SensitiveFieldInfo[],
+): string[] {
+  const vaultNames = vaultService.getVaultNames();
+  if (vaultNames.length === 0) {
+    const fieldList = sensitiveFields.map((f) => `'${f.path}'`).join(", ");
+    throw new Error(
+      `Cannot persist data: fields ${fieldList} are marked as sensitive ` +
+        `but no vault is configured. Create a vault using: swamp vault create <type> <name>`,
+    );
+  }
+  return vaultNames;
+}
+
+/**
+ * Stores a value in the vault and returns the vault reference expression.
+ */
+async function storeAndCreateRef(
+  vaultService: VaultService,
+  targetVault: string,
+  vaultKey: string,
+  value: unknown,
+): Promise<string> {
+  const stringValue = typeof value === "string" ? value : JSON.stringify(value);
+  await vaultService.put(targetVault, vaultKey, stringValue);
+  return `\${{ vault.get('${targetVault}', '${vaultKey}') }}`;
+}
+
+/**
+ * Applies a vault reference to an attribute set via ModelData.setAttribute or ModelResource.setAttribute.
+ */
+function applyVaultRef(
+  setAttribute: (key: string, value: unknown) => void,
+  getAttributes: () => Record<string, unknown>,
+  fieldPath: string,
+  vaultRef: string,
+): void {
+  if (fieldPath.includes(".")) {
+    const attrs = getAttributes();
+    setNestedValue(attrs, fieldPath, vaultRef);
+    const topLevelKey = fieldPath.split(".")[0];
+    setAttribute(topLevelKey, attrs[topLevelKey]);
+  } else {
+    setAttribute(fieldPath, vaultRef);
+  }
+}
+
+/**
+ * Processes sensitive fields in model data before persistence.
+ *
+ * For each field marked with `{ sensitive: true }` metadata in the schema
+ * (or all fields when `sensitiveOutput` is true):
+ * 1. Stores the actual value in the vault
+ * 2. Replaces the value with a vault reference expression
+ *
+ * Values are snapshotted before processing, so mutation of one field
+ * does not affect the value stored for another.
+ *
+ * @param options - Processing options
+ * @returns The processed ModelData with sensitive values replaced by vault references
+ * @throws Error if sensitive fields are found but no vault is available
+ */
+export async function processSensitiveFields(
+  options: ProcessSensitiveFieldsOptions,
+): Promise<ModelData> {
+  const {
+    data,
+    schema,
+    vaultService,
+    modelType,
+    modelId,
+    methodName,
+    sensitiveOutput,
+    methodVaultName,
+    defaultVaultName,
+  } = options;
+
+  const fieldsWithValues = resolveSensitiveFields(
+    schema,
+    data.attributes,
+    sensitiveOutput,
+  );
+
+  if (fieldsWithValues.length === 0) {
+    return data;
+  }
+
+  const vaultNames = validateVaultAvailability(
+    vaultService,
+    fieldsWithValues.map((f) => f.field),
+  );
+
+  for (const { field, originalValue } of fieldsWithValues) {
+    const targetVault = field.vaultName ?? methodVaultName ??
+      defaultVaultName ?? vaultNames[0];
+    const vaultKey = field.vaultKey ??
+      `${modelType.normalized}/${modelId}/${methodName}/${field.path}`;
+
+    const vaultRef = await storeAndCreateRef(
+      vaultService,
+      targetVault,
+      vaultKey,
+      originalValue,
+    );
+
+    applyVaultRef(
+      (key, value) => data.setAttribute(key, value),
+      () => data.attributes,
+      field.path,
+      vaultRef,
+    );
+  }
+
+  return data;
+}
+
+/**
+ * Processes sensitive fields in model resource before persistence.
+ *
+ * Same behavior as processSensitiveFields but operates on ModelResource.
+ *
+ * @param options - Processing options
+ * @returns The processed ModelResource with sensitive values replaced by vault references
+ * @throws Error if sensitive fields are found but no vault is available
+ */
+export async function processSensitiveResourceFields(
+  options: ProcessSensitiveResourceFieldsOptions,
+): Promise<ModelResource> {
+  const {
+    resource,
+    schema,
+    vaultService,
+    modelType,
+    modelId,
+    methodName,
+    sensitiveOutput,
+    methodVaultName,
+    defaultVaultName,
+  } = options;
+
+  const fieldsWithValues = resolveSensitiveFields(
+    schema,
+    resource.attributes,
+    sensitiveOutput,
+  );
+
+  if (fieldsWithValues.length === 0) {
+    return resource;
+  }
+
+  const vaultNames = validateVaultAvailability(
+    vaultService,
+    fieldsWithValues.map((f) => f.field),
+  );
+
+  for (const { field, originalValue } of fieldsWithValues) {
+    const targetVault = field.vaultName ?? methodVaultName ??
+      defaultVaultName ?? vaultNames[0];
+    const vaultKey = field.vaultKey ??
+      `${modelType.normalized}/${modelId}/${methodName}/${field.path}`;
+
+    const vaultRef = await storeAndCreateRef(
+      vaultService,
+      targetVault,
+      vaultKey,
+      originalValue,
+    );
+
+    applyVaultRef(
+      (key, value) => resource.setAttribute(key, value),
+      () => resource.attributes,
+      field.path,
+      vaultRef,
+    );
+  }
+
+  return resource;
+}

--- a/src/domain/models/data_writer_test.ts
+++ b/src/domain/models/data_writer_test.ts
@@ -1,0 +1,507 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { z } from "zod";
+import { ModelData } from "./model_data.ts";
+import { ModelResource } from "./model_resource.ts";
+import { ModelType } from "./model_type.ts";
+import { VaultService } from "../vaults/vault_service.ts";
+import {
+  processSensitiveFields,
+  processSensitiveResourceFields,
+} from "./data_writer.ts";
+
+/**
+ * Creates a VaultService with a mock vault for testing.
+ */
+function createMockVaultService(vaultName = "test-vault"): VaultService {
+  const service = new VaultService();
+  service.registerVault({ name: vaultName, type: "mock", config: {} });
+  return service;
+}
+
+const testModelType = ModelType.create("test/model");
+const testModelId = "test-model-id";
+const testMethodName = "create";
+
+Deno.test("processSensitiveFields - replaces sensitive field with vault reference", async () => {
+  const schema = z.object({
+    name: z.string(),
+    secret: z.string().meta({ sensitive: true }),
+  });
+
+  const data = ModelData.create({
+    attributes: { name: "public-value", secret: "my-secret-value" },
+  });
+
+  const vaultService = createMockVaultService();
+  await processSensitiveFields({
+    data,
+    schema,
+    vaultService,
+    modelType: testModelType,
+    modelId: testModelId,
+    methodName: testMethodName,
+    defaultVaultName: "test-vault",
+  });
+
+  // Non-sensitive field unchanged
+  assertEquals(data.attributes.name, "public-value");
+
+  // Sensitive field replaced with vault reference
+  assertStringIncludes(data.attributes.secret as string, "vault.get");
+  assertStringIncludes(data.attributes.secret as string, "'test-vault'");
+  assertStringIncludes(data.attributes.secret as string, "'test/model/");
+});
+
+Deno.test("processSensitiveFields - stores actual value in vault", async () => {
+  const schema = z.object({
+    apiKey: z.string().meta({ sensitive: true }),
+  });
+
+  const data = ModelData.create({
+    attributes: { apiKey: "sk-live-abc123" },
+  });
+
+  const vaultService = createMockVaultService();
+  await processSensitiveFields({
+    data,
+    schema,
+    vaultService,
+    modelType: testModelType,
+    modelId: testModelId,
+    methodName: testMethodName,
+    defaultVaultName: "test-vault",
+  });
+
+  // Verify the actual value was stored in vault
+  const vaultKey = `test/model/${testModelId}/${testMethodName}/apiKey`;
+  const storedValue = await vaultService.get("test-vault", vaultKey);
+  assertEquals(storedValue, "sk-live-abc123");
+});
+
+Deno.test("processSensitiveFields - uses quoted strings in vault reference for CEL compatibility", async () => {
+  const schema = z.object({
+    token: z.string().meta({ sensitive: true }),
+  });
+
+  const data = ModelData.create({
+    attributes: { token: "secret-token" },
+  });
+
+  const vaultService = createMockVaultService();
+  await processSensitiveFields({
+    data,
+    schema,
+    vaultService,
+    modelType: testModelType,
+    modelId: testModelId,
+    methodName: testMethodName,
+    defaultVaultName: "test-vault",
+  });
+
+  // Verify quoted strings (critical for CEL parsing)
+  const ref = data.attributes.token as string;
+  assertStringIncludes(ref, "vault.get('test-vault'");
+  assertStringIncludes(
+    ref,
+    `'test/model/${testModelId}/${testMethodName}/token'`,
+  );
+});
+
+Deno.test("processSensitiveFields - handles non-string values with JSON.stringify", async () => {
+  const schema = z.object({
+    config: z.record(z.string(), z.unknown()).meta({ sensitive: true }),
+  });
+
+  const configValue = { key1: "value1", key2: 42 };
+  const data = ModelData.create({
+    attributes: { config: configValue },
+  });
+
+  const vaultService = createMockVaultService();
+  await processSensitiveFields({
+    data,
+    schema,
+    vaultService,
+    modelType: testModelType,
+    modelId: testModelId,
+    methodName: testMethodName,
+    defaultVaultName: "test-vault",
+  });
+
+  // Verify the value stored is JSON stringified, not "[object Object]"
+  const vaultKey = `test/model/${testModelId}/${testMethodName}/config`;
+  const storedValue = await vaultService.get("test-vault", vaultKey);
+  assertEquals(storedValue, JSON.stringify(configValue));
+});
+
+Deno.test("processSensitiveFields - throws error when no vault configured", async () => {
+  const schema = z.object({
+    secret: z.string().meta({ sensitive: true }),
+  });
+
+  const data = ModelData.create({
+    attributes: { secret: "my-secret" },
+  });
+
+  const vaultService = new VaultService(); // No vaults registered
+
+  await assertRejects(
+    () =>
+      processSensitiveFields({
+        data,
+        schema,
+        vaultService,
+        modelType: testModelType,
+        modelId: testModelId,
+        methodName: testMethodName,
+      }),
+    Error,
+    "no vault is configured",
+  );
+});
+
+Deno.test("processSensitiveFields - sensitiveOutput flag treats all fields as sensitive", async () => {
+  const schema = z.object({
+    field1: z.string(),
+    field2: z.string(),
+  });
+
+  const data = ModelData.create({
+    attributes: { field1: "value1", field2: "value2" },
+  });
+
+  const vaultService = createMockVaultService();
+  await processSensitiveFields({
+    data,
+    schema,
+    vaultService,
+    modelType: testModelType,
+    modelId: testModelId,
+    methodName: testMethodName,
+    sensitiveOutput: true,
+    defaultVaultName: "test-vault",
+  });
+
+  // Both fields should be vault references
+  assertStringIncludes(data.attributes.field1 as string, "vault.get");
+  assertStringIncludes(data.attributes.field2 as string, "vault.get");
+
+  // Verify values stored in vault
+  const key1 = `test/model/${testModelId}/${testMethodName}/field1`;
+  const key2 = `test/model/${testModelId}/${testMethodName}/field2`;
+  assertEquals(await vaultService.get("test-vault", key1), "value1");
+  assertEquals(await vaultService.get("test-vault", key2), "value2");
+});
+
+Deno.test("processSensitiveFields - uses custom vaultName from field metadata", async () => {
+  const schema = z.object({
+    secret: z.string().meta({ sensitive: true, vaultName: "special-vault" }),
+  });
+
+  const data = ModelData.create({
+    attributes: { secret: "special-secret" },
+  });
+
+  const vaultService = new VaultService();
+  vaultService.registerVault({
+    name: "special-vault",
+    type: "mock",
+    config: {},
+  });
+  vaultService.registerVault({
+    name: "default-vault",
+    type: "mock",
+    config: {},
+  });
+
+  await processSensitiveFields({
+    data,
+    schema,
+    vaultService,
+    modelType: testModelType,
+    modelId: testModelId,
+    methodName: testMethodName,
+    defaultVaultName: "default-vault",
+  });
+
+  // Should use the field-level vault name, not the default
+  assertStringIncludes(data.attributes.secret as string, "'special-vault'");
+});
+
+Deno.test("processSensitiveFields - uses custom vaultKey from field metadata", async () => {
+  const schema = z.object({
+    apiKey: z.string().meta({ sensitive: true, vaultKey: "my-custom-key" }),
+  });
+
+  const data = ModelData.create({
+    attributes: { apiKey: "key-value" },
+  });
+
+  const vaultService = createMockVaultService();
+  await processSensitiveFields({
+    data,
+    schema,
+    vaultService,
+    modelType: testModelType,
+    modelId: testModelId,
+    methodName: testMethodName,
+    defaultVaultName: "test-vault",
+  });
+
+  // Should use custom vault key
+  assertStringIncludes(data.attributes.apiKey as string, "'my-custom-key'");
+
+  // Verify stored with custom key
+  assertEquals(
+    await vaultService.get("test-vault", "my-custom-key"),
+    "key-value",
+  );
+});
+
+Deno.test("processSensitiveFields - skips fields with null/undefined values", async () => {
+  const schema = z.object({
+    required: z.string().meta({ sensitive: true }),
+    optional: z.string().optional().meta({ sensitive: true }),
+  });
+
+  const data = ModelData.create({
+    attributes: { required: "has-value" },
+  });
+
+  const vaultService = createMockVaultService();
+  await processSensitiveFields({
+    data,
+    schema,
+    vaultService,
+    modelType: testModelType,
+    modelId: testModelId,
+    methodName: testMethodName,
+    defaultVaultName: "test-vault",
+  });
+
+  // Required field with value should be processed
+  assertStringIncludes(data.attributes.required as string, "vault.get");
+
+  // Optional field without value should not appear
+  assertEquals(data.attributes.optional, undefined);
+});
+
+Deno.test("processSensitiveFields - returns data unchanged when no sensitive fields", async () => {
+  const schema = z.object({
+    name: z.string(),
+    count: z.number(),
+  });
+
+  const data = ModelData.create({
+    attributes: { name: "test", count: 42 },
+  });
+
+  const vaultService = createMockVaultService();
+  const result = await processSensitiveFields({
+    data,
+    schema,
+    vaultService,
+    modelType: testModelType,
+    modelId: testModelId,
+    methodName: testMethodName,
+  });
+
+  // Data should be unchanged
+  assertEquals(result.attributes.name, "test");
+  assertEquals(result.attributes.count, 42);
+});
+
+Deno.test("processSensitiveFields - method vaultName overrides default", async () => {
+  const schema = z.object({
+    secret: z.string().meta({ sensitive: true }),
+  });
+
+  const data = ModelData.create({
+    attributes: { secret: "my-secret" },
+  });
+
+  const vaultService = new VaultService();
+  vaultService.registerVault({
+    name: "method-vault",
+    type: "mock",
+    config: {},
+  });
+
+  await processSensitiveFields({
+    data,
+    schema,
+    vaultService,
+    modelType: testModelType,
+    modelId: testModelId,
+    methodName: testMethodName,
+    methodVaultName: "method-vault",
+    defaultVaultName: "default-vault",
+  });
+
+  assertStringIncludes(data.attributes.secret as string, "'method-vault'");
+});
+
+Deno.test("processSensitiveFields - handles nested sensitive fields without spurious keys", async () => {
+  const schema = z.object({
+    credentials: z.object({
+      apiKey: z.string().meta({ sensitive: true }),
+      region: z.string(),
+    }),
+    name: z.string(),
+  });
+
+  const data = ModelData.create({
+    attributes: {
+      credentials: { apiKey: "secret-key-123", region: "us-east-1" },
+      name: "my-service",
+    },
+  });
+
+  const vaultService = createMockVaultService();
+  await processSensitiveFields({
+    data,
+    schema,
+    vaultService,
+    modelType: testModelType,
+    modelId: testModelId,
+    methodName: testMethodName,
+    defaultVaultName: "test-vault",
+  });
+
+  // Non-sensitive field unchanged
+  assertEquals(data.attributes.name, "my-service");
+
+  // Nested non-sensitive field unchanged
+  const creds = data.attributes.credentials as Record<string, unknown>;
+  assertEquals(creds.region, "us-east-1");
+
+  // Nested sensitive field replaced with vault reference
+  assertStringIncludes(creds.apiKey as string, "vault.get");
+
+  // No spurious literal dot-key should exist
+  assertEquals(data.attributes["credentials.apiKey"], undefined);
+
+  // Verify value stored in vault
+  const vaultKey =
+    `test/model/${testModelId}/${testMethodName}/credentials.apiKey`;
+  const stored = await vaultService.get("test-vault", vaultKey);
+  assertEquals(stored, "secret-key-123");
+
+  // Verify serialization is clean (no spurious keys)
+  const serialized = data.toData();
+  const keys = Object.keys(serialized.attributes);
+  assertEquals(keys.sort(), ["credentials", "name"]);
+});
+
+Deno.test("processSensitiveFields - snapshots values before mutation (no cross-contamination)", async () => {
+  // When sensitiveOutput is true and a schema has nested sensitive fields,
+  // both the parent (from sensitiveOutput) and child (from schema) may be processed.
+  // The parent should store the ORIGINAL object, not one already containing vault refs.
+  const schema = z.object({
+    credentials: z.object({
+      apiKey: z.string().meta({ sensitive: true }),
+      region: z.string(),
+    }),
+  });
+
+  const data = ModelData.create({
+    attributes: {
+      credentials: { apiKey: "original-secret", region: "us-east-1" },
+    },
+  });
+
+  const vaultService = createMockVaultService();
+  await processSensitiveFields({
+    data,
+    schema,
+    vaultService,
+    modelType: testModelType,
+    modelId: testModelId,
+    methodName: testMethodName,
+    sensitiveOutput: true, // This adds "credentials" as a top-level sensitive field
+    defaultVaultName: "test-vault",
+  });
+
+  // Both the nested field AND the top-level object should be vault refs
+  const creds = data.attributes.credentials;
+  assertStringIncludes(creds as string, "vault.get");
+
+  // The nested field value stored in vault should be the original secret
+  const nestedKey =
+    `test/model/${testModelId}/${testMethodName}/credentials.apiKey`;
+  assertEquals(
+    await vaultService.get("test-vault", nestedKey),
+    "original-secret",
+  );
+
+  // The top-level object stored in vault should contain the ORIGINAL values
+  // (snapshotted before the nested field was replaced)
+  const topKey = `test/model/${testModelId}/${testMethodName}/credentials`;
+  const storedObject = JSON.parse(
+    await vaultService.get("test-vault", topKey),
+  );
+  assertEquals(storedObject.apiKey, "original-secret");
+  assertEquals(storedObject.region, "us-east-1");
+});
+
+Deno.test("processSensitiveResourceFields - replaces sensitive field in resource", async () => {
+  const schema = z.object({
+    instanceId: z.string(),
+    privateKey: z.string().meta({ sensitive: true }),
+  });
+
+  const resource = ModelResource.create({
+    attributes: {
+      instanceId: "i-12345",
+      privateKey:
+        "-----BEGIN RSA PRIVATE KEY-----\nSECRET\n-----END RSA PRIVATE KEY-----",
+    },
+  });
+
+  const vaultService = createMockVaultService();
+  await processSensitiveResourceFields({
+    resource,
+    schema,
+    vaultService,
+    modelType: testModelType,
+    modelId: testModelId,
+    methodName: testMethodName,
+    defaultVaultName: "test-vault",
+  });
+
+  // Non-sensitive field unchanged
+  assertEquals(resource.attributes.instanceId, "i-12345");
+
+  // Sensitive field replaced with vault reference
+  assertStringIncludes(resource.attributes.privateKey as string, "vault.get");
+  assertStringIncludes(
+    resource.attributes.privateKey as string,
+    "'test-vault'",
+  );
+
+  // Verify value stored in vault
+  const vaultKey = `test/model/${testModelId}/${testMethodName}/privateKey`;
+  assertEquals(
+    await vaultService.get("test-vault", vaultKey),
+    "-----BEGIN RSA PRIVATE KEY-----\nSECRET\n-----END RSA PRIVATE KEY-----",
+  );
+});

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -13,6 +13,7 @@ import type {
   OutputRepository,
   ResourceRepository,
 } from "./repositories.ts";
+import type { VaultService } from "../vaults/vault_service.ts";
 
 /**
  * Context provided to method execution.
@@ -52,6 +53,16 @@ export interface MethodContext {
    * Optional output repository for tracking execution history.
    */
   outputRepository?: OutputRepository;
+
+  /**
+   * Optional vault service for storing/retrieving sensitive field values.
+   */
+  vaultService?: VaultService;
+
+  /**
+   * Optional default vault name to use when no vault is specified in field metadata.
+   */
+  defaultVaultName?: string;
 }
 
 /**
@@ -150,6 +161,18 @@ export interface MethodDefinition<
    * The method will only execute if the input's attributes match this schema.
    */
   inputAttributesSchema: TInputAttrs;
+
+  /**
+   * When true, all fields in the method's data output are treated as sensitive
+   * and will be stored in a vault before persistence.
+   */
+  sensitiveOutput?: boolean;
+
+  /**
+   * Vault name to use for sensitive output fields.
+   * Overrides field-level metadata and defaultVaultName from context.
+   */
+  vaultName?: string;
 
   /**
    * Executes the method with the given input and context.

--- a/src/domain/models/sensitive_field_extractor.ts
+++ b/src/domain/models/sensitive_field_extractor.ts
@@ -1,0 +1,224 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { z } from "zod";
+
+/**
+ * Information about a sensitive field extracted from a Zod schema.
+ */
+export interface SensitiveFieldInfo {
+  /** Dot-separated path to the field (e.g., "credentials.apiKey") */
+  path: string;
+  /** Optional vault name override from field metadata */
+  vaultName?: string;
+  /** Optional vault key override from field metadata */
+  vaultKey?: string;
+}
+
+/**
+ * Metadata shape expected on sensitive fields.
+ */
+interface SensitiveMetadata {
+  sensitive?: boolean;
+  vault?: boolean;
+  vaultName?: string;
+  vaultKey?: string;
+}
+
+/**
+ * Internal Zod v4 definition structure for schema introspection.
+ */
+interface ZodDef {
+  type: string;
+  innerType?: z.ZodTypeAny;
+  schema?: z.ZodTypeAny;
+  shape?: Record<string, z.ZodTypeAny>;
+}
+
+/**
+ * Gets the internal definition from a Zod schema.
+ */
+function getSchemaDef(schema: z.ZodTypeAny): ZodDef {
+  return (schema as unknown as { _def: ZodDef })._def;
+}
+
+/**
+ * Gets the definition type string from a Zod schema.
+ */
+function getSchemaType(schema: z.ZodTypeAny): string {
+  return getSchemaDef(schema)?.type ?? "";
+}
+
+/**
+ * Unwraps optional, nullable, default, and effects wrappers to get the underlying schema.
+ */
+function unwrapSchema(schema: z.ZodTypeAny): z.ZodTypeAny {
+  const schemaType = getSchemaType(schema);
+  const def = getSchemaDef(schema);
+
+  const wrapperTypes = ["optional", "nullable", "default"];
+  if (wrapperTypes.includes(schemaType) && def.innerType) {
+    return unwrapSchema(def.innerType);
+  }
+  if (schemaType === "effects" && def.schema) {
+    return unwrapSchema(def.schema);
+  }
+  return schema;
+}
+
+/**
+ * Checks metadata on a schema at multiple levels (before and after unwrapping).
+ * Handles both `.meta().optional()` and `.optional().meta()` orderings.
+ */
+function getSensitiveMetadata(
+  schema: z.ZodTypeAny,
+): SensitiveMetadata | undefined {
+  // Check metadata on the outer schema (handles `.optional().meta()`)
+  const outerMeta = z.globalRegistry.get(schema) as
+    | SensitiveMetadata
+    | undefined;
+  if (outerMeta?.sensitive) {
+    return outerMeta;
+  }
+
+  // Check at each unwrap level (handles `.meta().optional()`)
+  let current = schema;
+  while (true) {
+    const schemaType = getSchemaType(current);
+    const def = getSchemaDef(current);
+
+    const wrapperTypes = ["optional", "nullable", "default"];
+    if (wrapperTypes.includes(schemaType) && def.innerType) {
+      const innerMeta = z.globalRegistry.get(def.innerType) as
+        | SensitiveMetadata
+        | undefined;
+      if (innerMeta?.sensitive) {
+        return innerMeta;
+      }
+      current = def.innerType;
+    } else if (schemaType === "effects" && def.schema) {
+      const innerMeta = z.globalRegistry.get(def.schema) as
+        | SensitiveMetadata
+        | undefined;
+      if (innerMeta?.sensitive) {
+        return innerMeta;
+      }
+      current = def.schema;
+    } else {
+      break;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Extracts sensitive field information from a Zod schema.
+ *
+ * Walks the schema's object shape recursively, checking each field for
+ * `{ sensitive: true }` metadata via `z.globalRegistry`. Handles both
+ * `.meta().optional()` and `.optional().meta()` orderings.
+ *
+ * @param schema - A Zod schema (typically an object schema)
+ * @param prefix - Path prefix for nested fields (used in recursion)
+ * @returns Array of sensitive field info objects
+ */
+export function extractSensitiveFields(
+  schema: z.ZodTypeAny,
+  prefix = "",
+): SensitiveFieldInfo[] {
+  const unwrapped = unwrapSchema(schema);
+  const schemaType = getSchemaType(unwrapped);
+
+  if (schemaType !== "object") {
+    return [];
+  }
+
+  const def = getSchemaDef(unwrapped);
+  if (!def.shape) {
+    return [];
+  }
+
+  const results: SensitiveFieldInfo[] = [];
+
+  for (const [key, fieldSchema] of Object.entries(def.shape)) {
+    const fieldPath = prefix ? `${prefix}.${key}` : key;
+
+    // Check if this field has sensitive metadata
+    const meta = getSensitiveMetadata(fieldSchema);
+    if (meta?.sensitive) {
+      results.push({
+        path: fieldPath,
+        vaultName: meta.vaultName,
+        vaultKey: meta.vaultKey,
+      });
+    }
+
+    // Recurse into nested objects
+    const unwrappedField = unwrapSchema(fieldSchema);
+    if (getSchemaType(unwrappedField) === "object") {
+      results.push(...extractSensitiveFields(unwrappedField, fieldPath));
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Gets a nested value from an object by dot-separated path.
+ */
+export function getNestedValue(
+  obj: Record<string, unknown>,
+  path: string,
+): unknown {
+  const parts = path.split(".");
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (
+      current === null || current === undefined || typeof current !== "object"
+    ) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+/**
+ * Sets a nested value in an object by dot-separated path.
+ */
+export function setNestedValue(
+  obj: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): void {
+  const parts = path.split(".");
+  let current: Record<string, unknown> = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i];
+    if (
+      !(part in current) || current[part] === null ||
+      typeof current[part] !== "object"
+    ) {
+      current[part] = {};
+    }
+    current = current[part] as Record<string, unknown>;
+  }
+  current[parts[parts.length - 1]] = value;
+}

--- a/src/domain/models/sensitive_field_extractor_test.ts
+++ b/src/domain/models/sensitive_field_extractor_test.ts
@@ -1,0 +1,188 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { z } from "zod";
+import {
+  extractSensitiveFields,
+  getNestedValue,
+  setNestedValue,
+} from "./sensitive_field_extractor.ts";
+
+Deno.test("extractSensitiveFields: simple sensitive field", () => {
+  const schema = z.object({
+    apiKey: z.string().meta({ sensitive: true }),
+    name: z.string(),
+  });
+
+  const fields = extractSensitiveFields(schema);
+  assertEquals(fields.length, 1);
+  assertEquals(fields[0].path, "apiKey");
+  assertEquals(fields[0].vaultName, undefined);
+  assertEquals(fields[0].vaultKey, undefined);
+});
+
+Deno.test("extractSensitiveFields: meta then optional ordering", () => {
+  const schema = z.object({
+    secret: z.string().meta({ sensitive: true }).optional(),
+    normal: z.string(),
+  });
+
+  const fields = extractSensitiveFields(schema);
+  assertEquals(fields.length, 1);
+  assertEquals(fields[0].path, "secret");
+});
+
+Deno.test("extractSensitiveFields: optional then meta ordering", () => {
+  const schema = z.object({
+    secret: z.string().optional().meta({ sensitive: true }),
+    normal: z.string(),
+  });
+
+  const fields = extractSensitiveFields(schema);
+  assertEquals(fields.length, 1);
+  assertEquals(fields[0].path, "secret");
+});
+
+Deno.test("extractSensitiveFields: nested objects", () => {
+  const schema = z.object({
+    credentials: z.object({
+      apiKey: z.string().meta({ sensitive: true }),
+      token: z.string().meta({ sensitive: true }),
+    }),
+    name: z.string(),
+  });
+
+  const fields = extractSensitiveFields(schema);
+  assertEquals(fields.length, 2);
+  assertEquals(fields[0].path, "credentials.apiKey");
+  assertEquals(fields[1].path, "credentials.token");
+});
+
+Deno.test("extractSensitiveFields: custom vaultName and vaultKey", () => {
+  const schema = z.object({
+    apiKey: z.string().meta({
+      sensitive: true,
+      vaultName: "prod-vault",
+      vaultKey: "my-api-key",
+    }),
+  });
+
+  const fields = extractSensitiveFields(schema);
+  assertEquals(fields.length, 1);
+  assertEquals(fields[0].path, "apiKey");
+  assertEquals(fields[0].vaultName, "prod-vault");
+  assertEquals(fields[0].vaultKey, "my-api-key");
+});
+
+Deno.test("extractSensitiveFields: mixed sensitive and non-sensitive fields", () => {
+  const schema = z.object({
+    name: z.string(),
+    apiKey: z.string().meta({ sensitive: true }),
+    region: z.string(),
+    password: z.string().meta({ sensitive: true }),
+    port: z.number(),
+  });
+
+  const fields = extractSensitiveFields(schema);
+  assertEquals(fields.length, 2);
+  assertEquals(fields[0].path, "apiKey");
+  assertEquals(fields[1].path, "password");
+});
+
+Deno.test("extractSensitiveFields: non-object schema returns empty", () => {
+  const schema = z.string();
+  const fields = extractSensitiveFields(schema);
+  assertEquals(fields.length, 0);
+});
+
+Deno.test("extractSensitiveFields: no sensitive fields returns empty", () => {
+  const schema = z.object({
+    name: z.string(),
+    port: z.number(),
+  });
+
+  const fields = extractSensitiveFields(schema);
+  assertEquals(fields.length, 0);
+});
+
+Deno.test("extractSensitiveFields: nullable wrapping", () => {
+  const schema = z.object({
+    secret: z.string().meta({ sensitive: true }).nullable(),
+  });
+
+  const fields = extractSensitiveFields(schema);
+  assertEquals(fields.length, 1);
+  assertEquals(fields[0].path, "secret");
+});
+
+Deno.test("extractSensitiveFields: deeply nested", () => {
+  const schema = z.object({
+    level1: z.object({
+      level2: z.object({
+        secret: z.string().meta({ sensitive: true }),
+      }),
+    }),
+  });
+
+  const fields = extractSensitiveFields(schema);
+  assertEquals(fields.length, 1);
+  assertEquals(fields[0].path, "level1.level2.secret");
+});
+
+Deno.test("getNestedValue: simple path", () => {
+  const obj = { apiKey: "secret-value" };
+  assertEquals(getNestedValue(obj, "apiKey"), "secret-value");
+});
+
+Deno.test("getNestedValue: nested path", () => {
+  const obj = { credentials: { apiKey: "secret-value" } };
+  assertEquals(getNestedValue(obj, "credentials.apiKey"), "secret-value");
+});
+
+Deno.test("getNestedValue: missing path returns undefined", () => {
+  const obj = { name: "test" };
+  assertEquals(getNestedValue(obj, "missing"), undefined);
+});
+
+Deno.test("setNestedValue: simple path", () => {
+  const obj: Record<string, unknown> = { apiKey: "original" };
+  setNestedValue(obj, "apiKey", "replaced");
+  assertEquals(obj.apiKey, "replaced");
+});
+
+Deno.test("setNestedValue: nested path", () => {
+  const obj: Record<string, unknown> = {
+    credentials: { apiKey: "original" },
+  };
+  setNestedValue(obj, "credentials.apiKey", "replaced");
+  assertEquals(
+    (obj.credentials as Record<string, unknown>).apiKey,
+    "replaced",
+  );
+});
+
+Deno.test("setNestedValue: creates intermediate objects", () => {
+  const obj: Record<string, unknown> = {};
+  setNestedValue(obj, "a.b.c", "value");
+  assertEquals(
+    ((obj.a as Record<string, unknown>).b as Record<string, unknown>).c,
+    "value",
+  );
+});

--- a/src/domain/vaults/vault_service.ts
+++ b/src/domain/vaults/vault_service.ts
@@ -1,3 +1,4 @@
+import { parse } from "@std/yaml";
 import type { VaultConfiguration, VaultProvider } from "./vault_provider.ts";
 import { AwsVaultProvider } from "./aws_vault_provider.ts";
 import { MockVaultProvider } from "./mock_vault_provider.ts";
@@ -5,6 +6,21 @@ import {
   type LocalEncryptionConfig,
   LocalEncryptionVaultProvider,
 } from "./local_encryption_vault_provider.ts";
+
+/**
+ * Interface for vault configuration in .swamp.yaml
+ */
+interface VaultConfig {
+  type: string;
+  config: Record<string, unknown>;
+}
+
+/**
+ * Interface for the root configuration object
+ */
+interface SwampConfig {
+  vaults?: Record<string, VaultConfig>;
+}
 
 /**
  * Service for managing vault providers and resolving vault operations.
@@ -108,6 +124,37 @@ export class VaultService {
    */
   getVaultNames(): string[] {
     return Array.from(this.providers.keys());
+  }
+
+  /**
+   * Creates a VaultService configured from a repository's .swamp.yaml file.
+   *
+   * @param repoDir - The repository directory containing .swamp.yaml
+   * @returns A configured VaultService instance
+   */
+  static fromConfig(repoDir: string): VaultService {
+    const vaultService = new VaultService();
+
+    try {
+      const configPath = `${repoDir}/.swamp.yaml`;
+      const configText = Deno.readTextFileSync(configPath);
+      const config = parse(configText) as SwampConfig;
+
+      if (config.vaults) {
+        for (const [name, vaultConfig] of Object.entries(config.vaults)) {
+          vaultService.registerVault({
+            name,
+            type: vaultConfig.type,
+            config: vaultConfig.config,
+          });
+        }
+      }
+    } catch (_error) {
+      // Ignore file read errors - vault service will provide helpful error messages
+    }
+
+    vaultService.ensureDefaultVaults();
+    return vaultService;
   }
 
   /**

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -36,6 +36,11 @@ import {
   ModelResolver,
 } from "../expressions/model_resolver.ts";
 import { CelEvaluator } from "../../infrastructure/cel/cel_evaluator.ts";
+import { VaultService } from "../vaults/vault_service.ts";
+import {
+  processSensitiveFields,
+  processSensitiveResourceFields,
+} from "../models/data_writer.ts";
 
 /**
  * Context for step execution.
@@ -131,6 +136,7 @@ export class DefaultStepExecutor implements StepExecutor {
     const fileRepo = new FileSystemFileRepository(ctx.repoDir);
     const logRepo = new StreamingLogRepository(ctx.repoDir);
     const executionService = new DefaultMethodExecutionService();
+    const vaultService = VaultService.fromConfig(ctx.repoDir);
 
     // Look up the model input by ID or name
     const lookupResult = await findByIdOrName(inputRepo, task.modelIdOrName);
@@ -231,6 +237,7 @@ export class DefaultStepExecutor implements StepExecutor {
           resourceRepository: resourceRepo,
           logRepository: logRepo,
           fileRepository: fileRepo,
+          vaultService,
         },
       );
 
@@ -240,6 +247,20 @@ export class DefaultStepExecutor implements StepExecutor {
           // Delete the resource file
           await resourceRepo.delete(modelType, result.resource.id);
         } else {
+          // Process sensitive fields in resource before saving
+          if (definition.resourceAttributesSchema) {
+            const method = definition.methods[task.methodName];
+            await processSensitiveResourceFields({
+              resource: result.resource,
+              schema: definition.resourceAttributesSchema,
+              vaultService,
+              modelType,
+              modelId: originalInput.id,
+              methodName: task.methodName,
+              sensitiveOutput: method?.sensitiveOutput,
+              methodVaultName: method?.vaultName,
+            });
+          }
           // Save the resource
           await resourceRepo.save(modelType, result.resource);
           resourcePath = resourceRepo.getPath(modelType, result.resource.id);
@@ -256,6 +277,20 @@ export class DefaultStepExecutor implements StepExecutor {
         if (result.deleteData) {
           await dataRepo.delete(modelType, result.data.id);
         } else {
+          // Process sensitive fields before saving
+          if (definition.dataAttributesSchema) {
+            const method = definition.methods[task.methodName];
+            await processSensitiveFields({
+              data: result.data,
+              schema: definition.dataAttributesSchema,
+              vaultService,
+              modelType,
+              modelId: originalInput.id,
+              methodName: task.methodName,
+              sensitiveOutput: method?.sensitiveOutput,
+              methodVaultName: method?.vaultName,
+            });
+          }
           await dataRepo.save(modelType, result.data);
           output.setDataId(result.data.id);
         }


### PR DESCRIPTION
Closes #433

## Summary

- When upstream APIs return sensitive data (e.g., EC2 `CreateKeyPair` returns `KeyMaterial`), all fields were previously written as plaintext to `.swamp/data/` and `.swamp/resources/`
- This change automatically detects fields marked with `{ sensitive: true }` in Zod schema metadata and stores their values in the configured vault, replacing the persisted value with a CEL-compatible vault reference expression
- Zero impact on existing users — purely additive, no existing behavior changes

## What users can now do

**Mark individual output fields as sensitive:**
```typescript
dataAttributesSchema: z.object({
  keyId: z.string(),
  keyMaterial: z.string().meta({ sensitive: true }),
})
```

**Mark an entire method's output as sensitive:**
```typescript
methods: {
  createKeyPair: {
    sensitiveOutput: true,
    execute: async (input, context) => { ... },
  }
}
```

Persisted files will contain vault references instead of plaintext:
```
${{ vault.get('vault-name', 'modelType/modelId/methodName/fieldPath') }}
```

## Plan vs implementation

| Area | Plan | Implementation |
|------|------|----------------|
| **Where processing lives** | Modify existing `createResourceWriter()` | Standalone `processSensitiveFields()` / `processSensitiveResourceFields()` called at persistence sites |
| **What gets processed** | Data output only (via writer) | Both `ModelData` and `ModelResource` attributes |
| **Mutation safety** | Not addressed | `structuredClone()` snapshot before mutation prevents cross-contamination |
| **Config location** | `sensitiveOutput` on `ResourceOutputSpec` | `sensitiveOutput` on `MethodDefinition` (ResourceOutputSpec doesn't exist) |
| **Factory method** | `VaultService.fromRepository()` | `VaultService.fromConfig()` |
| **Nested fields** | Not addressed | Handled via `setNestedValue()` without creating spurious literal dot-keys |
| **`method_execution_service.ts`** | Modify to thread VaultService | Not needed — VaultService threaded via `MethodContext` |

The divergences were driven by the actual codebase structure (e.g., `ResourceOutputSpec` doesn't exist) and bugs caught during iterative review (missing resource coverage, mutation cross-contamination, nested path handling).

## Architecture benefits

- **Declarative security**: Model authors declare sensitivity in the schema via `.meta()`, not in imperative persistence code. The runtime enforces it automatically.
- **Fail-hard on misconfiguration**: If sensitive fields exist but no vault is configured, the operation fails with a clear error rather than silently writing plaintext.
- **Vault resolution hierarchy**: Field `vaultName` > method `vaultName` > context `defaultVaultName` > first available vault.
- **CEL-compatible references**: Single-quoted string arguments prevent the CEL parser from interpreting slashes in auto-generated keys as division.
- **Snapshot-before-mutation**: Deep clone prevents one field's vault ref from leaking into another field's stored value.

## Files changed

**New:**
- `src/domain/models/sensitive_field_extractor.ts` — Zod schema walker for `{ sensitive: true }` metadata
- `src/domain/models/sensitive_field_extractor_test.ts` — 16 unit tests
- `src/domain/models/data_writer.ts` — `processSensitiveFields()` + `processSensitiveResourceFields()`
- `src/domain/models/data_writer_test.ts` — 14 unit tests
- `integration/sensitive_field_vault_test.ts` — 3 integration tests

**Modified:**
- `src/domain/models/model.ts` — `vaultService`/`defaultVaultName` on `MethodContext`, `sensitiveOutput`/`vaultName` on `MethodDefinition`
- `src/domain/vaults/vault_service.ts` — `VaultService.fromConfig()` static factory
- `src/cli/commands/model_method_run.ts` — vault wiring + sensitive field processing for data and resources
- `src/domain/workflows/execution_service.ts` — same vault wiring for workflow execution
- `design/vaults.md` — updated "Sensitive Field Marking" section to reflect implementation

## Test plan

- [x] 16 unit tests for sensitive field extraction (schema walking, nested objects, metadata orderings)
- [x] 14 unit tests for data writer (vault references, storage, CEL format, nested paths, snapshots, resources)
- [x] 3 integration tests (end-to-end sensitive field → vault → reference flow)
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] `deno run test` — 1231 tests, 0 failures
- [x] `deno run compile` — binary compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)