### PR TITLE
fix: findBySpec() and findByTag() return only latest version

### DIFF
--- a/integration/data_tagging_test.ts
+++ b/integration/data_tagging_test.ts
@@ -308,7 +308,7 @@ Deno.test("Data Tagging: findByTag with custom tags", async () => {
   });
 });
 
-Deno.test("Data Tagging: findByTag returns all versions with matching tag", async () => {
+Deno.test("Data Tagging: findByTag returns only latest version with matching tag", async () => {
   await withTempDir(async (repoDir) => {
     await setupRepoDir(repoDir);
     const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
@@ -350,13 +350,12 @@ Deno.test("Data Tagging: findByTag returns all versions with matching tag", asyn
 
     assertExists(context.data);
 
-    // findByTag returns all versions with matching tag
+    // findByTag returns only the latest version, not all versions
     const results = context.data.findByTag("type", "versioned");
-    assertEquals(results.length, 5);
+    assertEquals(results.length, 1);
 
-    // Verify all versions are present
-    const versions = results.map((r) => r.version).sort((a, b) => a - b);
-    assertEquals(versions, [1, 2, 3, 4, 5]);
+    // Verify it's the latest version
+    assertEquals(results[0].version, 5);
   });
 });
 

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -572,35 +572,33 @@ export class ModelResolver {
         const seen = new Set<string>();
         for (const [, allCoords] of coordsMap) {
           for (const { modelType, modelId } of allCoords) {
-            // Get all data names, then scan all versions of each
             const allData = dataRepo.findAllForModelSync(modelType, modelId);
             for (const data of allData) {
-              const versions = dataRepo.listVersionsSync(
+              const latestVersion = dataRepo.getLatestVersionSync(
                 modelType,
                 modelId,
                 data.name,
               );
-              for (const version of versions) {
-                const versionData = dataRepo.findByNameSync(
+              if (latestVersion === null) continue;
+              const versionData = dataRepo.findByNameSync(
+                modelType,
+                modelId,
+                data.name,
+                latestVersion,
+              );
+              if (versionData && versionData.tags[tagKey] === tagValue) {
+                const dedupeKey =
+                  `${modelType.normalized}:${modelId}:${data.name}`;
+                if (seen.has(dedupeKey)) continue;
+                seen.add(dedupeKey);
+                const record = dataToRecord(
+                  versionData,
                   modelType,
                   modelId,
                   data.name,
-                  version,
+                  latestVersion,
                 );
-                if (versionData && versionData.tags[tagKey] === tagValue) {
-                  const dedupeKey =
-                    `${modelType.normalized}:${modelId}:${data.name}:${version}`;
-                  if (seen.has(dedupeKey)) continue;
-                  seen.add(dedupeKey);
-                  const record = dataToRecord(
-                    versionData,
-                    modelType,
-                    modelId,
-                    data.name,
-                    version,
-                  );
-                  if (record) results.push(record);
-                }
+                if (record) results.push(record);
               }
             }
           }
@@ -612,32 +610,35 @@ export class ModelResolver {
         const allCoords = coordsMap.get(modelName);
         if (!allCoords) return [];
         const results: DataRecord[] = [];
+        const seen = new Set<string>();
         for (const { modelType, modelId } of allCoords) {
-          // Get all data names, then scan all versions of each
           const allData = dataRepo.findAllForModelSync(modelType, modelId);
           for (const data of allData) {
-            const versions = dataRepo.listVersionsSync(
+            const latestVersion = dataRepo.getLatestVersionSync(
               modelType,
               modelId,
               data.name,
             );
-            for (const version of versions) {
-              const versionData = dataRepo.findByNameSync(
+            if (latestVersion === null) continue;
+            const versionData = dataRepo.findByNameSync(
+              modelType,
+              modelId,
+              data.name,
+              latestVersion,
+            );
+            if (versionData && versionData.tags["specName"] === specName) {
+              const dedupeKey =
+                `${modelType.normalized}:${modelId}:${data.name}`;
+              if (seen.has(dedupeKey)) continue;
+              seen.add(dedupeKey);
+              const record = dataToRecord(
+                versionData,
                 modelType,
                 modelId,
                 data.name,
-                version,
+                latestVersion,
               );
-              if (versionData && versionData.tags["specName"] === specName) {
-                const record = dataToRecord(
-                  versionData,
-                  modelType,
-                  modelId,
-                  data.name,
-                  version,
-                );
-                if (record) results.push(record);
-              }
+              if (record) results.push(record);
             }
           }
         }

--- a/src/domain/expressions/model_resolver_test.ts
+++ b/src/domain/expressions/model_resolver_test.ts
@@ -412,6 +412,110 @@ Deno.test("data.findBySpec() returns records matching specName tag", async () =>
   });
 });
 
+Deno.test("data.findBySpec() returns only latest version when multiple versions exist", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+
+    const model = Definition.create({
+      name: "spec-model",
+      globalArguments: {},
+    });
+    await defRepo.save(type, model);
+
+    // Create a data entry and save it multiple times to create multiple versions
+    const subnet = Data.create({
+      name: "subnet-versioned",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", specName: "subnet" },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      model.id,
+      subnet,
+      new TextEncoder().encode(JSON.stringify({ cidr: "10.0.1.0/24" })),
+    );
+    await dataRepo.save(
+      type,
+      model.id,
+      subnet,
+      new TextEncoder().encode(JSON.stringify({ cidr: "10.0.2.0/24" })),
+    );
+    await dataRepo.save(
+      type,
+      model.id,
+      subnet,
+      new TextEncoder().encode(JSON.stringify({ cidr: "10.0.3.0/24" })),
+    );
+
+    const resolver = new ModelResolver(defRepo, { repoDir, dataRepo });
+    const ctx = await resolver.buildContext();
+
+    assertExists(ctx.data);
+    const results = ctx.data.findBySpec("spec-model", "subnet");
+    // Should return only 1 record (the latest version), not 3
+    assertEquals(results.length, 1);
+    assertEquals(results[0].name, "subnet-versioned");
+  });
+});
+
+Deno.test("data.findByTag() returns only latest version when multiple versions exist", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+
+    const model = Definition.create({
+      name: "tag-model",
+      globalArguments: {},
+    });
+    await defRepo.save(type, model);
+
+    // Create a data entry and save it multiple times to create multiple versions
+    const item = Data.create({
+      name: "tagged-versioned",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", env: "staging" },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      model.id,
+      item,
+      new TextEncoder().encode(JSON.stringify({ v: 1 })),
+    );
+    await dataRepo.save(
+      type,
+      model.id,
+      item,
+      new TextEncoder().encode(JSON.stringify({ v: 2 })),
+    );
+    await dataRepo.save(
+      type,
+      model.id,
+      item,
+      new TextEncoder().encode(JSON.stringify({ v: 3 })),
+    );
+
+    const resolver = new ModelResolver(defRepo, { repoDir, dataRepo });
+    const ctx = await resolver.buildContext();
+
+    assertExists(ctx.data);
+    const results = ctx.data.findByTag("env", "staging");
+    // Should return only 1 record (the latest version), not 3
+    assertEquals(results.length, 1);
+    assertEquals(results[0].name, "tagged-versioned");
+  });
+});
+
 // ============================================================================
 // Graceful handling of missing models/data
 // ============================================================================


### PR DESCRIPTION
## Summary

Fixes #497

`data.findBySpec()` and `data.findByTag()` iterated **all versions** of each data entry and returned every match. When used in a workflow `forEach`, this produced duplicate expanded steps with identical names, which corrupted the topological sort dependency graph and triggered a spurious "Cyclic dependency detected" error.

Both functions now use `getLatestVersionSync()` to return only the most recent version of each data entry — matching the pattern already established by `data.latest()`.

## What changed

### `findBySpec()` (`src/domain/expressions/model_resolver.ts`)
- Replaced `listVersionsSync()` + version loop with a single `getLatestVersionSync()` call per data entry
- Added a `seen` Set for cross-coordinate deduplication (keyed by `modelType:modelId:dataName`, without version)

### `findByTag()` (`src/domain/expressions/model_resolver.ts`)
- Same fix: replaced version iteration with `getLatestVersionSync()`
- Fixed the dedup key to exclude `version` — the old key (`modelType:modelId:dataName:version`) only deduplicated the exact same version appearing under different coordinates, not different versions of the same entry

### Why this is correct

1. **`findBySpec` and `findByTag` are discovery functions** — they find distinct data entries matching criteria, not enumerate version histories. The docs describe them as "Find all data matching a tag" and "Find all data from a specific output spec", where "all" refers to distinct entries, not all versions of each.
2. **Version access has its own API** — `data.version()` and `data.listVersions()` exist specifically for accessing version history.
3. **`latest()` sets the precedent** — it already uses `getLatestVersionSync()`. The `findBy*` functions are semantically a filtered variant of `latest()` applied across multiple entries.
4. **The only consumers are CEL expressions in workflows** — specifically in `forEach` expansions where you want one step per logical data entry, not one step per version.

## Binary testing

Verified the fix end-to-end using the compiled `swamp` binary at `/tmp/fix-497`:

### Setup
- Initialized a fresh swamp repo
- Created 3 `command/shell` model instances: `service-a`, `service-b`, `service-c`
- Ran each model's `execute` method 3 times, creating **3 versions** of `result` data per model (9 total data versions)

### Test 1: `findBySpec` with single model
Created a workflow with `forEach` over `data.findBySpec("service-a", "result")`:
- **Result:** forEach expanded to **1 step** (latest version only), workflow ran and succeeded
- **Before fix:** would expand to 3+ duplicate steps, causing cyclic dependency error

### Test 2: `findByTag` across all models
Created a workflow with `forEach` over `data.findByTag("specName", "result")`:
- **Result:** forEach expanded to **3 steps** (one per model, latest version only), all succeeded
- **Before fix:** would expand to 9+ steps with triplicate names, causing cyclic dependency error

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt` — formatting passes
- [x] `deno run test` — 2248 tests pass (0 failed), including 2 new unit tests and 1 updated integration test
- [x] `deno run compile` — binary recompiles successfully
- [x] End-to-end binary testing with `findBySpec` forEach workflow
- [x] End-to-end binary testing with `findByTag` forEach workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)