### PR TITLE
fix: use pre-built bundle when dependency freshness check fails

### DIFF
--- a/src/domain/datastore/user_datastore_loader.ts
+++ b/src/domain/datastore/user_datastore_loader.ts
@@ -193,9 +193,15 @@ export class UserDatastoreLoader {
         relativePath.replace(/\.ts$/, ".js"),
       );
 
-      // Check mtime-based cache against all local dependencies
+      // Check mtime-based cache against all local dependencies.
+      // If the bundle exists but freshness cannot be determined (e.g. a
+      // dependency file is missing because the extension was pushed with an
+      // older swamp that had a single-line import regex), fall back to the
+      // cached bundle rather than attempting a re-bundle that will also fail.
+      let bundleExists = false;
       try {
         const bundleStat = await Deno.stat(bundlePath);
+        bundleExists = true;
         if (bundleStat.mtime) {
           const { resolvedFiles } = await resolveLocalImports(
             [absolutePath],
@@ -218,7 +224,11 @@ export class UserDatastoreLoader {
           }
         }
       } catch {
-        // Bundle doesn't exist, stat failed, or import resolution failed — rebundle
+        if (bundleExists) {
+          logger
+            .debug`Using cached datastore bundle for ${relativePath} (freshness check failed — missing dependency)`;
+          return await Deno.readTextFile(bundlePath);
+        }
       }
 
       // Bundle and write to cache

--- a/src/domain/drivers/user_driver_loader.ts
+++ b/src/domain/drivers/user_driver_loader.ts
@@ -192,9 +192,15 @@ export class UserDriverLoader {
         relativePath.replace(/\.ts$/, ".js"),
       );
 
-      // Check mtime-based cache against all local dependencies
+      // Check mtime-based cache against all local dependencies.
+      // If the bundle exists but freshness cannot be determined (e.g. a
+      // dependency file is missing because the extension was pushed with an
+      // older swamp that had a single-line import regex), fall back to the
+      // cached bundle rather than attempting a re-bundle that will also fail.
+      let bundleExists = false;
       try {
         const bundleStat = await Deno.stat(bundlePath);
+        bundleExists = true;
         if (bundleStat.mtime) {
           const { resolvedFiles } = await resolveLocalImports(
             [absolutePath],
@@ -217,7 +223,11 @@ export class UserDriverLoader {
           }
         }
       } catch {
-        // Bundle doesn't exist, stat failed, or import resolution failed — rebundle
+        if (bundleExists) {
+          logger
+            .debug`Using cached driver bundle for ${relativePath} (freshness check failed — missing dependency)`;
+          return await Deno.readTextFile(bundlePath);
+        }
       }
 
       // Bundle and write to cache

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -411,9 +411,15 @@ export class UserModelLoader {
         relativePath.replace(/\.ts$/, ".js"),
       );
 
-      // Check mtime-based cache against all local dependencies
+      // Check mtime-based cache against all local dependencies.
+      // If the bundle exists but freshness cannot be determined (e.g. a
+      // dependency file is missing because the extension was pushed with an
+      // older swamp that had a single-line import regex), fall back to the
+      // cached bundle rather than attempting a re-bundle that will also fail.
+      let bundleExists = false;
       try {
         const bundleStat = await Deno.stat(bundlePath);
+        bundleExists = true;
         if (bundleStat.mtime) {
           const { resolvedFiles } = await resolveLocalImports(
             [absolutePath],
@@ -436,7 +442,11 @@ export class UserModelLoader {
           }
         }
       } catch {
-        // Bundle doesn't exist, stat failed, or import resolution failed — rebundle
+        if (bundleExists) {
+          logger
+            .debug`Using cached bundle for ${relativePath} (freshness check failed — missing dependency)`;
+          return await Deno.readTextFile(bundlePath);
+        }
       }
 
       // Bundle and write to cache

--- a/src/domain/vaults/user_vault_loader.ts
+++ b/src/domain/vaults/user_vault_loader.ts
@@ -199,9 +199,15 @@ export class UserVaultLoader {
         relativePath.replace(/\.ts$/, ".js"),
       );
 
-      // Check mtime-based cache against all local dependencies
+      // Check mtime-based cache against all local dependencies.
+      // If the bundle exists but freshness cannot be determined (e.g. a
+      // dependency file is missing because the extension was pushed with an
+      // older swamp that had a single-line import regex), fall back to the
+      // cached bundle rather than attempting a re-bundle that will also fail.
+      let bundleExists = false;
       try {
         const bundleStat = await Deno.stat(bundlePath);
+        bundleExists = true;
         if (bundleStat.mtime) {
           const { resolvedFiles } = await resolveLocalImports(
             [absolutePath],
@@ -224,7 +230,11 @@ export class UserVaultLoader {
           }
         }
       } catch {
-        // Bundle doesn't exist, stat failed, or import resolution failed — rebundle
+        if (bundleExists) {
+          logger
+            .debug`Using cached vault bundle for ${relativePath} (freshness check failed — missing dependency)`;
+          return await Deno.readTextFile(bundlePath);
+        }
       }
 
       // Bundle and write to cache


### PR DESCRIPTION
Closes #737

## Summary

When an extension is pulled from the registry, swamp discards the valid pre-built bundle and fails with `Module not found` if any local dependency file is missing from disk. This fix makes `bundleWithCache` fall back to the cached bundle when the freshness check fails, rather than attempting a re-bundle that will also fail.

## Root cause

`bundleWithCache` validates cache freshness by resolving all local imports from the `.ts` source file and comparing mtimes. If a dependency file is missing (because the extension was pushed with an older swamp that had a single-line import regex and missed multi-line import declarations), `Deno.stat()` throws inside the try block. The catch block then falls through to re-bundle from source — which fails with the same `Module not found` error.

The `@keeb/grafana` extension hits this exactly: `grafana_instance.ts` has a multi-line import for `./lib/grafana.ts`. The older push regex only matched single-line imports, so `lib/grafana.ts` was never included in the archive. The pre-built bundle at `.swamp/bundles/grafana_instance.js` is perfectly valid (compiled at push time with all deps), but every load attempt discards it and fails.

The catch block comment said _"Bundle doesn't exist, stat failed, or import resolution failed — rebundle"_, conflating two distinct cases:

1. **Bundle file does not exist** → rebundle from source ✅ correct
2. **Bundle exists but freshness check threw** → rebundle from source ❌ wrong — the bundle is valid

## Fix

Track `bundleExists` before entering the try/catch. If the bundle file exists but the freshness check throws for any reason, use the cached bundle as a fallback and log at debug level. Only attempt a re-bundle when the bundle genuinely doesn't exist.

Applied to all four loaders: model, vault, driver, datastore.

## User impact

**Before:** `swamp extension install @keeb/grafana` succeeds but `swamp model type search grafana` fails with `deno bundle failed ... Module not found "lib/grafana.ts"`.

**After:** The pre-built bundle is used as a fallback. `@keeb/grafana/instance` appears in search results with no errors.

## Verification

- [x] `deno check` — passes
- [x] `deno lint` — passes
- [x] `deno fmt` — passes
- [x] `deno run test` — 3161 passed, 0 failed
- [x] `deno run compile` — binary compiles
- [x] Manual: `swamp extension install @keeb/grafana` → `swamp model type search grafana` returns `@keeb/grafana/instance`

🤖 Generated with [Claude Code](https://claude.com/claude-code)