### PR TITLE
fix: increase extension max file count to 150

### DIFF
--- a/.claude/skills/swamp-extension-model/references/publishing.md
+++ b/.claude/skills/swamp-extension-model/references/publishing.md
@@ -190,7 +190,7 @@ The safety analyzer scans all files before push. Issues are classified as
 | Disallowed extensions       | Only `.ts`, `.json`, `.md`, `.yaml`, `.yml`, `.txt` |
 | File too large              | Individual files must be under 1 MB                 |
 | Total size exceeded         | All files combined must be under 10 MB              |
-| Too many files              | Maximum 100 files per extension                     |
+| Too many files              | Maximum 150 files per extension                     |
 
 ### Warnings (prompted)
 

--- a/design/extension.md
+++ b/design/extension.md
@@ -174,7 +174,7 @@ after pull.
 - Symlinks
 - Individual file size exceeding 1 MB
 - Total extension size exceeding 10 MB
-- File count exceeding 100
+- File count exceeding 150
 - Use of `eval()` or `new Function()` (code injection)
 
 ### Warnings (prompt user)

--- a/src/domain/extensions/extension_safety_analyzer.ts
+++ b/src/domain/extensions/extension_safety_analyzer.ts
@@ -42,7 +42,7 @@ const ALLOWED_EXTENSIONS = new Set([
   ".txt",
 ]);
 
-const MAX_FILE_COUNT = 100;
+const MAX_FILE_COUNT = 150;
 const MAX_INDIVIDUAL_FILE_SIZE = 1_000_000; // 1 MB
 const MAX_TOTAL_SIZE = 10_000_000; // 10 MB
 const LONG_LINE_THRESHOLD = 500;

--- a/src/domain/extensions/extension_safety_analyzer_test.ts
+++ b/src/domain/extensions/extension_safety_analyzer_test.ts
@@ -153,12 +153,12 @@ Deno.test("analyzeExtensionSafety errors on symlinks", async () => {
   }
 });
 
-Deno.test("analyzeExtensionSafety errors on file count > 100", async () => {
-  // Generate 101 fake paths — we don't need real files for count check
+Deno.test("analyzeExtensionSafety errors on file count > 150", async () => {
+  // Generate 151 fake paths — we don't need real files for count check
   const tmpDir = await Deno.makeTempDir();
   try {
     const paths: string[] = [];
-    for (let i = 0; i < 101; i++) {
+    for (let i = 0; i < 151; i++) {
       const p = join(tmpDir, `file${i}.ts`);
       await Deno.writeTextFile(p, `export const x${i} = ${i};\n`);
       paths.push(p);
@@ -166,7 +166,7 @@ Deno.test("analyzeExtensionSafety errors on file count > 100", async () => {
 
     const result = await analyzeExtensionSafety(paths);
     assertEquals(
-      result.errors.some((e) => e.message.includes("100")),
+      result.errors.some((e) => e.message.includes("150")),
       true,
     );
   } finally {


### PR DESCRIPTION
## Summary

- The extension safety analyzer's `MAX_FILE_COUNT` was set to 100, which blocked pushing larger service extensions like `@swamp/aws/ec2` (104 models)
- Increased the limit from 100 to 150 to accommodate extensions that cover broad service APIs
- Updated the corresponding test, design doc, and skill reference to match

## Test Plan

- [x] Updated test now creates 151 files and asserts the limit is 150
- [x] All 111 extension domain tests pass
- [x] `deno fmt --check` passes
- [x] `deno lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)