### PR TITLE
docs: document instance name uniqueness constraint (#661)

### DIFF
--- a/.claude/skills/swamp-extension-model/references/api.md
+++ b/.claude/skills/swamp-extension-model/references/api.md
@@ -26,13 +26,31 @@ Write structured JSON data:
 | Parameter      | Description                                                     |
 | -------------- | --------------------------------------------------------------- |
 | `specName`     | Must match a key in the model's `resources`                     |
-| `instanceName` | The instance name (any non-empty string)                        |
+| `instanceName` | The instance name (must be unique across all specs — see below) |
 | `data`         | JSON data to write (validated against the resource's Zod schema |
 | `overrides`    | Optional overrides (see below)                                  |
 
 Data is validated against the resource's Zod schema (warns on mismatch, doesn't
 throw). The `instanceName` you pass here is used in CEL:
 `model.<defName>.resource.<specName>.<instanceName>.attributes.<field>`.
+
+**Instance name uniqueness:** Instance names map directly to storage paths on
+disk. If two different specs use the same instance name (e.g.,
+`writeResource("summary", "bixu", ...)` and
+`writeResource("repo", "bixu", ...)`), the second write overwrites the first.
+When a model has multiple resource specs, prefix instance names with the spec
+name or use another strategy to ensure uniqueness across all specs within a
+method execution.
+
+```typescript
+// Wrong — "bixu" collides across specs on disk
+await context.writeResource("summary", "bixu", summaryData);
+await context.writeResource("repo", "bixu", repoData); // overwrites!
+
+// Correct — prefix ensures unique storage paths
+await context.writeResource("summary", `summary-${user}`, summaryData);
+await context.writeResource("repo", `repo-${repo}`, repoData);
+```
 
 **ResourceWriteOverrides** (optional):
 

--- a/.claude/skills/swamp-extension-model/references/troubleshooting.md
+++ b/.claude/skills/swamp-extension-model/references/troubleshooting.md
@@ -111,6 +111,29 @@ The same method name appears in multiple elements of the `methods` array within
 a single extension file. Each method name must be unique across all array
 elements.
 
+### "Duplicate data instance name"
+
+This error occurs when two `writeResource` or `createFileWriter` calls within
+the same method execution use the same instance name, even across different
+specs. Instance names map to storage paths on disk — the path has no spec
+component, so `writeResource("summary", "bixu", ...)` and
+`writeResource("repo", "bixu", ...)` both write to the same `bixu/` directory,
+and the second overwrites the first.
+
+**Fix:** Use unique instance names across all specs within a method. Prefix with
+the spec name or another distinguishing value:
+
+```typescript
+// Wrong — same instance name across specs
+await context.writeResource("summary", user.name, summaryData);
+await context.writeResource("repo", repo.name, repoData);
+// Fails when user.name === repo.name (e.g., both are "bixu")
+
+// Correct — prefix ensures uniqueness
+await context.writeResource("summary", `summary-${user.name}`, summaryData);
+await context.writeResource("repo", `repo-${repo.name}`, repoData);
+```
+
 ### "No such key: &lt;specName&gt;" in CEL expressions
 
 This occurs when a CEL expression like


### PR DESCRIPTION
## Summary

- Documents that instance names must be unique across all specs within a method execution, since they map directly to storage paths on disk with no spec component
- Adds a "Duplicate data instance name" troubleshooting entry with the fix pattern (prefix instance names)
- Updates the `writeResource` API docs to call out the uniqueness constraint

This is a **skills/docs-only change** — no code changes. After investigating #661, we determined this is by-design behavior: instance names map to storage paths on disk (`.swamp/data/{type}/{model}/{instanceName}/`), and there's no spec component in the path. The duplicate name validation exists to catch collisions before they silently overwrite data. The gap was in our documentation, not the code.

## Test plan

- [ ] Verify skill docs render correctly
- [ ] No code changes, no tests to run

🤖 Generated with [Claude Code](https://claude.com/claude-code)