### PR TITLE
feat: add platforms and labels to extension push metadata

### DIFF
--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -500,6 +500,8 @@ export const extensionPushCommand = new Command()
         version: manifest.version,
         description: manifest.description ?? "",
         dependencies: manifest.dependencies,
+        platforms: manifest.platforms,
+        labels: manifest.labels,
       };
 
       // Phase 1: Initiate

--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -25,6 +25,8 @@ export interface PushMetadata {
   version: string;
   description: string;
   dependencies: string[];
+  platforms: string[];
+  labels: string[];
 }
 
 /** Response from the initiate push endpoint. */

--- a/src/infrastructure/http/extension_api_client_test.ts
+++ b/src/infrastructure/http/extension_api_client_test.ts
@@ -46,6 +46,8 @@ Deno.test("ExtensionApiClient.initiatePush throws UserError on connection failur
         version: "2026.02.26.1",
         description: "test",
         dependencies: [],
+        platforms: [],
+        labels: [],
       }, "fake-key"),
     UserError,
   );
@@ -61,6 +63,8 @@ Deno.test("ExtensionApiClient.confirmPush throws UserError on connection failure
         version: "2026.02.26.1",
         description: "test",
         dependencies: [],
+        platforms: [],
+        labels: [],
       }, "fake-key"),
     UserError,
   );


### PR DESCRIPTION
## Summary
- Adds `platforms` and `labels` fields to the `PushMetadata` interface in the extension API client
- Passes `platforms` and `labels` from the extension manifest through to the push metadata in the `extension push` command

## Test plan
- [ ] `deno check` passes
- [ ] `deno lint` passes
- [ ] `deno run test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)