### PR TITLE
fix: silence spurious warnings for type-only .ts files in extension models

### DIFF
--- a/src/domain/models/bundle.ts
+++ b/src/domain/models/bundle.ts
@@ -353,9 +353,10 @@ export async function bundleExtension(
     let js = await Deno.readTextFile(tempFile);
 
     if (!js) {
-      throw new Error(
-        `deno bundle produced empty output for: ${absolutePath}`,
-      );
+      // Type-only files (interfaces, type aliases) produce empty bundles
+      // because TypeScript erases them at compile time. Return a minimal
+      // module so the loader can silently skip it (no model/extension export).
+      js = "export {};\n";
     }
 
     // Fix CJS/ESM interop for packages like tslib that set __esModule.

--- a/src/domain/models/bundle_test.ts
+++ b/src/domain/models/bundle_test.ts
@@ -443,3 +443,22 @@ Deno.test("uint8ArrayToBase64 handles large input without stack overflow", () =>
   assertEquals(typeof result, "string");
   assertEquals(result.length > 0, true);
 });
+
+Deno.test("bundleExtension returns minimal module for type-only files", async () => {
+  const tsCode = `
+// A type-only file — all declarations are erased at compile time.
+export interface Config {
+  name: string;
+  value?: number;
+}
+
+export type Status = "running" | "stopped";
+`;
+
+  await withTempFile(tsCode, async (path) => {
+    const js = await bundleExtension(path, DENO_PATH);
+
+    // Should return a minimal module instead of throwing
+    assertEquals(js, "export {};\n");
+  });
+});

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -2067,6 +2067,49 @@ export class ProxmoxClient {
   });
 });
 
+Deno.test("UserModelLoader silently skips type-only .ts files in subdirectories", async () => {
+  const validModelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "@test/type-only-skip-${Date.now()}",
+  version: "2026.02.11.1",
+  methods: {
+    run: {
+      description: "Run",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+  const typeOnlyCode = `
+// Type-only file — all declarations erased at compile time.
+export interface ServerConfig {
+  host: string;
+  port: number;
+}
+
+export type Status = "running" | "stopped" | "error";
+`;
+
+  await withTempModels({
+    "models/my_model/mod.ts": validModelCode,
+    "models/my_model/types.ts": typeOnlyCode,
+  }, async (dir) => {
+    const loader = createTestLoader();
+    const result = await loader.loadModels(dir);
+
+    // Should load only the valid model
+    assertEquals(result.loaded.length, 1);
+    assertEquals(result.loaded[0], join("models", "my_model", "mod.ts"));
+
+    // Type-only files should be silently skipped (not in failed list)
+    assertEquals(result.failed.length, 0);
+  });
+});
+
 Deno.test("UserModelLoader invalidates bundle cache when dependency changes", async () => {
   const ts = Date.now();
   const helperCode = `export const greeting = "hello";`;


### PR DESCRIPTION
## Summary

Fixes #776.

- When extension models use a modular file structure with type-only `.ts` files (e.g., `my_model/types.ts`), `bundleExtension()` threw on the empty output because TypeScript erases interfaces and type aliases at compile time. This surfaced as **noisy warnings during model loading** even though the models worked fine.
- Replace the throw with a minimal `export {};` module so the existing loader skip logic (which already silently skips files without `model`/`extension` exports) handles these files naturally.
- The fix is in the shared `bundleExtension()` function, so it applies to **all 4 loaders** (models, vaults, drivers, datastores) with no loader changes needed.

## User impact

Users with modular extension models that include helper type files (interfaces, type aliases) will no longer see confusing "deno bundle produced empty output" warnings. No behavior change for valid models.

## Test plan

- [x] New unit test: `bundleExtension returns minimal module for type-only files` — verifies empty bundle produces `export {};` instead of throwing
- [x] New integration test: `UserModelLoader silently skips type-only .ts files in subdirectories` — verifies type-only files in a model subdirectory don't appear in `result.failed`
- [x] All existing tests pass (`deno run test`, `deno check`, `deno lint`, `deno fmt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Blake Irvin <blakeirvin@me.com>