### PR TITLE
fix: warn when check has empty appliesTo array

### DIFF
--- a/src/domain/models/validation_service.ts
+++ b/src/domain/models/validation_service.ts
@@ -862,6 +862,11 @@ export class DefaultModelValidationService implements ModelValidationService {
       const availableMethods = new Set(Object.keys(modelDef.methods));
       for (const [checkName, check] of Object.entries(modelDef.checks)) {
         if (check.appliesTo) {
+          if (check.appliesTo.length === 0) {
+            errors.push(
+              `Check "${checkName}" has empty appliesTo array — it will never run. Remove appliesTo to run on all mutating methods`,
+            );
+          }
           for (const methodName of check.appliesTo) {
             if (!availableMethods.has(methodName)) {
               errors.push(

--- a/src/domain/models/validation_service_test.ts
+++ b/src/domain/models/validation_service_test.ts
@@ -1442,3 +1442,32 @@ Deno.test("validateModel warns when appliesTo references nonexistent method", as
   assertStringIncludes(selResult?.error ?? "", "creat");
   assertStringIncludes(selResult?.error ?? "", "unknown method");
 });
+
+Deno.test("validateModel warns when appliesTo is empty array", async () => {
+  const service = new DefaultModelValidationService();
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: { message: "hello" },
+  });
+
+  const model: ModelDefinition = {
+    ...testModelWithChecks,
+    checks: {
+      "dead-check": {
+        description: "Empty appliesTo means it never runs",
+        appliesTo: [],
+        execute: () => Promise.resolve({ pass: true }),
+      },
+    },
+  };
+
+  const results = await service.validateModel(
+    definition,
+    model,
+  );
+
+  const selResult = results.find((r) => r.name === "Check selection");
+  assertEquals(selResult?.passed, false);
+  assertStringIncludes(selResult?.error ?? "", "empty appliesTo");
+  assertStringIncludes(selResult?.error ?? "", "will never run");
+});


### PR DESCRIPTION
## Summary

- Adds validation warning when a check has `appliesTo: []` (empty array), which silently disables the check since no method name can match
- The warning message tells the author to either remove `appliesTo` or populate it with method names

Addresses review feedback from #697.

## Review comment #2 (execution order)

The second comment about non-deterministic check execution order across extension loads is acknowledged but not actioned. Checks are documented as stateless and independent — order should not matter. `Object.entries` preserves insertion order per spec, and extension merging via spread is deterministic for a given set of extensions.

## Test plan

- [x] New test: `validateModel warns when appliesTo is empty array`
- [x] All 56 validation service tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)