### PR TITLE
feat: wire custom datastores into repo context

### DIFF
--- a/src/cli/commands/datastore_lock.ts
+++ b/src/cli/commands/datastore_lock.ts
@@ -24,6 +24,7 @@ import {
   createModelLock,
   resolveDatastoreForRepo,
 } from "../repo_context.ts";
+import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
 import { UserError } from "../../domain/errors.ts";
 import {
   type DatastoreLockReleaseData,
@@ -125,7 +126,7 @@ const datastoreLockStatusCommand = new Command()
     renderDatastoreLockStatus(data, ctx.outputMode);
 
     // Scan for per-model locks (filesystem only)
-    if (config.type === "filesystem") {
+    if (!isCustomDatastoreConfig(config) && config.type === "filesystem") {
       const modelLocks = await scanModelLocks(config.path);
       if (modelLocks.length > 0) {
         for (const ml of modelLocks) {

--- a/src/cli/commands/datastore_status.ts
+++ b/src/cli/commands/datastore_status.ts
@@ -20,7 +20,11 @@
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
-import { getDatastoreDirectories } from "../../domain/datastore/datastore_config.ts";
+import {
+  getDatastoreDirectories,
+  isCustomDatastoreConfig,
+} from "../../domain/datastore/datastore_config.ts";
+import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
 import { FilesystemDatastoreVerifier } from "../../infrastructure/persistence/filesystem_datastore_verifier.ts";
 import { S3DatastoreVerifier } from "../../infrastructure/persistence/s3_datastore_verifier.ts";
 import {
@@ -56,13 +60,23 @@ export const datastoreStatusCommand = new Command()
     let message = "Unknown";
     let latencyMs = 0;
 
-    if (config.type === "filesystem") {
+    if (isCustomDatastoreConfig(config)) {
+      const typeInfo = datastoreTypeRegistry.get(config.type);
+      if (typeInfo?.createProvider) {
+        const provider = typeInfo.createProvider(config.config);
+        const verifier = provider.createVerifier();
+        const result = await verifier.verify();
+        healthy = result.healthy;
+        message = result.message;
+        latencyMs = result.latencyMs;
+      }
+    } else if (config.type === "filesystem") {
       const verifier = new FilesystemDatastoreVerifier(config.path);
       const result = await verifier.verify();
       healthy = result.healthy;
       message = result.message;
       latencyMs = result.latencyMs;
-    } else if (config.type === "s3") {
+    } else {
       const verifier = new S3DatastoreVerifier(
         config.bucket,
         config.prefix,
@@ -76,10 +90,18 @@ export const datastoreStatusCommand = new Command()
 
     const data: DatastoreStatusData = {
       type: config.type,
-      path: config.type === "filesystem" ? config.path : undefined,
-      bucket: config.type === "s3" ? config.bucket : undefined,
-      prefix: config.type === "s3" ? config.prefix : undefined,
-      region: config.type === "s3" ? config.region : undefined,
+      path: !isCustomDatastoreConfig(config) && config.type === "filesystem"
+        ? config.path
+        : undefined,
+      bucket: !isCustomDatastoreConfig(config) && config.type === "s3"
+        ? config.bucket
+        : undefined,
+      prefix: !isCustomDatastoreConfig(config) && config.type === "s3"
+        ? config.prefix
+        : undefined,
+      region: !isCustomDatastoreConfig(config) && config.type === "s3"
+        ? config.region
+        : undefined,
       healthy,
       message,
       latencyMs,

--- a/src/cli/commands/datastore_sync.ts
+++ b/src/cli/commands/datastore_sync.ts
@@ -20,6 +20,8 @@
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
+import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
+import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
 import { UserError } from "../../domain/errors.ts";
 import { S3CacheSyncService } from "../../infrastructure/persistence/s3_cache_sync.ts";
 import { S3Client } from "../../infrastructure/persistence/s3_client.ts";
@@ -41,15 +43,70 @@ export const datastoreSyncCommand = new Command()
       "sync",
     ]);
 
-    const { datastoreResolver } = await requireInitializedRepo({
+    const { repoDir, datastoreResolver } = await requireInitializedRepo({
       repoDir: options.repoDir ?? ".",
       outputMode: ctx.outputMode,
     });
 
     const config = datastoreResolver.config();
+
+    // Handle custom datastore sync
+    if (isCustomDatastoreConfig(config)) {
+      const typeInfo = datastoreTypeRegistry.get(config.type);
+      if (!typeInfo?.createProvider) {
+        throw new UserError(
+          `Datastore type "${config.type}" has no provider.`,
+        );
+      }
+      const provider = typeInfo.createProvider(config.config);
+      if (!provider.createSyncService) {
+        throw new UserError(
+          `Datastore type "${config.type}" does not support sync operations. ` +
+            `Only lock-based operations are available.`,
+        );
+      }
+      if (!config.cachePath) {
+        throw new UserError(
+          `Datastore type "${config.type}" has no cache path configured for sync.`,
+        );
+      }
+      const syncService = provider.createSyncService(repoDir, config.cachePath);
+
+      if (options.push) {
+        ctx.logger.info`Pushing changes to datastore...`;
+        await syncService.pushChanged();
+        const data = { mode: "push" };
+        if (ctx.outputMode === "json") {
+          console.log(JSON.stringify(data, null, 2));
+        } else {
+          ctx.logger.info`Push complete`;
+        }
+      } else if (options.pull) {
+        ctx.logger.info`Pulling from datastore...`;
+        await syncService.pullChanged();
+        const data = { mode: "pull" };
+        if (ctx.outputMode === "json") {
+          console.log(JSON.stringify(data, null, 2));
+        } else {
+          ctx.logger.info`Pull complete`;
+        }
+      } else {
+        ctx.logger.info`Syncing with datastore...`;
+        await syncService.pullChanged();
+        await syncService.pushChanged();
+        const data = { mode: "sync" };
+        if (ctx.outputMode === "json") {
+          console.log(JSON.stringify(data, null, 2));
+        } else {
+          ctx.logger.info`Sync complete`;
+        }
+      }
+      return;
+    }
+
     if (config.type !== "s3") {
       throw new UserError(
-        "Datastore sync is only available for S3 datastores. " +
+        "Datastore sync is only available for S3 or sync-capable custom datastores. " +
           `Current datastore type: ${config.type}`,
       );
     }

--- a/src/cli/commands/model_evaluate.ts
+++ b/src/cli/commands/model_evaluate.ts
@@ -123,7 +123,7 @@ export const modelEvaluateCommand = new Command()
       // Acquire per-model lock (for S3, also pulls model-scoped files)
       const flushModelLocks = await acquireModelLocks(datastoreConfig, [
         { modelType: type.normalized, modelId: definition.id },
-      ]);
+      ], repoDir);
 
       const evaluationService = new ExpressionEvaluationService(
         definitionRepo,

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -189,7 +189,7 @@ export const modelMethodRunCommand = new Command()
             modelType: preResult.type.normalized,
             modelId: preResult.definition.id,
           },
-        ]);
+        ], repoDir);
       }
 
       try {

--- a/src/cli/commands/workflow_evaluate.ts
+++ b/src/cli/commands/workflow_evaluate.ts
@@ -196,6 +196,7 @@ export const workflowEvaluateCommand = new Command()
           flushModelLocks = await acquireModelLocks(
             unlocked.datastoreConfig,
             resolvedModels,
+            unlocked.repoDir,
           );
         }
 

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -131,6 +131,7 @@ export const workflowRunCommand = new Command()
             flushModelLocks = await acquireModelLocks(
               unlocked.datastoreConfig,
               resolvedModels,
+              unlocked.repoDir,
             );
           }
 

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -55,8 +55,29 @@ import { S3Lock } from "../infrastructure/persistence/s3_lock.ts";
 import { S3Client } from "../infrastructure/persistence/s3_client.ts";
 import { FileLock } from "../infrastructure/persistence/file_lock.ts";
 import type { DistributedLock } from "../domain/datastore/distributed_lock.ts";
-import type { DatastoreConfig } from "../domain/datastore/datastore_config.ts";
+import {
+  type CustomDatastoreConfig,
+  type DatastoreConfig,
+  isCustomDatastoreConfig,
+} from "../domain/datastore/datastore_config.ts";
+import type { DatastoreProvider } from "../domain/datastore/datastore_provider.ts";
+import { datastoreTypeRegistry } from "../domain/datastore/datastore_type_registry.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+
+/**
+ * Resolves a DatastoreProvider for a custom datastore config.
+ */
+function resolveCustomProvider(
+  config: CustomDatastoreConfig,
+): DatastoreProvider {
+  const typeInfo = datastoreTypeRegistry.get(config.type);
+  if (!typeInfo?.createProvider) {
+    throw new UserError(
+      `Datastore type "${config.type}" is not registered or has no provider.`,
+    );
+  }
+  return typeInfo.createProvider(config.config);
+}
 
 /**
  * Options for requireInitializedRepo.
@@ -151,7 +172,12 @@ export async function requireInitializedRepoReadOnly(
   );
 
   // Verify datastore is accessible
-  if (datastoreConfig.type === "filesystem") {
+  if (isCustomDatastoreConfig(datastoreConfig)) {
+    // Ensure cache/datastore dir exists — no health check or lock on read-only path
+    if (datastoreConfig.cachePath) {
+      await ensureDir(datastoreConfig.cachePath);
+    }
+  } else if (datastoreConfig.type === "filesystem") {
     try {
       const stat = await Deno.stat(datastoreConfig.path);
       if (!stat.isDirectory) {
@@ -173,8 +199,8 @@ export async function requireInitializedRepoReadOnly(
       }
     }
     // No lock acquisition — read-only path
-  } else if (datastoreConfig.type === "s3") {
-    // Ensure local cache directory exists for S3 datastore
+  } else {
+    // S3: Ensure local cache directory exists
     await ensureDir(datastoreConfig.cachePath);
     // No lock acquisition or sync — read-only path reads from local cache
   }
@@ -237,7 +263,25 @@ export async function requireInitializedRepo(
   );
 
   // Verify datastore is accessible
-  if (datastoreConfig.type === "filesystem") {
+  if (isCustomDatastoreConfig(datastoreConfig)) {
+    const provider = resolveCustomProvider(datastoreConfig);
+    const lock = provider.createLock(datastoreConfig.datastorePath);
+
+    // If the custom provider supports sync, register sync service too
+    const syncService = datastoreConfig.cachePath
+      ? provider.createSyncService?.(repoPath.value, datastoreConfig.cachePath)
+      : undefined;
+
+    if (datastoreConfig.cachePath) {
+      await ensureDir(datastoreConfig.cachePath);
+    }
+
+    await registerDatastoreSync({
+      service: syncService,
+      lock,
+      label: datastoreConfig.type,
+    });
+  } else if (datastoreConfig.type === "filesystem") {
     try {
       const stat = await Deno.stat(datastoreConfig.path);
       if (!stat.isDirectory) {
@@ -266,8 +310,8 @@ export async function requireInitializedRepo(
     // Wire file-based lock for filesystem datastores
     const lock = new FileLock(datastoreConfig.path);
     await registerDatastoreSync({ lock });
-  } else if (datastoreConfig.type === "s3") {
-    // Ensure local cache directory exists for S3 datastore
+  } else {
+    // S3: Ensure local cache directory exists
     await ensureDir(datastoreConfig.cachePath);
 
     // Share a single S3Client for both lock and sync service
@@ -279,7 +323,7 @@ export async function requireInitializedRepo(
 
     const lock = new S3Lock(s3);
     const syncService = new S3CacheSyncService(s3, datastoreConfig.cachePath);
-    await registerDatastoreSync({ service: syncService, lock });
+    await registerDatastoreSync({ service: syncService, lock, label: "S3" });
   }
 
   // Compute top-level directories for definitions, workflows, and vaults
@@ -340,7 +384,11 @@ export async function requireInitializedRepoUnlocked(
   );
 
   // Verify datastore is accessible (same checks as requireInitializedRepo)
-  if (datastoreConfig.type === "filesystem") {
+  if (isCustomDatastoreConfig(datastoreConfig)) {
+    if (datastoreConfig.cachePath) {
+      await ensureDir(datastoreConfig.cachePath);
+    }
+  } else if (datastoreConfig.type === "filesystem") {
     try {
       const stat = await Deno.stat(datastoreConfig.path);
       if (!stat.isDirectory) {
@@ -361,7 +409,8 @@ export async function requireInitializedRepoUnlocked(
         );
       }
     }
-  } else if (datastoreConfig.type === "s3") {
+  } else {
+    // S3
     await ensureDir(datastoreConfig.cachePath);
   }
 
@@ -400,6 +449,10 @@ export function createModelLock(
   modelId: string,
 ): DistributedLock {
   const lockKey = `data/${modelType}/${modelId}/.lock`;
+  if (isCustomDatastoreConfig(config)) {
+    const provider = resolveCustomProvider(config);
+    return provider.createLock(config.datastorePath, { lockKey });
+  }
   if (config.type === "s3") {
     const s3 = new S3Client({
       bucket: config.bucket,
@@ -493,11 +546,30 @@ async function waitForPerModelLocks(datastorePath: string): Promise<void> {
 export async function acquireModelLocks(
   config: DatastoreConfig,
   models: Array<{ modelType: string; modelId: string }>,
+  repoDir?: string,
 ): Promise<() => Promise<void>> {
   const logger = getSwampLogger(["datastore", "lock"]);
 
-  // Wait for global lock to be released (if held by a structural command)
-  const globalLock = createDatastoreLock(config);
+  // For custom datastores, resolve the provider once and reuse it everywhere
+  let customProvider: DatastoreProvider | undefined;
+  let customSyncService:
+    | ReturnType<NonNullable<DatastoreProvider["createSyncService"]>>
+    | undefined;
+  if (isCustomDatastoreConfig(config)) {
+    customProvider = resolveCustomProvider(config);
+    if (config.cachePath) {
+      customSyncService = customProvider.createSyncService?.(
+        repoDir ?? ".",
+        config.cachePath,
+      );
+    }
+  }
+
+  // Wait for global lock to be released (if held by a structural command).
+  // Use the cached provider for custom types so all locks share the same instance.
+  const globalLock = customProvider && isCustomDatastoreConfig(config)
+    ? customProvider.createLock(config.datastorePath)
+    : createDatastoreLock(config);
   const globalInfo = await globalLock.inspect();
   if (globalInfo) {
     logger.info(
@@ -542,7 +614,7 @@ export async function acquireModelLocks(
 
   // For S3 datastores, create a shared sync service for model-scoped pulls
   let s3SyncService: S3CacheSyncService | undefined;
-  if (config.type === "s3") {
+  if (!isCustomDatastoreConfig(config) && config.type === "s3") {
     const s3 = new S3Client({
       bucket: config.bucket,
       prefix: config.prefix,
@@ -552,8 +624,11 @@ export async function acquireModelLocks(
   }
 
   for (const { modelType, modelId } of unique) {
-    const lock = createModelLock(config, modelType, modelId);
     const key = `data/${modelType}/${modelId}/.lock`;
+    // Use cached provider for custom types to avoid repeated registry lookups
+    const lock = customProvider && isCustomDatastoreConfig(config)
+      ? customProvider.createLock(config.datastorePath, { lockKey: key })
+      : createModelLock(config, modelType, modelId);
     // Register lock only (no sync service — we handle S3 pull/push manually)
     await registerDatastoreSyncNamed(key, { lock });
     lockKeys.push(key);
@@ -589,7 +664,7 @@ export async function acquireModelLocks(
       }
 
       // Restart the entire per-model lock acquisition from scratch
-      return acquireModelLocks(config, models);
+      return acquireModelLocks(config, models, repoDir);
     }
 
     // For S3: pull model-scoped files after acquiring the per-model lock
@@ -616,6 +691,25 @@ export async function acquireModelLocks(
         );
       }
     }
+
+    // For custom sync-capable datastores: pull after acquiring per-model lock
+    if (customSyncService) {
+      try {
+        logger.info("Syncing model {type}/{id} from datastore...", {
+          type: modelType,
+          id: modelId,
+        });
+        await customSyncService.pullChanged();
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        logger.error("Failed to pull model data from datastore: {error}", {
+          error: msg,
+        });
+        throw new Error(
+          `Datastore sync failed: could not pull data for ${modelType}/${modelId}: ${msg}`,
+        );
+      }
+    }
   }
 
   return async () => {
@@ -623,7 +717,10 @@ export async function acquireModelLocks(
       // For S3 datastores: push changes BEFORE releasing per-model locks.
       // This prevents another process from acquiring the same per-model lock,
       // pulling stale data from S3, and overwriting our local changes.
-      if (s3SyncService && config.type === "s3") {
+      if (
+        s3SyncService && !isCustomDatastoreConfig(config) &&
+        config.type === "s3"
+      ) {
         const pushLock = createDatastoreLock(config);
         try {
           await pushLock.acquire();
@@ -639,6 +736,32 @@ export async function acquireModelLocks(
           });
           throw new Error(
             `S3 sync failed: could not push changes: ${msg}`,
+          );
+        } finally {
+          try {
+            await pushLock.release();
+          } catch {
+            // Best-effort release
+          }
+        }
+      }
+
+      // For custom sync-capable datastores: push under global lock
+      if (
+        customSyncService && customProvider && isCustomDatastoreConfig(config)
+      ) {
+        const pushLock = customProvider.createLock(config.datastorePath);
+        try {
+          await pushLock.acquire();
+          logger.info`Pushing changes to datastore...`;
+          await customSyncService.pushChanged();
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          logger.error("Failed to push changes to datastore: {error}", {
+            error: msg,
+          });
+          throw new Error(
+            `Datastore sync failed: could not push changes: ${msg}`,
           );
         } finally {
           try {
@@ -664,6 +787,10 @@ export async function acquireModelLocks(
  * going through the full sync coordinator lifecycle.
  */
 export function createDatastoreLock(config: DatastoreConfig): DistributedLock {
+  if (isCustomDatastoreConfig(config)) {
+    const provider = resolveCustomProvider(config);
+    return provider.createLock(config.datastorePath);
+  }
   if (config.type === "s3") {
     const s3 = new S3Client({
       bucket: config.bucket,

--- a/src/cli/repo_context_test.ts
+++ b/src/cli/repo_context_test.ts
@@ -430,7 +430,7 @@ Deno.test("acquireModelLocks - acquires and releases per-model locks", async () 
     const flush = await acquireModelLocks(datastoreConfig, [
       { modelType: "aws-ec2", modelId: "server-1" },
       { modelType: "aws-ec2", modelId: "server-2" },
-    ]);
+    ], dir);
 
     // Locks should be held — verify by inspecting
     const lock1 = createModelLock(datastoreConfig, "aws-ec2", "server-1");
@@ -460,7 +460,7 @@ Deno.test("acquireModelLocks - deduplicates same model", async () => {
     const flush = await acquireModelLocks(datastoreConfig, [
       { modelType: "aws-ec2", modelId: "server-1" },
       { modelType: "aws-ec2", modelId: "server-1" },
-    ]);
+    ], dir);
 
     await flush();
   });

--- a/src/cli/resolve_datastore.ts
+++ b/src/cli/resolve_datastore.ts
@@ -33,6 +33,8 @@ import { join } from "@std/path";
 import type { RepoMarkerData } from "../infrastructure/persistence/repo_marker_repository.ts";
 import type { DatastoreConfig } from "../domain/datastore/datastore_config.ts";
 import { getSwampDataDir } from "../infrastructure/persistence/paths.ts";
+import { datastoreTypeRegistry } from "../domain/datastore/datastore_type_registry.ts";
+import { UserError } from "../domain/errors.ts";
 
 /** S3 bucket naming rules: 3-63 chars, lowercase alphanumeric, hyphens, dots. */
 const S3_BUCKET_NAME_RE = /^[a-z0-9][a-z0-9.\-]{1,61}[a-z0-9]$/;
@@ -51,11 +53,13 @@ function validateBucketName(bucket: string): void {
  *
  * @param envValue - The env var value (e.g., "filesystem:/path" or "s3:bucket/prefix")
  * @param repoId - The repo ID for S3 cache path
+ * @param repoDir - The repository root directory (for custom datastore path resolution)
  * @returns Parsed DatastoreConfig
  */
 export function parseDatastoreEnvVar(
   envValue: string,
   repoId?: string,
+  repoDir?: string,
 ): DatastoreConfig {
   const colonIdx = envValue.indexOf(":");
   if (colonIdx === -1) {
@@ -85,9 +89,54 @@ export function parseDatastoreEnvVar(
     return { type: "s3", bucket, prefix, cachePath };
   }
 
-  throw new Error(
-    `Invalid SWAMP_DATASTORE type: "${type}". Expected "filesystem" or "s3".`,
-  );
+  // Custom datastore type: value is JSON config
+  const typeInfo = datastoreTypeRegistry.get(type);
+  if (!typeInfo) {
+    const available = datastoreTypeRegistry.getAll().map((t) => t.type).join(
+      ", ",
+    );
+    throw new UserError(
+      `Unknown datastore type: "${type}". Available types: ${available}`,
+    );
+  }
+  if (!typeInfo.createProvider) {
+    throw new UserError(
+      `Datastore type "${type}" is a built-in type without a provider. ` +
+        `Use the built-in format (e.g., "filesystem:/path" or "s3:bucket/prefix").`,
+    );
+  }
+
+  let config: Record<string, unknown> = {};
+  if (value) {
+    try {
+      config = JSON.parse(value) as Record<string, unknown>;
+    } catch {
+      throw new UserError(
+        `Invalid JSON config for datastore type "${type}": ${value}`,
+      );
+    }
+  }
+
+  if (typeInfo.configSchema) {
+    const result = typeInfo.configSchema.safeParse(config);
+    if (!result.success) {
+      throw new UserError(
+        `Invalid config for datastore type "${type}": ${result.error.message}`,
+      );
+    }
+  }
+
+  const provider = typeInfo.createProvider(config);
+  const resolvedRepoDir = repoDir ?? ".";
+  const datastorePath = provider.resolveDatastorePath(resolvedRepoDir);
+  const cachePath = provider.resolveCachePath?.(resolvedRepoDir);
+
+  return {
+    type,
+    config,
+    datastorePath,
+    cachePath,
+  };
 }
 
 /**
@@ -114,12 +163,12 @@ export function resolveDatastoreConfig(
   // 1. Environment variable takes highest priority
   const envDatastore = Deno.env.get("SWAMP_DATASTORE");
   if (envDatastore) {
-    return parseDatastoreEnvVar(envDatastore, repoId);
+    return parseDatastoreEnvVar(envDatastore, repoId, repoDir);
   }
 
   // 2. CLI argument
   if (cliArg) {
-    return parseDatastoreEnvVar(cliArg, repoId);
+    return parseDatastoreEnvVar(cliArg, repoId, repoDir);
   }
 
   // 3. .swamp.yaml datastore config
@@ -161,6 +210,46 @@ export function resolveDatastoreConfig(
         exclude: ds.exclude,
       };
     }
+
+    // Custom datastore type from YAML config
+    const typeInfo = datastoreTypeRegistry.get(ds.type);
+    if (!typeInfo) {
+      const available = datastoreTypeRegistry.getAll().map((t) => t.type).join(
+        ", ",
+      );
+      throw new UserError(
+        `Unknown datastore type "${ds.type}" in .swamp.yaml. Available types: ${available}`,
+      );
+    }
+    if (!typeInfo.createProvider) {
+      throw new UserError(
+        `Datastore type "${ds.type}" is registered but has no provider.`,
+      );
+    }
+
+    const customConfig = ds.config ?? {};
+
+    if (typeInfo.configSchema) {
+      const result = typeInfo.configSchema.safeParse(customConfig);
+      if (!result.success) {
+        throw new UserError(
+          `Invalid config for datastore type "${ds.type}": ${result.error.message}`,
+        );
+      }
+    }
+
+    const provider = typeInfo.createProvider(customConfig);
+    const datastorePath = provider.resolveDatastorePath(repoDir ?? ".");
+    const cachePath = provider.resolveCachePath?.(repoDir ?? ".");
+
+    return {
+      type: ds.type,
+      config: customConfig,
+      datastorePath,
+      cachePath,
+      directories: ds.directories,
+      exclude: ds.exclude,
+    };
   }
 
   // 4. Default: filesystem at {repoDir}/.swamp/

--- a/src/cli/resolve_datastore_test.ts
+++ b/src/cli/resolve_datastore_test.ts
@@ -22,12 +22,65 @@ import {
   parseDatastoreEnvVar,
   resolveDatastoreConfig,
 } from "./resolve_datastore.ts";
+import {
+  type CustomDatastoreConfig,
+  isCustomDatastoreConfig,
+} from "../domain/datastore/datastore_config.ts";
+import { datastoreTypeRegistry } from "../domain/datastore/datastore_type_registry.ts";
+import type { DatastoreProvider } from "../domain/datastore/datastore_provider.ts";
 import type { RepoMarkerData } from "../infrastructure/persistence/repo_marker_repository.ts";
+import { z } from "zod";
+
+/**
+ * Creates a stub DatastoreProvider for testing custom datastore resolution.
+ */
+function createStubProvider(
+  overrides?: Partial<DatastoreProvider>,
+): DatastoreProvider {
+  return {
+    createLock: () => ({
+      acquire: () => Promise.resolve(),
+      release: () => Promise.resolve(),
+      withLock: <T>(fn: () => Promise<T>) => fn(),
+      inspect: () => Promise.resolve(null),
+      forceRelease: () => Promise.resolve(true),
+    }),
+    createVerifier: () => ({
+      verify: () =>
+        Promise.resolve({
+          healthy: true,
+          message: "ok",
+          latencyMs: 1,
+          datastoreType: "test",
+        }),
+    }),
+    resolveDatastorePath: (repoDir: string) => `${repoDir}/.custom-store`,
+    resolveCachePath: (repoDir: string) => `${repoDir}/.custom-cache`,
+    ...overrides,
+  };
+}
+
+/** Registers a test custom datastore type if not already registered. */
+function ensureTestType(
+  type: string,
+  opts?: { configSchema?: z.ZodTypeAny },
+): void {
+  if (!datastoreTypeRegistry.has(type)) {
+    datastoreTypeRegistry.register({
+      type,
+      name: `Test ${type}`,
+      description: `Test datastore type: ${type}`,
+      isBuiltIn: false,
+      configSchema: opts?.configSchema,
+      createProvider: () => createStubProvider(),
+    });
+  }
+}
 
 Deno.test("parseDatastoreEnvVar - parses filesystem path", () => {
   const config = parseDatastoreEnvVar("filesystem:/data/my-project");
   assertEquals(config.type, "filesystem");
-  if (config.type === "filesystem") {
+  if (!isCustomDatastoreConfig(config) && config.type === "filesystem") {
     assertEquals(config.path, "/data/my-project");
   }
 });
@@ -35,7 +88,7 @@ Deno.test("parseDatastoreEnvVar - parses filesystem path", () => {
 Deno.test("parseDatastoreEnvVar - parses s3 bucket with prefix", () => {
   const config = parseDatastoreEnvVar("s3:my-bucket/my-prefix", "test-repo");
   assertEquals(config.type, "s3");
-  if (config.type === "s3") {
+  if (!isCustomDatastoreConfig(config) && config.type === "s3") {
     assertEquals(config.bucket, "my-bucket");
     assertEquals(config.prefix, "my-prefix");
   }
@@ -44,7 +97,7 @@ Deno.test("parseDatastoreEnvVar - parses s3 bucket with prefix", () => {
 Deno.test("parseDatastoreEnvVar - parses s3 bucket without prefix", () => {
   const config = parseDatastoreEnvVar("s3:my-bucket", "test-repo");
   assertEquals(config.type, "s3");
-  if (config.type === "s3") {
+  if (!isCustomDatastoreConfig(config) && config.type === "s3") {
     assertEquals(config.bucket, "my-bucket");
     assertEquals(config.prefix, undefined);
   }
@@ -58,11 +111,11 @@ Deno.test("parseDatastoreEnvVar - throws on invalid format", () => {
   );
 });
 
-Deno.test("parseDatastoreEnvVar - throws on invalid type", () => {
+Deno.test("parseDatastoreEnvVar - throws on unknown type", () => {
   assertThrows(
     () => parseDatastoreEnvVar("gcs:bucket"),
     Error,
-    "Invalid SWAMP_DATASTORE type",
+    "Unknown datastore type",
   );
 });
 
@@ -77,7 +130,7 @@ Deno.test("parseDatastoreEnvVar - throws on invalid S3 bucket name", () => {
 Deno.test("resolveDatastoreConfig - default is filesystem at .swamp/", () => {
   const config = resolveDatastoreConfig(null, undefined, "/repo");
   assertEquals(config.type, "filesystem");
-  if (config.type === "filesystem") {
+  if (!isCustomDatastoreConfig(config) && config.type === "filesystem") {
     assertEquals(config.path, "/repo/.swamp");
   }
 });
@@ -88,7 +141,7 @@ Deno.test("resolveDatastoreConfig - env var takes priority", () => {
     Deno.env.set("SWAMP_DATASTORE", "filesystem:/custom/path");
     const config = resolveDatastoreConfig(null, undefined, "/repo");
     assertEquals(config.type, "filesystem");
-    if (config.type === "filesystem") {
+    if (!isCustomDatastoreConfig(config) && config.type === "filesystem") {
       assertEquals(config.path, "/custom/path");
     }
   } finally {
@@ -113,7 +166,7 @@ Deno.test("resolveDatastoreConfig - CLI arg overrides marker", () => {
     "/repo",
   );
   assertEquals(config.type, "filesystem");
-  if (config.type === "filesystem") {
+  if (!isCustomDatastoreConfig(config) && config.type === "filesystem") {
     assertEquals(config.path, "/cli-path");
   }
 });
@@ -131,8 +184,149 @@ Deno.test("resolveDatastoreConfig - marker config used when no env/cli", () => {
   };
   const config = resolveDatastoreConfig(marker, undefined, "/repo");
   assertEquals(config.type, "filesystem");
-  if (config.type === "filesystem") {
+  if (!isCustomDatastoreConfig(config) && config.type === "filesystem") {
     assertEquals(config.path, "/marker-path");
     assertEquals(config.directories, ["data", "outputs"]);
   }
+});
+
+// ============================================================================
+// Custom datastore type tests
+// ============================================================================
+
+Deno.test("parseDatastoreEnvVar - parses custom type with JSON config", () => {
+  ensureTestType("test-custom-env");
+  const config = parseDatastoreEnvVar(
+    'test-custom-env:{"region":"us-east-1"}',
+    "repo-1",
+    "/my/repo",
+  );
+  assertEquals(config.type, "test-custom-env");
+  assertEquals(isCustomDatastoreConfig(config), true);
+  const custom = config as CustomDatastoreConfig;
+  assertEquals(custom.config, { region: "us-east-1" });
+  assertEquals(custom.datastorePath, "/my/repo/.custom-store");
+  assertEquals(custom.cachePath, "/my/repo/.custom-cache");
+});
+
+Deno.test("parseDatastoreEnvVar - parses custom type with empty config", () => {
+  ensureTestType("test-custom-empty");
+  const config = parseDatastoreEnvVar(
+    "test-custom-empty:",
+    "repo-1",
+    "/my/repo",
+  );
+  assertEquals(config.type, "test-custom-empty");
+  assertEquals(isCustomDatastoreConfig(config), true);
+  const custom = config as CustomDatastoreConfig;
+  assertEquals(custom.config, {});
+});
+
+Deno.test("parseDatastoreEnvVar - custom type uses repoDir not repoId for path resolution", () => {
+  ensureTestType("test-custom-path");
+  const config = parseDatastoreEnvVar(
+    "test-custom-path:{}",
+    "some-repo-id",
+    "/actual/repo/dir",
+  );
+  const custom = config as CustomDatastoreConfig;
+  // Should use repoDir, not repoId
+  assertEquals(custom.datastorePath, "/actual/repo/dir/.custom-store");
+});
+
+Deno.test("parseDatastoreEnvVar - custom type throws on invalid JSON", () => {
+  ensureTestType("test-custom-badjson");
+  assertThrows(
+    () => parseDatastoreEnvVar("test-custom-badjson:not-json", "r", "/repo"),
+    Error,
+    "Invalid JSON config",
+  );
+});
+
+Deno.test("parseDatastoreEnvVar - custom type validates config schema", () => {
+  const schema = z.object({ endpoint: z.string() });
+  ensureTestType("test-custom-schema", { configSchema: schema });
+  assertThrows(
+    () => parseDatastoreEnvVar("test-custom-schema:{}", "r", "/repo"),
+    Error,
+    "Invalid config for datastore type",
+  );
+});
+
+Deno.test("resolveDatastoreConfig - YAML custom type produces CustomDatastoreConfig", () => {
+  ensureTestType("test-custom-yaml");
+  const marker: RepoMarkerData = {
+    swampVersion: "0.1.0",
+    initializedAt: "2024-01-01",
+    repoId: "test-repo",
+    datastore: {
+      type: "test-custom-yaml",
+      config: { key: "value" },
+      directories: ["data"],
+    },
+  };
+  const config = resolveDatastoreConfig(marker, undefined, "/repo");
+  assertEquals(config.type, "test-custom-yaml");
+  assertEquals(isCustomDatastoreConfig(config), true);
+  const custom = config as CustomDatastoreConfig;
+  assertEquals(custom.config, { key: "value" });
+  assertEquals(custom.datastorePath, "/repo/.custom-store");
+  assertEquals(custom.cachePath, "/repo/.custom-cache");
+  assertEquals(custom.directories, ["data"]);
+});
+
+Deno.test("resolveDatastoreConfig - YAML unknown type throws UserError", () => {
+  const marker: RepoMarkerData = {
+    swampVersion: "0.1.0",
+    initializedAt: "2024-01-01",
+    repoId: "test-repo",
+    datastore: { type: "nonexistent-type" },
+  };
+  assertThrows(
+    () => resolveDatastoreConfig(marker, undefined, "/repo"),
+    Error,
+    "Unknown datastore type",
+  );
+});
+
+Deno.test("resolveDatastoreConfig - YAML custom type with no config defaults to empty object", () => {
+  ensureTestType("test-custom-noconfig");
+  const marker: RepoMarkerData = {
+    swampVersion: "0.1.0",
+    initializedAt: "2024-01-01",
+    repoId: "test-repo",
+    datastore: { type: "test-custom-noconfig" },
+  };
+  const config = resolveDatastoreConfig(marker, undefined, "/repo");
+  const custom = config as CustomDatastoreConfig;
+  assertEquals(custom.config, {});
+});
+
+Deno.test("isCustomDatastoreConfig - returns false for filesystem", () => {
+  assertEquals(
+    isCustomDatastoreConfig({ type: "filesystem", path: "/tmp" }),
+    false,
+  );
+});
+
+Deno.test("isCustomDatastoreConfig - returns false for s3", () => {
+  assertEquals(
+    isCustomDatastoreConfig({
+      type: "s3",
+      bucket: "b",
+      cachePath: "/tmp",
+    }),
+    false,
+  );
+});
+
+Deno.test("isCustomDatastoreConfig - returns true for custom type", () => {
+  assertEquals(
+    isCustomDatastoreConfig({
+      type: "my-custom-store",
+      config: {},
+      datastorePath: "/tmp",
+    }),
+    true,
+  );
 });

--- a/src/domain/datastore/datastore_config.ts
+++ b/src/domain/datastore/datastore_config.ts
@@ -89,19 +89,45 @@ export interface S3DatastoreConfig {
 }
 
 /**
+ * Custom datastore configuration for user-defined datastore types.
+ * Resolved eagerly during config resolution via the DatastoreProvider.
+ */
+export interface CustomDatastoreConfig {
+  readonly type: string; // anything other than "filesystem" | "s3"
+  readonly config: Record<string, unknown>;
+  readonly datastorePath: string;
+  readonly cachePath?: string;
+  readonly directories?: string[];
+  readonly exclude?: string[];
+}
+
+/**
  * Discriminated union of all datastore configurations.
  */
-export type DatastoreConfig = FilesystemDatastoreConfig | S3DatastoreConfig;
+export type DatastoreConfig =
+  | FilesystemDatastoreConfig
+  | S3DatastoreConfig
+  | CustomDatastoreConfig;
+
+/**
+ * Type guard for CustomDatastoreConfig.
+ */
+export function isCustomDatastoreConfig(
+  config: DatastoreConfig,
+): config is CustomDatastoreConfig {
+  return config.type !== "filesystem" && config.type !== "s3";
+}
 
 /**
  * Serializable datastore configuration for .swamp.yaml storage.
  */
 export interface DatastoreConfigData {
-  type: "filesystem" | "s3";
+  type: string;
   path?: string;
   bucket?: string;
   prefix?: string;
   region?: string;
+  config?: Record<string, unknown>;
   directories?: string[];
   exclude?: string[];
 }

--- a/src/domain/datastore/datastore_provider.ts
+++ b/src/domain/datastore/datastore_provider.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import type { DistributedLock } from "./distributed_lock.ts";
+import type { DistributedLock, LockOptions } from "./distributed_lock.ts";
 import type { DatastoreVerifier } from "./datastore_health.ts";
 import type { DatastoreSyncService } from "./datastore_sync_service.ts";
 
@@ -29,7 +29,7 @@ import type { DatastoreSyncService } from "./datastore_sync_service.ts";
  */
 export interface DatastoreProvider {
   /** Create a distributed lock for the datastore. */
-  createLock(datastorePath: string): DistributedLock;
+  createLock(datastorePath: string, options?: LockOptions): DistributedLock;
   /** Create a health verifier for the datastore. */
   createVerifier(): DatastoreVerifier;
   /** Optionally create a sync service for remote datastores. */

--- a/src/domain/datastore/mod.ts
+++ b/src/domain/datastore/mod.ts
@@ -19,12 +19,14 @@
 
 export {
   ALWAYS_LOCAL_SUBDIRS,
+  type CustomDatastoreConfig,
   type DatastoreConfig,
   type DatastoreConfigData,
   DEFAULT_DATASTORE_SUBDIRS,
   type FilesystemDatastoreConfig,
   getDatastoreDirectories,
   isAlwaysLocal,
+  isCustomDatastoreConfig,
   type S3DatastoreConfig,
 } from "./datastore_config.ts";
 

--- a/src/infrastructure/persistence/datastore_sync_coordinator.ts
+++ b/src/infrastructure/persistence/datastore_sync_coordinator.ts
@@ -32,22 +32,33 @@
  * command completes.
  */
 
-import type { S3CacheSyncService } from "./s3_cache_sync.ts";
 import type { DistributedLock } from "../../domain/datastore/distributed_lock.ts";
 import { getSwampLogger } from "../logging/logger.ts";
 
+/**
+ * Common interface for sync services compatible with the coordinator.
+ * Both S3CacheSyncService and DatastoreSyncService satisfy this.
+ */
+export interface SyncableService {
+  pullChanged(): Promise<number | void>;
+  pushChanged(): Promise<number | void>;
+}
+
 /** Options for registering a datastore sync lifecycle. */
 export interface RegisterDatastoreSyncOptions {
-  /** S3 sync service for pull/push operations. */
-  service?: S3CacheSyncService;
+  /** Sync service for pull/push operations. */
+  service?: SyncableService;
   /** Distributed lock for concurrency control. */
   lock?: DistributedLock;
+  /** Label for log messages (e.g. "S3", "custom"). Defaults to "datastore". */
+  label?: string;
 }
 
 /** Internal entry tracking a single lock/sync pair. */
 interface SyncEntry {
-  service?: S3CacheSyncService;
+  service?: SyncableService;
   lock?: DistributedLock;
+  label: string;
 }
 
 /** Key used by the global (structural) lock. */
@@ -115,7 +126,8 @@ export async function registerDatastoreSyncNamed(
   options: RegisterDatastoreSyncOptions,
 ): Promise<void> {
   const { service, lock } = options;
-  const entry: SyncEntry = { service, lock };
+  const label = options.label ?? "datastore";
+  const entry: SyncEntry = { service, lock, label };
   entries.set(key, entry);
 
   // Acquire distributed lock if provided
@@ -128,19 +140,25 @@ export async function registerDatastoreSyncNamed(
   if (service) {
     const logger = getSwampLogger(["datastore", "sync"]);
     try {
-      logger.info`Syncing from S3...`;
+      logger.info("Syncing from {label}...", { label });
       const pulled = await service.pullChanged();
-      if (pulled > 0) {
-        logger.info`Synced ${pulled} file(s) from S3`;
+      if (pulled && pulled > 0) {
+        logger.info("Synced {count} file(s) from {label}", {
+          count: pulled,
+          label,
+        });
       } else {
-        logger.info`S3 sync complete, already up to date`;
+        logger.info("{label} sync complete, already up to date", { label });
       }
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
-      logger.error("Failed to pull changes from S3: {error}", {
+      logger.error("Failed to pull changes from {label}: {error}", {
+        label,
         error: msg,
       });
-      throw new Error(`S3 sync failed: could not pull changes: ${msg}`);
+      throw new Error(
+        `${label} sync failed: could not pull changes: ${msg}`,
+      );
     }
   }
 }
@@ -174,16 +192,21 @@ export async function flushDatastoreSyncNamed(key: string): Promise<void> {
 
   if (entry.service) {
     const logger = getSwampLogger(["datastore", "sync"]);
+    const label = entry.label;
     try {
-      logger.info`Pushing changes to S3...`;
+      logger.info("Pushing changes to {label}...", { label });
       const pushed = await entry.service.pushChanged();
-      if (pushed > 0) {
-        logger.info`Pushed ${pushed} file(s) to S3`;
+      if (pushed && pushed > 0) {
+        logger.info("Pushed {count} file(s) to {label}", {
+          count: pushed,
+          label,
+        });
       } else {
-        logger.info`S3 push complete, no changes`;
+        logger.info("{label} push complete, no changes", { label });
       }
     } catch (error) {
-      logger.warn("Failed to push changes to S3: {error}", {
+      logger.warn("Failed to push changes to {label}: {error}", {
+        label,
         error: error instanceof Error ? error.message : String(error),
       });
     }

--- a/src/infrastructure/persistence/default_datastore_path_resolver.ts
+++ b/src/infrastructure/persistence/default_datastore_path_resolver.ts
@@ -23,6 +23,7 @@ import {
   type DatastoreConfig,
   getDatastoreDirectories,
   isAlwaysLocal,
+  isCustomDatastoreConfig,
 } from "../../domain/datastore/datastore_config.ts";
 import {
   compilePatterns,
@@ -50,7 +51,10 @@ export class DefaultDatastorePathResolver implements DatastorePathResolver {
     this.compiledExclude = compilePatterns(datastoreConfig.exclude ?? []);
 
     // Determine the base path for the datastore
-    if (datastoreConfig.type === "filesystem") {
+    if (isCustomDatastoreConfig(datastoreConfig)) {
+      // Custom: path was eagerly resolved during config resolution
+      this.datastoreBasePath = datastoreConfig.datastorePath;
+    } else if (datastoreConfig.type === "filesystem") {
       this.datastoreBasePath = datastoreConfig.path;
     } else {
       // S3: use local cache path

--- a/src/presentation/output/datastore_output.ts
+++ b/src/presentation/output/datastore_output.ts
@@ -23,7 +23,7 @@ import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import type { LockInfo } from "../../domain/datastore/distributed_lock.ts";
 
 export interface DatastoreStatusData {
-  type: "filesystem" | "s3";
+  type: string;
   path?: string;
   bucket?: string;
   prefix?: string;
@@ -78,7 +78,7 @@ export function renderDatastoreStatus(
 }
 
 export interface DatastoreSetupData {
-  type: "filesystem" | "s3";
+  type: string;
   path?: string;
   bucket?: string;
   prefix?: string;
@@ -132,7 +132,7 @@ function formatBytes(bytes: number): string {
 export interface DatastoreLockStatusData {
   held: boolean;
   info?: LockInfo;
-  datastoreType: "filesystem" | "s3";
+  datastoreType: string;
   /** If set, identifies this as a per-model lock (e.g. "aws-ec2/my-server"). */
   lockScope?: string;
 }


### PR DESCRIPTION
## Summary

PR 3 of 4 in the custom datastore extension series. PRs 1-2 (#735, #745) established the datastore type registry, loader, and extension push/pull. This PR wires registered custom datastore types into the runtime — every switch point in the repo context that previously hardcoded `if (type === "filesystem") ... else if (type === "s3") ...` now has a third path that delegates to the `DatastoreProvider` obtained from the registry.

- Add `CustomDatastoreConfig` to the `DatastoreConfig` discriminated union with eagerly-resolved `datastorePath`/`cachePath`
- Handle custom types in `resolve_datastore.ts` for env var, CLI arg, and `.swamp.yaml` paths
- Add custom branches to all 6 `repo_context.ts` switch points (read-only, locked, unlocked, model lock, model lock acquisition, global lock)
- Wire custom verifier/sync into `datastore status`, `datastore sync`, and `datastore lock` commands
- Generalize `DatastoreSyncCoordinator` to accept any `SyncableService`, not just `S3CacheSyncService`
- 11 new tests covering custom type resolution, config validation, type guard, and error paths

## Design decisions and trade-offs

### Built-in paths untouched
The filesystem and S3 code paths are **not modified** — they continue to use their richer interfaces (`S3CacheSyncService.pushAll()`, `pullChangedForModel()`, etc.) that the generic `DatastoreProvider` interface cannot expose. Custom types get the generic `pullChanged()`/`pushChanged()` interface. This means custom datastores don't support model-scoped sync (they pull everything), but it avoids breaking the well-tested built-in paths.

### Custom check first for type narrowing
Because `CustomDatastoreConfig.type` is `string` (it can be any registered type name), TypeScript can't narrow the discriminated union when checking `type === "filesystem"` first. All switch points check `isCustomDatastoreConfig()` first, then the built-in types narrow correctly in `else if` / `else` branches. This is a compile-time concern only — no runtime cost.

### Single provider instance in `acquireModelLocks`
The custom `DatastoreProvider` is resolved once at the top of `acquireModelLocks` and reused for global lock inspection, per-model lock creation, sync service creation, and the flush push lock. This avoids repeated registry lookups and prevents correctness issues with stateful providers that track locks internally.

### Sync coordinator label parameter
The coordinator's log messages now use a `label` parameter (`"S3"`, the custom type name, etc.) instead of hardcoded `"S3"`. **Existing S3 users see identical log output** — the label defaults to `"datastore"` but S3 registration passes `"S3"` explicitly.

### No health check on read-only path
The read-only path (`requireInitializedRepoReadOnly`) does **not** run a health check for custom datastores — it only ensures the cache directory exists, matching what S3 does. Health checks run in `datastore status` where they belong. This avoids adding potentially slow network round-trips to every read-only command (search, list, get, validate).

### `datastore sync` for custom types
Custom sync uses the generic `pullChanged()`/`pushChanged()` interface (no `pushAll`/`pullAll`/`sync` full-sync methods). The `datastore sync` command for custom types does pull + push sequentially. This parallels how `requireInitializedRepo` also registers a sync service with the coordinator, so there is some redundant pull/push — but this matches the existing S3 pattern where the coordinator does incremental sync and the manual command does full sync.

## User impact

- **Filesystem users**: Zero change. No new code executes.
- **S3 users**: Zero behavioral change. Log messages unchanged. Same lock/sync lifecycle.
- **Custom datastore users**: Can now configure a custom datastore in `.swamp.yaml` or via `SWAMP_DATASTORE` env var and have it work with locking, sync, health checks, and all CLI commands.

## Verification

- [x] `deno check` — clean (0 errors)
- [x] `deno lint` — clean
- [x] `deno fmt` — clean
- [x] `deno run test` — 3186 passed, 0 failed
- [x] `deno run compile` — binary compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>