### PR TITLE
fix: resolve race condition in concurrent vault put (#487)

### DIFF
--- a/src/infrastructure/repo/symlink_repo_index_service.ts
+++ b/src/infrastructure/repo/symlink_repo_index_service.ts
@@ -736,17 +736,21 @@ export class SymlinkRepoIndexService implements RepoIndexService {
   /**
    * Refreshes the secrets index for a local_encryption vault.
    * Creates symlinks for each secret key, removing the .enc extension.
+   *
+   * Uses incremental sync (ensureDir + create/remove individual symlinks)
+   * rather than destructive remove+recreate, so concurrent calls are safe.
    */
   private async refreshSecretsIndex(
     logicalSecretsDir: string,
     actualSecretsDir: string,
     vaultName: string,
   ): Promise<void> {
-    // Remove existing logical secrets directory if it exists (could be old symlink or directory)
+    // Migration: if logicalSecretsDir is an old-style symlink, remove it
+    // so we can replace it with a real directory of individual symlinks.
     try {
       const stat = await Deno.lstat(logicalSecretsDir);
-      if (stat.isSymlink || stat.isDirectory) {
-        await Deno.remove(logicalSecretsDir, { recursive: true });
+      if (stat.isSymlink) {
+        await Deno.remove(logicalSecretsDir);
       }
     } catch (error) {
       if (!(error instanceof Deno.errors.NotFound)) {
@@ -754,15 +758,16 @@ export class SymlinkRepoIndexService implements RepoIndexService {
       }
     }
 
-    // Create fresh logical secrets directory
+    // Idempotent directory creation — safe for concurrent calls
     await ensureDir(logicalSecretsDir);
 
-    // List all .enc files in the actual secrets directory
+    // Build the desired set of keys from actual .enc files
+    const desiredKeys = new Set<string>();
     try {
       for await (const entry of Deno.readDir(actualSecretsDir)) {
         if (entry.isFile && entry.name.endsWith(".enc")) {
-          // Remove .enc extension for the symlink name
           const keyName = entry.name.slice(0, -4);
+          desiredKeys.add(keyName);
           const targetPath = join(actualSecretsDir, entry.name);
           const linkPath = join(logicalSecretsDir, keyName);
           await this.createSymlink(targetPath, linkPath);
@@ -774,6 +779,25 @@ export class SymlinkRepoIndexService implements RepoIndexService {
           .warn`Failed to read secrets directory for vault '${vaultName}': ${error}`;
       }
       // Directory may not exist yet, that's OK
+    }
+
+    // Remove stale symlinks that no longer have a corresponding .enc file
+    try {
+      for await (const entry of Deno.readDir(logicalSecretsDir)) {
+        if (!desiredKeys.has(entry.name)) {
+          try {
+            await Deno.remove(join(logicalSecretsDir, entry.name));
+          } catch (error) {
+            if (!(error instanceof Deno.errors.NotFound)) {
+              throw error;
+            }
+          }
+        }
+      }
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
     }
   }
 

--- a/src/infrastructure/repo/symlink_repo_index_service_test.ts
+++ b/src/infrastructure/repo/symlink_repo_index_service_test.ts
@@ -657,6 +657,222 @@ Deno.test("path traversal protection: tag value in indexTagBasedData", async () 
   });
 });
 
+// ===========================================================================
+// Secrets indexing (refreshSecretsIndex) tests
+// ===========================================================================
+
+Deno.test("refreshSecretsIndex: basic secrets indexing creates symlinks", async () => {
+  await withTempDir(async (dir) => {
+    await setupRepoDir(dir);
+    const { indexService } = createIndexService(dir);
+
+    // Set up actual secrets directory with .enc files
+    const actualSecretsDir = join(
+      dir,
+      ".swamp",
+      "secrets",
+      "local_encryption",
+      "my-vault",
+    );
+    await ensureDir(actualSecretsDir);
+    await Deno.writeTextFile(
+      join(actualSecretsDir, "api-key.enc"),
+      "encrypted",
+    );
+    await Deno.writeTextFile(
+      join(actualSecretsDir, "db-password.enc"),
+      "encrypted",
+    );
+
+    // Set up vault config so indexVault works
+    const vaultDir = join(dir, ".swamp", "vault", "local_encryption");
+    await ensureDir(vaultDir);
+    await Deno.writeTextFile(
+      join(vaultDir, "vault-id.yaml"),
+      "name: my-vault\ntype: local_encryption\n",
+    );
+
+    const event = createVaultCreated(
+      "vault-id",
+      "local_encryption",
+      "my-vault",
+    );
+    await indexService.handleVaultCreated(event);
+
+    // Check that symlinks were created (without .enc extension)
+    const logicalSecretsDir = join(dir, "vaults", "my-vault", "secrets");
+    const apiKeyStat = await Deno.lstat(join(logicalSecretsDir, "api-key"));
+    assertEquals(apiKeyStat.isSymlink, true);
+    const dbPwStat = await Deno.lstat(join(logicalSecretsDir, "db-password"));
+    assertEquals(dbPwStat.isSymlink, true);
+  });
+});
+
+Deno.test("refreshSecretsIndex: incremental add preserves existing symlinks", async () => {
+  await withTempDir(async (dir) => {
+    await setupRepoDir(dir);
+    const { indexService } = createIndexService(dir);
+
+    const actualSecretsDir = join(
+      dir,
+      ".swamp",
+      "secrets",
+      "local_encryption",
+      "my-vault",
+    );
+    await ensureDir(actualSecretsDir);
+
+    // Set up vault config
+    const vaultDir = join(dir, ".swamp", "vault", "local_encryption");
+    await ensureDir(vaultDir);
+    await Deno.writeTextFile(
+      join(vaultDir, "vault-id.yaml"),
+      "name: my-vault\ntype: local_encryption\n",
+    );
+
+    // First secret
+    await Deno.writeTextFile(
+      join(actualSecretsDir, "secret-one.enc"),
+      "encrypted",
+    );
+    const event = createVaultCreated(
+      "vault-id",
+      "local_encryption",
+      "my-vault",
+    );
+    await indexService.handleVaultCreated(event);
+
+    // Add a second secret and re-index
+    await Deno.writeTextFile(
+      join(actualSecretsDir, "secret-two.enc"),
+      "encrypted",
+    );
+    await indexService.handleVaultCreated(event);
+
+    // Both symlinks should exist
+    const logicalSecretsDir = join(dir, "vaults", "my-vault", "secrets");
+    const oneStat = await Deno.lstat(join(logicalSecretsDir, "secret-one"));
+    assertEquals(oneStat.isSymlink, true);
+    const twoStat = await Deno.lstat(join(logicalSecretsDir, "secret-two"));
+    assertEquals(twoStat.isSymlink, true);
+  });
+});
+
+Deno.test("refreshSecretsIndex: stale symlinks are removed", async () => {
+  await withTempDir(async (dir) => {
+    await setupRepoDir(dir);
+    const { indexService } = createIndexService(dir);
+
+    const actualSecretsDir = join(
+      dir,
+      ".swamp",
+      "secrets",
+      "local_encryption",
+      "my-vault",
+    );
+    await ensureDir(actualSecretsDir);
+
+    // Set up vault config
+    const vaultDir = join(dir, ".swamp", "vault", "local_encryption");
+    await ensureDir(vaultDir);
+    await Deno.writeTextFile(
+      join(vaultDir, "vault-id.yaml"),
+      "name: my-vault\ntype: local_encryption\n",
+    );
+
+    // Create two secrets and index them
+    await Deno.writeTextFile(
+      join(actualSecretsDir, "keep-me.enc"),
+      "encrypted",
+    );
+    await Deno.writeTextFile(
+      join(actualSecretsDir, "remove-me.enc"),
+      "encrypted",
+    );
+    const event = createVaultCreated(
+      "vault-id",
+      "local_encryption",
+      "my-vault",
+    );
+    await indexService.handleVaultCreated(event);
+
+    // Remove one .enc file and re-index
+    await Deno.remove(join(actualSecretsDir, "remove-me.enc"));
+    await indexService.handleVaultCreated(event);
+
+    // Kept symlink should still exist
+    const logicalSecretsDir = join(dir, "vaults", "my-vault", "secrets");
+    const keepStat = await Deno.lstat(join(logicalSecretsDir, "keep-me"));
+    assertEquals(keepStat.isSymlink, true);
+
+    // Stale symlink should be gone
+    let staleExists = true;
+    try {
+      await Deno.lstat(join(logicalSecretsDir, "remove-me"));
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        staleExists = false;
+      }
+    }
+    assertEquals(staleExists, false);
+  });
+});
+
+Deno.test("refreshSecretsIndex: migrates old-style symlink to directory", async () => {
+  await withTempDir(async (dir) => {
+    await setupRepoDir(dir);
+    const { indexService } = createIndexService(dir);
+
+    const actualSecretsDir = join(
+      dir,
+      ".swamp",
+      "secrets",
+      "local_encryption",
+      "my-vault",
+    );
+    await ensureDir(actualSecretsDir);
+    await Deno.writeTextFile(
+      join(actualSecretsDir, "my-key.enc"),
+      "encrypted",
+    );
+
+    // Set up vault config
+    const vaultDir = join(dir, ".swamp", "vault", "local_encryption");
+    await ensureDir(vaultDir);
+    await Deno.writeTextFile(
+      join(vaultDir, "vault-id.yaml"),
+      "name: my-vault\ntype: local_encryption\n",
+    );
+
+    // Create old-style symlink (secrets -> actualSecretsDir)
+    const vaultLogicalDir = join(dir, "vaults", "my-vault");
+    await ensureDir(vaultLogicalDir);
+    const logicalSecretsDir = join(vaultLogicalDir, "secrets");
+    await Deno.symlink(actualSecretsDir, logicalSecretsDir);
+
+    // Verify it's a symlink before migration
+    const beforeStat = await Deno.lstat(logicalSecretsDir);
+    assertEquals(beforeStat.isSymlink, true);
+
+    // Index — should migrate from symlink to directory of individual symlinks
+    const event = createVaultCreated(
+      "vault-id",
+      "local_encryption",
+      "my-vault",
+    );
+    await indexService.handleVaultCreated(event);
+
+    // Should now be a directory, not a symlink
+    const afterStat = await Deno.lstat(logicalSecretsDir);
+    assertEquals(afterStat.isSymlink, false);
+    assertEquals(afterStat.isDirectory, true);
+
+    // Individual key symlink should exist
+    const keyStat = await Deno.lstat(join(logicalSecretsDir, "my-key"));
+    assertEquals(keyStat.isSymlink, true);
+  });
+});
+
 Deno.test("path traversal protection: step name in handleWorkflowRunStarted", async () => {
   await withTempDir(async (dir) => {
     await setupRepoDir(dir);


### PR DESCRIPTION
## Summary

Fixes the race condition in `refreshSecretsIndex` that caused intermittent `ENOTEMPTY` errors when multiple `vault put` processes ran concurrently against the same vault.

### Root cause

`refreshSecretsIndex` used a destructive remove+recreate pattern: it removed the entire `vaults/{name}/secrets/` directory with `Deno.remove({ recursive: true })` and rebuilt it from scratch on every `vault put`. When two processes collided, one would write symlinks into the directory while the other was trying to remove it, triggering `ENOTEMPTY` (os error 66).

This was the **only** index method using this pattern — `indexModel` and `indexWorkflow` both use idempotent `ensureDir` + atomic `createSymlink` without ever removing their parent directory.

### Fix

Replaced the remove+recreate with an incremental sync that matches the existing model/workflow pattern:

1. **Migration guard** — only remove `logicalSecretsDir` if `lstat` shows it's an old-style **symlink** (not a directory), preserving backward compatibility
2. **`ensureDir()`** — idempotent directory creation, safe for concurrent calls
3. **Build desired set** — read actual `.enc` files to determine which keys should have symlinks
4. **Create/update symlinks** — via existing atomic `createSymlink()` (temp file + rename)
5. **Remove stale entries** — iterate logical dir and remove any symlinks not in the desired set, with `NotFound` tolerance for concurrent removals

This is convergent: any number of concurrent executions produce the same final state without interfering with each other.

### Tests added

4 new test cases for `refreshSecretsIndex`:
- **Basic secrets indexing** — `.enc` files get symlinks created
- **Incremental add** — adding a new secret preserves existing symlinks
- **Stale cleanup** — removing a `.enc` file and re-indexing removes the stale symlink
- **Migration** — old-style symlink gets replaced with a directory of individual symlinks

### Manual verification

Ran the exact reproduction scenario from the issue — 5 rounds of 5 concurrent `vault put` operations against a fresh repo using the compiled binary. All 25 operations completed successfully with all keys present, zero `ENOTEMPTY` errors.

Closes #487

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt` — formatting passes
- [x] `deno run test` — all 2166 tests pass
- [x] `deno run compile` — binary compiles
- [x] Manual concurrent `vault put` stress test (5 rounds x 5 concurrent processes) — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)