### PR TITLE
fix: convert vault command Cliffy crashes to friendly UserError messages

### DIFF
--- a/src/cli/commands/vault_get.ts
+++ b/src/cli/commands/vault_get.ts
@@ -36,63 +36,77 @@ type AnyOptions = any;
 export const vaultGetCommand = new Command()
   .name("get")
   .description("Show details of a vault configuration")
-  .arguments("<vault_name_or_id:string>")
+  .arguments("<vault_name_or_id:string> [extra:string]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("-t, --type <type:string>", "Vault type (optional, narrows search)")
-  .action(async function (options: AnyOptions, vaultNameOrId: string) {
-    const ctx = createContext(options as GlobalOptions, ["vault", "get"]);
-    ctx.logger.debug`Getting vault: ${vaultNameOrId}`;
-
-    const { repoContext } = await requireInitializedRepo({
-      repoDir: options.repoDir ?? ".",
-      outputMode: ctx.outputMode,
-    });
-    const vaultType = options.type as string | undefined;
-    const repo = repoContext.vaultConfigRepo;
-
-    // Look up the vault
-    ctx.logger.debug`Looking up vault: ${vaultNameOrId}`;
-
-    // Try to find by name first (works across all types)
-    let config = await repo.findByName(vaultNameOrId);
-
-    // If not found by name, try to find by ID
-    if (!config) {
-      if (vaultType) {
-        // If type is specified, look up by type and ID
-        config = await repo.findById(vaultType, vaultNameOrId);
-      } else {
-        // Search all vaults for matching ID
-        const allVaults = await repo.findAll();
-        config = allVaults.find((v) => v.id === vaultNameOrId) ?? null;
+  .action(
+    async function (
+      options: AnyOptions,
+      vaultNameOrId: string,
+      extra?: string,
+    ) {
+      if (extra) {
+        throw new UserError(
+          `Unexpected argument: ${extra}\n\n` +
+            "Usage: swamp vault get <vault_name_or_id>\n\n" +
+            "To retrieve a secret value, use: swamp vault list-keys <vault_name>",
+        );
       }
-    }
 
-    // If type was specified, verify it matches
-    if (config && vaultType && config.type !== vaultType) {
-      throw new UserError(
-        `Vault '${vaultNameOrId}' found but has type '${config.type}', not '${vaultType}'`,
-      );
-    }
+      const ctx = createContext(options as GlobalOptions, ["vault", "get"]);
+      ctx.logger.debug`Getting vault: ${vaultNameOrId}`;
 
-    if (!config) {
-      const typeHint = vaultType ? ` of type '${vaultType}'` : "";
-      throw new UserError(`Vault not found: ${vaultNameOrId}${typeHint}`);
-    }
+      const { repoContext } = await requireInitializedRepo({
+        repoDir: options.repoDir ?? ".",
+        outputMode: ctx.outputMode,
+      });
+      const vaultType = options.type as string | undefined;
+      const repo = repoContext.vaultConfigRepo;
 
-    ctx.logger
-      .debug`Found vault: id=${config.id}, name=${config.name}, type=${config.type}`;
+      // Look up the vault
+      ctx.logger.debug`Looking up vault: ${vaultNameOrId}`;
 
-    const data: VaultGetData = {
-      id: config.id,
-      name: config.name,
-      type: config.type,
-      config: config.config,
-      createdAt: config.createdAt.toISOString(),
-      storagePath:
-        `${SWAMP_DATA_DIR}/${SWAMP_SUBDIRS.vault}/${config.type}/${config.id}.yaml`,
-    };
+      // Try to find by name first (works across all types)
+      let config = await repo.findByName(vaultNameOrId);
 
-    renderVaultGet(data, ctx.outputMode);
-    ctx.logger.debug("Vault get command completed");
-  });
+      // If not found by name, try to find by ID
+      if (!config) {
+        if (vaultType) {
+          // If type is specified, look up by type and ID
+          config = await repo.findById(vaultType, vaultNameOrId);
+        } else {
+          // Search all vaults for matching ID
+          const allVaults = await repo.findAll();
+          config = allVaults.find((v) => v.id === vaultNameOrId) ?? null;
+        }
+      }
+
+      // If type was specified, verify it matches
+      if (config && vaultType && config.type !== vaultType) {
+        throw new UserError(
+          `Vault '${vaultNameOrId}' found but has type '${config.type}', not '${vaultType}'`,
+        );
+      }
+
+      if (!config) {
+        const typeHint = vaultType ? ` of type '${vaultType}'` : "";
+        throw new UserError(`Vault not found: ${vaultNameOrId}${typeHint}`);
+      }
+
+      ctx.logger
+        .debug`Found vault: id=${config.id}, name=${config.name}, type=${config.type}`;
+
+      const data: VaultGetData = {
+        id: config.id,
+        name: config.name,
+        type: config.type,
+        config: config.config,
+        createdAt: config.createdAt.toISOString(),
+        storagePath:
+          `${SWAMP_DATA_DIR}/${SWAMP_SUBDIRS.vault}/${config.type}/${config.id}.yaml`,
+      };
+
+      renderVaultGet(data, ctx.outputMode);
+      ctx.logger.debug("Vault get command completed");
+    },
+  );

--- a/src/cli/commands/vault_list_keys.ts
+++ b/src/cli/commands/vault_list_keys.ts
@@ -33,9 +33,17 @@ type AnyOptions = any;
 export const vaultListKeysCommand = new Command()
   .name("list-keys")
   .description("List all secret keys in a vault (without values)")
-  .arguments("<vault_name:string>")
+  .arguments("[vault_name:string]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
-  .action(async function (options: AnyOptions, vaultName: string) {
+  .action(async function (options: AnyOptions, vaultName?: string) {
+    if (!vaultName) {
+      throw new UserError(
+        "Missing required argument: vault_name\n\n" +
+          "Usage: swamp vault list-keys <vault_name>\n\n" +
+          "Use 'swamp vault search' to see available vaults.",
+      );
+    }
+
     const ctx = createContext(options as GlobalOptions, ["vault", "list-keys"]);
     ctx.logger.debug`Listing secret keys in vault: ${vaultName}`;
 


### PR DESCRIPTION
Closes #449
Closes #450

## Summary

- `swamp vault list-keys` without a vault name now shows a clean error message instead of a Cliffy stack trace
- `swamp vault get <name> <key>` (extra argument) now shows a helpful error redirecting users to `vault list-keys`

## Problem

Several vault commands crash with raw Cliffy stack traces when users provide incorrect arguments:

**`swamp vault list-keys` (no vault name):**
```
17:54:44.691 FTL error Error: Missing argument(s): vault_name
    at Command.parseArguments (https://jsr.io/@cliffy/command/1.0.0/command.ts:2482:19)
    ...
```

**`swamp vault get my-vault KEY` (extra argument):**
```
17:57:52.947 FTL error Error: Too many arguments: ec2-keypair-KeyMaterial
    at Command.parseArguments (https://jsr.io/@cliffy/command/1.0.0/command.ts:2554:17)
    ...
```

These errors bypass the `UserError` system, so `renderError()` shows full stack traces instead of clean messages.

## Root cause

Cliffy's argument parser throws its own `Error` (not `UserError`) during `parseArguments()` **before** the action handler runs. Since `renderError()` only suppresses stack traces for `UserError` instances, these raw errors display internal implementation details to users.

## Fix

### vault list-keys — missing argument

Changed the Cliffy argument from required (`<vault_name:string>`) to optional (`[vault_name:string]`) so control reaches the action handler. Added an early guard that throws a `UserError`:

```
Error: Missing required argument: vault_name

Usage: swamp vault list-keys <vault_name>

Use 'swamp vault search' to see available vaults.
```

### vault get — extra argument

Added an optional `[extra:string]` argument to capture unexpected args that Cliffy would otherwise reject with a stack trace. When present, throws a `UserError`:

```
Error: Unexpected argument: KeyMaterial

Usage: swamp vault get <vault_name_or_id>

To retrieve a secret value, use: swamp vault list-keys <vault_name>
```

The `vault get` case is particularly important because users naturally try `vault get <name> <key>` when they want to retrieve a secret value — the error now redirects them to the correct command.

## User impact

- Users who forget the vault name on `list-keys` see actionable guidance instead of a stack trace
- Users who try `vault get <name> <key>` get redirected to `vault list-keys`
- No behavior change for correct usage — all existing functionality is preserved

## Test plan

- [x] `deno check` — passes
- [x] `deno lint` — passes
- [x] `deno fmt` — passes
- [x] `deno run test` — 1918 tests, 0 failures
- [x] `deno run compile` — binary compiles successfully

UAT test coverage tracked in systeminit/swamp-uat#33

🤖 Generated with [Claude Code](https://claude.com/claude-code)