### PR TITLE
fix: correct Kiro hook format and add USER_PROMPT env var support

### DIFF
--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -49,6 +49,21 @@ async function readStdin(): Promise<string> {
   return chunks.join("");
 }
 
+/**
+ * Reads hook input for the given tool.
+ *
+ * Kiro IDE passes postToolUse data via the USER_PROMPT environment variable
+ * rather than stdin. We check USER_PROMPT first for kiro, falling back to
+ * stdin for kiro-cli compatibility. All other tools read from stdin.
+ */
+function readHookInput(tool: HookTool): Promise<string> {
+  if (tool === "kiro") {
+    const envInput = Deno.env.get("USER_PROMPT");
+    if (envInput) return Promise.resolve(envInput);
+  }
+  return readStdin();
+}
+
 /** Valid values for the --tool option */
 const VALID_HOOK_TOOLS: HookTool[] = ["claude", "cursor", "kiro", "opencode"];
 
@@ -76,7 +91,7 @@ export const auditRecordCommand = new Command()
         return;
       }
 
-      const input = await readStdin();
+      const input = await readHookInput(tool);
       if (!input.trim()) {
         return;
       }

--- a/src/domain/audit/hook_input.ts
+++ b/src/domain/audit/hook_input.ts
@@ -141,23 +141,42 @@ function normalizeCursor(
 
 /**
  * Kiro: postToolUse hook (fires for both success and failure).
- * tool_name === "execute_bash", command from tool_input.command,
- * failure when tool_response.success === false.
+ *
+ * Supports two input formats:
+ * - kiro-cli (stdin, snake_case): tool_name, tool_input, tool_response
+ * - Kiro IDE (USER_PROMPT env var, camelCase): toolName, toolArgs, toolResult, toolSuccess
+ *
+ * tool_name/toolName === "execute_bash", command from tool_input/toolArgs,
+ * failure when tool_response.success === false or toolSuccess === false.
  */
 function normalizeKiro(
   raw: Record<string, unknown>,
 ): NormalizedHookInput | null {
-  if (raw.tool_name !== "execute_bash") return null;
+  // Support both kiro-cli (snake_case) and Kiro IDE (camelCase) field names
+  const toolName = (raw.tool_name ?? raw.toolName) as string | undefined;
+  if (toolName !== "execute_bash") return null;
 
-  const toolInput = raw.tool_input as { command?: string } | undefined;
+  const toolInput = (raw.tool_input ?? raw.toolArgs) as
+    | { command?: string }
+    | undefined;
   const command = toolInput?.command;
   if (!command) return null;
 
+  // kiro-cli format: tool_response.success / tool_response.error
   const toolResponse = raw.tool_response as
     | { success?: boolean; error?: string }
     | undefined;
-  const isFailure = toolResponse?.success === false;
-  const errorMessage = toolResponse?.error;
+  // Kiro IDE format: toolSuccess boolean, toolResult string
+  const toolSuccess = raw.toolSuccess as boolean | undefined;
+
+  const isFailure = toolResponse !== undefined
+    ? toolResponse.success === false
+    : toolSuccess !== undefined
+    ? !toolSuccess
+    : false;
+
+  const errorMessage = toolResponse?.error ??
+    (isFailure ? (raw.toolResult as string | undefined) : undefined);
 
   return {
     command,

--- a/src/domain/audit/hook_input_test.ts
+++ b/src/domain/audit/hook_input_test.ts
@@ -200,6 +200,57 @@ Deno.test("normalizeHookInput kiro: skips non-execute_bash tools", () => {
   assertEquals(result, null);
 });
 
+// ---- Kiro IDE (USER_PROMPT camelCase format) normalization ----
+
+Deno.test("normalizeHookInput kiro: normalizes Kiro IDE camelCase successful execute_bash", () => {
+  const result = normalizeHookInput("kiro", {
+    toolName: "execute_bash",
+    toolArgs: { command: "npm install" },
+    toolResult: "added 42 packages",
+    toolSuccess: true,
+  });
+
+  assertEquals(result, {
+    command: "npm install",
+    cwd: ".",
+    isFailure: false,
+  });
+});
+
+Deno.test("normalizeHookInput kiro: normalizes Kiro IDE camelCase failed execute_bash", () => {
+  const result = normalizeHookInput("kiro", {
+    toolName: "execute_bash",
+    toolArgs: { command: "npm test" },
+    toolResult: "tests failed with exit code 1",
+    toolSuccess: false,
+  });
+
+  assertEquals(result?.isFailure, true);
+  assertEquals(result?.errorMessage, "tests failed with exit code 1");
+});
+
+Deno.test("normalizeHookInput kiro: skips non-execute_bash Kiro IDE tools", () => {
+  const result = normalizeHookInput("kiro", {
+    toolName: "read",
+    toolArgs: { path: "/foo" },
+    toolResult: "file contents",
+    toolSuccess: true,
+  });
+
+  assertEquals(result, null);
+});
+
+Deno.test("normalizeHookInput kiro: returns null for Kiro IDE empty toolArgs", () => {
+  const result = normalizeHookInput("kiro", {
+    toolName: "execute_bash",
+    toolArgs: {},
+    toolResult: "",
+    toolSuccess: true,
+  });
+
+  assertEquals(result, null);
+});
+
 // ---- OpenCode normalization ----
 
 Deno.test("normalizeHookInput opencode: normalizes successful bash", () => {

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -991,7 +991,7 @@ ${body}`;
   }
 
   /**
-   * Generates the content for Kiro's .kiro/hooks/swamp-audit.json.
+   * Generates the content for Kiro's .kiro/hooks/swamp-audit.kiro.hook.
    * Uses the absolute path to the swamp binary because kiro-cli does not
    * perform PATH resolution when executing hook commands.
    */
@@ -1001,10 +1001,11 @@ ${body}`;
       name: "Swamp Audit",
       description: "Records agent tool usage for swamp audit tracking",
       version: "1",
-      when: { type: "postToolUse" },
+      when: { type: "postToolUse", toolTypes: ["*"] },
       then: {
         type: "runCommand",
         command: `"${swampBin}" audit record --from-hook --tool kiro`,
+        timeout: 5,
       },
     };
     return JSON.stringify(hook, null, 2) + "\n";
@@ -1033,12 +1034,17 @@ ${body}`;
   }
 
   /**
-   * Creates .kiro/hooks/swamp-audit.json if it doesn't already exist.
+   * Creates .kiro/hooks/swamp-audit.kiro.hook if it doesn't already exist.
    */
   private createKiroHooksIfNotExists(
     repoPath: RepoPath,
   ): Promise<boolean> {
-    const hookPath = join(repoPath.value, ".kiro", "hooks", "swamp-audit.json");
+    const hookPath = join(
+      repoPath.value,
+      ".kiro",
+      "hooks",
+      "swamp-audit.kiro.hook",
+    );
     return this.createFileIfNotExists(
       hookPath,
       this.generateKiroHookContent(),
@@ -1046,10 +1052,28 @@ ${body}`;
   }
 
   /**
-   * Updates .kiro/hooks/swamp-audit.json, always overwriting with latest content.
+   * Updates .kiro/hooks/swamp-audit.kiro.hook, always overwriting with latest content.
+   * Also removes the old swamp-audit.json hook file if it exists.
    */
-  private updateKiroHooks(repoPath: RepoPath): Promise<boolean> {
-    const hookPath = join(repoPath.value, ".kiro", "hooks", "swamp-audit.json");
+  private async updateKiroHooks(repoPath: RepoPath): Promise<boolean> {
+    // Remove old .json hook file if it exists
+    const oldHookPath = join(
+      repoPath.value,
+      ".kiro",
+      "hooks",
+      "swamp-audit.json",
+    );
+    try {
+      await Deno.remove(oldHookPath);
+    } catch {
+      // not found, ignore
+    }
+    const hookPath = join(
+      repoPath.value,
+      ".kiro",
+      "hooks",
+      "swamp-audit.kiro.hook",
+    );
     return this.overwriteIfChanged(hookPath, this.generateKiroHookContent());
   }
 

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -1346,7 +1346,7 @@ Deno.test("RepoService.upgrade with cursor updates hooks", async () => {
 
 // Kiro audit hook tests
 
-Deno.test("RepoService.init with kiro creates .kiro/hooks/swamp-audit.json", async () => {
+Deno.test("RepoService.init with kiro creates .kiro/hooks/swamp-audit.kiro.hook", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
@@ -1355,12 +1355,14 @@ Deno.test("RepoService.init with kiro creates .kiro/hooks/swamp-audit.json", asy
 
     assertEquals(result.settingsCreated, true);
 
-    const hookPath = join(tempDir, ".kiro", "hooks", "swamp-audit.json");
+    const hookPath = join(tempDir, ".kiro", "hooks", "swamp-audit.kiro.hook");
     const content = await Deno.readTextFile(hookPath);
     const hook = JSON.parse(content);
     assertEquals(hook.name, "Swamp Audit");
     assertEquals(hook.when.type, "postToolUse");
+    assertEquals(hook.when.toolTypes, ["*"]);
     assertEquals(hook.then.type, "runCommand");
+    assertEquals(hook.then.timeout, 5);
     assertStringIncludes(
       hook.then.command,
       "audit record --from-hook --tool kiro",
@@ -1389,13 +1391,51 @@ Deno.test("RepoService.upgrade with kiro updates hooks", async () => {
 
     assertEquals(result.tool, "kiro");
 
-    const hookPath = join(tempDir, ".kiro", "hooks", "swamp-audit.json");
+    const hookPath = join(
+      tempDir,
+      ".kiro",
+      "hooks",
+      "swamp-audit.kiro.hook",
+    );
     const content = await Deno.readTextFile(hookPath);
     const hook = JSON.parse(content);
     assertStringIncludes(
       hook.then.command,
       "audit record --from-hook --tool kiro",
     );
+  });
+});
+
+Deno.test("RepoService.upgrade with kiro removes old swamp-audit.json hook file", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath, { tool: "kiro" });
+
+    // Simulate an old hook file left from a previous version
+    const oldHookPath = join(tempDir, ".kiro", "hooks", "swamp-audit.json");
+    await Deno.writeTextFile(oldHookPath, "{}");
+
+    const upgradeService = new RepoService("0.2.0");
+    await upgradeService.upgrade(repoPath, { tool: "kiro" });
+
+    // Old .json hook file should be removed
+    await assertRejects(
+      () => Deno.stat(oldHookPath),
+      Deno.errors.NotFound,
+    );
+
+    // New .kiro.hook file should exist
+    const newHookPath = join(
+      tempDir,
+      ".kiro",
+      "hooks",
+      "swamp-audit.kiro.hook",
+    );
+    const content = await Deno.readTextFile(newHookPath);
+    const hook = JSON.parse(content);
+    assertEquals(hook.name, "Swamp Audit");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #581 — Kiro IDE does not recognize the swamp audit hook due to three issues, all addressed in this PR.

### 1. Hook file format
- **Wrong extension**: Kiro expects `.kiro.hook`, not `.json` — renamed `swamp-audit.json` → `swamp-audit.kiro.hook`
- **Missing `toolTypes`**: Kiro requires `toolTypes: ["*"]` in the `when` property — added
- **No timeout**: Added `timeout: 5` to the `then` property to prevent hangs as a safety net

### 2. Input mechanism — `USER_PROMPT` env var
Kiro IDE passes `postToolUse` data via the `USER_PROMPT` environment variable, **not** stdin. The `audit record` command was blocking on `readStdin()` which caused timeouts. The fix:
- For `--tool kiro`: check `USER_PROMPT` env var first, fall back to stdin (preserving kiro-cli compatibility)
- The Kiro IDE format uses camelCase keys (`toolName`, `toolArgs`, `toolResult`, `toolSuccess`) which differs from the kiro-cli snake_case format

### 3. Dual-format normalizer
Updated `normalizeKiro()` to handle both:
- **kiro-cli** (stdin, snake_case): `tool_name`, `tool_input`, `tool_response`
- **Kiro IDE** (`USER_PROMPT`, camelCase): `toolName`, `toolArgs`, `toolResult`, `toolSuccess`

### 4. Upgrade cleanup
`swamp repo upgrade --tool kiro` now removes the old `swamp-audit.json` file so stale hooks don't linger.

## Open question for @danmcclain

The `USER_PROMPT` env var format is based on Kiro's own description of its `postToolUse` data. Two things we'd appreciate verification on:

1. **Is `USER_PROMPT` valid JSON?** We parse it with `JSON.parse()` — if it's a different format, the hook will silently no-op (safe but won't record).
2. **Does `toolArgs` contain `{ command: "..." }` for `execute_bash` tools?** You noted it "appears to be empty `{}`" in your examples — if that's always the case, we won't be able to extract the command. Could you verify with your test hook on an `execute_bash` invocation?

## Files changed

| File | Change |
|------|--------|
| `src/domain/repo/repo_service.ts` | `.kiro.hook` extension, `toolTypes`, `timeout`, old file cleanup |
| `src/cli/commands/audit.ts` | `readHookInput()` with `USER_PROMPT` env var fallback |
| `src/domain/audit/hook_input.ts` | Dual-format `normalizeKiro()` |
| `src/domain/audit/hook_input_test.ts` | 4 new tests for Kiro IDE camelCase format |
| `src/domain/repo/repo_service_test.ts` | Updated hook format tests + old file cleanup test |

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] `deno run test` — 2605 tests pass (4 new)
- [x] `deno run compile` — binary builds
- [x] Manual test: `swamp repo init --tool kiro` creates `swamp-audit.kiro.hook` with correct format
- [ ] @danmcclain to verify with Kiro IDE that the hook appears and `USER_PROMPT` format works

🤖 Generated with [Claude Code](https://claude.com/claude-code)