### PR TITLE
fix: use index-based naming for forEach over object arrays with static step names

### DIFF
--- a/integration/foreach_test.ts
+++ b/integration/foreach_test.ts
@@ -610,6 +610,127 @@ Deno.test("CLI: workflow with forEach step depending on another forEach step", a
   });
 });
 
+// forEach with object items and static step name (no expression)
+
+Deno.test("CLI: workflow with forEach over object array and static step name uses index-based naming", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+    await createShellModel(repoDir, "test-model");
+
+    // forEach over an array of objects with a static step name (no ${{ }} expression)
+    // This should use index-based naming instead of [object Object]
+    const workflowData = {
+      id: crypto.randomUUID(),
+      name: "test-foreach-object-items-static",
+      version: 1,
+      inputs: {
+        properties: {
+          servers: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                host: { type: "string" },
+                port: { type: "number" },
+              },
+            },
+          },
+        },
+        required: ["servers"],
+      },
+      jobs: [
+        {
+          name: "deploy-job",
+          steps: [
+            {
+              name: "deploy-server",
+              forEach: {
+                item: "server",
+                in: "${{ inputs.servers }}",
+              },
+              task: {
+                type: "model_method",
+                modelIdOrName: "test-model",
+                methodName: "execute",
+              },
+              dependsOn: [],
+              weight: 0,
+            },
+          ],
+          dependsOn: [],
+          weight: 0,
+        },
+      ],
+    };
+
+    const workflowDir = join(repoDir, ".swamp/workflows");
+    await ensureDir(workflowDir);
+    await Deno.writeTextFile(
+      join(workflowDir, `workflow-${workflowData.id}.yaml`),
+      stringifyYaml(workflowData as Record<string, unknown>),
+    );
+
+    const result = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "test-foreach-object-items-static",
+        "--repo-dir",
+        repoDir,
+        "--input",
+        '{"servers": [{"host": "web1.example.com", "port": 8080}, {"host": "web2.example.com", "port": 8081}, {"host": "web3.example.com", "port": 8082}]}',
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Should succeed (no cyclic dependency error). stderr: ${result.stderr}`,
+    );
+
+    const output = JSON.parse(result.stdout);
+    const job = output.jobs?.find(
+      (j: { name: string }) => j.name === "deploy-job",
+    );
+
+    const steps = job?.steps as { name: string; status: string }[];
+
+    // Filter to expanded steps only (the index-suffixed ones)
+    const expandedSteps = steps.filter(
+      (s) => /^deploy-server-\d+$/.test(s.name),
+    );
+
+    // Should have 3 expanded steps with index-based suffixes
+    assertEquals(
+      expandedSteps.length,
+      3,
+      `Expected 3 expanded steps, got ${expandedSteps.length}: ${
+        JSON.stringify(steps.map((s) => s.name))
+      }`,
+    );
+
+    const expandedNames = expandedSteps.map((s) => s.name);
+    for (let i = 0; i < 3; i++) {
+      assertEquals(
+        expandedNames.includes(`deploy-server-${i}`),
+        true,
+        `Missing deploy-server-${i}, got: ${JSON.stringify(expandedNames)}`,
+      );
+    }
+
+    // All expanded steps should succeed
+    for (const step of expandedSteps) {
+      assertEquals(
+        step.status,
+        "succeeded",
+        `Expected ${step.name} to succeed but got ${step.status}`,
+      );
+    }
+  });
+});
+
 // Mixed forEach and regular steps
 
 Deno.test("CLI: workflow with mixed forEach and regular steps", async () => {

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { getLogger } from "@logtape/logtape";
 import { Workflow, type WorkflowInput } from "./workflow.ts";
 import type { Job } from "./job.ts";
 import type { Step } from "./step.ts";
@@ -1059,7 +1060,8 @@ export class WorkflowExecutionService {
 
       if (Array.isArray(items)) {
         // Array iteration: self.{item} = item value
-        for (const item of items) {
+        for (let index = 0; index < items.length; index++) {
+          const item = items[index];
           // Evaluate the step name with the forEach context
           const stepContext = {
             ...context,
@@ -1077,7 +1079,19 @@ export class WorkflowExecutionService {
             expandedName = step.name.replace(nameMatch[0], String(value));
           } else if (!nameHasExpression) {
             // Step name has no expression template — append item value for uniqueness
-            expandedName = `${step.name}-${String(item)}`;
+            if (
+              item !== null && typeof item === "object"
+            ) {
+              // Objects/arrays stringify to "[object Object]" which causes duplicate names
+              expandedName = `${step.name}-${index}`;
+              getLogger(["swamp", "workflows"]).warn(
+                "forEach step '{stepName}' uses index-based naming because item is an object. " +
+                  "Consider adding a ${{{{ self.{itemName}.<field> }}}} expression to the step name for better observability.",
+                { stepName: step.name, itemName },
+              );
+            } else {
+              expandedName = `${step.name}-${String(item)}`;
+            }
           }
 
           expandedSteps.push({


### PR DESCRIPTION
## Summary

Fixes #597

- When a `forEach` iterates over an array of objects and the step name has no `${{ }}` expression, the fallback naming used `String(item)` which produced `[object Object]` for every item — all expanded steps got identical names, causing the topological sort to report a spurious cyclic dependency error
- Now detects object/array items in the fallback path and uses index-based suffixes (`step-0`, `step-1`, ...) instead. Scalar items (strings, numbers, booleans) keep the existing `String(item)` behavior
- Logs a warning when falling back to index-based naming, suggesting the user add a `${{ self.<item>.<field> }}` expression to the step name for better observability

## How it works

In `expandForEachSteps()`, the array iteration loop now tracks the index. When the step name has no expression template and the current item is an object or array, it falls back to `${step.name}-${index}` instead of `${step.name}-${String(item)}`.

## Testing

### Automated
- Added integration test in `integration/foreach_test.ts` that creates a workflow with `forEach` over an array of 3 objects using a static step name, verifies no cyclic dependency error, and confirms index-based step names (`deploy-server-0`, `deploy-server-1`, `deploy-server-2`)
- All 2668 tests pass

### Manual (compiled binary)
Tested with a real swamp repo in `/tmp`:

**Bug scenario** — `forEach` over object array with static step name:
```
workflow run test-foreach-object-static \
  --input '{"servers": [{"host": "web1", "port": 8080}, {"host": "web2", "port": 8081}, {"host": "web3", "port": 8082}]}'
```
Result: `status: "succeeded"`, steps named `deploy-server-0`, `deploy-server-1`, `deploy-server-2`

**Existing scenario** — `forEach` over string array with expression:
```
workflow run test-foreach-string-expr \
  --input '{"environments": ["dev", "staging", "production"]}'
```
Result: `status: "succeeded"`, steps named `deploy-dev`, `deploy-staging`, `deploy-production` (no regression)

## Test plan

- [x] `deno check` — passes
- [x] `deno lint` — passes
- [x] `deno fmt` — passes
- [x] `deno run test` — 2668 passed, 0 failed
- [x] `deno run compile` — compiles successfully
- [x] Manual test with compiled binary confirms fix and no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)