### PR TITLE
fix: handle symlinks and YAML type field in definition repository

### DIFF
--- a/src/infrastructure/persistence/yaml_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository.ts
@@ -84,9 +84,14 @@ export class YamlDefinitionRepository implements DefinitionRepository {
 
     try {
       for await (const entry of Deno.readDir(dir)) {
-        if (entry.isFile && entry.name.endsWith(".yaml")) {
+        if (
+          (entry.isFile || entry.isSymlink) && entry.name.endsWith(".yaml")
+        ) {
           const path = join(dir, entry.name);
           try {
+            if (entry.isSymlink) {
+              await assertSafePath(path, this.repoDir);
+            }
             const content = await Deno.readTextFile(path);
             const data = parseYaml(content) as DefinitionData;
             definitions.push(Definition.fromData(data));
@@ -128,16 +133,21 @@ export class YamlDefinitionRepository implements DefinitionRepository {
       for await (const entry of Deno.readDir(currentDir)) {
         const fullPath = join(currentDir, entry.name);
 
-        if (entry.isFile && entry.name.endsWith(".yaml")) {
+        if (
+          (entry.isFile || entry.isSymlink) && entry.name.endsWith(".yaml")
+        ) {
           // Found a YAML file, check if it matches the name
           try {
+            if (entry.isSymlink) {
+              await assertSafePath(fullPath, this.repoDir);
+            }
             const content = await Deno.readTextFile(fullPath);
             const data = parseYaml(content) as DefinitionData;
             const definition = Definition.fromData(data);
 
             if (definition.name === name) {
-              // Reconstruct the model type from the path segments
-              const typeStr = pathSegments.join("/");
+              // Prefer the type from the YAML, fall back to path-based type
+              const typeStr = definition.type ?? pathSegments.join("/");
               return { definition, type: ModelType.create(typeStr) };
             }
           } catch (parseError) {
@@ -189,15 +199,20 @@ export class YamlDefinitionRepository implements DefinitionRepository {
       for await (const entry of Deno.readDir(currentDir)) {
         const fullPath = join(currentDir, entry.name);
 
-        if (entry.isFile && entry.name.endsWith(".yaml")) {
+        if (
+          (entry.isFile || entry.isSymlink) && entry.name.endsWith(".yaml")
+        ) {
           // Found a YAML file, add it to results
           try {
+            if (entry.isSymlink) {
+              await assertSafePath(fullPath, this.repoDir);
+            }
             const content = await Deno.readTextFile(fullPath);
             const data = parseYaml(content) as DefinitionData;
             const definition = Definition.fromData(data);
 
-            // Reconstruct the model type from the path segments
-            const typeStr = pathSegments.join("/");
+            // Prefer the type from the YAML, fall back to path-based type
+            const typeStr = definition.type ?? pathSegments.join("/");
             results.push({ definition, type: ModelType.create(typeStr) });
           } catch (parseError) {
             logger

--- a/src/infrastructure/persistence/yaml_definition_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertNotEquals } from "@std/assert";
+import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { stringify as stringifyYaml } from "@std/yaml";
 import { YamlDefinitionRepository } from "./yaml_definition_repository.ts";
@@ -41,6 +42,11 @@ function createTestDefinition(name: string): Definition {
 }
 
 const testType = ModelType.create("test/example");
+
+/** Serialize definition data to YAML, stripping undefined values like save() does. */
+function toCleanYaml(data: Record<string, unknown>): string {
+  return stringifyYaml(JSON.parse(JSON.stringify(data)));
+}
 
 Deno.test("YamlDefinitionRepository.save and findById roundtrip", async () => {
   await withTempDir(async (dir) => {
@@ -163,5 +169,243 @@ Deno.test("YamlDefinitionRepository.delete removes definition", async () => {
 
     await repo.delete(testType, definition.id);
     assertEquals(await repo.findById(testType, definition.id), null);
+  });
+});
+
+Deno.test("YamlDefinitionRepository.findAll discovers symlinked YAML files targeting outside models/", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const definition = createTestDefinition("real-def");
+
+    // Save a real definition first
+    await repo.save(testType, definition);
+
+    // Simulate legacy layout: real file lives in .swamp/definitions/ (inside repo,
+    // outside models/), symlinked into models/
+    const secondDef = createTestDefinition("legacy-def");
+    const legacyDir = join(
+      dir,
+      ".swamp",
+      "definitions",
+      testType.toDirectoryPath(),
+    );
+    await ensureDir(legacyDir);
+    const realFile = join(legacyDir, `${secondDef.id}.yaml`);
+    const data = secondDef.toData();
+    data.type = testType.normalized;
+    await Deno.writeTextFile(realFile, toCleanYaml(data));
+
+    const typeDir = join(dir, "models", testType.toDirectoryPath());
+    await Deno.symlink(realFile, join(typeDir, `${secondDef.id}.yaml`));
+
+    const results = await repo.findAll(testType);
+    assertEquals(results.length, 2);
+    const names = results.map((d) => d.name).sort();
+    assertEquals(names, ["legacy-def", "real-def"]);
+  });
+});
+
+Deno.test("YamlDefinitionRepository.findAllGlobal discovers symlinked YAML files targeting outside models/", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const definition = createTestDefinition("real-def");
+    await repo.save(testType, definition);
+
+    // Simulate extension layout: real file in extensions/models/ (inside repo,
+    // outside models/), symlinked into models/
+    const symDef = createTestDefinition("ext-def");
+    const extDir = join(
+      dir,
+      "extensions",
+      "models",
+      testType.toDirectoryPath(),
+    );
+    await ensureDir(extDir);
+    const realFile = join(extDir, `${symDef.id}.yaml`);
+    const data = symDef.toData();
+    data.type = testType.normalized;
+    await Deno.writeTextFile(realFile, toCleanYaml(data));
+
+    const typeDir = join(dir, "models", testType.toDirectoryPath());
+    await Deno.symlink(realFile, join(typeDir, `${symDef.id}.yaml`));
+
+    const results = await repo.findAllGlobal();
+    assertEquals(results.length, 2);
+    const names = results.map((r) => r.definition.name).sort();
+    assertEquals(names, ["ext-def", "real-def"]);
+  });
+});
+
+Deno.test("YamlDefinitionRepository.findByNameGlobal discovers symlinked YAML files targeting outside models/", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+
+    // Simulate extension layout: real file in extensions/models/, symlinked into models/
+    const symDef = createTestDefinition("ext-find");
+    const extDir = join(
+      dir,
+      "extensions",
+      "models",
+      testType.toDirectoryPath(),
+    );
+    await ensureDir(extDir);
+    const realFile = join(extDir, `${symDef.id}.yaml`);
+    const data = symDef.toData();
+    data.type = testType.normalized;
+    await Deno.writeTextFile(realFile, toCleanYaml(data));
+
+    const typeDir = join(dir, "models", testType.toDirectoryPath());
+    await ensureDir(typeDir);
+    await Deno.symlink(realFile, join(typeDir, `${symDef.id}.yaml`));
+
+    const result = await repo.findByNameGlobal("ext-find");
+    assertNotEquals(result, null);
+    assertEquals(result!.definition.name, "ext-find");
+  });
+});
+
+Deno.test("YamlDefinitionRepository.findAllGlobal uses YAML type field over path", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+
+    // Create a definition with a type that differs from the directory path
+    const def = Definition.create({
+      name: "typed-def",
+      type: "@smith/kibana-dev",
+      globalArguments: { key: "value" },
+    });
+
+    // Save it under a directory that doesn't match the YAML type
+    const typeDir = join(dir, "models", "kibana");
+    await ensureDir(typeDir);
+    const data = def.toData();
+    data.type = "@smith/kibana-dev";
+    await Deno.writeTextFile(
+      join(typeDir, `${def.id}.yaml`),
+      toCleanYaml(data),
+    );
+
+    const results = await repo.findAllGlobal();
+    assertEquals(results.length, 1);
+    assertEquals(results[0].type.normalized, "@smith/kibana-dev");
+  });
+});
+
+Deno.test("YamlDefinitionRepository.findByNameGlobal uses YAML type field over path", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+
+    // Create a definition with a type that differs from the directory path
+    const def = Definition.create({
+      name: "typed-find",
+      type: "@smith/kibana-dev",
+      globalArguments: { key: "value" },
+    });
+
+    const typeDir = join(dir, "models", "kibana");
+    await ensureDir(typeDir);
+    const data = def.toData();
+    data.type = "@smith/kibana-dev";
+    await Deno.writeTextFile(
+      join(typeDir, `${def.id}.yaml`),
+      toCleanYaml(data),
+    );
+
+    const result = await repo.findByNameGlobal("typed-find");
+    assertNotEquals(result, null);
+    assertEquals(result!.type.normalized, "@smith/kibana-dev");
+  });
+});
+
+Deno.test("YamlDefinitionRepository.findAllGlobal falls back to path-based type when YAML type is missing", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+
+    // Create a definition without a type field in the YAML
+    const def = Definition.create({
+      name: "no-type-def",
+      globalArguments: { key: "value" },
+    });
+
+    const typeDir = join(dir, "models", "test", "example");
+    await ensureDir(typeDir);
+    const data = def.toData();
+    delete data.type;
+    await Deno.writeTextFile(
+      join(typeDir, `${def.id}.yaml`),
+      toCleanYaml(data),
+    );
+
+    const results = await repo.findAllGlobal();
+    assertEquals(results.length, 1);
+    assertEquals(results[0].type.normalized, "test/example");
+  });
+});
+
+Deno.test("YamlDefinitionRepository.findAllGlobal resolves symlinked extension with scoped type", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+
+    // Simulate the real issue #683 scenario: user has @smith/kibana-dev extension
+    // installed. The definition YAML lives in extensions/models/ and is symlinked
+    // into models/. The YAML type field says "@smith/kibana-dev" but the directory
+    // path is just "kibana-dev".
+    const def = Definition.create({
+      name: "my-kibana",
+      type: "@smith/kibana-dev",
+      globalArguments: { host: "localhost" },
+    });
+
+    // Extension file lives in extensions/models/
+    const extDir = join(dir, "extensions", "models", "kibana-dev");
+    await ensureDir(extDir);
+    const realFile = join(extDir, `${def.id}.yaml`);
+    const data = def.toData();
+    data.type = "@smith/kibana-dev";
+    await Deno.writeTextFile(realFile, toCleanYaml(data));
+
+    // Symlink into models/ under directory that doesn't match full scoped type
+    const typeDir = join(dir, "models", "kibana-dev");
+    await ensureDir(typeDir);
+    await Deno.symlink(realFile, join(typeDir, `${def.id}.yaml`));
+
+    const results = await repo.findAllGlobal();
+    assertEquals(results.length, 1);
+    // Must use the YAML type "@smith/kibana-dev", not the path "kibana-dev"
+    assertEquals(results[0].type.normalized, "@smith/kibana-dev");
+    assertEquals(results[0].definition.name, "my-kibana");
+  });
+});
+
+Deno.test("YamlDefinitionRepository.findAll rejects symlink pointing outside repo", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const definition = createTestDefinition("good-def");
+    await repo.save(testType, definition);
+
+    // Create a symlink pointing completely outside the repo boundary
+    const outsideDir = await Deno.makeTempDir();
+    try {
+      const outsideFile = join(outsideDir, "evil.yaml");
+      const evilData = {
+        id: crypto.randomUUID(),
+        name: "evil-def",
+        version: 1,
+        tags: {},
+        globalArguments: {},
+        methods: {},
+      };
+      await Deno.writeTextFile(outsideFile, stringifyYaml(evilData));
+
+      const typeDir = join(dir, "models", testType.toDirectoryPath());
+      await Deno.symlink(outsideFile, join(typeDir, "evil.yaml"));
+
+      // Should only return the good definition, skipping the evil symlink
+      const results = await repo.findAll(testType);
+      assertEquals(results.length, 1);
+      assertEquals(results[0].name, "good-def");
+    } finally {
+      await Deno.remove(outsideDir, { recursive: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Fixes #683 — after the datastore refactor, model definitions using symlinks or scoped extension types (e.g., `@smith/kibana-dev`) were no longer discovered.

Two bugs in `yaml_definition_repository.ts`:

- **Symlinks silently skipped**: `Deno.readDir()` returns `isFile: false` for symlinks, so `findAll()`, `findByNameGlobal()`, and `findAllGlobal()` all missed symlinked YAML files. Fixed by also checking `entry.isSymlink`, with `assertSafePath()` guarding against symlinks that escape the repo boundary.

- **Type reconstructed from path instead of YAML**: `collectAllDefinitions()` and `searchDefinitionByName()` reconstructed the model type from directory path segments, ignoring the `type` field in the parsed YAML. This produced wrong types for scoped extensions where the directory name doesn't match the full type (e.g., path says `kibana-dev` but YAML says `@smith/kibana-dev`). Fixed by preferring `definition.type` from the YAML, falling back to path-based type only when absent.

**Important**: The path traversal boundary uses `repoDir` (not `baseDir`/`models/`) so that symlinks targeting `extensions/models/` or `.swamp/definitions/` — inside the repo but outside `models/` — are correctly allowed while symlinks escaping the repo are still rejected.

## User impact

Users with extension models installed via symlinks (or legacy symlink layouts from before `repo upgrade`) will have their models discovered again. Users with scoped extension types will see the correct type reported instead of a truncated path-based type.

## Test plan

- [x] Symlinked YAML file discovered by `findAll()` (target outside `models/`, in `.swamp/definitions/`)
- [x] Symlinked YAML file discovered by `findAllGlobal()` (target in `extensions/models/`)
- [x] Symlinked YAML file discovered by `findByNameGlobal()` (target in `extensions/models/`)
- [x] Combined scenario: symlinked extension with scoped type `@smith/kibana-dev` — both symlink discovery and type resolution work together
- [x] Type read from YAML `type` field, not path, when present
- [x] Path-based type used as fallback when YAML `type` field is missing
- [x] Symlink pointing outside repo boundary is rejected (path traversal protection)
- [x] All 2823 existing tests pass
- [x] `deno check`, `deno lint`, `deno fmt`, `deno run compile` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)