### PR TITLE
feat: add readResource() to MethodContext

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -200,6 +200,7 @@ execute: (async (args, context) => {
   // context.logger         - LogTape Logger
   // context.dataRepository - For advanced data operations
   // context.writeResource  - Write structured JSON data
+  // context.readResource   - Read stored JSON data by instance name
   // context.createFileWriter - Create a writer for files
 
   const handle = await context.writeResource("result", "main", {
@@ -297,14 +298,13 @@ Models that manage real resources typically have `create`, `update`, `delete`,
 and `sync` methods:
 
 - **`create`** — run a command/API call, store the result via `writeResource()`
-- **`update`** — read stored data via `context.dataRepository.getContent()`,
-  modify the resource, write updated state
-- **`delete`** — read stored data, clean up the resource, return
-  `{ dataHandles: [] }`
-- **`sync`** — read stored resource ID via
-  `context.dataRepository.getContent()`, call the live provider API to get
-  current state, write refreshed state via `writeResource()` (or mark as
-  `not_found` if the resource is gone)
+- **`update`** — read stored data via `context.readResource()`, modify the
+  resource, write updated state
+- **`delete`** — read stored data via `context.readResource()`, clean up the
+  resource, return `{ dataHandles: [] }`
+- **`sync`** — read stored resource ID via `context.readResource()`, call the
+  live provider API to get current state, write refreshed state via
+  `writeResource()` (or mark as `not_found` if the resource is gone)
 
 Unlike `get` (which requires the user to provide the resource ID as an
 argument), `sync` reads the ID from already-stored state, making it zero-arg.
@@ -329,10 +329,10 @@ model.
   returns complete state synchronously.
 
 - **[Idempotent creates](references/examples.md#idempotent-creates)** — Check
-  `context.dataRepository.getContent()` for existing state before creating, to
-  avoid duplicates on workflow re-runs. Useful for non-idempotent APIs
-  (droplets, EC2 instances). Not needed when the API is naturally idempotent
-  (tags, S3 buckets) or you intentionally want multiple instances.
+  `context.readResource()` for existing state before creating, to avoid
+  duplicates on workflow re-runs. Useful for non-idempotent APIs (droplets, EC2
+  instances). Not needed when the API is naturally idempotent (tags, S3 buckets)
+  or you intentionally want multiple instances.
 
 ## Pre-flight Checks
 

--- a/.claude/skills/swamp-extension-model/references/api.md
+++ b/.claude/skills/swamp-extension-model/references/api.md
@@ -162,25 +162,40 @@ The execute function returns `{ dataHandles?: DataHandle[] }`.
 ## Reading Stored Data
 
 Delete and update methods need to read back previously stored resource data
-(e.g., to get a resource ID for cleanup). Use `context.dataRepository` with
-`context.modelType` and `context.modelId`:
+(e.g., to get a resource ID for cleanup). Use `context.readResource()`:
+
+```typescript
+const data = await context.readResource!("<instanceName>");
+if (!data) {
+  throw new Error("No data found - nothing to delete");
+}
+// data is Record<string, unknown> — the parsed JSON object
+```
+
+**Signature:**
+
+```typescript
+readResource(
+  instanceName: string,  // instance name used when writing
+  version?: number,      // optional specific version (defaults to latest)
+): Promise<Record<string, unknown> | null>
+```
+
+- Returns the parsed JSON object, or `null` if no data exists
+- Vault reference expressions are returned as-is (not resolved)
+
+**Low-level alternative for binary data:**
+
+For non-JSON content (binary files, raw bytes), use `context.dataRepository`
+directly:
 
 ```typescript
 const content = await context.dataRepository.getContent(
   context.modelType,
   context.modelId,
-  "<instanceName>", // instance name used when writing
+  "<instanceName>",
 );
 // Returns Uint8Array | null
-```
-
-To parse the content:
-
-```typescript
-if (!content) {
-  throw new Error("No data found - nothing to delete");
-}
-const data = JSON.parse(new TextDecoder().decode(content));
 ```
 
 **Key dataRepository methods for model authors:**

--- a/.claude/skills/swamp-extension-model/references/examples.md
+++ b/.claude/skills/swamp-extension-model/references/examples.md
@@ -183,17 +183,12 @@ export const model = {
         const region = context.globalArgs.region;
 
         // 1. Read stored data to get the resource ID
-        const content = await context.dataRepository.getContent(
-          context.modelType,
-          context.modelId,
-          "vpc",
-        );
+        const existingData = await context.readResource!("vpc");
 
-        if (!content) {
+        if (!existingData) {
           throw new Error("No VPC data found - run create first");
         }
 
-        const existingData = JSON.parse(new TextDecoder().decode(content));
         const vpcId = existingData.VpcId;
 
         // 2. Modify the resource
@@ -245,17 +240,12 @@ export const model = {
         const region = context.globalArgs.region;
 
         // Read back stored data to get the VPC ID
-        const content = await context.dataRepository.getContent(
-          context.modelType,
-          context.modelId,
-          "vpc",
-        );
+        const vpcData = await context.readResource!("vpc");
 
-        if (!content) {
+        if (!vpcData) {
           throw new Error("No VPC data found - nothing to delete");
         }
 
-        const vpcData = JSON.parse(new TextDecoder().decode(content));
         const vpcId = vpcData.VpcId;
 
         const cmd = new Deno.Command("aws", {
@@ -283,17 +273,12 @@ export const model = {
         const region = context.globalArgs.region;
 
         // 1. Read stored data to get the VPC ID
-        const content = await context.dataRepository.getContent(
-          context.modelType,
-          context.modelId,
-          "vpc",
-        );
+        const existingData = await context.readResource!("vpc");
 
-        if (!content) {
+        if (!existingData) {
           throw new Error("No VPC data found - run create first");
         }
 
-        const existingData = JSON.parse(new TextDecoder().decode(content));
         const vpcId = existingData.VpcId;
 
         // 2. Call the live API to get current state
@@ -345,8 +330,8 @@ export const model = {
   via CEL expressions and to update/delete/sync methods via `dataRepository`
 - `update` reads stored data, modifies the resource, writes updated state via
   `writeResource` (creates a new version)
-- `delete` reads stored data via `context.dataRepository.getContent()` using
-  `context.modelType` and `context.modelId` to locate the model's own data
+- `delete` reads stored data via `context.readResource()` to locate the model's
+  own data
 - `delete` returns `{ dataHandles: [] }` since no new data is produced
 - `sync` reads the stored resource ID (zero-arg — no user input needed), calls
   the live API, and writes refreshed state or a `not_found` marker for drift
@@ -666,15 +651,10 @@ export const model = {
         const instanceName = "main";
 
         // 1. Check if we already have state for this instance
-        const existing = await context.dataRepository.getContent(
-          context.modelType,
-          context.modelId,
-          instanceName,
-        );
+        const existing = await context.readResource!(instanceName);
 
         if (existing) {
-          const state = JSON.parse(new TextDecoder().decode(existing));
-          const id = state.id;
+          const id = existing.id;
 
           // 2. Verify the resource still exists at the provider
           try {
@@ -729,8 +709,8 @@ export const model = {
 
 **Key points:**
 
-- `context.dataRepository.getContent()` is the primitive — it's already
-  available in every model method, no framework changes needed
+- `context.readResource()` reads stored JSON data by instance name — returns
+  parsed object or `null` if no data exists
 - The idempotency check verifies the resource **still exists at the provider**,
   not just that local data exists — this prevents stale data from blocking
   creation after a resource is externally deleted
@@ -760,17 +740,12 @@ sync: {
     const instanceName = "main";
 
     // 1. Read stored state to get the resource ID
-    const existing = await context.dataRepository.getContent(
-      context.modelType,
-      context.modelId,
-      instanceName,
-    );
+    const state = await context.readResource!(instanceName);
 
-    if (!existing) {
+    if (!state) {
       throw new Error("No stored state — run create first");
     }
 
-    const state = JSON.parse(new TextDecoder().decode(existing));
     const id = state.id; // Adapt to your identifier field (VpcId, Name, etc.)
 
     // 2. Call the live API

--- a/.claude/skills/swamp-extension-model/references/scenarios.md
+++ b/.claude/skills/swamp-extension-model/references/scenarios.md
@@ -108,17 +108,12 @@ export const model = {
       arguments: z.object({}),
       execute: async (_args, context) => {
         // Read stored customer ID
-        const content = await context.dataRepository.getContent(
-          context.modelType,
-          context.modelId,
-          "primary",
-        );
+        const stored = await context.readResource!("primary");
 
-        if (!content) {
+        if (!stored) {
           throw new Error("No customer found - run create first");
         }
 
-        const stored = JSON.parse(new TextDecoder().decode(content));
         const customerId = stored.id;
 
         const response = await fetch(
@@ -206,7 +201,7 @@ swamp model type search S3 → no local results
 swamp extension search S3 → no community extension
 No existing model → Create extension model
 Full lifecycle management → create, update, delete methods
-Update reads existing state → Use dataRepository.getContent
+Update reads existing state → Use context.readResource
 Delete cleans up → Return empty dataHandles
 Detect drift → sync method reads stored ID, refreshes from live API
 ```
@@ -299,13 +294,9 @@ export const model = {
         const { bucketName, versioning } = context.globalArgs;
 
         // Read existing data
-        const content = await context.dataRepository.getContent(
-          context.modelType,
-          context.modelId,
-          "main",
-        );
+        const existingData = await context.readResource!("main");
 
-        if (!content) {
+        if (!existingData) {
           throw new Error("No bucket found - run create first");
         }
 
@@ -325,8 +316,7 @@ export const model = {
           await cmd.output();
         }
 
-        // Re-read and store updated state
-        const existingData = JSON.parse(new TextDecoder().decode(content));
+        // Store updated state
         const updatedData = {
           ...existingData,
           Versioning: versioning ? "Enabled" : "Suspended",
@@ -346,18 +336,12 @@ export const model = {
       arguments: z.object({}),
       execute: async (_args, context) => {
         // Read stored data to get bucket name
-        const content = await context.dataRepository.getContent(
-          context.modelType,
-          context.modelId,
-          "main",
-        );
+        const bucketData = await context.readResource!("main");
 
-        if (!content) {
+        if (!bucketData) {
           context.logger.info("No bucket found - nothing to delete");
           return { dataHandles: [] };
         }
-
-        const bucketData = JSON.parse(new TextDecoder().decode(content));
 
         const cmd = new Deno.Command("aws", {
           args: [
@@ -388,17 +372,12 @@ export const model = {
       arguments: z.object({}),
       execute: async (_args, context) => {
         // Read stored data to get bucket name
-        const content = await context.dataRepository.getContent(
-          context.modelType,
-          context.modelId,
-          "main",
-        );
+        const bucketData = await context.readResource!("main");
 
-        if (!content) {
+        if (!bucketData) {
           throw new Error("No bucket found - run create first");
         }
 
-        const bucketData = JSON.parse(new TextDecoder().decode(content));
         const bucketName = bucketData.Name;
 
         // Check if bucket still exists

--- a/src/domain/drivers/docker_runner.ts
+++ b/src/domain/drivers/docker_runner.ts
@@ -88,6 +88,10 @@ const context = {
       metadata: {},
     };
   },
+  readResource: async (_instanceName, _version) => {
+    console.error("[WARN] readResource is not available in Docker execution mode");
+    return null;
+  },
   createFileWriter: (specName, name) => {
     const chunks = [];
     return {

--- a/src/domain/drivers/raw_execution_driver.ts
+++ b/src/domain/drivers/raw_execution_driver.ts
@@ -32,6 +32,7 @@ import type {
 } from "../models/model.ts";
 import {
   createFileWriterFactory,
+  createResourceReader,
   createResourceWriter,
 } from "../models/data_writer.ts";
 
@@ -116,10 +117,17 @@ export class RawExecutionDriver implements ExecutionDriver {
       this.definition.name,
     );
 
+    const readResource = createResourceReader(
+      this.context.dataRepository,
+      this.context.modelType,
+      this.context.modelId,
+    );
+
     this.contextWithWriters = {
       ...this.context,
       methodName: this.methodName,
       writeResource,
+      readResource,
       createFileWriter,
     };
 

--- a/src/domain/models/data_writer.ts
+++ b/src/domain/models/data_writer.ts
@@ -572,6 +572,46 @@ export function createResourceWriter(
 }
 
 /**
+ * Creates a readResource function bound to a specific execution context.
+ *
+ * The returned function reads previously stored resource data by instance name,
+ * returning the parsed JSON object or null if no data exists.
+ *
+ * @param repo - The unified data repository
+ * @param modelType - The model type
+ * @param modelId - The model ID (definition ID)
+ * @returns A readResource function
+ */
+export function createResourceReader(
+  repo: UnifiedDataRepository,
+  modelType: ModelType,
+  modelId: string,
+): (
+  instanceName: string,
+  version?: number,
+) => Promise<Record<string, unknown> | null> {
+  return async (
+    instanceName: string,
+    version?: number,
+  ): Promise<Record<string, unknown> | null> => {
+    const content = await repo.getContent(
+      modelType,
+      modelId,
+      instanceName,
+      version,
+    );
+    if (!content || content.length === 0) return null;
+    try {
+      return JSON.parse(new TextDecoder().decode(content));
+    } catch {
+      throw new Error(
+        `Failed to parse stored data for instance '${instanceName}': content is not valid JSON`,
+      );
+    }
+  };
+}
+
+/**
  * Creates a createFileWriter function bound to a specific execution context.
  *
  * The returned function creates DefaultDataWriter instances for writing

--- a/src/domain/models/data_writer_test.ts
+++ b/src/domain/models/data_writer_test.ts
@@ -21,6 +21,7 @@ import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import { z } from "zod";
 import {
   createFileWriterFactory,
+  createResourceReader,
   createResourceWriter,
   processSensitiveResourceData,
   sanitizeVaultKey,
@@ -766,6 +767,93 @@ Deno.test("sanitizeVaultKey: replaces slashes with dashes", () => {
 
 Deno.test("sanitizeVaultKey: removes @ prefix", () => {
   assertEquals(sanitizeVaultKey("@user/aws/ec2"), "user-aws-ec2");
+});
+
+// --- createResourceReader tests ---
+
+Deno.test("createResourceReader: returns parsed JSON for existing data", async () => {
+  const data = { name: "test", count: 42 };
+  const encoded = new TextEncoder().encode(JSON.stringify(data));
+  const repo = {
+    ...createMockRepo(),
+    getContent: () => Promise.resolve(encoded),
+  };
+
+  const readResource = createResourceReader(repo, modelType, modelId);
+  const result = await readResource("my-instance");
+  assertEquals(result, { name: "test", count: 42 });
+});
+
+Deno.test("createResourceReader: returns null for missing data", async () => {
+  const repo = createMockRepo();
+  const readResource = createResourceReader(repo, modelType, modelId);
+  const result = await readResource("nonexistent");
+  assertEquals(result, null);
+});
+
+Deno.test("createResourceReader: passes version parameter through to getContent", async () => {
+  let capturedVersion: number | undefined;
+  const data = { value: "versioned" };
+  const encoded = new TextEncoder().encode(JSON.stringify(data));
+  const repo = {
+    ...createMockRepo(),
+    getContent: (
+      _type: ModelType,
+      _modelId: string,
+      _dataName: string,
+      version?: number,
+    ) => {
+      capturedVersion = version;
+      return Promise.resolve(encoded);
+    },
+  };
+
+  const readResource = createResourceReader(repo, modelType, modelId);
+  await readResource("my-instance", 3);
+  assertEquals(capturedVersion, 3);
+});
+
+Deno.test("createResourceReader: preserves vault reference strings as-is", async () => {
+  const data = {
+    name: "my-resource",
+    secret: "vault.get('my-vault', 'my-key')",
+  };
+  const encoded = new TextEncoder().encode(JSON.stringify(data));
+  const repo = {
+    ...createMockRepo(),
+    getContent: () => Promise.resolve(encoded),
+  };
+
+  const readResource = createResourceReader(repo, modelType, modelId);
+  const result = await readResource("my-instance");
+  assertEquals(result?.secret, "vault.get('my-vault', 'my-key')");
+});
+
+Deno.test("createResourceReader: returns null for empty content", async () => {
+  const repo = {
+    ...createMockRepo(),
+    getContent: () => Promise.resolve(new Uint8Array([])),
+  };
+  const readResource = createResourceReader(repo, modelType, modelId);
+  const result = await readResource("empty-instance");
+  assertEquals(result, null);
+});
+
+Deno.test("createResourceReader: throws descriptive error for invalid JSON", async () => {
+  const repo = {
+    ...createMockRepo(),
+    getContent: () =>
+      Promise.resolve(new TextEncoder().encode("{name: invalid")),
+  };
+  const readResource = createResourceReader(repo, modelType, modelId);
+  const err = await assertRejects(
+    () => readResource("bad-instance"),
+    Error,
+  );
+  assertStringIncludes(
+    err.message,
+    "Failed to parse stored data for instance 'bad-instance'",
+  );
 });
 
 Deno.test("sanitizeVaultKey: replaces backslashes", () => {

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -364,6 +364,55 @@ Deno.test("execute error message includes Zod details", async () => {
   }
 });
 
+Deno.test("readResource is available on context during method execution", async () => {
+  const service = new DefaultMethodExecutionService();
+
+  let contextHadReadResource = false;
+  const readTestModel: ModelDefinition = {
+    type: ModelType.create("test/read"),
+    version: "2026.02.09.1",
+    globalArguments: z.object({}),
+    resources: {
+      "item": {
+        description: "Test item",
+        schema: z.object({ value: z.string() }),
+        lifetime: "ephemeral",
+        garbageCollection: 10,
+      },
+    },
+    methods: {
+      check: {
+        description: "Check readResource availability",
+        arguments: z.object({}),
+        execute: (_args: Record<string, unknown>, context) => {
+          contextHadReadResource = typeof context.readResource === "function";
+          return Promise.resolve({});
+        },
+      },
+    },
+  };
+
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: {},
+    methods: { check: { arguments: {} } },
+  });
+
+  const mockReadResource = (
+    _instanceName: string,
+    _version?: number,
+  ): Promise<Record<string, unknown> | null> => Promise.resolve(null);
+
+  const { context } = createTestContext({ readResource: mockReadResource });
+  await service.execute(
+    definition,
+    readTestModel.methods.check,
+    context,
+  );
+
+  assertEquals(contextHadReadResource, true);
+});
+
 // ---------- Workflow Tests ----------
 
 /**

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -214,6 +214,16 @@ export interface MethodContext {
   ) => Promise<DataHandle>;
 
   /**
+   * Read a previously stored resource by instance name.
+   * Returns the parsed JSON object, or null if no data exists.
+   * Vault reference expressions are returned as-is (not resolved).
+   */
+  readResource?: (
+    instanceName: string,
+    version?: number,
+  ) => Promise<Record<string, unknown> | null>;
+
+  /**
    * Create a file writer — returns DataWriter for binary/streaming content.
    */
   createFileWriter?: (


### PR DESCRIPTION
## Summary

- Add symmetric `readResource(instanceName, version?)` convenience method to `MethodContext`, eliminating the `JSON.parse(new TextDecoder().decode(context.dataRepository.getContent(...)))` boilerplate every extension model repeats when reading stored data
- Create `createResourceReader()` factory in `data_writer.ts` alongside the existing `createResourceWriter()` for symmetry
- Wire `readResource` into the raw execution driver and add a stub in the Docker runner (returns `null` with warning since containers lack host data access)
- Update all extension model docs (API reference, SKILL.md, examples, scenarios) to use `readResource` as the preferred read path

## User impact

Extension model authors can now read stored resource data with one call:

```typescript
// Before (every model repeated this)
const content = await context.dataRepository.getContent(
  context.modelType, context.modelId, "vpc");
if (!content) throw new Error("...");
const data = JSON.parse(new TextDecoder().decode(content));

// After
const data = await context.readResource!("vpc");
if (!data) throw new Error("...");
```

Vault reference expressions are returned as-is (not resolved). The low-level `getContent()` remains available for binary data.

## Test plan

- [x] 4 unit tests for `createResourceReader` (happy path, null for missing data, version passthrough, vault reference preservation)
- [x] 1 test verifying `readResource` is available on context during method execution
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] Full test suite passes (2957 tests, 0 failures)
- [x] `deno run compile` succeeds

Closes #709
Closes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Blake Irvin <blakeirvin@me.com>