### PR TITLE
fix: prevent macOS resource fork files in extension archives

### DIFF
--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -442,7 +442,7 @@ export const extensionPushCommand = new Command()
         args: ["-czf", tarPath, "-C", tmpDir, "extension"],
         stdout: "piped",
         stderr: "piped",
-        env: { GZIP: "-9" },
+        env: { GZIP: "-9", COPYFILE_DISABLE: "1" },
       });
       const tarOutput = await tarCommand.output();
       if (!tarOutput.success) {


### PR DESCRIPTION
## Summary

On macOS, the system `tar` command automatically includes AppleDouble resource fork files (`._*` prefix) alongside every file in the archive. When these archives are pulled on Linux, the pull command's safety analyzer rejects them with **"Hidden files are not allowed in extensions"** because filenames starting with `.` are flagged as hidden.

This adds `COPYFILE_DISABLE=1` to the `tar` command's environment in `extension push`. This is the standard macOS mechanism to suppress `._*` resource fork inclusion. The variable is harmlessly ignored on non-macOS systems.

### Why fix on push (not pull)

- The `._*` files are noise — they should never be in the archive in the first place
- Fixing on push prevents the problem at the source for all consumers
- The pull-side hidden file check is a valid security measure that should remain untouched

### Change

**`src/cli/commands/extension_push.ts`** (line 445)

```diff
- env: { GZIP: "-9" },
+ env: { GZIP: "-9", COPYFILE_DISABLE: "1" },
```

Fixes #515

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno run test` — 2290 tests pass, 0 failures
- [ ] Manual: on macOS, run `swamp extension push` and inspect the resulting archive to confirm no `._*` files are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)