### PR TITLE
refactor: rename "namespace" to "collective" across extensions, models, and vaults

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -102,7 +102,7 @@ export const model = {
 
 | Field             | Required | Description                                       |
 | ----------------- | -------- | ------------------------------------------------- |
-| `type`            | Yes      | Unique identifier (`@namespace/name`)             |
+| `type`            | Yes      | Unique identifier (`@collective/name`)            |
 | `version`         | Yes      | CalVer version (`YYYY.MM.DD.MICRO`)               |
 | `globalArguments` | No       | Zod schema for global arguments                   |
 | `resources`       | No       | Resource output specs (JSON data with Zod schema) |
@@ -366,7 +366,7 @@ swamp extension push manifest.yaml --dry-run    # Validate without pushing
 swamp extension push manifest.yaml -y           # Skip confirmation prompts
 ```
 
-The manifest `name` namespace must match your authenticated username. Model
+The manifest `name` collective must match your authenticated username. Model
 paths are relative to `extensions/models/`; local imports are auto-resolved.
 
 **Optional metadata fields:**
@@ -397,24 +397,24 @@ troubleshooting, see [references/publishing.md](references/publishing.md).
    `npm:lodash-es@4.17.21`, not `npm:lodash-es`). Swamp does not use a lockfile
    during bundling, so unpinned versions may resolve differently across runs.
    `npm:zod@4` is the one exception — it is externalized and provided by swamp.
-5. **Type naming**: Use `@<namespace>/<name>` or `<namespace>/<name>` format
+5. **Type naming**: Use `@<collective>/<name>` or `<collective>/<name>` format
    (e.g., `@user/my-model` or `myorg/my-model`)
 6. **No type annotations**: Avoid TypeScript types in execute parameters
 7. **File naming**: Use snake_case (`my_model.ts`)
 
-## Namespace Rules
+## Collective Rules
 
-User-defined models can use any namespace except reserved ones (`swamp`, `si`):
+User-defined models can use any collective except reserved ones (`swamp`, `si`):
 
 | Type                        | Valid? | Notes                       |
 | --------------------------- | ------ | --------------------------- |
-| `@user/my-model`            | ✅     | Valid namespace             |
-| `@myorg/deploy`             | ✅     | Custom namespace allowed    |
+| `@user/my-model`            | ✅     | Valid collective            |
+| `@myorg/deploy`             | ✅     | Custom collective allowed   |
 | `myorg/my-model`            | ✅     | Non-@ format allowed        |
 | `digitalocean/app-platform` | ✅     | Non-@ multi-segment allowed |
 | `@user/aws/s3`              | ✅     | Nested paths allowed        |
-| `swamp/my-model`            | ❌     | Reserved namespace          |
-| `si/my-model`               | ❌     | Reserved namespace          |
+| `swamp/my-model`            | ❌     | Reserved collective         |
+| `si/my-model`               | ❌     | Reserved collective         |
 
 ## Verify
 

--- a/.claude/skills/swamp-extension-model/references/publishing.md
+++ b/.claude/skills/swamp-extension-model/references/publishing.md
@@ -31,26 +31,26 @@ dependencies:
 
 ### Field Reference
 
-| Field             | Required | Description                                                      |
-| ----------------- | -------- | ---------------------------------------------------------------- |
-| `manifestVersion` | Yes      | Must be `1`                                                      |
-| `name`            | Yes      | Scoped name: `@namespace/name` (lowercase, hyphens, underscores) |
-| `version`         | Yes      | CalVer format: `YYYY.MM.DD.MICRO`                                |
-| `description`     | No       | Human-readable description                                       |
-| `models`          | No*      | Model file paths relative to `extensions/models/`                |
-| `workflows`       | No*      | Workflow file paths relative to `workflows/`                     |
-| `additionalFiles` | No       | Extra files relative to the manifest location                    |
-| `platforms`       | No       | OS/architecture hints (e.g. `darwin-aarch64`, `linux-x86_64`)    |
-| `labels`          | No       | Categorization labels (e.g. `aws`, `kubernetes`, `security`)     |
-| `dependencies`    | No       | Other extensions this one depends on                             |
+| Field             | Required | Description                                                       |
+| ----------------- | -------- | ----------------------------------------------------------------- |
+| `manifestVersion` | Yes      | Must be `1`                                                       |
+| `name`            | Yes      | Scoped name: `@collective/name` (lowercase, hyphens, underscores) |
+| `version`         | Yes      | CalVer format: `YYYY.MM.DD.MICRO`                                 |
+| `description`     | No       | Human-readable description                                        |
+| `models`          | No*      | Model file paths relative to `extensions/models/`                 |
+| `workflows`       | No*      | Workflow file paths relative to `workflows/`                      |
+| `additionalFiles` | No       | Extra files relative to the manifest location                     |
+| `platforms`       | No       | OS/architecture hints (e.g. `darwin-aarch64`, `linux-x86_64`)     |
+| `labels`          | No       | Categorization labels (e.g. `aws`, `kubernetes`, `security`)      |
+| `dependencies`    | No       | Other extensions this one depends on                              |
 
 *At least one of `models` or `workflows` must be present with entries.
 
 ### Name Rules
 
-- Must match pattern `@namespace/name` (e.g., `@myorg/s3-tools`)
-- Namespace must match your authenticated username
-- Reserved namespaces (`@swamp`, `@si`) cannot be used
+- Must match pattern `@collective/name` (e.g., `@myorg/s3-tools`)
+- Collective must match your authenticated username
+- Reserved collectives (`@swamp`, `@si`) cannot be used
 - Allowed characters: lowercase letters, numbers, hyphens, underscores
 
 ### How Models Map to Manifest
@@ -128,7 +128,7 @@ swamp extension push manifest.yaml --repo-dir /path/to/repo
 ### What Happens During Push
 
 1. **Parse manifest** — validates schema, checks required fields
-2. **Validate namespace** — confirms manifest name matches your username
+2. **Validate collective** — confirms manifest name matches your username
 3. **Resolve files** — collects model entry points, auto-resolves local imports,
    resolves workflow dependencies
 4. **Safety analysis** — scans all files for disallowed patterns and limits
@@ -218,7 +218,7 @@ the CLI will offer to bump the `MICRO` component automatically.
 | Error                            | Fix                                              |
 | -------------------------------- | ------------------------------------------------ |
 | "Not authenticated"              | Run `swamp auth login` first                     |
-| "namespace does not match"       | Manifest `name` must use `@your-username/...`    |
+| "collective does not match"      | Manifest `name` must use `@your-username/...`    |
 | "CalVer format" error            | Use `YYYY.MM.DD.MICRO` (e.g., `2026.02.26.1`)    |
 | "at least one model or workflow" | Add a `models` or `workflows` array with entries |
 | "Model file not found"           | Check path is relative to `extensions/models/`   |

--- a/.claude/skills/swamp-extension-model/references/troubleshooting.md
+++ b/.claude/skills/swamp-extension-model/references/troubleshooting.md
@@ -6,7 +6,7 @@
   - [No 'model' or 'extension' export found](#no-model-or-extension-export-found)
   - [Unknown resource spec / Unknown file spec](#unknown-resource-spec-or-unknown-file-spec)
   - [Model type already registered](#model-type-already-registered)
-  - [Uses a reserved namespace](#uses-a-reserved-namespace)
+  - [Uses a reserved collective](#uses-a-reserved-collective)
   - [Cannot extend unregistered model type](#cannot-extend-unregistered-model-type)
   - [Method already exists](#method-x-already-exists-on-model-type-y)
   - [Duplicate method name](#duplicate-method-name-x-within-extension-methods-array)
@@ -64,7 +64,7 @@ export const model = {
 
 ### "Model type already registered"
 
-Type name conflicts with built-in or another user model. Use unique namespaced
+Type name conflicts with built-in or another user model. Use unique collective
 names:
 
 ```typescript
@@ -72,21 +72,21 @@ names:
 type: "@user/echo"; // May conflict with other users
 
 // Use
-type: "@myorg/echo"; // Use your own namespace
+type: "@myorg/echo"; // Use your own collective
 ```
 
-### "Uses a reserved namespace"
+### "Uses a reserved collective"
 
-Reserved namespaces (`swamp`, `si`) are for built-in types only:
+Reserved collectives (`swamp`, `si`) are for built-in types only:
 
 ```typescript
-// Wrong - reserved namespace
+// Wrong - reserved collective
 type: "swamp/my-model";
 type: "@swamp/my-model";
 type: "si/auth";
 type: "@si/auth";
 
-// Correct - use any other namespace
+// Correct - use any other collective
 type: "@myorg/my-model";
 type: "myorg/my-model";
 type: "digitalocean/app-platform";

--- a/.claude/skills/swamp-vault/SKILL.md
+++ b/.claude/skills/swamp-vault/SKILL.md
@@ -64,7 +64,7 @@ details on each built-in type.
 ### User-Defined Types
 
 Create custom vault implementations in `extensions/vaults/*.ts`. User-defined
-vaults follow the `@namespace/name` type format (e.g., `@hashicorp/vault`,
+vaults follow the `@collective/name` type format (e.g., `@hashicorp/vault`,
 `@openbao/vault`).
 
 See [references/user-defined-vaults.md](references/user-defined-vaults.md) for

--- a/.claude/skills/swamp-vault/references/troubleshooting.md
+++ b/.claude/skills/swamp-vault/references/troubleshooting.md
@@ -112,8 +112,9 @@ op signin
 **Causes and solutions**:
 
 1. Missing `vault` export — ensure file has `export const vault = { ... }`
-2. Invalid type format — must match `@namespace/name` (e.g., `@hashicorp/vault`)
-3. Reserved namespace — cannot use `@swamp/` or `@si/` namespaces
+2. Invalid type format — must match `@collective/name` (e.g.,
+   `@hashicorp/vault`)
+3. Reserved collective — cannot use `@swamp/` or `@si/` collectives
 4. Duplicate type — another file already registered the same type
 5. Invalid `configSchema` — must be a Zod schema instance (`z.object({...})`)
 6. Missing `createProvider` — must be a function returning a VaultProvider

--- a/.claude/skills/swamp-vault/references/user-defined-vaults.md
+++ b/.claude/skills/swamp-vault/references/user-defined-vaults.md
@@ -11,7 +11,7 @@ Each file must export a `vault` object:
 import { z } from "npm:zod";
 
 export const vault = {
-  type: "@namespace/name",        // Required: @namespace/name format
+  type: "@collective/name",       // Required: @collective/name format
   name: "Display Name",           // Required: human-readable name
   description: "What this does",  // Required: shown in CLI help
   configSchema: z.object({...}),  // Optional: Zod schema for config validation
@@ -28,10 +28,10 @@ export const vault = {
 
 ## Type Naming
 
-- Must match `@namespace/name` or `namespace/name` pattern (e.g.,
+- Must match `@collective/name` or `collective/name` pattern (e.g.,
   `@hashicorp/vault`, `hashicorp/vault`)
 - Lowercase letters, numbers, and hyphens only
-- Reserved namespaces (`swamp`, `si`) are not allowed (with or without `@`
+- Reserved collectives (`swamp`, `si`) are not allowed (with or without `@`
   prefix)
 
 ## File Location
@@ -232,7 +232,7 @@ export const vault = {
 
 1. **Import**: Use `import { z } from "npm:zod";` (same as extension models)
 2. **Export**: Must be `export const vault` (named export, not default)
-3. **Namespaces**: `swamp` and `si` namespaces are reserved for built-in types
+3. **Collectives**: `swamp` and `si` collectives are reserved for built-in types
    (with or without `@` prefix)
 4. **Config**: User-defined vaults always use `--config <json>` on
    `vault create`

--- a/design/extension.md
+++ b/design/extension.md
@@ -6,12 +6,12 @@ reusable automation models and workflows that others can pull into their reposit
 
 ## Name
 
-Every extension has a scoped name in the format `@namespace/name`. The namespace
-identifies the organization, and the name identifies the extension.
+Every extension has a scoped name in the format `@collective/name`. The collective
+identifies the collective, and the name identifies the extension.
 Both parts must be lowercase and may contain alphanumeric characters, hyphens,
 and underscores. The pattern is `@[a-z0-9_-]+/[a-z0-9_-]+`.
 
-The namespaces `@swamp` and `@si` are reserved for built-in extensions and
+The collectives `@swamp` and `@si` are reserved for built-in extensions and
 cannot be used by external authors.
 
 You cannot use another person's name in the extensions that you publish.
@@ -35,7 +35,7 @@ what the extension contains and how it should be packaged.
 ### Required Fields
 
 - `manifestVersion`: Must be `1` (the only supported version).
-- `name`: Scoped name (`@namespace/name`).
+- `name`: Scoped name (`@collective/name`).
 - `version`: CalVer version string.
 - At least one of `models` or `workflows` must be present.
 
@@ -51,7 +51,7 @@ what the extension contains and how it should be packaged.
   `["darwin-aarch64", "linux-x86_64"]`). Informational only — displayed during
   pull.
 - `tags`: Array of categorization labels (e.g., `["aws", "kubernetes"]`).
-- `dependencies`: Array of extension names (`@namespace/name`) that this
+- `dependencies`: Array of extension names (`@collective/name`) that this
   extension requires. Dependencies are pulled automatically.
 
 ### Example
@@ -156,7 +156,7 @@ dependencies are resolved and pulled automatically if not already installed.
 
 During push, the CLI also resolves which models a workflow references. It
 parses workflow YAML to find `model_method` and `workflow` step tasks, then
-looks up the corresponding model source files. Only user-namespaced models
+looks up the corresponding model source files. Only user-collective models
 (types starting with `@`) are bundled — built-in models are skipped.
 
 ## Safety
@@ -196,7 +196,7 @@ Extensions are distributed through the swamp registry at `https://swamp.club`.
 
 Push operations require authentication via an API key (Bearer token). Pull
 operations are unauthenticated. Users can only push extensions to their own
-namespace. You need to authenticate to Swamp Club via the CLI `swamp auth login`
+collective. You need to authenticate to Swamp Club via the CLI `swamp auth login`
 to get the correct API Key used for push.
 
 ### Push Protocol

--- a/src/cli/commands/auth_whoami.ts
+++ b/src/cli/commands/auth_whoami.ts
@@ -20,7 +20,10 @@
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
-import { SwampClubClient } from "../../infrastructure/http/swamp_club_client.ts";
+import {
+  getCollectives,
+  SwampClubClient,
+} from "../../infrastructure/http/swamp_club_client.ts";
 import { UserError } from "../../domain/errors.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -52,6 +55,8 @@ export const authWhoamiCommand = new Command()
       );
     }
 
+    const collectives = getCollectives(whoami);
+
     if (ctx.outputMode === "json") {
       console.log(JSON.stringify(
         {
@@ -61,6 +66,7 @@ export const authWhoamiCommand = new Command()
           username: whoami.username,
           email: whoami.email,
           name: whoami.name,
+          ...(collectives ? { collectives } : {}),
         },
         null,
         2,
@@ -69,6 +75,9 @@ export const authWhoamiCommand = new Command()
       console.log(
         `${whoami.username} (${whoami.email}) on ${credentials.serverUrl}`,
       );
+      if (collectives && collectives.length > 0) {
+        console.log(`Collectives: ${collectives.join(", ")}`);
+      }
     }
 
     ctx.logger.debug("Auth whoami command completed");

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -130,7 +130,7 @@ type UpstreamExtensionsMap = Record<string, UpstreamExtensionEntry>;
 export function parseExtensionRef(ref: string): ExtensionRef {
   if (!ref.startsWith("@")) {
     throw new UserError(
-      `Invalid extension name: "${ref}". Extension names must start with "@" (e.g., @namespace/name).`,
+      `Invalid extension name: "${ref}". Extension names must start with "@" (e.g., @collective/name).`,
     );
   }
 
@@ -870,7 +870,7 @@ export const extensionPullCommand = new Command()
     // 3. Validate name format
     if (!SCOPED_NAME_PATTERN.test(ref.name)) {
       throw new UserError(
-        `Invalid extension name: "${ref.name}". Must match @namespace/name pattern (lowercase, alphanumeric, hyphens, underscores).`,
+        `Invalid extension name: "${ref.name}". Must match @collective/name pattern (lowercase, alphanumeric, hyphens, underscores).`,
       );
     }
 

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -37,15 +37,19 @@ import {
   type CompilationError,
   renderExtensionPush,
   renderExtensionPushCancelled,
+  renderExtensionPushCollectiveErrors,
   renderExtensionPushCompilationErrors,
   renderExtensionPushDryRun,
-  renderExtensionPushNamespaceErrors,
   renderExtensionPushQualityErrors,
   renderExtensionPushResolved,
   renderExtensionPushSafetyErrors,
   renderExtensionPushSafetyWarnings,
 } from "../../presentation/output/extension_push_output.ts";
-import { validateContentNamespaces } from "../../domain/extensions/extension_namespace_validator.ts";
+import { validateContentCollectives } from "../../domain/extensions/extension_collective_validator.ts";
+import {
+  getCollectives,
+  SwampClubClient,
+} from "../../infrastructure/http/swamp_club_client.ts";
 
 interface ExtensionPushOptions extends GlobalOptions {
   repoDir: string;
@@ -118,30 +122,28 @@ export const extensionPushCommand = new Command()
       );
     }
 
-    // 4. Validate namespace matches username
-    const namespacePart = manifest.name.slice(1, manifest.name.indexOf("/"));
-    if (namespacePart !== credentials.username) {
-      if (ctx.outputMode === "json") {
-        throw new UserError(
-          `Extension namespace "@${namespacePart}" does not match authenticated user "${credentials.username}". ` +
-            `Use "@${credentials.username}/${
-              manifest.name.split("/")[1]
-            }" instead.`,
-        );
-      }
-      const suggested = `@${credentials.username}/${
-        manifest.name.split("/")[1]
-      }`;
-      const confirmed = await promptConfirmation(
-        `Extension namespace "@${namespacePart}" does not match your username "${credentials.username}". ` +
-          `Would you like to push as "${suggested}" instead?`,
+    // 4. Validate collective matches user's collectives (with username fallback)
+    const collectivePart = manifest.name.slice(1, manifest.name.indexOf("/"));
+    let collectives: string[] | undefined;
+    try {
+      const swampClubClient = new SwampClubClient(credentials.serverUrl);
+      const whoami = await swampClubClient.whoami(credentials.apiKey);
+      collectives = getCollectives(whoami);
+    } catch {
+      ctx.logger
+        .debug`Could not fetch collectives from server, falling back to username check`;
+    }
+    const isAllowed = collectives
+      ? collectives.includes(collectivePart)
+      : collectivePart === credentials.username;
+    if (!isAllowed) {
+      const collectivesList = collectives
+        ? collectives.map((c) => `@${c}`).join(", ")
+        : `@${credentials.username}`;
+      throw new UserError(
+        `Extension collective "@${collectivePart}" is not one of your collectives (${collectivesList}). ` +
+          `Use one of: ${collectivesList}`,
       );
-      if (!confirmed) {
-        renderExtensionPushCancelled(ctx.outputMode);
-        return;
-      }
-      // Update name for the push
-      manifest.name = suggested;
     }
 
     // 9b. Extract content metadata early (for display and later registry push)
@@ -160,23 +162,23 @@ export const extensionPushCommand = new Command()
       ctx.logger.debug`Content metadata extraction failed, skipping`;
     }
 
-    // 9c. Validate content namespaces
+    // 9c. Validate content collectives
     if (contentMetadata) {
-      const namespaceResult = validateContentNamespaces(
+      const collectiveResult = validateContentCollectives(
         manifest.name,
         contentMetadata,
       );
-      if (!namespaceResult.valid) {
+      if (!collectiveResult.valid) {
         const slashIndex = manifest.name.indexOf("/");
-        const expectedNamespace = manifest.name.slice(0, slashIndex + 1);
-        renderExtensionPushNamespaceErrors(
-          expectedNamespace,
-          namespaceResult.mismatches,
+        const expectedCollective = manifest.name.slice(0, slashIndex + 1);
+        renderExtensionPushCollectiveErrors(
+          expectedCollective,
+          collectiveResult.mismatches,
           ctx.outputMode,
         );
         throw new UserError(
-          "Extension content uses namespaces that don't match the extension package. " +
-            "All model types, vault types, and workflow names must use the same namespace as the extension.",
+          "Extension content uses collectives that don't match the extension package. " +
+            "All model types, vault types, and workflow names must use the same collective as the extension.",
         );
       }
     }

--- a/src/cli/commands/extension_rm.ts
+++ b/src/cli/commands/extension_rm.ts
@@ -154,7 +154,7 @@ export const extensionRemoveCommand = new Command()
     // Validate name format
     if (!SCOPED_NAME_PATTERN.test(ref.name)) {
       throw new UserError(
-        `Invalid extension name: "${ref.name}". Must match @namespace/name pattern (lowercase, alphanumeric, hyphens, underscores).`,
+        `Invalid extension name: "${ref.name}". Must match @collective/name pattern (lowercase, alphanumeric, hyphens, underscores).`,
       );
     }
 

--- a/src/cli/commands/extension_search.ts
+++ b/src/cli/commands/extension_search.ts
@@ -52,7 +52,7 @@ export const extensionSearchCommand = new Command()
   .name("search")
   .description("Search the swamp extension registry")
   .arguments("[query:string]")
-  .option("--namespace <namespace:string>", "Filter by namespace")
+  .option("--collective <collective:string>", "Filter by collective")
   .option("--platform <platform:string>", "Filter by platform", {
     collect: true,
   })
@@ -65,7 +65,10 @@ export const extensionSearchCommand = new Command()
   .option("--page <page:number>", "Page number", { default: 1 })
   .example("Browse all extensions", "swamp extension search")
   .example("Search by keyword", "swamp extension search aws")
-  .example("Filter by namespace", "swamp extension search --namespace stack72")
+  .example(
+    "Filter by collective",
+    "swamp extension search --collective stack72",
+  )
   .example(
     "Filter by platform and label",
     "swamp extension search --platform aws --label networking",
@@ -102,7 +105,7 @@ export const extensionSearchCommand = new Command()
 
     const params: ExtensionSearchParams = {
       q: query,
-      namespace: options.namespace,
+      collective: options.collective,
       platform: options.platform,
       label: options.label,
       sort: options.sort,

--- a/src/cli/commands/extension_yank.ts
+++ b/src/cli/commands/extension_yank.ts
@@ -80,7 +80,7 @@ export const extensionYankCommand = new Command()
 
     if (!SCOPED_NAME_PATTERN.test(ref.name)) {
       throw new UserError(
-        `Invalid extension name: "${ref.name}". Must match @namespace/name pattern (lowercase, alphanumeric, hyphens, underscores).`,
+        `Invalid extension name: "${ref.name}". Must match @collective/name pattern (lowercase, alphanumeric, hyphens, underscores).`,
       );
     }
 

--- a/src/domain/extensions/extension_collective_validator.ts
+++ b/src/domain/extensions/extension_collective_validator.ts
@@ -19,40 +19,40 @@
 
 import type { ExtensionContentMetadata } from "./extension_content.ts";
 
-/** A single content item whose namespace doesn't match the extension's namespace. */
-export interface NamespaceMismatch {
+/** A single content item whose collective doesn't match the extension's collective. */
+export interface CollectiveMismatch {
   kind: "model" | "vault" | "workflow";
   identifier: string;
   fileName: string;
 }
 
-/** Result of validating content namespaces against the extension namespace. */
-export interface NamespaceValidationResult {
+/** Result of validating content collectives against the extension collective. */
+export interface CollectiveValidationResult {
   valid: boolean;
-  mismatches: NamespaceMismatch[];
+  mismatches: CollectiveMismatch[];
 }
 
 /**
  * Validates that all content items (models, vaults, workflows) in an extension
- * use the same namespace as the extension package itself.
+ * use the same collective as the extension package itself.
  *
  * For example, if the extension is `@stack72/my-extension`, all model types,
  * vault types, and workflow names must start with `@stack72/`.
  */
-export function validateContentNamespaces(
+export function validateContentCollectives(
   extensionName: string,
   contentMetadata: ExtensionContentMetadata,
-): NamespaceValidationResult {
+): CollectiveValidationResult {
   const slashIndex = extensionName.indexOf("/");
   if (slashIndex === -1) {
     return { valid: true, mismatches: [] };
   }
-  const namespacePrefix = extensionName.slice(0, slashIndex + 1);
+  const collectivePrefix = extensionName.slice(0, slashIndex + 1);
 
-  const mismatches: NamespaceMismatch[] = [];
+  const mismatches: CollectiveMismatch[] = [];
 
   for (const model of contentMetadata.models) {
-    if (!model.type.startsWith(namespacePrefix)) {
+    if (!model.type.startsWith(collectivePrefix)) {
       mismatches.push({
         kind: "model",
         identifier: model.type,
@@ -62,7 +62,7 @@ export function validateContentNamespaces(
   }
 
   for (const vault of contentMetadata.vaults) {
-    if (!vault.type.startsWith(namespacePrefix)) {
+    if (!vault.type.startsWith(collectivePrefix)) {
       mismatches.push({
         kind: "vault",
         identifier: vault.type,
@@ -72,7 +72,7 @@ export function validateContentNamespaces(
   }
 
   for (const workflow of contentMetadata.workflows) {
-    if (!workflow.name.startsWith(namespacePrefix)) {
+    if (!workflow.name.startsWith(collectivePrefix)) {
       mismatches.push({
         kind: "workflow",
         identifier: workflow.name,

--- a/src/domain/extensions/extension_collective_validator_test.ts
+++ b/src/domain/extensions/extension_collective_validator_test.ts
@@ -19,7 +19,7 @@
 
 import { assertEquals } from "@std/assert";
 import type { ExtensionContentMetadata } from "./extension_content.ts";
-import { validateContentNamespaces } from "./extension_namespace_validator.ts";
+import { validateContentCollectives } from "./extension_collective_validator.ts";
 
 function makeMetadata(
   overrides: Partial<ExtensionContentMetadata> = {},
@@ -32,8 +32,8 @@ function makeMetadata(
   };
 }
 
-Deno.test("validateContentNamespaces — all content matches namespace — valid", () => {
-  const result = validateContentNamespaces(
+Deno.test("validateContentCollectives — all content matches collective — valid", () => {
+  const result = validateContentCollectives(
     "@stack72/my-extension",
     makeMetadata({
       models: [{
@@ -66,8 +66,8 @@ Deno.test("validateContentNamespaces — all content matches namespace — valid
   assertEquals(result.mismatches.length, 0);
 });
 
-Deno.test("validateContentNamespaces — model type with wrong namespace — mismatch", () => {
-  const result = validateContentNamespaces(
+Deno.test("validateContentCollectives — model type with wrong collective — mismatch", () => {
+  const result = validateContentCollectives(
     "@stack72/my-extension",
     makeMetadata({
       models: [{
@@ -88,8 +88,8 @@ Deno.test("validateContentNamespaces — model type with wrong namespace — mis
   assertEquals(result.mismatches[0].fileName, "echo.ts");
 });
 
-Deno.test("validateContentNamespaces — model type without @ prefix — mismatch", () => {
-  const result = validateContentNamespaces(
+Deno.test("validateContentCollectives — model type without @ prefix — mismatch", () => {
+  const result = validateContentCollectives(
     "@stack72/my-extension",
     makeMetadata({
       models: [{
@@ -109,15 +109,15 @@ Deno.test("validateContentNamespaces — model type without @ prefix — mismatc
   assertEquals(result.mismatches[0].identifier, "aws/ec2");
 });
 
-Deno.test("validateContentNamespaces — vault type with wrong namespace — mismatch", () => {
-  const result = validateContentNamespaces(
+Deno.test("validateContentCollectives — vault type with wrong collective — mismatch", () => {
+  const result = validateContentCollectives(
     "@stack72/my-extension",
     makeMetadata({
       vaults: [{
         fileName: "vault.ts",
         type: "@other/vault",
         name: "Other Vault",
-        description: "Wrong namespace",
+        description: "Wrong collective",
         hasConfigSchema: false,
         configFields: [],
       }],
@@ -129,15 +129,15 @@ Deno.test("validateContentNamespaces — vault type with wrong namespace — mis
   assertEquals(result.mismatches[0].identifier, "@other/vault");
 });
 
-Deno.test("validateContentNamespaces — workflow name with wrong namespace — mismatch", () => {
-  const result = validateContentNamespaces(
+Deno.test("validateContentCollectives — workflow name with wrong collective — mismatch", () => {
+  const result = validateContentCollectives(
     "@stack72/my-extension",
     makeMetadata({
       workflows: [{
         fileName: "wf.yaml",
         id: "wf-1",
         name: "@swamp/reserved-workflow",
-        description: "Wrong namespace",
+        description: "Wrong collective",
         jobs: [],
       }],
     }),
@@ -148,15 +148,15 @@ Deno.test("validateContentNamespaces — workflow name with wrong namespace — 
   assertEquals(result.mismatches[0].identifier, "@swamp/reserved-workflow");
 });
 
-Deno.test("validateContentNamespaces — workflow name without namespace prefix — mismatch", () => {
-  const result = validateContentNamespaces(
+Deno.test("validateContentCollectives — workflow name without collective prefix — mismatch", () => {
+  const result = validateContentCollectives(
     "@stack72/my-extension",
     makeMetadata({
       workflows: [{
         fileName: "plain.yaml",
         id: "wf-2",
         name: "plain-workflow",
-        description: "No namespace",
+        description: "No collective",
         jobs: [],
       }],
     }),
@@ -167,8 +167,8 @@ Deno.test("validateContentNamespaces — workflow name without namespace prefix 
   assertEquals(result.mismatches[0].identifier, "plain-workflow");
 });
 
-Deno.test("validateContentNamespaces — mixed mismatches — all collected", () => {
-  const result = validateContentNamespaces(
+Deno.test("validateContentCollectives — mixed mismatches — all collected", () => {
+  const result = validateContentCollectives(
     "@stack72/my-extension",
     makeMetadata({
       models: [
@@ -202,8 +202,8 @@ Deno.test("validateContentNamespaces — mixed mismatches — all collected", ()
       workflows: [{
         fileName: "wf.yaml",
         id: "wf-1",
-        name: "no-namespace",
-        description: "Missing namespace",
+        name: "no-collective",
+        description: "Missing collective",
         jobs: [],
       }],
     }),
@@ -215,8 +215,8 @@ Deno.test("validateContentNamespaces — mixed mismatches — all collected", ()
   assertEquals(result.mismatches[2].kind, "workflow");
 });
 
-Deno.test("validateContentNamespaces — empty content — valid", () => {
-  const result = validateContentNamespaces(
+Deno.test("validateContentCollectives — empty content — valid", () => {
+  const result = validateContentCollectives(
     "@stack72/my-extension",
     makeMetadata(),
   );
@@ -224,8 +224,8 @@ Deno.test("validateContentNamespaces — empty content — valid", () => {
   assertEquals(result.mismatches.length, 0);
 });
 
-Deno.test("validateContentNamespaces — partial mismatches — only wrong ones reported", () => {
-  const result = validateContentNamespaces(
+Deno.test("validateContentCollectives — partial mismatches — only wrong ones reported", () => {
+  const result = validateContentCollectives(
     "@stack72/my-extension",
     makeMetadata({
       models: [

--- a/src/domain/extensions/extension_manifest.ts
+++ b/src/domain/extensions/extension_manifest.ts
@@ -23,7 +23,7 @@ import { CalVer } from "../models/calver.ts";
 import { ModelType } from "../models/model_type.ts";
 import { UserError } from "../errors.ts";
 
-/** Scoped name pattern: @namespace/name */
+/** Scoped name pattern: @collective/name */
 const SCOPED_NAME_PATTERN = /^@[a-z0-9_-]+\/[a-z0-9_-]+$/;
 
 const ExtensionManifestSchemaV1 = z.object({
@@ -32,11 +32,11 @@ const ExtensionManifestSchemaV1 = z.object({
     (name) => SCOPED_NAME_PATTERN.test(name),
     {
       message:
-        "Extension name must be scoped: @namespace/name (lowercase, alphanumeric, hyphens, underscores)",
+        "Extension name must be scoped: @collective/name (lowercase, alphanumeric, hyphens, underscores)",
     },
   ).refine(
-    (name) => !ModelType.isReservedNamespace(name),
-    { message: "Cannot use reserved namespace (@swamp or @si)" },
+    (name) => !ModelType.isReservedCollective(name),
+    { message: "Cannot use reserved collective (@swamp or @si)" },
   ),
   version: z.string().refine(CalVer.isValid, {
     message: "Version must be valid CalVer format: YYYY.MM.DD.MICRO",
@@ -52,7 +52,7 @@ const ExtensionManifestSchemaV1 = z.object({
   releaseNotes: z.string().max(5000).optional(),
   dependencies: z.array(
     z.string().refine((dep) => dep.includes("/"), {
-      message: "Dependencies must include a slash (e.g., @namespace/name)",
+      message: "Dependencies must include a slash (e.g., @collective/name)",
     }),
   ).optional(),
 }).refine(

--- a/src/domain/extensions/extension_manifest_test.ts
+++ b/src/domain/extensions/extension_manifest_test.ts
@@ -114,7 +114,7 @@ models:
   );
 });
 
-Deno.test("parseExtensionManifest rejects reserved namespace @swamp", () => {
+Deno.test("parseExtensionManifest rejects reserved collective @swamp", () => {
   const yaml = `
 manifestVersion: 1
 name: "@swamp/myext"
@@ -125,11 +125,11 @@ models:
   const error = assertThrows(() => parseExtensionManifest(yaml));
   assertStringIncludes(
     (error as Error).message,
-    "reserved namespace",
+    "reserved collective",
   );
 });
 
-Deno.test("parseExtensionManifest rejects reserved namespace @si", () => {
+Deno.test("parseExtensionManifest rejects reserved collective @si", () => {
   const yaml = `
 manifestVersion: 1
 name: "@si/myext"
@@ -140,7 +140,7 @@ models:
   const error = assertThrows(() => parseExtensionManifest(yaml));
   assertStringIncludes(
     (error as Error).message,
-    "reserved namespace",
+    "reserved collective",
   );
 });
 

--- a/src/domain/models/model_type.ts
+++ b/src/domain/models/model_type.ts
@@ -149,26 +149,26 @@ export class ModelType {
   }
 
   /**
-   * Reserved built-in namespaces that user extensions cannot use.
+   * Reserved built-in collectives that user extensions cannot use.
    */
-  private static readonly RESERVED_NAMESPACES = ["swamp", "si"];
+  private static readonly RESERVED_COLLECTIVES = ["swamp", "si"];
 
   /**
-   * Checks if a normalized type uses a reserved namespace.
-   * Reserved namespaces are: swamp, si (with or without @ prefix).
+   * Checks if a normalized type uses a reserved collective.
+   * Reserved collectives are: swamp, si (with or without @ prefix).
    */
-  static isReservedNamespace(normalized: string): boolean {
+  static isReservedCollective(normalized: string): boolean {
     // Check for @swamp/*, @si/*
     if (ModelType.isUserNamespace(normalized)) {
       const namespace = ModelType.getUserNamespace(normalized);
       return namespace !== undefined &&
-        ModelType.RESERVED_NAMESPACES.includes(namespace);
+        ModelType.RESERVED_COLLECTIVES.includes(namespace);
     }
     // Check for swamp/*, si/*
     const firstSlash = normalized.indexOf("/");
     const firstSegment = firstSlash === -1
       ? normalized
       : normalized.slice(0, firstSlash);
-    return ModelType.RESERVED_NAMESPACES.includes(firstSegment);
+    return ModelType.RESERVED_COLLECTIVES.includes(firstSegment);
   }
 }

--- a/src/domain/models/model_type_test.ts
+++ b/src/domain/models/model_type_test.ts
@@ -133,27 +133,27 @@ Deno.test("ModelType.getSegmentCount returns correct counts", () => {
   assertEquals(ModelType.getSegmentCount("single"), 1);
 });
 
-Deno.test("ModelType.isReservedNamespace identifies swamp as reserved", () => {
-  assertEquals(ModelType.isReservedNamespace("swamp/echo"), true);
-  assertEquals(ModelType.isReservedNamespace("swamp/foo/bar"), true);
-  assertEquals(ModelType.isReservedNamespace("@swamp/echo"), true);
-  assertEquals(ModelType.isReservedNamespace("@swamp/foo/bar"), true);
+Deno.test("ModelType.isReservedCollective identifies swamp as reserved", () => {
+  assertEquals(ModelType.isReservedCollective("swamp/echo"), true);
+  assertEquals(ModelType.isReservedCollective("swamp/foo/bar"), true);
+  assertEquals(ModelType.isReservedCollective("@swamp/echo"), true);
+  assertEquals(ModelType.isReservedCollective("@swamp/foo/bar"), true);
 });
 
-Deno.test("ModelType.isReservedNamespace identifies si as reserved", () => {
-  assertEquals(ModelType.isReservedNamespace("si/auth"), true);
-  assertEquals(ModelType.isReservedNamespace("si/foo/bar"), true);
-  assertEquals(ModelType.isReservedNamespace("@si/auth"), true);
-  assertEquals(ModelType.isReservedNamespace("@si/foo/bar"), true);
+Deno.test("ModelType.isReservedCollective identifies si as reserved", () => {
+  assertEquals(ModelType.isReservedCollective("si/auth"), true);
+  assertEquals(ModelType.isReservedCollective("si/foo/bar"), true);
+  assertEquals(ModelType.isReservedCollective("@si/auth"), true);
+  assertEquals(ModelType.isReservedCollective("@si/foo/bar"), true);
 });
 
-Deno.test("ModelType.isReservedNamespace returns false for user namespaces", () => {
-  assertEquals(ModelType.isReservedNamespace("@user/echo"), false);
-  assertEquals(ModelType.isReservedNamespace("@adam/foo"), false);
-  assertEquals(ModelType.isReservedNamespace("@mycompany/model"), false);
+Deno.test("ModelType.isReservedCollective returns false for user collectives", () => {
+  assertEquals(ModelType.isReservedCollective("@user/echo"), false);
+  assertEquals(ModelType.isReservedCollective("@adam/foo"), false);
+  assertEquals(ModelType.isReservedCollective("@mycompany/model"), false);
 });
 
-Deno.test("ModelType.isReservedNamespace returns false for non-reserved built-in", () => {
-  assertEquals(ModelType.isReservedNamespace("aws/ec2/vpc"), false);
-  assertEquals(ModelType.isReservedNamespace("docker/run"), false);
+Deno.test("ModelType.isReservedCollective returns false for non-reserved built-in", () => {
+  assertEquals(ModelType.isReservedCollective("aws/ec2/vpc"), false);
+  assertEquals(ModelType.isReservedCollective("docker/run"), false);
 });

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -303,7 +303,7 @@ export class UserModelLoader {
         const userModel = parsed.data;
 
         // Validate namespace before registration
-        const namespaceError = this.validateUserNamespace(userModel.type);
+        const namespaceError = this.validateUserCollective(userModel.type);
         if (namespaceError) {
           result.failed.push({ file, error: namespaceError });
           continue;
@@ -432,7 +432,7 @@ export class UserModelLoader {
   }
 
   /**
-   * Validates that a user-defined model type follows the required namespace conventions.
+   * Validates that a user-defined model type follows the required collective conventions.
    *
    * Requirements:
    * - Must have at least 2 segments (e.g., "@myorg/echo" or "myorg/echo")
@@ -440,13 +440,13 @@ export class UserModelLoader {
    * @param rawType - The raw type string from the user model
    * @returns Error message if validation fails, undefined if valid
    */
-  private validateUserNamespace(rawType: string): string | undefined {
+  private validateUserCollective(rawType: string): string | undefined {
     const normalized = ModelType.create(rawType).normalized;
 
     // Must have at least 2 segments
     const segmentCount = ModelType.getSegmentCount(normalized);
     if (segmentCount < 2) {
-      return `Model type '${rawType}' must have at least 2 segments. Expected format: @<namespace>/<name> or <namespace>/<name> (e.g., @myorg/my-model or myorg/my-model)`;
+      return `Model type '${rawType}' must have at least 2 segments. Expected format: @<collective>/<name> or <collective>/<name> (e.g., @myorg/my-model or myorg/my-model)`;
     }
 
     return undefined;

--- a/src/domain/vaults/user_vault_loader.ts
+++ b/src/domain/vaults/user_vault_loader.ts
@@ -33,7 +33,7 @@ import { assertSafePath } from "../../infrastructure/persistence/safe_path.ts";
 
 const logger = getLogger(["swamp", "vaults", "loader"]);
 
-/** Pattern for valid user vault type: @namespace/name or namespace/name */
+/** Pattern for valid user vault type: @collective/name or collective/name */
 const USER_VAULT_TYPE_PATTERN = /^@?[a-z0-9_-]+\/[a-z0-9_-]+$/;
 
 /**
@@ -44,7 +44,7 @@ const UserVaultSchema = z.object({
     (t) => USER_VAULT_TYPE_PATTERN.test(t),
     {
       message:
-        "Vault type must match @namespace/name or namespace/name (e.g., @myorg/custom-vault or myorg/custom-vault)",
+        "Vault type must match @collective/name or collective/name (e.g., @myorg/custom-vault or myorg/custom-vault)",
     },
   ),
   name: z.string(),

--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -67,7 +67,7 @@ export interface ExtensionInfo {
 /** Parameters for the extension search endpoint. */
 export interface ExtensionSearchParams {
   q?: string;
-  namespace?: string;
+  collective?: string;
   platform?: string[];
   label?: string[];
   sort?: "relevance" | "new" | "updated" | "name";
@@ -232,7 +232,7 @@ export class ExtensionApiClient {
   ): Promise<ExtensionSearchResponse> {
     const qs = new URLSearchParams();
     if (params.q) qs.set("q", params.q);
-    if (params.namespace) qs.set("namespace", params.namespace);
+    if (params.collective) qs.set("collective", params.collective);
     if (params.sort) qs.set("sort", params.sort);
     if (params.perPage !== undefined) {
       qs.set("perPage", String(params.perPage));

--- a/src/infrastructure/http/extension_api_client_test.ts
+++ b/src/infrastructure/http/extension_api_client_test.ts
@@ -168,7 +168,7 @@ Deno.test("ExtensionApiClient.searchExtensions builds correct URL with params", 
   const client = new ExtensionApiClient(`http://localhost:${addr.port}`);
   await client.searchExtensions({
     q: "aws",
-    namespace: "stack72",
+    collective: "stack72",
     sort: "new",
     perPage: 10,
     page: 2,
@@ -176,7 +176,7 @@ Deno.test("ExtensionApiClient.searchExtensions builds correct URL with params", 
   const url = new URL(capturedUrl);
   assertEquals(url.pathname, "/api/v1/extensions/search");
   assertEquals(url.searchParams.get("q"), "aws");
-  assertEquals(url.searchParams.get("namespace"), "stack72");
+  assertEquals(url.searchParams.get("collective"), "stack72");
   assertEquals(url.searchParams.get("sort"), "new");
   assertEquals(url.searchParams.get("perPage"), "10");
   assertEquals(url.searchParams.get("page"), "2");

--- a/src/infrastructure/http/swamp_club_client.ts
+++ b/src/infrastructure/http/swamp_club_client.ts
@@ -36,6 +36,14 @@ export interface CreateApiKeyResponse {
   key: string;
 }
 
+/** An organization the user belongs to. */
+export interface WhoamiOrganization {
+  slug: string;
+  name: string;
+  role: string;
+  personal: boolean;
+}
+
 /** Response from the /api/whoami endpoint. */
 export interface WhoamiResponse {
   authenticated: boolean;
@@ -43,6 +51,18 @@ export interface WhoamiResponse {
   username?: string;
   email?: string;
   name?: string;
+  organizations?: WhoamiOrganization[];
+}
+
+/**
+ * Returns the user's collectives (organization slugs) from a whoami response.
+ * Returns undefined if the server doesn't include organizations.
+ */
+export function getCollectives(
+  whoami: WhoamiResponse,
+): string[] | undefined {
+  if (!whoami.organizations) return undefined;
+  return whoami.organizations.map((org) => org.slug);
 }
 
 /**

--- a/src/presentation/output/extension_push_output.ts
+++ b/src/presentation/output/extension_push_output.ts
@@ -22,7 +22,7 @@ import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 import type { SafetyIssue } from "../../domain/extensions/extension_safety_analyzer.ts";
 import type { QualityIssue } from "../../domain/extensions/extension_quality_checker.ts";
 import type { ExtractedArgument } from "../../domain/extensions/extension_content.ts";
-import type { NamespaceMismatch } from "../../domain/extensions/extension_namespace_validator.ts";
+import type { CollectiveMismatch } from "../../domain/extensions/extension_collective_validator.ts";
 
 const logger = getSwampLogger(["extension", "push"]);
 
@@ -182,24 +182,24 @@ export function renderExtensionPushSafetyErrors(
 }
 
 /**
- * Renders namespace mismatch errors.
+ * Renders collective mismatch errors.
  */
-export function renderExtensionPushNamespaceErrors(
-  expectedNamespace: string,
-  mismatches: NamespaceMismatch[],
+export function renderExtensionPushCollectiveErrors(
+  expectedCollective: string,
+  mismatches: CollectiveMismatch[],
   mode: OutputMode,
 ): void {
   if (mode === "json") {
     console.log(
       JSON.stringify(
-        { namespaceErrors: { expectedNamespace, mismatches } },
+        { collectiveErrors: { expectedCollective, mismatches } },
         null,
         2,
       ),
     );
   } else {
-    logger.error`Namespace errors (push blocked):`;
-    logger.error`  All content must use namespace "${expectedNamespace}"`;
+    logger.error`Collective errors (push blocked):`;
+    logger.error`  All content must use collective "${expectedCollective}"`;
     for (const m of mismatches) {
       logger.error`  ${m.kind}: "${m.identifier}" in ${m.fileName}`;
     }


### PR DESCRIPTION
## Summary

Standardizes terminology across the codebase to use **"collective"** instead of "namespace" when referring to the swamp organizational unit (`@org/name` scoped names). "Collective" is the correct ubiquitous language — a user is a member of one or more collectives, and extensions are published to a collective.

### Scope rule
Only renames "namespace" → "collective" when it refers to swamp's organizational unit. External concepts (HashiCorp Vault enterprise namespaces, CEL expression namespaces) are left unchanged.

## Changes

### Domain layer
- **`extension_namespace_validator.ts` → `extension_collective_validator.ts`** — renamed file, types (`NamespaceMismatch` → `CollectiveMismatch`, `NamespaceValidationResult` → `CollectiveValidationResult`), and function (`validateContentNamespaces()` → `validateContentCollectives()`)
- **`extension_manifest.ts`** — error messages and comments: `@namespace/name` → `@collective/name`, `reserved namespace` → `reserved collective`
- **`model_type.ts`** — `RESERVED_NAMESPACES` → `RESERVED_COLLECTIVES`, `isReservedNamespace()` → `isReservedCollective()`
- **`user_model_loader.ts`** — `validateUserNamespace()` → `validateUserCollective()`
- **`user_vault_loader.ts`** — comments and error messages updated

### CLI commands
- **`extension search`** — `--namespace` flag → `--collective` flag
- **`extension push`** — now validates the manifest collective against the user's actual collectives from the whoami API (via organizations response), with username fallback when the server is unreachable. Blocks the push with a clear error if the collective doesn't match (no more prompt to continue)
- **`extension pull/yank/rm`** — error message format: `@namespace/name` → `@collective/name`
- **`auth whoami`** — now displays collectives (extracted from organizations) in both JSON and log output

### Infrastructure
- **`swamp_club_client.ts`** — added `WhoamiOrganization` interface, `organizations` field on `WhoamiResponse`, and `getCollectives()` helper that extracts org slugs
- **`extension_api_client.ts`** — search param `namespace` → `collective`

### Presentation
- **`extension_push_output.ts`** — `renderExtensionPushNamespaceErrors()` → `renderExtensionPushCollectiveErrors()`, JSON key `namespaceErrors` → `collectiveErrors`

### Documentation & skills
- **`design/extension.md`** — all organizational "namespace" → "collective"
- **`.claude/skills/swamp-extension-model/`** — SKILL.md, publishing.md, troubleshooting.md updated
- **`.claude/skills/swamp-vault/`** — SKILL.md, troubleshooting.md, user-defined-vaults.md updated (only swamp org references, not HashiCorp Vault namespace refs)

## User-facing changes

1. **`swamp extension search`**: The `--namespace` flag is now `--collective`
   ```bash
   # Before
   swamp extension search --namespace stack72
   # After
   swamp extension search --collective stack72
   ```

2. **`swamp extension push`**: Collective validation now checks against your actual collectives from the server (not just username). If the manifest collective isn't one of yours, the push is blocked with a clear error listing your available collectives:
   ```
   Extension collective "@swampadmin" is not one of your collectives (@swamp, @system-initiative, @stack72).
   Use one of: @swamp, @system-initiative, @stack72
   ```

3. **`swamp auth whoami`**: Now shows collectives in both output modes:
   ```
   stack72 (stack72@example.com) on https://club.swamp.sh
   Collectives: swamp, system-initiative, stack72
   ```

4. **Error messages**: All error messages now use "collective" instead of "namespace" (e.g., `reserved collective` instead of `reserved namespace`)

## Test plan

- [x] All 2733 tests pass
- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt` — formatting passes
- [x] `deno run compile` — binary compiles
- [x] Manual testing of `swamp extension push` with collective validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)