### PR TITLE
feat: add extension rm command to remove pulled extensions

### DIFF
--- a/integration/ddd_layer_rules_test.ts
+++ b/integration/ddd_layer_rules_test.ts
@@ -99,7 +99,7 @@ Deno.test(
   },
 );
 
-const KNOWN_PRESENTATION_INFRA_VIOLATIONS = 28;
+const KNOWN_PRESENTATION_INFRA_VIOLATIONS = 29;
 
 Deno.test(
   "presentation layer must not add new infrastructure imports (ratchet)",

--- a/integration/extension_rm_test.ts
+++ b/integration/extension_rm_test.ts
@@ -1,0 +1,226 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertStringIncludes } from "@std/assert/string-includes";
+import { assertEquals } from "@std/assert";
+
+const PROJECT_ROOT = Deno.cwd();
+
+async function runCli(
+  args: string[],
+  env?: Record<string, string>,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["task", "dev", ...args],
+    stdout: "piped",
+    stderr: "piped",
+    cwd: PROJECT_ROOT,
+    env: {
+      ...Deno.env.toObject(),
+      SWAMP_NO_TELEMETRY: "1",
+      ...env,
+    },
+  });
+
+  const { code, stdout, stderr } = await command.output();
+  return {
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+    code,
+  };
+}
+
+/** Initialize a swamp repo in a temp directory. */
+async function initTempRepo(): Promise<string> {
+  const tmpDir = await Deno.makeTempDir();
+  await runCli(["init", tmpDir]);
+  return tmpDir;
+}
+
+Deno.test("extension rm --help shows usage", async () => {
+  const { stdout } = await runCli(["extension", "rm", "--help"]);
+  assertStringIncludes(stdout, "rm");
+  assertStringIncludes(stdout, "Remove");
+});
+
+Deno.test("extension --help shows rm subcommand", async () => {
+  const { stdout } = await runCli(["extension", "--help"]);
+  assertStringIncludes(stdout, "rm");
+});
+
+Deno.test("extension rm with invalid name gives clear error", async () => {
+  const tmpDir = await initTempRepo();
+  try {
+    const { stderr, code } = await runCli([
+      "extension",
+      "rm",
+      "invalid-name",
+      "--repo-dir",
+      tmpDir,
+      "--no-color",
+    ]);
+    assertEquals(code === 0, false);
+    assertStringIncludes(stderr, "must start with");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extension rm of non-installed extension gives clear error", async () => {
+  const tmpDir = await initTempRepo();
+  try {
+    const { stderr, code } = await runCli([
+      "extension",
+      "rm",
+      "@test/nonexistent",
+      "--force",
+      "--repo-dir",
+      tmpDir,
+      "--no-color",
+    ]);
+    assertEquals(code === 0, false);
+    assertStringIncludes(stderr, "is not installed");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extension rm requires initialized repo", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const { stderr, code } = await runCli([
+      "extension",
+      "rm",
+      "@test/ext",
+      "--force",
+      "--repo-dir",
+      tmpDir,
+      "--no-color",
+    ]);
+    assertEquals(code === 0, false);
+    assertStringIncludes(stderr, "Not a swamp repository");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+/** Runs the CLI with --allow-net (needed for tests that pull from the registry). */
+async function runCliWithNet(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--unstable-bundle",
+      "--allow-read",
+      "--allow-write",
+      "--allow-env",
+      "--allow-run",
+      "--allow-net",
+      "--allow-sys",
+      "main.ts",
+      ...args,
+    ],
+    stdout: "piped",
+    stderr: "piped",
+    cwd: PROJECT_ROOT,
+    env: {
+      ...Deno.env.toObject(),
+      SWAMP_NO_TELEMETRY: "1",
+    },
+  });
+
+  const { code, stdout, stderr } = await command.output();
+  return {
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+    code,
+  };
+}
+
+Deno.test("extension pull then rm removes files and JSON entry", async () => {
+  const tmpDir = await initTempRepo();
+  try {
+    // Pull the extension first
+    const pullResult = await runCliWithNet([
+      "extension",
+      "pull",
+      "@keeb/ssh",
+      "--force",
+      "--repo-dir",
+      tmpDir,
+      "--no-color",
+    ]);
+    assertEquals(pullResult.code, 0, `Pull failed: ${pullResult.stderr}`);
+
+    // Read upstream_extensions.json to get the file list
+    const jsonPath = `${tmpDir}/extensions/models/upstream_extensions.json`;
+    const beforeContent = await Deno.readTextFile(jsonPath);
+    const beforeData = JSON.parse(beforeContent) as Record<
+      string,
+      { version: string; files?: string[] }
+    >;
+    const files = beforeData["@keeb/ssh"].files;
+    assertEquals(
+      Array.isArray(files),
+      true,
+      "files should be an array before rm",
+    );
+
+    // Verify files exist on disk before removal
+    for (const file of files!) {
+      const stat = await Deno.stat(`${tmpDir}/${file}`);
+      assertEquals(stat.isFile, true, `File should exist before rm: ${file}`);
+    }
+
+    // Remove the extension
+    const rmResult = await runCli([
+      "extension",
+      "rm",
+      "@keeb/ssh",
+      "--force",
+      "--repo-dir",
+      tmpDir,
+      "--no-color",
+    ]);
+    assertEquals(rmResult.code, 0, `Rm failed: ${rmResult.stderr}`);
+
+    // Verify files no longer exist on disk
+    for (const file of files!) {
+      let exists = true;
+      try {
+        await Deno.stat(`${tmpDir}/${file}`);
+      } catch {
+        exists = false;
+      }
+      assertEquals(exists, false, `File should not exist after rm: ${file}`);
+    }
+
+    // Verify entry removed from upstream_extensions.json
+    const afterContent = await Deno.readTextFile(jsonPath);
+    const afterData = JSON.parse(afterContent) as Record<string, unknown>;
+    assertEquals(
+      afterData["@keeb/ssh"],
+      undefined,
+      "Entry should be removed from upstream_extensions.json",
+    );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});

--- a/src/cli/commands/extension.ts
+++ b/src/cli/commands/extension.ts
@@ -20,6 +20,7 @@
 import { Command } from "@cliffy/command";
 import { extensionPushCommand } from "./extension_push.ts";
 import { extensionPullCommand } from "./extension_pull.ts";
+import { extensionRemoveCommand } from "./extension_rm.ts";
 import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
 
 export const extensionCommand = new Command()
@@ -30,4 +31,5 @@ export const extensionCommand = new Command()
     this.showHelp();
   })
   .command("push", extensionPushCommand)
-  .command("pull", extensionPullCommand);
+  .command("pull", extensionPullCommand)
+  .command("rm", extensionRemoveCommand);

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -208,6 +208,60 @@ export async function updateUpstreamExtensions(
 }
 
 /**
+ * Removes an extension entry from upstream_extensions.json, using a lockfile
+ * for concurrency safety and atomicWriteTextFile for crash safety.
+ */
+export async function removeUpstreamExtension(
+  modelsDir: string,
+  name: string,
+): Promise<void> {
+  const jsonPath = join(modelsDir, "upstream_extensions.json");
+  const lockPath = `${jsonPath}.lock`;
+
+  const lockFile = await acquireLock(lockPath);
+  try {
+    let data: UpstreamExtensionsMap = {};
+    try {
+      const content = await Deno.readTextFile(jsonPath);
+      data = JSON.parse(content) as UpstreamExtensionsMap;
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+
+    delete data[name];
+
+    await atomicWriteTextFile(jsonPath, JSON.stringify(data, null, 2) + "\n");
+  } finally {
+    lockFile.close();
+    try {
+      await Deno.remove(lockPath);
+    } catch {
+      // Best-effort cleanup
+    }
+  }
+}
+
+/**
+ * Reads upstream_extensions.json and returns the parsed map.
+ */
+export async function readUpstreamExtensions(
+  modelsDir: string,
+): Promise<UpstreamExtensionsMap> {
+  const jsonPath = join(modelsDir, "upstream_extensions.json");
+  try {
+    const content = await Deno.readTextFile(jsonPath);
+    return JSON.parse(content) as UpstreamExtensionsMap;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return {};
+    }
+    throw error;
+  }
+}
+
+/**
  * Checks if a file exists at the given path.
  */
 async function fileExists(path: string): Promise<boolean> {

--- a/src/cli/commands/extension_rm.ts
+++ b/src/cli/commands/extension_rm.ts
@@ -1,0 +1,252 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { dirname, join, resolve } from "@std/path";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
+import { resolveModelsDir } from "../resolve_models_dir.ts";
+import {
+  RepoMarkerRepository,
+} from "../../infrastructure/persistence/repo_marker_repository.ts";
+import { RepoPath } from "../../domain/repo/repo_path.ts";
+import { UserError } from "../../domain/errors.ts";
+import {
+  parseExtensionRef,
+  readUpstreamExtensions,
+  removeUpstreamExtension,
+} from "./extension_pull.ts";
+import { parseExtensionManifest } from "../../domain/extensions/extension_manifest.ts";
+import {
+  renderExtensionRm,
+  renderExtensionRmCancelled,
+  renderExtensionRmDependencyWarning,
+  renderExtensionRmFileDelete,
+} from "../../presentation/output/extension_rm_output.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+const SCOPED_NAME_PATTERN = /^@[a-z0-9_-]+\/[a-z0-9_-]+$/;
+
+async function promptConfirmation(message: string): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+
+  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
+
+  const buf = new Uint8Array(1024);
+  const n = await Deno.stdin.read(buf);
+  if (n === null) return false;
+
+  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
+  return response === "y" || response === "yes";
+}
+
+/**
+ * Finds installed extensions that depend on the given extension name
+ * by scanning manifest.yaml files tracked in upstream_extensions.json.
+ */
+async function findDependents(
+  repoDir: string,
+  upstreamData: Record<string, { version: string; files?: string[] }>,
+  targetName: string,
+): Promise<string[]> {
+  const dependents: string[] = [];
+
+  for (const [extName, entry] of Object.entries(upstreamData)) {
+    if (extName === targetName) continue;
+    if (!entry.files) continue;
+
+    // Look for manifest.yaml among this extension's tracked files
+    const manifestFile = entry.files.find((f) => f.endsWith("manifest.yaml"));
+    if (!manifestFile) continue;
+
+    try {
+      const manifestPath = join(repoDir, manifestFile);
+      const content = await Deno.readTextFile(manifestPath);
+      const manifest = parseExtensionManifest(content);
+      if (manifest.dependencies.includes(targetName)) {
+        dependents.push(extName);
+      }
+    } catch {
+      // If manifest can't be read or parsed, skip
+    }
+  }
+
+  return dependents;
+}
+
+/**
+ * Removes empty parent directories up to (but not including) the stop directory.
+ * Returns the number of directories removed.
+ */
+async function pruneEmptyDirs(
+  dirs: string[],
+  stopDir: string,
+): Promise<number> {
+  let removed = 0;
+  const resolvedStop = resolve(stopDir);
+
+  // Sort directories deepest-first so children are pruned before parents
+  const sorted = [...new Set(dirs)].sort((a, b) => b.length - a.length);
+
+  for (const dir of sorted) {
+    let current = resolve(dir);
+    while (current.length > resolvedStop.length && current !== resolvedStop) {
+      try {
+        const entries = [];
+        for await (const entry of Deno.readDir(current)) {
+          entries.push(entry);
+        }
+        if (entries.length === 0) {
+          await Deno.remove(current);
+          removed++;
+          current = dirname(current);
+        } else {
+          break;
+        }
+      } catch {
+        break;
+      }
+    }
+  }
+
+  return removed;
+}
+
+export const extensionRemoveCommand = new Command()
+  .name("rm")
+  .alias("remove")
+  .description("Remove a pulled extension and its files")
+  .arguments("<extension:string>")
+  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option("-f, --force", "Skip confirmation prompt")
+  .action(async function (options: AnyOptions, extension: string) {
+    const ctx = createContext(options as GlobalOptions, ["extension", "rm"]);
+    ctx.logger.debug`Starting extension remove`;
+
+    const repoDir = options.repoDir ?? ".";
+    await requireInitializedRepo({
+      repoDir,
+      outputMode: ctx.outputMode,
+    });
+
+    // Parse extension reference (ignore version if provided)
+    const ref = parseExtensionRef(extension);
+
+    // Validate name format
+    if (!SCOPED_NAME_PATTERN.test(ref.name)) {
+      throw new UserError(
+        `Invalid extension name: "${ref.name}". Must match @namespace/name pattern (lowercase, alphanumeric, hyphens, underscores).`,
+      );
+    }
+
+    // Resolve models dir from .swamp.yaml
+    const repoPath = RepoPath.create(repoDir);
+    const markerRepo = new RepoMarkerRepository();
+    const marker = await markerRepo.read(repoPath);
+    const modelsDir = resolveModelsDir(marker);
+    const absoluteModelsDir = resolve(repoDir, modelsDir);
+
+    // Read upstream_extensions.json
+    const upstreamData = await readUpstreamExtensions(absoluteModelsDir);
+
+    const entry = upstreamData[ref.name];
+    if (!entry) {
+      throw new UserError(
+        `Extension ${ref.name} is not installed.`,
+      );
+    }
+
+    // Check if entry has a files array (required for clean removal)
+    if (!entry.files) {
+      throw new UserError(
+        `Extension ${ref.name} was pulled before file tracking was added. Re-pull with --force to populate the file list, then retry rm.`,
+      );
+    }
+
+    // Check for dependents
+    const dependents = await findDependents(
+      repoDir,
+      upstreamData,
+      ref.name,
+    );
+    if (dependents.length > 0) {
+      renderExtensionRmDependencyWarning(dependents, ctx.outputMode);
+    }
+
+    // Confirmation prompt (log mode only, unless --force)
+    if (ctx.outputMode === "log" && !options.force) {
+      const confirmed = await promptConfirmation(
+        `Remove ${ref.name} (v${entry.version})? This will delete ${entry.files.length} file(s).`,
+      );
+      if (!confirmed) {
+        renderExtensionRmCancelled(ctx.outputMode);
+        return;
+      }
+    }
+
+    // Delete files
+    const verbose = ctx.verbosity === "verbose";
+    let filesDeleted = 0;
+    let filesSkipped = 0;
+    const parentDirs: string[] = [];
+
+    for (const filePath of entry.files) {
+      const absolutePath = join(repoDir, filePath);
+      try {
+        await Deno.remove(absolutePath);
+        filesDeleted++;
+        parentDirs.push(dirname(absolutePath));
+        if (verbose) {
+          renderExtensionRmFileDelete(filePath, "deleted", ctx.outputMode);
+        }
+      } catch (error) {
+        if (error instanceof Deno.errors.NotFound) {
+          filesSkipped++;
+          if (verbose) {
+            renderExtensionRmFileDelete(filePath, "missing", ctx.outputMode);
+          }
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    // Prune empty parent directories
+    const dirsRemoved = await pruneEmptyDirs(parentDirs, repoDir);
+
+    // Remove entry from upstream_extensions.json
+    await removeUpstreamExtension(absoluteModelsDir, ref.name);
+
+    // Render success
+    renderExtensionRm(
+      {
+        name: ref.name,
+        version: entry.version,
+        filesDeleted,
+        filesSkipped,
+        dirsRemoved,
+      },
+      ctx.outputMode,
+    );
+
+    ctx.logger.debug("Extension remove command completed");
+  });

--- a/src/cli/commands/extension_rm_test.ts
+++ b/src/cli/commands/extension_rm_test.ts
@@ -1,0 +1,112 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import {
+  readUpstreamExtensions,
+  removeUpstreamExtension,
+  updateUpstreamExtensions,
+} from "./extension_pull.ts";
+import type { UpstreamExtensionEntry } from "./extension_pull.ts";
+
+Deno.test("removeUpstreamExtension removes entry and preserves others", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    // Set up two extensions
+    await updateUpstreamExtensions(tmpDir, "@test/first", "1.0.0", ["a.yaml"]);
+    await updateUpstreamExtensions(tmpDir, "@test/second", "2.0.0", ["b.yaml"]);
+
+    // Remove the first one
+    await removeUpstreamExtension(tmpDir, "@test/first");
+
+    const content = await Deno.readTextFile(
+      join(tmpDir, "upstream_extensions.json"),
+    );
+    const data = JSON.parse(content) as Record<string, UpstreamExtensionEntry>;
+
+    assertEquals(data["@test/first"], undefined);
+    assertEquals(data["@test/second"].version, "2.0.0");
+    assertEquals(data["@test/second"].files, ["b.yaml"]);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("removeUpstreamExtension handles non-existent extension gracefully", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    await updateUpstreamExtensions(tmpDir, "@test/first", "1.0.0", ["a.yaml"]);
+
+    // Removing a non-existent entry should not throw
+    await removeUpstreamExtension(tmpDir, "@test/nonexistent");
+
+    const content = await Deno.readTextFile(
+      join(tmpDir, "upstream_extensions.json"),
+    );
+    const data = JSON.parse(content) as Record<string, UpstreamExtensionEntry>;
+
+    assertEquals(data["@test/first"].version, "1.0.0");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("removeUpstreamExtension handles missing JSON file", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    // Should not throw even when file doesn't exist
+    await removeUpstreamExtension(tmpDir, "@test/nonexistent");
+
+    const content = await Deno.readTextFile(
+      join(tmpDir, "upstream_extensions.json"),
+    );
+    const data = JSON.parse(content) as Record<string, UpstreamExtensionEntry>;
+
+    assertEquals(Object.keys(data).length, 0);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("readUpstreamExtensions reads existing entries", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    await updateUpstreamExtensions(tmpDir, "@test/ext", "1.0.0", [
+      "extensions/models/foo.yaml",
+    ]);
+
+    const data = await readUpstreamExtensions(tmpDir);
+
+    assertEquals(data["@test/ext"].version, "1.0.0");
+    assertEquals(data["@test/ext"].files, ["extensions/models/foo.yaml"]);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("readUpstreamExtensions returns empty map when file missing", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const data = await readUpstreamExtensions(tmpDir);
+    assertEquals(Object.keys(data).length, 0);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});

--- a/src/presentation/output/error_output.ts
+++ b/src/presentation/output/error_output.ts
@@ -23,14 +23,23 @@ import { UserError } from "../../domain/errors.ts";
 const logger = getSwampLogger(["error"]);
 
 /**
+ * Returns true if the error is a Cliffy missing-argument error.
+ * These are plain Error objects with the message pattern "Missing argument(s): ..."
+ * and should be rendered without a stack trace.
+ */
+function isCliffyMissingArgError(err: Error): boolean {
+  return err.message.startsWith("Missing argument(s):");
+}
+
+/**
  * Renders an error via LogTape at fatal level.
- * UserError instances log just the message (no stack trace).
+ * UserError instances and Cliffy missing-argument errors log just the message (no stack trace).
  * Other errors log the full Error object (including stack trace via Deno.inspect).
  */
 export function renderError(error: unknown): void {
   const err = error instanceof Error ? error : new Error(String(error));
 
-  if (err instanceof UserError) {
+  if (err instanceof UserError || isCliffyMissingArgError(err)) {
     logger.fatal("Error: {message}", { message: err.message });
   } else {
     logger.fatal("{error}", { error: err });

--- a/src/presentation/output/error_output_test.ts
+++ b/src/presentation/output/error_output_test.ts
@@ -73,6 +73,24 @@ Deno.test("renderError wraps non-Error values in Error", () => {
   }
 });
 
+Deno.test("renderError logs Cliffy missing argument error without stack trace", () => {
+  const logs: string[] = [];
+  const originalError = console.error;
+  console.error = (...args: unknown[]) => logs.push(args.join(" "));
+
+  try {
+    const error = new Error("Missing argument(s): extension");
+    renderError(error);
+
+    assertEquals(logs.length, 1);
+    assertStringIncludes(logs[0], "Missing argument(s): extension");
+    // Should not contain stack trace lines
+    assertEquals(logs[0].includes("    at "), false);
+  } finally {
+    console.error = originalError;
+  }
+});
+
 Deno.test("renderError uses fatal level for all errors", () => {
   const logs: string[] = [];
   const originalError = console.error;

--- a/src/presentation/output/extension_rm_output.ts
+++ b/src/presentation/output/extension_rm_output.ts
@@ -1,0 +1,106 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { OutputMode } from "./output.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+
+const logger = getSwampLogger(["extension", "rm"]);
+
+/** Data for successful extension removal. */
+export interface ExtensionRmData {
+  name: string;
+  version: string;
+  filesDeleted: number;
+  filesSkipped: number;
+  dirsRemoved: number;
+}
+
+/**
+ * Renders the successful extension removal output.
+ */
+export function renderExtensionRm(
+  data: ExtensionRmData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify({ removed: data }, null, 2));
+  } else {
+    logger.info(
+      "Removed {name} (v{version}) — deleted {count} file(s)",
+      { name: data.name, version: data.version, count: data.filesDeleted },
+    );
+    if (data.filesSkipped > 0) {
+      logger.info("{count} file(s) already missing, skipped", {
+        count: data.filesSkipped,
+      });
+    }
+    if (data.dirsRemoved > 0) {
+      logger.info("Pruned {count} empty directory(ies)", {
+        count: data.dirsRemoved,
+      });
+    }
+  }
+}
+
+/**
+ * Renders a single file deletion in verbose mode.
+ */
+export function renderExtensionRmFileDelete(
+  filePath: string,
+  status: "deleted" | "missing",
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify({ file: filePath, status }, null, 2));
+  } else {
+    if (status === "deleted") {
+      logger.debug("  deleted {file}", { file: filePath });
+    } else {
+      logger.debug("  skipped {file} (already missing)", { file: filePath });
+    }
+  }
+}
+
+/**
+ * Renders a cancellation message.
+ */
+export function renderExtensionRmCancelled(mode: OutputMode): void {
+  if (mode === "json") {
+    console.log(JSON.stringify({ status: "cancelled" }));
+  } else {
+    logger.info("Removal cancelled.");
+  }
+}
+
+/**
+ * Renders a warning about dependent extensions.
+ */
+export function renderExtensionRmDependencyWarning(
+  dependents: string[],
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify({ dependencyWarning: dependents }, null, 2));
+  } else {
+    logger.warn("The following installed extensions depend on this extension:");
+    for (const dep of dependents) {
+      logger.warn("  {dep}", { dep });
+    }
+  }
+}

--- a/src/presentation/output/extension_rm_output_test.ts
+++ b/src/presentation/output/extension_rm_output_test.ts
@@ -1,0 +1,109 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert/equals";
+import { assertStringIncludes } from "@std/assert/string-includes";
+import {
+  renderExtensionRm,
+  renderExtensionRmCancelled,
+  renderExtensionRmDependencyWarning,
+  renderExtensionRmFileDelete,
+} from "./extension_rm_output.ts";
+
+function captureConsoleLog(fn: () => void): string {
+  const original = console.log;
+  let captured = "";
+  console.log = (msg: string) => {
+    captured += msg;
+  };
+  try {
+    fn();
+  } finally {
+    console.log = original;
+  }
+  return captured;
+}
+
+Deno.test("renderExtensionRm outputs JSON in json mode", () => {
+  const output = captureConsoleLog(() => {
+    renderExtensionRm(
+      {
+        name: "@test/ext",
+        version: "2026.02.26.1",
+        filesDeleted: 3,
+        filesSkipped: 0,
+        dirsRemoved: 1,
+      },
+      "json",
+    );
+  });
+  const parsed = JSON.parse(output);
+  assertStringIncludes(parsed.removed.name, "@test/ext");
+  assertStringIncludes(parsed.removed.version, "2026.02.26.1");
+  assertEquals(parsed.removed.filesDeleted, 3);
+  assertEquals(parsed.removed.filesSkipped, 0);
+  assertEquals(parsed.removed.dirsRemoved, 1);
+});
+
+Deno.test("renderExtensionRmCancelled outputs JSON in json mode", () => {
+  const output = captureConsoleLog(() => {
+    renderExtensionRmCancelled("json");
+  });
+  const parsed = JSON.parse(output);
+  assertStringIncludes(parsed.status, "cancelled");
+});
+
+Deno.test("renderExtensionRmDependencyWarning outputs JSON in json mode", () => {
+  const output = captureConsoleLog(() => {
+    renderExtensionRmDependencyWarning(
+      ["@test/other", "@test/another"],
+      "json",
+    );
+  });
+  const parsed = JSON.parse(output);
+  assertEquals(parsed.dependencyWarning.length, 2);
+  assertStringIncludes(parsed.dependencyWarning[0], "@test/other");
+  assertStringIncludes(parsed.dependencyWarning[1], "@test/another");
+});
+
+Deno.test("renderExtensionRmFileDelete outputs JSON for deleted file", () => {
+  const output = captureConsoleLog(() => {
+    renderExtensionRmFileDelete(
+      "extensions/models/foo/bar.yaml",
+      "deleted",
+      "json",
+    );
+  });
+  const parsed = JSON.parse(output);
+  assertStringIncludes(parsed.file, "foo/bar.yaml");
+  assertEquals(parsed.status, "deleted");
+});
+
+Deno.test("renderExtensionRmFileDelete outputs JSON for missing file", () => {
+  const output = captureConsoleLog(() => {
+    renderExtensionRmFileDelete(
+      "extensions/models/gone.ts",
+      "missing",
+      "json",
+    );
+  });
+  const parsed = JSON.parse(output);
+  assertStringIncludes(parsed.file, "gone.ts");
+  assertEquals(parsed.status, "missing");
+});


### PR DESCRIPTION
Fixes: #522

- Add swamp extension rm <name> (aliased as extension remove) to cleanly remove pulled extensions by deleting all tracked files and removing the entry from upstream_extensions.json
- Support --force to skip confirmation, --verbose for per-file deletion output, and --repo-dir for non-default repos
- Handle edge cases: already-deleted files (skipped gracefully), legacy entries without file tracking (error with re-pull hint), dependent extensions (warning before removal), empty parent directory pruning
- Fix missing-argument errors globally — swamp extension rm, swamp extension pull, swamp model delete, and all other commands with required arguments now show a clean error message instead of a raw stack trace with Cliffy internals

## Why this approach

The recent addition of file tracking in upstream_extensions.json (PR #520) made clean removal possible — we know exactly which files an extension installed. The removeUpstreamExtension and readUpstreamExtensions functions are co-located with updateUpstreamExtensions in extension_pull.ts so all JSON mutations share the same lockfile and atomic-write pattern, preventing corruption from concurrent operations.

The missing-argument fix lives in error_output.ts (the global error renderer) rather than as a per-command .error() handler because this is a Cliffy framework issue that affects every command with required arguments. Fixing it at the render layer means all current and future commands benefit without needing individual error handlers.

Dependency checking scans locally-installed extensions' manifest.yaml files for references to the target extension. This is best-effort for v1 — it works without registry calls and covers the common case where dependents were pulled into the same repo.

## Test Plan

- 5 unit tests for removeUpstreamExtension and readUpstreamExtensions (removes entry preserving others, handles missing extension, handles missing JSON file, reads existing entries, returns empty map when file missing)
- 5 output renderer tests (JSON output for removal success, cancellation, dependency warning, file delete, file missing)
- 1 error output test for Cliffy missing-argument rendering
- 6 integration tests (--help output, extension --help shows rm, invalid name error, non-installed extension error, requires initialized repo, end-to-end pull-then-rm verifying files deleted and JSON entry removed)
- All 2312 tests pass, deno check, deno lint, deno fmt clean