### PR TITLE
fix: resolve stack overflow when loading extension bundles with large npm deps

### DIFF
--- a/src/domain/drivers/user_driver_loader.ts
+++ b/src/domain/drivers/user_driver_loader.ts
@@ -18,12 +18,13 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { z } from "zod";
-import { dirname, join, resolve } from "@std/path";
+import { dirname, join, resolve, toFileUrl } from "@std/path";
 import { getLogger } from "@logtape/logtape";
 import {
   bundleExtension,
   installZodGlobal,
   rewriteZodImports,
+  uint8ArrayToBase64,
 } from "../models/bundle.ts";
 import { resolveLocalImports } from "../models/local_import_resolver.ts";
 import type { DenoRuntime } from "../runtime/deno_runtime.ts";
@@ -253,20 +254,18 @@ export class UserDriverLoader {
         await Deno.stat(bundlePath);
         const cachedJs = await Deno.readTextFile(bundlePath);
         const rewrittenCached = rewriteZodImports(cachedJs);
-        const encoded = btoa(
-          String.fromCharCode(...new TextEncoder().encode(rewrittenCached)),
-        );
-        return await import(
-          `data:application/javascript;base64,${encoded}`
-        );
+        if (rewrittenCached !== cachedJs) {
+          await Deno.writeTextFile(bundlePath, rewrittenCached);
+        }
+        return await import(toFileUrl(bundlePath).href);
       } catch {
         // Fall through to data URL import
       }
     }
 
-    // Fallback: import via base64 data URL
-    const encoded = btoa(
-      String.fromCharCode(...new TextEncoder().encode(rewritten)),
+    // Fallback: import via base64 data URL (no file on disk)
+    const encoded = uint8ArrayToBase64(
+      new TextEncoder().encode(rewritten),
     );
     return await import(
       `data:application/javascript;base64,${encoded}`

--- a/src/domain/models/bundle.ts
+++ b/src/domain/models/bundle.ts
@@ -50,6 +50,27 @@ export function installZodGlobal(): void {
  * - Star imports: `import * as zod from "npm:zod@4"` → `const zod = globalThis.__swamp_zod;`
  * - Already-rewritten lines are left untouched (idempotent).
  */
+/**
+ * Converts a Uint8Array to a base64 string without blowing the call stack.
+ *
+ * The naive `btoa(String.fromCharCode(...bytes))` spreads every byte onto
+ * the call stack as a function argument, which causes `RangeError: Maximum
+ * call stack size exceeded` for large bundles (e.g., extensions with inlined
+ * npm packages like @octokit/rest or @slack/web-api).
+ *
+ * This function processes bytes in fixed-size chunks to stay well within
+ * V8's call-stack limits regardless of bundle size.
+ */
+export function uint8ArrayToBase64(bytes: Uint8Array): string {
+  const CHUNK_SIZE = 8192;
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += CHUNK_SIZE) {
+    const chunk = bytes.subarray(i, i + CHUNK_SIZE);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+}
+
 export function rewriteZodImports(js: string): string {
   // Match: import { ... } from "npm:zod..." or 'npm:zod...'
   // Captures the named import clause and handles aliased imports

--- a/src/domain/models/bundle_test.ts
+++ b/src/domain/models/bundle_test.ts
@@ -24,6 +24,7 @@ import {
   bundleExtension,
   installZodGlobal,
   rewriteZodImports,
+  uint8ArrayToBase64,
 } from "./bundle.ts";
 
 const DENO_PATH = Deno.execPath();
@@ -47,9 +48,7 @@ async function importBundled(
 ): Promise<Record<string, unknown>> {
   installZodGlobal();
   const rewritten = rewriteZodImports(js);
-  const encoded = btoa(
-    String.fromCharCode(...new TextEncoder().encode(rewritten)),
-  );
+  const encoded = uint8ArrayToBase64(new TextEncoder().encode(rewritten));
   return await import(`data:application/javascript;base64,${encoded}`);
 }
 
@@ -258,4 +257,30 @@ Deno.test("rewriteZodImports handles single-quoted specifiers", () => {
   const input = `import { z } from 'npm:zod@4';`;
   const result = rewriteZodImports(input);
   assertEquals(result, `const { z } = globalThis.__swamp_zod;`);
+});
+
+// --- uint8ArrayToBase64 unit tests ---
+
+Deno.test("uint8ArrayToBase64 matches btoa for small input", () => {
+  const text = "hello world";
+  const bytes = new TextEncoder().encode(text);
+  const expected = btoa(text);
+  assertEquals(uint8ArrayToBase64(bytes), expected);
+});
+
+Deno.test("uint8ArrayToBase64 handles empty input", () => {
+  assertEquals(uint8ArrayToBase64(new Uint8Array(0)), btoa(""));
+});
+
+Deno.test("uint8ArrayToBase64 handles large input without stack overflow", () => {
+  // 1MB of data — would blow the stack with String.fromCharCode(...bytes)
+  const size = 1_000_000;
+  const bytes = new Uint8Array(size);
+  for (let i = 0; i < size; i++) {
+    bytes[i] = i % 256;
+  }
+  // Should not throw RangeError: Maximum call stack size exceeded
+  const result = uint8ArrayToBase64(bytes);
+  assertEquals(typeof result, "string");
+  assertEquals(result.length > 0, true);
 });

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -18,12 +18,13 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { z } from "zod";
-import { dirname, join, resolve } from "@std/path";
+import { dirname, join, resolve, toFileUrl } from "@std/path";
 import { getLogger } from "@logtape/logtape";
 import {
   bundleExtension,
   installZodGlobal,
   rewriteZodImports,
+  uint8ArrayToBase64,
 } from "./bundle.ts";
 import { resolveLocalImports } from "./local_import_resolver.ts";
 import { ModelType } from "./model_type.ts";
@@ -473,23 +474,22 @@ export class UserModelLoader {
 
       try {
         await Deno.stat(bundlePath);
-        // Read the file and rewrite at import-time for cached bundles
+        // Rewrite zod imports in the cached file on disk so old cached
+        // bundles get fixed permanently, then import via file URL.
         const cachedJs = await Deno.readTextFile(bundlePath);
         const rewrittenCached = rewriteZodImports(cachedJs);
-        const encoded = btoa(
-          String.fromCharCode(...new TextEncoder().encode(rewrittenCached)),
-        );
-        return await import(
-          `data:application/javascript;base64,${encoded}`
-        );
+        if (rewrittenCached !== cachedJs) {
+          await Deno.writeTextFile(bundlePath, rewrittenCached);
+        }
+        return await import(toFileUrl(bundlePath).href);
       } catch {
         // Fall through to data URL import
       }
     }
 
-    // Fallback: import via base64 data URL
-    const encoded = btoa(
-      String.fromCharCode(...new TextEncoder().encode(rewritten)),
+    // Fallback: import via base64 data URL (no file on disk)
+    const encoded = uint8ArrayToBase64(
+      new TextEncoder().encode(rewritten),
     );
     return await import(
       `data:application/javascript;base64,${encoded}`

--- a/src/domain/vaults/user_vault_loader.ts
+++ b/src/domain/vaults/user_vault_loader.ts
@@ -18,12 +18,13 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { z } from "zod";
-import { dirname, join, resolve } from "@std/path";
+import { dirname, join, resolve, toFileUrl } from "@std/path";
 import { getLogger } from "@logtape/logtape";
 import {
   bundleExtension,
   installZodGlobal,
   rewriteZodImports,
+  uint8ArrayToBase64,
 } from "../models/bundle.ts";
 import { resolveLocalImports } from "../models/local_import_resolver.ts";
 import type { DenoRuntime } from "../runtime/deno_runtime.ts";
@@ -260,20 +261,18 @@ export class UserVaultLoader {
         await Deno.stat(bundlePath);
         const cachedJs = await Deno.readTextFile(bundlePath);
         const rewrittenCached = rewriteZodImports(cachedJs);
-        const encoded = btoa(
-          String.fromCharCode(...new TextEncoder().encode(rewrittenCached)),
-        );
-        return await import(
-          `data:application/javascript;base64,${encoded}`
-        );
+        if (rewrittenCached !== cachedJs) {
+          await Deno.writeTextFile(bundlePath, rewrittenCached);
+        }
+        return await import(toFileUrl(bundlePath).href);
       } catch {
         // Fall through to data URL import
       }
     }
 
-    // Fallback: import via base64 data URL
-    const encoded = btoa(
-      String.fromCharCode(...new TextEncoder().encode(rewritten)),
+    // Fallback: import via base64 data URL (no file on disk)
+    const encoded = uint8ArrayToBase64(
+      new TextEncoder().encode(rewritten),
     );
     return await import(
       `data:application/javascript;base64,${encoded}`


### PR DESCRIPTION
## Summary

Fixes #728.

- **Root cause:** `String.fromCharCode(...new TextEncoder().encode(js))` spreads every byte of a bundle onto the call stack as a function argument. Large inlined npm dependency trees (e.g., `@octokit/rest`, `@slack/web-api`) produce bundles of hundreds of KB, exceeding V8's maximum call stack size.
- **Cached bundles:** Restore `toFileUrl()` imports (the pre-#724 approach) with on-disk zod rewriting so old cached bundles are fixed permanently.
- **Fallback path:** Add `uint8ArrayToBase64()` which processes bytes in 8KB chunks, avoiding the stack overflow for the no-repo-dir codepath.
- **All three loaders fixed:** `UserModelLoader`, `UserDriverLoader`, `UserVaultLoader` all had the identical bug from #724.

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt` — formatting passes
- [x] `deno run test` — 3033/3033 tests pass
- [x] `deno run compile` — binary compiles
- [x] New `uint8ArrayToBase64` unit tests (small input, empty input, 1MB input)
- [x] Manual verification: `swamp repo init` → `swamp extension pull @bixu/github` → `swamp model type search --json` loads all 4 Octokit-based models without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Blake Irvin <blakeirvin@me.com>