### PR TITLE
fix: add 'install' as alias for 'extension pull'

### DIFF
--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -849,6 +849,7 @@ export async function pullExtension(
 
 export const extensionPullCommand = new Command()
   .name("pull")
+  .alias("install")
   .description("Pull an extension from the swamp registry")
   .arguments("<extension:string>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })


### PR DESCRIPTION
## Summary

- Add `.alias("install")` to the `extension pull` command so `swamp extension install` works as expected
- AI agents naturally try `swamp extension install` which previously failed with a confusing error

Closes #702

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `swamp extension --help` shows `pull, install` in the command list
- [x] `swamp extension install <ext>` routes to the pull handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)