### PR TITLE
fix: delete methods return last known state data

### DIFF
--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -654,6 +654,8 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
 
     // Write deletion markers after a successful delete method.
     // Only mark declared resource data — untagged or non-resource data is left alone.
+    // Markers include the last known active state so that data.latest() still
+    // resolves original attributes after deletion (enables idempotent workflow re-runs).
     if (methodKind === "delete") {
       const resources = modelDef.resources ?? {};
       if (Object.keys(resources).length > 0) {
@@ -667,10 +669,30 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
         );
         for (const data of resourceData) {
           if (!data.isDeleted) {
+            // Read last known active state to preserve in tombstone
+            let lastKnownState: Record<string, unknown> = {};
+            if (data.contentType === "application/json") {
+              try {
+                const activeContent = await context.dataRepository.getContent(
+                  context.modelType,
+                  context.modelId,
+                  data.name,
+                );
+                if (activeContent) {
+                  lastKnownState = JSON.parse(
+                    new TextDecoder().decode(activeContent),
+                  ) as Record<string, unknown>;
+                }
+              } catch {
+                // Not valid JSON or read error — proceed with empty state
+              }
+            }
+
             const marker = data.withDeletionMarker({
               version: data.version + 1,
             });
-            const content = new TextEncoder().encode(JSON.stringify({
+            const markerContent = new TextEncoder().encode(JSON.stringify({
+              ...lastKnownState,
               deletedAt: new Date().toISOString(),
               deletedByMethod: methodName,
             }));
@@ -678,8 +700,29 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
               context.modelType,
               context.modelId,
               marker,
-              content,
+              markerContent,
             );
+
+            // Append deletion marker as a data handle so it surfaces
+            // in the method response as a data artifact.
+            currentHandles.push({
+              name: data.name,
+              specName: data.tags["specName"] ?? data.name,
+              kind: "resource",
+              dataId: marker.id,
+              version: marker.version,
+              size: markerContent.byteLength,
+              tags: { ...marker.tags },
+              metadata: {
+                contentType: marker.contentType,
+                lifetime: marker.lifetime,
+                garbageCollection: marker.garbageCollection,
+                streaming: marker.streaming,
+                tags: { ...marker.tags },
+                ownerDefinition: marker.ownerDefinition,
+                lifecycle: marker.lifecycle,
+              },
+            });
           }
         }
       }

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -1192,6 +1192,7 @@ Deno.test("executeWorkflow - skips validation when model has no globalArguments 
  */
 function createMockDataRepoWithData(
   existingData: Data[],
+  contentByName?: Record<string, Uint8Array>,
 ): UnifiedDataRepository & {
   savedData: Array<{ data: Data; content: Uint8Array }>;
 } {
@@ -1208,12 +1209,16 @@ function createMockDataRepoWithData(
       savedData.push({ data, content });
       return Promise.resolve({ version: data.version });
     },
-    getContent: () => Promise.resolve(null),
+    getContent: (
+      _type: ModelType,
+      _modelId: string,
+      name: string,
+    ) => Promise.resolve(contentByName?.[name] ?? null),
     savedData,
   };
 }
 
-Deno.test("executeWorkflow - delete method writes deletion markers for existing resources", async () => {
+Deno.test("executeWorkflow - delete method writes deletion markers with last known state", async () => {
   const service = new DefaultMethodExecutionService();
 
   const existingData = Data.create({
@@ -1229,10 +1234,96 @@ Deno.test("executeWorkflow - delete method writes deletion markers for existing 
     version: 3,
   });
 
-  const mockRepo = createMockDataRepoWithData([existingData]);
+  const activeContent = new TextEncoder().encode(JSON.stringify({
+    id: "vol-abc123",
+    name: "my-volume",
+    region: "us-east-1",
+  }));
+
+  const mockRepo = createMockDataRepoWithData([existingData], {
+    "my-resource": activeContent,
+  });
 
   const model: ModelDefinition = {
     type: ModelType.create("test/delete-marker"),
+    version: "1",
+    resources: {
+      "my-resource": {
+        description: "A resource",
+        schema: z.object({}),
+        lifetime: "infinite",
+        garbageCollection: 10,
+      },
+    },
+    methods: {
+      delete: {
+        description: "Delete the resource",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({}),
+      },
+    },
+  };
+
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: {},
+  });
+
+  const { context } = createTestContext({ modelType: model.type });
+  const contextWithRepo: MethodContext = {
+    ...context,
+    dataRepository: mockRepo,
+  };
+
+  const result = await service.executeWorkflow(
+    definition,
+    model,
+    "delete",
+    contextWithRepo,
+  );
+
+  // Should have saved a deletion marker
+  assertEquals(mockRepo.savedData.length, 1);
+  const saved = mockRepo.savedData[0];
+  assertEquals(saved.data.lifecycle, "deleted");
+  assertEquals(saved.data.version, 4); // existingData.version + 1
+  assertEquals(saved.data.contentType, "application/json");
+
+  // Marker content should include last known state merged with deletion metadata
+  const content = JSON.parse(new TextDecoder().decode(saved.content));
+  assertEquals(content.id, "vol-abc123");
+  assertEquals(content.name, "my-volume");
+  assertEquals(content.region, "us-east-1");
+  assertEquals(typeof content.deletedAt, "string");
+  assertEquals(content.deletedByMethod, "delete");
+
+  // Result should include deletion marker as a data handle
+  assertEquals(result.dataHandles?.length, 1);
+  assertEquals(result.dataHandles?.[0].name, "my-resource");
+  assertEquals(result.dataHandles?.[0].kind, "resource");
+});
+
+Deno.test("executeWorkflow - delete marker gracefully handles missing active content", async () => {
+  const service = new DefaultMethodExecutionService();
+
+  const existingData = Data.create({
+    name: "my-resource",
+    contentType: "application/json",
+    lifetime: "infinite",
+    garbageCollection: 10,
+    tags: { type: "resource", specName: "my-resource" },
+    ownerDefinition: {
+      ownerType: "model-method",
+      ownerRef: "test/model:create",
+    },
+    version: 3,
+  });
+
+  // No content provided — getContent returns null
+  const mockRepo = createMockDataRepoWithData([existingData]);
+
+  const model: ModelDefinition = {
+    type: ModelType.create("test/delete-no-content"),
     version: "1",
     resources: {
       "my-resource": {
@@ -1269,17 +1360,15 @@ Deno.test("executeWorkflow - delete method writes deletion markers for existing 
     contextWithRepo,
   );
 
-  // Should have saved a deletion marker
+  // Should still write a deletion marker with just the metadata
   assertEquals(mockRepo.savedData.length, 1);
-  const saved = mockRepo.savedData[0];
-  assertEquals(saved.data.lifecycle, "deleted");
-  assertEquals(saved.data.version, 4); // existingData.version + 1
-  assertEquals(saved.data.contentType, "application/json");
-
-  // Check the marker content
-  const content = JSON.parse(new TextDecoder().decode(saved.content));
+  const content = JSON.parse(
+    new TextDecoder().decode(mockRepo.savedData[0].content),
+  );
   assertEquals(typeof content.deletedAt, "string");
   assertEquals(content.deletedByMethod, "delete");
+  // No last known state attributes since content was null
+  assertEquals(Object.keys(content).length, 2);
 });
 
 Deno.test("executeWorkflow - read after delete throws UserError", async () => {
@@ -1692,7 +1781,10 @@ Deno.test("executeWorkflow - deletion markers only written for declared resource
     version: 2,
   });
 
-  const mockRepo = createMockDataRepoWithData([resourceData, untaggedData]);
+  const mockRepo = createMockDataRepoWithData([resourceData, untaggedData], {
+    "my-resource": new TextEncoder().encode(JSON.stringify({ id: "res-1" })),
+    "some-old-data": new TextEncoder().encode(JSON.stringify({ id: "old-1" })),
+  });
 
   const model: ModelDefinition = {
     type: ModelType.create("test/delete-scoped-markers"),


### PR DESCRIPTION
## Summary

Closes #636

When a model's `delete` method succeeds, the deletion marker (tombstone) now includes the **last known active state** attributes merged with the deletion metadata. This fixes two problems reported in the issue:

- **Delete responses now include `dataArtifacts`** — Previously the JSON response had no `data` field, making it impossible to confirm *what* was deleted without a separate query. Now the response includes the full resource attributes alongside `deletedAt`/`deletedByMethod`.

- **`data.latest()` resolves original attributes after deletion** — Previously, tombstones only contained `{deletedAt, deletedByMethod}`, which broke CEL expressions like `data.latest("x", "y").attributes.RouteTableId` on workflow re-runs. Now those expressions resolve correctly, enabling idempotent re-runs of complex delete workflows.

## Design decisions

**Enrich the tombstone, not `data.latest()`** — We considered making `data.latest()` lifecycle-aware (skip tombstones, return last active version) but rejected it because:
1. It would be a breaking change for anyone checking `data.latest()` to detect deletion
2. Users would need to update existing CEL expressions to use a new function
3. The enriched tombstone approach requires zero changes to existing workflows on both sides — delete detection (`deletedAt` is still there) and re-runs (original attributes are still there)

**Flat merge, accepted collision risk** — Deletion metadata (`deletedAt`, `deletedByMethod`) is merged into the same JSON object as resource attributes. We considered namespacing (e.g. `_deleted.at`) but accepted the theoretical collision risk since cloud APIs don't use these field names, and the added complexity wasn't justified.

**Deletion markers as data handles** — Rather than adding special-case logic in `run.ts`, deletion markers are appended to `currentHandles` in `method_execution_service.ts` so they flow through the existing data artifact pipeline. This means `run.ts`, the JSON renderer, and all presentation code required zero changes.

## Before

```json
{
  "modelId": "ca9547ff-...",
  "modelName": "test-volume",
  "type": "@stack72/digitalocean/volume",
  "methodName": "delete",
  "dataArtifacts": []
}
```

## After

```json
{
  "modelId": "ca9547ff-...",
  "modelName": "test-volume",
  "type": "@stack72/digitalocean/volume",
  "methodName": "delete",
  "dataArtifacts": [
    {
      "name": "main",
      "attributes": {
        "id": "8290fa55-...",
        "name": "swamp-crud-test-vol",
        "region": "us-east-1",
        "status": "active",
        "deletedAt": "2026-03-20T00:02:15.524Z",
        "deletedByMethod": "delete"
      }
    }
  ]
}
```

## Changes

| File | Change |
|------|--------|
| `src/domain/models/method_execution_service.ts` | Read active content before writing tombstone; merge into marker; append as data handle |
| `src/domain/models/method_execution_service_test.ts` | Updated tests to verify enriched markers + new test for graceful degradation when no content exists |

## Test plan

- [x] All 3402 tests pass
- [x] E2E verified: create → delete returns enriched tombstone with full attributes
- [x] E2E verified: re-create after delete still works
- [x] Tombstone on disk contains merged state for `data.latest()` resolution
- [x] Graceful degradation when active content is missing (marker-only metadata)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)