### PR TITLE
fix: audit and wrap all CLI errors in UserError to suppress stack traces

### DIFF
--- a/src/cli/commands/auth_login.ts
+++ b/src/cli/commands/auth_login.ts
@@ -102,7 +102,8 @@ async function browserFlow(serverUrl: string): Promise<string> {
     if (err instanceof UserError) {
       console.log(err.message);
     } else {
-      throw err;
+      const message = err instanceof Error ? err.message : String(err);
+      throw new UserError(`Failed to open browser: ${message}`);
     }
   }
 

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -146,7 +146,7 @@ export const modelMethodRunCommand = new Command()
           const errorMessages = validationResult.errors
             .map((e) => `  ${e.message}`)
             .join("\n");
-          throw new Error(`Input validation failed:\n${errorMessages}`);
+          throw new UserError(`Input validation failed:\n${errorMessages}`);
         }
         // Use inputs with defaults applied
         Object.assign(inputs, inputsWithDefaults);

--- a/src/cli/commands/vault_edit.ts
+++ b/src/cli/commands/vault_edit.ts
@@ -153,7 +153,10 @@ export const vaultEditCommand = new Command()
           `Vault configuration file not found at: ${filePath}`,
         );
       }
-      throw error;
+      const message = error instanceof Error ? error.message : String(error);
+      throw new UserError(
+        `Failed to access vault configuration file: ${message}`,
+      );
     }
 
     ctx.logger.debug`Opening file: ${filePath}`;

--- a/src/cli/commands/workflow_evaluate.ts
+++ b/src/cli/commands/workflow_evaluate.ts
@@ -28,6 +28,7 @@ import { createContext, type GlobalOptions } from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { parseInputs } from "../input_parser.ts";
 import { InputValidationService } from "../../domain/inputs/mod.ts";
+import { UserError } from "../../domain/errors.ts";
 import { containsRuntimeExpression } from "../../domain/expressions/expression_evaluation_service.ts";
 import { YamlEvaluatedWorkflowRepository } from "../../infrastructure/persistence/yaml_evaluated_workflow_repository.ts";
 import {
@@ -124,7 +125,7 @@ export const workflowEvaluateCommand = new Command()
         await workflowRepo.findById(createWorkflowId(workflowIdOrName));
 
       if (!workflow) {
-        throw new Error(`Workflow not found: ${workflowIdOrName}`);
+        throw new UserError(`Workflow not found: ${workflowIdOrName}`);
       }
 
       // Validate inputs against workflow schema if provided
@@ -142,7 +143,7 @@ export const workflowEvaluateCommand = new Command()
           const errorMessages = validationResult.errors
             .map((e) => `  ${e.message}`)
             .join("\n");
-          throw new Error(`Input validation failed:\n${errorMessages}`);
+          throw new UserError(`Input validation failed:\n${errorMessages}`);
         }
         // Use inputs with defaults applied
         Object.assign(inputs, inputsWithDefaults);

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -230,7 +230,7 @@ export const workflowRunCommand = new Command()
           const errorMessages = validationResult.errors
             .map((e) => `  ${e.message}`)
             .join("\n");
-          throw new Error(`Input validation failed:\n${errorMessages}`);
+          throw new UserError(`Input validation failed:\n${errorMessages}`);
         }
         // Use inputs with defaults applied
         Object.assign(inputs, inputsWithDefaults);

--- a/src/cli/input_parser.ts
+++ b/src/cli/input_parser.ts
@@ -19,6 +19,7 @@
 
 import { parse as parseYaml } from "@std/yaml";
 import type { InputsSchema } from "../domain/definitions/definition.ts";
+import { UserError } from "../domain/errors.ts";
 
 /**
  * Result of parsing inputs.
@@ -76,11 +77,14 @@ async function resolveFileValue(
     return await Deno.readTextFile(resolvedPath);
   } catch (error) {
     if (error instanceof Deno.errors.NotFound) {
-      throw new Error(
+      throw new UserError(
         `Input file not found for key "${key}": ${resolvedPath}`,
       );
     }
-    throw error;
+    const message = error instanceof Error ? error.message : String(error);
+    throw new UserError(
+      `Failed to read input file for key "${key}": ${message}`,
+    );
   }
 }
 
@@ -100,14 +104,14 @@ export async function parseKeyValueInputs(
   for (const entry of entries) {
     const eqIndex = entry.indexOf("=");
     if (eqIndex === -1) {
-      throw new Error(
+      throw new UserError(
         `Invalid input format: "${entry}". Expected key=value format.`,
       );
     }
 
     const key = entry.slice(0, eqIndex);
     if (key === "") {
-      throw new Error(`Invalid input: empty key in "${entry}".`);
+      throw new UserError(`Invalid input: empty key in "${entry}".`);
     }
 
     let value: string = entry.slice(eqIndex + 1);
@@ -225,14 +229,15 @@ async function parseInputFile(
     if (
       typeof parsed !== "object" || parsed === null || Array.isArray(parsed)
     ) {
-      throw new Error("Input file must contain a YAML object");
+      throw new UserError("Input file must contain a YAML object");
     }
     return parsed as Record<string, unknown>;
   } catch (error) {
     if (error instanceof Deno.errors.NotFound) {
-      throw new Error(`Input file not found: ${inputFile}`);
+      throw new UserError(`Input file not found: ${inputFile}`);
     }
-    throw error;
+    const message = error instanceof Error ? error.message : String(error);
+    throw new UserError(`Failed to read input file: ${message}`);
   }
 }
 
@@ -263,7 +268,7 @@ export async function parseInputs(options: {
       if (
         typeof parsed !== "object" || parsed === null || Array.isArray(parsed)
       ) {
-        throw new Error("Input must be a JSON object");
+        throw new UserError("Input must be a JSON object");
       }
       return {
         inputs: parsed as Record<string, unknown>,
@@ -271,9 +276,10 @@ export async function parseInputs(options: {
       };
     } catch (error) {
       if (error instanceof SyntaxError) {
-        throw new Error(`Invalid JSON in --input: ${error.message}`);
+        throw new UserError(`Invalid JSON in --input: ${error.message}`);
       }
-      throw error;
+      const msg = error instanceof Error ? error.message : String(error);
+      throw new UserError(`Invalid input: ${msg}`);
     }
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #464. Comprehensive audit of all CLI commands to find and fix remaining places where stack traces leak to users through bare `Error` throws.

While #464 fixed the `model method run` catch block, the same pattern existed across the entire CLI layer — validation errors, not-found errors, and input parsing errors all used bare `Error` and exposed stack traces.

**Before:**
```
error: Uncaught (in promise) Error: Input validation failed:
  Missing required input: filePath
    at Object.action (file:///...model_method_run.ts:149:17)
    at Command.execute (file:///...command.ts:1023:24)
    ...
```

**After:**
```
error: Input validation failed:
  Missing required input: filePath
```

## Changes

### Command files
- **`model_method_run.ts`** — Input validation error now throws `UserError`
- **`workflow_evaluate.ts`** — "Workflow not found" and input validation error now throw `UserError` (added import)
- **`workflow_run.ts`** — Input validation error now throws `UserError` directly instead of being caught and re-wrapped with a misleading "Workflow execution failed:" prefix
- **`vault_edit.ts`** — Re-thrown filesystem error now wrapped in `UserError` with context
- **`auth_login.ts`** — Re-thrown browser open error now wrapped in `UserError` with context

### Shared infrastructure
- **`input_parser.ts`** — All 7 user-facing errors converted to `UserError` (added import):
  - Invalid input format (missing `=`)
  - Empty key in input
  - Input file not found (both `@file` references and `--input-file`)
  - Failed to read input file
  - Invalid YAML file format
  - Invalid JSON input
  - Non-object JSON input

## User impact

- All expected error conditions now show clean, message-only output — no stack traces
- Affects every command that accepts `--input`, `--input-file`, or does validation
- Full error details remain in model output logs and run log files for debugging

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt` — formatting passes
- [x] `deno run test` — all 2021 tests pass (`UserError extends Error` so existing `assertRejects(..., Error, ...)` assertions still work)
- [x] `deno run compile` — binary compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Blake Irvin <bixu@users.noreply.github.com>