### PR TITLE
fix: handle broken extensions with missing source files from older publishes

### DIFF
--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -46,11 +46,13 @@ import {
   renderExtensionPullConflicts,
   renderExtensionPullDependencyPull,
   renderExtensionPullIntegrity,
+  renderExtensionPullMissingSources,
   renderExtensionPullPlatforms,
   renderExtensionPullRepository,
   renderExtensionPullResolved,
   renderExtensionPullSafetyWarnings,
 } from "../../presentation/output/extension_pull_output.ts";
+import { resolveLocalImports } from "../../domain/models/local_import_resolver.ts";
 
 /** Returns true if the filename is a macOS resource fork (AppleDouble) file. */
 function isMacOsResourceFork(name: string): boolean {
@@ -83,6 +85,7 @@ export interface InstallResult {
   platforms: string[];
   safetyWarnings: SafetyIssue[];
   conflicts: string[];
+  missingSourceFiles: string[];
   dependencyResults: InstallResult[];
 }
 
@@ -556,6 +559,64 @@ export interface PullContext {
 }
 
 /**
+ * Validates that all source files referenced by imports are present.
+ * Returns paths of missing files (relative to the base directory).
+ */
+async function validateSourceCompleteness(
+  ...dirs: string[]
+): Promise<string[]> {
+  const entryPoints: string[] = [];
+  for (const dir of dirs) {
+    try {
+      for await (const entry of Deno.readDir(dir)) {
+        if (entry.isFile && entry.name.endsWith(".ts")) {
+          entryPoints.push(join(dir, entry.name));
+        } else if (entry.isDirectory && !entry.name.startsWith("_")) {
+          // Recurse into non-underscore subdirectories for entry points
+          const subEntries = await collectTsFiles(join(dir, entry.name));
+          entryPoints.push(...subEntries);
+        }
+      }
+    } catch {
+      // Directory may not exist
+    }
+  }
+
+  if (entryPoints.length === 0) return [];
+
+  // Use the first dir as the boundary for resolving imports
+  const boundaryDir = dirs[0];
+  const result = await resolveLocalImports(entryPoints, boundaryDir);
+
+  const missing: string[] = [];
+  for (const resolved of result.resolvedFiles) {
+    try {
+      await Deno.stat(resolved);
+    } catch {
+      missing.push(relative(boundaryDir, resolved));
+    }
+  }
+  return missing;
+}
+
+/** Recursively collects .ts files from a directory, skipping _-prefixed dirs. */
+async function collectTsFiles(dir: string): Promise<string[]> {
+  const files: string[] = [];
+  try {
+    for await (const entry of Deno.readDir(dir)) {
+      if (entry.isFile && entry.name.endsWith(".ts")) {
+        files.push(join(dir, entry.name));
+      } else if (entry.isDirectory && !entry.name.startsWith("_")) {
+        files.push(...await collectTsFiles(join(dir, entry.name)));
+      }
+    }
+  } catch {
+    // Directory may not exist
+  }
+  return files;
+}
+
+/**
  * Core install logic: download, verify, extract, copy, track.
  * No rendering — returns structured data for callers to present.
  * Throws ConflictError when !force and conflicts exist.
@@ -844,6 +905,14 @@ export async function installExtension(
     );
     extractedFiles.push(...filesExtracted);
 
+    // Validate source completeness — warn if imported files are missing
+    const missingSourceFiles = await validateSourceCompleteness(
+      absoluteModelsDir,
+      absoluteVaultsDir,
+      absoluteDriversDir,
+      absoluteDatastoresDir,
+    );
+
     // Update upstream_extensions.json
     await updateUpstreamExtensions(
       absoluteModelsDir,
@@ -902,6 +971,7 @@ export async function installExtension(
       platforms: manifest.platforms,
       safetyWarnings,
       conflicts,
+      missingSourceFiles,
       dependencyResults,
     };
   } finally {
@@ -948,6 +1018,10 @@ function renderInstallResult(
 
   if (result.safetyWarnings.length > 0) {
     renderExtensionPullSafetyWarnings(result.safetyWarnings, outputMode);
+  }
+
+  if (result.missingSourceFiles.length > 0) {
+    renderExtensionPullMissingSources(result.missingSourceFiles, outputMode);
   }
 
   renderExtensionPull(

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { setColorEnabled } from "@std/fmt/colors";
+import { setColorEnabled, stripAnsiCode } from "@std/fmt/colors";
 import { isAbsolute, resolve } from "@std/path";
 import { parseLogLevel } from "@logtape/logtape";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
@@ -210,7 +210,9 @@ async function loadUserModels(
     // Log failures as warnings (don't block CLI startup)
     for (const failure of result.failed) {
       console.error(
-        `Warning: Failed to load user model ${failure.file}: ${failure.error}`,
+        `Warning: Failed to load user model ${failure.file}: ${
+          stripAnsiCode(failure.error)
+        }`,
       );
     }
   } catch (error) {
@@ -248,7 +250,9 @@ async function loadUserVaults(
     // Log failures as warnings (don't block CLI startup)
     for (const failure of result.failed) {
       console.error(
-        `Warning: Failed to load user vault ${failure.file}: ${failure.error}`,
+        `Warning: Failed to load user vault ${failure.file}: ${
+          stripAnsiCode(failure.error)
+        }`,
       );
     }
   } catch (error) {
@@ -283,7 +287,9 @@ async function loadUserDrivers(
     // Log failures as warnings (don't block CLI startup)
     for (const failure of result.failed) {
       console.error(
-        `Warning: Failed to load user driver ${failure.file}: ${failure.error}`,
+        `Warning: Failed to load user driver ${failure.file}: ${
+          stripAnsiCode(failure.error)
+        }`,
       );
     }
   } catch (error) {
@@ -318,7 +324,9 @@ async function loadUserDatastores(
     // Log failures as warnings (don't block CLI startup)
     for (const failure of result.failed) {
       console.error(
-        `Warning: Failed to load user datastore ${failure.file}: ${failure.error}`,
+        `Warning: Failed to load user datastore ${failure.file}: ${
+          stripAnsiCode(failure.error)
+        }`,
       );
     }
   } catch (error) {

--- a/src/domain/datastore/user_datastore_loader.ts
+++ b/src/domain/datastore/user_datastore_loader.ts
@@ -316,6 +316,10 @@ export class UserDatastoreLoader {
     for await (const entry of Deno.readDir(dir)) {
       const relativePath = prefix ? join(prefix, entry.name) : entry.name;
       if (entry.isDirectory) {
+        // Skip _-prefixed directories (e.g. _lib/) — helper modules, not entry points
+        if (entry.name.startsWith("_")) {
+          continue;
+        }
         const nested = await this.discoverFiles(
           join(dir, entry.name),
           relativePath,

--- a/src/domain/drivers/user_driver_loader.ts
+++ b/src/domain/drivers/user_driver_loader.ts
@@ -315,6 +315,10 @@ export class UserDriverLoader {
     for await (const entry of Deno.readDir(dir)) {
       const relativePath = prefix ? join(prefix, entry.name) : entry.name;
       if (entry.isDirectory) {
+        // Skip _-prefixed directories (e.g. _lib/) — helper modules, not entry points
+        if (entry.name.startsWith("_")) {
+          continue;
+        }
         const nested = await this.discoverFiles(
           join(dir, entry.name),
           relativePath,

--- a/src/domain/models/bundle.ts
+++ b/src/domain/models/bundle.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { getLogger } from "@logtape/logtape";
+import { stripAnsiCode } from "@std/fmt/colors";
 import * as zodModule from "zod";
 
 const logger = getLogger(["swamp", "models", "bundle"]);
@@ -200,8 +201,9 @@ export async function bundleExtension(
     if (!output.success) {
       const stderr = new TextDecoder().decode(output.stderr);
       const stdout = new TextDecoder().decode(output.stdout);
-      const details = (stderr + stdout).trim() ||
+      const rawDetails = (stderr + stdout).trim() ||
         "(no output — try running deno 2.7.x or later)";
+      const details = stripAnsiCode(rawDetails);
       throw new Error(
         `deno bundle failed for ${absolutePath}: ${details}`,
       );

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -719,6 +719,10 @@ export class UserModelLoader {
     for await (const entry of Deno.readDir(dir)) {
       const relativePath = prefix ? join(prefix, entry.name) : entry.name;
       if (entry.isDirectory) {
+        // Skip _-prefixed directories (e.g. _lib/) — helper modules, not entry points
+        if (entry.name.startsWith("_")) {
+          continue;
+        }
         const nested = await this.discoverFiles(
           join(dir, entry.name),
           relativePath,

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -2265,3 +2265,65 @@ export const model = {
     assertEquals(modelDef!.methods.run.kind, undefined);
   });
 });
+
+Deno.test("UserModelLoader skips _-prefixed directories in discoverFiles", async () => {
+  const ts = Date.now();
+  const validModel = `
+import { z } from "npm:zod@4";
+export const model = {
+  type: "@user/skip-underscore-${ts}",
+  version: "2026.03.18.1",
+  globalArguments: z.object({}),
+  resources: {
+    "data": {
+      description: "Data output",
+      schema: z.object({}),
+      lifetime: "infinite",
+      garbageCollection: 10,
+    },
+  },
+  methods: {
+    run: {
+      description: "Run",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+  const helperCode = `
+export function helper() { return "helper"; }
+`;
+
+  await withTempModels(
+    {
+      "entry.ts": validModel,
+      "_lib/helper.ts": helperCode,
+    },
+    async (dir) => {
+      const loader = createTestLoader();
+      const result = await loader.loadModels(dir);
+
+      // The entry model should load successfully
+      assertEquals(result.loaded.length, 1);
+      assertEquals(result.loaded[0], "entry.ts");
+
+      // _lib/helper.ts should NOT appear in failed or loaded
+      for (const failure of result.failed) {
+        assertEquals(
+          failure.file.includes("_lib"),
+          false,
+          `_lib file should not appear in failed: ${failure.file}`,
+        );
+      }
+      for (const loaded of result.loaded) {
+        assertEquals(
+          loaded.includes("_lib"),
+          false,
+          `_lib file should not appear in loaded: ${loaded}`,
+        );
+      }
+    },
+  );
+});

--- a/src/domain/vaults/user_vault_loader.ts
+++ b/src/domain/vaults/user_vault_loader.ts
@@ -322,6 +322,10 @@ export class UserVaultLoader {
     for await (const entry of Deno.readDir(dir)) {
       const relativePath = prefix ? join(prefix, entry.name) : entry.name;
       if (entry.isDirectory) {
+        // Skip _-prefixed directories (e.g. _lib/) — helper modules, not entry points
+        if (entry.name.startsWith("_")) {
+          continue;
+        }
         const nested = await this.discoverFiles(
           join(dir, entry.name),
           relativePath,

--- a/src/presentation/output/extension_pull_output.ts
+++ b/src/presentation/output/extension_pull_output.ts
@@ -205,6 +205,28 @@ export function renderExtensionPullSafetyErrors(
 }
 
 /**
+ * Renders warning about missing source files in a pulled extension.
+ */
+export function renderExtensionPullMissingSources(
+  missingFiles: string[],
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify({ missingSourceFiles: missingFiles }, null, 2));
+  } else {
+    logger
+      .warn`Extension has incomplete source files (${
+      String(missingFiles.length)
+    } missing). The pre-built bundle will be used.`;
+    logger
+      .warn`To fix, ask the extension author to re-publish with swamp 20260316 or later.`;
+    for (const f of missingFiles) {
+      logger.warn`  missing: ${f}`;
+    }
+  }
+}
+
+/**
  * Renders safety warnings.
  */
 export function renderExtensionPullSafetyWarnings(

--- a/src/presentation/output/extension_pull_output_test.ts
+++ b/src/presentation/output/extension_pull_output_test.ts
@@ -23,6 +23,7 @@ import {
   renderExtensionPullCancelled,
   renderExtensionPullConflicts,
   renderExtensionPullDependencyPull,
+  renderExtensionPullMissingSources,
   renderExtensionPullPlatforms,
   renderExtensionPullRepository,
   renderExtensionPullResolved,
@@ -150,4 +151,16 @@ Deno.test("renderExtensionPullSafetyWarnings outputs JSON in json mode", () => {
   });
   const parsed = JSON.parse(output);
   assertStringIncludes(parsed.warnings[0].file, "model.ts");
+});
+
+Deno.test("renderExtensionPullMissingSources outputs JSON in json mode", () => {
+  const output = captureConsoleLog(() => {
+    renderExtensionPullMissingSources(
+      ["_lib/acme.ts", "_lib/dns.ts"],
+      "json",
+    );
+  });
+  const parsed = JSON.parse(output);
+  assertStringIncludes(parsed.missingSourceFiles[0], "_lib/acme.ts");
+  assertStringIncludes(parsed.missingSourceFiles[1], "_lib/dns.ts");
 });


### PR DESCRIPTION
## Summary

- **Skip `_`-prefixed directories** (`_lib/`, `_internal/`) in `discoverFiles()` across all four loaders (model, vault, driver, datastore) — these are helper modules imported by entry points, not standalone types that should be individually bundled
- **Strip ANSI escape codes** from `deno bundle` error messages and CLI startup warnings so users see clean text instead of raw escape sequences
- **Validate source completeness** during `extension pull` — after extraction, resolve imports from entry-point `.ts` files and warn if referenced source files are missing, with guidance to ask the author to re-publish

## Context

Extensions published before the multiline import regex fix (commit `4955f3d2`, March 16) may have incomplete source files. For example, `@stack72/letsencrypt-certificate` was published March 4 and is missing `_lib/acme.ts` because the old single-line regex in `local_import_resolver.ts` couldn't match multiline imports during publish.

When users pulled these extensions, `discoverFiles()` found helper files in `_lib/` and tried to bundle them independently, which failed because their imports were unresolvable. Users saw raw `deno bundle` errors with ANSI escape codes — a confusing experience since the pre-built JS bundle actually works fine.

## User impact

Before this fix, pulling `@stack72/letsencrypt-certificate` produced confusing bundle errors with ANSI garbage. After this fix, users see:

```
WRN Extension has incomplete source files (1 missing). The pre-built bundle will be used.
WRN To fix, ask the extension author to re-publish with swamp 20260316 or later.
WRN   missing: _lib/acme.ts
```

And `swamp model type describe @stack72/letsencrypt-certificate` works correctly via the pre-built bundle.

## Test plan

- [x] New test: `UserModelLoader skips _-prefixed directories in discoverFiles` — creates `_lib/helper.ts` alongside a valid model and verifies it never appears in `result.failed` or `result.loaded`
- [x] New test: `renderExtensionPullMissingSources outputs JSON in json mode` — verifies JSON output format for missing source file warnings
- [x] All 3363 existing tests pass
- [x] Manual verification: `swamp init && swamp extension pull @stack72/letsencrypt-certificate && swamp model type describe @stack72/letsencrypt-certificate` — shows missing source warning, no bundle errors, type describe works

🤖 Generated with [Claude Code](https://claude.com/claude-code)