### PR TITLE
fix: add model context to data-writer schema validation warnings

### DIFF
--- a/src/domain/models/data_writer.ts
+++ b/src/domain/models/data_writer.ts
@@ -433,6 +433,11 @@ export function createResourceWriter(
   getHandles: () => DataHandle[];
 } {
   const handles: DataHandle[] = [];
+  const writerLogger = getLogger([
+    "swamp",
+    "data-writer",
+    ...(definitionName ? [definitionName] : []),
+  ]);
 
   const writeResource = async (
     specName: string,
@@ -457,9 +462,9 @@ export function createResourceWriter(
           `${i.message} at "${i.path.join(".")}"`
         ).join("; ")
         : String(validationResult.error);
-      logger.warn(
-        "Resource '{specName}' data does not match schema: {error}",
-        { specName, error: formattedError },
+      writerLogger.warn(
+        "Resource '{specName}' (instance '{name}') data does not match schema: {error}",
+        { specName, name, error: formattedError },
       );
     }
 


### PR DESCRIPTION
## Summary

- Add contextual logger in `createResourceWriter()` that includes the model definition name in the LogTape category hierarchy, so schema validation warnings identify which model triggered them
- Include instance name in the warning message for additional context
- Fixes #620

**Before:**
```
swamp·data-writer    Resource 'state' data does not match schema: ...
```

**After:**
```
swamp·data-writer·web-droplet    Resource 'state' (instance 'web-1') data does not match schema: ...
```

## Test plan

- `deno check` — passes
- `deno lint` — passes
- `deno fmt` — passes
- `deno run test` — all 2692 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)