### PR TITLE
fix: handle instruction section edge cases from adversarial review

### DIFF
--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -454,7 +454,17 @@ export class RepoService {
       return true;
     }
 
-    // Case 3: File has legacy swamp content (no markers) — migrate
+    // Case 3: Orphaned BEGIN marker (END was accidentally deleted).
+    // Strip the orphaned BEGIN before falling through to prepend,
+    // so we don't end up with duplicate BEGIN markers.
+    if (existingContent.includes(INSTRUCTIONS_SECTION_BEGIN)) {
+      existingContent = existingContent.replace(
+        INSTRUCTIONS_SECTION_BEGIN + "\n",
+        "",
+      ).replace(INSTRUCTIONS_SECTION_BEGIN, "");
+    }
+
+    // Case 4: File has legacy swamp content (no markers) — migrate
     if (this.hasLegacyInstructionsContent(existingContent)) {
       const updatedContent = this.migrateLegacyInstructions(
         existingContent,
@@ -464,7 +474,7 @@ export class RepoService {
       return true;
     }
 
-    // Case 4: File has no swamp content — prepend managed section
+    // Case 5: File has no swamp content — prepend managed section
     const separator = existingContent.startsWith("\n") ? "" : "\n";
     await atomicWriteTextFile(
       filePath,
@@ -507,11 +517,12 @@ export class RepoService {
 
     if (endIndex === -1) {
       // Start matched but end didn't — the user edited the template.
-      // Replace from the start match to end-of-content to avoid duplication,
-      // preserving any content before the legacy template.
-      const before = content.substring(0, startMatch.index);
-      const prefix = before.length > 0 ? before : "";
-      return prefix + newSection + "\n";
+      // We can't determine where the legacy template ends, so prepend the
+      // new managed section to preserve ALL existing content (including user
+      // additions). This may leave some duplicate template text in the file,
+      // but that's preferable to silently deleting user content.
+      const separator = content.startsWith("\n") ? "" : "\n";
+      return newSection + "\n" + separator + content;
     }
 
     const endSlice = endIndex + endMarker.length;
@@ -742,7 +753,8 @@ ${body}`;
 
     // Detect duplicate marker pairs
     const secondBegin = content.indexOf(beginMarker, beginIndex + 1);
-    if (secondBegin !== -1) {
+    const secondEnd = content.indexOf(endMarker, endIndex + 1);
+    if (secondBegin !== -1 || secondEnd !== -1) {
       throw new UserError(
         "Found multiple swamp managed sections in file. " +
           "Please remove the duplicate section and run the command again.",

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -1888,10 +1888,27 @@ Deno.test("RepoService.upgrade recovers when END marker is missing from CLAUDE.m
       "<!-- BEGIN swamp managed section - DO NOT EDIT -->",
     );
     assertStringIncludes(content, "<!-- END swamp managed section -->");
+
+    // Must have exactly one of each marker (no duplicates)
+    const beginCount =
+      content.split("<!-- BEGIN swamp managed section - DO NOT EDIT -->")
+        .length - 1;
+    assertEquals(
+      beginCount,
+      1,
+      "Expected exactly one BEGIN marker, not duplicated",
+    );
+    const endCount =
+      content.split("<!-- END swamp managed section -->").length - 1;
+    assertEquals(
+      endCount,
+      1,
+      "Expected exactly one END marker, not duplicated",
+    );
   });
 });
 
-Deno.test("RepoService.upgrade legacy migration with partial template match avoids duplication", async () => {
+Deno.test("RepoService.upgrade legacy migration with partial template match preserves user content", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
@@ -1920,19 +1937,34 @@ User content here.
     assertEquals(result.instructionsUpdated, true);
 
     const content = await Deno.readTextFile(claudeMdPath);
-    // Should have markers
+    // Should have markers (new managed section was prepended)
     assertStringIncludes(
       content,
       "<!-- BEGIN swamp managed section - DO NOT EDIT -->",
     );
     assertStringIncludes(content, "<!-- END swamp managed section -->");
 
-    // Should NOT have duplicate "# Project" headings
-    const projectCount = content.split("# Project").length - 1;
-    assertEquals(
-      projectCount,
-      1,
-      "Expected exactly one '# Project' heading, not duplicated",
+    // Exactly one set of markers (no duplicates)
+    const beginCount =
+      content.split("<!-- BEGIN swamp managed section - DO NOT EDIT -->")
+        .length - 1;
+    assertEquals(beginCount, 1, "Expected exactly one BEGIN marker");
+    const endCount =
+      content.split("<!-- END swamp managed section -->").length - 1;
+    assertEquals(endCount, 1, "Expected exactly one END marker");
+
+    // User content MUST be preserved — this is the critical invariant.
+    // When the legacy template end marker can't be found, we prepend
+    // the new section rather than risk deleting user content.
+    assertStringIncludes(
+      content,
+      "## My Custom Section",
+      "User section heading should be preserved after migration",
+    );
+    assertStringIncludes(
+      content,
+      "User content here.",
+      "User content body should be preserved after migration",
     );
   });
 });
@@ -1949,6 +1981,29 @@ Deno.test("RepoService.upgrade with duplicate managed sections throws clear erro
     const original = await Deno.readTextFile(claudeMdPath);
     const duplicated = original + "\n" + original;
     await Deno.writeTextFile(claudeMdPath, duplicated);
+
+    const upgradeService = new RepoService("0.2.0");
+    await assertRejects(
+      () => upgradeService.upgrade(repoPath),
+      Error,
+      "multiple swamp managed sections",
+    );
+  });
+});
+
+Deno.test("RepoService.upgrade with duplicate END markers throws clear error", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath);
+
+    // Simulate duplicate END marker (e.g., from a bad merge)
+    const claudeMdPath = join(tempDir, "CLAUDE.md");
+    const original = await Deno.readTextFile(claudeMdPath);
+    const withDuplicateEnd = original +
+      "\n<!-- END swamp managed section -->\n";
+    await Deno.writeTextFile(claudeMdPath, withDuplicateEnd);
 
     const upgradeService = new RepoService("0.2.0");
     await assertRejects(


### PR DESCRIPTION
## Summary

Fixes three issues found by the adversarial review on #630:

- **Orphaned BEGIN marker creates duplicate markers**: When the END marker is
  accidentally deleted, the file falls through to legacy migration (which
  matches because the body contains the legacy signature). This prepends a new
  section with its own BEGIN marker, creating duplicates that break subsequent
  upgrades. Fixed by stripping orphaned BEGIN markers before legacy/prepend
  logic runs.

- **Legacy migration silently deletes user content**: When migrating legacy
  content and the end boundary text (`Use \`swamp --help\` to see available
  commands.`) was edited by the user, the fallback discarded everything after
  the legacy start pattern. Fixed by prepending the new managed section and
  preserving all existing content. Some template text duplication is acceptable;
  silent data loss is not.

- **Duplicate END markers not detected**: Only duplicate BEGIN markers were
  caught by `replaceManagedSection`. A bad merge leaving `BEGIN...END...END`
  would silently leave an orphaned END marker. Fixed by adding a matching check
  for duplicate END markers.

Also strengthened test assertions:
- Missing-END-marker test now asserts exactly one BEGIN and one END marker
  (not just presence via `assertStringIncludes`)
- Partial-template-match test now asserts user content is preserved after
  migration
- Added new test for duplicate END marker detection

## Test plan

- [x] `deno run test src/domain/repo/repo_service_test.ts` — all 77 tests pass
- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt --check` — formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)