### PR TITLE
docs: document extension npm dep bundling strategy

### DIFF
--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -572,6 +572,7 @@ This repository is managed with [swamp](https://github.com/systeminit/swamp).
 3. **Use the data model.** Once data exists in a model (via \`lookup\`, \`start\`, \`sync\`, etc.), reference it with CEL expressions. Don't re-fetch data that's already available.
 4. **CEL expressions everywhere.** Wire models together with CEL expressions. Always prefer \`data.latest("<name>", "<dataName>").attributes.<field>\` over the deprecated \`model.<name>.resource.<spec>.<instance>.attributes.<field>\` pattern.
 5. **Verify before destructive operations.** Always \`swamp model get <name> --json\` and verify resource IDs before running delete/stop/destroy methods.
+6. **Extension npm deps are bundled, not lockfile-tracked.** Swamp's bundler inlines all npm packages (except zod) into extension bundles at bundle time. \`deno.lock\` and \`package.json\` do NOT cover extension model dependencies — this is by design. Always pin explicit versions in \`npm:\` import specifiers (e.g., \`npm:lodash-es@4.17.21\`).
 
 ## Skills
 


### PR DESCRIPTION
## Summary

- Add Rule 6 to the generated CLAUDE.md template explaining that extension npm dependencies are inlined by swamp's bundler at bundle time and are not tracked in `deno.lock` or `package.json`
- Prevents AI code reviewers (pi-judge, Claude, etc.) from flagging missing lockfile entries as a reproducibility gap

Closes #617

## Test Plan

- `deno check` passes
- `deno lint` passes
- `deno fmt` passes
- 77/77 repo_service tests pass
- `deno run compile` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)