### PR TITLE
fix: health-check embedded deno after extraction, fall back to system deno on failure

### DIFF
--- a/src/domain/extensions/extension_quality_checker.ts
+++ b/src/domain/extensions/extension_quality_checker.ts
@@ -264,12 +264,7 @@ export async function checkExtensionQuality(
     const stderr = new TextDecoder().decode(fmtOutput.stderr);
     const stdout = new TextDecoder().decode(fmtOutput.stdout);
     const output = (stderr + stdout).trim();
-    // Only report if there is actionable output. Some deno versions (e.g.
-    // 2.7.x) may exit non-zero with no output due to a version-specific
-    // behaviour change; treat that as a pass to avoid false positives.
-    if (output) {
-      issues.push({ check: "fmt", output });
-    }
+    issues.push({ check: "fmt", output });
   }
 
   // Check linting
@@ -283,10 +278,7 @@ export async function checkExtensionQuality(
     const stderr = new TextDecoder().decode(lintOutput.stderr);
     const stdout = new TextDecoder().decode(lintOutput.stdout);
     const output = (stderr + stdout).trim();
-    // Only report if there is actionable output (same rationale as fmt above).
-    if (output) {
-      issues.push({ check: "lint", output });
-    }
+    issues.push({ check: "lint", output });
   }
 
   return {

--- a/src/domain/models/bundle.ts
+++ b/src/domain/models/bundle.ts
@@ -178,10 +178,7 @@ export async function bundleExtension(
   });
 
   try {
-    // --unstable-bundle is required for deno 2.7.x+; without it the
-    // subprocess exits non-zero with no output (silent failure).
-    // It is accepted (though not required) by deno 2.6.x as well.
-    const args = ["bundle", "--unstable-bundle", "--no-lock"];
+    const args = ["bundle", "--no-lock"];
 
     // Externalize zod by default so in-process extensions share the
     // host's zod instance (required for `instanceof` schema checks).

--- a/src/infrastructure/runtime/embedded_deno_runtime.ts
+++ b/src/infrastructure/runtime/embedded_deno_runtime.ts
@@ -34,6 +34,12 @@ const DENO_BINARY_NAME = Deno.build.os === "windows" ? "deno.exe" : "deno";
  * - **Standalone mode** (compiled binary): reads the embedded binary from
  *   `resources/deno/`, extracts it to `~/.swamp/deno/`, and returns that path.
  *   Skips extraction when `~/.swamp/deno/.version` already matches.
+ *
+ * After extraction (and on each startup when the version is already current),
+ * a health check runs `deno --version` to verify the binary executes cleanly.
+ * On macOS, extended attributes are cleared after writing to prevent
+ * provenance-based SIGKILL from the OS security layer. If the health check
+ * still fails after extraction, swamp falls back to a system `deno` in PATH.
  */
 export class EmbeddedDenoRuntime implements DenoRuntime {
   private cachedPath: string | null = null;
@@ -74,11 +80,14 @@ export class EmbeddedDenoRuntime implements DenoRuntime {
     try {
       const existingVersion = (await Deno.readTextFile(versionMarker)).trim();
       if (existingVersion === embeddedVersion.value) {
-        // Also verify the binary exists
         await Deno.stat(targetBinary);
         logger
           .debug`Deno ${embeddedVersion} already extracted at ${targetBinary}`;
-        return targetBinary;
+        if (await this.healthCheck(targetBinary)) {
+          return targetBinary;
+        }
+        logger
+          .warn`Extracted deno at ${targetBinary} failed health check — re-extracting`;
       }
     } catch {
       // Version marker missing or binary missing — need to extract
@@ -100,12 +109,97 @@ export class EmbeddedDenoRuntime implements DenoRuntime {
       await Deno.chmod(targetBinary, 0o755);
     }
 
+    // On macOS, clear extended attributes after writing so the OS doesn't
+    // apply provenance-based security restrictions (SIGKILL) to the binary.
+    await this.clearMacOSExtendedAttributes(targetBinary);
+
     // Write version marker
     await Deno.writeTextFile(versionMarker, embeddedVersion.value);
 
     logger
       .info`Extracted deno ${embeddedVersion} (${embeddedBinary.length} bytes)`;
-    return targetBinary;
+
+    if (await this.healthCheck(targetBinary)) {
+      return targetBinary;
+    }
+
+    // Extracted binary still unhealthy — fall back to system deno in PATH.
+    logger
+      .warn`Embedded deno at ${targetBinary} failed health check after extraction — falling back to system deno`;
+    const systemDeno = await this.findSystemDeno();
+    if (systemDeno) {
+      logger.warn`Using system deno at ${systemDeno}`;
+      return systemDeno;
+    }
+
+    throw new Error(
+      `Embedded deno at ${targetBinary} failed health check and no system deno found in PATH. ` +
+        `Try: xattr -c ${targetBinary}`,
+    );
+  }
+
+  /**
+   * Returns true if the binary at the given path executes cleanly.
+   */
+  private async healthCheck(binaryPath: string): Promise<boolean> {
+    try {
+      const result = await new Deno.Command(binaryPath, {
+        args: ["--version"],
+        stdout: "null",
+        stderr: "null",
+      }).output();
+      return result.success;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Clears all extended attributes on a file on macOS.
+   *
+   * When swamp writes the embedded deno binary via Deno.writeFile, macOS
+   * records the writing process's provenance in com.apple.provenance. This
+   * can cause the OS security layer to SIGKILL the binary when it is later
+   * spawned as a subprocess. Clearing attributes after writing prevents this.
+   */
+  private async clearMacOSExtendedAttributes(
+    binaryPath: string,
+  ): Promise<void> {
+    if (Deno.build.os !== "darwin") return;
+    try {
+      await new Deno.Command("xattr", {
+        args: ["-c", binaryPath],
+        stdout: "null",
+        stderr: "null",
+      }).output();
+      logger.debug`Cleared macOS extended attributes on ${binaryPath}`;
+    } catch {
+      // xattr not available — best effort, health check will catch failures
+    }
+  }
+
+  /**
+   * Searches PATH for a system-installed deno binary.
+   * Used as a fallback when the embedded binary fails its health check.
+   */
+  private async findSystemDeno(): Promise<string | null> {
+    const which = Deno.build.os === "windows" ? "where" : "which";
+    try {
+      const result = await new Deno.Command(which, {
+        args: ["deno"],
+        stdout: "piped",
+        stderr: "null",
+      }).output();
+      if (result.success) {
+        const path = new TextDecoder().decode(result.stdout).trim().split(
+          "\n",
+        )[0].trim();
+        if (path) return path;
+      }
+    } catch {
+      // which/where not available
+    }
+    return null;
   }
 
   private async readEmbeddedVersion(): Promise<DenoVersion> {


### PR DESCRIPTION
## Root Cause

When the compiled swamp binary extracts the embedded deno via `Deno.writeFile`, macOS records the writing process's provenance in `com.apple.provenance`. In certain conditions — a stale binary left by a prior swamp version, or OS-level security policy differences between how a programmatically-written file vs a user-copied file is treated — the extracted binary gets **SIGKILL'd (exit 137)** when spawned as a subprocess.

This produced the silent failure reported in the issue:
```
error: Bundle compilation failed:
  "/path/to/extensions/models/hello.ts": "deno bundle failed for /path/to/hello.ts: "
```
Exit code non-zero, stderr empty, stdout empty — because the deno subprocess never ran at all.

## Why the Previous Fixes Were Wrong

Two prior commits attempted to address this symptom:

- **#748** (`5705468c`) — treated empty output from `deno fmt`/`deno lint` as a pass, to avoid false-positive quality check failures. This masked the SIGKILL rather than fixing it: the quality check silently passed, and the failure surfaced later at bundle time with an even more confusing empty error.
- **#750** (`1efdc301`) — added `--unstable-bundle` to the `deno bundle` invocation, assuming a deno 2.7.x flag change was the cause. Testing confirmed deno 2.7.5 bundles correctly without this flag. The root cause was the bad binary, not a missing flag.

Both commits are reverted in this PR.

## Mitigations Added in `EmbeddedDenoRuntime`

### 1. Health check after extraction
After writing the binary, swamp immediately runs `deno --version`. If it fails (SIGKILL, permission error, or any other cause), swamp re-extracts rather than caching a broken path. The health check also runs on the **"version already matches" fast path**, so a stale/broken binary from a prior swamp version is caught on first use after upgrade.

### 2. `xattr -c` after writing (macOS only)
After writing the extracted binary, swamp runs `xattr -c <path>` to clear extended attributes. This is best-effort — macOS re-adds `com.apple.provenance` — but may prevent restrictions in configurations where the provenance value written during extraction differs from what macOS expects.

### 3. System deno fallback
If the extracted binary still fails the health check after a fresh extraction, swamp searches `PATH` for a system-installed `deno` and uses it with a warning. If no system deno is found either, a clear error is thrown:
```
Embedded deno at ~/.swamp/deno/deno failed health check and no system deno found in PATH.
Try: xattr -c ~/.swamp/deno/deno
```

## Also Reverted

| File | Change |
|------|--------|
| `src/domain/models/bundle.ts` | Removed `--unstable-bundle` (not needed on deno 2.7.5) |
| `src/domain/extensions/extension_quality_checker.ts` | Removed empty-output-as-pass logic (was masking failures; health check now catches bad binaries before quality checking runs) |

## Test Plan

- [x] Deleted `~/.swamp/deno/`, ran `swamp extension push --dry-run` with newly compiled binary — fresh extraction succeeded, `deno --version` health check passed, bundle completed
- [x] Verified `~/.swamp/deno/deno` runs cleanly (exit 0) after extraction by new binary
- [x] Full test suite: 3183 tests pass, 0 failed
- [x] `deno fmt --check` and `deno lint` clean