### PR TITLE
fix: add rollback and depth warning to data rename

### DIFF
--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -1027,11 +1027,16 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
           newVersion,
         );
         await Deno.remove(newVersionDir, { recursive: true });
-        // If this was the only version, clean up the data name directory
+        // If this was the only version, clean up the data name directory.
+        // Otherwise, reset the latest marker to the highest remaining version
+        // to avoid a corrupted marker pointing to the deleted version.
         const remaining = await this.listVersions(type, modelId, newName);
         if (remaining.length === 0) {
           const dataNameDir = this.getDataNameDir(type, modelId, newName);
           await Deno.remove(dataNameDir, { recursive: true }).catch(() => {});
+        } else {
+          const maxRemaining = Math.max(...remaining);
+          await this.updateLatestMarker(type, modelId, newName, maxRemaining);
         }
       } catch (rollbackError) {
         logger


### PR DESCRIPTION
## Summary

Addresses two findings from the adversarial review of #689 (data rename feature):

- **Non-atomic rename rollback**: The rename operation has two write phases — save new data, then write tombstone. If the tombstone write fails (e.g., disk full, permission error), the system was left with both names pointing to valid active data and no forward reference. Now wraps the tombstone phase in try/catch and rolls back the newly saved data on failure, removing the version directory and cleaning up the data name directory if it was the only version.

- **Deep rename chain warning**: When forward-reference depth exceeds 5 (e.g., A→B→C→D→E→F), `findByName` was silently returning null. Now logs a warning: `Rename chain depth exceeded for "<name>" (model <id>). Data exists but is unreachable — simplify the rename chain.` This applies to both the async and sync code paths.

## Test plan

- [x] `deno fmt` — passed
- [x] `deno lint` — passed  
- [x] `deno check` — passed
- [x] `deno run test` — 2835 passed, 0 failed
- [x] `deno run compile` — successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)