### PR TITLE
fix: prevent deno.lock creation during extension bundling

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -311,9 +311,13 @@ Files are classified by export name: `export const model` defines new types,
    Deno-compatible import (`npm:`, `jsr:`, `https://`) can also be used — swamp
    bundles all dependencies automatically (see
    [references/examples.md](references/examples.md#using-external-dependencies))
-3. **Type naming**: Use `@<namespace>/<name>` format (e.g., `@user/my-model`)
-4. **No type annotations**: Avoid TypeScript types in execute parameters
-5. **File naming**: Use snake_case (`my_model.ts`)
+3. **Pin npm versions**: Always pin explicit versions for npm imports (e.g.,
+   `npm:lodash-es@4.17.21`, not `npm:lodash-es`). Swamp does not use a lockfile
+   during bundling, so unpinned versions may resolve differently across runs.
+   `npm:zod@4` is the one exception — it is externalized and provided by swamp.
+4. **Type naming**: Use `@<namespace>/<name>` format (e.g., `@user/my-model`)
+5. **No type annotations**: Avoid TypeScript types in execute parameters
+6. **File naming**: Use snake_case (`my_model.ts`)
 
 ## Namespace Rules
 

--- a/.claude/skills/swamp-extension-model/references/examples.md
+++ b/.claude/skills/swamp-extension-model/references/examples.md
@@ -25,7 +25,7 @@ with swamp to preserve schema `instanceof` checks.
 ```typescript
 // extensions/models/text_analyzer.ts
 import { z } from "npm:zod@4";
-import { countBy, sortBy, words } from "npm:lodash-es";
+import { countBy, sortBy, words } from "npm:lodash-es@4.17.21";
 
 const GlobalArgsSchema = z.object({
   text: z.string().describe("Text to analyze"),
@@ -93,8 +93,8 @@ export const model = {
 | Import                                   | Bundled? | Notes                            |
 | ---------------------------------------- | -------- | -------------------------------- |
 | `npm:zod@4`                              | No       | Shared with swamp (externalized) |
-| `npm:lodash-es`                          | Yes      | Resolved and inlined             |
-| `npm:@aws-sdk/client-s3`                 | Yes      | Resolved and inlined             |
+| `npm:lodash-es@4.17.21`                  | Yes      | Resolved and inlined             |
+| `npm:@aws-sdk/client-s3@3.750.0`         | Yes      | Resolved and inlined             |
 | `jsr:@std/path`                          | Yes      | Resolved and inlined             |
 | `https://deno.land/std@0.224.0/async/..` | Yes      | Resolved and inlined             |
 | Any other Deno-compatible import         | Yes      | Resolved and inlined             |

--- a/src/domain/models/bundle.ts
+++ b/src/domain/models/bundle.ts
@@ -47,6 +47,7 @@ export async function bundleExtension(
     const command = new Deno.Command(denoPath, {
       args: [
         "bundle",
+        "--no-lock",
         "--external",
         "npm:zod@4",
         "--external",

--- a/src/domain/models/bundle_test.ts
+++ b/src/domain/models/bundle_test.ts
@@ -96,6 +96,52 @@ export const schema = z.object({ name: z.string() });
   });
 });
 
+Deno.test("bundleExtension resolves npm imports without creating deno.lock", async () => {
+  const tsCode = `
+import { z } from "npm:zod@4";
+import { parse, stringify } from "npm:yaml@2.7.1";
+
+const ConfigSchema = z.object({
+  data: z.string(),
+});
+
+export const model = {
+  type: "@test/yaml-model",
+  version: "2026.01.01.1",
+  schema: ConfigSchema,
+  transform: (input: string) => {
+    const parsed = parse(input);
+    return stringify(parsed);
+  },
+};
+`;
+
+  const dir = await Deno.makeTempDir({ prefix: "swamp_bundle_test_" });
+  const path = join(dir, "test_ext.ts");
+  await Deno.writeTextFile(path, tsCode);
+  try {
+    const js = await bundleExtension(path, DENO_PATH);
+
+    // Bundle should succeed and contain inlined yaml library code
+    assertEquals(js.length > 0, true);
+
+    // No deno.lock should be created in the source directory
+    let lockExists = true;
+    try {
+      await Deno.stat(join(dir, "deno.lock"));
+    } catch {
+      lockExists = false;
+    }
+    assertEquals(
+      lockExists,
+      false,
+      "deno.lock should not be created in the source directory",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
 Deno.test("bundleExtension produces importable module with working zod instanceof", async () => {
   const tsCode = `
 import { z } from "npm:zod@4";


### PR DESCRIPTION
## Summary

Fixes #490.

PR #452 introduced `deno bundle` for extension model transpilation. The subprocess inherits the user's CWD and Deno's default lockfile behavior creates/updates a `deno.lock` in the user's project root — polluting their repo with an unexpected file.

### Why `--no-lock` is the right fix

The `--no-lock` flag tells Deno to skip lockfile auto-discovery entirely. This is correct for swamp's bundling use case because:

1. **Bundling is a build step, not a dependency install.** Swamp bundles extensions at startup as an internal transpilation step. The user didn't ask Deno to manage their dependencies — swamp is doing it behind the scenes. Creating a `deno.lock` in their project is a side effect they never opted into.

2. **npm resolution still works without a lockfile.** Packages are fetched from the registry and fully inlined into the bundle. The lockfile only pins versions across runs — it doesn't enable resolution.

3. **Version pinning is handled at the source level instead.** Since there's no lockfile, users should pin explicit versions in their import specifiers (e.g., `npm:lodash-es@4.17.21`). The skill docs and examples are updated to reflect this guidance. This is actually more explicit and portable than relying on a lockfile that lives outside the extension source.

4. **Alternative approaches are worse:**
   - Setting `cwd` on the subprocess to a temp dir would break relative imports in extensions
   - Cleaning up `deno.lock` after bundling is fragile and races with other processes
   - Using `--lock=<temp-path>` still creates a lockfile (just elsewhere) for no benefit

### Changes

- **`src/domain/models/bundle.ts`** — Add `--no-lock` to `deno bundle` args
- **`src/domain/models/bundle_test.ts`** — Add test: bundles npm imports successfully and verifies no `deno.lock` is created in the source directory
- **`.claude/skills/swamp-extension-model/SKILL.md`** — Add version pinning rule to Key Rules section
- **`.claude/skills/swamp-extension-model/references/examples.md`** — Pin versions in import examples table and text analyzer example

## Test plan

- [x] New test passes: `deno run test src/domain/models/bundle_test.ts` (4/4 pass)
- [x] Full test suite passes: 2167 passed, 0 failed
- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt` — formatting passes
- [x] `deno run compile` — binary compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)