### PR TITLE
fix: improve vault create UX for deprecated types and optional config

### DIFF
--- a/src/cli/commands/vault_create.ts
+++ b/src/cli/commands/vault_create.ts
@@ -32,6 +32,7 @@ import {
   createVaultConfigId,
   VaultConfig,
 } from "../../domain/vaults/vault_config.ts";
+import { RENAMED_VAULT_TYPES } from "../../domain/vaults/vault_service.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -125,6 +126,12 @@ export const vaultCreateCommand = new Command()
       // Validate the vault type using the registry
       const typeInfo = vaultTypeRegistry.get(vaultType);
       if (!typeInfo) {
+        const renamed = RENAMED_VAULT_TYPES[vaultType.toLowerCase()];
+        if (renamed) {
+          throw new UserError(
+            `The type '${vaultType}' has been renamed to '${renamed}'. Use: swamp vault create ${renamed} ${vaultName}`,
+          );
+        }
         const availableTypes = vaultTypeRegistry.getAll().map((v) => v.type)
           .join(", ");
         throw new UserError(
@@ -152,22 +159,20 @@ export const vaultCreateCommand = new Command()
       let providerConfig: Record<string, unknown>;
 
       if (!typeInfo.isBuiltIn && typeInfo.createProvider) {
-        // Extension vault type: parse --config JSON
-        if (!options.config) {
-          throw new UserError(
-            `Vault type '${vaultType}' requires --config <json> with provider configuration.`,
-          );
-        }
-
-        try {
-          providerConfig = JSON.parse(options.config) as Record<
-            string,
-            unknown
-          >;
-        } catch {
-          throw new UserError(
-            `Invalid JSON in --config: ${options.config}`,
-          );
+        // Extension vault type: parse --config JSON, defaulting to {} if not provided
+        if (options.config) {
+          try {
+            providerConfig = JSON.parse(options.config) as Record<
+              string,
+              unknown
+            >;
+          } catch {
+            throw new UserError(
+              `Invalid JSON in --config: ${options.config}`,
+            );
+          }
+        } else {
+          providerConfig = {};
         }
 
         // Validate against configSchema if provided

--- a/src/domain/vaults/vault_service.ts
+++ b/src/domain/vaults/vault_service.ts
@@ -302,7 +302,7 @@ function assertVaultProvider(
 /**
  * Known renamed vault types and their current names.
  */
-const RENAMED_VAULT_TYPES: Record<string, string> = {
+export const RENAMED_VAULT_TYPES: Record<string, string> = {
   "aws": "@swamp/aws-sm",
   "aws-sm": "@swamp/aws-sm",
   "azure": "@swamp/azure-kv",


### PR DESCRIPTION
## Summary

- **Deprecated type hint**: When a user passes a renamed vault type (e.g. `aws-sm`, `azure-kv`), the error now says _"The type 'aws-sm' has been renamed to '@swamp/aws-sm'. Use: swamp vault create @swamp/aws-sm <name>"_ instead of the generic "Unknown vault type" message. Achieved by exporting `RENAMED_VAULT_TYPES` from `vault_service.ts` and checking it in the `vault_create` error path.
- **Optional `--config` for extension vaults**: Extension vault types no longer require `--config` to be passed. Omitting it defaults to `{}`, which is then validated against `configSchema` if one is defined. Users with config-free extension vaults no longer need to pass `--config '{}'`.

## Test Plan

- [ ] `deno fmt --check` passes
- [ ] `deno lint` passes
- [ ] `deno task test` passes (3175 tests, 0 failed)
- [ ] `swamp vault create aws-sm my-vault` gives rename hint instead of generic error
- [ ] `swamp vault create @swamp/aws-sm my-vault` (without `--config`) defaults to `{}`