### PR TITLE
feat: send content metadata during extension push

### DIFF
--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -42,6 +42,8 @@ import { resolveLocalImports } from "../../domain/extensions/extension_import_re
 import { resolveWorkflowDependencies } from "../../domain/extensions/extension_dependency_resolver.ts";
 import { analyzeExtensionSafety } from "../../domain/extensions/extension_safety_analyzer.ts";
 import { bundleExtension } from "../../domain/models/bundle.ts";
+import type { ExtensionContentMetadata } from "../../domain/extensions/extension_content.ts";
+import { extractContentMetadata } from "../../domain/extensions/extension_content_extractor.ts";
 import { EmbeddedDenoRuntime } from "../../infrastructure/runtime/embedded_deno_runtime.ts";
 import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
 import { CalVer } from "../../domain/models/calver.ts";
@@ -354,6 +356,20 @@ export const extensionPushCommand = new Command()
       );
     }
 
+    // 12b. Extract content metadata for registry (non-fatal)
+    let contentMetadata: ExtensionContentMetadata | undefined;
+    try {
+      contentMetadata = await extractContentMetadata(
+        allModelFiles,
+        modelsDir,
+        workflowFiles,
+      );
+      ctx.logger
+        .debug`Extracted content metadata: ${contentMetadata.models.length} models, ${contentMetadata.workflows.length} workflows`;
+    } catch {
+      ctx.logger.debug`Content metadata extraction failed, skipping`;
+    }
+
     // 13. Pre-flight version check (skip in dry-run)
     if (!options.dryRun) {
       const extensionClient = new ExtensionApiClient(credentials.serverUrl);
@@ -519,10 +535,10 @@ export const extensionPushCommand = new Command()
         archiveBytes,
       );
 
-      // Phase 3: Confirm
+      // Phase 3: Confirm (include content metadata)
       ctx.logger.debug("Confirming push...");
       const confirmResult = await extensionClient.confirmPush(
-        pushMetadata,
+        { ...pushMetadata, contentMetadata },
         credentials.apiKey,
       );
 

--- a/src/domain/extensions/extension_content.ts
+++ b/src/domain/extensions/extension_content.ts
@@ -1,0 +1,87 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/** A single argument extracted from a method's Zod schema. */
+export interface ExtractedArgument {
+  name: string;
+  type: string;
+  description: string;
+  required: boolean;
+}
+
+/** A method extracted from a model definition. */
+export interface ExtractedMethod {
+  name: string;
+  description: string;
+  arguments: ExtractedArgument[];
+}
+
+/** A resource output spec extracted from a model definition. */
+export interface ExtractedResource {
+  key: string;
+  description: string;
+  lifetime: string;
+}
+
+/** A file output spec extracted from a model definition. */
+export interface ExtractedFile {
+  key: string;
+  description: string;
+  contentType: string;
+}
+
+/** Metadata extracted from a single model TypeScript file. */
+export interface ExtractedModel {
+  fileName: string;
+  type: string;
+  version: string;
+  methods: ExtractedMethod[];
+  resources: ExtractedResource[];
+  files: ExtractedFile[];
+}
+
+/** A single step extracted from a workflow job. */
+export interface ExtractedWorkflowStep {
+  name: string;
+  description: string;
+  taskType: string;
+  modelIdOrName: string;
+  methodName: string;
+}
+
+/** A job extracted from a workflow definition. */
+export interface ExtractedWorkflowJob {
+  name: string;
+  description: string;
+  steps: ExtractedWorkflowStep[];
+}
+
+/** Metadata extracted from a single workflow YAML file. */
+export interface ExtractedWorkflow {
+  id: string;
+  name: string;
+  description: string;
+  jobs: ExtractedWorkflowJob[];
+}
+
+/** Content metadata extracted from all models and workflows in an extension. */
+export interface ExtensionContentMetadata {
+  models: ExtractedModel[];
+  workflows: ExtractedWorkflow[];
+}

--- a/src/domain/extensions/extension_content_extractor.ts
+++ b/src/domain/extensions/extension_content_extractor.ts
@@ -1,0 +1,469 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { relative } from "@std/path";
+import { parse as parseYaml } from "@std/yaml";
+import type {
+  ExtensionContentMetadata,
+  ExtractedArgument,
+  ExtractedFile,
+  ExtractedMethod,
+  ExtractedModel,
+  ExtractedResource,
+  ExtractedWorkflow,
+  ExtractedWorkflowJob,
+  ExtractedWorkflowStep,
+} from "./extension_content.ts";
+
+/**
+ * Extracts content metadata from model source files and workflow YAML files.
+ *
+ * This metadata is sent to the registry during `extension push` so the server
+ * can index extension contents without re-parsing the archive.
+ *
+ * Extraction is best-effort: individual file failures are silently skipped
+ * and partial results are returned.
+ */
+export async function extractContentMetadata(
+  modelFiles: string[],
+  modelsDir: string,
+  workflowFiles: Array<{ sourcePath: string; archiveName: string }>,
+): Promise<ExtensionContentMetadata> {
+  const models: ExtractedModel[] = [];
+  const workflows: ExtractedWorkflow[] = [];
+
+  for (const filePath of modelFiles) {
+    try {
+      const content = await Deno.readTextFile(filePath);
+      const model = extractModelFromSource(content, filePath, modelsDir);
+      if (model) {
+        models.push(model);
+      }
+    } catch {
+      // Non-fatal: skip files that can't be read or parsed
+    }
+  }
+
+  for (const wf of workflowFiles) {
+    try {
+      const content = await Deno.readTextFile(wf.sourcePath);
+      const workflow = extractWorkflowFromYaml(content);
+      if (workflow) {
+        workflows.push(workflow);
+      }
+    } catch {
+      // Non-fatal: skip files that can't be read or parsed
+    }
+  }
+
+  return { models, workflows };
+}
+
+/**
+ * Extracts model metadata from a TypeScript source file.
+ * Returns null if the file doesn't contain a recognizable model definition.
+ */
+function extractModelFromSource(
+  content: string,
+  filePath: string,
+  modelsDir: string,
+): ExtractedModel | null {
+  const type = extractModelType(content);
+  if (!type) return null;
+
+  const version = extractModelVersion(content);
+  if (!version) return null;
+
+  const methods = extractMethods(content);
+  const resources = extractResources(content);
+  const files = extractFiles(content);
+
+  return {
+    fileName: relative(modelsDir, filePath),
+    type,
+    version,
+    methods,
+    resources,
+    files,
+  };
+}
+
+/**
+ * Extracts the model type string.
+ * Matches `ModelType.create("...")` or `type: "..."` patterns.
+ */
+function extractModelType(content: string): string | null {
+  // Match ModelType.create("type-name") or ModelType.create('type-name')
+  const modelTypeMatch = content.match(
+    /ModelType\.create\(\s*["']([^"']+)["']\s*\)/,
+  );
+  if (modelTypeMatch) return modelTypeMatch[1];
+
+  // Match type: "type-name" or type: 'type-name' in object literal
+  const typeLiteralMatch = content.match(
+    /type:\s*["']([^"']+)["']/,
+  );
+  if (typeLiteralMatch) return typeLiteralMatch[1];
+
+  return null;
+}
+
+/**
+ * Extracts the model version string.
+ * Matches `version: "YYYY.MM.DD.N"` patterns.
+ */
+function extractModelVersion(content: string): string | null {
+  const match = content.match(/version:\s*["']([^"']+)["']/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Extracts method definitions from the source.
+ * Matches the `methods: { name: { description: "..." } }` pattern.
+ */
+function extractMethods(content: string): ExtractedMethod[] {
+  const methods: ExtractedMethod[] = [];
+
+  // Find the methods block
+  const methodsBlockMatch = content.match(/methods:\s*\{/);
+  if (!methodsBlockMatch || methodsBlockMatch.index === undefined) {
+    return methods;
+  }
+
+  const methodsStart = methodsBlockMatch.index + methodsBlockMatch[0].length;
+  const methodsBlock = extractBalancedBraces(content, methodsStart);
+  if (!methodsBlock) return methods;
+
+  // Match individual method entries: methodName: { description: "..." }
+  const methodPattern =
+    /(\w+)\s*:\s*\{[^}]*?description:\s*(?:"([^"]*?)"|'([^']*?)'|`([^`]*?)`)/gs;
+  let match;
+  while ((match = methodPattern.exec(methodsBlock)) !== null) {
+    const name = match[1];
+    const description = match[2] ?? match[3] ?? match[4] ?? "";
+
+    // Try to extract arguments for this method
+    const methodEntry = extractMethodEntry(methodsBlock, name);
+    const args = methodEntry
+      ? extractMethodArguments(methodEntry, content)
+      : [];
+
+    methods.push({ name, description, arguments: args });
+  }
+
+  return methods;
+}
+
+/**
+ * Extracts the full text of a single method entry from the methods block.
+ */
+function extractMethodEntry(
+  methodsBlock: string,
+  methodName: string,
+): string | null {
+  const pattern = new RegExp(`${methodName}\\s*:\\s*\\{`);
+  const match = methodsBlock.match(pattern);
+  if (!match || match.index === undefined) return null;
+
+  const start = match.index + match[0].length;
+  return extractBalancedBraces(methodsBlock, start);
+}
+
+/**
+ * Extracts method arguments from a Zod schema.
+ * Looks for `arguments: z.object({ ... })` or a reference to a named schema.
+ */
+function extractMethodArguments(
+  methodEntry: string,
+  fullContent: string,
+): ExtractedArgument[] {
+  // Check for inline z.object({...})
+  const inlineMatch = methodEntry.match(/arguments:\s*z\.object\(\s*\{/);
+  if (inlineMatch && inlineMatch.index !== undefined) {
+    const start = inlineMatch.index + inlineMatch[0].length;
+    const schemaBody = extractBalancedBraces(methodEntry, start);
+    if (schemaBody) {
+      return parseZodObjectFields(schemaBody);
+    }
+  }
+
+  // Check for reference to a named schema variable
+  const refMatch = methodEntry.match(/arguments:\s*(\w+)/);
+  if (refMatch) {
+    const schemaName = refMatch[1];
+    // Look up the named schema in the full file content
+    const namedPattern = new RegExp(
+      `(?:const|let)\\s+${schemaName}\\s*=\\s*z\\.object\\(\\s*\\{`,
+    );
+    const namedMatch = fullContent.match(namedPattern);
+    if (namedMatch && namedMatch.index !== undefined) {
+      const start = namedMatch.index + namedMatch[0].length;
+      const schemaBody = extractBalancedBraces(fullContent, start);
+      if (schemaBody) {
+        return parseZodObjectFields(schemaBody);
+      }
+    }
+  }
+
+  return [];
+}
+
+/**
+ * Parses individual fields from a z.object({...}) body.
+ * Extracts field name, type, description, and whether it's required.
+ */
+function parseZodObjectFields(schemaBody: string): ExtractedArgument[] {
+  const args: ExtractedArgument[] = [];
+
+  // Find field starts: fieldName: z.type(
+  const fieldStartPattern = /(\w+)\s*:\s*z\.(\w+)\(/g;
+  let startMatch;
+  while ((startMatch = fieldStartPattern.exec(schemaBody)) !== null) {
+    const name = startMatch[1];
+    const baseType = startMatch[2];
+    const afterParen = startMatch.index + startMatch[0].length;
+
+    // Use balanced paren matching to find the end of z.type(...)
+    const parenEnd = findBalancedParen(schemaBody, afterParen);
+    if (parenEnd === -1) continue;
+
+    // Extract chain methods after the initial z.type(...) call
+    // e.g. .optional().describe("...")
+    let chain = "";
+    let pos = parenEnd + 1;
+    while (pos < schemaBody.length) {
+      const chainMatch = schemaBody.slice(pos).match(/^\.\w+\(/);
+      if (!chainMatch) break;
+      const chainCallStart = pos + chainMatch[0].length;
+      const chainCallEnd = findBalancedParen(schemaBody, chainCallStart);
+      if (chainCallEnd === -1) break;
+      chain += schemaBody.slice(pos, chainCallEnd + 1);
+      pos = chainCallEnd + 1;
+    }
+
+    // Extract description from .describe("...")
+    const descMatch = chain.match(
+      /\.describe\(\s*(?:"([^"]*?)"|'([^']*?)')/,
+    );
+    const description = descMatch ? (descMatch[1] ?? descMatch[2] ?? "") : "";
+
+    // Determine if optional
+    const required = !chain.includes(".optional()") &&
+      !chain.includes(".nullable()");
+
+    args.push({ name, type: baseType, description, required });
+
+    // Advance past this field
+    fieldStartPattern.lastIndex = pos;
+  }
+
+  return args;
+}
+
+/**
+ * Finds the position of the closing parenthesis matching an opening one.
+ * `start` is the position right after the opening `(`.
+ * Returns the index of the closing `)` or -1 if not found.
+ */
+function findBalancedParen(text: string, start: number): number {
+  let depth = 1;
+  let i = start;
+
+  while (i < text.length && depth > 0) {
+    if (text[i] === "(") depth++;
+    else if (text[i] === ")") depth--;
+    i++;
+  }
+
+  return depth === 0 ? i - 1 : -1;
+}
+
+/**
+ * Extracts resource output specs from the source.
+ */
+function extractResources(content: string): ExtractedResource[] {
+  const resources: ExtractedResource[] = [];
+
+  // Find the resources block (but not inside methods)
+  const match = content.match(/(?<![.\w])resources:\s*\{/);
+  if (!match || match.index === undefined) return resources;
+
+  const start = match.index + match[0].length;
+  const block = extractBalancedBraces(content, start);
+  if (!block) return resources;
+
+  // Find each entry key and extract its balanced block
+  const keyPattern = /["']?(\w[\w-]*)["']?\s*:\s*\{/g;
+  let keyMatch;
+  while ((keyMatch = keyPattern.exec(block)) !== null) {
+    const entryStart = keyMatch.index! + keyMatch[0].length;
+    const entryBody = extractBalancedBraces(block, entryStart);
+    if (!entryBody) continue;
+
+    const descMatch = entryBody.match(
+      /description:\s*(?:"([^"]*?)"|'([^']*?)')/,
+    );
+    const lifetimeMatch = entryBody.match(/lifetime:\s*["'](\w+)["']/);
+    if (!descMatch || !lifetimeMatch) continue;
+
+    resources.push({
+      key: keyMatch[1],
+      description: descMatch[1] ?? descMatch[2] ?? "",
+      lifetime: lifetimeMatch[1],
+    });
+
+    // Advance past this entry to avoid re-matching nested braces
+    keyPattern.lastIndex = entryStart + (entryBody?.length ?? 0) + 1;
+  }
+
+  return resources;
+}
+
+/**
+ * Extracts file output specs from the source.
+ */
+function extractFiles(content: string): ExtractedFile[] {
+  const files: ExtractedFile[] = [];
+
+  // Find the files block
+  const match = content.match(/(?<![.\w])files:\s*\{/);
+  if (!match || match.index === undefined) return files;
+
+  const start = match.index + match[0].length;
+  const block = extractBalancedBraces(content, start);
+  if (!block) return files;
+
+  // Find each entry key and extract its balanced block
+  const keyPattern = /["']?(\w[\w-]*)["']?\s*:\s*\{/g;
+  let keyMatch;
+  while ((keyMatch = keyPattern.exec(block)) !== null) {
+    const entryStart = keyMatch.index! + keyMatch[0].length;
+    const entryBody = extractBalancedBraces(block, entryStart);
+    if (!entryBody) continue;
+
+    const descMatch = entryBody.match(
+      /description:\s*(?:"([^"]*?)"|'([^']*?)')/,
+    );
+    const ctMatch = entryBody.match(/contentType:\s*["']([^"']+)["']/);
+    if (!descMatch || !ctMatch) continue;
+
+    files.push({
+      key: keyMatch[1],
+      description: descMatch[1] ?? descMatch[2] ?? "",
+      contentType: ctMatch[1],
+    });
+
+    // Advance past this entry
+    keyPattern.lastIndex = entryStart + (entryBody?.length ?? 0) + 1;
+  }
+
+  return files;
+}
+
+/**
+ * Extracts workflow metadata from a YAML file content.
+ * Returns null if the content doesn't contain a valid workflow structure.
+ */
+function extractWorkflowFromYaml(content: string): ExtractedWorkflow | null {
+  const parsed = parseYaml(content);
+  if (!parsed || typeof parsed !== "object") return null;
+
+  const data = parsed as Record<string, unknown>;
+
+  const id = typeof data.id === "string" ? data.id : "";
+  const name = typeof data.name === "string" ? data.name : "";
+  if (!name) return null;
+
+  const description = typeof data.description === "string"
+    ? data.description
+    : "";
+
+  const jobs: ExtractedWorkflowJob[] = [];
+  if (Array.isArray(data.jobs)) {
+    for (const job of data.jobs) {
+      if (!job || typeof job !== "object") continue;
+      const jobData = job as Record<string, unknown>;
+
+      const jobName = typeof jobData.name === "string" ? jobData.name : "";
+      const jobDescription = typeof jobData.description === "string"
+        ? jobData.description
+        : "";
+
+      const steps: ExtractedWorkflowStep[] = [];
+      if (Array.isArray(jobData.steps)) {
+        for (const step of jobData.steps) {
+          if (!step || typeof step !== "object") continue;
+          const stepData = step as Record<string, unknown>;
+
+          const stepName = typeof stepData.name === "string"
+            ? stepData.name
+            : "";
+          const stepDescription = typeof stepData.description === "string"
+            ? stepData.description
+            : "";
+
+          const task = stepData.task as Record<string, unknown> | undefined;
+          const taskType = task && typeof task.type === "string"
+            ? task.type
+            : "";
+          const modelIdOrName = task && typeof task.modelIdOrName === "string"
+            ? task.modelIdOrName
+            : "";
+          const methodName = task && typeof task.methodName === "string"
+            ? task.methodName
+            : "";
+
+          steps.push({
+            name: stepName,
+            description: stepDescription,
+            taskType,
+            modelIdOrName,
+            methodName,
+          });
+        }
+      }
+
+      jobs.push({ name: jobName, description: jobDescription, steps });
+    }
+  }
+
+  return { id, name, description, jobs };
+}
+
+/**
+ * Extracts the content between balanced braces, starting after an opening brace.
+ * Returns the content between the braces (excluding the outer braces themselves).
+ */
+function extractBalancedBraces(
+  text: string,
+  startAfterBrace: number,
+): string | null {
+  let depth = 1;
+  let i = startAfterBrace;
+
+  while (i < text.length && depth > 0) {
+    if (text[i] === "{") depth++;
+    else if (text[i] === "}") depth--;
+    i++;
+  }
+
+  if (depth !== 0) return null;
+  // Return content between the braces (exclude closing brace)
+  return text.slice(startAfterBrace, i - 1);
+}

--- a/src/domain/extensions/extension_content_extractor_test.ts
+++ b/src/domain/extensions/extension_content_extractor_test.ts
@@ -1,0 +1,626 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { stringify as stringifyYaml } from "@std/yaml";
+import { extractContentMetadata } from "./extension_content_extractor.ts";
+
+Deno.test("extractContentMetadata returns empty for no inputs", async () => {
+  const result = await extractContentMetadata([], "/tmp/models", []);
+  assertEquals(result, { models: [], workflows: [] });
+});
+
+Deno.test("extractContentMetadata extracts model type from ModelType.create", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const modelsDir = join(tmpDir, "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+
+    const modelFile = join(modelsDir, "instance.ts");
+    await Deno.writeTextFile(
+      modelFile,
+      [
+        'import { ModelType } from "../../model_type.ts";',
+        'const MY_TYPE = ModelType.create("aws/ec2-instance");',
+        "export const model = {",
+        "  type: MY_TYPE,",
+        '  version: "2026.03.01.1",',
+        "  methods: {",
+        "    start: {",
+        '      description: "Start the EC2 instance",',
+        "      arguments: z.object({}),",
+        "      execute: async () => ({ dataHandles: [] }),",
+        "    },",
+        "  },",
+        "};",
+      ].join("\n"),
+    );
+
+    const result = await extractContentMetadata([modelFile], modelsDir, []);
+    assertEquals(result.models.length, 1);
+    assertEquals(result.models[0].type, "aws/ec2-instance");
+    assertEquals(result.models[0].version, "2026.03.01.1");
+    assertEquals(result.models[0].fileName, "instance.ts");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extractContentMetadata extracts model type from string literal", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const modelsDir = join(tmpDir, "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+
+    const modelFile = join(modelsDir, "echo.ts");
+    await Deno.writeTextFile(
+      modelFile,
+      [
+        'import { z } from "npm:zod@4";',
+        "export const model = {",
+        '  type: "@test/echo",',
+        '  version: "2026.02.27.1",',
+        "  methods: {",
+        "    run: {",
+        '      description: "Run echo",',
+        "      arguments: z.object({}),",
+        "      execute: async () => ({ dataHandles: [] }),",
+        "    },",
+        "  },",
+        "};",
+      ].join("\n"),
+    );
+
+    const result = await extractContentMetadata([modelFile], modelsDir, []);
+    assertEquals(result.models.length, 1);
+    assertEquals(result.models[0].type, "@test/echo");
+    assertEquals(result.models[0].version, "2026.02.27.1");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extractContentMetadata extracts methods with descriptions", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const modelsDir = join(tmpDir, "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+
+    const modelFile = join(modelsDir, "ec2.ts");
+    await Deno.writeTextFile(
+      modelFile,
+      [
+        'import { z } from "npm:zod@4";',
+        "export const model = {",
+        '  type: "aws/ec2",',
+        '  version: "2026.03.01.1",',
+        "  methods: {",
+        "    start: {",
+        '      description: "Start the instance",',
+        "      arguments: z.object({}),",
+        "      execute: async () => ({ dataHandles: [] }),",
+        "    },",
+        "    stop: {",
+        '      description: "Stop the instance",',
+        "      arguments: z.object({}),",
+        "      execute: async () => ({ dataHandles: [] }),",
+        "    },",
+        "  },",
+        "};",
+      ].join("\n"),
+    );
+
+    const result = await extractContentMetadata([modelFile], modelsDir, []);
+    assertEquals(result.models[0].methods.length, 2);
+    assertEquals(result.models[0].methods[0].name, "start");
+    assertEquals(
+      result.models[0].methods[0].description,
+      "Start the instance",
+    );
+    assertEquals(result.models[0].methods[1].name, "stop");
+    assertEquals(result.models[0].methods[1].description, "Stop the instance");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extractContentMetadata extracts method arguments from inline z.object", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const modelsDir = join(tmpDir, "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+
+    const modelFile = join(modelsDir, "shell.ts");
+    await Deno.writeTextFile(
+      modelFile,
+      [
+        'import { z } from "npm:zod@4";',
+        "export const model = {",
+        '  type: "command/shell",',
+        '  version: "2026.02.09.1",',
+        "  methods: {",
+        "    execute: {",
+        '      description: "Execute a shell command",',
+        "      arguments: z.object({",
+        '        run: z.string().min(1).describe("The command to execute"),',
+        '        workingDir: z.string().optional().describe("Working directory"),',
+        "      }),",
+        "      execute: async () => ({ dataHandles: [] }),",
+        "    },",
+        "  },",
+        "};",
+      ].join("\n"),
+    );
+
+    const result = await extractContentMetadata([modelFile], modelsDir, []);
+    const method = result.models[0].methods[0];
+    assertEquals(method.arguments.length, 2);
+    assertEquals(method.arguments[0].name, "run");
+    assertEquals(method.arguments[0].type, "string");
+    assertEquals(method.arguments[0].description, "The command to execute");
+    assertEquals(method.arguments[0].required, true);
+    assertEquals(method.arguments[1].name, "workingDir");
+    assertEquals(method.arguments[1].type, "string");
+    assertEquals(method.arguments[1].required, false);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extractContentMetadata extracts method arguments from named schema", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const modelsDir = join(tmpDir, "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+
+    const modelFile = join(modelsDir, "model.ts");
+    await Deno.writeTextFile(
+      modelFile,
+      [
+        'import { z } from "npm:zod@4";',
+        "const InputSchema = z.object({",
+        '  name: z.string().describe("Resource name"),',
+        '  count: z.number().optional().describe("Instance count"),',
+        "});",
+        "export const model = {",
+        '  type: "test/named-args",',
+        '  version: "2026.03.01.1",',
+        "  methods: {",
+        "    create: {",
+        '      description: "Create resource",',
+        "      arguments: InputSchema,",
+        "      execute: async () => ({ dataHandles: [] }),",
+        "    },",
+        "  },",
+        "};",
+      ].join("\n"),
+    );
+
+    const result = await extractContentMetadata([modelFile], modelsDir, []);
+    const method = result.models[0].methods[0];
+    assertEquals(method.arguments.length, 2);
+    assertEquals(method.arguments[0].name, "name");
+    assertEquals(method.arguments[0].type, "string");
+    assertEquals(method.arguments[0].required, true);
+    assertEquals(method.arguments[1].name, "count");
+    assertEquals(method.arguments[1].type, "number");
+    assertEquals(method.arguments[1].required, false);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extractContentMetadata extracts resources", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const modelsDir = join(tmpDir, "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+
+    const modelFile = join(modelsDir, "model.ts");
+    await Deno.writeTextFile(
+      modelFile,
+      [
+        'import { z } from "npm:zod@4";',
+        "export const model = {",
+        '  type: "test/resources",',
+        '  version: "2026.03.01.1",',
+        "  resources: {",
+        '    "result": {',
+        '      description: "Execution result",',
+        "      schema: z.object({}),",
+        '      lifetime: "infinite",',
+        "      garbageCollection: 10,",
+        "    },",
+        "  },",
+        "  methods: {",
+        "    run: {",
+        '      description: "Run",',
+        "      arguments: z.object({}),",
+        "      execute: async () => ({ dataHandles: [] }),",
+        "    },",
+        "  },",
+        "};",
+      ].join("\n"),
+    );
+
+    const result = await extractContentMetadata([modelFile], modelsDir, []);
+    assertEquals(result.models[0].resources.length, 1);
+    assertEquals(result.models[0].resources[0].key, "result");
+    assertEquals(
+      result.models[0].resources[0].description,
+      "Execution result",
+    );
+    assertEquals(result.models[0].resources[0].lifetime, "infinite");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extractContentMetadata extracts files", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const modelsDir = join(tmpDir, "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+
+    const modelFile = join(modelsDir, "model.ts");
+    await Deno.writeTextFile(
+      modelFile,
+      [
+        'import { z } from "npm:zod@4";',
+        "export const model = {",
+        '  type: "test/files",',
+        '  version: "2026.03.01.1",',
+        "  files: {",
+        '    "log": {',
+        '      description: "Command output log",',
+        '      contentType: "text/plain",',
+        '      lifetime: "infinite",',
+        "      garbageCollection: 10,",
+        "    },",
+        "  },",
+        "  methods: {",
+        "    run: {",
+        '      description: "Run",',
+        "      arguments: z.object({}),",
+        "      execute: async () => ({ dataHandles: [] }),",
+        "    },",
+        "  },",
+        "};",
+      ].join("\n"),
+    );
+
+    const result = await extractContentMetadata([modelFile], modelsDir, []);
+    assertEquals(result.models[0].files.length, 1);
+    assertEquals(result.models[0].files[0].key, "log");
+    assertEquals(result.models[0].files[0].description, "Command output log");
+    assertEquals(result.models[0].files[0].contentType, "text/plain");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extractContentMetadata skips model without type", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const modelsDir = join(tmpDir, "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+
+    const modelFile = join(modelsDir, "helper.ts");
+    await Deno.writeTextFile(
+      modelFile,
+      "export const helper = () => 42;\n",
+    );
+
+    const result = await extractContentMetadata([modelFile], modelsDir, []);
+    assertEquals(result.models.length, 0);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extractContentMetadata parses workflow YAML", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const wfFile = join(tmpDir, "workflow.yaml");
+    await Deno.writeTextFile(
+      wfFile,
+      stringifyYaml({
+        id: "abc-123",
+        name: "test-workflow",
+        description: "A test workflow",
+        version: 1,
+        jobs: [{
+          name: "main-job",
+          description: "The main job",
+          steps: [{
+            name: "step-one",
+            description: "First step",
+            task: {
+              type: "model_method",
+              modelIdOrName: "my-model",
+              methodName: "execute",
+            },
+          }],
+        }],
+      }),
+    );
+
+    const result = await extractContentMetadata(
+      [],
+      tmpDir,
+      [{ sourcePath: wfFile, archiveName: "workflow.yaml" }],
+    );
+    assertEquals(result.workflows.length, 1);
+    assertEquals(result.workflows[0].id, "abc-123");
+    assertEquals(result.workflows[0].name, "test-workflow");
+    assertEquals(result.workflows[0].description, "A test workflow");
+    assertEquals(result.workflows[0].jobs.length, 1);
+    assertEquals(result.workflows[0].jobs[0].name, "main-job");
+    assertEquals(result.workflows[0].jobs[0].description, "The main job");
+    assertEquals(result.workflows[0].jobs[0].steps.length, 1);
+    assertEquals(result.workflows[0].jobs[0].steps[0].name, "step-one");
+    assertEquals(result.workflows[0].jobs[0].steps[0].taskType, "model_method");
+    assertEquals(
+      result.workflows[0].jobs[0].steps[0].modelIdOrName,
+      "my-model",
+    );
+    assertEquals(result.workflows[0].jobs[0].steps[0].methodName, "execute");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extractContentMetadata parses workflow with multiple jobs and steps", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const wfFile = join(tmpDir, "multi.yaml");
+    await Deno.writeTextFile(
+      wfFile,
+      stringifyYaml({
+        id: "multi-123",
+        name: "multi-workflow",
+        description: "Multi-job workflow",
+        version: 1,
+        jobs: [
+          {
+            name: "setup",
+            description: "Setup phase",
+            steps: [
+              {
+                name: "init",
+                description: "Initialize",
+                task: {
+                  type: "model_method",
+                  modelIdOrName: "setup-model",
+                  methodName: "init",
+                },
+              },
+            ],
+          },
+          {
+            name: "deploy",
+            description: "Deploy phase",
+            steps: [
+              {
+                name: "build",
+                description: "Build artifacts",
+                task: {
+                  type: "model_method",
+                  modelIdOrName: "build-model",
+                  methodName: "build",
+                },
+              },
+              {
+                name: "push",
+                description: "Push to registry",
+                task: {
+                  type: "model_method",
+                  modelIdOrName: "push-model",
+                  methodName: "push",
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    const result = await extractContentMetadata(
+      [],
+      tmpDir,
+      [{ sourcePath: wfFile, archiveName: "multi.yaml" }],
+    );
+    assertEquals(result.workflows[0].jobs.length, 2);
+    assertEquals(result.workflows[0].jobs[0].steps.length, 1);
+    assertEquals(result.workflows[0].jobs[1].steps.length, 2);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extractContentMetadata skips unparseable files gracefully", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const modelsDir = join(tmpDir, "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+
+    // A good model file
+    const goodModel = join(modelsDir, "good.ts");
+    await Deno.writeTextFile(
+      goodModel,
+      [
+        "export const model = {",
+        '  type: "test/good",',
+        '  version: "2026.03.01.1",',
+        "  methods: {",
+        "    run: {",
+        '      description: "Run",',
+        "      arguments: z.object({}),",
+        "      execute: async () => ({ dataHandles: [] }),",
+        "    },",
+        "  },",
+        "};",
+      ].join("\n"),
+    );
+
+    // A nonexistent file path
+    const badModel = join(modelsDir, "nonexistent.ts");
+
+    // A good workflow
+    const goodWf = join(tmpDir, "good.yaml");
+    await Deno.writeTextFile(
+      goodWf,
+      stringifyYaml({
+        id: "wf-1",
+        name: "good-workflow",
+        version: 1,
+        jobs: [{
+          name: "main",
+          steps: [{
+            name: "run",
+            task: {
+              type: "model_method",
+              modelIdOrName: "m",
+              methodName: "r",
+            },
+          }],
+        }],
+      }),
+    );
+
+    // A bad workflow (nonexistent file)
+    const badWf = join(tmpDir, "nonexistent.yaml");
+
+    const result = await extractContentMetadata(
+      [goodModel, badModel],
+      modelsDir,
+      [
+        { sourcePath: goodWf, archiveName: "good.yaml" },
+        { sourcePath: badWf, archiveName: "bad.yaml" },
+      ],
+    );
+
+    // Should have partial results — the good files are extracted
+    assertEquals(result.models.length, 1);
+    assertEquals(result.models[0].type, "test/good");
+    assertEquals(result.workflows.length, 1);
+    assertEquals(result.workflows[0].name, "good-workflow");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extractContentMetadata preserves relative path for nested models", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const modelsDir = join(tmpDir, "models");
+    const subDir = join(modelsDir, "aws", "ec2");
+    await Deno.mkdir(subDir, { recursive: true });
+
+    const modelFile = join(subDir, "instance.ts");
+    await Deno.writeTextFile(
+      modelFile,
+      [
+        "export const model = {",
+        '  type: "aws/ec2-instance",',
+        '  version: "2026.03.01.1",',
+        "  methods: {",
+        "    start: {",
+        '      description: "Start",',
+        "      arguments: z.object({}),",
+        "      execute: async () => ({ dataHandles: [] }),",
+        "    },",
+        "  },",
+        "};",
+      ].join("\n"),
+    );
+
+    const result = await extractContentMetadata([modelFile], modelsDir, []);
+    assertEquals(result.models[0].fileName, "aws/ec2/instance.ts");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extractContentMetadata handles nested parens in zod types like z.record", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const modelsDir = join(tmpDir, "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+
+    const modelFile = join(modelsDir, "model.ts");
+    await Deno.writeTextFile(
+      modelFile,
+      [
+        'import { z } from "npm:zod@4";',
+        "export const model = {",
+        '  type: "test/nested-parens",',
+        '  version: "2026.03.01.1",',
+        "  methods: {",
+        "    run: {",
+        '      description: "Run it",',
+        "      arguments: z.object({",
+        '        name: z.string().describe("The name"),',
+        '        env: z.record(z.string(), z.string()).optional().describe("Environment vars"),',
+        "      }),",
+        "      execute: async () => ({ dataHandles: [] }),",
+        "    },",
+        "  },",
+        "};",
+      ].join("\n"),
+    );
+
+    const result = await extractContentMetadata([modelFile], modelsDir, []);
+    const method = result.models[0].methods[0];
+    assertEquals(method.arguments.length, 2);
+    assertEquals(method.arguments[0].name, "name");
+    assertEquals(method.arguments[0].required, true);
+    assertEquals(method.arguments[1].name, "env");
+    assertEquals(method.arguments[1].type, "record");
+    assertEquals(method.arguments[1].description, "Environment vars");
+    assertEquals(method.arguments[1].required, false);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extractContentMetadata skips workflow YAML without name", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const wfFile = join(tmpDir, "bad-wf.yaml");
+    await Deno.writeTextFile(
+      wfFile,
+      stringifyYaml({
+        id: "no-name",
+        version: 1,
+        jobs: [],
+      }),
+    );
+
+    const result = await extractContentMetadata(
+      [],
+      tmpDir,
+      [{ sourcePath: wfFile, archiveName: "bad-wf.yaml" }],
+    );
+    assertEquals(result.workflows.length, 0);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});

--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { UserError } from "../../domain/errors.ts";
+import type { ExtensionContentMetadata } from "../../domain/extensions/extension_content.ts";
 
 /** Metadata sent during push initiation and confirmation. */
 export interface PushMetadata {
@@ -28,6 +29,11 @@ export interface PushMetadata {
   platforms: string[];
   labels: string[];
   repository?: string;
+}
+
+/** Metadata sent during push confirmation (extends PushMetadata with content metadata). */
+export interface ConfirmPushMetadata extends PushMetadata {
+  contentMetadata?: ExtensionContentMetadata;
 }
 
 /** Response from the initiate push endpoint. */
@@ -196,7 +202,7 @@ export class ExtensionApiClient {
    * Phase 3: Confirm push — verify upload completed and persist version.
    */
   async confirmPush(
-    metadata: PushMetadata,
+    metadata: ConfirmPushMetadata,
     apiKey: string,
   ): Promise<ConfirmPushResult> {
     const res = await this.fetch("/api/v1/extensions/confirm", {


### PR DESCRIPTION
## Summary

- During `extension push`, extract metadata from model `.ts` files and workflow `.yaml` files already in memory
- Send the extracted `contentMetadata` to the registry in the confirm-push request
- The server can now index extension contents (methods, arguments, resources, files, workflow structure) without re-parsing the uploaded archive

## User impact

**No user-facing behavior changes.** The metadata extraction runs silently during push — results are logged at debug level only (visible with `--verbose` or `SWAMP_LOG=debug`). If extraction fails for any reason, push continues normally without metadata. The registry gains richer indexing data to power future extension search and discovery features.

## Design

**Why client-side extraction?** The CLI already has all source files in memory at push time. Extracting metadata here avoids redundant server-side archive unpacking and parsing, reducing registry latency and complexity.

**Why regex-based for models?** Model `.ts` files follow well-defined patterns (`ModelType.create(...)`, `methods: { name: { description: ... } }`, `z.object({...})`). Regex extraction matches the approach used by the swamp-club server (PR #145) and avoids needing to evaluate TypeScript. Balanced brace/paren matching handles nested structures like `z.record(z.string(), z.string())`.

**Why YAML parsing for workflows?** Workflow files are YAML — a proper parser (`@std/yaml`, already a dependency) gives exact results with no regex fragility.

**Non-fatal by design.** Every extraction is wrapped in try/catch at the per-file level. A single unparseable model or workflow is silently skipped, returning partial results. The top-level call is also wrapped, so even a catastrophic extractor bug cannot break `extension push`.

## Changes

| File | Change |
|------|--------|
| `src/domain/extensions/extension_content.ts` | New — type definitions matching swamp-club schema |
| `src/domain/extensions/extension_content_extractor.ts` | New — extraction logic (regex for models, YAML for workflows) |
| `src/domain/extensions/extension_content_extractor_test.ts` | New — 15 tests |
| `src/infrastructure/http/extension_api_client.ts` | Add `ConfirmPushMetadata` with optional `contentMetadata` |
| `src/cli/commands/extension_push.ts` | Wire extraction after bundling, pass to confirm call |

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt` — formatting passes
- [x] `deno run test` — 2601 tests pass (15 new + 2586 existing)
- [x] `deno run compile` — binary compiles
- [x] Validated against real `shell_model.ts` — correctly extracts type, version, methods with arguments, resources, and files
- [ ] Manual: `swamp extension push --dry-run` on an extension with models and workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)