### PR TITLE
fix: invalidate bundle cache when local dependencies change

### DIFF
--- a/src/domain/extensions/extension_import_resolver.ts
+++ b/src/domain/extensions/extension_import_resolver.ts
@@ -17,84 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { dirname, normalize, resolve } from "@std/path";
-
-/** Result of resolving local imports from entry points. */
-export interface ImportResolverResult {
-  /** All .ts files (entry points + dependencies), absolute paths. */
-  resolvedFiles: string[];
-  /** Non-local imports that were skipped (informational). */
-  skippedImports: string[];
-}
-
-/** Pattern matching import/export from relative paths. */
-const IMPORT_PATTERN = /(?:import|export)\s+.*?from\s+["'](\.\.?\/[^"']+)["']/g;
-
-/**
- * Scans model .ts entry points for relative import/export statements and
- * recursively resolves local .ts dependencies within the models directory.
- *
- * @param entryPoints - Absolute paths to entry point .ts files
- * @param modelsDir - Boundary directory; only files within this dir are included
- * @returns Resolved files and skipped non-local imports
- */
-export async function resolveLocalImports(
-  entryPoints: string[],
-  modelsDir: string,
-): Promise<ImportResolverResult> {
-  const normalizedModelsDir = normalize(modelsDir);
-  const visited = new Set<string>();
-  const skippedImports = new Set<string>();
-
-  async function visit(filePath: string): Promise<void> {
-    const normalized = normalize(filePath);
-    if (visited.has(normalized)) return;
-    visited.add(normalized);
-
-    // Only process files within the models directory
-    if (!normalized.startsWith(normalizedModelsDir)) return;
-
-    let content: string;
-    try {
-      content = await Deno.readTextFile(normalized);
-    } catch {
-      return; // File doesn't exist or can't be read
-    }
-
-    // Find all relative imports
-    for (const match of content.matchAll(IMPORT_PATTERN)) {
-      const importPath = match[1];
-      const resolved = resolveImportPath(normalized, importPath);
-
-      if (!resolved.startsWith(normalizedModelsDir)) {
-        skippedImports.add(importPath);
-        continue;
-      }
-
-      await visit(resolved);
-    }
-  }
-
-  for (const entry of entryPoints) {
-    await visit(entry);
-  }
-
-  return {
-    resolvedFiles: [...visited].sort(),
-    skippedImports: [...skippedImports].sort(),
-  };
-}
-
-/**
- * Resolves a relative import path to an absolute path.
- * Appends `.ts` if no extension is present.
- */
-function resolveImportPath(fromFile: string, importPath: string): string {
-  const dir = dirname(fromFile);
-  let resolved = resolve(dir, importPath);
-  // Add .ts extension if missing
-  if (!resolved.endsWith(".ts") && !resolved.endsWith(".js")) {
-    resolved = resolved + ".ts";
-  }
-  return normalize(resolved);
-}
+// Re-export from models/local_import_resolver.ts for backward compatibility.
+export {
+  type ImportResolverResult,
+  resolveLocalImports,
+} from "../models/local_import_resolver.ts";

--- a/src/domain/models/local_import_resolver.ts
+++ b/src/domain/models/local_import_resolver.ts
@@ -1,0 +1,100 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { dirname, normalize, resolve } from "@std/path";
+
+/** Result of resolving local imports from entry points. */
+export interface ImportResolverResult {
+  /** All .ts files (entry points + dependencies), absolute paths. */
+  resolvedFiles: string[];
+  /** Non-local imports that were skipped (informational). */
+  skippedImports: string[];
+}
+
+/** Pattern matching import/export from relative paths. */
+const IMPORT_PATTERN = /(?:import|export)\s+.*?from\s+["'](\.\.?\/[^"']+)["']/g;
+
+/**
+ * Scans .ts entry points for relative import/export statements and
+ * recursively resolves local .ts dependencies within the boundary directory.
+ *
+ * @param entryPoints - Absolute paths to entry point .ts files
+ * @param boundaryDir - Boundary directory; only files within this dir are included
+ * @returns Resolved files and skipped non-local imports
+ */
+export async function resolveLocalImports(
+  entryPoints: string[],
+  boundaryDir: string,
+): Promise<ImportResolverResult> {
+  const normalizedBoundaryDir = normalize(boundaryDir);
+  const visited = new Set<string>();
+  const skippedImports = new Set<string>();
+
+  async function visit(filePath: string): Promise<void> {
+    const normalized = normalize(filePath);
+    if (visited.has(normalized)) return;
+    visited.add(normalized);
+
+    // Only process files within the boundary directory
+    if (!normalized.startsWith(normalizedBoundaryDir)) return;
+
+    let content: string;
+    try {
+      content = await Deno.readTextFile(normalized);
+    } catch {
+      return; // File doesn't exist or can't be read
+    }
+
+    // Find all relative imports
+    for (const match of content.matchAll(IMPORT_PATTERN)) {
+      const importPath = match[1];
+      const resolved = resolveImportPath(normalized, importPath);
+
+      if (!resolved.startsWith(normalizedBoundaryDir)) {
+        skippedImports.add(importPath);
+        continue;
+      }
+
+      await visit(resolved);
+    }
+  }
+
+  for (const entry of entryPoints) {
+    await visit(entry);
+  }
+
+  return {
+    resolvedFiles: [...visited].sort(),
+    skippedImports: [...skippedImports].sort(),
+  };
+}
+
+/**
+ * Resolves a relative import path to an absolute path.
+ * Appends `.ts` if no extension is present.
+ */
+function resolveImportPath(fromFile: string, importPath: string): string {
+  const dir = dirname(fromFile);
+  let resolved = resolve(dir, importPath);
+  // Add .ts extension if missing
+  if (!resolved.endsWith(".ts") && !resolved.endsWith(".js")) {
+    resolved = resolved + ".ts";
+  }
+  return normalize(resolved);
+}

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -21,6 +21,7 @@ import { z } from "zod";
 import { dirname, join, resolve, toFileUrl } from "@std/path";
 import { getLogger } from "@logtape/logtape";
 import { bundleExtension } from "./bundle.ts";
+import { resolveLocalImports } from "./local_import_resolver.ts";
 import { ModelType } from "./model_type.ts";
 import { CalVer } from "./calver.ts";
 import {
@@ -268,7 +269,12 @@ export class UserModelLoader {
     for (const file of files) {
       try {
         const absolutePath = resolve(modelsDir, file);
-        const js = await this.bundleWithCache(absolutePath, file, denoPath);
+        const js = await this.bundleWithCache(
+          absolutePath,
+          file,
+          denoPath,
+          modelsDir,
+        );
         const module = await this.importBundle(js, file);
 
         if (module.model) {
@@ -339,6 +345,7 @@ export class UserModelLoader {
     absolutePath: string,
     relativePath: string,
     denoPath: string,
+    boundaryDir: string,
   ): Promise<string> {
     if (this.repoDir) {
       const bundlePath = join(
@@ -348,22 +355,32 @@ export class UserModelLoader {
         relativePath.replace(/\.ts$/, ".js"),
       );
 
-      // Check mtime-based cache
+      // Check mtime-based cache against all local dependencies
       try {
-        const [sourceStat, bundleStat] = await Promise.all([
-          Deno.stat(absolutePath),
-          Deno.stat(bundlePath),
-        ]);
-
-        if (
-          sourceStat.mtime && bundleStat.mtime &&
-          bundleStat.mtime > sourceStat.mtime
-        ) {
-          logger.debug`Using cached bundle for ${relativePath}`;
-          return await Deno.readTextFile(bundlePath);
+        const bundleStat = await Deno.stat(bundlePath);
+        if (bundleStat.mtime) {
+          const { resolvedFiles } = await resolveLocalImports(
+            [absolutePath],
+            boundaryDir,
+          );
+          const depStats = await Promise.all(
+            resolvedFiles.map((f) => Deno.stat(f)),
+          );
+          const newestSourceMtime = depStats.reduce<Date | null>(
+            (max, s) => {
+              if (!s.mtime) return max;
+              if (!max) return s.mtime;
+              return s.mtime > max ? s.mtime : max;
+            },
+            null,
+          );
+          if (newestSourceMtime && bundleStat.mtime > newestSourceMtime) {
+            logger.debug`Using cached bundle for ${relativePath}`;
+            return await Deno.readTextFile(bundlePath);
+          }
         }
       } catch {
-        // Bundle doesn't exist yet or source stat failed — will rebundle
+        // Bundle doesn't exist, stat failed, or import resolution failed — rebundle
       }
 
       // Bundle and write to cache

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -2063,6 +2063,67 @@ export class ProxmoxClient {
   });
 });
 
+Deno.test("UserModelLoader invalidates bundle cache when dependency changes", async () => {
+  const ts = Date.now();
+  const helperCode = `export const greeting = "hello";`;
+  const modelCode = `
+import { z } from "npm:zod@4";
+import { greeting } from "./helper.ts";
+
+export const model = {
+  type: "@user/cache-dep-${ts}",
+  version: "2026.02.09.1",
+  methods: {
+    run: {
+      description: "Run",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [], greeting }),
+    },
+  },
+};
+`;
+
+  const repoDir = await Deno.makeTempDir({ prefix: "swamp_cache_test_repo_" });
+  const modelsDir = await Deno.makeTempDir({
+    prefix: "swamp_cache_test_models_",
+  });
+  try {
+    // Write initial files
+    await Deno.writeTextFile(join(modelsDir, "helper.ts"), helperCode);
+    await Deno.writeTextFile(join(modelsDir, "model.ts"), modelCode);
+
+    // First load — populates cache
+    const loader1 = new UserModelLoader(testDenoRuntime, repoDir);
+    await loader1.loadModels(modelsDir);
+
+    // Read the cached bundle content
+    const bundlePath = join(repoDir, ".swamp", "bundles", "model.js");
+    const cachedBundle1 = await Deno.readTextFile(bundlePath);
+
+    // Wait so mtime differs
+    await new Promise((r) => setTimeout(r, 1100));
+
+    // Modify only the dependency (not the entry point)
+    await Deno.writeTextFile(
+      join(modelsDir, "helper.ts"),
+      `export const greeting = "goodbye";`,
+    );
+
+    // Second load — should detect dependency change and rebundle
+    // (registration will fail since type is already registered, but
+    //  bundleWithCache runs before registration, so the bundle updates)
+    const loader2 = new UserModelLoader(testDenoRuntime, repoDir);
+    await loader2.loadModels(modelsDir);
+
+    // The bundle should have been regenerated with the new dependency content
+    const cachedBundle2 = await Deno.readTextFile(bundlePath);
+    assertEquals(cachedBundle1 !== cachedBundle2, true);
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+    await Deno.remove(modelsDir, { recursive: true });
+  }
+});
+
 Deno.test("UserModelLoader loads model with TypeScript-specific syntax", async () => {
   const typeId = `@user/ts-syntax-${Date.now()}`;
   const modelCode = `

--- a/src/domain/vaults/user_vault_loader.ts
+++ b/src/domain/vaults/user_vault_loader.ts
@@ -21,6 +21,7 @@ import { z } from "zod";
 import { dirname, join, resolve, toFileUrl } from "@std/path";
 import { getLogger } from "@logtape/logtape";
 import { bundleExtension } from "../models/bundle.ts";
+import { resolveLocalImports } from "../models/local_import_resolver.ts";
 import type { DenoRuntime } from "../runtime/deno_runtime.ts";
 import type { VaultProvider } from "./vault_provider.ts";
 import { vaultTypeRegistry } from "./vault_type_registry.ts";
@@ -113,7 +114,12 @@ export class UserVaultLoader {
     for (const file of files) {
       try {
         const absolutePath = resolve(vaultsDir, file);
-        const js = await this.bundleWithCache(absolutePath, file, denoPath);
+        const js = await this.bundleWithCache(
+          absolutePath,
+          file,
+          denoPath,
+          vaultsDir,
+        );
         const module = await this.importBundle(js, file);
 
         if (!module.vault) {
@@ -166,6 +172,7 @@ export class UserVaultLoader {
     absolutePath: string,
     relativePath: string,
     denoPath: string,
+    boundaryDir: string,
   ): Promise<string> {
     if (this.repoDir) {
       const bundlePath = join(
@@ -175,22 +182,32 @@ export class UserVaultLoader {
         relativePath.replace(/\.ts$/, ".js"),
       );
 
-      // Check mtime-based cache
+      // Check mtime-based cache against all local dependencies
       try {
-        const [sourceStat, bundleStat] = await Promise.all([
-          Deno.stat(absolutePath),
-          Deno.stat(bundlePath),
-        ]);
-
-        if (
-          sourceStat.mtime && bundleStat.mtime &&
-          bundleStat.mtime > sourceStat.mtime
-        ) {
-          logger.debug`Using cached vault bundle for ${relativePath}`;
-          return await Deno.readTextFile(bundlePath);
+        const bundleStat = await Deno.stat(bundlePath);
+        if (bundleStat.mtime) {
+          const { resolvedFiles } = await resolveLocalImports(
+            [absolutePath],
+            boundaryDir,
+          );
+          const depStats = await Promise.all(
+            resolvedFiles.map((f) => Deno.stat(f)),
+          );
+          const newestSourceMtime = depStats.reduce<Date | null>(
+            (max, s) => {
+              if (!s.mtime) return max;
+              if (!max) return s.mtime;
+              return s.mtime > max ? s.mtime : max;
+            },
+            null,
+          );
+          if (newestSourceMtime && bundleStat.mtime > newestSourceMtime) {
+            logger.debug`Using cached vault bundle for ${relativePath}`;
+            return await Deno.readTextFile(bundlePath);
+          }
         }
       } catch {
-        // Bundle doesn't exist yet or source stat failed — will rebundle
+        // Bundle doesn't exist, stat failed, or import resolution failed — rebundle
       }
 
       // Bundle and write to cache

--- a/src/domain/vaults/user_vault_loader_test.ts
+++ b/src/domain/vaults/user_vault_loader_test.ts
@@ -233,6 +233,70 @@ export const vault = {
   }
 });
 
+Deno.test("UserVaultLoader - invalidates bundle cache when dependency changes", async () => {
+  const ts = Date.now();
+  const helperCode = `export const vaultName = "original";`;
+  const vaultCode = `
+import { z } from "npm:zod";
+import { vaultName } from "./helper.ts";
+
+export const vault = {
+  type: "@test/cache-dep-vault-${ts}",
+  name: vaultName,
+  description: "Cache test vault",
+  createProvider: (name, _config) => ({
+    get: async (_key) => "secret",
+    put: async (_key, _value) => {},
+    list: async () => [],
+    getName: () => name,
+  }),
+};
+`;
+
+  const repoDir = await Deno.makeTempDir({ prefix: "vault_cache_test_repo_" });
+  const vaultsDir = await Deno.makeTempDir({
+    prefix: "vault_cache_test_vaults_",
+  });
+  try {
+    // Write initial files
+    await Deno.writeTextFile(join(vaultsDir, "helper.ts"), helperCode);
+    await Deno.writeTextFile(join(vaultsDir, "my_vault.ts"), vaultCode);
+
+    // First load — populates cache
+    const loader1 = new UserVaultLoader(new StubDenoRuntime(), repoDir);
+    await loader1.loadVaults(vaultsDir);
+
+    // Read the cached bundle content
+    const bundlePath = join(
+      repoDir,
+      ".swamp",
+      "vault-bundles",
+      "my_vault.js",
+    );
+    const cachedBundle1 = await Deno.readTextFile(bundlePath);
+
+    // Wait so mtime differs
+    await new Promise((r) => setTimeout(r, 1100));
+
+    // Modify only the dependency (not the entry point)
+    await Deno.writeTextFile(
+      join(vaultsDir, "helper.ts"),
+      `export const vaultName = "updated";`,
+    );
+
+    // Second load — should detect dependency change and rebundle
+    const loader2 = new UserVaultLoader(new StubDenoRuntime(), repoDir);
+    await loader2.loadVaults(vaultsDir);
+
+    // The bundle should have been regenerated with the new dependency content
+    const cachedBundle2 = await Deno.readTextFile(bundlePath);
+    assertEquals(cachedBundle1 !== cachedBundle2, true);
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+    await Deno.remove(vaultsDir, { recursive: true });
+  }
+});
+
 Deno.test("UserVaultLoader - allows si/* namespace for local vaults", async () => {
   const tmpDir = await Deno.makeTempDir({ prefix: "vault_loader_test_" });
   try {


### PR DESCRIPTION
## Summary

Fixes #605.

When iterating on extensions, swamp serves stale bundled code because `bundleWithCache` only checks the entry point file's mtime against the cached bundle. If a locally imported dependency changes, the cache is incorrectly treated as fresh — the dependency change is invisible to the cache check.

### The fix

Replace the single-file mtime check with a full dependency graph mtime check:

1. Stat the cached bundle to get its mtime
2. Use `resolveLocalImports()` to walk the entry point's local import graph and collect all `.ts` dependencies
3. Stat every dependency and find the newest mtime
4. Only use the cache if the bundle is newer than **all** dependencies

This is correct because `resolveLocalImports` already existed and is well-tested — it recursively follows relative `import`/`export` statements within a boundary directory, which is exactly the set of files that `deno bundle` would process.

### Architecture boundary

`resolveLocalImports` previously lived in `extensions/`. Importing it directly into `models/` would have introduced a new `extensions <-> models` mutual dependency, caught by the architecture boundary ratchet test. To avoid this, the function was moved to `models/local_import_resolver.ts` (a natural home alongside `bundle.ts`), with `extensions/extension_import_resolver.ts` re-exporting for backward compatibility. No new cross-context dependencies.

### Future optimisation

The current approach re-resolves the import graph on every cache check by reading each dependency file to parse its imports. For small-to-moderate extensions this is negligible, but for large dependency trees with many files it adds I/O. A future optimisation would be to persist the resolved dependency list alongside the cached bundle (e.g. a `.deps.json` sidecar file), so cache checks only need `stat` calls rather than file reads + regex parsing. This would reduce the cache-hit path to N stat calls with no file reads. This isn't necessary today but is a clear path forward if profiling shows it matters.

## Test plan

- [x] New test: model loader invalidates cache when dependency file changes
- [x] New test: vault loader invalidates cache when dependency file changes
- [x] All 2689 existing tests pass
- [x] Architecture boundary ratchet test passes (no new mutual dependencies)
- [x] `deno check`, `deno lint`, `deno fmt` all pass
- [x] `deno run compile` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)