### PR TITLE
feat: embed deno runtime for extension bundling in compiled binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,10 +18,12 @@ resources/
 .swamp/files/
 .swamp/secrets/
 .swamp/telemetry/
+.swamp/bundles/
 
 test-repo/
 .vault-*/
 .claude/settings.local.json
 CLAUDE.local.md
 .envrc
+resources/deno/
 /scripts/dist

--- a/deno.json
+++ b/deno.json
@@ -4,8 +4,8 @@
   "license": "AGPL-3.0-only",
   "exports": "./main.ts",
   "tasks": {
-    "dev": "deno run --allow-read --allow-write --allow-env --allow-run --allow-sys main.ts",
-    "test": "deno test --allow-read --allow-write --allow-env --allow-run --allow-net --allow-sys",
+    "dev": "deno run --unstable-bundle --allow-read --allow-write --allow-env --allow-run --allow-sys main.ts",
+    "test": "deno test --unstable-bundle --allow-read --allow-write --allow-env --allow-run --allow-net --allow-sys",
     "check": "deno check main.ts",
     "lint": "deno lint",
     "fmt": "deno fmt",
@@ -46,6 +46,7 @@
     ".github/",
     ".agents/",
     "workflows/",
-    ".vault-test-vault/"
+    ".vault-test-vault/",
+    "resources/"
   ]
 }

--- a/deno.lock
+++ b/deno.lock
@@ -12,6 +12,7 @@
     "jsr:@std/fmt@^1.0.9": "1.0.9",
     "jsr:@std/fs@^1.0.22": "1.0.22",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@std/semver@^1.0.8": "1.0.8",
     "jsr:@std/text@^1.0.17": "1.0.17",
@@ -20,6 +21,7 @@
     "npm:@aws-sdk/client-secrets-manager@^3.993.0": "3.993.0",
     "npm:@azure/identity@^4.8.0": "4.13.0",
     "npm:@azure/keyvault-secrets@^4.9.0": "4.10.0_@azure+core-rest-pipeline@1.22.2",
+    "npm:@kubernetes/client-node@*": "1.4.0_ws@8.19.0",
     "npm:@marcbachmann/cel-js@7.5.1": "7.5.1",
     "npm:@types/node@24.0.7": "24.0.7",
     "npm:@types/react@^18.3.28": "18.3.28",
@@ -27,6 +29,7 @@
     "npm:fzf@0.5.2": "0.5.2",
     "npm:ink-testing-library@4": "4.0.0_@types+react@18.3.28",
     "npm:ink@^5.2.1": "5.2.1_@types+react@18.3.28_react@18.3.1",
+    "npm:lodash-es@4": "4.17.23",
     "npm:react@^18.3.1": "18.3.1",
     "npm:zod@4": "4.3.6",
     "npm:zod@^4.3.6": "4.3.6"
@@ -89,7 +92,7 @@
       "integrity": "de0f277a58a867147a8a01bc1b181d0dfa80bfddba8c9cf2bacd6747bcec9308",
       "dependencies": [
         "jsr:@std/internal",
-        "jsr:@std/path"
+        "jsr:@std/path@^1.1.4"
       ]
     },
     "@std/internal@1.0.12": {
@@ -726,6 +729,39 @@
         "uuid"
       ]
     },
+    "@jsep-plugin/assignment@1.3.0_jsep@1.4.0": {
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "dependencies": [
+        "jsep"
+      ]
+    },
+    "@jsep-plugin/regex@1.0.4_jsep@1.4.0": {
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "dependencies": [
+        "jsep"
+      ]
+    },
+    "@kubernetes/client-node@1.4.0_ws@8.19.0": {
+      "integrity": "sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==",
+      "dependencies": [
+        "@types/js-yaml",
+        "@types/node",
+        "@types/node-fetch",
+        "@types/stream-buffers",
+        "form-data",
+        "hpagent",
+        "isomorphic-ws",
+        "js-yaml",
+        "jsonpath-plus",
+        "node-fetch",
+        "openid-client",
+        "rfc4648",
+        "socks-proxy-agent",
+        "stream-buffers",
+        "tar-fs",
+        "ws"
+      ]
+    },
     "@marcbachmann/cel-js@7.5.1": {
       "integrity": "sha512-3X+TKpt/xyPsVSU3R2bVeZQCOW5L29y+EVDOmOp2xnyD7bifNM/UypBaqs2Z6oC075p+tKtjPUT1kUwnyY7cQg==",
       "bin": true
@@ -1098,6 +1134,16 @@
         "tslib"
       ]
     },
+    "@types/js-yaml@4.0.9": {
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="
+    },
+    "@types/node-fetch@2.6.13": {
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "dependencies": [
+        "@types/node",
+        "form-data"
+      ]
+    },
     "@types/node@24.0.7": {
       "integrity": "sha512-YIEUUr4yf8q8oQoXPpSlnvKNVKDQlPMWrmOcgzoduo7kvA2UF0/BwJ/eMKFTiTtkNL17I0M6Xe2tvwFU7be6iw==",
       "dependencies": [
@@ -1112,6 +1158,12 @@
       "dependencies": [
         "@types/prop-types",
         "csstype"
+      ]
+    },
+    "@types/stream-buffers@3.0.8": {
+      "integrity": "sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==",
+      "dependencies": [
+        "@types/node"
       ]
     },
     "@typespec/ts-http-runtime@0.3.3": {
@@ -1137,8 +1189,56 @@
     "ansi-styles@6.2.3": {
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="
     },
+    "argparse@2.0.1": {
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "asynckit@0.4.0": {
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "auto-bind@5.0.1": {
       "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="
+    },
+    "b4a@1.8.0": {
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg=="
+    },
+    "bare-events@2.8.2": {
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ=="
+    },
+    "bare-fs@4.5.4_bare-events@2.8.2": {
+      "integrity": "sha512-POK4oplfA7P7gqvetNmCs4CNtm9fNsx+IAh7jH7GgU0OJdge2rso0R20TNWVq6VoWcCvsTdlNDaleLHGaKx8CA==",
+      "dependencies": [
+        "bare-events",
+        "bare-path",
+        "bare-stream",
+        "bare-url",
+        "fast-fifo"
+      ]
+    },
+    "bare-os@3.6.2": {
+      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A=="
+    },
+    "bare-path@3.0.0": {
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dependencies": [
+        "bare-os"
+      ]
+    },
+    "bare-stream@2.8.0_bare-events@2.8.2": {
+      "integrity": "sha512-reUN0M2sHRqCdG4lUK3Fw8w98eeUIZHL5c3H7Mbhk2yVBL+oofgaIp0ieLfD5QXwPCypBpmEEKU2WZKzbAk8GA==",
+      "dependencies": [
+        "bare-events",
+        "streamx",
+        "teex"
+      ],
+      "optionalPeers": [
+        "bare-events"
+      ]
+    },
+    "bare-url@2.3.2": {
+      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "dependencies": [
+        "bare-path"
+      ]
     },
     "bowser@2.14.1": {
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="
@@ -1150,6 +1250,13 @@
       "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
       "dependencies": [
         "run-applescript"
+      ]
+    },
+    "call-bind-apply-helpers@1.0.2": {
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": [
+        "es-errors",
+        "function-bind"
       ]
     },
     "chalk@5.6.2": {
@@ -1177,6 +1284,12 @@
         "convert-to-spaces"
       ]
     },
+    "combined-stream@1.0.8": {
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": [
+        "delayed-stream"
+      ]
+    },
     "convert-to-spaces@2.0.1": {
       "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="
     },
@@ -1202,6 +1315,17 @@
     "define-lazy-prop@3.0.0": {
       "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="
     },
+    "delayed-stream@1.0.0": {
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "dunder-proto@1.0.1": {
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-errors",
+        "gopd"
+      ]
+    },
     "ecdsa-sig-formatter@1.0.11": {
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "dependencies": [
@@ -1211,14 +1335,50 @@
     "emoji-regex@10.6.0": {
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
     },
+    "end-of-stream@1.4.5": {
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dependencies": [
+        "once"
+      ]
+    },
     "environment@1.1.0": {
       "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="
+    },
+    "es-define-property@1.0.1": {
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors@1.3.0": {
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms@1.1.1": {
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": [
+        "es-errors"
+      ]
+    },
+    "es-set-tostringtag@2.1.0": {
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": [
+        "es-errors",
+        "get-intrinsic",
+        "has-tostringtag",
+        "hasown"
+      ]
     },
     "es-toolkit@1.44.0": {
       "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg=="
     },
     "escape-string-regexp@2.0.0": {
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+    },
+    "events-universal@1.0.1": {
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dependencies": [
+        "bare-events"
+      ]
+    },
+    "fast-fifo@1.3.2": {
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
     },
     "fast-json-patch@3.1.1": {
       "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="
@@ -1230,11 +1390,67 @@
       ],
       "bin": true
     },
+    "form-data@4.0.5": {
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dependencies": [
+        "asynckit",
+        "combined-stream",
+        "es-set-tostringtag",
+        "hasown",
+        "mime-types"
+      ]
+    },
+    "function-bind@1.1.2": {
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
     "fzf@0.5.2": {
       "integrity": "sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q=="
     },
     "get-east-asian-width@1.5.0": {
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="
+    },
+    "get-intrinsic@1.3.0": {
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "es-errors",
+        "es-object-atoms",
+        "function-bind",
+        "get-proto",
+        "gopd",
+        "has-symbols",
+        "hasown",
+        "math-intrinsics"
+      ]
+    },
+    "get-proto@1.0.1": {
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": [
+        "dunder-proto",
+        "es-object-atoms"
+      ]
+    },
+    "gopd@1.2.0": {
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "has-symbols@1.1.0": {
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "has-tostringtag@1.0.2": {
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": [
+        "has-symbols"
+      ]
+    },
+    "hasown@2.0.2": {
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": [
+        "function-bind"
+      ]
+    },
+    "hpagent@1.2.0": {
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA=="
     },
     "http-proxy-agent@7.0.2": {
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
@@ -1296,6 +1512,9 @@
         "@types/react"
       ]
     },
+    "ip-address@10.1.0": {
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="
+    },
     "is-docker@3.0.0": {
       "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
       "bin": true
@@ -1326,8 +1545,36 @@
         "is-inside-container"
       ]
     },
+    "isomorphic-ws@5.0.0_ws@8.19.0": {
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "dependencies": [
+        "ws"
+      ]
+    },
+    "jose@6.1.3": {
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="
+    },
     "js-tokens@4.0.0": {
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "js-yaml@4.1.1": {
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dependencies": [
+        "argparse"
+      ],
+      "bin": true
+    },
+    "jsep@1.4.0": {
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw=="
+    },
+    "jsonpath-plus@10.4.0_jsep@1.4.0": {
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "dependencies": [
+        "@jsep-plugin/assignment",
+        "@jsep-plugin/regex",
+        "jsep"
+      ],
+      "bin": true
     },
     "jsonwebtoken@9.0.2": {
       "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
@@ -1359,6 +1606,9 @@
         "safe-buffer"
       ]
     },
+    "lodash-es@4.17.23": {
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="
+    },
     "lodash.includes@4.3.0": {
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
     },
@@ -1387,11 +1637,38 @@
       ],
       "bin": true
     },
+    "math-intrinsics@1.1.0": {
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "mime-db@1.52.0": {
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types@2.1.35": {
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": [
+        "mime-db"
+      ]
+    },
     "mimic-fn@2.1.0": {
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node-fetch@2.7.0": {
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": [
+        "whatwg-url"
+      ]
+    },
+    "oauth4webapi@3.8.5": {
+      "integrity": "sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg=="
+    },
+    "once@1.4.0": {
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": [
+        "wrappy"
+      ]
     },
     "onetime@5.1.2": {
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
@@ -1408,8 +1685,22 @@
         "is-wsl"
       ]
     },
+    "openid-client@6.8.2": {
+      "integrity": "sha512-uOvTCndr4udZsKihJ68H9bUICrriHdUVJ6Az+4Ns6cW55rwM5h0bjVIzDz2SxgOI84LKjFyjOFvERLzdTUROGA==",
+      "dependencies": [
+        "jose",
+        "oauth4webapi"
+      ]
+    },
     "patch-console@2.0.0": {
       "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="
+    },
+    "pump@3.0.3": {
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dependencies": [
+        "end-of-stream",
+        "once"
+      ]
     },
     "react-reconciler@0.29.2_react@18.3.1": {
       "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
@@ -1431,6 +1722,9 @@
         "onetime",
         "signal-exit"
       ]
+    },
+    "rfc4648@1.5.4": {
+      "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg=="
     },
     "run-applescript@7.0.0": {
       "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A=="
@@ -1465,10 +1759,39 @@
         "is-fullwidth-code-point@5.1.0"
       ]
     },
+    "smart-buffer@4.2.0": {
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+    },
+    "socks-proxy-agent@8.0.5": {
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dependencies": [
+        "agent-base",
+        "debug",
+        "socks"
+      ]
+    },
+    "socks@2.8.7": {
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dependencies": [
+        "ip-address",
+        "smart-buffer"
+      ]
+    },
     "stack-utils@2.0.6": {
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
       "dependencies": [
         "escape-string-regexp"
+      ]
+    },
+    "stream-buffers@3.0.3": {
+      "integrity": "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw=="
+    },
+    "streamx@2.23.0": {
+      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "dependencies": [
+        "events-universal",
+        "fast-fifo",
+        "text-decoder"
       ]
     },
     "string-width@7.2.0": {
@@ -1488,6 +1811,40 @@
     "strnum@2.1.2": {
       "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ=="
     },
+    "tar-fs@3.1.1": {
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "dependencies": [
+        "pump",
+        "tar-stream"
+      ],
+      "optionalDependencies": [
+        "bare-fs",
+        "bare-path"
+      ]
+    },
+    "tar-stream@3.1.7": {
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dependencies": [
+        "b4a",
+        "fast-fifo",
+        "streamx"
+      ]
+    },
+    "teex@1.0.1": {
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dependencies": [
+        "streamx"
+      ]
+    },
+    "text-decoder@1.2.7": {
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dependencies": [
+        "b4a"
+      ]
+    },
+    "tr46@0.0.3": {
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "tslib@2.8.1": {
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
@@ -1500,6 +1857,16 @@
     "uuid@8.3.2": {
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": true
+    },
+    "webidl-conversions@3.0.1": {
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url@5.0.0": {
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": [
+        "tr46",
+        "webidl-conversions"
+      ]
     },
     "widest-line@5.0.0": {
       "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
@@ -1514,6 +1881,9 @@
         "string-width",
         "strip-ansi"
       ]
+    },
+    "wrappy@1.0.2": {
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "ws@8.19.0": {
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="

--- a/integration/simple_return_format_test.ts
+++ b/integration/simple_return_format_test.ts
@@ -31,8 +31,13 @@ import { ensureDir } from "@std/fs";
 import { Definition } from "../src/domain/definitions/definition.ts";
 import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
 import { UserModelLoader } from "../src/domain/models/user_model_loader.ts";
+import type { DenoRuntime } from "../src/domain/runtime/deno_runtime.ts";
 import { modelRegistry } from "../src/domain/models/model.ts";
 import { ModelType } from "../src/domain/models/model_type.ts";
+
+const testDenoRuntime: DenoRuntime = {
+  ensureDeno: () => Promise.resolve(Deno.execPath()),
+};
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   const dir = await Deno.makeTempDir({ prefix: "swamp-simple-return-" });
@@ -131,7 +136,7 @@ Deno.test("Integration: user model with dataWriter API works", async () => {
     );
 
     // 2. Load the user model
-    const loader = new UserModelLoader();
+    const loader = new UserModelLoader(testDenoRuntime);
     const loadResult = await loader.loadModels(modelsDir);
 
     // Debug: show any load failures
@@ -201,7 +206,7 @@ Deno.test("Integration: expression-aware validation allows expressions in requir
     );
 
     // 2. Load the model
-    const loader = new UserModelLoader();
+    const loader = new UserModelLoader(testDenoRuntime);
     const loadResult = await loader.loadModels(modelsDir);
 
     // Debug: show any load failures

--- a/scripts/compile.ts
+++ b/scripts/compile.ts
@@ -20,6 +20,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { parseArgs } from "@std/cli/parse-args";
+import { join } from "@std/path";
 
 interface CompileOptions {
   output: string;
@@ -38,6 +39,48 @@ async function stampVersion(version: string): Promise<string> {
   );
   await Deno.writeTextFile(VERSION_FILE, updated);
   return original;
+}
+
+/**
+ * Downloads the deno binary for the given target platform.
+ * Runs scripts/download_deno.ts to fetch from GitHub releases.
+ */
+async function downloadDeno(target?: string): Promise<void> {
+  const downloadArgs = ["run", "-A", "scripts/download_deno.ts"];
+  if (target) {
+    downloadArgs.push("--target", target);
+  }
+
+  console.log(`Downloading embedded deno runtime...`);
+  const command = new Deno.Command("deno", {
+    args: downloadArgs,
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+
+  const { success } = await command.output();
+  if (!success) {
+    throw new Error("Failed to download deno binary for embedding");
+  }
+}
+
+/**
+ * Cleans up the resources/deno/ directory after compilation.
+ * Removes platform-specific binary to avoid leaving it in the repo.
+ */
+async function cleanupDenoResources(): Promise<void> {
+  const denoDir = join(
+    import.meta.dirname ?? ".",
+    "..",
+    "resources",
+    "deno",
+  );
+  try {
+    await Deno.remove(denoDir, { recursive: true });
+    console.log("Cleaned up resources/deno/");
+  } catch {
+    // Directory may not exist — that's fine
+  }
 }
 
 async function main() {
@@ -72,9 +115,13 @@ async function main() {
   }
 
   try {
+    // Download deno binary for embedding
+    await downloadDeno(options.target);
+
     const baseCommand = [
       "deno",
       "compile",
+      "--unstable-bundle",
       "--allow-read",
       "--allow-write",
       "--allow-env",
@@ -83,6 +130,8 @@ async function main() {
       "--allow-net",
       "--include",
       ".claude/skills",
+      "--include",
+      "resources/deno",
       // Exclude development-only directories from the binary
       "--exclude",
       ".agents",
@@ -132,6 +181,9 @@ async function main() {
     if (originalContent !== null) {
       await Deno.writeTextFile(VERSION_FILE, originalContent);
     }
+
+    // Clean up downloaded deno binary
+    await cleanupDenoResources();
   }
 }
 

--- a/scripts/download_deno.ts
+++ b/scripts/download_deno.ts
@@ -1,0 +1,173 @@
+#!/usr/bin/env -S deno run -A
+
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { parseArgs } from "@std/cli/parse-args";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+
+/** Maps Deno build target triples to GitHub release artifact names. */
+const TARGET_ARTIFACT_MAP: Record<string, string> = {
+  "x86_64-unknown-linux-gnu": "deno-x86_64-unknown-linux-gnu.zip",
+  "aarch64-unknown-linux-gnu": "deno-aarch64-unknown-linux-gnu.zip",
+  "x86_64-apple-darwin": "deno-x86_64-apple-darwin.zip",
+  "aarch64-apple-darwin": "deno-aarch64-apple-darwin.zip",
+  "x86_64-pc-windows-msvc": "deno-x86_64-pc-windows-msvc.zip",
+};
+
+/** Maps Deno.build.os + Deno.build.arch to a target triple. */
+function detectCurrentTarget(): string {
+  const os = Deno.build.os;
+  const arch = Deno.build.arch;
+
+  if (os === "linux" && arch === "x86_64") {
+    return "x86_64-unknown-linux-gnu";
+  }
+  if (os === "linux" && arch === "aarch64") {
+    return "aarch64-unknown-linux-gnu";
+  }
+  if (os === "darwin" && arch === "x86_64") {
+    return "x86_64-apple-darwin";
+  }
+  if (os === "darwin" && arch === "aarch64") {
+    return "aarch64-apple-darwin";
+  }
+  if (os === "windows" && arch === "x86_64") {
+    return "x86_64-pc-windows-msvc";
+  }
+  throw new Error(`Unsupported platform: ${os}/${arch}`);
+}
+
+/** Parses the deno version from the currently running deno. */
+async function getDenoVersion(): Promise<string> {
+  const command = new Deno.Command("deno", {
+    args: ["--version"],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const output = await command.output();
+  const text = new TextDecoder().decode(output.stdout);
+  const match = text.match(/^deno\s+(\S+)/);
+  if (!match) {
+    throw new Error(`Cannot parse deno version from: ${text}`);
+  }
+  return match[1];
+}
+
+/** Downloads a file from a URL, returning the bytes. */
+async function downloadFile(url: string): Promise<Uint8Array> {
+  console.log(`Downloading: ${url}`);
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `Download failed: ${response.status} ${response.statusText} for ${url}`,
+    );
+  }
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+/** Extracts a zip archive and returns the contents of the deno binary. */
+async function extractDenoFromZip(
+  zipBytes: Uint8Array,
+  binaryName: string,
+): Promise<Uint8Array> {
+  // Write zip to temp file, extract with unzip
+  const tempDir = await Deno.makeTempDir({ prefix: "swamp_deno_download_" });
+  const zipPath = join(tempDir, "deno.zip");
+
+  try {
+    await Deno.writeFile(zipPath, zipBytes);
+
+    const command = new Deno.Command("unzip", {
+      args: ["-o", zipPath, "-d", tempDir],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const result = await command.output();
+    if (!result.success) {
+      const stderr = new TextDecoder().decode(result.stderr);
+      throw new Error(`unzip failed: ${stderr}`);
+    }
+
+    const binaryPath = join(tempDir, binaryName);
+    return await Deno.readFile(binaryPath);
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+}
+
+async function main() {
+  const args = parseArgs(Deno.args, {
+    string: ["target"],
+    alias: { "t": "target" },
+  });
+
+  const target = args.target ?? detectCurrentTarget();
+  const artifact = TARGET_ARTIFACT_MAP[target];
+  if (!artifact) {
+    console.error(`Unknown target: ${target}`);
+    console.error(`Supported targets: ${Object.keys(TARGET_ARTIFACT_MAP).join(", ")}`);
+    Deno.exit(1);
+  }
+
+  const version = await getDenoVersion();
+  const isWindows = target.includes("windows");
+  const binaryName = isWindows ? "deno.exe" : "deno";
+
+  console.log(`Deno version: ${version}`);
+  console.log(`Target: ${target}`);
+  console.log(`Artifact: ${artifact}`);
+
+  const url =
+    `https://github.com/denoland/deno/releases/download/v${version}/${artifact}`;
+  const zipBytes = await downloadFile(url);
+
+  console.log(`Downloaded ${zipBytes.length} bytes, extracting...`);
+  const binaryBytes = await extractDenoFromZip(zipBytes, binaryName);
+
+  // Write to resources/deno/
+  const outputDir = join(
+    import.meta.dirname ?? ".",
+    "..",
+    "resources",
+    "deno",
+  );
+  await ensureDir(outputDir);
+
+  const outputPath = join(outputDir, binaryName);
+  await Deno.writeFile(outputPath, binaryBytes);
+
+  // Set executable permissions on unix
+  if (!isWindows) {
+    await Deno.chmod(outputPath, 0o755);
+  }
+
+  // Write version file
+  const versionPath = join(outputDir, "version.txt");
+  await Deno.writeTextFile(versionPath, version);
+
+  const sizeMB = (binaryBytes.length / 1024 / 1024).toFixed(1);
+  console.log(`Wrote deno ${version} (${sizeMB} MB) to ${outputPath}`);
+  console.log(`Wrote version to ${versionPath}`);
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -41,6 +41,7 @@ import {
   WorkflowNameType,
 } from "./completion_types.ts";
 import { UserModelLoader } from "../domain/models/user_model_loader.ts";
+import { EmbeddedDenoRuntime } from "../infrastructure/runtime/embedded_deno_runtime.ts";
 import {
   type RepoMarkerData,
   RepoMarkerRepository,
@@ -135,7 +136,8 @@ async function loadUserModels(): Promise<void> {
       ? modelsDir
       : resolve(cwd, modelsDir);
 
-    const loader = new UserModelLoader();
+    const denoRuntime = new EmbeddedDenoRuntime();
+    const loader = new UserModelLoader(denoRuntime, cwd);
     const result = await loader.loadModels(absoluteModelsDir);
 
     // Log extension successes at debug level

--- a/src/domain/models/bundle.ts
+++ b/src/domain/models/bundle.ts
@@ -1,0 +1,90 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getLogger } from "@logtape/logtape";
+
+const logger = getLogger(["swamp", "models", "bundle"]);
+
+/**
+ * Bundles a TypeScript extension file into JavaScript using `deno bundle` subprocess.
+ *
+ * Transpiles TypeScript syntax (interfaces, type annotations, generics) and
+ * resolves npm imports, while externalizing zod so extensions share the same
+ * instance as swamp (preserving instanceof checks).
+ *
+ * @param absolutePath - Absolute filesystem path to the TypeScript file
+ * @param denoPath - Absolute path to the deno binary to use for bundling
+ * @returns Bundled JavaScript source code as a string
+ */
+export async function bundleExtension(
+  absolutePath: string,
+  denoPath: string,
+): Promise<string> {
+  logger.debug`Bundling extension: ${absolutePath}`;
+
+  const tempFile = await Deno.makeTempFile({
+    prefix: "swamp_bundle_",
+    suffix: ".js",
+  });
+
+  try {
+    const command = new Deno.Command(denoPath, {
+      args: [
+        "bundle",
+        "--external",
+        "npm:zod@4",
+        "--external",
+        "npm:zod",
+        "--platform",
+        "deno",
+        "-o",
+        tempFile,
+        absolutePath,
+      ],
+      stdout: "piped",
+      stderr: "piped",
+    });
+
+    const output = await command.output();
+
+    if (!output.success) {
+      const stderr = new TextDecoder().decode(output.stderr);
+      throw new Error(
+        `deno bundle failed for ${absolutePath}: ${stderr}`,
+      );
+    }
+
+    const js = await Deno.readTextFile(tempFile);
+
+    if (!js) {
+      throw new Error(
+        `deno bundle produced empty output for: ${absolutePath}`,
+      );
+    }
+
+    logger.debug`Bundled ${absolutePath} (${js.length} bytes)`;
+    return js;
+  } finally {
+    try {
+      await Deno.remove(tempFile);
+    } catch {
+      // Temp file cleanup is best-effort
+    }
+  }
+}

--- a/src/domain/models/bundle_test.ts
+++ b/src/domain/models/bundle_test.ts
@@ -1,0 +1,120 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { z } from "zod";
+import { bundleExtension } from "./bundle.ts";
+
+const DENO_PATH = Deno.execPath();
+
+async function withTempFile(
+  content: string,
+  fn: (path: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp_bundle_test_" });
+  const path = join(dir, "test_ext.ts");
+  await Deno.writeTextFile(path, content);
+  try {
+    await fn(path);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+async function importBundled(
+  js: string,
+): Promise<Record<string, unknown>> {
+  const encoded = btoa(String.fromCharCode(...new TextEncoder().encode(js)));
+  return await import(`data:application/javascript;base64,${encoded}`);
+}
+
+Deno.test("bundleExtension transpiles TypeScript to valid JS", async () => {
+  const tsCode = `
+import { z } from "npm:zod@4";
+
+interface Config {
+  name: string;
+  value?: number;
+}
+
+function greet<T extends Config>(config: T): string {
+  return config.name;
+}
+
+const schema = z.object({ message: z.string() });
+
+export const model = {
+  type: greet({ name: "test" }),
+  schema,
+};
+`;
+
+  await withTempFile(tsCode, async (path) => {
+    const js = await bundleExtension(path, DENO_PATH);
+
+    // Should not contain TypeScript syntax
+    assertEquals(js.includes("interface Config"), false);
+    assertEquals(js.includes(": string"), false);
+    assertEquals(js.includes("<T extends"), false);
+
+    // Should be importable
+    const mod = await importBundled(js);
+    assertEquals((mod.model as { type: string }).type, "test");
+  });
+});
+
+Deno.test("bundleExtension externalizes zod imports", async () => {
+  const tsCode = `
+import { z } from "npm:zod@4";
+
+export const schema = z.object({ name: z.string() });
+`;
+
+  await withTempFile(tsCode, async (path) => {
+    const js = await bundleExtension(path, DENO_PATH);
+
+    // Zod should not be inlined — the bundle should be small
+    // A fully inlined zod would be hundreds of KB
+    assertEquals(js.length < 10_000, true);
+  });
+});
+
+Deno.test("bundleExtension produces importable module with working zod instanceof", async () => {
+  const tsCode = `
+import { z } from "npm:zod@4";
+
+export const schema = z.object({ message: z.string() });
+`;
+
+  await withTempFile(tsCode, async (path) => {
+    const js = await bundleExtension(path, DENO_PATH);
+    const mod = await importBundled(js);
+
+    // The schema from the bundled module should be a ZodType instance
+    // because zod is externalized and shares the same instance
+    assertEquals(mod.schema instanceof z.ZodType, true);
+
+    // It should also parse correctly
+    const parsed = (mod.schema as z.ZodObject<{ message: z.ZodString }>).parse({
+      message: "hello",
+    });
+    assertEquals(parsed, { message: "hello" });
+  });
+});

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -18,7 +18,9 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { z } from "zod";
-import { join, resolve } from "@std/path";
+import { dirname, join, resolve, toFileUrl } from "@std/path";
+import { getLogger } from "@logtape/logtape";
+import { bundleExtension } from "./bundle.ts";
 import { ModelType } from "./model_type.ts";
 import { CalVer } from "./calver.ts";
 import {
@@ -32,6 +34,13 @@ import {
   ResourceOutputSpecSchema,
   type VersionUpgrade,
 } from "./model.ts";
+import type { DenoRuntime } from "../runtime/deno_runtime.ts";
+import {
+  SWAMP_DATA_DIR,
+  SWAMP_SUBDIRS,
+} from "../../infrastructure/persistence/paths.ts";
+
+const logger = getLogger(["swamp", "models", "loader"]);
 
 /**
  * Plain object result returned by user methods before conversion.
@@ -210,6 +219,19 @@ export interface LoadResult {
  * This loader validates the structure and registers/extends models with the global registry.
  */
 export class UserModelLoader {
+  private readonly denoRuntime: DenoRuntime;
+  private readonly repoDir: string | null;
+
+  /**
+   * @param denoRuntime - Runtime manager for obtaining a deno binary path
+   * @param repoDir - Repository root for writing bundles to .swamp/bundles/
+   *                   (pass null to skip bundle caching)
+   */
+  constructor(denoRuntime: DenoRuntime, repoDir: string | null = null) {
+    this.denoRuntime = denoRuntime;
+    this.repoDir = repoDir;
+  }
+
   /**
    * Loads all user models and extensions from the specified directory.
    * Uses two-pass loading: models first, then extensions.
@@ -227,6 +249,9 @@ export class UserModelLoader {
       return result; // No user models directory - not an error
     }
 
+    // Ensure deno is available before bundling
+    const denoPath = await this.denoRuntime.ensureDeno();
+
     const files = await this.discoverFiles(modelsDir);
 
     // Import all files and classify by export name
@@ -238,20 +263,19 @@ export class UserModelLoader {
       file: string;
       module: Record<string, unknown>;
     }> = [];
-    const unknownFiles: string[] = [];
 
     for (const file of files) {
       try {
         const absolutePath = resolve(modelsDir, file);
-        const module = await import(`file://${absolutePath}`);
+        const js = await this.bundleWithCache(absolutePath, file, denoPath);
+        const module = await this.importBundle(js, file);
 
         if (module.model) {
           modelFiles.push({ file, module });
         } else if (module.extension) {
           extensionFiles.push({ file, module });
-        } else {
-          unknownFiles.push(file);
         }
+        // Files with neither export are silently skipped (utility files)
       } catch (error) {
         result.failed.push({ file, error: String(error) });
       }
@@ -303,10 +327,88 @@ export class UserModelLoader {
       }
     }
 
-    // Files with neither 'model' nor 'extension' export are silently skipped
-    // (they are likely library/utility files imported by actual model files)
-
     return result;
+  }
+
+  /**
+   * Bundles an extension file, using cached bundle from .swamp/bundles/ when possible.
+   * Writes the bundle to disk for future caching and potential publishing.
+   */
+  private async bundleWithCache(
+    absolutePath: string,
+    relativePath: string,
+    denoPath: string,
+  ): Promise<string> {
+    if (this.repoDir) {
+      const bundlePath = join(
+        this.repoDir,
+        SWAMP_DATA_DIR,
+        SWAMP_SUBDIRS.bundles,
+        relativePath.replace(/\.ts$/, ".js"),
+      );
+
+      // Check mtime-based cache
+      try {
+        const [sourceStat, bundleStat] = await Promise.all([
+          Deno.stat(absolutePath),
+          Deno.stat(bundlePath),
+        ]);
+
+        if (
+          sourceStat.mtime && bundleStat.mtime &&
+          bundleStat.mtime > sourceStat.mtime
+        ) {
+          logger.debug`Using cached bundle for ${relativePath}`;
+          return await Deno.readTextFile(bundlePath);
+        }
+      } catch {
+        // Bundle doesn't exist yet or source stat failed — will rebundle
+      }
+
+      // Bundle and write to cache
+      const js = await bundleExtension(absolutePath, denoPath);
+      await Deno.mkdir(dirname(bundlePath), { recursive: true });
+      await Deno.writeTextFile(bundlePath, js);
+      logger.debug`Wrote bundle cache: ${bundlePath}`;
+      return js;
+    }
+
+    // No repo dir — just bundle without caching
+    return await bundleExtension(absolutePath, denoPath);
+  }
+
+  /**
+   * Imports bundled JavaScript and returns the module exports.
+   * Uses file URL import when a bundle file exists on disk, otherwise falls back to data URL.
+   */
+  private async importBundle(
+    js: string,
+    relativePath: string,
+  ): Promise<Record<string, unknown>> {
+    if (this.repoDir) {
+      const bundlePath = join(
+        this.repoDir,
+        SWAMP_DATA_DIR,
+        SWAMP_SUBDIRS.bundles,
+        relativePath.replace(/\.ts$/, ".js"),
+      );
+
+      try {
+        await Deno.stat(bundlePath);
+        // Import from file URL — avoids base64 encoding overhead
+        return await import(toFileUrl(bundlePath).href);
+      } catch {
+        // Fall through to data URL import
+      }
+    }
+
+    // Fallback: import via base64 data URL
+    const encoded = btoa(
+      String.fromCharCode(...new TextEncoder().encode(js)),
+    );
+    return await import(
+      `data:application/javascript;base64,${encoded}`
+    );
   }
 
   /**

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -28,9 +28,20 @@ import type { DefinitionRepository } from "../definitions/repositories.ts";
 import { type DataId, generateDataId } from "../data/data_id.ts";
 import { createDefinitionId } from "../definitions/definition.ts";
 import { getLogger } from "@logtape/logtape";
+import type { DenoRuntime } from "../runtime/deno_runtime.ts";
 
 // Import models barrel to ensure command/shell is registered for extension test
 import "./models.ts";
+
+/** Test DenoRuntime that returns the current deno binary path. */
+const testDenoRuntime: DenoRuntime = {
+  ensureDeno: () => Promise.resolve(Deno.execPath()),
+};
+
+/** Creates a UserModelLoader configured for tests. */
+function createTestLoader(): UserModelLoader {
+  return new UserModelLoader(testDenoRuntime);
+}
 
 /**
  * Stored result from mock data writer.
@@ -276,7 +287,7 @@ export const model = {
 `;
 
   await withTempModels({ "data_model.ts": modelCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.loaded.length, 1);
@@ -291,7 +302,7 @@ export const notAModel = { foo: "bar" };
 `;
 
   await withTempModels({ "no_export.ts": modelCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     // Files without model/extension exports are now silently skipped
@@ -310,7 +321,7 @@ export const model = {
 `;
 
   await withTempModels({ "invalid_structure.ts": modelCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.loaded.length, 0);
@@ -320,7 +331,7 @@ export const model = {
 });
 
 Deno.test("UserModelLoader handles non-existent directory", async () => {
-  const loader = new UserModelLoader();
+  const loader = createTestLoader();
   const result = await loader.loadModels("/nonexistent/path/to/models");
 
   assertEquals(result.loaded.length, 0);
@@ -359,7 +370,7 @@ export const model = {
   await withTempModels(
     { "model_test.ts": testFile, "model.ts": regularFile },
     async (dir) => {
-      const loader = new UserModelLoader();
+      const loader = createTestLoader();
       const result = await loader.loadModels(dir);
 
       assertEquals(result.loaded.length, 1);
@@ -426,7 +437,7 @@ export const model = {
   await withTempModels(
     { "aaa_first.ts": model1, "zzz_second.ts": model2 },
     async (dir) => {
-      const loader = new UserModelLoader();
+      const loader = createTestLoader();
       const result = await loader.loadModels(dir);
 
       // First model should load, second should fail as duplicate
@@ -476,7 +487,7 @@ export const model = {
 `;
 
   await withTempModels({ "passthrough_data.ts": modelCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.loaded.length, 1);
@@ -539,7 +550,7 @@ export const model = {
 `;
 
   await withTempModels({ "inherit_schema.ts": modelCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.loaded.length, 1);
@@ -607,7 +618,7 @@ export const model = {
   await withTempModels(
     { "model_a.ts": model1, "model_b.ts": model2 },
     async (dir) => {
-      const loader = new UserModelLoader();
+      const loader = createTestLoader();
       const result = await loader.loadModels(dir);
 
       assertEquals(result.loaded.length, 2);
@@ -653,7 +664,7 @@ export const model = {
 `;
 
   await withTempModels({ "empty_handles.ts": modelCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.loaded.length, 1);
@@ -707,7 +718,7 @@ export const model = {
 `;
 
   await withTempModels({ "no_handles.ts": modelCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.loaded.length, 1);
@@ -780,7 +791,7 @@ export const model = {
   await withTempModels(
     { "aws/ec2_start.ts": modelA, "echo_audit.ts": modelB },
     async (dir) => {
-      const loader = new UserModelLoader();
+      const loader = createTestLoader();
       const result = await loader.loadModels(dir);
 
       assertEquals(result.loaded.length, 2);
@@ -818,7 +829,7 @@ export const model = {
   await withTempModels(
     { "sub/model.ts": modelCode, "sub/model_test.ts": testFile },
     async (dir) => {
-      const loader = new UserModelLoader();
+      const loader = createTestLoader();
       const result = await loader.loadModels(dir);
 
       assertEquals(result.loaded.length, 1);
@@ -853,7 +864,7 @@ export const model = {
   await withTempModels(
     { "a/b/c/deep_model.ts": modelCode },
     async (dir) => {
-      const loader = new UserModelLoader();
+      const loader = createTestLoader();
       const result = await loader.loadModels(dir);
 
       assertEquals(result.loaded.length, 1);
@@ -909,7 +920,7 @@ export const extension = {
   await withTempModels(
     { "base_model.ts": modelCode, "ext_audit.ts": extCode },
     async (dir) => {
-      const loader = new UserModelLoader();
+      const loader = createTestLoader();
       const result = await loader.loadModels(dir);
 
       assertEquals(result.loaded.length, 1);
@@ -973,7 +984,7 @@ export const extension = {
   await withTempModels(
     { "base.ts": modelCode, "ext.ts": extCode },
     async (dir) => {
-      const loader = new UserModelLoader();
+      const loader = createTestLoader();
       const result = await loader.loadModels(dir);
 
       assertEquals(result.loaded.length, 1);
@@ -1004,7 +1015,7 @@ export const extension = {
 `;
 
   await withTempModels({ "ext_bad.ts": extCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.loaded.length, 0);
@@ -1056,7 +1067,7 @@ export const extension = {
   await withTempModels(
     { "base.ts": modelCode, "ext_conflict.ts": extCode },
     async (dir) => {
-      const loader = new UserModelLoader();
+      const loader = createTestLoader();
       const result = await loader.loadModels(dir);
 
       assertEquals(result.loaded.length, 1);
@@ -1119,7 +1130,7 @@ export const extension = {
   await withTempModels(
     { "base.ts": modelCode, "ext_dup.ts": extCode },
     async (dir) => {
-      const loader = new UserModelLoader();
+      const loader = createTestLoader();
       const result = await loader.loadModels(dir);
 
       assertEquals(result.loaded.length, 1);
@@ -1175,7 +1186,7 @@ export const extension = {
   await withTempModels(
     { "base.ts": modelCode, "ext.ts": extCode },
     async (dir) => {
-      const loader = new UserModelLoader();
+      const loader = createTestLoader();
       const result = await loader.loadModels(dir);
 
       assertEquals(result.extended.length, 1);
@@ -1207,7 +1218,7 @@ export const extension = {
 `;
 
   await withTempModels({ "shell_ext.ts": extCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.extended.length, 1);
@@ -1275,7 +1286,7 @@ export const extension = {
   await withTempModels(
     { "base.ts": modelCode, "ext_audit.ts": ext1, "ext_verify.ts": ext2 },
     async (dir) => {
-      const loader = new UserModelLoader();
+      const loader = createTestLoader();
       const result = await loader.loadModels(dir);
 
       assertEquals(result.loaded.length, 1);
@@ -1335,7 +1346,7 @@ export const extension = {
   await withTempModels(
     { "zzz_model.ts": modelCode, "aaa_ext.ts": extCode },
     async (dir) => {
-      const loader = new UserModelLoader();
+      const loader = createTestLoader();
       const result = await loader.loadModels(dir);
 
       assertEquals(result.loaded.length, 1);
@@ -1397,7 +1408,7 @@ export const extension = {
   await withTempModels(
     { "base.ts": modelCode, "ext.ts": extCode },
     async (dir) => {
-      const loader = new UserModelLoader();
+      const loader = createTestLoader();
       const result = await loader.loadModels(dir);
 
       assertEquals(result.extended.length, 1);
@@ -1466,7 +1477,7 @@ export const model = {
 `;
 
   await withTempModels({ "custom_specs.ts": modelCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.loaded.length, 1);
@@ -1516,7 +1527,7 @@ export const model = {
 `;
 
   await withTempModels({ "no_at_prefix.ts": modelCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.loaded.length, 0);
@@ -1552,7 +1563,7 @@ export const model = {
 `;
 
   await withTempModels({ "only_namespace.ts": modelCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.loaded.length, 0);
@@ -1588,7 +1599,7 @@ export const model = {
 `;
 
   await withTempModels({ "only_myorg.ts": modelCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.loaded.length, 0);
@@ -1625,7 +1636,7 @@ export const model = {
 `;
 
   await withTempModels({ "custom_namespace.ts": modelCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.loaded.length, 1);
@@ -1664,7 +1675,7 @@ export const model = {
 `;
 
   await withTempModels({ "stack72_model.ts": modelCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.loaded.length, 1);
@@ -1703,7 +1714,7 @@ export const model = {
 `;
 
   await withTempModels({ "keeb_model.ts": modelCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.loaded.length, 1);
@@ -1742,7 +1753,7 @@ export const model = {
 `;
 
   await withTempModels({ "valid_user_model.ts": modelCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.loaded.length, 1);
@@ -1781,7 +1792,7 @@ export const model = {
 `;
 
   await withTempModels({ "valid_nested.ts": modelCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.loaded.length, 1);
@@ -1816,7 +1827,7 @@ export const model = {
 `;
 
   await withTempModels({ "reserved_swamp.ts": modelCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.loaded.length, 0);
@@ -1852,7 +1863,7 @@ export const model = {
 `;
 
   await withTempModels({ "reserved_si.ts": modelCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.loaded.length, 0);
@@ -1888,7 +1899,7 @@ export const model = {
 `;
 
   await withTempModels({ "reserved_at_swamp.ts": modelCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.loaded.length, 0);
@@ -1924,7 +1935,7 @@ export const model = {
 `;
 
   await withTempModels({ "reserved_at_si.ts": modelCode }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     assertEquals(result.loaded.length, 0);
@@ -1967,7 +1978,7 @@ export class ProxmoxClient {
     "lib/proxmox.ts": libCode,
     "utils/helpers.ts": libCode,
   }, async (dir) => {
-    const loader = new UserModelLoader();
+    const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
     // Should load only the valid model
@@ -1976,5 +1987,89 @@ export class ProxmoxClient {
 
     // Library files should be silently skipped (not in failed list)
     assertEquals(result.failed.length, 0);
+  });
+});
+
+Deno.test("UserModelLoader loads model with TypeScript-specific syntax", async () => {
+  const typeId = `@user/ts-syntax-${Date.now()}`;
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+// TypeScript interface
+interface ModelConfig {
+  name: string;
+  retries?: number;
+}
+
+// Generic function
+function withDefault<T extends ModelConfig>(config: T): T {
+  return { ...config, retries: config.retries ?? 3 };
+}
+
+// Type annotation and optional parameter
+function formatName(name: string, prefix?: string): string {
+  return prefix ? prefix + "/" + name : name;
+}
+
+const config: ModelConfig = withDefault({ name: "ts-test" });
+const displayName: string = formatName(config.name, "@user");
+
+const InputSchema = z.object({
+  message: z.string(),
+});
+
+export const model = {
+  type: "${typeId}",
+  version: "2026.02.24.1",
+  globalArguments: InputSchema,
+  resources: {
+    "data": {
+      description: "Data output",
+      schema: z.object({ name: z.string(), retries: z.number() }),
+      lifetime: "infinite",
+      garbageCollection: 10,
+    },
+  },
+  methods: {
+    run: {
+      description: "Run with TypeScript features",
+      arguments: InputSchema,
+      execute: async (args, context) => {
+        const handle = await context.writeResource("data", "data", {
+          name: displayName,
+          retries: config.retries,
+        });
+        return { dataHandles: [handle] };
+      },
+    },
+  },
+};
+`;
+
+  await withTempModels({ "ts_syntax_model.ts": modelCode }, async (dir) => {
+    const loader = createTestLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 1);
+    assertEquals(result.loaded[0], "ts_syntax_model.ts");
+    assertEquals(result.failed.length, 0);
+
+    // Verify the model actually works by executing it
+    const modelDef = modelRegistry.get(typeId);
+    assertEquals(modelDef !== undefined, true);
+
+    const { context, getResults } = createTestContext(modelDef!.type);
+    const methodResult = await modelDef!.methods.run.execute(
+      { message: "hello" },
+      context,
+    );
+
+    assertEquals(methodResult.dataHandles !== undefined, true);
+    assertEquals(methodResult.dataHandles!.length, 1);
+
+    const results = getResults();
+    const content = JSON.parse(new TextDecoder().decode(results[0].content));
+    assertEquals(content.name, "@user/ts-test");
+    assertEquals(content.retries, 3);
   });
 });

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -378,6 +378,9 @@ ${body}`;
 # Encryption keyfile (NEVER commit - allows decrypting secrets)
 .swamp/secrets/keyfile
 
+# Cached extension bundles (regenerated at runtime)
+.swamp/bundles/
+
 ${GITIGNORE_TOOL_ENTRIES[tool]}
 `;
   }

--- a/src/domain/runtime/deno_runtime.ts
+++ b/src/domain/runtime/deno_runtime.ts
@@ -1,0 +1,30 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Port (interface) for the deno runtime manager.
+ *
+ * Provides access to a deno binary for bundling extensions.
+ * In dev mode this returns the running deno; in compiled mode
+ * it extracts the embedded binary to ~/.swamp/deno/.
+ */
+export interface DenoRuntime {
+  /** Returns the absolute path to a usable deno binary. */
+  ensureDeno(): Promise<string>;
+}

--- a/src/domain/runtime/deno_version.ts
+++ b/src/domain/runtime/deno_version.ts
@@ -1,0 +1,68 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Value object representing a pinned deno runtime version.
+ *
+ * Immutable, compared by value. Used to track which deno version
+ * is embedded in the compiled binary and whether re-extraction is needed.
+ */
+export class DenoVersion {
+  readonly value: string;
+
+  private constructor(value: string) {
+    this.value = value;
+  }
+
+  /**
+   * Creates a DenoVersion from a version string (e.g., "2.6.5").
+   *
+   * @param version - Semver version string
+   * @throws Error if version string is empty
+   */
+  static create(version: string): DenoVersion {
+    const trimmed = version.trim();
+    if (!trimmed) {
+      throw new Error("DenoVersion cannot be empty");
+    }
+    return new DenoVersion(trimmed);
+  }
+
+  /**
+   * Parses the version from `deno --version` output.
+   * Extracts the version from the first line: "deno X.Y.Z (...)"
+   */
+  static fromVersionOutput(output: string): DenoVersion {
+    const match = output.match(/^deno\s+(\S+)/);
+    if (!match) {
+      throw new Error(
+        `Cannot parse deno version from output: ${output.slice(0, 100)}`,
+      );
+    }
+    return DenoVersion.create(match[1]);
+  }
+
+  equals(other: DenoVersion): boolean {
+    return this.value === other.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}

--- a/src/domain/runtime/deno_version_test.ts
+++ b/src/domain/runtime/deno_version_test.ts
@@ -1,0 +1,71 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import { DenoVersion } from "./deno_version.ts";
+
+Deno.test("DenoVersion.create creates version from string", () => {
+  const v = DenoVersion.create("2.6.5");
+  assertEquals(v.value, "2.6.5");
+});
+
+Deno.test("DenoVersion.create trims whitespace", () => {
+  const v = DenoVersion.create("  2.6.5  ");
+  assertEquals(v.value, "2.6.5");
+});
+
+Deno.test("DenoVersion.create throws on empty string", () => {
+  assertThrows(() => DenoVersion.create(""), Error, "cannot be empty");
+});
+
+Deno.test("DenoVersion.create throws on whitespace-only string", () => {
+  assertThrows(() => DenoVersion.create("   "), Error, "cannot be empty");
+});
+
+Deno.test("DenoVersion.equals returns true for same version", () => {
+  const a = DenoVersion.create("2.6.5");
+  const b = DenoVersion.create("2.6.5");
+  assertEquals(a.equals(b), true);
+});
+
+Deno.test("DenoVersion.equals returns false for different versions", () => {
+  const a = DenoVersion.create("2.6.5");
+  const b = DenoVersion.create("2.7.0");
+  assertEquals(a.equals(b), false);
+});
+
+Deno.test("DenoVersion.fromVersionOutput parses deno --version output", () => {
+  const output =
+    "deno 2.6.5 (stable, release, x86_64-unknown-linux-gnu)\nv8 13.7.152.6\ntypescript 5.7.3";
+  const v = DenoVersion.fromVersionOutput(output);
+  assertEquals(v.value, "2.6.5");
+});
+
+Deno.test("DenoVersion.fromVersionOutput throws on invalid output", () => {
+  assertThrows(
+    () => DenoVersion.fromVersionOutput("not a version"),
+    Error,
+    "Cannot parse",
+  );
+});
+
+Deno.test("DenoVersion.toString returns version string", () => {
+  const v = DenoVersion.create("2.6.5");
+  assertEquals(v.toString(), "2.6.5");
+});

--- a/src/infrastructure/persistence/paths.ts
+++ b/src/infrastructure/persistence/paths.ts
@@ -64,6 +64,8 @@ export const SWAMP_SUBDIRS = {
   inputs: "inputs",
   /** Legacy: evaluated inputs */
   inputsEvaluated: "inputs-evaluated",
+  /** Cached extension bundles */
+  bundles: "bundles",
   /** Legacy: resource definitions */
   resources: "resources",
 } as const;

--- a/src/infrastructure/runtime/embedded_deno_runtime.ts
+++ b/src/infrastructure/runtime/embedded_deno_runtime.ts
@@ -1,0 +1,140 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join } from "@std/path";
+import { getLogger } from "@logtape/logtape";
+import type { DenoRuntime } from "../../domain/runtime/deno_runtime.ts";
+import { DenoVersion } from "../../domain/runtime/deno_version.ts";
+
+const logger = getLogger(["swamp", "runtime", "deno"]);
+
+/** Filename of the embedded deno binary (platform-dependent at build time). */
+const DENO_BINARY_NAME = Deno.build.os === "windows" ? "deno.exe" : "deno";
+
+/**
+ * DenoRuntime implementation that manages an embedded deno binary.
+ *
+ * - **Dev mode** (running from source): returns `Deno.execPath()` directly.
+ * - **Standalone mode** (compiled binary): reads the embedded binary from
+ *   `resources/deno/`, extracts it to `~/.swamp/deno/`, and returns that path.
+ *   Skips extraction when `~/.swamp/deno/.version` already matches.
+ */
+export class EmbeddedDenoRuntime implements DenoRuntime {
+  private cachedPath: string | null = null;
+
+  async ensureDeno(): Promise<string> {
+    if (this.cachedPath) {
+      return this.cachedPath;
+    }
+
+    // deno-lint-ignore no-explicit-any
+    if (!(Deno.build as any).standalone) {
+      // Dev mode: use the deno that's running us
+      this.cachedPath = Deno.execPath();
+      logger.debug`Dev mode: using system deno at ${this.cachedPath}`;
+      return this.cachedPath;
+    }
+
+    // Standalone mode: extract embedded binary
+    this.cachedPath = await this.extractEmbeddedDeno();
+    return this.cachedPath;
+  }
+
+  private async extractEmbeddedDeno(): Promise<string> {
+    const swampDir = this.getSwampDenoDir();
+    const targetBinary = join(swampDir, DENO_BINARY_NAME);
+    const versionMarker = join(swampDir, ".version");
+
+    // Read embedded version
+    const embeddedVersion = await this.readEmbeddedVersion();
+
+    // Check if already extracted with matching version
+    try {
+      const existingVersion = (await Deno.readTextFile(versionMarker)).trim();
+      if (existingVersion === embeddedVersion.value) {
+        // Also verify the binary exists
+        await Deno.stat(targetBinary);
+        logger
+          .debug`Deno ${embeddedVersion} already extracted at ${targetBinary}`;
+        return targetBinary;
+      }
+    } catch {
+      // Version marker missing or binary missing — need to extract
+    }
+
+    logger.info`Extracting embedded deno ${embeddedVersion} to ${swampDir}`;
+
+    // Ensure target directory exists
+    await Deno.mkdir(swampDir, { recursive: true });
+
+    // Read embedded binary
+    const embeddedBinary = await this.readEmbeddedBinary();
+
+    // Write binary to target
+    await Deno.writeFile(targetBinary, embeddedBinary);
+
+    // Set executable permissions (unix)
+    if (Deno.build.os !== "windows") {
+      await Deno.chmod(targetBinary, 0o755);
+    }
+
+    // Write version marker
+    await Deno.writeTextFile(versionMarker, embeddedVersion.value);
+
+    logger
+      .info`Extracted deno ${embeddedVersion} (${embeddedBinary.length} bytes)`;
+    return targetBinary;
+  }
+
+  private async readEmbeddedVersion(): Promise<DenoVersion> {
+    const versionPath = this.getEmbeddedResourcePath("version.txt");
+    const content = await Deno.readTextFile(versionPath);
+    return DenoVersion.create(content.trim());
+  }
+
+  private async readEmbeddedBinary(): Promise<Uint8Array> {
+    const binaryPath = this.getEmbeddedResourcePath(DENO_BINARY_NAME);
+    return await Deno.readFile(binaryPath);
+  }
+
+  /**
+   * Gets the path to an embedded resource file.
+   * Uses import.meta.dirname to navigate from this file's location
+   * (src/infrastructure/runtime/) up to repo root, then into resources/deno/.
+   */
+  private getEmbeddedResourcePath(filename: string): string {
+    const currentDir = import.meta.dirname ?? ".";
+    // From src/infrastructure/runtime -> ../../.. -> repo root
+    return join(currentDir, "..", "..", "..", "resources", "deno", filename);
+  }
+
+  /**
+   * Gets the ~/.swamp/deno/ directory path for extracting the runtime.
+   */
+  private getSwampDenoDir(): string {
+    const home = Deno.env.get("HOME") ??
+      Deno.env.get("USERPROFILE");
+    if (!home) {
+      throw new Error(
+        "Cannot determine home directory (HOME/USERPROFILE not set)",
+      );
+    }
+    return join(home, ".swamp", "deno");
+  }
+}

--- a/src/infrastructure/runtime/embedded_deno_runtime_test.ts
+++ b/src/infrastructure/runtime/embedded_deno_runtime_test.ts
@@ -1,0 +1,40 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { EmbeddedDenoRuntime } from "./embedded_deno_runtime.ts";
+
+Deno.test("EmbeddedDenoRuntime returns system deno in dev mode", async () => {
+  // When running from source (not compiled), Deno.build.standalone is falsy
+  const runtime = new EmbeddedDenoRuntime();
+  const denoPath = await runtime.ensureDeno();
+
+  // In dev mode, should return the running deno's path
+  assertEquals(denoPath, Deno.execPath());
+});
+
+Deno.test("EmbeddedDenoRuntime caches the deno path", async () => {
+  const runtime = new EmbeddedDenoRuntime();
+
+  const first = await runtime.ensureDeno();
+  const second = await runtime.ensureDeno();
+
+  // Should return the same path both times (cached)
+  assertEquals(first, second);
+});


### PR DESCRIPTION
Replace the Deno.bundle() API (unavailable in compiled binaries) with deno bundle CLI subprocess. Embed the deno binary inside the compiled swamp binary so extensions work without requiring users to install deno.

- Add DenoVersion value object and DenoRuntime interface (domain port)
- Add EmbeddedDenoRuntime that extracts embedded deno to ~/.swamp/deno/ in standalone mode, returns Deno.execPath() in dev mode
- Rewrite bundleExtension() to use deno bundle subprocess
- Add mtime-based bundle caching to .swamp/bundles/ in UserModelLoader
- Add download_deno.ts script to fetch deno from GitHub releases
- Update compile.ts to download + embed deno via --include resources/deno
- Add bundles to SWAMP_SUBDIRS, update .gitignore and deno.json excludes

Closes issue #443 and #442.

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbHprcGhmY3M0cjV0a2NzaWQwcndvdGV2amoyZnY3a3ZvZTgzZG02YyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/pVQUCfmpSv1Qs/giphy.gif"/>