### PR TITLE
fix: bundle missing skill files in repo init and upgrade

### DIFF
--- a/.claude/skills/swamp-extension-model/references/publishing.md
+++ b/.claude/skills/swamp-extension-model/references/publishing.md
@@ -104,6 +104,11 @@ dependencies:
 
 ## Push Workflow
 
+> **Before you push:** Your extension must pass
+> `swamp extension fmt <manifest> --check`. The push command enforces this
+> automatically — if your code has formatting or lint issues, the push will be
+> rejected. Run `swamp extension fmt <manifest>` to auto-fix before pushing.
+
 ### Commands
 
 ```bash

--- a/src/infrastructure/assets/skill_assets.ts
+++ b/src/infrastructure/assets/skill_assets.ts
@@ -106,6 +106,10 @@ const BUNDLED_SKILLS: SkillInfo[] = [
     name: "swamp-extension-model",
   },
   {
+    relativePath: "swamp-extension-model/references/publishing.md",
+    name: "swamp-extension-model",
+  },
+  {
     relativePath: "swamp-vault/SKILL.md",
     name: "swamp-vault",
   },
@@ -119,6 +123,10 @@ const BUNDLED_SKILLS: SkillInfo[] = [
   },
   {
     relativePath: "swamp-vault/references/examples.md",
+    name: "swamp-vault",
+  },
+  {
+    relativePath: "swamp-vault/references/user-defined-vaults.md",
     name: "swamp-vault",
   },
   {


### PR DESCRIPTION
## Summary

- Add `swamp-extension-model/references/publishing.md` and `swamp-vault/references/user-defined-vaults.md` to `BUNDLED_SKILLS` — these files existed on disk but were never copied during `swamp repo init` or `swamp repo upgrade`
- Add a formatting requirement callout to the publishing guide so agents know `swamp extension fmt` is a hard gate before push

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno run test` passes (2674/2674)
- [ ] Run `swamp repo init` in a fresh directory and verify both files are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)