### PR TITLE
fix: allow reserved collective members to push extensions

### DIFF
--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -25,6 +25,7 @@ import { requireInitializedRepo } from "../repo_context.ts";
 import { resolveExtensionFiles } from "../resolve_extension_files.ts";
 import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
 import { UserError } from "../../domain/errors.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
 import { analyzeExtensionSafety } from "../../domain/extensions/extension_safety_analyzer.ts";
 import { checkExtensionQuality } from "../../domain/extensions/extension_quality_checker.ts";
 import { bundleExtension } from "../../domain/models/bundle.ts";
@@ -124,6 +125,7 @@ export const extensionPushCommand = new Command()
 
     // 4. Validate collective matches user's collectives (with username fallback)
     const collectivePart = manifest.name.slice(1, manifest.name.indexOf("/"));
+    const isReserved = ModelType.isReservedCollective(manifest.name);
     let collectives: string[] | undefined;
     try {
       const swampClubClient = new SwampClubClient(credentials.serverUrl);
@@ -133,6 +135,15 @@ export const extensionPushCommand = new Command()
       ctx.logger
         .debug`Could not fetch collectives from server, falling back to username check`;
     }
+
+    // For reserved collectives, we MUST verify membership via the server
+    if (isReserved && !collectives) {
+      throw new UserError(
+        `Extension uses reserved collective "@${collectivePart}". ` +
+          `Could not verify membership — please check your network connection and try again.`,
+      );
+    }
+
     const isAllowed = collectives
       ? collectives.includes(collectivePart)
       : collectivePart === credentials.username;

--- a/src/domain/extensions/extension_manifest.ts
+++ b/src/domain/extensions/extension_manifest.ts
@@ -20,7 +20,6 @@
 import { z } from "zod";
 import { parse as parseYaml } from "@std/yaml";
 import { CalVer } from "../models/calver.ts";
-import { ModelType } from "../models/model_type.ts";
 import { UserError } from "../errors.ts";
 
 /** Scoped name pattern: @collective/name */
@@ -34,9 +33,6 @@ const ExtensionManifestSchemaV1 = z.object({
       message:
         "Extension name must be scoped: @collective/name (lowercase, alphanumeric, hyphens, underscores)",
     },
-  ).refine(
-    (name) => !ModelType.isReservedCollective(name),
-    { message: "Cannot use reserved collective (@swamp or @si)" },
   ),
   version: z.string().refine(CalVer.isValid, {
     message: "Version must be valid CalVer format: YYYY.MM.DD.MICRO",

--- a/src/domain/extensions/extension_manifest_test.ts
+++ b/src/domain/extensions/extension_manifest_test.ts
@@ -114,7 +114,7 @@ models:
   );
 });
 
-Deno.test("parseExtensionManifest rejects reserved collective @swamp", () => {
+Deno.test("parseExtensionManifest accepts reserved collective @swamp", () => {
   const yaml = `
 manifestVersion: 1
 name: "@swamp/myext"
@@ -122,14 +122,11 @@ version: "2026.02.26.1"
 models:
   - foo.ts
 `;
-  const error = assertThrows(() => parseExtensionManifest(yaml));
-  assertStringIncludes(
-    (error as Error).message,
-    "reserved collective",
-  );
+  const manifest = parseExtensionManifest(yaml);
+  assertEquals(manifest.name, "@swamp/myext");
 });
 
-Deno.test("parseExtensionManifest rejects reserved collective @si", () => {
+Deno.test("parseExtensionManifest accepts reserved collective @si", () => {
   const yaml = `
 manifestVersion: 1
 name: "@si/myext"
@@ -137,11 +134,8 @@ version: "2026.02.26.1"
 models:
   - foo.ts
 `;
-  const error = assertThrows(() => parseExtensionManifest(yaml));
-  assertStringIncludes(
-    (error as Error).message,
-    "reserved collective",
-  );
+  const manifest = parseExtensionManifest(yaml);
+  assertEquals(manifest.name, "@si/myext");
 });
 
 Deno.test("parseExtensionManifest rejects invalid CalVer version", () => {


### PR DESCRIPTION
fix: allow reserved collective members to push extensions

## Summary

- Moves the reserved collective (`@swamp`, `@si`) check from manifest schema validation to the push command's authorization flow
- Legitimate members of the `swamp` or `si` collectives (verified via `swamp auth whoami`) can now push extensions scoped to those collectives
- Non-members are still rejected with a clear error message listing their available collectives

## Problem

Running `swamp extension push manifest.yaml` with a `@swamp/` or `@si/` scoped extension was unconditionally rejected during Zod schema parsing — **before** the user's collective membership was ever checked. This made it impossible for actual collective members to publish official extensions.

## What changed

### Manifest validation (`extension_manifest.ts`)
- Removed the `.refine()` that rejected reserved collectives at parse time
- Removed the now-unused `ModelType` import
- The manifest parser now only validates **structure** (format, required fields), not authorization

### Push command (`extension_push.ts`)
- Added `ModelType.isReservedCollective()` check in the existing collective membership validation
- If the extension uses a reserved collective but the server can't be reached to verify membership, the push is rejected (no username fallback for reserved collectives)
- If the server confirms membership, the push proceeds normally

### Tests (`extension_manifest_test.ts`)
- Replaced the two rejection tests with acceptance tests verifying `@swamp/` and `@si/` names are valid at the manifest level

## Security boundaries preserved

1. **Server-side membership verification is required** for reserved collectives — the username fallback path is explicitly blocked
2. **Non-members are still rejected** — the existing `isAllowed` check validates collective membership via the API
3. **Network failures are safe** — if the server can't be reached for a reserved collective, the push fails closed with a clear error
4. **All other validation unchanged** — scoped name format, CalVer version, content collective matching, safety analysis, and quality checks remain in place

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] All 2733 tests pass (`deno run test`)
- [x] Manual: `swamp extension push` with `@swamp/` extension as a collective member succeeds
- [x] Manual: `swamp extension push` with `@swamp/` extension as a non-member is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
