### PR TITLE
fix: always create .gitignore on repo init

### DIFF
--- a/src/cli/commands/repo_init.ts
+++ b/src/cli/commands/repo_init.ts
@@ -52,12 +52,10 @@ export async function repoInitAction(
   const repoPath = RepoPath.create(pathArg ?? ".");
   const service = new RepoService(VERSION);
   const tool = (options.tool as AiTool) ?? "claude";
-  const includeGitignore = options.includeGitignore as boolean | undefined;
 
   const result = await service.init(repoPath, {
     force: options.force,
     tool,
-    includeGitignore,
   });
 
   ctx.logger.debug`Repository initialized: ${result.path}`;
@@ -87,7 +85,6 @@ export const repoInitCommand = new Command()
     "AI coding tool to configure for (claude, cursor, opencode, codex, kiro)",
     { default: "claude" },
   )
-  .option("--include-gitignore", "Manage a swamp section in .gitignore")
   .action(repoInitAction);
 
 export const repoUpgradeCommand = new Command()
@@ -142,7 +139,6 @@ export const repoCommand = new Command()
     "AI coding tool to configure for (claude, cursor, opencode, codex, kiro)",
     { default: "claude" },
   )
-  .option("--include-gitignore", "Manage a swamp section in .gitignore")
   .action(repoInitAction)
   .command(
     "init",
@@ -157,7 +153,6 @@ export const repoCommand = new Command()
         "AI coding tool to configure for (claude, cursor, opencode, codex, kiro)",
         { default: "claude" },
       )
-      .option("--include-gitignore", "Manage a swamp section in .gitignore")
       .action(repoInitAction),
   )
   .command("upgrade", repoUpgradeCommand)

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -109,7 +109,6 @@ export interface RepoUpgradeResult {
 export interface RepoInitOptions {
   force?: boolean;
   tool?: AiTool;
-  includeGitignore?: boolean;
 }
 
 /**
@@ -217,14 +216,9 @@ export class RepoService {
         assertNever(tool);
     }
 
-    // Manage .gitignore only when opted in
-    let gitignoreAction: GitignoreAction;
-    if (options.includeGitignore) {
-      gitignoreAction = await this.ensureGitignoreSection(repoPath, tool);
-      markerData.gitignoreManaged = true;
-    } else {
-      gitignoreAction = "skipped";
-    }
+    // Always manage .gitignore on init
+    const gitignoreAction = await this.ensureGitignoreSection(repoPath, tool);
+    markerData.gitignoreManaged = true;
 
     await this.markerRepo.write(repoPath, markerData);
 

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -403,38 +403,16 @@ Deno.test("RepoService.init generates CLAUDE.md with skills section", async () =
   });
 });
 
-Deno.test("RepoService.init skips .gitignore by default", async () => {
+Deno.test("RepoService.init always creates .gitignore with managed section", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
     const result = await service.init(repoPath);
 
-    assertEquals(result.gitignoreAction, "skipped");
-
-    // .gitignore should not exist
-    const gitignorePath = join(tempDir, ".gitignore");
-    let exists = false;
-    try {
-      await Deno.stat(gitignorePath);
-      exists = true;
-    } catch {
-      // expected
-    }
-    assertEquals(exists, false);
-  });
-});
-
-Deno.test("RepoService.init creates .gitignore with managed section when opted in", async () => {
-  await withTempDir(async (tempDir) => {
-    const service = new RepoService("0.1.0");
-    const repoPath = RepoPath.create(tempDir);
-
-    const result = await service.init(repoPath, { includeGitignore: true });
-
     assertEquals(result.gitignoreAction, "created");
 
-    // Check .gitignore exists and has expected content with markers
+    // .gitignore should exist with managed section
     const gitignorePath = join(tempDir, ".gitignore");
     const content = await Deno.readTextFile(gitignorePath);
     assertStringIncludes(
@@ -452,7 +430,20 @@ Deno.test("RepoService.init creates .gitignore with managed section when opted i
   });
 });
 
-Deno.test("RepoService.init appends managed section to existing .gitignore when opted in", async () => {
+Deno.test("RepoService.init sets gitignoreManaged in marker", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath);
+
+    // Check marker persists the preference for future upgrades
+    const marker = await service.getMarker(repoPath);
+    assertEquals(marker!.gitignoreManaged, true);
+  });
+});
+
+Deno.test("RepoService.init appends managed section to existing .gitignore", async () => {
   await withTempDir(async (tempDir) => {
     // Create existing .gitignore
     const gitignorePath = join(tempDir, ".gitignore");
@@ -464,7 +455,7 @@ Deno.test("RepoService.init appends managed section to existing .gitignore when 
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    const result = await service.init(repoPath, { includeGitignore: true });
+    const result = await service.init(repoPath);
 
     assertEquals(result.gitignoreAction, "updated");
 
@@ -487,12 +478,11 @@ Deno.test("RepoService.init with force returns unchanged when section is current
     const repoPath = RepoPath.create(tempDir);
 
     // First init creates .gitignore with managed section
-    await service.init(repoPath, { includeGitignore: true });
+    await service.init(repoPath);
 
     // Second init with force — section already matches
     const result = await service.init(repoPath, {
       force: true,
-      includeGitignore: true,
     });
 
     assertEquals(result.gitignoreAction, "unchanged");
@@ -511,7 +501,7 @@ Deno.test("RepoService.init with cursor creates .cursor/skills/ and .cursor/rule
     assertEquals(result.tool, "cursor");
     assertEquals(result.instructionsFileCreated, true);
     assertEquals(result.settingsCreated, true);
-    assertEquals(result.gitignoreAction, "skipped");
+    assertEquals(result.gitignoreAction, "created");
 
     // Check skills copied to .cursor/skills/
     const skillsDir = join(tempDir, ".cursor", "skills");
@@ -560,7 +550,7 @@ Deno.test("RepoService.init with opencode creates .agents/skills/ and AGENTS.md"
     assertEquals(result.tool, "opencode");
     assertEquals(result.instructionsFileCreated, true);
     assertEquals(result.settingsCreated, true);
-    assertEquals(result.gitignoreAction, "skipped");
+    assertEquals(result.gitignoreAction, "created");
 
     // Check skills copied to .agents/skills/
     const skillsDir = join(tempDir, ".agents", "skills");
@@ -592,7 +582,7 @@ Deno.test("RepoService.init with codex creates .agents/skills/ and AGENTS.md", a
     assertEquals(result.tool, "codex");
     assertEquals(result.instructionsFileCreated, true);
     assertEquals(result.settingsCreated, false);
-    assertEquals(result.gitignoreAction, "skipped");
+    assertEquals(result.gitignoreAction, "created");
 
     // Check skills copied to .agents/skills/
     const skillsDir = join(tempDir, ".agents", "skills");
@@ -772,17 +762,18 @@ Deno.test("RepoService.upgrade skips settings for non-claude tools", async () =>
   });
 });
 
-Deno.test("RepoService.upgrade skips .gitignore by default", async () => {
+Deno.test("RepoService.upgrade manages .gitignore when marker has gitignoreManaged from init", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
+    // Init always sets gitignoreManaged: true
     await service.init(repoPath);
 
     const upgradeService = new RepoService("0.2.0");
     const result = await upgradeService.upgrade(repoPath);
 
-    assertEquals(result.gitignoreAction, "skipped");
+    assertEquals(result.gitignoreAction, "unchanged");
   });
 });
 
@@ -791,8 +782,8 @@ Deno.test("RepoService.upgrade creates .gitignore when marker has gitignoreManag
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    // Init with gitignore opt-in (creates .gitignore and sets marker)
-    await service.init(repoPath, { includeGitignore: true });
+    // Init creates .gitignore and sets marker
+    await service.init(repoPath);
     const gitignorePath = join(tempDir, ".gitignore");
     await Deno.remove(gitignorePath);
 
@@ -820,7 +811,7 @@ Deno.test("RepoService.upgrade returns unchanged when section is current", async
     const repoPath = RepoPath.create(tempDir);
 
     // Init creates .gitignore with managed section
-    await service.init(repoPath, { includeGitignore: true });
+    await service.init(repoPath);
 
     // Upgrade — section already matches (marker has gitignoreManaged: true)
     const upgradeService = new RepoService("0.2.0");
@@ -847,7 +838,7 @@ Deno.test("RepoService.init cursor instructions have MDC frontmatter", async () 
   });
 });
 
-Deno.test("RepoService.init tool-specific gitignore entries when opted in", async () => {
+Deno.test("RepoService.init includes tool-specific gitignore entries", async () => {
   const toolGitignoreEntries: Record<AiTool, string> = {
     claude: ".claude/",
     cursor: ".cursor/skills/",
@@ -865,7 +856,7 @@ Deno.test("RepoService.init tool-specific gitignore entries when opted in", asyn
       const service = new RepoService("0.1.0");
       const repoPath = RepoPath.create(tempDir);
 
-      await service.init(repoPath, { tool, includeGitignore: true });
+      await service.init(repoPath, { tool });
 
       const gitignorePath = join(tempDir, ".gitignore");
       const content = await Deno.readTextFile(gitignorePath);
@@ -896,7 +887,7 @@ Deno.test("RepoService.init preserves user content before managed section", asyn
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    await service.init(repoPath, { includeGitignore: true });
+    await service.init(repoPath);
 
     const content = await Deno.readTextFile(gitignorePath);
     // User content comes first
@@ -914,17 +905,16 @@ Deno.test("RepoService.init replaces managed section on tool switch", async () =
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    // Init with claude and gitignore
-    await service.init(repoPath, { includeGitignore: true });
+    // Init with claude
+    await service.init(repoPath);
     const gitignorePath = join(tempDir, ".gitignore");
     let content = await Deno.readTextFile(gitignorePath);
     assertStringIncludes(content, ".claude/");
 
-    // Re-init with cursor (force) and gitignore
+    // Re-init with cursor (force)
     const result = await service.init(repoPath, {
       force: true,
       tool: "cursor",
-      includeGitignore: true,
     });
 
     assertEquals(result.gitignoreAction, "updated");
@@ -940,8 +930,8 @@ Deno.test("RepoService.upgrade updates managed section on tool switch", async ()
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    // Init with claude and gitignore
-    await service.init(repoPath, { includeGitignore: true });
+    // Init with claude
+    await service.init(repoPath);
 
     // Add user content after the managed section
     const gitignorePath = join(tempDir, ".gitignore");
@@ -968,7 +958,7 @@ Deno.test("RepoService.init handles .gitignore without trailing newline", async 
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    const result = await service.init(repoPath, { includeGitignore: true });
+    const result = await service.init(repoPath);
 
     assertEquals(result.gitignoreAction, "updated");
     const content = await Deno.readTextFile(gitignorePath);
@@ -982,7 +972,7 @@ Deno.test("RepoService.init handles .gitignore without trailing newline", async 
   });
 });
 
-Deno.test("RepoService.init migrates legacy gitignore format when opted in", async () => {
+Deno.test("RepoService.init migrates legacy gitignore format", async () => {
   await withTempDir(async (tempDir) => {
     // Create legacy-format .gitignore (as old swamp would have created it)
     const gitignorePath = join(tempDir, ".gitignore");
@@ -1006,7 +996,7 @@ Deno.test("RepoService.init migrates legacy gitignore format when opted in", asy
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    const result = await service.init(repoPath, { includeGitignore: true });
+    const result = await service.init(repoPath);
 
     assertEquals(result.gitignoreAction, "updated");
     const content = await Deno.readTextFile(gitignorePath);
@@ -1022,7 +1012,7 @@ Deno.test("RepoService.init migrates legacy gitignore format when opted in", asy
   });
 });
 
-Deno.test("RepoService.init migrates legacy gitignore with user additions when opted in", async () => {
+Deno.test("RepoService.init migrates legacy gitignore with user additions", async () => {
   await withTempDir(async (tempDir) => {
     // Create legacy-format .gitignore with user additions after it
     const gitignorePath = join(tempDir, ".gitignore");
@@ -1049,7 +1039,7 @@ build/
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    const result = await service.init(repoPath, { includeGitignore: true });
+    const result = await service.init(repoPath);
 
     assertEquals(result.gitignoreAction, "updated");
     const content = await Deno.readTextFile(gitignorePath);
@@ -1068,35 +1058,22 @@ build/
   });
 });
 
-// Opt-in/opt-out gitignore management tests
-
-Deno.test("RepoService.init without includeGitignore does not set gitignoreManaged", async () => {
-  await withTempDir(async (tempDir) => {
-    const service = new RepoService("0.1.0");
-    const repoPath = RepoPath.create(tempDir);
-
-    await service.init(repoPath);
-
-    const marker = await service.getMarker(repoPath);
-    assertEquals(marker!.gitignoreManaged, undefined);
-  });
-});
+// Opt-in/opt-out gitignore management tests (upgrade only)
 
 Deno.test("RepoService.upgrade with includeGitignore true opts in and persists", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    // Init without gitignore
     await service.init(repoPath);
 
-    // Upgrade with opt-in
+    // Upgrade with explicit opt-in
     const upgradeService = new RepoService("0.2.0");
     const result = await upgradeService.upgrade(repoPath, {
       includeGitignore: true,
     });
 
-    assertEquals(result.gitignoreAction, "created");
+    assertEquals(result.gitignoreAction, "unchanged");
 
     // Marker should persist the preference
     const marker = await upgradeService.getMarker(repoPath);
@@ -1109,8 +1086,8 @@ Deno.test("RepoService.upgrade with includeGitignore false opts out and persists
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    // Init with gitignore (sets gitignoreManaged: true)
-    await service.init(repoPath, { includeGitignore: true });
+    // Init (always sets gitignoreManaged: true)
+    await service.init(repoPath);
 
     // Upgrade with explicit opt-out
     const upgradeService = new RepoService("0.2.0");
@@ -1131,8 +1108,8 @@ Deno.test("RepoService.upgrade without flag honors marker gitignoreManaged true"
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    // Init with gitignore (sets gitignoreManaged: true)
-    await service.init(repoPath, { includeGitignore: true });
+    // Init (always sets gitignoreManaged: true)
+    await service.init(repoPath);
 
     // Upgrade without specifying flag — should honor marker
     const upgradeService = new RepoService("0.2.0");
@@ -1142,19 +1119,19 @@ Deno.test("RepoService.upgrade without flag honors marker gitignoreManaged true"
   });
 });
 
-Deno.test("RepoService.upgrade without flag and no marker gitignoreManaged skips", async () => {
+Deno.test("RepoService.upgrade without flag honors marker from init", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    // Init without gitignore (no gitignoreManaged in marker)
+    // Init always sets gitignoreManaged: true
     await service.init(repoPath);
 
-    // Upgrade without specifying flag — should skip
+    // Upgrade without specifying flag — should honor marker and manage gitignore
     const upgradeService = new RepoService("0.2.0");
     const result = await upgradeService.upgrade(repoPath);
 
-    assertEquals(result.gitignoreAction, "skipped");
+    assertEquals(result.gitignoreAction, "unchanged");
   });
 });
 
@@ -1272,12 +1249,12 @@ Deno.test("RepoService.init with kiro does not create claude settings", async ()
   });
 });
 
-Deno.test("RepoService.init kiro gitignore contains .kiro/skills/ when opted in", async () => {
+Deno.test("RepoService.init kiro gitignore contains .kiro/skills/", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    await service.init(repoPath, { tool: "kiro", includeGitignore: true });
+    await service.init(repoPath, { tool: "kiro" });
 
     const gitignorePath = join(tempDir, ".gitignore");
     const content = await Deno.readTextFile(gitignorePath);


### PR DESCRIPTION
## Summary

- `swamp repo init` now always creates/manages a `.gitignore` with the swamp managed section, instead of requiring the `--include-gitignore` flag
- If no `.gitignore` exists, one is created; if one already exists, the managed section is appended while preserving user content
- The `--include-gitignore` flag is removed from the `init` command but remains on `repo upgrade` for opt-in/opt-out control
- The `gitignoreManaged: true` marker is always set on init so subsequent upgrades continue managing the section

### Behavior Change

| Scenario | Before | After |
|----------|--------|-------|
| `swamp repo init` (no flag) | No `.gitignore` created | `.gitignore` created with managed section |
| `swamp repo init` with existing `.gitignore` | No changes | Managed section appended to existing file |
| `swamp repo upgrade` | Unchanged | Unchanged (still respects marker/flag) |

Without this fix, users could accidentally commit sensitive files like `.swamp/secrets/keyfile`.

## Test Plan

- All 64 unit tests in `repo_service_test.ts` pass (updated to reflect new behavior)
- Manual testing with compiled binary across 5 scenarios:
  1. Fresh init with no existing `.gitignore` — file created with managed section
  2. Init with existing user `.gitignore` — user content preserved, managed section appended
  3. Init with non-claude tool (cursor) — tool-specific entry (`.cursor/skills/`) included
  4. Upgrade after init — `.gitignore` maintained via marker
  5. Force re-init — `.gitignore` stays unchanged
- Full test suite passes (2585 tests)
- `deno check`, `deno lint`, `deno fmt` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)