### PR TITLE
fix: extension push resolves workflows from both indexer and extension dirs

### DIFF
--- a/integration/extension_push_test.ts
+++ b/integration/extension_push_test.ts
@@ -317,8 +317,8 @@ Deno.test("extension push --dry-run archives multiple workflows with unique name
       wf3Content,
     );
 
-    // Create symlinks at extensions/workflows/{name}/workflow.yaml (like swamp's indexer)
-    const workflowsDir = join(tmpDir, "extensions", "workflows");
+    // Create symlinks at workflows/{name}/workflow.yaml (like swamp's indexer)
+    const workflowsDir = join(tmpDir, "workflows");
     for (
       const [name, id] of [
         ["alpha-workflow", "a0a0a0a0-1111-4111-a111-111111111111"],
@@ -528,6 +528,110 @@ Deno.test("extension push --dry-run respects custom modelsDir from .swamp.yaml",
 
     const combined = stderr + "\n" + stdout;
     assertEquals(code, 0, `Expected success but got:\n${combined}`);
+    assertStringIncludes(combined, "Dry run complete");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extension push --dry-run resolves workflows from extensions/workflows", async () => {
+  const tmpDir = await initTempRepo();
+  try {
+    // Create a minimal model
+    const modelsDir = join(tmpDir, "extensions", "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+    await Deno.writeTextFile(
+      join(modelsDir, "echo.ts"),
+      [
+        'import { z } from "npm:zod@4";',
+        "export const model = {",
+        '  type: "@test/echo",',
+        '  version: "2026.02.27.1",',
+        "  methods: {",
+        "    run: {",
+        '      description: "echo",',
+        "      arguments: z.object({}),",
+        "      execute: async () => ({ dataHandles: [] }),",
+        "    },",
+        "  },",
+        "};",
+      ].join("\n"),
+    );
+
+    // Create workflow directly in extensions/workflows/ (not the indexer dir)
+    const extWfDir = join(tmpDir, "extensions", "workflows");
+    await Deno.mkdir(extWfDir, { recursive: true });
+    await Deno.writeTextFile(
+      join(extWfDir, "ext-wf.yaml"),
+      stringifyYaml({
+        id: "d0d0d0d0-4444-4444-a444-444444444444",
+        name: "ext-wf",
+        version: 1,
+        jobs: [{
+          name: "main",
+          steps: [{
+            name: "run",
+            task: {
+              type: "model_method",
+              modelIdOrName: "echo",
+              methodName: "run",
+            },
+            dependsOn: [],
+            weight: 0,
+          }],
+          dependsOn: [],
+          weight: 0,
+        }],
+      }),
+    );
+
+    // Create auth.json
+    const configDir = join(tmpDir, ".config", "swamp");
+    await Deno.mkdir(configDir, { recursive: true });
+    await Deno.writeTextFile(
+      join(configDir, "auth.json"),
+      JSON.stringify({
+        serverUrl: "http://localhost:9999",
+        apiKey: "swamp_test_key",
+        apiKeyId: "key-id",
+        username: "test",
+      }),
+    );
+
+    // Create manifest referencing a workflow in extensions/workflows/
+    const manifestPath = join(tmpDir, "manifest.yaml");
+    await Deno.writeTextFile(
+      manifestPath,
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/ext-wf-test",
+        version: "2026.02.27.1",
+        models: ["echo.ts"],
+        workflows: ["ext-wf.yaml"],
+      }),
+    );
+
+    // Run dry-run — should find the workflow in extensions/workflows/
+    const { stdout, stderr, code } = await runCli(
+      [
+        "extension",
+        "push",
+        manifestPath,
+        "--repo-dir",
+        tmpDir,
+        "--dry-run",
+        "-y",
+        "--no-color",
+      ],
+      {
+        HOME: tmpDir,
+        XDG_CONFIG_HOME: join(tmpDir, ".config"),
+      },
+    );
+
+    const combined = stderr + "\n" + stdout;
+    assertEquals(code, 0, `Expected success but got:\n${combined}`);
+    assertStringIncludes(combined, "Workflows (1)");
     assertStringIncludes(combined, "Dry run complete");
   } finally {
     await Deno.remove(tmpDir, { recursive: true });

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -176,17 +176,33 @@ export const extensionPushCommand = new Command()
     const workflowFiles: Array<{ sourcePath: string; archiveName: string }> =
       [];
     if (manifest.workflows.length > 0) {
-      const workflowsDir = resolve(repoDir, resolveWorkflowsDir(marker));
+      const indexerWorkflowsDir = resolve(repoDir, "workflows");
+      const extensionWorkflowsDir = resolve(
+        repoDir,
+        resolveWorkflowsDir(marker),
+      );
       // Validate workflow files exist and resolve symlinks
       const wfNames: string[] = [];
       for (const wfRef of manifest.workflows) {
-        const wfPath = resolve(workflowsDir, wfRef);
-        let realPath: string;
+        let realPath: string | null = null;
+
+        // Try indexer symlinks first (workflows/)
         try {
-          realPath = await Deno.realPath(wfPath);
-        } catch {
+          realPath = await Deno.realPath(resolve(indexerWorkflowsDir, wfRef));
+        } catch { /* not found here */ }
+
+        // Fall back to extension workflows dir
+        if (!realPath) {
+          try {
+            realPath = await Deno.realPath(
+              resolve(extensionWorkflowsDir, wfRef),
+            );
+          } catch { /* not found here either */ }
+        }
+
+        if (!realPath) {
           throw new UserError(
-            `Workflow file not found: ${wfRef} (expected at ${wfPath})`,
+            `Workflow file not found: ${wfRef} (looked in ${indexerWorkflowsDir} and ${extensionWorkflowsDir})`,
           );
         }
         // Derive a unique archive name from the manifest reference directory


### PR DESCRIPTION
## Summary

Follow-up to #513. `extension push` now resolves workflow references from **both** workflow directories instead of just one:

- **`workflows/`** — the indexer symlink tree (created by `swamp workflow create`)
- **`extensions/workflows/`** — the extension workflows directory (where `swamp extension pull` places files, configurable via `workflowsDir` in `.swamp.yaml`)

Previously, after #513 landed, workflow resolution only checked the extension workflows dir (`resolveWorkflowsDir(marker)`, default `extensions/workflows/`). This broke resolution of workflows created via `swamp workflow create`, which live at `workflows/{name}/workflow.yaml` as symlinks.

## What changed

**`src/cli/commands/extension_push.ts`**
- Workflow resolution now tries the indexer dir (`workflows/`) first, then falls back to the extension workflows dir (`resolveWorkflowsDir(marker)`)
- Error messages report both directories when a workflow can't be found in either location

**`integration/extension_push_test.ts`**
- Reverted the existing workflow test back to using `workflows/` (indexer symlinks) — confirms the indexer path works
- Added a new test that places a workflow directly in `extensions/workflows/` — confirms the extension path works

## Testing

1. **Integration tests** — All 11 tests pass, including both workflow resolution paths
2. **Manual end-to-end test** — Compiled the binary, created a fresh repo in `/tmp`, created one workflow via `swamp workflow create` (indexer dir at `workflows/`) and one manually in `extensions/workflows/`, created a manifest referencing both, and ran `swamp extension push --dry-run`. Both workflows resolved successfully:
   ```
   extension·push: Workflows (2):
   extension·push:   "../../private/tmp/.swamp/workflows/workflow-ccc8cfbb-...yaml"
   extension·push:   "../../private/tmp/extensions/workflows/ext-wf.yaml"
   extension·push: Dry run complete
   ```
3. `deno check` — pass
4. `deno lint` — pass
5. `deno fmt` — pass

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] Integration tests pass (11/11)
- [x] Manual test: workflow from `workflows/` (indexer) resolves
- [x] Manual test: workflow from `extensions/workflows/` resolves
- [x] Manual test: both in same manifest resolve together

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Blake Irvin <blakeirvin@me.com>