### PR TITLE
feat: add `swamp extension push` command for publishing extensions

### DIFF
--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -50,8 +50,11 @@ import {
   renderExtensionPushSafetyWarnings,
 } from "../../presentation/output/extension_push_output.ts";
 
-// deno-lint-ignore no-explicit-any
-type AnyOptions = any;
+interface ExtensionPushOptions extends GlobalOptions {
+  repoDir: string;
+  yes?: boolean;
+  dryRun?: boolean;
+}
 
 async function promptConfirmation(message: string): Promise<boolean> {
   const encoder = new TextEncoder();
@@ -74,8 +77,8 @@ export const extensionPushCommand = new Command()
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("-y, --yes", "Skip confirmation prompts")
   .option("--dry-run", "Build archive locally without pushing to registry")
-  .action(async function (options: AnyOptions, manifestPath: string) {
-    const ctx = createContext(options as GlobalOptions, ["extension", "push"]);
+  .action(async function (options: ExtensionPushOptions, manifestPath: string) {
+    const ctx = createContext(options, ["extension", "push"]);
     ctx.logger.debug`Starting extension push`;
 
     // 1. Validate repo


### PR DESCRIPTION
## Summary

Add the `swamp extension push` command, which packages and publishes extension models and workflows to the swamp registry.

- **Extension push command** — manifest-driven three-phase push workflow (initiate, upload to S3, confirm) with `--dry-run` and `-y` flags
- **Manifest validation** — Zod-based schema validation with clear error messages for missing fields, bad CalVer versions, reserved namespaces, and missing models/workflows
- **Safety analyzer** — scans all files before push; blocks `eval()`, `new Function()`, symlinks, hidden files, oversized files; warns on `Deno.Command()`, long lines, base64 blobs
- **Import/dependency resolution** — auto-discovers local TypeScript imports and workflow-to-model dependencies
- **Bundling** — compiles each model entry point to standalone JS via deno bundle
- **Version management** — pre-flight CalVer version check with interactive bump on duplicates
- **`ExtensionApiClient`** — HTTP client for the registry API with HTML error page detection (returns clean message instead of raw HTML dump)
- **Skill documentation** — publishing guide added to `swamp-extension-model` skill with full manifest schema, examples, push workflow, safety rules, and common errors

### Files changed

- `src/cli/commands/extension.ts` — Extension command group
- `src/cli/commands/extension_push.ts` — Push command implementation
- `src/cli/mod.ts` — Register extension command
- `src/cli/unknown_command_handler.ts` — Extension subcommand suggestions
- `src/domain/extensions/extension_manifest.ts` — Manifest schema and parser
- `src/domain/extensions/extension_safety_analyzer.ts` — Safety analysis rules
- `src/domain/extensions/extension_import_resolver.ts` — Local import resolver
- `src/domain/extensions/extension_dependency_resolver.ts` — Workflow dependency resolver
- `src/domain/models/calver.ts` — CalVer `bump()` support
- `src/infrastructure/http/extension_api_client.ts` — Registry HTTP client
- `src/presentation/output/extension_push_output.ts` — Push output rendering
- `.claude/skills/swamp-extension-model/SKILL.md` — Publishing section added
- `.claude/skills/swamp-extension-model/references/publishing.md` — Detailed publishing reference

## Test plan

- [x] All 2229 tests pass (`deno run test`)
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] Integration tests: CLI help, manifest validation errors, auth errors, safety hard errors
- [x] Unit tests: manifest parsing, safety analyzer, import resolver, dependency resolver, CalVer, API client, push output rendering
- [x] Manifest validation runs before auth check so CI tests pass without credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)