### PR TITLE
fix: omit empty platforms and labels from extension search JSON output

### DIFF
--- a/src/presentation/output/extension_search_output.tsx
+++ b/src/presentation/output/extension_search_output.tsx
@@ -75,7 +75,18 @@ export async function renderExtensionSearch(
   mode: OutputMode,
 ): Promise<ExtensionSearchResult | undefined> {
   if (mode === "json") {
-    console.log(JSON.stringify(data, null, 2));
+    const output = {
+      ...data,
+      extensions: data.extensions.map((ext) => {
+        const { platforms, labels, ...rest } = ext;
+        return {
+          ...rest,
+          ...(platforms.length > 0 ? { platforms } : {}),
+          ...(labels.length > 0 ? { labels } : {}),
+        };
+      }),
+    };
+    console.log(JSON.stringify(output, null, 2));
     return undefined;
   } else {
     return await renderInteractiveExtensionSearch(data);

--- a/src/presentation/output/extension_search_output_test.tsx
+++ b/src/presentation/output/extension_search_output_test.tsx
@@ -274,6 +274,57 @@ Deno.test("renderExtensionSearch with json mode outputs valid JSON", () => {
   }
 });
 
+Deno.test("renderExtensionSearch with json mode omits empty platforms and labels", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  const data: ExtensionSearchData = {
+    extensions: [{
+      name: "@keeb/terraria",
+      description: "Terraria server control via Docker tmux",
+      latestVersion: "2026.02.27.1",
+      platforms: [],
+      labels: [],
+      createdAt: "2026-02-27T17:06:27.544Z",
+      updatedAt: "2026-02-27T17:06:27.544Z",
+    }],
+    meta: { total: 1, page: 1, perPage: 20 },
+  };
+
+  try {
+    renderExtensionSearch(data, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.extensions[0].name, "@keeb/terraria");
+    assertEquals(parsed.extensions[0].platforms, undefined);
+    assertEquals(parsed.extensions[0].labels, undefined);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderExtensionSearch with json mode keeps non-empty platforms and labels", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  const data: ExtensionSearchData = {
+    extensions: [testExtensions[0]],
+    meta: { total: 1, page: 1, perPage: 20 },
+  };
+
+  try {
+    renderExtensionSearch(data, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.extensions[0].platforms, ["aws"]);
+    assertEquals(parsed.extensions[0].labels, ["networking", "infrastructure"]);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
 Deno.test("renderExtensionSearch with json mode includes meta", () => {
   const logs: string[] = [];
   const originalLog = console.log;


### PR DESCRIPTION
## Summary

- Omit empty `platforms` and `labels` arrays from JSON output of `extension search`
- Non-empty arrays are still included as before
- Adds tests verifying both empty-omission and non-empty-retention behavior

## Test plan

- [x] `deno run test src/presentation/output/extension_search_output_test.tsx` — all 14 tests pass
- [ ] Manual: `swamp extension search --json` — verify empty platforms/labels are absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)