### PR TITLE
feat: relax namespace validation for local models and vaults

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -366,7 +366,8 @@ troubleshooting, see [references/publishing.md](references/publishing.md).
    `npm:lodash-es@4.17.21`, not `npm:lodash-es`). Swamp does not use a lockfile
    during bundling, so unpinned versions may resolve differently across runs.
    `npm:zod@4` is the one exception — it is externalized and provided by swamp.
-4. **Type naming**: Use `@<namespace>/<name>` format (e.g., `@user/my-model`)
+4. **Type naming**: Use `@<namespace>/<name>` or `<namespace>/<name>` format
+   (e.g., `@user/my-model` or `myorg/my-model`)
 5. **No type annotations**: Avoid TypeScript types in execute parameters
 6. **File naming**: Use snake_case (`my_model.ts`)
 
@@ -374,13 +375,15 @@ troubleshooting, see [references/publishing.md](references/publishing.md).
 
 User-defined models can use any namespace except reserved ones (`swamp`, `si`):
 
-| Type              | Valid? | Notes                    |
-| ----------------- | ------ | ------------------------ |
-| `@user/my-model`  | ✅     | Valid namespace          |
-| `@myorg/deploy`   | ✅     | Custom namespace allowed |
-| `@user/aws/s3`    | ✅     | Nested paths allowed     |
-| `mycompany/model` | ❌     | Missing `@` prefix       |
-| `@swamp/my-model` | ❌     | Reserved namespace       |
+| Type                        | Valid? | Notes                       |
+| --------------------------- | ------ | --------------------------- |
+| `@user/my-model`            | ✅     | Valid namespace             |
+| `@myorg/deploy`             | ✅     | Custom namespace allowed    |
+| `myorg/my-model`            | ✅     | Non-@ format allowed        |
+| `digitalocean/app-platform` | ✅     | Non-@ multi-segment allowed |
+| `@user/aws/s3`              | ✅     | Nested paths allowed        |
+| `swamp/my-model`            | ❌     | Reserved namespace          |
+| `si/my-model`               | ❌     | Reserved namespace          |
 
 ## Verify
 

--- a/.claude/skills/swamp-extension-model/references/troubleshooting.md
+++ b/.claude/skills/swamp-extension-model/references/troubleshooting.md
@@ -6,7 +6,6 @@
   - [No 'model' or 'extension' export found](#no-model-or-extension-export-found)
   - [Unknown resource spec / Unknown file spec](#unknown-resource-spec-or-unknown-file-spec)
   - [Model type already registered](#model-type-already-registered)
-  - [Model type must use '@' prefix](#model-type-must-use--prefix)
   - [Uses a reserved namespace](#uses-a-reserved-namespace)
   - [Cannot extend unregistered model type](#cannot-extend-unregistered-model-type)
   - [Method already exists](#method-x-already-exists-on-model-type-y)
@@ -76,19 +75,6 @@ type: "@user/echo"; // May conflict with other users
 type: "@myorg/echo"; // Use your own namespace
 ```
 
-### "Model type must use '@' prefix"
-
-User-defined models must start with `@`:
-
-```typescript
-// Wrong - missing @ prefix
-type: "mycompany/echo";
-
-// Correct
-type: "@mycompany/echo";
-type: "@user/echo";
-```
-
 ### "Uses a reserved namespace"
 
 Reserved namespaces (`swamp`, `si`) are for built-in types only:
@@ -102,7 +88,8 @@ type: "@si/auth";
 
 // Correct - use any other namespace
 type: "@myorg/my-model";
-type: "@user/my-model";
+type: "myorg/my-model";
+type: "digitalocean/app-platform";
 ```
 
 ### "Cannot extend unregistered model type: ..."

--- a/.claude/skills/swamp-vault/references/user-defined-vaults.md
+++ b/.claude/skills/swamp-vault/references/user-defined-vaults.md
@@ -28,10 +28,11 @@ export const vault = {
 
 ## Type Naming
 
-- Must match `@namespace/name` pattern (e.g., `@hashicorp/vault`,
-  `@openbao/vault`)
+- Must match `@namespace/name` or `namespace/name` pattern (e.g.,
+  `@hashicorp/vault`, `hashicorp/vault`)
 - Lowercase letters, numbers, and hyphens only
-- Reserved namespaces (`@swamp/`, `@si/`) are not allowed
+- Reserved namespaces (`swamp`, `si`) are not allowed (with or without `@`
+  prefix)
 
 ## File Location
 
@@ -231,7 +232,8 @@ export const vault = {
 
 1. **Import**: Use `import { z } from "npm:zod";` (same as extension models)
 2. **Export**: Must be `export const vault` (named export, not default)
-3. **Namespaces**: `@swamp/` and `@si/` are reserved for built-in types
+3. **Namespaces**: `swamp` and `si` namespaces are reserved for built-in types
+   (with or without `@` prefix)
 4. **Config**: User-defined vaults always use `--config <json>` on
    `vault create`
 5. **Bundling**: Files are bundled by Deno before import — standard Deno imports

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -418,9 +418,8 @@ export class UserModelLoader {
    * Validates that a user-defined model type follows the required namespace conventions.
    *
    * Requirements:
-   * - Must not use reserved namespaces (swamp, si)
-   * - Must start with '@' (user namespace prefix)
-   * - Must have at least 2 segments (e.g., "@myorg/echo")
+   * - Must not use reserved namespaces (swamp, si) for non-@ types
+   * - Must have at least 2 segments (e.g., "@myorg/echo" or "myorg/echo")
    *
    * @param rawType - The raw type string from the user model
    * @returns Error message if validation fails, undefined if valid
@@ -428,15 +427,18 @@ export class UserModelLoader {
   private validateUserNamespace(rawType: string): string | undefined {
     const normalized = ModelType.create(rawType).normalized;
 
-    // Must start with '@'
-    if (!ModelType.isUserNamespace(normalized)) {
-      return `Model type '${rawType}' must use '@' prefix. Expected format: @<namespace>/<name> (e.g., @myorg/my-model)`;
-    }
-
     // Must have at least 2 segments
     const segmentCount = ModelType.getSegmentCount(normalized);
     if (segmentCount < 2) {
-      return `Model type '${rawType}' must have at least 2 segments. Expected format: @<namespace>/<name> (e.g., @myorg/my-model)`;
+      return `Model type '${rawType}' must have at least 2 segments. Expected format: @<namespace>/<name> or <namespace>/<name> (e.g., @myorg/my-model or myorg/my-model)`;
+    }
+
+    // Non-@ types must not use reserved namespaces
+    if (
+      !ModelType.isUserNamespace(normalized) &&
+      ModelType.isReservedNamespace(normalized)
+    ) {
+      return `Model type '${rawType}' uses a reserved namespace. 'swamp' and 'si' namespaces are reserved for built-in types.`;
     }
 
     return undefined;

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -1505,7 +1505,7 @@ export const model = {
 
 // --- Namespace validation tests ---
 
-Deno.test("UserModelLoader rejects model without @ prefix", async () => {
+Deno.test("UserModelLoader accepts non-@ prefixed model", async () => {
   const modelCode = `
 import { z } from "npm:zod@4";
 
@@ -1535,9 +1535,8 @@ export const model = {
     const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
-    assertEquals(result.loaded.length, 0);
-    assertEquals(result.failed.length, 1);
-    assertStringIncludes(result.failed[0].error, "must use '@' prefix");
+    assertEquals(result.loaded.length, 1);
+    assertEquals(result.failed.length, 0);
   });
 });
 
@@ -1837,7 +1836,7 @@ export const model = {
 
     assertEquals(result.loaded.length, 0);
     assertEquals(result.failed.length, 1);
-    assertStringIncludes(result.failed[0].error, "must use '@' prefix");
+    assertStringIncludes(result.failed[0].error, "reserved namespace");
   });
 });
 
@@ -1873,7 +1872,78 @@ export const model = {
 
     assertEquals(result.loaded.length, 0);
     assertEquals(result.failed.length, 1);
-    assertStringIncludes(result.failed[0].error, "must use '@' prefix");
+    assertStringIncludes(result.failed[0].error, "reserved namespace");
+  });
+});
+
+Deno.test("UserModelLoader accepts non-@ model like digitalocean/app-platform", async () => {
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "digitalocean/app-platform",
+  version: "2026.02.09.1",
+  globalArguments: z.object({ token: z.string() }),
+  resources: {
+    "data": {
+      description: "Data output",
+      schema: z.object({}),
+      lifetime: "infinite",
+      garbageCollection: 10,
+    },
+  },
+  methods: {
+    run: {
+      description: "Run",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+  await withTempModels({ "app_platform.ts": modelCode }, async (dir) => {
+    const loader = createTestLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 1);
+    assertEquals(result.failed.length, 0);
+  });
+});
+
+Deno.test("UserModelLoader rejects single-segment non-@ model type", async () => {
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "mymodel",
+  version: "2026.02.09.1",
+  globalArguments: z.object({ message: z.string() }),
+  resources: {
+    "data": {
+      description: "Data output",
+      schema: z.object({}),
+      lifetime: "infinite",
+      garbageCollection: 10,
+    },
+  },
+  methods: {
+    run: {
+      description: "Run",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+  await withTempModels({ "single_segment.ts": modelCode }, async (dir) => {
+    const loader = createTestLoader();
+    const result = await loader.loadModels(dir);
+
+    assertEquals(result.loaded.length, 0);
+    assertEquals(result.failed.length, 1);
+    assertStringIncludes(result.failed[0].error, "at least 2 segments");
   });
 });
 

--- a/src/domain/vaults/user_vault_loader.ts
+++ b/src/domain/vaults/user_vault_loader.ts
@@ -33,10 +33,10 @@ import { assertSafePath } from "../../infrastructure/persistence/safe_path.ts";
 const logger = getLogger(["swamp", "vaults", "loader"]);
 
 /** Reserved namespaces that user vault types cannot use. */
-const RESERVED_NAMESPACES = ["@swamp/", "@si/"];
+const RESERVED_NAMESPACES = ["@swamp/", "@si/", "swamp/", "si/"];
 
-/** Pattern for valid user vault type: @namespace/name */
-const USER_VAULT_TYPE_PATTERN = /^@[a-z0-9_-]+\/[a-z0-9_-]+$/;
+/** Pattern for valid user vault type: @namespace/name or namespace/name */
+const USER_VAULT_TYPE_PATTERN = /^@?[a-z0-9_-]+\/[a-z0-9_-]+$/;
 
 /**
  * Schema for validating user vault exports.
@@ -46,7 +46,7 @@ const UserVaultSchema = z.object({
     (t) => USER_VAULT_TYPE_PATTERN.test(t),
     {
       message:
-        "Vault type must match @namespace/name (e.g., @myorg/custom-vault)",
+        "Vault type must match @namespace/name or namespace/name (e.g., @myorg/custom-vault or myorg/custom-vault)",
     },
   ),
   name: z.string(),
@@ -258,7 +258,7 @@ export class UserVaultLoader {
   private validateUserNamespace(type: string): string | undefined {
     for (const reserved of RESERVED_NAMESPACES) {
       if (type.toLowerCase().startsWith(reserved)) {
-        return `Vault type '${type}' uses a reserved namespace. User vaults cannot use '@swamp' or '@si' namespaces.`;
+        return `Vault type '${type}' uses a reserved namespace. User vaults cannot use 'swamp' or 'si' namespaces (with or without '@' prefix).`;
       }
     }
     return undefined;

--- a/src/domain/vaults/user_vault_loader_test.ts
+++ b/src/domain/vaults/user_vault_loader_test.ts
@@ -160,3 +160,102 @@ Deno.test("VaultTypeRegistry standalone - rejects duplicate registration", () =>
   }
   assertEquals(threw, true);
 });
+
+Deno.test("UserVaultLoader - loads valid non-@ vault type", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "vault_loader_test_" });
+  try {
+    const vaultFile = join(tmpDir, "custom_vault.ts");
+    await Deno.writeTextFile(
+      vaultFile,
+      `
+import { z } from "npm:zod";
+
+export const vault = {
+  type: "hashicorp/vault",
+  name: "HashiCorp Vault",
+  description: "A test vault without @ prefix",
+  configSchema: z.object({ endpoint: z.string() }),
+  createProvider: (name, _config) => ({
+    get: async (_key) => "test-secret",
+    put: async (_key, _value) => {},
+    list: async () => [],
+    getName: () => name,
+  }),
+};
+`,
+    );
+
+    const loader = new UserVaultLoader(new StubDenoRuntime());
+    const result = await loader.loadVaults(tmpDir);
+
+    assertEquals(result.loaded.length, 1);
+    assertEquals(result.loaded[0], "custom_vault.ts");
+    assertEquals(result.failed.length, 0);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("UserVaultLoader - rejects non-@ vault with reserved swamp namespace", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "vault_loader_test_" });
+  try {
+    const vaultFile = join(tmpDir, "bad_vault.ts");
+    await Deno.writeTextFile(
+      vaultFile,
+      `
+export const vault = {
+  type: "swamp/my-vault",
+  name: "Bad Vault",
+  description: "Uses reserved namespace without @",
+  createProvider: (name, _config) => ({
+    get: async (_key) => "",
+    put: async (_key, _value) => {},
+    list: async () => [],
+    getName: () => name,
+  }),
+};
+`,
+    );
+
+    const loader = new UserVaultLoader(new StubDenoRuntime());
+    const result = await loader.loadVaults(tmpDir);
+
+    assertEquals(result.loaded.length, 0);
+    assertEquals(result.failed.length, 1);
+    assertStringIncludes(result.failed[0].error, "reserved namespace");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("UserVaultLoader - rejects non-@ vault with reserved si namespace", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "vault_loader_test_" });
+  try {
+    const vaultFile = join(tmpDir, "bad_vault.ts");
+    await Deno.writeTextFile(
+      vaultFile,
+      `
+export const vault = {
+  type: "si/my-vault",
+  name: "Bad Vault",
+  description: "Uses reserved si namespace without @",
+  createProvider: (name, _config) => ({
+    get: async (_key) => "",
+    put: async (_key, _value) => {},
+    list: async () => [],
+    getName: () => name,
+  }),
+};
+`,
+    );
+
+    const loader = new UserVaultLoader(new StubDenoRuntime());
+    const result = await loader.loadVaults(tmpDir);
+
+    assertEquals(result.loaded.length, 0);
+    assertEquals(result.failed.length, 1);
+    assertStringIncludes(result.failed[0].error, "reserved namespace");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Remove the `@` prefix requirement for user-defined extension model and vault types
- Non-`@` types like `digitalocean/app-platform` are now valid (implicitly `@swamp/digitalocean/app-platform`)
- Reserved namespaces (`swamp/*`, `si/*`) remain blocked for non-`@` types
- `@swamp/*` and `@si/*` remain allowed for local development

## Why

Swamp-managed extensions are moving from `@swamp/aws/ec2` to just `aws/ec2` — a missing `@` namespace is implicitly treated as `@swamp`. This means user-defined extension models without the `@` prefix should also be valid, but loading `extensions/models/app_platform.ts` with `type: "digitalocean/app-platform"` previously failed with *"Model type must use '@' prefix"*.

This change is scoped to local model/vault loading only. Extension push validation (manifest, namespace validator) is deferred.

## Changes

| File | Change |
|------|--------|
| `src/domain/models/user_model_loader.ts` | Remove `@` prefix check, add reserved namespace check for non-`@` types |
| `src/domain/vaults/user_vault_loader.ts` | Make `@` optional in type pattern, extend reserved namespace list |
| `src/domain/models/user_model_loader_test.ts` | Update 3 existing tests, add 2 new tests |
| `src/domain/vaults/user_vault_loader_test.ts` | Add 3 new tests for non-`@` vault types |
| `.claude/skills/swamp-extension-model/SKILL.md` | Update type naming docs |
| `.claude/skills/swamp-extension-model/references/troubleshooting.md` | Replace `@` prefix error section with reserved namespace guidance |
| `.claude/skills/swamp-vault/references/user-defined-vaults.md` | Update vault type format docs |

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — clean
- [x] `deno fmt` — clean
- [x] `deno run test` — all 50 tests pass (41 model loader + 9 vault loader)
- [x] `deno run compile` — binary compiles
- [x] Verified no UAT tests broken by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)