### PR TITLE
feat: support reading secret values from stdin in vault put

### DIFF
--- a/.claude/skills/swamp-vault/SKILL.md
+++ b/.claude/skills/swamp-vault/SKILL.md
@@ -10,16 +10,17 @@ for machine-readable output.
 
 ## Quick Reference
 
-| Task              | Command                                    |
-| ----------------- | ------------------------------------------ |
-| List vault types  | `swamp vault type search --json`           |
-| Create a vault    | `swamp vault create <type> <name> --json`  |
-| Search vaults     | `swamp vault search [query] --json`        |
-| Get vault details | `swamp vault get <name_or_id> --json`      |
-| Edit vault config | `swamp vault edit <name_or_id>`            |
-| Store a secret    | `swamp vault put <vault> KEY=VALUE --json` |
-| Get a secret      | `swamp vault get <vault> <key> --json`     |
-| List secret keys  | `swamp vault list-keys <vault> --json`     |
+| Task              | Command                                            |
+| ----------------- | -------------------------------------------------- |
+| List vault types  | `swamp vault type search --json`                   |
+| Create a vault    | `swamp vault create <type> <name> --json`          |
+| Search vaults     | `swamp vault search [query] --json`                |
+| Get vault details | `swamp vault get <name_or_id> --json`              |
+| Edit vault config | `swamp vault edit <name_or_id>`                    |
+| Store a secret    | `swamp vault put <vault> KEY=VALUE --json`         |
+| Store from stdin  | `echo "val" \| swamp vault put <vault> KEY --json` |
+| Get a secret      | `swamp vault get <vault> <key> --json`             |
+| List secret keys  | `swamp vault list-keys <vault> --json`             |
 
 ## Repository Structure
 
@@ -100,10 +101,28 @@ swamp vault edit dev-secrets
 
 ## Store Secrets
 
+**Inline value (appears in shell history):**
+
 ```bash
 swamp vault put dev-secrets API_KEY=sk-1234567890 --json
 swamp vault put prod-secrets DB_PASSWORD=secret123 -f --json  # Skip confirmation
 ```
+
+**Piped value (recommended — keeps secrets out of shell history):**
+
+```bash
+echo "$API_KEY" | swamp vault put dev-secrets API_KEY --json
+cat ~/secrets/token.txt | swamp vault put dev-secrets TOKEN --json
+op read "op://vault/item/field" | swamp vault put dev-secrets SECRET --json
+```
+
+When no `=` is present in the argument, the value is read from stdin. A single
+trailing newline is stripped automatically.
+
+**IMPORTANT — agent security:** Never ask the user to paste or type a secret
+value into conversation. Instead, instruct them to run `vault put` directly in
+their terminal using piped input. This prevents secrets from being logged in
+agent context or chat history.
 
 **Output shape:**
 

--- a/src/cli/commands/vault_put.ts
+++ b/src/cli/commands/vault_put.ts
@@ -28,6 +28,7 @@ import { requireInitializedRepo } from "../repo_context.ts";
 import { VaultService } from "../../domain/vaults/vault_service.ts";
 import { UserError } from "../../domain/errors.ts";
 import { createVaultSecretUpdated } from "../../domain/events/types.ts";
+import { readStdin } from "../../infrastructure/io/stdin_reader.ts";
 
 /**
  * Prompts user for confirmation in interactive mode.
@@ -53,7 +54,9 @@ async function promptConfirmation(message: string): Promise<boolean> {
  * Parses a KEY=VALUE string into key and value parts.
  * Handles values that contain = signs.
  */
-function parseKeyValue(input: string): { key: string; value: string } | null {
+export function parseKeyValue(
+  input: string,
+): { key: string; value: string } | null {
   const equalsIndex = input.indexOf("=");
   if (equalsIndex === -1) {
     return null;
@@ -67,6 +70,46 @@ function parseKeyValue(input: string): { key: string; value: string } | null {
   }
 
   return { key, value };
+}
+
+/**
+ * Resolves a key and value from a CLI argument and optional stdin content.
+ *
+ * Resolution order:
+ * 1. If the argument contains '=', parse as KEY=VALUE (existing behavior)
+ * 2. If no '=', treat argument as KEY and use stdinContent as the value
+ * 3. If no '=' and no stdinContent, return an error
+ *
+ * Stdin values have a single trailing newline stripped (pipes/files
+ * typically append one).
+ */
+export function resolveKeyValue(
+  argument: string,
+  stdinContent: string | null,
+): { key: string; value: string } | { error: string } {
+  const parsed = parseKeyValue(argument);
+  if (parsed) {
+    return parsed;
+  }
+
+  // No '=' found — treat argument as key and use stdin as value
+  const key = argument;
+  if (key.length === 0) {
+    return { error: "Key cannot be empty" };
+  }
+
+  if (stdinContent !== null) {
+    // Strip a single trailing newline (pipes/files typically append one)
+    const value = stdinContent.replace(/\n$/, "");
+    return { key, value };
+  }
+
+  return {
+    error: `Invalid argument format: ${argument}\n\n` +
+      `Provide the value inline or via stdin:\n` +
+      `  swamp vault put <vault> ${argument}=<value>\n` +
+      `  echo "<value>" | swamp vault put <vault> ${argument}`,
+  };
 }
 
 /**
@@ -108,15 +151,19 @@ export const vaultPutCommand = new Command()
       outputMode: ctx.outputMode,
     });
 
-    // Parse KEY=VALUE argument
+    // Parse KEY=VALUE argument, or KEY with value from stdin.
+    // Only consume stdin when the argument has no '=' — this preserves
+    // the ability for promptConfirmation to read interactive input later.
     const parsed = parseKeyValue(keyValue);
+    let stdinContent: string | null = null;
     if (!parsed) {
-      throw new UserError(
-        `Invalid argument format. Expected KEY=VALUE, got: ${keyValue}`,
-      );
+      stdinContent = await readStdin();
     }
-
-    const { key, value } = parsed;
+    const resolved = resolveKeyValue(keyValue, stdinContent);
+    if ("error" in resolved) {
+      throw new UserError(resolved.error);
+    }
+    const { key, value } = resolved;
     ctx.logger.debug`Parsed key: ${key}`;
 
     // Verify vault exists
@@ -146,8 +193,16 @@ export const vaultPutCommand = new Command()
     const exists = await secretExists(vaultService, vaultName, key);
     ctx.logger.debug`Secret exists: ${exists}`;
 
-    // Prompt for confirmation if overwriting in interactive mode
+    // Prompt for confirmation if overwriting in interactive mode.
+    // When stdin was piped (stdinContent is not null), skip the prompt since
+    // there's no interactive user — require --force instead.
     if (exists && ctx.outputMode === "log" && !options.force) {
+      if (stdinContent !== null) {
+        throw new UserError(
+          `Secret '${key}' already exists in vault '${vaultName}'.\n` +
+            `Use --force (-f) to overwrite when piping from stdin.`,
+        );
+      }
       const confirmed = await promptConfirmation(
         `Secret '${key}' already exists in vault '${vaultName}'. Overwrite?`,
       );

--- a/src/cli/commands/vault_put_test.ts
+++ b/src/cli/commands/vault_put_test.ts
@@ -18,26 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-
-/**
- * Parses a KEY=VALUE string into key and value parts.
- * Handles values that contain = signs.
- */
-function parseKeyValue(input: string): { key: string; value: string } | null {
-  const equalsIndex = input.indexOf("=");
-  if (equalsIndex === -1) {
-    return null;
-  }
-
-  const key = input.substring(0, equalsIndex);
-  const value = input.substring(equalsIndex + 1);
-
-  if (key.length === 0) {
-    return null;
-  }
-
-  return { key, value };
-}
+import { parseKeyValue, resolveKeyValue } from "./vault_put.ts";
 
 Deno.test("parseKeyValue - simple key=value", () => {
   const result = parseKeyValue("API_KEY=secret123");
@@ -77,4 +58,50 @@ Deno.test("parseKeyValue - key with dashes", () => {
 Deno.test("parseKeyValue - key with underscores", () => {
   const result = parseKeyValue("MY_API_KEY=secret");
   assertEquals(result, { key: "MY_API_KEY", value: "secret" });
+});
+
+// resolveKeyValue tests
+
+Deno.test("resolveKeyValue - KEY=VALUE inline takes precedence over stdin", () => {
+  const result = resolveKeyValue("API_KEY=inline-secret", "stdin-secret\n");
+  assertEquals(result, { key: "API_KEY", value: "inline-secret" });
+});
+
+Deno.test("resolveKeyValue - KEY=VALUE works without stdin", () => {
+  const result = resolveKeyValue("API_KEY=secret123", null);
+  assertEquals(result, { key: "API_KEY", value: "secret123" });
+});
+
+Deno.test("resolveKeyValue - KEY with stdin value", () => {
+  const result = resolveKeyValue("API_KEY", "piped-secret");
+  assertEquals(result, { key: "API_KEY", value: "piped-secret" });
+});
+
+Deno.test("resolveKeyValue - strips trailing newline from stdin", () => {
+  const result = resolveKeyValue("API_KEY", "piped-secret\n");
+  assertEquals(result, { key: "API_KEY", value: "piped-secret" });
+});
+
+Deno.test("resolveKeyValue - strips only one trailing newline", () => {
+  const result = resolveKeyValue("API_KEY", "line1\nline2\n");
+  assertEquals(result, { key: "API_KEY", value: "line1\nline2" });
+});
+
+Deno.test("resolveKeyValue - preserves value with no trailing newline", () => {
+  const result = resolveKeyValue("API_KEY", "exact-value");
+  assertEquals(result, { key: "API_KEY", value: "exact-value" });
+});
+
+Deno.test("resolveKeyValue - error when no = and no stdin", () => {
+  const result = resolveKeyValue("API_KEY", null);
+  assertEquals("error" in result, true);
+});
+
+Deno.test("resolveKeyValue - error message includes both usage formats", () => {
+  const result = resolveKeyValue("MY_KEY", null);
+  assertEquals("error" in result, true);
+  if ("error" in result) {
+    assertEquals(result.error.includes("MY_KEY=<value>"), true);
+    assertEquals(result.error.includes("echo"), true);
+  }
 });


### PR DESCRIPTION
## Summary

Closes #548. `vault put` now supports reading secret values from stdin, so secrets don't need to appear as CLI arguments (which are visible in shell history and `ps` output).

## The problem

`swamp vault put <vault> KEY=secret` exposes the secret in:
1. **Shell history** (`~/.zsh_history`, `~/.bash_history`)
2. **Process listings** (`ps aux`)
3. **Agent context** — when an AI agent assists with vault setup, it may prompt the user to paste a token into conversation where it gets logged

## The plan

Add stdin piping as an alternative input method using the existing `readStdin()` utility (already used by `model edit` and `workflow edit`), with this resolution order:

1. If the argument contains `=`, parse as `KEY=VALUE` — **existing behavior, unchanged**
2. If no `=`, treat argument as just `KEY` and read the value from stdin
3. If no `=` AND no stdin data, throw a clear error explaining both formats

This preserves full backward compatibility. No new flags, no new subcommands.

## The implementation

### `src/cli/commands/vault_put.ts`

- Extracted `parseKeyValue()` and new `resolveKeyValue()` as exported functions for testability
- `resolveKeyValue(argument, stdinContent)` encapsulates the resolution order: inline `KEY=VALUE` first, stdin fallback second, error third
- Stdin values have a single trailing newline stripped (`.replace(/\n$/, "")`) since pipes/files typically append one
- **Key detail**: `readStdin()` is only called when `parseKeyValue()` returns `null` (no `=` found). This avoids consuming stdin unnecessarily, which would break `promptConfirmation()` for the overwrite check in the `KEY=VALUE` path
- When stdin was piped and the key already exists, a clear `UserError` is thrown instead of attempting an interactive prompt (which can't work with a consumed stdin stream). The user must pass `--force` in this case

### `src/cli/commands/vault_put_test.ts`

- Existing `parseKeyValue` tests now import from source instead of duplicating the function
- 8 new `resolveKeyValue` tests covering: inline precedence over stdin, stdin value used when no `=`, trailing newline stripping, only-one-newline stripping, no-trailing-newline preservation, error on missing value, error message format

### `.claude/skills/swamp-vault/SKILL.md`

- Added piped input syntax to quick reference table
- Documented piped value examples (env var, file, 1Password CLI)
- Added agent security note: never ask users to paste secrets into conversation

## Why this is the right fix

- **Reuses existing patterns** — `readStdin()` and the "check stdin, fallback to existing behavior" pattern are already proven in `model edit` and `workflow edit`
- **Fully backward compatible** — `KEY=VALUE` works identically, zero breakage
- **No new flags or subcommands** — just a natural extension of the existing argument
- **Covers all secure input sources** — files, env vars, password managers, other CLIs
- **Addresses agent leakage** — skill update prevents agents from asking for secrets in conversation
- **Handles edge cases correctly** — stdin only consumed when needed, overwrite with piped stdin requires `--force`

## End-to-end testing

Created a fresh swamp repo in `/tmp` with a `local_encryption` vault and verified all scenarios with the compiled binary:

| # | Test | Command | Result |
|---|------|---------|--------|
| 1 | Inline `KEY=VALUE` (backward compat) | `vault put test-vault API_KEY=inline-secret-123 --json` | Stored successfully |
| 2 | Piped from echo | `echo "piped-secret-456" \| vault put test-vault PIPED_KEY --json` | Stored successfully |
| 3 | Piped from file | `cat secret.txt \| vault put test-vault FILE_KEY --json` | Stored successfully |
| 4 | No `=` and no stdin | `vault put test-vault BARE_KEY --json` | Clear error with both usage formats |
| 5 | Inline overwrite with `--force` | `vault put test-vault API_KEY=updated -f --json` | Overwritten, `overwritten: true` |
| 6 | Piped overwrite without `--force` (log mode) | `echo "new" \| vault put test-vault PIPED_KEY` | Clear error: "Use --force (-f) to overwrite when piping from stdin" |
| 7 | Piped overwrite with `--force` | `echo "forced" \| vault put test-vault PIPED_KEY -f --json` | Overwritten successfully |
| 8 | Piped from env var | `echo "$MY_SECRET" \| vault put test-vault ENV_KEY --json` | Stored successfully |

Then created a workflow using `${{ vault.get(test-vault, KEY) }}` expressions to read all 4 secrets back. All steps succeeded with values correctly resolved (redacted as `***` in persisted data, confirming the secret redactor recognized them as real vault values).

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt` — formatting passes
- [x] `deno run test` — 2376 tests pass (16 vault_put tests including 8 new)
- [x] `deno run compile` — binary compiles
- [x] End-to-end manual test with compiled binary in fresh repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)