### PR TITLE
feat: add per-version releaseNotes field to extension push

### DIFF
--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -51,6 +51,7 @@ interface ExtensionPushOptions extends GlobalOptions {
   repoDir: string;
   yes?: boolean;
   dryRun?: boolean;
+  releaseNotes?: string;
 }
 
 async function promptConfirmation(message: string): Promise<boolean> {
@@ -74,6 +75,10 @@ export const extensionPushCommand = new Command()
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("-y, --yes", "Skip confirmation prompts")
   .option("--dry-run", "Build archive locally without pushing to registry")
+  .option(
+    "--release-notes <text:string>",
+    "Per-version release notes (max 5000 chars)",
+  )
   .action(async function (options: ExtensionPushOptions, manifestPath: string) {
     const ctx = createContext(options, ["extension", "push"]);
     ctx.logger.debug`Starting extension push`;
@@ -207,12 +212,14 @@ export const extensionPushCommand = new Command()
       };
     });
 
+    const resolvedReleaseNotes = options.releaseNotes ?? manifest.releaseNotes;
     renderExtensionPushResolved(
       {
         name: manifest.name,
         version: manifest.version,
         description: manifest.description,
         repository: manifest.repository,
+        releaseNotes: resolvedReleaseNotes,
         models: resolvedModels,
         workflowFiles: workflowFiles.map((wf) =>
           relative(repoDir, wf.sourcePath)
@@ -469,6 +476,7 @@ export const extensionPushCommand = new Command()
 
       // 17. Three-phase push
       const extensionClient = new ExtensionApiClient(credentials.serverUrl);
+      const releaseNotes = options.releaseNotes ?? manifest.releaseNotes;
       const pushMetadata = {
         name: manifest.name,
         version: manifest.version,
@@ -477,6 +485,7 @@ export const extensionPushCommand = new Command()
         platforms: manifest.platforms,
         labels: manifest.labels,
         repository: manifest.repository || undefined,
+        ...(releaseNotes ? { releaseNotes } : {}),
       };
 
       // Phase 1: Initiate

--- a/src/domain/extensions/extension_manifest.ts
+++ b/src/domain/extensions/extension_manifest.ts
@@ -49,6 +49,7 @@ const ExtensionManifestSchemaV1 = z.object({
   additionalFiles: z.array(z.string()).optional(),
   platforms: z.array(z.string().min(1)).optional(),
   labels: z.array(z.string().min(1)).optional(),
+  releaseNotes: z.string().max(5000).optional(),
   dependencies: z.array(
     z.string().refine((dep) => dep.includes("/"), {
       message: "Dependencies must include a slash (e.g., @namespace/name)",
@@ -77,6 +78,7 @@ export interface ExtensionManifest {
   additionalFiles: string[];
   platforms: string[];
   labels: string[];
+  releaseNotes: string | undefined;
   dependencies: string[];
 }
 
@@ -131,6 +133,7 @@ export function parseExtensionManifest(content: string): ExtensionManifest {
     additionalFiles: result.data.additionalFiles ?? [],
     platforms: result.data.platforms ?? [],
     labels: result.data.labels ?? [],
+    releaseNotes: result.data.releaseNotes,
     dependencies: result.data.dependencies ?? [],
   };
 }

--- a/src/domain/extensions/extension_manifest_test.ts
+++ b/src/domain/extensions/extension_manifest_test.ts
@@ -273,6 +273,22 @@ models:
   assertStringIncludes((error as Error).message, "Invalid");
 });
 
+Deno.test("parseExtensionManifest parses valid manifest with releaseNotes", () => {
+  const yaml = `
+manifestVersion: 1
+name: "@myuser/myext"
+version: "2026.02.26.1"
+models:
+  - foo.ts
+releaseNotes: "Fixed a critical bug in the deploy step"
+`;
+  const manifest = parseExtensionManifest(yaml);
+  assertEquals(
+    manifest.releaseNotes,
+    "Fixed a critical bug in the deploy step",
+  );
+});
+
 Deno.test("parseExtensionManifest defaults optional fields", () => {
   const yaml = `
 manifestVersion: 1
@@ -284,6 +300,7 @@ models:
   const manifest = parseExtensionManifest(yaml);
   assertEquals(manifest.description, undefined);
   assertEquals(manifest.repository, undefined);
+  assertEquals(manifest.releaseNotes, undefined);
   assertEquals(manifest.workflows, []);
   assertEquals(manifest.vaults, []);
   assertEquals(manifest.additionalFiles, []);

--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -29,6 +29,7 @@ export interface PushMetadata {
   platforms: string[];
   labels: string[];
   repository?: string;
+  releaseNotes?: string;
 }
 
 /** Metadata sent during push confirmation (extends PushMetadata with content metadata). */

--- a/src/presentation/output/extension_push_output.ts
+++ b/src/presentation/output/extension_push_output.ts
@@ -48,6 +48,7 @@ export interface ExtensionPushResolvedData {
   version: string;
   description: string | undefined;
   repository: string | undefined;
+  releaseNotes: string | undefined;
   models: ResolvedModelEntry[];
   workflowFiles: string[];
   vaults: ResolvedVaultEntry[];
@@ -91,6 +92,9 @@ export function renderExtensionPushResolved(
     }
     if (data.repository) {
       logger.info`Repository: ${data.repository}`;
+    }
+    if (data.releaseNotes) {
+      logger.info`Release Notes: ${data.releaseNotes}`;
     }
     if (data.models.length > 0) {
       logger.info`Models (${data.models.length}):`;

--- a/src/presentation/output/extension_push_output_test.ts
+++ b/src/presentation/output/extension_push_output_test.ts
@@ -50,6 +50,7 @@ Deno.test("renderExtensionPushResolved outputs JSON in json mode", () => {
         version: "2026.02.26.1",
         description: "Test extension",
         repository: undefined,
+        releaseNotes: undefined,
         models: [{ type: "@test/echo", fileName: "echo.ts" }],
         workflowFiles: [],
         vaults: [],


### PR DESCRIPTION
## Summary

Closes #567

Adds an optional `releaseNotes` field so extension authors can attach per-version changelogs when publishing with `swamp extension push`, without overloading the `description` field.

## Why this design

Previously, the only way to communicate what changed in a version was to modify `description`, which conflates the stable extension summary with ephemeral patch notes. This adds a dedicated `releaseNotes` string (max 5000 chars) that flows through the full push pipeline alongside existing metadata like `description`, `labels`, and `platforms`.

Two input methods are supported:
- **Manifest field** (`releaseNotes` in `manifest.yaml`) — for checked-in release notes
- **CLI flag** (`--release-notes <text>`) — for ad-hoc or CI-generated notes; takes precedence over the manifest value

This mirrors the precedence pattern already used for other fields like `version`.

## User impact

Extension authors can now include release notes when pushing:

```yaml
# manifest.yaml
releaseNotes: |
  - Fixed deployment timeout bug
  - Added retry logic for transient failures
```

Or via the CLI:

```bash
swamp extension push --release-notes "Hotfix for auth token refresh" manifest.yaml
```

Release notes are displayed in the resolved bundle output before push confirmation, giving authors a chance to verify.

## Backward compatibility

- `releaseNotes` is **optional everywhere** — existing manifests and workflows continue to work unchanged
- Older CLI versions that don't send `releaseNotes` will simply have `null` stored on the registry side (the registry uses the established `?? null` fallback pattern)
- No breaking changes to the API contract; the field is additive only

Registry-side changes are tracked separately in systeminit/swamp-club#196.

## Files changed

| File | Change |
|------|--------|
| `src/domain/extensions/extension_manifest.ts` | Zod schema + interface |
| `src/cli/commands/extension_push.ts` | CLI flag + metadata wiring |
| `src/infrastructure/http/extension_api_client.ts` | `PushMetadata` type |
| `src/presentation/output/extension_push_output.ts` | Resolved bundle display |
| `src/domain/extensions/extension_manifest_test.ts` | Tests for presence/absence |

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — clean
- [x] `deno fmt` — clean
- [x] `deno run test` — all 19 manifest tests pass (including new releaseNotes test)
- [x] `deno run compile` — binary compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)