### PR TITLE
fix: collective validator error message omits drivers and datastores

### DIFF
--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -207,7 +207,7 @@ export const extensionPushCommand = new Command()
         );
         throw new UserError(
           "Extension content uses collectives that don't match the extension package. " +
-            "All model types, vault types, and workflow names must use the same collective as the extension.",
+            "All model types, vault types, workflow names, driver types, and datastore types must use the same collective as the extension.",
         );
       }
     }

--- a/src/domain/extensions/extension_collective_validator.ts
+++ b/src/domain/extensions/extension_collective_validator.ts
@@ -33,11 +33,11 @@ export interface CollectiveValidationResult {
 }
 
 /**
- * Validates that all content items (models, vaults, workflows) in an extension
+ * Validates that all content items (models, vaults, workflows, drivers, datastores) in an extension
  * use the same collective as the extension package itself.
  *
  * For example, if the extension is `@stack72/my-extension`, all model types,
- * vault types, and workflow names must start with `@stack72/`.
+ * vault types, workflow names, driver types, and datastore types must start with `@stack72/`.
  */
 export function validateContentCollectives(
   extensionName: string,


### PR DESCRIPTION
## Summary

Fixes #755.

When `swamp extension push` fails collective validation, the error message only mentioned _"model types, vault types, and workflow names"_ — it did not mention drivers or datastores. This was confusing for users whose push failed due to a driver or datastore type not matching the extension collective.

**Changes:**
- `src/cli/commands/extension_push.ts` — updated the user-facing `UserError` message to include "driver types, and datastore types"
- `src/domain/extensions/extension_collective_validator.ts` — updated the JSDoc comment to reflect that drivers and datastores are also validated

No logic changes; the validator already correctly checked driver and datastore types.

## User Impact

Before this fix, a user pushing an extension with a mismatched driver or datastore type would see:

> All model types, vault types, and workflow names must use the same collective as the extension.

…with no mention of drivers or datastores, leaving them uncertain what was actually wrong.

After this fix, the message reads:

> All model types, vault types, workflow names, driver types, and datastore types must use the same collective as the extension.

## Test Plan

- [x] `deno check` — passes
- [x] `deno lint` — passes
- [x] `deno fmt --check` — passes
- [x] `deno run test` — 3198 tests pass