### PR TITLE
fix: reject path traversal in definition names

### DIFF
--- a/src/domain/definitions/definition.ts
+++ b/src/domain/definitions/definition.ts
@@ -124,7 +124,15 @@ export const DefinitionSchema = z.object({
     z.string().optional(),
   ),
   id: z.string().uuid(),
-  name: z.string().min(1),
+  name: z.string().min(1).refine(
+    (name) =>
+      !name.includes("..") && !name.includes("/") && !name.includes("\\") &&
+      !name.includes("\0"),
+    {
+      message:
+        "Definition name must not contain '..', '/', '\\', or null bytes (path traversal)",
+    },
+  ),
   version: z.number().int().positive(),
   tags: z.record(z.string(), z.string()).default({}),
   globalArguments: z.record(z.string(), z.unknown()).default({}),

--- a/src/domain/definitions/definition_test.ts
+++ b/src/domain/definitions/definition_test.ts
@@ -104,6 +104,42 @@ Deno.test("Definition.create throws on empty name", () => {
   );
 });
 
+Deno.test("Definition.create throws on name with forward slash", () => {
+  assertThrows(
+    () => Definition.create({ name: "/etc/passwd" }),
+    Error,
+  );
+  assertThrows(
+    () => Definition.create({ name: "foo/bar" }),
+    Error,
+  );
+});
+
+Deno.test("Definition.create throws on name with backslash", () => {
+  assertThrows(
+    () => Definition.create({ name: "foo\\bar" }),
+    Error,
+  );
+});
+
+Deno.test("Definition.create throws on name with path traversal", () => {
+  assertThrows(
+    () => Definition.create({ name: "../../../etc/passwd" }),
+    Error,
+  );
+  assertThrows(
+    () => Definition.create({ name: "foo..bar" }),
+    Error,
+  );
+});
+
+Deno.test("Definition.create throws on name with null bytes", () => {
+  assertThrows(
+    () => Definition.create({ name: "foo\0bar" }),
+    Error,
+  );
+});
+
 Deno.test("Definition.create throws on invalid version", () => {
   assertThrows(
     () => Definition.create({ name: "test", version: 0 }),


### PR DESCRIPTION
## Summary

Fixes: #477 

**Defense in depth:** `swamp model create` currently accepts absolute paths and path traversal sequences (e.g., `/etc/passwd`, `../../../foo`) as model names without error. While definition names are not currently used to construct file paths (UUIDs are used instead), this is a validation gap that could become a security issue if naming conventions change in the future.

This PR adds Zod validation to `DefinitionSchema` that rejects `..`, `/`, `\`, and null bytes in definition names, mirroring the existing pattern already present in `DataMetadataSchema`.

### Changes

- **`src/domain/definitions/definition.ts`** — Added `.refine()` validation to the `name` field in `DefinitionSchema` that rejects path traversal characters
- **`src/domain/definitions/definition_test.ts`** — Added 4 test cases covering forward slashes, backslashes, `..` path traversal, and null bytes

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt` — formatting passes
- [x] `deno run test src/domain/definitions/definition_test.ts` — all 40 tests pass (4 new)
- [x] `deno run test` — full test suite passes (2078 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)