### PR TITLE
refactor: rename tags to labels in extension manifest

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -336,7 +336,7 @@ paths are relative to `extensions/models/`; local imports are auto-resolved.
 
 - `platforms` — OS/architecture hints (e.g. `darwin-aarch64`, `linux-x86_64`).
   Use when your extension contains platform-specific code.
-- `tags` — Categorization labels (e.g. `aws`, `kubernetes`, `security`).
+- `labels` — Categorization labels (e.g. `aws`, `kubernetes`, `security`).
 
 Both are omitted from the archive when not specified.
 

--- a/.claude/skills/swamp-extension-model/references/publishing.md
+++ b/.claude/skills/swamp-extension-model/references/publishing.md
@@ -22,7 +22,7 @@ additionalFiles:
 platforms:
   - darwin-aarch64
   - linux-x86_64
-tags:
+labels:
   - aws
   - security
 dependencies:
@@ -41,7 +41,7 @@ dependencies:
 | `workflows`       | No*      | Workflow file paths relative to `workflows/`                     |
 | `additionalFiles` | No       | Extra files relative to the manifest location                    |
 | `platforms`       | No       | OS/architecture hints (e.g. `darwin-aarch64`, `linux-x86_64`)    |
-| `tags`            | No       | Categorization labels (e.g. `aws`, `kubernetes`, `security`)     |
+| `labels`          | No       | Categorization labels (e.g. `aws`, `kubernetes`, `security`)     |
 | `dependencies`    | No       | Other extensions this one depends on                             |
 
 *At least one of `models` or `workflows` must be present with entries.

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -289,7 +289,7 @@ export const extensionPushCommand = new Command()
         ),
         additionalFiles: additionalFilePaths.map((f) => relative(repoDir, f)),
         platforms: manifest.platforms,
-        tags: manifest.tags,
+        labels: manifest.labels,
         dependencies: manifest.dependencies,
       },
       ctx.outputMode,
@@ -410,7 +410,7 @@ export const extensionPushCommand = new Command()
           ...(manifest.platforms.length > 0
             ? { platforms: manifest.platforms }
             : {}),
-          ...(manifest.tags.length > 0 ? { tags: manifest.tags } : {}),
+          ...(manifest.labels.length > 0 ? { labels: manifest.labels } : {}),
           dependencies: manifest.dependencies,
         }),
       );

--- a/src/domain/extensions/extension_manifest.ts
+++ b/src/domain/extensions/extension_manifest.ts
@@ -46,7 +46,7 @@ const ExtensionManifestSchemaV1 = z.object({
   models: z.array(z.string()).optional(),
   additionalFiles: z.array(z.string()).optional(),
   platforms: z.array(z.string().min(1)).optional(),
-  tags: z.array(z.string().min(1)).optional(),
+  labels: z.array(z.string().min(1)).optional(),
   dependencies: z.array(
     z.string().refine((dep) => dep.includes("/"), {
       message: "Dependencies must include a slash (e.g., @namespace/name)",
@@ -69,7 +69,7 @@ export interface ExtensionManifest {
   models: string[];
   additionalFiles: string[];
   platforms: string[];
-  tags: string[];
+  labels: string[];
   dependencies: string[];
 }
 
@@ -121,7 +121,7 @@ export function parseExtensionManifest(content: string): ExtensionManifest {
     models: result.data.models ?? [],
     additionalFiles: result.data.additionalFiles ?? [],
     platforms: result.data.platforms ?? [],
-    tags: result.data.tags ?? [],
+    labels: result.data.labels ?? [],
     dependencies: result.data.dependencies ?? [],
   };
 }

--- a/src/domain/extensions/extension_manifest_test.ts
+++ b/src/domain/extensions/extension_manifest_test.ts
@@ -213,20 +213,20 @@ platforms:
   assertEquals(manifest.platforms, ["darwin-aarch64", "linux-x86_64"]);
 });
 
-Deno.test("parseExtensionManifest parses valid manifest with tags", () => {
+Deno.test("parseExtensionManifest parses valid manifest with labels", () => {
   const yaml = `
 manifestVersion: 1
 name: "@myuser/myext"
 version: "2026.02.26.1"
 models:
   - foo.ts
-tags:
+labels:
   - aws
   - kubernetes
   - security
 `;
   const manifest = parseExtensionManifest(yaml);
-  assertEquals(manifest.tags, ["aws", "kubernetes", "security"]);
+  assertEquals(manifest.labels, ["aws", "kubernetes", "security"]);
 });
 
 Deno.test("parseExtensionManifest defaults optional fields", () => {
@@ -242,6 +242,6 @@ models:
   assertEquals(manifest.workflows, []);
   assertEquals(manifest.additionalFiles, []);
   assertEquals(manifest.platforms, []);
-  assertEquals(manifest.tags, []);
+  assertEquals(manifest.labels, []);
   assertEquals(manifest.dependencies, []);
 });

--- a/src/presentation/output/extension_pull_output.ts
+++ b/src/presentation/output/extension_pull_output.ts
@@ -29,7 +29,7 @@ export interface ExtensionPullResolvedData {
   version: string;
   description: string | undefined;
   platforms?: string[];
-  tags?: string[];
+  labels?: string[];
 }
 
 /** Data for successful pull output. */
@@ -56,8 +56,8 @@ export function renderExtensionPullResolved(
     if (data.platforms && data.platforms.length > 0) {
       logger.info`Platforms: ${data.platforms.join(", ")}`;
     }
-    if (data.tags && data.tags.length > 0) {
-      logger.info`Tags: ${data.tags.join(", ")}`;
+    if (data.labels && data.labels.length > 0) {
+      logger.info`Labels: ${data.labels.join(", ")}`;
     }
   }
 }

--- a/src/presentation/output/extension_push_output.ts
+++ b/src/presentation/output/extension_push_output.ts
@@ -32,7 +32,7 @@ export interface ExtensionPushResolvedData {
   workflowFiles: string[];
   additionalFiles: string[];
   platforms: string[];
-  tags: string[];
+  labels: string[];
   dependencies: string[];
 }
 
@@ -88,8 +88,8 @@ export function renderExtensionPushResolved(
     if (data.platforms.length > 0) {
       logger.info`Platforms: ${data.platforms.join(", ")}`;
     }
-    if (data.tags.length > 0) {
-      logger.info`Tags: ${data.tags.join(", ")}`;
+    if (data.labels.length > 0) {
+      logger.info`Labels: ${data.labels.join(", ")}`;
     }
     if (data.dependencies.length > 0) {
       logger.info`Dependencies: ${data.dependencies.join(", ")}`;

--- a/src/presentation/output/extension_push_output_test.ts
+++ b/src/presentation/output/extension_push_output_test.ts
@@ -53,7 +53,7 @@ Deno.test("renderExtensionPushResolved outputs JSON in json mode", () => {
         workflowFiles: [],
         additionalFiles: [],
         platforms: [],
-        tags: [],
+        labels: [],
         dependencies: [],
       },
       "json",


### PR DESCRIPTION
## Summary

Renames the `tags` field to `labels` in the extension manifest, introduced
in #508. This is a follow-up rename before the field sees any adoption.

## Test plan

- [x] All existing tests updated and passing
- [x] `deno check` passes
- [x] Skill docs updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)