### PR TITLE
feat: add repository field to extension manifest schema

### DIFF
--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -43,6 +43,7 @@ import {
   renderExtensionPullDependencyPull,
   renderExtensionPullIntegrity,
   renderExtensionPullPlatforms,
+  renderExtensionPullRepository,
   renderExtensionPullResolved,
   renderExtensionPullSafetyErrors,
   renderExtensionPullSafetyWarnings,
@@ -508,6 +509,10 @@ async function pullExtension(
       );
     }
     const manifest = parseExtensionManifest(manifestContent);
+
+    if (manifest.repository) {
+      renderExtensionPullRepository(manifest.repository, outputMode);
+    }
 
     if (manifest.platforms.length > 0) {
       renderExtensionPullPlatforms(manifest.platforms, outputMode);

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -283,6 +283,7 @@ export const extensionPushCommand = new Command()
         name: manifest.name,
         version: manifest.version,
         description: manifest.description,
+        repository: manifest.repository,
         modelFiles: allModelFiles.map((f) => relative(repoDir, f)),
         workflowFiles: workflowFiles.map((wf) =>
           relative(repoDir, wf.sourcePath)
@@ -404,6 +405,7 @@ export const extensionPushCommand = new Command()
           name: manifest.name,
           version: manifest.version,
           description: manifest.description ?? "",
+          ...(manifest.repository ? { repository: manifest.repository } : {}),
           models: manifest.models,
           workflows: manifest.workflows,
           additionalFiles: manifest.additionalFiles,

--- a/src/domain/extensions/extension_manifest.ts
+++ b/src/domain/extensions/extension_manifest.ts
@@ -42,6 +42,7 @@ const ExtensionManifestSchemaV1 = z.object({
     message: "Version must be valid CalVer format: YYYY.MM.DD.MICRO",
   }),
   description: z.string().optional(),
+  repository: z.string().url().optional(),
   workflows: z.array(z.string()).optional(),
   models: z.array(z.string()).optional(),
   additionalFiles: z.array(z.string()).optional(),
@@ -65,6 +66,7 @@ export interface ExtensionManifest {
   name: string;
   version: string;
   description: string | undefined;
+  repository: string | undefined;
   workflows: string[];
   models: string[];
   additionalFiles: string[];
@@ -117,6 +119,7 @@ export function parseExtensionManifest(content: string): ExtensionManifest {
     name: result.data.name,
     version: result.data.version,
     description: result.data.description,
+    repository: result.data.repository,
     workflows: result.data.workflows ?? [],
     models: result.data.models ?? [],
     additionalFiles: result.data.additionalFiles ?? [],

--- a/src/domain/extensions/extension_manifest_test.ts
+++ b/src/domain/extensions/extension_manifest_test.ts
@@ -229,6 +229,36 @@ labels:
   assertEquals(manifest.labels, ["aws", "kubernetes", "security"]);
 });
 
+Deno.test("parseExtensionManifest parses valid manifest with repository", () => {
+  const yaml = `
+manifestVersion: 1
+name: "@myuser/myext"
+version: "2026.02.26.1"
+description: "My extension"
+repository: "https://github.com/myuser/swamp-myext"
+models:
+  - foo.ts
+`;
+  const manifest = parseExtensionManifest(yaml);
+  assertEquals(
+    manifest.repository,
+    "https://github.com/myuser/swamp-myext",
+  );
+});
+
+Deno.test("parseExtensionManifest rejects invalid repository URL", () => {
+  const yaml = `
+manifestVersion: 1
+name: "@myuser/myext"
+version: "2026.02.26.1"
+repository: "not-a-url"
+models:
+  - foo.ts
+`;
+  const error = assertThrows(() => parseExtensionManifest(yaml));
+  assertStringIncludes((error as Error).message, "Invalid");
+});
+
 Deno.test("parseExtensionManifest defaults optional fields", () => {
   const yaml = `
 manifestVersion: 1
@@ -239,6 +269,7 @@ models:
 `;
   const manifest = parseExtensionManifest(yaml);
   assertEquals(manifest.description, undefined);
+  assertEquals(manifest.repository, undefined);
   assertEquals(manifest.workflows, []);
   assertEquals(manifest.additionalFiles, []);
   assertEquals(manifest.platforms, []);

--- a/src/presentation/output/extension_pull_output.ts
+++ b/src/presentation/output/extension_pull_output.ts
@@ -63,6 +63,20 @@ export function renderExtensionPullResolved(
 }
 
 /**
+ * Renders repository URL from the extension manifest.
+ */
+export function renderExtensionPullRepository(
+  repository: string,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify({ repository }, null, 2));
+  } else {
+    logger.info`Repository: ${repository}`;
+  }
+}
+
+/**
  * Renders platform compatibility hint from the extension manifest.
  */
 export function renderExtensionPullPlatforms(

--- a/src/presentation/output/extension_pull_output_test.ts
+++ b/src/presentation/output/extension_pull_output_test.ts
@@ -24,6 +24,7 @@ import {
   renderExtensionPullConflicts,
   renderExtensionPullDependencyPull,
   renderExtensionPullPlatforms,
+  renderExtensionPullRepository,
   renderExtensionPullResolved,
   renderExtensionPullSafetyErrors,
   renderExtensionPullSafetyWarnings,
@@ -112,6 +113,20 @@ Deno.test("renderExtensionPullSafetyErrors outputs JSON in json mode", () => {
   });
   const parsed = JSON.parse(output);
   assertStringIncludes(parsed.errors[0].file, "evil.ts");
+});
+
+Deno.test("renderExtensionPullRepository outputs JSON in json mode", () => {
+  const output = captureConsoleLog(() => {
+    renderExtensionPullRepository(
+      "https://github.com/myuser/swamp-myext",
+      "json",
+    );
+  });
+  const parsed = JSON.parse(output);
+  assertStringIncludes(
+    parsed.repository,
+    "https://github.com/myuser/swamp-myext",
+  );
 });
 
 Deno.test("renderExtensionPullPlatforms outputs JSON in json mode", () => {

--- a/src/presentation/output/extension_push_output.ts
+++ b/src/presentation/output/extension_push_output.ts
@@ -28,6 +28,7 @@ export interface ExtensionPushResolvedData {
   name: string;
   version: string;
   description: string | undefined;
+  repository: string | undefined;
   modelFiles: string[];
   workflowFiles: string[];
   additionalFiles: string[];
@@ -66,6 +67,9 @@ export function renderExtensionPushResolved(
     logger.info`Extension: ${data.name}@${data.version}`;
     if (data.description) {
       logger.info`Description: ${data.description}`;
+    }
+    if (data.repository) {
+      logger.info`Repository: ${data.repository}`;
     }
     if (data.modelFiles.length > 0) {
       logger.info`Models (${data.modelFiles.length}):`;

--- a/src/presentation/output/extension_push_output_test.ts
+++ b/src/presentation/output/extension_push_output_test.ts
@@ -49,6 +49,7 @@ Deno.test("renderExtensionPushResolved outputs JSON in json mode", () => {
         name: "@test/ext",
         version: "2026.02.26.1",
         description: "Test extension",
+        repository: undefined,
         modelFiles: ["model.ts"],
         workflowFiles: [],
         additionalFiles: [],


### PR DESCRIPTION
## Summary

Closes #528

Adds an optional `repository` field to the extension manifest schema so extension authors can link to their source code repository directly in the manifest, rather than hacking it into the description field.

### Example manifest

```yaml
manifestVersion: 1
name: "@keeb/proxmox"
version: "2026.02.27.1"
description: "Proxmox API auth + VM fleet lifecycle management"
repository: "https://github.com/keeb/swamp-proxmox"
```

## What changed

**Schema & domain** (`src/domain/extensions/extension_manifest.ts`)
- Added `repository: z.string().url().optional()` to `ExtensionManifestSchemaV1` — Zod validates it as a proper URL when provided
- Added `repository: string | undefined` to the `ExtensionManifest` interface
- Parser now passes `repository` through from validated data

**Pull output** (`extension_pull_output.ts`, `extension_pull.ts`)
- Added `renderExtensionPullRepository()` — displayed after manifest is parsed from the downloaded archive, following the same pattern as `renderExtensionPullPlatforms()`
- This is the correct placement because `repository` lives in the manifest YAML inside the archive, not in the registry API response (`extInfo`), so it's only available after download + parse

**Push output** (`extension_push_output.ts`, `extension_push.ts`)
- Added `repository` to `ExtensionPushResolvedData` and `renderExtensionPushResolved()` — shown during the pre-push confirmation display
- Archive manifest normalization omits `repository` when not provided (same pattern as `labels` and `platforms`)

**Deliberately not changed:**
- `PushMetadata` in `extension_api_client.ts` — `repository` is a manifest-only field, not registry API metadata. The registry reads it from the archive manifest if needed.

## Test Plan

- Added test: valid manifest with `repository` parses correctly
- Added test: invalid URL (`"not-a-url"`) is rejected by Zod validation
- Added test: `repository` defaults to `undefined` when omitted
- Added test: `renderExtensionPullRepository` JSON output
- Updated existing push output test to include `repository` field
- Full test suite passes (2340 tests, 0 failures)
- `deno check`, `deno lint`, `deno fmt` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)