### PR TITLE
fix: inline non-zod npm packages in extension bundler

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -388,14 +388,19 @@ troubleshooting, see [references/publishing.md](references/publishing.md).
    Deno-compatible import (`npm:`, `jsr:`, `https://`) can also be used — swamp
    bundles all dependencies automatically (see
    [references/examples.md](references/examples.md#using-external-dependencies))
-3. **Pin npm versions**: Always pin explicit versions for npm imports (e.g.,
+3. **Static imports only**: All npm imports must be static top-level imports
+   (e.g., `import { x } from "npm:pkg@1"`). Dynamic `import()` calls are not
+   supported — the bundler cannot correctly handle CJS/ESM interop for
+   dynamically imported packages. The quality checker rejects dynamic imports
+   during `extension push`.
+4. **Pin npm versions**: Always pin explicit versions for npm imports (e.g.,
    `npm:lodash-es@4.17.21`, not `npm:lodash-es`). Swamp does not use a lockfile
    during bundling, so unpinned versions may resolve differently across runs.
    `npm:zod@4` is the one exception — it is externalized and provided by swamp.
-4. **Type naming**: Use `@<namespace>/<name>` or `<namespace>/<name>` format
+5. **Type naming**: Use `@<namespace>/<name>` or `<namespace>/<name>` format
    (e.g., `@user/my-model` or `myorg/my-model`)
-5. **No type annotations**: Avoid TypeScript types in execute parameters
-6. **File naming**: Use snake_case (`my_model.ts`)
+6. **No type annotations**: Avoid TypeScript types in execute parameters
+7. **File naming**: Use snake_case (`my_model.ts`)
 
 ## Namespace Rules
 

--- a/.claude/skills/swamp-extension-model/references/examples.md
+++ b/.claude/skills/swamp-extension-model/references/examples.md
@@ -85,23 +85,27 @@ export const model = {
   TypeScript into a `.js` file
 - The bundle is cached to `.swamp/bundles/` — subsequent runs skip bundling
   unless the source file's modification time is newer than the cached bundle
-- All `npm:` packages are externalized (`--packages external`) — they are left
-  as `npm:` specifiers in the output and resolved at runtime by Deno's native
-  npm resolver, preserving correct CJS/ESM interop
-- This ensures your model shares the same zod instance as swamp, which is
-  required for schema validation to work
+- All `npm:` packages except `zod` are **inlined** into the bundle — they are
+  resolved and included at bundle time, which ensures they work in the compiled
+  binary where only swamp's own embedded dependency graph is available
+- `zod` is externalized so your model shares the same zod instance as swamp,
+  which is required for schema `instanceof` checks to work
 - Local `.ts` code and other imports are still transpiled and bundled
+- **Dynamic `import()` calls are not supported** — use static top-level imports
+  only. The bundler cannot correctly handle CJS/ESM interop for dynamically
+  imported packages.
 
 **Import rules:**
 
-| Import                                   | Bundled? | Notes                                     |
-| ---------------------------------------- | -------- | ----------------------------------------- |
-| `npm:zod@4`                              | No       | Externalized, resolved at runtime by Deno |
-| `npm:lodash-es@4.17.21`                  | No       | Externalized, resolved at runtime by Deno |
-| `npm:@aws-sdk/client-s3@3.750.0`         | No       | Externalized, resolved at runtime by Deno |
-| `jsr:@std/path`                          | Yes      | Resolved and inlined                      |
-| `https://deno.land/std@0.224.0/async/..` | Yes      | Resolved and inlined                      |
-| Local `.ts` imports                      | Yes      | Transpiled and inlined                    |
+| Import                                   | Bundled? | Notes                                    |
+| ---------------------------------------- | -------- | ---------------------------------------- |
+| `npm:zod@4`                              | No       | Externalized, shares instance with swamp |
+| `npm:lodash-es@4.17.21`                  | Yes      | Inlined into the bundle                  |
+| `npm:@aws-sdk/client-s3@3.750.0`         | Yes      | Inlined into the bundle                  |
+| `jsr:@std/path`                          | Yes      | Resolved and inlined                     |
+| `https://deno.land/std@0.224.0/async/..` | Yes      | Resolved and inlined                     |
+| Local `.ts` imports                      | Yes      | Transpiled and inlined                   |
+| `await import("npm:pkg")`                | N/A      | **Not supported** — use static imports   |
 
 ## CRUD Lifecycle Model (VPC)
 

--- a/design/extension.md
+++ b/design/extension.md
@@ -109,11 +109,14 @@ if `connection.ts` imports `./helpers.ts`, both files are included.
 
 ### Bundles
 
-Each model entry point is compiled using `deno bundle` with all npm packages
-externalized (`--external npm:*`). This means npm dependencies resolve at
-runtime via Deno's native npm resolver, preserving correct CJS/ESM interop and
-ensuring extensions share the host's zod instance. Bundles are JavaScript files
-stored alongside their source counterparts under `bundles/`.
+Each model entry point is compiled using `deno bundle` with only `zod`
+externalized (`--external npm:zod@4 --external npm:zod`). All other npm
+packages are inlined into the bundle, which ensures they work in the compiled
+binary where only swamp's own embedded dependency graph is available. Zod is
+externalized so extensions share the same zod instance as swamp (required for
+schema `instanceof` checks). Dynamic `import()` calls are not supported — all
+imports must be static top-level imports. Bundles are JavaScript files stored
+alongside their source counterparts under `bundles/`.
 
 ### Workflows
 

--- a/src/domain/extensions/extension_quality_checker.ts
+++ b/src/domain/extensions/extension_quality_checker.ts
@@ -19,7 +19,7 @@
 
 /** A quality issue found during checking. */
 export interface QualityIssue {
-  check: "fmt" | "lint";
+  check: "fmt" | "lint" | "dynamic-import";
   output: string;
 }
 
@@ -27,6 +27,42 @@ export interface QualityIssue {
 export interface QualityCheckResult {
   passed: boolean;
   issues: QualityIssue[];
+}
+
+/**
+ * Strips comments and string literals from a single line of code,
+ * so that pattern matching only sees actual code tokens.
+ */
+export function stripCommentsAndStrings(line: string): string {
+  let result = "";
+  let i = 0;
+  while (i < line.length) {
+    // Single-line comment — rest of line is not code
+    if (line[i] === "/" && i + 1 < line.length && line[i + 1] === "/") {
+      break;
+    }
+    // Block comment opening — skip until closing or end of line
+    if (line[i] === "/" && i + 1 < line.length && line[i + 1] === "*") {
+      const end = line.indexOf("*/", i + 2);
+      if (end === -1) break;
+      i = end + 2;
+      continue;
+    }
+    // String literal — skip contents
+    if (line[i] === '"' || line[i] === "'" || line[i] === "`") {
+      const quote = line[i];
+      i++;
+      while (i < line.length && line[i] !== quote) {
+        if (line[i] === "\\") i++;
+        i++;
+      }
+      i++; // skip closing quote
+      continue;
+    }
+    result += line[i];
+    i++;
+  }
+  return result;
 }
 
 /**
@@ -50,6 +86,27 @@ export async function checkExtensionQuality(
   }
 
   const issues: QualityIssue[] = [];
+
+  // Check for dynamic imports — these break CJS/ESM interop when bundled
+  const dynamicImportPattern = /\bimport\s*\(/;
+  for (const file of tsFiles) {
+    const content = await Deno.readTextFile(file);
+    const lines = content.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const stripped = stripCommentsAndStrings(lines[i]);
+      if (dynamicImportPattern.test(stripped)) {
+        issues.push({
+          check: "dynamic-import",
+          output:
+            `${file}:${
+              i + 1
+            }: Dynamic import() is not supported in extensions. ` +
+            `Use static top-level imports instead (e.g., import { x } from "npm:pkg"). ` +
+            `Dynamic imports break CJS/ESM interop when bundled.`,
+        });
+      }
+    }
+  }
 
   // Check formatting
   const fmtCommand = new Deno.Command(denoPath, {

--- a/src/domain/extensions/extension_quality_checker_test.ts
+++ b/src/domain/extensions/extension_quality_checker_test.ts
@@ -19,7 +19,10 @@
 
 import { assertEquals } from "@std/assert";
 import { join } from "@std/path";
-import { checkExtensionQuality } from "./extension_quality_checker.ts";
+import {
+  checkExtensionQuality,
+  stripCommentsAndStrings,
+} from "./extension_quality_checker.ts";
 
 const DENO_PATH = Deno.execPath();
 
@@ -111,4 +114,161 @@ Deno.test("checkExtensionQuality passes when file list is empty", async () => {
   const result = await checkExtensionQuality([], DENO_PATH);
   assertEquals(result.passed, true);
   assertEquals(result.issues, []);
+});
+
+Deno.test("checkExtensionQuality rejects await import()", async () => {
+  await withTempFiles(
+    {
+      "model.ts":
+        'const mod = await import("npm:@aws-sdk/client-s3@3");\nexport const x = mod;\n',
+    },
+    async (_dir, paths) => {
+      const result = await checkExtensionQuality(paths, DENO_PATH);
+      assertEquals(result.passed, false);
+      assertEquals(
+        result.issues.some((i) => i.check === "dynamic-import"),
+        true,
+      );
+    },
+  );
+});
+
+Deno.test("checkExtensionQuality rejects bare import()", async () => {
+  await withTempFiles(
+    {
+      "model.ts":
+        'const mod = import("npm:some-pkg@1.0.0");\nexport const x = mod;\n',
+    },
+    async (_dir, paths) => {
+      const result = await checkExtensionQuality(paths, DENO_PATH);
+      assertEquals(result.passed, false);
+      assertEquals(
+        result.issues.some((i) => i.check === "dynamic-import"),
+        true,
+      );
+    },
+  );
+});
+
+Deno.test("checkExtensionQuality allows static import from", async () => {
+  await withTempFiles(
+    {
+      "model.ts":
+        'import { z } from "npm:zod@4";\nexport const schema = z.string();\n',
+    },
+    async (_dir, paths) => {
+      const result = await checkExtensionQuality(paths, DENO_PATH);
+      assertEquals(result.passed, true);
+      assertEquals(
+        result.issues.some((i) => i.check === "dynamic-import"),
+        false,
+      );
+    },
+  );
+});
+
+Deno.test("checkExtensionQuality allows static import * as", async () => {
+  await withTempFiles(
+    {
+      "helpers.ts": "export const SEP = '/';\n",
+      "model.ts":
+        'import * as helpers from "./helpers.ts";\nexport const sep = helpers.SEP;\n',
+    },
+    async (_dir, paths) => {
+      const result = await checkExtensionQuality(paths, DENO_PATH);
+      assertEquals(
+        result.issues.some((i) => i.check === "dynamic-import"),
+        false,
+      );
+    },
+  );
+});
+
+Deno.test("checkExtensionQuality allows export from", async () => {
+  await withTempFiles(
+    {
+      "model.ts": 'export { z } from "npm:zod@4";\n',
+    },
+    async (_dir, paths) => {
+      const result = await checkExtensionQuality(paths, DENO_PATH);
+      assertEquals(result.passed, true);
+      assertEquals(
+        result.issues.some((i) => i.check === "dynamic-import"),
+        false,
+      );
+    },
+  );
+});
+
+Deno.test("checkExtensionQuality ignores import() in comments", async () => {
+  await withTempFiles(
+    {
+      "model.ts": '// do not use import("npm:pkg")\nexport const x = 1;\n',
+    },
+    async (_dir, paths) => {
+      const result = await checkExtensionQuality(paths, DENO_PATH);
+      assertEquals(
+        result.issues.some((i) => i.check === "dynamic-import"),
+        false,
+      );
+    },
+  );
+});
+
+Deno.test("checkExtensionQuality ignores import() in string literals", async () => {
+  await withTempFiles(
+    {
+      "model.ts": 'export const msg = "use import() for dynamic loading";\n',
+    },
+    async (_dir, paths) => {
+      const result = await checkExtensionQuality(paths, DENO_PATH);
+      assertEquals(
+        result.issues.some((i) => i.check === "dynamic-import"),
+        false,
+      );
+    },
+  );
+});
+
+Deno.test("checkExtensionQuality ignores import() in block comments", async () => {
+  await withTempFiles(
+    {
+      "model.ts": '/* import("npm:pkg") */\nexport const x = 1;\n',
+    },
+    async (_dir, paths) => {
+      const result = await checkExtensionQuality(paths, DENO_PATH);
+      assertEquals(
+        result.issues.some((i) => i.check === "dynamic-import"),
+        false,
+      );
+    },
+  );
+});
+
+Deno.test("stripCommentsAndStrings removes single-line comments", () => {
+  assertEquals(
+    stripCommentsAndStrings('code(); // import("pkg")'),
+    "code(); ",
+  );
+});
+
+Deno.test("stripCommentsAndStrings removes string contents", () => {
+  assertEquals(
+    stripCommentsAndStrings('const s = "import(pkg)";'),
+    "const s = ;",
+  );
+});
+
+Deno.test("stripCommentsAndStrings removes block comments", () => {
+  assertEquals(
+    stripCommentsAndStrings("code /* import(x) */ more"),
+    "code  more",
+  );
+});
+
+Deno.test("stripCommentsAndStrings preserves bare code", () => {
+  assertEquals(
+    stripCommentsAndStrings("await import(url)"),
+    "await import(url)",
+  );
 });

--- a/src/domain/models/bundle.ts
+++ b/src/domain/models/bundle.ts
@@ -25,8 +25,11 @@ const logger = getLogger(["swamp", "models", "bundle"]);
  * Bundles a TypeScript extension file into JavaScript using `deno bundle` subprocess.
  *
  * Transpiles TypeScript syntax (interfaces, type annotations, generics) and
- * externalizes all npm packages so they resolve at runtime via Deno's native
- * npm resolver (preserving correct CJS/ESM interop and zod instanceof checks).
+ * inlines all npm packages into the bundle. Only `zod` is externalized so that
+ * extensions share the same zod instance as swamp (required for schema
+ * `instanceof` checks). All other npm packages are resolved and inlined at
+ * bundle time, which ensures they work in the compiled binary where only
+ * swamp's own embedded dependency graph is available.
  *
  * @param absolutePath - Absolute filesystem path to the TypeScript file
  * @param denoPath - Absolute path to the deno binary to use for bundling
@@ -49,7 +52,9 @@ export async function bundleExtension(
         "bundle",
         "--no-lock",
         "--external",
-        "npm:*",
+        "npm:zod@4",
+        "--external",
+        "npm:zod",
         "--platform",
         "deno",
         "-o",

--- a/src/domain/models/bundle_test.ts
+++ b/src/domain/models/bundle_test.ts
@@ -96,7 +96,7 @@ export const schema = z.object({ name: z.string() });
   });
 });
 
-Deno.test("bundleExtension resolves npm imports without creating deno.lock", async () => {
+Deno.test("bundleExtension inlines non-zod npm packages", async () => {
   const tsCode = `
 import { z } from "npm:zod@4";
 import { parse, stringify } from "npm:yaml@2.7.1";
@@ -122,8 +122,15 @@ export const model = {
   try {
     const js = await bundleExtension(path, DENO_PATH);
 
-    // Bundle should succeed — yaml is externalized (not inlined)
+    // Bundle should succeed — yaml is inlined into the bundle
     assertEquals(js.length > 0, true);
+
+    // yaml package should be inlined (bundle > 10KB with yaml code included)
+    assertEquals(
+      js.length > 10_000,
+      true,
+      "yaml should be inlined into the bundle, making it larger than 10KB",
+    );
 
     // No deno.lock should be created in the source directory
     let lockExists = true;


### PR DESCRIPTION
## Summary

- **Only externalize zod** in the extension bundler (`--external npm:zod@4 --external npm:zod`) instead of all npm packages (`--external npm:*`). All other npm packages are now inlined into the bundle, which fixes extensions failing in the compiled binary.
- **Ban dynamic `import()` calls** in extensions — the quality checker now rejects them during `extension push` with a clear error message. The checker strips comments and string literals before scanning to avoid false positives.
- **Update docs** (SKILL.md, examples.md, design/extension.md) to reflect the new bundling behavior and static import requirement.

### Why

The `--external npm:*` flag (added in #611 to work around #609) left all npm packages as runtime `npm:` specifiers. This works in development with Deno's npm resolver, but breaks in the compiled binary which can only resolve packages from its own embedded dependency graph. Only zod needs to be externalized (to share instances with swamp for `instanceof` checks).

Dynamic `import()` was the pattern that triggered #609's CJS/ESM interop breakage. Static top-level imports are handled correctly by `deno bundle` inlining.

### Breaking change for extension authors

**Dynamic `import()` calls are no longer allowed in extensions.** The quality checker will reject them during `extension push`. Extension authors must use static top-level imports instead:

```typescript
// Before (no longer allowed)
const mod = await import("npm:@aws-sdk/client-s3@3");

// After (use static imports)
import { S3Client } from "npm:@aws-sdk/client-s3@3.750.0";
```

This only affects `extension push` — local extensions in `extensions/models/` are not checked.

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] `deno run test` — 2704 tests pass
- [x] `deno run compile` succeeds
- [ ] Test compiled binary with an extension that uses non-zod npm packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)