### PR TITLE
fix: resolve multi-line imports in local_import_resolver

### DIFF
--- a/src/domain/extensions/extension_import_resolver_test.ts
+++ b/src/domain/extensions/extension_import_resolver_test.ts
@@ -141,6 +141,31 @@ Deno.test("resolveLocalImports handles subdirectories", async () => {
   }
 });
 
+Deno.test("resolveLocalImports resolves multi-line imports", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const modelsDir = join(tmpDir, "models");
+    const libDir = join(modelsDir, "_lib");
+    await Deno.mkdir(libDir, { recursive: true });
+    const libFile = join(libDir, "aws.ts");
+    await Deno.writeTextFile(
+      libFile,
+      "export function createResource() {}\nexport function deleteResource() {}\n",
+    );
+    const entryFile = join(modelsDir, "entry.ts");
+    await Deno.writeTextFile(
+      entryFile,
+      `import {\n  createResource,\n  deleteResource,\n} from "./_lib/aws.ts";\nexport const x = createResource;\n`,
+    );
+
+    const result = await resolveLocalImports([entryFile], modelsDir);
+    assertEquals(result.resolvedFiles.sort(), [entryFile, libFile].sort());
+    assertEquals(result.skippedImports, []);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
 Deno.test("resolveLocalImports handles export from statements", async () => {
   const tmpDir = await Deno.makeTempDir();
   try {

--- a/src/domain/models/local_import_resolver.ts
+++ b/src/domain/models/local_import_resolver.ts
@@ -28,7 +28,8 @@ export interface ImportResolverResult {
 }
 
 /** Pattern matching import/export from relative paths. */
-const IMPORT_PATTERN = /(?:import|export)\s+.*?from\s+["'](\.\.?\/[^"']+)["']/g;
+const IMPORT_PATTERN =
+  /(?:import|export)\s+[\s\S]*?from\s+["'](\.\.?\/[^"']+)["']/g;
 
 /**
  * Scans .ts entry points for relative import/export statements and


### PR DESCRIPTION
## Summary

- Fix `IMPORT_PATTERN` regex in `local_import_resolver.ts` to match across newlines (`.*?` → `[\s\S]*?`), resolving #715
- The clover code generator writes multi-line imports (e.g., `import {\n  createResource,\n  deleteResource,\n} from "./_lib/aws.ts"`), which the previous single-line regex silently skipped
- This caused shared dependencies like `_lib/aws.ts` to be excluded from extension packages during `swamp extension push`, making all `@swamp/aws/*` extensions fail on pull with `Module not found` errors

## Changes

- **`src/domain/models/local_import_resolver.ts`**: Changed `IMPORT_PATTERN` from `/(?:import|export)\s+.*?from\s+["'](\.\.?\/[^"']+)["']/g` to `/(?:import|export)\s+[\s\S]*?from\s+["'](\.\.?\/[^"']+)["']/g` so the regex matches import/export statements that span multiple lines
- **`src/domain/extensions/extension_import_resolver_test.ts`**: Added test case `"resolveLocalImports resolves multi-line imports"` that creates a `_lib/aws.ts` dependency imported via a multi-line import statement and verifies it is correctly discovered

## Test plan

- [x] New multi-line import test passes
- [x] All 8 import resolver tests pass
- [x] Full test suite passes (2979 tests)
- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt` — formatting passes
- [x] `deno run compile` — binary compiles successfully

Fixes #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)