### PR TITLE
fix: validate user-defined vault providers and YAML configs at load time

### DIFF
--- a/src/domain/vaults/vault_config.ts
+++ b/src/domain/vaults/vault_config.ts
@@ -17,6 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { z } from "zod";
+
 /**
  * Unique identifier for a vault configuration.
  */
@@ -28,6 +30,17 @@ export type VaultConfigId = string;
 export function createVaultConfigId(id: string): VaultConfigId {
   return id;
 }
+
+/**
+ * Zod schema for validating vault configuration data loaded from YAML files.
+ */
+export const VaultConfigDataSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.string(),
+  config: z.record(z.string(), z.unknown()).default({}),
+  createdAt: z.string(),
+});
 
 /**
  * Data structure for vault configuration stored in YAML files.

--- a/src/domain/vaults/vault_service.ts
+++ b/src/domain/vaults/vault_service.ts
@@ -118,6 +118,7 @@ export class VaultService {
         }
       }
       provider = registeredType.createProvider(config.name, config.config);
+      assertVaultProvider(provider, config.type, config.name);
       this.providers.set(config.name, provider);
       return;
     }
@@ -288,6 +289,35 @@ export class VaultService {
       }
       // If no credentials, leave providers empty to trigger helpful error messages
     }
+  }
+}
+
+/**
+ * Validates that an object returned by a user-defined createProvider implements
+ * the VaultProvider interface. Throws a descriptive error if any required method
+ * is missing or not a function.
+ */
+function assertVaultProvider(
+  obj: unknown,
+  vaultType: string,
+  vaultName: string,
+): asserts obj is VaultProvider {
+  const required: (keyof VaultProvider)[] = ["get", "put", "list", "getName"];
+  const missing: string[] = [];
+  for (const method of required) {
+    if (
+      typeof obj !== "object" || obj === null ||
+      typeof (obj as Record<string, unknown>)[method] !== "function"
+    ) {
+      missing.push(method);
+    }
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `createProvider for vault type '${vaultType}' (vault '${vaultName}') returned an invalid provider: ` +
+        `missing methods: ${missing.join(", ")}. ` +
+        `A VaultProvider must implement get, put, list, and getName.`,
+    );
   }
 }
 

--- a/src/domain/vaults/vault_service_test.ts
+++ b/src/domain/vaults/vault_service_test.ts
@@ -27,6 +27,7 @@ import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { stringify as stringifyYaml } from "@std/yaml";
 import { VaultService } from "./vault_service.ts";
+import { vaultTypeRegistry } from "./vault_type_registry.ts";
 
 Deno.test("VaultService - missing vault configuration error handling", async (t) => {
   await t.step(
@@ -343,6 +344,102 @@ Deno.test("VaultService - basic functionality", async (t) => {
     const vaultNames = vaultService.getVaultNames();
     assertEquals(vaultNames, ["my-1p-vault"]);
   });
+});
+
+Deno.test("VaultService - rejects invalid provider from createProvider", async (t) => {
+  const testType = "@test/broken-provider";
+
+  await t.step(
+    "should throw when createProvider returns an empty object",
+    () => {
+      // Register a user-defined type that returns an invalid provider
+      if (!vaultTypeRegistry.has(testType)) {
+        vaultTypeRegistry.register({
+          type: testType,
+          name: "Broken Provider",
+          description: "Test broken provider",
+          isBuiltIn: false,
+          createProvider: () => ({}) as never,
+        });
+      }
+
+      const vaultService = new VaultService();
+      assertThrows(
+        () => {
+          vaultService.registerVault({
+            name: "broken-vault",
+            type: testType,
+            config: {},
+          });
+        },
+        Error,
+        "missing methods: get, put, list, getName",
+      );
+    },
+  );
+
+  await t.step(
+    "should throw when createProvider returns null",
+    () => {
+      const nullType = "@test/null-provider";
+      if (!vaultTypeRegistry.has(nullType)) {
+        vaultTypeRegistry.register({
+          type: nullType,
+          name: "Null Provider",
+          description: "Test null provider",
+          isBuiltIn: false,
+          createProvider: () => null as never,
+        });
+      }
+
+      const vaultService = new VaultService();
+      assertThrows(
+        () => {
+          vaultService.registerVault({
+            name: "null-vault",
+            type: nullType,
+            config: {},
+          });
+        },
+        Error,
+        "missing methods",
+      );
+    },
+  );
+
+  await t.step(
+    "should throw when createProvider returns partial implementation",
+    () => {
+      const partialType = "@test/partial-provider";
+      if (!vaultTypeRegistry.has(partialType)) {
+        vaultTypeRegistry.register({
+          type: partialType,
+          name: "Partial Provider",
+          description: "Test partial provider",
+          isBuiltIn: false,
+          createProvider: (name: string) =>
+            ({
+              get: (_key: string) => Promise.resolve("value"),
+              getName: () => name,
+              // missing put and list
+            }) as never,
+        });
+      }
+
+      const vaultService = new VaultService();
+      assertThrows(
+        () => {
+          vaultService.registerVault({
+            name: "partial-vault",
+            type: partialType,
+            config: {},
+          });
+        },
+        Error,
+        "missing methods: put, list",
+      );
+    },
+  );
 });
 
 Deno.test("VaultService - fromRepository auto-remaps renamed vault types", async (t) => {

--- a/src/infrastructure/persistence/yaml_vault_config_repository.ts
+++ b/src/infrastructure/persistence/yaml_vault_config_repository.ts
@@ -26,6 +26,7 @@ import { assertSafePath } from "./safe_path.ts";
 import {
   VaultConfig,
   type VaultConfigData,
+  VaultConfigDataSchema,
   type VaultConfigId,
 } from "../../domain/vaults/vault_config.ts";
 import type { EventBus } from "../../domain/events/event_bus.ts";
@@ -59,7 +60,7 @@ export class YamlVaultConfigRepository {
     const path = this.getPath(vaultType, id);
     try {
       const content = await Deno.readTextFile(path);
-      const data = parseYaml(content) as VaultConfigData;
+      const data = this.parseVaultConfig(content, path);
       return VaultConfig.fromData(data);
     } catch (error) {
       if (error instanceof Deno.errors.NotFound) {
@@ -82,7 +83,7 @@ export class YamlVaultConfigRepository {
         })
       ) {
         const content = await Deno.readTextFile(entry.path);
-        const data = parseYaml(content) as VaultConfigData;
+        const data = this.parseVaultConfig(content, entry.path);
         if (data.name === name) {
           return VaultConfig.fromData(data);
         }
@@ -111,7 +112,7 @@ export class YamlVaultConfigRepository {
         })
       ) {
         const content = await Deno.readTextFile(entry.path);
-        const data = parseYaml(content) as VaultConfigData;
+        const data = this.parseVaultConfig(content, entry.path);
         configs.push(VaultConfig.fromData(data));
       }
     } catch (error) {
@@ -139,7 +140,7 @@ export class YamlVaultConfigRepository {
         })
       ) {
         const content = await Deno.readTextFile(entry.path);
-        const data = parseYaml(content) as VaultConfigData;
+        const data = this.parseVaultConfig(content, entry.path);
         configs.push(VaultConfig.fromData(data));
       }
     } catch (error) {
@@ -260,5 +261,20 @@ export class YamlVaultConfigRepository {
    */
   private getPath(vaultType: string, id: VaultConfigId): string {
     return join(this.getTypeDir(vaultType), `${id}.yaml`);
+  }
+
+  /**
+   * Parses YAML content and validates it against the VaultConfigData schema.
+   * Throws a descriptive error if the YAML is malformed or missing required fields.
+   */
+  private parseVaultConfig(content: string, path: string): VaultConfigData {
+    const raw = parseYaml(content);
+    const result = VaultConfigDataSchema.safeParse(raw);
+    if (!result.success) {
+      throw new Error(
+        `Invalid vault config in ${path}: ${result.error.message}`,
+      );
+    }
+    return result.data;
   }
 }

--- a/src/infrastructure/persistence/yaml_vault_config_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_vault_config_repository_test.ts
@@ -17,7 +17,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertRejects } from "@std/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
 import { VaultConfig } from "../../domain/vaults/vault_config.ts";
 import { YamlVaultConfigRepository } from "./yaml_vault_config_repository.ts";
 
@@ -160,4 +162,96 @@ Deno.test("YamlVaultConfigRepository - findById works for namespaced type", asyn
   } finally {
     await Deno.remove(dir, { recursive: true });
   }
+});
+
+Deno.test("YamlVaultConfigRepository - rejects malformed YAML config", async (t) => {
+  await t.step("should reject YAML missing required 'id' field", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      const vaultDir = join(dir, ".swamp", "vault", "mock");
+      await ensureDir(vaultDir);
+      // Write YAML missing the 'id' field
+      await Deno.writeTextFile(
+        join(vaultDir, "bad.yaml"),
+        "name: bad-vault\ntype: mock\nconfig: {}\ncreatedAt: '2025-01-01T00:00:00Z'\n",
+      );
+
+      const repo = new YamlVaultConfigRepository(dir);
+      const error = await assertRejects(
+        () => repo.findAll(),
+        Error,
+      );
+      assertStringIncludes(error.message, "Invalid vault config");
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  await t.step(
+    "should reject YAML missing required 'name' field",
+    async () => {
+      const dir = await Deno.makeTempDir();
+      try {
+        const vaultDir = join(dir, ".swamp", "vault", "mock");
+        await ensureDir(vaultDir);
+        await Deno.writeTextFile(
+          join(vaultDir, "bad.yaml"),
+          "id: test-id\ntype: mock\nconfig: {}\ncreatedAt: '2025-01-01T00:00:00Z'\n",
+        );
+
+        const repo = new YamlVaultConfigRepository(dir);
+        const error = await assertRejects(
+          () => repo.findAll(),
+          Error,
+        );
+        assertStringIncludes(error.message, "Invalid vault config");
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
+    },
+  );
+
+  await t.step(
+    "should reject YAML with completely wrong structure",
+    async () => {
+      const dir = await Deno.makeTempDir();
+      try {
+        const vaultDir = join(dir, ".swamp", "vault", "mock");
+        await ensureDir(vaultDir);
+        await Deno.writeTextFile(
+          join(vaultDir, "bad.yaml"),
+          "just-a-string\n",
+        );
+
+        const repo = new YamlVaultConfigRepository(dir);
+        const error = await assertRejects(
+          () => repo.findAll(),
+          Error,
+        );
+        assertStringIncludes(error.message, "Invalid vault config");
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
+    },
+  );
+
+  await t.step("should default config to empty object if missing", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      const vaultDir = join(dir, ".swamp", "vault", "mock");
+      await ensureDir(vaultDir);
+      // Config field omitted - should default to {}
+      await Deno.writeTextFile(
+        join(vaultDir, "ok.yaml"),
+        "id: test-id\nname: ok-vault\ntype: mock\ncreatedAt: '2025-01-01T00:00:00Z'\n",
+      );
+
+      const repo = new YamlVaultConfigRepository(dir);
+      const configs = await repo.findAll();
+      assertEquals(configs.length, 1);
+      assertEquals(configs[0].name, "ok-vault");
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Addresses two findings from the [adversarial code review](https://github.com/systeminit/swamp/pull/578#pullrequestreview-3884609246) on the user-defined vault implementations PR (#578):

- **Runtime VaultProvider validation**: `createProvider()` return values are now checked for required methods (`get`, `put`, `list`, `getName`) before being registered. A broken user vault extension now fails immediately with a clear error listing the missing methods, instead of silently registering and crashing at runtime on first use.

- **YAML vault config schema validation**: Vault config files loaded from `.swamp/vault/` are now validated against a Zod schema (`VaultConfigDataSchema`) instead of being cast with `as VaultConfigData`. Malformed or corrupted YAML files (missing `id`, `name`, `type`, or `createdAt`) produce descriptive errors at load time. The `config` field defaults to `{}` if omitted.

## User Impact

**Improved error messages for vault extension authors:**
Previously, a user-defined vault with a broken `createProvider` (e.g., returning `null` or an object missing required methods) would silently register and only fail when a secret operation was attempted. Now it fails at registration time with a message like:

```
createProvider for vault type '@myorg/broken' (vault 'my-vault') returned an invalid provider:
missing methods: put, list. A VaultProvider must implement get, put, list, and getName.
```

**Improved resilience for corrupted vault configs:**
Previously, a corrupted `.swamp/vault/` YAML file (e.g., missing the `id` field) would cause an opaque runtime error deep in the call stack. Now it produces:

```
Invalid vault config in .swamp/vault/mock/bad.yaml: ...
```

**No breaking changes** — all existing vault configs and user-defined vault implementations continue to work identically. The `config` field now defaults to `{}` if omitted from YAML, which is more permissive than the previous behavior.

## Changes

| File | Change |
|------|--------|
| `src/domain/vaults/vault_service.ts` | Added `assertVaultProvider()` validation after `createProvider` call |
| `src/domain/vaults/vault_config.ts` | Added `VaultConfigDataSchema` Zod schema for YAML validation |
| `src/infrastructure/persistence/yaml_vault_config_repository.ts` | Replaced 4 raw `as VaultConfigData` casts with `parseVaultConfig()` schema validation |
| `src/domain/vaults/vault_service_test.ts` | 3 new tests: empty object, null, partial provider |
| `src/infrastructure/persistence/yaml_vault_config_repository_test.ts` | 4 new tests: missing id, missing name, wrong structure, config defaulting |

## Test plan

- [x] 2630 tests pass (7 new tests added)
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] `deno run compile` produces working binary
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)