### PR TITLE
fix: use unique archive names for workflow files in extension push

### DIFF
--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -164,10 +164,12 @@ export const extensionPushCommand = new Command()
     const allModelFiles = [...importResult.resolvedFiles];
 
     // 8. Resolve workflow dependencies if workflows present
-    const workflowFiles: string[] = [];
+    const workflowFiles: Array<{ sourcePath: string; archiveName: string }> =
+      [];
     if (manifest.workflows.length > 0) {
       const workflowsDir = resolve(repoDir, "workflows");
-      // Validate workflow files exist
+      // Validate workflow files exist and resolve symlinks
+      const wfNames: string[] = [];
       for (const wfRef of manifest.workflows) {
         const wfPath = resolve(workflowsDir, wfRef);
         let realPath: string;
@@ -178,33 +180,47 @@ export const extensionPushCommand = new Command()
             `Workflow file not found: ${wfRef} (expected at ${wfPath})`,
           );
         }
-        workflowFiles.push(realPath);
+        // Derive workflow name from the manifest reference directory
+        // e.g. "namespace-debug/workflow.yaml" → "namespace-debug"
+        const refDir = dirname(wfRef);
+        const archiveName = refDir !== "."
+          ? `${refDir.replace(/\//g, "-")}.yaml`
+          : basename(realPath);
+        workflowFiles.push({ sourcePath: realPath, archiveName });
+        wfNames.push(
+          refDir !== "."
+            ? refDir.replace(/_/g, "-")
+            : basename(wfRef, ".yaml").replace(/_/g, "-"),
+        );
       }
 
       // Also resolve models referenced by workflows
-      const wfNames = manifest.workflows.map((wf) =>
-        basename(wf, ".yaml").replace(/_/g, "-")
-      );
       const depResult = await resolveWorkflowDependencies(wfNames, {
         workflowRepo: repoContext.workflowRepo,
         definitionRepo: repoContext.definitionRepo,
         modelsDir,
       });
 
-      // Merge auto-resolved model files (dedup)
+      // Merge auto-resolved model files (dedup, skip non-existent)
       const existingSet = new Set(allModelFiles);
       for (const mf of depResult.modelFiles) {
-        if (!existingSet.has(mf)) {
+        if (existingSet.has(mf)) continue;
+        try {
+          await Deno.stat(mf);
           allModelFiles.push(mf);
           existingSet.add(mf);
+        } catch {
+          // Model source not at conventional path — it may already be
+          // included in the manifest under a different filename.
+          ctx.logger.debug`Skipping auto-resolved model (not found): ${mf}`;
         }
       }
 
       // Merge workflow files from dependency resolution
-      const wfSet = new Set(workflowFiles);
+      const wfSet = new Set(workflowFiles.map((wf) => wf.sourcePath));
       for (const wf of depResult.workflowFiles) {
         if (!wfSet.has(wf)) {
-          workflowFiles.push(wf);
+          workflowFiles.push({ sourcePath: wf, archiveName: basename(wf) });
           wfSet.add(wf);
         }
       }
@@ -231,7 +247,9 @@ export const extensionPushCommand = new Command()
         version: manifest.version,
         description: manifest.description,
         modelFiles: allModelFiles.map((f) => relative(repoDir, f)),
-        workflowFiles: workflowFiles.map((f) => relative(repoDir, f)),
+        workflowFiles: workflowFiles.map((wf) =>
+          relative(repoDir, wf.sourcePath)
+        ),
         additionalFiles: additionalFilePaths.map((f) => relative(repoDir, f)),
         dependencies: manifest.dependencies,
       },
@@ -241,7 +259,7 @@ export const extensionPushCommand = new Command()
     // 11. Run safety analysis
     const allFiles = [
       ...allModelFiles,
-      ...workflowFiles,
+      ...workflowFiles.map((wf) => wf.sourcePath),
       ...additionalFilePaths,
     ];
     const safetyResult = await analyzeExtensionSafety(allFiles);
@@ -368,10 +386,10 @@ export const extensionPushCommand = new Command()
         );
       }
 
-      // Copy workflow files
-      for (const wfFile of workflowFiles) {
-        const destPath = join(extDir, "workflows", basename(wfFile));
-        await Deno.copyFile(wfFile, destPath);
+      // Copy workflow files using unique archive names
+      for (const wf of workflowFiles) {
+        const destPath = join(extDir, "workflows", wf.archiveName);
+        await Deno.copyFile(wf.sourcePath, destPath);
       }
 
       // Copy additional files


### PR DESCRIPTION
## Summary

- Fix workflow file collision in archives: all `{name}/workflow.yaml` entries produced the same `basename()` → `workflow.yaml`, so only the last workflow survived in the tar.gz
- Fix workflow name extraction for dependency resolver: `basename("namespace-debug/workflow.yaml", ".yaml")` gave `workflow` for all entries instead of the actual workflow name
- Skip auto-resolved model files that don't exist at the conventional path (they may already be in the manifest under a different filename)

## Problem

A user published `@john/k8s` — an extension with 15 models and 13 workflows. When pulled, only 1 workflow was present. The manifest listed:

```yaml
workflows:
  - namespace-debug/workflow.yaml
  - deployment-status/workflow.yaml
  - service-connectivity/workflow.yaml
  - cluster-health/workflow.yaml
  - security-audit/workflow.yaml
  - rbac-audit/workflow.yaml
  - storage-health/workflow.yaml
  - autoscaling-status/workflow.yaml
  - batch-jobs-status/workflow.yaml
  - network-audit/workflow.yaml
  - pod-inventory/workflow.yaml
  - pod-health-check/workflow.yaml
  - cluster-summary/workflow.yaml
```

The archive copy step used `basename()` to name files in the tar.gz:

```typescript
// basename("namespace-debug/workflow.yaml") → "workflow.yaml"
// basename("deployment-status/workflow.yaml") → "workflow.yaml"
// basename("cluster-summary/workflow.yaml") → "workflow.yaml"
// ... all 13 resolve to the same filename
const destPath = join(extDir, "workflows", basename(wfFile));
await Deno.copyFile(wfFile, destPath);  // each overwrites the previous
```

Inspecting the published `2026.02.27.1.tar.gz` confirmed only `cluster-summary` (the last manifest entry) survived:

```
$ tar -tzf 2026.02.27.1.tar.gz | grep workflows
extension/workflows/
extension/workflows/workflow.yaml       ← 1 file instead of 13

$ head -2 extension/workflows/workflow.yaml
id: eaea8dd8-54f0-4d86-ab75-68bd3dd5ec1b
name: cluster-summary                    ← last entry wins
```

The models directory was fine (15 unique filenames), but all 13 workflows collapsed into one.

## Fix

Track each workflow's unique archive name derived from its manifest reference directory:

```typescript
// "namespace-debug/workflow.yaml" → "namespace-debug.yaml"
// "deployment-status/workflow.yaml" → "deployment-status.yaml"
// "cluster-summary/workflow.yaml" → "cluster-summary.yaml"
const refDir = dirname(wfRef);
const archiveName = refDir !== "."
  ? `${refDir.replace(/\//g, "-")}.yaml`
  : basename(realPath);
```

Also fixed two related issues in the same flow:

1. **Workflow name extraction for dependency resolver** — `basename("namespace-debug/workflow.yaml", ".yaml")` gave `"workflow"` for all entries. Now correctly extracts the directory name (`"namespace-debug"`) so the resolver can look up the right workflows.

2. **Phantom model paths from dependency resolver** — when models are at non-conventional paths (e.g., `greeter.ts` instead of `@stack72/greeter/model.ts`), the resolver guessed a path that didn't exist on disk and the safety analyzer blocked the push. Now validates file existence before adding auto-resolved model files.

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] All 2287 tests pass
- [x] Manual: created test project with 2 models + 2 workflows, verified archive contains both workflow files with unique names
- [x] Manual: verified project with model instances (dependency resolver) no longer fails with phantom model paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)