### PR TITLE
feat: check community extensions before building custom models

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -10,11 +10,18 @@ startup.
 
 ## When to Create a Custom Model
 
-**Create an extension model when no built-in type exists for your use case.**
+**Create an extension model when no built-in or community type exists for your
+use case.**
 
-If you search for a type with `swamp model type search <query>` and get no
-results, you should create a custom model rather than assuming the functionality
-doesn't exist. Extension models let you:
+Before creating a custom model, always check both local types and community
+extensions:
+
+1. Search local types: `swamp model type search <query>`
+2. Search community extensions: `swamp extension search <query>`
+3. If a community extension exists, install it instead of building from scratch
+4. Only create a custom model if nothing exists locally or in the community
+
+Extension models let you:
 
 - Integrate with any API or service (AWS S3, Stripe, custom APIs, etc.)
 - Define any automation logic you need
@@ -23,9 +30,10 @@ doesn't exist. Extension models let you:
 **Example decision flow:**
 
 ```
-1. User wants to work with S3 buckets
-2. Run: swamp model type search S3 → no results
-3. Solution: Create extensions/models/s3_bucket.ts with the S3 logic you need
+User wants to work with S3 buckets
+swamp model type search S3 → no local results
+swamp extension search S3 → no community extension
+No existing model → Create extensions/models/s3_bucket.ts
 ```
 
 **Important:** Do not default to generic CLI types (like `command/shell`) for
@@ -37,6 +45,7 @@ than wrapping CLI commands.
 
 | Task                | Command/Action                                          |
 | ------------------- | ------------------------------------------------------- |
+| Search community    | `swamp extension search <query>`                        |
 | Create model file   | Create `extensions/models/my_model.ts`                  |
 | Verify registration | `swamp model type search --json`                        |
 | Check schema        | `swamp model type describe @myorg/my-model --json`      |

--- a/.claude/skills/swamp-extension-model/references/scenarios.md
+++ b/.claude/skills/swamp-extension-model/references/scenarios.md
@@ -26,7 +26,9 @@ End-to-end scenarios showing how to build custom extension models.
 ### Decision Tree
 
 ```
-No built-in model for this API → Create extension model
+swamp model type search Stripe → no local results
+swamp extension search Stripe → no community extension
+No existing model → Create extension model
 Need typed input validation → Define Zod schemas
 Store response data for CEL access → Use writeResource
 ```
@@ -200,6 +202,9 @@ globalArguments:
 ### Decision Tree
 
 ```
+swamp model type search S3 → no local results
+swamp extension search S3 → no community extension
+No existing model → Create extension model
 Full lifecycle management → create, update, delete methods
 Update reads existing state → Use dataRepository.getContent
 Delete cleans up → Return empty dataHandles
@@ -435,6 +440,9 @@ jobs:
 ### Decision Tree
 
 ```
+swamp model type search VPC → no local results
+swamp extension search VPC → no community extension
+No existing model → Create extension model
 Discover multiple resources → Factory model pattern
 Each resource needs unique ID → Dynamic instance names
 Query all discovered resources → data.findBySpec()
@@ -586,7 +594,8 @@ jobs:
 ### Decision Tree
 
 ```
-Add functionality to existing type → export const extension
+swamp model type search command/shell → exists locally
+Want to add methods, not create new type → export const extension
 Cannot change schema → Only add new methods
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,11 @@ When users ask you to build automation for specific services (AWS, APIs, etc.):
 1. **Always create extension models** in `extensions/models/` - do NOT use
    `command/shell` to wrap CLI commands
 2. Search for existing model types first: `swamp model type search <query>`
-3. If no type exists, create a dedicated extension model for that service
-4. Use the `swamp-extension-model` skill for guidance on creating models
+3. Search community extensions: `swamp extension search <query>` — if a matching
+   extension exists, install it instead of building from scratch
+4. If no type exists locally or in the community, create a dedicated extension
+   model for that service
+5. Use the `swamp-extension-model` skill for guidance on creating models
 
 The `command/shell` model is only for ad-hoc shell commands, NOT for building
 service integrations.

--- a/src/cli/commands/type_search.ts
+++ b/src/cli/commands/type_search.ts
@@ -118,6 +118,10 @@ export const typeSearchCommand = new Command()
         query: query ?? "",
         results: filteredTypes,
       };
+      if (filteredTypes.length === 0 && query) {
+        data.hint =
+          `No local types matched. Try: swamp extension search ${query}`;
+      }
       await renderTypeSearch(data, ctx.outputMode);
     } else {
       // Interactive: show fuzzy search UI

--- a/src/presentation/output/type_search_output.tsx
+++ b/src/presentation/output/type_search_output.tsx
@@ -39,6 +39,7 @@ export interface TypeSearchItem {
 export interface TypeSearchData {
   query: string;
   results: TypeSearchItem[];
+  hint?: string;
 }
 
 /**
@@ -215,7 +216,15 @@ export function TypeSearchUI(
           </Text>
         )}
         {results.length === 0 && (
-          <Text color="yellow">No matching types found</Text>
+          <>
+            <Text color="yellow">No matching types found</Text>
+            {query && (
+              <Text dimColor>
+                Tip: run `swamp extension search{" "}
+                {query}` to check community extensions
+              </Text>
+            )}
+          </>
         )}
       </Box>
 

--- a/src/presentation/output/type_search_output_test.tsx
+++ b/src/presentation/output/type_search_output_test.tsx
@@ -515,3 +515,100 @@ Deno.test({
     assertStringIncludes(output, "1 more below");
   },
 });
+
+// Community extension hint tests
+Deno.test({
+  name:
+    "TypeSearchUI shows community extension hint when no results match with a query",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <TypeSearchUI
+        types={testTypes}
+        initialQuery="nonexistent"
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    const output = lastFrame() ?? "";
+    assertStringIncludes(output, "swamp extension search");
+    assertStringIncludes(output, "community extensions");
+  },
+});
+
+Deno.test({
+  name: "TypeSearchUI does not show hint when results exist",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <TypeSearchUI
+        types={testTypes}
+        initialQuery="echo"
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    const output = lastFrame() ?? "";
+    assertEquals(output.includes("swamp extension search"), false);
+  },
+});
+
+Deno.test({
+  name:
+    "TypeSearchUI does not show hint when query is empty and no types loaded",
+  ...inkTestOptions,
+  fn: () => {
+    const { lastFrame } = render(
+      <TypeSearchUI
+        types={[]}
+        initialQuery=""
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    const output = lastFrame() ?? "";
+    assertStringIncludes(output, "No matching types found");
+    assertEquals(output.includes("swamp extension search"), false);
+  },
+});
+
+Deno.test("renderTypeSearch JSON output includes hint when no results and query provided", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  const dataWithHint: TypeSearchData = {
+    query: "nonexistent",
+    results: [],
+    hint: "No local types matched. Try: swamp extension search nonexistent",
+  };
+
+  try {
+    renderTypeSearch(dataWithHint, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.query, "nonexistent");
+    assertEquals(parsed.results.length, 0);
+    assertStringIncludes(parsed.hint, "swamp extension search");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderTypeSearch JSON output omits hint when results exist", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderTypeSearch(testData, "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.hint, undefined);
+  } finally {
+    console.log = originalLog;
+  }
+});


### PR DESCRIPTION
## Summary

Closes #546

When AI agents are asked to create models for services (e.g., "I need a model
for Tailscale"), they immediately build custom extension models from scratch.
The `swamp extension search` command already exists (PR #555) but isn't wired
into the model creation workflow — agents and users have no guidance to check
community extensions first.

This PR closes the gap at two levels:

### 1. Agent guidance updates

- **`CLAUDE.md`**: Adds step 3 to the "Building Automation with Swamp" workflow
  — `swamp extension search <query>` — between local type search and building
  from scratch.
- **`swamp-extension-model` skill (`SKILL.md`)**: Updates the "When to Create a
  Custom Model" decision flow to check community extensions before creating a
  model. Adds a "Search community" row to the Quick Reference table.
- **`swamp-extension-model` scenarios (`references/scenarios.md`)**: Updates all
  4 scenario decision trees to start with checking local types and community
  extensions.

### 2. User-facing hint in `model type search`

When `model type search` returns zero results and the user typed a query, a tip
is shown suggesting `swamp extension search <query>`:

- **Interactive UI**: Displays the hint below "No matching types found" (only
  when a query is present, not when the list is simply empty).
- **JSON output**: Adds an optional `hint` field to `TypeSearchData` when no
  results match.

### Why this is the correct fix

The agent workflow previously was:

```
local type search → not found → build from scratch
```

Now it's:

```
local type search → community extension search → install or build
```

The guidance changes fix the **agent workflow** (the primary consumer of skills
and CLAUDE.md). The hint fixes the **human workflow** — a user who runs
`swamp model type search tailscale`, gets zero results, and doesn't know what
to do next. Both close the same gap: the missing link between "no local type
found" and "check the community registry."

### User impact

- **Agents** will now check community extensions before building custom models,
  avoiding duplicate work when a community extension already exists.
- **Users** running `model type search` with no results will see a helpful tip
  pointing them to `extension search`.
- **No breaking changes** — the `hint` field is optional in `TypeSearchData`,
  and the interactive hint only appears conditionally.

## Test Plan

- 5 new tests covering hint behavior in both interactive and JSON modes
- All 2454 existing tests pass
- `deno check`, `deno lint`, `deno fmt` all pass
- Binary recompiled successfully


🤖 Generated with [Claude Code](https://claude.com/claude-code)