### PR TITLE
fix: externalize all npm packages in extension bundler

### DIFF
--- a/.claude/skills/swamp-extension-model/references/examples.md
+++ b/.claude/skills/swamp-extension-model/references/examples.md
@@ -81,23 +81,26 @@ export const model = {
 **How bundling works:**
 
 - On first run (or after editing), swamp runs `deno bundle` to transpile your
-  TypeScript and resolve all `npm:` imports into a single `.js` file
+  TypeScript into a `.js` file
 - The bundle is cached to `.swamp/bundles/` — subsequent runs skip bundling
   unless the source file's modification time is newer than the cached bundle
-- `npm:zod` is externalized (not bundled) so your model shares the same zod
-  instance as swamp, which is required for schema validation to work
-- All other npm imports are fully resolved and inlined into the bundle
+- All `npm:` packages are externalized (`--packages external`) — they are left
+  as `npm:` specifiers in the output and resolved at runtime by Deno's native
+  npm resolver, preserving correct CJS/ESM interop
+- This ensures your model shares the same zod instance as swamp, which is
+  required for schema validation to work
+- Local `.ts` code and other imports are still transpiled and bundled
 
 **Import rules:**
 
-| Import                                   | Bundled? | Notes                            |
-| ---------------------------------------- | -------- | -------------------------------- |
-| `npm:zod@4`                              | No       | Shared with swamp (externalized) |
-| `npm:lodash-es@4.17.21`                  | Yes      | Resolved and inlined             |
-| `npm:@aws-sdk/client-s3@3.750.0`         | Yes      | Resolved and inlined             |
-| `jsr:@std/path`                          | Yes      | Resolved and inlined             |
-| `https://deno.land/std@0.224.0/async/..` | Yes      | Resolved and inlined             |
-| Any other Deno-compatible import         | Yes      | Resolved and inlined             |
+| Import                                   | Bundled? | Notes                                     |
+| ---------------------------------------- | -------- | ----------------------------------------- |
+| `npm:zod@4`                              | No       | Externalized, resolved at runtime by Deno |
+| `npm:lodash-es@4.17.21`                  | No       | Externalized, resolved at runtime by Deno |
+| `npm:@aws-sdk/client-s3@3.750.0`         | No       | Externalized, resolved at runtime by Deno |
+| `jsr:@std/path`                          | Yes      | Resolved and inlined                      |
+| `https://deno.land/std@0.224.0/async/..` | Yes      | Resolved and inlined                      |
+| Local `.ts` imports                      | Yes      | Transpiled and inlined                    |
 
 ## CRUD Lifecycle Model (VPC)
 

--- a/design/extension.md
+++ b/design/extension.md
@@ -109,8 +109,10 @@ if `connection.ts` imports `./helpers.ts`, both files are included.
 
 ### Bundles
 
-Each model entry point is compiled using `deno bundle` with `zod` externalized
-(so extensions share the host's zod instance). Bundles are JavaScript files
+Each model entry point is compiled using `deno bundle` with all npm packages
+externalized (`--external npm:*`). This means npm dependencies resolve at
+runtime via Deno's native npm resolver, preserving correct CJS/ESM interop and
+ensuring extensions share the host's zod instance. Bundles are JavaScript files
 stored alongside their source counterparts under `bundles/`.
 
 ### Workflows

--- a/src/domain/models/bundle.ts
+++ b/src/domain/models/bundle.ts
@@ -25,8 +25,8 @@ const logger = getLogger(["swamp", "models", "bundle"]);
  * Bundles a TypeScript extension file into JavaScript using `deno bundle` subprocess.
  *
  * Transpiles TypeScript syntax (interfaces, type annotations, generics) and
- * resolves npm imports, while externalizing zod so extensions share the same
- * instance as swamp (preserving instanceof checks).
+ * externalizes all npm packages so they resolve at runtime via Deno's native
+ * npm resolver (preserving correct CJS/ESM interop and zod instanceof checks).
  *
  * @param absolutePath - Absolute filesystem path to the TypeScript file
  * @param denoPath - Absolute path to the deno binary to use for bundling
@@ -49,9 +49,7 @@ export async function bundleExtension(
         "bundle",
         "--no-lock",
         "--external",
-        "npm:zod@4",
-        "--external",
-        "npm:zod",
+        "npm:*",
         "--platform",
         "deno",
         "-o",

--- a/src/domain/models/bundle_test.ts
+++ b/src/domain/models/bundle_test.ts
@@ -122,7 +122,7 @@ export const model = {
   try {
     const js = await bundleExtension(path, DENO_PATH);
 
-    // Bundle should succeed and contain inlined yaml library code
+    // Bundle should succeed — yaml is externalized (not inlined)
     assertEquals(js.length > 0, true);
 
     // No deno.lock should be created in the source directory


### PR DESCRIPTION
Fixes #609

## Summary

- Replace `--external npm:zod@4 --external npm:zod` with `--external npm:*` in the extension bundler so all npm packages are externalized
- Update docs and skill references to reflect the new bundling behavior

## Problem

When extensions import npm packages like `@aws-sdk/client-s3` that transitively depend on `tslib` (a CJS module), `deno bundle` inlines the package and wraps the CJS code in a `__toESM` bridge. This bridge produces `import_tslib.default === undefined`, causing runtime destructuring failures:

```
Cannot destructure property '__extends' of 'import_tslib.default' as it is undefined.
```

## Fix

Use `--external npm:*` to externalize **all** npm packages. They are left as `npm:` specifiers in the bundled output and resolved at runtime by Deno's native npm resolver, which handles CJS/ESM interop correctly.

### Why `--external npm:*` and not `--packages external`

The original plan was to use `--packages external`, which is documented in `deno bundle --help`. However, testing on deno 2.6.8 showed it **does not actually externalize npm packages** — it silently inlines everything (510KB bundle for a file that only imports zod). The `--external npm:*` wildcard flag achieves the intended behavior and actually works.

### Why JSR imports are unaffected

`--external npm:*` only targets npm packages. JSR (`jsr:`) and HTTPS imports are still bundled and inlined. This is correct because:

- **JSR packages are native ESM** — they don't have CJS interop issues
- **JSR packages don't need instance sharing** — unlike zod, there's no `instanceof` concern
- **They're self-contained** — inlining them keeps bundles portable

### What this means for extension bundles

| Import | Before | After |
|--------|--------|-------|
| `npm:zod@4` | Externalized | Externalized |
| `npm:@aws-sdk/client-s3@3` | Inlined (broken CJS) | Externalized |
| `npm:yaml@2.7.1` | Inlined | Externalized |
| `jsr:@std/path` | Inlined | Inlined |
| `https://deno.land/...` | Inlined | Inlined |
| Local `.ts` imports | Transpiled & inlined | Transpiled & inlined |

npm packages are cached by `deno bundle` during bundling and reused at runtime — no extra download step.

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt` — formatting passes
- [x] `deno run test src/domain/models/bundle_test.ts` — all 4 bundle tests pass
- [x] `deno run test` — full suite (2689 tests) passes
- [x] `deno run compile` — binary compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)