### PR TITLE
fix: skip unresolvable cross-model resource expressions in globalArguments

### DIFF
--- a/.claude/skills/swamp-model/references/troubleshooting.md
+++ b/.claude/skills/swamp-model/references/troubleshooting.md
@@ -135,7 +135,15 @@ swamp model validate my-model --json
    vpcId: ${{ model.my-vpc.resource.vpc.main.attributes.VpcId }}
    ```
 
-2. **Model never executed**:
+2. **Model never executed** — expressions referencing `model.*.resource` or
+   `model.*.file` are automatically skipped when the referenced model has no
+   data. If a method accesses a skipped field, it throws a clear error:
+
+   ```
+   Unresolved expression in globalArguments.ssh_keys: ${{ model.ssh-key.resource... }}
+   ```
+
+   To fix, run the referenced model first:
 
    ```bash
    swamp model method run my-vpc create --json
@@ -157,6 +165,26 @@ swamp model validate my-model --json
    # Check actual attribute names
    swamp data get my-vpc vpc --json
    ```
+
+### "Unresolved expression in globalArguments"
+
+**Symptom**:
+`Error: Unresolved expression in globalArguments.<field>: ${{ ... }}`
+
+**Cause**: A `globalArguments` field contains a CEL expression that couldn't be
+resolved (e.g., the referenced model has no resource data), and the method tried
+to use that field.
+
+**Solutions**:
+
+1. **Run the referenced model first** so its data is available:
+
+   ```bash
+   swamp model method run <referenced-model> create --json
+   ```
+
+2. **Use a workflow** that runs models in the correct order — dependencies are
+   resolved automatically within a workflow run.
 
 ### "Model type not found"
 

--- a/integration/keeb_shell_model_test.ts
+++ b/integration/keeb_shell_model_test.ts
@@ -412,3 +412,69 @@ Deno.test("CLI: command/shell model with self-reference expressions", async () =
     assertEquals(output.data.attributes.exitCode, 0);
   });
 });
+
+Deno.test("CLI: model method run succeeds when globalArguments has unresolvable cross-model resource expression", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+
+    // Create source model (no data — never executed)
+    const sourceModel = Definition.create({
+      name: "source-shell",
+      globalArguments: {
+        run: "echo source",
+      },
+      methods: {
+        execute: {
+          arguments: {
+            run: "echo source",
+          },
+        },
+      },
+    });
+    await definitionRepo.save(SHELL_MODEL_TYPE, sourceModel);
+
+    // Create dependent model that references source model's resource state
+    // in globalArguments — this resource does NOT exist yet
+    const dependentModel = Definition.create({
+      name: "dependent-shell",
+      globalArguments: {
+        run: "echo hello",
+        workingDir:
+          "${{ model.source-shell.resource.state.result.attributes.stdout }}",
+      },
+      methods: {
+        execute: {
+          arguments: {
+            run: "echo hello",
+          },
+        },
+      },
+    });
+    await definitionRepo.save(SHELL_MODEL_TYPE, dependentModel);
+
+    // Run the dependent model directly — should succeed because:
+    // 1. The unresolvable resource expression in globalArguments.workingDir is skipped
+    // 2. The method only uses the "run" argument, not "workingDir"
+    const result = await runCliCommand(
+      [
+        "model",
+        "method",
+        "run",
+        "dependent-shell",
+        "execute",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Command should succeed. stderr: ${result.stderr}`,
+    );
+  });
+});

--- a/src/domain/expressions/expression_evaluation_service.ts
+++ b/src/domain/expressions/expression_evaluation_service.ts
@@ -29,7 +29,10 @@ import {
   replaceExpressions,
 } from "./expression_parser.ts";
 import type { ExpressionLocation } from "./expression.ts";
-import { extractModelRefs } from "./dependency_extractor.ts";
+import {
+  extractDependencies,
+  extractModelRefs,
+} from "./dependency_extractor.ts";
 import {
   buildEnvContext,
   type ExpressionContext,
@@ -215,17 +218,39 @@ export class ExpressionEvaluationService {
       // This allows methods that don't need certain inputs to run without
       // those inputs being provided (e.g., delete doesn't need create-time inputs).
       const inputRefs = extractInputReferencesFromCel(expr.celExpression);
+      let hasMissing = false;
       if (inputRefs.size > 0) {
-        let hasMissing = false;
         for (const ref of inputRefs) {
           if (!providedInputKeys.has(ref)) {
             hasMissing = true;
             break;
           }
         }
-        if (hasMissing) {
-          continue;
+      }
+
+      // Skip expressions referencing model resource/file data that isn't
+      // available in context (e.g., referenced model was never executed).
+      // This mirrors the inputs skip above — the raw expression is preserved
+      // so the Proxy on globalArgs will throw if the method actually needs it.
+      if (!hasMissing) {
+        const deps = extractDependencies(expr.celExpression);
+        for (const dep of deps) {
+          if (dep.type === "resource" || dep.type === "file") {
+            const modelData = ctx.model[dep.modelRef];
+            if (
+              !modelData ||
+              (dep.type === "resource" && !modelData.resource) ||
+              (dep.type === "file" && !modelData.file)
+            ) {
+              hasMissing = true;
+              break;
+            }
+          }
         }
+      }
+
+      if (hasMissing) {
+        continue;
       }
 
       const value = this.celEvaluator.evaluate(expr.celExpression, ctx);

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -38,10 +38,7 @@ import {
   createResourceWriter,
 } from "./data_writer.ts";
 import { coerceMethodArgs } from "./zod_type_coercion.ts";
-import {
-  containsExpression,
-  extractInputReferencesFromCel,
-} from "../expressions/expression_parser.ts";
+import { containsExpression } from "../expressions/expression_parser.ts";
 
 /**
  * Maximum depth for recursive follow-up action processing.
@@ -133,8 +130,8 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
 
     // Populate context with global args and definition metadata.
     // Wrap globalArgs in a Proxy that throws a clear error when the method
-    // accesses a field with an unresolved ${{ inputs.* }} expression.
-    // This allows methods that don't need certain inputs to succeed while
+    // accesses a field with an unresolved ${{ ... }} expression.
+    // This allows methods that don't need certain fields to succeed while
     // failing fast with a helpful message if they do.
     const rawGlobalArgs = definition.globalArguments;
     const globalArgsProxy = new Proxy(rawGlobalArgs, {
@@ -144,13 +141,9 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
           typeof prop === "string" && typeof value === "string" &&
           containsExpression(value)
         ) {
-          const refs = extractInputReferencesFromCel(value);
-          if (refs.size > 0) {
-            const missing = [...refs].join(", ");
-            throw new Error(
-              `Missing required input(s): ${missing} (needed by globalArguments.${prop})`,
-            );
-          }
+          throw new Error(
+            `Unresolved expression in globalArguments.${prop}: ${value}`,
+          );
         }
         return value;
       },
@@ -219,14 +212,12 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
     if (modelDef.globalArguments) {
       const rawGlobalArgs = currentDefinition.globalArguments;
 
-      // Identify globalArg fields with unresolved input expressions
+      // Identify globalArg fields with unresolved expressions (inputs,
+      // model resource/file refs, or any other ${{ ... }} that wasn't evaluated)
       let hasUnresolved = false;
       const resolvedGlobalArgs: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(rawGlobalArgs)) {
-        if (
-          typeof value === "string" && containsExpression(value) &&
-          extractInputReferencesFromCel(value).size > 0
-        ) {
+        if (typeof value === "string" && containsExpression(value)) {
           hasUnresolved = true;
         } else {
           resolvedGlobalArgs[key] = value;

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -1530,3 +1530,121 @@ Deno.test("executeWorkflow - explicit kind overrides name inference for deletion
   // kind: "action" should NOT trigger deletion markers
   assertEquals(mockRepo.savedData.length, 0);
 });
+
+// ---------- Unresolved Expression Tests ----------
+
+Deno.test("execute - Proxy throws for any unresolved expression in globalArgs", async () => {
+  const service = new DefaultMethodExecutionService();
+
+  const model: ModelDefinition = {
+    type: ModelType.create("test/unresolved-expr"),
+    version: "1",
+    methods: {
+      run: {
+        description: "Test method",
+        arguments: z.object({}),
+        execute: (_args: Record<string, unknown>, context) => {
+          // Access the unresolved field — should throw
+          const _val = context.globalArgs.ssh_keys;
+          return Promise.resolve({});
+        },
+      },
+    },
+  };
+
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: {
+      name: "my-server",
+      ssh_keys:
+        '${{ string(model["test-ssh-key"].resource.state.key.attributes.id) }}',
+    },
+    methods: { run: { arguments: {} } },
+  });
+
+  const { context } = createTestContext({ modelType: model.type });
+  await assertRejects(
+    () => service.execute(definition, model.methods.run, context),
+    Error,
+    "Unresolved expression in globalArguments.ssh_keys",
+  );
+});
+
+Deno.test("execute - Proxy allows access to resolved globalArgs fields", async () => {
+  const service = new DefaultMethodExecutionService();
+
+  let receivedName = "";
+  const model: ModelDefinition = {
+    type: ModelType.create("test/resolved-expr"),
+    version: "1",
+    methods: {
+      run: {
+        description: "Test method",
+        arguments: z.object({}),
+        execute: (_args: Record<string, unknown>, context) => {
+          receivedName = context.globalArgs.name as string;
+          return Promise.resolve({});
+        },
+      },
+    },
+  };
+
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: {
+      name: "my-server",
+      ssh_keys:
+        '${{ string(model["test-ssh-key"].resource.state.key.attributes.id) }}',
+    },
+    methods: { run: { arguments: {} } },
+  });
+
+  const { context } = createTestContext({ modelType: model.type });
+  await service.execute(definition, model.methods.run, context);
+  assertEquals(receivedName, "my-server");
+});
+
+Deno.test("executeWorkflow - skips validation for globalArgs with unresolved model resource expressions", async () => {
+  const service = new DefaultMethodExecutionService();
+
+  const schema = z.object({
+    name: z.string(),
+    ssh_keys: z.array(z.string()),
+  });
+
+  let receivedName = "";
+  const model: ModelDefinition = {
+    type: ModelType.create("test/unresolved-resource-expr"),
+    version: "1",
+    globalArguments: schema,
+    methods: {
+      update: {
+        description: "Update method",
+        arguments: z.object({}),
+        execute: (_args: Record<string, unknown>, context) => {
+          receivedName = context.globalArgs.name as string;
+          return Promise.resolve({});
+        },
+      },
+    },
+  };
+
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: {
+      name: "my-server",
+      ssh_keys:
+        '${{ [string(model["test-ssh-key"].resource.state.key.attributes.id)] }}',
+    },
+  });
+
+  const { context } = createTestContext({ modelType: model.type });
+  const result = await service.executeWorkflow(
+    definition,
+    model,
+    "update",
+    context,
+  );
+  assertEquals(result !== undefined, true);
+  assertEquals(receivedName, "my-server");
+});


### PR DESCRIPTION
## Summary

Fixes #641. When a model's `globalArguments` contain CEL expressions referencing another model's resource or file data (e.g., `${{ model.ssh-key.resource.state.key.attributes.id }}`), method execution crashes with `No such key: resource` if the referenced model has no data on disk. This prevents methods like `update` from running even when they don't need the unresolvable field.

## What Changed

### 1. Expression evaluation skips unresolvable resource/file references

In `ExpressionEvaluationService.evaluateDefinition()`, expressions referencing `model.*.resource` or `model.*.file` are now skipped when the context proves the data doesn't exist (the referenced model was never executed or its data was cleaned up). This extends the existing pattern that already skips unresolved `inputs.*` references.

The raw `${{ ... }}` expression is preserved in the definition — it is not silently discarded.

### 2. Broadened unresolved-expression detection in globalArgs validation

In `DefaultMethodExecutionService.executeWorkflow()`, the check for unresolved globalArgs fields now catches *any* remaining `${{ ... }}` expression, not just `inputs.*` ones. This is safe because vault/env expressions are always resolved before `executeWorkflow()` is called (both in the CLI path via `model_method_run.ts:282` and the workflow path via `execution_service.ts:402`).

### 3. Fixed pre-existing silent data corruption bug in globalArgs Proxy

The Proxy on `context.globalArgs` previously only threw for unresolved `inputs.*` expressions. If a globalArg contained an unresolved `model.*.resource` expression, the Proxy would silently return the raw `${{ ... }}` string to the method. A model method could unknowingly send that literal string to an API. The Proxy now throws for *any* unresolved expression:

```
Unresolved expression in globalArguments.ssh_keys: ${{ model["ssh-key"].resource.state... }}
```

## Design Rationale

**Follows an established pattern.** The codebase already skips unresolved `inputs.*` expressions in `evaluateDefinition()` (lines 214-229). The `model.*.resource` case is structurally identical — an expression references context data that doesn't exist yet. Extending the same skip logic is a natural, consistent extension.

**The safety net already exists.** The Proxy on `context.globalArgs` catches any attempt to *use* an unresolved expression at runtime. The flow is:
1. Expression can't be resolved → skip it, leave the raw `${{ ... }}` in the definition
2. If the method actually needs that field → Proxy throws a clear error
3. If the method doesn't need that field → everything works fine

**`buildContext()` already loads data from disk.** When `dataRepo` is provided (which it is in both CLI and workflow paths), `ModelResolver.buildContext()` eagerly populates `model.*.resource` from on-disk data. If the data exists, the expression resolves normally. The skip only triggers when data genuinely doesn't exist.

**Alternative approaches are worse:**
- "Only evaluate fields the method schema needs" — requires the evaluation service to understand method schemas, a layer violation
- "Make `model.*.resource` persistently available" — already happens; the problem is the referenced model has *no data at all*
- "Allow `data.latest()` in definitions" — pushes complexity to users

## User Impact

- **No breaking changes.** Every expression that resolved before still resolves. The skip logic only triggers when the CEL evaluation would have crashed anyway.
- **What was broken now works.** Models with cross-model resource references in `globalArguments` can run methods that don't need those fields (e.g., `update` doesn't need `ssh_keys`).
- **Better error messages.** If a method accesses an unresolved field, the error is now `Unresolved expression in globalArguments.ssh_keys: ${{ ... }}` instead of the cryptic `No such key: resource`.
- **Fixes silent corruption.** Unresolved non-input expressions can no longer silently leak through the Proxy as raw strings.

## Files Changed

| File | Change |
|------|--------|
| `src/domain/expressions/expression_evaluation_service.ts` | Skip expressions with unresolvable `model.*.resource`/`model.*.file` deps |
| `src/domain/models/method_execution_service.ts` | Broaden globalArgs unresolved detection + fix Proxy to catch all expressions |
| `src/domain/models/method_execution_service_test.ts` | 3 new unit tests for Proxy and globalArgs validation behavior |
| `integration/keeb_shell_model_test.ts` | Integration test: model method run with unresolvable cross-model resource ref |
| `.claude/skills/swamp-model/references/troubleshooting.md` | Document new error message and updated behavior |

## Testing

- All 2769 existing tests pass
- 3 new unit tests covering Proxy throws, Proxy allows resolved fields, and executeWorkflow skips validation
- 1 new integration test verifying standalone method run succeeds with unresolvable cross-model resource expression
- Manually verified against reproduction case in `/tmp/swamp-641-test`