### PR TITLE
feat: search community extensions before creating custom models

### DIFF
--- a/.claude/skills/swamp-extension-model/references/scenarios.md
+++ b/.claude/skills/swamp-extension-model/references/scenarios.md
@@ -8,6 +8,7 @@ End-to-end scenarios showing how to build custom extension models.
 - [Scenario 2: Cloud Resource CRUD](#scenario-2-cloud-resource-crud)
 - [Scenario 3: Factory Model for Discovery](#scenario-3-factory-model-for-discovery)
 - [Scenario 4: Extending Built-in Models](#scenario-4-extending-built-in-models)
+- [Scenario 5: Community Extension Found](#scenario-5-community-extension-found)
 
 ---
 
@@ -765,3 +766,65 @@ swamp model method run my-script dryRun --json
 | Only add new methods         | No overriding existing methods             |
 | Use `export const extension` | Distinguishes from new model definitions   |
 | Methods array format         | Allows multiple methods per extension file |
+
+---
+
+## Scenario 5: Community Extension Found
+
+### User Request
+
+> "I need to manage DigitalOcean droplets."
+
+### What You'll Build
+
+Nothing — a community extension already exists.
+
+### Decision Tree
+
+```
+swamp model type search DigitalOcean → no local results
+swamp extension search DigitalOcean → found @swamp/digitalocean
+Community extension exists → Install and use it
+swamp extension pull @swamp/digitalocean → installs the extension
+```
+
+### Step-by-Step
+
+**1. Search local types**
+
+```bash
+swamp model type search DigitalOcean --json
+# No results
+```
+
+**2. Search community extensions**
+
+```bash
+swamp extension search DigitalOcean --json
+# Found: @swamp/digitalocean
+```
+
+**3. Install the community extension**
+
+```bash
+swamp extension pull @swamp/digitalocean
+```
+
+**4. Use the installed model type**
+
+```bash
+swamp model type search DigitalOcean --json
+# Now shows @swamp/digitalocean types
+
+swamp model type describe @swamp/digitalocean-droplet --json
+# Review available methods and schema
+
+swamp model create @swamp/digitalocean-droplet my-droplet --json
+```
+
+### Expected Agent Behavior
+
+- The agent does NOT offer to create a custom extension model
+- The agent installs the community extension and uses it directly
+- The agent only creates a custom model if the community extension is missing or
+  does not cover the needed functionality

--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -477,13 +477,17 @@ swamp model output data d1e2f3a4-b5c6-4d7e-f8a9-b0c1d2e3f4a5 --json
 ## Workflow Example
 
 1. **Search** for the right type: `swamp model type search "shell" --json`
-2. **Describe** to understand the schema:
+2. **Search community** if no local type:
+   `swamp extension search <query> --json` — if a matching extension exists,
+   install it with `swamp extension pull <package>` instead of building from
+   scratch
+3. **Describe** to understand the schema:
    `swamp model type describe command/shell --json`
-3. **Create** an input file: `swamp model create command/shell my-shell --json`
-4. **Edit** the YAML file to set `methods.execute.arguments.run`
-5. **Validate** the model: `swamp model validate my-shell --json`
-6. **Run** the method: `swamp model method run my-shell execute --json`
-7. **View** the output: `swamp model output get my-shell --json`
+4. **Create** an input file: `swamp model create command/shell my-shell --json`
+5. **Edit** the YAML file to set `methods.execute.arguments.run`
+6. **Validate** the model: `swamp model validate my-shell --json`
+7. **Run** the method: `swamp model method run my-shell execute --json`
+8. **View** the output: `swamp model output get my-shell --json`
 
 ## Data Ownership
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,14 @@ This repository is managed with [swamp](https://github.com/systeminit/swamp).
 
 ## Rules
 
-1. **Extension models for service integrations.** When automating AWS, APIs, or
-   any external service, ALWAYS create an extension model in
-   `extensions/models/`. Use the `swamp-extension-model` skill for guidance. The
-   `command/shell` model is ONLY for ad-hoc one-off shell commands, NEVER for
-   wrapping CLI tools or building integrations.
+1. **Search before you build.** When automating AWS, APIs, or any external
+   service: (a) search local types with `swamp model type search <query>`, (b)
+   search community extensions with `swamp extension search <query>`, (c) if a
+   community extension exists, install it with `swamp extension pull <package>`
+   instead of building from scratch, (d) only create a custom extension model in
+   `extensions/models/` if nothing exists. Use the `swamp-extension-model` skill
+   for guidance. The `command/shell` model is ONLY for ad-hoc one-off shell
+   commands, NEVER for wrapping CLI tools or building integrations.
 2. **Extend, don't be clever.** Don't work around a missing capability with
    shell scripts or multi-step hacks. Add a method to the extension model. One
    method, one purpose.

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -567,7 +567,7 @@ This repository is managed with [swamp](https://github.com/systeminit/swamp).
 
 ## Rules
 
-1. **Extension models for service integrations.** When automating AWS, APIs, or any external service, ALWAYS create an extension model in \`extensions/models/\`. Use the \`swamp-extension-model\` skill for guidance. The \`command/shell\` model is ONLY for ad-hoc one-off shell commands, NEVER for wrapping CLI tools or building integrations.
+1. **Search before you build.** When automating AWS, APIs, or any external service: (a) search local types with \`swamp model type search <query>\`, (b) search community extensions with \`swamp extension search <query>\`, (c) if a community extension exists, install it with \`swamp extension pull <package>\` instead of building from scratch, (d) only create a custom extension model in \`extensions/models/\` if nothing exists. Use the \`swamp-extension-model\` skill for guidance. The \`command/shell\` model is ONLY for ad-hoc one-off shell commands, NEVER for wrapping CLI tools or building integrations.
 2. **Extend, don't be clever.** Don't work around a missing capability with shell scripts or multi-step hacks. Add a method to the extension model. One method, one purpose.
 3. **Use the data model.** Once data exists in a model (via \`lookup\`, \`start\`, \`sync\`, etc.), reference it with CEL expressions. Don't re-fetch data that's already available.
 4. **CEL expressions everywhere.** Wire models together with CEL expressions. Always prefer \`data.latest("<name>", "<dataName>").attributes.<field>\` over the deprecated \`model.<name>.resource.<spec>.<instance>.attributes.<field>\` pattern.

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -423,6 +423,22 @@ Deno.test("RepoService.init generates CLAUDE.md with skills section", async () =
   });
 });
 
+Deno.test("RepoService.init generates CLAUDE.md with extension search guidance", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath);
+
+    const claudeMdPath = join(tempDir, "CLAUDE.md");
+    const content = await Deno.readTextFile(claudeMdPath);
+
+    assertStringIncludes(content, "extension search");
+    assertStringIncludes(content, "Search before you build");
+    assertStringIncludes(content, "swamp model type search");
+  });
+});
+
 Deno.test("RepoService.init always creates .gitignore with managed section", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");


### PR DESCRIPTION
feat: search community extensions before creating custom models

## Summary

- Rewrites Rule #1 in the CLAUDE.md template from "Extension models for service integrations" to **"Search before you build"**, with explicit steps: search local types → search community extensions (`swamp extension pull`) → install if found → only then create custom
- Adds a community search step to the `swamp-model` skill workflow
- Adds Scenario 5 ("Community Extension Found") to the `swamp-extension-model` skill showing the happy path where a community extension exists

## User Impact

Previously, agents only saw guidance to "create an extension model" in the CLAUDE.md Rules section. The `swamp-extension-model` skill documented the search-first flow, but agents only loaded that skill *after* deciding to create a model — too late. Now agents see the search-first guidance immediately in Rule #1, prompting them to run `swamp extension search` before building anything custom.

## Test Plan

- [x] New unit test: `RepoService.init generates CLAUDE.md with extension search guidance` — asserts generated CLAUDE.md contains `extension search`, `Search before you build`, and `swamp model type search`
- [x] All 78 repo service tests pass
- [x] Full test suite passes
- [x] `deno check`, `deno lint`, `deno fmt` all pass
- [x] `deno run compile` — binary recompiled
- [x] **Manual verification**: Asked an agent to "create me a model that I can use to create an aws ec2 instance" — the agent correctly ran `swamp model type search "ec2"` followed by `swamp extension search "ec2 instance"` before attempting to create anything, then found a community extension and used `swamp extension pull` to install it

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)
