### PR TITLE
fix: manage a swamp section in existing .gitignore files

### DIFF
--- a/src/cli/commands/repo_init.ts
+++ b/src/cli/commands/repo_init.ts
@@ -58,7 +58,7 @@ export async function repoInitAction(
     skillsCopied: result.skillsCopied,
     instructionsFileCreated: result.instructionsFileCreated,
     settingsCreated: result.settingsCreated,
-    gitignoreCreated: result.gitignoreCreated,
+    gitignoreAction: result.gitignoreAction,
     tool: result.tool,
   };
 
@@ -105,7 +105,7 @@ export const repoUpgradeCommand = new Command()
       upgradedAt: result.upgradedAt,
       skillsUpdated: result.skillsUpdated,
       settingsUpdated: result.settingsUpdated,
-      gitignoreCreated: result.gitignoreCreated,
+      gitignoreAction: result.gitignoreAction,
       tool: result.tool,
     };
 

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -37,6 +37,17 @@ import { UserError } from "../errors.ts";
 export type { AiTool } from "../../infrastructure/persistence/repo_marker_repository.ts";
 
 const GITIGNORE_FILENAME = ".gitignore";
+const GITIGNORE_SECTION_BEGIN = "# BEGIN swamp managed section - DO NOT EDIT";
+const GITIGNORE_SECTION_END = "# END swamp managed section";
+const GITIGNORE_LEGACY_HEADER = "# Swamp managed defaults";
+
+/**
+ * Describes what happened to the .gitignore during init/upgrade.
+ * - "created": a new .gitignore file was created with the managed section
+ * - "updated": an existing .gitignore had its managed section added or refreshed
+ * - "unchanged": the managed section already existed and was up-to-date
+ */
+export type GitignoreAction = "created" | "updated" | "unchanged";
 
 const SKILL_DIRS: Record<AiTool, string> = {
   claude: ".claude/skills",
@@ -69,7 +80,7 @@ export interface RepoInitResult {
   skillsCopied: string[];
   instructionsFileCreated: boolean;
   settingsCreated: boolean;
-  gitignoreCreated: boolean;
+  gitignoreAction: GitignoreAction;
   tool: AiTool;
 }
 
@@ -83,7 +94,7 @@ export interface RepoUpgradeResult {
   upgradedAt: string;
   skillsUpdated: string[];
   settingsUpdated: boolean;
-  gitignoreCreated: boolean;
+  gitignoreAction: GitignoreAction;
   tool: AiTool;
 }
 
@@ -169,8 +180,8 @@ export class RepoService {
       settingsCreated = await this.createClaudeSettingsIfNotExists(repoPath);
     }
 
-    // Create .gitignore if it doesn't exist
-    const gitignoreCreated = await this.createGitignoreIfNotExists(
+    // Ensure .gitignore has swamp managed section
+    const gitignoreAction = await this.ensureGitignoreSection(
       repoPath,
       tool,
     );
@@ -182,7 +193,7 @@ export class RepoService {
       skillsCopied,
       instructionsFileCreated,
       settingsCreated,
-      gitignoreCreated,
+      gitignoreAction,
       tool,
     };
   }
@@ -232,8 +243,8 @@ export class RepoService {
       settingsUpdated = await this.updateClaudeSettings(repoPath);
     }
 
-    // Create .gitignore if it doesn't exist
-    const gitignoreCreated = await this.createGitignoreIfNotExists(
+    // Ensure .gitignore has swamp managed section
+    const gitignoreAction = await this.ensureGitignoreSection(
       repoPath,
       tool,
     );
@@ -252,7 +263,7 @@ export class RepoService {
       upgradedAt: updatedMarker.upgradedAt,
       skillsUpdated,
       settingsUpdated,
-      gitignoreCreated,
+      gitignoreAction,
       tool,
     };
   }
@@ -342,47 +353,177 @@ ${body}`;
   }
 
   /**
-   * Creates .gitignore if it doesn't already exist.
+   * Ensures the .gitignore contains an up-to-date swamp managed section.
+   *
+   * - If no .gitignore exists: creates one with the managed section.
+   * - If .gitignore exists without a swamp section: appends the managed section.
+   * - If .gitignore exists with a swamp section: replaces the section if content differs.
+   * - If .gitignore has legacy format (pre-marker): migrates to managed section.
    */
-  private async createGitignoreIfNotExists(
+  private async ensureGitignoreSection(
     repoPath: RepoPath,
     tool: AiTool,
-  ): Promise<boolean> {
+  ): Promise<GitignoreAction> {
     const gitignorePath = join(repoPath.value, GITIGNORE_FILENAME);
+    const newSection = this.buildGitignoreSection(tool);
 
+    let existingContent: string | null = null;
     try {
-      await Deno.stat(gitignorePath);
-      // File exists, don't overwrite
-      return false;
+      existingContent = await Deno.readTextFile(gitignorePath);
     } catch (error) {
-      if (error instanceof Deno.errors.NotFound) {
-        // Create the file
-        const content = this.generateGitignoreContent(tool);
-        await Deno.writeTextFile(gitignorePath, content);
-        return true;
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
       }
-      throw error;
     }
+
+    // Case 1: No .gitignore exists — create new file
+    if (existingContent === null) {
+      await Deno.writeTextFile(gitignorePath, newSection + "\n");
+      return "created";
+    }
+
+    // Case 2: File exists with markers — replace managed section
+    if (existingContent.includes(GITIGNORE_SECTION_BEGIN)) {
+      const updatedContent = this.replaceManagedSection(
+        existingContent,
+        newSection,
+      );
+      if (updatedContent === existingContent) {
+        return "unchanged";
+      }
+      await atomicWriteTextFile(gitignorePath, updatedContent);
+      return "updated";
+    }
+
+    // Case 3: File exists with legacy header — migrate
+    if (existingContent.includes(GITIGNORE_LEGACY_HEADER)) {
+      const updatedContent = this.migrateLegacyGitignore(
+        existingContent,
+        newSection,
+      );
+      await atomicWriteTextFile(gitignorePath, updatedContent);
+      return "updated";
+    }
+
+    // Case 4: File exists without any swamp content — append section
+    const separator = existingContent.endsWith("\n") ? "\n" : "\n\n";
+    await atomicWriteTextFile(
+      gitignorePath,
+      existingContent + separator + newSection + "\n",
+    );
+    return "updated";
   }
 
   /**
-   * Generates the content for .gitignore.
+   * Builds the full managed section including BEGIN/END markers.
    */
-  private generateGitignoreContent(tool: AiTool): string {
-    return `# Swamp managed defaults
-# Feel free to modify this file to suit your needs
+  private buildGitignoreSection(tool: AiTool): string {
+    const body = this.generateGitignoreSectionBody(tool);
+    return GITIGNORE_SECTION_BEGIN + "\n" + body + GITIGNORE_SECTION_END;
+  }
 
-# Local telemetry (not needed for reconstruction)
-.swamp/telemetry/
+  /**
+   * Generates the content between markers (not including the markers).
+   */
+  private generateGitignoreSectionBody(tool: AiTool): string {
+    return [
+      "",
+      "# Local telemetry (not needed for reconstruction)",
+      ".swamp/telemetry/",
+      "",
+      "# Encryption keyfile (NEVER commit - allows decrypting secrets)",
+      ".swamp/secrets/keyfile",
+      "",
+      "# Cached extension bundles (regenerated at runtime)",
+      ".swamp/bundles/",
+      "",
+      GITIGNORE_TOOL_ENTRIES[tool],
+      "",
+    ].join("\n");
+  }
 
-# Encryption keyfile (NEVER commit - allows decrypting secrets)
-.swamp/secrets/keyfile
+  /**
+   * Replaces the managed section between BEGIN and END markers.
+   * Preserves all content outside the markers exactly as-is.
+   */
+  private replaceManagedSection(
+    content: string,
+    newSection: string,
+  ): string {
+    const beginIndex = content.indexOf(GITIGNORE_SECTION_BEGIN);
+    const endIndex = content.indexOf(GITIGNORE_SECTION_END);
 
-# Cached extension bundles (regenerated at runtime)
-.swamp/bundles/
+    if (beginIndex === -1 || endIndex === -1) {
+      throw new Error("Internal error: managed section markers not found");
+    }
 
-${GITIGNORE_TOOL_ENTRIES[tool]}
-`;
+    const endOfEndMarker = endIndex + GITIGNORE_SECTION_END.length;
+    // Consume the trailing newline after END marker if present
+    const nextChar = content[endOfEndMarker];
+    const endSlice = nextChar === "\n" ? endOfEndMarker + 1 : endOfEndMarker;
+
+    const before = content.substring(0, beginIndex);
+    const after = content.substring(endSlice);
+
+    return before + newSection + "\n" + after;
+  }
+
+  /**
+   * Migrates a legacy .gitignore (with "Swamp managed defaults" header
+   * but no section markers) to the new managed section format.
+   * Replaces the legacy swamp block; preserves user content after it.
+   */
+  private migrateLegacyGitignore(
+    content: string,
+    newSection: string,
+  ): string {
+    const lines = content.split("\n");
+    const headerLineIndex = lines.findIndex((l) =>
+      l.includes(GITIGNORE_LEGACY_HEADER)
+    );
+
+    if (headerLineIndex === -1) {
+      throw new Error("Internal error: legacy header not found");
+    }
+
+    // Scan forward from the header to find the end of the legacy block.
+    // The legacy block consists of comments and entries that match known patterns.
+    const swampPatterns = [
+      ".swamp/telemetry/",
+      ".swamp/secrets/keyfile",
+      ".swamp/bundles/",
+      ".claude/",
+      ".cursor/skills/",
+      ".agents/skills/",
+      "# Feel free to modify",
+      "# Local telemetry",
+      "# Encryption keyfile",
+      "# Cached extension bundles",
+      "# Claude Code configuration",
+      "# Cursor skills",
+      "# Agent skills",
+      "# Swamp managed defaults",
+    ];
+
+    let legacyEndIndex = headerLineIndex;
+    for (let i = headerLineIndex; i < lines.length; i++) {
+      const trimmed = lines[i].trim();
+      if (
+        trimmed === "" || swampPatterns.some((p) => trimmed.includes(p))
+      ) {
+        legacyEndIndex = i;
+      } else {
+        break;
+      }
+    }
+
+    const before = lines.slice(0, headerLineIndex).join("\n");
+    const after = lines.slice(legacyEndIndex + 1).join("\n");
+
+    const prefix = before.length > 0 ? before + "\n" : "";
+    const suffix = after.length > 0 ? "\n" + after : "\n";
+
+    return prefix + newSection + suffix;
   }
 
   /**

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -403,25 +403,30 @@ Deno.test("RepoService.init generates CLAUDE.md with skills section", async () =
   });
 });
 
-Deno.test("RepoService.init creates .gitignore", async () => {
+Deno.test("RepoService.init creates .gitignore with managed section", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
     const result = await service.init(repoPath);
 
-    assertEquals(result.gitignoreCreated, true);
+    assertEquals(result.gitignoreAction, "created");
 
-    // Check .gitignore exists and has expected content
+    // Check .gitignore exists and has expected content with markers
     const gitignorePath = join(tempDir, ".gitignore");
     const content = await Deno.readTextFile(gitignorePath);
+    assertStringIncludes(
+      content,
+      "# BEGIN swamp managed section - DO NOT EDIT",
+    );
+    assertStringIncludes(content, "# END swamp managed section");
     assertStringIncludes(content, ".swamp/telemetry/");
     assertStringIncludes(content, ".swamp/secrets/keyfile");
     assertStringIncludes(content, ".claude/");
   });
 });
 
-Deno.test("RepoService.init does not overwrite existing .gitignore", async () => {
+Deno.test("RepoService.init appends managed section to existing .gitignore", async () => {
   await withTempDir(async (tempDir) => {
     // Create existing .gitignore
     const gitignorePath = join(tempDir, ".gitignore");
@@ -435,37 +440,33 @@ Deno.test("RepoService.init does not overwrite existing .gitignore", async () =>
 
     const result = await service.init(repoPath);
 
-    assertEquals(result.gitignoreCreated, false);
+    assertEquals(result.gitignoreAction, "updated");
 
-    // Check content is unchanged
+    // Check user content is preserved and managed section is appended
     const content = await Deno.readTextFile(gitignorePath);
-    assertEquals(content, "# My existing gitignore\nnode_modules/\n");
+    assertStringIncludes(content, "# My existing gitignore");
+    assertStringIncludes(content, "node_modules/");
+    assertStringIncludes(
+      content,
+      "# BEGIN swamp managed section - DO NOT EDIT",
+    );
+    assertStringIncludes(content, ".swamp/telemetry/");
+    assertStringIncludes(content, "# END swamp managed section");
   });
 });
 
-Deno.test("RepoService.init with force does not overwrite existing .gitignore", async () => {
+Deno.test("RepoService.init with force returns unchanged when section is current", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    // First init
+    // First init creates .gitignore with managed section
     await service.init(repoPath);
 
-    // Modify .gitignore with custom content
-    const gitignorePath = join(tempDir, ".gitignore");
-    await Deno.writeTextFile(
-      gitignorePath,
-      "# Custom gitignore\nmy-custom-file.txt\n",
-    );
-
-    // Second init with force
+    // Second init with force — section already matches
     const result = await service.init(repoPath, { force: true });
 
-    assertEquals(result.gitignoreCreated, false);
-
-    // Check content is unchanged
-    const content = await Deno.readTextFile(gitignorePath);
-    assertEquals(content, "# Custom gitignore\nmy-custom-file.txt\n");
+    assertEquals(result.gitignoreAction, "unchanged");
   });
 });
 
@@ -736,28 +737,33 @@ Deno.test("RepoService.upgrade creates .gitignore if missing", async () => {
     const upgradeService = new RepoService("0.2.0");
     const result = await upgradeService.upgrade(repoPath);
 
-    assertEquals(result.gitignoreCreated, true);
+    assertEquals(result.gitignoreAction, "created");
 
     const content = await Deno.readTextFile(gitignorePath);
+    assertStringIncludes(
+      content,
+      "# BEGIN swamp managed section - DO NOT EDIT",
+    );
     assertStringIncludes(content, ".swamp/telemetry/");
     assertStringIncludes(content, ".swamp/secrets/keyfile");
     assertStringIncludes(content, ".claude/");
+    assertStringIncludes(content, "# END swamp managed section");
   });
 });
 
-Deno.test("RepoService.upgrade does not overwrite existing .gitignore", async () => {
+Deno.test("RepoService.upgrade returns unchanged when section is current", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    // Init creates .gitignore
+    // Init creates .gitignore with managed section
     await service.init(repoPath);
 
-    // Upgrade should leave .gitignore unchanged
+    // Upgrade — section already matches
     const upgradeService = new RepoService("0.2.0");
     const result = await upgradeService.upgrade(repoPath);
 
-    assertEquals(result.gitignoreCreated, false);
+    assertEquals(result.gitignoreAction, "unchanged");
   });
 });
 
@@ -804,9 +810,195 @@ Deno.test("RepoService.init tool-specific gitignore entries", async () => {
         expectedEntry,
         `${tool} gitignore should include ${expectedEntry}`,
       );
-      // All tools should have common entries
+      // All tools should have common entries within managed section
       assertStringIncludes(content, ".swamp/telemetry/");
       assertStringIncludes(content, ".swamp/secrets/keyfile");
+      assertStringIncludes(
+        content,
+        "# BEGIN swamp managed section - DO NOT EDIT",
+      );
+      assertStringIncludes(content, "# END swamp managed section");
     });
   }
+});
+
+// Managed .gitignore section tests
+
+Deno.test("RepoService.init preserves user content before managed section", async () => {
+  await withTempDir(async (tempDir) => {
+    const gitignorePath = join(tempDir, ".gitignore");
+    await Deno.writeTextFile(gitignorePath, "node_modules/\ndist/\n");
+
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath);
+
+    const content = await Deno.readTextFile(gitignorePath);
+    // User content comes first
+    const beginIndex = content.indexOf(
+      "# BEGIN swamp managed section - DO NOT EDIT",
+    );
+    const userContentIndex = content.indexOf("node_modules/");
+    assertEquals(userContentIndex < beginIndex, true);
+    assertStringIncludes(content, "dist/");
+  });
+});
+
+Deno.test("RepoService.init replaces managed section on tool switch", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    // Init with claude
+    await service.init(repoPath);
+    const gitignorePath = join(tempDir, ".gitignore");
+    let content = await Deno.readTextFile(gitignorePath);
+    assertStringIncludes(content, ".claude/");
+
+    // Re-init with cursor (force)
+    const result = await service.init(repoPath, {
+      force: true,
+      tool: "cursor",
+    });
+
+    assertEquals(result.gitignoreAction, "updated");
+    content = await Deno.readTextFile(gitignorePath);
+    assertStringIncludes(content, ".cursor/skills/");
+    // Old tool entry should be replaced
+    assertEquals(content.includes(".claude/"), false);
+  });
+});
+
+Deno.test("RepoService.upgrade updates managed section on tool switch", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    // Init with claude
+    await service.init(repoPath);
+
+    // Add user content after the managed section
+    const gitignorePath = join(tempDir, ".gitignore");
+    const original = await Deno.readTextFile(gitignorePath);
+    await Deno.writeTextFile(gitignorePath, original + "*.log\n");
+
+    // Upgrade with tool switch to cursor
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath, { tool: "cursor" });
+
+    assertEquals(result.gitignoreAction, "updated");
+    const content = await Deno.readTextFile(gitignorePath);
+    assertStringIncludes(content, ".cursor/skills/");
+    // User content after section is preserved
+    assertStringIncludes(content, "*.log");
+  });
+});
+
+Deno.test("RepoService.init handles .gitignore without trailing newline", async () => {
+  await withTempDir(async (tempDir) => {
+    const gitignorePath = join(tempDir, ".gitignore");
+    await Deno.writeTextFile(gitignorePath, "node_modules/"); // no trailing newline
+
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    const result = await service.init(repoPath);
+
+    assertEquals(result.gitignoreAction, "updated");
+    const content = await Deno.readTextFile(gitignorePath);
+    assertStringIncludes(content, "node_modules/");
+    assertStringIncludes(
+      content,
+      "# BEGIN swamp managed section - DO NOT EDIT",
+    );
+    // Ensure there's separation between user content and managed section
+    assertEquals(content.includes("node_modules/\n\n#"), true);
+  });
+});
+
+Deno.test("RepoService.init migrates legacy gitignore format", async () => {
+  await withTempDir(async (tempDir) => {
+    // Create legacy-format .gitignore (as old swamp would have created it)
+    const gitignorePath = join(tempDir, ".gitignore");
+    const legacyContent = `# Swamp managed defaults
+# Feel free to modify this file to suit your needs
+
+# Local telemetry (not needed for reconstruction)
+.swamp/telemetry/
+
+# Encryption keyfile (NEVER commit - allows decrypting secrets)
+.swamp/secrets/keyfile
+
+# Cached extension bundles (regenerated at runtime)
+.swamp/bundles/
+
+# Claude Code configuration (managed by swamp)
+.claude/
+`;
+    await Deno.writeTextFile(gitignorePath, legacyContent);
+
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    const result = await service.init(repoPath);
+
+    assertEquals(result.gitignoreAction, "updated");
+    const content = await Deno.readTextFile(gitignorePath);
+    // Legacy header should be replaced by markers
+    assertEquals(content.includes("# Swamp managed defaults"), false);
+    assertStringIncludes(
+      content,
+      "# BEGIN swamp managed section - DO NOT EDIT",
+    );
+    assertStringIncludes(content, "# END swamp managed section");
+    assertStringIncludes(content, ".swamp/telemetry/");
+    assertStringIncludes(content, ".claude/");
+  });
+});
+
+Deno.test("RepoService.init migrates legacy gitignore with user additions", async () => {
+  await withTempDir(async (tempDir) => {
+    // Create legacy-format .gitignore with user additions after it
+    const gitignorePath = join(tempDir, ".gitignore");
+    const legacyContent = `# Swamp managed defaults
+# Feel free to modify this file to suit your needs
+
+# Local telemetry (not needed for reconstruction)
+.swamp/telemetry/
+
+# Encryption keyfile (NEVER commit - allows decrypting secrets)
+.swamp/secrets/keyfile
+
+# Cached extension bundles (regenerated at runtime)
+.swamp/bundles/
+
+# Claude Code configuration (managed by swamp)
+.claude/
+# My custom additions
+*.log
+build/
+`;
+    await Deno.writeTextFile(gitignorePath, legacyContent);
+
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    const result = await service.init(repoPath);
+
+    assertEquals(result.gitignoreAction, "updated");
+    const content = await Deno.readTextFile(gitignorePath);
+    // Legacy header should be replaced
+    assertEquals(content.includes("# Swamp managed defaults"), false);
+    // New markers should be present
+    assertStringIncludes(
+      content,
+      "# BEGIN swamp managed section - DO NOT EDIT",
+    );
+    assertStringIncludes(content, "# END swamp managed section");
+    // User additions should be preserved
+    assertStringIncludes(content, "# My custom additions");
+    assertStringIncludes(content, "*.log");
+    assertStringIncludes(content, "build/");
+  });
 });

--- a/src/presentation/output/repo_output.ts
+++ b/src/presentation/output/repo_output.ts
@@ -32,7 +32,7 @@ export interface RepoInitData {
   skillsCopied: string[];
   instructionsFileCreated: boolean;
   settingsCreated: boolean;
-  gitignoreCreated: boolean;
+  gitignoreAction: string;
   tool: string;
 }
 
@@ -46,7 +46,7 @@ export interface RepoUpgradeData {
   upgradedAt: string;
   skillsUpdated: string[];
   settingsUpdated: boolean;
-  gitignoreCreated: boolean;
+  gitignoreAction: string;
   tool: string;
 }
 


### PR DESCRIPTION
## Summary

Fixes #461

Previously, `swamp repo init` and `swamp repo upgrade` would skip `.gitignore` entirely if one already existed. This meant repos with an existing `.gitignore` — the common case for any established project — never got swamp's required entries (telemetry dir, secrets keyfile, cached bundles, tool-specific dirs) added to their `.gitignore`. Worse, `swamp repo upgrade` could never deliver new gitignore entries to users who had already run `init`.

This PR introduces a **managed section** pattern using sentinel comment markers:

```
# BEGIN swamp managed section - DO NOT EDIT
...swamp entries...
# END swamp managed section
```

### Why this matters

- **New users initializing in an existing repo** get swamp entries added to their `.gitignore` automatically, instead of silently getting nothing
- **Existing users running `upgrade`** receive new gitignore entries as swamp evolves (e.g., new cache directories, new tool integrations) — the same way `upgrade` already merges Claude `settings.local.json` permissions
- **User content is never touched** — everything outside the markers is preserved byte-for-byte

### Behavior

| Scenario | Action |
|---|---|
| No `.gitignore` exists | Create file with managed section |
| `.gitignore` exists, no swamp section | Append managed section |
| `.gitignore` exists, has managed section | Replace section if content differs |
| `.gitignore` has legacy format (`# Swamp managed defaults` header, no markers) | Migrate: replace legacy block with managed section |

### Breaking change

The JSON output field `gitignoreCreated: boolean` is replaced by `gitignoreAction: "created" | "updated" | "unchanged"` in both `swamp repo init --json` and `swamp repo upgrade --json`. This provides more granular information about what happened to the `.gitignore`.

### Files changed

- `src/domain/repo/repo_service.ts` — Core logic: `ensureGitignoreSection` replaces `createGitignoreIfNotExists`, handles all four scenarios above plus legacy migration
- `src/domain/repo/repo_service_test.ts` — Updated 6 existing tests, added 7 new tests (append, tool switch, unchanged detection, legacy migration, trailing newline handling)
- `src/presentation/output/repo_output.ts` — Output interface field rename
- `src/cli/commands/repo_init.ts` — CLI data mapping update

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] All 2047 tests pass (43 repo service tests, including 7 new ones)
- [x] `deno run compile` succeeds
- [ ] Manual: `swamp repo init` in a dir with existing `.gitignore` → section appended
- [ ] Manual: `swamp repo upgrade` on repo with managed section → unchanged
- [ ] Manual: `swamp repo upgrade` with tool switch → section updated in-place

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Blake Irvin <blakeirvin@me.com>