### PR TITLE
fix: false update notification when current version is newer than cache

### DIFF
--- a/src/domain/update/update_notification_service.ts
+++ b/src/domain/update/update_notification_service.ts
@@ -84,9 +84,11 @@ export class UpdateNotificationService {
       }
     }
 
-    // Check cache for a known newer version
+    // Check cache for a known newer version.
+    // Use lexicographic comparison: CalVer versions (YYYYMMDD.HHMMSS.patch-sha.hash)
+    // are naturally sortable, so "greater than" means "newer than".
     const cache = await this.cacheRepository.read();
-    if (cache && cache.latestVersion !== this.currentVersion) {
+    if (cache && cache.latestVersion > this.currentVersion) {
       return {
         type: "update_available",
         currentVersion: this.currentVersion,

--- a/src/domain/update/update_notification_service_test.ts
+++ b/src/domain/update/update_notification_service_test.ts
@@ -118,6 +118,25 @@ Deno.test("getNotification returns update_available when cache has newer version
   });
 });
 
+Deno.test("getNotification returns null when current version is newer than cache", async () => {
+  // User updated via another channel (e.g. deno run compile) to a version
+  // newer than what the background check last cached.
+  const cache: UpdateCheckCacheData = {
+    latestVersion: "20260228.200442.0-sha.abc123",
+    checkedAt: new Date().toISOString(),
+  };
+  const cacheRepo = createMockCacheRepo(cache);
+  const checker = createMockChecker();
+  const service = new UpdateNotificationService(
+    "20260301.120000.0-sha.def456",
+    cacheRepo,
+    checker,
+  );
+
+  const result = await service.getNotification();
+  assertEquals(result, null);
+});
+
 Deno.test("getNotification returns null when cache matches current version", async () => {
   const version = "20260228.200442.0-sha.abc123";
   const cache: UpdateCheckCacheData = {


### PR DESCRIPTION
## Summary

- Fixed false "update available" notification that appeared on every command even when the user was already on the latest (or newer) version

## Root cause

The `UpdateNotificationService.getNotification()` method compared the cached latest version with the current running version using `!==` (not-equal). This meant **any** difference between the two triggered the notification — including when the user's version was *newer* than the cached value.

**Concrete scenario:** The background update check cached `latestVersion: "20260302.220424.0-sha.cc1fb239"`. The user then updated to `"20260303.151256.0-sha.471cac05"` (a newer build). On every subsequent command, the notification fired because `"20260302..." !== "20260303..."`, even though the user was ahead.

## Fix

Changed the comparison from `!==` (different) to `>` (lexicographically greater). Since CalVer versions (`YYYYMMDD.HHMMSS.patch-sha.hash`) are zero-padded and naturally sortable, the notification now only triggers when the cached version is genuinely **newer** than the running binary.

Added a test covering the "current version newer than cache" scenario.

## Test plan

- [x] `deno check` — passes
- [x] `deno lint` — passes  
- [x] `deno fmt` — passes
- [x] `deno run test` — all 79 update-related tests pass (1 new)
- [x] Verified: cached version `20260302...` < current version `20260303...` → no notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)