### PR TITLE
fix: gracefully handle non-TTY context in interactive commands

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -20,13 +20,17 @@
 import { runCli } from "./src/cli/mod.ts";
 import { initializeLogging } from "./src/infrastructure/logging/logger.ts";
 import { renderError } from "./src/presentation/output/error_output.ts";
+import { flushDatastoreSync } from "./src/infrastructure/persistence/datastore_sync_coordinator.ts";
+import { getOutputModeFromArgs } from "./src/cli/context.ts";
 
 if (import.meta.main) {
   try {
     await runCli(Deno.args);
   } catch (error) {
+    // Release datastore lock if still held (safety net for uncaught errors)
+    await flushDatastoreSync();
     await initializeLogging({
-      jsonMode: Deno.args.includes("--json"),
+      jsonMode: getOutputModeFromArgs(Deno.args) === "json",
     });
     renderError(error);
     Deno.exit(1);

--- a/src/cli/commands/data_search.ts
+++ b/src/cli/commands/data_search.ts
@@ -27,7 +27,11 @@ import {
   type DataGetData,
   renderDataGet,
 } from "../../presentation/output/data_get_output.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  interactiveOutputMode,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import type { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
@@ -331,11 +335,12 @@ export const dataSearchCommand = new Command()
   .option("--limit <n:number>", "Max results", { default: 50 })
   .action(async function (options: AnyOptions, query?: string) {
     const ctx = createContext(options as GlobalOptions, ["data", "search"]);
+    const effectiveMode = interactiveOutputMode(ctx);
     ctx.logger.debug`Searching data with query: ${query ?? "(none)"}`;
 
     const { repoContext } = await requireInitializedRepo({
       repoDir: options.repoDir ?? ".",
-      outputMode: ctx.outputMode,
+      outputMode: effectiveMode,
     });
     const definitionRepo = repoContext.definitionRepo;
     const dataRepo = repoContext.unifiedDataRepo;
@@ -419,11 +424,11 @@ export const dataSearchCommand = new Command()
       limited,
     };
 
-    const selected = await renderDataSearch(data, ctx.outputMode);
+    const selected = await renderDataSearch(data, effectiveMode);
 
     if (selected) {
       const repoDir = options.repoDir ?? ".";
-      await displayDataDetail(selected, dataRepo, repoDir, ctx.outputMode);
+      await displayDataDetail(selected, dataRepo, repoDir, effectiveMode);
     }
 
     ctx.logger.debug("Data search command completed");

--- a/src/cli/commands/model_method_history_search.ts
+++ b/src/cli/commands/model_method_history_search.ts
@@ -27,7 +27,11 @@ import {
   renderModelOutputGet,
 } from "../../presentation/output/model_output_get_output.ts";
 import type { OutputMode } from "../../presentation/output/output.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  interactiveOutputMode,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import type { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
@@ -96,11 +100,12 @@ export const modelMethodHistorySearchCommand = new Command()
       "history",
       "search",
     ]);
+    const effectiveMode = interactiveOutputMode(ctx);
     ctx.logger.debug`Searching method history with query: ${query ?? "(none)"}`;
 
     const { repoContext } = await requireInitializedRepo({
       repoDir: options.repoDir ?? ".",
-      outputMode: ctx.outputMode,
+      outputMode: effectiveMode,
     });
     const definitionRepo = repoContext.definitionRepo;
     const outputRepo = repoContext.outputRepo;
@@ -112,14 +117,14 @@ export const modelMethodHistorySearchCommand = new Command()
       definitionRepo,
     );
 
-    if (ctx.outputMode === "json") {
+    if (effectiveMode === "json") {
       // Non-interactive: filter and output JSON
       const filteredOutputs = filterOutputs(allOutputs, query ?? "");
       const data: ModelOutputSearchData = {
         query: query ?? "",
         results: filteredOutputs,
       };
-      await renderModelOutputSearch(data, ctx.outputMode);
+      await renderModelOutputSearch(data, effectiveMode);
     } else {
       // Interactive: show fuzzy search UI
       const data: ModelOutputSearchData = {
@@ -127,7 +132,7 @@ export const modelMethodHistorySearchCommand = new Command()
         results: allOutputs,
       };
 
-      const selected = await renderModelOutputSearch(data, ctx.outputMode);
+      const selected = await renderModelOutputSearch(data, effectiveMode);
 
       if (selected) {
         ctx.logger.debug`Selected output: ${selected.id}`;
@@ -135,7 +140,7 @@ export const modelMethodHistorySearchCommand = new Command()
           selected,
           definitionRepo,
           outputRepo,
-          ctx.outputMode,
+          effectiveMode,
         );
       } else {
         ctx.logger.debug`Search cancelled`;

--- a/src/cli/commands/model_output_search.ts
+++ b/src/cli/commands/model_output_search.ts
@@ -28,7 +28,11 @@ import {
   renderModelOutputGet,
 } from "../../presentation/output/model_output_get_output.ts";
 import type { OutputMode } from "../../presentation/output/output.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  interactiveOutputMode,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import type { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
@@ -157,11 +161,12 @@ export const modelOutputSearchCommand = new Command()
       "output",
       "search",
     ]);
+    const effectiveMode = interactiveOutputMode(ctx);
     ctx.logger.debug`Searching outputs with query: ${query ?? "(none)"}`;
 
     const { repoContext } = await requireInitializedRepo({
       repoDir: options.repoDir ?? ".",
-      outputMode: ctx.outputMode,
+      outputMode: effectiveMode,
     });
     const definitionRepo = repoContext.definitionRepo;
     const outputRepo = repoContext.outputRepo;
@@ -173,14 +178,14 @@ export const modelOutputSearchCommand = new Command()
       definitionRepo,
     );
 
-    if (ctx.outputMode === "json") {
+    if (effectiveMode === "json") {
       // Non-interactive: filter and output JSON
       const filteredOutputs = filterOutputs(allOutputs, query ?? "");
       const data: ModelOutputSearchData = {
         query: query ?? "",
         results: filteredOutputs,
       };
-      await renderModelOutputSearch(data, ctx.outputMode);
+      await renderModelOutputSearch(data, effectiveMode);
     } else {
       // Interactive: show fuzzy search UI
       const data: ModelOutputSearchData = {
@@ -188,7 +193,7 @@ export const modelOutputSearchCommand = new Command()
         results: allOutputs,
       };
 
-      const selected = await renderModelOutputSearch(data, ctx.outputMode);
+      const selected = await renderModelOutputSearch(data, effectiveMode);
 
       if (selected) {
         ctx.logger.debug`Selected output: ${selected.id}`;
@@ -197,7 +202,7 @@ export const modelOutputSearchCommand = new Command()
           selected,
           definitionRepo,
           outputRepo,
-          ctx.outputMode,
+          effectiveMode,
         );
       } else {
         ctx.logger.debug`Search cancelled`;

--- a/src/cli/commands/model_search.ts
+++ b/src/cli/commands/model_search.ts
@@ -28,7 +28,11 @@ import {
   renderModelGet,
 } from "../../presentation/output/model_get_output.ts";
 import type { OutputMode } from "../../presentation/output/output.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  interactiveOutputMode,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { createDefinitionId } from "../../domain/definitions/definition.ts";
@@ -128,11 +132,14 @@ export async function modelSearchAction(
   query?: string,
 ): Promise<void> {
   const ctx = createContext(options as GlobalOptions, ["model", "search"]);
+  // Use interactiveOutputMode to fall back to JSON in non-TTY contexts,
+  // preventing Ink from crashing with "Raw mode is not supported"
+  const effectiveMode = interactiveOutputMode(ctx);
   ctx.logger.debug`Searching models with query: ${query ?? "(none)"}`;
 
   const { repoContext } = await requireInitializedRepo({
     repoDir: options.repoDir ?? ".",
-    outputMode: ctx.outputMode,
+    outputMode: effectiveMode,
   });
   const definitionRepo = repoContext.definitionRepo;
 
@@ -140,7 +147,7 @@ export async function modelSearchAction(
   const allResults = await definitionRepo.findAllGlobal();
   const allModels = toModelSearchItems(allResults);
 
-  if (ctx.outputMode === "json") {
+  if (effectiveMode === "json") {
     // Non-interactive: filter and output JSON
     const filteredModels = filterModels(allModels, query ?? "");
 
@@ -149,14 +156,14 @@ export async function modelSearchAction(
       await displayModelGet(
         filteredModels[0],
         definitionRepo,
-        ctx.outputMode,
+        effectiveMode,
       );
     } else {
       const data: ModelSearchData = {
         query: query ?? "",
         results: filteredModels,
       };
-      await renderModelSearch(data, ctx.outputMode);
+      await renderModelSearch(data, effectiveMode);
     }
   } else {
     // Interactive: show fuzzy search UI
@@ -165,12 +172,12 @@ export async function modelSearchAction(
       results: allModels,
     };
 
-    const selected = await renderModelSearch(data, ctx.outputMode);
+    const selected = await renderModelSearch(data, effectiveMode);
 
     if (selected) {
       ctx.logger.debug`Selected model: ${selected.name} (${selected.id})`;
       // Display the full model details
-      await displayModelGet(selected, definitionRepo, ctx.outputMode);
+      await displayModelGet(selected, definitionRepo, effectiveMode);
     } else {
       ctx.logger.debug`Search cancelled`;
     }

--- a/src/cli/commands/type_search.ts
+++ b/src/cli/commands/type_search.ts
@@ -24,7 +24,11 @@ import {
   type TypeSearchItem,
 } from "../../presentation/output/type_search_output.tsx";
 import { renderTypeDescribe } from "../../presentation/output/type_describe_output.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  interactiveOutputMode,
+} from "../context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
@@ -70,6 +74,7 @@ function filterTypes(types: TypeSearchItem[], query: string): TypeSearchItem[] {
  */
 function displayTypeDescribe(item: TypeSearchItem, options: AnyOptions): void {
   const ctx = createContext(options as GlobalOptions, ["type", "search"]);
+  const effectiveMode = interactiveOutputMode(ctx);
   const modelType = ModelType.create(item.normalized);
   const definition = modelRegistry.get(modelType);
 
@@ -97,7 +102,7 @@ function displayTypeDescribe(item: TypeSearchItem, options: AnyOptions): void {
       globalArguments,
       methods,
     },
-    ctx.outputMode,
+    effectiveMode,
   );
 }
 
@@ -107,11 +112,12 @@ export const typeSearchCommand = new Command()
   .arguments("[query:string]")
   .action(async function (options: AnyOptions, query?: string) {
     const ctx = createContext(options as GlobalOptions, ["type", "search"]);
+    const effectiveMode = interactiveOutputMode(ctx);
     ctx.logger.debug`Searching types with query: ${query ?? "(none)"}`;
 
     const allTypes = getAllTypes();
 
-    if (ctx.outputMode === "json") {
+    if (effectiveMode === "json") {
       // Non-interactive: filter and output JSON
       const filteredTypes = filterTypes(allTypes, query ?? "");
       const data: TypeSearchData = {
@@ -122,7 +128,7 @@ export const typeSearchCommand = new Command()
         data.hint =
           `No local types matched. Try: swamp extension search ${query}`;
       }
-      await renderTypeSearch(data, ctx.outputMode);
+      await renderTypeSearch(data, effectiveMode);
     } else {
       // Interactive: show fuzzy search UI
       const data: TypeSearchData = {
@@ -130,7 +136,7 @@ export const typeSearchCommand = new Command()
         results: allTypes,
       };
 
-      const selected = await renderTypeSearch(data, ctx.outputMode);
+      const selected = await renderTypeSearch(data, effectiveMode);
 
       if (selected) {
         ctx.logger.debug`Selected type: ${selected.normalized}`;

--- a/src/cli/commands/vault_search.ts
+++ b/src/cli/commands/vault_search.ts
@@ -27,7 +27,11 @@ import {
 import {
   renderVaultDescribe,
 } from "../../presentation/output/vault_describe_output.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  interactiveOutputMode,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import type { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
 import type { VaultConfig } from "../../domain/vaults/vault_config.ts";
@@ -83,10 +87,11 @@ async function displayVaultDescribe(
   options: AnyOptions,
 ): Promise<void> {
   const ctx = createContext(options as GlobalOptions, ["vault", "search"]);
+  const effectiveMode = interactiveOutputMode(ctx);
   const config = await getVaultConfig(repo, item.name);
 
   if (config) {
-    renderVaultDescribe(config, ctx.outputMode);
+    renderVaultDescribe(config, effectiveMode);
   }
 }
 
@@ -97,23 +102,24 @@ export const vaultSearchCommand = new Command()
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .action(async function (options: AnyOptions, query?: string) {
     const ctx = createContext(options as GlobalOptions, ["vault", "search"]);
+    const effectiveMode = interactiveOutputMode(ctx);
     ctx.logger.debug`Searching vaults with query: ${query ?? "(none)"}`;
 
     const { repoContext } = await requireInitializedRepo({
       repoDir: options.repoDir ?? ".",
-      outputMode: ctx.outputMode,
+      outputMode: effectiveMode,
     });
     const repo = repoContext.vaultConfigRepo;
     const allVaults = await getAllVaults(repo);
 
-    if (ctx.outputMode === "json") {
+    if (effectiveMode === "json") {
       // Non-interactive: filter and output JSON
       const filteredVaults = filterVaults(allVaults, query ?? "");
       const data: VaultSearchData = {
         query: query ?? "",
         results: filteredVaults,
       };
-      await renderVaultSearch(data, ctx.outputMode);
+      await renderVaultSearch(data, effectiveMode);
     } else {
       // Interactive: show fuzzy search UI
       const data: VaultSearchData = {
@@ -121,7 +127,7 @@ export const vaultSearchCommand = new Command()
         results: allVaults,
       };
 
-      const selected = await renderVaultSearch(data, ctx.outputMode);
+      const selected = await renderVaultSearch(data, effectiveMode);
 
       if (selected) {
         ctx.logger.debug`Selected vault: ${selected.name}`;

--- a/src/cli/commands/vault_type_search.ts
+++ b/src/cli/commands/vault_type_search.ts
@@ -27,7 +27,11 @@ import {
 import {
   renderVaultTypeDescribe,
 } from "../../presentation/output/vault_type_describe_output.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  interactiveOutputMode,
+} from "../context.ts";
 import { getVaultTypes } from "../../domain/vaults/vault_types.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -67,7 +71,8 @@ function displayVaultTypeDescribe(
   options: AnyOptions,
 ): void {
   const ctx = createContext(options as GlobalOptions, ["vault", "type-search"]);
-  renderVaultTypeDescribe(item, ctx.outputMode);
+  const effectiveMode = interactiveOutputMode(ctx);
+  renderVaultTypeDescribe(item, effectiveMode);
 }
 
 export async function vaultTypeSearchAction(
@@ -78,18 +83,19 @@ export async function vaultTypeSearchAction(
     "vault",
     "type-search",
   ]);
+  const effectiveMode = interactiveOutputMode(ctx);
   ctx.logger.debug`Searching vault types with query: ${query ?? "(none)"}`;
 
   const allTypes = getAllVaultTypes();
 
-  if (ctx.outputMode === "json") {
+  if (effectiveMode === "json") {
     // Non-interactive: filter and output JSON
     const filteredTypes = filterVaultTypes(allTypes, query ?? "");
     const data: VaultTypeSearchData = {
       query: query ?? "",
       results: filteredTypes,
     };
-    await renderVaultTypeSearch(data, ctx.outputMode);
+    await renderVaultTypeSearch(data, effectiveMode);
   } else {
     // Interactive: show fuzzy search UI
     const data: VaultTypeSearchData = {
@@ -97,7 +103,7 @@ export async function vaultTypeSearchAction(
       results: allTypes,
     };
 
-    const selected = await renderVaultTypeSearch(data, ctx.outputMode);
+    const selected = await renderVaultTypeSearch(data, effectiveMode);
 
     if (selected) {
       ctx.logger.debug`Selected vault type: ${selected.type}`;

--- a/src/cli/commands/workflow_history_search.ts
+++ b/src/cli/commands/workflow_history_search.ts
@@ -29,7 +29,11 @@ import {
   type WorkflowHistorySearchData,
   type WorkflowHistorySearchItem,
 } from "../../presentation/output/workflow_history_search_output.tsx";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  interactiveOutputMode,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
 import {
@@ -127,11 +131,12 @@ export async function workflowHistorySearchAction(
     options as GlobalOptions,
     ["workflow", "history", "search"],
   );
+  const effectiveMode = interactiveOutputMode(ctx);
   ctx.logger.debug`Searching workflow history with query: ${query ?? "(none)"}`;
 
   const { repoContext } = await requireInitializedRepo({
     repoDir: options.repoDir ?? ".",
-    outputMode: ctx.outputMode,
+    outputMode: effectiveMode,
   });
   const workflowRepo = repoContext.workflowRepo;
   const runRepo = repoContext.workflowRunRepo;
@@ -155,14 +160,14 @@ export async function workflowHistorySearchAction(
 
   const searchItems = allRuns.map(toSearchItem);
 
-  if (ctx.outputMode === "json") {
+  if (effectiveMode === "json") {
     // Non-interactive: filter and output JSON
     const filteredRuns = filterRuns(searchItems, query ?? "");
     const data: WorkflowHistorySearchData = {
       query: query ?? "",
       results: filteredRuns,
     };
-    await renderWorkflowHistorySearch(data, ctx.outputMode);
+    await renderWorkflowHistorySearch(data, effectiveMode);
   } else {
     // Interactive: show fuzzy search UI
     const data: WorkflowHistorySearchData = {
@@ -170,7 +175,7 @@ export async function workflowHistorySearchAction(
       results: searchItems,
     };
 
-    const selected = await renderWorkflowHistorySearch(data, ctx.outputMode);
+    const selected = await renderWorkflowHistorySearch(data, effectiveMode);
 
     if (selected) {
       ctx.logger.debug`Selected run: ${selected.runId}`;
@@ -185,7 +190,7 @@ export async function workflowHistorySearchAction(
           createWorkflowRunId(selected.runId),
         );
         const runData = toRunData(run, path);
-        renderWorkflowRun(runData, ctx.outputMode);
+        renderWorkflowRun(runData, effectiveMode);
       }
     } else {
       ctx.logger.debug`Search cancelled`;

--- a/src/cli/commands/workflow_run_search.ts
+++ b/src/cli/commands/workflow_run_search.ts
@@ -29,7 +29,11 @@ import {
   type WorkflowHistorySearchData,
   type WorkflowHistorySearchItem,
 } from "../../presentation/output/workflow_history_search_output.tsx";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  interactiveOutputMode,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
 import {
@@ -185,11 +189,12 @@ export async function workflowRunSearchAction(
     options as GlobalOptions,
     ["workflow", "run", "search"],
   );
+  const effectiveMode = interactiveOutputMode(ctx);
   ctx.logger.debug`Searching workflow runs with query: ${query ?? "(none)"}`;
 
   const { repoContext } = await requireInitializedRepo({
     repoDir: options.repoDir ?? ".",
-    outputMode: ctx.outputMode,
+    outputMode: effectiveMode,
   });
   const workflowRepo = repoContext.workflowRepo;
   const runRepo = repoContext.workflowRunRepo;
@@ -226,14 +231,14 @@ export async function workflowRunSearchAction(
     limit: options.limit as number | undefined,
   });
 
-  if (ctx.outputMode === "json") {
+  if (effectiveMode === "json") {
     // Non-interactive: also apply query text filter
     const filteredRuns = filterByQuery(searchItems, query ?? "");
     const data: WorkflowHistorySearchData = {
       query: query ?? "",
       results: filteredRuns,
     };
-    await renderWorkflowHistorySearch(data, ctx.outputMode);
+    await renderWorkflowHistorySearch(data, effectiveMode);
   } else {
     // Interactive: show fuzzy search UI
     const data: WorkflowHistorySearchData = {
@@ -241,7 +246,7 @@ export async function workflowRunSearchAction(
       results: searchItems,
     };
 
-    const selected = await renderWorkflowHistorySearch(data, ctx.outputMode);
+    const selected = await renderWorkflowHistorySearch(data, effectiveMode);
 
     if (selected) {
       ctx.logger.debug`Selected run: ${selected.runId}`;
@@ -256,7 +261,7 @@ export async function workflowRunSearchAction(
           createWorkflowRunId(selected.runId),
         );
         const runData = toRunData(run, path);
-        renderWorkflowRun(runData, ctx.outputMode);
+        renderWorkflowRun(runData, effectiveMode);
       }
     } else {
       ctx.logger.debug`Search cancelled`;

--- a/src/cli/commands/workflow_search.ts
+++ b/src/cli/commands/workflow_search.ts
@@ -29,7 +29,11 @@ import {
 } from "../../presentation/output/workflow_get_output.ts";
 import { renderWorkflowActionSelect } from "../../presentation/output/workflow_action_select_output.tsx";
 import { renderInputFileSelect } from "../../presentation/output/input_file_select_output.tsx";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  interactiveOutputMode,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import type { Workflow } from "../../domain/workflows/workflow.ts";
@@ -84,6 +88,7 @@ async function displayWorkflowGet(
   options: AnyOptions,
 ): Promise<void> {
   const ctx = createContext(options as GlobalOptions, ["workflow", "search"]);
+  const effectiveMode = interactiveOutputMode(ctx);
   const workflow = await repo.findByName(item.name);
 
   if (!workflow) {
@@ -107,7 +112,7 @@ async function displayWorkflowGet(
     path: repo.getPath(workflow.id),
   };
 
-  renderWorkflowGet(data, ctx.outputMode);
+  renderWorkflowGet(data, effectiveMode);
 }
 
 /**
@@ -171,6 +176,7 @@ async function executeWorkflowFromSearch(
   options: AnyOptions,
 ): Promise<void> {
   const ctx = createContext(options as GlobalOptions, ["workflow", "search"]);
+  const effectiveMode = interactiveOutputMode(ctx);
   const workflow = await repo.findByName(item.name);
 
   if (!workflow) {
@@ -192,7 +198,7 @@ async function executeWorkflowFromSearch(
         hasDefaults: allHaveDefaults,
         searchDir: repoDir,
       },
-      ctx.outputMode,
+      effectiveMode,
     );
 
     if (!selection) {
@@ -259,11 +265,12 @@ export const workflowSearchCommand = new Command()
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .action(async function (options: AnyOptions, query?: string) {
     const ctx = createContext(options as GlobalOptions, ["workflow", "search"]);
+    const effectiveMode = interactiveOutputMode(ctx);
     ctx.logger.debug`Searching workflows with query: ${query ?? "(none)"}`;
 
     const { repoDir, repoContext } = await requireInitializedRepo({
       repoDir: options.repoDir ?? ".",
-      outputMode: ctx.outputMode,
+      outputMode: effectiveMode,
     });
     const repo = repoContext.workflowRepo;
     const runRepo = repoContext.workflowRunRepo;
@@ -271,7 +278,7 @@ export const workflowSearchCommand = new Command()
     const allWorkflows = await repo.findAll();
     const searchItems = allWorkflows.map(toSearchItem);
 
-    if (ctx.outputMode === "json") {
+    if (effectiveMode === "json") {
       // Non-interactive: filter and output JSON
       const filteredWorkflows = filterWorkflows(searchItems, query ?? "");
 
@@ -283,7 +290,7 @@ export const workflowSearchCommand = new Command()
           query: query ?? "",
           results: filteredWorkflows,
         };
-        await renderWorkflowSearch(data, ctx.outputMode);
+        await renderWorkflowSearch(data, effectiveMode);
       }
     } else {
       // Interactive: show fuzzy search UI
@@ -292,7 +299,7 @@ export const workflowSearchCommand = new Command()
         results: searchItems,
       };
 
-      const selected = await renderWorkflowSearch(data, ctx.outputMode);
+      const selected = await renderWorkflowSearch(data, effectiveMode);
 
       if (selected) {
         ctx.logger.debug`Selected workflow: ${selected.name}`;
@@ -309,7 +316,7 @@ export const workflowSearchCommand = new Command()
             workflowDescription: selected.description,
             hasInputs,
           },
-          ctx.outputMode,
+          effectiveMode,
         );
 
         if (!action) {

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -71,6 +71,19 @@ export function createContext(
 }
 
 /**
+ * Returns the effective output mode for commands that use interactive Ink UIs.
+ * Falls back to "json" when stdin is not a TTY, since Ink requires raw mode
+ * on stdin and will crash with "Raw mode is not supported" in non-TTY contexts
+ * (piped input, CI, AI agents).
+ */
+export function interactiveOutputMode(ctx: CommandContext): OutputMode {
+  if (ctx.outputMode === "json" || !isStdinTty()) {
+    return "json";
+  }
+  return "log";
+}
+
+/**
  * Determines the output mode from raw CLI arguments.
  * Used for error handling before the CLI has fully parsed options.
  */


### PR DESCRIPTION
Fixes #674

## Summary

- Interactive search commands (model search, type search, workflow search, etc.) use Ink for terminal UIs which requires raw mode on stdin. In non-TTY contexts (piped input, CI, AI agents), Ink crashes with **"Raw mode is not supported"**. **This was a pre-existing bug** — it existed before datastores — but the introduction of the datastore lock made it much worse: the crash now leaks the lock, blocking all subsequent swamp commands for ~60 seconds until timeout.

- **Fix 1 — `interactiveOutputMode()` helper** (`src/cli/context.ts`): A new function that returns `"json"` when `ctx.outputMode` is `"json"` OR when stdin is not a TTY. Applied surgically to all 10 interactive search commands so they fall back to structured JSON output instead of crashing. Non-interactive commands (version, model get, workflow run, etc.) are unaffected — they keep their normal output mode.

- **Fix 2 — Safety net in `main.ts`**: Added `flushDatastoreSync()` to the top-level catch block so the datastore lock is released even on unexpected crashes that bypass `runCli()`'s own error handling. `flushDatastoreSync()` is idempotent (nulls its state on first call), so calling it a second time is harmless.

### Commands updated with `interactiveOutputMode`:
- `model search`, `type search`, `vault search`, `vault type search`
- `workflow search`, `workflow run search`, `workflow history search`
- `model method history search`, `model output search`, `data search`

## Test Plan

- [x] All 2797 tests pass (zero failures)
- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno check` passes
- [x] Verified the global outputMode approach (auto-switching all commands) caused 6 test failures — confirmed the surgical per-command approach is correct
- [x] Verified non-interactive commands retain log-mode output in non-TTY contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)