### PR TITLE
fix: strip build metadata from deno version in embedded runtime download

### DIFF
--- a/scripts/download_deno.ts
+++ b/scripts/download_deno.ts
@@ -68,7 +68,9 @@ async function getDenoVersion(): Promise<string> {
   if (!match) {
     throw new Error(`Cannot parse deno version from: ${text}`);
   }
-  return match[1];
+  // Strip build metadata suffix (e.g. "2.7.0+fb4db33" → "2.7.0")
+  // GitHub releases use semver without build metadata
+  return match[1].replace(/\+.*$/, "");
 }
 
 /** Downloads a file from a URL, returning the bytes. */


### PR DESCRIPTION
## Summary

Fixes the release workflow failure: https://github.com/systeminit/swamp/actions/runs/22400151598/job/64844202816

## Problem

Deno 2.7.0 started including build metadata in its version string (semver `+build` suffix):

```
deno 2.7.0+fb4db33
```

The `download_deno.ts` script parses this version and uses it to construct the GitHub release download URL:

```
https://github.com/denoland/deno/releases/download/v2.7.0+fb4db33/deno-x86_64-unknown-linux-gnu.zip
                                                       ^^^^^^^^^^
```

But Deno's GitHub releases use tags **without** build metadata:

```
https://github.com/denoland/deno/releases/download/v2.7.0/deno-x86_64-unknown-linux-gnu.zip
                                                   ^^^^^^
```

This causes a **404 Not Found** during `deno run compile`, breaking all release builds.

Verified:
- `v2.7.0` → **302** (asset exists)
- `v2.7.0+fb4db33` → **404** (does not exist)

## Fix

Strip the build metadata suffix (everything after `+`) from the parsed version string in `getDenoVersion()` before constructing the download URL. This follows semver spec where build metadata is informational and should not affect version resolution.

```ts
// "2.7.0+fb4db33" → "2.7.0"
return match[1].replace(/\+.*$/, "");
```

## Test plan

- [x] `deno check` — passes
- [x] `deno lint` — passes
- [x] `deno fmt` — passes
- [x] `deno run test` — all 2021 tests pass
- [x] `deno run compile` — binary compiles successfully (downloads deno with clean version)
- [x] Manually verified v2.7.0 URL returns 302, v2.7.0+fb4db33 returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)