### PR TITLE
fix: resolve path mismatches in extension push dedup and bundle naming

### DIFF
--- a/integration/extension_push_test.ts
+++ b/integration/extension_push_test.ts
@@ -215,6 +215,184 @@ Deno.test("extension push without auth credentials gives clear error", async () 
   }
 });
 
+Deno.test("extension push --dry-run archives multiple workflows with unique names", async () => {
+  const tmpDir = await initTempRepo();
+  try {
+    // Create a minimal model (uses z from npm:zod@4 which is externalized)
+    const modelsDir = join(tmpDir, "extensions", "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+    await Deno.writeTextFile(
+      join(modelsDir, "echo.ts"),
+      [
+        'import { z } from "npm:zod@4";',
+        "export const model = {",
+        '  type: "@test/echo",',
+        '  version: "2026.02.27.1",',
+        "  methods: {",
+        "    run: {",
+        '      description: "echo",',
+        "      arguments: z.object({}),",
+        "      execute: async () => ({ dataHandles: [] }),",
+        "    },",
+        "  },",
+        "};",
+      ].join("\n"),
+    );
+
+    // Create workflow YAML files in .swamp/workflows/ (the real files)
+    const swampWfDir = join(tmpDir, ".swamp", "workflows");
+    await Deno.mkdir(swampWfDir, { recursive: true });
+
+    const wf1Content = stringifyYaml({
+      id: "a0a0a0a0-1111-4111-a111-111111111111",
+      name: "alpha-workflow",
+      version: 1,
+      jobs: [{
+        name: "main",
+        steps: [{
+          name: "run",
+          task: {
+            type: "model_method",
+            modelIdOrName: "echo",
+            methodName: "run",
+          },
+          dependsOn: [],
+          weight: 0,
+        }],
+        dependsOn: [],
+        weight: 0,
+      }],
+    });
+    const wf2Content = stringifyYaml({
+      id: "b0b0b0b0-2222-4222-b222-222222222222",
+      name: "beta-workflow",
+      version: 1,
+      jobs: [{
+        name: "main",
+        steps: [{
+          name: "run",
+          task: {
+            type: "model_method",
+            modelIdOrName: "echo",
+            methodName: "run",
+          },
+          dependsOn: [],
+          weight: 0,
+        }],
+        dependsOn: [],
+        weight: 0,
+      }],
+    });
+    const wf3Content = stringifyYaml({
+      id: "c0c0c0c0-3333-4333-b333-333333333333",
+      name: "gamma-workflow",
+      version: 1,
+      jobs: [{
+        name: "main",
+        steps: [{
+          name: "run",
+          task: {
+            type: "model_method",
+            modelIdOrName: "echo",
+            methodName: "run",
+          },
+          dependsOn: [],
+          weight: 0,
+        }],
+        dependsOn: [],
+        weight: 0,
+      }],
+    });
+
+    await Deno.writeTextFile(
+      join(swampWfDir, "workflow-a0a0a0a0-1111-4111-a111-111111111111.yaml"),
+      wf1Content,
+    );
+    await Deno.writeTextFile(
+      join(swampWfDir, "workflow-b0b0b0b0-2222-4222-b222-222222222222.yaml"),
+      wf2Content,
+    );
+    await Deno.writeTextFile(
+      join(swampWfDir, "workflow-c0c0c0c0-3333-4333-b333-333333333333.yaml"),
+      wf3Content,
+    );
+
+    // Create symlinks at workflows/{name}/workflow.yaml (like swamp's indexer)
+    const workflowsDir = join(tmpDir, "workflows");
+    for (
+      const [name, id] of [
+        ["alpha-workflow", "a0a0a0a0-1111-4111-a111-111111111111"],
+        ["beta-workflow", "b0b0b0b0-2222-4222-b222-222222222222"],
+        ["gamma-workflow", "c0c0c0c0-3333-4333-b333-333333333333"],
+      ]
+    ) {
+      const dir = join(workflowsDir, name);
+      await Deno.mkdir(dir, { recursive: true });
+      await Deno.symlink(
+        join(swampWfDir, `workflow-${id}.yaml`),
+        join(dir, "workflow.yaml"),
+      );
+    }
+
+    // Create auth.json
+    const configDir = join(tmpDir, ".config", "swamp");
+    await Deno.mkdir(configDir, { recursive: true });
+    await Deno.writeTextFile(
+      join(configDir, "auth.json"),
+      JSON.stringify({
+        serverUrl: "http://localhost:9999",
+        apiKey: "swamp_test_key",
+        apiKeyId: "key-id",
+        username: "test",
+      }),
+    );
+
+    // Create manifest with 3 workflows
+    const manifestPath = join(tmpDir, "manifest.yaml");
+    await Deno.writeTextFile(
+      manifestPath,
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/multi-wf",
+        version: "2026.02.27.1",
+        models: ["echo.ts"],
+        workflows: [
+          "alpha-workflow/workflow.yaml",
+          "beta-workflow/workflow.yaml",
+          "gamma-workflow/workflow.yaml",
+        ],
+      }),
+    );
+
+    // Run dry-run
+    const { stdout, stderr, code } = await runCli(
+      [
+        "extension",
+        "push",
+        manifestPath,
+        "--repo-dir",
+        tmpDir,
+        "--dry-run",
+        "-y",
+        "--no-color",
+      ],
+      {
+        HOME: tmpDir,
+        XDG_CONFIG_HOME: join(tmpDir, ".config"),
+      },
+    );
+
+    const combined = stderr + "\n" + stdout;
+    assertEquals(code, 0);
+
+    // Verify all 3 workflows appear in the output
+    assertStringIncludes(combined, "Workflows (3)");
+    assertStringIncludes(combined, "Dry run complete");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
 Deno.test("extension push safety hard errors block push", async () => {
   const tmpDir = await initTempRepo();
   try {

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -180,8 +180,8 @@ export const extensionPushCommand = new Command()
             `Workflow file not found: ${wfRef} (expected at ${wfPath})`,
           );
         }
-        // Derive workflow name from the manifest reference directory
-        // e.g. "namespace-debug/workflow.yaml" → "namespace-debug"
+        // Derive a unique archive name from the manifest reference directory
+        // e.g. "namespace-debug/workflow.yaml" → "namespace-debug.yaml"
         const refDir = dirname(wfRef);
         const archiveName = refDir !== "."
           ? `${refDir.replace(/\//g, "-")}.yaml`
@@ -216,12 +216,24 @@ export const extensionPushCommand = new Command()
         }
       }
 
-      // Merge workflow files from dependency resolution
+      // Merge workflow files from dependency resolution.
+      // Use realPath on dep-resolver paths so they match the manifest paths
+      // (which were already realPath'd). Without this, symlinks in the repo
+      // path itself (e.g. /tmp → /private/tmp on macOS) cause mismatches.
       const wfSet = new Set(workflowFiles.map((wf) => wf.sourcePath));
       for (const wf of depResult.workflowFiles) {
-        if (!wfSet.has(wf)) {
-          workflowFiles.push({ sourcePath: wf, archiveName: basename(wf) });
-          wfSet.add(wf);
+        let realWf: string;
+        try {
+          realWf = await Deno.realPath(wf);
+        } catch {
+          continue; // Skip if the file doesn't exist
+        }
+        if (!wfSet.has(realWf)) {
+          workflowFiles.push({
+            sourcePath: realWf,
+            archiveName: basename(realWf),
+          });
+          wfSet.add(realWf);
         }
       }
     }
@@ -287,11 +299,13 @@ export const extensionPushCommand = new Command()
     // 12. Bundle each model entry point
     const denoRuntime = new EmbeddedDenoRuntime();
     const denoPath = await denoRuntime.ensureDeno();
-    const bundles = new Map<string, string>(); // entryPoint basename -> JS content
+    const bundles = new Map<string, string>(); // relative path (no ext) -> JS
     const compilationErrors: CompilationError[] = [];
 
     for (const entryPoint of modelEntryPoints) {
-      const entryName = basename(entryPoint, ".ts");
+      // Use relative path from modelsDir to avoid collisions with nested
+      // paths (e.g. aws/ec2/instance.ts and aws/ecs/instance.ts).
+      const entryName = relative(modelsDir, entryPoint).replace(/\.ts$/, "");
       try {
         const js = await bundleExtension(entryPoint, denoPath);
         bundles.set(entryName, js);
@@ -378,12 +392,11 @@ export const extensionPushCommand = new Command()
         await Deno.copyFile(modelFile, destPath);
       }
 
-      // Write compiled bundles (flat)
+      // Write compiled bundles (preserving relative paths from modelsDir)
       for (const [entryName, js] of bundles) {
-        await Deno.writeTextFile(
-          join(extDir, "bundles", `${entryName}.js`),
-          js,
-        );
+        const destPath = join(extDir, "bundles", `${entryName}.js`);
+        await Deno.mkdir(dirname(destPath), { recursive: true });
+        await Deno.writeTextFile(destPath, js);
       }
 
       // Copy workflow files using unique archive names


### PR DESCRIPTION
## Summary

Fixes two path-handling bugs in `swamp extension push` that affect extensions with symlinked workflow files and nested model paths.

### Bug 1: Workflow dedup path mismatch

When merging workflow files from the dependency resolver with those from the manifest, the code compares file paths to avoid duplicates. But the two sources produce different path formats for the same file:

- **Manifest paths**: resolved via `Deno.realPath()`, which canonicalizes the *entire* path including parent directory symlinks (e.g. `/tmp` → `/private/tmp` on macOS)
- **Dependency resolver paths**: built with `join(repoDir, ".swamp/workflows/...")`, which doesn't resolve parent symlinks

This caused the dedup to miss matches when any part of the repo path was a symlink, potentially including duplicate workflow files in the archive.

**Fix**: `realPath()` the dependency resolver paths before comparison, so both sides use canonical absolute paths.

### Bug 2: Bundle naming collision with nested model paths

Bundle entry names used `basename(entryPoint, ".ts")`, which strips all directory structure. For extensions with nested model paths, this causes silent collisions:

```
extensions/models/aws/ec2/instance.ts  → basename → instance.js
extensions/models/aws/ecs/instance.ts  → basename → instance.js  ← overwrites!
```

Only the last model bundled survives. The runtime (`user_model_loader.ts`) already expects bundles at their relative paths (e.g. `.swamp/bundles/aws/ec2/instance.js`), so the archive was inconsistent with what the runtime produces locally.

**Fix**: Use `relative(modelsDir, entryPoint)` as the bundle key, preserving the full directory structure (e.g. `aws/ec2/instance` → `aws/ec2/instance.js`). The pull side already uses a recursive `copyDir()` for bundles, so nested paths are extracted correctly.

### Integration test

Adds a test that creates 3 workflows with symlinks (mimicking swamp's indexer: `workflows/{name}/workflow.yaml` → `.swamp/workflows/workflow-{uuid}.yaml`), builds a manifest referencing all 3, and verifies all 3 appear in the `--dry-run` output.

## User impact

- **Workflow dedup**: Prevents edge-case duplicate workflows when the repo lives under a symlinked path. Most visible on macOS where `/tmp` is a symlink.
- **Bundle naming**: **Critical for anyone publishing models with nested directory structures** (e.g. `aws/ec2/instance.ts`, `aws/ecs/instance.ts`). Without this fix, only one model per basename would survive in the archive. This is a blocker for publishing large extension sets organized in subdirectories.

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — no lint errors
- [x] `deno fmt` — formatting correct
- [x] `deno run test` — all 2288 tests pass
- [x] Integration test verifies multi-workflow archiving with symlinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)