### PR TITLE
fix: create models dir before writing upstream_extensions.json lock

### DIFF
--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -693,6 +693,7 @@ export async function installExtension(
     const extractedFiles: string[] = [];
 
     // Models → modelsDir
+    await Deno.mkdir(absoluteModelsDir, { recursive: true });
     const modelsExtracted = await copyDir(
       join(extractDir, "models"),
       absoluteModelsDir,


### PR DESCRIPTION
## Summary

Fixes #734.

When auto-resolving a vault-only extension (e.g. `@swamp/1password`), the installer fails if the `extensions/models/` directory does not exist:

```
No such file or directory (os error 2): open '/private/tmp/swamp-vault-test/extensions/models/upstream_extensions.json.lock'
```

The root cause: `installExtension` always calls `updateUpstreamExtensions` (which creates `upstream_extensions.json.lock` inside `modelsDir`) regardless of whether the extension contains any models. Every other destination directory — vaults, workflows, drivers, datastores, bundles — was already guarded with `Deno.mkdir({ recursive: true })` before use, but `modelsDir` was not.

The fix adds `await Deno.mkdir(absoluteModelsDir, { recursive: true })` before the models `copyDir` call, making it consistent with all other directories.

## Steps to Reproduce (from issue)

1. `swamp repo init` in a fresh directory (no `extensions/models/` exists)
2. Create a vault config referencing `@swamp/1password`
3. Run a vault command that triggers auto-resolution (e.g. `swamp vault list-keys <name>`)
4. Extension is found and downloaded, but installation fails

**Workaround:** `mkdir -p extensions/models/` before triggering auto-resolution.

## Test Plan

- Existing `updateUpstreamExtensions` unit tests pass
- `deno check`, `deno lint`, `deno fmt --check` all pass