### PR TITLE
feat: auto-detect localhost telemetry endpoint from auth serverUrl

### DIFF
--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -152,6 +152,42 @@ async function loadUserModels(): Promise<void> {
 /** Default telemetry endpoint */
 const DEFAULT_TELEMETRY_ENDPOINT = "https://telemetry.swamp.club";
 
+/** Telemetry endpoint used when auth serverUrl is a localhost address */
+const LOCALHOST_TELEMETRY_ENDPOINT = "http://localhost:8080";
+
+/**
+ * Checks whether the given URL points to a localhost address.
+ *
+ * @internal Exported for testing
+ */
+export function isLocalhostUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname === "localhost" ||
+      parsed.hostname === "127.0.0.1" ||
+      parsed.hostname === "[::1]";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolves the telemetry endpoint.
+ * Priority: .swamp.yaml telemetryEndpoint > localhost auto-detect from auth serverUrl > default
+ *
+ * @internal Exported for testing
+ */
+export function resolveTelemetryEndpoint(
+  markerEndpoint: string | undefined,
+  authServerUrl: string | null,
+): string {
+  if (markerEndpoint) return markerEndpoint;
+  if (authServerUrl && isLocalhostUrl(authServerUrl)) {
+    return LOCALHOST_TELEMETRY_ENDPOINT;
+  }
+  return DEFAULT_TELEMETRY_ENDPOINT;
+}
+
 interface TelemetryContext {
   service: TelemetryService;
   userId: string | null;
@@ -192,24 +228,31 @@ async function initTelemetryService(): Promise<TelemetryContext | null> {
     const identityRepo = new UserIdentityRepository();
     const userId = await identityRepo.getUserId();
 
-    const repository = new JsonTelemetryRepository(cwd);
-    const service = new TelemetryService(repository, VERSION);
-    const telemetryEndpoint = marker.telemetryEndpoint ??
-      DEFAULT_TELEMETRY_ENDPOINT;
-
-    const keepFlushed = marker.telemetryKeepFlushed ?? false;
-
     // Try loading auth credentials for authenticated telemetry
+    // (loaded before telemetry endpoint resolution for localhost auto-detect)
     let authToken: string | null = null;
+    let authServerUrl: string | null = null;
     try {
       const authRepo = new AuthRepository();
       const creds = await authRepo.load();
       if (creds?.apiKey) {
         authToken = creds.apiKey;
       }
+      if (creds?.serverUrl) {
+        authServerUrl = creds.serverUrl;
+      }
     } catch {
       // Auth file unreadable — continue without auth
     }
+
+    const repository = new JsonTelemetryRepository(cwd);
+    const service = new TelemetryService(repository, VERSION);
+    const telemetryEndpoint = resolveTelemetryEndpoint(
+      marker.telemetryEndpoint,
+      authServerUrl,
+    );
+
+    const keepFlushed = marker.telemetryKeepFlushed ?? false;
 
     return {
       service,

--- a/src/cli/mod_test.ts
+++ b/src/cli/mod_test.ts
@@ -19,10 +19,12 @@
 
 import { assertEquals } from "@std/assert";
 import {
+  isLocalhostUrl,
   isTelemetryDisabledByConfig,
   isTelemetryDisabledByEnv,
   resolveLogLevel,
   resolveModelsDir,
+  resolveTelemetryEndpoint,
   resolveWorkflowsDir,
 } from "./mod.ts";
 
@@ -401,4 +403,63 @@ Deno.test("resolveWorkflowsDir env var takes priority over default", () => {
       Deno.env.delete("SWAMP_WORKFLOWS_DIR");
     }
   }
+});
+
+// --- isLocalhostUrl tests ---
+
+Deno.test("isLocalhostUrl returns true for http://localhost", () => {
+  assertEquals(isLocalhostUrl("http://localhost"), true);
+});
+
+Deno.test("isLocalhostUrl returns true for http://localhost:3000", () => {
+  assertEquals(isLocalhostUrl("http://localhost:3000"), true);
+});
+
+Deno.test("isLocalhostUrl returns true for http://127.0.0.1:3000", () => {
+  assertEquals(isLocalhostUrl("http://127.0.0.1:3000"), true);
+});
+
+Deno.test("isLocalhostUrl returns true for http://[::1]:3000", () => {
+  assertEquals(isLocalhostUrl("http://[::1]:3000"), true);
+});
+
+Deno.test("isLocalhostUrl returns false for https://swamp.club", () => {
+  assertEquals(isLocalhostUrl("https://swamp.club"), false);
+});
+
+Deno.test("isLocalhostUrl returns false for https://example.com", () => {
+  assertEquals(isLocalhostUrl("https://example.com"), false);
+});
+
+Deno.test("isLocalhostUrl returns false for invalid URL", () => {
+  assertEquals(isLocalhostUrl("not-a-url"), false);
+});
+
+Deno.test("isLocalhostUrl returns false for empty string", () => {
+  assertEquals(isLocalhostUrl(""), false);
+});
+
+// --- resolveTelemetryEndpoint tests ---
+
+Deno.test("resolveTelemetryEndpoint returns marker endpoint when set", () => {
+  const result = resolveTelemetryEndpoint(
+    "https://custom.endpoint",
+    "http://localhost:3000",
+  );
+  assertEquals(result, "https://custom.endpoint");
+});
+
+Deno.test("resolveTelemetryEndpoint returns localhost endpoint when auth serverUrl is localhost", () => {
+  const result = resolveTelemetryEndpoint(undefined, "http://localhost:3000");
+  assertEquals(result, "http://localhost:8080");
+});
+
+Deno.test("resolveTelemetryEndpoint returns default when auth serverUrl is remote", () => {
+  const result = resolveTelemetryEndpoint(undefined, "https://swamp.club");
+  assertEquals(result, "https://telemetry.swamp.club");
+});
+
+Deno.test("resolveTelemetryEndpoint returns default when auth serverUrl is null", () => {
+  const result = resolveTelemetryEndpoint(undefined, null);
+  assertEquals(result, "https://telemetry.swamp.club");
 });


### PR DESCRIPTION
## Summary

- When the stored auth `serverUrl` is a localhost address (`localhost`, `127.0.0.1`, `[::1]`), automatically use `http://localhost:8080` as the telemetry endpoint instead of production `https://telemetry.swamp.club`
- Adds `isLocalhostUrl()` and `resolveTelemetryEndpoint()` pure functions following the existing `resolveLogLevel`/`resolveModelsDir` pattern
- Refactors `initTelemetryService()` to load auth credentials before resolving the telemetry endpoint (needed for localhost detection)

## Test Plan

- Added 8 tests for `isLocalhostUrl` covering localhost variants, remote URLs, invalid URLs, and empty strings
- Added 4 tests for `resolveTelemetryEndpoint` covering all three priority tiers (explicit config > localhost auto-detect > default)
- `deno check` — passed
- `deno lint` — passed
- `deno fmt --check` — passed
- `deno run test` — 2284/2284 passed