### PR TITLE
feat: add swamp help command and wire it into all skills

### DIFF
--- a/.claude/skills/swamp-data/SKILL.md
+++ b/.claude/skills/swamp-data/SKILL.md
@@ -8,6 +8,9 @@ description: Manage model data lifecycle and garbage collection. Use when listin
 Manage model data lifecycle through the CLI. All commands support `--json` for
 machine-readable output.
 
+**Verify CLI syntax:** If unsure about exact flags or subcommands, run
+`swamp help data` for the complete, up-to-date CLI schema.
+
 ## Quick Reference
 
 | Task                   | Command                                               |

--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -41,6 +41,9 @@ specific service integrations. If the user wants to manage S3 buckets, EC2
 instances, or other resources, create a dedicated model for that service rather
 than wrapping CLI commands.
 
+**Verify CLI syntax:** If unsure about exact flags or subcommands, run
+`swamp help extension` for the complete, up-to-date CLI schema.
+
 ## Quick Reference
 
 | Task                | Command/Action                                          |

--- a/.claude/skills/swamp-issue/SKILL.md
+++ b/.claude/skills/swamp-issue/SKILL.md
@@ -8,6 +8,9 @@ description: Submit bug reports and feature requests for swamp. Use when the use
 Submit bug reports and feature requests through the swamp CLI. Issues are
 submitted directly to GitHub with appropriate labels.
 
+**Verify CLI syntax:** If unsure about exact flags or subcommands, run
+`swamp help issue` for the complete, up-to-date CLI schema.
+
 ## Quick Reference
 
 | Task                  | Command                                                       |

--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -16,6 +16,8 @@ machine-readable output.
   `swamp model create <type> <name> --json` first, then edit the scaffold at the
   returned `path`, preserving the assigned `id`.
 - **Never modify the `id` field** in an existing model file.
+- **Verify CLI syntax**: If unsure about exact flags or subcommands, run
+  `swamp help model` for the complete, up-to-date CLI schema.
 
 Correct flow: `swamp model create <type> <name> --json` → edit the YAML →
 validate → run.

--- a/.claude/skills/swamp-repo/SKILL.md
+++ b/.claude/skills/swamp-repo/SKILL.md
@@ -8,6 +8,9 @@ description: Manage swamp repositories. Use when initializing repos, upgrading s
 Manage swamp repositories through the CLI. All commands support `--json` for
 machine-readable output.
 
+**Verify CLI syntax:** If unsure about exact flags or subcommands, run
+`swamp help repo` for the complete, up-to-date CLI schema.
+
 ## Quick Reference
 
 | Task                   | Command                            |

--- a/.claude/skills/swamp-troubleshooting/SKILL.md
+++ b/.claude/skills/swamp-troubleshooting/SKILL.md
@@ -8,6 +8,9 @@ description: Debug and diagnose swamp issues using source code. Use when trouble
 Diagnose and troubleshoot swamp issues by fetching and reading the swamp source
 code. All commands support `--json` for machine-readable output.
 
+**Verify CLI syntax:** If unsure about exact flags or subcommands, run
+`swamp help source` for the complete, up-to-date CLI schema.
+
 ## Quick Reference
 
 | Task                | Command                                      |

--- a/.claude/skills/swamp-vault/SKILL.md
+++ b/.claude/skills/swamp-vault/SKILL.md
@@ -16,6 +16,8 @@ for machine-readable output.
   `swamp vault create <type> <name> --json` first, then edit the scaffold at the
   returned `path`, preserving the assigned `id`.
 - **Never modify the `id` field** in an existing vault file.
+- **Verify CLI syntax**: If unsure about exact flags or subcommands, run
+  `swamp help vault` for the complete, up-to-date CLI schema.
 
 Correct flow: `swamp vault create <type> <name> --json` → edit config if needed
 → store secrets.

--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -16,6 +16,8 @@ machine-readable output.
   `swamp workflow create <name> --json` first, then edit the scaffold at the
   returned `path`, preserving the assigned `id`.
 - **Never modify the `id` field** in an existing workflow file.
+- **Verify CLI syntax**: If unsure about exact flags or subcommands, run
+  `swamp help workflow` for the complete, up-to-date CLI schema.
 
 Correct flow: `swamp workflow create <name> --json` → edit the YAML → validate →
 run.

--- a/src/cli/cli_schema.ts
+++ b/src/cli/cli_schema.ts
@@ -1,0 +1,120 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { Command } from "@cliffy/command";
+
+export interface CliOptionSchema {
+  flags: string;
+  description: string;
+  required: boolean;
+  default?: unknown;
+  collect: boolean;
+}
+
+export interface CliArgumentSchema {
+  name: string;
+  required: boolean;
+  variadic: boolean;
+}
+
+export interface CliCommandSchema {
+  name: string;
+  description: string;
+  arguments: CliArgumentSchema[];
+  options: CliOptionSchema[];
+  subcommands: CliCommandSchema[];
+}
+
+export interface CliSchema {
+  version: string;
+  root: CliCommandSchema;
+}
+
+/** Option names that Cliffy adds automatically and should be filtered out. */
+const BUILTIN_OPTION_NAMES = new Set(["help", "version"]);
+
+/**
+ * Relaxed Command type — Cliffy's Command has 8 generic parameters that change
+ * with every chained call, making it impossible to type precisely.
+ */
+// deno-lint-ignore no-explicit-any
+export type AnyCommand = Command<any>;
+
+export interface BuildCliSchemaOptions {
+  /** When true, strip global options from all commands including the root. */
+  stripGlobalOptions?: boolean;
+}
+
+/**
+ * Builds a structured CLI schema by recursively walking a Cliffy command tree.
+ */
+export function buildCliSchema(
+  rootCommand: AnyCommand,
+  version: string,
+  options?: BuildCliSchemaOptions,
+): CliSchema {
+  const stripGlobals = options?.stripGlobalOptions ?? false;
+  return {
+    version,
+    root: walkCommand(rootCommand, !stripGlobals, stripGlobals),
+  };
+}
+
+function walkCommand(
+  cmd: AnyCommand,
+  isRoot: boolean,
+  stripGlobals: boolean,
+): CliCommandSchema {
+  const args: CliArgumentSchema[] = cmd.getArguments().map(
+    // deno-lint-ignore no-explicit-any
+    (arg: any) => ({
+      name: arg.name as string,
+      required: !arg.optional,
+      variadic: arg.variadic === true,
+    }),
+  );
+
+  const options: CliOptionSchema[] = cmd.getOptions()
+    .filter((opt: { name: string }) => !BUILTIN_OPTION_NAMES.has(opt.name))
+    .filter((opt: { global?: boolean }) => isRoot || !opt.global)
+    // deno-lint-ignore no-explicit-any
+    .map((opt: any) => {
+      const schema: CliOptionSchema = {
+        flags: (opt.flags as string[]).join(", "),
+        description: opt.description as string,
+        required: opt.required === true,
+        collect: opt.collect === true,
+      };
+      if (opt.default !== undefined) {
+        schema.default = opt.default;
+      }
+      return schema;
+    });
+
+  const subcommands: CliCommandSchema[] = cmd.getCommands(false)
+    .map((sub: AnyCommand) => walkCommand(sub, false, stripGlobals));
+
+  return {
+    name: cmd.getName(),
+    description: cmd.getDescription(),
+    arguments: args,
+    options,
+    subcommands,
+  };
+}

--- a/src/cli/cli_schema_test.ts
+++ b/src/cli/cli_schema_test.ts
@@ -1,0 +1,199 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { Command } from "@cliffy/command";
+import { buildCliSchema } from "./cli_schema.ts";
+
+Deno.test("buildCliSchema captures root command name and version", () => {
+  const root = new Command().name("test-cli").description("A test CLI");
+  const schema = buildCliSchema(root, "1.0.0");
+
+  assertEquals(schema.version, "1.0.0");
+  assertEquals(schema.root.name, "test-cli");
+  assertEquals(schema.root.description, "A test CLI");
+});
+
+Deno.test("buildCliSchema captures subcommands recursively", () => {
+  const root = new Command()
+    .name("cli")
+    .description("root")
+    .command(
+      "parent",
+      new Command().description("parent cmd").command(
+        "child",
+        new Command().description("child cmd"),
+      ),
+    );
+
+  const schema = buildCliSchema(root, "1.0.0");
+
+  assertEquals(schema.root.subcommands.length, 1);
+  assertEquals(schema.root.subcommands[0].name, "parent");
+  assertEquals(schema.root.subcommands[0].subcommands.length, 1);
+  assertEquals(schema.root.subcommands[0].subcommands[0].name, "child");
+  assertEquals(
+    schema.root.subcommands[0].subcommands[0].description,
+    "child cmd",
+  );
+});
+
+Deno.test("buildCliSchema excludes hidden commands", () => {
+  const hidden = new Command().description("secret").hidden();
+  const visible = new Command().description("visible");
+  const root = new Command()
+    .name("cli")
+    .description("root")
+    .command("visible", visible)
+    .command("hidden", hidden);
+
+  const schema = buildCliSchema(root, "1.0.0");
+
+  assertEquals(schema.root.subcommands.length, 1);
+  assertEquals(schema.root.subcommands[0].name, "visible");
+});
+
+Deno.test("buildCliSchema captures arguments with required and variadic", () => {
+  const root = new Command()
+    .name("cli")
+    .description("root")
+    .command(
+      "cmd",
+      new Command()
+        .description("with args")
+        .arguments("<required:string> [optional:string] [...rest:string]"),
+    );
+
+  const schema = buildCliSchema(root, "1.0.0");
+  const args = schema.root.subcommands[0].arguments;
+
+  assertEquals(args.length, 3);
+  assertEquals(args[0].name, "required");
+  assertEquals(args[0].required, true);
+  assertEquals(args[0].variadic, false);
+  assertEquals(args[1].name, "optional");
+  assertEquals(args[1].required, false);
+  assertEquals(args[1].variadic, false);
+  assertEquals(args[2].name, "rest");
+  assertEquals(args[2].required, false);
+  assertEquals(args[2].variadic, true);
+});
+
+Deno.test("buildCliSchema captures options with flags and defaults", () => {
+  const root = new Command()
+    .name("cli")
+    .description("root")
+    .command(
+      "cmd",
+      new Command()
+        .description("with opts")
+        .option("-n, --name <name:string>", "The name", { required: true })
+        .option("--count <count:number>", "Count", { default: 5 })
+        .option("--tags <tag:string>", "Tags", { collect: true }),
+    );
+
+  const schema = buildCliSchema(root, "1.0.0");
+  const opts = schema.root.subcommands[0].options;
+
+  const nameOpt = opts.find((o) => o.flags.includes("--name"));
+  assertEquals(nameOpt?.required, true);
+  assertEquals(nameOpt?.description, "The name");
+
+  const countOpt = opts.find((o) => o.flags.includes("--count"));
+  assertEquals(countOpt?.default, 5);
+  assertEquals(countOpt?.required, false);
+
+  const tagsOpt = opts.find((o) => o.flags.includes("--tags"));
+  assertEquals(tagsOpt?.collect, true);
+});
+
+Deno.test("buildCliSchema filters global options from subcommands", () => {
+  const root = new Command()
+    .name("cli")
+    .description("root")
+    .globalOption("--json", "JSON output")
+    .command(
+      "sub",
+      new Command().description("subcommand").option(
+        "--local",
+        "Local option",
+      ),
+    );
+
+  const schema = buildCliSchema(root, "1.0.0");
+
+  // Global option appears on root
+  const rootJson = schema.root.options.find((o) => o.flags.includes("--json"));
+  assertEquals(rootJson !== undefined, true);
+
+  // Global option does NOT appear on subcommand
+  const subOpts = schema.root.subcommands[0].options;
+  const subJson = subOpts.find((o) => o.flags.includes("--json"));
+  assertEquals(subJson, undefined);
+
+  // Local option does appear on subcommand
+  const subLocal = subOpts.find((o) => o.flags.includes("--local"));
+  assertEquals(subLocal !== undefined, true);
+});
+
+Deno.test("buildCliSchema stripGlobalOptions removes globals from root too", () => {
+  const sub = new Command().description("subcommand").option(
+    "--local",
+    "Local option",
+  );
+  const _root = new Command()
+    .name("cli")
+    .description("root")
+    .globalOption("--json", "JSON output")
+    .command("sub", sub);
+
+  // Build schema for the subcommand with stripGlobalOptions
+  const schema = buildCliSchema(sub, "1.0.0", { stripGlobalOptions: true });
+
+  // Global option should NOT appear even though sub is the root of this schema
+  const jsonOpt = schema.root.options.find((o) => o.flags.includes("--json"));
+  assertEquals(jsonOpt, undefined);
+
+  // Local option should still appear
+  const localOpt = schema.root.options.find((o) => o.flags.includes("--local"));
+  assertEquals(localOpt !== undefined, true);
+});
+
+Deno.test("buildCliSchema filters builtin --help and --version flags", () => {
+  const root = new Command()
+    .name("cli")
+    .version("1.0.0")
+    .description("root")
+    .option("--custom", "Custom option");
+
+  const schema = buildCliSchema(root, "1.0.0");
+
+  const helpOpt = schema.root.options.find((o) => o.flags.includes("--help"));
+  assertEquals(helpOpt, undefined);
+
+  const versionOpt = schema.root.options.find((o) =>
+    o.flags.includes("--version")
+  );
+  assertEquals(versionOpt, undefined);
+
+  const customOpt = schema.root.options.find((o) =>
+    o.flags.includes("--custom")
+  );
+  assertEquals(customOpt !== undefined, true);
+});

--- a/src/cli/commands/help.ts
+++ b/src/cli/commands/help.ts
@@ -1,0 +1,75 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { type AnyCommand, buildCliSchema } from "../cli_schema.ts";
+import { VERSION } from "./version.ts";
+
+/**
+ * Walks down the command tree following the given path segments.
+ * Returns the matched command or null if a segment doesn't match.
+ */
+function resolveSubcommand(
+  root: AnyCommand,
+  path: string[],
+): AnyCommand | null {
+  let current: AnyCommand = root;
+  for (const segment of path) {
+    const child = current.getCommands(true).find((c) =>
+      c.getName() === segment
+    );
+    if (!child) return null;
+    current = child;
+  }
+  return current;
+}
+
+/**
+ * Creates the help command. Hidden from normal CLI help — intended for AI
+ * agent consumption. Always outputs JSON.
+ *
+ * Usage:
+ *   swamp help              — full CLI schema
+ *   swamp help model        — schema for the "model" subtree
+ *   swamp help model method — schema for "model method" subtree
+ */
+export function createHelpCommand(rootCommand: AnyCommand): AnyCommand {
+  return new Command()
+    .hidden()
+    .description("Output full CLI schema for AI agent consumption")
+    .arguments("[...command:string]")
+    .action(function (_options: void, ...commandPath: string[]) {
+      const target = commandPath.length > 0
+        ? resolveSubcommand(rootCommand, commandPath)
+        : rootCommand;
+
+      if (!target) {
+        console.error(
+          `Unknown command: swamp ${commandPath.join(" ")}`,
+        );
+        Deno.exit(1);
+      }
+
+      const isSubtree = commandPath.length > 0;
+      const schema = buildCliSchema(target, VERSION, {
+        stripGlobalOptions: isSubtree,
+      });
+      console.log(JSON.stringify(schema, null, 2));
+    });
+}

--- a/src/cli/commands/help_test.ts
+++ b/src/cli/commands/help_test.ts
@@ -1,0 +1,48 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { Command } from "@cliffy/command";
+import { createHelpCommand } from "./help.ts";
+
+Deno.test("createHelpCommand has description", () => {
+  const root = new Command().name("cli").description("root");
+  const helpCmd = createHelpCommand(root);
+  assertEquals(
+    helpCmd.getDescription(),
+    "Output full CLI schema for AI agent consumption",
+  );
+});
+
+Deno.test("createHelpCommand is hidden", () => {
+  const root = new Command().name("cli").description("root");
+  root.command("help", createHelpCommand(root));
+  const visible = root.getCommands(false);
+  const helpVisible = visible.find((c) => c.getName() === "help");
+  assertEquals(helpVisible, undefined);
+});
+
+Deno.test("createHelpCommand accepts variadic command path", () => {
+  const root = new Command().name("cli").description("root");
+  const helpCmd = createHelpCommand(root);
+  const args = helpCmd.getArguments();
+  assertEquals(args.length, 1);
+  assertEquals(args[0].name, "command");
+  assertEquals(args[0].variadic, true);
+});

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -37,6 +37,7 @@ import { sourceCommand } from "./commands/source.ts";
 import { authCommand } from "./commands/auth.ts";
 import { extensionCommand } from "./commands/extension.ts";
 import { summariseCommand } from "./commands/summarise.ts";
+import { createHelpCommand } from "./commands/help.ts";
 import { unknownCommandErrorHandler } from "./unknown_command_handler.ts";
 import { type GlobalOptions, isStdinTty } from "./context.ts";
 import {
@@ -434,6 +435,9 @@ export async function runCli(args: string[]): Promise<void> {
     .command("auth", authCommand)
     .command("extension", extensionCommand)
     .command("summarise", summariseCommand);
+
+  // Register help command last — needs reference to the fully-built CLI tree
+  cli.command("help", createHelpCommand(cli));
 
   try {
     await cli.parse(args);


### PR DESCRIPTION
## Summary

Fixes #657

Adds a hidden `swamp help [command...]` command and teaches all 8 skills to reference it, giving AI agents a reliable way to verify exact CLI syntax on demand.

### Step 1: `swamp help` command

Added a hidden CLI command that outputs structured JSON schema for any swamp command tree. When an agent runs `swamp help model` or `swamp help workflow run`, it gets the complete, up-to-date flags, subcommands, and argument types — no guessing, no trial-and-error.

**Why this is the right approach:** Skills contain curated Quick Reference tables, but they can drift from the actual CLI as flags are added or renamed. `swamp help` reads directly from the Cliffy command tree at runtime, so it's always accurate. It's hidden from `--help` output to avoid cluttering the human-facing CLI, but fully available to agents.

### Step 2: Skill references to `swamp help`

Added prominent `**Verify CLI syntax**` callouts to all 8 skills:

- **Skills with CRITICAL sections** (model, workflow, vault): Added as a bullet in the CRITICAL rules block — the section agents are trained to read first and follow strictly
- **Skills without CRITICAL sections** (data, repo, extension-model, issue, troubleshooting): Added as a bold callout right after the intro paragraph, before Quick Reference — the first thing an agent reads after the heading

**Why prominent placement matters:** An earlier iteration placed subtle blockquotes after Quick Reference tables. These were easy to skim past — an agent confused about flags would scan the table itself, not a quiet note below it. Moving the references into CRITICAL sections and intro blocks ensures agents see them at the point where they're forming their understanding of how to use the CLI.

### User Impact

AI agents working with swamp will encounter fewer trial-and-error cycles when constructing CLI commands. Instead of guessing at flags or hallucinating options from the Quick Reference tables, agents can run `swamp help <command>` to get authoritative syntax. This reduces failed command attempts, speeds up automation workflows, and improves the overall agent experience for users delegating tasks to AI.

## Test Plan

- [x] `swamp help` outputs full CLI schema as JSON
- [x] `swamp help model` scopes output to model subtree
- [x] `swamp help model method run` drills into nested commands
- [x] Unit tests for schema generation and help command
- [x] All 8 skills updated with prominent references
- [x] `deno run compile` succeeds with updated skills embedded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Blake Irvin <blakeirvin@me.com>