### PR TITLE
fix: prevent datastore lock commands from deadlocking on stuck lock

### DIFF
--- a/src/cli/commands/datastore_lock.ts
+++ b/src/cli/commands/datastore_lock.ts
@@ -21,7 +21,7 @@ import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
 import {
   createDatastoreLock,
-  requireInitializedRepo,
+  resolveDatastoreForRepo,
 } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import {
@@ -48,12 +48,9 @@ const datastoreLockStatusCommand = new Command()
       "status",
     ]);
 
-    const { datastoreResolver } = await requireInitializedRepo({
-      repoDir: options.repoDir ?? ".",
-      outputMode: ctx.outputMode,
-    });
-
-    const config = datastoreResolver.config();
+    const { datastoreConfig: config } = await resolveDatastoreForRepo(
+      options.repoDir ?? ".",
+    );
     const lock = createDatastoreLock(config);
     const info = await lock.inspect();
 
@@ -87,12 +84,9 @@ const datastoreLockReleaseCommand = new Command()
       );
     }
 
-    const { datastoreResolver } = await requireInitializedRepo({
-      repoDir: options.repoDir ?? ".",
-      outputMode: ctx.outputMode,
-    });
-
-    const config = datastoreResolver.config();
+    const { datastoreConfig: config } = await resolveDatastoreForRepo(
+      options.repoDir ?? ".",
+    );
     const lock = createDatastoreLock(config);
     const info = await lock.inspect();
 

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -69,6 +69,42 @@ export interface RepoValidationContext {
 }
 
 /**
+ * Lightweight repo + datastore resolution without acquiring the datastore lock.
+ *
+ * Used by breakglass commands (lock status, lock release) that need the
+ * datastore config to inspect/release a lock but must not acquire it.
+ */
+export interface DatastoreResolutionResult {
+  repoDir: string;
+  datastoreConfig: DatastoreConfig;
+}
+
+export async function resolveDatastoreForRepo(
+  repoDir: string,
+): Promise<DatastoreResolutionResult> {
+  const repoPath = RepoPath.create(repoDir);
+  const service = new RepoService(VERSION);
+  const isInit = await service.isInitialized(repoPath);
+
+  if (!isInit) {
+    throw new UserError(
+      `Not a swamp repository: ${repoPath.value}. To initialize a new repository, run 'swamp repo init', or specify an existing repository with 'swamp <command> --repo-dir /path/to/repo'.`,
+    );
+  }
+
+  const markerRepo = new RepoMarkerRepository();
+  const marker = await markerRepo.read(repoPath);
+
+  const datastoreConfig = resolveDatastoreConfig(
+    marker,
+    undefined,
+    repoPath.value,
+  );
+
+  return { repoDir: repoPath.value, datastoreConfig };
+}
+
+/**
  * Validates that a directory is an initialized swamp repository.
  *
  * Throws a UserError with helpful instructions if the directory
@@ -83,19 +119,11 @@ export async function requireInitializedRepo(
   options: RequireRepoOptions,
   factoryConfig?: Partial<Omit<RepositoryFactoryConfig, "repoDir">>,
 ): Promise<RepoValidationContext> {
-  const { repoDir } = options;
+  const { repoDir, datastoreConfig } = await resolveDatastoreForRepo(
+    options.repoDir,
+  );
 
   const repoPath = RepoPath.create(repoDir);
-  const service = new RepoService(VERSION);
-  const isInit = await service.isInitialized(repoPath);
-
-  if (!isInit) {
-    throw new UserError(
-      `Not a swamp repository: ${repoPath.value}. To initialize a new repository, run 'swamp repo init', or specify an existing repository with 'swamp <command> --repo-dir /path/to/repo'.`,
-    );
-  }
-
-  // Read marker to resolve workflowsDir and datastore config
   const markerRepo = new RepoMarkerRepository();
   const marker = await markerRepo.read(repoPath);
 
@@ -104,12 +132,6 @@ export async function requireInitializedRepo(
     ? workflowsDirRel
     : resolve(repoPath.value, workflowsDirRel);
 
-  // Resolve datastore configuration
-  const datastoreConfig = resolveDatastoreConfig(
-    marker,
-    undefined,
-    repoPath.value,
-  );
   const datastoreResolver = new DefaultDatastorePathResolver(
     repoPath.value,
     datastoreConfig,

--- a/src/cli/repo_context_test.ts
+++ b/src/cli/repo_context_test.ts
@@ -21,7 +21,10 @@ import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
-import { requireInitializedRepo } from "./repo_context.ts";
+import {
+  requireInitializedRepo,
+  resolveDatastoreForRepo,
+} from "./repo_context.ts";
 import { flushDatastoreSync } from "../infrastructure/persistence/datastore_sync_coordinator.ts";
 import { RepoPath } from "../domain/repo/repo_path.ts";
 import { RepoService } from "../domain/repo/repo_service.ts";
@@ -200,6 +203,35 @@ Deno.test("requireInitializedRepo - handles nested directory paths", async () =>
     assertEquals(result.repoDir, nestedDir);
 
     await flushDatastoreSync();
+  });
+});
+
+// ============================================================================
+// resolveDatastoreForRepo Tests
+// ============================================================================
+
+Deno.test("resolveDatastoreForRepo - returns config for initialized repo without acquiring lock", async () => {
+  await withTempDir(async (dir) => {
+    await initializeRepo(dir);
+
+    const result = await resolveDatastoreForRepo(dir);
+
+    assertEquals(result.repoDir, dir);
+    assertEquals(result.datastoreConfig.type, "filesystem");
+
+    // flushDatastoreSync should be a no-op (no lock was acquired)
+    await flushDatastoreSync();
+  });
+});
+
+Deno.test("resolveDatastoreForRepo - throws UserError for non-initialized repo", async () => {
+  await withTempDir(async (dir) => {
+    const error = await assertRejects(
+      () => resolveDatastoreForRepo(dir),
+      UserError,
+    );
+
+    assertStringIncludes(error.message, "Not a swamp repository");
   });
 });
 


### PR DESCRIPTION
Fixes #676

## Summary

- `datastore lock status` and `datastore lock release --force` called `requireInitializedRepo()` which acquires the datastore lock via `registerDatastoreSync()` — causing the breakglass commands to deadlock on the very lock they were meant to inspect or release
- Added `resolveDatastoreForRepo()` to `src/cli/repo_context.ts` — a lightweight function that resolves repo path + datastore config **without** acquiring the lock. The lock commands now use this instead
- Refactored `requireInitializedRepo()` to call `resolveDatastoreForRepo()` internally, keeping a single source of truth for repo validation and datastore config resolution
- Zero user impact for normal usage — only the two broken breakglass commands are affected, and they now work

## Test Plan

- [x] New tests for `resolveDatastoreForRepo`: returns correct config without acquiring lock, throws `UserError` for non-initialized repos
- [x] All 2799 tests pass
- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno check` passes
- [x] Verified no UAT test impact — no UAT tests exercise `datastore lock` commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)