### PR TITLE
fix: coerceInputTypes handles flat InputsSchema without properties wrapper

### DIFF
--- a/src/cli/input_parser.ts
+++ b/src/cli/input_parser.ts
@@ -18,7 +18,10 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { parse as parseYaml } from "@std/yaml";
-import type { InputsSchema } from "../domain/definitions/definition.ts";
+import type {
+  InputsSchema,
+  JsonSchemaProperty,
+} from "../domain/definitions/definition.ts";
 import { UserError } from "../domain/errors.ts";
 
 /**
@@ -171,7 +174,8 @@ export function coerceInputTypes(
   inputs: Record<string, unknown>,
   schema?: InputsSchema,
 ): Record<string, unknown> {
-  if (!schema?.properties) {
+  const properties = schema?.properties ?? schema;
+  if (!properties) {
     return inputs;
   }
 
@@ -182,7 +186,7 @@ export function coerceInputTypes(
       continue;
     }
 
-    const propSchema = schema.properties[key];
+    const propSchema = properties[key] as JsonSchemaProperty | undefined;
     if (!propSchema?.type) {
       continue;
     }

--- a/src/cli/input_parser_test.ts
+++ b/src/cli/input_parser_test.ts
@@ -238,6 +238,19 @@ Deno.test("coerceInputTypes: non-string values are untouched", () => {
   assertEquals(result, { count: 42 });
 });
 
+Deno.test("coerceInputTypes: flat schema without properties wrapper", () => {
+  const schema: InputsSchema = {
+    memory: { type: "number" },
+    enabled: { type: "boolean" },
+    name: { type: "string" },
+  };
+  const result = coerceInputTypes(
+    { memory: "2048", enabled: "true", name: "test" },
+    schema,
+  );
+  assertEquals(result, { memory: 2048, enabled: true, name: "test" });
+});
+
 Deno.test("coerceInputTypes: keys not in schema stay as strings", () => {
   const schema: InputsSchema = {
     properties: {


### PR DESCRIPTION
## Summary

- `coerceInputTypes()` only checked `schema.properties`, skipping type coercion entirely for flat schemas (properties directly on the schema object without a `properties` wrapper). This caused `--input key=value` with numeric/boolean types to fail validation since strings were never coerced.
- Applied the same `schema.properties ?? schema` fallback pattern already used by `InputValidationService` and other `InputsSchema` consumers.
- Added test covering flat schema coercion for number and boolean types.

## Test Plan

- Added `coerceInputTypes: flat schema without properties wrapper` test
- All 2294 existing tests pass
- `deno check`, `deno lint`, `deno fmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)