### PR TITLE
fix: redirect to swamp.club/cli/success after CLI auth

### DIFF
--- a/src/cli/commands/auth_login.ts
+++ b/src/cli/commands/auth_login.ts
@@ -86,7 +86,7 @@ async function readPassword(prompt: string): Promise<string> {
 /** Get a session token via the browser-based login flow. */
 async function browserFlow(serverUrl: string): Promise<string> {
   const state = crypto.randomUUID();
-  const server = startCallbackServer(state);
+  const server = startCallbackServer(state, serverUrl);
 
   const callbackUrl = `http://localhost:${server.port}/callback`;
   const loginUrl = `${serverUrl}/login?cli_callback=${

--- a/src/infrastructure/http/callback_server.ts
+++ b/src/infrastructure/http/callback_server.ts
@@ -29,17 +29,6 @@ export interface CallbackServerHandle {
   shutdown(): Promise<void>;
 }
 
-const SUCCESS_HTML = `<!DOCTYPE html>
-<html>
-<head><title>swamp CLI</title></head>
-<body style="background:#000;color:#39ff14;font-family:monospace;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
-<div style="text-align:center">
-<h1 style="font-size:2rem">Authentication successful</h1>
-<p>You can close this tab and return to the terminal.</p>
-</div>
-</body>
-</html>`;
-
 const ERROR_HTML = `<!DOCTYPE html>
 <html>
 <head><title>swamp CLI</title></head>
@@ -58,9 +47,11 @@ const TIMEOUT_MS = 120_000;
  * callback from the browser containing a session token.
  *
  * @param expectedState  The random state nonce the CLI generated.
+ * @param serverUrl      The swamp-club server URL used to build the success redirect.
  */
 export function startCallbackServer(
   expectedState: string,
+  serverUrl: string,
 ): CallbackServerHandle {
   let resolveToken: (token: string) => void;
   let rejectToken: (err: Error) => void;
@@ -110,9 +101,10 @@ export function startCallbackServer(
       clearTimeout(timer);
       resolveToken(token);
 
-      return new Response(SUCCESS_HTML, {
-        status: 200,
-        headers: { "Content-Type": "text/html; charset=utf-8" },
+      const successUrl = `${serverUrl}/cli/success`;
+      return new Response(null, {
+        status: 302,
+        headers: { Location: successUrl },
       });
     },
   );
@@ -124,7 +116,7 @@ export function startCallbackServer(
     token: tokenPromise,
     async shutdown() {
       clearTimeout(timer);
-      // Brief delay so the success HTML response flushes to the browser
+      // Brief delay so the 302 redirect response flushes to the browser
       // before we tear down the server.
       await new Promise((r) => setTimeout(r, 500));
       ac.abort();

--- a/src/infrastructure/http/callback_server_test.ts
+++ b/src/infrastructure/http/callback_server_test.ts
@@ -22,17 +22,19 @@ import { startCallbackServer } from "./callback_server.ts";
 
 Deno.test("callback server - resolves token on valid callback", async () => {
   const state = crypto.randomUUID();
-  const server = startCallbackServer(state);
+  const serverUrl = "https://swamp.club";
+  const server = startCallbackServer(state, serverUrl);
   assertExists(server.port);
 
   const token = "test-session-token-123";
   const res = await fetch(
     `http://localhost:${server.port}/callback?token=${token}&state=${state}`,
+    { redirect: "manual" },
   );
 
-  assertEquals(res.status, 200);
-  const body = await res.text();
-  assertEquals(body.includes("Authentication successful"), true);
+  assertEquals(res.status, 302);
+  assertEquals(res.headers.get("location"), "https://swamp.club/cli/success");
+  await res.body?.cancel();
 
   const resolved = await server.token;
   assertEquals(resolved, token);
@@ -41,7 +43,7 @@ Deno.test("callback server - resolves token on valid callback", async () => {
 
 Deno.test("callback server - rejects mismatched state", async () => {
   const state = crypto.randomUUID();
-  const server = startCallbackServer(state);
+  const server = startCallbackServer(state, "https://swamp.club");
 
   const res = await fetch(
     `http://localhost:${server.port}/callback?token=tok&state=wrong-state`,
@@ -54,7 +56,7 @@ Deno.test("callback server - rejects mismatched state", async () => {
 
 Deno.test("callback server - rejects missing token", async () => {
   const state = crypto.randomUUID();
-  const server = startCallbackServer(state);
+  const server = startCallbackServer(state, "https://swamp.club");
 
   const res = await fetch(
     `http://localhost:${server.port}/callback?state=${state}`,
@@ -67,7 +69,7 @@ Deno.test("callback server - rejects missing token", async () => {
 
 Deno.test("callback server - returns 404 for non-callback paths", async () => {
   const state = crypto.randomUUID();
-  const server = startCallbackServer(state);
+  const server = startCallbackServer(state, "https://swamp.club");
 
   const res = await fetch(`http://localhost:${server.port}/other`);
 
@@ -77,7 +79,7 @@ Deno.test("callback server - returns 404 for non-callback paths", async () => {
 });
 
 Deno.test("callback server - allocates a random port", async () => {
-  const server = startCallbackServer("test-state");
+  const server = startCallbackServer("test-state", "https://swamp.club");
   assertEquals(server.port > 0, true);
   await server.shutdown();
 });


### PR DESCRIPTION
## Summary

- Replace the localhost HTML success page with a `302 Found` redirect to `{serverUrl}/cli/success` after the CLI captures the auth token
- Pass `serverUrl` through to `startCallbackServer` so the redirect respects `SWAMP_CLUB_URL` env var
- Remove the now-unused `SUCCESS_HTML` constant

Fixes systeminit/swamp-club#118

## Test Plan

- Updated `callback_server_test.ts` to verify 302 status and `Location` header
- All 2315 tests pass, `deno check`, `deno lint`, and `deno fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)