### PR TITLE
feat: add adversarial code review to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,140 @@ jobs:
             --model claude-opus-4-5-20251101
             --allowedTools Read,Glob,Grep,Bash(gh pr review:*),Bash(gh pr view:*),Bash(gh pr diff:*)
 
+  claude-adversarial-review:
+    name: Adversarial Code Review
+    needs: [test, deps-audit]
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    concurrency:
+      group: claude-adversarial-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Claude environment
+        run: |
+          mkdir -p ~/.claude
+
+      - name: Adversarial Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            You are an ADVERSARIAL code reviewer. Your job is to be the skeptic — assume
+            the code is broken until proven otherwise. You are not here to be helpful or
+            encouraging. You are here to find problems that the author and a standard
+            reviewer would miss.
+
+            First, read CLAUDE.md to understand the project's requirements and conventions.
+            Then read every changed file in this PR thoroughly.
+
+            Your review MUST systematically attempt to break the code across these dimensions:
+
+            ## 1. Logic & Correctness
+            - Trace every code path mentally. Are there unreachable branches? Wrong operators?
+              Off-by-one errors? Short-circuit evaluation that skips important side effects?
+            - What happens with empty arrays, empty strings, zero, negative numbers, NaN, undefined, null?
+            - Are there implicit type coercions that could produce surprising results?
+            - Do switch statements have missing cases or fallthrough bugs?
+            - Are comparisons correct? (=== vs ==, < vs <=, && vs ||)
+
+            ## 2. Error Handling & Failure Modes
+            - What happens when every external call fails? Network timeout? Disk full? Permission denied?
+            - Are errors caught and swallowed silently? Are error messages useful or misleading?
+            - Can a thrown error leave the system in an inconsistent state? (partial writes, leaked resources)
+            - Are try/catch blocks too broad, catching errors they shouldn't?
+            - Is cleanup code (finally blocks, resource disposal) actually correct?
+
+            ## 3. Security
+            - Command injection via string interpolation in shell commands or subprocess calls
+            - Path traversal — can user input escape intended directories?
+            - Sensitive data exposure in logs, error messages, or stack traces
+            - Prototype pollution, ReDoS, or other JS/TS-specific vulnerabilities
+            - Are secrets, tokens, or credentials ever hardcoded or logged?
+            - TOCTOU (time-of-check-time-of-use) race conditions on file operations
+
+            ## 4. Concurrency & State
+            - Can concurrent operations corrupt shared state?
+            - Are there race conditions in async code? (await ordering, Promise.all error handling)
+            - Could event handlers fire in an unexpected order?
+            - Are there potential deadlocks or starvation scenarios?
+
+            ## 5. Data Integrity
+            - Can data be silently truncated, rounded, or lost during transformation?
+            - Are array/object mutations happening where immutability is expected?
+            - Could cache staleness cause incorrect behavior?
+            - Are database/file operations atomic where they need to be?
+
+            ## 6. Resource Management
+            - Are file handles, network connections, or timers properly cleaned up on all paths?
+            - Could this code leak memory through growing collections, closures, or event listeners?
+            - Are there unbounded loops or recursion that could exhaust the stack or hang?
+
+            ## 7. API Contract Violations
+            - Does the PR change any function signatures, return types, or error types that callers depend on?
+            - Are there breaking changes to public interfaces without corresponding updates to callers?
+            - Do new functions follow the existing patterns in the codebase, or do they introduce inconsistencies?
+
+            ## Review Rules
+
+            - Be SPECIFIC. Don't say "this could have edge cases" — name the exact input that breaks it.
+            - Be CONCRETE. Don't say "error handling could be improved" — show the exact failure scenario.
+            - Every finding must include: the file and line, what's wrong, a concrete example of how it breaks,
+              and a suggested fix.
+            - Do NOT flag style issues, naming preferences, or documentation gaps. Those are not your job.
+            - Do NOT repeat findings from the standard Claude Code Review. Focus on what a normal review misses.
+            - If the code is genuinely solid, say so. Do not invent problems to justify your existence.
+
+            ## Severity Classification
+
+            - **CRITICAL**: Security vulnerabilities, data loss/corruption, or crashes in production paths.
+              These BLOCK the merge.
+            - **HIGH**: Logic errors that produce wrong results, resource leaks, or unhandled failure modes
+              in common paths. These BLOCK the merge.
+            - **MEDIUM**: Edge cases in uncommon paths, minor race conditions, or API contract concerns.
+              These are warnings but do NOT block.
+            - **LOW**: Theoretical issues that are unlikely in practice. Mention but do NOT block.
+
+            After reviewing, submit your review using ONE of these commands:
+
+            If there are NO critical or high severity findings:
+            ```
+            gh pr review ${{ github.event.pull_request.number }} --comment --body "your review here"
+            ```
+
+            If there ARE critical or high severity findings:
+            ```
+            gh pr review ${{ github.event.pull_request.number }} --request-changes --body "your review here"
+            ```
+
+            Format your review body as:
+            ## Adversarial Review
+
+            ### Critical / High (if any)
+            [numbered list with file:line, description, breaking example, suggested fix]
+
+            ### Medium (if any)
+            [numbered list]
+
+            ### Low (if any)
+            [numbered list]
+
+            ### Verdict
+            [PASS / FAIL with one-line summary]
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --model claude-opus-4-5-20251101
+            --allowedTools Read,Glob,Grep,Bash(gh pr review:*),Bash(gh pr view:*),Bash(gh pr diff:*)
+
   auto-merge:
     name: Auto-merge PR
-    needs: [test, deps-audit, claude-review]
+    needs: [test, deps-audit, claude-review, claude-adversarial-review]
     runs-on: ubuntu-latest
     # Only auto-merge PRs from the same repo (not forks) for security
     # Skip auto-merge if PR has the 'hold' label


### PR DESCRIPTION
## Summary

Adds a second Claude-powered code review step to the CI pipeline that acts as a devil's advocate — systematically attempting to break the code rather than just assessing its quality.

The existing "Claude Code Review" is a constructive reviewer that checks style, DDD, tests, and general quality. The new "Adversarial Code Review" is a skeptic whose job is to find problems that the author and a standard reviewer would miss.

## How it differs from the existing review

| Aspect | Existing Review | Adversarial Review |
|--------|----------------|-------------------|
| **Mindset** | Constructive colleague | Skeptic trying to break the code |
| **Scope** | Broad (style, DDD, tests, quality) | Deep (logic, security, failure modes) |
| **Style concerns** | Yes | Explicitly excluded |
| **DDD/architecture** | Yes | No — focuses on correctness |
| **Blocking bar** | Bugs, type errors, missing tests | Only CRITICAL/HIGH severity (security, data loss, logic errors) |
| **Pass action** | `--approve` (counts toward merge) | `--comment` (doesn't count as approval) |
| **Output format** | Free-form with categories | Structured severity levels + verdict |

The adversarial reviewer systematically attacks the code across 7 dimensions:
1. **Logic & Correctness** — off-by-one, wrong operators, edge case inputs
2. **Error Handling & Failure Modes** — swallowed errors, inconsistent state after failures
3. **Security** — command injection, path traversal, data exposure, TOCTOU
4. **Concurrency & State** — race conditions, async ordering, shared state corruption
5. **Data Integrity** — silent truncation, unexpected mutations, cache staleness
6. **Resource Management** — leaked handles, unbounded loops, memory leaks
7. **API Contract Violations** — breaking changes, signature mismatches

## Key design choices

1. **Runs in parallel** with the existing review (both `needs: [test, deps-audit]`) — no added wall-clock time to the pipeline
2. **Uses `--comment` when passing** instead of `--approve` — only the standard review grants approval, the adversarial reviewer never rubber-stamps
3. **Only blocks on CRITICAL/HIGH** — security vulnerabilities, data corruption, logic errors in production paths. Medium/Low findings are advisory warnings
4. **Demands concrete examples** — the prompt requires "name the exact input that breaks it" rather than vague warnings like "this could have edge cases"
5. **Explicit "don't invent problems"** instruction — if the code is solid, the reviewer must say so rather than manufacturing findings to justify its existence
6. **Auto-merge now requires both reviews** to pass before merging

## Test plan

- [ ] Open a PR with a deliberate bug (e.g., off-by-one error) and verify the adversarial review catches it
- [ ] Open a clean PR and verify the adversarial review passes with `--comment` (not `--approve`)
- [ ] Verify both reviews run in parallel (not sequentially)
- [ ] Verify auto-merge waits for both reviews to complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)