### PR TITLE
fix: skip macOS resource fork files during extension pull

### DIFF
--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
+import type { Logger } from "@logtape/logtape";
 import { basename, dirname, join, relative, resolve } from "@std/path";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
@@ -45,6 +46,11 @@ import {
   renderExtensionPullSafetyErrors,
   renderExtensionPullSafetyWarnings,
 } from "../../presentation/output/extension_pull_output.ts";
+
+/** Returns true if the filename is a macOS resource fork (AppleDouble) file. */
+function isMacOsResourceFork(name: string): boolean {
+  return name.startsWith("._");
+}
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -220,6 +226,9 @@ async function copyDir(
   const extracted: string[] = [];
   try {
     for await (const entry of Deno.readDir(srcDir)) {
+      // Skip macOS resource fork files (._*)
+      if (isMacOsResourceFork(entry.name)) continue;
+
       const srcPath = join(srcDir, entry.name);
       const destPath = join(destDir, entry.name);
       if (entry.isDirectory) {
@@ -247,6 +256,9 @@ async function listFiles(dir: string): Promise<string[]> {
   const files: string[] = [];
   try {
     for await (const entry of Deno.readDir(dir)) {
+      // Skip macOS resource fork files (._*)
+      if (isMacOsResourceFork(entry.name)) continue;
+
       const path = join(dir, entry.name);
       if (entry.isDirectory) {
         files.push(...await listFiles(path));
@@ -317,6 +329,7 @@ async function detectConflicts(
 
 interface PullContext {
   extensionClient: ExtensionApiClient;
+  logger: Logger;
   modelsDir: string;
   workflowsDir: string;
   repoDir: string;
@@ -333,7 +346,7 @@ async function pullExtension(
   ref: ExtensionRef,
   ctx: PullContext,
 ): Promise<void> {
-  const { extensionClient, modelsDir, repoDir, outputMode } = ctx;
+  const { extensionClient, logger, modelsDir, repoDir, outputMode } = ctx;
 
   // Guard against circular deps
   if (ctx.alreadyPulled.has(ref.name)) {
@@ -403,10 +416,12 @@ async function pullExtension(
     await Deno.writeFile(archivePath, archiveBytes);
 
     // Extract using tar
+    // COPYFILE_DISABLE prevents macOS tar from creating ._ resource fork files
     const tarCommand = new Deno.Command("tar", {
       args: ["-xzf", archivePath, "-C", tmpDir],
       stdout: "piped",
       stderr: "piped",
+      env: { COPYFILE_DISABLE: "1" },
     });
     const tarOutput = await tarCommand.output();
     if (!tarOutput.success) {
@@ -415,6 +430,12 @@ async function pullExtension(
     }
 
     const extractDir = join(tmpDir, "extension");
+
+    // Log extracted files for debugging
+    const allExtractedFiles = await listFiles(extractDir);
+    for (const f of allExtractedFiles) {
+      logger.debug`Archive contains: ${relative(extractDir, f)}`;
+    }
 
     // Parse manifest
     let manifestContent: string;
@@ -610,6 +631,7 @@ export const extensionPullCommand = new Command()
 
     await pullExtension(ref, {
       extensionClient,
+      logger: ctx.logger,
       modelsDir,
       workflowsDir,
       repoDir,


### PR DESCRIPTION
- Skip macOS AppleDouble resource fork files (._*) during extension pull extraction, file listing, and file copying
- Set COPYFILE_DISABLE=1 on the tar extraction command to prevent macOS tar from creating resource fork files during extraction
- Add debug-level logging of extracted archive contents for diagnosing pull issues

## Context  

A user on Arch Linux reported that swamp extension pull failed with:

"/tmp/swamp_pull_.../extension/models/._zfs_health.ts":
"Hidden files are not allowed in extensions."

The extension archive itself is clean — tar -tzf confirms it only contains zfs_health.ts, not ._zfs_health.ts. The ._ file was
being created on the user's filesystem during or after extraction, not bundled in the archive.

## Why this is the right fix

PR #516 added COPYFILE_DISABLE=1 to the push side, which prevents macOS tar from including ._ files when creating archives.
That fix is correct but insufficient — the ._ files can also appear on the pull side:

1. macOS tar extraction — On macOS, tar can create ._ resource fork files when extracting, even if the archive doesn't contain
them. Setting COPYFILE_DISABLE=1 on the extraction command prevents this.
2. Filesystem-level creation — The reporting user was on Arch Linux with ZFS. Certain filesystem configurations or tools can
create ._ AppleDouble files independently of tar. The archive was verified clean, yet the ._ file appeared in the temp
extraction directory.
3. Older archives — Archives pushed before PR #516 may still contain ._ files bundled inside them.

By filtering ._* files in listFiles() and copyDir(), we handle all three cases regardless of origin. These files are
universally recognized as macOS metadata artifacts — they are never legitimate model files (they'd fail the existing hidden
file safety check anyway, and no model should start with ._).

The safety analyzer's hidden file check remains unchanged — it still catches genuinely suspicious hidden files like .env or
.secret. The ._* files simply never reach it because they're filtered out during file enumeration.

## Test plan

- Verify deno check passes
- Verify deno run test passes
- Verify deno run test integration/extension_pull_test.ts passes
- Test swamp extension pull @bixu/zfs completes without resource fork errors
- Test swamp extension pull @bixu/zfs --log-level debug shows "Archive contains:" lines