### PR TITLE
feat: add Kiro IDE support to `swamp repo init`

### DIFF
--- a/src/cli/commands/repo_init.ts
+++ b/src/cli/commands/repo_init.ts
@@ -33,7 +33,13 @@ import { repoIndexCommand } from "./repo_index.ts";
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-const aiToolType = new EnumType(["claude", "cursor", "opencode", "codex"]);
+const aiToolType = new EnumType([
+  "claude",
+  "cursor",
+  "opencode",
+  "codex",
+  "kiro",
+]);
 
 // Exported for reuse by repoCommand default action
 export async function repoInitAction(
@@ -78,7 +84,7 @@ export const repoInitCommand = new Command()
   .type("aiTool", aiToolType)
   .option(
     "-t, --tool <tool:aiTool>",
-    "AI coding tool to configure for (claude, cursor, opencode, codex)",
+    "AI coding tool to configure for (claude, cursor, opencode, codex, kiro)",
     { default: "claude" },
   )
   .option("--include-gitignore", "Manage a swamp section in .gitignore")
@@ -132,7 +138,7 @@ export const repoCommand = new Command()
   .type("aiTool", aiToolType)
   .option(
     "-t, --tool <tool:aiTool>",
-    "AI coding tool to configure for (claude, cursor, opencode, codex)",
+    "AI coding tool to configure for (claude, cursor, opencode, codex, kiro)",
     { default: "claude" },
   )
   .option("--include-gitignore", "Manage a swamp section in .gitignore")
@@ -147,7 +153,7 @@ export const repoCommand = new Command()
       .type("aiTool", aiToolType)
       .option(
         "-t, --tool <tool:aiTool>",
-        "AI coding tool to configure for (claude, cursor, opencode, codex)",
+        "AI coding tool to configure for (claude, cursor, opencode, codex, kiro)",
         { default: "claude" },
       )
       .option("--include-gitignore", "Manage a swamp section in .gitignore")

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -55,6 +55,7 @@ const SKILL_DIRS: Record<AiTool, string> = {
   cursor: ".cursor/skills",
   opencode: ".agents/skills",
   codex: ".agents/skills",
+  kiro: ".kiro/skills",
 };
 
 const INSTRUCTIONS_FILES: Record<AiTool, string> = {
@@ -62,6 +63,7 @@ const INSTRUCTIONS_FILES: Record<AiTool, string> = {
   cursor: ".cursor/rules/swamp.mdc",
   opencode: "AGENTS.md",
   codex: "AGENTS.md",
+  kiro: ".kiro/steering/swamp-rules.md",
 };
 
 const GITIGNORE_TOOL_ENTRIES: Record<AiTool, string> = {
@@ -69,6 +71,7 @@ const GITIGNORE_TOOL_ENTRIES: Record<AiTool, string> = {
   cursor: "# Cursor skills (managed by swamp)\n.cursor/skills/",
   opencode: "# Agent skills (managed by swamp)\n.agents/skills/",
   codex: "# Agent skills (managed by swamp)\n.agents/skills/",
+  kiro: "# Kiro skills (managed by swamp)\n.kiro/skills/",
 };
 
 /**
@@ -176,10 +179,12 @@ export class RepoService {
     const instructionsFileCreated = await this
       .createInstructionsFileIfNotExists(repoPath, tool);
 
-    // Create Claude settings.local.json only for Claude
+    // Create tool-specific settings
     let settingsCreated = false;
     if (tool === "claude") {
       settingsCreated = await this.createClaudeSettingsIfNotExists(repoPath);
+    } else if (tool === "kiro") {
+      settingsCreated = await this.createKiroSettingsIfNotExists(repoPath);
     }
 
     // Manage .gitignore only when opted in
@@ -243,10 +248,12 @@ export class RepoService {
     // Create instructions file if it doesn't exist (e.g., when switching tools)
     await this.createInstructionsFileIfNotExists(repoPath, tool);
 
-    // Update Claude settings only for Claude tool
+    // Update tool-specific settings
     let settingsUpdated = false;
     if (tool === "claude") {
       settingsUpdated = await this.updateClaudeSettings(repoPath);
+    } else if (tool === "kiro") {
+      settingsUpdated = await this.updateKiroSettings(repoPath);
     }
 
     // Determine gitignore management: CLI flag > marker preference > default off
@@ -363,6 +370,13 @@ Use \`swamp --help\` to see available commands.
       return `---
 description: Swamp automation rules
 alwaysApply: true
+---
+${body}`;
+    }
+
+    if (tool === "kiro") {
+      return `---
+inclusion: always
 ---
 ${body}`;
     }
@@ -513,6 +527,7 @@ ${body}`;
       ".claude/",
       ".cursor/skills/",
       ".agents/skills/",
+      ".kiro/skills/",
       "# Feel free to modify",
       "# Local telemetry",
       "# Encryption keyfile",
@@ -520,6 +535,7 @@ ${body}`;
       "# Claude Code configuration",
       "# Cursor skills",
       "# Agent skills",
+      "# Kiro skills",
       "# Swamp managed defaults",
     ];
 
@@ -663,6 +679,87 @@ ${body}`;
         ...existingSettings.permissions,
         allow: mergedAllow,
       },
+    };
+    await atomicWriteTextFile(
+      settingsPath,
+      JSON.stringify(newSettings, null, 2) + "\n",
+    );
+    return true;
+  }
+
+  /**
+   * Generates the content for Kiro's .vscode/settings.local.json.
+   */
+  private generateKiroSettingsContent(): string {
+    const settings = {
+      "kiroAgent.trustedCommands": [
+        "swamp *",
+      ],
+    };
+    return JSON.stringify(settings, null, 2) + "\n";
+  }
+
+  /**
+   * Creates .vscode/settings.local.json for Kiro if it doesn't already exist.
+   */
+  private async createKiroSettingsIfNotExists(
+    repoPath: RepoPath,
+  ): Promise<boolean> {
+    const vscodeDir = join(repoPath.value, ".vscode");
+    const settingsPath = join(vscodeDir, "settings.local.json");
+
+    try {
+      await Deno.stat(settingsPath);
+      return false;
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        await ensureDir(vscodeDir);
+        const content = this.generateKiroSettingsContent();
+        await Deno.writeTextFile(settingsPath, content);
+        return true;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Updates .vscode/settings.local.json for Kiro, merging trusted commands.
+   */
+  private async updateKiroSettings(repoPath: RepoPath): Promise<boolean> {
+    const vscodeDir = join(repoPath.value, ".vscode");
+    const settingsPath = join(vscodeDir, "settings.local.json");
+
+    await ensureDir(vscodeDir);
+
+    let existingSettings: Record<string, unknown> = {};
+    let settingsExisted = false;
+
+    try {
+      const content = await Deno.readTextFile(settingsPath);
+      existingSettings = JSON.parse(content);
+      settingsExisted = true;
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+
+    const ourCommands = ["swamp *"];
+    const existingCommands =
+      (existingSettings["kiroAgent.trustedCommands"] as string[] | undefined) ??
+        [];
+    const mergedCommands = [...new Set([...existingCommands, ...ourCommands])];
+
+    const hasChanges = mergedCommands.length !== existingCommands.length ||
+      !ourCommands.every((cmd) => existingCommands.includes(cmd));
+
+    if (!hasChanges && settingsExisted) {
+      return false;
+    }
+
+    const newSettings = {
+      ...existingSettings,
+      "kiroAgent.trustedCommands": mergedCommands,
     };
     await atomicWriteTextFile(
       settingsPath,

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -821,6 +821,7 @@ Deno.test("RepoService.init tool-specific gitignore entries when opted in", asyn
     cursor: ".cursor/skills/",
     opencode: ".agents/skills/",
     codex: ".agents/skills/",
+    kiro: ".kiro/skills/",
   };
 
   for (
@@ -1122,5 +1123,134 @@ Deno.test("RepoService.upgrade without flag and no marker gitignoreManaged skips
     const result = await upgradeService.upgrade(repoPath);
 
     assertEquals(result.gitignoreAction, "skipped");
+  });
+});
+
+// Kiro tool tests
+
+Deno.test("RepoService.init with kiro creates .kiro/skills/ and steering file with frontmatter", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    const result = await service.init(repoPath, { tool: "kiro" });
+
+    assertEquals(result.tool, "kiro");
+    assertEquals(result.instructionsFileCreated, true);
+    assertEquals(result.settingsCreated, true);
+
+    // Check skills copied to .kiro/skills/
+    const skillsDir = join(tempDir, ".kiro", "skills");
+    const stat = await Deno.stat(skillsDir);
+    assertEquals(stat.isDirectory, true);
+
+    // Check steering file with frontmatter
+    const steeringPath = join(
+      tempDir,
+      ".kiro",
+      "steering",
+      "swamp-rules.md",
+    );
+    const content = await Deno.readTextFile(steeringPath);
+    assertStringIncludes(content, "---\ninclusion: always\n---");
+    assertStringIncludes(content, "swamp");
+    assertStringIncludes(content, "## Skills");
+
+    // Check .vscode/settings.local.json created with trusted commands
+    const settingsPath = join(tempDir, ".vscode", "settings.local.json");
+    const settingsContent = await Deno.readTextFile(settingsPath);
+    const settings = JSON.parse(settingsContent);
+    assertEquals(
+      Array.isArray(settings["kiroAgent.trustedCommands"]),
+      true,
+    );
+    assertStringIncludes(
+      JSON.stringify(settings["kiroAgent.trustedCommands"]),
+      "swamp *",
+    );
+  });
+});
+
+Deno.test("RepoService.upgrade allows switching to kiro and creates steering file", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    // Init with claude (default)
+    await service.init(repoPath);
+
+    // Upgrade with tool switch to kiro
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath, { tool: "kiro" });
+
+    assertEquals(result.tool, "kiro");
+    assertEquals(result.settingsUpdated, true);
+
+    // Verify skills exist in kiro dir
+    const skillsDir = join(tempDir, ".kiro", "skills");
+    const stat = await Deno.stat(skillsDir);
+    assertEquals(stat.isDirectory, true);
+
+    // Verify marker updated with new tool
+    const marker = await upgradeService.getMarker(repoPath);
+    assertEquals(marker!.tool, "kiro");
+
+    // Verify steering file created
+    const steeringPath = join(
+      tempDir,
+      ".kiro",
+      "steering",
+      "swamp-rules.md",
+    );
+    const content = await Deno.readTextFile(steeringPath);
+    assertStringIncludes(content, "inclusion: always");
+
+    // Verify kiro settings created
+    const settingsPath = join(tempDir, ".vscode", "settings.local.json");
+    const settingsContent = await Deno.readTextFile(settingsPath);
+    const settings = JSON.parse(settingsContent);
+    assertStringIncludes(
+      JSON.stringify(settings["kiroAgent.trustedCommands"]),
+      "swamp *",
+    );
+  });
+});
+
+Deno.test("RepoService.init with kiro does not create claude settings", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath, { tool: "kiro" });
+
+    // Check no .claude/ settings created
+    const claudeSettingsPath = join(
+      tempDir,
+      ".claude",
+      "settings.local.json",
+    );
+    let settingsExist = false;
+    try {
+      await Deno.stat(claudeSettingsPath);
+      settingsExist = true;
+    } catch {
+      // expected
+    }
+    assertEquals(settingsExist, false);
+  });
+});
+
+Deno.test("RepoService.init kiro gitignore contains .kiro/skills/ when opted in", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath, { tool: "kiro", includeGitignore: true });
+
+    const gitignorePath = join(tempDir, ".gitignore");
+    const content = await Deno.readTextFile(gitignorePath);
+    assertStringIncludes(content, ".kiro/skills/");
+    assertStringIncludes(content, "# Kiro skills (managed by swamp)");
+    assertStringIncludes(content, ".swamp/telemetry/");
   });
 });

--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -26,7 +26,7 @@ import { swampMarkerPath } from "./paths.ts";
 /**
  * The AI coding tool to configure skills and instructions for.
  */
-export type AiTool = "claude" | "cursor" | "opencode" | "codex";
+export type AiTool = "claude" | "cursor" | "opencode" | "codex" | "kiro";
 
 /**
  * Data structure for the .swamp.yaml marker file.


### PR DESCRIPTION
## Summary

Closes #565

Adds [Kiro IDE](https://kiro.dev) as a supported AI coding tool for `swamp repo init --tool kiro`, requested by @danmcclain.

- **Skills**: copied to `.kiro/skills/` (Kiro's standard skills directory)
- **Steering**: `.kiro/steering/swamp-rules.md` with `inclusion: always` YAML frontmatter, ensuring rules are loaded in every Kiro session
- **Settings**: `.vscode/settings.local.json` with `kiroAgent.trustedCommands: ["swamp *"]` — uses Kiro's prefix matching to trust all swamp subcommands with a single entry
- **Gitignore**: `.kiro/skills/` added to managed section and legacy migration patterns
- **Upgrade**: full `updateKiroSettings()` with merge logic, matching the existing Claude upgrade path

## Design differences from the contributor's reference commit

@danmcclain provided a helpful [reference commit](https://github.com/danmcclain/swamp/commit/bb7b2fc8e334ab9cc3c0e697ae66d5559139d7f9). This PR takes a different approach in several areas:

| Aspect | Reference commit | This PR |
|---|---|---|
| **Settings key** | `kiro.allowedCommands` | `kiroAgent.trustedCommands` — matches the [documented Kiro setting](https://kiro.dev/docs/chat/terminal/) |
| **Trusted commands** | 26 per-command entries (e.g. `swamp model type search *`) | Single `"swamp *"` prefix — Kiro uses prefix matching, so one entry trusts all subcommands |
| **Code structure** | Refactored `getClaudeAllowedCommands()` into shared `getSwampCommands()` base | Kept `getClaudeAllowedCommands()` unchanged; Kiro doesn't need per-command entries so a shared base doesn't apply |
| **Steering frontmatter** | Not added | `inclusion: always` YAML frontmatter per Kiro steering conventions |
| **Upgrade support** | Not implemented | Full `updateKiroSettings()` with merge logic for `swamp repo upgrade --tool kiro` |
| **Legacy gitignore** | Not updated | Added `.kiro/skills/` and `# Kiro skills` to migration patterns |
| **Tests** | 1 test | 4 tests covering init, upgrade tool-switch, settings isolation, and gitignore |

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt` — formatting passes
- [x] `deno run test src/domain/repo/repo_service_test.ts` — all 54 tests pass (4 new)
- [x] `deno run test` — full suite (2505 tests) passes
- [x] `deno run compile` — binary compiles
- [x] Manual verification: `swamp repo init /tmp/test --tool kiro --include-gitignore` creates correct files

🤖 Generated with [Claude Code](https://claude.com/claude-code)