### PR TITLE
fix: extension push follows symlinks when collecting workflow files

### DIFF
--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -170,14 +170,15 @@ export const extensionPushCommand = new Command()
       // Validate workflow files exist
       for (const wfRef of manifest.workflows) {
         const wfPath = resolve(workflowsDir, wfRef);
+        let realPath: string;
         try {
-          await Deno.stat(wfPath);
+          realPath = await Deno.realPath(wfPath);
         } catch {
           throw new UserError(
             `Workflow file not found: ${wfRef} (expected at ${wfPath})`,
           );
         }
-        workflowFiles.push(wfPath);
+        workflowFiles.push(realPath);
       }
 
       // Also resolve models referenced by workflows


### PR DESCRIPTION
## Summary

Closes #503.

- Resolve symlinks to real paths using `Deno.realPath()` in `extension_push.ts` when collecting manifest workflow files, instead of passing symlink paths to the safety analyzer

## Problem

Swamp's indexing service creates symlinks at `workflows/{name}/workflow.yaml` → `.swamp/workflows/workflow-{uuid}.yaml`. When `extension push` collects workflow files listed in the manifest, it resolved them from `workflows/` and passed the symlink paths directly to the safety analyzer, which rejected them with:

```
"Symlinks are not allowed in extensions."
```

This meant workflows created with `swamp workflow create` couldn't be published without manually replacing symlinks with real files first.

## Fix

Replace `Deno.stat()` with `Deno.realPath()` when collecting manifest workflow files. `realPath()` resolves symlinks to their target path and also verifies the file exists — so the separate existence check becomes unnecessary.

This is consistent with how the dependency resolver already works — it calls `workflowRepo.getPath(id)` which returns the real `.swamp/workflows/` path, not the symlink. The safety analyzer's `lstat()` + symlink rejection is preserved as defense-in-depth.

## Reproduction

Created a test project in `/tmp` to verify both before and after:

**Before (original code):**
```
$ swamp extension push manifest.yaml --dry-run -y
ERR extension·push Safety errors (push blocked):
ERR extension·push   "/private/tmp/swamp-test-503/workflows/greet-workflow/workflow.yaml": "Symlinks are not allowed in extensions."
FTL error Error: "Extension has safety errors that must be resolved before pushing."
```

**After (with fix):**
```
$ swamp extension push manifest.yaml --dry-run -y
INF extension·push Extension: "@stack72/greeter"@"2026.02.27.1"
INF extension·push Models (1):
INF extension·push   "extensions/models/greeter.ts"
INF extension·push Workflows (1):
INF extension·push   ".swamp/workflows/workflow-a55742d8-1dec-471f-b9b0-c6e6e3345d4e.yaml"
INF extension·push Dry run complete for "@stack72/greeter"@"2026.02.27.1"
INF extension·push Archive size: "1.8KB"
INF extension·push No API calls were made.
```

The symlink at `workflows/greet-workflow/workflow.yaml` is resolved to the real file in `.swamp/workflows/`, passes the safety analyzer, and is correctly archived.

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] All 2272 tests pass
- [x] Manual verification: `swamp workflow create` + `swamp extension push --dry-run` succeeds with symlinked workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)