### PR TITLE
feat: add integrity verification to `swamp extension pull`

### DIFF
--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -32,11 +32,14 @@ import { analyzeExtensionSafety } from "../../domain/extensions/extension_safety
 import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
 import { atomicWriteTextFile } from "../../infrastructure/persistence/atomic_write.ts";
 import { swampPath } from "../../infrastructure/persistence/paths.ts";
+import { computeChecksum } from "../../domain/models/checksum.ts";
+import { verifyChecksum } from "../../domain/update/integrity.ts";
 import {
   renderExtensionPull,
   renderExtensionPullCancelled,
   renderExtensionPullConflicts,
   renderExtensionPullDependencyPull,
+  renderExtensionPullIntegrity,
   renderExtensionPullResolved,
   renderExtensionPullSafetyErrors,
   renderExtensionPullSafetyWarnings,
@@ -373,6 +376,22 @@ async function pullExtension(
     ref.name,
     version,
   );
+
+  // Verify integrity
+  const serverChecksum = await extensionClient.getChecksum(ref.name, version);
+  const localChecksum = await computeChecksum(archiveBytes);
+  if (serverChecksum !== null) {
+    verifyChecksum(serverChecksum, localChecksum);
+    renderExtensionPullIntegrity(
+      { name: ref.name, version, status: "verified" },
+      outputMode,
+    );
+  } else {
+    renderExtensionPullIntegrity(
+      { name: ref.name, version, status: "unverified" },
+      outputMode,
+    );
+  }
 
   // Extract to temp dir
   const tmpDir = await Deno.makeTempDir({ prefix: "swamp_pull_" });

--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -296,6 +296,32 @@ export class ExtensionApiClient {
     }
   }
 
+  /**
+   * Fetch the SHA-256 checksum for a specific extension version.
+   * Returns null if the extension predates checksum support (legacy) or is not found.
+   */
+  async getChecksum(
+    name: string,
+    version: string,
+  ): Promise<string | null> {
+    const encodedName = encodeURIComponent(name);
+    const res = await this.fetch(
+      `/api/v1/extensions/${encodedName}@${version}/checksum`,
+      {
+        method: "GET",
+      },
+    );
+
+    if (res.status === 404) {
+      await res.body?.cancel();
+      return null;
+    }
+
+    await this.checkResponse(res);
+    const data = await res.json();
+    return data.checksum ?? null;
+  }
+
   private authHeaders(apiKey: string): Record<string, string> {
     return { "Authorization": `Bearer ${apiKey}` };
   }

--- a/src/presentation/output/extension_pull_output.ts
+++ b/src/presentation/output/extension_pull_output.ts
@@ -117,6 +117,38 @@ export function renderExtensionPullDependencyPull(
   }
 }
 
+/** Data for integrity verification output. */
+export interface ExtensionPullIntegrityData {
+  name: string;
+  version: string;
+  status: "verified" | "unverified";
+}
+
+/**
+ * Renders integrity verification result.
+ */
+export function renderExtensionPullIntegrity(
+  data: ExtensionPullIntegrityData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(
+      JSON.stringify(
+        { integrity: data.status, name: data.name, version: data.version },
+        null,
+        2,
+      ),
+    );
+  } else {
+    if (data.status === "verified") {
+      logger.info`Identity verified: ${data.name}@${data.version}`;
+    } else {
+      logger
+        .warn`No checksum available: ${data.name}@${data.version} (legacy extension)`;
+    }
+  }
+}
+
 /**
  * Renders safety errors.
  */


### PR DESCRIPTION
## Summary

Part 2 of extension integrity verification. Part 1 (swamp-club PR #105) added server-side SHA-256 checksum computation during `extension push` and a `GET .../checksum` API endpoint. This adds **client-side verification** to `swamp extension pull` so the CLI computes the SHA-256 of the downloaded archive, fetches the expected checksum from the server, and compares them — blocking extraction on mismatch.

## Why this design

### API client: `getChecksum(name, version)` returns `string | null`

The nullable return keeps backward compatibility with extensions published before Part 1 added checksum support. A `404` or a `null` checksum in the response both gracefully degrade to an "unverified" warning rather than failing the pull. This matches the existing `getLatestVersion()` and `getExtension()` 404→null pattern in the same client class.

### Verification placement: after download, before extraction

The integrity check runs **after** the archive bytes are fully downloaded and **before** any extraction happens. This ensures a tampered archive is never written to disk. It also means `verifyChecksum()` throws a `UserError` that the existing command error flow already handles — no new error rendering needed.

### Reuse of existing utilities

`computeChecksum` (domain/models) and `verifyChecksum` (domain/update/integrity) already exist and are tested. No new crypto code was introduced.

### Output: verified vs unverified

Two states, not three — mismatch is a hard failure (thrown `UserError`), so it never reaches the render function. `"verified"` logs at info level, `"unverified"` logs at warn level to flag legacy extensions that lack checksums.

## Verified output

```
$ swamp extension pull @stack72/system-extensions
00:23:44.618   info    extension·pull       Pulling "@stack72/system-extensions"@"2026.02.26.2"
00:23:44.623   info    extension·pull       Description: "Few system extensions for system and disk usage"
00:23:47.026   info    extension·pull       Identity verified: "@stack72/system-extensions"@"2026.02.26.2"
00:23:47.050   info    extension·pull       Pulled "@stack72/system-extensions"@"2026.02.26.2"
00:23:47.050   info    extension·pull       Extracted 4 files:
00:23:47.051   info    extension·pull         "extensions/models/system_usage.ts"
00:23:47.051   info    extension·pull         "extensions/models/disk_usage.ts"
00:23:47.051   info    extension·pull         ".swamp/bundles/system_usage.js"
00:23:47.051   info    extension·pull         ".swamp/bundles/disk_usage.js"
```

## Changes

| File | Change |
|------|--------|
| `src/infrastructure/http/extension_api_client.ts` | Add `getChecksum()` method |
| `src/presentation/output/extension_pull_output.ts` | Add `renderExtensionPullIntegrity()` render function |
| `src/cli/commands/extension_pull.ts` | Wire integrity verification into pull flow |

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt` — formatting passes
- [x] `deno run test` — all 2246 tests pass
- [x] Manual: `swamp extension pull @stack72/system-extensions` shows "Identity verified"

🤖 Generated with [Claude Code](https://claude.com/claude-code)