### PR TITLE
feat: track extracted files in upstream_extensions.json

### DIFF
--- a/integration/extension_pull_test.ts
+++ b/integration/extension_pull_test.ts
@@ -100,6 +100,81 @@ Deno.test("extension pull requires initialized repo", async () => {
   }
 });
 
+/** Runs the CLI with --allow-net (needed for tests that pull from the registry). */
+async function runCliWithNet(
+  args: string[],
+  env?: Record<string, string>,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--unstable-bundle",
+      "--allow-read",
+      "--allow-write",
+      "--allow-env",
+      "--allow-run",
+      "--allow-net",
+      "--allow-sys",
+      "main.ts",
+      ...args,
+    ],
+    stdout: "piped",
+    stderr: "piped",
+    cwd: PROJECT_ROOT,
+    env: {
+      ...Deno.env.toObject(),
+      SWAMP_NO_TELEMETRY: "1",
+      ...env,
+    },
+  });
+
+  const { code, stdout, stderr } = await command.output();
+  return {
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+    code,
+  };
+}
+
+Deno.test("extension pull persists files in upstream_extensions.json", async () => {
+  const tmpDir = await initTempRepo();
+  try {
+    const { code, stderr } = await runCliWithNet([
+      "extension",
+      "pull",
+      "@keeb/ssh",
+      "--force",
+      "--repo-dir",
+      tmpDir,
+      "--no-color",
+    ]);
+    assertEquals(code, 0, `Pull failed: ${stderr}`);
+
+    // Read upstream_extensions.json and verify files array
+    const jsonPath = `${tmpDir}/extensions/models/upstream_extensions.json`;
+    const content = await Deno.readTextFile(jsonPath);
+    const data = JSON.parse(content) as Record<
+      string,
+      { version: string; pulledAt: string; files?: string[] }
+    >;
+
+    const entry = data["@keeb/ssh"];
+    assertEquals(typeof entry, "object", "Entry for @keeb/ssh should exist");
+    assertEquals(
+      Array.isArray(entry.files),
+      true,
+      "files should be an array",
+    );
+    assertEquals(
+      (entry.files as string[]).length > 0,
+      true,
+      "files array should be non-empty",
+    );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
 Deno.test("extension pull does not require authentication", async () => {
   const tmpDir = await initTempRepo();
   try {

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -62,9 +62,10 @@ interface ExtensionRef {
 }
 
 /** Entry in upstream_extensions.json. */
-interface UpstreamExtensionEntry {
+export interface UpstreamExtensionEntry {
   version: string;
   pulledAt: string;
+  files?: string[];
 }
 
 /** Shape of upstream_extensions.json. */
@@ -158,10 +159,11 @@ async function acquireLock(lockPath: string): Promise<Deno.FsFile> {
  * Updates upstream_extensions.json with a new entry, using a lockfile
  * for concurrency safety and atomicWriteTextFile for crash safety.
  */
-async function updateUpstreamExtensions(
+export async function updateUpstreamExtensions(
   modelsDir: string,
   name: string,
   version: string,
+  files: string[],
 ): Promise<void> {
   const jsonPath = join(modelsDir, "upstream_extensions.json");
   const lockPath = `${jsonPath}.lock`;
@@ -183,6 +185,7 @@ async function updateUpstreamExtensions(
     data[name] = {
       version,
       pulledAt: new Date().toISOString(),
+      files,
     };
 
     // Write atomically
@@ -515,7 +518,12 @@ async function pullExtension(
     extractedFiles.push(...filesExtracted);
 
     // Update upstream_extensions.json
-    await updateUpstreamExtensions(absoluteModelsDir, ref.name, version);
+    await updateUpstreamExtensions(
+      absoluteModelsDir,
+      ref.name,
+      version,
+      extractedFiles,
+    );
 
     // Render success
     renderExtensionPull(

--- a/src/cli/commands/extension_pull_test.ts
+++ b/src/cli/commands/extension_pull_test.ts
@@ -19,8 +19,13 @@
 
 import { assertEquals, assertThrows } from "@std/assert";
 import { assertStringIncludes } from "@std/assert/string-includes";
-import { parseExtensionRef } from "./extension_pull.ts";
+import {
+  parseExtensionRef,
+  updateUpstreamExtensions,
+} from "./extension_pull.ts";
+import type { UpstreamExtensionEntry } from "./extension_pull.ts";
 import { UserError } from "../../domain/errors.ts";
+import { join } from "@std/path";
 
 Deno.test("parseExtensionRef parses name without version", () => {
   const ref = parseExtensionRef("@myorg/my-ext");
@@ -48,4 +53,64 @@ Deno.test("parseExtensionRef throws on empty version after @", () => {
     UserError,
   );
   assertStringIncludes(error.message, "Version cannot be empty");
+});
+
+Deno.test("updateUpstreamExtensions persists files array", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const files = [
+      "extensions/models/foo/bar.yaml",
+      "extensions/models/foo/baz.ts",
+    ];
+    await updateUpstreamExtensions(tmpDir, "@test/ext", "1.0.0", files);
+
+    const content = await Deno.readTextFile(
+      join(tmpDir, "upstream_extensions.json"),
+    );
+    const data = JSON.parse(content) as Record<string, UpstreamExtensionEntry>;
+
+    assertEquals(data["@test/ext"].version, "1.0.0");
+    assertEquals(data["@test/ext"].files, files);
+    assertEquals(typeof data["@test/ext"].pulledAt, "string");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("updateUpstreamExtensions preserves existing entries", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    // Write first extension
+    await updateUpstreamExtensions(tmpDir, "@test/first", "1.0.0", ["a.yaml"]);
+    // Write second extension
+    await updateUpstreamExtensions(tmpDir, "@test/second", "2.0.0", ["b.yaml"]);
+
+    const content = await Deno.readTextFile(
+      join(tmpDir, "upstream_extensions.json"),
+    );
+    const data = JSON.parse(content) as Record<string, UpstreamExtensionEntry>;
+
+    assertEquals(data["@test/first"].version, "1.0.0");
+    assertEquals(data["@test/first"].files, ["a.yaml"]);
+    assertEquals(data["@test/second"].version, "2.0.0");
+    assertEquals(data["@test/second"].files, ["b.yaml"]);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("updateUpstreamExtensions handles empty files array", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    await updateUpstreamExtensions(tmpDir, "@test/empty", "1.0.0", []);
+
+    const content = await Deno.readTextFile(
+      join(tmpDir, "upstream_extensions.json"),
+    );
+    const data = JSON.parse(content) as Record<string, UpstreamExtensionEntry>;
+
+    assertEquals(data["@test/empty"].files, []);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
 });


### PR DESCRIPTION
## Summary

- Persist the list of extracted files in `upstream_extensions.json` when an extension is pulled
- Add optional `files: string[]` field to `UpstreamExtensionEntry` (backward compatible — existing JSON files without it parse fine)
- Add 3 unit tests and 1 integration test

## Why this is needed

When an extension is pulled, the list of extracted files is computed and displayed to the user but **never persisted**. This means there's no way to know which files belong to which extension after the fact.

This is a **prerequisite for `extension rm`** — without knowing which files an extension installed, a remove command would have to guess or require the user to manually specify files. By recording the file list at pull time, a future `extension rm` can cleanly remove exactly the files that were installed.

The `extractedFiles` array was already computed during pull; this change simply saves it alongside the existing `version` and `pulledAt` fields.

## Example output

After pulling an extension, `upstream_extensions.json` now looks like:

```json
{
  "@keeb/ssh": {
    "version": "2026.02.26.1",
    "pulledAt": "2026-02-27T17:32:41.000Z",
    "files": [
      "extensions/models/ssh/ssh.yaml",
      "extensions/models/ssh/ssh.ts"
    ]
  }
}
```

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt` — formatting passes
- [x] `deno run test` — all 2294 tests pass
- [x] Unit tests verify files are persisted, existing entries preserved, and empty arrays handled
- [x] Integration test pulls `@keeb/ssh` from registry and asserts `files` array is present and non-empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)