### PR TITLE
feat: add extension list command to show installed extensions

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -304,3 +304,16 @@ Options:
 - `-f, --force` — Skip confirmation prompt
 
 With `--verbose`, individual file deletions are logged.
+
+### extension list
+
+Alias is ls.
+
+Lists the upstream installed extensions, sorted alphabetical by name.
+
+Options:
+
+- `--repo-dir <dir>` — Repository directory (default: `.`)
+
+With `--verbose`, lists each file under the extension. With `--json`
+it will also include the file list

--- a/integration/ddd_layer_rules_test.ts
+++ b/integration/ddd_layer_rules_test.ts
@@ -99,7 +99,7 @@ Deno.test(
   },
 );
 
-const KNOWN_PRESENTATION_INFRA_VIOLATIONS = 29;
+const KNOWN_PRESENTATION_INFRA_VIOLATIONS = 30;
 
 Deno.test(
   "presentation layer must not add new infrastructure imports (ratchet)",

--- a/integration/extension_list_test.ts
+++ b/integration/extension_list_test.ts
@@ -1,0 +1,235 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertStringIncludes } from "@std/assert/string-includes";
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+
+const PROJECT_ROOT = Deno.cwd();
+
+async function runCli(
+  args: string[],
+  env?: Record<string, string>,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["task", "dev", ...args],
+    stdout: "piped",
+    stderr: "piped",
+    cwd: PROJECT_ROOT,
+    env: {
+      ...Deno.env.toObject(),
+      SWAMP_NO_TELEMETRY: "1",
+      ...env,
+    },
+  });
+
+  const { code, stdout, stderr } = await command.output();
+  return {
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+    code,
+  };
+}
+
+/** Initialize a swamp repo in a temp directory. */
+async function initTempRepo(): Promise<string> {
+  const tmpDir = await Deno.makeTempDir();
+  await runCli(["init", tmpDir]);
+  return tmpDir;
+}
+
+/** Write a fake upstream_extensions.json into the models dir of a repo. */
+async function writeUpstreamExtensions(
+  repoDir: string,
+  data: Record<string, unknown>,
+): Promise<void> {
+  const modelsDir = join(repoDir, "extensions", "models");
+  await Deno.mkdir(modelsDir, { recursive: true });
+  await Deno.writeTextFile(
+    join(modelsDir, "upstream_extensions.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+Deno.test("extension list --help shows usage", async () => {
+  const { stdout } = await runCli(["extension", "list", "--help"]);
+  assertStringIncludes(stdout, "list");
+  assertStringIncludes(stdout, "List");
+});
+
+Deno.test("extension --help shows list subcommand", async () => {
+  const { stdout } = await runCli(["extension", "--help"]);
+  assertStringIncludes(stdout, "list");
+});
+
+Deno.test("extension list requires initialized repo", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const { stderr, code } = await runCli([
+      "extension",
+      "list",
+      "--repo-dir",
+      tmpDir,
+      "--no-color",
+    ]);
+    assertEquals(code === 0, false);
+    assertStringIncludes(stderr, "Not a swamp repository");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extension list with no extensions shows empty message", async () => {
+  const tmpDir = await initTempRepo();
+  try {
+    const { stdout, code } = await runCli([
+      "extension",
+      "list",
+      "--repo-dir",
+      tmpDir,
+      "--no-color",
+    ]);
+    assertEquals(code, 0);
+    assertStringIncludes(stdout, "No upstream extensions installed");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extension list --json with no extensions returns empty array", async () => {
+  const tmpDir = await initTempRepo();
+  try {
+    const { stdout, code } = await runCli([
+      "extension",
+      "list",
+      "--json",
+      "--repo-dir",
+      tmpDir,
+      "--no-color",
+    ]);
+    assertEquals(code, 0);
+    const parsed = JSON.parse(stdout);
+    assertEquals(parsed.extensions, []);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extension list shows installed extensions", async () => {
+  const tmpDir = await initTempRepo();
+  try {
+    await writeUpstreamExtensions(tmpDir, {
+      "@test/beta": {
+        version: "2026.01.01.1",
+        pulledAt: "2026-01-01T00:00:00.000Z",
+        files: ["extensions/models/beta/model.yaml"],
+      },
+      "@test/alpha": {
+        version: "2026.02.01.1",
+        pulledAt: "2026-02-01T00:00:00.000Z",
+        files: [
+          "extensions/models/alpha/model.yaml",
+          "extensions/models/alpha/handler.ts",
+        ],
+      },
+    });
+
+    const { stdout, code } = await runCli([
+      "extension",
+      "list",
+      "--repo-dir",
+      tmpDir,
+      "--no-color",
+    ]);
+    assertEquals(code, 0);
+    // Should be sorted alphabetically — alpha before beta
+    const alphaIdx = stdout.indexOf("@test/alpha");
+    const betaIdx = stdout.indexOf("@test/beta");
+    assertEquals(alphaIdx < betaIdx, true, "alpha should appear before beta");
+    assertStringIncludes(stdout, "v2026.02.01.1");
+    assertStringIncludes(stdout, "v2026.01.01.1");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extension list --json shows installed extensions", async () => {
+  const tmpDir = await initTempRepo();
+  try {
+    await writeUpstreamExtensions(tmpDir, {
+      "@test/one": {
+        version: "2026.01.15.1",
+        pulledAt: "2026-01-15T12:00:00.000Z",
+        files: ["extensions/models/one/model.yaml"],
+      },
+    });
+
+    const { stdout, code } = await runCli([
+      "extension",
+      "list",
+      "--json",
+      "--repo-dir",
+      tmpDir,
+      "--no-color",
+    ]);
+    assertEquals(code, 0);
+    const parsed = JSON.parse(stdout);
+    assertEquals(parsed.extensions.length, 1);
+    assertEquals(parsed.extensions[0].name, "@test/one");
+    assertEquals(parsed.extensions[0].version, "2026.01.15.1");
+    assertEquals(parsed.extensions[0].files.length, 1);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extension list --verbose shows individual files", async () => {
+  const tmpDir = await initTempRepo();
+  try {
+    await writeUpstreamExtensions(tmpDir, {
+      "@test/verbose-ext": {
+        version: "2026.01.01.1",
+        pulledAt: "2026-01-01T00:00:00.000Z",
+        files: [
+          "extensions/models/verbose-ext/model.yaml",
+          "extensions/models/verbose-ext/handler.ts",
+        ],
+      },
+    });
+
+    const { stdout, code } = await runCli([
+      "extension",
+      "list",
+      "--verbose",
+      "--repo-dir",
+      tmpDir,
+      "--no-color",
+    ]);
+    assertEquals(code, 0);
+    assertStringIncludes(stdout, "model.yaml");
+    assertStringIncludes(stdout, "handler.ts");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extension ls alias works", async () => {
+  const { stdout } = await runCli(["extension", "ls", "--help"]);
+  assertStringIncludes(stdout, "List");
+});

--- a/src/cli/commands/extension.ts
+++ b/src/cli/commands/extension.ts
@@ -21,6 +21,7 @@ import { Command } from "@cliffy/command";
 import { extensionPushCommand } from "./extension_push.ts";
 import { extensionPullCommand } from "./extension_pull.ts";
 import { extensionRemoveCommand } from "./extension_rm.ts";
+import { extensionListCommand } from "./extension_list.ts";
 import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
 
 export const extensionCommand = new Command()
@@ -32,4 +33,5 @@ export const extensionCommand = new Command()
   })
   .command("push", extensionPushCommand)
   .command("pull", extensionPullCommand)
-  .command("rm", extensionRemoveCommand);
+  .command("rm", extensionRemoveCommand)
+  .command("list", extensionListCommand);

--- a/src/cli/commands/extension_list.ts
+++ b/src/cli/commands/extension_list.ts
@@ -1,0 +1,75 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { resolve } from "@std/path";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
+import { resolveModelsDir } from "../resolve_models_dir.ts";
+import {
+  RepoMarkerRepository,
+} from "../../infrastructure/persistence/repo_marker_repository.ts";
+import { RepoPath } from "../../domain/repo/repo_path.ts";
+import { readUpstreamExtensions } from "./extension_pull.ts";
+import {
+  type ExtensionListEntry,
+  renderExtensionList,
+} from "../../presentation/output/extension_list_output.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const extensionListCommand = new Command()
+  .name("list")
+  .alias("ls")
+  .description("List upstream installed extensions")
+  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .action(async function (options: AnyOptions) {
+    const ctx = createContext(options as GlobalOptions, ["extension", "list"]);
+    ctx.logger.debug`Starting extension list`;
+
+    const repoDir = options.repoDir ?? ".";
+    await requireInitializedRepo({
+      repoDir,
+      outputMode: ctx.outputMode,
+    });
+
+    const repoPath = RepoPath.create(repoDir);
+    const markerRepo = new RepoMarkerRepository();
+    const marker = await markerRepo.read(repoPath);
+    const modelsDir = resolveModelsDir(marker);
+    const absoluteModelsDir = resolve(repoDir, modelsDir);
+
+    const upstreamData = await readUpstreamExtensions(absoluteModelsDir);
+
+    const entries: ExtensionListEntry[] = Object.entries(upstreamData)
+      .map(([name, entry]) => ({
+        name,
+        version: entry.version,
+        pulledAt: entry.pulledAt ?? "",
+        files: entry.files ?? [],
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    const verbose = ctx.verbosity === "verbose";
+
+    renderExtensionList({ extensions: entries }, ctx.outputMode, verbose);
+
+    ctx.logger.debug("Extension list command completed");
+  });

--- a/src/presentation/output/extension_list_output.ts
+++ b/src/presentation/output/extension_list_output.ts
@@ -1,0 +1,77 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { OutputMode } from "./output.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+
+const logger = getSwampLogger(["extension", "list"]);
+
+/** A single extension entry for list output. */
+export interface ExtensionListEntry {
+  name: string;
+  version: string;
+  pulledAt: string;
+  files: string[];
+}
+
+/** Data for extension list output. */
+export interface ExtensionListData {
+  extensions: ExtensionListEntry[];
+}
+
+/**
+ * Renders the extension list output.
+ */
+export function renderExtensionList(
+  data: ExtensionListData,
+  mode: OutputMode,
+  verbose: boolean,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+
+  if (data.extensions.length === 0) {
+    logger.info("No upstream extensions installed.");
+    logger.info(
+      "Use 'swamp extension pull @namespace/name' to install one.",
+    );
+    return;
+  }
+
+  const maxName = Math.max(...data.extensions.map((e) => e.name.length));
+  const maxVersion = Math.max(
+    ...data.extensions.map((e) => e.version.length + 1),
+  ); // +1 for "v" prefix
+
+  for (const ext of data.extensions) {
+    const paddedName = ext.name.padEnd(maxName);
+    const paddedVersion = `v${ext.version}`.padEnd(maxVersion);
+    logger.info(
+      "{line}",
+      { line: `${paddedName}  ${paddedVersion}  (pulled ${ext.pulledAt})` },
+    );
+    if (verbose) {
+      for (const file of ext.files) {
+        logger.info("  {file}", { file });
+      }
+    }
+  }
+}

--- a/src/presentation/output/extension_list_output_test.ts
+++ b/src/presentation/output/extension_list_output_test.ts
@@ -1,0 +1,158 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert/equals";
+import { assertStringIncludes } from "@std/assert/string-includes";
+import { renderExtensionList } from "./extension_list_output.ts";
+
+function captureConsoleLog(fn: () => void): string {
+  const original = console.log;
+  let captured = "";
+  console.log = (msg: string) => {
+    captured += msg;
+  };
+  try {
+    fn();
+  } finally {
+    console.log = original;
+  }
+  return captured;
+}
+
+Deno.test("renderExtensionList outputs valid JSON in json mode", () => {
+  const output = captureConsoleLog(() => {
+    renderExtensionList(
+      {
+        extensions: [
+          {
+            name: "@test/ext",
+            version: "2026.01.01.1",
+            pulledAt: "2026-01-01T00:00:00.000Z",
+            files: ["extensions/models/ext/model.yaml"],
+          },
+        ],
+      },
+      "json",
+      false,
+    );
+  });
+  const parsed = JSON.parse(output);
+  assertEquals(parsed.extensions.length, 1);
+  assertEquals(parsed.extensions[0].name, "@test/ext");
+  assertEquals(parsed.extensions[0].version, "2026.01.01.1");
+  assertEquals(parsed.extensions[0].files.length, 1);
+});
+
+Deno.test("renderExtensionList outputs empty array in json mode when no extensions", () => {
+  const output = captureConsoleLog(() => {
+    renderExtensionList({ extensions: [] }, "json", false);
+  });
+  const parsed = JSON.parse(output);
+  assertEquals(parsed.extensions, []);
+});
+
+Deno.test("renderExtensionList in log mode with empty list does not throw", () => {
+  renderExtensionList({ extensions: [] }, "log", false);
+});
+
+Deno.test("renderExtensionList in log mode with extensions does not throw", () => {
+  renderExtensionList(
+    {
+      extensions: [
+        {
+          name: "@test/alpha",
+          version: "2026.01.01.1",
+          pulledAt: "2026-01-01T00:00:00.000Z",
+          files: ["extensions/models/alpha/model.yaml"],
+        },
+        {
+          name: "@test/beta",
+          version: "2026.02.01.1",
+          pulledAt: "2026-02-01T00:00:00.000Z",
+          files: [],
+        },
+      ],
+    },
+    "log",
+    false,
+  );
+});
+
+Deno.test("renderExtensionList in log mode verbose does not throw", () => {
+  renderExtensionList(
+    {
+      extensions: [
+        {
+          name: "@test/ext",
+          version: "2026.01.01.1",
+          pulledAt: "2026-01-01T00:00:00.000Z",
+          files: [
+            "extensions/models/ext/model.yaml",
+            "extensions/models/ext/handler.ts",
+          ],
+        },
+      ],
+    },
+    "log",
+    true,
+  );
+});
+
+Deno.test("renderExtensionList json mode includes version without v prefix", () => {
+  const output = captureConsoleLog(() => {
+    renderExtensionList(
+      {
+        extensions: [
+          {
+            name: "@test/ext",
+            version: "2026.01.01.1",
+            pulledAt: "2026-01-01T00:00:00.000Z",
+            files: [],
+          },
+        ],
+      },
+      "json",
+      false,
+    );
+  });
+  const parsed = JSON.parse(output);
+  assertEquals(parsed.extensions[0].version, "2026.01.01.1");
+  assertStringIncludes(parsed.extensions[0].pulledAt, "2026-01-01");
+});
+
+Deno.test("renderExtensionList json mode verbose still outputs all files", () => {
+  const output = captureConsoleLog(() => {
+    renderExtensionList(
+      {
+        extensions: [
+          {
+            name: "@test/ext",
+            version: "2026.01.01.1",
+            pulledAt: "2026-01-01T00:00:00.000Z",
+            files: ["a.yaml", "b.ts"],
+          },
+        ],
+      },
+      "json",
+      true,
+    );
+  });
+  const parsed = JSON.parse(output);
+  assertEquals(parsed.extensions[0].files, ["a.yaml", "b.ts"]);
+});


### PR DESCRIPTION
Fixes: #525

- Add `extension list` (alias `ls`) command that reads `upstream_extensions.json`
and displays installed upstream extensions
- Supports `--json` for structured output and `--verbose` to show individual files
- Log mode output is column-aligned for readability, sorted alphabetically by name

## Why this design

Before this change, the only way to see what extensions were installed was to
manually read `upstream_extensions.json`. This completes the extension lifecycle
CLI surface alongside `push`, `pull`, and `rm`.

The command follows the same patterns as `extension rm` — reusing
`readUpstreamExtensions()`, `createContext()`, `requireInitializedRepo()`, and
the established output rendering split. Column-aligned output keeps the list
scannable as extension names vary in length.

## User impact

Users can now run `swamp extension list` (or `swamp extension ls`) to see all
installed upstream extensions at a glance, with version and pull date. The
`--json` flag gives machine-readable output for scripting, and `--verbose` lists
every file belonging to each extension.

## Test plan

- [x] `extension list --help` shows usage
- [x] `extension --help` shows `list` subcommand
- [x] Requires initialized repo
- [x] Empty repo shows "No upstream extensions installed" with CTA
- [x] `--json` with no extensions returns `{ extensions: [] }`
- [x] Populated repo displays entries sorted alphabetically
- [x] `--json` returns structured data with name, version, pulledAt, files
- [x] `--verbose` shows individual file paths
- [x] `ls` alias works