### PR TITLE
feat: accept both US and UK English for summarise command

### DIFF
--- a/src/cli/commands/summarise.ts
+++ b/src/cli/commands/summarise.ts
@@ -34,6 +34,7 @@ import {
  */
 export const summariseCommand = new Command()
   .name("summarise")
+  .alias("summarize")
   .description(
     "Show a high-level overview of repo activity (method executions, workflows, data)",
   )


### PR DESCRIPTION
## Summary

- Adds `.alias("summarize")` to the `summarise` command so both `swamp summarise` and `swamp summarize` work
- Audited all CLI commands — `summarise` is the **only** command using a -ise/-ize verb. All others use dialect-neutral verbs (`init`, `create`, `delete`, `run`, `search`, `validate`, `evaluate`, `describe`, `edit`, `get`, `push`, `pull`, `list`, `update`, etc.)
- The only built-in model method (`execute` on `command/shell`) is also dialect-neutral
- Internal code and filenames remain unchanged — this is purely an input alias

Closes #608

## Test Plan

- Verified `swamp summarize --help` resolves correctly
- Verified `swamp summarise --help` still works
- All 2689 tests pass, `deno fmt`, `deno lint`, and `deno check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)