### PR TITLE
fix: prevent 1Password CLI from reading exhausted stdin pipe

### DIFF
--- a/src/domain/vaults/onepassword_vault_provider.ts
+++ b/src/domain/vaults/onepassword_vault_provider.ts
@@ -247,6 +247,7 @@ export class OnePasswordVaultProvider implements VaultProvider {
     try {
       const command = new Deno.Command("op", {
         args: ["--version"],
+        stdin: "null",
         stdout: "piped",
         stderr: "piped",
       });
@@ -275,6 +276,7 @@ export class OnePasswordVaultProvider implements VaultProvider {
   private async runOp(args: string[]): Promise<string> {
     const command = new Deno.Command("op", {
       args,
+      stdin: "null",
       stdout: "piped",
       stderr: "piped",
     });


### PR DESCRIPTION
## Summary

Fixes #668 — `swamp vault put` to a 1Password-backed vault stores an empty password field when the secret value is piped via stdin.

**Root cause:** The `runOp()` helper in `OnePasswordVaultProvider` spawned `op` subprocesses without setting `stdin: "null"`, so they inherited the parent process's stdin. When stdin was a pipe (already consumed by `readStdin()`), the `op` CLI detected the pipe and attempted to read from it, getting an empty string that overwrote the `field=value` command-line argument.

**Fix:** Add `stdin: "null"` to both `Deno.Command` calls in the 1Password vault provider (`runOp` and `checkOpInstalled`) so child processes never inherit the parent's stdin. No other vault providers are affected — only the 1Password provider shells out to a CLI tool.

The inline `KEY=VALUE` syntax was unaffected because stdin remains a TTY in that path, so `op` never tries to read from it.

## Test Plan

- Existing unit tests pass (`deno run test`)
- `deno check`, `deno lint`, `deno fmt` all clean
- The fix can be verified manually with: `echo "test-value" | swamp vault put <1p-vault> TEST_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)