### PR TITLE
fix: evaluate workflow expressions at runtime and forward task.inputs in --last-evaluated

### DIFF
--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -55,6 +55,7 @@ import {
   hasStepOutputDependency,
 } from "../expressions/dependency_extractor.ts";
 import {
+  buildEnvContext,
   type DataRecord,
   type ExpressionContext,
   type FileDataRecord,
@@ -311,6 +312,7 @@ export class DefaultStepExecutor implements StepExecutor {
 
     // Evaluate CEL expressions (vault left raw for persistence)
     let evaluatedDefinition = originalDefinition;
+    let stepInputs: Record<string, unknown> = {};
     if (ctx.useLastEvaluated) {
       // Load previously-evaluated definition from cache
       runLogger?.info("Loading last evaluated definition");
@@ -328,6 +330,11 @@ export class DefaultStepExecutor implements StepExecutor {
         );
       }
       evaluatedDefinition = lastEvaluated;
+
+      // Values are already resolved in the pre-evaluated workflow
+      if (task.inputs) {
+        stepInputs = task.inputs;
+      }
     } else if (ctx.expressionContext) {
       runLogger.info("Evaluating expressions");
       // Set self context for this specific model before evaluating
@@ -346,7 +353,6 @@ export class DefaultStepExecutor implements StepExecutor {
       };
 
       // Evaluate step task inputs and merge into context
-      let stepInputs: Record<string, unknown> = {};
       if (task.inputs) {
         // Evaluate any expressions in the step task inputs
         const evalService = new ExpressionEvaluationService(
@@ -368,18 +374,18 @@ export class DefaultStepExecutor implements StepExecutor {
         ctx.expressionContext,
         ctx.repoDir,
       );
+    }
 
-      // Forward all step inputs as method arguments.
-      // This runs after evaluateDefinitionExpressions, so task.inputs values
-      // take precedence over any values resolved from ${{ inputs.X }} expressions.
-      if (Object.keys(stepInputs).length > 0) {
-        for (const [key, value] of Object.entries(stepInputs)) {
-          evaluatedDefinition.setMethodArgument(
-            task.methodName,
-            key,
-            value,
-          );
-        }
+    // Forward all step inputs as method arguments.
+    // This runs after expression evaluation, so task.inputs values
+    // take precedence over any values resolved from ${{ inputs.X }} expressions.
+    if (Object.keys(stepInputs).length > 0) {
+      for (const [key, value] of Object.entries(stepInputs)) {
+        evaluatedDefinition.setMethodArgument(
+          task.methodName,
+          key,
+          value,
+        );
       }
     }
 
@@ -756,6 +762,17 @@ export class WorkflowExecutionService {
       }
       // Use the fully evaluated workflow (forEach expanded, expressions resolved)
       workflow = lastEvaluated;
+
+      // Build a minimal expression context so step outputs can be tracked
+      // and deferred expressions (e.g. model.previous.resource.*) can be
+      // evaluated at step execution time.
+      expressionContext = {
+        model: {},
+        env: buildEnvContext(),
+      };
+      if (options?.inputs) {
+        expressionContext.inputs = options.inputs;
+      }
     } else {
       // Build expression context and evaluate workflow
       expressionContext = await this.modelResolver.buildContext();
@@ -765,14 +782,14 @@ export class WorkflowExecutionService {
         expressionContext.inputs = options.inputs;
       }
 
-      const evaluatedWorkflow = await this.evaluateWorkflow(
+      workflow = this.evaluateWorkflow(
         workflow,
         expressionContext,
       );
       const evaluatedWorkflowRepo = new YamlEvaluatedWorkflowRepository(
         this.repoDir,
       );
-      await evaluatedWorkflowRepo.save(evaluatedWorkflow);
+      await evaluatedWorkflowRepo.save(workflow);
     }
 
     // Create workflow run with merged tags (runtime tags take precedence)
@@ -1156,7 +1173,7 @@ export class WorkflowExecutionService {
         jobName: job.name,
         stepName,
         repoDir: this.repoDir,
-        expressionContext: lastEvaluated ? undefined : expressionContext,
+        expressionContext,
         progress,
         workflowRun: run,
         step,
@@ -1327,7 +1344,7 @@ export class WorkflowExecutionService {
         jobName: job.name,
         stepName,
         repoDir: this.repoDir,
-        expressionContext: lastEvaluated ? undefined : stepExprContext,
+        expressionContext: stepExprContext,
         progress,
         workflowRun: run,
         step,

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -1512,3 +1512,152 @@ Deno.test("task.inputs matching definition input keys are forwarded to step exec
     assertEquals(exprCtx !== undefined, true);
   });
 });
+
+// Regression test for issue #537 Bug A: workflow expressions must be evaluated
+// before reaching the step executor.
+Deno.test("workflow expressions are evaluated before step execution (Bug A)", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+
+    // Executor that captures the step task data to verify expression resolution
+    class TaskCapturingExecutor implements StepExecutor {
+      capturedSteps: Array<{ step: Step; ctx: StepExecutionContext }> = [];
+      execute(step: Step, ctx: StepExecutionContext): Promise<unknown> {
+        this.capturedSteps.push({ step, ctx });
+        return Promise.resolve({ executed: true });
+      }
+    }
+    const executor = new TaskCapturingExecutor();
+
+    // Create a workflow with an expression in the model name.
+    // The expression ${{ inputs.deviceModel }} should be resolved
+    // to the actual value before execution.
+    const workflow = Workflow.create({
+      name: "expression-eval-test",
+      jobs: [
+        Job.create({
+          name: "deploy",
+          steps: [
+            Step.create({
+              name: "run-model",
+              task: StepTask.model(
+                "${{ inputs.deviceModel }}",
+                "create",
+              ),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+    );
+
+    const run = await service.execute(workflow.name, undefined, {
+      inputs: { deviceModel: "my-device" },
+    });
+
+    assertEquals(run.status, "succeeded");
+    assertEquals(executor.capturedSteps.length, 1);
+
+    // The step executor should receive the resolved model name,
+    // not the raw expression string.
+    const captured = executor.capturedSteps[0];
+    const taskData = captured.step.task.data;
+    assertEquals(taskData.type, "model_method");
+    if (taskData.type === "model_method") {
+      assertEquals(taskData.modelIdOrName, "my-device");
+      assertNotEquals(taskData.modelIdOrName, "${{ inputs.deviceModel }}");
+    }
+  });
+});
+
+// Regression test for issue #537 Bug B: --last-evaluated must still forward
+// task.inputs and provide an expression context.
+Deno.test("useLastEvaluated context carries task.inputs and expressionContext (Bug B)", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+
+    // Executor that captures context for verification
+    class ContextCapturingExecutor implements StepExecutor {
+      capturedSteps: Array<{ step: Step; ctx: StepExecutionContext }> = [];
+      execute(step: Step, ctx: StepExecutionContext): Promise<unknown> {
+        this.capturedSteps.push({ step, ctx });
+        return Promise.resolve({ executed: true });
+      }
+    }
+    const executor = new ContextCapturingExecutor();
+
+    // Create a workflow with task.inputs (values already resolved since
+    // this simulates a pre-evaluated workflow)
+    const workflow = Workflow.create({
+      name: "last-evaluated-inputs-test",
+      jobs: [
+        Job.create({
+          name: "deploy",
+          steps: [
+            Step.create({
+              name: "run-model",
+              task: StepTask.model("my-model", "create", {
+                region: "us-west-2",
+                instance_type: "t3.large",
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    // Pre-save the evaluated workflow so --last-evaluated can find it
+    const { YamlEvaluatedWorkflowRepository } = await import(
+      "../../infrastructure/persistence/yaml_evaluated_workflow_repository.ts"
+    );
+    const evalWorkflowRepo = new YamlEvaluatedWorkflowRepository(tempDir);
+    await evalWorkflowRepo.save(workflow);
+
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+    );
+
+    const run = await service.execute(workflow.name, undefined, {
+      lastEvaluated: true,
+    });
+
+    assertEquals(run.status, "succeeded");
+    assertEquals(executor.capturedSteps.length, 1);
+
+    const captured = executor.capturedSteps[0];
+
+    // The expression context should be provided even with --last-evaluated
+    assertEquals(captured.ctx.expressionContext !== undefined, true);
+    assertEquals(
+      typeof captured.ctx.expressionContext?.model,
+      "object",
+    );
+    assertEquals(
+      typeof captured.ctx.expressionContext?.env,
+      "object",
+    );
+
+    // task.inputs should be present on the step
+    const taskData = captured.step.task.data;
+    assertEquals(taskData.type, "model_method");
+    if (taskData.type === "model_method") {
+      assertEquals(taskData.inputs, {
+        region: "us-west-2",
+        instance_type: "t3.large",
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #537. Two bugs in `workflow run` caused `${{ inputs.* }}` expressions and `task.inputs` to be silently dropped during execution.

### Bug A — evaluated workflow not used for execution

`evaluateWorkflow()` returned a correctly evaluated workflow, but the result was stored in a local `const evaluatedWorkflow` variable that was only saved to cache. The original `workflow` variable — still containing raw `${{ }}` expression strings — was used for the rest of execution. This meant `modelIdOrName` arrived at the step executor as the literal string `${{ inputs.deviceModel }}` instead of the resolved model name.

**Fix:** Change `const evaluatedWorkflow = ...` to `workflow = ...` so the evaluated workflow is actually used for execution.

### Bug B — `--last-evaluated` drops task.inputs

In `executeModelMethod()`, the `task.inputs` evaluation and `setMethodArgument()` forwarding was inside the `else if (ctx.expressionContext)` branch (the normal expression evaluation path). When `useLastEvaluated` was true, `expressionContext` was forced to `undefined` by a ternary (`lastEvaluated ? undefined : expressionContext`), so the entire block was skipped and model methods received `undefined` for all input fields.

**Fix:**
- Hoist `stepInputs` declaration above the if/else
- In the `useLastEvaluated` branch, set `stepInputs = task.inputs` (values are already resolved in the pre-evaluated workflow)
- Move the `setMethodArgument` forwarding loop outside the if/else so it runs for both paths

### Minimal expression context for `--last-evaluated`

To support step-output-dependent expressions (e.g. `${{ model.previous.resource.foo.bar }}`) that were deferred during `workflow evaluate`:

- Build a minimal expression context (`{ model: {}, env: buildEnvContext() }`) even when `lastEvaluated` is true
- Remove the `lastEvaluated ? undefined : expressionContext` ternaries at both `executeStep` and `executeExpandedStep` — the expression context is now always passed through

This allows step outputs to be tracked in the context during execution, enabling deferred expressions to be evaluated at step execution time.

## Test plan

### Unit tests (2 new regression tests)

- [x] **Bug A test** — `workflow expressions are evaluated before step execution`: creates a workflow with `${{ inputs.deviceModel }}` as the model name, verifies the step executor receives `"my-device"` (not the raw expression string)
- [x] **Bug B test** — `useLastEvaluated context carries task.inputs and expressionContext`: creates a workflow with task.inputs, saves it as an evaluated workflow, runs with `lastEvaluated: true`, verifies the expression context is provided and task.inputs are present
- [x] All 2348 existing tests continue to pass

### End-to-end manual testing

Created a fresh swamp repo in `/tmp` with a `command/shell` model (`my-echo`) and two workflows:

**Bug A verification** — workflow with `modelIdOrName: ${{ inputs.modelName }}`:
```
swamp workflow run test-bug-a --input '{"modelName":"my-echo"}' --json
```
Result: **succeeded** — `${{ inputs.modelName }}` resolved to `my-echo`, model found and executed.

**Bug B verification** — workflow with both expression in model name and `task.inputs`:
```
swamp workflow evaluate test-bug-b --input '{"modelName":"my-echo","message":"echo hello-from-bug-b-test"}' --json
swamp workflow run test-bug-b --last-evaluated --json
```
Result: **succeeded** — evaluated YAML shows resolved values, `--last-evaluated` correctly forwarded `task.inputs.run` as `"echo hello-from-bug-b-test"`, stdout confirmed `hello-from-bug-b-test`.

**Combined verification** — direct `workflow run` with both expressions (no evaluate step needed):
```
swamp workflow run test-bug-b --input '{"modelName":"my-echo","message":"echo direct-run-works"}' --json
```
Result: **succeeded** — both `modelIdOrName` and `task.inputs.run` resolved correctly, stdout confirmed `direct-run-works`.

### Verification checklist

- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt` — formatting passes
- [x] `deno run test` — 2348 tests pass
- [x] `deno run compile` — binary compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)