### PR TITLE
docs: document external dependency support in extension models

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -307,7 +307,10 @@ Files are classified by export name: `export const model` defines new types,
 
 1. **Export**: Use `export const model = { ... }` for new types or
    `export const extension = { ... }` for extending existing types
-2. **Import**: Only `import { z } from "npm:zod@4";` is needed
+2. **Import**: `import { z } from "npm:zod@4";` is always required. Any
+   Deno-compatible import (`npm:`, `jsr:`, `https://`) can also be used — swamp
+   bundles all dependencies automatically (see
+   [references/examples.md](references/examples.md#using-external-dependencies))
 3. **Type naming**: Use `@<namespace>/<name>` format (e.g., `@user/my-model`)
 4. **No type annotations**: Avoid TypeScript types in execute parameters
 5. **File naming**: Use snake_case (`my_model.ts`)

--- a/.claude/skills/swamp-extension-model/references/examples.md
+++ b/.claude/skills/swamp-extension-model/references/examples.md
@@ -9,7 +9,95 @@
 - [Data Chaining Model](#data-chaining-model)
 - [Shell Command with Streamed Logging](#shell-command-with-streamed-logging)
 - [AWS Model with Pre-flight Credential Check](#aws-model-with-pre-flight-credential-check)
+- [Using External Dependencies](#using-external-dependencies)
 - [Extending Existing Model Types](#extending-existing-model-types)
+
+## Using External Dependencies
+
+Extension models are written in TypeScript and can import any package using
+Deno's import specifiers: `npm:`, `jsr:`, or `https://` URLs. Swamp
+automatically bundles the TypeScript source and all dependencies into a single
+JavaScript file at startup — no install step required.
+
+The bundler resolves and inlines all dependencies except `zod`, which is shared
+with swamp to preserve schema `instanceof` checks.
+
+```typescript
+// extensions/models/text_analyzer.ts
+import { z } from "npm:zod@4";
+import { countBy, sortBy, words } from "npm:lodash-es";
+
+const GlobalArgsSchema = z.object({
+  text: z.string().describe("Text to analyze"),
+});
+
+const AnalysisSchema = z.object({
+  wordCount: z.number(),
+  topWords: z.array(z.object({
+    word: z.string(),
+    count: z.number(),
+  })),
+  analyzedAt: z.string(),
+});
+
+export const model = {
+  type: "@user/text-analyzer",
+  version: "2026.02.24.1",
+  globalArguments: GlobalArgsSchema,
+  resources: {
+    "analysis": {
+      description: "Text analysis results",
+      schema: AnalysisSchema,
+      lifetime: "infinite",
+      garbageCollection: 10,
+    },
+  },
+  methods: {
+    analyze: {
+      description: "Analyze word frequency in the text",
+      arguments: z.object({
+        topN: z.number().default(5),
+      }),
+      execute: async (args, context) => {
+        const allWords = words(context.globalArgs.text.toLowerCase());
+        const counts = countBy(allWords);
+        const sorted = sortBy(
+          Object.entries(counts).map(([word, count]) => ({ word, count })),
+          (entry) => -entry.count,
+        );
+
+        const handle = await context.writeResource("analysis", "analysis", {
+          wordCount: allWords.length,
+          topWords: sorted.slice(0, args.topN),
+          analyzedAt: new Date().toISOString(),
+        });
+        return { dataHandles: [handle] };
+      },
+    },
+  },
+};
+```
+
+**How bundling works:**
+
+- On first run (or after editing), swamp runs `deno bundle` to transpile your
+  TypeScript and resolve all `npm:` imports into a single `.js` file
+- The bundle is cached to `.swamp/bundles/` — subsequent runs skip bundling
+  unless the source file's modification time is newer than the cached bundle
+- `npm:zod` is externalized (not bundled) so your model shares the same zod
+  instance as swamp, which is required for schema validation to work
+- All other npm imports are fully resolved and inlined into the bundle
+
+**Import rules:**
+
+| Import                                   | Bundled? | Notes                            |
+| ---------------------------------------- | -------- | -------------------------------- |
+| `npm:zod@4`                              | No       | Shared with swamp (externalized) |
+| `npm:lodash-es`                          | Yes      | Resolved and inlined             |
+| `npm:@aws-sdk/client-s3`                 | Yes      | Resolved and inlined             |
+| `jsr:@std/path`                          | Yes      | Resolved and inlined             |
+| `https://deno.land/std@0.224.0/async/..` | Yes      | Resolved and inlined             |
+| Any other Deno-compatible import         | Yes      | Resolved and inlined             |
 
 ## CRUD Lifecycle Model (VPC)
 


### PR DESCRIPTION
## Summary

- Document that extension models support all Deno-compatible imports (`npm:`, `jsr:`, `https://`), not just `npm:zod@4`
- Add a verified `lodash-es` example showing npm package usage in a model
- Explain how the bundling pipeline works (auto-bundle, mtime cache, zod externalization)
- Add import rules table covering all supported specifiers

## Context

PR #452 embedded the deno runtime and added `deno bundle` for extension model
transpilation. This made it possible for extension models to use any npm (or
jsr/https) dependency — the bundler resolves and inlines everything except zod
(which is externalized to share `instanceof` checks with swamp).

However, the `swamp-extension-model` skill only documented
`import { z } from "npm:zod@4"` as the sole import, giving the impression that
no other dependencies were available. Users and Claude had no guidance on how to
bring in external packages.

All three import specifiers were tested against the actual bundler:
- `npm:lodash-es` — bundles (298KB, 641 modules)
- `jsr:@std/path` — bundles (8.8KB, 73 modules)
- `https://deno.land/std@0.224.0/async/delay.ts` — bundles (1.2KB, 2 modules)

## Changes

**`.claude/skills/swamp-extension-model/SKILL.md`**
- Updated Key Rules #2 to mention `npm:`, `jsr:`, `https://` imports with a
  link to the examples reference

**`.claude/skills/swamp-extension-model/references/examples.md`**
- Added "Using External Dependencies" section with:
  - A complete, verified `lodash-es` text analyzer model example
  - "How bundling works" explanation (deno bundle, mtime cache, zod externalization)
  - Import rules table showing what gets bundled vs externalized
- Updated table of contents with correct anchor link

## Test plan

- [ ] Verify the lodash-es example bundles: `deno bundle --external npm:zod@4 --external npm:zod --platform deno -o /tmp/test.js extensions/models/text_analyzer.ts`
- [ ] Verify skill SKILL.md link to `#using-external-dependencies` resolves correctly
- [ ] Review that SKILL.md stays lean (detail in references, per skill-creator guidelines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)