### PR TITLE
fix: prevent auto-merge race with adversarial review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,8 +266,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Enable auto-merge
-        run: gh pr merge --auto --squash --delete-branch "$PR_NUMBER"
+      - name: Merge PR
+        run: gh pr merge --squash --delete-branch "$PR_NUMBER"
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ secrets.UAT_TRIGGER_TOKEN }}


### PR DESCRIPTION
## Summary

- Replaces `gh pr merge --auto --squash` with `gh pr merge --squash` in the CI auto-merge job
- The `--auto` flag enables GitHub's persistent auto-merge, which merges based on **branch protection rules** rather than the YAML `needs:` dependencies
- This caused PR #669 to auto-merge after the normal review passed but before the adversarial review completed

## Root cause

The `auto-merge` job has `needs: [test, deps-audit, claude-review, claude-adversarial-review]`, but `--auto` tells GitHub "merge this PR whenever branch protection requirements are met." If `claude-adversarial-review` isn't a required status check in branch protection settings, GitHub merges as soon as the other checks pass — ignoring the YAML dependency.

## Fix

Remove `--auto` so the merge command executes directly when the job runs. Since the job is gated by `needs:`, it only runs after all four dependencies (including adversarial review) succeed.

## Test plan

- [ ] Verify CI workflow passes on this PR
- [ ] Confirm PRs no longer merge before adversarial review completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)