### PR TITLE
fix: scope CRUD lifecycle deleted-resource check to declared resource data (#645)

### DIFF
--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -39,12 +39,29 @@ import {
 } from "./data_writer.ts";
 import { coerceMethodArgs } from "./zod_type_coercion.ts";
 import { containsExpression } from "../expressions/expression_parser.ts";
+import type { Data } from "../data/data.ts";
 
 /**
  * Maximum depth for recursive follow-up action processing.
  * Prevents infinite loops in misconfigured workflows.
  */
 const DEFAULT_MAX_FOLLOW_UP_DEPTH = 100;
+
+/**
+ * Filters data entries to only those belonging to declared resource specs.
+ * Uses the `specName` tag that `writeResource()` auto-injects on every write.
+ */
+function filterDeclaredResourceData(
+  allData: Data[],
+  declaredResources: Record<string, unknown>,
+): Data[] {
+  const specNames = new Set(Object.keys(declaredResources));
+  return allData.filter((d) =>
+    d.tags["type"] === "resource" &&
+    d.tags["specName"] !== undefined &&
+    specNames.has(d.tags["specName"])
+  );
+}
 
 /**
  * Formats a Zod error into a human-readable string.
@@ -264,7 +281,10 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
     // Infer method kind for lifecycle checks
     const methodKind = inferMethodKind(methodName, method);
 
-    // Fast-fail: reject read/update on deleted resources
+    // Fast-fail: reject read/update on deleted resources.
+    // Only check declared resource data (tagged with specName matching a
+    // declared resource spec). Block only when ALL declared resource data
+    // is deleted — old historical data entries should not cause false positives.
     if (methodKind === "read" || methodKind === "update") {
       const resources = modelDef.resources ?? {};
       if (Object.keys(resources).length > 0) {
@@ -272,31 +292,35 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
           context.modelType,
           context.modelId,
         );
-        for (const data of existingData) {
-          if (data.isDeleted) {
-            // Read the deletion marker content for the timestamp
-            let deletedAt = "unknown";
-            try {
-              const content = await context.dataRepository.getContent(
-                context.modelType,
-                context.modelId,
-                data.name,
-              );
-              if (content) {
-                const marker = JSON.parse(
-                  new TextDecoder().decode(content),
-                );
-                if (marker.deletedAt) {
-                  deletedAt = marker.deletedAt;
-                }
-              }
-            } catch {
-              // Use default "unknown" timestamp
-            }
-            throw new UserError(
-              `Resource '${data.name}' was deleted at ${deletedAt} — run a 'create' method to re-create it first`,
+        const resourceData = filterDeclaredResourceData(
+          existingData,
+          resources,
+        );
+        if (
+          resourceData.length > 0 && resourceData.every((d) => d.isDeleted)
+        ) {
+          const deleted = resourceData[0];
+          let deletedAt = "unknown";
+          try {
+            const content = await context.dataRepository.getContent(
+              context.modelType,
+              context.modelId,
+              deleted.name,
             );
+            if (content) {
+              const marker = JSON.parse(
+                new TextDecoder().decode(content),
+              );
+              if (marker.deletedAt) {
+                deletedAt = marker.deletedAt;
+              }
+            }
+          } catch {
+            // Use default "unknown" timestamp
           }
+          throw new UserError(
+            `Resource '${deleted.name}' was deleted at ${deletedAt} — run a 'create' method to re-create it first`,
+          );
         }
       }
     }
@@ -380,7 +404,8 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
       await context.outputRepository.save(modelDef.type, methodName, output);
     }
 
-    // Write deletion markers after a successful delete method
+    // Write deletion markers after a successful delete method.
+    // Only mark declared resource data — untagged or non-resource data is left alone.
     if (methodKind === "delete") {
       const resources = modelDef.resources ?? {};
       if (Object.keys(resources).length > 0) {
@@ -388,7 +413,11 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
           context.modelType,
           context.modelId,
         );
-        for (const data of existingData) {
+        const resourceData = filterDeclaredResourceData(
+          existingData,
+          resources,
+        );
+        for (const data of resourceData) {
           if (!data.isDeleted) {
             const marker = data.withDeletionMarker({
               version: data.version + 1,

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -1168,7 +1168,7 @@ Deno.test("executeWorkflow - delete method writes deletion markers for existing 
     contentType: "application/json",
     lifetime: "infinite",
     garbageCollection: 10,
-    tags: { type: "resource" },
+    tags: { type: "resource", specName: "my-resource" },
     ownerDefinition: {
       ownerType: "model-method",
       ownerRef: "test/model:create",
@@ -1237,7 +1237,7 @@ Deno.test("executeWorkflow - read after delete throws UserError", async () => {
     contentType: "application/json",
     lifetime: "infinite",
     garbageCollection: 10,
-    tags: { type: "resource" },
+    tags: { type: "resource", specName: "my-resource" },
     ownerDefinition: {
       ownerType: "model-method",
       ownerRef: "test/model:create",
@@ -1302,7 +1302,7 @@ Deno.test("executeWorkflow - update after delete throws UserError", async () => 
     contentType: "application/json",
     lifetime: "infinite",
     garbageCollection: 10,
-    tags: { type: "resource" },
+    tags: { type: "resource", specName: "my-resource" },
     ownerDefinition: {
       ownerType: "model-method",
       ownerRef: "test/model:create",
@@ -1418,7 +1418,7 @@ Deno.test("executeWorkflow - delete skips already-deleted resources", async () =
     contentType: "application/json",
     lifetime: "infinite",
     garbageCollection: 10,
-    tags: { type: "resource" },
+    tags: { type: "resource", specName: "my-resource" },
     ownerDefinition: {
       ownerType: "model-method",
       ownerRef: "test/model:create",
@@ -1479,7 +1479,7 @@ Deno.test("executeWorkflow - explicit kind overrides name inference for deletion
     contentType: "application/json",
     lifetime: "infinite",
     garbageCollection: 10,
-    tags: { type: "resource" },
+    tags: { type: "resource", specName: "my-resource" },
     ownerDefinition: {
       ownerType: "model-method",
       ownerRef: "test/model:create",
@@ -1529,6 +1529,227 @@ Deno.test("executeWorkflow - explicit kind overrides name inference for deletion
 
   // kind: "action" should NOT trigger deletion markers
   assertEquals(mockRepo.savedData.length, 0);
+});
+
+Deno.test("executeWorkflow - read succeeds when old data is deleted but current resource data is active", async () => {
+  const service = new DefaultMethodExecutionService();
+
+  // Old historical data entry (no specName tag) that was deleted — should NOT block
+  const oldDeletedData = Data.create({
+    name: "old-vpc-id-123",
+    contentType: "application/json",
+    lifetime: "infinite",
+    garbageCollection: 10,
+    tags: { type: "resource" },
+    ownerDefinition: {
+      ownerType: "model-method",
+      ownerRef: "test/model:create",
+    },
+    lifecycle: "deleted",
+  });
+
+  // Current active resource data with specName tag
+  const activeData = Data.create({
+    name: "my-resource",
+    contentType: "application/json",
+    lifetime: "infinite",
+    garbageCollection: 10,
+    tags: { type: "resource", specName: "my-resource" },
+    ownerDefinition: {
+      ownerType: "model-method",
+      ownerRef: "test/model:create",
+    },
+  });
+
+  const mockRepo = {
+    ...createMockDataRepo(),
+    findAllForModel: () => Promise.resolve([oldDeletedData, activeData]),
+    getContent: () => Promise.resolve(null),
+  };
+
+  const model: ModelDefinition = {
+    type: ModelType.create("test/read-mixed-data"),
+    version: "1",
+    resources: {
+      "my-resource": {
+        description: "A resource",
+        schema: z.object({}),
+        lifetime: "infinite",
+        garbageCollection: 10,
+      },
+    },
+    methods: {
+      get: {
+        description: "Get the resource",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({}),
+      },
+    },
+  };
+
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: {},
+  });
+
+  const { context } = createTestContext({ modelType: model.type });
+  const contextWithRepo: MethodContext = {
+    ...context,
+    dataRepository: mockRepo,
+  };
+
+  // Should succeed — old deleted data without specName should not block read
+  const result = await service.executeWorkflow(
+    definition,
+    model,
+    "get",
+    contextWithRepo,
+  );
+  assertEquals(result !== undefined, true);
+});
+
+Deno.test("executeWorkflow - deletion markers only written for declared resource data, not untagged data", async () => {
+  const service = new DefaultMethodExecutionService();
+
+  // Declared resource data with specName tag — should get a deletion marker
+  const resourceData = Data.create({
+    name: "my-resource",
+    contentType: "application/json",
+    lifetime: "infinite",
+    garbageCollection: 10,
+    tags: { type: "resource", specName: "my-resource" },
+    ownerDefinition: {
+      ownerType: "model-method",
+      ownerRef: "test/model:create",
+    },
+    version: 3,
+  });
+
+  // Untagged data (no specName) — should NOT get a deletion marker
+  const untaggedData = Data.create({
+    name: "some-old-data",
+    contentType: "application/json",
+    lifetime: "infinite",
+    garbageCollection: 10,
+    tags: { type: "resource" },
+    ownerDefinition: {
+      ownerType: "model-method",
+      ownerRef: "test/model:create",
+    },
+    version: 2,
+  });
+
+  const mockRepo = createMockDataRepoWithData([resourceData, untaggedData]);
+
+  const model: ModelDefinition = {
+    type: ModelType.create("test/delete-scoped-markers"),
+    version: "1",
+    resources: {
+      "my-resource": {
+        description: "A resource",
+        schema: z.object({}),
+        lifetime: "infinite",
+        garbageCollection: 10,
+      },
+    },
+    methods: {
+      delete: {
+        description: "Delete the resource",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({}),
+      },
+    },
+  };
+
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: {},
+  });
+
+  const { context } = createTestContext({ modelType: model.type });
+  const contextWithRepo: MethodContext = {
+    ...context,
+    dataRepository: mockRepo,
+  };
+
+  await service.executeWorkflow(
+    definition,
+    model,
+    "delete",
+    contextWithRepo,
+  );
+
+  // Only the declared resource data should get a deletion marker
+  assertEquals(mockRepo.savedData.length, 1);
+  assertEquals(mockRepo.savedData[0].data.name, "my-resource");
+  assertEquals(mockRepo.savedData[0].data.lifecycle, "deleted");
+});
+
+Deno.test("executeWorkflow - read blocked when all declared resource data is deleted", async () => {
+  const service = new DefaultMethodExecutionService();
+
+  // All declared resource data is deleted
+  const deletedResource = Data.create({
+    name: "my-resource",
+    contentType: "application/json",
+    lifetime: "infinite",
+    garbageCollection: 10,
+    tags: { type: "resource", specName: "my-resource" },
+    ownerDefinition: {
+      ownerType: "model-method",
+      ownerRef: "test/model:create",
+    },
+    lifecycle: "deleted",
+  });
+
+  const markerContent = new TextEncoder().encode(JSON.stringify({
+    deletedAt: "2026-03-07T10:00:00.000Z",
+    deletedByMethod: "delete",
+  }));
+
+  const mockRepo = {
+    ...createMockDataRepo(),
+    findAllForModel: () => Promise.resolve([deletedResource]),
+    getContent: () => Promise.resolve(markerContent),
+  };
+
+  const model: ModelDefinition = {
+    type: ModelType.create("test/read-all-deleted"),
+    version: "1",
+    resources: {
+      "my-resource": {
+        description: "A resource",
+        schema: z.object({}),
+        lifetime: "infinite",
+        garbageCollection: 10,
+      },
+    },
+    methods: {
+      get: {
+        description: "Get the resource",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({}),
+      },
+    },
+  };
+
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: {},
+  });
+
+  const { context } = createTestContext({ modelType: model.type });
+  const contextWithRepo: MethodContext = {
+    ...context,
+    dataRepository: mockRepo,
+  };
+
+  // Should throw — all declared resource data is deleted
+  await assertRejects(
+    () => service.executeWorkflow(definition, model, "get", contextWithRepo),
+    UserError,
+    "was deleted at 2026-03-07T10:00:00.000Z",
+  );
 });
 
 // ---------- Unresolved Expression Tests ----------


### PR DESCRIPTION
## Summary

Fixes #645. PR #640 introduced a deleted-resource lifecycle check (#637) that calls `findAllForModel()` and throws if **any** data entry has `lifecycle: "deleted"`. This is too broad — models accumulate multiple data entries over time (old data names, VPC IDs as data names, etc.), and old deleted entries cause false positives that block `read`/`update` operations on active resources.

## Why This Is the Right Fix

The root cause is that the lifecycle check operates on **all** data entries for a model, but it should only consider data that belongs to **declared resource specs**. The `writeResource()` function already auto-injects a `specName` tag on every resource write (line 493 in `data_writer.ts`), so the infrastructure to distinguish declared resource data from historical/untagged data already exists — it just wasn't being used.

This fix:

1. **Adds `filterDeclaredResourceData()` helper** — filters data entries to only those with `tags.type === "resource"` AND `tags.specName` matching a key in the model's declared `resources` map.

2. **Scopes the read/update pre-check** — instead of "fail if ANY data is deleted", the semantic is now "fail if ALL declared-resource data is deleted." Old historical entries without `specName` tags are excluded from the check entirely.

3. **Scopes deletion marker writing** — the `delete` method now only writes deletion markers for declared resource data, not for untagged historical entries.

### Why "all deleted" instead of "any deleted"

A model may have multiple declared resource specs. If one is deleted but another is active, blocking the entire model is too aggressive — the active resource should still be readable. The check now only blocks when every single declared resource data entry is deleted, which means the model genuinely has no active resources.

### Backwards compatibility

Data created before PR #640 won't have `specName` tags. This is fine — those entries are excluded from the filter, so they can't trigger false positives. The lifecycle check only activates for data written by the current `writeResource()` which always injects `specName`.

## User Impact

- **Bug fixed:** Models that accumulate data entries over multiple workflow runs no longer get falsely blocked on `read`/`update` with "Resource was deleted" errors
- **No breaking changes:** The #637 protection is preserved — genuinely deleted resources (all declared resource data marked deleted) still block read/update and require a `create` to re-create
- **No action required:** Existing repos work without migration — pre-existing data without `specName` tags is simply excluded from the check

## Files Changed

| File | Change |
|------|--------|
| `src/domain/models/method_execution_service.ts` | Add `filterDeclaredResourceData()` helper; scope read/update pre-check and deletion marker writing to declared resource data |
| `src/domain/models/method_execution_service_test.ts` | Add `specName` tags to 5 existing test data entries; add 3 new tests for the scoped behavior |

## Testing

- All 2772 tests pass (32 in method_execution_service_test.ts, including 3 new)
- New tests cover:
  - "read succeeds when old data is deleted but current resource data is active" (the #645 bug scenario)
  - "deletion markers only written for declared resource data, not untagged data"
  - "read blocked when all declared resource data is deleted" (preserves #637)
- `deno check`, `deno lint`, `deno fmt` all pass
- `deno run compile` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)