### PR TITLE
docs: document custom datastore and driver extensibility

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -46,6 +46,72 @@ datastore:
 The local cache is fully disposable. Deleting it or cloning the repo on a new
 machine repopulates the cache from S3 on the next command.
 
+## Custom Backends
+
+Extensions can register custom datastore backends via `extensions/datastores/`.
+These are TypeScript files that export a `datastore` object conforming to the
+`DatastoreProvider` interface, enabling storage on any backend swamp doesn't
+ship with.
+
+### Type Registry
+
+The `DatastoreTypeRegistry` is a Map-backed singleton
+(`datastoreTypeRegistry`). Built-in types (filesystem, s3) are registered at
+startup. User-defined types are loaded from `extensions/datastores/` via
+`UserDatastoreLoader`. Types must follow the `@collective/name` or
+`collective/name` pattern (e.g., `@myorg/redis-store`). Duplicate type
+registrations are rejected with an error.
+
+### DatastoreProvider Interface
+
+A custom datastore implements five methods:
+
+- **`createLock`** — returns a `DistributedLock` for concurrency control
+- **`createVerifier`** — returns a `DatastoreVerifier` for health checks
+- **`createSyncService?`** — optional; returns a `DatastoreSyncService` for
+  remote sync (pull/push)
+- **`resolveDatastorePath`** — resolves the datastore path relative to the repo
+- **`resolveCachePath?`** — optional; resolves a local cache path (for remote
+  backends)
+
+See `src/domain/datastore/datastore_provider.ts` for the full interface.
+
+### Loading & Bundling
+
+`UserDatastoreLoader` discovers `.ts` files recursively in the datastores
+directory (excluding `_test.ts` files), bundles each via Deno with zod
+externalized, and validates the export against `UserDatastoreSchema` — a Zod
+schema requiring `type`, `name`, `description`, an optional `configSchema`, and
+a `createProvider` factory function. Files without a `datastore` export are
+silently skipped. Bundles are cached in `.swamp/datastore-bundles/` with
+mtime-based invalidation to avoid redundant compilation.
+
+### Custom Type Configuration
+
+Custom types use the same resolution priority as built-in types. In
+`.swamp.yaml`, custom types use the `type:` and `config:` fields:
+
+```yaml
+datastore:
+  type: "@myorg/redis-store"
+  config:
+    host: localhost
+    port: 6379
+```
+
+In environment variable format: `SWAMP_DATASTORE=@org/name:{"key":"val"}`. The
+config object is validated against the optional `configSchema` Zod schema
+defined by the extension.
+
+### Custom Backend Implementation Files
+
+| File | Purpose |
+|------|---------|
+| `src/domain/datastore/datastore_provider.ts` | `DatastoreProvider` interface |
+| `src/domain/datastore/datastore_type_registry.ts` | Type registry singleton |
+| `src/domain/datastore/user_datastore_loader.ts` | Loader, validator, bundler |
+| `src/domain/datastore/datastore_sync_service.ts` | `DatastoreSyncService` interface |
+
 ## Configuration
 
 ### Resolution Priority

--- a/design/execution-drivers.md
+++ b/design/execution-drivers.md
@@ -157,6 +157,62 @@ Has methodArgs.run?  ──yes──▶  Command mode
 4. Parse JSON output from stdout: `{ resources, files }`
 5. Clean up temp directory
 
+## Custom Drivers
+
+Extensions can register custom execution drivers via `extensions/drivers/`.
+These are TypeScript files that export a `driver` object with a `createDriver`
+factory that returns an `ExecutionDriver`. Custom drivers enable execution in
+environments swamp doesn't ship with — remote servers, cloud functions, custom
+sandboxes, etc.
+
+### Type Registry
+
+The `DriverTypeRegistry` is a Map-backed singleton (`driverTypeRegistry`), using
+the same pattern as the datastore registry. Built-in types (raw, docker) are
+registered at startup. User-defined types are loaded from `extensions/drivers/`
+via `UserDriverLoader`. Types must follow the `@collective/name` or
+`collective/name` pattern. Duplicate type registrations are rejected with an
+error.
+
+### ExecutionDriver Interface
+
+A custom driver implements a minimal interface:
+
+- **`type`** (readonly) — the driver type identifier
+- **`execute`** (required) — receives an `ExecutionRequest` (method name, args,
+  definition metadata, optional bundle) and returns an `ExecutionResult` with
+  status, outputs, logs, and duration. Outputs use `kind: "persisted"` when the
+  driver writes data in-process, or `kind: "pending"` when the host must persist
+  the data after execution.
+- **`initialize?`** — optional setup hook
+- **`shutdown?`** — optional cleanup hook
+
+See `src/domain/drivers/execution_driver.ts` for the full interface.
+
+### Loading & Bundling
+
+`UserDriverLoader` follows the same pattern as `UserDatastoreLoader`: discovers
+`.ts` files recursively (excluding `_test.ts`), bundles via Deno with zod
+externalized, and validates the export against `UserDriverSchema` — requiring
+`type`, `name`, `description`, an optional `configSchema`, and a `createDriver`
+factory function. Files without a `driver` export are silently skipped. Bundles
+are cached in `.swamp/driver-bundles/` with mtime-based invalidation.
+
+### Resolution with Custom Drivers
+
+Custom driver types follow the same resolution priority as built-in types
+(CLI > step > job > workflow > definition > raw). The first non-undefined
+`driver` value wins. Custom types are referenced by their full scoped name
+(e.g., `driver: "@myorg/lambda"`).
+
+### Custom Driver Implementation Files
+
+| File | Purpose |
+|------|---------|
+| `src/domain/drivers/execution_driver.ts` | `ExecutionDriver` interface |
+| `src/domain/drivers/driver_type_registry.ts` | Type registry singleton |
+| `src/domain/drivers/user_driver_loader.ts` | Loader, validator, bundler |
+
 ## Self-contained Bundling
 
 Extension models are bundled into JavaScript at load time. By default, zod is

--- a/design/extension.md
+++ b/design/extension.md
@@ -128,6 +128,30 @@ schema `instanceof` checks). Dynamic `import()` calls are not supported — all
 imports must be static top-level imports. Bundles are JavaScript files stored
 alongside their source counterparts under `bundles/`.
 
+### Vaults, Drivers, and Datastores
+
+Vault, driver, and datastore entry points are bundled with the same strategy as
+models — deno bundle with zod externalized. Each entry point gets a compiled
+`.js` file in its corresponding `-bundles/` directory (`vault-bundles/`,
+`driver-bundles/`, `datastore-bundles/`). Local imports are resolved recursively
+within the directory boundary.
+
+The export from each bundle is validated against a Zod schema:
+
+- **Vaults**: `export const vault` — must have `type`, `name`, `description`,
+  optional `configSchema`, and `createProvider`
+- **Drivers**: `export const driver` — must have `type`, `name`, `description`,
+  optional `configSchema`, and `createDriver`
+- **Datastores**: `export const datastore` — must have `type`, `name`,
+  `description`, optional `configSchema`, and `createProvider`
+
+### Collective Validation
+
+All content types — model types, vault types, workflow names, driver types,
+datastore types — must use the same collective as the extension name. This is
+enforced during push to prevent an extension from registering types under a
+different collective.
+
 ### Workflows
 
 Workflow YAML files are included with unique archive names derived from their


### PR DESCRIPTION
## Summary

The design docs (`datastores.md`, `execution-drivers.md`, `extension.md`) only documented built-in backends but the codebase fully supports user-defined datastores and drivers via the extension system. This gap meant contributors and advanced users reading design docs had no understanding of the plugin architecture — even though the code, type registries, loaders, and bundling are all in place.

### Why this matters

- **Contributor onboarding**: Someone reading `design/datastores.md` to understand the architecture would conclude swamp only supports filesystem and S3. They'd miss that the entire system is pluggable via `DatastoreProvider` and `DriverTypeRegistry`. This makes it harder for contributors to extend swamp correctly.
- **Design doc ↔ code drift**: The skills (`swamp-extension-datastore`, `swamp-extension-driver`) teach users *how* to create custom backends, but the design docs didn't explain the *architecture* behind the extensibility. Design docs should be the authoritative source for architectural decisions.
- **Discoverability**: Custom datastores and drivers are a major capability. Without design doc coverage, users discovering swamp through the docs would never know these extension points exist.

### Changes

- **`design/datastores.md`** — Added "Custom Backends" section covering: type registry singleton, `DatastoreProvider` interface (5 methods), `UserDatastoreLoader` bundling pipeline, configuration with custom types, and implementation files table
- **`design/execution-drivers.md`** — Added "Custom Drivers" section covering: `DriverTypeRegistry` singleton, `ExecutionDriver` interface, `UserDriverLoader` bundling pipeline, resolution priority with custom types, and implementation files table
- **`design/extension.md`** — Added "Vaults, Drivers, and Datastores" subsection explaining the bundling strategy and export validation schemas for all three content types, plus "Collective Validation" subsection

All interface details and file paths were verified against the current source code.

## Test plan

- [x] Verified all referenced source files exist and type-check
- [x] Confirmed interface details match actual code (`DatastoreProvider`, `ExecutionDriver`, registries, loaders)
- [x] No duplication with skills — design docs explain architecture, skills explain workflow
- [ ] Review for accuracy and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)