### PR TITLE
feat: auto-trust collectives from user membership

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -21,9 +21,9 @@ extensions:
 3. If a community extension exists, install it instead of building from scratch
 4. Only create a custom model if nothing exists locally or in the community
 
-Note: Extensions from trusted collectives (`@swamp/*`, `@si/*`) auto-resolve on
-first use — no manual `extension pull` needed. Just reference the type and swamp
-installs the extension automatically.
+Note: Extensions from trusted collectives (`@swamp/*`, `@si/*`, and your
+membership collectives) auto-resolve on first use — no manual `extension pull`
+needed. Just reference the type and swamp installs the extension automatically.
 
 Extension models let you:
 

--- a/.claude/skills/swamp-extension-model/references/troubleshooting.md
+++ b/.claude/skills/swamp-extension-model/references/troubleshooting.md
@@ -227,15 +227,17 @@ Models directory priority:
 
 ## Auto-Resolution Failures
 
-Extensions from trusted collectives auto-resolve on first use. If
+Extensions from trusted collectives (explicit `trustedCollectives` in
+`.swamp.yaml` plus your membership collectives) auto-resolve on first use. If
 auto-resolution fails:
 
-| Symptom                       | Cause                                      | Fix                                                      |
-| ----------------------------- | ------------------------------------------ | -------------------------------------------------------- |
-| "no matching extension found" | Extension doesn't exist in registry        | `swamp extension search <query>` to find correct name    |
-| Network/timeout error         | Can't reach swamp.club                     | Check connectivity; manual: `swamp extension pull @name` |
-| Type not auto-resolving       | Collective not trusted                     | Add to `trustedCollectives` in `.swamp.yaml`             |
-| Silent "Unknown model type"   | Type uses non-`@` prefix or single segment | Use `@collective/name` format                            |
+| Symptom                       | Cause                                      | Fix                                                                |
+| ----------------------------- | ------------------------------------------ | ------------------------------------------------------------------ |
+| "no matching extension found" | Extension doesn't exist in registry        | `swamp extension search <query>` to find correct name              |
+| Network/timeout error         | Can't reach swamp.club                     | Check connectivity; manual: `swamp extension pull @name`           |
+| Type not auto-resolving       | Collective not trusted                     | Run `swamp auth whoami` to refresh, or add to `trustedCollectives` |
+| Silent "Unknown model type"   | Type uses non-`@` prefix or single segment | Use `@collective/name` format                                      |
+| Stale membership              | Collectives changed since last login       | Run `swamp auth whoami` to refresh cached collectives              |
 
 ## Verification Commands
 

--- a/.claude/skills/swamp-model/references/troubleshooting.md
+++ b/.claude/skills/swamp-model/references/troubleshooting.md
@@ -214,12 +214,14 @@ to use that field.
    ```
 
 4. **Extension not auto-resolved** — types from trusted collectives (`@swamp/*`,
-   `@si/*`) auto-resolve on first use. If resolution failed:
+   `@si/*`, and your membership collectives) auto-resolve on first use. If
+   resolution failed:
    - Check network connectivity (registry at swamp.club)
    - Check if extension exists: `swamp extension search <query>`
    - Manual fallback: `swamp extension pull @collective/name`
-   - If using a non-default collective, add it to `trustedCollectives` in
-     `.swamp.yaml`
+   - Run `swamp auth whoami` to refresh cached membership collectives
+   - If using a collective you're not a member of, add it to
+     `trustedCollectives` in `.swamp.yaml`
 
 ## Expression Debugging
 

--- a/.claude/skills/swamp-repo/references/structure.md
+++ b/.claude/skills/swamp-repo/references/structure.md
@@ -121,10 +121,15 @@ vaultsDir: "extensions/vaults" # optional, default shown
 trustedCollectives: # optional, default: ["swamp", "si"]
   - swamp
   - si
+trustMemberCollectives: true # optional, default: true
 ```
 
 `trustedCollectives` controls which extension collectives auto-resolve on first
-use. The `swamp` collective is trusted by default.
+use. The `swamp` and `si` collectives are trusted by default.
+
+Additionally, collectives the user belongs to (cached during `auth login` /
+`auth whoami`) are automatically trusted. Set `trustMemberCollectives: false` to
+disable this and only trust the explicit list.
 
 ### CLAUDE.md
 

--- a/design/extension.md
+++ b/design/extension.md
@@ -170,10 +170,15 @@ it, and continues.
 
 ### Trusted Collectives
 
-The `swamp` collective is trusted by default. Extensions from `@swamp/*`
-auto-resolve with no configuration required.
+The `swamp` and `si` collectives are trusted by default. Extensions from
+`@swamp/*` and `@si/*` auto-resolve with no configuration required.
 
 Default trusted collectives: `["swamp", "si"]`.
+
+Additionally, collectives the user belongs to are automatically trusted. Membership
+collectives are cached in `auth.json` during `auth login` and `auth whoami`, and
+merged with the explicit list at CLI startup. This means if a user is a member of
+`@myorg`, extensions from `@myorg/*` auto-resolve without any configuration.
 
 Configurable via `trustedCollectives` in `.swamp.yaml`:
 
@@ -184,7 +189,9 @@ trustedCollectives:
   - myorg
 ```
 
-Set to `[]` to disable automatic resolution entirely.
+Set `trustMemberCollectives: false` to disable membership-based trust and only
+use the explicit `trustedCollectives` list. Set `trustedCollectives` to `[]` and
+`trustMemberCollectives: false` to disable automatic resolution entirely.
 
 ### Resolution Algorithm
 

--- a/design/repo.md
+++ b/design/repo.md
@@ -45,6 +45,9 @@ attributes to control the behaviour of the swamp operations.
   Multitple vaults can be specified for a each swamp repository.
 - `trustedCollectives`: List of collectives whose extensions auto-resolve on
   first use. Default: `["swamp", "si"]`. Set to `[]` to disable.
+- `trustMemberCollectives`: Whether to auto-trust collectives the user belongs
+  to (cached from `auth login`/`auth whoami`). Default: `true`. Set to `false`
+  to only trust the explicit `trustedCollectives` list.
 
 ## RepoIndexService
 

--- a/src/cli/commands/auth_login.ts
+++ b/src/cli/commands/auth_login.ts
@@ -20,7 +20,10 @@
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions, isStdinTty } from "../context.ts";
 import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
-import { SwampClubClient } from "../../infrastructure/http/swamp_club_client.ts";
+import {
+  getCollectives,
+  SwampClubClient,
+} from "../../infrastructure/http/swamp_club_client.ts";
 import { startCallbackServer } from "../../infrastructure/http/callback_server.ts";
 import { openBrowser } from "../../infrastructure/process/browser.ts";
 import { UserError } from "../../domain/errors.ts";
@@ -187,13 +190,15 @@ export const authLoginCommand = new Command()
       const whoami = await client.whoami(apiKey.key);
       const username = whoami.username ?? knownUsername ?? "unknown";
 
-      // Store credentials
+      // Store credentials (including cached collectives for auto-trust)
+      const collectives = getCollectives(whoami);
       const repo = new AuthRepository();
       await repo.save({
         serverUrl,
         apiKey: apiKey.key,
         apiKeyId: apiKey.id,
         username,
+        ...(collectives ? { collectives } : {}),
       });
 
       spinner?.stop();

--- a/src/cli/commands/auth_whoami.ts
+++ b/src/cli/commands/auth_whoami.ts
@@ -57,6 +57,12 @@ export const authWhoamiCommand = new Command()
 
     const collectives = getCollectives(whoami);
 
+    // Refresh cached collectives in auth.json so they stay current
+    await repo.save({
+      ...credentials,
+      collectives: collectives ?? [],
+    });
+
     if (ctx.outputMode === "json") {
       console.log(JSON.stringify(
         {

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -308,6 +308,32 @@ export function resolveTelemetryEndpoint(
   return DEFAULT_TELEMETRY_ENDPOINT;
 }
 
+/**
+ * Resolves the full list of trusted collectives by merging explicit
+ * trustedCollectives from .swamp.yaml with the user's membership collectives
+ * from cached auth credentials.
+ *
+ * @internal Exported for testing
+ */
+export function resolveTrustedCollectives(
+  marker: RepoMarkerData | null,
+  authCollectives?: string[],
+): string[] {
+  const explicit = marker?.trustedCollectives ?? ["swamp", "si"];
+
+  // If opt-out is set, only use explicit list
+  if (marker?.trustMemberCollectives === false) {
+    return explicit;
+  }
+
+  // Merge membership collectives (deduplicated)
+  if (authCollectives && authCollectives.length > 0) {
+    return [...new Set([...explicit, ...authCollectives])];
+  }
+
+  return explicit;
+}
+
 interface TelemetryContext {
   service: TelemetryService;
   userId: string | null;
@@ -424,8 +450,18 @@ export async function runCli(args: string[]): Promise<void> {
     // Not in a swamp repo - marker stays null
   }
 
-  // Create auto-resolver for trusted collectives
-  const trustedCollectives = marker?.trustedCollectives ?? ["swamp", "si"];
+  // Load cached auth collectives for membership-based trust
+  let authCollectives: string[] | undefined;
+  try {
+    const authRepo = new AuthRepository();
+    const creds = await authRepo.load();
+    authCollectives = creds?.collectives;
+  } catch {
+    // Auth file unreadable — continue without membership collectives
+  }
+
+  // Create auto-resolver for trusted collectives (merging membership collectives)
+  const trustedCollectives = resolveTrustedCollectives(marker, authCollectives);
   if (trustedCollectives.length > 0 && marker) {
     const outputMode = getOutputModeFromArgs(args);
     const serverUrl = Deno.env.get("SWAMP_CLUB_URL") ?? "https://swamp.club";

--- a/src/cli/mod_test.ts
+++ b/src/cli/mod_test.ts
@@ -26,6 +26,7 @@ import {
   resolveLogLevel,
   resolveModelsDir,
   resolveTelemetryEndpoint,
+  resolveTrustedCollectives,
   resolveWorkflowsDir,
 } from "./mod.ts";
 
@@ -547,4 +548,73 @@ Deno.test("isUpdateCheckDisabledByEnv returns false when env var is ''", () => {
       Deno.env.delete("SWAMP_NO_UPDATE_CHECK");
     }
   }
+});
+
+// --- resolveTrustedCollectives tests ---
+
+Deno.test("resolveTrustedCollectives returns defaults when no marker", () => {
+  const result = resolveTrustedCollectives(null);
+  assertEquals(result, ["swamp", "si"]);
+});
+
+Deno.test("resolveTrustedCollectives returns explicit collectives from marker", () => {
+  const marker = {
+    swampVersion: "0.1.0",
+    initializedAt: "2024-01-01T00:00:00Z",
+    trustedCollectives: ["myorg"],
+  };
+  const result = resolveTrustedCollectives(marker);
+  assertEquals(result, ["myorg"]);
+});
+
+Deno.test("resolveTrustedCollectives merges auth collectives with defaults", () => {
+  const result = resolveTrustedCollectives(null, ["myorg", "other"]);
+  assertEquals(result, ["swamp", "si", "myorg", "other"]);
+});
+
+Deno.test("resolveTrustedCollectives deduplicates merged collectives", () => {
+  const marker = {
+    swampVersion: "0.1.0",
+    initializedAt: "2024-01-01T00:00:00Z",
+    trustedCollectives: ["swamp", "si", "myorg"],
+  };
+  const result = resolveTrustedCollectives(marker, ["myorg", "neworg"]);
+  assertEquals(result, ["swamp", "si", "myorg", "neworg"]);
+});
+
+Deno.test("resolveTrustedCollectives respects trustMemberCollectives false", () => {
+  const marker = {
+    swampVersion: "0.1.0",
+    initializedAt: "2024-01-01T00:00:00Z",
+    trustedCollectives: ["swamp"],
+    trustMemberCollectives: false,
+  };
+  const result = resolveTrustedCollectives(marker, ["myorg", "other"]);
+  assertEquals(result, ["swamp"]);
+});
+
+Deno.test("resolveTrustedCollectives merges when trustMemberCollectives is true", () => {
+  const marker = {
+    swampVersion: "0.1.0",
+    initializedAt: "2024-01-01T00:00:00Z",
+    trustedCollectives: ["swamp"],
+    trustMemberCollectives: true,
+  };
+  const result = resolveTrustedCollectives(marker, ["myorg"]);
+  assertEquals(result, ["swamp", "myorg"]);
+});
+
+Deno.test("resolveTrustedCollectives handles undefined auth collectives", () => {
+  const marker = {
+    swampVersion: "0.1.0",
+    initializedAt: "2024-01-01T00:00:00Z",
+    trustedCollectives: ["swamp", "si"],
+  };
+  const result = resolveTrustedCollectives(marker, undefined);
+  assertEquals(result, ["swamp", "si"]);
+});
+
+Deno.test("resolveTrustedCollectives handles empty auth collectives", () => {
+  const result = resolveTrustedCollectives(null, []);
+  assertEquals(result, ["swamp", "si"]);
 });

--- a/src/domain/auth/auth_credentials.ts
+++ b/src/domain/auth/auth_credentials.ts
@@ -27,4 +27,6 @@ export interface AuthCredentials {
   apiKeyId: string;
   /** The authenticated username */
   username: string;
+  /** Cached collective memberships (slugs) from the last login/whoami */
+  collectives?: string[];
 }

--- a/src/infrastructure/persistence/auth_repository_test.ts
+++ b/src/infrastructure/persistence/auth_repository_test.ts
@@ -101,6 +101,48 @@ Deno.test("AuthRepository - delete is idempotent (no error when missing)", async
   }
 });
 
+Deno.test("AuthRepository - save and load round trip with collectives", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  const originalXdg = Deno.env.get("XDG_CONFIG_HOME");
+  try {
+    Deno.env.set("XDG_CONFIG_HOME", tmpDir);
+    const repo = new AuthRepository();
+
+    const credsWithCollectives: AuthCredentials = {
+      ...TEST_CREDENTIALS,
+      collectives: ["myorg", "swamp"],
+    };
+    await repo.save(credsWithCollectives);
+    const loaded = await repo.load();
+
+    assertExists(loaded);
+    assertEquals(loaded.collectives, ["myorg", "swamp"]);
+  } finally {
+    if (originalXdg) Deno.env.set("XDG_CONFIG_HOME", originalXdg);
+    else Deno.env.delete("XDG_CONFIG_HOME");
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("AuthRepository - load without collectives returns undefined for field", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  const originalXdg = Deno.env.get("XDG_CONFIG_HOME");
+  try {
+    Deno.env.set("XDG_CONFIG_HOME", tmpDir);
+    const repo = new AuthRepository();
+
+    await repo.save(TEST_CREDENTIALS);
+    const loaded = await repo.load();
+
+    assertExists(loaded);
+    assertEquals(loaded.collectives, undefined);
+  } finally {
+    if (originalXdg) Deno.env.set("XDG_CONFIG_HOME", originalXdg);
+    else Deno.env.delete("XDG_CONFIG_HOME");
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
 Deno.test("AuthRepository - save sets restrictive file permissions", async () => {
   if (Deno.build.os === "windows") return; // mode not enforced on Windows
   const tmpDir = await Deno.makeTempDir();

--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -49,6 +49,7 @@ export interface RepoMarkerData {
   gitignoreManaged?: boolean;
   datastore?: DatastoreConfigData;
   trustedCollectives?: string[];
+  trustMemberCollectives?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Cache the user's collective memberships in `auth.json` during `auth login` and `auth whoami`, then merge them into the trusted collectives list at CLI startup
- Removes friction of manually adding each collective to `trustedCollectives` in `.swamp.yaml` — if you're a member of a collective, its extensions auto-resolve automatically
- Adds `trustMemberCollectives` option to `.swamp.yaml` for opt-out

## Design Decisions

**Cache at login time, not per-invocation.** Calling the `whoami` API on every CLI invocation would add latency. Instead, collectives are cached in `auth.json` during `auth login` (already makes a whoami call) and refreshed on `auth whoami`. This means membership changes require a `swamp auth whoami` to take effect — an acceptable tradeoff for zero-latency startup.

**Merge, don't replace.** Membership collectives are merged with the explicit `trustedCollectives` list (deduplicated via `Set`). This means explicit config is never lost, and membership adds to it additively.

**Opt-out via `trustMemberCollectives: false`.** Defaults to `true` (absent = true). When set to `false`, only the explicit `trustedCollectives` list is used — exactly matching the previous behavior. This gives security-conscious users full control.

**Graceful degradation.** If not authenticated, auth.json is missing/unreadable, or the `collectives` field doesn't exist (old auth.json), the feature silently falls back to the current behavior with no errors.

## User Impact

**Before:** Users who are members of collectives (e.g., their org's `@myorg` collective) had to manually add `myorg` to `trustedCollectives` in every repo's `.swamp.yaml` to get auto-resolution working. Without this, `swamp model create @myorg/some-type my-model` would fail with "Unknown model type".

**After:** After logging in, membership collectives are automatically trusted. Extensions from any collective the user belongs to auto-resolve on first use with zero configuration.

## Changes

| File | Change |
|------|--------|
| `src/domain/auth/auth_credentials.ts` | Added `collectives?: string[]` to `AuthCredentials` |
| `src/cli/commands/auth_login.ts` | Cache collectives from whoami response during login |
| `src/cli/commands/auth_whoami.ts` | Refresh cached collectives on whoami |
| `src/infrastructure/persistence/repo_marker_repository.ts` | Added `trustMemberCollectives?: boolean` to `RepoMarkerData` |
| `src/cli/mod.ts` | Added `resolveTrustedCollectives()` to merge membership + explicit collectives; load auth at startup |
| `src/cli/mod_test.ts` | 8 new tests for `resolveTrustedCollectives` |
| `src/infrastructure/persistence/auth_repository_test.ts` | 2 new tests for collectives round-trip |
| Skills & design docs (5 files) | Updated to document membership-based trust and `trustMemberCollectives` opt-out |

## Test Plan

- [x] `deno check` — all modified files pass type checking
- [x] `deno lint` — no lint errors
- [x] `deno fmt --check` — formatting clean
- [x] `deno run test src/cli/mod_test.ts` — 51 tests pass (8 new `resolveTrustedCollectives` tests)
- [x] `deno run test src/infrastructure/persistence/auth_repository_test.ts` — 7 tests pass (2 new)
- [x] Manual E2E test:
  1. Compiled binary with `deno run compile`
  2. Created fresh repo in `/tmp/swamp-test-autotrust` with `swamp repo init`
  3. Ran `swamp auth whoami` → cached collectives `["swamp", "system-initiative", "stack72"]` in `auth.json`
  4. Ran `swamp model create @stack72/unifi-traffic test-traffic` → auto-resolved and installed `@stack72/ubiquity` extension successfully
  5. The `stack72` collective was NOT in `.swamp.yaml`'s `trustedCollectives` — it was trusted purely via membership

🤖 Generated with [Claude Code](https://claude.com/claude-code)