### PR TITLE
feat: add 1Password vault provider

### DIFF
--- a/design/vaults.md
+++ b/design/vaults.md
@@ -306,6 +306,55 @@ evaluated, ensuring:
 - Secret values are never logged or exposed in intermediate files
 - Expression evaluation errors don't expose secret values
 
+## 1Password Provider
+
+The 1Password provider uses the `op` CLI to access secrets stored in 1Password
+vaults.
+
+### Authentication
+
+- **Service Account Token**: `export OP_SERVICE_ACCOUNT_TOKEN=<token>`
+  (recommended for CI/CD)
+- **Desktop App**: Enable CLI integration in 1Password desktop app settings
+  (recommended for local development)
+- **Connect Server**: Set `OP_CONNECT_HOST` and `OP_CONNECT_TOKEN` environment
+  variables
+- **Manual Sign-in**: `op signin` for interactive sessions
+
+### Configuration Options
+
+```yaml
+# Created via: swamp vault create 1password my-vault --op-vault Engineering
+type: "1password"
+config:
+  op_vault: "Engineering" # Required: 1Password vault name
+  op_account: "my-team" # Optional: Account shorthand (multi-account)
+```
+
+### Secret Key Mapping
+
+Secret keys are mapped to `op://` URIs:
+
+| Expression | Maps to | Notes |
+| --- | --- | --- |
+| `vault.get(my-1p, api-key)` | `op read op://Engineering/api-key/password` | Default field: `password` |
+| `vault.get(my-1p, api-key/token)` | `op read op://Engineering/api-key/token` | Explicit field |
+| `vault.get(my-1p, db/connection/host)` | `op read op://Engineering/db/connection/host` | Section + field |
+| `vault.get(my-1p, op://Shared/cert/pem)` | `op read op://Shared/cert/pem` | Full `op://` override |
+
+### Usage Examples
+
+```yaml
+# Retrieve a secret using default "password" field
+apiKey: ${{ vault.get(my-1p, api-key) }}
+
+# Retrieve a specific field
+dbHost: ${{ vault.get(my-1p, database/host) }}
+
+# Override vault with full op:// URI
+sharedCert: ${{ vault.get(my-1p, op://Shared/tls-cert/pem) }}
+```
+
 ## Extensibility
 
 The vault system is designed for easy extension to new providers:
@@ -338,9 +387,7 @@ class HashiCorpVaultProvider implements VaultProvider {
 The architecture supports adding:
 
 - **HashiCorp Vault**: Enterprise secret management
-- **Azure Key Vault**: Microsoft cloud secrets
 - **Google Secret Manager**: Google Cloud Platform secrets
-- **Local File Vault**: Development and testing scenarios
 - **Environment Variables**: Simple local development
 
 ## Error Handling

--- a/src/cli/commands/vault_create.ts
+++ b/src/cli/commands/vault_create.ts
@@ -37,6 +37,8 @@ type AnyOptions = any;
 interface VaultCreateOptions {
   region?: string;
   vaultUrl?: string;
+  opVault?: string;
+  opAccount?: string;
 }
 
 /**
@@ -78,6 +80,28 @@ function resolveProviderConfig(
           .info`Using vault URL from AZURE_KEYVAULT_URL environment variable: ${vaultUrl}`;
       }
       return { vault_url: vaultUrl };
+    }
+    case "1password": {
+      const opVault = options.opVault || Deno.env.get("OP_VAULT");
+      if (!opVault) {
+        throw new UserError(
+          "1Password vault name is required. Provide --op-vault or set OP_VAULT environment variable.",
+        );
+      }
+      if (!options.opVault) {
+        logger
+          .info`Using vault name from OP_VAULT environment variable: ${opVault}`;
+      }
+      const opAccount = options.opAccount || Deno.env.get("OP_ACCOUNT");
+      if (opAccount && !options.opAccount) {
+        logger
+          .info`Using account from OP_ACCOUNT environment variable: ${opAccount}`;
+      }
+      const config: Record<string, unknown> = { op_vault: opVault };
+      if (opAccount) {
+        config.op_account = opAccount;
+      }
+      return config;
     }
     case "local_encryption":
       return {
@@ -126,6 +150,14 @@ export const vaultCreateCommand = new Command()
   .option(
     "--vault-url <url:string>",
     "Azure Key Vault URL (for azure-kv type). Falls back to AZURE_KEYVAULT_URL env var.",
+  )
+  .option(
+    "--op-vault <vault:string>",
+    "1Password vault name (for 1password type). Falls back to OP_VAULT env var.",
+  )
+  .option(
+    "--op-account <account:string>",
+    "1Password account shorthand (for 1password type). Falls back to OP_ACCOUNT env var.",
   )
   .action(
     async function (
@@ -184,7 +216,12 @@ export const vaultCreateCommand = new Command()
       const providerConfig = resolveProviderConfig(
         vaultType,
         repoDir,
-        { region: options.region, vaultUrl: options.vaultUrl },
+        {
+          region: options.region,
+          vaultUrl: options.vaultUrl,
+          opVault: options.opVault,
+          opAccount: options.opAccount,
+        },
         ctx.logger,
       );
       const vaultId = createVaultConfigId(generateVaultId());

--- a/src/domain/vaults/onepassword_vault_provider.ts
+++ b/src/domain/vaults/onepassword_vault_provider.ts
@@ -1,0 +1,323 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { VaultProvider } from "./vault_provider.ts";
+
+/**
+ * Configuration for the 1Password vault provider.
+ */
+export interface OnePasswordVaultConfig {
+  /** 1Password vault name (required) */
+  op_vault: string;
+  /** Account shorthand for multi-account setups (optional) */
+  op_account?: string;
+}
+
+/**
+ * Parsed representation of a 1Password secret key.
+ */
+export interface ParsedSecretKey {
+  /** The item name in 1Password */
+  item: string;
+  /** The field path (e.g., "password", "token", "connection/host") */
+  field: string;
+  /** Whether the key was a full op:// URI passthrough */
+  isFullUri: boolean;
+  /** The full op:// URI to use with `op read` */
+  uri: string;
+}
+
+/**
+ * Parses a secret key into its 1Password components.
+ *
+ * Mapping rules:
+ * - Full `op://` URI → passed through directly
+ * - `item` (no slash) → `op://vault/item/password` (default field)
+ * - `item/field` → `op://vault/item/field`
+ * - `item/section/field` → `op://vault/item/section/field`
+ */
+export function parseSecretKey(
+  secretKey: string,
+  opVault: string,
+): ParsedSecretKey {
+  // Full op:// URI passthrough
+  if (secretKey.startsWith("op://")) {
+    // Extract item and field from the URI for metadata
+    const uriPath = secretKey.slice("op://".length);
+    const parts = uriPath.split("/");
+    // op://vault/item/field... → item is parts[1], field is the rest
+    const item = parts[1] ?? "";
+    const field = parts.slice(2).join("/") || "password";
+    return {
+      item,
+      field,
+      isFullUri: true,
+      uri: secretKey,
+    };
+  }
+
+  // Split on first "/" to get item and field path
+  const slashIndex = secretKey.indexOf("/");
+  if (slashIndex === -1) {
+    // No slash → item name only, default field to "password"
+    return {
+      item: secretKey,
+      field: "password",
+      isFullUri: false,
+      uri: `op://${opVault}/${secretKey}/password`,
+    };
+  }
+
+  const item = secretKey.slice(0, slashIndex);
+  const field = secretKey.slice(slashIndex + 1);
+
+  return {
+    item,
+    field,
+    isFullUri: false,
+    uri: `op://${opVault}/${secretKey}`,
+  };
+}
+
+/**
+ * 1Password vault provider.
+ *
+ * Uses the 1Password CLI (`op`) for secret operations. Supports authentication
+ * via service account tokens (OP_SERVICE_ACCOUNT_TOKEN), desktop app biometric
+ * unlock, or 1Password Connect Server.
+ */
+export class OnePasswordVaultProvider implements VaultProvider {
+  private readonly name: string;
+  private readonly opVault: string;
+  private readonly opAccount: string | undefined;
+  private opInstalled: boolean | undefined;
+
+  constructor(name: string, config: OnePasswordVaultConfig) {
+    if (!config.op_vault) {
+      throw new Error(
+        "1Password vault name is required. Ensure op_vault is set in the vault configuration.",
+      );
+    }
+
+    this.name = name;
+    this.opVault = config.op_vault;
+    this.opAccount = config.op_account;
+  }
+
+  async get(secretKey: string): Promise<string> {
+    await this.checkOpInstalled();
+
+    const parsed = parseSecretKey(secretKey, this.opVault);
+    const args = ["read", parsed.uri];
+    if (this.opAccount) {
+      args.push("--account", this.opAccount);
+    }
+
+    const result = await this.runOp(args);
+    return result.trim();
+  }
+
+  async put(secretKey: string, secretValue: string): Promise<void> {
+    await this.checkOpInstalled();
+
+    const parsed = parseSecretKey(secretKey, this.opVault);
+
+    if (parsed.isFullUri) {
+      throw new Error(
+        "Cannot use full op:// URI for put operations. Use a relative key (e.g., 'item-name' or 'item-name/field').",
+      );
+    }
+
+    // Check if the item already exists
+    const itemExists = await this.itemExists(parsed.item);
+
+    if (itemExists) {
+      // Update existing item's field
+      const args = [
+        "item",
+        "edit",
+        parsed.item,
+        `${parsed.field}=${secretValue}`,
+        "--vault",
+        this.opVault,
+      ];
+      if (this.opAccount) {
+        args.push("--account", this.opAccount);
+      }
+      await this.runOp(args);
+    } else {
+      // Create new item as a Secure Note with the field
+      const args = [
+        "item",
+        "create",
+        "--category",
+        "Secure Note",
+        "--title",
+        parsed.item,
+        `${parsed.field}=${secretValue}`,
+        "--vault",
+        this.opVault,
+      ];
+      if (this.opAccount) {
+        args.push("--account", this.opAccount);
+      }
+      await this.runOp(args);
+    }
+  }
+
+  async list(): Promise<string[]> {
+    await this.checkOpInstalled();
+
+    const args = [
+      "item",
+      "list",
+      "--vault",
+      this.opVault,
+      "--format",
+      "json",
+    ];
+    if (this.opAccount) {
+      args.push("--account", this.opAccount);
+    }
+
+    const result = await this.runOp(args);
+
+    if (!result.trim()) {
+      return [];
+    }
+
+    const items: Array<{ title: string }> = JSON.parse(result);
+    return items.map((item) => item.title).sort();
+  }
+
+  getName(): string {
+    return this.name;
+  }
+
+  /**
+   * Checks if a 1Password item exists in the configured vault.
+   */
+  private async itemExists(itemName: string): Promise<boolean> {
+    const args = [
+      "item",
+      "get",
+      itemName,
+      "--vault",
+      this.opVault,
+      "--format",
+      "json",
+    ];
+    if (this.opAccount) {
+      args.push("--account", this.opAccount);
+    }
+
+    try {
+      await this.runOp(args);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Checks if the `op` CLI is installed and available.
+   * Result is cached after the first successful check.
+   */
+  private async checkOpInstalled(): Promise<void> {
+    if (this.opInstalled === true) {
+      return;
+    }
+
+    try {
+      const command = new Deno.Command("op", {
+        args: ["--version"],
+        stdout: "piped",
+        stderr: "piped",
+      });
+      const { success } = await command.output();
+      if (success) {
+        this.opInstalled = true;
+        return;
+      }
+    } catch {
+      // op not found
+    }
+
+    throw new Error(
+      "1Password CLI (op) is not installed or not in PATH.\n\n" +
+        "Install it from: https://developer.1password.com/docs/cli/get-started/\n\n" +
+        "After installing, authenticate using one of:\n" +
+        "  - Service account: export OP_SERVICE_ACCOUNT_TOKEN=<token>\n" +
+        "  - Desktop app: enable CLI integration in 1Password settings\n" +
+        "  - Connect Server: export OP_CONNECT_HOST and OP_CONNECT_TOKEN",
+    );
+  }
+
+  /**
+   * Runs an `op` CLI command and returns the stdout output.
+   */
+  private async runOp(args: string[]): Promise<string> {
+    const command = new Deno.Command("op", {
+      args,
+      stdout: "piped",
+      stderr: "piped",
+    });
+
+    const { success, stdout, stderr } = await command.output();
+    const stdoutText = new TextDecoder().decode(stdout);
+    const stderrText = new TextDecoder().decode(stderr);
+
+    if (!success) {
+      const errorMessage = stderrText.trim() || "Unknown error";
+
+      // Detect common authentication errors
+      if (
+        errorMessage.includes("not signed in") ||
+        errorMessage.includes("authorization") ||
+        errorMessage.includes("authenticate")
+      ) {
+        throw new Error(
+          `1Password authentication failed for vault '${this.name}'.\n\n` +
+            `Authenticate using one of:\n` +
+            `  - Service account: export OP_SERVICE_ACCOUNT_TOKEN=<token>\n` +
+            `  - Desktop app: enable CLI integration in 1Password settings\n` +
+            `  - Sign in: op signin\n\n` +
+            `Error: ${errorMessage}`,
+        );
+      }
+
+      // Detect vault not found
+      if (
+        errorMessage.includes("isn't a vault") ||
+        errorMessage.includes("vault") && errorMessage.includes("not found")
+      ) {
+        throw new Error(
+          `1Password vault '${this.opVault}' not found. Verify the vault name in your configuration.\n\n` +
+            `Error: ${errorMessage}`,
+        );
+      }
+
+      throw new Error(
+        `1Password CLI error: ${errorMessage}`,
+      );
+    }
+
+    return stdoutText;
+  }
+}

--- a/src/domain/vaults/onepassword_vault_provider_test.ts
+++ b/src/domain/vaults/onepassword_vault_provider_test.ts
@@ -1,0 +1,128 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  OnePasswordVaultProvider,
+  parseSecretKey,
+} from "./onepassword_vault_provider.ts";
+
+Deno.test("OnePasswordVaultProvider - constructor and configuration", async (t) => {
+  await t.step("should store and return the vault name via getName", () => {
+    const provider = new OnePasswordVaultProvider("my-1p-vault", {
+      op_vault: "Engineering",
+    });
+    assertEquals(provider.getName(), "my-1p-vault");
+  });
+
+  await t.step("should accept config with op_vault and op_account", () => {
+    const provider = new OnePasswordVaultProvider("multi-account", {
+      op_vault: "Engineering",
+      op_account: "my-team.1password.com",
+    });
+    assertEquals(provider.getName(), "multi-account");
+  });
+
+  await t.step("should throw error when op_vault is empty", () => {
+    assertThrows(
+      () =>
+        new OnePasswordVaultProvider("bad-vault", {
+          op_vault: "",
+        }),
+      Error,
+      "1Password vault name is required",
+    );
+  });
+
+  await t.step("should handle various vault name formats", () => {
+    let provider = new OnePasswordVaultProvider("simple", {
+      op_vault: "Engineering",
+    });
+    assertEquals(provider.getName(), "simple");
+
+    provider = new OnePasswordVaultProvider("my-production-vault", {
+      op_vault: "Production Secrets",
+    });
+    assertEquals(provider.getName(), "my-production-vault");
+  });
+});
+
+Deno.test("parseSecretKey - key mapping", async (t) => {
+  await t.step(
+    "should default field to 'password' when no slash present",
+    () => {
+      const result = parseSecretKey("api-key", "Engineering");
+      assertEquals(result.item, "api-key");
+      assertEquals(result.field, "password");
+      assertEquals(result.isFullUri, false);
+      assertEquals(result.uri, "op://Engineering/api-key/password");
+    },
+  );
+
+  await t.step("should split item and field on first slash", () => {
+    const result = parseSecretKey("api-key/token", "Engineering");
+    assertEquals(result.item, "api-key");
+    assertEquals(result.field, "token");
+    assertEquals(result.isFullUri, false);
+    assertEquals(result.uri, "op://Engineering/api-key/token");
+  });
+
+  await t.step("should support section/field paths", () => {
+    const result = parseSecretKey("db/connection/host", "Engineering");
+    assertEquals(result.item, "db");
+    assertEquals(result.field, "connection/host");
+    assertEquals(result.isFullUri, false);
+    assertEquals(result.uri, "op://Engineering/db/connection/host");
+  });
+
+  await t.step("should pass through full op:// URIs", () => {
+    const result = parseSecretKey("op://Shared/cert/pem", "Engineering");
+    assertEquals(result.item, "cert");
+    assertEquals(result.field, "pem");
+    assertEquals(result.isFullUri, true);
+    assertEquals(result.uri, "op://Shared/cert/pem");
+  });
+
+  await t.step(
+    "should default field to 'password' for op:// URI with no field",
+    () => {
+      const result = parseSecretKey("op://Shared/cert", "Engineering");
+      assertEquals(result.item, "cert");
+      assertEquals(result.field, "password");
+      assertEquals(result.isFullUri, true);
+      assertEquals(result.uri, "op://Shared/cert");
+    },
+  );
+
+  await t.step("should handle vault names with spaces", () => {
+    const result = parseSecretKey("api-key", "My Vault Name");
+    assertEquals(result.uri, "op://My Vault Name/api-key/password");
+  });
+
+  await t.step("should handle complex item names", () => {
+    const result = parseSecretKey("my-app-prod-db", "Engineering");
+    assertEquals(result.item, "my-app-prod-db");
+    assertEquals(result.field, "password");
+    assertEquals(result.uri, "op://Engineering/my-app-prod-db/password");
+  });
+});
+
+// Note: Integration tests for get/put/list operations require the 1Password CLI
+// and authentication. The op CLI operations are tested through integration tests
+// or manual testing.

--- a/src/domain/vaults/vault_expression_test.ts
+++ b/src/domain/vaults/vault_expression_test.ts
@@ -48,8 +48,9 @@ Deno.test("Direct Vault Service Error Messages", async (t) => {
       );
       assertStringIncludes(
         error.message,
-        "Available vault types: aws-sm, azure-kv, local_encryption",
+        "Available vault types:",
       );
+      assertStringIncludes(error.message, "1password");
       assertStringIncludes(
         error.message,
         "Or set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY",

--- a/src/domain/vaults/vault_service.ts
+++ b/src/domain/vaults/vault_service.ts
@@ -30,6 +30,10 @@ import {
   type LocalEncryptionConfig,
   LocalEncryptionVaultProvider,
 } from "./local_encryption_vault_provider.ts";
+import {
+  type OnePasswordVaultConfig,
+  OnePasswordVaultProvider,
+} from "./onepassword_vault_provider.ts";
 import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
 
 /**
@@ -119,6 +123,12 @@ export class VaultService {
           config.config as Record<string, string>,
         );
         break;
+      case "1password":
+        provider = new OnePasswordVaultProvider(
+          config.name,
+          config.config as unknown as OnePasswordVaultConfig,
+        );
+        break;
       case "local_encryption":
         provider = new LocalEncryptionVaultProvider(
           config.name,
@@ -147,7 +157,9 @@ export class VaultService {
           `Vault '${vaultName}' not found. No vaults are configured.\n\n` +
             `Note: Vaults are NOT configured in .swamp.yaml. Create a vault using:\n` +
             `  swamp vault create <type> ${vaultName}\n\n` +
-            `Available vault types: aws-sm, azure-kv, local_encryption\n` +
+            `Available vault types: ${
+              getVaultTypes().map((v) => v.type).join(", ")
+            }\n` +
             `Or set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY for automatic AWS vault.`,
         );
       } else {
@@ -179,7 +191,9 @@ export class VaultService {
           `Vault '${vaultName}' not found. No vaults are configured.\n\n` +
             `Note: Vaults are NOT configured in .swamp.yaml. Create a vault using:\n` +
             `  swamp vault create <type> ${vaultName}\n\n` +
-            `Available vault types: aws-sm, azure-kv, local_encryption`,
+            `Available vault types: ${
+              getVaultTypes().map((v) => v.type).join(", ")
+            }`,
         );
       } else {
         throw new Error(
@@ -207,7 +221,9 @@ export class VaultService {
           `Vault '${vaultName}' not found. No vaults are configured.\n\n` +
             `Note: Vaults are NOT configured in .swamp.yaml. Create a vault using:\n` +
             `  swamp vault create <type> ${vaultName}\n\n` +
-            `Available vault types: aws-sm, azure-kv, local_encryption`,
+            `Available vault types: ${
+              getVaultTypes().map((v) => v.type).join(", ")
+            }`,
         );
       } else {
         throw new Error(

--- a/src/domain/vaults/vault_service_test.ts
+++ b/src/domain/vaults/vault_service_test.ts
@@ -53,8 +53,9 @@ Deno.test("VaultService - missing vault configuration error handling", async (t)
       );
       assertStringIncludes(
         error.message,
-        "Available vault types: aws-sm, azure-kv, local_encryption",
+        "Available vault types:",
       );
+      assertStringIncludes(error.message, "1password");
       assertStringIncludes(
         error.message,
         "Or set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY",
@@ -328,6 +329,19 @@ Deno.test("VaultService - basic functionality", async (t) => {
 
     const vaultNames = vaultService.getVaultNames();
     assertEquals(vaultNames, ["local-vault"]);
+  });
+
+  await t.step("should register 1password vault", () => {
+    const vaultService = new VaultService();
+
+    vaultService.registerVault({
+      name: "my-1p-vault",
+      type: "1password",
+      config: { op_vault: "Engineering" },
+    });
+
+    const vaultNames = vaultService.getVaultNames();
+    assertEquals(vaultNames, ["my-1p-vault"]);
   });
 });
 

--- a/src/domain/vaults/vault_types.ts
+++ b/src/domain/vaults/vault_types.ts
@@ -47,6 +47,12 @@ export const VAULT_TYPES: VaultTypeInfo[] = [
       "Store and retrieve secrets using Azure Key Vault. Requires vault URL and Azure credentials via environment variables, managed identity, or Azure CLI.",
   },
   {
+    type: "1password",
+    name: "1Password",
+    description:
+      "Store and retrieve secrets using 1Password. Requires the 1Password CLI (op) and authentication via service account token, desktop app, or Connect Server.",
+  },
+  {
     type: "local_encryption",
     name: "Local Encryption",
     description:

--- a/src/domain/vaults/vault_types_test.ts
+++ b/src/domain/vaults/vault_types_test.ts
@@ -24,6 +24,7 @@ Deno.test("VAULT_TYPES contains expected types", () => {
   const types = VAULT_TYPES.map((v) => v.type);
   assertEquals(types.includes("aws-sm"), true);
   assertEquals(types.includes("azure-kv"), true);
+  assertEquals(types.includes("1password"), true);
   assertEquals(types.includes("local_encryption"), true);
   // mock vault is excluded from public listing (internal testing only)
   assertEquals(types.includes("mock"), false);
@@ -31,7 +32,7 @@ Deno.test("VAULT_TYPES contains expected types", () => {
 
 Deno.test("getVaultTypes returns all vault types", () => {
   const types = getVaultTypes();
-  assertEquals(types.length, 3);
+  assertEquals(types.length, 4);
   assertEquals(types, VAULT_TYPES);
 });
 
@@ -45,6 +46,11 @@ Deno.test("getVaultType returns vault type by identifier", () => {
   assertExists(azureKv);
   assertEquals(azureKv.type, "azure-kv");
   assertEquals(azureKv.name, "Azure Key Vault");
+
+  const onePassword = getVaultType("1password");
+  assertExists(onePassword);
+  assertEquals(onePassword.type, "1password");
+  assertEquals(onePassword.name, "1Password");
 
   const local = getVaultType("local_encryption");
   assertExists(local);


### PR DESCRIPTION
## Summary

- Adds `1password` vault type wrapping the `op` CLI for secret operations (get/put/list)
- Secret keys map to `op://` URIs: `api-key` → `op://vault/api-key/password`, `api-key/token` → `op://vault/api-key/token`, full `op://` URIs pass through directly
- Adds `--op-vault` and `--op-account` CLI flags to `swamp vault create` with `OP_VAULT`/`OP_ACCOUNT` env var fallbacks
- Replaces hardcoded vault type lists in error messages with dynamic generation from the registry

Closes #441

## Test Plan

- Unit tests for `parseSecretKey()` covering all mapping branches (default field, explicit field, section/field, full URI passthrough)
- Unit tests for provider constructor validation (empty `op_vault` throws)
- `VaultService` registration test for 1password type
- Updated `vault_types_test.ts`, `vault_service_test.ts`, `vault_expression_test.ts` assertions
- All 1879 tests pass, `deno check`, `deno lint`, `deno fmt` clean
- Manual e2e testing with live 1Password CLI (create → read → cleanup workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)