### PR TITLE
fix: extension push respects modelsDir/workflowsDir from .swamp.yaml

### DIFF
--- a/integration/extension_push_test.ts
+++ b/integration/extension_push_test.ts
@@ -317,8 +317,8 @@ Deno.test("extension push --dry-run archives multiple workflows with unique name
       wf3Content,
     );
 
-    // Create symlinks at workflows/{name}/workflow.yaml (like swamp's indexer)
-    const workflowsDir = join(tmpDir, "workflows");
+    // Create symlinks at extensions/workflows/{name}/workflow.yaml (like swamp's indexer)
+    const workflowsDir = join(tmpDir, "extensions", "workflows");
     for (
       const [name, id] of [
         ["alpha-workflow", "a0a0a0a0-1111-4111-a111-111111111111"],
@@ -444,6 +444,91 @@ Deno.test("extension push safety hard errors block push", async () => {
     );
     assertEquals(code === 0, false);
     assertStringIncludes(stderr, "safety errors");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extension push --dry-run respects custom modelsDir from .swamp.yaml", async () => {
+  const tmpDir = await initTempRepo();
+  try {
+    // Set custom modelsDir in .swamp.yaml
+    const markerPath = join(tmpDir, ".swamp.yaml");
+    const markerContent = await Deno.readTextFile(markerPath);
+    const { parse: parseYaml, stringify: yamlStringify } = await import(
+      "@std/yaml"
+    );
+    const markerData = parseYaml(markerContent) as Record<string, unknown>;
+    markerData.modelsDir = "custom/models";
+    await Deno.writeTextFile(markerPath, yamlStringify(markerData));
+
+    // Create model file in the CUSTOM directory (not extensions/models)
+    const customModelsDir = join(tmpDir, "custom", "models");
+    await Deno.mkdir(customModelsDir, { recursive: true });
+    await Deno.writeTextFile(
+      join(customModelsDir, "echo.ts"),
+      [
+        'import { z } from "npm:zod@4";',
+        "export const model = {",
+        '  type: "@test/echo",',
+        '  version: "2026.02.27.1",',
+        "  methods: {",
+        "    run: {",
+        '      description: "echo",',
+        "      arguments: z.object({}),",
+        "      execute: async () => ({ dataHandles: [] }),",
+        "    },",
+        "  },",
+        "};",
+      ].join("\n"),
+    );
+
+    // Create auth.json so we pass the auth check
+    const configDir = join(tmpDir, ".config", "swamp");
+    await Deno.mkdir(configDir, { recursive: true });
+    await Deno.writeTextFile(
+      join(configDir, "auth.json"),
+      JSON.stringify({
+        serverUrl: "http://localhost:9999",
+        apiKey: "swamp_test_key",
+        apiKeyId: "key-id",
+        username: "test",
+      }),
+    );
+
+    // Create manifest referencing the model
+    const manifestPath = join(tmpDir, "manifest.yaml");
+    await Deno.writeTextFile(
+      manifestPath,
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/custom-dir",
+        version: "2026.02.27.1",
+        models: ["echo.ts"],
+      }),
+    );
+
+    // Run dry-run — should find the model in custom/models, not extensions/models
+    const { stdout, stderr, code } = await runCli(
+      [
+        "extension",
+        "push",
+        manifestPath,
+        "--repo-dir",
+        tmpDir,
+        "--dry-run",
+        "-y",
+        "--no-color",
+      ],
+      {
+        HOME: tmpDir,
+        XDG_CONFIG_HOME: join(tmpDir, ".config"),
+      },
+    );
+
+    const combined = stderr + "\n" + stdout;
+    assertEquals(code, 0, `Expected success but got:\n${combined}`);
+    assertStringIncludes(combined, "Dry run complete");
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -29,6 +29,12 @@ import {
 import { stringify as stringifyYaml } from "@std/yaml";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
+import { resolveModelsDir } from "../resolve_models_dir.ts";
+import { resolveWorkflowsDir } from "../resolve_workflows_dir.ts";
+import {
+  RepoMarkerRepository,
+} from "../../infrastructure/persistence/repo_marker_repository.ts";
+import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
 import { UserError } from "../../domain/errors.ts";
 import { parseExtensionManifest } from "../../domain/extensions/extension_manifest.ts";
@@ -143,7 +149,10 @@ export const extensionPushCommand = new Command()
     }
 
     // 5. Resolve models dir
-    const modelsDir = resolve(repoDir, "extensions/models");
+    const repoPath = RepoPath.create(repoDir);
+    const markerRepo = new RepoMarkerRepository();
+    const marker = await markerRepo.read(repoPath);
+    const modelsDir = resolve(repoDir, resolveModelsDir(marker));
 
     // 6. Collect model files from manifest
     const modelEntryPoints: string[] = [];
@@ -167,7 +176,7 @@ export const extensionPushCommand = new Command()
     const workflowFiles: Array<{ sourcePath: string; archiveName: string }> =
       [];
     if (manifest.workflows.length > 0) {
-      const workflowsDir = resolve(repoDir, "workflows");
+      const workflowsDir = resolve(repoDir, resolveWorkflowsDir(marker));
       // Validate workflow files exist and resolve symlinks
       const wfNames: string[] = [];
       for (const wfRef of manifest.workflows) {


### PR DESCRIPTION
## Summary

Fixes #512

`swamp extension push` hardcoded model and workflow directory paths (`extensions/models` and `workflows`) instead of reading them from `.swamp.yaml`. Other commands (`extension pull`, `mod.ts`) correctly use `resolveModelsDir(marker)` / `resolveWorkflowsDir(marker)` to respect user configuration. This PR makes `extension push` consistent with the rest of the codebase.

## What changed

**`src/cli/commands/extension_push.ts`**
- Added imports for `resolveModelsDir`, `resolveWorkflowsDir`, `RepoMarkerRepository`, and `RepoPath`
- Replaced hardcoded `resolve(repoDir, "extensions/models")` with `resolve(repoDir, resolveModelsDir(marker))` — reads `modelsDir` from `.swamp.yaml`, falls back to env var `SWAMP_MODELS_DIR`, then default `extensions/models`
- Replaced hardcoded `resolve(repoDir, "workflows")` with `resolve(repoDir, resolveWorkflowsDir(marker))` — reads `workflowsDir` from `.swamp.yaml`, falls back to env var `SWAMP_WORKFLOWS_DIR`, then default `extensions/workflows`

**`integration/extension_push_test.ts`**
- Fixed existing workflow test to use `extensions/workflows/` (the correct default from `resolveWorkflowsDir`) instead of the old hardcoded `workflows/`
- Added new integration test that creates a repo with a custom `modelsDir` in `.swamp.yaml`, places model files in that custom directory, and verifies `extension push --dry-run` finds them correctly

## Why this is the right fix

The resolver functions (`resolveModelsDir` / `resolveWorkflowsDir`) are the canonical way to determine directory paths throughout the codebase. They implement a clear priority chain: env var > `.swamp.yaml` config > default. Using them in `extension push` makes it consistent with `extension pull` and all other commands, and ensures users who configure custom directories in `.swamp.yaml` get the expected behavior.

## Testing

1. **Integration tests** — All 10 `extension_push_test.ts` tests pass, including the new custom `modelsDir` test
2. **Manual end-to-end test** — Compiled the binary (`deno run compile`), created a fresh repo in `/tmp` with `modelsDir: custom/my-models` in `.swamp.yaml`, placed a model file in `custom/my-models/echo.ts`, and ran `swamp extension push --dry-run`. The command correctly resolved the model at the custom path and completed successfully:
   ```
   extension·push: Models (1):
   extension·push:   "custom/my-models/echo.ts"
   extension·push: Dry run complete for "@test/custom-dir-test"@"2026.02.27.1"
   ```
3. `deno check` — pass
4. `deno lint` — pass
5. `deno fmt` — pass

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] Integration tests pass (10/10)
- [x] Manual test with compiled binary and custom `modelsDir`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Blake Irvin <blakeirvin@me.com>