### PR TITLE
fix: switch API token auth from Bearer to x-api-key header

### DIFF
--- a/src/cli/commands/auth_login.ts
+++ b/src/cli/commands/auth_login.ts
@@ -198,17 +198,17 @@ export const authLoginCommand = new Command()
         sessionToken = await browserFlow(serverUrl, spinner);
       }
 
-      // Verify identity using the session token (bearer plugin handles this)
-      spinner?.update("Securing session...");
-      const whoami = await client.whoami(sessionToken);
-      const username = whoami.username ?? knownUsername ?? "unknown";
-
       // Create an API key for CLI use
       // BetterAuth limits API key names to 32 characters
+      spinner?.update("Securing session...");
       const host = (Deno.hostname?.() ?? "unknown").slice(0, 14);
       const keyName = `cli-${host}-${Date.now()}`;
       ctx.logger.debug`Creating API key: ${keyName}`;
       const apiKey = await client.createApiKey(sessionToken, keyName);
+
+      // Verify identity using the new API key
+      const whoami = await client.whoami(apiKey.key);
+      const username = whoami.username ?? knownUsername ?? "unknown";
 
       // Store credentials
       const repo = new AuthRepository();

--- a/src/domain/telemetry/telemetry_sender.ts
+++ b/src/domain/telemetry/telemetry_sender.ts
@@ -30,7 +30,7 @@ export interface TelemetrySender {
    * @param entries - The entries to send
    * @param distinctId - The user or repo UUID used as distinct_id
    * @param repoId - Optional repo UUID included as a property
-   * @param authToken - Optional API key used as Bearer token to authenticate the flush request
+   * @param authToken - Optional API key sent via x-api-key header to authenticate the flush request
    * @returns true if the batch was accepted, false otherwise
    */
   sendBatch(

--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -396,7 +396,7 @@ export class ExtensionApiClient {
   }
 
   private authHeaders(apiKey: string): Record<string, string> {
-    return { "Authorization": `Bearer ${apiKey}` };
+    return { "x-api-key": apiKey };
   }
 
   private async checkResponse(res: Response): Promise<void> {

--- a/src/infrastructure/http/extension_api_client_test.ts
+++ b/src/infrastructure/http/extension_api_client_test.ts
@@ -245,7 +245,7 @@ Deno.test("ExtensionApiClient.yankExtension sends POST with reason to version ya
   const server = Deno.serve({ port: 0, onListen: () => {} }, async (req) => {
     capturedUrl = req.url;
     capturedMethod = req.method;
-    capturedAuth = req.headers.get("authorization") ?? "";
+    capturedAuth = req.headers.get("x-api-key") ?? "";
     capturedBody = await req.text();
     return new Response(
       JSON.stringify({ message: "Yanked @test/ext@2026.02.26.1" }),
@@ -266,7 +266,7 @@ Deno.test("ExtensionApiClient.yankExtension sends POST with reason to version ya
     url.pathname,
     "/api/v1/extensions/%40test%2Fext@2026.02.26.1/yank",
   );
-  assertEquals(capturedAuth, "Bearer swamp_fake-key");
+  assertEquals(capturedAuth, "swamp_fake-key");
   assertEquals(JSON.parse(capturedBody).reason, "Security vulnerability");
   assertStringIncludes(result.message, "Yanked");
   await server.shutdown();

--- a/src/infrastructure/http/swamp_club_client.ts
+++ b/src/infrastructure/http/swamp_club_client.ts
@@ -113,12 +113,12 @@ export class SwampClubClient {
 
   /**
    * Call /api/whoami to verify identity.
-   * Accepts either a session token or an API key as a Bearer token.
+   * Authenticates using the x-api-key header.
    */
-  async whoami(token: string): Promise<WhoamiResponse> {
+  async whoami(apiKey: string): Promise<WhoamiResponse> {
     const res = await this.fetch("/api/whoami", {
       method: "GET",
-      headers: { "Authorization": `Bearer ${token}` },
+      headers: { "x-api-key": apiKey },
     });
 
     if (!res.ok) {

--- a/src/infrastructure/http/swamp_club_client_test.ts
+++ b/src/infrastructure/http/swamp_club_client_test.ts
@@ -149,16 +149,16 @@ Deno.test("SwampClubClient - throws UserError on connection failure", async () =
   );
 });
 
-Deno.test("SwampClubClient - sends Authorization Bearer header for whoami", async () => {
-  let capturedAuth = "";
+Deno.test("SwampClubClient - sends x-api-key header for whoami", async () => {
+  let capturedApiKey = "";
   const mock = startMockServer((req) => {
-    capturedAuth = req.headers.get("authorization") ?? "";
+    capturedApiKey = req.headers.get("x-api-key") ?? "";
     return Response.json({ authenticated: true, username: "u" });
   });
   try {
     const client = new SwampClubClient(`http://localhost:${mock.port}`);
     await client.whoami("my-api-key");
-    assertEquals(capturedAuth, "Bearer my-api-key");
+    assertEquals(capturedApiKey, "my-api-key");
   } finally {
     await mock.shutdown();
   }

--- a/src/infrastructure/telemetry/http_telemetry_sender.ts
+++ b/src/infrastructure/telemetry/http_telemetry_sender.ts
@@ -49,7 +49,7 @@ export class HttpTelemetrySender implements TelemetrySender {
     try {
       const headers: Record<string, string> = {
         "Content-Type": "application/json",
-        ...(authToken ? { "Authorization": `Bearer ${authToken}` } : {}),
+        ...(authToken ? { "x-api-key": authToken } : {}),
       };
 
       const response = await fetch(`${this.endpointUrl}/ingest`, {

--- a/src/infrastructure/telemetry/http_telemetry_sender_test.ts
+++ b/src/infrastructure/telemetry/http_telemetry_sender_test.ts
@@ -178,11 +178,11 @@ Deno.test("HttpTelemetrySender.sendBatch omits $repo_id when not provided", asyn
   await server.shutdown();
 });
 
-Deno.test("HttpTelemetrySender.sendBatch includes Authorization header when authToken provided", async () => {
-  let capturedAuthHeader: string | null = null;
+Deno.test("HttpTelemetrySender.sendBatch includes x-api-key header when authToken provided", async () => {
+  let capturedApiKey: string | null = null;
 
   const server = Deno.serve({ port: 0 }, async (req: Request) => {
-    capturedAuthHeader = req.headers.get("Authorization");
+    capturedApiKey = req.headers.get("x-api-key");
     await req.body?.cancel();
     return new Response(JSON.stringify({ accepted: 1 }), { status: 202 });
   });
@@ -202,16 +202,16 @@ Deno.test("HttpTelemetrySender.sendBatch includes Authorization header when auth
   );
 
   assertEquals(result, true);
-  assertEquals(capturedAuthHeader, "Bearer test-api-key-abc");
+  assertEquals(capturedApiKey, "test-api-key-abc");
 
   await server.shutdown();
 });
 
-Deno.test("HttpTelemetrySender.sendBatch omits Authorization header when authToken not provided", async () => {
-  let capturedAuthHeader: string | null = null;
+Deno.test("HttpTelemetrySender.sendBatch omits x-api-key header when authToken not provided", async () => {
+  let capturedApiKey: string | null = null;
 
   const server = Deno.serve({ port: 0 }, async (req: Request) => {
-    capturedAuthHeader = req.headers.get("Authorization");
+    capturedApiKey = req.headers.get("x-api-key");
     await req.body?.cancel();
     return new Response(JSON.stringify({ accepted: 1 }), { status: 202 });
   });
@@ -226,7 +226,7 @@ Deno.test("HttpTelemetrySender.sendBatch omits Authorization header when authTok
   const result = await sender.sendBatch([entry], "user-uuid-123");
 
   assertEquals(result, true);
-  assertEquals(capturedAuthHeader, null);
+  assertEquals(capturedApiKey, null);
 
   await server.shutdown();
 });


### PR DESCRIPTION
## Summary

- Switch all API key authentication from `Authorization: Bearer` to `x-api-key` header, reserving Bearer exclusively for the `createApiKey` call during login (session token auth)
- Reorder login flow to create the API key first, then verify identity with `whoami` using the new API key
- Update `ExtensionApiClient`, `HttpTelemetrySender`, and all related tests

Fixes #577

## Test Plan

- All 2586 existing tests pass
- `swamp_club_client_test.ts`: Verifies `whoami` sends `x-api-key` header
- `extension_api_client_test.ts`: Verifies yank sends `x-api-key` header
- `http_telemetry_sender_test.ts`: Verifies telemetry sends `x-api-key` header
- `deno check`, `deno lint`, `deno fmt --check` all pass
- `deno run compile` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)