### PR TITLE
feat: add createXxxDeps factories for all 12 Batch 2 commands

### DIFF
--- a/src/cli/commands/data_list.ts
+++ b/src/cli/commands/data_list.ts
@@ -20,12 +20,9 @@
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
-import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
-import type { ModelType } from "../../domain/models/model_type.ts";
-import { WorkflowDataService } from "../../domain/data/workflow_data_service.ts";
-import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
 import {
   consumeStream,
+  createDataListDeps,
   createLibSwampContext,
   dataList,
 } from "../../libswamp/mod.ts";
@@ -55,55 +52,13 @@ export const dataListCommand = new Command()
   .action(async function (options: AnyOptions, modelIdOrName?: string) {
     const cliCtx = createContext(options as GlobalOptions, ["data", "list"]);
 
-    const { repoContext } = await requireInitializedRepoReadOnly({
+    const { repoDir } = await requireInitializedRepoReadOnly({
       repoDir: options.repoDir ?? ".",
       outputMode: cliCtx.outputMode,
     });
-    const definitionRepo = repoContext.definitionRepo;
-    const dataRepo = repoContext.unifiedDataRepo;
-    const workflowRepo = repoContext.workflowRepo;
-    const runRepo = repoContext.workflowRunRepo;
-
-    const workflowDataService = new WorkflowDataService(
-      definitionRepo,
-      dataRepo,
-    );
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = {
-      lookupDefinition: (idOrName: string) =>
-        findDefinitionByIdOrName(definitionRepo, idOrName),
-      findAllForModel: (
-        type: ModelType,
-        definitionId: string,
-      ) => dataRepo.findAllForModel(type, definitionId),
-      findWorkflow: async (nameOrId: string) => {
-        const wf = await workflowRepo.findByName(nameOrId) ??
-          await workflowRepo.findById(createWorkflowId(nameOrId));
-        return wf ? { id: wf.id, name: wf.name } : null;
-      },
-      findWorkflowRun: async (workflowId: string, runId: string) => {
-        const run = await runRepo.findById(
-          createWorkflowId(workflowId),
-          runId as ReturnType<typeof runRepo.nextId>,
-        );
-        return run ? { id: run.id, status: run.status } : null;
-      },
-      findLatestRun: async (workflowId: string) => {
-        const run = await runRepo.findLatestByWorkflowId(
-          createWorkflowId(workflowId),
-        );
-        return run ? { id: run.id, status: run.status } : null;
-      },
-      findAllForWorkflowRun: async (workflowId: string, runId: string) => {
-        const fullRun = await runRepo.findById(
-          createWorkflowId(workflowId),
-          runId as ReturnType<typeof runRepo.nextId>,
-        );
-        if (!fullRun) return [];
-        return workflowDataService.findAllForWorkflowRun(fullRun);
-      },
-    };
+    const deps = createDataListDeps(repoDir);
 
     const renderer = createDataListRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/cli/commands/data_versions.ts
+++ b/src/cli/commands/data_versions.ts
@@ -20,10 +20,9 @@
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
-import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
-import type { ModelType } from "../../domain/models/model_type.ts";
 import {
   consumeStream,
+  createDataVersionsDeps,
   createLibSwampContext,
   dataVersions,
 } from "../../libswamp/mod.ts";
@@ -51,29 +50,13 @@ export const dataVersionsCommand = new Command()
       cliCtx.logger
         .debug`Listing versions: model=${modelIdOrName}, name=${dataName}`;
 
-      const { repoContext } = await requireInitializedRepoReadOnly({
+      const { repoDir } = await requireInitializedRepoReadOnly({
         repoDir: options.repoDir ?? ".",
         outputMode: cliCtx.outputMode,
       });
-      const definitionRepo = repoContext.definitionRepo;
-      const dataRepo = repoContext.unifiedDataRepo;
 
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
-      const deps = {
-        lookupDefinition: (idOrName: string) =>
-          findDefinitionByIdOrName(definitionRepo, idOrName),
-        listVersions: (
-          type: ModelType,
-          definitionId: string,
-          name: string,
-        ) => dataRepo.listVersions(type, definitionId, name),
-        findByName: (
-          type: ModelType,
-          definitionId: string,
-          name: string,
-          version: number,
-        ) => dataRepo.findByName(type, definitionId, name, version),
-      };
+      const deps = createDataVersionsDeps(repoDir);
 
       const renderer = createDataVersionsRenderer(cliCtx.outputMode);
       await consumeStream(

--- a/src/cli/commands/extension_list.ts
+++ b/src/cli/commands/extension_list.ts
@@ -18,17 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { resolve } from "@std/path";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
-import { resolveModelsDir } from "../resolve_models_dir.ts";
-import {
-  RepoMarkerRepository,
-} from "../../infrastructure/persistence/repo_marker_repository.ts";
-import { RepoPath } from "../../domain/repo/repo_path.ts";
-import { readUpstreamExtensions } from "./extension_pull.ts";
 import {
   consumeStream,
+  createExtensionListDeps,
   createLibSwampContext,
   extensionList,
 } from "../../libswamp/mod.ts";
@@ -55,16 +49,8 @@ export const extensionListCommand = new Command()
       outputMode: cliCtx.outputMode,
     });
 
-    const repoPath = RepoPath.create(repoDir);
-    const markerRepo = new RepoMarkerRepository();
-    const marker = await markerRepo.read(repoPath);
-    const modelsDir = resolveModelsDir(marker);
-    const absoluteModelsDir = resolve(repoDir, modelsDir);
-
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = {
-      readUpstreamExtensions: () => readUpstreamExtensions(absoluteModelsDir),
-    };
+    const deps = await createExtensionListDeps(repoDir);
 
     const verbose = cliCtx.verbosity === "verbose";
     const renderer = createExtensionListRenderer(cliCtx.outputMode, verbose);

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -36,6 +36,7 @@ import { parseExtensionManifest } from "../../domain/extensions/extension_manife
 import { analyzeExtensionSafety } from "../../domain/extensions/extension_safety_analyzer.ts";
 import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
 import { atomicWriteTextFile } from "../../infrastructure/persistence/atomic_write.ts";
+import type { UpstreamExtensionsMap } from "../../infrastructure/persistence/upstream_extensions.ts";
 import { swampPath } from "../../infrastructure/persistence/paths.ts";
 import { computeChecksum } from "../../domain/models/checksum.ts";
 import { verifyChecksum } from "../../domain/update/integrity.ts";
@@ -117,15 +118,11 @@ export class ConflictError extends UserError {
   }
 }
 
-/** Entry in upstream_extensions.json. */
-export interface UpstreamExtensionEntry {
-  version: string;
-  pulledAt: string;
-  files?: string[];
-}
-
-/** Shape of upstream_extensions.json. */
-type UpstreamExtensionsMap = Record<string, UpstreamExtensionEntry>;
+export {
+  readUpstreamExtensions,
+  type UpstreamExtensionEntry,
+  type UpstreamExtensionsMap,
+} from "../../infrastructure/persistence/upstream_extensions.ts";
 
 /**
  * Parses an extension reference string into name and optional version.
@@ -289,24 +286,6 @@ export async function removeUpstreamExtension(
     } catch {
       // Best-effort cleanup
     }
-  }
-}
-
-/**
- * Reads upstream_extensions.json and returns the parsed map.
- */
-export async function readUpstreamExtensions(
-  modelsDir: string,
-): Promise<UpstreamExtensionsMap> {
-  const jsonPath = join(modelsDir, "upstream_extensions.json");
-  try {
-    const content = await Deno.readTextFile(jsonPath);
-    return JSON.parse(content) as UpstreamExtensionsMap;
-  } catch (error) {
-    if (error instanceof Deno.errors.NotFound) {
-      return {};
-    }
-    throw error;
   }
 }
 

--- a/src/cli/commands/extension_pull_test.ts
+++ b/src/cli/commands/extension_pull_test.ts
@@ -24,7 +24,7 @@ import {
   parseExtensionRef,
   updateUpstreamExtensions,
 } from "./extension_pull.ts";
-import type { UpstreamExtensionEntry } from "./extension_pull.ts";
+import type { UpstreamExtensionEntry } from "../../infrastructure/persistence/upstream_extensions.ts";
 import { UserError } from "../../domain/errors.ts";
 import { join } from "@std/path";
 

--- a/src/cli/commands/extension_rm.ts
+++ b/src/cli/commands/extension_rm.ts
@@ -29,9 +29,9 @@ import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { UserError } from "../../domain/errors.ts";
 import {
   parseExtensionRef,
-  readUpstreamExtensions,
   removeUpstreamExtension,
 } from "./extension_pull.ts";
+import { readUpstreamExtensions } from "../../infrastructure/persistence/upstream_extensions.ts";
 import { parseExtensionManifest } from "../../domain/extensions/extension_manifest.ts";
 import {
   renderExtensionRm,

--- a/src/cli/commands/extension_rm_test.ts
+++ b/src/cli/commands/extension_rm_test.ts
@@ -20,11 +20,13 @@
 import { assertEquals } from "@std/assert";
 import { join } from "@std/path";
 import {
-  readUpstreamExtensions,
   removeUpstreamExtension,
   updateUpstreamExtensions,
 } from "./extension_pull.ts";
-import type { UpstreamExtensionEntry } from "./extension_pull.ts";
+import {
+  readUpstreamExtensions,
+  type UpstreamExtensionEntry,
+} from "../../infrastructure/persistence/upstream_extensions.ts";
 
 Deno.test("removeUpstreamExtension removes entry and preserves others", async () => {
   const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });

--- a/src/cli/commands/extension_update.ts
+++ b/src/cli/commands/extension_update.ts
@@ -36,8 +36,8 @@ import {
   type InstallContext,
   installExtension,
   parseExtensionRef,
-  readUpstreamExtensions,
 } from "./extension_pull.ts";
+import { readUpstreamExtensions } from "../../infrastructure/persistence/upstream_extensions.ts";
 import {
   buildUpdateResult,
   checkExtensionVersion,

--- a/src/cli/commands/model_method_history_logs.ts
+++ b/src/cli/commands/model_method_history_logs.ts
@@ -20,19 +20,10 @@
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
-import type { DefinitionId } from "../../domain/definitions/definition.ts";
-import {
-  findDefinitionByIdOrName,
-  isPartialId,
-  matchByPartialId,
-} from "../../domain/models/model_lookup.ts";
-import { modelRegistry } from "../../domain/models/model.ts";
-import type { ModelType } from "../../domain/models/model_type.ts";
-import { readLogFile } from "../../presentation/output/log_file_reader.ts";
-import { toRelativePath } from "../../infrastructure/persistence/paths.ts";
 import {
   consumeStream,
   createLibSwampContext,
+  createModelMethodHistoryLogsDeps,
   modelMethodHistoryLogs,
 } from "../../libswamp/mod.ts";
 import { createModelMethodHistoryLogsRenderer } from "../../presentation/renderers/model_method_history_logs.ts";
@@ -55,58 +46,13 @@ export const modelMethodHistoryLogsCommand = new Command()
     ]);
     cliCtx.logger.debug`Getting logs for method run: ${outputIdOrModelName}`;
 
-    const { repoDir, repoContext } = await requireInitializedRepoReadOnly({
+    const { repoDir } = await requireInitializedRepoReadOnly({
       repoDir: options.repoDir ?? ".",
       outputMode: cliCtx.outputMode,
     });
-    const definitionRepo = repoContext.definitionRepo;
-    const outputRepo = repoContext.outputRepo;
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = {
-      isPartialId,
-      matchOutputByPartialId: async (idPrefix: string) => {
-        const allOutputs = await outputRepo.findAllGlobal();
-        const result = matchByPartialId(
-          allOutputs.map((o) => ({ id: o.output.id, item: o.output })),
-          idPrefix,
-        );
-        if (result.status === "found") {
-          return { status: "found" as const, match: result.match };
-        }
-        if (result.status === "ambiguous") {
-          return {
-            status: "ambiguous" as const,
-            matches: result.matches.map((m) => ({ id: m.id })),
-          };
-        }
-        return { status: "not_found" as const };
-      },
-      findDefinition: (idOrName: string) =>
-        findDefinitionByIdOrName(definitionRepo, idOrName),
-      findLatestOutput: (
-        type: ModelType,
-        definitionId: string,
-      ) =>
-        outputRepo.findLatestByDefinition(
-          type,
-          definitionId as DefinitionId,
-        ),
-      getModelName: async (definitionId: string) => {
-        for (const modelType of modelRegistry.types()) {
-          const definition = await definitionRepo.findById(
-            modelType,
-            definitionId as DefinitionId,
-          );
-          if (definition) {
-            return definition.name;
-          }
-        }
-        return outputIdOrModelName;
-      },
-      readLogFile,
-      toRelativePath,
-    };
+    const deps = createModelMethodHistoryLogsDeps(repoDir);
 
     const renderer = createModelMethodHistoryLogsRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/cli/commands/model_output_data.ts
+++ b/src/cli/commands/model_output_data.ts
@@ -21,14 +21,9 @@ import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import {
-  isPartialId,
-  matchByPartialId,
-} from "../../domain/models/model_lookup.ts";
-import type { DefinitionId } from "../../domain/definitions/definition.ts";
-import type { ModelType } from "../../domain/models/model_type.ts";
-import {
   consumeStream,
   createLibSwampContext,
+  createModelOutputDataDeps,
   modelOutputData,
 } from "../../libswamp/mod.ts";
 import { createModelOutputDataRenderer } from "../../presentation/renderers/model_output_data.ts";
@@ -58,57 +53,13 @@ export const modelOutputDataCommand = new Command()
     ]);
     cliCtx.logger.debug`Getting data for output: ${outputIdArg}`;
 
-    const { repoContext } = await requireInitializedRepoReadOnly({
+    const { repoDir } = await requireInitializedRepoReadOnly({
       repoDir: options.repoDir ?? ".",
       outputMode: cliCtx.outputMode,
     });
-    const outputRepo = repoContext.outputRepo;
-    const definitionRepo = repoContext.definitionRepo;
-    const dataRepo = repoContext.unifiedDataRepo;
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = {
-      isPartialId,
-      matchOutputByPartialId: async (idPrefix: string) => {
-        const allOutputs = await outputRepo.findAllGlobal();
-        const result = matchByPartialId(
-          allOutputs.map((o) => ({ id: o.output.id, item: o })),
-          idPrefix,
-        );
-        if (result.status === "found") {
-          return {
-            status: "found" as const,
-            match: { output: result.match.output, type: result.match.type },
-          };
-        }
-        if (result.status === "ambiguous") {
-          return {
-            status: "ambiguous" as const,
-            matches: result.matches.map((m) => ({ id: m.id })),
-          };
-        }
-        return { status: "not_found" as const };
-      },
-      findDefinition: async (
-        type: ModelType,
-        definitionId: DefinitionId,
-      ) => {
-        const def = await definitionRepo.findById(type, definitionId);
-        return def ? { id: def.id, name: def.name } : null;
-      },
-      findDataByName: (
-        type: ModelType,
-        definitionId: string,
-        name: string,
-        version?: number,
-      ) => dataRepo.findByName(type, definitionId, name, version),
-      getContent: (
-        type: ModelType,
-        definitionId: string,
-        name: string,
-        version?: number,
-      ) => dataRepo.getContent(type, definitionId, name, version),
-    };
+    const deps = createModelOutputDataDeps(repoDir);
 
     const renderer = createModelOutputDataRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/cli/commands/model_output_logs.ts
+++ b/src/cli/commands/model_output_logs.ts
@@ -21,13 +21,9 @@ import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import {
-  isPartialId,
-  matchByPartialId,
-} from "../../domain/models/model_lookup.ts";
-import type { ModelType } from "../../domain/models/model_type.ts";
-import {
   consumeStream,
   createLibSwampContext,
+  createModelOutputLogsDeps,
   modelOutputLogs,
 } from "../../libswamp/mod.ts";
 import { createModelOutputLogsRenderer } from "../../presentation/renderers/model_output_logs.ts";
@@ -49,47 +45,13 @@ export const modelOutputLogsCommand = new Command()
     ]);
     cliCtx.logger.debug`Getting logs for output: ${outputIdArg}`;
 
-    const { repoContext } = await requireInitializedRepoReadOnly({
+    const { repoDir } = await requireInitializedRepoReadOnly({
       repoDir: options.repoDir ?? ".",
       outputMode: cliCtx.outputMode,
     });
-    const outputRepo = repoContext.outputRepo;
-    const dataRepo = repoContext.unifiedDataRepo;
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = {
-      isPartialId,
-      matchOutputByPartialId: async (idPrefix: string) => {
-        const allOutputs = await outputRepo.findAllGlobal();
-        const result = matchByPartialId(
-          allOutputs.map((o) => ({ id: o.output.id, item: o })),
-          idPrefix,
-        );
-        if (result.status === "found") {
-          return {
-            status: "found" as const,
-            match: { output: result.match.output, type: result.match.type },
-          };
-        }
-        if (result.status === "ambiguous") {
-          return {
-            status: "ambiguous" as const,
-            matches: result.matches.map((m) => ({ id: m.id })),
-          };
-        }
-        return { status: "not_found" as const };
-      },
-      findDataByName: (
-        type: ModelType,
-        definitionId: string,
-        name: string,
-      ) => dataRepo.findByName(type, definitionId, name),
-      getContent: (
-        type: ModelType,
-        definitionId: string,
-        name: string,
-      ) => dataRepo.getContent(type, definitionId, name),
-    };
+    const deps = createModelOutputLogsDeps(repoDir);
 
     const renderer = createModelOutputLogsRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/cli/commands/model_validate.ts
+++ b/src/cli/commands/model_validate.ts
@@ -23,18 +23,10 @@ import {
   requireInitializedRepo,
   requireInitializedRepoReadOnly,
 } from "../repo_context.ts";
-import type { Definition } from "../../domain/definitions/definition.ts";
-import { resolveModelType } from "../../domain/extensions/extension_auto_resolver.ts";
-import type { ModelType } from "../../domain/models/model_type.ts";
-import { getAutoResolver } from "../auto_resolver_context.ts";
-import {
-  type CheckValidationContext,
-  DefaultModelValidationService,
-} from "../../domain/models/validation_service.ts";
-import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import {
   consumeStream,
   createLibSwampContext,
+  createModelValidateDeps,
   modelValidate,
 } from "../../libswamp/mod.ts";
 import { createModelValidateRenderer } from "../../presentation/renderers/model_validate.ts";
@@ -67,7 +59,7 @@ export const modelValidateCommand = new Command()
       const method = options.method as string | undefined;
       const hasCheckOptions = (labels && labels.length > 0) || method;
 
-      const { repoDir, repoContext } = hasCheckOptions
+      const { repoDir } = hasCheckOptions
         ? await requireInitializedRepo({
           repoDir: options.repoDir ?? ".",
           outputMode: cliCtx.outputMode,
@@ -76,39 +68,9 @@ export const modelValidateCommand = new Command()
           repoDir: options.repoDir ?? ".",
           outputMode: cliCtx.outputMode,
         });
-      const definitionRepo = repoContext.definitionRepo;
-      const validationService = new DefaultModelValidationService();
-
-      const buildCheckContext = (): CheckValidationContext | undefined => {
-        return {
-          repoDir,
-          dataRepository: repoContext.unifiedDataRepo,
-          definitionRepository: definitionRepo,
-          labels,
-          method,
-        };
-      };
 
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
-      const deps = {
-        lookupDefinition: (idOrName: string) =>
-          findDefinitionByIdOrName(definitionRepo, idOrName),
-        findAllDefinitions: () => definitionRepo.findAllGlobal(),
-        resolveModelType: (type: ModelType) =>
-          resolveModelType(type, getAutoResolver()),
-        validateModel: (
-          definition: Definition,
-          modelDef: unknown,
-          _type: ModelType,
-        ) =>
-          validationService.validateModel(
-            definition,
-            // deno-lint-ignore no-explicit-any
-            modelDef as any,
-            definitionRepo,
-            buildCheckContext(),
-          ),
-      };
+      const deps = createModelValidateDeps(repoDir, { labels, method });
 
       const renderer = createModelValidateRenderer(cliCtx.outputMode);
       await consumeStream(

--- a/src/cli/commands/telemetry_stats.ts
+++ b/src/cli/commands/telemetry_stats.ts
@@ -20,11 +20,10 @@
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
-import { TelemetryService } from "../../domain/telemetry/telemetry_service.ts";
-import { JsonTelemetryRepository } from "../../infrastructure/persistence/json_telemetry_repository.ts";
 import {
   consumeStream,
   createLibSwampContext,
+  createTelemetryStatsDeps,
   telemetryStats,
 } from "../../libswamp/mod.ts";
 import { createTelemetryStatsRenderer } from "../../presentation/renderers/telemetry_stats.ts";
@@ -47,11 +46,8 @@ export const telemetryStatsCommand = new Command()
       outputMode: cliCtx.outputMode,
     });
 
-    const repository = new JsonTelemetryRepository(repoDir);
-    const service = new TelemetryService(repository, VERSION);
-
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = { getStats: (days: number) => service.getStats(days) };
+    const deps = createTelemetryStatsDeps(repoDir, VERSION);
     const renderer = createTelemetryStatsRenderer(cliCtx.outputMode);
 
     await consumeStream(

--- a/src/cli/commands/vault_list_keys.ts
+++ b/src/cli/commands/vault_list_keys.ts
@@ -20,10 +20,10 @@
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
-import { VaultService } from "../../domain/vaults/vault_service.ts";
 import {
   consumeStream,
   createLibSwampContext,
+  createVaultListKeysDeps,
   vaultListKeys,
 } from "../../libswamp/mod.ts";
 import { createVaultListKeysRenderer } from "../../presentation/renderers/vault_list_keys.ts";
@@ -43,20 +43,13 @@ export const vaultListKeysCommand = new Command()
     ]);
     cliCtx.logger.debug`Listing secret keys in vault: ${vaultName}`;
 
-    const { repoDir, repoContext } = await requireInitializedRepoReadOnly({
+    const { repoDir } = await requireInitializedRepoReadOnly({
       repoDir: options.repoDir ?? ".",
       outputMode: cliCtx.outputMode,
     });
 
-    const repo = repoContext.vaultConfigRepo;
-    const vaultService = await VaultService.fromRepository(repoDir);
-
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = {
-      findVaultByName: (name: string) => repo.findByName(name),
-      findAllVaults: () => repo.findAll(),
-      listKeys: (name: string) => vaultService.list(name),
-    };
+    const deps = await createVaultListKeysDeps(repoDir);
 
     const renderer = createVaultListKeysRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/cli/commands/workflow_history_logs.ts
+++ b/src/cli/commands/workflow_history_logs.ts
@@ -20,16 +20,10 @@
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
-import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
-import {
-  isPartialId,
-  matchByPartialId,
-} from "../../domain/models/model_lookup.ts";
-import { readLogFile } from "../../presentation/output/log_file_reader.ts";
-import { toRelativePath } from "../../infrastructure/persistence/paths.ts";
 import {
   consumeStream,
   createLibSwampContext,
+  createWorkflowHistoryLogsDeps,
   workflowHistoryLogs,
 } from "../../libswamp/mod.ts";
 import { createWorkflowHistoryLogsRenderer } from "../../presentation/renderers/workflow_history_logs.ts";
@@ -53,43 +47,13 @@ export const workflowHistoryLogsCommand = new Command()
     );
     cliCtx.logger.debug`Getting logs for workflow run: ${runIdOrWorkflow}`;
 
-    const { repoDir, repoContext } = await requireInitializedRepoReadOnly({
+    const { repoDir } = await requireInitializedRepoReadOnly({
       repoDir: options.repoDir ?? ".",
       outputMode: cliCtx.outputMode,
     });
-    const runRepo = repoContext.workflowRunRepo;
-    const workflowRepo = repoContext.workflowRepo;
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = {
-      isPartialId,
-      matchRunByPartialId: async (idPrefix: string) => {
-        const allRuns = await runRepo.findAllGlobal();
-        const result = matchByPartialId(
-          allRuns.map((r) => ({ id: r.run.id, item: r.run })),
-          idPrefix,
-        );
-        if (result.status === "found") {
-          return { status: "found" as const, match: result.match };
-        }
-        if (result.status === "ambiguous") {
-          return {
-            status: "ambiguous" as const,
-            matches: result.matches.map((m) => ({ id: m.id })),
-          };
-        }
-        return { status: "not_found" as const };
-      },
-      findWorkflow: async (nameOrId: string) =>
-        await workflowRepo.findByName(nameOrId) ??
-          await workflowRepo.findById(createWorkflowId(nameOrId)),
-      findLatestRun: (workflowId: string) =>
-        runRepo.findLatestByWorkflowId(
-          createWorkflowId(workflowId),
-        ),
-      readLogFile,
-      toRelativePath,
-    };
+    const deps = createWorkflowHistoryLogsDeps(repoDir);
 
     const renderer = createWorkflowHistoryLogsRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/cli/commands/workflow_schema.ts
+++ b/src/cli/commands/workflow_schema.ts
@@ -18,15 +18,6 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { z } from "zod";
-import { WorkflowSchema } from "../../domain/workflows/workflow.ts";
-import { JobDependencySchema, JobSchema } from "../../domain/workflows/job.ts";
-import {
-  StepDependencySchema,
-  StepSchema,
-} from "../../domain/workflows/step.ts";
-import { StepTaskSchema } from "../../domain/workflows/step_task.ts";
-import { TriggerConditionSchema } from "../../domain/workflows/trigger_condition.ts";
 import {
   consumeStream,
   createLibSwampContext,
@@ -38,13 +29,6 @@ import { createContext, type GlobalOptions } from "../context.ts";
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-/**
- * Converts a Zod schema to JSON Schema format.
- */
-function zodToJsonSchema(schema: z.ZodTypeAny): object {
-  return z.toJSONSchema(schema);
-}
-
 export const workflowSchemaGetCommand = new Command()
   .description("Get the schema for workflow files")
   .action(async function (options: AnyOptions) {
@@ -54,21 +38,9 @@ export const workflowSchemaGetCommand = new Command()
       "get",
     ]);
 
-    const deps = {
-      getSchemas: () => ({
-        workflow: zodToJsonSchema(WorkflowSchema),
-        job: zodToJsonSchema(JobSchema),
-        jobDependency: zodToJsonSchema(JobDependencySchema),
-        step: zodToJsonSchema(StepSchema),
-        stepDependency: zodToJsonSchema(StepDependencySchema),
-        stepTask: zodToJsonSchema(StepTaskSchema),
-        triggerCondition: zodToJsonSchema(TriggerConditionSchema),
-      }),
-    };
-
     const lctx = createLibSwampContext({ logger: ctx.logger });
     const renderer = createWorkflowSchemaRenderer(ctx.outputMode);
-    await consumeStream(workflowSchema(lctx, deps), renderer.handlers());
+    await consumeStream(workflowSchema(lctx), renderer.handlers());
 
     ctx.logger.debug("Workflow schema get command completed");
   });

--- a/src/cli/commands/workflow_validate.ts
+++ b/src/cli/commands/workflow_validate.ts
@@ -20,14 +20,10 @@
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
-import type { Workflow } from "../../domain/workflows/workflow.ts";
-import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
-import {
-  DefaultWorkflowValidationService,
-} from "../../domain/workflows/validation_service.ts";
 import {
   consumeStream,
   createLibSwampContext,
+  createWorkflowValidateDeps,
   workflowValidate,
 } from "../../libswamp/mod.ts";
 import { createWorkflowValidateRenderer } from "../../presentation/renderers/workflow_validate.ts";
@@ -45,20 +41,13 @@ export const workflowValidateCommand = new Command()
       "workflow",
       "validate",
     ]);
-    const { repoContext } = await requireInitializedRepoReadOnly({
+    const { repoDir } = await requireInitializedRepoReadOnly({
       repoDir: options.repoDir ?? ".",
       outputMode: cliCtx.outputMode,
     });
-    const repo = repoContext.workflowRepo;
-    const validationService = new DefaultWorkflowValidationService();
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = {
-      findWorkflowById: (id: string) => repo.findById(createWorkflowId(id)),
-      findWorkflowByName: (name: string) => repo.findByName(name),
-      findAllWorkflows: () => repo.findAll(),
-      validate: (workflow: Workflow) => validationService.validate(workflow),
-    };
+    const deps = createWorkflowValidateDeps(repoDir);
 
     const renderer = createWorkflowValidateRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/infrastructure/persistence/upstream_extensions.ts
+++ b/src/infrastructure/persistence/upstream_extensions.ts
@@ -1,0 +1,48 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join } from "@std/path";
+
+/** Entry in upstream_extensions.json. */
+export interface UpstreamExtensionEntry {
+  version: string;
+  pulledAt: string;
+  files?: string[];
+}
+
+/** Shape of upstream_extensions.json. */
+export type UpstreamExtensionsMap = Record<string, UpstreamExtensionEntry>;
+
+/**
+ * Reads upstream_extensions.json and returns the parsed map.
+ */
+export async function readUpstreamExtensions(
+  modelsDir: string,
+): Promise<UpstreamExtensionsMap> {
+  const jsonPath = join(modelsDir, "upstream_extensions.json");
+  try {
+    const content = await Deno.readTextFile(jsonPath);
+    return JSON.parse(content) as UpstreamExtensionsMap;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return {};
+    }
+    throw error;
+  }
+}

--- a/src/libswamp/data/list.ts
+++ b/src/libswamp/data/list.ts
@@ -18,7 +18,14 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { Definition } from "../../domain/definitions/definition.ts";
+import { WorkflowDataService } from "../../domain/data/workflow_data_service.ts";
+import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
+import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
+import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
+import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
@@ -140,6 +147,50 @@ export interface DataListDeps {
     workflowId: string,
     runId: string,
   ) => Promise<WorkflowDataEntry[]>;
+}
+
+/** Wires real infrastructure into DataListDeps. */
+export function createDataListDeps(repoDir: string): DataListDeps {
+  const definitionRepo = new YamlDefinitionRepository(repoDir);
+  const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+  const workflowRepo = new YamlWorkflowRepository(repoDir);
+  const runRepo = new YamlWorkflowRunRepository(repoDir);
+  const workflowDataService = new WorkflowDataService(
+    definitionRepo,
+    dataRepo,
+  );
+  return {
+    lookupDefinition: (idOrName) =>
+      findDefinitionByIdOrName(definitionRepo, idOrName),
+    findAllForModel: (type, definitionId) =>
+      dataRepo.findAllForModel(type, definitionId),
+    findWorkflow: async (nameOrId) => {
+      const wf = await workflowRepo.findByName(nameOrId) ??
+        await workflowRepo.findById(createWorkflowId(nameOrId));
+      return wf ? { id: wf.id, name: wf.name } : null;
+    },
+    findWorkflowRun: async (workflowId, runId) => {
+      const run = await runRepo.findById(
+        createWorkflowId(workflowId),
+        runId as ReturnType<typeof runRepo.nextId>,
+      );
+      return run ? { id: run.id, status: run.status } : null;
+    },
+    findLatestRun: async (workflowId) => {
+      const run = await runRepo.findLatestByWorkflowId(
+        createWorkflowId(workflowId),
+      );
+      return run ? { id: run.id, status: run.status } : null;
+    },
+    findAllForWorkflowRun: async (workflowId, runId) => {
+      const fullRun = await runRepo.findById(
+        createWorkflowId(workflowId),
+        runId as ReturnType<typeof runRepo.nextId>,
+      );
+      if (!fullRun) return [];
+      return workflowDataService.findAllForWorkflowRun(fullRun);
+    },
+  };
 }
 
 /** Standard type ordering for grouping. */

--- a/src/libswamp/data/versions.ts
+++ b/src/libswamp/data/versions.ts
@@ -18,7 +18,10 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { Definition } from "../../domain/definitions/definition.ts";
+import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
+import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError } from "../errors.ts";
 
@@ -75,6 +78,20 @@ export interface DataVersionsDeps {
     dataName: string,
     version: number,
   ) => Promise<DataEntry | null>;
+}
+
+/** Wires real infrastructure into DataVersionsDeps. */
+export function createDataVersionsDeps(repoDir: string): DataVersionsDeps {
+  const definitionRepo = new YamlDefinitionRepository(repoDir);
+  const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+  return {
+    lookupDefinition: (idOrName) =>
+      findDefinitionByIdOrName(definitionRepo, idOrName),
+    listVersions: (type, definitionId, name) =>
+      dataRepo.listVersions(type, definitionId, name),
+    findByName: (type, definitionId, name, version) =>
+      dataRepo.findByName(type, definitionId, name, version),
+  };
 }
 
 /** Yields all versions of a specific data entry for a model. */

--- a/src/libswamp/extensions/list.ts
+++ b/src/libswamp/extensions/list.ts
@@ -17,6 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { resolve } from "@std/path";
+import { RepoPath } from "../../domain/repo/repo_path.ts";
+import {
+  RepoMarkerRepository,
+} from "../../infrastructure/persistence/repo_marker_repository.ts";
+import { readUpstreamExtensions } from "../../infrastructure/persistence/upstream_extensions.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
@@ -48,6 +54,21 @@ interface UpstreamEntry {
 /** Dependencies for the extension list operation. */
 export interface ExtensionListDeps {
   readUpstreamExtensions: () => Promise<Record<string, UpstreamEntry>>;
+}
+
+/** Wires real infrastructure into ExtensionListDeps. */
+export async function createExtensionListDeps(
+  repoDir: string,
+): Promise<ExtensionListDeps> {
+  const repoPath = RepoPath.create(repoDir);
+  const markerRepo = new RepoMarkerRepository();
+  const marker = await markerRepo.read(repoPath);
+  const envModelsDir = Deno.env.get("SWAMP_MODELS_DIR");
+  const modelsDir = envModelsDir ?? marker?.modelsDir ?? "extensions/models";
+  const absoluteModelsDir = resolve(repoDir, modelsDir);
+  return {
+    readUpstreamExtensions: () => readUpstreamExtensions(absoluteModelsDir),
+  };
 }
 
 /** Yields the list of installed upstream extensions. */

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -156,6 +156,7 @@ export {
   type DataGetInput,
 } from "./data/get.ts";
 export {
+  createDataVersionsDeps,
   type DataVersionInfo,
   dataVersions,
   type DataVersionsData,
@@ -164,6 +165,7 @@ export {
   type DataVersionsInput,
 } from "./data/versions.ts";
 export {
+  createDataListDeps,
   type DataGroupedByType,
   dataList,
   type DataListData,
@@ -226,12 +228,12 @@ export {
 export {
   workflowSchema,
   type WorkflowSchemaData,
-  type WorkflowSchemaDeps,
   type WorkflowSchemaEvent,
 } from "./workflows/schema.ts";
 
 // Workflow validate operations
 export {
+  createWorkflowValidateDeps,
   isWorkflowValidateAllData,
   type ValidationItemData as WorkflowValidationItemData,
   workflowValidate,
@@ -244,6 +246,7 @@ export {
 
 // Workflow history logs operations
 export {
+  createWorkflowHistoryLogsDeps,
   workflowHistoryLogs,
   type WorkflowHistoryLogsDeps,
   type WorkflowHistoryLogsEvent,
@@ -252,6 +255,7 @@ export {
 
 // Model validate operations
 export {
+  createModelValidateDeps,
   isModelValidateAllData,
   modelValidate,
   type ModelValidateAllData,
@@ -264,6 +268,7 @@ export {
 
 // Model method history logs operations
 export {
+  createModelMethodHistoryLogsDeps,
   modelMethodHistoryLogs,
   type ModelMethodHistoryLogsDeps,
   type ModelMethodHistoryLogsEvent,
@@ -272,6 +277,7 @@ export {
 
 // Model output logs operations
 export {
+  createModelOutputLogsDeps,
   modelOutputLogs,
   type ModelOutputLogsDeps,
   type ModelOutputLogsEvent,
@@ -280,6 +286,7 @@ export {
 
 // Model output data operations
 export {
+  createModelOutputDataDeps,
   modelOutputData,
   type ModelOutputDataDeps,
   type ModelOutputDataEvent,
@@ -288,6 +295,7 @@ export {
 
 // Vault list-keys operations
 export {
+  createVaultListKeysDeps,
   vaultListKeys,
   type VaultListKeysData,
   type VaultListKeysDeps,
@@ -297,6 +305,7 @@ export {
 
 // Extension operations
 export {
+  createExtensionListDeps,
   extensionList,
   type ExtensionListData,
   type ExtensionListDeps,
@@ -306,6 +315,7 @@ export {
 
 // Telemetry operations
 export {
+  createTelemetryStatsDeps,
   telemetryStats,
   type TelemetryStatsData,
   type TelemetryStatsDeps,

--- a/src/libswamp/models/method_history_logs.ts
+++ b/src/libswamp/models/method_history_logs.ts
@@ -17,9 +17,22 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import type { Definition } from "../../domain/definitions/definition.ts";
+import type {
+  Definition,
+  DefinitionId,
+} from "../../domain/definitions/definition.ts";
 import type { ModelOutput } from "../../domain/models/model_output.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
+import {
+  findDefinitionByIdOrName,
+  isPartialId,
+  matchByPartialId,
+} from "../../domain/models/model_lookup.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
+import { readLogFile } from "../../presentation/output/log_file_reader.ts";
+import { toRelativePath } from "../../infrastructure/persistence/paths.ts";
+import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
@@ -87,6 +100,52 @@ export interface ModelMethodHistoryLogsDeps {
     options?: { tail?: number },
   ) => Promise<LogData>;
   toRelativePath: (repoDir: string, path: string) => string;
+}
+
+/** Wires real infrastructure into ModelMethodHistoryLogsDeps. */
+export function createModelMethodHistoryLogsDeps(
+  repoDir: string,
+): ModelMethodHistoryLogsDeps {
+  const definitionRepo = new YamlDefinitionRepository(repoDir);
+  const outputRepo = new YamlOutputRepository(repoDir);
+  return {
+    isPartialId,
+    matchOutputByPartialId: async (idPrefix: string) => {
+      const allOutputs = await outputRepo.findAllGlobal();
+      const result = matchByPartialId(
+        allOutputs.map((o) => ({ id: o.output.id, item: o.output })),
+        idPrefix,
+      );
+      if (result.status === "found") {
+        return { status: "found" as const, match: result.match };
+      }
+      if (result.status === "ambiguous") {
+        return {
+          status: "ambiguous" as const,
+          matches: result.matches.map((m) => ({ id: m.id })),
+        };
+      }
+      return { status: "not_found" as const };
+    },
+    findDefinition: (idOrName: string) =>
+      findDefinitionByIdOrName(definitionRepo, idOrName),
+    findLatestOutput: (type, definitionId) =>
+      outputRepo.findLatestByDefinition(type, definitionId as DefinitionId),
+    getModelName: async (definitionId: string) => {
+      for (const modelType of modelRegistry.types()) {
+        const definition = await definitionRepo.findById(
+          modelType,
+          definitionId as DefinitionId,
+        );
+        if (definition) {
+          return definition.name;
+        }
+      }
+      return definitionId;
+    },
+    readLogFile,
+    toRelativePath,
+  };
 }
 
 /** Yields log content for a model method run. */

--- a/src/libswamp/models/output_data.ts
+++ b/src/libswamp/models/output_data.ts
@@ -23,6 +23,13 @@ import type {
   ModelOutput,
 } from "../../domain/models/model_output.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
+import {
+  isPartialId,
+  matchByPartialId,
+} from "../../domain/models/model_lookup.ts";
+import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
+import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
@@ -87,6 +94,46 @@ export interface ModelOutputDataDeps {
     name: string,
     version?: number,
   ) => Promise<Uint8Array | null>;
+}
+
+/** Wires real infrastructure into ModelOutputDataDeps. */
+export function createModelOutputDataDeps(
+  repoDir: string,
+): ModelOutputDataDeps {
+  const outputRepo = new YamlOutputRepository(repoDir);
+  const definitionRepo = new YamlDefinitionRepository(repoDir);
+  const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+  return {
+    isPartialId,
+    matchOutputByPartialId: async (idPrefix: string) => {
+      const allOutputs = await outputRepo.findAllGlobal();
+      const result = matchByPartialId(
+        allOutputs.map((o) => ({ id: o.output.id, item: o })),
+        idPrefix,
+      );
+      if (result.status === "found") {
+        return {
+          status: "found" as const,
+          match: { output: result.match.output, type: result.match.type },
+        };
+      }
+      if (result.status === "ambiguous") {
+        return {
+          status: "ambiguous" as const,
+          matches: result.matches.map((m) => ({ id: m.id })),
+        };
+      }
+      return { status: "not_found" as const };
+    },
+    findDefinition: async (type, definitionId) => {
+      const def = await definitionRepo.findById(type, definitionId);
+      return def ? { id: def.id, name: def.name } : null;
+    },
+    findDataByName: (type, definitionId, name, version) =>
+      dataRepo.findByName(type, definitionId, name, version),
+    getContent: (type, definitionId, name, version) =>
+      dataRepo.getContent(type, definitionId, name, version),
+  };
 }
 
 /** Yields data artifact content for a model output. */

--- a/src/libswamp/models/output_logs.ts
+++ b/src/libswamp/models/output_logs.ts
@@ -19,6 +19,12 @@
 
 import type { ModelOutput } from "../../domain/models/model_output.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
+import {
+  isPartialId,
+  matchByPartialId,
+} from "../../domain/models/model_lookup.ts";
+import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
+import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
@@ -65,6 +71,41 @@ export interface ModelOutputLogsDeps {
     definitionId: string,
     name: string,
   ) => Promise<Uint8Array | null>;
+}
+
+/** Wires real infrastructure into ModelOutputLogsDeps. */
+export function createModelOutputLogsDeps(
+  repoDir: string,
+): ModelOutputLogsDeps {
+  const outputRepo = new YamlOutputRepository(repoDir);
+  const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+  return {
+    isPartialId,
+    matchOutputByPartialId: async (idPrefix: string) => {
+      const allOutputs = await outputRepo.findAllGlobal();
+      const result = matchByPartialId(
+        allOutputs.map((o) => ({ id: o.output.id, item: o })),
+        idPrefix,
+      );
+      if (result.status === "found") {
+        return {
+          status: "found" as const,
+          match: { output: result.match.output, type: result.match.type },
+        };
+      }
+      if (result.status === "ambiguous") {
+        return {
+          status: "ambiguous" as const,
+          matches: result.matches.map((m) => ({ id: m.id })),
+        };
+      }
+      return { status: "not_found" as const };
+    },
+    findDataByName: (type, definitionId, name) =>
+      dataRepo.findByName(type, definitionId, name),
+    getContent: (type, definitionId, name) =>
+      dataRepo.getContent(type, definitionId, name),
+  };
 }
 
 /** Yields log artifact content for a model output. */

--- a/src/libswamp/models/validate.ts
+++ b/src/libswamp/models/validate.ts
@@ -18,6 +18,15 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { Definition } from "../../domain/definitions/definition.ts";
+import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
+import { resolveModelType } from "../../domain/extensions/extension_auto_resolver.ts";
+import { getAutoResolver } from "../../domain/extensions/auto_resolver_context.ts";
+import {
+  type CheckValidationContext,
+  DefaultModelValidationService,
+} from "../../domain/models/validation_service.ts";
+import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
@@ -78,6 +87,39 @@ export interface ModelValidateDeps {
     modelDef: unknown,
     type: ModelType,
   ) => Promise<ValidationResult[]>;
+}
+
+/** Wires real infrastructure into ModelValidateDeps. */
+export function createModelValidateDeps(
+  repoDir: string,
+  options?: { labels?: string[]; method?: string },
+): ModelValidateDeps {
+  const definitionRepo = new YamlDefinitionRepository(repoDir);
+  const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+  const validationService = new DefaultModelValidationService();
+
+  const checkContext: CheckValidationContext = {
+    repoDir,
+    dataRepository: dataRepo,
+    definitionRepository: definitionRepo,
+    labels: options?.labels,
+    method: options?.method,
+  };
+
+  return {
+    lookupDefinition: (idOrName) =>
+      findDefinitionByIdOrName(definitionRepo, idOrName),
+    findAllDefinitions: () => definitionRepo.findAllGlobal(),
+    resolveModelType: (type) => resolveModelType(type, getAutoResolver()),
+    validateModel: (definition, modelDef, _type) =>
+      validationService.validateModel(
+        definition,
+        // deno-lint-ignore no-explicit-any
+        modelDef as any,
+        definitionRepo,
+        checkContext,
+      ),
+  };
 }
 
 /** Converts raw validation results to the presentation format. */

--- a/src/libswamp/telemetry/stats.ts
+++ b/src/libswamp/telemetry/stats.ts
@@ -17,7 +17,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import type { TelemetryStats } from "../../domain/telemetry/telemetry_service.ts";
+import {
+  TelemetryService,
+  type TelemetryStats,
+} from "../../domain/telemetry/telemetry_service.ts";
+import { JsonTelemetryRepository } from "../../infrastructure/persistence/json_telemetry_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
@@ -36,6 +40,18 @@ export interface TelemetryStatsDeps {
 
 export interface TelemetryStatsInput {
   days: number;
+}
+
+/** Wires real infrastructure into TelemetryStatsDeps. */
+export function createTelemetryStatsDeps(
+  repoDir: string,
+  version: string,
+): TelemetryStatsDeps {
+  const repository = new JsonTelemetryRepository(repoDir);
+  const service = new TelemetryService(repository, version);
+  return {
+    getStats: (days: number) => service.getStats(days),
+  };
 }
 
 /** Yields telemetry usage statistics. */

--- a/src/libswamp/vaults/list_keys.ts
+++ b/src/libswamp/vaults/list_keys.ts
@@ -17,6 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { VaultService } from "../../domain/vaults/vault_service.ts";
+import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
@@ -48,6 +50,19 @@ export interface VaultListKeysDeps {
   findVaultByName: (name: string) => Promise<VaultConfig | null>;
   findAllVaults: () => Promise<VaultConfig[]>;
   listKeys: (vaultName: string) => Promise<string[]>;
+}
+
+/** Wires real infrastructure into VaultListKeysDeps. */
+export async function createVaultListKeysDeps(
+  repoDir: string,
+): Promise<VaultListKeysDeps> {
+  const repo = new YamlVaultConfigRepository(repoDir);
+  const vaultService = await VaultService.fromRepository(repoDir);
+  return {
+    findVaultByName: (name) => repo.findByName(name),
+    findAllVaults: () => repo.findAll(),
+    listKeys: (name) => vaultService.list(name),
+  };
 }
 
 /** Yields all secret key names in a vault. */

--- a/src/libswamp/workflows/history_logs.ts
+++ b/src/libswamp/workflows/history_logs.ts
@@ -19,6 +19,15 @@
 
 import type { Workflow } from "../../domain/workflows/workflow.ts";
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
+import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
+import {
+  isPartialId,
+  matchByPartialId,
+} from "../../domain/models/model_lookup.ts";
+import { readLogFile } from "../../presentation/output/log_file_reader.ts";
+import { toRelativePath } from "../../infrastructure/persistence/paths.ts";
+import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
+import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
@@ -77,6 +86,41 @@ export interface WorkflowHistoryLogsDeps {
     options?: { tail?: number },
   ) => Promise<LogData>;
   toRelativePath: (repoDir: string, path: string) => string;
+}
+
+/** Wires real infrastructure into WorkflowHistoryLogsDeps. */
+export function createWorkflowHistoryLogsDeps(
+  repoDir: string,
+): WorkflowHistoryLogsDeps {
+  const runRepo = new YamlWorkflowRunRepository(repoDir);
+  const workflowRepo = new YamlWorkflowRepository(repoDir);
+  return {
+    isPartialId,
+    matchRunByPartialId: async (idPrefix: string) => {
+      const allRuns = await runRepo.findAllGlobal();
+      const result = matchByPartialId(
+        allRuns.map((r) => ({ id: r.run.id, item: r.run })),
+        idPrefix,
+      );
+      if (result.status === "found") {
+        return { status: "found" as const, match: result.match };
+      }
+      if (result.status === "ambiguous") {
+        return {
+          status: "ambiguous" as const,
+          matches: result.matches.map((m) => ({ id: m.id })),
+        };
+      }
+      return { status: "not_found" as const };
+    },
+    findWorkflow: async (nameOrId: string) =>
+      await workflowRepo.findByName(nameOrId) ??
+        await workflowRepo.findById(createWorkflowId(nameOrId)),
+    findLatestRun: (workflowId: string) =>
+      runRepo.findLatestByWorkflowId(createWorkflowId(workflowId)),
+    readLogFile,
+    toRelativePath,
+  };
 }
 
 /** Yields log content for a workflow run. */

--- a/src/libswamp/workflows/schema.ts
+++ b/src/libswamp/workflows/schema.ts
@@ -17,8 +17,17 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { WorkflowSchema } from "../../domain/workflows/workflow.ts";
+import { JobDependencySchema, JobSchema } from "../../domain/workflows/job.ts";
+import {
+  StepDependencySchema,
+  StepSchema,
+} from "../../domain/workflows/step.ts";
+import { StepTaskSchema } from "../../domain/workflows/step_task.ts";
+import { TriggerConditionSchema } from "../../domain/workflows/trigger_condition.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
+import { zodToJsonSchema } from "../types/schema_helpers.ts";
 
 /** Schema data for all workflow-related Zod schemas. */
 export interface WorkflowSchemaData {
@@ -35,15 +44,20 @@ export type WorkflowSchemaEvent =
   | { kind: "completed"; data: WorkflowSchemaData }
   | { kind: "error"; error: SwampError };
 
-/** Dependencies for the workflow schema operation. */
-export interface WorkflowSchemaDeps {
-  getSchemas: () => WorkflowSchemaData;
-}
-
 /** Yields the JSON Schema representation of all workflow schemas. */
 export async function* workflowSchema(
   _ctx: LibSwampContext,
-  deps: WorkflowSchemaDeps,
 ): AsyncIterable<WorkflowSchemaEvent> {
-  yield { kind: "completed", data: deps.getSchemas() };
+  yield {
+    kind: "completed",
+    data: {
+      workflow: zodToJsonSchema(WorkflowSchema),
+      job: zodToJsonSchema(JobSchema),
+      jobDependency: zodToJsonSchema(JobDependencySchema),
+      step: zodToJsonSchema(StepSchema),
+      stepDependency: zodToJsonSchema(StepDependencySchema),
+      stepTask: zodToJsonSchema(StepTaskSchema),
+      triggerCondition: zodToJsonSchema(TriggerConditionSchema),
+    },
+  };
 }

--- a/src/libswamp/workflows/schema_test.ts
+++ b/src/libswamp/workflows/schema_test.ts
@@ -17,41 +17,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { createLibSwampContext } from "../context.ts";
 import { collect } from "../testing.ts";
-import {
-  workflowSchema,
-  type WorkflowSchemaData,
-  type WorkflowSchemaDeps,
-  type WorkflowSchemaEvent,
-} from "./schema.ts";
-
-function makeSchemaData(): WorkflowSchemaData {
-  return {
-    workflow: { type: "object" },
-    job: { type: "object" },
-    jobDependency: { type: "object" },
-    step: { type: "object" },
-    stepDependency: { type: "object" },
-    stepTask: { type: "object" },
-    triggerCondition: { type: "object" },
-  };
-}
-
-function makeDeps(
-  overrides?: Partial<WorkflowSchemaDeps>,
-): WorkflowSchemaDeps {
-  return {
-    getSchemas: () => makeSchemaData(),
-    ...overrides,
-  };
-}
+import { workflowSchema, type WorkflowSchemaEvent } from "./schema.ts";
 
 Deno.test("workflowSchema yields completed with schema data", async () => {
   const ctx = createLibSwampContext();
-  const deps = makeDeps();
-  const events = await collect<WorkflowSchemaEvent>(workflowSchema(ctx, deps));
+  const events = await collect<WorkflowSchemaEvent>(workflowSchema(ctx));
 
   assertEquals(events.length, 1);
   assertEquals(events[0].kind, "completed");
@@ -59,6 +32,10 @@ Deno.test("workflowSchema yields completed with schema data", async () => {
     WorkflowSchemaEvent,
     { kind: "completed" }
   >;
-  assertEquals(completed.data.workflow, { type: "object" });
-  assertEquals(completed.data.job, { type: "object" });
+  // The generator now produces real JSON schemas from Zod, not stubs
+  assert(typeof completed.data.workflow === "object");
+  assert(typeof completed.data.job === "object");
+  assert(typeof completed.data.step === "object");
+  assert(typeof completed.data.stepTask === "object");
+  assert(typeof completed.data.triggerCondition === "object");
 });

--- a/src/libswamp/workflows/validate.ts
+++ b/src/libswamp/workflows/validate.ts
@@ -19,6 +19,11 @@
 
 import type { Workflow } from "../../domain/workflows/workflow.ts";
 import type { WorkflowValidationResult } from "../../domain/workflows/validation_service.ts";
+import {
+  DefaultWorkflowValidationService,
+} from "../../domain/workflows/validation_service.ts";
+import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
+import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
@@ -72,6 +77,20 @@ export interface WorkflowValidateDeps {
   findWorkflowByName: (name: string) => Promise<Workflow | null>;
   findAllWorkflows: () => Promise<Workflow[]>;
   validate: (workflow: Workflow) => WorkflowValidationResult[];
+}
+
+/** Wires real infrastructure into WorkflowValidateDeps. */
+export function createWorkflowValidateDeps(
+  repoDir: string,
+): WorkflowValidateDeps {
+  const repo = new YamlWorkflowRepository(repoDir);
+  const validationService = new DefaultWorkflowValidationService();
+  return {
+    findWorkflowById: (id) => repo.findById(createWorkflowId(id)),
+    findWorkflowByName: (name) => repo.findByName(name),
+    findAllWorkflows: () => repo.findAll(),
+    validate: (workflow) => validationService.validate(workflow),
+  };
 }
 
 /** Converts raw results to presentation format. */


### PR DESCRIPTION
## Summary

- **Extract `readUpstreamExtensions`** to `src/infrastructure/persistence/upstream_extensions.ts` so it can be imported from libswamp without reaching into CLI code
- **Add `createXxxDeps()` factory functions** to all 12 Batch 2 libswamp generators, following the same pattern as `createDataGetDeps()` from Batch 1
- **Simplify all 12 CLI handlers** to ~20-line wrappers: parse args → factory → renderer → `consumeStream()`
- **Rewrite `workflowSchema` generator** to import Zod schemas directly (pure computation, no deps needed)

### Factories added

| Command | Factory |
|---|---|
| `workflow_schema` | *(no deps — generator does pure computation)* |
| `extension_list` | `createExtensionListDeps(repoDir)` |
| `telemetry_stats` | `createTelemetryStatsDeps(repoDir, version)` |
| `data_list` | `createDataListDeps(repoDir)` |
| `data_versions` | `createDataVersionsDeps(repoDir)` |
| `vault_list_keys` | `createVaultListKeysDeps(repoDir)` |
| `model_validate` | `createModelValidateDeps(repoDir, options?)` |
| `workflow_validate` | `createWorkflowValidateDeps(repoDir)` |
| `workflow_history_logs` | `createWorkflowHistoryLogsDeps(repoDir)` |
| `model_method_history_logs` | `createModelMethodHistoryLogsDeps(repoDir)` |
| `model_output_logs` | `createModelOutputLogsDeps(repoDir)` |
| `model_output_data` | `createModelOutputDataDeps(repoDir)` |

Any consumer can now `import { dataList, createDataListDeps } from "libswamp/mod.ts"` and have a fully working operation without importing domain internals.

## Test Plan

- `deno check src/` — passes (0 errors)
- `deno lint` — passes (737 files)
- `deno fmt --check` — passes (798 files)
- `deno run test` — all 3361 tests pass
- `deno run compile` — binary compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>