### PR TITLE
docs: improve extension datastore skill workflow clarity

### DIFF
--- a/.claude/skills/swamp-extension-datastore/SKILL.md
+++ b/.claude/skills/swamp-extension-datastore/SKILL.md
@@ -145,22 +145,27 @@ swamp datastore status --json
 **Priority order:** `SWAMP_DATASTORE` env var > CLI `--datastore` arg >
 `.swamp.yaml` config > default filesystem.
 
-## Verify
+## Development Workflow
 
-After creating your datastore:
-
-```bash
-swamp datastore status --json              # Should show your custom type
-```
-
-If `healthy: false`, check the error message, fix the issue in your
-`createVerifier().verify()` implementation, then delete stale bundles and
-re-verify:
-
-```bash
-rm -rf .swamp/datastore-bundles/
-swamp datastore status --json
-```
+1. **Search existing**: `swamp extension search datastore` — if a match exists,
+   install it and skip to step 5
+2. **Create mod.ts**: Create `extensions/datastores/my-store/mod.ts` using the
+   Quick Start template above
+3. **Configure**: Add the datastore type and config to `.swamp.yaml` (or set
+   `SWAMP_DATASTORE` env var)
+4. **Verify**: Run `swamp datastore status --json` — should show your custom
+   type with `healthy: true`
+   - If `healthy: false`, check the error message and fix your
+     `createVerifier().verify()` implementation
+   - If type not found, check the export name is `export const datastore` and
+     the file is under `extensions/datastores/`
+   - After fixes, delete stale bundles and re-verify:
+     ```bash
+     rm -rf .swamp/datastore-bundles/
+     swamp datastore status --json
+     ```
+5. **Test**: Run a model operation that uses the datastore to confirm end-to-end
+   functionality
 
 ## Discovery & Loading
 


### PR DESCRIPTION
## Summary

- Replace flat "Verify" section in the `swamp-extension-datastore` skill with a numbered **Development Workflow** section
- Adds explicit validation checkpoints and "if X fails, do Y" error recovery feedback loops
- Addresses `tessl skill review` suggestions for workflow clarity, bringing the skill score from 94% to 100%

## Context

PR #770 updated several extension skills but the datastore skill's workflow clarity scored 2/3 on the tessl review. This PR addresses the two specific suggestions:
1. Add an explicit numbered workflow section that sequences the full create-configure-verify cycle
2. Integrate verification commands and error recovery into the workflow with feedback loops

## Test plan

- [x] `npx tessl skill review .claude/skills/swamp-extension-datastore` — 100% score (was 94%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)