### PR TITLE
fix: make .gitignore management opt-in via --include-gitignore flag

### DIFF
--- a/src/cli/commands/repo_init.ts
+++ b/src/cli/commands/repo_init.ts
@@ -46,8 +46,13 @@ export async function repoInitAction(
   const repoPath = RepoPath.create(pathArg ?? ".");
   const service = new RepoService(VERSION);
   const tool = (options.tool as AiTool) ?? "claude";
+  const includeGitignore = options.includeGitignore as boolean | undefined;
 
-  const result = await service.init(repoPath, { force: options.force, tool });
+  const result = await service.init(repoPath, {
+    force: options.force,
+    tool,
+    includeGitignore,
+  });
 
   ctx.logger.debug`Repository initialized: ${result.path}`;
 
@@ -76,6 +81,7 @@ export const repoInitCommand = new Command()
     "AI coding tool to configure for (claude, cursor, opencode, codex)",
     { default: "claude" },
   )
+  .option("--include-gitignore", "Manage a swamp section in .gitignore")
   .action(repoInitAction);
 
 export const repoUpgradeCommand = new Command()
@@ -86,6 +92,7 @@ export const repoUpgradeCommand = new Command()
     "-t, --tool <tool:aiTool>",
     "Switch to a different AI coding tool",
   )
+  .option("--include-gitignore", "Manage a swamp section in .gitignore")
   .action(async function (options: AnyOptions, pathArg?: string) {
     const ctx = createContext(options as GlobalOptions, ["repo", "upgrade"]);
     ctx.logger.debug`Upgrading repository at: ${pathArg ?? "."}`;
@@ -93,8 +100,12 @@ export const repoUpgradeCommand = new Command()
     const repoPath = RepoPath.create(pathArg ?? ".");
     const service = new RepoService(VERSION);
     const tool = options.tool as AiTool | undefined;
+    const includeGitignore = options.includeGitignore as boolean | undefined;
 
-    const result = await service.upgrade(repoPath, { tool });
+    const result = await service.upgrade(repoPath, {
+      tool,
+      includeGitignore,
+    });
 
     ctx.logger.debug`Repository upgraded: ${result.path}`;
 
@@ -124,6 +135,7 @@ export const repoCommand = new Command()
     "AI coding tool to configure for (claude, cursor, opencode, codex)",
     { default: "claude" },
   )
+  .option("--include-gitignore", "Manage a swamp section in .gitignore")
   .action(repoInitAction)
   .command(
     "init",
@@ -138,6 +150,7 @@ export const repoCommand = new Command()
         "AI coding tool to configure for (claude, cursor, opencode, codex)",
         { default: "claude" },
       )
+      .option("--include-gitignore", "Manage a swamp section in .gitignore")
       .action(repoInitAction),
   )
   .command("upgrade", repoUpgradeCommand)

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -46,8 +46,9 @@ const GITIGNORE_LEGACY_HEADER = "# Swamp managed defaults";
  * - "created": a new .gitignore file was created with the managed section
  * - "updated": an existing .gitignore had its managed section added or refreshed
  * - "unchanged": the managed section already existed and was up-to-date
+ * - "skipped": gitignore management was not opted in
  */
-export type GitignoreAction = "created" | "updated" | "unchanged";
+export type GitignoreAction = "created" | "updated" | "unchanged" | "skipped";
 
 const SKILL_DIRS: Record<AiTool, string> = {
   claude: ".claude/skills",
@@ -104,6 +105,7 @@ export interface RepoUpgradeResult {
 export interface RepoInitOptions {
   force?: boolean;
   tool?: AiTool;
+  includeGitignore?: boolean;
 }
 
 /**
@@ -111,6 +113,7 @@ export interface RepoInitOptions {
  */
 export interface RepoUpgradeOptions {
   tool?: AiTool;
+  includeGitignore?: boolean;
 }
 
 /**
@@ -160,7 +163,6 @@ export class RepoService {
     // Create marker file with tool choice
     const markerData = this.markerRepo.createInitMarker(this.currentVersion);
     markerData.tool = tool;
-    await this.markerRepo.write(repoPath, markerData);
 
     // Create data directory structure
     await this.createDataDirectoryStructure(repoPath);
@@ -180,11 +182,16 @@ export class RepoService {
       settingsCreated = await this.createClaudeSettingsIfNotExists(repoPath);
     }
 
-    // Ensure .gitignore has swamp managed section
-    const gitignoreAction = await this.ensureGitignoreSection(
-      repoPath,
-      tool,
-    );
+    // Manage .gitignore only when opted in
+    let gitignoreAction: GitignoreAction;
+    if (options.includeGitignore) {
+      gitignoreAction = await this.ensureGitignoreSection(repoPath, tool);
+      markerData.gitignoreManaged = true;
+    } else {
+      gitignoreAction = "skipped";
+    }
+
+    await this.markerRepo.write(repoPath, markerData);
 
     return {
       path: repoPath.value,
@@ -227,7 +234,6 @@ export class RepoService {
       this.currentVersion,
     );
     updatedMarker.tool = tool;
-    await this.markerRepo.write(repoPath, updatedMarker);
 
     // Update skills in tool-appropriate directory
     const skillsDir = join(repoPath.value, SKILL_DIRS[tool]);
@@ -243,11 +249,23 @@ export class RepoService {
       settingsUpdated = await this.updateClaudeSettings(repoPath);
     }
 
-    // Ensure .gitignore has swamp managed section
-    const gitignoreAction = await this.ensureGitignoreSection(
-      repoPath,
-      tool,
-    );
+    // Determine gitignore management: CLI flag > marker preference > default off
+    const shouldManageGitignore = options.includeGitignore ??
+      existingMarker.gitignoreManaged ?? false;
+
+    // Persist the CLI flag choice if explicitly provided
+    if (options.includeGitignore !== undefined) {
+      updatedMarker.gitignoreManaged = options.includeGitignore;
+    }
+
+    let gitignoreAction: GitignoreAction;
+    if (shouldManageGitignore) {
+      gitignoreAction = await this.ensureGitignoreSection(repoPath, tool);
+    } else {
+      gitignoreAction = "skipped";
+    }
+
+    await this.markerRepo.write(repoPath, updatedMarker);
 
     // createUpgradeMarker always sets upgradedAt, but TypeScript doesn't know this
     if (!updatedMarker.upgradedAt) {

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -403,12 +403,34 @@ Deno.test("RepoService.init generates CLAUDE.md with skills section", async () =
   });
 });
 
-Deno.test("RepoService.init creates .gitignore with managed section", async () => {
+Deno.test("RepoService.init skips .gitignore by default", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
     const result = await service.init(repoPath);
+
+    assertEquals(result.gitignoreAction, "skipped");
+
+    // .gitignore should not exist
+    const gitignorePath = join(tempDir, ".gitignore");
+    let exists = false;
+    try {
+      await Deno.stat(gitignorePath);
+      exists = true;
+    } catch {
+      // expected
+    }
+    assertEquals(exists, false);
+  });
+});
+
+Deno.test("RepoService.init creates .gitignore with managed section when opted in", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    const result = await service.init(repoPath, { includeGitignore: true });
 
     assertEquals(result.gitignoreAction, "created");
 
@@ -423,10 +445,14 @@ Deno.test("RepoService.init creates .gitignore with managed section", async () =
     assertStringIncludes(content, ".swamp/telemetry/");
     assertStringIncludes(content, ".swamp/secrets/keyfile");
     assertStringIncludes(content, ".claude/");
+
+    // Check marker persists the preference
+    const marker = await service.getMarker(repoPath);
+    assertEquals(marker!.gitignoreManaged, true);
   });
 });
 
-Deno.test("RepoService.init appends managed section to existing .gitignore", async () => {
+Deno.test("RepoService.init appends managed section to existing .gitignore when opted in", async () => {
   await withTempDir(async (tempDir) => {
     // Create existing .gitignore
     const gitignorePath = join(tempDir, ".gitignore");
@@ -438,7 +464,7 @@ Deno.test("RepoService.init appends managed section to existing .gitignore", asy
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    const result = await service.init(repoPath);
+    const result = await service.init(repoPath, { includeGitignore: true });
 
     assertEquals(result.gitignoreAction, "updated");
 
@@ -461,10 +487,13 @@ Deno.test("RepoService.init with force returns unchanged when section is current
     const repoPath = RepoPath.create(tempDir);
 
     // First init creates .gitignore with managed section
-    await service.init(repoPath);
+    await service.init(repoPath, { includeGitignore: true });
 
     // Second init with force — section already matches
-    const result = await service.init(repoPath, { force: true });
+    const result = await service.init(repoPath, {
+      force: true,
+      includeGitignore: true,
+    });
 
     assertEquals(result.gitignoreAction, "unchanged");
   });
@@ -482,6 +511,7 @@ Deno.test("RepoService.init with cursor creates .cursor/skills/ and .cursor/rule
     assertEquals(result.tool, "cursor");
     assertEquals(result.instructionsFileCreated, true);
     assertEquals(result.settingsCreated, false);
+    assertEquals(result.gitignoreAction, "skipped");
 
     // Check skills copied to .cursor/skills/
     const skillsDir = join(tempDir, ".cursor", "skills");
@@ -494,11 +524,6 @@ Deno.test("RepoService.init with cursor creates .cursor/skills/ and .cursor/rule
     assertStringIncludes(content, "alwaysApply: true");
     assertStringIncludes(content, "swamp");
     assertStringIncludes(content, "## Skills");
-
-    // Check .gitignore has cursor-specific entries
-    const gitignorePath = join(tempDir, ".gitignore");
-    const gitignoreContent = await Deno.readTextFile(gitignorePath);
-    assertStringIncludes(gitignoreContent, ".cursor/skills/");
 
     // Check no .claude/ settings created
     const claudeSettingsPath = join(
@@ -527,6 +552,7 @@ Deno.test("RepoService.init with opencode creates .agents/skills/ and AGENTS.md"
     assertEquals(result.tool, "opencode");
     assertEquals(result.instructionsFileCreated, true);
     assertEquals(result.settingsCreated, false);
+    assertEquals(result.gitignoreAction, "skipped");
 
     // Check skills copied to .agents/skills/
     const skillsDir = join(tempDir, ".agents", "skills");
@@ -538,11 +564,6 @@ Deno.test("RepoService.init with opencode creates .agents/skills/ and AGENTS.md"
     const content = await Deno.readTextFile(agentsMdPath);
     assertStringIncludes(content, "swamp");
     assertStringIncludes(content, "## Skills");
-
-    // Check .gitignore has agents-specific entries
-    const gitignorePath = join(tempDir, ".gitignore");
-    const gitignoreContent = await Deno.readTextFile(gitignorePath);
-    assertStringIncludes(gitignoreContent, ".agents/skills/");
   });
 });
 
@@ -556,6 +577,7 @@ Deno.test("RepoService.init with codex creates .agents/skills/ and AGENTS.md", a
     assertEquals(result.tool, "codex");
     assertEquals(result.instructionsFileCreated, true);
     assertEquals(result.settingsCreated, false);
+    assertEquals(result.gitignoreAction, "skipped");
 
     // Check skills copied to .agents/skills/
     const skillsDir = join(tempDir, ".agents", "skills");
@@ -566,11 +588,6 @@ Deno.test("RepoService.init with codex creates .agents/skills/ and AGENTS.md", a
     const agentsMdPath = join(tempDir, "AGENTS.md");
     const content = await Deno.readTextFile(agentsMdPath);
     assertStringIncludes(content, "swamp");
-
-    // Check .gitignore has agents-specific entries
-    const gitignorePath = join(tempDir, ".gitignore");
-    const gitignoreContent = await Deno.readTextFile(gitignorePath);
-    assertStringIncludes(gitignoreContent, ".agents/skills/");
   });
 });
 
@@ -723,17 +740,31 @@ Deno.test("RepoService.upgrade skips settings for non-claude tools", async () =>
   });
 });
 
-Deno.test("RepoService.upgrade creates .gitignore if missing", async () => {
+Deno.test("RepoService.upgrade skips .gitignore by default", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    // Init (creates .gitignore), then delete it
     await service.init(repoPath);
+
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath);
+
+    assertEquals(result.gitignoreAction, "skipped");
+  });
+});
+
+Deno.test("RepoService.upgrade creates .gitignore when marker has gitignoreManaged", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    // Init with gitignore opt-in (creates .gitignore and sets marker)
+    await service.init(repoPath, { includeGitignore: true });
     const gitignorePath = join(tempDir, ".gitignore");
     await Deno.remove(gitignorePath);
 
-    // Upgrade should recreate .gitignore
+    // Upgrade should recreate .gitignore because marker has gitignoreManaged
     const upgradeService = new RepoService("0.2.0");
     const result = await upgradeService.upgrade(repoPath);
 
@@ -757,9 +788,9 @@ Deno.test("RepoService.upgrade returns unchanged when section is current", async
     const repoPath = RepoPath.create(tempDir);
 
     // Init creates .gitignore with managed section
-    await service.init(repoPath);
+    await service.init(repoPath, { includeGitignore: true });
 
-    // Upgrade — section already matches
+    // Upgrade — section already matches (marker has gitignoreManaged: true)
     const upgradeService = new RepoService("0.2.0");
     const result = await upgradeService.upgrade(repoPath);
 
@@ -784,7 +815,7 @@ Deno.test("RepoService.init cursor instructions have MDC frontmatter", async () 
   });
 });
 
-Deno.test("RepoService.init tool-specific gitignore entries", async () => {
+Deno.test("RepoService.init tool-specific gitignore entries when opted in", async () => {
   const toolGitignoreEntries: Record<AiTool, string> = {
     claude: ".claude/",
     cursor: ".cursor/skills/",
@@ -801,7 +832,7 @@ Deno.test("RepoService.init tool-specific gitignore entries", async () => {
       const service = new RepoService("0.1.0");
       const repoPath = RepoPath.create(tempDir);
 
-      await service.init(repoPath, { tool });
+      await service.init(repoPath, { tool, includeGitignore: true });
 
       const gitignorePath = join(tempDir, ".gitignore");
       const content = await Deno.readTextFile(gitignorePath);
@@ -832,7 +863,7 @@ Deno.test("RepoService.init preserves user content before managed section", asyn
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    await service.init(repoPath);
+    await service.init(repoPath, { includeGitignore: true });
 
     const content = await Deno.readTextFile(gitignorePath);
     // User content comes first
@@ -850,16 +881,17 @@ Deno.test("RepoService.init replaces managed section on tool switch", async () =
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    // Init with claude
-    await service.init(repoPath);
+    // Init with claude and gitignore
+    await service.init(repoPath, { includeGitignore: true });
     const gitignorePath = join(tempDir, ".gitignore");
     let content = await Deno.readTextFile(gitignorePath);
     assertStringIncludes(content, ".claude/");
 
-    // Re-init with cursor (force)
+    // Re-init with cursor (force) and gitignore
     const result = await service.init(repoPath, {
       force: true,
       tool: "cursor",
+      includeGitignore: true,
     });
 
     assertEquals(result.gitignoreAction, "updated");
@@ -875,15 +907,15 @@ Deno.test("RepoService.upgrade updates managed section on tool switch", async ()
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    // Init with claude
-    await service.init(repoPath);
+    // Init with claude and gitignore
+    await service.init(repoPath, { includeGitignore: true });
 
     // Add user content after the managed section
     const gitignorePath = join(tempDir, ".gitignore");
     const original = await Deno.readTextFile(gitignorePath);
     await Deno.writeTextFile(gitignorePath, original + "*.log\n");
 
-    // Upgrade with tool switch to cursor
+    // Upgrade with tool switch to cursor (marker has gitignoreManaged: true)
     const upgradeService = new RepoService("0.2.0");
     const result = await upgradeService.upgrade(repoPath, { tool: "cursor" });
 
@@ -903,7 +935,7 @@ Deno.test("RepoService.init handles .gitignore without trailing newline", async 
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    const result = await service.init(repoPath);
+    const result = await service.init(repoPath, { includeGitignore: true });
 
     assertEquals(result.gitignoreAction, "updated");
     const content = await Deno.readTextFile(gitignorePath);
@@ -917,7 +949,7 @@ Deno.test("RepoService.init handles .gitignore without trailing newline", async 
   });
 });
 
-Deno.test("RepoService.init migrates legacy gitignore format", async () => {
+Deno.test("RepoService.init migrates legacy gitignore format when opted in", async () => {
   await withTempDir(async (tempDir) => {
     // Create legacy-format .gitignore (as old swamp would have created it)
     const gitignorePath = join(tempDir, ".gitignore");
@@ -941,7 +973,7 @@ Deno.test("RepoService.init migrates legacy gitignore format", async () => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    const result = await service.init(repoPath);
+    const result = await service.init(repoPath, { includeGitignore: true });
 
     assertEquals(result.gitignoreAction, "updated");
     const content = await Deno.readTextFile(gitignorePath);
@@ -957,7 +989,7 @@ Deno.test("RepoService.init migrates legacy gitignore format", async () => {
   });
 });
 
-Deno.test("RepoService.init migrates legacy gitignore with user additions", async () => {
+Deno.test("RepoService.init migrates legacy gitignore with user additions when opted in", async () => {
   await withTempDir(async (tempDir) => {
     // Create legacy-format .gitignore with user additions after it
     const gitignorePath = join(tempDir, ".gitignore");
@@ -984,7 +1016,7 @@ build/
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    const result = await service.init(repoPath);
+    const result = await service.init(repoPath, { includeGitignore: true });
 
     assertEquals(result.gitignoreAction, "updated");
     const content = await Deno.readTextFile(gitignorePath);
@@ -1000,5 +1032,95 @@ build/
     assertStringIncludes(content, "# My custom additions");
     assertStringIncludes(content, "*.log");
     assertStringIncludes(content, "build/");
+  });
+});
+
+// Opt-in/opt-out gitignore management tests
+
+Deno.test("RepoService.init without includeGitignore does not set gitignoreManaged", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath);
+
+    const marker = await service.getMarker(repoPath);
+    assertEquals(marker!.gitignoreManaged, undefined);
+  });
+});
+
+Deno.test("RepoService.upgrade with includeGitignore true opts in and persists", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    // Init without gitignore
+    await service.init(repoPath);
+
+    // Upgrade with opt-in
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath, {
+      includeGitignore: true,
+    });
+
+    assertEquals(result.gitignoreAction, "created");
+
+    // Marker should persist the preference
+    const marker = await upgradeService.getMarker(repoPath);
+    assertEquals(marker!.gitignoreManaged, true);
+  });
+});
+
+Deno.test("RepoService.upgrade with includeGitignore false opts out and persists", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    // Init with gitignore (sets gitignoreManaged: true)
+    await service.init(repoPath, { includeGitignore: true });
+
+    // Upgrade with explicit opt-out
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath, {
+      includeGitignore: false,
+    });
+
+    assertEquals(result.gitignoreAction, "skipped");
+
+    // Marker should persist the opt-out
+    const marker = await upgradeService.getMarker(repoPath);
+    assertEquals(marker!.gitignoreManaged, false);
+  });
+});
+
+Deno.test("RepoService.upgrade without flag honors marker gitignoreManaged true", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    // Init with gitignore (sets gitignoreManaged: true)
+    await service.init(repoPath, { includeGitignore: true });
+
+    // Upgrade without specifying flag — should honor marker
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath);
+
+    assertEquals(result.gitignoreAction, "unchanged");
+  });
+});
+
+Deno.test("RepoService.upgrade without flag and no marker gitignoreManaged skips", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    // Init without gitignore (no gitignoreManaged in marker)
+    await service.init(repoPath);
+
+    // Upgrade without specifying flag — should skip
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath);
+
+    assertEquals(result.gitignoreAction, "skipped");
   });
 });

--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -42,6 +42,7 @@ export interface RepoMarkerData {
   telemetryKeepFlushed?: boolean;
   tool?: AiTool;
   logLevel?: string;
+  gitignoreManaged?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Follows up on #461, which added automatic `.gitignore` managed section
during `swamp repo init` and `swamp repo upgrade`.

**Problem:** Automatically modifying `.gitignore` is surprising behavior.
Established repos have their own gitignore conventions, and many users
track their `.swamp/` or `.claude/` directories intentionally. Writing to
`.gitignore` without being asked violates the principle of least surprise
and can create unwanted noise in diffs/PRs.

**Solution:** Make gitignore management **opt-in** via a `--include-gitignore`
CLI flag, with the preference persisted in `.swamp.yaml` so subsequent
upgrades honor the choice without requiring the flag again.

### Behavior

| Command | Behavior |
|---------|----------|
| `swamp init` | Does NOT manage .gitignore (default off) |
| `swamp init --include-gitignore` | Manages .gitignore, persists `gitignoreManaged: true` in marker |
| `swamp upgrade` | Manages .gitignore ONLY if marker has `gitignoreManaged: true` |
| `swamp upgrade --include-gitignore` | Opts in, manages .gitignore, persists preference |
| `swamp upgrade --no-include-gitignore` | Opts out, persists `gitignoreManaged: false`, skips gitignore |

### Changes

- **`repo_marker_repository.ts`** — Added `gitignoreManaged?: boolean` to `RepoMarkerData`
- **`repo_service.ts`** — Added `"skipped"` to `GitignoreAction` type; `init()` skips gitignore by default, manages when `includeGitignore: true`; `upgrade()` respects persisted marker preference with CLI override
- **`repo_init.ts`** — Added `--include-gitignore` option to init, upgrade, and repo commands
- **`repo_service_test.ts`** — Updated 15 existing tests, added 5 new tests covering opt-in/opt-out/persistence behavior

### Why this matters

The managed section machinery from #461 is preserved — when a user opts in, they get the same sentinel-marker-based section management with legacy migration, tool-specific entries, and safe upgrades. The only change is that users must explicitly ask for it, which respects repos that:
- Already have comprehensive `.gitignore` files
- Intentionally track `.claude/` or `.agents/` directories
- Use CI workflows that would be disrupted by unexpected `.gitignore` changes

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] All 2054 tests pass (50 repo service tests, including 5 new ones)
- [x] `deno run compile` succeeds
- [ ] Manual: `swamp repo init` does NOT create/modify .gitignore
- [ ] Manual: `swamp repo init --include-gitignore` creates managed section
- [ ] Manual: `swamp repo upgrade` after opt-in preserves gitignore management
- [ ] Manual: `swamp repo upgrade --no-include-gitignore` opts out and persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)