### PR TITLE
docs: remove logical views and fix .swamp/ references in design docs

### DIFF
--- a/design/agent.md
+++ b/design/agent.md
@@ -6,28 +6,27 @@ writing files, etc.
 
 ## Repository Exploration
 
-Agents can explore a swamp repository through two layers:
+Agents can explore a swamp repository through the following layers:
 
-### Logical Views (Recommended)
+### Source-of-Truth Directories
 
-The logical views provide human/agent-friendly exploration:
+The top-level directories contain source-of-truth files tracked in git:
 
-- **`/models/{name}/`** - Model-centric view with definitions, data (resources,
-  logs, files), and outputs organized by model name
-- **`/workflows/{name}/`** - Workflow-centric view with definitions and run
-  history organized by workflow name
+- **`models/`** — Model definitions organized by normalized type
+- **`workflows/`** — Workflow definitions
+- **`vaults/`** — Vault configurations
 
-These views use symlinks to reference data in the internal data directory. They
-are the recommended way to explore and understand the repository structure.
+These are the primary directories for exploring and understanding the repository
+structure.
 
-### Internal Storage Directory (Direct Access)
+### Runtime Data (Datastore)
 
-The `/.swamp/` directory contains the internal storage format. Agents can access
-it directly when needed, but the layout reflects swamp's internal architecture
-rather than user-facing concerns.
+Runtime data (versioned model data, workflow runs, method outputs) is stored in
+the datastore. The default datastore uses `.swamp/`, but it can be configured to
+use an external path or S3. See [./datastores.md] for details.
 
 ### CLI Abstraction
 
 The CLI commands (`swamp model`, `swamp workflow`, etc.) abstract away the
 storage layer entirely. Agents should prefer using CLI commands for operations,
-and use the logical views for exploration and understanding context.
+and use the top-level directories for exploration and understanding context.

--- a/design/datastores.md
+++ b/design/datastores.md
@@ -2,9 +2,11 @@
 
 A datastore in swamp determines where runtime data is stored. Runtime data
 includes versioned model data, workflow runs, method outputs, audit logs,
-telemetry, encrypted secrets, and cached bundles. Source-of-truth files (model
-definitions, workflow definitions, vault configs) always live in the top-level
-`models/`, `workflows/`, `vaults/` directories and are never part of the
+telemetry, encrypted secrets, and cached bundles.
+
+**Important:** Source-of-truth files (model definitions, workflow definitions,
+vault configs) always live in the top-level `models/`, `workflows/`, `vaults/`
+directories of the repository and are tracked in git. They are never part of the
 datastore.
 
 ## Backends

--- a/design/expressions.md
+++ b/design/expressions.md
@@ -232,10 +232,11 @@ attributes:
 
 > **Warning:** Values accessed via `env` are **not redacted or filtered**. If
 > you use an environment variable as a model attribute, its value will be
-> **stored on disk** in `.swamp/data/` as part of the model output data and
-> will be visible in the output of `swamp data get`. This includes any
-> sensitive environment variables present at runtime (e.g.
-> `AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, database passwords).
+> **stored on disk** in the datastore `data/` directory (default
+> `.swamp/data/`) as part of the model output data and will be visible in the
+> output of `swamp data get`. This includes any sensitive environment variables
+> present at runtime (e.g. `AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, database
+> passwords).
 
 ### Use `vault.get()` for Sensitive Values
 
@@ -243,7 +244,7 @@ For API keys, tokens, passwords, and other secrets, always use
 `vault.get()` instead of `env`. Vault values are fetched at runtime and are
 **never persisted** in model output data.
 
-**Wrong — secret will be stored in `.swamp/data/` on disk:**
+**Wrong — secret will be stored in the datastore `data/` directory on disk:**
 
 ```yaml
 attributes:
@@ -267,14 +268,13 @@ registering custom types, functions, etc in their swamp repo.
 ## Runtime Guidance
 
 When loading the YAML, first parse the CEL expressions. Then take the data
-structures they emit and embed them in the data structure. Write those to a
-directory in the repository called `/.swamp/definitions-evaluated/` whose
-structure is the same as `/.swamp/definitions/`. This directory should be in a
+structures they emit and embed them in the data structure. Write those to the
+datastore at `definitions-evaluated/` (default `.swamp/definitions-evaluated/`),
+whose structure mirrors the `models/` directory. This directory should be in a
 swamp repo's .gitignore file.
 
-The same is true for `/.swamp/workflows-evaluated/`, and it should also be in
-.gitignore.
+The same is true for `workflows-evaluated/` (default
+`.swamp/workflows-evaluated/`), and it should also be in .gitignore.
 
-These evaluated directories are internal working directories in the data layer,
-used by the expression evaluation system. They are not exposed through logical
-views.
+These evaluated directories are internal working directories in the datastore,
+used by the expression evaluation system.

--- a/design/extension.md
+++ b/design/extension.md
@@ -256,7 +256,7 @@ When pulled, extension files are extracted to their destinations:
 | ----------------- | ---------------------------------------------------------------------- |
 | `models/`         | `{modelsDir}` (from `.swamp.yaml`, default `extensions/models/`)       |
 | `workflows/`      | `{workflowsDir}` (from `.swamp.yaml`, default `extensions/workflows/`) |
-| `bundles/`        | `.swamp/bundles/`                                                      |
+| `bundles/`        | Datastore `bundles/` (default `.swamp/bundles/`)                       |
 | `files/`          | `{modelsDir}`                                                          |
 
 If files already exist at the destination and `--force` is not set, the user is

--- a/design/high-level.md
+++ b/design/high-level.md
@@ -8,8 +8,9 @@ can then validate are correct. Each model has a Type, which specifies metadata,
 attributes, methods, and inputs (variables/parameters as JsonSchema). Model
 definitions contain attributes and can be configured using inputs (variables).
 Methods take the definition and produce data (with data tags like "resource",
-"log", or "file"). Model definitions and data are stored as YAML files in the
-`.swamp/` directory. Definitions support a CEL expression language for dynamic
+"log", or "file"). Model definitions are stored as YAML files in the top-level
+`models/` directory, while runtime data is stored in the datastore (default
+`.swamp/`). Definitions support a CEL expression language for dynamic
 configuration.
 
 Swamp also has workflows, which allow for executing workflow steps in parallel
@@ -24,33 +25,26 @@ All this is stored in a 'swamp repo', which is a git repository.
 
 ## Storage Architecture
 
-A swamp repo uses a dual-layer storage architecture:
+A swamp repo separates source-of-truth files from runtime data:
 
-### Internal Storage Directory (`.swamp/`)
+### Source-of-Truth Files (Top-Level Directories)
 
-The `.swamp/` directory is the internal storage format optimized for swamp's
-software architecture. Aggregate repositories (ModelRepository,
-WorkflowRepository, WorkflowRunRepository) persist domain objects here.
+Model definitions, workflow definitions, and vault configurations are stored in
+top-level directories that are tracked in git:
 
-Both agents and humans can explore the `.swamp/` directory directly, but its
-layout reflects swamp's internal domain model rather than user-facing concerns.
+- **`models/`** — Model definitions organized by normalized type:
+  `models/{type}/{id}.yaml`
+- **`workflows/`** — Workflow definitions: `workflows/workflow-{id}.yaml`
+- **`vaults/`** — Vault configurations: `vaults/{vault-type}/{id}.yaml`
 
-### Logical Views
+These directories are the primary way to explore and understand the repository.
 
-Logical views are symlinked directories that provide human/agent-friendly
-perspectives into the `.swamp/` directory. They are automatically maintained by
-the RepoIndexService whenever aggregate repositories mutate data.
+### Runtime Data (Datastore)
 
-**Model View (`/models/`):** Explore models by name, with easy access to
-definitions, data (resources, logs, files), and outputs for each model.
-
-**Workflow View (`/workflows/`):** Explore workflows by name, with access to
-workflow definitions and run history.
-
-These views allow exploration of the same underlying data from different
-perspectives. For example, a method output can be viewed from the model's
-perspective (`/models/{name}/outputs/`) or from the workflow run that triggered
-it (`/workflows/{name}/runs/{run}/steps/{step}/`).
+Runtime data (versioned model data, workflow runs, method outputs, secrets,
+telemetry) is managed through a datastore abstraction. The default datastore
+uses the `.swamp/` directory, but it can be configured to use an external
+filesystem path or S3. See [./datastores.md] for details.
 
 See [./repo.md] for detailed architecture documentation.
 

--- a/design/models.md
+++ b/design/models.md
@@ -131,10 +131,10 @@ first method execution and persisted with the new CalVer `typeVersion`.
 
 ## Definitions
 
-Definitions are specified as YAML files that live in the `/.swamp/definitions/`
+Definitions are specified as YAML files that live in the top-level `models/`
 directory of a repository, underneath the normalized type as a directory. The
 file name is `${id}.yaml`. For example,
-`.swamp/definitions/aws/ec2/vpc/fc7fd41e-ae16-4b31-b57a-86de716e3ece.yaml`.
+`models/aws/ec2/vpc/fc7fd41e-ae16-4b31-b57a-86de716e3ece.yaml`.
 
 The valid shape of a definition is specified with a Zod 4 schema as part of the
 type.
@@ -239,14 +239,17 @@ CEL function. Versions will be auto-incrementing integers, starting at 1.
 Data can only be written by a model instantiated from the same definition that
 originally wrote the data. This is called the _owner_ of the data.
 
-The raw data will be written to
-`.swamp/data/{normalized-type}/{model-id}/{data-name}/{version}/raw`.
+The raw data will be written to the datastore at
+`data/{normalized-type}/{model-id}/{data-name}/{version}/raw` (default path:
+`.swamp/data/{normalized-type}/{model-id}/{data-name}/{version}/raw`).
 
-The metadata will be written to
-`.swamp/data/{normalized-type}/{model-id}/{data-name}/{version}/metadata.yaml`.
+The metadata will be written to the datastore at
+`data/{normalized-type}/{model-id}/{data-name}/{version}/metadata.yaml`.
 
 There will be a symlink to the latest version at
-`.swamp/data/{normalized-type}/{model-id}/{data-name}/latest/`.
+`data/{normalized-type}/{model-id}/{data-name}/latest/`.
+
+See [./datastores.md] for how the datastore path is resolved.
 
 ## Data Output API
 
@@ -311,31 +314,13 @@ Lightweight reference to data already persisted:
 ## Output
 
 Each method invocation produces an output record, which gets tracked in the
-`/.swamp/outputs/` directory of a repository (which should not be tracked in
-git). The output record should track the state of the method execution, and the
-list of artifacts produced by the method. It should track state as the method
+datastore `outputs/` directory (default `.swamp/outputs/`, not tracked in git).
+The output record should track the state of the method execution, and the list
+of artifacts produced by the method. It should track state as the method
 executes. It should be structured as
-`/.swamp/outputs/{normalized-type}/{method}/{definition-id}-{timestamp}.yaml`.
+`outputs/{normalized-type}/{method}/{definition-id}-{timestamp}.yaml`.
 
-## Logical Views
-
-The RepoIndexService maintains a model-centric logical view at `/models/` that
-provides human/agent-friendly exploration of models by name.
-
-### Model View Structure
-
-```
-/models/{model-name}/
-  definition.yaml                → symlink to /.swamp/definitions/{type}/{id}.yaml
-  {data-tag-key}/{data-tag-value}/  → symlink to /.swamp/data for the data as tagged
-  outputs/
-    {method}/                    → symlinks to /.swamp/outputs/{type}/{method}/{id}-*.yaml
-```
-
-This structure allows exploring all artifacts for a model in one place, using
-the model's human-readable name rather than UUIDs or type-based paths.
-
-### Domain Events
+## Domain Events
 
 The ModelRepository emits domain events when model data changes:
 
@@ -344,6 +329,5 @@ The ModelRepository emits domain events when model data changes:
 - `ModelUpdated` - Emitted when a model definition or data is modified
 - `ModelDeleted` - Emitted when a model is deleted
 
-The RepoIndexService subscribes to these events and updates the logical views
-accordingly, ensuring the `/models/` view stays synchronized with the data
-directory.
+The RepoIndexService subscribes to these events (currently a noop
+implementation). See [./repo.md] for details on domain events.

--- a/design/repo.md
+++ b/design/repo.md
@@ -20,36 +20,18 @@ The compiled swamp binary should include everything it needs to initialize a
 repository, including the skill files, so that they can be written out by the
 cli.
 
-## Internal storage directory (.swamp/)
+## Repository Layout
 
-Swamp repos store information from the various infrastructure repositories (in
-the domain driven design sense) in the `.swamp/` directory. This is the internal
-format for swamp data.
+Source-of-truth files live in top-level directories tracked in git:
 
-Both agents and humans are free to explore the `.swamp/` directory, but it is
-laid out in a way that is useful for swamp's internal software architecture.
+- **`models/`** — Model definitions: `models/{normalized-type}/{id}.yaml`
+- **`workflows/`** — Workflow definitions: `workflows/workflow-{id}.yaml`
+- **`vaults/`** — Vault configurations: `vaults/{vault-type}/{id}.yaml`
 
-## Logical view
-
-The swamp repo represents a logical view into the `.swamp/` directory that is
-useful for humans and agents. It is constructed by making symlinks into
-information in the `.swamp/` directory, laid out in ways that make sense for
-exploration of the information.
-
-For example, a person might want to explore the outputs of a given method run on
-a model both from the perspective of that model and from the perspective of the
-workflow that triggered it. There should be a logical directory called 'models'
-that shows the model perspective, and one called 'workflows' that shows it from
-the perspective of workflows and workflow runs.
-
-### Constructing logical views
-
-Logical views should be constructed automatically when any mutation occurs in an
-entity repository, by calling an logical index service that maintains the tree.
-
-So any time a change is made through a given entities repository, the index
-service will analyze the repo and update the logical views, ensuring they are
-always up to date.
+Runtime data (versioned model data, workflow runs, method outputs, secrets) is
+stored through a datastore abstraction. The default datastore uses the `.swamp/`
+directory, but it can be configured to use an external filesystem path or S3.
+See [./datastores.md] for details.
 
 ## Configuration
 
@@ -64,8 +46,11 @@ attributes to control the behaviour of the swamp operations.
 
 ## RepoIndexService
 
-The RepoIndexService is a domain event handler that maintains the logical views
-(read models) whenever aggregate repositories mutate data.
+The RepoIndexService is a domain event handler that responds to aggregate
+repository mutations. It is currently a noop implementation
+(`NoopRepoIndexService`) — the old symlink-based logical views have been
+removed. Domain events are still emitted by repositories and can be used for
+future event-driven features.
 
 ### Domain Events
 
@@ -93,50 +78,35 @@ Aggregate repositories emit domain events when data changes:
 
 When an aggregate repository emits an event:
 
-1. The repository persists the aggregate to the `.swamp/` directory
+1. The repository persists the aggregate (definitions to top-level directories,
+   runtime data to the datastore)
 2. The repository emits the appropriate domain event
-3. The RepoIndexService receives the event
-4. The RepoIndexService updates the relevant logical views (symlinks)
+3. The RepoIndexService receives the event (currently a noop)
 
-### Logical View Structure
+### Directory Structure
 
-The RepoIndexService maintains two primary logical views:
-
-**Model View (`/models/`):**
+**Model definitions (`models/`):**
 
 ```
-/models/{model-name}/
-  definition.yaml              → /.swamp/definitions/{type}/{id}.yaml
-  type/
-    logs/                      → symlinks to data with type=log tag
-    files/                     → symlinks to data with type=file tag
-    resources/                 → symlinks to data with type=resource tag
-  {tag-key}/{tag-value}/       → data organized by custom tag key/value pairs
-  outputs/
-    {method}/                  → /.swamp/outputs/{type}/{method}/
+models/{normalized-type}/{id}.yaml
 ```
 
-See [./models.md] for detailed data structure including versioning, metadata,
-and data tags.
+These are real files (not symlinks) tracked in git.
 
-**Workflow View (`/workflows/`):**
+**Workflow definitions (`workflows/`):**
 
 ```
-/workflows/{workflow-name}/
-  workflow.yaml              → /.swamp/workflows/workflow-{id}.yaml
-  runs/
-    latest/                  → {latest-timestamp}/
-    {timestamp}/
-      run.yaml               → /.swamp/workflow-runs/{workflow-id}/workflow-run-{run-id}.yaml
-      steps/
-        {step-name}/
-          output.yaml        → symlink to step output
-          model/             → ../models/{model-name}/ (for model method steps)
+workflows/workflow-{id}.yaml
 ```
 
-### Symlink Naming Conventions
+These are real files (not symlinks) tracked in git.
 
-- Model logical views use the model's unique `name` as the directory name
-- Workflow logical views use the workflow's unique `name` as the directory name
-- Run directories use a shortened run ID or timestamp-based identifier
-- All symlinks point to absolute paths within the `.swamp/` directory
+**Runtime data (datastore, default `.swamp/`):**
+
+```
+.swamp/data/{normalized-type}/{model-id}/{data-name}/{version}/
+.swamp/outputs/{normalized-type}/{method}/{definition-id}-{timestamp}.yaml
+.swamp/workflow-runs/{workflow-id}/{run-id}.yaml
+```
+
+See [./datastores.md] for how the datastore path is resolved.

--- a/design/vaults.md
+++ b/design/vaults.md
@@ -10,7 +10,7 @@ retrieval and storage during workflow execution.
 The vault system is built around a named vault architecture where:
 
 - **Named Vaults**: Each vault instance has a user-defined name configured in
-  `/.swamp/vault/{vault type}/{id}.yaml`
+  `vaults/{vault-type}/{id}.yaml`
 - **Vault Types**: The underlying storage system (AWS Secrets Manager, HashiCorp
   Vault, etc.) is specified per vault
 - **Clean Interface**: All vaults implement a common interface for consistent
@@ -18,46 +18,26 @@ The vault system is built around a named vault architecture where:
 - **Expression Integration**: Vaults are accessed through CEL expressions using
   `${{ vault.get(vault_name, key) }}` syntax
 
-## Logical Views
-
-The RepoIndexService maintains a vault-centric logical view at `/vaults/` that
-provides human/agent-friendly exploration of vaults by name.
-
-### Vault View Structure
-
-```
-/vaults/{vault-name}/
-  vault.yaml   → symlink to /.swamp/vault/{vault-type}/{id}.yaml
-  secrets/     → symlink to /.swamp/secrets/{vault-type}/{vault-name}/ (local vaults only)
-```
-
-Since vault names are unique across all types, the logical view uses a flat
-structure that allows exploring vault definitions using human-readable names
-without needing to know the vault type.
-
-For vault types that store secrets locally (e.g., `local_encryption`), a
-`secrets/` symlink is included to provide access to the encrypted secret files.
-Remote vault types (e.g., `aws`) do not have a local secrets directory.
-
 ## Secret Storage
 
-Vault secrets are stored in `.swamp/secrets/` organized by vault type and name:
+Vault secrets are stored in the datastore `secrets/` directory (default
+`.swamp/secrets/`), organized by vault type and name:
 
 ```
-.swamp/
-├── vault/
-│   └── {vault-type}/
-│       └── {id}.yaml              # Vault configuration
-└── secrets/
-    └── {vault-type}/
-        └── {vault-name}/
-            ├── .key               # Encryption key (for local_encryption with auto_generate)
-            └── {secret-key}.enc   # Encrypted secret files
+vaults/
+  {vault-type}/
+    {id}.yaml                        # Vault configuration (top-level, tracked in git)
+
+.swamp/secrets/                      # Datastore path (default)
+  {vault-type}/
+    {vault-name}/
+      .key                           # Encryption key (for local_encryption with auto_generate)
+      {secret-key}.enc               # Encrypted secret files
 ```
 
-The secrets path is computed at runtime from `base_dir` + vault type + vault
-name. The vault configuration stores the `base_dir` (repository root), and the
-full path is derived as `{base_dir}/.swamp/secrets/{vault-type}/{vault-name}/`.
+The secrets path is computed at runtime through the datastore path resolver. The
+vault configuration stores the `base_dir` (repository root), and the full path
+is derived through the datastore abstraction. See [./datastores.md] for details.
 
 ## Vault Provider Interface
 

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -18,13 +18,14 @@ weighted topological sort, so thtat htye have maximum paralleism through the
 workflow. Like steps, jobs also have conditions that trigger them.
 
 Workflows are specified in YAML files, that are validated with Zod, in the
-`/.swamp/workflows/` directory of the repository, with their `{uuid}.yaml`.
-Workflow run output is stored in `/.swamp/workflow-runs/` at
-`/.swamp/workflow-runs/{workflow-uuid}/{run-uuid}.yaml`.
+top-level `workflows/` directory of the repository, as
+`workflows/workflow-{uuid}.yaml`. Workflow run output is stored in the datastore
+at `workflow-runs/{workflow-uuid}/{run-uuid}.yaml` (default path:
+`.swamp/workflow-runs/`).
 
 ## Workflow Definition
 
-Workflows are specified in `/.swamp/workflows/{uuid}.yaml`. They have a unique
+Workflows are specified in `workflows/workflow-{uuid}.yaml`. They have a unique
 id, a globally unique name, a set of jobs, and optionally workflow inputs.
 
 ### Workflow Inputs
@@ -145,7 +146,7 @@ steps:
 With `environments: ["dev", "staging", "prod"]`, the above produces:
 
 ```
-.swamp/data/scanner/{id}/
+data/scanner/{id}/
   result-dev/
     1/content.json
     latest → 1
@@ -184,45 +185,11 @@ order should be topologically sorted for dependencies, and weighted so it does
 not vary between identical inputs. (If the inputs are identical, the run order
 should be deterministic.)
 
-The output of the run will be written to a workflow run log, kept in
-`/.swamp/workflow-runs/{workflow-uuid}/{run-uuid}.yaml`.
+The output of the run will be written to a workflow run log, kept in the
+datastore at `workflow-runs/{workflow-uuid}/{run-uuid}.yaml` (default path:
+`.swamp/workflow-runs/`).
 
-## Logical Views
-
-The RepoIndexService maintains a workflow-centric logical view at `/workflows/`
-that provides human/agent-friendly exploration of workflows by name.
-
-### Workflow View Structure
-
-```
-/workflows/{workflow-name}/
-  workflow.yaml   → symlink to /.swamp/workflows/{uuid}.yaml
-  runs/
-    {run-id}/
-      run.yaml    → symlink to /.swamp/workflow-runs/{workflow-uuid}/{run-uuid}.yaml
-      steps/
-        {step-name}/
-          output.yaml → symlink to step output
-          model/      → symlink to /models/{model-name}/ (for model method steps)
-```
-
-This structure allows exploring workflow definitions and their run history using
-human-readable names.
-
-### Cross-View References
-
-When a workflow step executes a model method, the data appears in both views:
-
-- **Model view:** `/models/{model-name}/outputs/{method}/` contains the method
-  output and generated data
-- **Workflow view:** `/workflows/{workflow-name}/runs/{run-id}/steps/{step}/`
-  contains a symlink to the same output, plus a reference to the model's logical
-  view
-
-This enables exploration from either the model's perspective or the workflow's
-perspective.
-
-### Domain Events
+## Domain Events
 
 The WorkflowRepository and WorkflowRunRepository emit domain events:
 
@@ -239,6 +206,5 @@ The WorkflowRepository and WorkflowRunRepository emit domain events:
 - `WorkflowRunCompleted` - Emitted when a workflow run completes successfully
 - `WorkflowRunFailed` - Emitted when a workflow run fails
 
-The RepoIndexService subscribes to these events and updates the logical views
-accordingly, ensuring the `/workflows/` view stays synchronized with the data
-directory.
+The RepoIndexService subscribes to these events (currently a noop
+implementation). See [./repo.md] for details on domain events.


### PR DESCRIPTION
docs: remove logical views and fix .swamp/ references in design docs

## Summary

The datastore refactor moved source-of-truth files from `.swamp/` to top-level `models/`, `workflows/`, `vaults/` directories and replaced symlink-based "logical views" with a `NoopRepoIndexService`. The design docs were stale — they still referenced logical views and `.swamp/` as the canonical storage for definitions/workflows/vaults.

This PR updates all 9 design docs to reflect the current architecture:

- **high-level.md**: Replace `.swamp/` aggregate storage + logical views with top-level source-of-truth dirs + datastore
- **repo.md**: Remove `.swamp/` internal storage and logical view sections; document `NoopRepoIndexService`; replace symlink directory structure with real file layout
- **agent.md**: Replace logical views + `.swamp/` direct access with source-of-truth directories + datastore + CLI abstraction
- **models.md**: Fix definition paths (`models/`), data paths (datastore), output paths (datastore); remove logical views section
- **workflow.md**: Fix workflow paths (`workflows/`), run paths (datastore), data paths (datastore); remove logical views section
- **vaults.md**: Fix vault config path (`vaults/{type}/{id}.yaml`); remove logical views; update secret storage to note datastore paths
- **expressions.md**: Add datastore path notes for `data/` and evaluated directories
- **extension.md**: Note `.swamp/bundles/` as a datastore path
- **datastores.md**: Emphasize source-of-truth files are always top-level

## Test plan

- [x] All paths verified against `src/infrastructure/persistence/paths.ts`, `src/cli/repo_context.ts`, and repository implementations
- [x] No remaining stale references to `/.swamp/definitions/`, `/.swamp/workflows/`, or `/.swamp/vault/`
- [x] Remaining "symlink" references are appropriate (latest data symlinks, extension safety checks, noop explanation)
- [ ] Docs-only change — no code changes, no tests/compilation needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
