### PR TITLE
fix: command/shell throws on non-zero exit codes

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -207,6 +207,32 @@ execute: (async (args, context) => {
 });
 ```
 
+### Error Handling
+
+Models should throw when execution fails. Throw **before** writing data — failed
+executions should not persist incorrect or misleading data.
+
+```typescript
+execute: (async (args, context) => {
+  const result = await callExternalApi(args);
+
+  // Throw BEFORE writing data — don't persist failure data
+  if (result.status >= 400) {
+    throw new Error(`API request failed with status ${result.status}`);
+  }
+
+  const handle = await context.writeResource("result", "main", {
+    statusCode: result.status,
+    response: result.body,
+  });
+
+  return { dataHandles: [handle] };
+});
+```
+
+The workflow engine catches exceptions and marks the step as failed. Use
+`allowFailure: true` on a workflow step to continue execution after a failure.
+
 For detailed API documentation on `writeResource`, `createFileWriter`,
 `DataWriter`, `DataHandle`, and `dataRepository`, see
 [references/api.md](references/api.md).

--- a/.claude/skills/swamp-extension-model/references/api.md
+++ b/.claude/skills/swamp-extension-model/references/api.md
@@ -11,6 +11,7 @@ Detailed API documentation for extension model development.
 - [Reading Stored Data](#reading-stored-data)
 - [Lifetime Values](#lifetime-values)
 - [Standard Tags](#standard-tags)
+- [Error Handling](#error-handling)
 - [Logging API](#logging-api)
 
 ---
@@ -195,6 +196,38 @@ Tags are auto-applied based on the spec kind:
 | `type: "resource"`   | resources  | Auto-added to all resource data outputs  |
 | `type: "file"`       | files      | Auto-added to all file data outputs      |
 | `specName: "<name>"` | both       | Auto-added with the output spec key name |
+
+---
+
+## Error Handling
+
+Models should throw when execution fails. Throw **before** writing data — failed
+executions should not persist incorrect or misleading data.
+
+**Pattern: check for failure first, only write data on success.**
+
+```typescript
+execute: (async (args, context) => {
+  const result = await callExternalApi(args);
+
+  // Throw BEFORE writing data — don't persist failure data
+  if (result.status >= 400) {
+    throw new Error(`API request failed with status ${result.status}`);
+  }
+
+  const handle = await context.writeResource("result", "main", {
+    statusCode: result.status,
+    response: result.body,
+    timestamp: new Date().toISOString(),
+  });
+
+  return { dataHandles: [handle] };
+});
+```
+
+**Workflow integration:** When a model method throws, the workflow engine
+automatically marks the step as failed. Use `allowFailure: true` on a workflow
+step to catch exceptions and allow continued execution of subsequent steps.
 
 ---
 

--- a/.claude/skills/swamp-extension-model/references/examples.md
+++ b/.claude/skills/swamp-extension-model/references/examples.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 
 - [CRUD Lifecycle Model (VPC)](#crud-lifecycle-model-vpc)
+- [Error Handling Model](#error-handling-model)
 - [Text Processor Model](#text-processor-model)
 - [Deployment Model](#deployment-model)
 - [Minimal Echo Model](#minimal-echo-model)
@@ -280,6 +281,80 @@ export const model = {
   `context.modelType` and `context.modelId` to locate the model's own data
 - `delete` returns `{ dataHandles: [] }` since no new data is produced
 - Always check for `null` content — the model may not have been created yet
+
+## Error Handling Model
+
+Models should throw when execution fails. Throw **before** writing data — failed
+executions should not persist incorrect or misleading data.
+
+**Pattern: check for failure first, only write data on success.**
+
+```typescript
+// extensions/models/health_check.ts
+import { z } from "npm:zod@4";
+
+const GlobalArgsSchema = z.object({
+  url: z.string().url(),
+  expectedStatus: z.number().default(200),
+});
+
+const ResultSchema = z.object({
+  url: z.string(),
+  statusCode: z.number(),
+  responseTimeMs: z.number(),
+  checkedAt: z.string(),
+});
+
+export const model = {
+  type: "@user/health-check",
+  version: "2026.03.05.1",
+  globalArguments: GlobalArgsSchema,
+  resources: {
+    result: {
+      description: "Health check result",
+      schema: ResultSchema,
+      lifetime: "infinite",
+      garbageCollection: 10,
+    },
+  },
+  methods: {
+    check: {
+      description: "Check endpoint health",
+      arguments: z.object({}),
+      execute: async (_args, context) => {
+        const { url, expectedStatus } = context.globalArgs;
+        const start = Date.now();
+
+        const response = await fetch(url);
+        const responseTimeMs = Date.now() - start;
+
+        // Throw BEFORE writing data — don't persist failure data
+        if (response.status !== expectedStatus) {
+          throw new Error(
+            `Health check failed: expected status ${expectedStatus}, got ${response.status}`,
+          );
+        }
+
+        const handle = await context.writeResource("result", "main", {
+          url,
+          statusCode: response.status,
+          responseTimeMs,
+          checkedAt: new Date().toISOString(),
+        });
+
+        return { dataHandles: [handle] };
+      },
+    },
+  },
+};
+```
+
+**Key points:**
+
+- Throw before `writeResource()` — failed executions should not write data
+- The workflow engine catches the exception and marks the step as failed
+- Use `allowFailure: true` on a workflow step to continue execution after a
+  failure
 
 ## Text Processor Model
 

--- a/integration/input_override_validation_test.ts
+++ b/integration/input_override_validation_test.ts
@@ -370,7 +370,7 @@ Deno.test("Workflow: step input override with CEL expression preserves type", as
         "--repo-dir",
         repoDir,
         "--input",
-        '{"customMessage": "from CEL"}',
+        '{"customMessage": "echo from CEL"}',
         "--json",
       ],
       Deno.cwd(),

--- a/integration/keeb_shell_model_test.ts
+++ b/integration/keeb_shell_model_test.ts
@@ -132,7 +132,7 @@ Deno.test("CLI: command/shell model executes simple shell commands", async () =>
   });
 });
 
-Deno.test("CLI: command/shell model handles failing commands", async () => {
+Deno.test("CLI: command/shell model reports failure on non-zero exit code", async () => {
   await withTempDir(async (repoDir) => {
     await initializeTestRepo(repoDir);
 
@@ -151,7 +151,7 @@ Deno.test("CLI: command/shell model handles failing commands", async () => {
     });
     await definitionRepo.save(SHELL_MODEL_TYPE, definition);
 
-    // Execute the model
+    // Execute the model — should fail because `false` exits with code 1
     const result = await runCliCommand(
       [
         "model",
@@ -168,13 +168,9 @@ Deno.test("CLI: command/shell model handles failing commands", async () => {
 
     assertEquals(
       result.code,
-      0,
-      `swamp command should succeed even when shell command fails. stderr: ${result.stderr}`,
+      1,
+      `swamp command should fail when shell command exits non-zero. stderr: ${result.stderr}`,
     );
-
-    const output = JSON.parse(result.stdout);
-    assertEquals(output.modelName, "failing-shell");
-    assertEquals(output.data.attributes.exitCode, 1); // Shell command failed
   });
 });
 

--- a/integration/workflow_new_architecture_test.ts
+++ b/integration/workflow_new_architecture_test.ts
@@ -106,7 +106,7 @@ Deno.test("Workflow Architecture: workflow references model by name", async () =
     // Create model definition
     const model = Definition.create({
       name: "my-shell-model",
-      methods: { execute: { arguments: { run: "Hello from model" } } },
+      methods: { execute: { arguments: { run: "echo 'Hello from model'" } } },
     });
     await definitionRepo.save(SHELL_MODEL_TYPE, model);
 
@@ -162,7 +162,7 @@ Deno.test("Workflow Architecture: workflow references model by UUID", async () =
     // Create model definition
     const model = Definition.create({
       name: "uuid-ref-model",
-      methods: { execute: { arguments: { run: "Referenced by UUID" } } },
+      methods: { execute: { arguments: { run: "echo 'Referenced by UUID'" } } },
     });
     await definitionRepo.save(SHELL_MODEL_TYPE, model);
 
@@ -214,7 +214,9 @@ Deno.test("Workflow Architecture: step creates Data artifact", async () => {
     // Create model
     const model = Definition.create({
       name: "data-creator-model",
-      methods: { execute: { arguments: { run: "Creating data artifact" } } },
+      methods: {
+        execute: { arguments: { run: "echo 'Creating data artifact'" } },
+      },
     });
     await definitionRepo.save(SHELL_MODEL_TYPE, model);
 
@@ -296,11 +298,11 @@ Deno.test("Workflow Architecture: multiple steps create multiple Data artifacts"
     // Create multiple models
     const model1 = Definition.create({
       name: "model-one",
-      methods: { execute: { arguments: { run: "First model" } } },
+      methods: { execute: { arguments: { run: "echo 'First model'" } } },
     });
     const model2 = Definition.create({
       name: "model-two",
-      methods: { execute: { arguments: { run: "Second model" } } },
+      methods: { execute: { arguments: { run: "echo 'Second model'" } } },
     });
     await definitionRepo.save(SHELL_MODEL_TYPE, model1);
     await definitionRepo.save(SHELL_MODEL_TYPE, model2);
@@ -383,7 +385,7 @@ Deno.test("Workflow Architecture: workflow run is persisted", async () => {
     // Create model and workflow
     const model = Definition.create({
       name: "tracked-model",
-      methods: { execute: { arguments: { run: "Tracked execution" } } },
+      methods: { execute: { arguments: { run: "echo 'Tracked execution'" } } },
     });
     await definitionRepo.save(SHELL_MODEL_TYPE, model);
 
@@ -440,7 +442,7 @@ Deno.test("Workflow Architecture: workflow run history", async () => {
 
     const model = Definition.create({
       name: "history-model",
-      methods: { execute: { arguments: { run: "History test" } } },
+      methods: { execute: { arguments: { run: "echo 'History test'" } } },
     });
     await definitionRepo.save(SHELL_MODEL_TYPE, model);
 
@@ -495,7 +497,7 @@ Deno.test("Workflow Architecture: step execution duration is tracked", async () 
 
     const model = Definition.create({
       name: "timing-model",
-      methods: { execute: { arguments: { run: "Timing test" } } },
+      methods: { execute: { arguments: { run: "echo 'Timing test'" } } },
     });
     await definitionRepo.save(SHELL_MODEL_TYPE, model);
 
@@ -709,7 +711,7 @@ Deno.test("Workflow Architecture: dependent step skipped on failure", async () =
 
     const model = Definition.create({
       name: "skip-test-model",
-      methods: { execute: { arguments: { run: "Should be skipped" } } },
+      methods: { execute: { arguments: { run: "echo 'Should be skipped'" } } },
     });
     await definitionRepo.save(SHELL_MODEL_TYPE, model);
 
@@ -793,7 +795,7 @@ Deno.test("Workflow Architecture: data persists after workflow completion", asyn
 
     const model = Definition.create({
       name: "persist-data-model",
-      methods: { execute: { arguments: { run: "Persistent data" } } },
+      methods: { execute: { arguments: { run: "echo 'Persistent data'" } } },
     });
     await definitionRepo.save(SHELL_MODEL_TYPE, model);
 
@@ -855,15 +857,15 @@ Deno.test("Workflow Architecture: multi-job workflow with dependencies", async (
     // Create models for different stages
     const buildModel = Definition.create({
       name: "build-model",
-      methods: { execute: { arguments: { run: "Building..." } } },
+      methods: { execute: { arguments: { run: "echo 'Building...'" } } },
     });
     const testModel = Definition.create({
       name: "test-model",
-      methods: { execute: { arguments: { run: "Testing..." } } },
+      methods: { execute: { arguments: { run: "echo 'Testing...'" } } },
     });
     const deployModel = Definition.create({
       name: "deploy-model",
-      methods: { execute: { arguments: { run: "Deploying..." } } },
+      methods: { execute: { arguments: { run: "echo 'Deploying...'" } } },
     });
 
     await definitionRepo.save(SHELL_MODEL_TYPE, buildModel);
@@ -950,19 +952,21 @@ Deno.test("Workflow Architecture: mixed model steps", async () => {
 
     const shellModel = Definition.create({
       name: "shell-model",
-      methods: { execute: { arguments: { run: "Shell step replacement" } } },
+      methods: {
+        execute: { arguments: { run: "echo 'Shell step replacement'" } },
+      },
     });
     await definitionRepo.save(SHELL_MODEL_TYPE, shellModel);
 
     const mixedModel = Definition.create({
       name: "mixed-model",
-      methods: { execute: { arguments: { run: "Model step" } } },
+      methods: { execute: { arguments: { run: "echo 'Model step'" } } },
     });
     await definitionRepo.save(SHELL_MODEL_TYPE, mixedModel);
 
     const finalModel = Definition.create({
       name: "final-model",
-      methods: { execute: { arguments: { run: "Final step" } } },
+      methods: { execute: { arguments: { run: "echo 'Final step'" } } },
     });
     await definitionRepo.save(SHELL_MODEL_TYPE, finalModel);
 

--- a/src/domain/models/command/shell/shell_model.ts
+++ b/src/domain/models/command/shell/shell_model.ts
@@ -41,6 +41,9 @@ export const ShellInputAttributesSchema = z.object({
   env: z.record(z.string(), z.string()).optional().describe(
     "Environment variables",
   ),
+  ignoreExitCode: z.boolean().optional().describe(
+    "If true, non-zero exit codes will not cause the method to throw",
+  ),
 });
 
 /**
@@ -113,7 +116,11 @@ async function executeCommand(
     exitCode = -1;
   }
 
-  // Create data attributes for the result
+  if (exitCode !== 0 && !args.ignoreExitCode) {
+    throw new Error(`Command exited with code ${exitCode}`);
+  }
+
+  // Only persist data for successful executions
   const resultAttributes = {
     exitCode,
     executedAt: new Date().toISOString(),

--- a/src/domain/models/command/shell/shell_model_test.ts
+++ b/src/domain/models/command/shell/shell_model_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import { assertNotEquals } from "@std/assert/not-equals";
 import { createDefinitionId } from "../../../definitions/definition.ts";
 import {
@@ -396,24 +396,26 @@ Deno.test("shellModel.methods.execute captures stderr", async () => {
   assertStringIncludes(logContent, "error");
 });
 
-Deno.test("shellModel.methods.execute captures exit code", async () => {
+Deno.test("shellModel.methods.execute throws on non-zero exit code", async () => {
   const args: ShellInputAttributes = { run: "exit 42" };
 
-  const { context, getResults } = createTestContext();
-  await shellModel.methods.execute.execute(args, context);
-
-  const attrs = getResultAttributes(getResults(), "result");
-  assertEquals(attrs?.exitCode, 42);
+  const { context } = createTestContext();
+  await assertRejects(
+    () => shellModel.methods.execute.execute(args, context),
+    Error,
+    "Command exited with code 42",
+  );
 });
 
-Deno.test("shellModel.methods.execute handles command failure gracefully", async () => {
+Deno.test("shellModel.methods.execute throws on command failure", async () => {
   const args: ShellInputAttributes = { run: "false" };
 
-  const { context, getResults } = createTestContext();
-  await shellModel.methods.execute.execute(args, context);
-
-  const attrs = getResultAttributes(getResults(), "result");
-  assertEquals(attrs?.exitCode, 1);
+  const { context } = createTestContext();
+  await assertRejects(
+    () => shellModel.methods.execute.execute(args, context),
+    Error,
+    "Command exited with code 1",
+  );
 });
 
 Deno.test("shellModel.methods.execute respects workingDir", async () => {
@@ -490,19 +492,14 @@ Deno.test("ShellInputAttributesSchema rejects empty run command via schema", () 
   assertEquals(result.success, false);
 });
 
-Deno.test("shellModel.methods.execute handles nonexistent command", async () => {
+Deno.test("shellModel.methods.execute throws on nonexistent command", async () => {
   const args: ShellInputAttributes = { run: "nonexistent_command_12345" };
 
-  const { context, getResults } = createTestContext();
-  await shellModel.methods.execute.execute(args, context);
-
-  // Should return non-zero exit code and error in output
-  const attrs = getResultAttributes(getResults(), "result");
-  assertEquals(attrs?.exitCode !== 0, true);
-
-  // Check output contains error about nonexistent command
-  const logContent = getOutputLogContent(getResults());
-  assertStringIncludes(logContent, "nonexistent_command_12345");
+  const { context } = createTestContext();
+  await assertRejects(
+    () => shellModel.methods.execute.execute(args, context),
+    Error,
+  );
 });
 
 Deno.test("shellModel.methods.execute records execution duration", async () => {
@@ -609,11 +606,48 @@ Deno.test("shellModel.methods.execute redacts secrets from error messages on fai
   const args: ShellInputAttributes = {
     run: "echo error-secret >&2 && exit 1",
   };
-  const { context, getResults } = createTestContext({ redactor });
-  await shellModel.methods.execute.execute(args, context);
+  const { context } = createTestContext({ redactor });
+  await assertRejects(
+    () => shellModel.methods.execute.execute(args, context),
+    Error,
+    "Command exited with code 1",
+  );
+});
+
+Deno.test("shellModel.methods.execute ignoreExitCode suppresses throw", async () => {
+  const args: ShellInputAttributes = { run: "exit 42", ignoreExitCode: true };
+
+  const { context, getResults } = createTestContext();
+  const result = await shellModel.methods.execute.execute(args, context);
 
   const attrs = getResultAttributes(getResults(), "result");
-  // stderr should be redacted
-  assertNotEquals(attrs?.stderr, undefined);
-  assertEquals((attrs?.stderr as string).includes("error-secret"), false);
+  assertEquals(attrs?.exitCode, 42);
+  assertEquals(result.dataHandles !== undefined, true);
+});
+
+Deno.test("shellModel.methods.execute exit code 0 returns normally", async () => {
+  const args: ShellInputAttributes = { run: "true" };
+
+  const { context, getResults } = createTestContext();
+  const result = await shellModel.methods.execute.execute(args, context);
+
+  const attrs = getResultAttributes(getResults(), "result");
+  assertEquals(attrs?.exitCode, 0);
+  assertEquals(result.dataHandles !== undefined, true);
+});
+
+Deno.test("shellModel.methods.execute does not persist data on failure", async () => {
+  const args: ShellInputAttributes = {
+    run: "echo 'some output' && exit 1",
+  };
+
+  const { context, getResults } = createTestContext();
+  await assertRejects(
+    () => shellModel.methods.execute.execute(args, context),
+    Error,
+    "Command exited with code 1",
+  );
+
+  // No data should be written for a failed command
+  assertEquals(getResults().length, 0);
 });


### PR DESCRIPTION
## Summary

Fixes #614 — workflows reported "succeeded" even when shell commands failed (e.g., `nvidia-smi: command not found`).

### Problem

`command/shell` captured exit codes as data but never threw on non-zero values. The workflow engine determines step success by whether the method throws, so every shell step was treated as successful regardless of the command's actual outcome.

### Why this approach

The simplest correct fix is to make `command/shell` throw before writing any data when the exit code is non-zero:

- **Throw before data writes** — failed commands should not persist incorrect or misleading result data. If the command failed, there's nothing useful to store as a "result".
- **No engine changes needed** — the existing workflow engine try/catch chains already handle `stepRun.fail()`, `allowFailure`, and error logging. Making the model throw is the standard convention for signaling failure.
- **`ignoreExitCode` opt-out** — an optional `ignoreExitCode: true` attribute is available for definitions where non-zero exits are expected and the caller wants data persisted regardless.

### Changes

- **`src/domain/models/command/shell/shell_model.ts`** — Added `ignoreExitCode` (optional boolean) to `ShellInputAttributesSchema`. Throws `Error` before `writeResource`/`createFileWriter` when exit code is non-zero and `ignoreExitCode` is not set.
- **`src/domain/models/command/shell/shell_model_test.ts`** — Updated 4 tests to expect `assertRejects`, added 3 new tests (ignoreExitCode suppression, exit 0 normal return, no data on failure).
- **`integration/keeb_shell_model_test.ts`** — Updated failing-command test to expect CLI exit code 1.
- **`integration/workflow_new_architecture_test.ts`** — Fixed 15 model definitions that used invalid shell commands (bare strings like `"Hello from model"` instead of `"echo 'Hello from model'"`). These were silently failing before but passing because exit codes were swallowed.
- **`integration/input_override_validation_test.ts`** — Fixed CEL expression test input to be a valid shell command.
- **Skill docs** (`SKILL.md`, `references/api.md`, `references/examples.md`) — Added error handling guidance establishing the convention: check for failure first, throw before writing data, only persist data on success.

### User impact

- **Breaking change for workflows using `command/shell` with commands that exit non-zero.** These workflows will now correctly report as failed instead of falsely succeeding.
- **Opt-out available:** Add `ignoreExitCode: true` to any shell model definition that intentionally uses commands with non-zero exit codes.
- **`allowFailure: true`** on workflow steps continues to work — the engine catches the exception and allows the workflow to proceed.

## Test Plan

- [x] `deno check` — passes
- [x] `deno lint` — passes
- [x] `deno fmt` — passes
- [x] `deno run test` — 2692 passed, 0 failed
- [x] `deno run compile` — binary compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)