### PR TITLE
feat: add device verification code to CLI browser login flow

### DIFF
--- a/src/cli/commands/auth_login.ts
+++ b/src/cli/commands/auth_login.ts
@@ -26,6 +26,7 @@ import { openBrowser } from "../../infrastructure/process/browser.ts";
 import { UserError } from "../../domain/errors.ts";
 import { Spinner } from "../../presentation/spinner.ts";
 import { renderAuthLoginSuccess } from "../../presentation/output/auth_login_output.ts";
+import { generateDeviceCode } from "../../domain/auth/device_code.ts";
 
 const DEFAULT_SERVER_URL = "https://swamp.club";
 
@@ -91,12 +92,15 @@ async function browserFlow(
   spinner: Spinner | null,
 ): Promise<string> {
   const state = crypto.randomUUID();
+  const deviceCode = generateDeviceCode();
   const server = startCallbackServer(state, serverUrl);
 
   const callbackUrl = `http://localhost:${server.port}/callback`;
   const loginUrl = `${serverUrl}/login?cli_callback=${
     encodeURIComponent(callbackUrl)
-  }&state=${encodeURIComponent(state)}`;
+  }&state=${encodeURIComponent(state)}&device_code=${
+    encodeURIComponent(deviceCode)
+  }`;
 
   try {
     await openBrowser(loginUrl);
@@ -112,7 +116,15 @@ async function browserFlow(
     }
   }
 
-  spinner?.update("Waiting for authentication...");
+  spinner?.stop();
+  console.log();
+  console.log(`  Verification code: ${deviceCode}`);
+  console.log();
+  console.log(
+    "  Confirm this code matches in your browser before signing in.",
+  );
+  console.log();
+  spinner?.start("Waiting for authentication...");
 
   try {
     const token = await server.token;

--- a/src/domain/auth/device_code.ts
+++ b/src/domain/auth/device_code.ts
@@ -1,0 +1,29 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/** Characters excluding ambiguous glyphs (0, O, 1, I, L). */
+const SAFE_CHARS = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+
+/** Generate a device verification code in XXXX-XXXX format. */
+export function generateDeviceCode(): string {
+  const bytes = new Uint8Array(8);
+  crypto.getRandomValues(bytes);
+  const chars = Array.from(bytes, (b) => SAFE_CHARS[b % SAFE_CHARS.length]);
+  return `${chars.slice(0, 4).join("")}-${chars.slice(4).join("")}`;
+}

--- a/src/domain/auth/device_code_test.ts
+++ b/src/domain/auth/device_code_test.ts
@@ -1,0 +1,52 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertMatch, assertNotEquals } from "@std/assert";
+import { generateDeviceCode } from "./device_code.ts";
+
+Deno.test("generateDeviceCode - format matches XXXX-XXXX", () => {
+  const code = generateDeviceCode();
+  assertMatch(code, /^[A-Z2-9]{4}-[A-Z2-9]{4}$/);
+});
+
+Deno.test("generateDeviceCode - length is 9 (4 + hyphen + 4)", () => {
+  const code = generateDeviceCode();
+  assertEquals(code.length, 9);
+});
+
+Deno.test("generateDeviceCode - contains no ambiguous characters", () => {
+  // Generate several codes to increase confidence
+  for (let i = 0; i < 50; i++) {
+    const code = generateDeviceCode();
+    assertEquals(code.includes("0"), false, `code ${code} contains 0`);
+    assertEquals(code.includes("O"), false, `code ${code} contains O`);
+    assertEquals(code.includes("1"), false, `code ${code} contains 1`);
+    assertEquals(code.includes("I"), false, `code ${code} contains I`);
+    assertEquals(code.includes("L"), false, `code ${code} contains L`);
+  }
+});
+
+Deno.test("generateDeviceCode - multiple calls produce different results", () => {
+  const codes = new Set<string>();
+  for (let i = 0; i < 10; i++) {
+    codes.add(generateDeviceCode());
+  }
+  // With 31^8 possible codes, collisions in 10 calls are astronomically unlikely
+  assertNotEquals(codes.size, 1, "all codes were identical");
+});


### PR DESCRIPTION
The browser-based login flow (`swamp auth login`) previously had no way for users to confirm that the browser session they're authenticating actually corresponds to their CLI instance. This is a security gap: if a user has multiple terminal sessions, or if a phishing page mimics the login flow, there's no visual confirmation linking browser to terminal.

This is addressed by RFC 8628 (OAuth 2.0 Device Authorization Grant), which recommends displaying a short user-visible code on both the device (CLI) and the authorization page (browser) so the user can cross-check before authenticating.

Changes:

- Add `generateDeviceCode()` in `src/domain/auth/device_code.ts` that produces an `XXXX-XXXX` code using `crypto.getRandomValues()` with a 31-character alphabet excluding ambiguous glyphs (0/O/1/I/L)
- Append `device_code` as a URL parameter to the login URL sent to the browser, alongside the existing `cli_callback` and `state` params
- Display the verification code in the terminal between the "Opening browser..." and "Waiting for authentication..." messages so the user can visually match it against the browser UI

The approach is fully backward-compatible in both directions:
- If the web UI hasn't been updated yet, the `device_code` param sits harmlessly in the URL and is ignored
- If the CLI hasn't been updated yet, the web UI sees no `device_code` and renders identically to before

Ref: #532