### PR TITLE
fix: redact vault secrets from stdout/stderr output

### DIFF
--- a/design/models.md
+++ b/design/models.md
@@ -174,7 +174,8 @@ Methods can be called on instantiated models. Each method declares a required
 method's `execute` function receives the merged arguments (global arguments from
 the definition combined with per-method arguments) as its first parameter, and a
 `MethodContext` as its second. The `MethodContext` includes `globalArgs`,
-`definition` metadata (id, name, version, tags), and `methodName`.
+`definition` metadata (id, name, version, tags), `methodName`, and an optional
+`redactor` (`SecretRedactor`) for stripping vault secrets from output.
 
 Methods can write data, which is tracked by the method invocation and the
 definition required to re-instantiate the object.

--- a/design/vaults.md
+++ b/design/vaults.md
@@ -352,7 +352,11 @@ evaluated, ensuring:
 ### Expression Security
 
 - Vault expressions are evaluated server-side only
-- Secret values are never logged or exposed in intermediate files
+- Vault secrets resolved via `vault.get()` are automatically redacted from
+  stdout/stderr output, log files, and persisted data artifacts
+- Redaction replaces secret values with `***` using the `SecretRedactor`
+- The redactor is threaded through `MethodContext` and available to all model
+  implementations
 - Expression evaluation errors don't expose secret values
 
 ## 1Password Provider

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -311,6 +311,7 @@ export const modelMethodRunCommand = new Command()
             definitionRepository: definitionRepo,
             runtimeTags,
             vaultService,
+            redactor,
           },
         );
 

--- a/src/domain/models/command/shell/shell_model.ts
+++ b/src/domain/models/command/shell/shell_model.ts
@@ -88,6 +88,9 @@ async function executeCommand(
   let exitCode = 0;
   let durationMs = 0;
 
+  const redact = (text: string) =>
+    context.redactor?.hasSecrets ? context.redactor.redact(text) : text;
+
   try {
     const result = await executeProcess({
       command: "sh",
@@ -96,15 +99,17 @@ async function executeCommand(
       env: args.env,
       timeoutMs: args.timeout,
       logger: context.logger,
+      redactor: context.redactor,
     });
 
-    stdout = result.stdout;
-    stderr = result.stderr;
+    stdout = redact(result.stdout);
+    stderr = redact(result.stderr);
     exitCode = result.exitCode;
     durationMs = result.durationMs;
   } catch (error) {
     // Handle execution errors (command not found, timeout, etc.)
-    stderr = error instanceof Error ? error.message : String(error);
+    const rawError = error instanceof Error ? error.message : String(error);
+    stderr = redact(rawError);
     exitCode = -1;
   }
 
@@ -112,7 +117,7 @@ async function executeCommand(
   const resultAttributes = {
     exitCode,
     executedAt: new Date().toISOString(),
-    command: args.run,
+    command: redact(args.run),
     durationMs,
     stdout,
     stderr,

--- a/src/domain/models/command/shell/shell_model_test.ts
+++ b/src/domain/models/command/shell/shell_model_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assertNotEquals } from "@std/assert/not-equals";
 import { createDefinitionId } from "../../../definitions/definition.ts";
 import {
   SHELL_MODEL_TYPE,
@@ -31,6 +32,7 @@ import type { UnifiedDataRepository } from "../../../../infrastructure/persisten
 import type { DefinitionRepository } from "../../../definitions/repositories.ts";
 import { type DataId, generateDataId } from "../../../data/data_id.ts";
 import { getLogger } from "@logtape/logtape";
+import { SecretRedactor } from "../../../secrets/mod.ts";
 
 /**
  * Stored result from mock data writer.
@@ -539,4 +541,79 @@ Deno.test("shellModel.methods.execute returns output for no output command", asy
 
   // Should still have data handles
   assertEquals(result.dataHandles !== undefined, true);
+});
+
+// Secret redaction tests
+Deno.test("shellModel.methods.execute redacts secrets from stdout in result attributes", async () => {
+  const redactor = new SecretRedactor();
+  redactor.addSecret("super-secret-value");
+
+  const args: ShellInputAttributes = { run: "echo super-secret-value" };
+  const { context, getResults } = createTestContext({ redactor });
+  await shellModel.methods.execute.execute(args, context);
+
+  const attrs = getResultAttributes(getResults(), "result");
+  assertNotEquals(attrs?.stdout, undefined);
+  assertStringIncludes(attrs?.stdout as string, "***");
+  assertEquals((attrs?.stdout as string).includes("super-secret-value"), false);
+});
+
+Deno.test("shellModel.methods.execute redacts secrets from stderr in result attributes", async () => {
+  const redactor = new SecretRedactor();
+  redactor.addSecret("stderr-secret");
+
+  const args: ShellInputAttributes = { run: "echo stderr-secret >&2" };
+  const { context, getResults } = createTestContext({ redactor });
+  await shellModel.methods.execute.execute(args, context);
+
+  const attrs = getResultAttributes(getResults(), "result");
+  assertNotEquals(attrs?.stderr, undefined);
+  assertStringIncludes(attrs?.stderr as string, "***");
+  assertEquals((attrs?.stderr as string).includes("stderr-secret"), false);
+});
+
+Deno.test("shellModel.methods.execute redacts secrets from output log file", async () => {
+  const redactor = new SecretRedactor();
+  redactor.addSecret("log-file-secret");
+
+  const args: ShellInputAttributes = {
+    run: "echo log-file-secret && echo log-file-secret >&2",
+  };
+  const { context, getResults } = createTestContext({ redactor });
+  await shellModel.methods.execute.execute(args, context);
+
+  const logContent = getOutputLogContent(getResults());
+  assertStringIncludes(logContent, "***");
+  assertEquals(logContent.includes("log-file-secret"), false);
+});
+
+Deno.test("shellModel.methods.execute redacts secrets from command in result attributes", async () => {
+  const redactor = new SecretRedactor();
+  redactor.addSecret("command-secret");
+
+  const args: ShellInputAttributes = { run: "echo command-secret" };
+  const { context, getResults } = createTestContext({ redactor });
+  await shellModel.methods.execute.execute(args, context);
+
+  const attrs = getResultAttributes(getResults(), "result");
+  assertNotEquals(attrs?.command, undefined);
+  assertStringIncludes(attrs?.command as string, "***");
+  assertEquals((attrs?.command as string).includes("command-secret"), false);
+});
+
+Deno.test("shellModel.methods.execute redacts secrets from error messages on failure", async () => {
+  const redactor = new SecretRedactor();
+  redactor.addSecret("error-secret");
+
+  // Use a command that will produce an error containing the secret
+  const args: ShellInputAttributes = {
+    run: "echo error-secret >&2 && exit 1",
+  };
+  const { context, getResults } = createTestContext({ redactor });
+  await shellModel.methods.execute.execute(args, context);
+
+  const attrs = getResultAttributes(getResults(), "result");
+  // stderr should be redacted
+  assertNotEquals(attrs?.stderr, undefined);
+  assertEquals((attrs?.stderr as string).includes("error-secret"), false);
 });

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -22,6 +22,7 @@ import type { CloudControlClient } from "@aws-sdk/client-cloudcontrol";
 import type { Logger } from "@logtape/logtape";
 import { ModelType } from "./model_type.ts";
 import type { VaultService } from "../vaults/vault_service.ts";
+import type { SecretRedactor } from "../secrets/mod.ts";
 import { CalVer } from "./calver.ts";
 import type { DefinitionRepository } from "../definitions/repositories.ts";
 import {
@@ -220,6 +221,11 @@ export interface MethodContext {
     name: string,
     overrides?: FileWriterOverrides,
   ) => DataWriter;
+
+  /**
+   * Optional secret redactor for stripping vault secrets from output.
+   */
+  redactor?: SecretRedactor;
 
   /**
    * Tags merged into every writer created during execution.

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -516,6 +516,7 @@ export class DefaultStepExecutor implements StepExecutor {
           runtimeTags: ctx.runtimeTags,
           dataOutputOverrides: stepDataOutputOverrides,
           vaultService,
+          redactor: ctx.secretRedactor,
         },
       );
 

--- a/src/infrastructure/process/process_executor.ts
+++ b/src/infrastructure/process/process_executor.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { Logger } from "@logtape/logtape";
+import type { SecretRedactor } from "../../domain/secrets/mod.ts";
 
 /**
  * Options for executing a process.
@@ -35,6 +36,8 @@ export interface ProcessExecutorOptions {
   timeoutMs?: number;
   /** Logger for streaming stdout (info) and stderr (warning). */
   logger?: Logger;
+  /** Secret redactor for stripping vault secrets from streamed output. */
+  redactor?: SecretRedactor;
 }
 
 /**
@@ -147,9 +150,11 @@ export async function executeProcess(
 
     try {
       const logger = options.logger;
+      const redact = (line: string) =>
+        options.redactor?.hasSecrets ? options.redactor.redact(line) : line;
       const [stdoutResult, stderrResult, status] = await Promise.all([
-        streamLines(process.stdout, (line) => logger.info(line)),
-        streamLines(process.stderr, (line) => logger.warn(line)),
+        streamLines(process.stdout, (line) => logger.info(redact(line))),
+        streamLines(process.stderr, (line) => logger.warn(redact(line))),
         process.status,
       ]);
 

--- a/src/infrastructure/process/process_executor_test.ts
+++ b/src/infrastructure/process/process_executor_test.ts
@@ -19,6 +19,7 @@
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { executeProcess, streamLines } from "./process_executor.ts";
+import { SecretRedactor } from "../../domain/secrets/mod.ts";
 
 Deno.test("streamLines processes complete lines", async () => {
   const encoder = new TextEncoder();
@@ -194,4 +195,36 @@ Deno.test("executeProcess handles timeout with logger", async () => {
   } catch (error) {
     assertStringIncludes((error as Error).message, "timed out");
   }
+});
+
+Deno.test("executeProcess redacts secrets from streamed stdout lines", async () => {
+  const infoLines: string[] = [];
+  const warnLines: string[] = [];
+
+  const mockLogger = {
+    info: (line: string) => {
+      infoLines.push(line);
+    },
+    warn: (line: string) => {
+      warnLines.push(line);
+    },
+  } as unknown as import("@logtape/logtape").Logger;
+
+  const redactor = new SecretRedactor();
+  redactor.addSecret("my-secret-token");
+
+  const result = await executeProcess({
+    command: "sh",
+    args: ["-c", "echo my-secret-token && echo my-secret-token >&2"],
+    logger: mockLogger,
+    redactor,
+  });
+
+  assertEquals(result.success, true);
+  // Streamed lines to logger should be redacted
+  assertEquals(infoLines, ["***"]);
+  assertEquals(warnLines, ["***"]);
+  // Raw captured output is NOT redacted by process executor (shell model handles that)
+  assertStringIncludes(result.stdout, "my-secret-token");
+  assertStringIncludes(result.stderr, "my-secret-token");
 });


### PR DESCRIPTION
## Summary

Fixes #478 — when a model method references a vault secret via `vault.get(...)` and the command runs, the resolved secret value appeared in plaintext in:

1. **Console output** — real-time streaming via `logger.info(line)`
2. **Data artifacts** — stdout/stderr/command in result.json persisted to `.swamp/data/`
3. **Log file artifacts** — output log written to `.swamp/data/.../log/`
4. **Run log files** — `.swamp/outputs/*.log` files
5. **Error messages** — catch block in shell_model.ts

The `SecretRedactor` existed and was populated during vault resolution, but was only wired to the `RunFileSink` (the `.swamp/outputs/*.log` files). It never reached the shell model or the process executor.

### The fix

Thread the `SecretRedactor` through `MethodContext` so models can apply redaction to all output before persistence and streaming.

**Changes:**

- Add `redactor?: SecretRedactor` to `MethodContext` interface
- Add `redactor?: SecretRedactor` to `ProcessExecutorOptions` — redacts lines before passing to logger in streaming mode
- In `shell_model.ts` — pass `context.redactor` to `executeProcess()`, redact `stdout`, `stderr`, and `command` fields before storing in result attributes, redact error messages in catch block
- In `model_method_run.ts` — pass the `redactor` in the context object to `executionService.executeWorkflow()`
- In `execution_service.ts` — pass `ctx.secretRedactor` as `redactor` in the context for workflow step execution

### What users see

Before this fix, running a model with a vault secret:
```
$ swamp model method run secret-test execute
... Executing method "execute"
... my-super-secret-password-12345    ← secret in plaintext
```

After this fix:
```
$ swamp model method run secret-test execute
... Executing method "execute"
... ***                                ← redacted
```

The redaction applies everywhere the secret could appear:

| Output channel | Before | After |
|---|---|---|
| Console streaming | `my-super-secret-password-12345` | `***` |
| result.json `stdout` | `my-super-secret-password-12345` | `***` |
| result.json `command` | `echo 'my-super-secret-password-12345'` | `echo '***'` |
| Log data artifact | `my-super-secret-password-12345` | `***` |
| Run log file | `my-super-secret-password-12345` | `***` |
| JSON mode (`--json`) | `my-super-secret-password-12345` | `***` |
| Error messages | `my-super-secret-password-12345` | `***` |

### User impact

- **No breaking changes** for normal usage. Commands that don't use vault secrets behave identically.
- The `command` field in result data now shows the redacted command (e.g., `curl -H 'Authorization: Bearer ***' https://api.example.com`) instead of the resolved secret. Users who need to see which vault/key was referenced can check the definition YAML, which preserves the original `vault.get()` expression.
- In practice, the `***` replacement in the command field has minimal impact — the command structure remains visible and the secret is hidden, which is the desired behavior for audit logs.

### End-to-end CLI verification

Tested with the compiled binary in a fresh swamp repo:

1. Created a `local_encryption` vault with secret `my-super-secret-password-12345`
2. Created a `command/shell` model with `run: "echo '${{ vault.get(test-vault, my-api-key) }}'"`
3. Ran `swamp model method run secret-test execute`
4. Verified console output shows `***`
5. Checked all persisted artifacts:
   - **result.json**: `{"command":"echo '***'","stdout":"***","stderr":"",  ...}`
   - **log artifact**: `[stdout]\n***`
   - **run log**: `... ***`
6. Ran `grep -r "my-super-secret-password-12345" .swamp/` — **zero matches**, no plaintext secret in any persisted artifact
7. Verified `--json` mode also shows redacted values

### Files changed (9)

**Domain model:**
- `src/domain/models/model.ts` — add `redactor` to `MethodContext`
- `src/domain/models/command/shell/shell_model.ts` — apply redaction to stdout, stderr, command, and error messages

**Infrastructure:**
- `src/infrastructure/process/process_executor.ts` — add `redactor` to options, redact streamed lines before logger

**CLI / Workflow threading:**
- `src/cli/commands/model_method_run.ts` — pass `redactor` in context
- `src/domain/workflows/execution_service.ts` — pass `secretRedactor` as `redactor` in workflow step context

**Tests (6 new):**
- `src/domain/models/command/shell/shell_model_test.ts` — 5 new tests (stdout, stderr, command, log file, error message redaction)
- `src/infrastructure/process/process_executor_test.ts` — 1 new test (streamed line redaction)

**Design docs:**
- `design/vaults.md` — updated Expression Security section
- `design/models.md` — mention `redactor` in MethodContext description

## Test plan

- [x] `deno check` — passes
- [x] `deno lint` — passes
- [x] `deno fmt` — passes
- [x] `deno run test` — 2085 tests pass
- [x] `deno run compile` — binary compiles
- [x] End-to-end CLI test with compiled binary confirms no secret leakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)