### PR TITLE
fix: detectConflicts uses correct nested paths for bundles

### DIFF
--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -335,7 +335,7 @@ async function listFiles(dir: string): Promise<string[]> {
 /**
  * Detects files that already exist at target paths.
  */
-async function detectConflicts(
+export async function detectConflicts(
   extractDir: string,
   modelsDir: string,
   workflowsDir: string,
@@ -366,7 +366,8 @@ async function detectConflicts(
   // Check bundles
   const bundlesSrc = join(extractDir, "bundles");
   for (const file of await listFiles(bundlesSrc)) {
-    const destPath = join(bundlesDir, basename(file));
+    const relPath = relative(bundlesSrc, file);
+    const destPath = join(bundlesDir, relPath);
     if (await fileExists(destPath)) {
       conflicts.push(relative(repoDir, destPath));
     }

--- a/src/cli/commands/extension_pull_test.ts
+++ b/src/cli/commands/extension_pull_test.ts
@@ -20,6 +20,7 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import { assertStringIncludes } from "@std/assert/string-includes";
 import {
+  detectConflicts,
   parseExtensionRef,
   updateUpstreamExtensions,
 } from "./extension_pull.ts";
@@ -110,6 +111,43 @@ Deno.test("updateUpstreamExtensions handles empty files array", async () => {
     const data = JSON.parse(content) as Record<string, UpstreamExtensionEntry>;
 
     assertEquals(data["@test/empty"].files, []);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("detectConflicts uses nested path for bundles, not basename", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    // Set up extract dir with a nested bundle: bundles/k8s/netpol.js
+    const extractDir = join(tmpDir, "extract");
+    const bundleSubdir = join(extractDir, "bundles", "k8s");
+    await Deno.mkdir(bundleSubdir, { recursive: true });
+    await Deno.writeTextFile(join(bundleSubdir, "netpol.js"), "// bundle");
+
+    // Set up the repo with the same nested bundle already installed
+    const repoDir = join(tmpDir, "repo");
+    const bundlesDir = join(repoDir, ".swamp", "bundles");
+    const nestedBundleDir = join(bundlesDir, "k8s");
+    await Deno.mkdir(nestedBundleDir, { recursive: true });
+    await Deno.writeTextFile(join(nestedBundleDir, "netpol.js"), "// existing");
+
+    // Also create empty dirs for models and workflows
+    const modelsDir = join(repoDir, "extensions", "models");
+    const workflowsDir = join(repoDir, ".swamp", "workflows");
+    await Deno.mkdir(modelsDir, { recursive: true });
+    await Deno.mkdir(workflowsDir, { recursive: true });
+
+    const conflicts = await detectConflicts(
+      extractDir,
+      modelsDir,
+      workflowsDir,
+      bundlesDir,
+      repoDir,
+    );
+
+    // Should detect the conflict at the nested path, not the flat basename
+    assertEquals(conflicts, [join(".swamp", "bundles", "k8s", "netpol.js")]);
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }


### PR DESCRIPTION
## Summary

- Fixes `detectConflicts` to use `relative(bundlesSrc, file)` instead of `basename(file)` for bundle paths, aligning it with how `copyDir` actually installs bundles and how models/additional files already handle paths.
- Adds a unit test verifying nested bundle conflict detection.
- Exports `detectConflicts` to enable direct testing.

## Context

Commit c637ddd (#509) fixed extension **push** to preserve nested directory structure for bundles, but `detectConflicts` (which runs during **pull**) was not updated. It still used `basename(file)` — the old flat-path pattern from before the fix.

## User impact

**Before this fix**, extensions with nested bundles (like `@john/k8s` which installs 15 bundles under `.swamp/bundles/k8s/`) had broken conflict detection:

1. **Missed conflicts** — Re-pulling would silently overwrite files without the "files already exist" warning, because `detectConflicts` checked flat paths (`.swamp/bundles/netpol.js`) while `copyDir` installed to nested paths (`.swamp/bundles/k8s/netpol.js`).

2. **False positives** — Stale files from pre-fix flat installs could trigger spurious conflict warnings for paths that didn't match actual installed files.

3. **Inconsistent path output** — `extension rm` (which uses correct nested tracking from `upstream_extensions.json`) reported different paths than `extension pull` conflict detection.

**After this fix**, `detectConflicts` checks the same nested paths that `copyDir` writes to, so conflict detection is accurate for all extensions regardless of bundle nesting depth.

## Verified with

- `@john/k8s` — 57 files including 15 nested bundles under `.swamp/bundles/k8s/`; all conflicts correctly detected on re-pull
- `@stack72/system-extensions` — flat bundles continue to work correctly
- Full test suite (2316 tests passing)

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] `deno run test` — all 2316 tests pass, including new `detectConflicts` test
- [x] `deno run compile` — binary compiles
- [x] Manual: init repo, pull `@john/k8s`, pull again → all 57 conflicts detected at correct nested paths
- [x] Manual: init repo, pull `@stack72/system-extensions`, pull again → flat bundles still detected correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)