### PR TITLE
feat: associate telemetry with authenticated users

### DIFF
--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -56,6 +56,7 @@ import {
   isTelemetryDisabled,
 } from "./telemetry_integration.ts";
 import { UserIdentityRepository } from "../infrastructure/persistence/user_identity_repository.ts";
+import { AuthRepository } from "../infrastructure/persistence/auth_repository.ts";
 
 // Import models barrel to trigger self-registration
 import "../domain/models/models.ts";
@@ -171,6 +172,7 @@ interface TelemetryContext {
   repoId: string;
   telemetryEndpoint: string;
   keepFlushed: boolean;
+  authToken: string | null;
 }
 
 /**
@@ -211,7 +213,26 @@ async function initTelemetryService(): Promise<TelemetryContext | null> {
 
     const keepFlushed = marker.telemetryKeepFlushed ?? false;
 
-    return { service, userId, repoId, telemetryEndpoint, keepFlushed };
+    // Try loading auth credentials for authenticated telemetry
+    let authToken: string | null = null;
+    try {
+      const authRepo = new AuthRepository();
+      const creds = await authRepo.load();
+      if (creds?.apiKey) {
+        authToken = creds.apiKey;
+      }
+    } catch {
+      // Auth file unreadable — continue without auth
+    }
+
+    return {
+      service,
+      userId,
+      repoId,
+      telemetryEndpoint,
+      keepFlushed,
+      authToken,
+    };
   } catch {
     // Not in a swamp repo or other error
     return null;
@@ -329,6 +350,7 @@ export async function runCli(args: string[]): Promise<void> {
         sender,
         distinctId: telemetryCtx.userId ?? telemetryCtx.repoId,
         repoId: telemetryCtx.repoId,
+        authToken: telemetryCtx.authToken ?? undefined,
         keepFlushed: telemetryCtx.keepFlushed,
       });
 

--- a/src/domain/telemetry/telemetry_sender.ts
+++ b/src/domain/telemetry/telemetry_sender.ts
@@ -30,11 +30,13 @@ export interface TelemetrySender {
    * @param entries - The entries to send
    * @param distinctId - The user or repo UUID used as distinct_id
    * @param repoId - Optional repo UUID included as a property
+   * @param authToken - Optional API key used as Bearer token to authenticate the flush request
    * @returns true if the batch was accepted, false otherwise
    */
   sendBatch(
     entries: TelemetryEntry[],
     distinctId: string,
     repoId?: string,
+    authToken?: string,
   ): Promise<boolean>;
 }

--- a/src/domain/telemetry/telemetry_service.ts
+++ b/src/domain/telemetry/telemetry_service.ts
@@ -38,6 +38,7 @@ export interface TelemetryFlushConfig {
   sender: TelemetrySender;
   distinctId: string;
   repoId?: string;
+  authToken?: string;
   batchSize?: number;
   keepFlushed?: boolean;
 }
@@ -170,6 +171,7 @@ export class TelemetryService {
       batchSize,
       keepFlushed,
       config.repoId,
+      config.authToken,
     )
       .catch(
         (error) => {
@@ -186,11 +188,17 @@ export class TelemetryService {
     batchSize: number,
     keepFlushed: boolean,
     repoId?: string,
+    authToken?: string,
   ): Promise<void> {
     const entries = await this.repository.findUnflushed(batchSize);
     if (entries.length === 0) return;
 
-    const success = await sender.sendBatch(entries, distinctId, repoId);
+    const success = await sender.sendBatch(
+      entries,
+      distinctId,
+      repoId,
+      authToken,
+    );
     if (success) {
       for (const entry of entries) {
         await this.repository.markFlushed(entry, keepFlushed);

--- a/src/domain/telemetry/telemetry_service_test.ts
+++ b/src/domain/telemetry/telemetry_service_test.ts
@@ -68,6 +68,7 @@ class MockTelemetrySender implements TelemetrySender {
     entries: TelemetryEntry[];
     distinctId: string;
     repoId?: string;
+    authToken?: string;
   }> = [];
   shouldSucceed = true;
 
@@ -75,8 +76,9 @@ class MockTelemetrySender implements TelemetrySender {
     entries: TelemetryEntry[],
     distinctId: string,
     repoId?: string,
+    authToken?: string,
   ): Promise<boolean> {
-    this.sentBatches.push({ entries, distinctId, repoId });
+    this.sentBatches.push({ entries, distinctId, repoId, authToken });
     return Promise.resolve(this.shouldSucceed);
   }
 }
@@ -340,4 +342,52 @@ Deno.test("TelemetryService.flushTelemetry passes repoId to sender", async () =>
   assertEquals(sender.sentBatches.length, 1);
   assertEquals(sender.sentBatches[0].distinctId, "user-uuid");
   assertEquals(sender.sentBatches[0].repoId, "repo-uuid-456");
+});
+
+Deno.test("TelemetryService.flushTelemetry passes authToken to sender", async () => {
+  const repo = new MockTelemetryRepository();
+  const sender = new MockTelemetrySender();
+  const service = new TelemetryService(repo, "1.0.0");
+
+  const entry = createFlushTestEntry(
+    "uuid-1",
+    new Date("2024-03-10T10:00:00Z"),
+  );
+  repo.mockUnflushedEntries = [entry];
+
+  service.flushTelemetry({
+    sender,
+    distinctId: "user-uuid",
+    repoId: "repo-uuid-456",
+    authToken: "test-api-key-123",
+  });
+
+  // Wait for fire-and-forget to settle
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  assertEquals(sender.sentBatches.length, 1);
+  assertEquals(sender.sentBatches[0].authToken, "test-api-key-123");
+});
+
+Deno.test("TelemetryService.flushTelemetry passes undefined authToken when not provided", async () => {
+  const repo = new MockTelemetryRepository();
+  const sender = new MockTelemetrySender();
+  const service = new TelemetryService(repo, "1.0.0");
+
+  const entry = createFlushTestEntry(
+    "uuid-1",
+    new Date("2024-03-10T10:00:00Z"),
+  );
+  repo.mockUnflushedEntries = [entry];
+
+  service.flushTelemetry({
+    sender,
+    distinctId: "user-uuid",
+  });
+
+  // Wait for fire-and-forget to settle
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  assertEquals(sender.sentBatches.length, 1);
+  assertEquals(sender.sentBatches[0].authToken, undefined);
 });

--- a/src/infrastructure/telemetry/http_telemetry_sender.ts
+++ b/src/infrastructure/telemetry/http_telemetry_sender.ts
@@ -31,6 +31,7 @@ export class HttpTelemetrySender implements TelemetrySender {
     entries: TelemetryEntry[],
     distinctId: string,
     repoId?: string,
+    authToken?: string,
   ): Promise<boolean> {
     const events = entries.map((entry) => ({
       event: "cli_invocation",
@@ -46,9 +47,14 @@ export class HttpTelemetrySender implements TelemetrySender {
       : JSON.stringify({ events });
 
     try {
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        ...(authToken ? { "Authorization": `Bearer ${authToken}` } : {}),
+      };
+
       const response = await fetch(`${this.endpointUrl}/ingest`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers,
         body,
         signal: AbortSignal.timeout(5000),
       });

--- a/src/infrastructure/telemetry/http_telemetry_sender_test.ts
+++ b/src/infrastructure/telemetry/http_telemetry_sender_test.ts
@@ -177,3 +177,56 @@ Deno.test("HttpTelemetrySender.sendBatch omits $repo_id when not provided", asyn
 
   await server.shutdown();
 });
+
+Deno.test("HttpTelemetrySender.sendBatch includes Authorization header when authToken provided", async () => {
+  let capturedAuthHeader: string | null = null;
+
+  const server = Deno.serve({ port: 0 }, async (req: Request) => {
+    capturedAuthHeader = req.headers.get("Authorization");
+    await req.body?.cancel();
+    return new Response(JSON.stringify({ accepted: 1 }), { status: 202 });
+  });
+
+  const port = server.addr.port;
+  const sender = new HttpTelemetrySender(`http://localhost:${port}`);
+  const entry = createTestEntry(
+    "test-uuid-1",
+    new Date("2024-03-10T10:00:00Z"),
+  );
+
+  const result = await sender.sendBatch(
+    [entry],
+    "user-uuid-123",
+    undefined,
+    "test-api-key-abc",
+  );
+
+  assertEquals(result, true);
+  assertEquals(capturedAuthHeader, "Bearer test-api-key-abc");
+
+  await server.shutdown();
+});
+
+Deno.test("HttpTelemetrySender.sendBatch omits Authorization header when authToken not provided", async () => {
+  let capturedAuthHeader: string | null = null;
+
+  const server = Deno.serve({ port: 0 }, async (req: Request) => {
+    capturedAuthHeader = req.headers.get("Authorization");
+    await req.body?.cancel();
+    return new Response(JSON.stringify({ accepted: 1 }), { status: 202 });
+  });
+
+  const port = server.addr.port;
+  const sender = new HttpTelemetrySender(`http://localhost:${port}`);
+  const entry = createTestEntry(
+    "test-uuid-1",
+    new Date("2024-03-10T10:00:00Z"),
+  );
+
+  const result = await sender.sendBatch([entry], "user-uuid-123");
+
+  assertEquals(result, true);
+  assertEquals(capturedAuthHeader, null);
+
+  await server.shutdown();
+});


### PR DESCRIPTION
## Summary

- Send authenticated user's API key as `Authorization: Bearer` header on telemetry flush requests, enabling server-side user resolution in Mixpanel
- `distinct_id` remains the anonymous UUID — no identity data added to the event payload
- Auth credentials loaded from `~/.config/swamp/auth.json` at init; silently skipped if absent or unreadable

Closes #475

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] All 18 telemetry tests pass (4 new)
- [ ] Manual: run a `swamp` command with `auth.json` present, confirm flush request includes `Authorization` header
- [ ] Manual: run without `auth.json`, confirm no `Authorization` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)