### PR TITLE
feat: send repository URL to registry during extension push

### DIFF
--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -502,6 +502,7 @@ export const extensionPushCommand = new Command()
         dependencies: manifest.dependencies,
         platforms: manifest.platforms,
         labels: manifest.labels,
+        repository: manifest.repository || undefined,
       };
 
       // Phase 1: Initiate

--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -27,6 +27,7 @@ export interface PushMetadata {
   dependencies: string[];
   platforms: string[];
   labels: string[];
+  repository?: string;
 }
 
 /** Response from the initiate push endpoint. */


### PR DESCRIPTION
## Summary

- Add optional `repository` field to `PushMetadata` interface in the extension API client
- Wire `manifest.repository` through to the push metadata in the `extension push` command

## Why this is correct

The swamp-club registry backend already accepts an optional `repository` field in both push API endpoints, but the CLI was never sending it — even though the manifest parser already reads the field. This change closes that gap with two minimal additions:

1. **`PushMetadata` interface** (`extension_api_client.ts`): Adding `repository?: string` makes the type reflect what the API accepts. The field is optional, so all existing callers remain valid without changes.

2. **Push metadata construction** (`extension_push.ts`): `manifest.repository || undefined` uses logical-OR coercion so that empty strings (`""`) become `undefined`, which `JSON.stringify` omits entirely. The registry receives either a real URL or no field at all — never a blank string.

## User impact

Extension authors who set `repository` in their `extension.yaml` manifest will now have that URL visible on the registry after pushing. Authors who don't set it (or leave it empty) see no change — the field is simply absent from the API payload.

## Test plan

- [x] `deno check` — type-checks pass
- [x] `deno lint` — no lint issues
- [x] `deno fmt` — formatting clean
- [x] `deno run test` — all 2488 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)