### PR TITLE
fix: resolve vault expressions in readResource()

### DIFF
--- a/src/domain/drivers/raw_execution_driver.ts
+++ b/src/domain/drivers/raw_execution_driver.ts
@@ -121,6 +121,8 @@ export class RawExecutionDriver implements ExecutionDriver {
       this.context.dataRepository,
       this.context.modelType,
       this.context.modelId,
+      this.context.vaultService,
+      this.context.redactor,
     );
 
     this.contextWithWriters = {

--- a/src/domain/models/data_writer.ts
+++ b/src/domain/models/data_writer.ts
@@ -35,6 +35,7 @@ import type {
 } from "./model.ts";
 import type { GarbageCollectionPolicy, Lifetime } from "../data/mod.ts";
 import type { VaultService } from "../vaults/vault_service.ts";
+import type { SecretRedactor } from "../secrets/mod.ts";
 import {
   extractSensitiveFields,
   getNestedValue,
@@ -572,20 +573,86 @@ export function createResourceWriter(
 }
 
 /**
+ * Regex matching vault expression strings produced by `processSensitiveResourceData()`.
+ * Captures the vault name (group 1) and key (group 2).
+ */
+const VAULT_REF_REGEX =
+  /^\$\{\{\s*vault\.get\(\s*'([^']+)'\s*,\s*'([^']+)'\s*\)\s*\}\}$/;
+
+/**
+ * Recursively walks an object/array and resolves any string values that match
+ * the vault expression pattern `${{ vault.get('name', 'key') }}`.
+ *
+ * Resolved secret values are registered with the optional `redactor` to prevent
+ * log leakage (mirrors the pattern in `model_resolver.ts`).
+ *
+ * @param data - The object to walk (mutated in place)
+ * @param vaultService - The vault service for retrieving secrets
+ * @param redactor - Optional secret redactor to register resolved values
+ */
+export async function resolveVaultRefsInData(
+  data: Record<string, unknown>,
+  vaultService: VaultService,
+  redactor?: SecretRedactor,
+): Promise<void> {
+  await walkAndResolve(data, vaultService, redactor);
+}
+
+async function walkAndResolve(
+  obj: unknown,
+  vaultService: VaultService,
+  redactor?: SecretRedactor,
+): Promise<unknown> {
+  if (typeof obj === "string") {
+    const match = VAULT_REF_REGEX.exec(obj);
+    if (match) {
+      const [, vaultName, key] = match;
+      const value = await vaultService.get(vaultName, key);
+      redactor?.addSecret(value);
+      return value;
+    }
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    for (let i = 0; i < obj.length; i++) {
+      obj[i] = await walkAndResolve(obj[i], vaultService, redactor);
+    }
+    return obj;
+  }
+
+  if (obj !== null && typeof obj === "object") {
+    const record = obj as Record<string, unknown>;
+    for (const key of Object.keys(record)) {
+      record[key] = await walkAndResolve(record[key], vaultService, redactor);
+    }
+    return record;
+  }
+
+  return obj;
+}
+
+/**
  * Creates a readResource function bound to a specific execution context.
  *
  * The returned function reads previously stored resource data by instance name,
  * returning the parsed JSON object or null if no data exists.
+ * When a VaultService is provided, vault reference expressions are automatically
+ * resolved to their original secret values.
  *
  * @param repo - The unified data repository
  * @param modelType - The model type
  * @param modelId - The model ID (definition ID)
+ * @param vaultService - Optional vault service for resolving vault references
+ * @param redactor - Optional secret redactor to register resolved secrets
  * @returns A readResource function
  */
 export function createResourceReader(
   repo: UnifiedDataRepository,
   modelType: ModelType,
   modelId: string,
+  vaultService?: VaultService,
+  redactor?: SecretRedactor,
 ): (
   instanceName: string,
   version?: number,
@@ -601,13 +668,26 @@ export function createResourceReader(
       version,
     );
     if (!content || content.length === 0) return null;
+    let parsed: unknown;
     try {
-      return JSON.parse(new TextDecoder().decode(content));
+      parsed = JSON.parse(new TextDecoder().decode(content));
     } catch {
       throw new Error(
         `Failed to parse stored data for instance '${instanceName}': content is not valid JSON`,
       );
     }
+    if (
+      parsed === null || typeof parsed !== "object" || Array.isArray(parsed)
+    ) {
+      throw new Error(
+        `Stored data for instance '${instanceName}' is not a JSON object`,
+      );
+    }
+    const data = parsed as Record<string, unknown>;
+    if (vaultService) {
+      await resolveVaultRefsInData(data, vaultService, redactor);
+    }
+    return data;
   };
 }
 

--- a/src/domain/models/data_writer_test.ts
+++ b/src/domain/models/data_writer_test.ts
@@ -24,6 +24,7 @@ import {
   createResourceReader,
   createResourceWriter,
   processSensitiveResourceData,
+  resolveVaultRefsInData,
   sanitizeVaultKey,
 } from "./data_writer.ts";
 import { ModelType } from "./model_type.ts";
@@ -813,10 +814,10 @@ Deno.test("createResourceReader: passes version parameter through to getContent"
   assertEquals(capturedVersion, 3);
 });
 
-Deno.test("createResourceReader: preserves vault reference strings as-is", async () => {
+Deno.test("createResourceReader: preserves vault reference strings without VaultService", async () => {
   const data = {
     name: "my-resource",
-    secret: "vault.get('my-vault', 'my-key')",
+    secret: "${{ vault.get('my-vault', 'my-key') }}",
   };
   const encoded = new TextEncoder().encode(JSON.stringify(data));
   const repo = {
@@ -826,7 +827,89 @@ Deno.test("createResourceReader: preserves vault reference strings as-is", async
 
   const readResource = createResourceReader(repo, modelType, modelId);
   const result = await readResource("my-instance");
-  assertEquals(result?.secret, "vault.get('my-vault', 'my-key')");
+  assertEquals(result?.secret, "${{ vault.get('my-vault', 'my-key') }}");
+});
+
+Deno.test("createResourceReader: resolves vault references when VaultService provided", async () => {
+  const vaultService = createTestVaultService();
+  await vaultService.put("test-vault", "my-key", "resolved-secret");
+
+  const data = {
+    name: "my-resource",
+    secret: "${{ vault.get('test-vault', 'my-key') }}",
+  };
+  const encoded = new TextEncoder().encode(JSON.stringify(data));
+  const repo = {
+    ...createMockRepo(),
+    getContent: () => Promise.resolve(encoded),
+  };
+
+  const readResource = createResourceReader(
+    repo,
+    modelType,
+    modelId,
+    vaultService,
+  );
+  const result = await readResource("my-instance");
+  assertEquals(result?.name, "my-resource");
+  assertEquals(result?.secret, "resolved-secret");
+});
+
+Deno.test("createResourceReader: resolves vault references in nested objects", async () => {
+  const vaultService = createTestVaultService();
+  await vaultService.put("test-vault", "nested-key", "nested-secret");
+
+  const data = {
+    config: {
+      region: "us-east-1",
+      token: "${{ vault.get('test-vault', 'nested-key') }}",
+    },
+  };
+  const encoded = new TextEncoder().encode(JSON.stringify(data));
+  const repo = {
+    ...createMockRepo(),
+    getContent: () => Promise.resolve(encoded),
+  };
+
+  const readResource = createResourceReader(
+    repo,
+    modelType,
+    modelId,
+    vaultService,
+  );
+  const result = await readResource("my-instance");
+  const config = result?.config as Record<string, unknown>;
+  assertEquals(config.region, "us-east-1");
+  assertEquals(config.token, "nested-secret");
+});
+
+Deno.test("createResourceReader: mixed vault and non-vault strings work correctly", async () => {
+  const vaultService = createTestVaultService();
+  await vaultService.put("test-vault", "secret-key", "the-secret");
+
+  const data = {
+    name: "plain-string",
+    secret: "${{ vault.get('test-vault', 'secret-key') }}",
+    count: 42,
+    nested: { flag: true },
+  };
+  const encoded = new TextEncoder().encode(JSON.stringify(data));
+  const repo = {
+    ...createMockRepo(),
+    getContent: () => Promise.resolve(encoded),
+  };
+
+  const readResource = createResourceReader(
+    repo,
+    modelType,
+    modelId,
+    vaultService,
+  );
+  const result = await readResource("my-instance");
+  assertEquals(result?.name, "plain-string");
+  assertEquals(result?.secret, "the-secret");
+  assertEquals(result?.count, 42);
+  assertEquals((result?.nested as Record<string, unknown>).flag, true);
 });
 
 Deno.test("createResourceReader: returns null for empty content", async () => {
@@ -856,6 +939,32 @@ Deno.test("createResourceReader: throws descriptive error for invalid JSON", asy
   );
 });
 
+Deno.test("createResourceReader: throws when stored data is an array", async () => {
+  const repo = {
+    ...createMockRepo(),
+    getContent: () => Promise.resolve(new TextEncoder().encode("[1, 2, 3]")),
+  };
+  const readResource = createResourceReader(repo, modelType, modelId);
+  const err = await assertRejects(
+    () => readResource("array-instance"),
+    Error,
+  );
+  assertStringIncludes(err.message, "is not a JSON object");
+});
+
+Deno.test("createResourceReader: throws when stored data is a primitive", async () => {
+  const repo = {
+    ...createMockRepo(),
+    getContent: () => Promise.resolve(new TextEncoder().encode("42")),
+  };
+  const readResource = createResourceReader(repo, modelType, modelId);
+  const err = await assertRejects(
+    () => readResource("primitive-instance"),
+    Error,
+  );
+  assertStringIncludes(err.message, "is not a JSON object");
+});
+
 Deno.test("sanitizeVaultKey: replaces backslashes", () => {
   assertEquals(sanitizeVaultKey("a\\b\\c"), "a-b-c");
 });
@@ -874,6 +983,90 @@ Deno.test("sanitizeVaultKey: handles full namespaced model type path", () => {
   assertEquals(
     sanitizeVaultKey(raw),
     `user-aws-ec2-keypair-${modelId}-create-KeyMaterial`,
+  );
+});
+
+// --- resolveVaultRefsInData tests ---
+
+Deno.test("resolveVaultRefsInData: resolves top-level vault expressions", async () => {
+  const vaultService = createTestVaultService();
+  await vaultService.put("test-vault", "k1", "secret-value");
+
+  const data: Record<string, unknown> = {
+    plain: "hello",
+    secret: "${{ vault.get('test-vault', 'k1') }}",
+  };
+
+  await resolveVaultRefsInData(data, vaultService);
+  assertEquals(data.plain, "hello");
+  assertEquals(data.secret, "secret-value");
+});
+
+Deno.test("resolveVaultRefsInData: resolves nested vault expressions", async () => {
+  const vaultService = createTestVaultService();
+  await vaultService.put("test-vault", "nested", "nested-secret");
+
+  const data: Record<string, unknown> = {
+    outer: {
+      inner: "${{ vault.get('test-vault', 'nested') }}",
+      keep: "unchanged",
+    },
+  };
+
+  await resolveVaultRefsInData(data, vaultService);
+  const outer = data.outer as Record<string, unknown>;
+  assertEquals(outer.inner, "nested-secret");
+  assertEquals(outer.keep, "unchanged");
+});
+
+Deno.test("resolveVaultRefsInData: resolves vault expressions in arrays", async () => {
+  const vaultService = createTestVaultService();
+  await vaultService.put("test-vault", "arr-key", "arr-secret");
+
+  const data: Record<string, unknown> = {
+    items: ["plain", "${{ vault.get('test-vault', 'arr-key') }}"],
+  };
+
+  await resolveVaultRefsInData(data, vaultService);
+  assertEquals(data.items, ["plain", "arr-secret"]);
+});
+
+Deno.test("resolveVaultRefsInData: does not modify non-matching strings", async () => {
+  const vaultService = createTestVaultService();
+
+  const data: Record<string, unknown> = {
+    normal: "just a string",
+    partial: "prefix ${{ vault.get('x', 'y') }} suffix",
+    number: 42,
+    flag: true,
+    nothing: null,
+  };
+
+  await resolveVaultRefsInData(data, vaultService);
+  assertEquals(data.normal, "just a string");
+  // Partial match should NOT resolve (regex requires full-string match)
+  assertEquals(data.partial, "prefix ${{ vault.get('x', 'y') }} suffix");
+  assertEquals(data.number, 42);
+  assertEquals(data.flag, true);
+  assertEquals(data.nothing, null);
+});
+
+Deno.test("resolveVaultRefsInData: registers resolved secrets with redactor", async () => {
+  const { SecretRedactor } = await import("../secrets/mod.ts");
+  const vaultService = createTestVaultService();
+  await vaultService.put("test-vault", "redact-key", "super-secret");
+
+  const redactor = new SecretRedactor();
+  const data: Record<string, unknown> = {
+    secret: "${{ vault.get('test-vault', 'redact-key') }}",
+  };
+
+  await resolveVaultRefsInData(data, vaultService, redactor);
+  assertEquals(data.secret, "super-secret");
+  assertEquals(redactor.hasSecrets, true);
+  assertEquals(
+    redactor.redact("the value is super-secret here"),
+    "the value is *** here",
   );
 });
 

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -216,7 +216,7 @@ export interface MethodContext {
   /**
    * Read a previously stored resource by instance name.
    * Returns the parsed JSON object, or null if no data exists.
-   * Vault reference expressions are returned as-is (not resolved).
+   * Vault reference expressions are automatically resolved when a vault service is available.
    */
   readResource?: (
     instanceName: string,


### PR DESCRIPTION
Closes #710

## Summary

- Add `resolveVaultRefsInData()` to transparently resolve vault expression strings (`${{ vault.get('...', '...') }}`) back to their original secret values when reading resource data via `readResource()`
- Wire `VaultService` and `SecretRedactor` from the execution context into `createResourceReader()` in `RawExecutionDriver`
- Add runtime validation that `JSON.parse` returns a plain object (not an array or primitive), fixing a type safety gap where the `Record<string, unknown>` return type was not enforced

## Why this is needed

When extension models write resource data with sensitive fields, `processSensitiveResourceData()` replaces actual values with vault expression strings like `${{ vault.get('vault-name', 'key') }}`. Before this change, `readResource()` returned these as literal strings, which meant:

1. **Leaked vault internals** — extension authors had to know about and parse vault expression syntax
2. **Confusing errors** — code expecting an API key got a template string instead, causing opaque failures downstream
3. **Broken round-trips** — write a secret, read it back, get something completely different

## How it works

- After JSON parsing, `resolveVaultRefsInData()` recursively walks all string values in the result object
- Strings matching the vault ref pattern (anchored regex — must be the entire string) are resolved via `VaultService.get()`
- Resolved secrets are registered with `SecretRedactor.addSecret()` to prevent log leakage
- Without a `VaultService`, behavior is unchanged (backward compatible)
- The JSON parse type safety fix ensures corrupted/manually-edited data files fail fast with a clear error instead of silently returning wrong types

## Files changed

| File | Change |
|------|--------|
| `src/domain/models/data_writer.ts` | Add `resolveVaultRefsInData()`, update `createResourceReader()` signature and implementation |
| `src/domain/drivers/raw_execution_driver.ts` | Pass `vaultService` and `redactor` to `createResourceReader()` |
| `src/domain/models/model.ts` | Update JSDoc to reflect new behavior |
| `src/domain/models/data_writer_test.ts` | 10 new tests covering vault resolution, backward compat, type safety |

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — no lint errors
- [x] `deno fmt` — properly formatted
- [x] `deno run test` — all 2967 tests pass (48 in data_writer_test.ts)
- [x] `deno run compile` — binary compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Blake Irvin <blakeirvin@me.com>