### PR TITLE
docs: add extension datastore and driver skills

### DIFF
--- a/.claude/skills/swamp-extension-datastore/SKILL.md
+++ b/.claude/skills/swamp-extension-datastore/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: swamp-extension-datastore
+description: Create user-defined TypeScript datastores for swamp — implement DatastoreProvider, configure locking, health checks, and optional sync. Use when users want to extend swamp with custom datastore backends. Triggers on "custom datastore", "extension datastore", "DatastoreProvider", "extensions/datastores", "create datastore", "new datastore type", "datastore plugin", "datastore implementation".
+---
+
+# Swamp Extension Datastore
+
+Create TypeScript datastores in `extensions/datastores/` that swamp loads at
+startup.
+
+## When to Create a Custom Datastore
+
+**Create an extension datastore when the built-in backends (filesystem, S3)
+don't meet your needs.**
+
+Before creating a custom datastore, check what's available:
+
+1. Built-in types: `filesystem` (local directory), `s3` (AWS S3 bucket)
+2. Search community extensions: `swamp extension search datastore`
+3. If a community extension exists, install it instead of building from scratch
+4. Only create a custom datastore if nothing fits
+
+Extensions from trusted collectives (`@swamp/*`, `@si/*`, and your membership
+collectives) auto-resolve on first use — no manual `extension pull` needed.
+
+Custom datastores let you:
+
+- Store runtime data in any backend (GCS, Azure Blob, databases, etc.)
+- Implement custom locking strategies
+- Add custom sync logic for remote datastores
+
+## Quick Reference
+
+| Task                | Command/Action                                 |
+| ------------------- | ---------------------------------------------- |
+| Search community    | `swamp extension search datastore --json`      |
+| Create datastore    | Create `extensions/datastores/my-store/mod.ts` |
+| Verify registration | `swamp datastore status --json`                |
+| Check config        | View `.swamp.yaml` datastore section           |
+| Push extension      | `swamp extension push manifest.yaml --json`    |
+| Dry-run push        | `swamp extension push manifest.yaml --dry-run` |
+
+## Quick Start
+
+```typescript
+// extensions/datastores/my-store/mod.ts
+import { z } from "npm:zod@4";
+
+const ConfigSchema = z.object({
+  endpoint: z.string().url(),
+  bucket: z.string(),
+});
+
+export const datastore = {
+  type: "@myorg/my-store",
+  name: "My Custom Store",
+  description: "Stores runtime data in a custom backend",
+  configSchema: ConfigSchema,
+  createProvider: (config: Record<string, unknown>) => {
+    const parsed = ConfigSchema.parse(config);
+    return {
+      createLock: (
+        datastorePath: string,
+        options?: {
+          lockKey?: string;
+          ttlMs?: number;
+          retryIntervalMs?: number;
+          maxWaitMs?: number;
+        },
+      ) => ({
+        acquire: async () => {/* acquire lock */},
+        release: async () => {/* release lock */},
+        withLock: async <T>(fn: () => Promise<T>) => {
+          // acquire, run fn, release
+          return await fn();
+        },
+        inspect: async () => null,
+        forceRelease: async (_nonce: string) => false,
+      }),
+      createVerifier: () => ({
+        verify: async () => ({
+          healthy: true,
+          message: "OK",
+          latencyMs: 1,
+          datastoreType: "@myorg/my-store",
+        }),
+      }),
+      resolveDatastorePath: (repoDir: string) => `${repoDir}/.my-store`,
+    };
+  },
+};
+```
+
+## Export Contract
+
+| Field            | Required | Description                                         |
+| ---------------- | -------- | --------------------------------------------------- |
+| `type`           | Yes      | Namespaced identifier (`@collective/name`)          |
+| `name`           | Yes      | Human-readable display name                         |
+| `description`    | Yes      | What this datastore does                            |
+| `configSchema`   | No       | Zod schema for validating config from `.swamp.yaml` |
+| `createProvider` | Yes      | Factory function `(config) => DatastoreProvider`    |
+
+The `type` must match the pattern `@collective/name` or `collective/name` (e.g.,
+`@myorg/custom-store`). Reserved collectives (`swamp`, `si`) cannot be used.
+
+## DatastoreProvider Methods
+
+| Method                 | Required | Description                                         |
+| ---------------------- | -------- | --------------------------------------------------- |
+| `createLock`           | Yes      | Returns a `DistributedLock` for write serialization |
+| `createVerifier`       | Yes      | Returns a `DatastoreVerifier` for health checks     |
+| `createSyncService`    | No       | Returns a `DatastoreSyncService` for remote sync    |
+| `resolveDatastorePath` | Yes      | Returns the absolute path for runtime data storage  |
+| `resolveCachePath`     | No       | Returns a local cache path for remote datastores    |
+
+For full interface signatures and type details, see
+[references/api.md](references/api.md).
+
+## Configuration
+
+Configure a custom datastore in `.swamp.yaml`:
+
+```yaml
+datastore:
+  type: "@myorg/my-store"
+  config:
+    endpoint: "https://storage.example.com"
+    bucket: "my-data"
+```
+
+Or via environment variable (JSON config after the type):
+
+```bash
+export SWAMP_DATASTORE='@myorg/my-store:{"endpoint":"https://storage.example.com","bucket":"my-data"}'
+```
+
+Verify with:
+
+```bash
+swamp datastore status --json
+```
+
+**Priority order:** `SWAMP_DATASTORE` env var > CLI `--datastore` arg >
+`.swamp.yaml` config > default filesystem.
+
+## Verify
+
+After creating your datastore:
+
+```bash
+swamp datastore status --json              # Should show your custom type
+```
+
+If `healthy: false`, check the error message, fix the issue in your
+`createVerifier().verify()` implementation, then delete stale bundles and
+re-verify:
+
+```bash
+rm -rf .swamp/datastore-bundles/
+swamp datastore status --json
+```
+
+## Discovery & Loading
+
+- Location: `{repo}/extensions/datastores/**/*.ts`
+- Discovery: Recursive, all `.ts` files
+- Excluded: Files ending in `_test.ts`
+- Export: Files without `export const datastore` are silently skipped
+- Caching: Bundles are cached in `.swamp/datastore-bundles/` (mtime-based)
+
+## Key Rules
+
+1. **Import**: `import { z } from "npm:zod@4";` — always required for config
+   schemas
+2. **Export name**: Must be `export const datastore = { ... }`
+3. **Reserved collectives**: Cannot use `swamp` or `si` in the type
+4. **Type pattern**: `@collective/name` or `collective/name` (lowercase,
+   alphanumeric, hyphens, underscores)
+5. **Static imports only**: All npm imports must be static top-level imports —
+   dynamic `import()` is not supported
+6. **Pin npm versions**: Always pin versions (e.g., `npm:pkg@1.2.3`) except
+   `npm:zod@4`
+7. **Locking is required**: `createLock` must return a working `DistributedLock`
+   — swamp acquires locks for all write operations
+
+## When to Use Other Skills
+
+| Need                                | Use Skill                |
+| ----------------------------------- | ------------------------ |
+| Use existing datastores             | `swamp-repo`             |
+| Create custom models                | `swamp-extension-model`  |
+| Create custom execution drivers     | `swamp-extension-driver` |
+| Repository setup and configuration  | `swamp-repo`             |
+| Manage secrets for datastore config | `swamp-vault`            |
+
+## References
+
+- **API Reference**: See [references/api.md](references/api.md) for full
+  `DatastoreProvider`, `DistributedLock`, `DatastoreVerifier`, and
+  `DatastoreSyncService` interface documentation
+- **Examples**: See [references/examples.md](references/examples.md) for
+  complete working examples (local and remote datastores)
+- **Troubleshooting**: See
+  [references/troubleshooting.md](references/troubleshooting.md) for common
+  issues (type not found, config validation, stale bundles)

--- a/.claude/skills/swamp-extension-datastore/references/api.md
+++ b/.claude/skills/swamp-extension-datastore/references/api.md
@@ -1,0 +1,170 @@
+# API Reference — Extension Datastores
+
+Full interface documentation for implementing custom datastore providers.
+
+Source files:
+
+- `src/domain/datastore/datastore_provider.ts`
+- `src/domain/datastore/distributed_lock.ts`
+- `src/domain/datastore/datastore_health.ts`
+- `src/domain/datastore/datastore_sync_service.ts`
+
+## DatastoreProvider
+
+Factory interface returned by `createProvider`. Implementations provide the
+components needed to operate a datastore.
+
+```typescript
+interface DatastoreProvider {
+  createLock(datastorePath: string, options?: LockOptions): DistributedLock;
+  createVerifier(): DatastoreVerifier;
+  createSyncService?(repoDir: string, cachePath: string): DatastoreSyncService;
+  resolveDatastorePath(repoDir: string): string;
+  resolveCachePath?(repoDir: string): string;
+}
+```
+
+### `createLock(datastorePath, options?)`
+
+Returns a `DistributedLock` for serializing write access. Called by every write
+command (`model create`, `model method run`, `workflow run`, `data gc`, etc.).
+
+- `datastorePath` — the resolved datastore path from `resolveDatastorePath`
+- `options` — optional lock configuration (see `LockOptions` below)
+
+### `createVerifier()`
+
+Returns a `DatastoreVerifier` used by `swamp datastore status` and the health
+check in `requireInitializedRepo()`.
+
+### `createSyncService(repoDir, cachePath)?`
+
+Optional. Returns a `DatastoreSyncService` for remote datastores that need
+pull/push synchronization. If not provided, the datastore is assumed to be
+locally accessible (no sync needed).
+
+- `repoDir` — repository root directory
+- `cachePath` — local cache path from `resolveCachePath`
+
+### `resolveDatastorePath(repoDir)`
+
+Returns the absolute path where runtime data should be stored. For local
+datastores, this is the actual data directory. For remote datastores, this
+should be the local cache path.
+
+### `resolveCachePath(repoDir)?`
+
+Optional. Returns a local cache path for remote datastores. When present, swamp
+uses this path for local caching and syncs to/from the remote backend via the
+sync service.
+
+## DistributedLock
+
+Distributed lock for serializing write access across processes.
+
+```typescript
+interface DistributedLock {
+  acquire(): Promise<void>;
+  release(): Promise<void>;
+  withLock<T>(fn: () => Promise<T>): Promise<T>;
+  inspect(): Promise<LockInfo | null>;
+  forceRelease(expectedNonce: string): Promise<boolean>;
+}
+```
+
+### `acquire()`
+
+Acquire the lock. Starts an internal heartbeat to prevent expiry. Retries until
+`maxWaitMs`. Force-acquires stale locks (TTL expired).
+
+Throws `LockTimeoutError` if the lock cannot be acquired within `maxWaitMs`.
+
+### `release()`
+
+Release the lock. Stops internal heartbeat. Safe to call multiple times.
+
+### `withLock(fn)`
+
+Convenience: acquires the lock, runs `fn`, releases the lock (even on error).
+
+### `inspect()`
+
+Read the current lock info without acquiring. Returns `null` if no lock is held.
+
+### `forceRelease(expectedNonce)`
+
+Breakglass operation for stuck locks. Only releases if the nonce matches.
+Returns `true` if released, `false` if nonce didn't match.
+
+## LockInfo
+
+Metadata stored in the lock file.
+
+```typescript
+interface LockInfo {
+  holder: string; // e.g., "user@hostname"
+  hostname: string; // Machine name
+  pid: number; // Process ID
+  acquiredAt: string; // ISO timestamp
+  ttlMs: number; // Lock duration before considered stale
+  nonce?: string; // Fencing token for force-release
+}
+```
+
+## LockOptions
+
+Configuration for lock behavior.
+
+```typescript
+interface LockOptions {
+  lockKey?: string; // Backend-specific key (default varies)
+  ttlMs?: number; // TTL in ms (default: 30_000)
+  retryIntervalMs?: number; // Retry interval in ms (default: 1_000)
+  maxWaitMs?: number; // Max wait in ms (default: 60_000)
+}
+```
+
+## DatastoreVerifier
+
+Health check interface for verifying datastore accessibility.
+
+```typescript
+interface DatastoreVerifier {
+  verify(): Promise<DatastoreHealthResult>;
+}
+```
+
+## DatastoreHealthResult
+
+Result of a health check.
+
+```typescript
+interface DatastoreHealthResult {
+  readonly healthy: boolean; // Whether accessible
+  readonly message: string; // Human-readable status
+  readonly latencyMs: number; // Check latency in ms
+  readonly datastoreType: string; // Datastore type that was checked
+  readonly details?: Record<string, string>; // Additional info
+}
+```
+
+## DatastoreSyncService
+
+Optional interface for remote datastore synchronization.
+
+```typescript
+interface DatastoreSyncService {
+  pullChanged(): Promise<void>;
+  pushChanged(): Promise<void>;
+}
+```
+
+### `pullChanged()`
+
+Pull changed files from the remote datastore to the local cache. Called before
+read/write operations on remote datastores.
+
+### `pushChanged()`
+
+Push changed files from the local cache to the remote datastore. Called after
+write operations complete.

--- a/.claude/skills/swamp-extension-datastore/references/examples.md
+++ b/.claude/skills/swamp-extension-datastore/references/examples.md
@@ -1,0 +1,278 @@
+# Examples — Extension Datastores
+
+## Minimal Local Datastore
+
+A simple local filesystem variant that stores data in a custom directory:
+
+```typescript
+// extensions/datastores/custom-fs/mod.ts
+import { z } from "npm:zod@4";
+
+const ConfigSchema = z.object({
+  basePath: z.string().describe("Base directory for data storage"),
+});
+
+export const datastore = {
+  type: "@myorg/custom-fs",
+  name: "Custom Filesystem",
+  description:
+    "Stores data in a custom local directory with file-based locking",
+  configSchema: ConfigSchema,
+  createProvider: (config: Record<string, unknown>) => {
+    const parsed = ConfigSchema.parse(config);
+
+    return {
+      createLock: (
+        datastorePath: string,
+        options?: {
+          lockKey?: string;
+          ttlMs?: number;
+          retryIntervalMs?: number;
+          maxWaitMs?: number;
+        },
+      ) => {
+        const lockFile = `${datastorePath}/${options?.lockKey ?? ".lock"}`;
+        const ttlMs = options?.ttlMs ?? 30_000;
+        const retryIntervalMs = options?.retryIntervalMs ?? 1_000;
+        const maxWaitMs = options?.maxWaitMs ?? 60_000;
+        let heartbeatId: number | undefined;
+
+        return {
+          acquire: async () => {
+            const start = Date.now();
+            while (Date.now() - start < maxWaitMs) {
+              try {
+                const info = {
+                  holder: `${
+                    Deno.env.get("USER") ?? "unknown"
+                  }@${Deno.hostname()}`,
+                  hostname: Deno.hostname(),
+                  pid: Deno.pid,
+                  acquiredAt: new Date().toISOString(),
+                  ttlMs,
+                  nonce: crypto.randomUUID(),
+                };
+                await Deno.writeTextFile(lockFile, JSON.stringify(info), {
+                  createNew: true,
+                });
+                // Start heartbeat
+                heartbeatId = setInterval(async () => {
+                  try {
+                    const current = JSON.parse(
+                      await Deno.readTextFile(lockFile),
+                    );
+                    current.acquiredAt = new Date().toISOString();
+                    await Deno.writeTextFile(lockFile, JSON.stringify(current));
+                  } catch { /* lock may have been released */ }
+                }, ttlMs / 3);
+                return;
+              } catch {
+                // Check if existing lock is stale
+                try {
+                  const existing = JSON.parse(
+                    await Deno.readTextFile(lockFile),
+                  );
+                  const age = Date.now() -
+                    new Date(existing.acquiredAt).getTime();
+                  if (age > existing.ttlMs) {
+                    await Deno.remove(lockFile);
+                    continue;
+                  }
+                } catch { /* lock file gone, retry */ }
+                await new Promise((r) => setTimeout(r, retryIntervalMs));
+              }
+            }
+            throw new Error(`Lock timeout after ${maxWaitMs}ms`);
+          },
+          release: async () => {
+            if (heartbeatId !== undefined) {
+              clearInterval(heartbeatId);
+              heartbeatId = undefined;
+            }
+            try {
+              await Deno.remove(lockFile);
+            } catch { /* already released */ }
+          },
+          withLock: async <T>(fn: () => Promise<T>): Promise<T> => {
+            // Implementation calls acquire/release around fn
+            throw new Error("Use acquire/release directly");
+          },
+          inspect: async () => {
+            try {
+              return JSON.parse(await Deno.readTextFile(lockFile));
+            } catch {
+              return null;
+            }
+          },
+          forceRelease: async (expectedNonce: string) => {
+            try {
+              const info = JSON.parse(await Deno.readTextFile(lockFile));
+              if (info.nonce === expectedNonce) {
+                await Deno.remove(lockFile);
+                return true;
+              }
+            } catch { /* no lock */ }
+            return false;
+          },
+        };
+      },
+
+      createVerifier: () => ({
+        verify: async () => {
+          const start = performance.now();
+          try {
+            await Deno.stat(parsed.basePath);
+            // Test write access
+            const testFile = `${parsed.basePath}/.health-check`;
+            await Deno.writeTextFile(testFile, "ok");
+            await Deno.remove(testFile);
+            return {
+              healthy: true,
+              message: "OK",
+              latencyMs: Math.round(performance.now() - start),
+              datastoreType: "@myorg/custom-fs",
+              details: { path: parsed.basePath },
+            };
+          } catch (error) {
+            return {
+              healthy: false,
+              message: String(error),
+              latencyMs: Math.round(performance.now() - start),
+              datastoreType: "@myorg/custom-fs",
+            };
+          }
+        },
+      }),
+
+      resolveDatastorePath: (_repoDir: string) => parsed.basePath,
+    };
+  },
+};
+```
+
+### `.swamp.yaml` config
+
+```yaml
+datastore:
+  type: "@myorg/custom-fs"
+  config:
+    basePath: "/data/swamp-storage"
+```
+
+### Environment variable
+
+```bash
+export SWAMP_DATASTORE='@myorg/custom-fs:{"basePath":"/data/swamp-storage"}'
+```
+
+## Remote Datastore with Sync
+
+A remote datastore that caches locally and syncs to a remote backend:
+
+```typescript
+// extensions/datastores/remote-store/mod.ts
+import { z } from "npm:zod@4";
+
+const ConfigSchema = z.object({
+  endpoint: z.string().url(),
+  bucket: z.string(),
+  region: z.string().default("us-east-1"),
+});
+
+export const datastore = {
+  type: "@myorg/remote-store",
+  name: "Remote Object Store",
+  description: "Stores data in a remote object store with local caching",
+  configSchema: ConfigSchema,
+  createProvider: (config: Record<string, unknown>) => {
+    const parsed = ConfigSchema.parse(config);
+
+    return {
+      createLock: (
+        datastorePath: string,
+        options?: {
+          lockKey?: string;
+          ttlMs?: number;
+          retryIntervalMs?: number;
+          maxWaitMs?: number;
+        },
+      ) => {
+        // Remote lock implementation (e.g., conditional PUT)
+        return {
+          acquire: async () => {/* remote lock acquire */},
+          release: async () => {/* remote lock release */},
+          withLock: async <T>(fn: () => Promise<T>) => fn(),
+          inspect: async () => null,
+          forceRelease: async (_nonce: string) => false,
+        };
+      },
+
+      createVerifier: () => ({
+        verify: async () => {
+          const start = performance.now();
+          try {
+            // Check remote endpoint accessibility
+            const response = await fetch(`${parsed.endpoint}/health`);
+            return {
+              healthy: response.ok,
+              message: response.ok ? "OK" : `HTTP ${response.status}`,
+              latencyMs: Math.round(performance.now() - start),
+              datastoreType: "@myorg/remote-store",
+              details: {
+                endpoint: parsed.endpoint,
+                bucket: parsed.bucket,
+                region: parsed.region,
+              },
+            };
+          } catch (error) {
+            return {
+              healthy: false,
+              message: String(error),
+              latencyMs: Math.round(performance.now() - start),
+              datastoreType: "@myorg/remote-store",
+            };
+          }
+        },
+      }),
+
+      // Sync service for pull/push operations
+      createSyncService: (_repoDir: string, cachePath: string) => ({
+        pullChanged: async () => {
+          // Download changed files from remote to cachePath
+          console.log(`Pulling from ${parsed.endpoint} to ${cachePath}`);
+        },
+        pushChanged: async () => {
+          // Upload changed files from cachePath to remote
+          console.log(`Pushing from ${cachePath} to ${parsed.endpoint}`);
+        },
+      }),
+
+      resolveDatastorePath: (repoDir: string) => {
+        // For remote datastores, return the cache path
+        return `${repoDir}/.swamp/remote-cache`;
+      },
+
+      resolveCachePath: (repoDir: string) => {
+        return `${repoDir}/.swamp/remote-cache`;
+      },
+    };
+  },
+};
+```
+
+### `.swamp.yaml` config
+
+```yaml
+datastore:
+  type: "@myorg/remote-store"
+  config:
+    endpoint: "https://storage.example.com"
+    bucket: "my-automation-data"
+    region: "us-west-2"
+```
+
+### Environment variable
+
+```bash
+export SWAMP_DATASTORE='@myorg/remote-store:{"endpoint":"https://storage.example.com","bucket":"my-data","region":"us-west-2"}'
+```

--- a/.claude/skills/swamp-extension-datastore/references/troubleshooting.md
+++ b/.claude/skills/swamp-extension-datastore/references/troubleshooting.md
@@ -1,0 +1,91 @@
+# Troubleshooting — Extension Datastores
+
+## Datastore type not appearing
+
+**Symptom:** `swamp datastore status` doesn't show your custom type.
+
+**Causes:**
+
+1. File not in `extensions/datastores/` — check directory location
+2. Missing or wrong export: must be `export const datastore = { ... }`
+3. Type pattern invalid — must match `@collective/name` or `collective/name`
+   (lowercase, alphanumeric, hyphens, underscores only)
+4. Reserved collective — cannot use `swamp` or `si`
+5. Duplicate type — another extension already registered this type
+
+**Debug:** Check swamp's startup logs for loader errors. Files without
+`export const datastore` are silently skipped (they're treated as utility
+files).
+
+## Config validation errors
+
+**Symptom:** `Invalid config for datastore type "...": <zod error>`
+
+**Causes:**
+
+1. `.swamp.yaml` `config:` section doesn't match your `configSchema`
+2. Environment variable JSON is malformed
+3. Missing required fields in the config
+
+**Fix:** Check your Zod schema against the config you're providing. Run
+`swamp datastore status --json` to see the full error message.
+
+## Stale bundles
+
+**Symptom:** Changes to your datastore code aren't taking effect.
+
+**Cause:** Bundles are cached in `.swamp/datastore-bundles/` with mtime-based
+invalidation. If file timestamps are incorrect (e.g., after `git checkout`), the
+cache may serve stale code.
+
+**Fix:** Delete the cached bundle:
+
+```bash
+rm -rf .swamp/datastore-bundles/
+```
+
+Then run any swamp command to trigger re-bundling.
+
+## Import errors
+
+**Symptom:** `Error: Cannot resolve module "npm:some-package"` or similar.
+
+**Causes:**
+
+1. Dynamic `import()` — not supported, use static imports only
+2. Unpinned npm version — always pin (e.g., `npm:pkg@1.2.3`)
+3. Package not compatible with Deno — check Deno compatibility
+
+**Fix:** Ensure all imports are static top-level `import` statements with pinned
+versions.
+
+## Lock implementation issues
+
+**Symptom:** `LockTimeoutError` or concurrent write corruption.
+
+**Common mistakes:**
+
+1. Not implementing heartbeat — lock expires while operation runs
+2. Not handling stale lock detection — process crashes leave orphaned locks
+3. Missing `forceRelease` nonce check — allows force-release of wrong lock
+
+**Requirements:**
+
+- `acquire()` must retry until `maxWaitMs`, then throw
+- `acquire()` must force-acquire stale locks (TTL expired)
+- `release()` must be safe to call multiple times
+- `inspect()` must return current lock info without side effects
+
+## Health check failures
+
+**Symptom:** `swamp datastore status` shows `healthy: false`.
+
+**Debug:** Check the `message` field in the status output for details. Common
+causes:
+
+- Directory doesn't exist or isn't writable (local datastores)
+- Network connectivity issues (remote datastores)
+- Missing credentials (cloud storage backends)
+
+**Fix:** The `createVerifier().verify()` method should return a descriptive
+error message. Include relevant details in the `details` field.

--- a/.claude/skills/swamp-extension-driver/SKILL.md
+++ b/.claude/skills/swamp-extension-driver/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: swamp-extension-driver
+description: Create user-defined TypeScript execution drivers for swamp — implement ExecutionDriver to control where and how model methods run. Use when users want custom execution environments (remote servers, cloud functions, custom containers). Triggers on "custom driver", "extension driver", "execution driver", "ExecutionDriver", "extensions/drivers", "create driver", "new driver type", "driver plugin", "remote execution", "driver implementation".
+---
+
+# Swamp Extension Driver
+
+Create TypeScript execution drivers in `extensions/drivers/` that swamp loads at
+startup.
+
+## When to Create a Custom Driver
+
+**Create an extension driver when the built-in drivers (raw, docker) don't meet
+your execution needs.**
+
+Drivers control _where and how_ model methods execute, not _what_ they do:
+
+- `raw` — in-process execution (default)
+- `docker` — isolated Docker container execution
+- Custom — SSH, Lambda, Kubernetes, cloud functions, etc.
+
+Before creating a custom driver:
+
+1. Built-in drivers: `raw` (in-process), `docker` (container isolation)
+2. Search community: `swamp extension search driver`
+3. If a community extension exists, install it instead
+4. Only create a custom driver if nothing fits
+
+Extensions from trusted collectives (`@swamp/*`, `@si/*`, and your membership
+collectives) auto-resolve on first use.
+
+## Quick Reference
+
+| Task                | Command/Action                                 |
+| ------------------- | ---------------------------------------------- |
+| Search community    | `swamp extension search driver --json`         |
+| Create driver file  | Create `extensions/drivers/my-driver/mod.ts`   |
+| Verify registration | `swamp model type search --json`               |
+| Push extension      | `swamp extension push manifest.yaml --json`    |
+| Dry-run push        | `swamp extension push manifest.yaml --dry-run` |
+
+## Quick Start
+
+```typescript
+// extensions/drivers/my-driver/mod.ts
+import { z } from "npm:zod@4";
+
+const ConfigSchema = z.object({
+  host: z.string(),
+  port: z.number().default(22),
+});
+
+export const driver = {
+  type: "@myorg/my-driver",
+  name: "My Custom Driver",
+  description: "Executes model methods on a remote host via SSH",
+  configSchema: ConfigSchema,
+  createDriver: (config: Record<string, unknown>) => {
+    const parsed = ConfigSchema.parse(config);
+    return {
+      type: "@myorg/my-driver",
+      execute: async (request: {
+        protocolVersion: number;
+        modelType: string;
+        modelId: string;
+        methodName: string;
+        globalArgs: Record<string, unknown>;
+        methodArgs: Record<string, unknown>;
+        definitionMeta: {
+          id: string;
+          name: string;
+          version: number;
+          tags: Record<string, string>;
+        };
+        bundle?: Uint8Array;
+      }, callbacks?: { onLog?: (line: string) => void }) => {
+        const start = performance.now();
+        const logs: string[] = [];
+
+        try {
+          callbacks?.onLog?.(
+            `Executing ${request.methodName} on ${parsed.host}:${parsed.port}`,
+          );
+          logs.push(`Connected to ${parsed.host}`);
+
+          // Your execution logic here
+          const output = new TextEncoder().encode(
+            JSON.stringify({ result: "ok" }),
+          );
+
+          return {
+            status: "success" as const,
+            outputs: [{
+              kind: "pending" as const,
+              specName: request.methodName,
+              name: request.methodName,
+              type: "resource" as const,
+              content: output,
+            }],
+            logs,
+            durationMs: performance.now() - start,
+          };
+        } catch (error) {
+          return {
+            status: "error" as const,
+            error: String(error),
+            outputs: [],
+            logs,
+            durationMs: performance.now() - start,
+          };
+        }
+      },
+    };
+  },
+};
+```
+
+## Export Contract
+
+| Field          | Required | Description                                    |
+| -------------- | -------- | ---------------------------------------------- |
+| `type`         | Yes      | Namespaced identifier (`@collective/name`)     |
+| `name`         | Yes      | Human-readable display name                    |
+| `description`  | Yes      | What this driver does                          |
+| `configSchema` | No       | Zod schema for validating driver config        |
+| `createDriver` | Yes      | Factory function `(config) => ExecutionDriver` |
+
+The `type` must match the pattern `@collective/name` or `collective/name`.
+Reserved collectives (`swamp`, `si`) cannot be used.
+
+## ExecutionDriver Methods
+
+| Method       | Required | Description                                      |
+| ------------ | -------- | ------------------------------------------------ |
+| `type`       | Yes      | The driver type identifier (readonly property)   |
+| `execute`    | Yes      | Execute a model method and return results        |
+| `initialize` | No       | One-time setup (e.g., pull Docker image)         |
+| `shutdown`   | No       | Cleanup (e.g., stop container, close connection) |
+
+For full interface signatures (`ExecutionRequest`, `ExecutionCallbacks`,
+`ExecutionResult`, `DriverOutput`), see [references/api.md](references/api.md).
+
+## Using Drivers
+
+Set the `driver` field in YAML definitions, workflows, or steps:
+
+### Definition level (applies to all methods)
+
+```yaml
+# models/my-model.yaml
+type: "@myorg/my-model"
+name: my-instance
+driver: "@myorg/my-driver"
+driverConfig:
+  host: "build-server.example.com"
+  port: 22
+```
+
+### Workflow level (applies to all jobs/steps)
+
+```yaml
+# workflows/deploy.yaml
+name: deploy
+driver: docker
+driverConfig:
+  image: "node:20-alpine"
+jobs:
+  build:
+    steps:
+      - method: run
+        model: my-builder
+```
+
+### Step level (overrides workflow/definition)
+
+```yaml
+jobs:
+  build:
+    steps:
+      - method: run
+        model: my-builder
+        driver: "@myorg/my-driver"
+        driverConfig:
+          host: "gpu-server.example.com"
+```
+
+### Resolution priority
+
+```
+step > job > workflow > definition > "raw" (default)
+```
+
+The first non-undefined `driver` value wins. Its `driverConfig` is used as-is —
+no merging across levels.
+
+## Verify
+
+After creating your driver:
+
+1. Check registration: `swamp model type search --json` — your driver type
+   should be loadable
+2. Test with a model: create a definition with `driver: "@myorg/my-driver"` and
+   run a method
+3. If the driver isn't found, delete stale bundles and retry:
+
+```bash
+rm -rf .swamp/driver-bundles/
+swamp model method run my-instance run --json
+```
+
+## Discovery & Loading
+
+- Location: `{repo}/extensions/drivers/**/*.ts`
+- Discovery: Recursive, all `.ts` files
+- Excluded: Files ending in `_test.ts`
+- Export: Files without `export const driver` are silently skipped
+- Caching: Bundles are cached in `.swamp/driver-bundles/` (mtime-based)
+
+## Key Rules
+
+1. **Import**: `import { z } from "npm:zod@4";` — always required for config
+   schemas
+2. **Export name**: Must be `export const driver = { ... }`
+3. **Reserved collectives**: Cannot use `swamp` or `si` in the type
+4. **Type pattern**: `@collective/name` or `collective/name` (lowercase,
+   alphanumeric, hyphens, underscores)
+5. **Static imports only**: All npm imports must be static top-level imports —
+   dynamic `import()` is not supported
+6. **Pin npm versions**: Always pin versions (e.g., `npm:pkg@1.2.3`) except
+   `npm:zod@4`
+7. **Output types**: Drivers return `"pending"` outputs (data to be persisted by
+   swamp) or `"persisted"` outputs (already written by in-process drivers)
+
+## When to Use Other Skills
+
+| Need                              | Use Skill                   |
+| --------------------------------- | --------------------------- |
+| Create custom models              | `swamp-extension-model`     |
+| Create custom datastores          | `swamp-extension-datastore` |
+| Create/run workflows with drivers | `swamp-workflow`            |
+| Repository setup                  | `swamp-repo`                |
+
+## References
+
+- **API Reference**: See [references/api.md](references/api.md) for full
+  `ExecutionDriver`, `ExecutionRequest`, `ExecutionCallbacks`,
+  `ExecutionResult`, and `DriverOutput` interface documentation
+- **Examples**: See [references/examples.md](references/examples.md) for
+  complete working examples (subprocess, remote execution, Docker reference)
+- **Troubleshooting**: See
+  [references/troubleshooting.md](references/troubleshooting.md) for common
+  issues (driver not found, output types, resolution priority)

--- a/.claude/skills/swamp-extension-driver/references/api.md
+++ b/.claude/skills/swamp-extension-driver/references/api.md
@@ -1,0 +1,194 @@
+# API Reference — Extension Drivers
+
+Full interface documentation for implementing custom execution drivers.
+
+Source files:
+
+- `src/domain/drivers/execution_driver.ts`
+- `src/domain/drivers/docker_execution_driver.ts` (reference implementation)
+
+## ExecutionDriver
+
+Pluggable execution driver interface. Drivers control how model methods are
+executed — in-process (raw), in a container (docker), or remotely.
+
+```typescript
+interface ExecutionDriver {
+  readonly type: string;
+  execute(
+    request: ExecutionRequest,
+    callbacks?: ExecutionCallbacks,
+  ): Promise<ExecutionResult>;
+  initialize?(): Promise<void>;
+  shutdown?(): Promise<void>;
+}
+```
+
+### `type`
+
+Readonly property identifying the driver type. Must match the `type` field in
+the driver export.
+
+### `execute(request, callbacks?)`
+
+Execute a model method. This is the core method — receives the full execution
+context and returns results.
+
+### `initialize()?`
+
+Optional one-time setup. Called before the first `execute()` invocation. Use for
+expensive setup like pulling Docker images or establishing connections.
+
+### `shutdown()?`
+
+Optional cleanup. Called when the driver is no longer needed. Use for closing
+connections, stopping containers, etc.
+
+## ExecutionRequest
+
+Serializable request envelope sent to a driver.
+
+```typescript
+interface ExecutionRequest {
+  protocolVersion: number;
+  modelType: string;
+  modelId: string;
+  methodName: string;
+  globalArgs: Record<string, unknown>;
+  methodArgs: Record<string, unknown>;
+  definitionMeta: {
+    id: string;
+    name: string;
+    version: number;
+    tags: Record<string, string>;
+  };
+  resourceSpecs?: Record<string, unknown>;
+  fileSpecs?: Record<string, unknown>;
+  bundle?: Uint8Array;
+}
+```
+
+### Fields
+
+| Field             | Description                                            |
+| ----------------- | ------------------------------------------------------ |
+| `protocolVersion` | Protocol version for forward compatibility             |
+| `modelType`       | The model type identifier                              |
+| `modelId`         | The model/definition ID                                |
+| `methodName`      | The method name to execute                             |
+| `globalArgs`      | Pre-validated global arguments from the definition     |
+| `methodArgs`      | Pre-validated per-method arguments                     |
+| `definitionMeta`  | Definition metadata (id, name, version, tags)          |
+| `resourceSpecs`   | Resource output spec metadata (optional)               |
+| `fileSpecs`       | File output spec metadata (optional)                   |
+| `bundle`          | Bundled TypeScript module for out-of-process execution |
+
+The `bundle` field is populated when the model has been bundled for
+out-of-process execution. Drivers can use this to send the code to a remote
+runtime (e.g., Docker container, Lambda function).
+
+## ExecutionCallbacks
+
+Real-time event callbacks during execution.
+
+```typescript
+interface ExecutionCallbacks {
+  onLog?: (line: string) => void;
+  onResourceWritten?: (handle: DataHandle) => void;
+}
+```
+
+### `onLog(line)`
+
+Called when a log line is emitted during execution. Use this to stream real-time
+output to the user.
+
+### `onResourceWritten(handle)`
+
+Called when a resource is written during execution. Only used by in-process
+drivers that write data directly.
+
+## ExecutionResult
+
+Result returned by a driver after execution.
+
+```typescript
+interface ExecutionResult {
+  status: "success" | "error";
+  error?: string;
+  outputs: DriverOutput[];
+  logs: string[];
+  durationMs: number;
+  followUpActions?: unknown[];
+}
+```
+
+### Fields
+
+| Field             | Description                                   |
+| ----------------- | --------------------------------------------- |
+| `status`          | `"success"` or `"error"`                      |
+| `error`           | Error message (when status is `"error"`)      |
+| `outputs`         | Array of `DriverOutput` (resources and files) |
+| `logs`            | Log lines captured during execution           |
+| `durationMs`      | Execution duration in milliseconds            |
+| `followUpActions` | Follow-up actions (in-process drivers only)   |
+
+## DriverOutput
+
+Discriminated union for driver outputs.
+
+```typescript
+type DriverOutput =
+  | { kind: "persisted"; handle: DataHandle }
+  | {
+    kind: "pending";
+    specName: string;
+    name: string;
+    type: "resource" | "file";
+    content: Uint8Array;
+    tags?: Record<string, string>;
+    metadata?: Record<string, unknown>;
+  };
+```
+
+### `"persisted"` outputs
+
+Data was already written in-process. The `handle` references existing data in
+the datastore. Only used by in-process drivers (like `raw`).
+
+### `"pending"` outputs
+
+Data needs to be persisted by swamp after the driver returns. This is the
+standard output type for out-of-process drivers.
+
+| Field      | Description                                        |
+| ---------- | -------------------------------------------------- |
+| `specName` | Output spec name (from model resources/files)      |
+| `name`     | Instance name for this output                      |
+| `type`     | `"resource"` (JSON data) or `"file"` (binary/text) |
+| `content`  | Raw content as `Uint8Array`                        |
+| `tags`     | Optional key-value tags                            |
+| `metadata` | Execution metadata (exit code, timing, etc.)       |
+
+## Docker Driver Config (Reference)
+
+The built-in Docker driver's config schema is a useful reference for designing
+driver configuration:
+
+```typescript
+const DockerDriverConfigSchema = z.object({
+  image: z.string().min(1), // Required: Docker image
+  bundleImage: z.string().optional(), // Image for bundle mode
+  command: z.string().default("docker"), // docker, podman, nerdctl
+  timeout: z.number().positive().optional(),
+  network: z.string().optional(),
+  memory: z.string().optional(), // e.g., "512m"
+  cpus: z.string().optional(), // e.g., "1.5"
+  volumes: z.array(z.string()).optional(),
+  env: z.record(z.string(), z.string()).optional(),
+  extraArgs: z.array(z.string()).optional(),
+});
+```
+
+See `src/domain/drivers/docker_execution_driver.ts` for the full implementation.

--- a/.claude/skills/swamp-extension-driver/references/examples.md
+++ b/.claude/skills/swamp-extension-driver/references/examples.md
@@ -1,0 +1,327 @@
+# Examples — Extension Drivers
+
+## Minimal Subprocess Driver
+
+A driver that executes commands via a local subprocess:
+
+```typescript
+// extensions/drivers/subprocess/mod.ts
+import { z } from "npm:zod@4";
+
+const ConfigSchema = z.object({
+  shell: z.string().default("/bin/sh"),
+  timeout: z.number().positive().optional(),
+});
+
+export const driver = {
+  type: "@myorg/subprocess",
+  name: "Subprocess Driver",
+  description: "Executes model methods as subprocess commands",
+  configSchema: ConfigSchema,
+  createDriver: (config: Record<string, unknown>) => {
+    const parsed = ConfigSchema.parse(config);
+    return {
+      type: "@myorg/subprocess",
+      execute: async (request: {
+        protocolVersion: number;
+        modelType: string;
+        modelId: string;
+        methodName: string;
+        globalArgs: Record<string, unknown>;
+        methodArgs: Record<string, unknown>;
+        definitionMeta: {
+          id: string;
+          name: string;
+          version: number;
+          tags: Record<string, string>;
+        };
+        bundle?: Uint8Array;
+      }, callbacks?: { onLog?: (line: string) => void }) => {
+        const start = performance.now();
+        const logs: string[] = [];
+        const run = request.methodArgs.run as string | undefined;
+
+        if (!run) {
+          return {
+            status: "error" as const,
+            error: "Subprocess driver requires a 'run' string in methodArgs",
+            outputs: [],
+            logs: [],
+            durationMs: 0,
+          };
+        }
+
+        try {
+          const command = new Deno.Command(parsed.shell, {
+            args: ["-c", run],
+            stdout: "piped",
+            stderr: "piped",
+            env: {
+              SWAMP_MODEL_TYPE: request.modelType,
+              SWAMP_MODEL_ID: request.modelId,
+              SWAMP_METHOD: request.methodName,
+              ...Object.fromEntries(
+                Object.entries(request.globalArgs)
+                  .filter(([_, v]) => typeof v === "string")
+                  .map((
+                    [k, v],
+                  ) => [`SWAMP_ARG_${k.toUpperCase()}`, v as string]),
+              ),
+            },
+          });
+
+          const process = command.spawn();
+          const [stdout, stderr, status] = await Promise.all([
+            new Response(process.stdout).text(),
+            new Response(process.stderr).text(),
+            process.status,
+          ]);
+
+          for (const line of stderr.split("\n").filter(Boolean)) {
+            logs.push(line);
+            callbacks?.onLog?.(line);
+          }
+
+          const durationMs = performance.now() - start;
+
+          if (status.code !== 0) {
+            return {
+              status: "error" as const,
+              error: stderr || `Process exited with code ${status.code}`,
+              outputs: [],
+              logs,
+              durationMs,
+            };
+          }
+
+          return {
+            status: "success" as const,
+            outputs: [{
+              kind: "pending" as const,
+              specName: request.methodName,
+              name: request.methodName,
+              type: "resource" as const,
+              content: new TextEncoder().encode(stdout),
+              metadata: {
+                exitCode: status.code,
+                durationMs: Math.round(durationMs),
+              },
+            }],
+            logs,
+            durationMs,
+          };
+        } catch (error) {
+          return {
+            status: "error" as const,
+            error: String(error),
+            outputs: [],
+            logs,
+            durationMs: performance.now() - start,
+          };
+        }
+      },
+    };
+  },
+};
+```
+
+## Remote Execution Driver with Lifecycle
+
+A driver that connects to a remote server, with `initialize` and `shutdown`:
+
+```typescript
+// extensions/drivers/remote-exec/mod.ts
+import { z } from "npm:zod@4";
+
+const ConfigSchema = z.object({
+  host: z.string(),
+  port: z.number().default(22),
+  apiEndpoint: z.string().url(),
+});
+
+export const driver = {
+  type: "@myorg/remote-exec",
+  name: "Remote Execution Driver",
+  description: "Executes model methods on a remote server via API",
+  configSchema: ConfigSchema,
+  createDriver: (config: Record<string, unknown>) => {
+    const parsed = ConfigSchema.parse(config);
+    let sessionToken: string | undefined;
+
+    return {
+      type: "@myorg/remote-exec",
+
+      // One-time setup: establish session
+      initialize: async () => {
+        const res = await fetch(`${parsed.apiEndpoint}/sessions`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ host: parsed.host, port: parsed.port }),
+        });
+        const data = await res.json();
+        sessionToken = data.token;
+      },
+
+      execute: async (request: {
+        protocolVersion: number;
+        modelType: string;
+        modelId: string;
+        methodName: string;
+        globalArgs: Record<string, unknown>;
+        methodArgs: Record<string, unknown>;
+        definitionMeta: {
+          id: string;
+          name: string;
+          version: number;
+          tags: Record<string, string>;
+        };
+        bundle?: Uint8Array;
+      }, callbacks?: { onLog?: (line: string) => void }) => {
+        const start = performance.now();
+        const logs: string[] = [];
+
+        try {
+          callbacks?.onLog?.(
+            `Executing ${request.methodName} on ${parsed.host}`,
+          );
+
+          const res = await fetch(`${parsed.apiEndpoint}/execute`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "Authorization": `Bearer ${sessionToken}`,
+            },
+            body: JSON.stringify({
+              method: request.methodName,
+              args: request.methodArgs,
+              globalArgs: request.globalArgs,
+              bundle: request.bundle
+                ? btoa(String.fromCharCode(...request.bundle))
+                : undefined,
+            }),
+          });
+
+          const result = await res.json();
+          const durationMs = performance.now() - start;
+
+          if (!res.ok) {
+            return {
+              status: "error" as const,
+              error: result.error || `HTTP ${res.status}`,
+              outputs: [],
+              logs,
+              durationMs,
+            };
+          }
+
+          return {
+            status: "success" as const,
+            outputs: [{
+              kind: "pending" as const,
+              specName: request.methodName,
+              name: request.methodName,
+              type: "resource" as const,
+              content: new TextEncoder().encode(JSON.stringify(result.data)),
+            }],
+            logs: [...logs, ...(result.logs || [])],
+            durationMs,
+          };
+        } catch (error) {
+          return {
+            status: "error" as const,
+            error: String(error),
+            outputs: [],
+            logs,
+            durationMs: performance.now() - start,
+          };
+        }
+      },
+
+      // Cleanup: close session
+      shutdown: async () => {
+        if (sessionToken) {
+          await fetch(`${parsed.apiEndpoint}/sessions/${sessionToken}`, {
+            method: "DELETE",
+          });
+          sessionToken = undefined;
+        }
+      },
+    };
+  },
+};
+```
+
+## YAML Configuration Examples
+
+### Definition level
+
+```yaml
+# models/my-build.yaml
+type: "@myorg/builder"
+name: my-build
+driver: "@myorg/remote-exec"
+driverConfig:
+  host: "build-server.example.com"
+  port: 22
+  apiEndpoint: "https://api.example.com"
+globalArguments:
+  project: "my-app"
+```
+
+### Workflow level
+
+```yaml
+# workflows/deploy.yaml
+name: deploy
+driver: docker
+driverConfig:
+  image: "node:20-alpine"
+  memory: "1g"
+jobs:
+  build:
+    steps:
+      - method: compile
+        model: my-builder
+  test:
+    depends_on: [build]
+    steps:
+      - method: run
+        model: my-tests
+```
+
+### Step-level override
+
+```yaml
+jobs:
+  build:
+    steps:
+      - method: compile
+        model: my-builder
+        # Override workflow-level driver for this step
+        driver: "@myorg/remote-exec"
+        driverConfig:
+          host: "gpu-server.example.com"
+          apiEndpoint: "https://api.example.com"
+```
+
+### Resolution priority
+
+```
+step > job > workflow > definition > "raw" (default)
+```
+
+The first non-undefined `driver` value wins. Config is NOT merged across levels
+— the winning level's `driverConfig` is used as-is.
+
+## Built-in Docker Driver Reference
+
+The Docker driver (`src/domain/drivers/docker_execution_driver.ts`) supports two
+modes:
+
+- **Command mode**: `methodArgs.run` is a shell command. Stdout becomes resource
+  data, stderr streams as logs.
+- **Bundle mode**: A pre-compiled TypeScript bundle is mounted and executed with
+  Deno inside the container.
+
+Use the Docker driver source as a reference for implementing complex drivers
+with timeout handling, process management, and output parsing.

--- a/.claude/skills/swamp-extension-driver/references/troubleshooting.md
+++ b/.claude/skills/swamp-extension-driver/references/troubleshooting.md
@@ -1,0 +1,98 @@
+# Troubleshooting — Extension Drivers
+
+## Driver type not found
+
+**Symptom:** `Driver type "..." not found` when running a model or workflow.
+
+**Causes:**
+
+1. File not in `extensions/drivers/` — check directory location
+2. Missing or wrong export: must be `export const driver = { ... }`
+3. Type pattern invalid — must match `@collective/name` or `collective/name`
+   (lowercase, alphanumeric, hyphens, underscores only)
+4. Reserved collective — cannot use `swamp` or `si`
+5. Duplicate type — another extension already registered this type
+
+**Debug:** Check swamp's startup logs for loader errors. Files without
+`export const driver` are silently skipped (treated as utility files).
+
+## Pending vs persisted outputs
+
+**Symptom:** Data not appearing in `swamp model get` after driver execution.
+
+**Understanding output types:**
+
+- `"pending"` — driver returns raw content; swamp persists it to the datastore.
+  This is the standard type for out-of-process drivers.
+- `"persisted"` — driver already wrote data; handle references existing data.
+  Only used by in-process drivers (like `raw`).
+
+**Common mistake:** Returning `"persisted"` from an out-of-process driver
+without actually writing data. Always use `"pending"` for custom drivers unless
+you're writing directly to the datastore.
+
+## Resolution priority confusion
+
+**Symptom:** Wrong driver being used for a step.
+
+**Priority:** `step > job > workflow > definition > "raw"`
+
+The first non-undefined `driver` value wins. There is **no config merging**
+across levels — the winning level's `driverConfig` is used as-is.
+
+**Debug:** Check all levels (step, job, workflow, definition) for `driver:`
+fields. The most specific (step-level) takes precedence.
+
+## Stale bundles
+
+**Symptom:** Changes to your driver code aren't taking effect.
+
+**Cause:** Bundles are cached in `.swamp/driver-bundles/` with mtime-based
+invalidation. If file timestamps are incorrect (e.g., after `git checkout`), the
+cache may serve stale code.
+
+**Fix:** Delete the cached bundle:
+
+```bash
+rm -rf .swamp/driver-bundles/
+```
+
+Then run any swamp command to trigger re-bundling.
+
+## Import errors
+
+**Symptom:** `Error: Cannot resolve module "npm:some-package"` or similar.
+
+**Causes:**
+
+1. Dynamic `import()` — not supported, use static imports only
+2. Unpinned npm version — always pin (e.g., `npm:pkg@1.2.3`)
+3. Package not compatible with Deno — check Deno compatibility
+
+**Fix:** Ensure all imports are static top-level `import` statements with pinned
+versions.
+
+## Timeout and process management
+
+**Symptom:** Driver hangs or doesn't respect timeouts.
+
+**Best practices:**
+
+- Always implement timeout handling in your `execute()` method
+- Use `AbortSignal` or `setTimeout` with process cleanup
+- Send SIGTERM first, then SIGKILL after a grace period
+- Return `status: "error"` with a descriptive message on timeout
+
+See the Docker driver (`docker_execution_driver.ts`) for a reference
+implementation of timeout handling with SIGTERM/SIGKILL.
+
+## Initialize/shutdown lifecycle
+
+**Symptom:** Resources not cleaned up after workflow execution.
+
+**Notes:**
+
+- `initialize()` is called before the first `execute()` invocation
+- `shutdown()` is called when the driver is no longer needed
+- Both are optional — only implement if your driver needs setup/teardown
+- `shutdown()` should be idempotent (safe to call multiple times)

--- a/.claude/skills/swamp-repo/SKILL.md
+++ b/.claude/skills/swamp-repo/SKILL.md
@@ -211,6 +211,42 @@ swamp datastore lock release --force --json  # Force-release stuck lock
 
 Returns `null` if no lock is held.
 
+### Custom Datastores
+
+Install a community datastore or create your own in `extensions/datastores/`:
+
+```bash
+swamp extension search datastore --json    # Find community datastores
+```
+
+Configure in `.swamp.yaml` with `type:` and `config:` fields:
+
+```yaml
+datastore:
+  type: "@myorg/my-store"
+  config:
+    endpoint: "https://storage.example.com"
+    bucket: "my-data"
+```
+
+Or via environment variable (JSON config after the type):
+
+```bash
+export SWAMP_DATASTORE='@myorg/my-store:{"endpoint":"https://storage.example.com","bucket":"my-data"}'
+```
+
+For creating custom datastore implementations, see the
+`swamp-extension-datastore` skill.
+
+### Custom Drivers
+
+Custom execution drivers control where and how model methods run (SSH, Lambda,
+Kubernetes, etc.). Drivers are configured per-definition, per-workflow, or
+per-step via the `driver:` and `driverConfig:` YAML fields.
+
+For creating custom driver implementations, see the `swamp-extension-driver`
+skill.
+
 ### Environment Variable Override
 
 For CI/CD, override the datastore without modifying `.swamp.yaml`:
@@ -218,17 +254,20 @@ For CI/CD, override the datastore without modifying `.swamp.yaml`:
 ```bash
 export SWAMP_DATASTORE=s3:my-bucket/my-prefix
 export SWAMP_DATASTORE=filesystem:/tmp/swamp-data
+export SWAMP_DATASTORE='@myorg/my-store:{"key":"val"}'
 ```
 
 ## When to Use Other Skills
 
-| Need                            | Use Skill               |
-| ------------------------------- | ----------------------- |
-| Create/run models               | `swamp-model`           |
-| Create/run workflows            | `swamp-workflow`        |
-| Manage secrets                  | `swamp-vault`           |
-| Manage model data               | `swamp-data`            |
-| Create custom TypeScript models | `swamp-extension-model` |
+| Need                            | Use Skill                   |
+| ------------------------------- | --------------------------- |
+| Create/run models               | `swamp-model`               |
+| Create/run workflows            | `swamp-workflow`            |
+| Manage secrets                  | `swamp-vault`               |
+| Manage model data               | `swamp-data`                |
+| Create custom TypeScript models | `swamp-extension-model`     |
+| Create custom datastores        | `swamp-extension-datastore` |
+| Create custom drivers           | `swamp-extension-driver`    |
 
 ## References
 

--- a/src/infrastructure/assets/skill_assets.ts
+++ b/src/infrastructure/assets/skill_assets.ts
@@ -162,6 +162,38 @@ const BUNDLED_SKILLS: SkillInfo[] = [
     name: "swamp-vault",
   },
   {
+    relativePath: "swamp-extension-datastore/SKILL.md",
+    name: "swamp-extension-datastore",
+  },
+  {
+    relativePath: "swamp-extension-datastore/references/api.md",
+    name: "swamp-extension-datastore",
+  },
+  {
+    relativePath: "swamp-extension-datastore/references/examples.md",
+    name: "swamp-extension-datastore",
+  },
+  {
+    relativePath: "swamp-extension-datastore/references/troubleshooting.md",
+    name: "swamp-extension-datastore",
+  },
+  {
+    relativePath: "swamp-extension-driver/SKILL.md",
+    name: "swamp-extension-driver",
+  },
+  {
+    relativePath: "swamp-extension-driver/references/api.md",
+    name: "swamp-extension-driver",
+  },
+  {
+    relativePath: "swamp-extension-driver/references/examples.md",
+    name: "swamp-extension-driver",
+  },
+  {
+    relativePath: "swamp-extension-driver/references/troubleshooting.md",
+    name: "swamp-extension-driver",
+  },
+  {
     relativePath: "swamp-issue/SKILL.md",
     name: "swamp-issue",
   },

--- a/src/infrastructure/assets/skill_assets_test.ts
+++ b/src/infrastructure/assets/skill_assets_test.ts
@@ -399,6 +399,98 @@ Deno.test("SkillAssets.copySkillsTo copies swamp-workflow expressions-and-foreac
   });
 });
 
+Deno.test("SkillAssets includes swamp-extension-datastore skill", () => {
+  const assets = new SkillAssets();
+  const names = assets.getSkillNames();
+
+  assertEquals(names.includes("swamp-extension-datastore"), true);
+});
+
+Deno.test("SkillAssets.copySkillsTo copies swamp-extension-datastore reference files", async () => {
+  await withTempDir(async (dir) => {
+    const assets = new SkillAssets();
+    await assets.copySkillsTo(dir);
+
+    const skillPath = join(dir, "swamp-extension-datastore", "SKILL.md");
+    const apiPath = join(
+      dir,
+      "swamp-extension-datastore",
+      "references",
+      "api.md",
+    );
+    const examplesPath = join(
+      dir,
+      "swamp-extension-datastore",
+      "references",
+      "examples.md",
+    );
+    const troubleshootingPath = join(
+      dir,
+      "swamp-extension-datastore",
+      "references",
+      "troubleshooting.md",
+    );
+
+    const skillStat = await Deno.stat(skillPath);
+    assertEquals(skillStat.isFile, true);
+
+    const apiStat = await Deno.stat(apiPath);
+    assertEquals(apiStat.isFile, true);
+
+    const examplesStat = await Deno.stat(examplesPath);
+    assertEquals(examplesStat.isFile, true);
+
+    const troubleshootingStat = await Deno.stat(troubleshootingPath);
+    assertEquals(troubleshootingStat.isFile, true);
+  });
+});
+
+Deno.test("SkillAssets includes swamp-extension-driver skill", () => {
+  const assets = new SkillAssets();
+  const names = assets.getSkillNames();
+
+  assertEquals(names.includes("swamp-extension-driver"), true);
+});
+
+Deno.test("SkillAssets.copySkillsTo copies swamp-extension-driver reference files", async () => {
+  await withTempDir(async (dir) => {
+    const assets = new SkillAssets();
+    await assets.copySkillsTo(dir);
+
+    const skillPath = join(dir, "swamp-extension-driver", "SKILL.md");
+    const apiPath = join(
+      dir,
+      "swamp-extension-driver",
+      "references",
+      "api.md",
+    );
+    const examplesPath = join(
+      dir,
+      "swamp-extension-driver",
+      "references",
+      "examples.md",
+    );
+    const troubleshootingPath = join(
+      dir,
+      "swamp-extension-driver",
+      "references",
+      "troubleshooting.md",
+    );
+
+    const skillStat = await Deno.stat(skillPath);
+    assertEquals(skillStat.isFile, true);
+
+    const apiStat = await Deno.stat(apiPath);
+    assertEquals(apiStat.isFile, true);
+
+    const examplesStat = await Deno.stat(examplesPath);
+    assertEquals(examplesStat.isFile, true);
+
+    const troubleshootingStat = await Deno.stat(troubleshootingPath);
+    assertEquals(troubleshootingStat.isFile, true);
+  });
+});
+
 Deno.test("SkillAssets.copySkillsTo copies swamp-troubleshooting skill", async () => {
   await withTempDir(async (dir) => {
     const assets = new SkillAssets();


### PR DESCRIPTION
## Summary

PRs #745-#750 built the full custom datastore/driver extension pipeline (type registries, loaders, extension push/pull, runtime wiring) but shipped with zero skill documentation. Without these skills, AI assistants have no guidance to help users build custom datastores or drivers.

This PR adds:

- **`swamp-extension-datastore` skill** — Full documentation for creating custom datastore backends (GCS, Azure Blob, databases, etc.). Covers `DatastoreProvider`, `DistributedLock`, `DatastoreVerifier`, and `DatastoreSyncService` interfaces with quick start, working examples, API reference, and troubleshooting.
- **`swamp-extension-driver` skill** — Full documentation for creating custom execution drivers (SSH, Lambda, Kubernetes, etc.). Covers `ExecutionDriver`, `ExecutionRequest`, `ExecutionResult`, and `DriverOutput` interfaces with quick start, working examples, API reference, and troubleshooting.
- **`swamp-repo` skill updates** — Adds "Custom Datastores" and "Custom Drivers" subsections with `.swamp.yaml` config format, env var format (`SWAMP_DATASTORE='@org/name:{"key":"val"}'`), and cross-references to the new skills. Updated "When to Use Other Skills" table.
- **`skill_assets.ts`** — Both new skills (8 files total) registered in `BUNDLED_SKILLS` so they are installed during `swamp repo init` and `swamp repo upgrade`.
- **`skill_assets_test.ts`** — 4 new tests verifying all skill files are discovered and copied correctly.

## User Impact

Before this PR, users who wanted to create a custom datastore or driver had to read the TypeScript source code directly — there was no skill to guide them through the workflow, export contract, configuration, or verification steps.

After this PR:
- AI assistants can guide users through the full create → configure → verify workflow for both datastores and drivers
- `swamp repo init` and `swamp repo upgrade` install the new skills automatically
- The `swamp-repo` skill now documents custom datastore/driver configuration alongside the built-in filesystem and S3 options

## Why This Is Correct

- All interface signatures were verified against the actual source files (`datastore_provider.ts`, `distributed_lock.ts`, `datastore_health.ts`, `datastore_sync_service.ts`, `execution_driver.ts`, `docker_execution_driver.ts`, `driver_resolution.ts`, `user_datastore_loader.ts`, `user_driver_loader.ts`, `resolve_datastore.ts`)
- Skill structure follows the established pattern from `swamp-extension-model` and `swamp-vault` skills
- Both new skills score **100%** on `tessl skill review` validation (description + content)
- All 27 skill asset tests pass
- `deno check`, `deno lint` pass with no regressions

## Test Plan

- [x] `deno check` — no type errors
- [x] `deno lint` — no lint issues
- [x] `deno run test src/infrastructure/assets/skill_assets_test.ts` — 27/27 pass (4 new)
- [x] `npx tessl skill review .claude/skills/swamp-extension-datastore` — 100%
- [x] `npx tessl skill review .claude/skills/swamp-extension-driver` — 100%
- [x] `npx tessl skill review .claude/skills/swamp-repo` — 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>