### PR TITLE
feat: add interactive secret prompt to vault put

### DIFF
--- a/.claude/skills/swamp-vault/SKILL.md
+++ b/.claude/skills/swamp-vault/SKILL.md
@@ -31,6 +31,7 @@ Correct flow: `swamp vault create <type> <name> --json` → edit config if neede
 | Edit vault config | `swamp vault edit <name_or_id>`                    |
 | Store a secret    | `swamp vault put <vault> KEY=VALUE --json`         |
 | Store from stdin  | `echo "val" \| swamp vault put <vault> KEY --json` |
+| Store interactive | `swamp vault put <vault> KEY` (prompts for value)  |
 | Get a secret      | `swamp vault get <vault> <key> --json`             |
 | List secret keys  | `swamp vault list-keys <vault> --json`             |
 
@@ -109,7 +110,8 @@ swamp vault put dev-secrets API_KEY=sk-1234567890 --json
 swamp vault put prod-secrets DB_PASSWORD=secret123 -f --json  # Skip confirmation
 ```
 
-**Piped value (recommended — keeps secrets out of shell history):**
+**Piped value (recommended for scripts/CI — keeps secrets out of shell
+history):**
 
 ```bash
 echo "$API_KEY" | swamp vault put dev-secrets API_KEY --json
@@ -117,8 +119,19 @@ cat ~/secrets/token.txt | swamp vault put dev-secrets TOKEN --json
 op read "op://vault/item/field" | swamp vault put dev-secrets SECRET --json
 ```
 
-When no `=` is present in the argument, the value is read from stdin. A single
-trailing newline is stripped automatically.
+**Interactive prompt (recommended for humans — value is hidden):**
+
+```bash
+swamp vault put dev-secrets API_KEY
+# Enter value for API_KEY: ********
+```
+
+When run interactively (TTY, no `=`, no piped stdin), the user is prompted to
+enter the value with echo suppressed. This keeps secrets out of both shell
+history and the visible terminal. Not available in `--json` mode.
+
+When no `=` is present and stdin is piped, the value is read from stdin. A
+single trailing newline is stripped automatically.
 
 **IMPORTANT — agent security:** Never ask the user to paste or type a secret
 value into conversation. Instead, instruct them to run `vault put` directly in

--- a/.claude/skills/swamp-vault/references/examples.md
+++ b/.claude/skills/swamp-vault/references/examples.md
@@ -54,6 +54,23 @@ swamp vault create local_encryption backend-secrets --json
 
 ### Store Secrets
 
+There are three ways to provide a secret value:
+
+```bash
+# 1. Inline KEY=VALUE
+swamp vault put dev-secrets API_KEY=dev-key-12345 --json
+
+# 2. Piped from stdin (useful in scripts/CI)
+echo "dev-db-pass" | swamp vault put dev-secrets DB_PASSWORD --json
+cat secret.txt | swamp vault put dev-secrets CERT --json
+
+# 3. Interactive prompt (TTY only, value is hidden)
+#    Just provide the key without a value — you'll be prompted:
+#    $ swamp vault put dev-secrets API_KEY
+#    Enter value for API_KEY: ********
+swamp vault put dev-secrets API_KEY
+```
+
 ```bash
 # Dev environment
 swamp vault put dev-secrets API_KEY=dev-key-12345 --json

--- a/src/cli/commands/auth_login.ts
+++ b/src/cli/commands/auth_login.ts
@@ -24,6 +24,7 @@ import { SwampClubClient } from "../../infrastructure/http/swamp_club_client.ts"
 import { startCallbackServer } from "../../infrastructure/http/callback_server.ts";
 import { openBrowser } from "../../infrastructure/process/browser.ts";
 import { UserError } from "../../domain/errors.ts";
+import { readSecretFromTty } from "../../infrastructure/io/stdin_reader.ts";
 import { Spinner } from "../../presentation/spinner.ts";
 import {
   renderAuthLoginSuccess,
@@ -55,37 +56,13 @@ async function readLine(prompt: string): Promise<string> {
 
 /** Read a password from stdin without echoing. */
 async function readPassword(prompt: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-
-  await Deno.stdout.write(encoder.encode(prompt));
-
-  // Attempt to disable echo for password input
-  Deno.stdin.setRaw(true);
   try {
-    const chars: number[] = [];
-    const buf = new Uint8Array(1);
-    while (true) {
-      const n = await Deno.stdin.read(buf);
-      if (n === null) break;
-      // Enter key
-      if (buf[0] === 13 || buf[0] === 10) break;
-      // Backspace
-      if (buf[0] === 127 || buf[0] === 8) {
-        chars.pop();
-        continue;
-      }
-      // Ctrl-C
-      if (buf[0] === 3) {
-        await Deno.stdout.write(encoder.encode("\n"));
-        throw new UserError("Cancelled.");
-      }
-      chars.push(buf[0]);
+    return await readSecretFromTty(prompt);
+  } catch (err) {
+    if (err instanceof Error && err.message === "Cancelled.") {
+      throw new UserError("Cancelled.");
     }
-    await Deno.stdout.write(encoder.encode("\n"));
-    return decoder.decode(new Uint8Array(chars));
-  } finally {
-    Deno.stdin.setRaw(false);
+    throw err;
   }
 }
 

--- a/src/cli/commands/vault_put.ts
+++ b/src/cli/commands/vault_put.ts
@@ -23,12 +23,15 @@ import {
   renderVaultPutCancelled,
   type VaultPutData,
 } from "../../presentation/output/vault_put_output.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import { createContext, type GlobalOptions, isStdinTty } from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { VaultService } from "../../domain/vaults/vault_service.ts";
 import { UserError } from "../../domain/errors.ts";
 import { createVaultSecretUpdated } from "../../domain/events/types.ts";
-import { readStdin } from "../../infrastructure/io/stdin_reader.ts";
+import {
+  readSecretFromTty,
+  readStdin,
+} from "../../infrastructure/io/stdin_reader.ts";
 
 /**
  * Prompts user for confirmation in interactive mode.
@@ -151,19 +154,50 @@ export const vaultPutCommand = new Command()
       outputMode: ctx.outputMode,
     });
 
-    // Parse KEY=VALUE argument, or KEY with value from stdin.
+    // Parse KEY=VALUE argument, or KEY with value from stdin/interactive prompt.
     // Only consume stdin when the argument has no '=' — this preserves
     // the ability for promptConfirmation to read interactive input later.
     const parsed = parseKeyValue(keyValue);
+    let key: string;
+    let value: string;
     let stdinContent: string | null = null;
-    if (!parsed) {
+
+    if (parsed) {
+      key = parsed.key;
+      value = parsed.value;
+    } else if (!isStdinTty()) {
+      // Stdin is piped — read value from stdin
       stdinContent = await readStdin();
+      const resolved = resolveKeyValue(keyValue, stdinContent);
+      if ("error" in resolved) {
+        throw new UserError(resolved.error);
+      }
+      key = resolved.key;
+      value = resolved.value;
+    } else if (ctx.outputMode === "log") {
+      // Interactive TTY — prompt for the secret value
+      key = keyValue;
+      if (key.length === 0) {
+        throw new UserError("Key cannot be empty");
+      }
+      try {
+        value = await readSecretFromTty(`Enter value for ${key}: `);
+      } catch (err) {
+        if (err instanceof Error && err.message === "Cancelled.") {
+          renderVaultPutCancelled(ctx.outputMode);
+          return;
+        }
+        throw err;
+      }
+    } else {
+      // JSON mode, no piped input, no inline value — error
+      const resolved = resolveKeyValue(keyValue, null);
+      if ("error" in resolved) {
+        throw new UserError(resolved.error);
+      }
+      key = resolved.key;
+      value = resolved.value;
     }
-    const resolved = resolveKeyValue(keyValue, stdinContent);
-    if ("error" in resolved) {
-      throw new UserError(resolved.error);
-    }
-    const { key, value } = resolved;
     ctx.logger.debug`Parsed key: ${key}`;
 
     // Verify vault exists

--- a/src/infrastructure/io/stdin_reader.ts
+++ b/src/infrastructure/io/stdin_reader.ts
@@ -71,3 +71,47 @@ export async function readStdin(): Promise<string | null> {
   const decoder = new TextDecoder();
   return decoder.decode(result);
 }
+
+/**
+ * Reads a secret value from a TTY with echo suppression.
+ *
+ * Prompts the user and reads input character-by-character without echoing
+ * to the terminal. Supports backspace and Ctrl-C to cancel.
+ *
+ * Must only be called when stdin is a TTY (interactive terminal).
+ *
+ * @throws {Error} If the user cancels with Ctrl-C (throws with message "Cancelled.")
+ */
+export async function readSecretFromTty(prompt: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+
+  await Deno.stdout.write(encoder.encode(prompt));
+
+  Deno.stdin.setRaw(true);
+  try {
+    const chars: number[] = [];
+    const buf = new Uint8Array(1);
+    while (true) {
+      const n = await Deno.stdin.read(buf);
+      if (n === null) break;
+      // Enter key
+      if (buf[0] === 13 || buf[0] === 10) break;
+      // Backspace
+      if (buf[0] === 127 || buf[0] === 8) {
+        chars.pop();
+        continue;
+      }
+      // Ctrl-C
+      if (buf[0] === 3) {
+        await Deno.stdout.write(encoder.encode("\n"));
+        throw new Error("Cancelled.");
+      }
+      chars.push(buf[0]);
+    }
+    await Deno.stdout.write(encoder.encode("\n"));
+    return decoder.decode(new Uint8Array(chars));
+  } finally {
+    Deno.stdin.setRaw(false);
+  }
+}


### PR DESCRIPTION
## Summary

- When a user runs `swamp vault put <vault> KEY` in an interactive terminal (TTY, no `=`, no piped stdin), they are now prompted to enter the value with echo suppression — keeping secrets out of both shell history and the visible terminal
- Extracted a shared `readSecretFromTty()` utility in `src/infrastructure/io/stdin_reader.ts` and refactored `auth_login.ts` to use it, removing duplicated raw-mode input code
- Updated vault skill documentation (`SKILL.md` and `references/examples.md`) to describe all three input methods

## Motivation

Previously, `vault put` only supported two ways to provide a secret value:

1. **Inline:** `swamp vault put my-vault API_KEY=secret` — convenient but exposes the secret in shell history
2. **Piped stdin:** `echo "secret" | swamp vault put my-vault API_KEY` — secure but less discoverable

Users who simply run `swamp vault put my-vault API_KEY` in a terminal got an error telling them to use one of the above formats. The interactive prompt is a natural third option that is both secure (hidden input) and ergonomic (no shell history exposure, no pipe gymnastics).

## How it works

The resolution order in the command action is:

1. Has `=`? → parse as `KEY=VALUE` (unchanged)
2. No `=` + stdin is piped? → read value from stdin (unchanged)
3. No `=` + stdin is TTY + log mode? → prompt with `readSecretFromTty()` (new)
4. No `=` + JSON mode + no pipe? → error with usage hint (unchanged)

This means **all existing behaviour is preserved exactly** — the interactive prompt only activates when the user is at a TTY and doesn't provide a value through any other method.

## Testing

All 16 existing unit tests pass (`deno run test src/cli/commands/vault_put_test.ts`).

Additionally, the compiled binary was tested end-to-end against a fresh repo:

```bash
# Setup
mkdir /tmp/swamp-test-interactive
cd /tmp/swamp-test-interactive
swamp repo init
swamp vault create local_encryption test-vault

# Test 1: Inline KEY=VALUE (existing behaviour) ✅
swamp vault put test-vault MY_KEY=inline-secret
# → Stored secret "MY_KEY" in vault "test-vault"

# Test 2: Piped stdin (existing behaviour) ✅
echo "piped-secret-value" | swamp vault put test-vault PIPED_KEY
# → Stored secret "PIPED_KEY" in vault "test-vault"

# Test 3: Overwrite protection with piped stdin (existing behaviour) ✅
echo "new-value" | swamp vault put test-vault MY_KEY
# → Error: Secret 'MY_KEY' already exists... Use --force (-f)

# Test 4: Overwrite with --force (existing behaviour) ✅
echo "new-value" | swamp vault put test-vault MY_KEY --force
# → Stored secret "MY_KEY" in vault "test-vault"

# Test 5: Verified both secrets stored correctly ✅
swamp vault list-keys test-vault
# → MY_KEY, PIPED_KEY (2 keys)
```

The interactive TTY prompt path (`swamp vault put test-vault KEY` with no value) cannot be tested in a non-TTY CI environment, but it uses the same `readSecretFromTty` function that powers `auth login` password input, which is proven in production.

## Test plan

- [x] All 16 existing `vault_put_test.ts` unit tests pass
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] Compiled binary tested: inline `KEY=VALUE` works
- [x] Compiled binary tested: piped stdin works
- [x] Compiled binary tested: overwrite protection works
- [x] Compiled binary tested: `--force` overwrite works
- [ ] Manual test: interactive TTY prompt with hidden input

🤖 Generated with [Claude Code](https://claude.com/claude-code)