### PR TITLE
fix: respect --repo-dir for user model and vault loading

### DIFF
--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { Logger } from "@logtape/logtape";
+import { resolve } from "@std/path";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 import type { OutputMode } from "../presentation/output/output.ts";
 
@@ -92,4 +93,23 @@ export function getOutputModeFromArgs(args: string[]): OutputMode {
     return "json";
   }
   return "log";
+}
+
+/**
+ * Pre-parses --repo-dir from raw CLI arguments before Cliffy option parsing.
+ *
+ * Supports both `--repo-dir <value>` and `--repo-dir=<value>` forms.
+ * Returns the resolved absolute path, defaulting to cwd when not specified.
+ */
+export function getRepoDirFromArgs(args: string[]): string {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--repo-dir" && i + 1 < args.length) {
+      return resolve(args[i + 1]);
+    }
+    if (arg.startsWith("--repo-dir=")) {
+      return resolve(arg.slice("--repo-dir=".length));
+    }
+  }
+  return Deno.cwd();
 }

--- a/src/cli/context_test.ts
+++ b/src/cli/context_test.ts
@@ -21,6 +21,7 @@ import { assertEquals } from "@std/assert";
 import {
   createContext,
   getOutputModeFromArgs,
+  getRepoDirFromArgs,
   type GlobalOptions,
 } from "./context.ts";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
@@ -88,4 +89,56 @@ Deno.test("getOutputModeFromArgs returns json when --json is present", () => {
   assertEquals(getOutputModeFromArgs(["--json"]), "json");
   assertEquals(getOutputModeFromArgs(["model", "create", "--json"]), "json");
   assertEquals(getOutputModeFromArgs(["--json", "model", "create"]), "json");
+});
+
+// ============================================================================
+// getRepoDirFromArgs Tests
+// ============================================================================
+
+Deno.test("getRepoDirFromArgs returns cwd when no --repo-dir flag", () => {
+  assertEquals(getRepoDirFromArgs([]), Deno.cwd());
+  assertEquals(getRepoDirFromArgs(["model", "create"]), Deno.cwd());
+});
+
+Deno.test("getRepoDirFromArgs parses --repo-dir with space separator", () => {
+  const result = getRepoDirFromArgs([
+    "model",
+    "run",
+    "--repo-dir",
+    "/tmp/my-repo",
+  ]);
+  assertEquals(result, "/tmp/my-repo");
+});
+
+Deno.test("getRepoDirFromArgs parses --repo-dir with equals separator", () => {
+  const result = getRepoDirFromArgs([
+    "model",
+    "run",
+    "--repo-dir=/tmp/my-repo",
+  ]);
+  assertEquals(result, "/tmp/my-repo");
+});
+
+Deno.test("getRepoDirFromArgs resolves relative paths to absolute", () => {
+  const result = getRepoDirFromArgs(["--repo-dir", "./relative/path"]);
+  assertEquals(result.startsWith("/"), true);
+  assertEquals(result.endsWith("relative/path"), true);
+});
+
+Deno.test("getRepoDirFromArgs returns cwd when --repo-dir is last arg with no value", () => {
+  assertEquals(getRepoDirFromArgs(["model", "run", "--repo-dir"]), Deno.cwd());
+});
+
+Deno.test("getRepoDirFromArgs finds flag among other args", () => {
+  const result = getRepoDirFromArgs([
+    "model",
+    "method",
+    "run",
+    "--json",
+    "--repo-dir",
+    "/tmp/my-repo",
+    "my-model",
+    "my-method",
+  ]);
+  assertEquals(result, "/tmp/my-repo");
 });

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -40,7 +40,11 @@ import { summariseCommand } from "./commands/summarise.ts";
 import { datastoreCommand } from "./commands/datastore.ts";
 import { createHelpCommand } from "./commands/help.ts";
 import { unknownCommandErrorHandler } from "./unknown_command_handler.ts";
-import { type GlobalOptions, isStdinTty } from "./context.ts";
+import {
+  getRepoDirFromArgs,
+  type GlobalOptions,
+  isStdinTty,
+} from "./context.ts";
 import {
   ModelNameType,
   ModelTypeType,
@@ -137,22 +141,21 @@ export function isUpdateCheckDisabledByEnv(): boolean {
 /**
  * Load user models from configured directory.
  */
-async function loadUserModels(): Promise<void> {
-  const cwd = Deno.cwd();
+async function loadUserModels(repoDir: string): Promise<void> {
   const markerRepo = new RepoMarkerRepository();
 
   try {
-    const repoPath = RepoPath.create(cwd);
+    const repoPath = RepoPath.create(repoDir);
     const marker = await markerRepo.read(repoPath);
 
     const modelsDir = resolveModelsDir(marker);
     // Handle both absolute and relative paths (cross-platform)
     const absoluteModelsDir = isAbsolute(modelsDir)
       ? modelsDir
-      : resolve(cwd, modelsDir);
+      : resolve(repoDir, modelsDir);
 
     const denoRuntime = new EmbeddedDenoRuntime();
-    const loader = new UserModelLoader(denoRuntime, cwd);
+    const loader = new UserModelLoader(denoRuntime, repoDir);
     const result = await loader.loadModels(absoluteModelsDir);
 
     // Log extension successes at debug level
@@ -179,21 +182,20 @@ async function loadUserModels(): Promise<void> {
 /**
  * Load user vault implementations from configured directory.
  */
-async function loadUserVaults(): Promise<void> {
-  const cwd = Deno.cwd();
+async function loadUserVaults(repoDir: string): Promise<void> {
   const markerRepo = new RepoMarkerRepository();
 
   try {
-    const repoPath = RepoPath.create(cwd);
+    const repoPath = RepoPath.create(repoDir);
     const marker = await markerRepo.read(repoPath);
 
     const vaultsDir = resolveVaultsDir(marker);
     const absoluteVaultsDir = isAbsolute(vaultsDir)
       ? vaultsDir
-      : resolve(cwd, vaultsDir);
+      : resolve(repoDir, vaultsDir);
 
     const denoRuntime = new EmbeddedDenoRuntime();
-    const loader = new UserVaultLoader(denoRuntime, cwd);
+    const loader = new UserVaultLoader(denoRuntime, repoDir);
     const result = await loader.loadVaults(absoluteVaultsDir);
 
     // Log successes at debug level
@@ -269,11 +271,12 @@ interface TelemetryContext {
  * Initialize telemetry service if in a swamp repository.
  * Lazy-migrates repoId if missing from marker file.
  */
-async function initTelemetryService(): Promise<TelemetryContext | null> {
+async function initTelemetryService(
+  repoDir: string,
+): Promise<TelemetryContext | null> {
   try {
-    const cwd = Deno.cwd();
     const markerRepo = new RepoMarkerRepository();
-    const repoPath = RepoPath.create(cwd);
+    const repoPath = RepoPath.create(repoDir);
 
     const marker = await markerRepo.read(repoPath);
     if (!marker) {
@@ -313,7 +316,7 @@ async function initTelemetryService(): Promise<TelemetryContext | null> {
       // Auth file unreadable — continue without auth
     }
 
-    const repository = new JsonTelemetryRepository(cwd);
+    const repository = new JsonTelemetryRepository(repoDir);
     const service = new TelemetryService(repository, VERSION);
     const telemetryEndpoint = resolveTelemetryEndpoint(
       marker.telemetryEndpoint,
@@ -340,6 +343,9 @@ export async function runCli(args: string[]): Promise<void> {
   // Capture start time for telemetry
   const startTime = new Date();
 
+  // Pre-parse --repo-dir so startup functions use the correct repository
+  const repoDir = getRepoDirFromArgs(args);
+
   // Pre-parse check for telemetry disable flag
   const telemetryDisabled = isTelemetryDisabled(args) ||
     isTelemetryDisabledByEnv();
@@ -350,18 +356,18 @@ export async function runCli(args: string[]): Promise<void> {
   // Initialize telemetry service (only if in a swamp repo)
   let telemetryCtx: TelemetryContext | null = null;
   if (!telemetryDisabled) {
-    telemetryCtx = await initTelemetryService();
+    telemetryCtx = await initTelemetryService(repoDir);
   }
 
   // Load user models and vaults before setting up CLI
-  await loadUserModels();
-  await loadUserVaults();
+  await loadUserModels(repoDir);
+  await loadUserVaults(repoDir);
 
   // Read marker for resolveLogLevel (used in globalAction closure)
   let marker: RepoMarkerData | null = null;
   try {
     const markerRepo = new RepoMarkerRepository();
-    const repoPath = RepoPath.create(Deno.cwd());
+    const repoPath = RepoPath.create(repoDir);
     marker = await markerRepo.read(repoPath);
   } catch {
     // Not in a swamp repo - marker stays null


### PR DESCRIPTION
## Summary

Fixes #682.

`loadUserModels()`, `loadUserVaults()`, and `initTelemetryService()` in `src/cli/mod.ts` hardcoded `Deno.cwd()` to locate the swamp repo at CLI startup — **before** Cliffy parses command options. This meant `--repo-dir` was completely ignored for:

- Extension model type registration → "Unknown model type" when running from a different directory
- User vault implementation loading
- Telemetry config and log level resolution from `.swamp.yaml`

### Approach

Pre-parse `--repo-dir` from the raw args array (following the existing `getOutputModeFromArgs` pattern for `--json`) and thread the resolved path through all four startup functions. This is the minimal fix — no command-level changes, no changes to `requireInitializedRepo`, and behavior is identical when `--repo-dir` is not specified.

### Changes

- **`src/cli/context.ts`** — Added `getRepoDirFromArgs(args)` that extracts `--repo-dir` from raw CLI args (supports both `--repo-dir <value>` and `--repo-dir=<value>` forms), resolves to an absolute path, defaults to cwd
- **`src/cli/mod.ts`** — Call `getRepoDirFromArgs(args)` once at the top of `runCli()`, pass the result to `loadUserModels(repoDir)`, `loadUserVaults(repoDir)`, `initTelemetryService(repoDir)`, and the marker read block
- **`src/cli/context_test.ts`** — 6 new tests for the pre-parser (no flag, space separator, equals separator, relative path resolution, missing value, flag among other args)

## Test Plan

- 6 new unit tests for `getRepoDirFromArgs` covering all arg forms and edge cases
- Full test suite passes (2811 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)