### PR TITLE
fix: add --json to all non-interactive CLI examples in skill files

### DIFF
--- a/.claude/skills/swamp-data/SKILL.md
+++ b/.claude/skills/swamp-data/SKILL.md
@@ -10,21 +10,21 @@ machine-readable output.
 
 ## Quick Reference
 
-| Task                   | Command                                        |
-| ---------------------- | ---------------------------------------------- |
-| Search all data        | `swamp data search --json`                     |
-| Search with filters    | `swamp data search --type output --since 1d`   |
-| Search by workflow     | `swamp data search --workflow my-workflow`     |
-| Search by model        | `swamp data search --model my-model`           |
-| Free-text search       | `swamp data search vpc --json`                 |
-| List model data        | `swamp data list <model> --json`               |
-| List workflow data     | `swamp data list --workflow <name> --json`     |
-| Get specific data      | `swamp data get <model> <name> --json`         |
-| Get metadata only      | `swamp data get <model> <name> --no-content`   |
-| Get data via workflow  | `swamp data get --workflow <name> <data_name>` |
-| View version history   | `swamp data versions <model> <name> --json`    |
-| Run garbage collection | `swamp data gc --json`                         |
-| Preview GC (dry run)   | `swamp data gc --dry-run --json`               |
+| Task                   | Command                                               |
+| ---------------------- | ----------------------------------------------------- |
+| Search all data        | `swamp data search --json`                            |
+| Search with filters    | `swamp data search --type output --since 1d --json`   |
+| Search by workflow     | `swamp data search --workflow my-workflow --json`     |
+| Search by model        | `swamp data search --model my-model --json`           |
+| Free-text search       | `swamp data search vpc --json`                        |
+| List model data        | `swamp data list <model> --json`                      |
+| List workflow data     | `swamp data list --workflow <name> --json`            |
+| Get specific data      | `swamp data get <model> <name> --json`                |
+| Get metadata only      | `swamp data get <model> <name> --no-content --json`   |
+| Get data via workflow  | `swamp data get --workflow <name> <data_name> --json` |
+| View version history   | `swamp data versions <model> <name> --json`           |
+| Run garbage collection | `swamp data gc --json`                                |
+| Preview GC (dry run)   | `swamp data gc --dry-run --json`                      |
 
 ## Data Concepts
 

--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -45,17 +45,17 @@ than wrapping CLI commands.
 
 | Task                | Command/Action                                          |
 | ------------------- | ------------------------------------------------------- |
-| Search community    | `swamp extension search <query>`                        |
+| Search community    | `swamp extension search <query> --json`                 |
 | Create model file   | Create `extensions/models/my_model.ts`                  |
 | Verify registration | `swamp model type search --json`                        |
 | Check schema        | `swamp model type describe @myorg/my-model --json`      |
 | Create instance     | `swamp model create @myorg/my-model my-instance --json` |
 | Run method          | `swamp model method run my-instance run --json`         |
 | Create manifest     | Create `manifest.yaml` with model/workflow entries      |
-| Format extension    | `swamp extension fmt manifest.yaml`                     |
-| Check formatting    | `swamp extension fmt manifest.yaml --check`             |
-| Push extension      | `swamp extension push manifest.yaml`                    |
-| Dry-run push        | `swamp extension push manifest.yaml --dry-run`          |
+| Format extension    | `swamp extension fmt manifest.yaml --json`              |
+| Check formatting    | `swamp extension fmt manifest.yaml --check --json`      |
+| Push extension      | `swamp extension push manifest.yaml --json`             |
+| Dry-run push        | `swamp extension push manifest.yaml --dry-run --json`   |
 
 ## Quick Start
 
@@ -361,9 +361,9 @@ models:
 **Push commands:**
 
 ```bash
-swamp extension push manifest.yaml              # Push to registry
-swamp extension push manifest.yaml --dry-run    # Validate without pushing
-swamp extension push manifest.yaml -y           # Skip confirmation prompts
+swamp extension push manifest.yaml --json           # Push to registry
+swamp extension push manifest.yaml --dry-run --json # Validate without pushing
+swamp extension push manifest.yaml -y --json        # Skip confirmation prompts
 ```
 
 The manifest `name` collective must match your authenticated username. Model
@@ -422,7 +422,7 @@ After creating your model:
 
 ```bash
 swamp model type search --json              # Model should appear
-swamp model type describe @myorg/my-model   # Check schema
+swamp model type describe @myorg/my-model --json  # Check schema
 ```
 
 ## When to Use Other Skills

--- a/.claude/skills/swamp-extension-model/references/publishing.md
+++ b/.claude/skills/swamp-extension-model/references/publishing.md
@@ -113,16 +113,16 @@ dependencies:
 
 ```bash
 # Full push to registry
-swamp extension push manifest.yaml
+swamp extension push manifest.yaml --json
 
 # Validate locally without pushing (builds archive, runs safety checks)
-swamp extension push manifest.yaml --dry-run
+swamp extension push manifest.yaml --dry-run --json
 
 # Skip all confirmation prompts
-swamp extension push manifest.yaml -y
+swamp extension push manifest.yaml -y --json
 
 # Specify a different repo directory
-swamp extension push manifest.yaml --repo-dir /path/to/repo
+swamp extension push manifest.yaml --repo-dir /path/to/repo --json
 ```
 
 ### What Happens During Push
@@ -147,13 +147,13 @@ their local imports), then runs `deno fmt` and `deno lint --fix` on them.
 
 ```bash
 # Auto-fix formatting and lint issues
-swamp extension fmt manifest.yaml
+swamp extension fmt manifest.yaml --json
 
 # Check-only mode (exit non-zero if issues exist, does not modify files)
-swamp extension fmt manifest.yaml --check
+swamp extension fmt manifest.yaml --check --json
 
 # Specify a different repo directory
-swamp extension fmt manifest.yaml --repo-dir /path/to/repo
+swamp extension fmt manifest.yaml --repo-dir /path/to/repo --json
 ```
 
 ### What Happens During Fmt

--- a/.claude/skills/swamp-extension-model/references/troubleshooting.md
+++ b/.claude/skills/swamp-extension-model/references/troubleshooting.md
@@ -212,6 +212,6 @@ swamp model type search --json
 swamp model type describe @myorg/my-model --json
 
 # Test the model
-swamp model create @myorg/my-model test --set fieldName="test"
+swamp model create @myorg/my-model test --set fieldName="test" --json
 swamp model method run test methodName --json
 ```

--- a/.claude/skills/swamp-issue/SKILL.md
+++ b/.claude/skills/swamp-issue/SKILL.md
@@ -10,12 +10,12 @@ submitted directly to GitHub with appropriate labels.
 
 ## Quick Reference
 
-| Task                  | Command                                                |
-| --------------------- | ------------------------------------------------------ |
-| Report a bug          | `swamp issue bug`                                      |
-| Request a feature     | `swamp issue feature`                                  |
-| Submit bug (CLI args) | `swamp issue bug --title "Title" --body "Description"` |
-| Submit feature (args) | `swamp issue feature --title "Title" --body "Desc"`    |
+| Task                  | Command                                                       |
+| --------------------- | ------------------------------------------------------------- |
+| Report a bug          | `swamp issue bug`                                             |
+| Request a feature     | `swamp issue feature`                                         |
+| Submit bug (CLI args) | `swamp issue bug --title "Title" --body "Description" --json` |
+| Submit feature (args) | `swamp issue feature --title "Title" --body "Desc" --json`    |
 
 ## Submitting a Bug Report
 
@@ -39,7 +39,7 @@ This opens your configured `$EDITOR` with a template containing:
 **Non-interactive mode:**
 
 ```bash
-swamp issue bug --title "CLI crashes on empty input" --body "When running..."
+swamp issue bug --title "CLI crashes on empty input" --body "When running..." --json
 swamp issue bug -t "Title" -b "Body" --json
 ```
 
@@ -66,7 +66,7 @@ This opens your editor with a template containing:
 **Non-interactive mode:**
 
 ```bash
-swamp issue feature --title "Add dark mode" --body "I'd like..."
+swamp issue feature --title "Add dark mode" --body "I'd like..." --json
 swamp issue feature -t "Title" -b "Body" --json
 ```
 

--- a/.claude/skills/swamp-model/references/scenarios.md
+++ b/.claude/skills/swamp-model/references/scenarios.md
@@ -335,9 +335,9 @@ swamp vault create aws prod-secrets --json  # Production uses AWS
 **2. Store secrets in each vault**
 
 ```bash
-swamp vault put dev-secrets API_KEY=dev-key-12345
-swamp vault put staging-secrets API_KEY=staging-key-67890
-swamp vault put prod-secrets API_KEY=prod-key-secure
+swamp vault put dev-secrets API_KEY=dev-key-12345 --json
+swamp vault put staging-secrets API_KEY=staging-key-67890 --json
+swamp vault put prod-secrets API_KEY=prod-key-secure --json
 ```
 
 **3. Create model with conditional vault access**

--- a/.claude/skills/swamp-repo/SKILL.md
+++ b/.claude/skills/swamp-repo/SKILL.md
@@ -10,14 +10,14 @@ machine-readable output.
 
 ## Quick Reference
 
-| Task                   | Command                     |
-| ---------------------- | --------------------------- |
-| Initialize repository  | `swamp repo init [path]`    |
-| Upgrade repository     | `swamp repo upgrade [path]` |
-| Rebuild symlink index  | `swamp repo index`          |
-| Verify symlinks        | `swamp repo index --verify` |
-| Remove broken symlinks | `swamp repo index --prune`  |
-| Start web interface    | `swamp repo webapp [path]`  |
+| Task                   | Command                            |
+| ---------------------- | ---------------------------------- |
+| Initialize repository  | `swamp repo init [path] --json`    |
+| Upgrade repository     | `swamp repo upgrade [path] --json` |
+| Rebuild symlink index  | `swamp repo index --json`          |
+| Verify symlinks        | `swamp repo index --verify --json` |
+| Remove broken symlinks | `swamp repo index --prune --json`  |
+| Start web interface    | `swamp repo webapp [path] --json`  |
 
 ## Repository Structure
 

--- a/.claude/skills/swamp-vault/references/examples.md
+++ b/.claude/skills/swamp-vault/references/examples.md
@@ -56,16 +56,16 @@ swamp vault create local_encryption backend-secrets --json
 
 ```bash
 # Dev environment
-swamp vault put dev-secrets API_KEY=dev-key-12345
-swamp vault put dev-secrets DB_PASSWORD=dev-db-pass
+swamp vault put dev-secrets API_KEY=dev-key-12345 --json
+swamp vault put dev-secrets DB_PASSWORD=dev-db-pass --json
 
 # Staging environment
-swamp vault put staging-secrets API_KEY=staging-key-67890
-swamp vault put staging-secrets DB_PASSWORD=staging-db-pass
+swamp vault put staging-secrets API_KEY=staging-key-67890 --json
+swamp vault put staging-secrets DB_PASSWORD=staging-db-pass --json
 
 # Production environment (via AWS)
-swamp vault put prod-secrets API_KEY=prod-key-secure
-swamp vault put prod-secrets DB_PASSWORD=prod-db-secure
+swamp vault put prod-secrets API_KEY=prod-key-secure --json
+swamp vault put prod-secrets DB_PASSWORD=prod-db-secure --json
 ```
 
 ## Using Vaults in Models
@@ -182,11 +182,11 @@ Create a user-defined vault implementation, then use it like any built-in vault:
 ```bash
 # Create vault instance (user-defined types use --config)
 swamp vault create @hashicorp/vault my-hcv \
-  --config '{"address": "https://vault.example.com:8200", "path_prefix": "myapp/prod"}'
+  --config '{"address": "https://vault.example.com:8200", "path_prefix": "myapp/prod"}' --json
 
 # Store and retrieve secrets
-swamp vault put my-hcv db-password "s3cur3-p@ssw0rd"
-swamp vault list-keys my-hcv
+swamp vault put my-hcv db-password "s3cur3-p@ssw0rd" --json
+swamp vault list-keys my-hcv --json
 ```
 
 ### User-Defined Vault in Workflows
@@ -211,11 +211,11 @@ jobs:
 
 ```bash
 # Local vault for dev secrets
-swamp vault create local_encryption dev-secrets
+swamp vault create local_encryption dev-secrets --json
 
 # HashiCorp Vault for production
 swamp vault create @hashicorp/vault prod-hcv \
-  --config '{"address": "https://vault.prod.internal:8200", "path_prefix": "prod"}'
+  --config '{"address": "https://vault.prod.internal:8200", "path_prefix": "prod"}' --json
 ```
 
 Reference both in models:
@@ -255,7 +255,7 @@ swamp vault get prod-secrets API_KEY --json
 # Copy the value
 
 # Put into AWS vault
-swamp vault put prod-secrets-aws API_KEY=<copied-value>
+swamp vault put prod-secrets-aws API_KEY=<copied-value> --json
 ```
 
 **Step 3: Update model references**

--- a/.claude/skills/swamp-vault/references/providers.md
+++ b/.claude/skills/swamp-vault/references/providers.md
@@ -74,11 +74,11 @@ createdAt: 2025-02-01T...
 
 ```bash
 # Explicit region
-swamp vault create aws-sm prod-vault --region us-east-1
+swamp vault create aws-sm prod-vault --region us-east-1 --json
 
 # From environment variable (logs a message confirming env var usage)
 export AWS_REGION=us-east-1
-swamp vault create aws-sm prod-vault
+swamp vault create aws-sm prod-vault --json
 ```
 
 ### Authentication
@@ -122,11 +122,11 @@ createdAt: 2025-02-01T...
 
 ```bash
 # Explicit vault URL
-swamp vault create azure-kv azure-secrets --vault-url https://myvault.vault.azure.net/
+swamp vault create azure-kv azure-secrets --vault-url https://myvault.vault.azure.net/ --json
 
 # From environment variable (logs a message confirming env var usage)
 export AZURE_KEYVAULT_URL=https://myvault.vault.azure.net/
-swamp vault create azure-kv azure-secrets
+swamp vault create azure-kv azure-secrets --json
 ```
 
 ### Authentication
@@ -169,15 +169,15 @@ createdAt: 2025-02-01T...
 
 ```bash
 # Explicit vault name
-swamp vault create 1password op-secrets --op-vault "my-vault"
+swamp vault create 1password op-secrets --op-vault "my-vault" --json
 
 # With account shorthand
-swamp vault create 1password op-secrets --op-vault "my-vault" --op-account "my-team"
+swamp vault create 1password op-secrets --op-vault "my-vault" --op-account "my-team" --json
 
 # From environment variables
 export OP_VAULT=my-vault
 export OP_ACCOUNT=my-team
-swamp vault create 1password op-secrets
+swamp vault create 1password op-secrets --json
 ```
 
 ### Authentication

--- a/.claude/skills/swamp-vault/references/troubleshooting.md
+++ b/.claude/skills/swamp-vault/references/troubleshooting.md
@@ -10,7 +10,7 @@
 
 1. Vault doesn't exist - Create it:
    ```bash
-   swamp vault create local_encryption my-vault
+   swamp vault create local_encryption my-vault --json
    ```
 
 2. Typo in vault name - List available vaults:
@@ -31,7 +31,7 @@
 
 1. Secret not stored yet:
    ```bash
-   swamp vault put dev-secrets API_KEY=your-value
+   swamp vault put dev-secrets API_KEY=your-value --json
    ```
 
 2. Wrong key name - List available keys:
@@ -155,7 +155,7 @@ swamp vault type search --json
 
 ```bash
 swamp vault create @myorg/my-vault my-vault \
-  --config '{"address": "https://example.com"}'
+  --config '{"address": "https://example.com"}' --json
 ```
 
 ### Expression Evaluation Errors
@@ -183,9 +183,9 @@ swamp vault create @myorg/my-vault my-vault \
 3. Test retrieval manually (won't display value, but confirms access):
    ```bash
    # Use the swamp/lets-get-sensitive model to test
-   swamp model create swamp/lets-get-sensitive test-get
+   swamp model create swamp/lets-get-sensitive test-get --json
    # Edit to set operation: get, vaultName, secretKey
-   swamp model method run test-get get
+   swamp model method run test-get get --json
    ```
 
 ## Vault Name Validation
@@ -204,7 +204,7 @@ names**: `dev-secrets`, `prod-vault`, `api-keys-v2`
 If vault symlinks are missing or broken:
 
 ```bash
-swamp repo index
+swamp repo index --json
 ```
 
 This rebuilds all logical views including `/vaults/{name}/` directories.

--- a/.claude/skills/swamp-vault/references/user-defined-vaults.md
+++ b/.claude/skills/swamp-vault/references/user-defined-vaults.md
@@ -51,7 +51,7 @@ User-defined vaults require `--config` with a JSON object:
 
 ```bash
 swamp vault create @hashicorp/vault my-hcv \
-  --config '{"address": "https://vault.example.com:8200", "path_prefix": "myapp"}'
+  --config '{"address": "https://vault.example.com:8200", "path_prefix": "myapp"}' --json
 ```
 
 The config JSON is validated against `configSchema` if provided.
@@ -181,10 +181,10 @@ Usage:
 
 ```bash
 swamp vault create @hashicorp/vault my-hcv \
-  --config '{"address": "https://vault.example.com:8200"}'
+  --config '{"address": "https://vault.example.com:8200"}' --json
 
-swamp vault put my-hcv db-password "s3cur3-p@ssw0rd"
-swamp vault list-keys my-hcv
+swamp vault put my-hcv db-password "s3cur3-p@ssw0rd" --json
+swamp vault list-keys my-hcv --json
 ```
 
 Works identically with OpenBao — just point `address` at the OpenBao server.


### PR DESCRIPTION
## Summary

- Added `--json` flag to all non-interactive CLI command examples across 11 skill files
- Skill files are the primary way the agent interacts with the CLI — commands missing `--json` cause the agent to receive human-readable log output instead of structured JSON, making parsing unreliable
- Interactive commands (`edit`, bare `issue bug/feature`) are intentionally left unchanged since the agent cannot use them

**Files changed:** `swamp-data`, `swamp-repo`, `swamp-extension-model`, `swamp-issue`, `swamp-vault`, and `swamp-model` skill files and their references.

## Test Plan

- [x] Verified all non-interactive commands now include `--json`
- [x] Verified no `--json` was added to interactive `edit` commands
- [x] Ran `deno fmt` to ensure formatting is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)