### PR TITLE
refactor: unify data access — make data.latest() the canonical accessor

### DIFF
--- a/.claude/skills/swamp-model/references/data-chaining.md
+++ b/.claude/skills/swamp-model/references/data-chaining.md
@@ -3,7 +3,11 @@
 The `command/shell` model enables data chaining by running shell commands and
 capturing output for use in other models. For JSON output, use `jq` in the
 command to extract specific fields, then access the result via
-`resource.result.result.attributes.stdout`.
+`data.latest("model-name", "result").attributes.stdout`.
+
+> **Note:** `data.latest()` is the preferred accessor for all cross-model data.
+> The `model.*.resource` pattern is deprecated and will be removed in a future
+> release. Existing examples below show both patterns for reference.
 
 ## command/shell Data Attributes
 

--- a/.claude/skills/swamp-model/references/examples.md
+++ b/.claude/skills/swamp-model/references/examples.md
@@ -11,21 +11,21 @@
 
 ## CEL Expression Quick Reference
 
-| Expression Pattern                                           | Description                                | Example Value                 |
-| ------------------------------------------------------------ | ------------------------------------------ | ----------------------------- |
-| `model.<name>.resource.<spec>.<instance>.attributes.<field>` | Cross-model resource reference (PREFERRED) | VPC ID, subnet CIDR, etc.     |
-| `model.<name>.resource.result.result.attributes.stdout`      | command/shell stdout                       | AMI ID from aws cli command   |
-| `model.<name>.file.<spec>.<instance>.path`                   | File path from another model               | `/path/to/file.txt`           |
-| `self.name`                                                  | Current model's name                       | `my-vpc`                      |
-| `self.version`                                               | Current model's version                    | `1`                           |
-| `self.globalArguments.<field>`                               | This model's own global argument           | CIDR block, region, etc.      |
-| `inputs.<name>`                                              | Runtime input value                        | `production`, `true`, etc.    |
-| `env.<VAR_NAME>`                                             | Environment variable                       | AWS region, credentials       |
-| `vault.get("<vault>", "<key>")`                              | Vault secret                               | API key, password             |
-| `data.version("<model>", "<name>", <version>)`               | Specific version of data                   | Rollback to version 1         |
-| `data.latest("<model>", "<name>")`                           | Latest version snapshot                    | Workflow-start snapshot       |
-| `data.findBySpec("<model>", "<spec>")`                       | Find all instances from a spec             | All subnets from scanner      |
-| `data.findByTag("<key>", "<value>")`                         | Find data by tag                           | All resources tagged env=prod |
+| Expression Pattern                                           | Description                               | Example Value                 |
+| ------------------------------------------------------------ | ----------------------------------------- | ----------------------------- |
+| `data.latest("<model>", "<name>").attributes.<field>`        | Latest data (PREFERRED, sync disk read)   | VPC ID, subnet CIDR, etc.     |
+| `data.version("<model>", "<name>", N).attributes.<field>`    | Specific version of data                  | Rollback to version 1         |
+| `data.findBySpec("<model>", "<spec>")`                       | Find all instances from a spec            | All subnets from scanner      |
+| `data.findByTag("<key>", "<value>")`                         | Find data by tag                          | All resources tagged env=prod |
+| `model.<name>.resource.<spec>.<instance>.attributes.<field>` | Cross-model resource (DEPRECATED)         | VPC ID, subnet CIDR, etc.     |
+| `model.<name>.resource.result.result.attributes.stdout`      | command/shell stdout (DEPRECATED)         | AMI ID from aws cli command   |
+| `model.<name>.file.<spec>.<instance>.path`                   | File path from another model (DEPRECATED) | `/path/to/file.txt`           |
+| `self.name`                                                  | Current model's name                      | `my-vpc`                      |
+| `self.version`                                               | Current model's version                   | `1`                           |
+| `self.globalArguments.<field>`                               | This model's own global argument          | CIDR block, region, etc.      |
+| `inputs.<name>`                                              | Runtime input value                       | `production`, `true`, etc.    |
+| `env.<VAR_NAME>`                                             | Environment variable                      | AWS region, credentials       |
+| `vault.get("<vault>", "<key>")`                              | Vault secret                              | API key, password             |
 
 ### CEL Path Patterns by Model Type
 
@@ -205,42 +205,44 @@ dryRun: true
 
 ## Cross-Model Data References
 
-### Preferred: model.* Expressions
+### Preferred: data.latest() Expressions
 
-Always use `model.*` expressions for referencing other models' data:
+Always use `data.latest()` for referencing other models' data. It reads directly
+from disk on every call, so it always reflects the latest state:
 
 ```yaml
-# CORRECT: model.* expression
-globalArguments:
-  vpcId: ${{ model.my-vpc.resource.vpc.main.attributes.VpcId }}
-
-# AVOID: data.latest() for cross-model references
+# CORRECT: data.latest() — always reads fresh data from disk
 globalArguments:
   vpcId: ${{ data.latest("my-vpc", "main").attributes.VpcId }}
+
+# DEPRECATED: model.*.resource — will be removed in a future release
+globalArguments:
+  vpcId: ${{ model.my-vpc.resource.vpc.main.attributes.VpcId }}
 ```
 
-### Why model.* is Preferred
+### Why data.latest() is Preferred
 
-| Feature                   | `model.*`        | `data.latest()` |
-| ------------------------- | ---------------- | --------------- |
-| In-workflow updates       | Yes (live)       | No (snapshot)   |
-| Clear dependency tracking | Yes              | Yes             |
-| Type validation           | Yes (via schema) | No              |
-| Expression readability    | More explicit    | Less explicit   |
+| Feature                   | `data.latest()` | `model.*.resource` |
+| ------------------------- | --------------- | ------------------ |
+| Always fresh (no cache)   | Yes (sync disk) | Yes (eager load)   |
+| Supports vary dimensions  | Yes             | No                 |
+| Clear dependency tracking | Yes             | Yes                |
+| Future-proof              | Yes (canonical) | No (deprecated)    |
 
-### When to Use data.latest()
-
-Only use `data.latest()` when you specifically need:
-
-1. **Snapshot semantics** — value frozen at workflow start
-2. **Dynamic model names** — building model name from variables
+### Other data.* Functions
 
 ```yaml
-# Rollback scenario: get the previous version
+# Specific version (rollback scenario)
 previousConfig: ${{ data.version("app-config", "config", 1).attributes.setting }}
 
-# Dynamic model name (rare)
+# Dynamic model name
 dynamicValue: ${{ data.latest(inputs.modelName, "state").attributes.value }}
+
+# Find all instances of a spec
+allSubnets: ${{ data.findBySpec("scanner", "subnet") }}
+
+# Find by tag
+prodResources: ${{ data.findByTag("env", "prod") }}
 ```
 
 ### Self-References

--- a/.claude/skills/swamp-workflow/references/data-chaining.md
+++ b/.claude/skills/swamp-workflow/references/data-chaining.md
@@ -68,31 +68,33 @@ globalArguments:
 
 Use `dependsOn` to ensure step B runs after step A when B references A's output.
 
-## Choosing `model.*` vs `data.latest()` Expressions
+## Choosing `data.latest()` vs `model.*` Expressions
 
 Model instance definitions use CEL expressions to reference other models' data.
-Both expression forms work for cross-workflow data access, but they have
-different characteristics:
+**`data.latest()` is the preferred (canonical) accessor.** The
+`model.*.resource` and `model.*.file` patterns are deprecated and will be
+removed in a future release.
 
-| Expression                        | Sees current-run data?                              | Sees prior-run data?                              |
-| --------------------------------- | --------------------------------------------------- | ------------------------------------------------- |
-| `model.<name>.resource.<spec>`    | **Yes** — in-memory context updated after each step | **Yes** — reads persisted data with `type` intact |
-| `data.latest("<name>", "<spec>")` | **No** — snapshot taken at workflow start           | **Yes** — reads persisted data regardless of tags |
+| Expression                            | Sees current-run data?                 | Sees prior-run data? | Status         |
+| ------------------------------------- | -------------------------------------- | -------------------- | -------------- |
+| `data.latest("<name>", "<spec>")`     | **Yes** — sync disk read on every call | **Yes**              | **Preferred**  |
+| `data.version("<name>", "<spec>", N)` | **Yes** — sync disk read               | **Yes**              | **Preferred**  |
+| `model.<name>.resource.<spec>`        | **Yes** — eagerly populated            | **Yes**              | **Deprecated** |
 
 ### When to use each
 
-**Use `model.*`** for most cases:
+**Use `data.latest()` / `data.version()`** for all cases:
 
 - Intra-workflow chaining (step B reads step A's output in the same run)
 - Cross-workflow chaining (workflow B reads data from prior workflow A run)
+- Data always reflects the latest on-disk state (no stale cache)
+- Supports vary dimensions for environment isolation
 
-**Use `data.latest()`** when:
+**Avoid `model.*.resource` / `model.*.file`** — these patterns are deprecated
+and will emit a warning. They still work for backward compatibility but should
+be migrated to `data.latest()`.
 
-- You need to query data by model name dynamically
-- You want a snapshot from workflow start rather than live in-memory context
-
-Both forms are equivalent for dependency purposes — use explicit `dependsOn` to
-control step ordering.
+Use explicit `dependsOn` to control step ordering.
 
 ## Example: Multi-Step Infrastructure Workflow
 

--- a/design/expressions.md
+++ b/design/expressions.md
@@ -37,7 +37,8 @@ attributes:
   message: ${{ model.foo.definition.attributes.message }}
 ```
 
-Or the data output of the same model:
+Or the data output of the same model (using the preferred `data.latest()`
+accessor):
 
 ```yaml
 id: 0bc79a8f-d9d2-4ec5-a37f-8d88bbb3ee27
@@ -45,7 +46,7 @@ name: baz
 version: 1
 tags: {}
 attributes:
-  message: ${{ model.foo.data.attributes.message }}
+  message: ${{ data.latest('foo', 'result').attributes.message }}
 ```
 
 You can refer to your own model with `self`, for things like name, version,
@@ -90,14 +91,12 @@ dynamic configuration without modifying definition files.
 
 ## Data Versioning
 
-When accessing model data, the "latest" version is implied by default:
+`data.latest()` is the **canonical accessor** for model data. It reads directly
+from disk on every call, so it always reflects the latest on-disk state with no
+cache staleness. The `model.*.resource` and `model.*.file` patterns are
+**deprecated** and will be removed in a future release.
 
-```yaml
-message: ${{ model.foo.data.attributes.message }} # accesses latest version
-```
-
-Data is immutable and versioned. To access specific versions or list available
-versions, use the following CEL functions:
+Data is immutable and versioned. Use the following CEL functions to access data:
 
 ### data.latest(modelName, dataName)
 

--- a/design/vaults.md
+++ b/design/vaults.md
@@ -293,7 +293,7 @@ version: 1
 attributes:
   vaultName: aws
   secretKey: new-auth-token
-  secretValue: ${{ model.api-generator.data.attributes.token }}
+  secretValue: ${{ data.latest('api-generator', 'result').attributes.token }}
   operation: put
 ```
 

--- a/integration/cel_data_access_test.ts
+++ b/integration/cel_data_access_test.ts
@@ -1078,3 +1078,62 @@ Deno.test("CEL Data Access: resource resolves after model delete and recreate wi
     assertEquals(result.definition.globalArguments.bucket_count, 42);
   });
 });
+
+// ============================================================================
+// Sync Disk Read: data.latest() sees fresh data written after buildContext()
+// ============================================================================
+
+Deno.test("CEL Data Access: data.latest() sees data written after buildContext()", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const type = ModelType.create("test/model");
+    const owner = createOwner("test/model:fresh-data");
+
+    const model = Definition.create({
+      name: "fresh_data_model",
+      globalArguments: {},
+    });
+    await definitionRepo.save(type, model);
+
+    // Write initial data
+    const data = Data.create({
+      name: "live_state",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource" },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      model.id,
+      data,
+      new TextEncoder().encode(JSON.stringify({ step: 1 })),
+    );
+
+    // Build context — captures a snapshot of coordinates
+    const modelResolver = new ModelResolver(definitionRepo, {
+      repoDir,
+      dataRepo,
+    });
+    const context = await modelResolver.buildContext();
+
+    // Write NEW data AFTER context was built
+    await dataRepo.save(
+      type,
+      model.id,
+      data,
+      new TextEncoder().encode(JSON.stringify({ step: 2, fresh: true })),
+    );
+
+    // data.latest() should see the fresh version (sync disk read, no cache)
+    assertExists(context.data);
+    const latest = context.data.latest("fresh_data_model", "live_state");
+    assertExists(latest);
+    assertEquals(latest.version, 2);
+    assertEquals(latest.attributes.step, 2);
+    assertEquals(latest.attributes.fresh, true);
+  });
+});

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -230,121 +230,21 @@ export interface ModelResolverRepositories {
 }
 
 /**
- * Cache for pre-loaded data to enable synchronous CEL function evaluation.
- *
- * The cache indexes data by:
- * - (modelName, dataName, version) for direct lookups
- * - (tagKey, tagValue) for tag-based queries
+ * Coordinates for locating a model's data on disk.
+ * The modelType and modelId identify the disk path where data is stored,
+ * which may differ from the current definition's UUID (e.g., after delete/recreate).
  */
-export class DataCache {
-  // (modelName) -> (dataName) -> (version) -> DataRecord
-  private byModelData: Map<string, Map<string, Map<number, DataRecord>>> =
-    new Map();
-
-  // (tagKey:tagValue) -> DataRecord[]
-  private byTag: Map<string, DataRecord[]> = new Map();
-
-  // (modelName) -> (specName) -> DataRecord[]
-  private byModelSpec: Map<string, Map<string, DataRecord[]>> = new Map();
-
-  /**
-   * Adds a data record to the cache.
-   */
-  addData(
-    modelName: string,
-    dataName: string,
-    version: number,
-    record: DataRecord,
-  ): void {
-    // Add to model/data/version index
-    if (!this.byModelData.has(modelName)) {
-      this.byModelData.set(modelName, new Map());
-    }
-    const dataMap = this.byModelData.get(modelName)!;
-    if (!dataMap.has(dataName)) {
-      dataMap.set(dataName, new Map());
-    }
-    dataMap.get(dataName)!.set(version, record);
-
-    // Add to tag index
-    for (const [key, value] of Object.entries(record.tags)) {
-      const tagKey = `${key}:${value}`;
-      if (!this.byTag.has(tagKey)) {
-        this.byTag.set(tagKey, []);
-      }
-      this.byTag.get(tagKey)!.push(record);
-    }
-
-    // Add to model+spec index (from specName tag)
-    const specTag = record.tags["specName"];
-    if (specTag) {
-      if (!this.byModelSpec.has(modelName)) {
-        this.byModelSpec.set(modelName, new Map());
-      }
-      const specMap = this.byModelSpec.get(modelName)!;
-      if (!specMap.has(specTag)) {
-        specMap.set(specTag, []);
-      }
-      specMap.get(specTag)!.push(record);
-    }
-  }
-
-  /**
-   * Gets a specific version of data.
-   */
-  getVersion(
-    modelName: string,
-    dataName: string,
-    version: number,
-  ): DataRecord | null {
-    return (
-      this.byModelData.get(modelName)?.get(dataName)?.get(version) ?? null
-    );
-  }
-
-  /**
-   * Gets the latest version of data.
-   */
-  getLatest(modelName: string, dataName: string): DataRecord | null {
-    const versions = this.listVersions(modelName, dataName);
-    if (versions.length === 0) return null;
-    const latestVersion = Math.max(...versions);
-    return this.getVersion(modelName, dataName, latestVersion);
-  }
-
-  /**
-   * Lists all version numbers for a data item in ascending order.
-   */
-  listVersions(modelName: string, dataName: string): number[] {
-    const versionMap = this.byModelData.get(modelName)?.get(dataName);
-    if (!versionMap) return [];
-    return Array.from(versionMap.keys()).sort((a, b) => a - b);
-  }
-
-  /**
-   * Finds all data records with a specific tag.
-   */
-  findByTag(tagKey: string, tagValue: string): DataRecord[] {
-    return this.byTag.get(`${tagKey}:${tagValue}`) ?? [];
-  }
-
-  /**
-   * Finds all data records for a model that match a given spec name.
-   * Uses the `specName` tag populated during data writes.
-   */
-  findBySpec(modelName: string, specName: string): DataRecord[] {
-    return this.byModelSpec.get(modelName)?.get(specName) ?? [];
-  }
-
-  /**
-   * Gets all data names for a model.
-   */
-  getDataNames(modelName: string): string[] {
-    const dataMap = this.byModelData.get(modelName);
-    if (!dataMap) return [];
-    return Array.from(dataMap.keys());
-  }
+export interface ModelCoordinates {
+  modelType: ModelType;
+  modelId: string;
 }
+
+/**
+ * Map from model name to its disk coordinates.
+ * A model may have multiple coordinate sets when data exists under
+ * both the current and a previous UUID (orphan recovery).
+ */
+export type ModelCoordinatesMap = Map<string, ModelCoordinates[]>;
 
 /**
  * Resolves model references to build CEL evaluation context.
@@ -452,11 +352,11 @@ export class ModelResolver {
       context.model[definition.id] = modelData;
     }
 
-    // Build data cache if dataRepo is available.
+    // Build model coordinates map and populate model.resource/file eagerly.
     // Uses findAllGlobal() to discover data from disk first, then matches
     // to definitions. This handles the case where a model was deleted and
     // recreated (new UUID) — data under the old UUID is still found.
-    const dataCache = new DataCache();
+    const coordsMap: ModelCoordinatesMap = new Map();
     if (this.dataRepo) {
       // Build definition lookup maps
       const defById = new Map<
@@ -473,9 +373,17 @@ export class ModelResolver {
         const typeKey = defType.normalized;
         if (!defsByType.has(typeKey)) defsByType.set(typeKey, []);
         defsByType.get(typeKey)!.push({ definition: def, type: defType });
+
+        // Add current definition coordinates
+        const coords: ModelCoordinates = {
+          modelType: defType,
+          modelId: def.id,
+        };
+        if (!coordsMap.has(def.name)) coordsMap.set(def.name, []);
+        coordsMap.get(def.name)!.push(coords);
       }
 
-      // Discover all data on disk
+      // Discover all data on disk for orphan recovery and eager population
       const allGlobalData = await this.dataRepo.findAllGlobal();
 
       // Group data items by (modelType, modelId) — the disk coordinates
@@ -493,7 +401,7 @@ export class ModelResolver {
         groupedData.get(key)!.items.push(data);
       }
 
-      // Match each group to a definition and load data
+      // Match each group to a definition and populate model.resource/file
       for (const [_key, group] of groupedData) {
         const { modelType, modelId, items } = group;
 
@@ -525,93 +433,56 @@ export class ModelResolver {
 
         const modelName = matchedDef.definition.name;
 
-        // Process data items — use disk modelId for all repo calls
-        for (const data of items) {
-          const versions = await this.dataRepo.listVersions(
-            modelType,
-            modelId,
-            data.name,
+        // Add orphan coordinates (disk modelId differs from current definition UUID)
+        if (modelId !== matchedDef.definition.id) {
+          const orphanCoords: ModelCoordinates = { modelType, modelId };
+          if (!coordsMap.has(modelName)) coordsMap.set(modelName, []);
+          const existing = coordsMap.get(modelName)!;
+          const alreadyTracked = existing.some(
+            (c) =>
+              c.modelType.normalized === modelType.normalized &&
+              c.modelId === modelId,
           );
+          if (!alreadyTracked) existing.push(orphanCoords);
+        }
 
-          for (const version of versions) {
-            const versionData = await this.dataRepo.findByName(
+        // Populate model.resource and model.file eagerly (backward compat)
+        const modelData = context.model[modelName];
+        if (modelData) {
+          for (const data of items) {
+            const latestRecord = this.dataToRecord(
+              data,
               modelType,
               modelId,
               data.name,
-              version,
             );
-
-            if (versionData) {
-              // Parse attributes from content if JSON
-              let attributes: Record<string, unknown> = {};
-              if (versionData.contentType === "application/json") {
-                const content = await this.dataRepo.getContent(
-                  modelType,
-                  modelId,
-                  data.name,
-                  version,
-                );
-                if (content) {
-                  try {
-                    attributes = JSON.parse(
-                      new TextDecoder().decode(content),
-                    ) as Record<string, unknown>;
-                  } catch {
-                    // Not valid JSON, use empty attributes
-                  }
-                }
-              }
-
-              const record: DataRecord = {
-                id: versionData.id,
-                name: versionData.name,
-                version: versionData.version,
-                createdAt: versionData.createdAt.toISOString(),
-                attributes,
-                tags: { ...versionData.tags },
-              };
-
-              dataCache.addData(modelName, data.name, version, record);
-            }
-          }
-        }
-
-        // Populate model.resource and model.file from latest data versions
-        const modelData = context.model[modelName];
-        if (modelData) {
-          const dataNames = dataCache.getDataNames(modelName);
-          for (const dataName of dataNames) {
-            const latestRecord = dataCache.getLatest(modelName, dataName);
             if (!latestRecord) continue;
 
             const dataType = latestRecord.tags["type"];
 
             if (dataType === "resource") {
-              // Populate resource context: specName → instanceName → full DataRecord
               if (!modelData.resource) modelData.resource = {};
-              const specName = latestRecord.tags["specName"] ?? dataName;
+              const specName = latestRecord.tags["specName"] ?? data.name;
               if (!modelData.resource[specName]) {
                 modelData.resource[specName] = {};
               }
-              modelData.resource[specName][dataName] = latestRecord;
+              modelData.resource[specName][data.name] = latestRecord;
             } else if (dataType === "file") {
-              // Populate file context: specName → instanceName → file metadata
               if (!modelData.file) modelData.file = {};
-              const specName = latestRecord.tags["specName"] ?? dataName;
+              const specName = latestRecord.tags["specName"] ?? data.name;
               if (!modelData.file[specName]) modelData.file[specName] = {};
-              // Use disk modelId for content path lookup
               const contentPath = this.dataRepo.getContentPath(
                 modelType,
                 modelId,
-                dataName,
-                latestRecord.version as number,
+                data.name,
+                latestRecord.version,
               );
               try {
                 const stat = Deno.statSync(contentPath);
-                modelData.file[specName][dataName] = {
-                  id: latestRecord.id as string,
-                  version: latestRecord.version as number,
-                  createdAt: latestRecord.createdAt as string,
+                modelData.file[specName][data.name] = {
+                  id: latestRecord.id,
+                  version: latestRecord.version,
+                  createdAt: latestRecord.createdAt,
                   path: contentPath,
                   size: stat.size,
                   contentType: latestRecord.tags["contentType"] ??
@@ -626,26 +497,151 @@ export class ModelResolver {
       }
     }
 
-    // Create data namespace with functions that query the cache
+    // Create data namespace with sync disk reads
+    const dataRepo = this.dataRepo;
+    const dataToRecord = this.dataToRecord.bind(this);
     context.data = {
       version: (
         modelName: string,
         dataName: string,
         version: number,
       ): DataRecord | null => {
-        return dataCache.getVersion(modelName, dataName, version);
+        if (!dataRepo) return null;
+        const allCoords = coordsMap.get(modelName);
+        if (!allCoords) return null;
+        for (const { modelType, modelId } of allCoords) {
+          const data = dataRepo.findByNameSync(
+            modelType,
+            modelId,
+            dataName,
+            version,
+          );
+          if (data) {
+            return dataToRecord(data, modelType, modelId, dataName, version);
+          }
+        }
+        return null;
       },
       latest: (modelName: string, dataName: string): DataRecord | null => {
-        return dataCache.getLatest(modelName, dataName);
+        if (!dataRepo) return null;
+        const allCoords = coordsMap.get(modelName);
+        if (!allCoords) return null;
+        for (const { modelType, modelId } of allCoords) {
+          const latestVersion = dataRepo.getLatestVersionSync(
+            modelType,
+            modelId,
+            dataName,
+          );
+          if (latestVersion !== null) {
+            const data = dataRepo.findByNameSync(
+              modelType,
+              modelId,
+              dataName,
+              latestVersion,
+            );
+            if (data) {
+              return dataToRecord(
+                data,
+                modelType,
+                modelId,
+                dataName,
+                latestVersion,
+              );
+            }
+          }
+        }
+        return null;
       },
       listVersions: (modelName: string, dataName: string): number[] => {
-        return dataCache.listVersions(modelName, dataName);
+        if (!dataRepo) return [];
+        const allCoords = coordsMap.get(modelName);
+        if (!allCoords) return [];
+        for (const { modelType, modelId } of allCoords) {
+          const versions = dataRepo.listVersionsSync(
+            modelType,
+            modelId,
+            dataName,
+          );
+          if (versions.length > 0) return versions;
+        }
+        return [];
       },
       findByTag: (tagKey: string, tagValue: string): DataRecord[] => {
-        return dataCache.findByTag(tagKey, tagValue);
+        if (!dataRepo) return [];
+        const results: DataRecord[] = [];
+        const seen = new Set<string>();
+        for (const [, allCoords] of coordsMap) {
+          for (const { modelType, modelId } of allCoords) {
+            // Get all data names, then scan all versions of each
+            const allData = dataRepo.findAllForModelSync(modelType, modelId);
+            for (const data of allData) {
+              const versions = dataRepo.listVersionsSync(
+                modelType,
+                modelId,
+                data.name,
+              );
+              for (const version of versions) {
+                const versionData = dataRepo.findByNameSync(
+                  modelType,
+                  modelId,
+                  data.name,
+                  version,
+                );
+                if (versionData && versionData.tags[tagKey] === tagValue) {
+                  const dedupeKey =
+                    `${modelType.normalized}:${modelId}:${data.name}:${version}`;
+                  if (seen.has(dedupeKey)) continue;
+                  seen.add(dedupeKey);
+                  const record = dataToRecord(
+                    versionData,
+                    modelType,
+                    modelId,
+                    data.name,
+                    version,
+                  );
+                  if (record) results.push(record);
+                }
+              }
+            }
+          }
+        }
+        return results;
       },
       findBySpec: (modelName: string, specName: string): DataRecord[] => {
-        return dataCache.findBySpec(modelName, specName);
+        if (!dataRepo) return [];
+        const allCoords = coordsMap.get(modelName);
+        if (!allCoords) return [];
+        const results: DataRecord[] = [];
+        for (const { modelType, modelId } of allCoords) {
+          // Get all data names, then scan all versions of each
+          const allData = dataRepo.findAllForModelSync(modelType, modelId);
+          for (const data of allData) {
+            const versions = dataRepo.listVersionsSync(
+              modelType,
+              modelId,
+              data.name,
+            );
+            for (const version of versions) {
+              const versionData = dataRepo.findByNameSync(
+                modelType,
+                modelId,
+                data.name,
+                version,
+              );
+              if (versionData && versionData.tags["specName"] === specName) {
+                const record = dataToRecord(
+                  versionData,
+                  modelType,
+                  modelId,
+                  data.name,
+                  version,
+                );
+                if (record) results.push(record);
+              }
+            }
+          }
+        }
+        return results;
       },
     };
 
@@ -761,6 +757,50 @@ export class ModelResolver {
         inputs: definition.inputs,
       };
     }
+  }
+
+  /**
+   * Converts a Data entity to a DataRecord by reading content from disk synchronously.
+   * Used by data.* namespace functions for sync CEL evaluation.
+   */
+  private dataToRecord(
+    data: Data,
+    modelType: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): DataRecord | null {
+    if (!this.dataRepo) return null;
+
+    const resolvedVersion = version ?? data.version;
+    let attributes: Record<string, unknown> = {};
+
+    if (data.contentType === "application/json") {
+      const content = this.dataRepo.getContentSync(
+        modelType,
+        modelId,
+        dataName,
+        resolvedVersion,
+      );
+      if (content) {
+        try {
+          attributes = JSON.parse(
+            new TextDecoder().decode(content),
+          ) as Record<string, unknown>;
+        } catch {
+          // Not valid JSON, use empty attributes
+        }
+      }
+    }
+
+    return {
+      id: data.id,
+      name: data.name,
+      version: resolvedVersion,
+      createdAt: data.createdAt.toISOString(),
+      attributes,
+      tags: { ...data.tags },
+    };
   }
 
   /**

--- a/src/domain/expressions/model_resolver_test.ts
+++ b/src/domain/expressions/model_resolver_test.ts
@@ -18,328 +18,441 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertExists } from "@std/assert";
-import { DataCache, type DataRecord } from "./model_resolver.ts";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { ModelResolver } from "./model_resolver.ts";
+import { Definition } from "../definitions/definition.ts";
+import { Data } from "../data/data.ts";
+import { ModelType } from "../models/model_type.ts";
+import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 
-// Test DataCache
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-resolver-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
 
-Deno.test("DataCache.addData and getVersion retrieves specific version", () => {
-  const cache = new DataCache();
-  const record: DataRecord = {
-    id: "data-123",
-    name: "my-data",
-    version: 1,
-    createdAt: "2024-01-01T00:00:00Z",
-    attributes: { foo: "bar" },
-    tags: { type: "test" },
-  };
+async function setupRepoDir(dir: string): Promise<void> {
+  await ensureDir(join(dir, ".swamp", "data"));
+  await ensureDir(join(dir, ".swamp", "definitions"));
+  await ensureDir(join(dir, ".swamp", "vault"));
+}
 
-  cache.addData("my-model", "my-data", 1, record);
-  const result = cache.getVersion("my-model", "my-data", 1);
+const owner = {
+  ownerType: "model-method" as const,
+  ownerRef: "test/model:test",
+};
 
-  assertExists(result);
-  assertEquals(result.id, "data-123");
-  assertEquals(result.version, 1);
-  assertEquals(result.attributes.foo, "bar");
+// ============================================================================
+// data.latest() reads from disk synchronously
+// ============================================================================
+
+Deno.test("data.latest() reads from disk synchronously", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+
+    const model = Definition.create({
+      name: "my-model",
+      globalArguments: {},
+    });
+    await defRepo.save(type, model);
+
+    const data = Data.create({
+      name: "info",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource" },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      model.id,
+      data,
+      new TextEncoder().encode(JSON.stringify({ value: 42 })),
+    );
+
+    const resolver = new ModelResolver(defRepo, { repoDir, dataRepo });
+    const ctx = await resolver.buildContext();
+
+    assertExists(ctx.data);
+    const result = ctx.data.latest("my-model", "info");
+    assertExists(result);
+    assertEquals(result.attributes.value, 42);
+  });
 });
 
-Deno.test("DataCache.getVersion returns null for missing data", () => {
-  const cache = new DataCache();
-  const result = cache.getVersion("nonexistent", "data", 1);
-  assertEquals(result, null);
+// ============================================================================
+// data.latest() sees data written after buildContext()
+// ============================================================================
+
+Deno.test("data.latest() sees data written after buildContext()", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+
+    const model = Definition.create({
+      name: "fresh-model",
+      globalArguments: {},
+    });
+    await defRepo.save(type, model);
+
+    // Write initial data
+    const data = Data.create({
+      name: "state",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource" },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      model.id,
+      data,
+      new TextEncoder().encode(JSON.stringify({ step: 1 })),
+    );
+
+    // Build context
+    const resolver = new ModelResolver(defRepo, { repoDir, dataRepo });
+    const ctx = await resolver.buildContext();
+
+    // Write new data AFTER context was built
+    await dataRepo.save(
+      type,
+      model.id,
+      data,
+      new TextEncoder().encode(JSON.stringify({ step: 2 })),
+    );
+
+    // data.latest() should see the fresh version (sync disk read)
+    assertExists(ctx.data);
+    const result = ctx.data.latest("fresh-model", "state");
+    assertExists(result);
+    assertEquals(result.attributes.step, 2);
+    assertEquals(result.version, 2);
+  });
 });
 
-Deno.test("DataCache.getLatest returns the highest version", () => {
-  const cache = new DataCache();
+// ============================================================================
+// data.version() reads specific version from disk
+// ============================================================================
 
-  const v1: DataRecord = {
-    id: "data-123",
-    name: "my-data",
-    version: 1,
-    createdAt: "2024-01-01T00:00:00Z",
-    attributes: { value: 1 },
-    tags: { type: "test" },
-  };
-  const v2: DataRecord = {
-    id: "data-123",
-    name: "my-data",
-    version: 2,
-    createdAt: "2024-01-02T00:00:00Z",
-    attributes: { value: 2 },
-    tags: { type: "test" },
-  };
-  const v3: DataRecord = {
-    id: "data-123",
-    name: "my-data",
-    version: 3,
-    createdAt: "2024-01-03T00:00:00Z",
-    attributes: { value: 3 },
-    tags: { type: "test" },
-  };
+Deno.test("data.version() reads specific version from disk", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
 
-  // Add in non-sequential order to test proper max finding
-  cache.addData("my-model", "my-data", 2, v2);
-  cache.addData("my-model", "my-data", 1, v1);
-  cache.addData("my-model", "my-data", 3, v3);
+    const model = Definition.create({
+      name: "versioned",
+      globalArguments: {},
+    });
+    await defRepo.save(type, model);
 
-  const result = cache.getLatest("my-model", "my-data");
-  assertExists(result);
-  assertEquals(result.version, 3);
-  assertEquals(result.attributes.value, 3);
+    const data = Data.create({
+      name: "history",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource" },
+      ownerDefinition: owner,
+    });
+
+    for (let i = 1; i <= 3; i++) {
+      await dataRepo.save(
+        type,
+        model.id,
+        data,
+        new TextEncoder().encode(JSON.stringify({ step: i })),
+      );
+    }
+
+    const resolver = new ModelResolver(defRepo, { repoDir, dataRepo });
+    const ctx = await resolver.buildContext();
+
+    assertExists(ctx.data);
+    const v2 = ctx.data.version("versioned", "history", 2);
+    assertExists(v2);
+    assertEquals(v2.attributes.step, 2);
+    assertEquals(v2.version, 2);
+  });
 });
 
-Deno.test("DataCache.getLatest returns null for missing model", () => {
-  const cache = new DataCache();
-  const result = cache.getLatest("nonexistent", "data");
-  assertEquals(result, null);
+// ============================================================================
+// data.listVersions() returns sorted version numbers
+// ============================================================================
+
+Deno.test("data.listVersions() returns sorted version numbers", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+
+    const model = Definition.create({
+      name: "list-model",
+      globalArguments: {},
+    });
+    await defRepo.save(type, model);
+
+    const data = Data.create({
+      name: "logs",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 100,
+      tags: { type: "log" },
+      ownerDefinition: owner,
+    });
+
+    for (let i = 1; i <= 5; i++) {
+      await dataRepo.save(
+        type,
+        model.id,
+        data,
+        new TextEncoder().encode(`entry ${i}`),
+      );
+    }
+
+    const resolver = new ModelResolver(defRepo, { repoDir, dataRepo });
+    const ctx = await resolver.buildContext();
+
+    assertExists(ctx.data);
+    const versions = ctx.data.listVersions("list-model", "logs");
+    assertEquals(versions, [1, 2, 3, 4, 5]);
+  });
 });
 
-Deno.test("DataCache.listVersions returns sorted version numbers", () => {
-  const cache = new DataCache();
+// ============================================================================
+// data.findByTag() returns matching records
+// ============================================================================
 
-  const v1: DataRecord = {
-    id: "data-123",
-    name: "my-data",
-    version: 1,
-    createdAt: "2024-01-01T00:00:00Z",
-    attributes: {},
-    tags: {},
-  };
-  const v2: DataRecord = {
-    id: "data-123",
-    name: "my-data",
-    version: 2,
-    createdAt: "2024-01-02T00:00:00Z",
-    attributes: {},
-    tags: {},
-  };
-  const v5: DataRecord = {
-    id: "data-123",
-    name: "my-data",
-    version: 5,
-    createdAt: "2024-01-05T00:00:00Z",
-    attributes: {},
-    tags: {},
-  };
+Deno.test("data.findByTag() returns matching records from disk", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
 
-  // Add in non-sequential order
-  cache.addData("my-model", "my-data", 5, v5);
-  cache.addData("my-model", "my-data", 1, v1);
-  cache.addData("my-model", "my-data", 2, v2);
+    const model = Definition.create({
+      name: "tag-model",
+      globalArguments: {},
+    });
+    await defRepo.save(type, model);
 
-  const versions = cache.listVersions("my-model", "my-data");
-  assertEquals(versions, [1, 2, 5]);
+    // Create resource data
+    const resourceData = Data.create({
+      name: "resource-item",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", env: "prod" },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      model.id,
+      resourceData,
+      new TextEncoder().encode(JSON.stringify({ key: "value" })),
+    );
+
+    // Create non-matching data
+    const otherData = Data.create({
+      name: "other-item",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", env: "staging" },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      model.id,
+      otherData,
+      new TextEncoder().encode(JSON.stringify({ key: "other" })),
+    );
+
+    const resolver = new ModelResolver(defRepo, { repoDir, dataRepo });
+    const ctx = await resolver.buildContext();
+
+    assertExists(ctx.data);
+    const prodResults = ctx.data.findByTag("env", "prod");
+    assertEquals(prodResults.length, 1);
+    assertEquals(prodResults[0].name, "resource-item");
+
+    const stagingResults = ctx.data.findByTag("env", "staging");
+    assertEquals(stagingResults.length, 1);
+    assertEquals(stagingResults[0].name, "other-item");
+
+    const noResults = ctx.data.findByTag("env", "dev");
+    assertEquals(noResults.length, 0);
+  });
 });
 
-Deno.test("DataCache.listVersions returns empty array for missing data", () => {
-  const cache = new DataCache();
-  const versions = cache.listVersions("nonexistent", "data");
-  assertEquals(versions, []);
+// ============================================================================
+// data.findByTag() deduplicates across coordinate sets
+// ============================================================================
+
+Deno.test("data.findByTag() deduplicates when data exists under orphan coordinates", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+
+    // Step 1: Create model and save data under its UUID
+    const originalModel = Definition.create({
+      name: "dup-model",
+      globalArguments: {},
+    });
+    await defRepo.save(type, originalModel);
+
+    const data = Data.create({
+      name: "tagged-item",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", env: "prod", modelName: "dup-model" },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      originalModel.id,
+      data,
+      new TextEncoder().encode(JSON.stringify({ v: 1 })),
+    );
+
+    // Step 2: Delete and recreate model with new UUID
+    await defRepo.delete(type, originalModel.id);
+    const recreatedModel = Definition.create({
+      name: "dup-model",
+      globalArguments: {},
+    });
+    await defRepo.save(type, recreatedModel);
+
+    // Step 3: Build context — orphan recovery maps old UUID data to new model name
+    const resolver = new ModelResolver(defRepo, { repoDir, dataRepo });
+    const ctx = await resolver.buildContext();
+
+    assertExists(ctx.data);
+
+    // findByTag should return the record only once, not duplicated
+    const results = ctx.data.findByTag("env", "prod");
+    assertEquals(results.length, 1);
+    assertEquals(results[0].name, "tagged-item");
+  });
 });
 
-Deno.test("DataCache.findByTag returns matching records", () => {
-  const cache = new DataCache();
+// ============================================================================
+// data.findBySpec() returns records matching specName tag
+// ============================================================================
 
-  const logRecord1: DataRecord = {
-    id: "log-1",
-    name: "output-log",
-    version: 1,
-    createdAt: "2024-01-01T00:00:00Z",
-    attributes: { message: "hello" },
-    tags: { type: "log" },
-  };
-  const logRecord2: DataRecord = {
-    id: "log-2",
-    name: "error-log",
-    version: 1,
-    createdAt: "2024-01-02T00:00:00Z",
-    attributes: { message: "error" },
-    tags: { type: "log" },
-  };
-  const dataRecord: DataRecord = {
-    id: "data-1",
-    name: "config",
-    version: 1,
-    createdAt: "2024-01-03T00:00:00Z",
-    attributes: { key: "value" },
-    tags: { type: "config" },
-  };
+Deno.test("data.findBySpec() returns records matching specName tag", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
 
-  cache.addData("model-a", "output-log", 1, logRecord1);
-  cache.addData("model-b", "error-log", 1, logRecord2);
-  cache.addData("model-a", "config", 1, dataRecord);
+    const model = Definition.create({
+      name: "spec-model",
+      globalArguments: {},
+    });
+    await defRepo.save(type, model);
 
-  const logs = cache.findByTag("type", "log");
-  assertEquals(logs.length, 2);
-  assertEquals(logs.some((r) => r.id === "log-1"), true);
-  assertEquals(logs.some((r) => r.id === "log-2"), true);
+    // Create items with specName tag
+    const subnetA = Data.create({
+      name: "subnet-a",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", specName: "subnet" },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      model.id,
+      subnetA,
+      new TextEncoder().encode(JSON.stringify({ cidr: "10.0.1.0/24" })),
+    );
 
-  const configs = cache.findByTag("type", "config");
-  assertEquals(configs.length, 1);
-  assertEquals(configs[0].id, "data-1");
+    const subnetB = Data.create({
+      name: "subnet-b",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", specName: "subnet" },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      model.id,
+      subnetB,
+      new TextEncoder().encode(JSON.stringify({ cidr: "10.0.2.0/24" })),
+    );
+
+    const resolver = new ModelResolver(defRepo, { repoDir, dataRepo });
+    const ctx = await resolver.buildContext();
+
+    assertExists(ctx.data);
+    const results = ctx.data.findBySpec("spec-model", "subnet");
+    assertEquals(results.length, 2);
+    assertEquals(results.some((r) => r.name === "subnet-a"), true);
+    assertEquals(results.some((r) => r.name === "subnet-b"), true);
+  });
 });
 
-Deno.test("DataCache.findByTag returns empty array for no matches", () => {
-  const cache = new DataCache();
-  const result = cache.findByTag("nonexistent", "tag");
-  assertEquals(result, []);
+// ============================================================================
+// Graceful handling of missing models/data
+// ============================================================================
+
+Deno.test("data.* returns null/empty for missing model", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+
+    const resolver = new ModelResolver(defRepo, { repoDir, dataRepo });
+    const ctx = await resolver.buildContext();
+
+    assertExists(ctx.data);
+    assertEquals(ctx.data.latest("nonexistent", "data"), null);
+    assertEquals(ctx.data.version("nonexistent", "data", 1), null);
+    assertEquals(ctx.data.listVersions("nonexistent", "data"), []);
+    assertEquals(ctx.data.findByTag("key", "value"), []);
+    assertEquals(ctx.data.findBySpec("nonexistent", "spec"), []);
+  });
 });
 
-Deno.test("DataCache.getDataNames returns all data names for a model", () => {
-  const cache = new DataCache();
+Deno.test("data.* returns null/empty for missing data name", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
 
-  const data1: DataRecord = {
-    id: "d1",
-    name: "data-a",
-    version: 1,
-    createdAt: "2024-01-01T00:00:00Z",
-    attributes: {},
-    tags: {},
-  };
-  const data2: DataRecord = {
-    id: "d2",
-    name: "data-b",
-    version: 1,
-    createdAt: "2024-01-01T00:00:00Z",
-    attributes: {},
-    tags: {},
-  };
+    const model = Definition.create({
+      name: "empty-model",
+      globalArguments: {},
+    });
+    await defRepo.save(type, model);
 
-  cache.addData("my-model", "data-a", 1, data1);
-  cache.addData("my-model", "data-b", 1, data2);
+    const resolver = new ModelResolver(defRepo, { repoDir, dataRepo });
+    const ctx = await resolver.buildContext();
 
-  const names = cache.getDataNames("my-model");
-  assertEquals(names.length, 2);
-  assertEquals(names.includes("data-a"), true);
-  assertEquals(names.includes("data-b"), true);
-});
-
-Deno.test("DataCache.getDataNames returns empty array for missing model", () => {
-  const cache = new DataCache();
-  const names = cache.getDataNames("nonexistent");
-  assertEquals(names, []);
-});
-
-// DataCache.findBySpec tests
-
-Deno.test("DataCache.findBySpec returns records matching model and specName tag", () => {
-  const cache = new DataCache();
-
-  const subnetA: DataRecord = {
-    id: "sub-1",
-    name: "subnet-a",
-    version: 1,
-    createdAt: "2024-01-01T00:00:00Z",
-    attributes: { cidr: "10.0.1.0/24" },
-    tags: { type: "resource", specName: "subnet" },
-  };
-  const subnetB: DataRecord = {
-    id: "sub-2",
-    name: "subnet-b",
-    version: 1,
-    createdAt: "2024-01-01T00:00:00Z",
-    attributes: { cidr: "10.0.2.0/24" },
-    tags: { type: "resource", specName: "subnet" },
-  };
-  const other: DataRecord = {
-    id: "other-1",
-    name: "vpc",
-    version: 1,
-    createdAt: "2024-01-01T00:00:00Z",
-    attributes: {},
-    tags: { type: "resource", specName: "vpc" },
-  };
-
-  cache.addData("factory-model", "subnet-a", 1, subnetA);
-  cache.addData("factory-model", "subnet-b", 1, subnetB);
-  cache.addData("factory-model", "vpc", 1, other);
-
-  const results = cache.findBySpec("factory-model", "subnet");
-  assertEquals(results.length, 2);
-  assertEquals(results.some((r) => r.name === "subnet-a"), true);
-  assertEquals(results.some((r) => r.name === "subnet-b"), true);
-});
-
-Deno.test("DataCache.findBySpec returns empty array for no matches", () => {
-  const cache = new DataCache();
-  const results = cache.findBySpec("nonexistent", "spec");
-  assertEquals(results, []);
-});
-
-Deno.test("DataCache.findBySpec does not mix models", () => {
-  const cache = new DataCache();
-
-  const recordA: DataRecord = {
-    id: "r1",
-    name: "item-a",
-    version: 1,
-    createdAt: "2024-01-01T00:00:00Z",
-    attributes: {},
-    tags: { specName: "item" },
-  };
-  const recordB: DataRecord = {
-    id: "r2",
-    name: "item-b",
-    version: 1,
-    createdAt: "2024-01-01T00:00:00Z",
-    attributes: {},
-    tags: { specName: "item" },
-  };
-
-  cache.addData("model-a", "item-a", 1, recordA);
-  cache.addData("model-b", "item-b", 1, recordB);
-
-  assertEquals(cache.findBySpec("model-a", "item").length, 1);
-  assertEquals(cache.findBySpec("model-a", "item")[0].name, "item-a");
-  assertEquals(cache.findBySpec("model-b", "item").length, 1);
-  assertEquals(cache.findBySpec("model-b", "item")[0].name, "item-b");
-});
-
-Deno.test("DataCache handles hyphenated model names", () => {
-  const cache = new DataCache();
-  const record: DataRecord = {
-    id: "data-123",
-    name: "my-data",
-    version: 1,
-    createdAt: "2024-01-01T00:00:00Z",
-    attributes: { foo: "bar" },
-    tags: { type: "test" },
-  };
-
-  cache.addData("my-hyphenated-model", "my-data", 1, record);
-  const result = cache.getVersion("my-hyphenated-model", "my-data", 1);
-
-  assertExists(result);
-  assertEquals(result.id, "data-123");
-});
-
-Deno.test("DataCache handles multiple data items per model", () => {
-  const cache = new DataCache();
-
-  const result1: DataRecord = {
-    id: "result-1",
-    name: "result",
-    version: 1,
-    createdAt: "2024-01-01T00:00:00Z",
-    attributes: { output: "hello" },
-    tags: { type: "output" },
-  };
-  const log1: DataRecord = {
-    id: "log-1",
-    name: "execution-log",
-    version: 1,
-    createdAt: "2024-01-01T00:00:00Z",
-    attributes: { entries: [] },
-    tags: { type: "log" },
-  };
-
-  cache.addData("my-model", "result", 1, result1);
-  cache.addData("my-model", "execution-log", 1, log1);
-
-  const resultData = cache.getLatest("my-model", "result");
-  const logData = cache.getLatest("my-model", "execution-log");
-
-  assertExists(resultData);
-  assertExists(logData);
-  assertEquals(resultData.name, "result");
-  assertEquals(logData.name, "execution-log");
+    assertExists(ctx.data);
+    assertEquals(ctx.data.latest("empty-model", "nonexistent"), null);
+    assertEquals(ctx.data.version("empty-model", "nonexistent", 1), null);
+    assertEquals(ctx.data.listVersions("empty-model", "nonexistent"), []);
+  });
 });

--- a/src/domain/models/command/shell/shell_model_test.ts
+++ b/src/domain/models/command/shell/shell_model_test.ts
@@ -201,6 +201,11 @@ function createMockDataRepo(): UnifiedDataRepository {
       Promise.resolve({ version: 1, contentPath: "/tmp/mock" }),
     finalizeVersion: () =>
       Promise.resolve({ size: 0, checksum: "mock-checksum" }),
+    getLatestVersionSync: () => null,
+    findByNameSync: () => null,
+    listVersionsSync: () => [],
+    getContentSync: () => null,
+    findAllForModelSync: () => [],
   };
 }
 

--- a/src/domain/models/data_writer_test.ts
+++ b/src/domain/models/data_writer_test.ts
@@ -56,6 +56,11 @@ function createMockRepo(): UnifiedDataRepository {
       Promise.resolve({ version: 1, contentPath: "/tmp/mock" }),
     finalizeVersion: () =>
       Promise.resolve({ size: 0, checksum: "mock-checksum" }),
+    getLatestVersionSync: () => null,
+    findByNameSync: () => null,
+    listVersionsSync: () => [],
+    getContentSync: () => null,
+    findAllForModelSync: () => [],
   };
 }
 

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -211,6 +211,11 @@ function createMockDataRepo(): UnifiedDataRepository {
       Promise.resolve({ version: 1, contentPath: "/tmp/mock" }),
     finalizeVersion: () =>
       Promise.resolve({ size: 0, checksum: "mock-checksum" }),
+    getLatestVersionSync: () => null,
+    findByNameSync: () => null,
+    listVersionsSync: () => [],
+    getContentSync: () => null,
+    findAllForModelSync: () => [],
   };
 }
 

--- a/src/domain/models/model_test.ts
+++ b/src/domain/models/model_test.ts
@@ -178,6 +178,11 @@ function createMockDataRepo(): UnifiedDataRepository {
       Promise.resolve({ version: 1, contentPath: "/tmp/mock" }),
     finalizeVersion: () =>
       Promise.resolve({ size: 0, checksum: "mock-checksum" }),
+    getLatestVersionSync: () => null,
+    findByNameSync: () => null,
+    listVersionsSync: () => [],
+    getContentSync: () => null,
+    findAllForModelSync: () => [],
   };
 }
 

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -176,6 +176,11 @@ function createMockDataRepo(): UnifiedDataRepository {
       Promise.resolve({ version: 1, contentPath: "/tmp/mock" }),
     finalizeVersion: () =>
       Promise.resolve({ size: 0, checksum: "mock-checksum" }),
+    getLatestVersionSync: () => null,
+    findByNameSync: () => null,
+    listVersionsSync: () => [],
+    getContentSync: () => null,
+    findAllForModelSync: () => [],
   };
 }
 

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -304,7 +304,7 @@ This repository is managed with [swamp](https://github.com/systeminit/swamp).
 1. **Extension models for service integrations.** When automating AWS, APIs, or any external service, ALWAYS create an extension model in \`extensions/models/\`. Use the \`swamp-extension-model\` skill for guidance. The \`command/shell\` model is ONLY for ad-hoc one-off shell commands, NEVER for wrapping CLI tools or building integrations.
 2. **Extend, don't be clever.** Don't work around a missing capability with shell scripts or multi-step hacks. Add a method to the extension model. One method, one purpose.
 3. **Use the data model.** Once data exists in a model (via \`lookup\`, \`start\`, \`sync\`, etc.), reference it with CEL expressions. Don't re-fetch data that's already available.
-4. **CEL expressions everywhere.** Wire models together with \`model.*\` expressions. Always prefer \`model.<name>.resource.<spec>.<instance>.attributes.<field>\` over \`data.latest()\`.
+4. **CEL expressions everywhere.** Wire models together with CEL expressions. Always prefer \`data.latest("<name>", "<dataName>").attributes.<field>\` over the deprecated \`model.<name>.resource.<spec>.<instance>.attributes.<field>\` pattern.
 5. **Verify before destructive operations.** Always \`swamp model get <name> --json\` and verify resource IDs before running delete/stop/destroy methods.
 
 ## Skills

--- a/src/infrastructure/cel/cel_evaluator.ts
+++ b/src/infrastructure/cel/cel_evaluator.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Environment } from "cel-js";
+import { getLogger } from "@logtape/logtape";
 import { InvalidExpressionError } from "../../domain/expressions/errors.ts";
 import { transformHyphenatedModelRefs } from "../../domain/expressions/expression_parser.ts";
 import { composeDataName } from "../../domain/data/mod.ts";
@@ -174,6 +175,7 @@ export class CelDataNamespace {
  */
 export class CelEvaluator {
   private readonly env: Environment;
+  private readonly warnedPatterns = new Set<string>();
 
   constructor() {
     this.env = new Environment({ unlistedVariablesAreDyn: true });
@@ -315,6 +317,9 @@ export class CelEvaluator {
       // Transform hyphenated model names to bracket notation before evaluation
       const transformedExpr = transformHyphenatedModelRefs(expression);
 
+      // Warn about deprecated model.*.resource / model.*.file patterns
+      this.warnDeprecatedPatterns(transformedExpr);
+
       // Wrap file/data namespace objects in registered types so cel-js can
       // resolve receiver methods instead of treating them as maps.
       const wrappedContext = this.wrapNamespaces(context);
@@ -373,5 +378,21 @@ export class CelEvaluator {
       wrapped["data"] = new CelDataNamespace(data as Record<string, unknown>);
     }
     return wrapped;
+  }
+
+  /**
+   * Emits a deprecation warning when an expression uses model.*.resource or
+   * model.*.file patterns. Warnings are deduplicated per expression.
+   */
+  private warnDeprecatedPatterns(expression: string): void {
+    // Match model.X.resource or model["X"].resource (and .file)
+    const pattern = /model(?:\.\w[\w-]*|\["[^"]+"\])\.(?:resource|file)\b/;
+    if (pattern.test(expression)) {
+      if (!this.warnedPatterns.has(expression)) {
+        this.warnedPatterns.add(expression);
+        getLogger(["expressions"])
+          .warn`Deprecated: expression "${expression}" uses model.*.resource or model.*.file which will be removed in a future release. Use data.latest() or data.version() instead.`;
+      }
+    }
   }
 }

--- a/src/infrastructure/cel/cel_evaluator_test.ts
+++ b/src/infrastructure/cel/cel_evaluator_test.ts
@@ -777,13 +777,81 @@ Deno.test("CelEvaluator data.listVersions() with vary dimensions", () => {
   assertEquals(result, [1, 2, 3]);
 });
 
+// Tests for deprecation warnings
+
+Deno.test("CelEvaluator emits deprecation warning for model.X.resource pattern but still evaluates", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    model: {
+      vpc: {
+        resource: {
+          result: {
+            result: {
+              attributes: { vpcId: "vpc-123" },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  // Should still evaluate correctly despite deprecation
+  const result = evaluator.evaluate(
+    "model.vpc.resource.result.result.attributes.vpcId",
+    context,
+  );
+  assertEquals(result, "vpc-123");
+});
+
+Deno.test("CelEvaluator emits deprecation warning for model[X].file pattern but still evaluates", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    model: {
+      "my-model": {
+        file: {
+          config: {
+            path: "/tmp/config.json",
+          },
+        },
+      },
+    },
+  };
+
+  const result = evaluator.evaluate(
+    'model["my-model"].file.config.path',
+    context,
+  );
+  assertEquals(result, "/tmp/config.json");
+});
+
+Deno.test("CelEvaluator does not emit deprecation warning for data.latest() pattern", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    data: {
+      latest: (modelName: string, dataName: string) => {
+        if (modelName === "vpc" && dataName === "info") {
+          return { id: "d1", attributes: { vpcId: "vpc-123" } };
+        }
+        return null;
+      },
+    },
+  };
+
+  // Should work without any deprecation concern
+  const result = evaluator.evaluate(
+    'data.latest("vpc", "info").attributes.vpcId',
+    context,
+  );
+  assertEquals(result, "vpc-123");
+});
+
 Deno.test("CelEvaluator data.version() converts CEL int (bigint) to number for cache lookup", () => {
-  // Regression test: CEL represents integers as bigint, but DataCache uses
-  // number keys. Map.get(1n) !== Map.get(1), so the CelDataNamespace must
-  // convert to Number() before delegating.
+  // Regression test: CEL represents integers as bigint, but the data
+  // functions use number keys. Map.get(1n) !== Map.get(1), so the
+  // CelDataNamespace must convert to Number() before delegating.
   const evaluator = new CelEvaluator();
 
-  // Simulate a DataCache-like delegate that uses strict number equality
+  // Simulate a delegate that uses strict number equality
   const versionStore = new Map<number, Record<string, unknown>>();
   versionStore.set(1, { id: "d1", attributes: { value: "first" } });
   versionStore.set(2, { id: "d2", attributes: { value: "second" } });
@@ -795,7 +863,7 @@ Deno.test("CelEvaluator data.version() converts CEL int (bigint) to number for c
         _dataName: string,
         version: number,
       ) => {
-        // This mirrors DataCache.getVersion() — uses Map.get with number keys
+        // Uses Map.get with number keys — same pattern as sync disk reads
         return versionStore.get(version) ?? null;
       },
     },

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -299,6 +299,77 @@ export interface UnifiedDataRepository {
     type: ModelType,
     modelId: string,
   ): Promise<GarbageCollectionResult>;
+
+  // --- Sync read methods (for CEL expression evaluation) ---
+
+  /**
+   * Gets the latest version number synchronously.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param dataName - The data name
+   * @returns The latest version number, or null if not found
+   */
+  getLatestVersionSync(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+  ): number | null;
+
+  /**
+   * Finds data by name synchronously, optionally for a specific version.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param dataName - The data name
+   * @param version - Optional version (defaults to latest)
+   * @returns The data if found, or null
+   */
+  findByNameSync(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): Data | null;
+
+  /**
+   * Lists all versions for a data name synchronously.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param dataName - The data name
+   * @returns Array of version numbers in ascending order
+   */
+  listVersionsSync(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+  ): number[];
+
+  /**
+   * Gets the full content of data synchronously.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @param dataName - The data name
+   * @param version - Optional version (defaults to latest)
+   * @returns The content or null if not found
+   */
+  getContentSync(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): Uint8Array | null;
+
+  /**
+   * Finds all data for a model synchronously.
+   *
+   * @param type - The model type
+   * @param modelId - The model input ID
+   * @returns Array of data (latest version of each)
+   */
+  findAllForModelSync(type: ModelType, modelId: string): Data[];
 }
 
 /**
@@ -866,6 +937,137 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     return join(this.getPath(type, modelId, dataName, version), "raw");
   }
 
+  // --- Sync read methods ---
+
+  getLatestVersionSync(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+  ): number | null {
+    const latestPath = join(
+      this.getDataNameDir(type, modelId, dataName),
+      "latest",
+    );
+    try {
+      const linkTarget = Deno.readLinkSync(latestPath);
+      const version = parseInt(linkTarget.replace(/\/$/, ""), 10);
+      return isNaN(version) ? null : version;
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        // Fall back to scanning versions
+        const versions = this.listVersionsSync(type, modelId, dataName);
+        return versions.length > 0 ? Math.max(...versions) : null;
+      }
+      throw error;
+    }
+  }
+
+  findByNameSync(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): Data | null {
+    const versionToRead = version ??
+      this.getLatestVersionSync(type, modelId, dataName);
+    if (versionToRead === null) return null;
+
+    const metadataPath = this.getMetadataPath(
+      type,
+      modelId,
+      dataName,
+      versionToRead,
+    );
+    try {
+      const content = Deno.readTextFileSync(metadataPath);
+      const metadata = parseYaml(content) as DataMetadata;
+      return Data.fromData(metadata);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  listVersionsSync(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+  ): number[] {
+    const dataNameDir = this.getDataNameDir(type, modelId, dataName);
+    const versions: number[] = [];
+
+    try {
+      for (const entry of Deno.readDirSync(dataNameDir)) {
+        if (!entry.isDirectory) continue;
+        if (entry.name === "latest") continue;
+
+        const version = parseInt(entry.name, 10);
+        if (!isNaN(version) && version > 0) {
+          versions.push(version);
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+
+    return versions.sort((a, b) => a - b);
+  }
+
+  getContentSync(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): Uint8Array | null {
+    const versionToRead = version ??
+      this.getLatestVersionSync(type, modelId, dataName);
+    if (versionToRead === null) return null;
+
+    const contentPath = this.getContentPath(
+      type,
+      modelId,
+      dataName,
+      versionToRead,
+    );
+    try {
+      return Deno.readFileSync(contentPath);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  findAllForModelSync(type: ModelType, modelId: string): Data[] {
+    const dataDir = this.getModelDataDir(type, modelId);
+    const results: Data[] = [];
+
+    try {
+      for (const entry of Deno.readDirSync(dataDir)) {
+        if (!entry.isDirectory) continue;
+        const dataName = entry.name;
+
+        const data = this.findByNameSync(type, modelId, dataName);
+        if (data) {
+          results.push(data);
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+
+    return results;
+  }
+
   async collectGarbage(
     type: ModelType,
     modelId: string,
@@ -946,7 +1148,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     return result;
   }
 
-  private getDataNameDir(
+  getDataNameDir(
     type: ModelType,
     modelId: string,
     dataName: string,
@@ -1009,7 +1211,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     }
   }
 
-  private getMetadataPath(
+  getMetadataPath(
     type: ModelType,
     modelId: string,
     dataName: string,

--- a/src/infrastructure/persistence/unified_data_repository_test.ts
+++ b/src/infrastructure/persistence/unified_data_repository_test.ts
@@ -17,7 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import {
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
 import { FileSystemUnifiedDataRepository } from "./unified_data_repository.ts";
 import { Data } from "../../domain/data/mod.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
@@ -148,4 +153,186 @@ Deno.test("concurrent save returns unique versions with distinct content", async
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }
+});
+
+// ============================================================================
+// Sync read methods
+// ============================================================================
+
+function makeJsonData(name: string): Data {
+  return Data.create({
+    name,
+    contentType: "application/json",
+    lifetime: "infinite",
+    garbageCollection: 100,
+    tags: { type: "resource" },
+    ownerDefinition: owner,
+  });
+}
+
+Deno.test("getLatestVersionSync reads latest symlink", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new FileSystemUnifiedDataRepository(tmpDir);
+    const data = makeJsonData("sync-latest");
+
+    await repo.save(
+      testType,
+      "model-1",
+      data,
+      new TextEncoder().encode('{"v":1}'),
+    );
+    await repo.save(
+      testType,
+      "model-1",
+      data,
+      new TextEncoder().encode('{"v":2}'),
+    );
+
+    const latest = repo.getLatestVersionSync(
+      testType,
+      "model-1",
+      "sync-latest",
+    );
+    assertEquals(latest, 2);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("getLatestVersionSync returns null for missing data", () => {
+  const repo = new FileSystemUnifiedDataRepository("/tmp/nonexistent-repo");
+  const result = repo.getLatestVersionSync(
+    testType,
+    "missing-model",
+    "missing-data",
+  );
+  assertEquals(result, null);
+});
+
+Deno.test("findByNameSync reads metadata", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new FileSystemUnifiedDataRepository(tmpDir);
+    const data = makeJsonData("sync-find");
+
+    await repo.save(
+      testType,
+      "model-1",
+      data,
+      new TextEncoder().encode('{"key":"value"}'),
+    );
+
+    const result = repo.findByNameSync(testType, "model-1", "sync-find");
+    assertExists(result);
+    assertEquals(result.name, "sync-find");
+    assertEquals(result.contentType, "application/json");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("findByNameSync returns null for missing data", () => {
+  const repo = new FileSystemUnifiedDataRepository("/tmp/nonexistent-repo");
+  const result = repo.findByNameSync(
+    testType,
+    "missing-model",
+    "missing-data",
+  );
+  assertEquals(result, null);
+});
+
+Deno.test("listVersionsSync returns sorted version numbers", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new FileSystemUnifiedDataRepository(tmpDir);
+    const data = makeJsonData("sync-list");
+
+    for (let i = 0; i < 3; i++) {
+      await repo.save(
+        testType,
+        "model-1",
+        data,
+        new TextEncoder().encode(`{"i":${i}}`),
+      );
+    }
+
+    const versions = repo.listVersionsSync(testType, "model-1", "sync-list");
+    assertEquals(versions, [1, 2, 3]);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("listVersionsSync returns empty for missing data", () => {
+  const repo = new FileSystemUnifiedDataRepository("/tmp/nonexistent-repo");
+  const versions = repo.listVersionsSync(
+    testType,
+    "missing-model",
+    "missing-data",
+  );
+  assertEquals(versions, []);
+});
+
+Deno.test("getContentSync reads content bytes", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new FileSystemUnifiedDataRepository(tmpDir);
+    const data = makeJsonData("sync-content");
+    const content = new TextEncoder().encode('{"hello":"world"}');
+
+    await repo.save(testType, "model-1", data, content);
+
+    const result = repo.getContentSync(testType, "model-1", "sync-content");
+    assertExists(result);
+    assertEquals(new TextDecoder().decode(result), '{"hello":"world"}');
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("getContentSync returns null for missing content", () => {
+  const repo = new FileSystemUnifiedDataRepository("/tmp/nonexistent-repo");
+  const result = repo.getContentSync(
+    testType,
+    "missing-model",
+    "missing-data",
+  );
+  assertEquals(result, null);
+});
+
+Deno.test("findAllForModelSync returns all data items", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new FileSystemUnifiedDataRepository(tmpDir);
+
+    const data1 = makeJsonData("item-a");
+    const data2 = makeJsonData("item-b");
+
+    await repo.save(
+      testType,
+      "model-1",
+      data1,
+      new TextEncoder().encode('{"a":1}'),
+    );
+    await repo.save(
+      testType,
+      "model-1",
+      data2,
+      new TextEncoder().encode('{"b":2}'),
+    );
+
+    const results = repo.findAllForModelSync(testType, "model-1");
+    assertEquals(results.length, 2);
+    const names = results.map((d) => d.name).sort();
+    assertEquals(names, ["item-a", "item-b"]);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("findAllForModelSync returns empty for missing model", () => {
+  const repo = new FileSystemUnifiedDataRepository("/tmp/nonexistent-repo");
+  const results = repo.findAllForModelSync(testType, "missing-model");
+  assertEquals(results, []);
 });

--- a/src/infrastructure/repo/symlink_repo_index_service_test.ts
+++ b/src/infrastructure/repo/symlink_repo_index_service_test.ts
@@ -115,6 +115,11 @@ function createStubUnifiedDataRepo(
     getPath: notImplemented,
     getContentPath: notImplemented,
     collectGarbage: notImplemented,
+    getLatestVersionSync: () => null,
+    findByNameSync: () => null,
+    listVersionsSync: () => [],
+    getContentSync: () => null,
+    findAllForModelSync: () => [],
   };
 }
 


### PR DESCRIPTION
Closes #434

## Summary

- Remove the `DataCache` class and replace with direct synchronous disk reads via Deno's sync filesystem APIs
- `data.latest()` now always returns fresh on-disk state instead of reading from a snapshot taken at `buildContext()` time
- `model.*.resource` and `model.*.file` CEL patterns are deprecated with warnings but still work for backward compatibility

## Why this is the right move

**The DataCache was an implementation accident, not a design choice.** It existed solely because CEL evaluation is synchronous but all `UnifiedDataRepository` methods were async. Deno provides sync filesystem APIs (`readTextFileSync`, `readLinkSync`, `readDirSync`, `readFileSync`), making the cache unnecessary complexity.

**Simplicity of reasoning.** Before this change, users and contributors had to think about "which accessor sees what data when" — `data.latest()` read from a cache snapshot taken at `buildContext()` time, and `model.*.resource` was eagerly populated from a `findAllGlobal()` scan. After this change, `data.latest()` always means "read the latest from disk" — no hidden staleness, no snapshot timing to reason about. The behavior is obvious.

**Alpha is the right time.** The user base is small, `model.*.resource` is embedded in docs/skills/examples, and this kind of simplification only gets harder later. We keep backward compatibility with deprecation warnings so nothing breaks immediately.

**The alternative is worse.** Keeping the cache but updating it after each workflow step would leave unnecessary abstraction in place, add update logic, and make the code harder to reason about ("is the cache up to date? when was it last refreshed?"). Removing it entirely is cleaner.

## What changed

### Core implementation

- **Removed `DataCache` class** from `model_resolver.ts` — the unnecessary abstraction that bridged sync CEL with async repo methods
- **Added `ModelCoordinates` interface and `ModelCoordinatesMap` type** — maps model names to disk coordinates (modelType + modelId), supporting orphan recovery when models are deleted and recreated with new UUIDs
- **Added 5 sync methods** to `UnifiedDataRepository` interface and `FileSystemUnifiedDataRepository`:
  - `getLatestVersionSync` — reads `latest` symlink, falls back to dir scan
  - `findByNameSync` — resolves version, reads metadata.yaml
  - `listVersionsSync` — scans version directories
  - `getContentSync` — reads raw content file
  - `findAllForModelSync` — scans all data names for a model
- **Rewrote `data.*` CEL namespace functions** to use sync disk reads instead of cache lookups
- **Fixed `findByTag` deduplication** — prevents duplicate records when data exists under both current and orphan coordinates
- **Fixed `findByTag`/`findBySpec` to scan all versions** — not just latest

### Deprecation

- **Added deprecation warnings** in `CelEvaluator` for `model.*.resource` and `model.*.file` patterns via LogTape logger with deduplication
- `model.*.resource` and `model.*.file` are still eagerly populated in `buildContext()` for backward compatibility — they work but emit warnings
- `model.*.input`, `model.*.definition`, `model.*.execution` are **NOT deprecated** — these are model metadata, not versioned data

### Documentation

- Updated `design/expressions.md` and `design/vaults.md` — examples use `data.latest()` instead of deprecated patterns
- Updated `repo_service.ts` CLAUDE.md guidance — now recommends `data.latest()` over `model.*.resource`
- Updated skill references (swamp-model, swamp-workflow) — marked `data.latest()` as preferred, `model.*.resource` as deprecated

### Tests

- Rewrote `model_resolver_test.ts` — removed DataCache tests, added 8+ sync behavior tests including deduplication and post-buildContext freshness
- Added 8 sync method tests to `unified_data_repository_test.ts`
- Added 3 deprecation warning tests to `cel_evaluator_test.ts`
- Added integration test verifying `data.latest()` sees data written after `buildContext()`
- Fixed 6 mock files to implement new sync interface methods

## Plan vs implementation

All 5 planned steps were fully implemented as designed:

| Step | Planned | Result |
|------|---------|--------|
| 1. Add sync read methods to repo | 5 sync methods + make helpers public | Fully implemented |
| 2. Remove DataCache, rewrite data.* functions | Delete cache, add coords map, sync reads | Fully implemented |
| 3. Add deprecation warnings | Regex detection, LogTape logger, dedup | Fully implemented |
| 4. Update tests | Remove cache tests, add sync tests | Fully implemented |
| 5. Update documentation | Design docs, skill refs, repo guidance | Fully implemented |

**Three unplanned items** were discovered and fixed during testing:

1. **6 mock `UnifiedDataRepository` implementations** needed sync method stubs to pass type checking
2. **`findByTag`/`findBySpec`** initially only scanned latest version — fixed to scan all versions
3. **`findByTag`** needed deduplication logic to prevent duplicate records when data exists under both current and orphan coordinates

## Known trade-off

`findByTag()` and `findBySpec()` scan all metadata files synchronously on every call — O(total_data_items). This is acceptable for alpha: these functions are rarely used compared to `data.latest()`, the data is local filesystem (not network I/O), and if performance becomes a problem the fix (lightweight tag index during `findAllGlobal()`) is well-understood.

## User impact

- **`data.latest()` now always returns fresh data** — no more stale snapshots from `buildContext()` time. If step A writes data, step B's `data.latest()` sees it immediately.
- **`model.*.resource`/`model.*.file` still work** but emit deprecation warnings; users should migrate to `data.latest()`
- **No breaking changes** — all existing workflows and models continue to work without modification
- **Vary dimensions fully supported** via `data.latest()` 3-argument form
- **Migration path is clear** — replace `model.<name>.resource.<spec>.<instance>.attributes.<field>` with `data.latest("<name>", "<dataName>").attributes.<field>`

## Test plan

- [x] `deno check` — passes
- [x] `deno lint` — passes
- [x] `deno fmt` — passes
- [x] `deno run test` — 1926 tests, 0 failures
- [x] `deno run compile` — binary compiles successfully
- [x] Integration tests for `cel_data_access` — 20/20 pass
- [x] Integration tests for `data_tagging` — 13/13 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)