### PR TITLE
feat: style device verification code as a card

### DIFF
--- a/src/cli/commands/auth_login.ts
+++ b/src/cli/commands/auth_login.ts
@@ -25,7 +25,10 @@ import { startCallbackServer } from "../../infrastructure/http/callback_server.t
 import { openBrowser } from "../../infrastructure/process/browser.ts";
 import { UserError } from "../../domain/errors.ts";
 import { Spinner } from "../../presentation/spinner.ts";
-import { renderAuthLoginSuccess } from "../../presentation/output/auth_login_output.ts";
+import {
+  renderAuthLoginSuccess,
+  renderDeviceVerification,
+} from "../../presentation/output/auth_login_output.ts";
 import { generateDeviceCode } from "../../domain/auth/device_code.ts";
 
 const DEFAULT_SERVER_URL = "https://swamp.club";
@@ -117,12 +120,7 @@ async function browserFlow(
   }
 
   spinner?.stop();
-  console.log();
-  console.log(`  Verification code: ${deviceCode}`);
-  console.log();
-  console.log(
-    "  Confirm this code matches in your browser before signing in.",
-  );
+  renderDeviceVerification(deviceCode);
   console.log();
   spinner?.start("Waiting for authentication...");
 

--- a/src/presentation/output/auth_login_output.ts
+++ b/src/presentation/output/auth_login_output.ts
@@ -17,9 +17,22 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { bold, cyan, dim, green } from "@std/fmt/colors";
+import { bold, cyan, dim, green, yellow } from "@std/fmt/colors";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import type { OutputMode } from "./output.ts";
+
+export function renderDeviceVerification(deviceCode: string): void {
+  const lines = renderCard(
+    bold("Verify your device"),
+    [[{ label: "Code", value: bold(yellow(deviceCode)) }]],
+  );
+  lines.push("");
+  lines.push(
+    "  Confirm this code matches in your browser before signing in.",
+  );
+
+  writeOutput(lines.join("\n"));
+}
 
 export interface AuthLoginSuccessData {
   username: string;

--- a/src/presentation/output/auth_login_output_test.ts
+++ b/src/presentation/output/auth_login_output_test.ts
@@ -23,6 +23,7 @@ import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 import {
   type AuthLoginSuccessData,
   renderAuthLoginSuccess,
+  renderDeviceVerification,
 } from "./auth_login_output.ts";
 
 await initializeLogging({});
@@ -34,6 +35,28 @@ const testData: AuthLoginSuccessData = {
   serverUrl: "https://swamp.club",
   apiKey: "swamp_abc123def456ghi789",
 };
+
+Deno.test("renderDeviceVerification shows code in a styled card", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderDeviceVerification("NDUZ-32AA");
+    const combined = stripAnsiCode(logs.join("\n"));
+    assertStringIncludes(combined, "Verify your device");
+    assertStringIncludes(combined, "Code");
+    assertStringIncludes(combined, "NDUZ-32AA");
+    assertStringIncludes(combined, "╔");
+    assertStringIncludes(combined, "╚");
+    assertStringIncludes(
+      combined,
+      "Confirm this code matches in your browser before signing in.",
+    );
+  } finally {
+    console.log = originalLog;
+  }
+});
 
 Deno.test("renderAuthLoginSuccess json mode outputs valid JSON", () => {
   const logs: string[] = [];


### PR DESCRIPTION
## Summary
- Renders the device verification code in a styled double-line box card (matching the authentication success card) instead of plain text
- Code value displayed in bold yellow for visibility
- Hint text shown below the card in normal white text

## Test plan
- [x] `renderDeviceVerification` unit test added and passing
- [x] Existing auth login output tests still pass
- [x] `deno check`, `deno lint`, `deno fmt` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)