### PR TITLE
fix: `swamp repo upgrade` merges instructions instead of overwriting

### DIFF
--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -41,6 +41,11 @@ const GITIGNORE_SECTION_BEGIN = "# BEGIN swamp managed section - DO NOT EDIT";
 const GITIGNORE_SECTION_END = "# END swamp managed section";
 const GITIGNORE_LEGACY_HEADER = "# Swamp managed defaults";
 
+const INSTRUCTIONS_SECTION_BEGIN =
+  "<!-- BEGIN swamp managed section - DO NOT EDIT -->";
+const INSTRUCTIONS_SECTION_END = "<!-- END swamp managed section -->";
+const LEGACY_INSTRUCTIONS_SIGNATURE = "This repository is managed with [swamp]";
+
 /**
  * Describes what happened to the .gitignore during init/upgrade.
  * - "created": a new .gitignore file was created with the managed section
@@ -351,6 +356,7 @@ export class RepoService {
 
   /**
    * Creates the tool-appropriate instructions file if it doesn't already exist.
+   * For shared-file tools, creates with section markers from the start.
    */
   private async createInstructionsFileIfNotExists(
     repoPath: RepoPath,
@@ -358,18 +364,24 @@ export class RepoService {
   ): Promise<boolean> {
     const filePath = join(repoPath.value, INSTRUCTIONS_FILES[tool]);
 
+    // For shared-file tools, always ensure the managed section exists
+    // (merges into existing file or creates new one)
+    if (this.usesSharedInstructionsFile(tool)) {
+      return this.ensureInstructionsSection(filePath);
+    }
+
+    // For tool-specific files, only create if missing
     try {
       await Deno.stat(filePath);
-      // File exists, don't overwrite
       return false;
     } catch (error) {
       if (error instanceof Deno.errors.NotFound) {
-        // Ensure parent directory exists (for cursor: .cursor/rules/)
         const parentDir = join(filePath, "..");
         await ensureDir(parentDir);
-
-        const content = this.generateInstructionsContent(tool);
-        await Deno.writeTextFile(filePath, content);
+        await Deno.writeTextFile(
+          filePath,
+          this.generateInstructionsContent(tool),
+        );
         return true;
       }
       throw error;
@@ -377,24 +389,165 @@ export class RepoService {
   }
 
   /**
-   * Updates the tool-appropriate instructions file, overwriting if content changed.
+   * Updates the tool-appropriate instructions file.
+   * For tool-specific files (cursor/kiro): overwrites entirely.
+   * For shared files (claude/opencode/codex): merges using section markers.
    */
   private updateInstructionsFile(
     repoPath: RepoPath,
     tool: AiTool,
   ): Promise<boolean> {
     const filePath = join(repoPath.value, INSTRUCTIONS_FILES[tool]);
-    return this.overwriteIfChanged(
-      filePath,
-      this.generateInstructionsContent(tool),
-    );
+    if (!this.usesSharedInstructionsFile(tool)) {
+      return this.overwriteIfChanged(
+        filePath,
+        this.generateInstructionsContent(tool),
+      );
+    }
+    return this.ensureInstructionsSection(filePath);
   }
 
   /**
-   * Generates the instructions content for the given tool.
+   * Ensures the shared instructions file contains an up-to-date managed section.
+   *
+   * - If no file exists: creates with managed section.
+   * - If file has markers: replaces content between markers.
+   * - If file has legacy swamp content (no markers): migrates to marked section.
+   * - If file has no swamp content: prepends managed section.
    */
-  private generateInstructionsContent(tool: AiTool): string {
-    const body = `# Project
+  private async ensureInstructionsSection(filePath: string): Promise<boolean> {
+    const newSection = this.buildInstructionsSection();
+
+    let existingContent: string | null = null;
+    try {
+      existingContent = await Deno.readTextFile(filePath);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+
+    // Case 1: No file exists — create with managed section
+    if (existingContent === null) {
+      await ensureDir(join(filePath, ".."));
+      await Deno.writeTextFile(filePath, newSection + "\n");
+      return true;
+    }
+
+    // Case 2: File has markers — replace managed section
+    // Only proceed if both BEGIN and END markers are present;
+    // a missing END marker (accidental deletion) falls through to case 4.
+    if (
+      existingContent.includes(INSTRUCTIONS_SECTION_BEGIN) &&
+      existingContent.includes(INSTRUCTIONS_SECTION_END)
+    ) {
+      const updatedContent = this.replaceManagedSection(
+        existingContent,
+        newSection,
+        INSTRUCTIONS_SECTION_BEGIN,
+        INSTRUCTIONS_SECTION_END,
+      );
+      if (updatedContent === existingContent) {
+        return false;
+      }
+      await atomicWriteTextFile(filePath, updatedContent);
+      return true;
+    }
+
+    // Case 3: File has legacy swamp content (no markers) — migrate
+    if (this.hasLegacyInstructionsContent(existingContent)) {
+      const updatedContent = this.migrateLegacyInstructions(
+        existingContent,
+        newSection,
+      );
+      await atomicWriteTextFile(filePath, updatedContent);
+      return true;
+    }
+
+    // Case 4: File has no swamp content — prepend managed section
+    const separator = existingContent.startsWith("\n") ? "" : "\n";
+    await atomicWriteTextFile(
+      filePath,
+      newSection + "\n" + separator + existingContent,
+    );
+    return true;
+  }
+
+  /**
+   * Detects legacy swamp-generated instructions content (without markers).
+   */
+  private hasLegacyInstructionsContent(content: string): boolean {
+    return content.includes(LEGACY_INSTRUCTIONS_SIGNATURE);
+  }
+
+  /**
+   * Migrates legacy instructions content to the marked section format.
+   * Finds the old template boundaries and replaces with the marked section,
+   * preserving any user content before/after.
+   * Falls back to prepend if boundaries can't be found.
+   */
+  private migrateLegacyInstructions(
+    content: string,
+    newSection: string,
+  ): string {
+    // Find start: "# Project\n\nThis repository is managed with [swamp]"
+    const startPattern =
+      /# Project\n\nThis repository is managed with \[swamp\]/;
+    const startMatch = startPattern.exec(content);
+
+    if (!startMatch) {
+      // Can't find boundaries — prepend
+      const separator = content.startsWith("\n") ? "" : "\n";
+      return newSection + "\n" + separator + content;
+    }
+
+    // Find end: "Use `swamp --help` to see available commands.\n"
+    const endMarker = "Use `swamp --help` to see available commands.\n";
+    const endIndex = content.indexOf(endMarker, startMatch.index);
+
+    if (endIndex === -1) {
+      // Start matched but end didn't — the user edited the template.
+      // Replace from the start match to end-of-content to avoid duplication,
+      // preserving any content before the legacy template.
+      const before = content.substring(0, startMatch.index);
+      const prefix = before.length > 0 ? before : "";
+      return prefix + newSection + "\n";
+    }
+
+    const endSlice = endIndex + endMarker.length;
+
+    const before = content.substring(0, startMatch.index);
+    const after = content.substring(endSlice);
+
+    const prefix = before.length > 0 ? before : "";
+    const suffix = after.length > 0 ? after : "\n";
+
+    return prefix + newSection + "\n" + suffix;
+  }
+
+  /**
+   * Returns true if the tool shares its instructions file with user content
+   * (CLAUDE.md, AGENTS.md) and needs section markers to avoid overwriting.
+   */
+  private usesSharedInstructionsFile(tool: AiTool): boolean {
+    switch (tool) {
+      case "claude":
+      case "opencode":
+      case "codex":
+        return true;
+      case "cursor":
+      case "kiro":
+        return false;
+      default:
+        assertNever(tool);
+    }
+  }
+
+  /**
+   * Generates the raw instructions body without any frontmatter or markers.
+   */
+  private generateInstructionsBody(): string {
+    return `# Project
 
 This repository is managed with [swamp](https://github.com/systeminit/swamp).
 
@@ -428,6 +581,23 @@ Always start by using the \`swamp-model\` skill to work with swamp models.
 
 Use \`swamp --help\` to see available commands.
 `;
+  }
+
+  /**
+   * Wraps the instructions body in BEGIN/END markers for shared files.
+   */
+  private buildInstructionsSection(): string {
+    const body = this.generateInstructionsBody();
+    return INSTRUCTIONS_SECTION_BEGIN + "\n" + body +
+      INSTRUCTIONS_SECTION_END;
+  }
+
+  /**
+   * Generates the full instructions content for tool-specific files (cursor/kiro).
+   * Shared-file tools should use buildInstructionsSection() instead.
+   */
+  private generateInstructionsContent(tool: AiTool): string {
+    const body = this.generateInstructionsBody();
 
     switch (tool) {
       case "cursor":
@@ -485,6 +655,8 @@ ${body}`;
       const updatedContent = this.replaceManagedSection(
         existingContent,
         newSection,
+        GITIGNORE_SECTION_BEGIN,
+        GITIGNORE_SECTION_END,
       );
       if (updatedContent === existingContent) {
         return "unchanged";
@@ -547,19 +719,37 @@ ${body}`;
   /**
    * Replaces the managed section between BEGIN and END markers.
    * Preserves all content outside the markers exactly as-is.
+   * Works for both gitignore and instructions files.
    */
   private replaceManagedSection(
     content: string,
     newSection: string,
+    beginMarker: string,
+    endMarker: string,
   ): string {
-    const beginIndex = content.indexOf(GITIGNORE_SECTION_BEGIN);
-    const endIndex = content.indexOf(GITIGNORE_SECTION_END);
+    const beginIndex = content.indexOf(beginMarker);
+    const endIndex = content.indexOf(endMarker);
 
     if (beginIndex === -1 || endIndex === -1) {
       throw new Error("Internal error: managed section markers not found");
     }
 
-    const endOfEndMarker = endIndex + GITIGNORE_SECTION_END.length;
+    if (endIndex < beginIndex) {
+      throw new Error(
+        "Internal error: managed section END marker appears before BEGIN marker",
+      );
+    }
+
+    // Detect duplicate marker pairs
+    const secondBegin = content.indexOf(beginMarker, beginIndex + 1);
+    if (secondBegin !== -1) {
+      throw new UserError(
+        "Found multiple swamp managed sections in file. " +
+          "Please remove the duplicate section and run the command again.",
+      );
+    }
+
+    const endOfEndMarker = endIndex + endMarker.length;
     // Consume the trailing newline after END marker if present
     const nextChar = content[endOfEndMarker];
     const endSlice = nextChar === "\n" ? endOfEndMarker + 1 : endOfEndMarker;

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -53,7 +53,7 @@ Deno.test("RepoService.init creates marker file", async () => {
   });
 });
 
-Deno.test("RepoService.init creates CLAUDE.md by default", async () => {
+Deno.test("RepoService.init creates CLAUDE.md with section markers", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
@@ -62,29 +62,39 @@ Deno.test("RepoService.init creates CLAUDE.md by default", async () => {
 
     assertEquals(result.instructionsFileCreated, true);
 
-    // Check CLAUDE.md exists
+    // Check CLAUDE.md exists with markers
     const claudeMdPath = join(tempDir, "CLAUDE.md");
     const content = await Deno.readTextFile(claudeMdPath);
     assertStringIncludes(content, "swamp");
+    assertStringIncludes(
+      content,
+      "<!-- BEGIN swamp managed section - DO NOT EDIT -->",
+    );
+    assertStringIncludes(content, "<!-- END swamp managed section -->");
   });
 });
 
-Deno.test("RepoService.init does not overwrite existing CLAUDE.md", async () => {
+Deno.test("RepoService.init merges managed section into existing CLAUDE.md", async () => {
   await withTempDir(async (tempDir) => {
-    // Create existing CLAUDE.md
+    // Create existing CLAUDE.md with user content
     const claudeMdPath = join(tempDir, "CLAUDE.md");
-    await Deno.writeTextFile(claudeMdPath, "# Existing Content");
+    await Deno.writeTextFile(claudeMdPath, "# Existing Content\n");
 
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
     const result = await service.init(repoPath);
 
-    assertEquals(result.instructionsFileCreated, false);
+    assertEquals(result.instructionsFileCreated, true);
 
-    // Check content is unchanged
+    // Check managed section was prepended and user content preserved
     const content = await Deno.readTextFile(claudeMdPath);
-    assertEquals(content, "# Existing Content");
+    assertStringIncludes(
+      content,
+      "<!-- BEGIN swamp managed section - DO NOT EDIT -->",
+    );
+    assertStringIncludes(content, "<!-- END swamp managed section -->");
+    assertStringIncludes(content, "# Existing Content");
   });
 });
 
@@ -686,7 +696,7 @@ Deno.test("RepoService.upgrade creates AGENTS.md when switching to codex", async
   });
 });
 
-Deno.test("RepoService.upgrade overwrites instructions file with managed content", async () => {
+Deno.test("RepoService.upgrade prepends managed section when file has no swamp content", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
@@ -694,19 +704,30 @@ Deno.test("RepoService.upgrade overwrites instructions file with managed content
     // Init with claude
     await service.init(repoPath);
 
-    // Write stale content to the instructions file
+    // Replace CLAUDE.md with unrelated content (no swamp signature, no markers)
     const instructionsPath = join(tempDir, "CLAUDE.md");
-    await Deno.writeTextFile(instructionsPath, "# Old content");
+    await Deno.writeTextFile(instructionsPath, "# Old content\n");
 
-    // Upgrade — should overwrite with current template
+    // Upgrade — should prepend managed section
     const upgradeService = new RepoService("0.2.0");
     const result = await upgradeService.upgrade(repoPath);
 
     assertEquals(result.instructionsUpdated, true);
 
     const content = await Deno.readTextFile(instructionsPath);
+    assertStringIncludes(
+      content,
+      "<!-- BEGIN swamp managed section - DO NOT EDIT -->",
+    );
     assertStringIncludes(content, "# Project");
-    assertStringIncludes(content, "swamp");
+    assertStringIncludes(content, "# Old content");
+
+    // Managed section should come before user content
+    const beginIdx = content.indexOf(
+      "<!-- BEGIN swamp managed section - DO NOT EDIT -->",
+    );
+    const userIdx = content.indexOf("# Old content");
+    assertEquals(beginIdx < userIdx, true);
   });
 });
 
@@ -715,14 +736,22 @@ Deno.test("RepoService.upgrade returns instructionsUpdated false when content is
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
-    // Init with claude — instructions file is created with current template
+    // Init with claude — instructions file is created with markers
     await service.init(repoPath);
 
-    // Upgrade with same version — instructions content hasn't changed
+    // Upgrade with same version — managed section hasn't changed
     const upgradeService = new RepoService("0.2.0");
     const result = await upgradeService.upgrade(repoPath);
 
     assertEquals(result.instructionsUpdated, false);
+
+    // Verify markers are still present
+    const content = await Deno.readTextFile(join(tempDir, "CLAUDE.md"));
+    assertStringIncludes(
+      content,
+      "<!-- BEGIN swamp managed section - DO NOT EDIT -->",
+    );
+    assertStringIncludes(content, "<!-- END swamp managed section -->");
   });
 });
 
@@ -1547,5 +1576,385 @@ Deno.test("RepoService.init with opencode force reinit overwrites plugin", async
     const content = await Deno.readTextFile(pluginPath);
     assertStringIncludes(content, '"--from-hook"');
     assertStringIncludes(content, '"opencode"');
+  });
+});
+
+// Managed instructions section tests
+
+Deno.test("RepoService.upgrade with markers preserves user content before and after section", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath);
+
+    // Add user content before and after the managed section
+    const claudeMdPath = join(tempDir, "CLAUDE.md");
+    const original = await Deno.readTextFile(claudeMdPath);
+    const withUserContent = "# My Project Notes\n\n" + original +
+      "\n## My Custom Rules\n\nDo things my way.\n";
+    await Deno.writeTextFile(claudeMdPath, withUserContent);
+
+    // Upgrade — should replace only managed section
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath);
+
+    // Content hasn't actually changed in the managed section, so no update
+    assertEquals(result.instructionsUpdated, false);
+
+    const content = await Deno.readTextFile(claudeMdPath);
+    assertStringIncludes(content, "# My Project Notes");
+    assertStringIncludes(content, "## My Custom Rules");
+    assertStringIncludes(content, "Do things my way.");
+    assertStringIncludes(
+      content,
+      "<!-- BEGIN swamp managed section - DO NOT EDIT -->",
+    );
+  });
+});
+
+Deno.test("RepoService.upgrade with markers replaces only managed section when template changes", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath);
+
+    // Add user content after the managed section
+    const claudeMdPath = join(tempDir, "CLAUDE.md");
+    const original = await Deno.readTextFile(claudeMdPath);
+    const withUserContent = original + "\n## My Custom Rules\n\nDo my thing.\n";
+    await Deno.writeTextFile(claudeMdPath, withUserContent);
+
+    // Tamper with the managed section to simulate old template
+    const tampered = withUserContent.replace(
+      "Use `swamp --help` to see available commands.",
+      "Use `swamp help` to see available commands.",
+    );
+    await Deno.writeTextFile(claudeMdPath, tampered);
+
+    // Upgrade — should replace managed section, preserve user content
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath);
+
+    assertEquals(result.instructionsUpdated, true);
+
+    const content = await Deno.readTextFile(claudeMdPath);
+    // Template restored
+    assertStringIncludes(
+      content,
+      "Use `swamp --help` to see available commands.",
+    );
+    // User content preserved
+    assertStringIncludes(content, "## My Custom Rules");
+    assertStringIncludes(content, "Do my thing.");
+  });
+});
+
+Deno.test("RepoService.upgrade migrates legacy content (template-only) to markers", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath);
+
+    // Simulate legacy CLAUDE.md (no markers, just raw template)
+    const claudeMdPath = join(tempDir, "CLAUDE.md");
+    const legacyContent = `# Project
+
+This repository is managed with [swamp](https://github.com/systeminit/swamp).
+
+## Rules
+
+1. **Extension models for service integrations.** Old rule text.
+
+## Skills
+
+- \`swamp-model\` - Work with swamp models
+
+## Getting Started
+
+Always start by using the \`swamp-model\` skill to work with swamp models.
+
+## Commands
+
+Use \`swamp --help\` to see available commands.
+`;
+    await Deno.writeTextFile(claudeMdPath, legacyContent);
+
+    // Upgrade — should migrate to markers
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath);
+
+    assertEquals(result.instructionsUpdated, true);
+
+    const content = await Deno.readTextFile(claudeMdPath);
+    assertStringIncludes(
+      content,
+      "<!-- BEGIN swamp managed section - DO NOT EDIT -->",
+    );
+    assertStringIncludes(content, "<!-- END swamp managed section -->");
+    // Updated template content
+    assertStringIncludes(content, "swamp-workflow");
+  });
+});
+
+Deno.test("RepoService.upgrade migrates legacy content and preserves user additions after template", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath);
+
+    // Simulate legacy CLAUDE.md with user additions after
+    const claudeMdPath = join(tempDir, "CLAUDE.md");
+    const legacyWithUserContent = `# Project
+
+This repository is managed with [swamp](https://github.com/systeminit/swamp).
+
+## Commands
+
+Use \`swamp --help\` to see available commands.
+
+## My Team Standards
+
+Always write tests.
+`;
+    await Deno.writeTextFile(claudeMdPath, legacyWithUserContent);
+
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath);
+
+    assertEquals(result.instructionsUpdated, true);
+
+    const content = await Deno.readTextFile(claudeMdPath);
+    assertStringIncludes(
+      content,
+      "<!-- BEGIN swamp managed section - DO NOT EDIT -->",
+    );
+    // User content preserved
+    assertStringIncludes(content, "## My Team Standards");
+    assertStringIncludes(content, "Always write tests.");
+  });
+});
+
+Deno.test("RepoService.upgrade migrates legacy content and preserves user additions before template", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath);
+
+    // Simulate legacy CLAUDE.md with user additions before
+    const claudeMdPath = join(tempDir, "CLAUDE.md");
+    const legacyWithUserBefore = `## My Project Setup
+
+Run npm install first.
+
+# Project
+
+This repository is managed with [swamp](https://github.com/systeminit/swamp).
+
+## Commands
+
+Use \`swamp --help\` to see available commands.
+`;
+    await Deno.writeTextFile(claudeMdPath, legacyWithUserBefore);
+
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath);
+
+    assertEquals(result.instructionsUpdated, true);
+
+    const content = await Deno.readTextFile(claudeMdPath);
+    assertStringIncludes(
+      content,
+      "<!-- BEGIN swamp managed section - DO NOT EDIT -->",
+    );
+    // User content before preserved
+    assertStringIncludes(content, "## My Project Setup");
+    assertStringIncludes(content, "Run npm install first.");
+  });
+});
+
+Deno.test("RepoService.upgrade cursor files are still fully overwritten (no markers)", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath, { tool: "cursor" });
+
+    // Replace cursor instructions with stale content
+    const mdcPath = join(tempDir, ".cursor", "rules", "swamp.mdc");
+    await Deno.writeTextFile(mdcPath, "---\nalwaysApply: true\n---\nold");
+
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath, { tool: "cursor" });
+
+    assertEquals(result.instructionsUpdated, true);
+
+    const content = await Deno.readTextFile(mdcPath);
+    // Full overwrite — should not have markers
+    assertEquals(
+      content.includes("<!-- BEGIN swamp managed section"),
+      false,
+    );
+    // Should have current template
+    assertStringIncludes(content, "## Skills");
+    assertStringIncludes(content, "alwaysApply: true");
+  });
+});
+
+Deno.test("RepoService.upgrade kiro files are still fully overwritten (no markers)", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath, { tool: "kiro" });
+
+    // Replace kiro instructions with stale content
+    const steeringPath = join(
+      tempDir,
+      ".kiro",
+      "steering",
+      "swamp-rules.md",
+    );
+    await Deno.writeTextFile(
+      steeringPath,
+      "---\ninclusion: always\n---\nold content",
+    );
+
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath, { tool: "kiro" });
+
+    assertEquals(result.instructionsUpdated, true);
+
+    const content = await Deno.readTextFile(steeringPath);
+    // Full overwrite — should not have markers
+    assertEquals(
+      content.includes("<!-- BEGIN swamp managed section"),
+      false,
+    );
+    // Should have current template
+    assertStringIncludes(content, "## Skills");
+    assertStringIncludes(content, "inclusion: always");
+  });
+});
+
+Deno.test("RepoService.init with opencode creates AGENTS.md with markers", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath, { tool: "opencode" });
+
+    const agentsMdPath = join(tempDir, "AGENTS.md");
+    const content = await Deno.readTextFile(agentsMdPath);
+    assertStringIncludes(
+      content,
+      "<!-- BEGIN swamp managed section - DO NOT EDIT -->",
+    );
+    assertStringIncludes(content, "<!-- END swamp managed section -->");
+    assertStringIncludes(content, "swamp");
+  });
+});
+
+Deno.test("RepoService.upgrade recovers when END marker is missing from CLAUDE.md", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath);
+
+    // Simulate user accidentally deleting the END marker
+    const claudeMdPath = join(tempDir, "CLAUDE.md");
+    const original = await Deno.readTextFile(claudeMdPath);
+    const corrupted = original.replace(
+      "<!-- END swamp managed section -->",
+      "",
+    );
+    await Deno.writeTextFile(claudeMdPath, corrupted);
+
+    // Upgrade should recover — falls through to prepend
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath);
+
+    assertEquals(result.instructionsUpdated, true);
+
+    const content = await Deno.readTextFile(claudeMdPath);
+    // Both markers now present
+    assertStringIncludes(
+      content,
+      "<!-- BEGIN swamp managed section - DO NOT EDIT -->",
+    );
+    assertStringIncludes(content, "<!-- END swamp managed section -->");
+  });
+});
+
+Deno.test("RepoService.upgrade legacy migration with partial template match avoids duplication", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath);
+
+    // Simulate legacy CLAUDE.md where user modified the end of the template
+    const claudeMdPath = join(tempDir, "CLAUDE.md");
+    const legacyWithEditedEnd = `# Project
+
+This repository is managed with [swamp](https://github.com/systeminit/swamp).
+
+## Commands
+
+Use \`swamp --help\` to see commands.
+
+## My Custom Section
+
+User content here.
+`;
+    await Deno.writeTextFile(claudeMdPath, legacyWithEditedEnd);
+
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath);
+
+    assertEquals(result.instructionsUpdated, true);
+
+    const content = await Deno.readTextFile(claudeMdPath);
+    // Should have markers
+    assertStringIncludes(
+      content,
+      "<!-- BEGIN swamp managed section - DO NOT EDIT -->",
+    );
+    assertStringIncludes(content, "<!-- END swamp managed section -->");
+
+    // Should NOT have duplicate "# Project" headings
+    const projectCount = content.split("# Project").length - 1;
+    assertEquals(
+      projectCount,
+      1,
+      "Expected exactly one '# Project' heading, not duplicated",
+    );
+  });
+});
+
+Deno.test("RepoService.upgrade with duplicate managed sections throws clear error", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath);
+
+    // Simulate duplicate markers (e.g., from a bad merge)
+    const claudeMdPath = join(tempDir, "CLAUDE.md");
+    const original = await Deno.readTextFile(claudeMdPath);
+    const duplicated = original + "\n" + original;
+    await Deno.writeTextFile(claudeMdPath, duplicated);
+
+    const upgradeService = new RepoService("0.2.0");
+    await assertRejects(
+      () => upgradeService.upgrade(repoPath),
+      Error,
+      "multiple swamp managed sections",
+    );
   });
 });


### PR DESCRIPTION
## Summary

Fixes #628 — `swamp repo upgrade` was fully overwriting `CLAUDE.md`/`AGENTS.md` with the swamp template, destroying any project-specific content users had added.

- Adopt the same section-marker pattern already used for `.gitignore` management
- Shared instruction files (`CLAUDE.md`, `AGENTS.md`) now use HTML comment markers to delimit the swamp-managed section
- Tool-specific files (`.cursor/rules/swamp.mdc`, `.kiro/steering/swamp-rules.md`) continue to be fully overwritten since they are not shared with user content
- On `init`: if a `CLAUDE.md` already exists, the managed section is merged in rather than skipping the file
- On `upgrade`, four cases are handled: no file, file with markers, file with legacy content, file with no swamp content

## Test plan

- [x] `deno check` — passes
- [x] `deno lint` — passes  
- [x] `deno fmt` — passes
- [x] `deno run test` — 2700/2700 passed
- [x] `deno run compile` — binary compiles
- [ ] Manual: `swamp repo init` in empty dir creates CLAUDE.md with markers
- [ ] Manual: `swamp repo init` in dir with existing CLAUDE.md merges managed section
- [ ] Manual: Add user content to CLAUDE.md, `swamp repo upgrade` preserves it

🤖 Generated with [Claude Code](https://claude.com/claude-code)