### PR TITLE
feat: show SHA-256 integrity check status in update output

### DIFF
--- a/src/presentation/output/update_output.ts
+++ b/src/presentation/output/update_output.ts
@@ -45,6 +45,7 @@ export function renderUpdateResult(
       case "updated":
         logger.info("swamp updated successfully!");
         logger.info`${result.previousVersion} \u2192 ${result.newVersion}`;
+        logger.info("SHA-256 integrity check passed");
         break;
     }
     if (result.warning) {


### PR DESCRIPTION
## Summary

- Adds an info line "SHA-256 integrity check passed" to the `swamp update` output after a successful update

After this change, the output looks like:

```
15:48:34.397   info    update    swamp updated successfully!
15:48:34.400   info    update    "20260206.200442.0-sha." → "20260225.153610.0-sha.c4405aab"
15:48:34.401   info    update    SHA-256 integrity check passed
```

This gives users confidence that the checksum verification from #472 actually ran. If verification had failed, the update would have aborted with an error before reaching this point.

## Test plan

- [x] `deno run test src/presentation/output/update_output_test.ts` — all 8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)