### PR TITLE
feat: add driver and datastore support to extension push/pull

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -399,7 +399,8 @@ Files are classified by export name: `export const model` defines new types,
 ## Publishing Extensions
 
 Extensions are published to the swamp registry via a `manifest.yaml` and the
-`swamp extension push` command.
+`swamp extension push` command. Extensions can contain models, workflows,
+vaults, drivers, and datastores.
 
 **Minimal manifest:**
 
@@ -419,16 +420,10 @@ swamp extension push manifest.yaml --dry-run --json # Validate without pushing
 swamp extension push manifest.yaml -y --json        # Skip confirmation prompts
 ```
 
-The manifest `name` collective must match your authenticated username. Model
-paths are relative to `extensions/models/`; local imports are auto-resolved.
-
-**Optional metadata fields:**
-
-- `platforms` — OS/architecture hints (e.g. `darwin-aarch64`, `linux-x86_64`).
-  Use when your extension contains platform-specific code.
-- `labels` — Categorization labels (e.g. `aws`, `kubernetes`, `security`).
-
-Both are omitted from the archive when not specified.
+The manifest `name` collective must match your authenticated username. Content
+paths are relative to their respective directories (`extensions/models/`,
+`extensions/vaults/`, `extensions/drivers/`, `extensions/datastores/`). Local
+imports are auto-resolved.
 
 For the full manifest schema, safety rules, CalVer versioning, and
 troubleshooting, see [references/publishing.md](references/publishing.md).

--- a/.claude/skills/swamp-extension-model/references/publishing.md
+++ b/.claude/skills/swamp-extension-model/references/publishing.md
@@ -1,7 +1,7 @@
 # Publishing Extensions
 
-Publish extension models and workflows to the swamp registry so others can
-install and use them.
+Publish extension models, workflows, vaults, drivers, and datastores to the
+swamp registry so others can install and use them.
 
 ## Manifest Schema (v1)
 
@@ -39,12 +39,16 @@ dependencies:
 | `description`     | No       | Human-readable description                                                                       |
 | `models`          | No*      | Model file paths relative to `extensions/models/`                                                |
 | `workflows`       | No*      | Workflow file paths relative to `workflows/`                                                     |
+| `vaults`          | No*      | Vault file paths relative to `extensions/vaults/`                                                |
+| `drivers`         | No*      | Driver file paths relative to `extensions/drivers/`                                              |
+| `datastores`      | No*      | Datastore file paths relative to `extensions/datastores/`                                        |
 | `additionalFiles` | No       | Extra files relative to the manifest location                                                    |
 | `platforms`       | No       | OS/architecture hints (e.g. `darwin-aarch64`, `linux-x86_64`)                                    |
 | `labels`          | No       | Categorization labels (e.g. `aws`, `kubernetes`, `security`)                                     |
 | `dependencies`    | No       | Other extensions this one depends on                                                             |
 
-*At least one of `models` or `workflows` must be present with entries.
+*At least one of `models`, `workflows`, `vaults`, `drivers`, or `datastores`
+must be present with entries.
 
 ### Name Rules
 
@@ -54,11 +58,13 @@ dependencies:
 - Reserved collectives (`@swamp`, `@si`) cannot be used
 - Allowed characters: lowercase letters, numbers, hyphens, underscores
 
-### How Models Map to Manifest
+### How Content Maps to Manifest
 
-- Paths in `models` are resolved relative to `extensions/models/`
-- Only list entry-point files — local imports (files imported by your model) are
-  auto-resolved and included automatically
+- `models` paths resolve relative to `extensions/models/`
+- `vaults` paths resolve relative to `extensions/vaults/`
+- `drivers` paths resolve relative to `extensions/drivers/`
+- `datastores` paths resolve relative to `extensions/datastores/`
+- Only list entry-point files — local imports are auto-resolved and included
 - Each entry-point is bundled into a standalone JS file for the registry
 
 ## Examples
@@ -133,9 +139,10 @@ swamp extension push manifest.yaml --repo-dir /path/to/repo --json
 3. **Resolve files** — collects model entry points, auto-resolves local imports,
    resolves workflow dependencies
 4. **Safety analysis** — scans all files for disallowed patterns and limits
-5. **Bundle models** — compiles each model entry point to standalone JS
+5. **Bundle TypeScript** — compiles each entry point (models, vaults, drivers,
+   datastores) to standalone JS
 6. **Version check** — verifies version doesn't already exist (offers to bump)
-7. **Build archive** — creates tar.gz with models, bundles, workflows, and files
+7. **Build archive** — creates tar.gz with all content types and their bundles
 8. **Upload** — three-phase push: initiate, upload archive, confirm
 
 ## Extension Formatting
@@ -216,15 +223,15 @@ the CLI will offer to bump the `MICRO` component automatically.
 
 ## Common Errors and Fixes
 
-| Error                            | Fix                                              |
-| -------------------------------- | ------------------------------------------------ |
-| "Not authenticated"              | Run `swamp auth login` first                     |
-| "collective does not match"      | Manifest `name` must use `@your-username/...`    |
-| "CalVer format" error            | Use `YYYY.MM.DD.MICRO` (e.g., `2026.02.26.1`)    |
-| "at least one model or workflow" | Add a `models` or `workflows` array with entries |
-| "Model file not found"           | Check path is relative to `extensions/models/`   |
-| "Workflow file not found"        | Check path is relative to `workflows/`           |
-| "eval() or new Function()"       | Remove dynamic code execution from your models   |
-| "Version already exists"         | Bump the MICRO component or let CLI auto-bump    |
-| "Missing manifestVersion"        | Add `manifestVersion: 1` to your manifest        |
-| "Bundle compilation failed"      | Fix TypeScript errors in your model files        |
+| Error                           | Fix                                                                     |
+| ------------------------------- | ----------------------------------------------------------------------- |
+| "Not authenticated"             | Run `swamp auth login` first                                            |
+| "collective does not match"     | Manifest `name` must use `@your-username/...`                           |
+| "CalVer format" error           | Use `YYYY.MM.DD.MICRO` (e.g., `2026.02.26.1`)                           |
+| "at least one model, workflow…" | Add a `models`, `workflows`, `vaults`, `drivers`, or `datastores` array |
+| "Model file not found"          | Check path is relative to `extensions/models/`                          |
+| "Workflow file not found"       | Check path is relative to `workflows/`                                  |
+| "eval() or new Function()"      | Remove dynamic code execution from your models                          |
+| "Version already exists"        | Bump the MICRO component or let CLI auto-bump                           |
+| "Missing manifestVersion"       | Add `manifestVersion: 1` to your manifest                               |
+| "Bundle compilation failed"     | Fix TypeScript errors in your model files                               |

--- a/.claude/skills/swamp-repo/SKILL.md
+++ b/.claude/skills/swamp-repo/SKILL.md
@@ -32,8 +32,11 @@ my-swamp-repo/
 ├── models/                  # Model definitions (YAML)
 ├── workflows/               # Workflow definitions (YAML)
 ├── vaults/                  # Vault configurations (YAML)
-├── extensions/              # Custom model extensions
-│   └── models/              # TypeScript model definitions
+├── extensions/              # Custom extensions
+│   ├── models/              # TypeScript model definitions
+│   ├── vaults/              # TypeScript vault implementations
+│   ├── drivers/             # TypeScript driver implementations
+│   └── datastores/          # TypeScript datastore implementations
 ├── .swamp/                  # Runtime data (datastore)
 │   ├── data/                # Versioned model data
 │   ├── outputs/             # Method execution outputs

--- a/.claude/skills/swamp-repo/references/structure.md
+++ b/.claude/skills/swamp-repo/references/structure.md
@@ -85,10 +85,13 @@ my-swamp-repo/
 │       └── secrets/ → ../.swamp/secrets/{type}/{vault-name}/ (local only)
 │
 ├── extensions/                  # Custom user extensions
-│   └── models/                  # TypeScript model definitions
-│       ├── my_model.ts
-│       └── aws/
-│           └── s3_bucket.ts     # Nested organization supported
+│   ├── models/                  # TypeScript model definitions
+│   │   ├── my_model.ts
+│   │   └── aws/
+│   │       └── s3_bucket.ts     # Nested organization supported
+│   ├── vaults/                  # TypeScript vault implementations
+│   ├── drivers/                 # TypeScript driver implementations
+│   └── datastores/              # TypeScript datastore implementations
 │
 ├── .claude/                     # Claude Code configuration
 │   ├── skills/                  # Skill definitions
@@ -118,6 +121,8 @@ upgradedAt: "2025-01-20T14:00:00Z"
 modelsDir: "extensions/models" # optional, default shown
 workflowsDir: "extensions/workflows" # optional, default shown
 vaultsDir: "extensions/vaults" # optional, default shown
+driversDir: "extensions/drivers" # optional, default shown
+datastoresDir: "extensions/datastores" # optional, default shown
 trustedCollectives: # optional, default: ["swamp", "si"]
   - swamp
   - si

--- a/design/extension.md
+++ b/design/extension.md
@@ -1,8 +1,9 @@
 # Extensions
 
-An extension in swamp is a distributable package of models and workflows that
-can be shared through a registry. Extensions allow the community to share
-reusable automation models and workflows that others can pull into their repositories.
+An extension in swamp is a distributable package of models, workflows, vaults,
+drivers, and datastores that can be shared through a registry. Extensions allow
+the community to share reusable automation components that others can pull into
+their repositories.
 
 ## Name
 
@@ -39,7 +40,8 @@ what the extension contains and how it should be packaged.
 - `manifestVersion`: Must be `1` (the only supported version).
 - `name`: Scoped name (`@collective/name`).
 - `version`: CalVer version string.
-- At least one of `models` or `workflows` must be present.
+- At least one of `models`, `workflows`, `vaults`, `drivers`, or `datastores`
+  must be present.
 
 ### Optional Fields
 
@@ -47,6 +49,9 @@ what the extension contains and how it should be packaged.
 - `models`: Array of relative paths to TypeScript model files (e.g.,
   `["aws/ec2/instance.ts"]`).
 - `workflows`: Array of relative paths to YAML workflow files.
+- `vaults`: Array of relative paths to TypeScript vault files.
+- `drivers`: Array of relative paths to TypeScript driver files.
+- `datastores`: Array of relative paths to TypeScript datastore files.
 - `additionalFiles`: Array of paths to non-model files to include (README,
   config, etc.).
 - `platforms`: Array of platform identifiers the extension supports (e.g.,
@@ -88,19 +93,22 @@ following structure:
 extension.tar.gz
 └── extension/
     ├── manifest.yaml
-    ├── models/           # Source TypeScript files
+    ├── models/              # Source TypeScript model files
     │   └── ssh/
     │       ├── connection.ts
     │       └── helpers.ts
-    ├── bundles/           # Compiled JavaScript bundles
+    ├── bundles/              # Compiled model JavaScript bundles
     │   └── ssh/
-    │       ├── connection.js
-    │       └── helpers.js
-    ├── workflows/         # YAML workflow files
+    │       └── connection.js
+    ├── workflows/            # YAML workflow files
     │   └── ssh-check.yaml
-    └── files/             # Additional files
-        └── ssh/
-            └── known_hosts_template.txt
+    ├── vaults/               # Source TypeScript vault files
+    ├── vault-bundles/        # Compiled vault JavaScript bundles
+    ├── drivers/              # Source TypeScript driver files
+    ├── driver-bundles/       # Compiled driver JavaScript bundles
+    ├── datastores/           # Source TypeScript datastore files
+    ├── datastore-bundles/    # Compiled datastore JavaScript bundles
+    └── files/                # Additional files
 ```
 
 ### Models
@@ -133,11 +141,11 @@ preserving their relative paths.
 ## Import Resolution
 
 When packaging an extension, the CLI resolves all local TypeScript imports
-starting from each model entry point. The resolver follows relative
-`import`/`export` statements (e.g., `./helpers.ts`, `../shared.ts`) and
-includes all transitively imported files. Only files within the models directory
-boundary are included. Non-local imports (npm packages) are skipped as they are
-resolved at runtime.
+starting from each entry point (model, vault, driver, or datastore). The
+resolver follows relative `import`/`export` statements (e.g., `./helpers.ts`,
+`../shared.ts`) and includes all transitively imported files. Only files within
+the respective directory boundary are included. Non-local imports (npm packages)
+are skipped as they are resolved at runtime.
 
 ## Dependencies
 
@@ -316,12 +324,18 @@ and atomic file writes to prevent corruption from concurrent operations.
 
 When pulled, extension files are extracted to their destinations:
 
-| Archive directory | Destination                                                            |
-| ----------------- | ---------------------------------------------------------------------- |
-| `models/`         | `{modelsDir}` (from `.swamp.yaml`, default `extensions/models/`)       |
-| `workflows/`      | `{workflowsDir}` (from `.swamp.yaml`, default `extensions/workflows/`) |
-| `bundles/`        | Datastore `bundles/` (default `.swamp/bundles/`)                       |
-| `files/`          | `{modelsDir}`                                                          |
+| Archive directory    | Destination                                                            |
+| -------------------- | ---------------------------------------------------------------------- |
+| `models/`            | `{modelsDir}` (from `.swamp.yaml`, default `extensions/models/`)       |
+| `bundles/`           | `.swamp/bundles/`                                                      |
+| `workflows/`         | `{workflowsDir}` (from `.swamp.yaml`, default `extensions/workflows/`) |
+| `vaults/`            | `{vaultsDir}` (from `.swamp.yaml`, default `extensions/vaults/`)       |
+| `vault-bundles/`     | `.swamp/vault-bundles/`                                                |
+| `drivers/`           | `{driversDir}` (from `.swamp.yaml`, default `extensions/drivers/`)     |
+| `driver-bundles/`    | `.swamp/driver-bundles/`                                               |
+| `datastores/`        | `{datastoresDir}` (from `.swamp.yaml`, default `extensions/datastores/`) |
+| `datastore-bundles/` | `.swamp/datastore-bundles/`                                            |
+| `files/`             | `{modelsDir}`                                                          |
 
 If files already exist at the destination and `--force` is not set, the user is
 prompted to confirm overwriting.

--- a/integration/extension_push_test.ts
+++ b/integration/extension_push_test.ts
@@ -164,7 +164,10 @@ Deno.test("extension push with invalid manifest (no models or workflows) gives c
       "--no-color",
     ]);
     assertEquals(code === 0, false);
-    assertStringIncludes(stderr, "at least one model, workflow, or vault");
+    assertStringIncludes(
+      stderr,
+      "at least one model, workflow, vault, driver, or datastore",
+    );
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }

--- a/src/cli/auto_resolver_adapters.ts
+++ b/src/cli/auto_resolver_adapters.ts
@@ -44,6 +44,8 @@ interface InstallerAdapterConfig {
   modelsDir: string;
   workflowsDir: string;
   vaultsDir: string;
+  driversDir: string;
+  datastoresDir: string;
   repoDir: string;
   denoRuntime: DenoRuntime;
 }
@@ -60,6 +62,8 @@ export function createAutoResolveInstallerAdapter(
     modelsDir,
     workflowsDir,
     vaultsDir,
+    driversDir,
+    datastoresDir,
     repoDir,
     denoRuntime,
   } = config;
@@ -74,6 +78,8 @@ export function createAutoResolveInstallerAdapter(
           modelsDir,
           workflowsDir,
           vaultsDir,
+          driversDir,
+          datastoresDir,
           repoDir,
           force: true,
           alreadyPulled: new Set(),

--- a/src/cli/commands/extension_fmt.ts
+++ b/src/cli/commands/extension_fmt.ts
@@ -52,19 +52,26 @@ export const extensionFmtCommand = new Command()
     });
 
     // 2. Resolve extension files (manifest, models, workflows, additional files)
-    const { allModelFiles, allVaultFiles, additionalFilePaths } =
-      await resolveExtensionFiles({
-        repoDir,
-        manifestPath,
-        repoContext,
-        logger: ctx.logger,
-      });
+    const {
+      allModelFiles,
+      allVaultFiles,
+      allDriverFiles,
+      allDatastoreFiles,
+      additionalFilePaths,
+    } = await resolveExtensionFiles({
+      repoDir,
+      manifestPath,
+      repoContext,
+      logger: ctx.logger,
+    });
 
     // 3. Combine all files and filter to .ts
     //    (fmt only operates on TypeScript files)
     const allFiles = [
       ...allModelFiles,
       ...allVaultFiles,
+      ...allDriverFiles,
+      ...allDatastoreFiles,
       ...additionalFilePaths,
     ];
     const tsFiles = allFiles.filter((f) => f.endsWith(".ts"));

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -25,6 +25,8 @@ import { requireInitializedRepo } from "../repo_context.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
 import { resolveVaultsDir } from "../resolve_vaults_dir.ts";
 import { resolveWorkflowsDir } from "../resolve_workflows_dir.ts";
+import { resolveDriversDir } from "../resolve_drivers_dir.ts";
+import { resolveDatastoresDir } from "../resolve_datastores_dir.ts";
 import {
   RepoMarkerRepository,
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
@@ -91,6 +93,8 @@ export interface InstallContext {
   modelsDir: string;
   workflowsDir: string;
   vaultsDir: string;
+  driversDir: string;
+  datastoresDir: string;
   repoDir: string;
   force: boolean;
   alreadyPulled: Set<string>;
@@ -385,6 +389,10 @@ export async function detectConflicts(
   repoDir: string,
   vaultsDir?: string,
   vaultBundlesDir?: string,
+  driversDir?: string,
+  driverBundlesDir?: string,
+  datastoresDir?: string,
+  datastoreBundlesDir?: string,
 ): Promise<string[]> {
   const conflicts: string[] = [];
 
@@ -441,6 +449,54 @@ export async function detectConflicts(
     }
   }
 
+  // Check drivers
+  if (driversDir) {
+    const driversSrc = join(extractDir, "drivers");
+    for (const file of await listFiles(driversSrc)) {
+      const relPath = relative(driversSrc, file);
+      const destPath = join(driversDir, relPath);
+      if (await fileExists(destPath)) {
+        conflicts.push(relative(repoDir, destPath));
+      }
+    }
+  }
+
+  // Check driver bundles
+  if (driverBundlesDir) {
+    const driverBundlesSrc = join(extractDir, "driver-bundles");
+    for (const file of await listFiles(driverBundlesSrc)) {
+      const relPath = relative(driverBundlesSrc, file);
+      const destPath = join(driverBundlesDir, relPath);
+      if (await fileExists(destPath)) {
+        conflicts.push(relative(repoDir, destPath));
+      }
+    }
+  }
+
+  // Check datastores
+  if (datastoresDir) {
+    const datastoresSrc = join(extractDir, "datastores");
+    for (const file of await listFiles(datastoresSrc)) {
+      const relPath = relative(datastoresSrc, file);
+      const destPath = join(datastoresDir, relPath);
+      if (await fileExists(destPath)) {
+        conflicts.push(relative(repoDir, destPath));
+      }
+    }
+  }
+
+  // Check datastore bundles
+  if (datastoreBundlesDir) {
+    const datastoreBundlesSrc = join(extractDir, "datastore-bundles");
+    for (const file of await listFiles(datastoreBundlesSrc)) {
+      const relPath = relative(datastoreBundlesSrc, file);
+      const destPath = join(datastoreBundlesDir, relPath);
+      if (await fileExists(destPath)) {
+        conflicts.push(relative(repoDir, destPath));
+      }
+    }
+  }
+
   // Check additional files
   const filesSrc = join(extractDir, "files");
   for (const file of await listFiles(filesSrc)) {
@@ -460,6 +516,8 @@ export interface PullContext {
   modelsDir: string;
   workflowsDir: string;
   vaultsDir: string;
+  driversDir: string;
+  datastoresDir: string;
   repoDir: string;
   force: boolean;
   outputMode: "log" | "json";
@@ -575,7 +633,17 @@ export async function installExtension(
     const vaultTsFiles = (await listFiles(join(extractDir, "vaults"))).filter(
       (f) => f.endsWith(".ts"),
     );
-    const tsFiles = [...modelTsFiles, ...vaultTsFiles];
+    const driverTsFiles = (await listFiles(join(extractDir, "drivers")))
+      .filter((f) => f.endsWith(".ts"));
+    const datastoreTsFiles = (
+      await listFiles(join(extractDir, "datastores"))
+    ).filter((f) => f.endsWith(".ts"));
+    const tsFiles = [
+      ...modelTsFiles,
+      ...vaultTsFiles,
+      ...driverTsFiles,
+      ...datastoreTsFiles,
+    ];
     if (tsFiles.length > 0) {
       const safetyResult = await analyzeExtensionSafety(tsFiles);
 
@@ -596,8 +664,12 @@ export async function installExtension(
     const absoluteModelsDir = resolve(repoDir, modelsDir);
     const absoluteWorkflowsDir = resolve(repoDir, ctx.workflowsDir);
     const absoluteVaultsDir = resolve(repoDir, ctx.vaultsDir);
+    const absoluteDriversDir = resolve(repoDir, ctx.driversDir);
+    const absoluteDatastoresDir = resolve(repoDir, ctx.datastoresDir);
     const bundlesDir = swampPath(repoDir, "bundles");
     const vaultBundlesDir = swampPath(repoDir, "vault-bundles");
+    const driverBundlesDir = swampPath(repoDir, "driver-bundles");
+    const datastoreBundlesDir = swampPath(repoDir, "datastore-bundles");
 
     const conflicts = await detectConflicts(
       extractDir,
@@ -607,6 +679,10 @@ export async function installExtension(
       repoDir,
       absoluteVaultsDir,
       vaultBundlesDir,
+      absoluteDriversDir,
+      driverBundlesDir,
+      absoluteDatastoresDir,
+      datastoreBundlesDir,
     );
 
     if (conflicts.length > 0 && !ctx.force) {
@@ -659,6 +735,42 @@ export async function installExtension(
       repoDir,
     );
     extractedFiles.push(...vaultBundlesExtracted);
+
+    // Drivers → driversDir
+    await Deno.mkdir(absoluteDriversDir, { recursive: true });
+    const driversExtracted = await copyDir(
+      join(extractDir, "drivers"),
+      absoluteDriversDir,
+      repoDir,
+    );
+    extractedFiles.push(...driversExtracted);
+
+    // Driver bundles → .swamp/driver-bundles/
+    await Deno.mkdir(driverBundlesDir, { recursive: true });
+    const driverBundlesExtracted = await copyDir(
+      join(extractDir, "driver-bundles"),
+      driverBundlesDir,
+      repoDir,
+    );
+    extractedFiles.push(...driverBundlesExtracted);
+
+    // Datastores → datastoresDir
+    await Deno.mkdir(absoluteDatastoresDir, { recursive: true });
+    const datastoresExtracted = await copyDir(
+      join(extractDir, "datastores"),
+      absoluteDatastoresDir,
+      repoDir,
+    );
+    extractedFiles.push(...datastoresExtracted);
+
+    // Datastore bundles → .swamp/datastore-bundles/
+    await Deno.mkdir(datastoreBundlesDir, { recursive: true });
+    const datastoreBundlesExtracted = await copyDir(
+      join(extractDir, "datastore-bundles"),
+      datastoreBundlesDir,
+      repoDir,
+    );
+    extractedFiles.push(...datastoreBundlesExtracted);
 
     // Additional files → modelsDir
     const filesExtracted = await copyDir(
@@ -807,6 +919,8 @@ export async function pullExtension(
     modelsDir: ctx.modelsDir,
     workflowsDir: ctx.workflowsDir,
     vaultsDir: ctx.vaultsDir,
+    driversDir: ctx.driversDir,
+    datastoresDir: ctx.datastoresDir,
     repoDir: ctx.repoDir,
     force: ctx.force,
     alreadyPulled: ctx.alreadyPulled,
@@ -882,6 +996,8 @@ export const extensionPullCommand = new Command()
     const modelsDir = resolveModelsDir(marker);
     const workflowsDir = resolveWorkflowsDir(marker);
     const vaultsDir = resolveVaultsDir(marker);
+    const driversDir = resolveDriversDir(marker);
+    const datastoresDir = resolveDatastoresDir(marker);
 
     // 5. Resolve server URL (from env or default)
     const serverUrl = resolveServerUrl();
@@ -895,6 +1011,8 @@ export const extensionPullCommand = new Command()
       modelsDir,
       workflowsDir,
       vaultsDir,
+      driversDir,
+      datastoresDir,
       repoDir,
       force: options.force ?? false,
       outputMode: ctx.outputMode,

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -110,6 +110,12 @@ export const extensionPushCommand = new Command()
       vaultsDir,
       vaultEntryPoints,
       allVaultFiles,
+      driversDir,
+      driverEntryPoints,
+      allDriverFiles,
+      datastoresDir,
+      datastoreEntryPoints,
+      allDatastoreFiles,
       workflowFiles,
       additionalFilePaths,
     } = resolved;
@@ -174,9 +180,13 @@ export const extensionPushCommand = new Command()
         workflowFiles,
         allVaultFiles,
         vaultsDir,
+        allDriverFiles,
+        driversDir,
+        allDatastoreFiles,
+        datastoresDir,
       );
       ctx.logger
-        .debug`Extracted content metadata: ${contentMetadata.models.length} models, ${contentMetadata.workflows.length} workflows, ${contentMetadata.vaults.length} vaults`;
+        .debug`Extracted content metadata: ${contentMetadata.models.length} models, ${contentMetadata.workflows.length} workflows, ${contentMetadata.vaults.length} vaults, ${contentMetadata.drivers.length} drivers, ${contentMetadata.datastores.length} datastores`;
     } catch {
       ctx.logger.debug`Content metadata extraction failed, skipping`;
     }
@@ -233,6 +243,38 @@ export const extensionPushCommand = new Command()
       };
     });
 
+    const extractedDriversByFile = new Map(
+      (contentMetadata?.drivers ?? []).map((d) => [d.fileName, d]),
+    );
+    const extractedDatastoresByFile = new Map(
+      (contentMetadata?.datastores ?? []).map((d) => [d.fileName, d]),
+    );
+
+    const resolvedDrivers = allDriverFiles.map((f) => {
+      const relPath = relative(repoDir, f);
+      const extracted = extractedDriversByFile.get(relative(driversDir, f));
+      return {
+        type: extracted?.type ?? relPath,
+        fileName: relPath,
+        name: extracted?.name,
+        hasConfigSchema: extracted?.hasConfigSchema,
+        configFields: extracted?.configFields,
+      };
+    });
+    const resolvedDatastores = allDatastoreFiles.map((f) => {
+      const relPath = relative(repoDir, f);
+      const extracted = extractedDatastoresByFile.get(
+        relative(datastoresDir, f),
+      );
+      return {
+        type: extracted?.type ?? relPath,
+        fileName: relPath,
+        name: extracted?.name,
+        hasConfigSchema: extracted?.hasConfigSchema,
+        configFields: extracted?.configFields,
+      };
+    });
+
     const resolvedReleaseNotes = options.releaseNotes ?? manifest.releaseNotes;
     renderExtensionPushResolved(
       {
@@ -246,6 +288,8 @@ export const extensionPushCommand = new Command()
           relative(repoDir, wf.sourcePath)
         ),
         vaults: resolvedVaults,
+        drivers: resolvedDrivers,
+        datastores: resolvedDatastores,
         additionalFiles: additionalFilePaths.map((f) => relative(repoDir, f)),
         platforms: manifest.platforms,
         labels: manifest.labels,
@@ -258,6 +302,8 @@ export const extensionPushCommand = new Command()
     const allFiles = [
       ...allModelFiles,
       ...allVaultFiles,
+      ...allDriverFiles,
+      ...allDatastoreFiles,
       ...workflowFiles.map((wf) => wf.sourcePath),
       ...additionalFilePaths,
     ];
@@ -328,6 +374,38 @@ export const extensionPushCommand = new Command()
       }
     }
 
+    // Bundle driver entry points
+    const driverBundles = new Map<string, string>();
+    for (const entryPoint of driverEntryPoints) {
+      const entryName = relative(driversDir, entryPoint).replace(/\.ts$/, "");
+      try {
+        const js = await bundleExtension(entryPoint, denoPath);
+        driverBundles.set(entryName, js);
+        ctx.logger.debug`Bundled driver ${entryName} (${js.length} bytes)`;
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        compilationErrors.push({ file: entryPoint, error: msg });
+      }
+    }
+
+    // Bundle datastore entry points
+    const datastoreBundles = new Map<string, string>();
+    for (const entryPoint of datastoreEntryPoints) {
+      const entryName = relative(datastoresDir, entryPoint).replace(
+        /\.ts$/,
+        "",
+      );
+      try {
+        const js = await bundleExtension(entryPoint, denoPath);
+        datastoreBundles.set(entryName, js);
+        ctx.logger
+          .debug`Bundled datastore ${entryName} (${js.length} bytes)`;
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        compilationErrors.push({ file: entryPoint, error: msg });
+      }
+    }
+
     if (compilationErrors.length > 0) {
       renderExtensionPushCompilationErrors(
         compilationErrors,
@@ -381,6 +459,10 @@ export const extensionPushCommand = new Command()
       await Deno.mkdir(join(extDir, "workflows"), { recursive: true });
       await Deno.mkdir(join(extDir, "vaults"), { recursive: true });
       await Deno.mkdir(join(extDir, "vault-bundles"), { recursive: true });
+      await Deno.mkdir(join(extDir, "drivers"), { recursive: true });
+      await Deno.mkdir(join(extDir, "driver-bundles"), { recursive: true });
+      await Deno.mkdir(join(extDir, "datastores"), { recursive: true });
+      await Deno.mkdir(join(extDir, "datastore-bundles"), { recursive: true });
       await Deno.mkdir(join(extDir, "files"), { recursive: true });
 
       // Write normalized manifest
@@ -395,6 +477,8 @@ export const extensionPushCommand = new Command()
           models: manifest.models,
           workflows: manifest.workflows,
           vaults: manifest.vaults,
+          drivers: manifest.drivers,
+          datastores: manifest.datastores,
           additionalFiles: manifest.additionalFiles,
           ...(manifest.platforms.length > 0
             ? { platforms: manifest.platforms }
@@ -436,6 +520,40 @@ export const extensionPushCommand = new Command()
       // Write compiled vault bundles
       for (const [entryName, js] of vaultBundles) {
         const destPath = join(extDir, "vault-bundles", `${entryName}.js`);
+        await Deno.mkdir(dirname(destPath), { recursive: true });
+        await Deno.writeTextFile(destPath, js);
+      }
+
+      // Copy driver source files (preserving relative paths from driversDir)
+      for (const driverFile of allDriverFiles) {
+        const relPath = relative(driversDir, driverFile);
+        const destPath = join(extDir, "drivers", relPath);
+        await Deno.mkdir(dirname(destPath), { recursive: true });
+        await Deno.copyFile(driverFile, destPath);
+      }
+
+      // Write compiled driver bundles
+      for (const [entryName, js] of driverBundles) {
+        const destPath = join(extDir, "driver-bundles", `${entryName}.js`);
+        await Deno.mkdir(dirname(destPath), { recursive: true });
+        await Deno.writeTextFile(destPath, js);
+      }
+
+      // Copy datastore source files (preserving relative paths from datastoresDir)
+      for (const datastoreFile of allDatastoreFiles) {
+        const relPath = relative(datastoresDir, datastoreFile);
+        const destPath = join(extDir, "datastores", relPath);
+        await Deno.mkdir(dirname(destPath), { recursive: true });
+        await Deno.copyFile(datastoreFile, destPath);
+      }
+
+      // Write compiled datastore bundles
+      for (const [entryName, js] of datastoreBundles) {
+        const destPath = join(
+          extDir,
+          "datastore-bundles",
+          `${entryName}.js`,
+        );
         await Deno.mkdir(dirname(destPath), { recursive: true });
         await Deno.writeTextFile(destPath, js);
       }
@@ -541,6 +659,8 @@ export const extensionPushCommand = new Command()
           workflowCount: workflowFiles.length,
           bundleCount: bundles.size,
           vaultCount: allVaultFiles.length,
+          driverCount: allDriverFiles.length,
+          datastoreCount: allDatastoreFiles.length,
         },
         ctx.outputMode,
       );

--- a/src/cli/commands/extension_search.ts
+++ b/src/cli/commands/extension_search.ts
@@ -26,6 +26,8 @@ import {
 import { requireInitializedRepo } from "../repo_context.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
 import { resolveVaultsDir } from "../resolve_vaults_dir.ts";
+import { resolveDriversDir } from "../resolve_drivers_dir.ts";
+import { resolveDatastoresDir } from "../resolve_datastores_dir.ts";
 import { resolveWorkflowsDir } from "../resolve_workflows_dir.ts";
 import {
   RepoMarkerRepository,
@@ -154,6 +156,8 @@ export const extensionSearchCommand = new Command()
       const modelsDir = resolveModelsDir(marker);
       const workflowsDir = resolveWorkflowsDir(marker);
       const vaultsDir = resolveVaultsDir(marker);
+      const driversDir = resolveDriversDir(marker);
+      const datastoresDir = resolveDatastoresDir(marker);
 
       const pullCtx: PullContext = {
         extensionClient: client,
@@ -161,6 +165,8 @@ export const extensionSearchCommand = new Command()
         modelsDir,
         workflowsDir,
         vaultsDir,
+        driversDir,
+        datastoresDir,
         repoDir,
         force: false,
         outputMode: ctx.outputMode,

--- a/src/cli/commands/extension_update.ts
+++ b/src/cli/commands/extension_update.ts
@@ -23,6 +23,8 @@ import { createContext, type GlobalOptions } from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
 import { resolveVaultsDir } from "../resolve_vaults_dir.ts";
+import { resolveDriversDir } from "../resolve_drivers_dir.ts";
+import { resolveDatastoresDir } from "../resolve_datastores_dir.ts";
 import { resolveWorkflowsDir } from "../resolve_workflows_dir.ts";
 import {
   RepoMarkerRepository,
@@ -87,6 +89,8 @@ export const extensionUpdateCommand = new Command()
     const modelsDir = resolveModelsDir(marker);
     const workflowsDir = resolveWorkflowsDir(marker);
     const vaultsDir = resolveVaultsDir(marker);
+    const driversDir = resolveDriversDir(marker);
+    const datastoresDir = resolveDatastoresDir(marker);
     const absoluteModelsDir = resolve(repoDir, modelsDir);
 
     // 3. Read installed extensions
@@ -166,6 +170,8 @@ export const extensionUpdateCommand = new Command()
           modelsDir,
           workflowsDir,
           vaultsDir,
+          driversDir,
+          datastoresDir,
           repoDir,
           force: true,
           alreadyPulled: new Set(),

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -545,6 +545,8 @@ export async function runCli(args: string[]): Promise<void> {
           modelsDir,
           workflowsDir,
           vaultsDir,
+          driversDir: resolveDriversDir(marker),
+          datastoresDir: resolveDatastoresDir(marker),
           repoDir,
           denoRuntime,
         }),

--- a/src/cli/resolve_extension_files.ts
+++ b/src/cli/resolve_extension_files.ts
@@ -34,6 +34,8 @@ import { resolveWorkflowDependencies } from "../domain/extensions/extension_depe
 import { resolveModelsDir } from "./resolve_models_dir.ts";
 import { resolveVaultsDir } from "./resolve_vaults_dir.ts";
 import { resolveWorkflowsDir } from "./resolve_workflows_dir.ts";
+import { resolveDriversDir } from "./resolve_drivers_dir.ts";
+import { resolveDatastoresDir } from "./resolve_datastores_dir.ts";
 
 export interface ResolveExtensionFilesContext {
   repoDir: string;
@@ -51,6 +53,12 @@ export interface ResolvedExtensionFiles {
   vaultsDir: string;
   vaultEntryPoints: string[];
   allVaultFiles: string[];
+  driversDir: string;
+  driverEntryPoints: string[];
+  allDriverFiles: string[];
+  datastoresDir: string;
+  datastoreEntryPoints: string[];
+  allDatastoreFiles: string[];
   workflowFiles: Array<{ sourcePath: string; archiveName: string }>;
   additionalFilePaths: string[];
 }
@@ -85,6 +93,8 @@ export async function resolveExtensionFiles(
   const marker = await markerRepo.read(repoPath);
   const modelsDir = resolve(repoDir, resolveModelsDir(marker));
   const vaultsDir = resolve(repoDir, resolveVaultsDir(marker));
+  const driversDir = resolve(repoDir, resolveDriversDir(marker));
+  const datastoresDir = resolve(repoDir, resolveDatastoresDir(marker));
 
   // 3. Collect model files from manifest
   const modelEntryPoints: string[] = [];
@@ -218,7 +228,55 @@ export async function resolveExtensionFiles(
     allVaultFiles.push(...vaultImportResult.resolvedFiles);
   }
 
-  // 8. Validate additional files
+  // 8. Collect driver files from manifest
+  const driverEntryPoints: string[] = [];
+  for (const driverRef of manifest.drivers) {
+    const driverPath = resolve(driversDir, driverRef);
+    try {
+      await Deno.stat(driverPath);
+    } catch {
+      throw new UserError(
+        `Driver file not found: ${driverRef} (expected at ${driverPath})`,
+      );
+    }
+    driverEntryPoints.push(driverPath);
+  }
+
+  // 9. Resolve local imports for driver entry points
+  const allDriverFiles: string[] = [];
+  if (driverEntryPoints.length > 0) {
+    const driverImportResult = await resolveLocalImports(
+      driverEntryPoints,
+      driversDir,
+    );
+    allDriverFiles.push(...driverImportResult.resolvedFiles);
+  }
+
+  // 10. Collect datastore files from manifest
+  const datastoreEntryPoints: string[] = [];
+  for (const datastoreRef of manifest.datastores) {
+    const datastorePath = resolve(datastoresDir, datastoreRef);
+    try {
+      await Deno.stat(datastorePath);
+    } catch {
+      throw new UserError(
+        `Datastore file not found: ${datastoreRef} (expected at ${datastorePath})`,
+      );
+    }
+    datastoreEntryPoints.push(datastorePath);
+  }
+
+  // 11. Resolve local imports for datastore entry points
+  const allDatastoreFiles: string[] = [];
+  if (datastoreEntryPoints.length > 0) {
+    const datastoreImportResult = await resolveLocalImports(
+      datastoreEntryPoints,
+      datastoresDir,
+    );
+    allDatastoreFiles.push(...datastoreImportResult.resolvedFiles);
+  }
+
+  // 12. Validate additional files
   const additionalFilePaths: string[] = [];
   for (const af of manifest.additionalFiles) {
     const afPath = resolve(dirname(absoluteManifestPath), af);
@@ -241,6 +299,12 @@ export async function resolveExtensionFiles(
     vaultsDir,
     vaultEntryPoints,
     allVaultFiles,
+    driversDir,
+    driverEntryPoints,
+    allDriverFiles,
+    datastoresDir,
+    datastoreEntryPoints,
+    allDatastoreFiles,
     workflowFiles,
     additionalFilePaths,
   };

--- a/src/domain/extensions/extension_collective_validator.ts
+++ b/src/domain/extensions/extension_collective_validator.ts
@@ -21,7 +21,7 @@ import type { ExtensionContentMetadata } from "./extension_content.ts";
 
 /** A single content item whose collective doesn't match the extension's collective. */
 export interface CollectiveMismatch {
-  kind: "model" | "vault" | "workflow";
+  kind: "model" | "vault" | "workflow" | "driver" | "datastore";
   identifier: string;
   fileName: string;
 }
@@ -77,6 +77,26 @@ export function validateContentCollectives(
         kind: "workflow",
         identifier: workflow.name,
         fileName: workflow.fileName,
+      });
+    }
+  }
+
+  for (const driver of contentMetadata.drivers) {
+    if (!driver.type.startsWith(collectivePrefix)) {
+      mismatches.push({
+        kind: "driver",
+        identifier: driver.type,
+        fileName: driver.fileName,
+      });
+    }
+  }
+
+  for (const datastore of contentMetadata.datastores) {
+    if (!datastore.type.startsWith(collectivePrefix)) {
+      mismatches.push({
+        kind: "datastore",
+        identifier: datastore.type,
+        fileName: datastore.fileName,
       });
     }
   }

--- a/src/domain/extensions/extension_collective_validator_test.ts
+++ b/src/domain/extensions/extension_collective_validator_test.ts
@@ -28,6 +28,8 @@ function makeMetadata(
     models: [],
     workflows: [],
     vaults: [],
+    drivers: [],
+    datastores: [],
     ...overrides,
   };
 }

--- a/src/domain/extensions/extension_content.ts
+++ b/src/domain/extensions/extension_content.ts
@@ -92,9 +92,31 @@ export interface ExtractedVault {
   configFields: ExtractedArgument[];
 }
 
-/** Content metadata extracted from all models, workflows, and vaults in an extension. */
+/** Metadata extracted from a single driver TypeScript file. */
+export interface ExtractedDriver {
+  fileName: string;
+  type: string;
+  name: string;
+  description: string;
+  hasConfigSchema: boolean;
+  configFields: ExtractedArgument[];
+}
+
+/** Metadata extracted from a single datastore TypeScript file. */
+export interface ExtractedDatastore {
+  fileName: string;
+  type: string;
+  name: string;
+  description: string;
+  hasConfigSchema: boolean;
+  configFields: ExtractedArgument[];
+}
+
+/** Content metadata extracted from all models, workflows, vaults, drivers, and datastores in an extension. */
 export interface ExtensionContentMetadata {
   models: ExtractedModel[];
   workflows: ExtractedWorkflow[];
   vaults: ExtractedVault[];
+  drivers: ExtractedDriver[];
+  datastores: ExtractedDatastore[];
 }

--- a/src/domain/extensions/extension_content_extractor.ts
+++ b/src/domain/extensions/extension_content_extractor.ts
@@ -22,6 +22,8 @@ import { parse as parseYaml } from "@std/yaml";
 import type {
   ExtensionContentMetadata,
   ExtractedArgument,
+  ExtractedDatastore,
+  ExtractedDriver,
   ExtractedFile,
   ExtractedMethod,
   ExtractedModel,
@@ -47,10 +49,16 @@ export async function extractContentMetadata(
   workflowFiles: Array<{ sourcePath: string; archiveName: string }>,
   vaultFiles: string[] = [],
   vaultsDir = "",
+  driverFiles: string[] = [],
+  driversDir = "",
+  datastoreFiles: string[] = [],
+  datastoresDir = "",
 ): Promise<ExtensionContentMetadata> {
   const models: ExtractedModel[] = [];
   const workflows: ExtractedWorkflow[] = [];
   const vaults: ExtractedVault[] = [];
+  const drivers: ExtractedDriver[] = [];
+  const datastores: ExtractedDatastore[] = [];
 
   for (const filePath of modelFiles) {
     try {
@@ -88,7 +96,35 @@ export async function extractContentMetadata(
     }
   }
 
-  return { models, workflows, vaults };
+  for (const filePath of driverFiles) {
+    try {
+      const content = await Deno.readTextFile(filePath);
+      const driver = extractDriverFromSource(content, filePath, driversDir);
+      if (driver) {
+        drivers.push(driver);
+      }
+    } catch {
+      // Non-fatal: skip files that can't be read or parsed
+    }
+  }
+
+  for (const filePath of datastoreFiles) {
+    try {
+      const content = await Deno.readTextFile(filePath);
+      const ds = extractDatastoreFromSource(
+        content,
+        filePath,
+        datastoresDir,
+      );
+      if (ds) {
+        datastores.push(ds);
+      }
+    } catch {
+      // Non-fatal: skip files that can't be read or parsed
+    }
+  }
+
+  return { models, workflows, vaults, drivers, datastores };
 }
 
 /**
@@ -580,6 +616,141 @@ function extractWorkflowFromYaml(
   }
 
   return { fileName, id, name, description, jobs };
+}
+
+/**
+ * Extracts driver metadata from a TypeScript source file.
+ * Returns null if the file doesn't contain a recognizable driver definition.
+ * Uses `createDriver` as the discriminator.
+ */
+function extractDriverFromSource(
+  content: string,
+  filePath: string,
+  driversDir: string,
+): ExtractedDriver | null {
+  if (!/createDriver/.test(content)) return null;
+
+  const driverMatch = content.match(/export\s+const\s+driver\s*=\s*\{/);
+  if (!driverMatch || driverMatch.index === undefined) return null;
+
+  const driverStart = driverMatch.index + driverMatch[0].length;
+  const driverBody = extractBalancedBraces(content, driverStart);
+  if (!driverBody) return null;
+
+  const typeMatch = driverBody.match(/type:\s*["']([^"']+)["']/);
+  if (!typeMatch) return null;
+
+  const nameMatch = driverBody.match(/(?<![.\w])name:\s*["']([^"']+)["']/);
+  const descMatch = driverBody.match(
+    /(?<![.\w])description:\s*(?:"([^"]*?)"|'([^']*?)')/,
+  );
+  const hasConfigSchema = /configSchema\s*:/.test(driverBody);
+
+  let configFields: ExtractedArgument[] = [];
+  const configInline = driverBody.match(/configSchema:\s*z\.object\(\s*\{/);
+  if (configInline && configInline.index !== undefined) {
+    const start = configInline.index + configInline[0].length;
+    const schemaBody = extractBalancedBraces(driverBody, start);
+    if (schemaBody) {
+      configFields = parseZodObjectFields(schemaBody);
+    }
+  } else if (hasConfigSchema) {
+    const configRef = driverBody.match(/configSchema:\s*(\w+)/);
+    if (configRef && configRef[1] !== "z") {
+      const schemaName = configRef[1];
+      const namedPattern = new RegExp(
+        `(?:const|let)\\s+${schemaName}\\s*=\\s*z\\.object\\(\\s*\\{`,
+      );
+      const namedMatch = content.match(namedPattern);
+      if (namedMatch && namedMatch.index !== undefined) {
+        const start = namedMatch.index + namedMatch[0].length;
+        const schemaBody = extractBalancedBraces(content, start);
+        if (schemaBody) {
+          configFields = parseZodObjectFields(schemaBody);
+        }
+      }
+    }
+  }
+
+  return {
+    fileName: relative(driversDir, filePath),
+    type: typeMatch[1],
+    name: nameMatch ? nameMatch[1] : "",
+    description: descMatch ? (descMatch[1] ?? descMatch[2] ?? "") : "",
+    hasConfigSchema,
+    configFields,
+  };
+}
+
+/**
+ * Extracts datastore metadata from a TypeScript source file.
+ * Returns null if the file doesn't contain a recognizable datastore definition.
+ * Uses `createProvider` as the discriminator combined with `export const datastore`.
+ */
+function extractDatastoreFromSource(
+  content: string,
+  filePath: string,
+  datastoresDir: string,
+): ExtractedDatastore | null {
+  const datastoreMatch = content.match(
+    /export\s+const\s+datastore\s*=\s*\{/,
+  );
+  if (!datastoreMatch || datastoreMatch.index === undefined) return null;
+
+  // Must contain createProvider to be a datastore file
+  if (!/createProvider/.test(content)) return null;
+
+  const datastoreStart = datastoreMatch.index + datastoreMatch[0].length;
+  const datastoreBody = extractBalancedBraces(content, datastoreStart);
+  if (!datastoreBody) return null;
+
+  const typeMatch = datastoreBody.match(/type:\s*["']([^"']+)["']/);
+  if (!typeMatch) return null;
+
+  const nameMatch = datastoreBody.match(
+    /(?<![.\w])name:\s*["']([^"']+)["']/,
+  );
+  const descMatch = datastoreBody.match(
+    /(?<![.\w])description:\s*(?:"([^"]*?)"|'([^']*?)')/,
+  );
+  const hasConfigSchema = /configSchema\s*:/.test(datastoreBody);
+
+  let configFields: ExtractedArgument[] = [];
+  const configInline = datastoreBody.match(
+    /configSchema:\s*z\.object\(\s*\{/,
+  );
+  if (configInline && configInline.index !== undefined) {
+    const start = configInline.index + configInline[0].length;
+    const schemaBody = extractBalancedBraces(datastoreBody, start);
+    if (schemaBody) {
+      configFields = parseZodObjectFields(schemaBody);
+    }
+  } else if (hasConfigSchema) {
+    const configRef = datastoreBody.match(/configSchema:\s*(\w+)/);
+    if (configRef && configRef[1] !== "z") {
+      const schemaName = configRef[1];
+      const namedPattern = new RegExp(
+        `(?:const|let)\\s+${schemaName}\\s*=\\s*z\\.object\\(\\s*\\{`,
+      );
+      const namedMatch = content.match(namedPattern);
+      if (namedMatch && namedMatch.index !== undefined) {
+        const start = namedMatch.index + namedMatch[0].length;
+        const schemaBody = extractBalancedBraces(content, start);
+        if (schemaBody) {
+          configFields = parseZodObjectFields(schemaBody);
+        }
+      }
+    }
+  }
+
+  return {
+    fileName: relative(datastoresDir, filePath),
+    type: typeMatch[1],
+    name: nameMatch ? nameMatch[1] : "",
+    description: descMatch ? (descMatch[1] ?? descMatch[2] ?? "") : "",
+    hasConfigSchema,
+    configFields,
+  };
 }
 
 /**

--- a/src/domain/extensions/extension_content_extractor_test.ts
+++ b/src/domain/extensions/extension_content_extractor_test.ts
@@ -24,7 +24,13 @@ import { extractContentMetadata } from "./extension_content_extractor.ts";
 
 Deno.test("extractContentMetadata returns empty for no inputs", async () => {
   const result = await extractContentMetadata([], "/tmp/models", []);
-  assertEquals(result, { models: [], workflows: [], vaults: [] });
+  assertEquals(result, {
+    models: [],
+    workflows: [],
+    vaults: [],
+    drivers: [],
+    datastores: [],
+  });
 });
 
 Deno.test("extractContentMetadata extracts model type from ModelType.create", async () => {

--- a/src/domain/extensions/extension_manifest.ts
+++ b/src/domain/extensions/extension_manifest.ts
@@ -42,6 +42,8 @@ const ExtensionManifestSchemaV1 = z.object({
   workflows: z.array(z.string()).optional(),
   models: z.array(z.string()).optional(),
   vaults: z.array(z.string()).optional(),
+  drivers: z.array(z.string()).optional(),
+  datastores: z.array(z.string()).optional(),
   additionalFiles: z.array(z.string()).optional(),
   platforms: z.array(z.string().min(1)).optional(),
   labels: z.array(z.string().min(1)).optional(),
@@ -55,9 +57,12 @@ const ExtensionManifestSchemaV1 = z.object({
   (data) =>
     (data.models && data.models.length > 0) ||
     (data.workflows && data.workflows.length > 0) ||
-    (data.vaults && data.vaults.length > 0),
+    (data.vaults && data.vaults.length > 0) ||
+    (data.drivers && data.drivers.length > 0) ||
+    (data.datastores && data.datastores.length > 0),
   {
-    message: "Extension must include at least one model, workflow, or vault",
+    message:
+      "Extension must include at least one model, workflow, vault, driver, or datastore",
   },
 );
 
@@ -71,6 +76,8 @@ export interface ExtensionManifest {
   workflows: string[];
   models: string[];
   vaults: string[];
+  drivers: string[];
+  datastores: string[];
   additionalFiles: string[];
   platforms: string[];
   labels: string[];
@@ -126,6 +133,8 @@ export function parseExtensionManifest(content: string): ExtensionManifest {
     workflows: result.data.workflows ?? [],
     models: result.data.models ?? [],
     vaults: result.data.vaults ?? [],
+    drivers: result.data.drivers ?? [],
+    datastores: result.data.datastores ?? [],
     additionalFiles: result.data.additionalFiles ?? [],
     platforms: result.data.platforms ?? [],
     labels: result.data.labels ?? [],

--- a/src/domain/extensions/extension_manifest_test.ts
+++ b/src/domain/extensions/extension_manifest_test.ts
@@ -191,7 +191,7 @@ vaults:
   assertEquals(manifest.workflows, []);
 });
 
-Deno.test("parseExtensionManifest rejects no models, workflows, or vaults", () => {
+Deno.test("parseExtensionManifest rejects no models, workflows, vaults, drivers, or datastores", () => {
   const yaml = `
 manifestVersion: 1
 name: "@myuser/myext"
@@ -200,7 +200,7 @@ version: "2026.02.26.1"
   const error = assertThrows(() => parseExtensionManifest(yaml));
   assertStringIncludes(
     (error as Error).message,
-    "at least one model, workflow, or vault",
+    "at least one model, workflow, vault, driver, or datastore",
   );
 });
 

--- a/src/presentation/output/extension_push_output.ts
+++ b/src/presentation/output/extension_push_output.ts
@@ -42,6 +42,24 @@ export interface ResolvedVaultEntry {
   configFields?: ExtractedArgument[];
 }
 
+/** A driver entry enriched with extracted metadata for the resolved display. */
+export interface ResolvedDriverEntry {
+  type: string;
+  fileName: string;
+  name?: string;
+  hasConfigSchema?: boolean;
+  configFields?: ExtractedArgument[];
+}
+
+/** A datastore entry enriched with extracted metadata for the resolved display. */
+export interface ResolvedDatastoreEntry {
+  type: string;
+  fileName: string;
+  name?: string;
+  hasConfigSchema?: boolean;
+  configFields?: ExtractedArgument[];
+}
+
 /** Data for showing resolved extension contents before push. */
 export interface ExtensionPushResolvedData {
   name: string;
@@ -52,6 +70,8 @@ export interface ExtensionPushResolvedData {
   models: ResolvedModelEntry[];
   workflowFiles: string[];
   vaults: ResolvedVaultEntry[];
+  drivers: ResolvedDriverEntry[];
+  datastores: ResolvedDatastoreEntry[];
   additionalFiles: string[];
   platforms: string[];
   labels: string[];
@@ -68,6 +88,8 @@ export interface ExtensionPushSuccessData {
   workflowCount: number;
   bundleCount: number;
   vaultCount: number;
+  driverCount: number;
+  datastoreCount: number;
 }
 
 /** Data for compilation error output. */
@@ -123,6 +145,34 @@ export function renderExtensionPushResolved(
         if (v.configFields && v.configFields.length > 0) {
           logger.info`    Config Fields:`;
           for (const field of v.configFields) {
+            const opt = field.required ? "" : " (optional)";
+            logger.info`      ${field.name}: ${field.type}${opt}`;
+          }
+        }
+      }
+    }
+    if (data.drivers.length > 0) {
+      logger.info`Drivers (${data.drivers.length}):`;
+      for (const d of data.drivers) {
+        const nameLabel = d.name ? ` - ${d.name}` : "";
+        logger.info`  ${d.type}${nameLabel} (${d.fileName})`;
+        if (d.configFields && d.configFields.length > 0) {
+          logger.info`    Config Fields:`;
+          for (const field of d.configFields) {
+            const opt = field.required ? "" : " (optional)";
+            logger.info`      ${field.name}: ${field.type}${opt}`;
+          }
+        }
+      }
+    }
+    if (data.datastores.length > 0) {
+      logger.info`Datastores (${data.datastores.length}):`;
+      for (const d of data.datastores) {
+        const nameLabel = d.name ? ` - ${d.name}` : "";
+        logger.info`  ${d.type}${nameLabel} (${d.fileName})`;
+        if (d.configFields && d.configFields.length > 0) {
+          logger.info`    Config Fields:`;
+          for (const field of d.configFields) {
             const opt = field.required ? "" : " (optional)";
             logger.info`      ${field.name}: ${field.type}${opt}`;
           }
@@ -219,8 +269,17 @@ export function renderExtensionPush(
     logger.info`Pushed ${data.name}@${data.version}`;
     logger.info`Extension ID: ${data.extensionId}`;
     logger.info`Archive size: ${formatBytes(data.archiveSize)}`;
-    logger
-      .info`Models: ${data.modelCount}, Workflows: ${data.workflowCount}, Vaults: ${data.vaultCount}, Bundles: ${data.bundleCount}`;
+    const parts = [
+      `Models: ${data.modelCount}`,
+      `Workflows: ${data.workflowCount}`,
+      `Vaults: ${data.vaultCount}`,
+    ];
+    if (data.driverCount > 0) parts.push(`Drivers: ${data.driverCount}`);
+    if (data.datastoreCount > 0) {
+      parts.push(`Datastores: ${data.datastoreCount}`);
+    }
+    parts.push(`Bundles: ${data.bundleCount}`);
+    logger.info`${parts.join(", ")}`;
   }
 }
 

--- a/src/presentation/output/extension_push_output_test.ts
+++ b/src/presentation/output/extension_push_output_test.ts
@@ -54,6 +54,8 @@ Deno.test("renderExtensionPushResolved outputs JSON in json mode", () => {
         models: [{ type: "@test/echo", fileName: "echo.ts" }],
         workflowFiles: [],
         vaults: [],
+        drivers: [],
+        datastores: [],
         additionalFiles: [],
         platforms: [],
         labels: [],
@@ -79,6 +81,8 @@ Deno.test("renderExtensionPush outputs JSON in json mode", () => {
         workflowCount: 0,
         bundleCount: 1,
         vaultCount: 0,
+        driverCount: 0,
+        datastoreCount: 0,
       },
       "json",
     );


### PR DESCRIPTION
## Summary

- Extend the extension system to support packaging and distributing drivers and datastores alongside models, workflows, and vaults
- Extensions can now be driver-only or datastore-only — no longer require models or workflows
- This is PR 2 of 4 in the Extension Drivers & Datastores series (builds on #735)

## What changed

### Manifest schema
- New optional `drivers` and `datastores` array fields
- Validation accepts at least one of: models, workflows, vaults, drivers, or datastores

### Push (`extension push`)
- Resolves driver/datastore files from `extensions/drivers/` and `extensions/datastores/` with transitive import resolution
- Bundles each entry point to standalone JS
- Adds `drivers/`, `driver-bundles/`, `datastores/`, `datastore-bundles/` to archive
- Runs safety analysis and quality checks on all TypeScript files
- Validates collective naming for driver/datastore types
- Extracts content metadata (type, name, description, configSchema fields)

### Pull (`extension pull`)
- Extracts and installs driver/datastore files to correct directories
- Conflict detection for driver/datastore paths and bundle paths
- Safety analysis on driver/datastore TypeScript files
- Tracks all files in `upstream_extensions.json`

### Content extraction
- `ExtractedDriver` and `ExtractedDatastore` types
- Detects `export const driver` + `createDriver` and `export const datastore` + `createProvider` patterns
- Config schema field extraction for both

### Updated commands
- `extension search`, `extension update`, `extension fmt`, and auto-resolver all pass `driversDir`/`datastoresDir` through install contexts

### Documentation
- `design/extension.md` — updated archive structure, file extraction table, manifest fields
- `swamp-extension-model` skill — updated publishing reference (manifest schema, field reference, content mapping, push workflow, error messages)
- `swamp-repo` skill — updated repository structure and `.swamp.yaml` config reference

## User-facing behavior

Users can create and distribute driver-only or datastore-only extensions:

```yaml
manifestVersion: 1
name: "@myorg/custom-driver"
version: "2026.03.17.1"
drivers:
  - my_driver.ts
```

`swamp extension push` bundles and uploads. `swamp extension pull` installs to the correct directories. The server accepts the new archive directories without changes (they pass through opaquely).

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — no lint errors (649 files)
- [x] `deno fmt` — formatting clean (702 files)
- [x] `deno run test` — 3175 passed, 0 failed
- [x] `deno run compile` — binary compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>