### PR TITLE
feat: allow all namespaces for local model and vault loading

### DIFF
--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -418,7 +418,6 @@ export class UserModelLoader {
    * Validates that a user-defined model type follows the required namespace conventions.
    *
    * Requirements:
-   * - Must not use reserved namespaces (swamp, si) for non-@ types
    * - Must have at least 2 segments (e.g., "@myorg/echo" or "myorg/echo")
    *
    * @param rawType - The raw type string from the user model
@@ -431,14 +430,6 @@ export class UserModelLoader {
     const segmentCount = ModelType.getSegmentCount(normalized);
     if (segmentCount < 2) {
       return `Model type '${rawType}' must have at least 2 segments. Expected format: @<namespace>/<name> or <namespace>/<name> (e.g., @myorg/my-model or myorg/my-model)`;
-    }
-
-    // Non-@ types must not use reserved namespaces
-    if (
-      !ModelType.isUserNamespace(normalized) &&
-      ModelType.isReservedNamespace(normalized)
-    ) {
-      return `Model type '${rawType}' uses a reserved namespace. 'swamp' and 'si' namespaces are reserved for built-in types.`;
     }
 
     return undefined;

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -1804,7 +1804,7 @@ export const model = {
   });
 });
 
-Deno.test("UserModelLoader rejects unscoped swamp/* namespace (no @ prefix)", async () => {
+Deno.test("UserModelLoader allows swamp/* namespace for local models", async () => {
   const modelCode = `
 import { z } from "npm:zod@4";
 
@@ -1830,17 +1830,16 @@ export const model = {
 };
 `;
 
-  await withTempModels({ "reserved_swamp.ts": modelCode }, async (dir) => {
+  await withTempModels({ "swamp_model.ts": modelCode }, async (dir) => {
     const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
-    assertEquals(result.loaded.length, 0);
-    assertEquals(result.failed.length, 1);
-    assertStringIncludes(result.failed[0].error, "reserved namespace");
+    assertEquals(result.loaded.length, 1);
+    assertEquals(result.failed.length, 0);
   });
 });
 
-Deno.test("UserModelLoader rejects unscoped si/* namespace (no @ prefix)", async () => {
+Deno.test("UserModelLoader allows si/* namespace for local models", async () => {
   const modelCode = `
 import { z } from "npm:zod@4";
 
@@ -1866,13 +1865,12 @@ export const model = {
 };
 `;
 
-  await withTempModels({ "reserved_si.ts": modelCode }, async (dir) => {
+  await withTempModels({ "si_model.ts": modelCode }, async (dir) => {
     const loader = createTestLoader();
     const result = await loader.loadModels(dir);
 
-    assertEquals(result.loaded.length, 0);
-    assertEquals(result.failed.length, 1);
-    assertStringIncludes(result.failed[0].error, "reserved namespace");
+    assertEquals(result.loaded.length, 1);
+    assertEquals(result.failed.length, 0);
   });
 });
 

--- a/src/domain/vaults/user_vault_loader.ts
+++ b/src/domain/vaults/user_vault_loader.ts
@@ -32,9 +32,6 @@ import { assertSafePath } from "../../infrastructure/persistence/safe_path.ts";
 
 const logger = getLogger(["swamp", "vaults", "loader"]);
 
-/** Reserved namespaces that user vault types cannot use. */
-const RESERVED_NAMESPACES = ["@swamp/", "@si/", "swamp/", "si/"];
-
 /** Pattern for valid user vault type: @namespace/name or namespace/name */
 const USER_VAULT_TYPE_PATTERN = /^@?[a-z0-9_-]+\/[a-z0-9_-]+$/;
 
@@ -134,13 +131,6 @@ export class UserVaultLoader {
         }
 
         const userVault = parsed.data;
-
-        // Validate namespace
-        const namespaceError = this.validateUserNamespace(userVault.type);
-        if (namespaceError) {
-          result.failed.push({ file, error: namespaceError });
-          continue;
-        }
 
         // Register with the vault type registry
         if (vaultTypeRegistry.has(userVault.type)) {
@@ -249,19 +239,6 @@ export class UserVaultLoader {
     return await import(
       `data:application/javascript;base64,${encoded}`
     );
-  }
-
-  /**
-   * Validates that a user-defined vault type follows namespace conventions.
-   * Must not use reserved namespaces (@swamp/, @si/).
-   */
-  private validateUserNamespace(type: string): string | undefined {
-    for (const reserved of RESERVED_NAMESPACES) {
-      if (type.toLowerCase().startsWith(reserved)) {
-        return `Vault type '${type}' uses a reserved namespace. User vaults cannot use 'swamp' or 'si' namespaces (with or without '@' prefix).`;
-      }
-    }
-    return undefined;
   }
 
   /**

--- a/src/domain/vaults/user_vault_loader_test.ts
+++ b/src/domain/vaults/user_vault_loader_test.ts
@@ -18,7 +18,6 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { assertStringIncludes } from "@std/assert/string-includes";
 import { join } from "@std/path";
 import { UserVaultLoader } from "./user_vault_loader.ts";
 import { VaultTypeRegistry } from "./vault_type_registry.ts";
@@ -74,19 +73,22 @@ export const vault = {
   }
 });
 
-Deno.test("UserVaultLoader - rejects vault with reserved namespace", async () => {
+Deno.test("UserVaultLoader - allows @swamp/* namespace for local vaults", async () => {
   const tmpDir = await Deno.makeTempDir({ prefix: "vault_loader_test_" });
   try {
-    const vaultFile = join(tmpDir, "bad_vault.ts");
+    const vaultFile = join(tmpDir, "swamp_vault.ts");
     await Deno.writeTextFile(
       vaultFile,
       `
+import { z } from "npm:zod";
+
 export const vault = {
   type: "@swamp/my-vault",
-  name: "Bad Vault",
-  description: "Uses reserved namespace",
+  name: "Swamp Vault",
+  description: "Local dev vault using @swamp namespace",
+  configSchema: z.object({ endpoint: z.string() }),
   createProvider: (name: string, _config: Record<string, unknown>) => ({
-    get: async (_key: string) => "",
+    get: async (_key: string) => "test-secret",
     put: async (_key: string, _value: string) => {},
     list: async () => [],
     getName: () => name,
@@ -98,9 +100,9 @@ export const vault = {
     const loader = new UserVaultLoader(new StubDenoRuntime());
     const result = await loader.loadVaults(tmpDir);
 
-    assertEquals(result.loaded.length, 0);
-    assertEquals(result.failed.length, 1);
-    assertStringIncludes(result.failed[0].error, "reserved namespace");
+    assertEquals(result.loaded.length, 1);
+    assertEquals(result.loaded[0], "swamp_vault.ts");
+    assertEquals(result.failed.length, 0);
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }
@@ -196,20 +198,23 @@ export const vault = {
   }
 });
 
-Deno.test("UserVaultLoader - rejects non-@ vault with reserved swamp namespace", async () => {
+Deno.test("UserVaultLoader - allows swamp/* namespace for local vaults", async () => {
   const tmpDir = await Deno.makeTempDir({ prefix: "vault_loader_test_" });
   try {
-    const vaultFile = join(tmpDir, "bad_vault.ts");
+    const vaultFile = join(tmpDir, "swamp_vault.ts");
     await Deno.writeTextFile(
       vaultFile,
       `
+import { z } from "npm:zod";
+
 export const vault = {
   type: "swamp/my-vault",
-  name: "Bad Vault",
-  description: "Uses reserved namespace without @",
-  createProvider: (name, _config) => ({
-    get: async (_key) => "",
-    put: async (_key, _value) => {},
+  name: "Swamp Vault",
+  description: "Local dev vault using swamp namespace",
+  configSchema: z.object({ endpoint: z.string() }),
+  createProvider: (name: string, _config: Record<string, unknown>) => ({
+    get: async (_key: string) => "test-secret",
+    put: async (_key: string, _value: string) => {},
     list: async () => [],
     getName: () => name,
   }),
@@ -220,28 +225,31 @@ export const vault = {
     const loader = new UserVaultLoader(new StubDenoRuntime());
     const result = await loader.loadVaults(tmpDir);
 
-    assertEquals(result.loaded.length, 0);
-    assertEquals(result.failed.length, 1);
-    assertStringIncludes(result.failed[0].error, "reserved namespace");
+    assertEquals(result.loaded.length, 1);
+    assertEquals(result.loaded[0], "swamp_vault.ts");
+    assertEquals(result.failed.length, 0);
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
 
-Deno.test("UserVaultLoader - rejects non-@ vault with reserved si namespace", async () => {
+Deno.test("UserVaultLoader - allows si/* namespace for local vaults", async () => {
   const tmpDir = await Deno.makeTempDir({ prefix: "vault_loader_test_" });
   try {
-    const vaultFile = join(tmpDir, "bad_vault.ts");
+    const vaultFile = join(tmpDir, "si_vault.ts");
     await Deno.writeTextFile(
       vaultFile,
       `
+import { z } from "npm:zod";
+
 export const vault = {
   type: "si/my-vault",
-  name: "Bad Vault",
-  description: "Uses reserved si namespace without @",
-  createProvider: (name, _config) => ({
-    get: async (_key) => "",
-    put: async (_key, _value) => {},
+  name: "SI Vault",
+  description: "Local dev vault using si namespace",
+  configSchema: z.object({ endpoint: z.string() }),
+  createProvider: (name: string, _config: Record<string, unknown>) => ({
+    get: async (_key: string) => "test-secret",
+    put: async (_key: string, _value: string) => {},
     list: async () => [],
     getName: () => name,
   }),
@@ -252,9 +260,9 @@ export const vault = {
     const loader = new UserVaultLoader(new StubDenoRuntime());
     const result = await loader.loadVaults(tmpDir);
 
-    assertEquals(result.loaded.length, 0);
-    assertEquals(result.failed.length, 1);
-    assertStringIncludes(result.failed[0].error, "reserved namespace");
+    assertEquals(result.loaded.length, 1);
+    assertEquals(result.loaded[0], "si_vault.ts");
+    assertEquals(result.failed.length, 0);
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }


### PR DESCRIPTION
## Summary

- Remove reserved namespace blocking from local model and vault loaders
- All namespace combinations (`@swamp/*`, `@si/*`, `swamp/*`, `si/*`, `myorg/*`) are now valid for local loading
- Only validation remaining is the minimum 2-segment requirement (e.g., `myorg/my-model`)

## Why

This is a follow-up to #600. That PR relaxed the `@` prefix requirement but still blocked `swamp/*` and `si/*` without `@` prefix locally, and blocked `@swamp/*`/`@si/*` for vaults. The model loader already allowed `@swamp/*` and `@si/*` for local development, but the vault loader didn't — and neither loader allowed bare `swamp/*` or `si/*`.

For local development, developers need to build and test extensions with any namespace. Reserved namespace enforcement should only happen at the extension push boundary, not during local loading.

## What still blocks reserved namespaces

The extension push pipeline is **unchanged** and still blocks `@swamp/*`, `@si/*`, `swamp/*`, and `si/*` when publishing to the registry:

- `src/domain/extensions/extension_manifest.ts` — manifest validation
- `src/domain/extensions/extension_namespace_validator.ts` — content namespace validation
- `src/domain/extensions/extension_dependency_resolver.ts` — dependency resolution

This separation allows developers to build and test extensions locally with any namespace while preventing unauthorized use of reserved namespaces in the public registry.

## Changes

| File | Change |
|------|--------|
| `src/domain/models/user_model_loader.ts` | Remove reserved namespace check from `validateUserNamespace()` — only segment count validation remains |
| `src/domain/vaults/user_vault_loader.ts` | Remove `RESERVED_NAMESPACES` constant and `validateUserNamespace()` method entirely |
| `src/domain/models/user_model_loader_test.ts` | Change `swamp/*` and `si/*` rejection tests to acceptance tests |
| `src/domain/vaults/user_vault_loader_test.ts` | Change `@swamp/*` rejection test to acceptance test; change `swamp/*` and `si/*` rejection tests to acceptance tests |

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — clean
- [x] `deno fmt` — clean
- [x] `deno run test` — all 50 tests pass (41 model loader + 9 vault loader)

🤖 Generated with [Claude Code](https://claude.com/claude-code)