### PR TITLE
fix: allow @swamp and @si namespaces for local extension models

### DIFF
--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -428,11 +428,6 @@ export class UserModelLoader {
   private validateUserNamespace(rawType: string): string | undefined {
     const normalized = ModelType.create(rawType).normalized;
 
-    // Check for reserved built-in namespaces
-    if (ModelType.isReservedNamespace(normalized)) {
-      return `Model type '${rawType}' uses a reserved namespace. User models cannot use 'swamp' or 'si' namespaces.`;
-    }
-
     // Must start with '@'
     if (!ModelType.isUserNamespace(normalized)) {
       return `Model type '${rawType}' must use '@' prefix. Expected format: @<namespace>/<name> (e.g., @myorg/my-model)`;

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -1805,7 +1805,7 @@ export const model = {
   });
 });
 
-Deno.test("UserModelLoader rejects reserved namespace swamp/*", async () => {
+Deno.test("UserModelLoader rejects unscoped swamp/* namespace (no @ prefix)", async () => {
   const modelCode = `
 import { z } from "npm:zod@4";
 
@@ -1837,11 +1837,11 @@ export const model = {
 
     assertEquals(result.loaded.length, 0);
     assertEquals(result.failed.length, 1);
-    assertStringIncludes(result.failed[0].error, "reserved namespace");
+    assertStringIncludes(result.failed[0].error, "must use '@' prefix");
   });
 });
 
-Deno.test("UserModelLoader rejects reserved namespace si/*", async () => {
+Deno.test("UserModelLoader rejects unscoped si/* namespace (no @ prefix)", async () => {
   const modelCode = `
 import { z } from "npm:zod@4";
 
@@ -1873,11 +1873,11 @@ export const model = {
 
     assertEquals(result.loaded.length, 0);
     assertEquals(result.failed.length, 1);
-    assertStringIncludes(result.failed[0].error, "reserved namespace");
+    assertStringIncludes(result.failed[0].error, "must use '@' prefix");
   });
 });
 
-Deno.test("UserModelLoader rejects reserved namespace @swamp/*", async () => {
+Deno.test("UserModelLoader allows @swamp/* namespace for local models", async () => {
   const modelCode = `
 import { z } from "npm:zod@4";
 
@@ -1903,17 +1903,17 @@ export const model = {
 };
 `;
 
-  await withTempModels({ "reserved_at_swamp.ts": modelCode }, async (dir) => {
+  await withTempModels({ "swamp_model.ts": modelCode }, async (dir) => {
     const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
-    assertEquals(result.loaded.length, 0);
-    assertEquals(result.failed.length, 1);
-    assertStringIncludes(result.failed[0].error, "reserved namespace");
+    assertEquals(result.failed.length, 0);
+    assertEquals(result.loaded.length, 1);
+    assertEquals(result.loaded[0], "swamp_model.ts");
   });
 });
 
-Deno.test("UserModelLoader rejects reserved namespace @si/*", async () => {
+Deno.test("UserModelLoader allows @si/* namespace for local models", async () => {
   const modelCode = `
 import { z } from "npm:zod@4";
 
@@ -1939,13 +1939,13 @@ export const model = {
 };
 `;
 
-  await withTempModels({ "reserved_at_si.ts": modelCode }, async (dir) => {
+  await withTempModels({ "si_model.ts": modelCode }, async (dir) => {
     const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
-    assertEquals(result.loaded.length, 0);
-    assertEquals(result.failed.length, 1);
-    assertStringIncludes(result.failed[0].error, "reserved namespace");
+    assertEquals(result.failed.length, 0);
+    assertEquals(result.loaded.length, 1);
+    assertEquals(result.loaded[0], "si_model.ts");
   });
 });
 


### PR DESCRIPTION
## Summary

- Local extension models using `@swamp/*` or `@si/*` namespaces were incorrectly rejected during loading with "uses a reserved namespace" errors
- Removed the reserved namespace check from the user model loader — users should be free to use any `@`-prefixed namespace locally since we don't enforce namespace ownership on publish
- The extension manifest validation (for `extension push`) still blocks publishing under `@swamp` or `@si`

## Test plan

- [x] Updated 4 tests: `swamp/*` and `si/*` (no `@`) now check for "must use '@' prefix" error; `@swamp/*` and `@si/*` now expect successful loading
- [x] All 39 user model loader tests pass
- [x] All 80 extension tests pass (manifest still enforces reserved namespaces for publishing)
- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno run compile` produces working binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)