### PR TITLE
fix: resolve dual Zod instance in compiled binary

### DIFF
--- a/src/domain/drivers/user_driver_loader.ts
+++ b/src/domain/drivers/user_driver_loader.ts
@@ -18,9 +18,13 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { z } from "zod";
-import { dirname, join, resolve, toFileUrl } from "@std/path";
+import { dirname, join, resolve } from "@std/path";
 import { getLogger } from "@logtape/logtape";
-import { bundleExtension } from "../models/bundle.ts";
+import {
+  bundleExtension,
+  installZodGlobal,
+  rewriteZodImports,
+} from "../models/bundle.ts";
 import { resolveLocalImports } from "../models/local_import_resolver.ts";
 import type { DenoRuntime } from "../runtime/deno_runtime.ts";
 import type { ExecutionDriver } from "./execution_driver.ts";
@@ -98,6 +102,9 @@ export class UserDriverLoader {
    */
   async loadDrivers(driversDir: string): Promise<DriverLoadResult> {
     const result: DriverLoadResult = { loaded: [], failed: [] };
+
+    // Ensure swamp's Zod is available on globalThis before importing bundles.
+    installZodGlobal();
 
     // Check if directory exists
     try {
@@ -232,6 +239,8 @@ export class UserDriverLoader {
     js: string,
     relativePath: string,
   ): Promise<Record<string, unknown>> {
+    const rewritten = rewriteZodImports(js);
+
     if (this.repoDir) {
       const bundlePath = join(
         this.repoDir,
@@ -242,8 +251,14 @@ export class UserDriverLoader {
 
       try {
         await Deno.stat(bundlePath);
-        // Import from file URL — avoids base64 encoding overhead
-        return await import(toFileUrl(bundlePath).href);
+        const cachedJs = await Deno.readTextFile(bundlePath);
+        const rewrittenCached = rewriteZodImports(cachedJs);
+        const encoded = btoa(
+          String.fromCharCode(...new TextEncoder().encode(rewrittenCached)),
+        );
+        return await import(
+          `data:application/javascript;base64,${encoded}`
+        );
       } catch {
         // Fall through to data URL import
       }
@@ -251,7 +266,7 @@ export class UserDriverLoader {
 
     // Fallback: import via base64 data URL
     const encoded = btoa(
-      String.fromCharCode(...new TextEncoder().encode(js)),
+      String.fromCharCode(...new TextEncoder().encode(rewritten)),
     );
     return await import(
       `data:application/javascript;base64,${encoded}`

--- a/src/domain/models/bundle.ts
+++ b/src/domain/models/bundle.ts
@@ -18,8 +18,68 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { getLogger } from "@logtape/logtape";
+import * as zodModule from "zod";
 
 const logger = getLogger(["swamp", "models", "bundle"]);
+
+declare global {
+  var __swamp_zod: typeof zodModule | undefined;
+}
+
+/**
+ * Installs swamp's Zod module on globalThis so that extension bundles
+ * with externalized `import { z } from "npm:zod@4"` (rewritten to
+ * `const { z } = globalThis.__swamp_zod`) share the same Zod instance.
+ *
+ * This prevents dual-instance problems in the compiled binary where
+ * `deno compile` resolves dynamic imports to a separate module instance.
+ */
+export function installZodGlobal(): void {
+  if (!globalThis.__swamp_zod) {
+    globalThis.__swamp_zod = zodModule;
+    logger.debug`Installed Zod global (globalThis.__swamp_zod)`;
+  }
+}
+
+/**
+ * Rewrites externalized Zod imports in a bundle to reference `globalThis.__swamp_zod`.
+ *
+ * Handles:
+ * - Named imports: `import { z } from "npm:zod@4"` → `const { z } = globalThis.__swamp_zod;`
+ * - Aliased imports: `import { z as z2 } from "npm:zod"` → `const { z: z2 } = globalThis.__swamp_zod;`
+ * - Star imports: `import * as zod from "npm:zod@4"` → `const zod = globalThis.__swamp_zod;`
+ * - Already-rewritten lines are left untouched (idempotent).
+ */
+export function rewriteZodImports(js: string): string {
+  // Match: import { ... } from "npm:zod..." or 'npm:zod...'
+  // Captures the named import clause and handles aliased imports
+  const namedImportPattern =
+    /import\s*\{([^}]+)\}\s*from\s*["']npm:zod(?:@[^"']*)?["']\s*;?/g;
+  js = js.replace(namedImportPattern, (_match, imports: string) => {
+    // Convert `z as z2` to `z: z2` for destructuring syntax
+    const destructured = imports
+      .split(",")
+      .map((s: string) => {
+        const parts = s.trim().split(/\s+as\s+/);
+        if (parts.length === 2) {
+          return `${parts[0].trim()}: ${parts[1].trim()}`;
+        }
+        return parts[0].trim();
+      })
+      .filter((s: string) => s.length > 0)
+      .join(", ");
+    return `const { ${destructured} } = globalThis.__swamp_zod;`;
+  });
+
+  // Match: import * as <name> from "npm:zod..."
+  const starImportPattern =
+    /import\s*\*\s*as\s+(\w+)\s+from\s*["']npm:zod(?:@[^"']*)?["']\s*;?/g;
+  js = js.replace(starImportPattern, (_match, name: string) => {
+    return `const ${name} = globalThis.__swamp_zod;`;
+  });
+
+  return js;
+}
 
 /** Options for controlling bundle output. */
 export interface BundleOptions {
@@ -89,12 +149,18 @@ export async function bundleExtension(
       );
     }
 
-    const js = await Deno.readTextFile(tempFile);
+    let js = await Deno.readTextFile(tempFile);
 
     if (!js) {
       throw new Error(
         `deno bundle produced empty output for: ${absolutePath}`,
       );
+    }
+
+    // Rewrite externalized zod imports to use globalThis.__swamp_zod
+    // so extensions share swamp's Zod instance in the compiled binary.
+    if (!options?.selfContained) {
+      js = rewriteZodImports(js);
     }
 
     logger.debug`Bundled ${absolutePath} (${js.length} bytes)`;

--- a/src/domain/models/bundle_test.ts
+++ b/src/domain/models/bundle_test.ts
@@ -20,7 +20,11 @@
 import { assertEquals } from "@std/assert";
 import { join } from "@std/path";
 import { z } from "zod";
-import { bundleExtension } from "./bundle.ts";
+import {
+  bundleExtension,
+  installZodGlobal,
+  rewriteZodImports,
+} from "./bundle.ts";
 
 const DENO_PATH = Deno.execPath();
 
@@ -41,7 +45,11 @@ async function withTempFile(
 async function importBundled(
   js: string,
 ): Promise<Record<string, unknown>> {
-  const encoded = btoa(String.fromCharCode(...new TextEncoder().encode(js)));
+  installZodGlobal();
+  const rewritten = rewriteZodImports(js);
+  const encoded = btoa(
+    String.fromCharCode(...new TextEncoder().encode(rewritten)),
+  );
   return await import(`data:application/javascript;base64,${encoded}`);
 }
 
@@ -170,4 +178,84 @@ export const schema = z.object({ message: z.string() });
     });
     assertEquals(parsed, { message: "hello" });
   });
+});
+
+Deno.test("bundleExtension produces module where z.toJSONSchema works", async () => {
+  const tsCode = `
+import { z } from "npm:zod@4";
+
+export const schema = z.object({ id: z.string(), data: z.unknown() });
+`;
+
+  await withTempFile(tsCode, async (path) => {
+    const js = await bundleExtension(path, DENO_PATH);
+    const mod = await importBundled(js);
+
+    // Should be a ZodType from swamp's Zod instance
+    assertEquals(mod.schema instanceof z.ZodType, true);
+
+    // z.toJSONSchema should work without _zod errors
+    const jsonSchema = z.toJSONSchema(mod.schema as z.ZodTypeAny);
+    assertEquals(jsonSchema.type, "object");
+  });
+});
+
+// --- rewriteZodImports unit tests ---
+
+Deno.test("rewriteZodImports rewrites named imports", () => {
+  const input = `import { z } from "npm:zod@4";`;
+  const result = rewriteZodImports(input);
+  assertEquals(result, `const { z } = globalThis.__swamp_zod;`);
+});
+
+Deno.test("rewriteZodImports rewrites aliased imports", () => {
+  const input = `import { z as z2 } from "npm:zod@4";`;
+  const result = rewriteZodImports(input);
+  assertEquals(result, `const { z: z2 } = globalThis.__swamp_zod;`);
+});
+
+Deno.test("rewriteZodImports rewrites star imports", () => {
+  const input = `import * as zod from "npm:zod@4";`;
+  const result = rewriteZodImports(input);
+  assertEquals(result, `const zod = globalThis.__swamp_zod;`);
+});
+
+Deno.test("rewriteZodImports rewrites unversioned npm:zod", () => {
+  const input = `import { z } from "npm:zod";`;
+  const result = rewriteZodImports(input);
+  assertEquals(result, `const { z } = globalThis.__swamp_zod;`);
+});
+
+Deno.test("rewriteZodImports rewrites multiple zod imports", () => {
+  const input = [
+    `import { z as z2 } from "npm:zod@4";`,
+    `import { z } from "npm:zod@4";`,
+    `console.log(z, z2);`,
+  ].join("\n");
+  const result = rewriteZodImports(input);
+  const expected = [
+    `const { z: z2 } = globalThis.__swamp_zod;`,
+    `const { z } = globalThis.__swamp_zod;`,
+    `console.log(z, z2);`,
+  ].join("\n");
+  assertEquals(result, expected);
+});
+
+Deno.test("rewriteZodImports leaves non-zod imports untouched", () => {
+  const input = `import { parse } from "npm:yaml@2";`;
+  const result = rewriteZodImports(input);
+  assertEquals(result, input);
+});
+
+Deno.test("rewriteZodImports is idempotent", () => {
+  const input = `import { z } from "npm:zod@4";`;
+  const first = rewriteZodImports(input);
+  const second = rewriteZodImports(first);
+  assertEquals(first, second);
+});
+
+Deno.test("rewriteZodImports handles single-quoted specifiers", () => {
+  const input = `import { z } from 'npm:zod@4';`;
+  const result = rewriteZodImports(input);
+  assertEquals(result, `const { z } = globalThis.__swamp_zod;`);
 });

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -18,9 +18,13 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { z } from "zod";
-import { dirname, join, resolve, toFileUrl } from "@std/path";
+import { dirname, join, resolve } from "@std/path";
 import { getLogger } from "@logtape/logtape";
-import { bundleExtension } from "./bundle.ts";
+import {
+  bundleExtension,
+  installZodGlobal,
+  rewriteZodImports,
+} from "./bundle.ts";
 import { resolveLocalImports } from "./local_import_resolver.ts";
 import { ModelType } from "./model_type.ts";
 import { CalVer } from "./calver.ts";
@@ -268,6 +272,10 @@ export class UserModelLoader {
   async loadModels(modelsDir: string): Promise<LoadResult> {
     const result: LoadResult = { loaded: [], extended: [], failed: [] };
 
+    // Ensure swamp's Zod is available on globalThis before importing bundles.
+    // This prevents dual-instance issues in the compiled binary.
+    installZodGlobal();
+
     // Check if directory exists
     try {
       await Deno.stat(modelsDir);
@@ -444,6 +452,11 @@ export class UserModelLoader {
     js: string,
     relativePath: string,
   ): Promise<Record<string, unknown>> {
+    // Rewrite zod imports at import-time as well — catches old cached
+    // bundles that still have raw `import ... from "npm:zod..."` lines.
+    // The rewrite is idempotent so already-rewritten bundles are unaffected.
+    const rewritten = rewriteZodImports(js);
+
     if (this.repoDir) {
       const bundlePath = join(
         this.repoDir,
@@ -454,8 +467,15 @@ export class UserModelLoader {
 
       try {
         await Deno.stat(bundlePath);
-        // Import from file URL — avoids base64 encoding overhead
-        return await import(toFileUrl(bundlePath).href);
+        // Read the file and rewrite at import-time for cached bundles
+        const cachedJs = await Deno.readTextFile(bundlePath);
+        const rewrittenCached = rewriteZodImports(cachedJs);
+        const encoded = btoa(
+          String.fromCharCode(...new TextEncoder().encode(rewrittenCached)),
+        );
+        return await import(
+          `data:application/javascript;base64,${encoded}`
+        );
       } catch {
         // Fall through to data URL import
       }
@@ -463,7 +483,7 @@ export class UserModelLoader {
 
     // Fallback: import via base64 data URL
     const encoded = btoa(
-      String.fromCharCode(...new TextEncoder().encode(js)),
+      String.fromCharCode(...new TextEncoder().encode(rewritten)),
     );
     return await import(
       `data:application/javascript;base64,${encoded}`

--- a/src/domain/vaults/user_vault_loader.ts
+++ b/src/domain/vaults/user_vault_loader.ts
@@ -18,9 +18,13 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { z } from "zod";
-import { dirname, join, resolve, toFileUrl } from "@std/path";
+import { dirname, join, resolve } from "@std/path";
 import { getLogger } from "@logtape/logtape";
-import { bundleExtension } from "../models/bundle.ts";
+import {
+  bundleExtension,
+  installZodGlobal,
+  rewriteZodImports,
+} from "../models/bundle.ts";
 import { resolveLocalImports } from "../models/local_import_resolver.ts";
 import type { DenoRuntime } from "../runtime/deno_runtime.ts";
 import type { VaultProvider } from "./vault_provider.ts";
@@ -98,6 +102,9 @@ export class UserVaultLoader {
    */
   async loadVaults(vaultsDir: string): Promise<VaultLoadResult> {
     const result: VaultLoadResult = { loaded: [], failed: [] };
+
+    // Ensure swamp's Zod is available on globalThis before importing bundles.
+    installZodGlobal();
 
     // Check if directory exists
     try {
@@ -232,6 +239,8 @@ export class UserVaultLoader {
     js: string,
     relativePath: string,
   ): Promise<Record<string, unknown>> {
+    const rewritten = rewriteZodImports(js);
+
     if (this.repoDir) {
       const bundlePath = join(
         this.repoDir,
@@ -242,8 +251,14 @@ export class UserVaultLoader {
 
       try {
         await Deno.stat(bundlePath);
-        // Import from file URL — avoids base64 encoding overhead
-        return await import(toFileUrl(bundlePath).href);
+        const cachedJs = await Deno.readTextFile(bundlePath);
+        const rewrittenCached = rewriteZodImports(cachedJs);
+        const encoded = btoa(
+          String.fromCharCode(...new TextEncoder().encode(rewrittenCached)),
+        );
+        return await import(
+          `data:application/javascript;base64,${encoded}`
+        );
       } catch {
         // Fall through to data URL import
       }
@@ -251,7 +266,7 @@ export class UserVaultLoader {
 
     // Fallback: import via base64 data URL
     const encoded = btoa(
-      String.fromCharCode(...new TextEncoder().encode(js)),
+      String.fromCharCode(...new TextEncoder().encode(rewritten)),
     );
     return await import(
       `data:application/javascript;base64,${encoded}`


### PR DESCRIPTION
## Summary

Fixes #723.

In the compiled binary (`deno compile`), extension bundles with externalized `import { z } from "npm:zod@4"` resolve to a **different Zod module instance** than swamp's own embedded Zod. This causes `instanceof z.ZodType` checks, `z.toJSONSchema()`, and `_zod` property lookups to fail — even though both are the same Zod version (4.3.6). Works fine in dev mode (`deno run`) because Deno resolves both to the same cached module.

## Problem

The `--external npm:zod@4` flag in `deno bundle` was meant to make extensions share swamp's Zod instance. In dev mode, the dynamic `import("npm:zod@4")` in the bundle resolves to the same cached module. But in the compiled binary, `deno compile` resolves it to a separate module instance, breaking:

- `schema instanceof z.ZodType` → `false`
- `z.toJSONSchema(schema)` → `Cannot read properties of undefined (reading '_zod')`
- Any cross-instance Zod operations (`.passthrough()`, `.default()`, etc.)

## Fix

Post-process extension bundles to replace external Zod imports with references to swamp's Zod instance exposed via `globalThis.__swamp_zod`:

**Before** (bundle output):
```js
import { z } from "npm:zod@4";
```

**After** (rewritten):
```js
const { z } = globalThis.__swamp_zod;
```

### Changes

- **`src/domain/models/bundle.ts`**: Add `installZodGlobal()` (sets `globalThis.__swamp_zod` to swamp's Zod module) and `rewriteZodImports()` (regex replaces Zod imports — handles named, aliased, star imports, versioned/unversioned specifiers). Applied in `bundleExtension()` for non-selfContained bundles.
- **`src/domain/models/user_model_loader.ts`**: Call `installZodGlobal()` before loading bundles; apply `rewriteZodImports` at import-time for old cached bundles.
- **`src/domain/drivers/user_driver_loader.ts`**: Same pattern.
- **`src/domain/vaults/user_vault_loader.ts`**: Same pattern.
- **`src/domain/models/bundle_test.ts`**: 9 new tests — unit tests for `rewriteZodImports` (named, aliased, star, unversioned, multiple, non-zod untouched, idempotency, single-quoted) and end-to-end test verifying `z.toJSONSchema()` works on bundled schemas.

## Design decisions

- **Rewrite at both bundle-time AND import-time**: Bundle-time ensures new cached bundles are correct. Import-time catches old cached bundles that still have raw `import` statements. The rewrite is idempotent.
- **selfContained bundles are unaffected**: They inline Zod and never have external imports.
- **No changes to extension author workflow**: Extensions still write `import { z } from "npm:zod@4"` — the rewrite is transparent.

## Alternatives rejected

- **Stop externalizing Zod**: Bloats every bundle by ~500KB and doesn't fix the problem — swamp's own code still uses its `z` for `instanceof`/`toJSONSchema`.
- **Duck-typing instead of `instanceof`**: Much larger change surface across 6+ files, fragile, loses Zod's built-in schema capabilities.
- **Import maps**: Don't work in compiled binaries.

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt` — formatting passes
- [x] `deno run test` — 3004/3004 tests pass
- [x] `deno run compile` — binary compiles
- [x] Standalone PoC validates approach in both dev mode and compiled binary
- [ ] Manual test with compiled binary: `swamp extension pull @dougschaefer/cisco-collaboration-endpoints` → `swamp model type describe` shows JSON schema without `_zod` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Douglas Schaefer <dougschaefer6@users.noreply.github.com>