### PR TITLE
feat: persist evaluated definitions in model evaluate

### DIFF
--- a/integration/model_evaluate_test.ts
+++ b/integration/model_evaluate_test.ts
@@ -1,0 +1,212 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Integration tests for model evaluate persistence.
+ *
+ * Tests that `swamp model evaluate` persists evaluated definitions
+ * to `.swamp/definitions-evaluated/`, matching the behavior of
+ * `swamp workflow evaluate`.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { existsSync } from "@std/fs";
+import { parse as parseYaml } from "@std/yaml";
+import { Definition } from "../src/domain/definitions/definition.ts";
+import { ModelType } from "../src/domain/models/model_type.ts";
+import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
+import { initializeTestRepo, runCliCommand } from "./test_helpers.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-model-evaluate-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("CLI: model evaluate persists single model to definitions-evaluated", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    // Create a model definition with a CEL expression
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const modelType = ModelType.create("command/shell");
+    const definition = Definition.create({
+      name: "eval-persist-test",
+      globalArguments: { computed: "${{ 1 + 1 }}" },
+      methods: { execute: { arguments: { run: "echo hello" } } },
+    });
+    await definitionRepo.save(modelType, definition);
+
+    const result = await runCliCommand(
+      [
+        "model",
+        "evaluate",
+        "eval-persist-test",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(result.code, 0, `Should succeed. stderr: ${result.stderr}`);
+
+    // Check that evaluated definition was persisted
+    const evaluatedPath = join(
+      repoDir,
+      ".swamp/definitions-evaluated/command/shell",
+      `${definition.id}.yaml`,
+    );
+    assertEquals(
+      existsSync(evaluatedPath),
+      true,
+      `Evaluated definition should be persisted at ${evaluatedPath}`,
+    );
+
+    // Verify the persisted content has evaluated expressions
+    const content = await Deno.readTextFile(evaluatedPath);
+    const evaluated = parseYaml(content) as Record<string, unknown>;
+    const globalArgs = evaluated.globalArguments as Record<string, unknown>;
+    assertEquals(
+      globalArgs.computed,
+      2,
+      "CEL expression should be evaluated to 2",
+    );
+
+    // Verify JSON output includes outputPath
+    const output = JSON.parse(result.stdout);
+    assertEquals(
+      typeof output.outputPath,
+      "string",
+      "outputPath should be set",
+    );
+    assertStringIncludes(
+      output.outputPath,
+      "definitions-evaluated",
+      "outputPath should point to definitions-evaluated directory",
+    );
+  });
+});
+
+Deno.test("CLI: model evaluate --all persists all models", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const modelType = ModelType.create("command/shell");
+
+    // Create multiple model definitions
+    for (let i = 1; i <= 3; i++) {
+      const definition = Definition.create({
+        name: `eval-all-test-${i}`,
+        methods: { execute: { arguments: { run: `echo model-${i}` } } },
+      });
+      await definitionRepo.save(modelType, definition);
+    }
+
+    const result = await runCliCommand(
+      [
+        "model",
+        "evaluate",
+        "--all",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(result.code, 0, `Should succeed. stderr: ${result.stderr}`);
+
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.total, 3, "Should have evaluated 3 models");
+
+    // Verify all items have outputPath set
+    for (const item of output.items) {
+      assertEquals(
+        typeof item.outputPath,
+        "string",
+        `outputPath should be set for ${item.name}`,
+      );
+    }
+
+    // Verify files exist in definitions-evaluated
+    const evaluatedDir = join(
+      repoDir,
+      ".swamp/definitions-evaluated/command/shell",
+    );
+    assertEquals(
+      existsSync(evaluatedDir),
+      true,
+      "Evaluated definitions directory should exist",
+    );
+    const files = Array.from(Deno.readDirSync(evaluatedDir));
+    assertEquals(files.length, 3, "Should have 3 evaluated definition files");
+  });
+});
+
+Deno.test("CLI: model evaluate preserves vault expressions as raw strings", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const modelType = ModelType.create("command/shell");
+    const definition = Definition.create({
+      name: "vault-preserve-test",
+      globalArguments: {
+        secret: "${{ vault.get('my-vault', 'api-key') }}",
+      },
+      methods: { execute: { arguments: { run: "echo secret" } } },
+    });
+    await definitionRepo.save(modelType, definition);
+
+    const result = await runCliCommand(
+      [
+        "model",
+        "evaluate",
+        "vault-preserve-test",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(result.code, 0, `Should succeed. stderr: ${result.stderr}`);
+
+    // Read the persisted evaluated definition
+    const evaluatedPath = join(
+      repoDir,
+      ".swamp/definitions-evaluated/command/shell",
+      `${definition.id}.yaml`,
+    );
+    const content = await Deno.readTextFile(evaluatedPath);
+
+    // Vault expression should still be present as raw string
+    assertStringIncludes(
+      content,
+      "vault.get",
+      "Vault expression should be preserved as raw string",
+    );
+  });
+});

--- a/src/cli/commands/model_evaluate.ts
+++ b/src/cli/commands/model_evaluate.ts
@@ -62,15 +62,20 @@ export const modelEvaluateCommand = new Command()
         ctx.logger.debug`Evaluating all model definitions`;
 
         const results = await evaluationService.evaluateAllDefinitions();
+        const evaluatedDefRepo = repoContext.evaluatedDefinitionRepo;
         const items: ModelEvaluateItemData[] = [];
 
         for (const result of results) {
+          await evaluatedDefRepo.save(result.type, result.definition);
           items.push({
             id: result.definition.id,
             name: result.definition.name,
             type: result.type.normalized,
             hadExpressions: result.hadExpressions,
-            outputPath: undefined, // Definitions don't use evaluated repo
+            outputPath: evaluatedDefRepo.getPath(
+              result.type,
+              result.definition.id,
+            ),
           });
         }
 
@@ -108,12 +113,16 @@ export const modelEvaluateCommand = new Command()
         type,
       );
 
+      // Persist evaluated definition for --last-evaluated
+      const evaluatedDefRepo = repoContext.evaluatedDefinitionRepo;
+      await evaluatedDefRepo.save(type, result.definition);
+
       const item: ModelEvaluateItemData = {
         id: result.definition.id,
         name: result.definition.name,
         type: type.normalized,
         hadExpressions: result.hadExpressions,
-        outputPath: undefined, // Definitions don't use evaluated repo
+        outputPath: evaluatedDefRepo.getPath(type, result.definition.id),
         // Include evaluated globalArguments for JSON output
         globalArguments: result.definition.globalArguments,
       };


### PR DESCRIPTION
## Summary

Fixes #538 — `swamp model evaluate` resolves CEL expressions correctly but never persisted evaluated definitions to `.swamp/definitions-evaluated/`. This was inconsistent with `swamp workflow evaluate` (which persists to `.swamp/workflows-evaluated/`), and meant `--last-evaluated` flags on downstream commands couldn't find the evaluated definitions.

### What changed

- **`src/cli/commands/model_evaluate.ts`**: Added `evaluatedDefinitionRepo.save()` calls in both the single-model and `--all` code paths, following the exact pattern already used by `model method run` (lines 240-242 of `model_method_run.ts`). Also populated `outputPath` in the output data so JSON consumers can locate the persisted file.

### Secret safety

No additional redaction logic is needed. The evaluation service uses a two-phase model:

1. **Persist phase** (what `model evaluate` does): Only CEL expressions are resolved. Vault expressions (`vault.get(...)`) and env expressions (`env.*`) are detected by `containsVaultExpression()` / `containsEnvExpression()` and left as raw `${{ ... }}` strings.
2. **Runtime phase** (only during method execution): `resolveRuntimeExpressionsInDefinition()` resolves vault/env expressions in memory, registers secrets with `SecretRedactor`, and never persists them.

Since `model evaluate` only calls the persist-phase evaluation, the persisted YAML files will never contain actual secret values.

## Testing

### Integration tests (`integration/model_evaluate_test.ts`)

Three new integration tests verify the fix:

1. **Single model persistence** — Creates a model with CEL expressions (`${{ 1 + 1 }}`), runs `model evaluate`, verifies:
   - File written to `.swamp/definitions-evaluated/command/shell/<id>.yaml`
   - CEL expression evaluated to `2` in persisted file
   - `outputPath` present in JSON output pointing to `definitions-evaluated/`

2. **`--all` persistence** — Creates 3 models, runs `model evaluate --all`, verifies:
   - All 3 files exist in `.swamp/definitions-evaluated/command/shell/`
   - All items in JSON output have `outputPath` set

3. **Vault expression preservation** — Creates a model with `${{ vault.get('my-vault', 'api-key') }}`, runs `model evaluate`, verifies:
   - Persisted file still contains `vault.get` as a raw string (not resolved)

### Manual end-to-end verification

Created a fresh swamp repo in `/tmp`, added models with CEL and vault expressions, and verified:

```
$ swamp model evaluate my-server --json
{
  "id": "f57604ae-...",
  "name": "my-server",
  "type": "command/shell",
  "hadExpressions": true,
  "outputPath": "/tmp/swamp-evaluate-test/.swamp/definitions-evaluated/command/shell/f57604ae-....yaml",
  "globalArguments": {
    "computed_value": 2,       # was "${{ 1 + 1 }}"
    "static_value": "hello"
  }
}
```

Persisted evaluated definition:
```yaml
globalArguments:
  computed_value: 2            # CEL evaluated
  static_value: hello
methods:
  execute:
    arguments:
      run: echo deploying version 6   # was "${{ 2 * 3 }}"
```

Vault expressions preserved as raw strings:
```yaml
globalArguments:
  api_key: '${{ vault.get(''my-vault'', ''api-key'') }}'   # NOT resolved
  env_var: '${{ env.HOME }}'                                  # NOT resolved
```

### CI verification

- `deno check` — passed
- `deno lint` — passed
- `deno fmt` — passed
- `deno run test` — all 2349 tests pass, 0 failures
- `deno run compile` — binary compiled successfully

## Test plan

- [x] Integration test: single model persists to `definitions-evaluated/`
- [x] Integration test: `--all` persists all models
- [x] Integration test: vault expressions preserved as raw strings
- [x] Manual: `swamp model evaluate <name> --json` produces `outputPath`
- [x] Manual: `swamp model evaluate --all --json` produces `outputPath` for all items
- [x] Manual: persisted files have evaluated CEL, raw vault/env expressions
- [x] Full test suite passes (2349 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)