### PR TITLE
fix: audit timeline misses today's entries in UTC+ timezones

### DIFF
--- a/src/infrastructure/persistence/jsonl_audit_repository.ts
+++ b/src/infrastructure/persistence/jsonl_audit_repository.ts
@@ -87,10 +87,10 @@ export class JsonlAuditRepository implements AuditRepository {
 
       // Iterate date range to find relevant files
       const current = new Date(startTime);
-      current.setHours(0, 0, 0, 0);
+      current.setUTCHours(0, 0, 0, 0);
 
       const end = new Date(endTime);
-      end.setHours(23, 59, 59, 999);
+      end.setUTCHours(23, 59, 59, 999);
 
       while (current <= end) {
         const dateStr = current.toISOString().split("T")[0];
@@ -123,7 +123,7 @@ export class JsonlAuditRepository implements AuditRepository {
           }
         }
 
-        current.setDate(current.getDate() + 1);
+        current.setUTCDate(current.getUTCDate() + 1);
       }
     } catch (error) {
       if (error instanceof Deno.errors.NotFound) {

--- a/src/infrastructure/persistence/jsonl_audit_repository_test.ts
+++ b/src/infrastructure/persistence/jsonl_audit_repository_test.ts
@@ -121,6 +121,78 @@ Deno.test("JsonlAuditRepository.findByTimeRange returns entries in range", async
   });
 });
 
+Deno.test("JsonlAuditRepository.findByTimeRange reads correct UTC-dated file for same-day queries", async () => {
+  // Regression test for https://github.com/systeminit/swamp/issues/659
+  // Ensures date iteration uses UTC dates to match filenames written by append().
+  // The bug: setHours(0,0,0,0) uses local time, so in UTC+ timezones,
+  // toISOString() would produce the previous day's date, missing today's file.
+  await withTempDir(async (dir) => {
+    const repo = new JsonlAuditRepository(dir);
+    const auditDir = join(dir, ".swamp", "audit");
+    await Deno.mkdir(auditDir, { recursive: true });
+
+    // Write an entry to a file dated 2025-03-09 (UTC)
+    const entry = {
+      timestamp: "2025-03-09T00:30:00.000Z",
+      sessionId: "s1",
+      command: "aws s3 ls",
+      cwd: "/repo",
+    };
+    await Deno.writeTextFile(
+      join(auditDir, "commands-2025-03-09.jsonl"),
+      JSON.stringify(entry) + "\n",
+    );
+
+    // Query a range that starts and ends on March 9 UTC.
+    // Before the fix, in UTC+1, the date iteration would generate
+    // "2025-03-08" instead of "2025-03-09" and miss this file.
+    const startTime = new Date("2025-03-09T00:00:00.000Z");
+    const endTime = new Date("2025-03-09T23:59:59.999Z");
+
+    const result = await repo.findByTimeRange(startTime, endTime);
+
+    assertEquals(result.length, 1);
+    assertEquals(result[0].command, "aws s3 ls");
+  });
+});
+
+Deno.test("JsonlAuditRepository.findByTimeRange spans multiple UTC dates correctly", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new JsonlAuditRepository(dir);
+    const auditDir = join(dir, ".swamp", "audit");
+    await Deno.mkdir(auditDir, { recursive: true });
+
+    // Write entries across two UTC dates
+    await Deno.writeTextFile(
+      join(auditDir, "commands-2025-03-09.jsonl"),
+      JSON.stringify({
+        timestamp: "2025-03-09T22:00:00.000Z",
+        sessionId: "s1",
+        command: "cmd-day1",
+        cwd: "/repo",
+      }) + "\n",
+    );
+    await Deno.writeTextFile(
+      join(auditDir, "commands-2025-03-10.jsonl"),
+      JSON.stringify({
+        timestamp: "2025-03-10T02:00:00.000Z",
+        sessionId: "s1",
+        command: "cmd-day2",
+        cwd: "/repo",
+      }) + "\n",
+    );
+
+    const startTime = new Date("2025-03-09T20:00:00.000Z");
+    const endTime = new Date("2025-03-10T03:00:00.000Z");
+
+    const result = await repo.findByTimeRange(startTime, endTime);
+
+    assertEquals(result.length, 2);
+    assertEquals(result[0].command, "cmd-day1");
+    assertEquals(result[1].command, "cmd-day2");
+  });
+});
+
 Deno.test("JsonlAuditRepository.findByTimeRange returns empty for missing directory", async () => {
   await withTempDir(async (dir) => {
     const repo = new JsonlAuditRepository(dir);


### PR DESCRIPTION
## Summary

Fixes #659

`swamp audit` failed to read the current day's audit file when the local timezone is east of UTC (e.g. CET/UTC+1). The root cause was a mismatch between how audit files are **written** vs **read**:

- **Write path** (`append`): Uses the UTC date from the ISO timestamp (`entry.timestamp.split("T")[0]`), so files are named with UTC dates (e.g. `commands-2026-03-09.jsonl`).
- **Read path** (`findByTimeRange`): Used `setHours(0,0,0,0)` (local time) then `toISOString()` (UTC) to generate filenames. In UTC+ timezones, local midnight converts to the **previous UTC day**, so today's file was never opened.

### Fix

Changed three lines in `findByTimeRange` to use UTC methods consistently:

- `setHours(0,0,0,0)` → `setUTCHours(0,0,0,0)` — start of date range
- `setHours(23,59,59,999)` → `setUTCHours(23,59,59,999)` — end of date range
- `setDate(getDate()+1)` → `setUTCDate(getUTCDate()+1)` — date iteration step

This ensures the read path generates the same UTC-based date strings as the write path, regardless of the user's local timezone.

### User Impact

Users in UTC+ timezones (CET, IST, JST, AEST, etc.) will now see today's audit entries when running `swamp audit`. Previously, today's entries were silently missing — only older days' data appeared.

## Test Plan

- Added regression test verifying `findByTimeRange` reads the correct UTC-dated file for same-day queries
- Added test verifying multi-day UTC date spanning works correctly
- All 2775 existing tests continue to pass
- `deno check`, `deno lint`, `deno fmt` all pass

Co-authored-by: Blake Irvin <blakeirvin@me.com>