### PR TITLE
feat: validate extension content namespaces during push

### DIFF
--- a/integration/extension_push_test.ts
+++ b/integration/extension_push_test.ts
@@ -245,7 +245,7 @@ Deno.test("extension push --dry-run archives multiple workflows with unique name
 
     const wf1Content = stringifyYaml({
       id: "a0a0a0a0-1111-4111-a111-111111111111",
-      name: "alpha-workflow",
+      name: "@test/alpha-workflow",
       version: 1,
       jobs: [{
         name: "main",
@@ -265,7 +265,7 @@ Deno.test("extension push --dry-run archives multiple workflows with unique name
     });
     const wf2Content = stringifyYaml({
       id: "b0b0b0b0-2222-4222-b222-222222222222",
-      name: "beta-workflow",
+      name: "@test/beta-workflow",
       version: 1,
       jobs: [{
         name: "main",
@@ -285,7 +285,7 @@ Deno.test("extension push --dry-run archives multiple workflows with unique name
     });
     const wf3Content = stringifyYaml({
       id: "c0c0c0c0-3333-4333-b333-333333333333",
-      name: "gamma-workflow",
+      name: "@test/gamma-workflow",
       version: 1,
       jobs: [{
         name: "main",
@@ -677,7 +677,7 @@ Deno.test("extension push --dry-run resolves workflows from extensions/workflows
       join(extWfDir, "ext-wf.yaml"),
       stringifyYaml({
         id: "d0d0d0d0-4444-4444-a444-444444444444",
-        name: "ext-wf",
+        name: "@test/ext-wf",
         version: 1,
         jobs: [{
           name: "main",

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -39,11 +39,13 @@ import {
   renderExtensionPushCancelled,
   renderExtensionPushCompilationErrors,
   renderExtensionPushDryRun,
+  renderExtensionPushNamespaceErrors,
   renderExtensionPushQualityErrors,
   renderExtensionPushResolved,
   renderExtensionPushSafetyErrors,
   renderExtensionPushSafetyWarnings,
 } from "../../presentation/output/extension_push_output.ts";
+import { validateContentNamespaces } from "../../domain/extensions/extension_namespace_validator.ts";
 
 interface ExtensionPushOptions extends GlobalOptions {
   repoDir: string;
@@ -151,6 +153,27 @@ export const extensionPushCommand = new Command()
         .debug`Extracted content metadata: ${contentMetadata.models.length} models, ${contentMetadata.workflows.length} workflows, ${contentMetadata.vaults.length} vaults`;
     } catch {
       ctx.logger.debug`Content metadata extraction failed, skipping`;
+    }
+
+    // 9c. Validate content namespaces
+    if (contentMetadata) {
+      const namespaceResult = validateContentNamespaces(
+        manifest.name,
+        contentMetadata,
+      );
+      if (!namespaceResult.valid) {
+        const slashIndex = manifest.name.indexOf("/");
+        const expectedNamespace = manifest.name.slice(0, slashIndex + 1);
+        renderExtensionPushNamespaceErrors(
+          expectedNamespace,
+          namespaceResult.mismatches,
+          ctx.outputMode,
+        );
+        throw new UserError(
+          "Extension content uses namespaces that don't match the extension package. " +
+            "All model types, vault types, and workflow names must use the same namespace as the extension.",
+        );
+      }
     }
 
     // 10. Show resolved bundle contents (use extracted metadata for richer display)

--- a/src/domain/extensions/extension_content.ts
+++ b/src/domain/extensions/extension_content.ts
@@ -75,6 +75,7 @@ export interface ExtractedWorkflowJob {
 
 /** Metadata extracted from a single workflow YAML file. */
 export interface ExtractedWorkflow {
+  fileName: string;
   id: string;
   name: string;
   description: string;

--- a/src/domain/extensions/extension_content_extractor.ts
+++ b/src/domain/extensions/extension_content_extractor.ts
@@ -67,7 +67,7 @@ export async function extractContentMetadata(
   for (const wf of workflowFiles) {
     try {
       const content = await Deno.readTextFile(wf.sourcePath);
-      const workflow = extractWorkflowFromYaml(content);
+      const workflow = extractWorkflowFromYaml(content, wf.archiveName);
       if (workflow) {
         workflows.push(workflow);
       }
@@ -513,7 +513,10 @@ function extractFiles(content: string): ExtractedFile[] {
  * Extracts workflow metadata from a YAML file content.
  * Returns null if the content doesn't contain a valid workflow structure.
  */
-function extractWorkflowFromYaml(content: string): ExtractedWorkflow | null {
+function extractWorkflowFromYaml(
+  content: string,
+  fileName: string,
+): ExtractedWorkflow | null {
   const parsed = parseYaml(content);
   if (!parsed || typeof parsed !== "object") return null;
 
@@ -576,7 +579,7 @@ function extractWorkflowFromYaml(content: string): ExtractedWorkflow | null {
     }
   }
 
-  return { id, name, description, jobs };
+  return { fileName, id, name, description, jobs };
 }
 
 /**

--- a/src/domain/extensions/extension_content_extractor_test.ts
+++ b/src/domain/extensions/extension_content_extractor_test.ts
@@ -369,6 +369,7 @@ Deno.test("extractContentMetadata parses workflow YAML", async () => {
       [{ sourcePath: wfFile, archiveName: "workflow.yaml" }],
     );
     assertEquals(result.workflows.length, 1);
+    assertEquals(result.workflows[0].fileName, "workflow.yaml");
     assertEquals(result.workflows[0].id, "abc-123");
     assertEquals(result.workflows[0].name, "test-workflow");
     assertEquals(result.workflows[0].description, "A test workflow");
@@ -448,6 +449,7 @@ Deno.test("extractContentMetadata parses workflow with multiple jobs and steps",
       tmpDir,
       [{ sourcePath: wfFile, archiveName: "multi.yaml" }],
     );
+    assertEquals(result.workflows[0].fileName, "multi.yaml");
     assertEquals(result.workflows[0].jobs.length, 2);
     assertEquals(result.workflows[0].jobs[0].steps.length, 1);
     assertEquals(result.workflows[0].jobs[1].steps.length, 2);
@@ -522,6 +524,7 @@ Deno.test("extractContentMetadata skips unparseable files gracefully", async () 
     assertEquals(result.models.length, 1);
     assertEquals(result.models[0].type, "test/good");
     assertEquals(result.workflows.length, 1);
+    assertEquals(result.workflows[0].fileName, "good.yaml");
     assertEquals(result.workflows[0].name, "good-workflow");
   } finally {
     await Deno.remove(tmpDir, { recursive: true });

--- a/src/domain/extensions/extension_namespace_validator.ts
+++ b/src/domain/extensions/extension_namespace_validator.ts
@@ -1,0 +1,88 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ExtensionContentMetadata } from "./extension_content.ts";
+
+/** A single content item whose namespace doesn't match the extension's namespace. */
+export interface NamespaceMismatch {
+  kind: "model" | "vault" | "workflow";
+  identifier: string;
+  fileName: string;
+}
+
+/** Result of validating content namespaces against the extension namespace. */
+export interface NamespaceValidationResult {
+  valid: boolean;
+  mismatches: NamespaceMismatch[];
+}
+
+/**
+ * Validates that all content items (models, vaults, workflows) in an extension
+ * use the same namespace as the extension package itself.
+ *
+ * For example, if the extension is `@stack72/my-extension`, all model types,
+ * vault types, and workflow names must start with `@stack72/`.
+ */
+export function validateContentNamespaces(
+  extensionName: string,
+  contentMetadata: ExtensionContentMetadata,
+): NamespaceValidationResult {
+  const slashIndex = extensionName.indexOf("/");
+  if (slashIndex === -1) {
+    return { valid: true, mismatches: [] };
+  }
+  const namespacePrefix = extensionName.slice(0, slashIndex + 1);
+
+  const mismatches: NamespaceMismatch[] = [];
+
+  for (const model of contentMetadata.models) {
+    if (!model.type.startsWith(namespacePrefix)) {
+      mismatches.push({
+        kind: "model",
+        identifier: model.type,
+        fileName: model.fileName,
+      });
+    }
+  }
+
+  for (const vault of contentMetadata.vaults) {
+    if (!vault.type.startsWith(namespacePrefix)) {
+      mismatches.push({
+        kind: "vault",
+        identifier: vault.type,
+        fileName: vault.fileName,
+      });
+    }
+  }
+
+  for (const workflow of contentMetadata.workflows) {
+    if (!workflow.name.startsWith(namespacePrefix)) {
+      mismatches.push({
+        kind: "workflow",
+        identifier: workflow.name,
+        fileName: workflow.fileName,
+      });
+    }
+  }
+
+  return {
+    valid: mismatches.length === 0,
+    mismatches,
+  };
+}

--- a/src/domain/extensions/extension_namespace_validator_test.ts
+++ b/src/domain/extensions/extension_namespace_validator_test.ts
@@ -1,0 +1,257 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import type { ExtensionContentMetadata } from "./extension_content.ts";
+import { validateContentNamespaces } from "./extension_namespace_validator.ts";
+
+function makeMetadata(
+  overrides: Partial<ExtensionContentMetadata> = {},
+): ExtensionContentMetadata {
+  return {
+    models: [],
+    workflows: [],
+    vaults: [],
+    ...overrides,
+  };
+}
+
+Deno.test("validateContentNamespaces — all content matches namespace — valid", () => {
+  const result = validateContentNamespaces(
+    "@stack72/my-extension",
+    makeMetadata({
+      models: [{
+        fileName: "echo.ts",
+        type: "@stack72/echo",
+        version: "2026.03.01.1",
+        globalArguments: [],
+        methods: [],
+        resources: [],
+        files: [],
+      }],
+      vaults: [{
+        fileName: "vault.ts",
+        type: "@stack72/my-vault",
+        name: "My Vault",
+        description: "A vault",
+        hasConfigSchema: false,
+        configFields: [],
+      }],
+      workflows: [{
+        fileName: "workflow.yaml",
+        id: "wf-1",
+        name: "@stack72/my-workflow",
+        description: "A workflow",
+        jobs: [],
+      }],
+    }),
+  );
+  assertEquals(result.valid, true);
+  assertEquals(result.mismatches.length, 0);
+});
+
+Deno.test("validateContentNamespaces — model type with wrong namespace — mismatch", () => {
+  const result = validateContentNamespaces(
+    "@stack72/my-extension",
+    makeMetadata({
+      models: [{
+        fileName: "echo.ts",
+        type: "@evil/echo",
+        version: "2026.03.01.1",
+        globalArguments: [],
+        methods: [],
+        resources: [],
+        files: [],
+      }],
+    }),
+  );
+  assertEquals(result.valid, false);
+  assertEquals(result.mismatches.length, 1);
+  assertEquals(result.mismatches[0].kind, "model");
+  assertEquals(result.mismatches[0].identifier, "@evil/echo");
+  assertEquals(result.mismatches[0].fileName, "echo.ts");
+});
+
+Deno.test("validateContentNamespaces — model type without @ prefix — mismatch", () => {
+  const result = validateContentNamespaces(
+    "@stack72/my-extension",
+    makeMetadata({
+      models: [{
+        fileName: "instance.ts",
+        type: "aws/ec2",
+        version: "2026.03.01.1",
+        globalArguments: [],
+        methods: [],
+        resources: [],
+        files: [],
+      }],
+    }),
+  );
+  assertEquals(result.valid, false);
+  assertEquals(result.mismatches.length, 1);
+  assertEquals(result.mismatches[0].kind, "model");
+  assertEquals(result.mismatches[0].identifier, "aws/ec2");
+});
+
+Deno.test("validateContentNamespaces — vault type with wrong namespace — mismatch", () => {
+  const result = validateContentNamespaces(
+    "@stack72/my-extension",
+    makeMetadata({
+      vaults: [{
+        fileName: "vault.ts",
+        type: "@other/vault",
+        name: "Other Vault",
+        description: "Wrong namespace",
+        hasConfigSchema: false,
+        configFields: [],
+      }],
+    }),
+  );
+  assertEquals(result.valid, false);
+  assertEquals(result.mismatches.length, 1);
+  assertEquals(result.mismatches[0].kind, "vault");
+  assertEquals(result.mismatches[0].identifier, "@other/vault");
+});
+
+Deno.test("validateContentNamespaces — workflow name with wrong namespace — mismatch", () => {
+  const result = validateContentNamespaces(
+    "@stack72/my-extension",
+    makeMetadata({
+      workflows: [{
+        fileName: "wf.yaml",
+        id: "wf-1",
+        name: "@swamp/reserved-workflow",
+        description: "Wrong namespace",
+        jobs: [],
+      }],
+    }),
+  );
+  assertEquals(result.valid, false);
+  assertEquals(result.mismatches.length, 1);
+  assertEquals(result.mismatches[0].kind, "workflow");
+  assertEquals(result.mismatches[0].identifier, "@swamp/reserved-workflow");
+});
+
+Deno.test("validateContentNamespaces — workflow name without namespace prefix — mismatch", () => {
+  const result = validateContentNamespaces(
+    "@stack72/my-extension",
+    makeMetadata({
+      workflows: [{
+        fileName: "plain.yaml",
+        id: "wf-2",
+        name: "plain-workflow",
+        description: "No namespace",
+        jobs: [],
+      }],
+    }),
+  );
+  assertEquals(result.valid, false);
+  assertEquals(result.mismatches.length, 1);
+  assertEquals(result.mismatches[0].kind, "workflow");
+  assertEquals(result.mismatches[0].identifier, "plain-workflow");
+});
+
+Deno.test("validateContentNamespaces — mixed mismatches — all collected", () => {
+  const result = validateContentNamespaces(
+    "@stack72/my-extension",
+    makeMetadata({
+      models: [
+        {
+          fileName: "good.ts",
+          type: "@stack72/good-model",
+          version: "2026.03.01.1",
+          globalArguments: [],
+          methods: [],
+          resources: [],
+          files: [],
+        },
+        {
+          fileName: "bad.ts",
+          type: "@evil/bad-model",
+          version: "2026.03.01.1",
+          globalArguments: [],
+          methods: [],
+          resources: [],
+          files: [],
+        },
+      ],
+      vaults: [{
+        fileName: "vault.ts",
+        type: "@other/vault",
+        name: "Other",
+        description: "Wrong",
+        hasConfigSchema: false,
+        configFields: [],
+      }],
+      workflows: [{
+        fileName: "wf.yaml",
+        id: "wf-1",
+        name: "no-namespace",
+        description: "Missing namespace",
+        jobs: [],
+      }],
+    }),
+  );
+  assertEquals(result.valid, false);
+  assertEquals(result.mismatches.length, 3);
+  assertEquals(result.mismatches[0].kind, "model");
+  assertEquals(result.mismatches[1].kind, "vault");
+  assertEquals(result.mismatches[2].kind, "workflow");
+});
+
+Deno.test("validateContentNamespaces — empty content — valid", () => {
+  const result = validateContentNamespaces(
+    "@stack72/my-extension",
+    makeMetadata(),
+  );
+  assertEquals(result.valid, true);
+  assertEquals(result.mismatches.length, 0);
+});
+
+Deno.test("validateContentNamespaces — partial mismatches — only wrong ones reported", () => {
+  const result = validateContentNamespaces(
+    "@stack72/my-extension",
+    makeMetadata({
+      models: [
+        {
+          fileName: "good.ts",
+          type: "@stack72/good",
+          version: "2026.03.01.1",
+          globalArguments: [],
+          methods: [],
+          resources: [],
+          files: [],
+        },
+        {
+          fileName: "bad.ts",
+          type: "@swamp/squatted",
+          version: "2026.03.01.1",
+          globalArguments: [],
+          methods: [],
+          resources: [],
+          files: [],
+        },
+      ],
+    }),
+  );
+  assertEquals(result.valid, false);
+  assertEquals(result.mismatches.length, 1);
+  assertEquals(result.mismatches[0].identifier, "@swamp/squatted");
+  assertEquals(result.mismatches[0].fileName, "bad.ts");
+});

--- a/src/presentation/output/extension_push_output.ts
+++ b/src/presentation/output/extension_push_output.ts
@@ -22,6 +22,7 @@ import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 import type { SafetyIssue } from "../../domain/extensions/extension_safety_analyzer.ts";
 import type { QualityIssue } from "../../domain/extensions/extension_quality_checker.ts";
 import type { ExtractedArgument } from "../../domain/extensions/extension_content.ts";
+import type { NamespaceMismatch } from "../../domain/extensions/extension_namespace_validator.ts";
 
 const logger = getSwampLogger(["extension", "push"]);
 
@@ -172,6 +173,31 @@ export function renderExtensionPushSafetyErrors(
     logger.error`Safety errors (push blocked):`;
     for (const e of errors) {
       logger.error`  ${e.file}: ${e.message}`;
+    }
+  }
+}
+
+/**
+ * Renders namespace mismatch errors.
+ */
+export function renderExtensionPushNamespaceErrors(
+  expectedNamespace: string,
+  mismatches: NamespaceMismatch[],
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(
+      JSON.stringify(
+        { namespaceErrors: { expectedNamespace, mismatches } },
+        null,
+        2,
+      ),
+    );
+  } else {
+    logger.error`Namespace errors (push blocked):`;
+    logger.error`  All content must use namespace "${expectedNamespace}"`;
+    for (const m of mismatches) {
+      logger.error`  ${m.kind}: "${m.identifier}" in ${m.fileName}`;
     }
   }
 }


### PR DESCRIPTION
Fixes: #594

## Summary

Prevents namespace squatting by validating that all content items (models, vaults, workflows) inside an extension use the same namespace as the extension package itself during `extension push`.

### Why this matters

Previously, `extension push` only validated the manifest `name` field against reserved namespaces (`@swamp`, `@si`) and the authenticated user. But models, vaults, and workflows inside the extension could claim any namespace — e.g., a model with type `@swamp/echo` inside `@stack72/my-extension`. This is a namespace squatting risk that could allow:

- **Impersonation**: An extension under `@stack72/` could register model types under `@swamp/` or `@si/`, making them appear official
- **Namespace pollution**: Content could use arbitrary namespaces like `aws/ec2` without any `@` prefix at all
- **User spoofing**: An extension under `@stack72/` could register content under `@eviluser/`, squatting on another user's namespace

### How it works

A new domain validation function `validateContentNamespaces()` runs after content metadata extraction during push. It extracts the namespace prefix from the extension name (e.g., `@stack72/` from `@stack72/my-extension`) and checks that every:

- **Model type** starts with the prefix
- **Vault type** starts with the prefix
- **Workflow name** starts with the prefix

Validation runs after the manifest name may have been rewritten to match the authenticated user (when the user accepts the namespace correction prompt), so it always checks against the correct namespace.

## Changes

- **NEW** `src/domain/extensions/extension_namespace_validator.ts` — Pure domain function with `NamespaceMismatch` and `NamespaceValidationResult` types
- **NEW** `src/domain/extensions/extension_namespace_validator_test.ts` — 9 unit tests (pure function, no filesystem)
- **MODIFIED** `src/domain/extensions/extension_content.ts` — Added `fileName` to `ExtractedWorkflow` for error reporting
- **MODIFIED** `src/domain/extensions/extension_content_extractor.ts` — Populates `fileName` on workflows using `archiveName`
- **MODIFIED** `src/presentation/output/extension_push_output.ts` — Added `renderExtensionPushNamespaceErrors()` for both log and JSON output modes
- **MODIFIED** `src/cli/commands/extension_push.ts` — Inserted validation step (9c) after content metadata extraction
- **MODIFIED** `src/domain/extensions/extension_content_extractor_test.ts` — Updated 3 workflow tests for new `fileName` field
- **MODIFIED** `integration/extension_push_test.ts` — Updated 4 workflow names in 2 integration tests to use `@test/` namespace prefix

## Test scenarios

All scenarios were verified end-to-end with `extension push --dry-run` against a real compiled binary, authenticated as `@stack72`:

| # | Scenario | Expected | Result |
|---|----------|----------|--------|
| 1 | All content uses `@stack72/` (model + vault + workflow) | Pass | Dry run complete |
| 2 | Model squats `@swamp/sneaky-model` | Block | `model: "@swamp/sneaky-model" in bad-squatter.ts` |
| 3 | Model uses `aws/ec2` (no `@` prefix) | Block | `model: "aws/ec2" in bad-no-namespace.ts` |
| 4 | Vault squats `@si/stolen-vault` | Block | `vault: "@si/stolen-vault" in bad-vault.ts` |
| 5 | Workflow uses `no-namespace-workflow` (no prefix) | Block | `workflow: "no-namespace-workflow" in bad-wf.yaml` |
| 6 | Mixed: wrong model + wrong vault + wrong workflow | Block | All 3 mismatches reported together |
| 7 | Same as #6 with `--json` output | Block | Structured JSON with `namespaceErrors` object |

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt` — formatting passes
- [x] `deno run test` — all 2667 tests pass (0 failed)
- [x] `deno run compile` — binary compiles
- [x] E2E dry-run scenarios verified against compiled binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)