### PR TITLE
fix: store auth.json in XDG config dir alongside identity.json

### DIFF
--- a/src/infrastructure/persistence/auth_repository.ts
+++ b/src/infrastructure/persistence/auth_repository.ts
@@ -19,18 +19,19 @@
 
 import { join } from "@std/path";
 import { atomicWriteTextFile } from "./atomic_write.ts";
-import { getSwampDataDir } from "./paths.ts";
+import { getSwampConfigDir } from "./paths.ts";
 import type { AuthCredentials } from "../../domain/auth/auth_credentials.ts";
 
 const AUTH_FILE = "auth.json";
 
 /**
  * Repository for managing swamp-club authentication credentials.
- * Stores API key and server info at ~/.swamp/auth.json.
+ * Stores API key and server info at ~/.config/swamp/auth.json
+ * (or $XDG_CONFIG_HOME/swamp/auth.json).
  */
 export class AuthRepository {
   private getAuthPath(): string {
-    return join(getSwampDataDir(), AUTH_FILE);
+    return join(getSwampConfigDir(), AUTH_FILE);
   }
 
   /** Read stored auth credentials. Returns null if not found. */
@@ -48,8 +49,8 @@ export class AuthRepository {
 
   /** Write auth credentials to disk. Creates directory if needed. */
   async save(credentials: AuthCredentials): Promise<void> {
-    const dataDir = getSwampDataDir();
-    await Deno.mkdir(dataDir, { recursive: true });
+    const configDir = getSwampConfigDir();
+    await Deno.mkdir(configDir, { recursive: true });
     await atomicWriteTextFile(
       this.getAuthPath(),
       JSON.stringify(credentials, null, 2) + "\n",

--- a/src/infrastructure/persistence/auth_repository_test.ts
+++ b/src/infrastructure/persistence/auth_repository_test.ts
@@ -30,9 +30,9 @@ const TEST_CREDENTIALS: AuthCredentials = {
 
 Deno.test("AuthRepository - save and load round trip", async () => {
   const tmpDir = await Deno.makeTempDir();
-  const originalHome = Deno.env.get("HOME");
+  const originalXdg = Deno.env.get("XDG_CONFIG_HOME");
   try {
-    Deno.env.set("HOME", tmpDir);
+    Deno.env.set("XDG_CONFIG_HOME", tmpDir);
     const repo = new AuthRepository();
 
     await repo.save(TEST_CREDENTIALS);
@@ -44,33 +44,33 @@ Deno.test("AuthRepository - save and load round trip", async () => {
     assertEquals(loaded.apiKeyId, TEST_CREDENTIALS.apiKeyId);
     assertEquals(loaded.username, TEST_CREDENTIALS.username);
   } finally {
-    if (originalHome) Deno.env.set("HOME", originalHome);
-    else Deno.env.delete("HOME");
+    if (originalXdg) Deno.env.set("XDG_CONFIG_HOME", originalXdg);
+    else Deno.env.delete("XDG_CONFIG_HOME");
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
 
 Deno.test("AuthRepository - load returns null when no file exists", async () => {
   const tmpDir = await Deno.makeTempDir();
-  const originalHome = Deno.env.get("HOME");
+  const originalXdg = Deno.env.get("XDG_CONFIG_HOME");
   try {
-    Deno.env.set("HOME", tmpDir);
+    Deno.env.set("XDG_CONFIG_HOME", tmpDir);
     const repo = new AuthRepository();
 
     const loaded = await repo.load();
     assertEquals(loaded, null);
   } finally {
-    if (originalHome) Deno.env.set("HOME", originalHome);
-    else Deno.env.delete("HOME");
+    if (originalXdg) Deno.env.set("XDG_CONFIG_HOME", originalXdg);
+    else Deno.env.delete("XDG_CONFIG_HOME");
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
 
 Deno.test("AuthRepository - delete removes credentials", async () => {
   const tmpDir = await Deno.makeTempDir();
-  const originalHome = Deno.env.get("HOME");
+  const originalXdg = Deno.env.get("XDG_CONFIG_HOME");
   try {
-    Deno.env.set("HOME", tmpDir);
+    Deno.env.set("XDG_CONFIG_HOME", tmpDir);
     const repo = new AuthRepository();
 
     await repo.save(TEST_CREDENTIALS);
@@ -79,24 +79,24 @@ Deno.test("AuthRepository - delete removes credentials", async () => {
     await repo.delete();
     assertEquals(await repo.load(), null);
   } finally {
-    if (originalHome) Deno.env.set("HOME", originalHome);
-    else Deno.env.delete("HOME");
+    if (originalXdg) Deno.env.set("XDG_CONFIG_HOME", originalXdg);
+    else Deno.env.delete("XDG_CONFIG_HOME");
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
 
 Deno.test("AuthRepository - delete is idempotent (no error when missing)", async () => {
   const tmpDir = await Deno.makeTempDir();
-  const originalHome = Deno.env.get("HOME");
+  const originalXdg = Deno.env.get("XDG_CONFIG_HOME");
   try {
-    Deno.env.set("HOME", tmpDir);
+    Deno.env.set("XDG_CONFIG_HOME", tmpDir);
     const repo = new AuthRepository();
 
     // Should not throw
     await repo.delete();
   } finally {
-    if (originalHome) Deno.env.set("HOME", originalHome);
-    else Deno.env.delete("HOME");
+    if (originalXdg) Deno.env.set("XDG_CONFIG_HOME", originalXdg);
+    else Deno.env.delete("XDG_CONFIG_HOME");
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
@@ -104,19 +104,19 @@ Deno.test("AuthRepository - delete is idempotent (no error when missing)", async
 Deno.test("AuthRepository - save sets restrictive file permissions", async () => {
   if (Deno.build.os === "windows") return; // mode not enforced on Windows
   const tmpDir = await Deno.makeTempDir();
-  const originalHome = Deno.env.get("HOME");
+  const originalXdg = Deno.env.get("XDG_CONFIG_HOME");
   try {
-    Deno.env.set("HOME", tmpDir);
+    Deno.env.set("XDG_CONFIG_HOME", tmpDir);
     const repo = new AuthRepository();
 
     await repo.save(TEST_CREDENTIALS);
 
-    const stat = await Deno.stat(`${tmpDir}/.swamp/auth.json`);
+    const stat = await Deno.stat(`${tmpDir}/swamp/auth.json`);
     // mode 0o600 = owner read/write only
     assertEquals(stat.mode !== null && (stat.mode & 0o777) === 0o600, true);
   } finally {
-    if (originalHome) Deno.env.set("HOME", originalHome);
-    else Deno.env.delete("HOME");
+    if (originalXdg) Deno.env.set("XDG_CONFIG_HOME", originalXdg);
+    else Deno.env.delete("XDG_CONFIG_HOME");
     await Deno.remove(tmpDir, { recursive: true });
   }
 });

--- a/src/infrastructure/persistence/paths.ts
+++ b/src/infrastructure/persistence/paths.ts
@@ -133,9 +133,9 @@ export function toAbsolutePath(repoDir: string, relativePath: string): string {
 /**
  * Returns the user-level swamp data directory (`~/.swamp/`).
  *
- * This directory stores operational data like auth credentials, installed
- * binaries, and downloaded source code. Distinct from the XDG config
- * directory which stores identity configuration.
+ * This directory stores operational data like installed binaries and
+ * downloaded source code. Distinct from the XDG config directory which
+ * stores identity and auth configuration.
  *
  * @returns The absolute path to the ~/.swamp directory
  * @throws Error if HOME environment variable is not set


### PR DESCRIPTION
## Summary

- Moves auth credentials storage from `~/.swamp/auth.json` to `~/.config/swamp/auth.json` (or `$XDG_CONFIG_HOME/swamp/auth.json`)
- All user-level config (identity + auth) now lives in the same XDG-compliant directory
- Updates tests to use `XDG_CONFIG_HOME` instead of `HOME` for consistent path resolution

## Test Plan

- All 2021 existing tests pass
- Auth repository tests verify save/load/delete at the new XDG config path
- File permission test confirms `0o600` mode at the new location

🤖 Generated with [Claude Code](https://claude.com/claude-code)