### PR TITLE
feat: add reporting as a top level primitive

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -122,6 +122,7 @@ export const model = {
 | `inputsSchema`    | No       | Zod schema for runtime inputs                     |
 | `methods`         | Yes      | Object of method definitions with `arguments` Zod |
 | `checks`          | No       | Pre-flight checks run before mutating methods     |
+| `reports`         | No       | Inline report definitions (see `swamp-report`)    |
 
 ## Resources & Files
 

--- a/.claude/skills/swamp-report/SKILL.md
+++ b/.claude/skills/swamp-report/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: swamp-report
+description: Create, register, configure, and run reports for swamp models and workflows. Use when creating report extensions, configuring reports in definition YAML, running reports via CLI, or viewing report output. Triggers on "report", "swamp report", "model report", "create report", "run report", "report extension", "report label", "skip report", "report output", "cost report", "audit report", "workflow report", "report results".
+---
+
+# Swamp Report Skill
+
+Create and run reports that analyze model and workflow executions. Reports
+produce markdown (human-readable) and JSON (machine-readable) output. All
+commands support `--json` for machine-readable output.
+
+**Verify CLI syntax:** If unsure about exact flags or subcommands, run
+`swamp help model report` or `swamp help model method run` for the complete,
+up-to-date CLI schema.
+
+## Quick Reference
+
+| Task                     | Command                                                              |
+| ------------------------ | -------------------------------------------------------------------- |
+| Run reports for a model  | `swamp model report <model> --json`                                  |
+| Filter by label          | `swamp model report <model> --label cost --json`                     |
+| Simulate method context  | `swamp model report <model> --method create --json`                  |
+| Run method with reports  | `swamp model method run <model> <method> --json`                     |
+| Skip all reports         | `swamp model method run <model> <method> --skip-reports --json`      |
+| Skip report by name      | `swamp model method run <model> <method> --skip-report <n> -j`       |
+| Skip report by label     | `swamp model method run <model> <method> --skip-report-label <l> -j` |
+| Run only named report    | `swamp model method run <model> <method> --report <n> -j`            |
+| Run only labeled reports | `swamp model method run <model> <method> --report-label <l> -j`      |
+| Workflow with reports    | `swamp workflow run <workflow> --json`                               |
+| Workflow skip reports    | `swamp workflow run <workflow> --skip-reports --json`                |
+
+## Creating a Standalone Report Extension
+
+Reports are standalone TypeScript files in `extensions/reports/`. Each file
+exports a `report` object with a `name`, `description`, `scope`, optional
+`labels`, and an `execute` function.
+
+```typescript
+// extensions/reports/cost_report.ts
+export const report = {
+  name: "@myorg/cost-report",
+  description: "Estimate costs for the executed method",
+  scope: "method",
+  labels: ["cost", "finops"],
+  execute: async (context) => {
+    const modelName = context.definition.name;
+    const method = context.methodName;
+    const status = context.executionStatus;
+
+    return {
+      markdown:
+        `# Cost Report\n\n- **Model**: ${modelName}\n- **Method**: ${method}\n- **Status**: ${status}\n`,
+      json: { modelName, method, status },
+    };
+  },
+};
+```
+
+### Name Conventions
+
+Report names must follow the `@collective/name` pattern (e.g.,
+`@myorg/cost-report`). This matches the same collective conventions used by
+models, drivers, vaults, and datastores.
+
+### Report Scopes
+
+| Scope      | Context type            | When it runs                    |
+| ---------- | ----------------------- | ------------------------------- |
+| `method`   | `MethodReportContext`   | After a single method execution |
+| `model`    | `ModelReportContext`    | After all method-scope reports  |
+| `workflow` | `WorkflowReportContext` | After a workflow run completes  |
+
+**Method context** includes: `modelType`, `modelId`, `definition`, `globalArgs`,
+`methodName`, `executionStatus`, `dataHandles`.
+
+**Workflow context** includes: `workflowId`, `workflowRunId`, `workflowName`,
+`workflowStatus`, `stepExecutions[]` (each with `jobName`, `stepName`,
+`modelName`, `modelType`, `methodName`, `status`, `dataHandles`).
+
+All contexts include: `repoDir`, `logger`, `dataRepository`,
+`definitionRepository`.
+
+Reports are generic — they receive a `ReportContext` and decide at runtime how
+to handle their inputs. They don't declare which model types they support.
+
+See [references/report-types.md](references/report-types.md) for full type
+definitions.
+
+### Key Rules
+
+1. **Return both markdown and json** — every report must produce both
+2. **Labels are optional** — use them for filtering (e.g., `["cost", "audit"]`)
+3. **One report per file** — export a single `report` object from each file
+4. **Use scope correctly** — method-scope for per-execution analysis,
+   model-scope for cross-method analysis, workflow-scope for multi-step
+   aggregation
+
+## Three-Level Report Control Model
+
+Reports are controlled at three levels, from most general to most specific:
+
+### 1. Model Type Defaults (TypeScript `ModelDefinition`)
+
+The `reports` field on model definitions lists standalone report names that are
+defaults for any model of this type:
+
+```typescript
+// extensions/models/my_model.ts
+export const model = {
+  type: "@myorg/ec2",
+  version: "2026.03.01.1",
+  reports: ["@myorg/cost-report", "@myorg/drift-report"],
+  // ... methods, resources, etc.
+};
+```
+
+### 2. Definition YAML Overrides (`reportSelection`)
+
+The `reports:` field in definition YAML provides per-definition overrides.
+`require` adds reports beyond model-type defaults. `skip` removes reports from
+the defaults.
+
+```yaml
+# definitions/my-vpc.yaml
+id: 550e8400-e29b-41d4-a716-446655440000
+name: my-vpc
+version: 1
+tags: {}
+reports:
+  require:
+    - "@myorg/compliance-report" # adds to model-type defaults
+    - name: security-audit # only run for these methods
+      methods: ["create", "delete"]
+  skip:
+    - "@myorg/drift-report" # removes from model-type defaults
+globalArguments:
+  cidrBlock: "10.0.0.0/16"
+methods:
+  create:
+    arguments: {}
+```
+
+### 3. Workflow YAML Overrides
+
+The `reports:` field in workflow YAML controls workflow-scope reports and can
+also override model-level reports for the workflow run.
+
+```yaml
+# workflows/deploy.yaml
+name: deploy
+reports:
+  require:
+    - "@myorg/workflow-summary" # workflow-scope report
+  skip:
+    - "@myorg/cost-report" # skip for all models in this workflow
+```
+
+### Filtering Semantics
+
+For **method/model scope** reports, the candidate set is:
+
+- Model-type defaults (`ModelDefinition.reports`)
+- Plus definition YAML `require`
+- Minus definition YAML `skip` (always wins)
+- Minus CLI skip flags (unless report is in `require`)
+- Narrowed by CLI inclusion flags (`--report`, `--report-label`)
+
+For **workflow scope** reports, the candidate set is:
+
+- Workflow YAML `require` (no model-type defaults apply)
+- Minus workflow YAML `skip`
+- Minus CLI skip flags (unless in `require`)
+- Narrowed by CLI inclusion flags
+
+### Precedence Rules
+
+- `skip` always wins — even over `require` for the same report name
+- `require` makes reports immune to `--skip-reports`, `--skip-report <name>`,
+  and `--skip-report-label <label>` CLI flags
+- Method scoping (`methods: [...]`) restricts a required report to specific
+  methods — it won't run for unlisted methods
+- CLI inclusion filters (`--report`, `--report-label`) narrow to a subset
+
+## Publishing Reports
+
+Reports can be published as part of extensions via the manifest `reports:`
+field:
+
+```yaml
+# manifest.yaml
+manifestVersion: 1
+name: "@myorg/reports"
+version: "2026.03.01.1"
+description: "Cost and compliance reports"
+reports:
+  - cost_report.ts
+  - compliance_report.ts
+```
+
+## CLI Flags
+
+### model method run / workflow run
+
+| Flag                          | Description                                   |
+| ----------------------------- | --------------------------------------------- |
+| `--skip-reports`              | Skip all reports (except definition-required) |
+| `--skip-report <name>`        | Skip a specific report by name (repeatable)   |
+| `--skip-report-label <label>` | Skip reports with this label (repeatable)     |
+| `--report <name>`             | Only run this report (repeatable, inclusion)  |
+| `--report-label <label>`      | Only run reports with this label (repeatable) |
+
+### model report (standalone)
+
+| Flag                | Description                         |
+| ------------------- | ----------------------------------- |
+| `--label <label>`   | Only run reports with this label    |
+| `--method <method>` | Simulate method context for reports |
+
+The standalone `swamp model report` command runs reports without executing a
+method. It builds a `MethodReportContext` with `executionStatus: "succeeded"`
+and empty `dataHandles`.
+
+## Report Data Storage
+
+Report results are automatically persisted as data artifacts:
+
+- **Markdown**: data name `report-{reportName}`, content type `text/markdown`
+- **JSON**: data name `report-{reportName}-json`, content type
+  `application/json`
+- **Lifetime**: 30 days, garbage collection keeps 5 versions
+- **Tags**: `type=report`, `reportName={name}`, `reportScope={scope}`
+
+Access stored reports via the data commands:
+
+```bash
+swamp data search --tag type=report --json
+swamp data get my-model report-cost-estimate --json
+```
+
+## Output
+
+**Log mode** (default): Renders report markdown with terminal formatting.
+Displays a separator line, the rendered markdown content, and a pass/fail
+summary.
+
+**JSON mode** (`--json`): Outputs reports keyed by name with their JSON data:
+
+```json
+{
+  "outputId": "...",
+  "modelName": "my-vpc",
+  "method": "create",
+  "status": "succeeded",
+  "reports": {
+    "cost-estimate": {
+      "modelName": "my-vpc",
+      "method": "create",
+      "status": "succeeded"
+    }
+  }
+}
+```
+
+Failed reports appear as `{ "_error": "error message" }`.
+
+## When to Use Other Skills
+
+| Need                      | Use Skill               |
+| ------------------------- | ----------------------- |
+| Work with models          | `swamp-model`           |
+| Create/run workflows      | `swamp-workflow`        |
+| Create custom model types | `swamp-extension-model` |
+| Manage model data         | `swamp-data`            |
+| Repository structure      | `swamp-repo`            |
+
+## References
+
+- **Report API**: See [references/report-types.md](references/report-types.md)
+  for full `ReportDefinition`, `ReportContext`, `ReportRegistry`, and
+  `ReportSelection` type definitions

--- a/.claude/skills/swamp-report/references/report-types.md
+++ b/.claude/skills/swamp-report/references/report-types.md
@@ -1,0 +1,151 @@
+# Report Types Reference
+
+## ReportDefinition Interface
+
+```typescript
+interface ReportDefinition {
+  /** Human-readable description of what the report produces. */
+  description: string;
+  /** The scope at which this report operates. */
+  scope: ReportScope;
+  /** Labels for filtering (e.g., ["cost", "finops"]). */
+  labels?: string[];
+  /** Execute the report and produce results. */
+  execute(context: ReportContext): Promise<ReportResult>;
+}
+```
+
+## ReportScope
+
+```typescript
+type ReportScope = "method" | "model" | "workflow";
+```
+
+| Scope      | When it runs                        | Context type            |
+| ---------- | ----------------------------------- | ----------------------- |
+| `method`   | After a single method execution     | `MethodReportContext`   |
+| `model`    | After method-scope reports complete | `ModelReportContext`    |
+| `workflow` | After a workflow run completes      | `WorkflowReportContext` |
+
+## ReportResult
+
+```typescript
+interface ReportResult {
+  /** Human-readable markdown content. */
+  markdown: string;
+  /** Machine-readable structured data. */
+  json: Record<string, unknown>;
+}
+```
+
+## Context Types
+
+### Base Fields (shared by all contexts)
+
+```typescript
+interface BaseReportContext {
+  repoDir: string;
+  logger: Logger;
+  dataRepository: UnifiedDataRepository;
+  definitionRepository: DefinitionRepository;
+}
+```
+
+### MethodReportContext
+
+```typescript
+interface MethodReportContext extends BaseReportContext {
+  scope: "method";
+  modelType: ModelType;
+  modelId: string;
+  definition: {
+    id: string;
+    name: string;
+    version: number;
+    tags: Record<string, string>;
+  };
+  globalArgs: Record<string, unknown>;
+  methodName: string;
+  executionStatus: "succeeded" | "failed";
+  dataHandles: DataHandle[];
+}
+```
+
+### ModelReportContext
+
+Same fields as `MethodReportContext` but with `scope: "model"`. Runs after all
+method-scope reports complete.
+
+### WorkflowReportContext
+
+```typescript
+interface WorkflowReportContext extends BaseReportContext {
+  scope: "workflow";
+  workflowId: string;
+  workflowRunId: string;
+  workflowName: string;
+  workflowStatus: "succeeded" | "failed";
+  stepExecutions: Array<{
+    jobName: string;
+    stepName: string;
+    modelName: string;
+    modelType: string;
+    methodName: string;
+    status: "succeeded" | "failed" | "skipped";
+    dataHandles: DataHandle[];
+  }>;
+}
+```
+
+## Report Registry
+
+**Extension models define reports inline** on the model's `reports` field (just
+like `checks` and `methods`). The model loader auto-registers them — do not call
+`register()` directly from extension code.
+
+The global `reportRegistry` singleton manages report registration internally:
+
+```typescript
+reportRegistry.get("my-report"); // ReportDefinition | undefined
+reportRegistry.has("my-report"); // boolean
+reportRegistry.getAll(); // Array<{ name, report }>
+reportRegistry.getByScope("method"); // Array<{ name, report }>
+```
+
+Names must be unique — `register()` throws on duplicates.
+
+## Report Selection Schema (YAML)
+
+```typescript
+const ReportRefSchema = z.union([
+  z.string(), // shorthand: applies to all methods
+  z.object({
+    name: z.string(),
+    methods: z.array(z.string()).optional(), // restrict to specific methods
+  }),
+]);
+
+const ReportSelectionSchema = z.object({
+  require: z.array(ReportRefSchema).optional(),
+  skip: z.array(z.string()).optional(),
+}).optional();
+```
+
+## Filtering Precedence
+
+1. Definition-level `skip` always wins (even over `require`)
+2. YAML method scoping is respected
+3. `require` makes reports immune to CLI skip flags
+4. CLI `--skip-report` / `--skip-report-label` apply to non-required reports
+5. CLI `--report` / `--report-label` narrow to a subset (inclusion filter)
+
+## Data Persistence
+
+Report results are automatically persisted as data artifacts:
+
+- **Markdown**: data name `report-{reportName}`, content type `text/markdown`
+- **JSON**: data name `report-{reportName}-json`, content type
+  `application/json`
+- **Lifetime**: 30 days
+- **Garbage collection**: keeps 5 versions
+- **Tags**: `type=report`, `reportName={name}`, `reportScope={scope}`

--- a/deno.json
+++ b/deno.json
@@ -35,7 +35,9 @@
     "@aws-sdk/client-s3": "npm:@aws-sdk/client-s3@^3.1013.0",
     "cel-js": "npm:@marcbachmann/cel-js@7.5.1",
     "fast-json-patch": "npm:fast-json-patch@^3.1.1",
-    "fast-check": "npm:fast-check@^3.22.0"
+    "fast-check": "npm:fast-check@^3.22.0",
+    "marked": "npm:marked@^14.0.0",
+    "marked-terminal": "npm:marked-terminal@^7.3.0"
   },
   "compilerOptions": {
     "jsx": "react",

--- a/deno.lock
+++ b/deno.lock
@@ -5,23 +5,19 @@
     "jsr:@cliffy/flags@1.0.0": "1.0.0",
     "jsr:@cliffy/internal@1.0.0": "1.0.0",
     "jsr:@cliffy/table@1.0.0": "1.0.0",
-    "jsr:@logtape/logtape@2.0.2": "2.0.2",
-    "jsr:@logtape/logtape@^2.0.2": "2.0.2",
+    "jsr:@logtape/logtape@^2.0.2": "2.0.4",
     "jsr:@logtape/pretty@^2.0.2": "2.0.2",
-    "jsr:@std/assert@^1.0.18": "1.0.18",
+    "jsr:@std/assert@^1.0.18": "1.0.19",
     "jsr:@std/cli@^1.0.27": "1.0.27",
     "jsr:@std/fmt@^1.0.9": "1.0.9",
-    "jsr:@std/fs@^1.0.22": "1.0.22",
+    "jsr:@std/fs@^1.0.22": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.12",
-    "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@std/semver@^1.0.8": "1.0.8",
     "jsr:@std/text@^1.0.17": "1.0.17",
-    "jsr:@std/yaml@^1.0.11": "1.0.11",
+    "jsr:@std/yaml@^1.0.11": "1.0.12",
     "npm:@aws-sdk/client-cloudcontrol@^3.1013.0": "3.1013.0",
     "npm:@aws-sdk/client-s3@^3.1013.0": "3.1013.0",
-    "npm:@kubernetes/client-node@*": "1.4.0_ws@8.19.0",
-    "npm:@logtape/pretty@*": "2.0.4_@logtape+logtape@2.0.4",
     "npm:@marcbachmann/cel-js@7.5.1": "7.5.1",
     "npm:@types/node@24.0.7": "24.0.7",
     "npm:@types/react@^18.3.28": "18.3.28",
@@ -30,10 +26,9 @@
     "npm:fzf@0.5.2": "0.5.2",
     "npm:ink-testing-library@4": "4.0.0_@types+react@18.3.28",
     "npm:ink@^5.2.1": "5.2.1_@types+react@18.3.28_react@18.3.1",
-    "npm:lodash-es@4": "4.17.23",
+    "npm:marked-terminal@^7.3.0": "7.3.0_marked@14.1.4",
+    "npm:marked@14": "14.1.4",
     "npm:react@^18.3.1": "18.3.1",
-    "npm:zod@*": "4.3.6",
-    "npm:zod@4": "4.3.6",
     "npm:zod@^4.3.6": "4.3.6"
   },
   "jsr": {
@@ -64,18 +59,18 @@
         "jsr:@std/fmt"
       ]
     },
-    "@logtape/logtape@2.0.2": {
-      "integrity": "546fcd514e66f2b841c6f261fa3a3d905b52d876dc1bba8ffe1a087d9275c4c9"
+    "@logtape/logtape@2.0.4": {
+      "integrity": "d4b6e85d82954f3d58014d85e4c0f93d6a836181ef4fbb4a852da7ed47979acb"
     },
     "@logtape/pretty@2.0.2": {
       "integrity": "5addabab67f654f4aa828bdd88e611c8bf76f91a038cb72c01857708066896f0",
       "dependencies": [
-        "jsr:@logtape/logtape@^2.0.2",
+        "jsr:@logtape/logtape",
         "npm:@types/node"
       ]
     },
-    "@std/assert@1.0.18": {
-      "integrity": "270245e9c2c13b446286de475131dc688ca9abcd94fc5db41d43a219b34d1c78",
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
         "jsr:@std/internal"
       ]
@@ -90,11 +85,11 @@
     "@std/fmt@1.0.9": {
       "integrity": "2487343e8899fb2be5d0e3d35013e54477ada198854e52dd05ed0422eddcabe0"
     },
-    "@std/fs@1.0.22": {
-      "integrity": "de0f277a58a867147a8a01bc1b181d0dfa80bfddba8c9cf2bacd6747bcec9308",
+    "@std/fs@1.0.23": {
+      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
       "dependencies": [
         "jsr:@std/internal",
-        "jsr:@std/path@^1.1.4"
+        "jsr:@std/path"
       ]
     },
     "@std/internal@1.0.12": {
@@ -112,15 +107,15 @@
     "@std/text@1.0.17": {
       "integrity": "4b2c4ef67ae5b6c1dfd447c81c83a43718f52e3c7e748d8b33f694aba9895f95"
     },
-    "@std/yaml@1.0.11": {
-      "integrity": "bd139ce77f2d06cbed3713c8b26d301d2a2e12ecc7986130a268107e212143ee"
+    "@std/yaml@1.0.12": {
+      "integrity": "7deabca4545bcedd07c5f69ea53acea71b8b4c67562f224e17b90d75944cb20c"
     }
   },
   "npm": {
     "@alcalzone/ansi-tokenize@0.1.3": {
       "integrity": "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==",
       "dependencies": [
-        "ansi-styles",
+        "ansi-styles@6.2.3",
         "is-fullwidth-code-point@4.0.0"
       ]
     },
@@ -676,51 +671,15 @@
     "@aws/lambda-invoke-store@0.2.4": {
       "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="
     },
-    "@jsep-plugin/assignment@1.3.0_jsep@1.4.0": {
-      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
-      "dependencies": [
-        "jsep"
-      ]
-    },
-    "@jsep-plugin/regex@1.0.4_jsep@1.4.0": {
-      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
-      "dependencies": [
-        "jsep"
-      ]
-    },
-    "@kubernetes/client-node@1.4.0_ws@8.19.0": {
-      "integrity": "sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==",
-      "dependencies": [
-        "@types/js-yaml",
-        "@types/node",
-        "@types/node-fetch",
-        "@types/stream-buffers",
-        "form-data",
-        "hpagent",
-        "isomorphic-ws",
-        "js-yaml",
-        "jsonpath-plus",
-        "node-fetch",
-        "openid-client",
-        "rfc4648",
-        "socks-proxy-agent",
-        "stream-buffers",
-        "tar-fs",
-        "ws"
-      ]
-    },
-    "@logtape/logtape@2.0.4": {
-      "integrity": "sha512-Z4COeAMdedcBFuFkXaPFvDPOVuHoEom1hwNnPCIkSyojyikuNguplwPoSG+kZthWrS7GiOJo1USQyjWwIFfTKA=="
-    },
-    "@logtape/pretty@2.0.4_@logtape+logtape@2.0.4": {
-      "integrity": "sha512-y1nubV70avD9Gx8Q3gcWBlVUsVwpaBdHUntrkkpXIrC/UPRoHuWnBo+FNrtyvgjCEHSbKuxIaOgsE8rxTPEhzg==",
-      "dependencies": [
-        "@logtape/logtape"
-      ]
+    "@colors/colors@1.5.0": {
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
     "@marcbachmann/cel-js@7.5.1": {
       "integrity": "sha512-3X+TKpt/xyPsVSU3R2bVeZQCOW5L29y+EVDOmOp2xnyD7bifNM/UypBaqs2Z6oC075p+tKtjPUT1kUwnyY7cQg==",
       "bin": true
+    },
+    "@sindresorhus/is@4.6.0": {
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
     },
     "@smithy/abort-controller@4.2.12": {
       "integrity": "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==",
@@ -1169,16 +1128,6 @@
         "tslib"
       ]
     },
-    "@types/js-yaml@4.0.9": {
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="
-    },
-    "@types/node-fetch@2.6.13": {
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "dependencies": [
-        "@types/node",
-        "form-data"
-      ]
-    },
     "@types/node@24.0.7": {
       "integrity": "sha512-YIEUUr4yf8q8oQoXPpSlnvKNVKDQlPMWrmOcgzoduo7kvA2UF0/BwJ/eMKFTiTtkNL17I0M6Xe2tvwFU7be6iw==",
       "dependencies": [
@@ -1195,90 +1144,48 @@
         "csstype"
       ]
     },
-    "@types/stream-buffers@3.0.8": {
-      "integrity": "sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==",
-      "dependencies": [
-        "@types/node"
-      ]
-    },
-    "agent-base@7.1.4": {
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
-    },
     "ansi-escapes@7.3.0": {
       "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
       "dependencies": [
         "environment"
       ]
     },
+    "ansi-regex@5.0.1": {
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+    },
     "ansi-regex@6.2.2": {
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="
+    },
+    "ansi-styles@4.3.0": {
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": [
+        "color-convert"
+      ]
     },
     "ansi-styles@6.2.3": {
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="
     },
-    "argparse@2.0.1": {
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-    },
-    "asynckit@0.4.0": {
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    "any-promise@1.3.0": {
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
     },
     "auto-bind@5.0.1": {
       "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="
     },
-    "b4a@1.8.0": {
-      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg=="
-    },
-    "bare-events@2.8.2": {
-      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ=="
-    },
-    "bare-fs@4.5.4_bare-events@2.8.2": {
-      "integrity": "sha512-POK4oplfA7P7gqvetNmCs4CNtm9fNsx+IAh7jH7GgU0OJdge2rso0R20TNWVq6VoWcCvsTdlNDaleLHGaKx8CA==",
-      "dependencies": [
-        "bare-events",
-        "bare-path",
-        "bare-stream",
-        "bare-url",
-        "fast-fifo"
-      ]
-    },
-    "bare-os@3.6.2": {
-      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A=="
-    },
-    "bare-path@3.0.0": {
-      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
-      "dependencies": [
-        "bare-os"
-      ]
-    },
-    "bare-stream@2.8.0_bare-events@2.8.2": {
-      "integrity": "sha512-reUN0M2sHRqCdG4lUK3Fw8w98eeUIZHL5c3H7Mbhk2yVBL+oofgaIp0ieLfD5QXwPCypBpmEEKU2WZKzbAk8GA==",
-      "dependencies": [
-        "bare-events",
-        "streamx",
-        "teex"
-      ],
-      "optionalPeers": [
-        "bare-events"
-      ]
-    },
-    "bare-url@2.3.2": {
-      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
-      "dependencies": [
-        "bare-path"
-      ]
-    },
     "bowser@2.14.1": {
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="
     },
-    "call-bind-apply-helpers@1.0.2": {
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+    "chalk@4.1.2": {
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dependencies": [
-        "es-errors",
-        "function-bind"
+        "ansi-styles@4.3.0",
+        "supports-color"
       ]
     },
     "chalk@5.6.2": {
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="
+    },
+    "char-regex@1.0.2": {
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="
     },
     "cli-boxes@3.0.0": {
       "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="
@@ -1289,11 +1196,40 @@
         "restore-cursor"
       ]
     },
+    "cli-highlight@2.1.11": {
+      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+      "dependencies": [
+        "chalk@4.1.2",
+        "highlight.js",
+        "mz",
+        "parse5@5.1.1",
+        "parse5-htmlparser2-tree-adapter",
+        "yargs"
+      ],
+      "bin": true
+    },
+    "cli-table3@0.6.5": {
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "dependencies": [
+        "string-width@4.2.3"
+      ],
+      "optionalDependencies": [
+        "@colors/colors"
+      ]
+    },
     "cli-truncate@4.0.0": {
       "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
       "dependencies": [
         "slice-ansi@5.0.0",
-        "string-width"
+        "string-width@7.2.0"
+      ]
+    },
+    "cliui@7.0.4": {
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dependencies": [
+        "string-width@4.2.3",
+        "strip-ansi@6.0.1",
+        "wrap-ansi@7.0.0"
       ]
     },
     "code-excerpt@4.0.0": {
@@ -1302,11 +1238,14 @@
         "convert-to-spaces"
       ]
     },
-    "combined-stream@1.0.8": {
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+    "color-convert@2.0.1": {
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dependencies": [
-        "delayed-stream"
+        "color-name"
       ]
+    },
+    "color-name@1.1.4": {
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "convert-to-spaces@2.0.1": {
       "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="
@@ -1314,76 +1253,32 @@
     "csstype@3.2.3": {
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
-    "debug@4.4.3": {
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dependencies": [
-        "ms"
-      ]
-    },
-    "delayed-stream@1.0.0": {
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
-    },
-    "dunder-proto@1.0.1": {
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dependencies": [
-        "call-bind-apply-helpers",
-        "es-errors",
-        "gopd"
-      ]
-    },
     "emoji-regex@10.6.0": {
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
     },
-    "end-of-stream@1.4.5": {
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dependencies": [
-        "once"
-      ]
+    "emoji-regex@8.0.0": {
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "emojilib@2.4.0": {
+      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="
     },
     "environment@1.1.0": {
       "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="
     },
-    "es-define-property@1.0.1": {
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    "es-toolkit@1.45.1": {
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="
     },
-    "es-errors@1.3.0": {
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
-    },
-    "es-object-atoms@1.1.1": {
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dependencies": [
-        "es-errors"
-      ]
-    },
-    "es-set-tostringtag@2.1.0": {
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dependencies": [
-        "es-errors",
-        "get-intrinsic",
-        "has-tostringtag",
-        "hasown"
-      ]
-    },
-    "es-toolkit@1.44.0": {
-      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg=="
+    "escalade@3.2.0": {
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="
     },
     "escape-string-regexp@2.0.0": {
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
-    },
-    "events-universal@1.0.1": {
-      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
-      "dependencies": [
-        "bare-events"
-      ]
     },
     "fast-check@3.23.2": {
       "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
       "dependencies": [
         "pure-rand"
       ]
-    },
-    "fast-fifo@1.3.2": {
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
     },
     "fast-json-patch@3.1.1": {
       "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="
@@ -1403,67 +1298,20 @@
       ],
       "bin": true
     },
-    "form-data@4.0.5": {
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dependencies": [
-        "asynckit",
-        "combined-stream",
-        "es-set-tostringtag",
-        "hasown",
-        "mime-types"
-      ]
-    },
-    "function-bind@1.1.2": {
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-    },
     "fzf@0.5.2": {
       "integrity": "sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q=="
+    },
+    "get-caller-file@2.0.5": {
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-east-asian-width@1.5.0": {
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="
     },
-    "get-intrinsic@1.3.0": {
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dependencies": [
-        "call-bind-apply-helpers",
-        "es-define-property",
-        "es-errors",
-        "es-object-atoms",
-        "function-bind",
-        "get-proto",
-        "gopd",
-        "has-symbols",
-        "hasown",
-        "math-intrinsics"
-      ]
+    "has-flag@4.0.0": {
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
-    "get-proto@1.0.1": {
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dependencies": [
-        "dunder-proto",
-        "es-object-atoms"
-      ]
-    },
-    "gopd@1.2.0": {
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
-    },
-    "has-symbols@1.1.0": {
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
-    },
-    "has-tostringtag@1.0.2": {
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dependencies": [
-        "has-symbols"
-      ]
-    },
-    "hasown@2.0.2": {
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dependencies": [
-        "function-bind"
-      ]
-    },
-    "hpagent@1.2.0": {
-      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA=="
+    "highlight.js@10.7.3": {
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
     },
     "indent-string@5.0.0": {
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
@@ -1483,9 +1331,9 @@
         "@alcalzone/ansi-tokenize",
         "@types/react",
         "ansi-escapes",
-        "ansi-styles",
+        "ansi-styles@6.2.3",
         "auto-bind",
-        "chalk",
+        "chalk@5.6.2",
         "cli-boxes",
         "cli-cursor",
         "cli-truncate",
@@ -1500,10 +1348,10 @@
         "signal-exit",
         "slice-ansi@7.1.2",
         "stack-utils",
-        "string-width",
+        "string-width@7.2.0",
         "type-fest",
         "widest-line",
-        "wrap-ansi",
+        "wrap-ansi@9.0.2",
         "ws",
         "yoga-layout"
       ],
@@ -1511,8 +1359,8 @@
         "@types/react"
       ]
     },
-    "ip-address@10.1.0": {
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="
+    "is-fullwidth-code-point@3.0.0": {
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-fullwidth-code-point@4.0.0": {
       "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="
@@ -1527,39 +1375,8 @@
       "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
       "bin": true
     },
-    "isomorphic-ws@5.0.0_ws@8.19.0": {
-      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
-      "dependencies": [
-        "ws"
-      ]
-    },
-    "jose@6.1.3": {
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="
-    },
     "js-tokens@4.0.0": {
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    },
-    "js-yaml@4.1.1": {
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dependencies": [
-        "argparse"
-      ],
-      "bin": true
-    },
-    "jsep@1.4.0": {
-      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw=="
-    },
-    "jsonpath-plus@10.4.0_jsep@1.4.0": {
-      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
-      "dependencies": [
-        "@jsep-plugin/assignment",
-        "@jsep-plugin/regex",
-        "jsep"
-      ],
-      "bin": true
-    },
-    "lodash-es@4.17.23": {
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="
     },
     "loose-envify@1.4.0": {
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
@@ -1568,38 +1385,45 @@
       ],
       "bin": true
     },
-    "math-intrinsics@1.1.0": {
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
-    },
-    "mime-db@1.52.0": {
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-    },
-    "mime-types@2.1.35": {
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+    "marked-terminal@7.3.0_marked@14.1.4": {
+      "integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
       "dependencies": [
-        "mime-db"
+        "ansi-escapes",
+        "ansi-regex@6.2.2",
+        "chalk@5.6.2",
+        "cli-highlight",
+        "cli-table3",
+        "marked",
+        "node-emoji",
+        "supports-hyperlinks"
       ]
+    },
+    "marked@14.1.4": {
+      "integrity": "sha512-vkVZ8ONmUdPnjCKc5uTRvmkRbx4EAi2OkTOXmfTDhZz3OFqMNBM1oTTWwTr4HY4uAEojhzPf+Fy8F1DWa3Sndg==",
+      "bin": true
     },
     "mimic-fn@2.1.0": {
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
-    "ms@2.1.3": {
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node-fetch@2.7.0": {
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+    "mz@2.7.0": {
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dependencies": [
-        "whatwg-url"
+        "any-promise",
+        "object-assign",
+        "thenify-all"
       ]
     },
-    "oauth4webapi@3.8.5": {
-      "integrity": "sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg=="
-    },
-    "once@1.4.0": {
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+    "node-emoji@2.2.0": {
+      "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
       "dependencies": [
-        "wrappy"
+        "@sindresorhus/is",
+        "char-regex",
+        "emojilib",
+        "skin-tone"
       ]
+    },
+    "object-assign@4.1.1": {
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "onetime@5.1.2": {
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
@@ -1607,25 +1431,23 @@
         "mimic-fn"
       ]
     },
-    "openid-client@6.8.2": {
-      "integrity": "sha512-uOvTCndr4udZsKihJ68H9bUICrriHdUVJ6Az+4Ns6cW55rwM5h0bjVIzDz2SxgOI84LKjFyjOFvERLzdTUROGA==",
+    "parse5-htmlparser2-tree-adapter@6.0.1": {
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
       "dependencies": [
-        "jose",
-        "oauth4webapi"
+        "parse5@6.0.1"
       ]
+    },
+    "parse5@5.1.1": {
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
+    },
+    "parse5@6.0.1": {
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
     "patch-console@2.0.0": {
       "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="
     },
     "path-expression-matcher@1.1.3": {
       "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ=="
-    },
-    "pump@3.0.3": {
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-      "dependencies": [
-        "end-of-stream",
-        "once"
-      ]
     },
     "pure-rand@6.1.0": {
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="
@@ -1644,15 +1466,15 @@
         "loose-envify"
       ]
     },
+    "require-directory@2.1.1": {
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
+    },
     "restore-cursor@4.0.0": {
       "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
       "dependencies": [
         "onetime",
         "signal-exit"
       ]
-    },
-    "rfc4648@1.5.4": {
-      "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg=="
     },
     "scheduler@0.23.2": {
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
@@ -1663,36 +1485,24 @@
     "signal-exit@3.0.7": {
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
+    "skin-tone@2.0.0": {
+      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+      "dependencies": [
+        "unicode-emoji-modifier-base"
+      ]
+    },
     "slice-ansi@5.0.0": {
       "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
       "dependencies": [
-        "ansi-styles",
+        "ansi-styles@6.2.3",
         "is-fullwidth-code-point@4.0.0"
       ]
     },
     "slice-ansi@7.1.2": {
       "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
       "dependencies": [
-        "ansi-styles",
+        "ansi-styles@6.2.3",
         "is-fullwidth-code-point@5.1.0"
-      ]
-    },
-    "smart-buffer@4.2.0": {
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
-    },
-    "socks-proxy-agent@8.0.5": {
-      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-      "dependencies": [
-        "agent-base",
-        "debug",
-        "socks"
-      ]
-    },
-    "socks@2.8.7": {
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-      "dependencies": [
-        "ip-address",
-        "smart-buffer"
       ]
     },
     "stack-utils@2.0.6": {
@@ -1701,67 +1511,61 @@
         "escape-string-regexp"
       ]
     },
-    "stream-buffers@3.0.3": {
-      "integrity": "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw=="
-    },
-    "streamx@2.23.0": {
-      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+    "string-width@4.2.3": {
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dependencies": [
-        "events-universal",
-        "fast-fifo",
-        "text-decoder"
+        "emoji-regex@8.0.0",
+        "is-fullwidth-code-point@3.0.0",
+        "strip-ansi@6.0.1"
       ]
     },
     "string-width@7.2.0": {
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dependencies": [
-        "emoji-regex",
+        "emoji-regex@10.6.0",
         "get-east-asian-width",
-        "strip-ansi"
+        "strip-ansi@7.2.0"
       ]
     },
-    "strip-ansi@7.1.2": {
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+    "strip-ansi@6.0.1": {
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dependencies": [
-        "ansi-regex"
+        "ansi-regex@5.0.1"
+      ]
+    },
+    "strip-ansi@7.2.0": {
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dependencies": [
+        "ansi-regex@6.2.2"
       ]
     },
     "strnum@2.2.1": {
       "integrity": "sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg=="
     },
-    "tar-fs@3.1.1": {
-      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+    "supports-color@7.2.0": {
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dependencies": [
-        "pump",
-        "tar-stream"
-      ],
-      "optionalDependencies": [
-        "bare-fs",
-        "bare-path"
+        "has-flag"
       ]
     },
-    "tar-stream@3.1.7": {
-      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+    "supports-hyperlinks@3.2.0": {
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
       "dependencies": [
-        "b4a",
-        "fast-fifo",
-        "streamx"
+        "has-flag",
+        "supports-color"
       ]
     },
-    "teex@1.0.1": {
-      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+    "thenify-all@1.6.0": {
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
       "dependencies": [
-        "streamx"
+        "thenify"
       ]
     },
-    "text-decoder@1.2.7": {
-      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+    "thenify@3.3.1": {
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
       "dependencies": [
-        "b4a"
+        "any-promise"
       ]
-    },
-    "tr46@0.0.3": {
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "tslib@2.8.1": {
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
@@ -1772,35 +1576,51 @@
     "undici-types@7.8.0": {
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="
     },
-    "webidl-conversions@3.0.1": {
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "whatwg-url@5.0.0": {
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": [
-        "tr46",
-        "webidl-conversions"
-      ]
+    "unicode-emoji-modifier-base@1.0.0": {
+      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g=="
     },
     "widest-line@5.0.0": {
       "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
       "dependencies": [
-        "string-width"
+        "string-width@7.2.0"
+      ]
+    },
+    "wrap-ansi@7.0.0": {
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": [
+        "ansi-styles@4.3.0",
+        "string-width@4.2.3",
+        "strip-ansi@6.0.1"
       ]
     },
     "wrap-ansi@9.0.2": {
       "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "dependencies": [
-        "ansi-styles",
-        "string-width",
-        "strip-ansi"
+        "ansi-styles@6.2.3",
+        "string-width@7.2.0",
+        "strip-ansi@7.2.0"
       ]
-    },
-    "wrappy@1.0.2": {
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "ws@8.19.0": {
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="
+    },
+    "y18n@5.0.8": {
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+    },
+    "yargs-parser@20.2.9": {
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+    },
+    "yargs@16.2.0": {
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dependencies": [
+        "cliui",
+        "escalade",
+        "get-caller-file",
+        "require-directory",
+        "string-width@4.2.3",
+        "y18n",
+        "yargs-parser"
+      ]
     },
     "yoga-layout@3.2.1": {
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="
@@ -1829,6 +1649,8 @@
       "npm:fzf@0.5.2",
       "npm:ink-testing-library@4",
       "npm:ink@^5.2.1",
+      "npm:marked-terminal@^7.3.0",
+      "npm:marked@14",
       "npm:react@^18.3.1",
       "npm:zod@^4.3.6"
     ]

--- a/design/extension.md
+++ b/design/extension.md
@@ -1,9 +1,9 @@
 # Extensions
 
 An extension in swamp is a distributable package of models, workflows, vaults,
-drivers, and datastores that can be shared through a registry. Extensions allow
-the community to share reusable automation components that others can pull into
-their repositories.
+drivers, datastores, and reports that can be shared through a registry.
+Extensions allow the community to share reusable automation components that
+others can pull into their repositories.
 
 ## Name
 
@@ -40,8 +40,8 @@ what the extension contains and how it should be packaged.
 - `manifestVersion`: Must be `1` (the only supported version).
 - `name`: Scoped name (`@collective/name`).
 - `version`: CalVer version string.
-- At least one of `models`, `workflows`, `vaults`, `drivers`, or `datastores`
-  must be present.
+- At least one of `models`, `workflows`, `vaults`, `drivers`, `datastores`, or
+  `reports` must be present.
 
 ### Optional Fields
 
@@ -52,6 +52,7 @@ what the extension contains and how it should be packaged.
 - `vaults`: Array of relative paths to TypeScript vault files.
 - `drivers`: Array of relative paths to TypeScript driver files.
 - `datastores`: Array of relative paths to TypeScript datastore files.
+- `reports`: Array of relative paths to TypeScript report files.
 - `additionalFiles`: Array of paths to non-model files to include (README,
   config, etc.).
 - `platforms`: Array of platform identifiers the extension supports (e.g.,
@@ -72,6 +73,8 @@ models:
   - ssh/connection.ts
 workflows:
   - ssh-check.yaml
+reports:
+  - cost-summary.ts
 additionalFiles:
   - ssh/known_hosts_template.txt
 dependencies:
@@ -108,6 +111,8 @@ extension.tar.gz
     ├── driver-bundles/       # Compiled driver JavaScript bundles
     ├── datastores/           # Source TypeScript datastore files
     ├── datastore-bundles/    # Compiled datastore JavaScript bundles
+    ├── reports/              # Source TypeScript report files
+    ├── report-bundles/       # Compiled report JavaScript bundles
     └── files/                # Additional files
 ```
 
@@ -186,13 +191,14 @@ config. This supports pulled extensions that were built with a `deno.json` or
 `package.json` project — the archive includes pre-built bundles but not the
 project config.
 
-### Vaults, Drivers, and Datastores
+### Vaults, Drivers, Datastores, and Reports
 
-Vault, driver, and datastore entry points are bundled with the same strategy as
-models — deno bundle with zod externalized. Each entry point gets a compiled
-`.js` file in its corresponding `-bundles/` directory (`vault-bundles/`,
-`driver-bundles/`, `datastore-bundles/`). Local imports are resolved recursively
-within the directory boundary.
+Vault, driver, datastore, and report entry points are bundled with the same
+strategy as models — deno bundle with zod externalized. Each entry point gets a
+compiled `.js` file in its corresponding `-bundles/` directory
+(`vault-bundles/`, `driver-bundles/`, `datastore-bundles/`,
+`report-bundles/`). Local imports are resolved recursively within the directory
+boundary.
 
 The export from each bundle is validated against a Zod schema:
 
@@ -202,13 +208,15 @@ The export from each bundle is validated against a Zod schema:
   optional `configSchema`, and `createDriver`
 - **Datastores**: `export const datastore` — must have `type`, `name`,
   `description`, optional `configSchema`, and `createProvider`
+- **Reports**: `export const report` — must have `name`, `description`,
+  `scope`, optional `labels`, and `execute`
 
 ### Collective Validation
 
 All content types — model types, vault types, workflow names, driver types,
-datastore types — must use the same collective as the extension name. This is
-enforced during push to prevent an extension from registering types under a
-different collective.
+datastore types, report names — must use the same collective as the extension
+name. This is enforced during push to prevent an extension from registering
+types under a different collective.
 
 ### Workflows
 
@@ -223,11 +231,11 @@ preserving their relative paths.
 ## Import Resolution
 
 When packaging an extension, the CLI resolves all local TypeScript imports
-starting from each entry point (model, vault, driver, or datastore). The
-resolver follows relative `import`/`export` statements (e.g., `./helpers.ts`,
-`../shared.ts`) and includes all transitively imported files. Only files within
-the respective directory boundary are included. Non-local imports (npm packages)
-are skipped as they are resolved at runtime.
+starting from each entry point (model, vault, driver, datastore, or report).
+The resolver follows relative `import`/`export` statements (e.g.,
+`./helpers.ts`, `../shared.ts`) and includes all transitively imported files.
+Only files within the respective directory boundary are included. Non-local
+imports (npm packages) are skipped as they are resolved at runtime.
 
 ## Dependencies
 
@@ -428,6 +436,8 @@ When pulled, extension files are extracted to their destinations:
 | `driver-bundles/`    | `.swamp/driver-bundles/`                                               |
 | `datastores/`        | `{datastoresDir}` (from `.swamp.yaml`, default `extensions/datastores/`) |
 | `datastore-bundles/` | `.swamp/datastore-bundles/`                                            |
+| `reports/`           | `{reportsDir}` (from `.swamp.yaml`, default `extensions/reports/`)     |
+| `report-bundles/`    | `.swamp/report-bundles/`                                               |
 | `files/`             | `{modelsDir}`                                                          |
 
 If files already exist at the destination and `--force` is not set, the user is

--- a/design/reports.md
+++ b/design/reports.md
@@ -1,0 +1,342 @@
+# Reports
+
+Reports are post-execution analysis functions that produce markdown and JSON
+output from model and workflow execution context. They run after a method
+completes (or on demand) and persist their results as data artifacts. Reports
+are generic — they operate on whatever context they receive at runtime, not on
+specific model types. This decouples report logic from model implementation.
+
+## Report Definition
+
+A report is defined by the `ReportDefinition` interface:
+
+```typescript
+interface ReportDefinition {
+  description: string;
+  scope: ReportScope;
+  labels?: string[];
+  execute(context: ReportContext): Promise<ReportResult>;
+}
+
+interface ReportResult {
+  markdown: string;
+  json: Record<string, unknown>;
+}
+```
+
+- **description** — what the report produces (human-readable).
+- **scope** — `"method"`, `"model"`, or `"workflow"`. Determines which context
+  variant the report receives.
+- **labels** — optional categorization tags for filtering (e.g., `["cost",
+  "finops"]`).
+- **execute** — the function that analyzes context and returns a result.
+
+See `src/domain/reports/report.ts` for the full interface.
+
+## Scopes
+
+Each report declares the scope at which it operates. The scope determines the
+shape of the context passed to `execute`.
+
+| Scope      | When it runs                             | Context variant          |
+| ---------- | ---------------------------------------- | ------------------------ |
+| `method`   | After a single method execution          | `MethodReportContext`    |
+| `model`    | After a method execution (model-level)   | `ModelReportContext`     |
+| `workflow`  | After a full workflow run completes      | `WorkflowReportContext`  |
+
+Reports with `scope: "method"` or `scope: "model"` run in the context of a
+specific model instance and method invocation. Reports with `scope: "workflow"`
+run after all workflow steps complete and receive summary data about every step.
+
+## Report Context
+
+The three context variants share a base set of fields and diverge based on
+scope. See `src/domain/reports/report_context.ts`.
+
+### Base Fields (all scopes)
+
+| Field                  | Type                       | Description                              |
+| ---------------------- | -------------------------- | ---------------------------------------- |
+| `repoDir`              | `string`                   | Repository root path                     |
+| `logger`               | `Logger`                   | LogTape logger for report output         |
+| `dataRepository`       | `UnifiedDataRepository`    | Read/query persisted data                |
+| `definitionRepository` | `DefinitionRepository`     | Read model definitions                   |
+
+### MethodReportContext / ModelReportContext
+
+Both method and model scope contexts carry the same fields:
+
+| Field             | Type                         | Description                                  |
+| ----------------- | ---------------------------- | -------------------------------------------- |
+| `scope`           | `"method"` / `"model"`       | Discriminant                                 |
+| `modelType`       | `ModelType`                  | The model type                               |
+| `modelId`         | `string`                     | Model instance ID                            |
+| `definition`      | `{ id, name, version, tags }`| Definition metadata                          |
+| `globalArgs`      | `Record<string, unknown>`    | Evaluated global arguments                   |
+| `methodArgs`      | `Record<string, unknown>`    | Per-method arguments                         |
+| `methodName`      | `string`                     | Which method was invoked                     |
+| `executionStatus` | `"succeeded"` / `"failed"`   | Method outcome                               |
+| `dataHandles`     | `DataHandle[]`               | Data artifacts produced by the method        |
+
+### WorkflowReportContext
+
+| Field              | Type                             | Description                                   |
+| ------------------ | -------------------------------- | --------------------------------------------- |
+| `scope`            | `"workflow"`                     | Discriminant                                  |
+| `workflowId`       | `string`                         | Workflow UUID                                 |
+| `workflowRunId`    | `string`                         | Run UUID                                      |
+| `workflowName`     | `string`                         | Workflow name                                 |
+| `workflowStatus`   | `"succeeded"` / `"failed"`      | Overall run outcome                           |
+| `stepExecutions`   | `StepExecution[]`                | Per-step details (job, model, method, status) |
+
+Each `stepExecutions` entry contains `jobName`, `stepName`, `modelName`,
+`modelType`, `methodName`, `status`, `dataHandles`, `methodArgs`, `modelId`,
+and `globalArgs`.
+
+## Standalone Report Extensions
+
+Reports are implemented as TypeScript files in `extensions/reports/`. Each file
+exports a `report` object:
+
+```typescript
+export const report = {
+  name: "@myorg/cost-summary",
+  description: "Summarize estimated costs from resource attributes",
+  scope: "method" as const,
+  labels: ["cost", "finops"],
+  execute: async (context) => {
+    // Analyze context.dataHandles, context.globalArgs, etc.
+    return {
+      markdown: "## Cost Summary\n...",
+      json: { totalEstimatedCost: 42.50 },
+    };
+  },
+};
+```
+
+### Name Convention
+
+Report names follow the `@collective/name` pattern (e.g.,
+`@myorg/cost-report`). The collective must match the extension's collective
+when distributed via `extension push`.
+
+### Loader Validation
+
+`UserReportLoader` discovers `.ts` files recursively in the reports directory
+(excluding `_test.ts`), bundles each with Deno (zod externalized), and
+validates the export against a Zod schema requiring:
+
+- `name` — matches `@collective/name` or `collective/name`
+- `description` — non-empty string
+- `scope` — one of `"method"`, `"model"`, `"workflow"`
+- `labels` — optional `string[]`
+- `execute` — function
+
+Files without a `report` export are silently skipped (they may be utility
+modules). Bundles are cached in `.swamp/report-bundles/` with mtime-based
+invalidation.
+
+See `src/domain/reports/user_report_loader.ts`.
+
+## Report Registry
+
+The `ReportRegistry` is a `Map`-backed registry of report definitions keyed by
+name. It provides `register`, `get`, `getAll`, `getByScope`, and `has` methods.
+
+The global singleton uses `globalThis` so the same registry is shared across
+module boundaries (important when extensions are loaded outside the bundle):
+
+```typescript
+const REPORT_REGISTRY_KEY = "__swampReportRegistry";
+export const reportRegistry: ReportRegistry =
+  (globalThis as any)[REPORT_REGISTRY_KEY] ??= new ReportRegistry();
+```
+
+Duplicate name registration throws an error. See
+`src/domain/reports/report_registry.ts`.
+
+## Three-Level Control Model
+
+Reports are selected through three layers, from broadest to most specific:
+
+### 1. Model-Type Defaults
+
+A model type declares default reports via `ModelDefinition.reports: string[]`.
+These are report names (not values) — the model references reports by name,
+decoupling the model and report bounded contexts:
+
+```typescript
+export const model = {
+  type: "@myorg/ec2-instance",
+  reports: ["@myorg/cost-summary", "@myorg/compliance-check"],
+  // ...
+};
+```
+
+All registered reports whose name appears in this list are candidates whenever
+a method runs on this model type.
+
+### 2. Definition YAML Overrides
+
+Each definition can refine which reports run via a `reports` field:
+
+```yaml
+reports:
+  require:
+    - "@myorg/cost-summary"
+    - name: "@myorg/security-audit"
+      methods: ["create", "update"]
+  skip:
+    - "@myorg/compliance-check"
+```
+
+- **`require`** — reports listed here are added to the candidate set and are
+  immune to CLI skip flags. Entries can be a plain string (applies to all
+  methods) or an object with `name` and optional `methods` array for method
+  scoping.
+- **`skip`** — reports listed here are always skipped. Skip wins over require
+  if the same report appears in both.
+
+### 3. Workflow YAML Overrides
+
+Workflows also support a `reports` field at the workflow level with the same
+`require`/`skip` structure. This applies to workflow-scope reports.
+
+```yaml
+reports:
+  require:
+    - "@myorg/workflow-summary"
+  skip:
+    - "@myorg/verbose-audit"
+```
+
+## Report Selection
+
+The `ReportSelection` type and `ReportRef` union define the YAML-driven
+selection schema. See `src/domain/reports/report_selection.ts`.
+
+```typescript
+type ReportRef = string | { name: string; methods?: string[] };
+
+type ReportSelection = {
+  require?: ReportRef[];
+  skip?: string[];
+};
+```
+
+The `ReportSelectionSchema` (Zod) validates report selection in both definition
+and workflow YAML files.
+
+## Filtering Semantics
+
+The `filterReports` function in `report_execution_service.ts` applies the full
+filtering pipeline. The algorithm:
+
+1. **Build candidate set** — union of model-type defaults
+   (`ModelDefinition.reports`) and `selection.require` names. For workflow scope
+   (no model-type defaults), candidates are `selection.require` only.
+2. **Scope filter** — only reports matching the requested scope pass.
+3. **Definition/workflow skip** — `selection.skip` names are removed. Skip
+   always wins.
+4. **Method scoping** — required refs with a `methods` array are excluded when
+   the current method is not in the list.
+5. **Required immunity** — reports in `selection.require` survive all CLI skip
+   flags.
+6. **CLI skip flags** — `--skip-reports` removes all non-required reports.
+   `--skip-report <name>` and `--skip-report-label <label>` remove matching
+   non-required reports.
+7. **Inclusion filters** — `--report <name>` and `--report-label <label>`
+   narrow the remaining set to only matching reports.
+
+Key invariants:
+
+- **Skip always wins over require.** If a report is in both `skip` and
+  `require`, it is skipped.
+- **Required reports are immune to CLI skip flags.** `--skip-reports` and
+  `--skip-report <name>` cannot suppress a required report.
+- **Only candidates run.** A report must be in model-type defaults or in
+  `require` to be considered. Registration alone is not enough.
+
+## Data Persistence
+
+Report results are automatically persisted as data artifacts via
+`persistReportData`. Each report produces two artifacts:
+
+| Artifact   | Data name                     | Content type         |
+| ---------- | ----------------------------- | -------------------- |
+| Markdown   | `report-{reportName}`         | `text/markdown`      |
+| JSON       | `report-{reportName}-json`    | `application/json`   |
+
+Both artifacts are written with:
+
+- **Lifetime**: `30d`
+- **Garbage collection**: `5` (keep latest 5 versions)
+- **Tags**: `{ type: "report", reportName, reportScope }`
+
+Data handles are returned in the `ReportExecutionResult` and included in the
+final view. The `buildReportDataHandles` helper (in
+`src/domain/reports/report_data_handles.ts`) reconstructs `DataHandle[]` from
+persisted data for standalone report invocations.
+
+## CLI
+
+### `swamp model report`
+
+Runs reports for a model without executing a method. Uses the evaluated
+(post-CEL) definition when available.
+
+```bash
+swamp model report my-model
+swamp model report my-model --method create
+swamp model report my-model --label cost
+```
+
+| Flag               | Description                                     |
+| ------------------ | ----------------------------------------------- |
+| `--method <name>`  | Simulate a method context for report scoping    |
+| `--label <label>`  | Only run reports matching this label (repeatable)|
+
+See `src/cli/commands/model_report.ts`.
+
+### Report Flags on `model method run`
+
+| Flag                              | Description                                      |
+| --------------------------------- | ------------------------------------------------ |
+| `--skip-reports`                  | Skip all post-run reports                        |
+| `--skip-report <name>`           | Skip a specific report by name (repeatable)      |
+| `--skip-report-label <label>`    | Skip reports matching a label (repeatable)       |
+| `--report <name>`                | Only run this report (inclusion, repeatable)     |
+| `--report-label <label>`         | Only run reports with this label (inclusion)     |
+
+### Report Flags on `workflow run`
+
+| Flag                              | Description                                      |
+| --------------------------------- | ------------------------------------------------ |
+| `--skip-reports`                  | Skip all post-run reports                        |
+| `--skip-report <name>`           | Skip a specific report by name (repeatable)      |
+| `--skip-report-label <label>`    | Skip reports matching a label (repeatable)       |
+| `--report <name>`                | Only run this report (inclusion, repeatable)     |
+| `--report-label <label>`         | Only run reports with this label (inclusion)     |
+
+## Output
+
+Reports support two output modes, consistent with the rest of the CLI:
+
+- **Log mode** — renders each report's markdown to the terminal with a
+  separator header showing the report name. Uses `renderMarkdownToTerminal`
+  for terminal-friendly formatting.
+- **JSON mode** — emits a single JSON object with the full `ModelReportView`
+  containing all report results (name, scope, success, markdown, json, error).
+
+See `src/presentation/renderers/model_report.ts`.
+
+## Reports Directory Resolution
+
+The reports directory is resolved with the same priority as other extension
+directories:
+
+1. `SWAMP_REPORTS_DIR` environment variable
+2. `reportsDir` in `.swamp.yaml`
+3. Default: `extensions/reports/`
+
+See `src/cli/resolve_reports_dir.ts`.

--- a/integration/architecture_boundary_test.ts
+++ b/integration/architecture_boundary_test.ts
@@ -131,7 +131,7 @@ function importsLayer(
 // Ratchet: current number of mutual dependencies between bounded contexts.
 // If someone breaks a cycle, the count decreases and the test still passes.
 // If someone introduces a new mutual dependency, the test fails.
-const KNOWN_MUTUAL_DEPENDENCIES = 9;
+const KNOWN_MUTUAL_DEPENDENCIES = 10;
 
 Deno.test(
   "no new mutual dependencies between bounded contexts (ratchet)",

--- a/integration/ddd_layer_rules_test.ts
+++ b/integration/ddd_layer_rules_test.ts
@@ -54,7 +54,7 @@ function importsLayer(
 // Ratchet counts: current number of known violations.
 // If someone fixes a violation, the count decreases and the test still passes.
 // If someone adds a new violation, the count increases and the test fails.
-const KNOWN_DOMAIN_INFRA_VIOLATIONS = 18;
+const KNOWN_DOMAIN_INFRA_VIOLATIONS = 21;
 
 Deno.test(
   "domain layer must not add new infrastructure imports (ratchet)",
@@ -99,7 +99,7 @@ Deno.test(
   },
 );
 
-const KNOWN_PRESENTATION_INFRA_VIOLATIONS = 46;
+const KNOWN_PRESENTATION_INFRA_VIOLATIONS = 48;
 
 Deno.test(
   "presentation layer must not add new infrastructure imports (ratchet)",

--- a/src/cli/auto_resolver_adapters.ts
+++ b/src/cli/auto_resolver_adapters.ts
@@ -46,6 +46,7 @@ interface InstallerAdapterConfig {
   vaultsDir: string;
   driversDir: string;
   datastoresDir: string;
+  reportsDir: string;
   repoDir: string;
   denoRuntime: DenoRuntime;
 }
@@ -64,6 +65,7 @@ export function createAutoResolveInstallerAdapter(
     vaultsDir,
     driversDir,
     datastoresDir,
+    reportsDir,
     repoDir,
     denoRuntime,
   } = config;
@@ -80,6 +82,7 @@ export function createAutoResolveInstallerAdapter(
           vaultsDir,
           driversDir,
           datastoresDir,
+          reportsDir,
           repoDir,
           force: true,
           alreadyPulled: new Set(),

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -27,6 +27,7 @@ import { resolveVaultsDir } from "../resolve_vaults_dir.ts";
 import { resolveWorkflowsDir } from "../resolve_workflows_dir.ts";
 import { resolveDriversDir } from "../resolve_drivers_dir.ts";
 import { resolveDatastoresDir } from "../resolve_datastores_dir.ts";
+import { resolveReportsDir } from "../resolve_reports_dir.ts";
 import {
   RepoMarkerRepository,
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
@@ -99,6 +100,7 @@ export interface InstallContext {
   vaultsDir: string;
   driversDir: string;
   datastoresDir: string;
+  reportsDir: string;
   repoDir: string;
   force: boolean;
   alreadyPulled: Set<string>;
@@ -405,6 +407,8 @@ export async function detectConflicts(
   driverBundlesDir?: string,
   datastoresDir?: string,
   datastoreBundlesDir?: string,
+  reportsDir?: string,
+  reportBundlesDir?: string,
 ): Promise<string[]> {
   const conflicts: string[] = [];
 
@@ -509,6 +513,30 @@ export async function detectConflicts(
     }
   }
 
+  // Check reports
+  if (reportsDir) {
+    const reportsSrc = join(extractDir, "reports");
+    for (const file of await listFiles(reportsSrc)) {
+      const relPath = relative(reportsSrc, file);
+      const destPath = join(reportsDir, relPath);
+      if (await fileExists(destPath)) {
+        conflicts.push(relative(repoDir, destPath));
+      }
+    }
+  }
+
+  // Check report bundles
+  if (reportBundlesDir) {
+    const reportBundlesSrc = join(extractDir, "report-bundles");
+    for (const file of await listFiles(reportBundlesSrc)) {
+      const relPath = relative(reportBundlesSrc, file);
+      const destPath = join(reportBundlesDir, relPath);
+      if (await fileExists(destPath)) {
+        conflicts.push(relative(repoDir, destPath));
+      }
+    }
+  }
+
   // Check additional files
   const filesSrc = join(extractDir, "files");
   for (const file of await listFiles(filesSrc)) {
@@ -530,6 +558,7 @@ export interface PullContext {
   vaultsDir: string;
   driversDir: string;
   datastoresDir: string;
+  reportsDir: string;
   repoDir: string;
   force: boolean;
   outputMode: "log" | "json";
@@ -741,11 +770,15 @@ export async function installExtension(
     const datastoreTsFiles = (
       await listFiles(join(extractDir, "datastores"))
     ).filter((f) => f.endsWith(".ts"));
+    const reportTsFiles = (await listFiles(join(extractDir, "reports"))).filter(
+      (f) => f.endsWith(".ts"),
+    );
     const tsFiles = [
       ...modelTsFiles,
       ...vaultTsFiles,
       ...driverTsFiles,
       ...datastoreTsFiles,
+      ...reportTsFiles,
     ];
     if (tsFiles.length > 0) {
       const safetyResult = await analyzeExtensionSafety(tsFiles);
@@ -769,10 +802,12 @@ export async function installExtension(
     const absoluteVaultsDir = resolve(repoDir, ctx.vaultsDir);
     const absoluteDriversDir = resolve(repoDir, ctx.driversDir);
     const absoluteDatastoresDir = resolve(repoDir, ctx.datastoresDir);
+    const absoluteReportsDir = resolve(repoDir, ctx.reportsDir);
     const bundlesDir = swampPath(repoDir, "bundles");
     const vaultBundlesDir = swampPath(repoDir, "vault-bundles");
     const driverBundlesDir = swampPath(repoDir, "driver-bundles");
     const datastoreBundlesDir = swampPath(repoDir, "datastore-bundles");
+    const reportBundlesDir = swampPath(repoDir, "report-bundles");
 
     const conflicts = await detectConflicts(
       extractDir,
@@ -786,6 +821,8 @@ export async function installExtension(
       driverBundlesDir,
       absoluteDatastoresDir,
       datastoreBundlesDir,
+      absoluteReportsDir,
+      reportBundlesDir,
     );
 
     if (conflicts.length > 0 && !ctx.force) {
@@ -875,6 +912,24 @@ export async function installExtension(
       repoDir,
     );
     extractedFiles.push(...datastoreBundlesExtracted);
+
+    // Reports → reportsDir
+    await Deno.mkdir(absoluteReportsDir, { recursive: true });
+    const reportsExtracted = await copyDir(
+      join(extractDir, "reports"),
+      absoluteReportsDir,
+      repoDir,
+    );
+    extractedFiles.push(...reportsExtracted);
+
+    // Report bundles → .swamp/report-bundles/
+    await Deno.mkdir(reportBundlesDir, { recursive: true });
+    const reportBundlesExtracted = await copyDir(
+      join(extractDir, "report-bundles"),
+      reportBundlesDir,
+      repoDir,
+    );
+    extractedFiles.push(...reportBundlesExtracted);
 
     // Additional files → modelsDir
     const filesExtracted = await copyDir(
@@ -1038,6 +1093,7 @@ export async function pullExtension(
     vaultsDir: ctx.vaultsDir,
     driversDir: ctx.driversDir,
     datastoresDir: ctx.datastoresDir,
+    reportsDir: ctx.reportsDir,
     repoDir: ctx.repoDir,
     force: ctx.force,
     alreadyPulled: ctx.alreadyPulled,
@@ -1115,6 +1171,7 @@ export const extensionPullCommand = new Command()
     const vaultsDir = resolveVaultsDir(marker);
     const driversDir = resolveDriversDir(marker);
     const datastoresDir = resolveDatastoresDir(marker);
+    const reportsDir = resolveReportsDir(marker);
 
     // 5. Resolve server URL (from env or default)
     const serverUrl = resolveServerUrl();
@@ -1130,6 +1187,7 @@ export const extensionPullCommand = new Command()
       vaultsDir,
       driversDir,
       datastoresDir,
+      reportsDir,
       repoDir,
       force: options.force ?? false,
       outputMode: ctx.outputMode,

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -206,6 +206,9 @@ export const extensionPushCommand = new Command()
       datastoresDir,
       datastoreEntryPoints,
       allDatastoreFiles,
+      reportsDir,
+      reportEntryPoints,
+      allReportFiles,
       workflowFiles,
       additionalFilePaths,
     } = resolved;
@@ -318,6 +321,8 @@ export const extensionPushCommand = new Command()
         driversDir,
         allDatastoreFiles,
         datastoresDir,
+        allReportFiles,
+        reportsDir,
       );
       ctx.logger
         .debug`Extracted content metadata: ${contentMetadata.models.length} models, ${contentMetadata.workflows.length} workflows, ${contentMetadata.vaults.length} vaults, ${contentMetadata.drivers.length} drivers, ${contentMetadata.datastores.length} datastores`;
@@ -409,6 +414,21 @@ export const extensionPushCommand = new Command()
       };
     });
 
+    const extractedReportsByFile = new Map(
+      (contentMetadata?.reports ?? []).map((r) => [r.fileName, r]),
+    );
+    const resolvedReports = allReportFiles.map((f) => {
+      const relPath = relative(repoDir, f);
+      const extracted = extractedReportsByFile.get(relative(reportsDir, f));
+      return {
+        name: extracted?.name ?? relPath,
+        fileName: relPath,
+        description: extracted?.description,
+        scope: extracted?.scope,
+        labels: extracted?.labels,
+      };
+    });
+
     const resolvedReleaseNotes = options.releaseNotes ?? manifest.releaseNotes;
     renderExtensionPushResolved(
       {
@@ -424,6 +444,7 @@ export const extensionPushCommand = new Command()
         vaults: resolvedVaults,
         drivers: resolvedDrivers,
         datastores: resolvedDatastores,
+        reports: resolvedReports,
         additionalFiles: additionalFilePaths.map((f) => relative(repoDir, f)),
         platforms: manifest.platforms,
         labels: manifest.labels,
@@ -438,6 +459,7 @@ export const extensionPushCommand = new Command()
       ...allVaultFiles,
       ...allDriverFiles,
       ...allDatastoreFiles,
+      ...allReportFiles,
       ...workflowFiles.map((wf) => wf.sourcePath),
       ...additionalFilePaths,
     ];
@@ -550,6 +572,20 @@ export const extensionPushCommand = new Command()
       }
     }
 
+    // Bundle report entry points
+    const reportBundles = new Map<string, string>();
+    for (const entryPoint of reportEntryPoints) {
+      const entryName = relative(reportsDir, entryPoint).replace(/\.ts$/, "");
+      try {
+        const js = await bundleExtension(entryPoint, denoPath);
+        reportBundles.set(entryName, js);
+        ctx.logger.debug`Bundled report ${entryName} (${js.length} bytes)`;
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        compilationErrors.push({ file: entryPoint, error: msg });
+      }
+    }
+
     if (compilationErrors.length > 0) {
       renderExtensionPushCompilationErrors(
         compilationErrors,
@@ -607,6 +643,8 @@ export const extensionPushCommand = new Command()
       await Deno.mkdir(join(extDir, "driver-bundles"), { recursive: true });
       await Deno.mkdir(join(extDir, "datastores"), { recursive: true });
       await Deno.mkdir(join(extDir, "datastore-bundles"), { recursive: true });
+      await Deno.mkdir(join(extDir, "reports"), { recursive: true });
+      await Deno.mkdir(join(extDir, "report-bundles"), { recursive: true });
       await Deno.mkdir(join(extDir, "files"), { recursive: true });
 
       // Write normalized manifest
@@ -623,6 +661,7 @@ export const extensionPushCommand = new Command()
           vaults: manifest.vaults,
           drivers: manifest.drivers,
           datastores: manifest.datastores,
+          reports: manifest.reports,
           additionalFiles: manifest.additionalFiles,
           ...(manifest.platforms.length > 0
             ? { platforms: manifest.platforms }
@@ -698,6 +737,21 @@ export const extensionPushCommand = new Command()
           "datastore-bundles",
           `${entryName}.js`,
         );
+        await Deno.mkdir(dirname(destPath), { recursive: true });
+        await Deno.writeTextFile(destPath, js);
+      }
+
+      // Copy report source files (preserving relative paths from reportsDir)
+      for (const reportFile of allReportFiles) {
+        const relPath = relative(reportsDir, reportFile);
+        const destPath = join(extDir, "reports", relPath);
+        await Deno.mkdir(dirname(destPath), { recursive: true });
+        await Deno.copyFile(reportFile, destPath);
+      }
+
+      // Write compiled report bundles
+      for (const [entryName, js] of reportBundles) {
+        const destPath = join(extDir, "report-bundles", `${entryName}.js`);
         await Deno.mkdir(dirname(destPath), { recursive: true });
         await Deno.writeTextFile(destPath, js);
       }
@@ -805,6 +859,7 @@ export const extensionPushCommand = new Command()
           vaultCount: allVaultFiles.length,
           driverCount: allDriverFiles.length,
           datastoreCount: allDatastoreFiles.length,
+          reportCount: allReportFiles.length,
         },
         ctx.outputMode,
       );

--- a/src/cli/commands/extension_search.ts
+++ b/src/cli/commands/extension_search.ts
@@ -28,6 +28,7 @@ import { resolveModelsDir } from "../resolve_models_dir.ts";
 import { resolveVaultsDir } from "../resolve_vaults_dir.ts";
 import { resolveDriversDir } from "../resolve_drivers_dir.ts";
 import { resolveDatastoresDir } from "../resolve_datastores_dir.ts";
+import { resolveReportsDir } from "../resolve_reports_dir.ts";
 import { resolveWorkflowsDir } from "../resolve_workflows_dir.ts";
 import {
   RepoMarkerRepository,
@@ -187,6 +188,7 @@ export const extensionSearchCommand = new Command()
       const vaultsDir = resolveVaultsDir(marker);
       const driversDir = resolveDriversDir(marker);
       const datastoresDir = resolveDatastoresDir(marker);
+      const reportsDir = resolveReportsDir(marker);
 
       const pullCtx: PullContext = {
         extensionClient: client,
@@ -196,6 +198,7 @@ export const extensionSearchCommand = new Command()
         vaultsDir,
         driversDir,
         datastoresDir,
+        reportsDir,
         repoDir,
         force: false,
         outputMode: ctx.outputMode,

--- a/src/cli/commands/extension_update.ts
+++ b/src/cli/commands/extension_update.ts
@@ -25,6 +25,7 @@ import { resolveModelsDir } from "../resolve_models_dir.ts";
 import { resolveVaultsDir } from "../resolve_vaults_dir.ts";
 import { resolveDriversDir } from "../resolve_drivers_dir.ts";
 import { resolveDatastoresDir } from "../resolve_datastores_dir.ts";
+import { resolveReportsDir } from "../resolve_reports_dir.ts";
 import { resolveWorkflowsDir } from "../resolve_workflows_dir.ts";
 import {
   RepoMarkerRepository,
@@ -91,6 +92,7 @@ export const extensionUpdateCommand = new Command()
     const vaultsDir = resolveVaultsDir(marker);
     const driversDir = resolveDriversDir(marker);
     const datastoresDir = resolveDatastoresDir(marker);
+    const reportsDir = resolveReportsDir(marker);
     const absoluteModelsDir = resolve(repoDir, modelsDir);
 
     // 3. Read installed extensions
@@ -172,6 +174,7 @@ export const extensionUpdateCommand = new Command()
           vaultsDir,
           driversDir,
           datastoresDir,
+          reportsDir,
           repoDir,
           force: true,
           alreadyPulled: new Set(),

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -91,6 +91,27 @@ export const modelMethodRunCommand = new Command()
     { collect: true },
   )
   .option("--skip-checks", "Skip all pre-flight checks", { default: false })
+  .option("--skip-reports", "Skip all post-run reports", { default: false })
+  .option(
+    "--skip-report <name:string>",
+    "Skip a specific post-run report by name",
+    { collect: true },
+  )
+  .option(
+    "--skip-report-label <label:string>",
+    "Skip post-run reports with this label",
+    { collect: true },
+  )
+  .option(
+    "--report <name:string>",
+    "Run only this report (inclusion filter)",
+    { collect: true },
+  )
+  .option(
+    "--report-label <label:string>",
+    "Run only reports with this label (inclusion filter)",
+    { collect: true },
+  )
   .option(
     "--driver <driver:string>",
     "Override execution driver (e.g. raw, docker)",
@@ -203,6 +224,11 @@ export const modelMethodRunCommand = new Command()
             skipCheckNames: options.skipCheck as string[] | undefined,
             skipCheckLabels: options.skipCheckLabel as string[] | undefined,
             skipAllChecks: options.skipChecks as boolean | undefined,
+            skipReportNames: options.skipReport as string[] | undefined,
+            skipReportLabels: options.skipReportLabel as string[] | undefined,
+            skipAllReports: options.skipReports as boolean | undefined,
+            reportNames: options.report as string[] | undefined,
+            reportLabels: options.reportLabel as string[] | undefined,
             driver: options.driver as string | undefined,
           }),
           renderer.handlers(),

--- a/src/cli/commands/report.ts
+++ b/src/cli/commands/report.ts
@@ -1,0 +1,35 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { reportSearchCommand } from "./report_search.ts";
+import { reportGetCommand } from "./report_get.ts";
+import { reportDescribeCommand } from "./report_describe.ts";
+import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
+
+export const reportCommand = new Command()
+  .name("report")
+  .description("Browse and view stored report results")
+  .error(unknownCommandErrorHandler)
+  .action(function () {
+    this.showHelp();
+  })
+  .command("search", reportSearchCommand)
+  .command("get", reportGetCommand)
+  .command("describe", reportDescribeCommand);

--- a/src/cli/commands/report_describe.ts
+++ b/src/cli/commands/report_describe.ts
@@ -1,0 +1,57 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { reportRegistry } from "../../domain/reports/report_registry.ts";
+import {
+  consumeStream,
+  createLibSwampContext,
+  reportDescribe,
+  type ReportDescribeDeps,
+} from "../../libswamp/mod.ts";
+import { createReportDescribeRenderer } from "../../presentation/renderers/report_describe.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const reportDescribeCommand = new Command()
+  .name("describe")
+  .description("Show report definition metadata from the registry")
+  .arguments("<report_name:string>")
+  .action(async function (options: AnyOptions, reportName: string) {
+    const ctx = createContext(options as GlobalOptions, [
+      "report",
+      "describe",
+    ]);
+
+    const deps: ReportDescribeDeps = {
+      getReport: (name) => reportRegistry.get(name),
+    };
+
+    const libCtx = createLibSwampContext({ logger: ctx.logger });
+    const renderer = createReportDescribeRenderer(ctx.outputMode);
+
+    await consumeStream(
+      reportDescribe(libCtx, deps, reportName),
+      renderer.handlers(),
+    );
+
+    ctx.logger.debug("Report describe command completed");
+  });

--- a/src/cli/commands/report_get.ts
+++ b/src/cli/commands/report_get.ts
@@ -1,0 +1,99 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { requireInitializedRepoReadOnly } from "../repo_context.ts";
+import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
+import { createDefinitionId } from "../../domain/definitions/definition.ts";
+import {
+  consumeStream,
+  createLibSwampContext,
+  reportGet,
+  type ReportGetDeps,
+} from "../../libswamp/mod.ts";
+import { createReportGetRenderer } from "../../presentation/renderers/report_get.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const reportGetCommand = new Command()
+  .name("get")
+  .description("Show a stored report's content")
+  .arguments("<report_name:string>")
+  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option("--model <name:string>", "Scope to a specific model")
+  .option("--workflow <name:string>", "Scope to a specific workflow")
+  .option(
+    "--version <version:number>",
+    "Get specific version (default: latest)",
+  )
+  .option("--variant <variant:string>", "Select a specific forEach variant")
+  .action(async function (options: AnyOptions, reportName: string) {
+    const ctx = createContext(options as GlobalOptions, ["report", "get"]);
+
+    const { repoContext } = await requireInitializedRepoReadOnly({
+      repoDir: options.repoDir ?? ".",
+      outputMode: ctx.outputMode,
+    });
+
+    const deps: ReportGetDeps = {
+      findAllGlobal: () => repoContext.unifiedDataRepo.findAllGlobal(),
+      findAllForModel: (type, modelId) =>
+        repoContext.unifiedDataRepo.findAllForModel(type, modelId),
+      getContent: (type, modelId, dataName, version) =>
+        repoContext.unifiedDataRepo.getContent(
+          type,
+          modelId,
+          dataName,
+          version,
+        ),
+      lookupDefinition: (idOrName) =>
+        findDefinitionByIdOrName(repoContext.definitionRepo, idOrName),
+      lookupDefinitionById: (type, id) =>
+        repoContext.definitionRepo.findById(type, createDefinitionId(id)),
+      findWorkflowByName: async (name) => {
+        const wf = await repoContext.workflowRepo.findByName(name);
+        if (!wf) return null;
+        return { id: wf.id, name: wf.name };
+      },
+      findWorkflowById: async (id) => {
+        const all = await repoContext.workflowRepo.findAll();
+        const wf = all.find((w) => w.id === id);
+        if (!wf) return null;
+        return { id: wf.id, name: wf.name };
+      },
+    };
+
+    const libCtx = createLibSwampContext({ logger: ctx.logger });
+    const renderer = createReportGetRenderer(ctx.outputMode);
+
+    await consumeStream(
+      reportGet(libCtx, deps, {
+        reportName,
+        model: options.model as string | undefined,
+        workflow: options.workflow as string | undefined,
+        version: options.version as number | undefined,
+        variant: options.variant as string | undefined,
+      }),
+      renderer.handlers(),
+    );
+
+    ctx.logger.debug("Report get command completed");
+  });

--- a/src/cli/commands/report_search.ts
+++ b/src/cli/commands/report_search.ts
@@ -1,0 +1,200 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  createContext,
+  type GlobalOptions,
+  interactiveOutputMode,
+} from "../context.ts";
+import { requireInitializedRepoReadOnly } from "../repo_context.ts";
+import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
+import { reportRegistry } from "../../domain/reports/report_registry.ts";
+import { createDefinitionId } from "../../domain/definitions/definition.ts";
+import {
+  consumeStream,
+  createLibSwampContext,
+  type LibSwampContext,
+  reportGet,
+  type ReportGetDeps,
+  reportSearch,
+  type ReportSearchDeps,
+  result,
+  type StoredReportSummary,
+  type SwampError,
+} from "../../libswamp/mod.ts";
+import type { RepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
+import type { OutputMode } from "../../presentation/output/output.ts";
+import {
+  renderReportSearch,
+  type ReportSearchData,
+} from "../../presentation/output/report_search_output.tsx";
+import { createReportGetRenderer } from "../../presentation/renderers/report_get.ts";
+import { UserError } from "../../domain/errors.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+function buildSearchDeps(repoContext: RepositoryContext): ReportSearchDeps {
+  return {
+    findAllGlobal: () => repoContext.unifiedDataRepo.findAllGlobal(),
+    findAllForModel: (type, modelId) =>
+      repoContext.unifiedDataRepo.findAllForModel(type, modelId),
+    lookupDefinition: (idOrName) =>
+      findDefinitionByIdOrName(repoContext.definitionRepo, idOrName),
+    lookupDefinitionById: (type, id) =>
+      repoContext.definitionRepo.findById(type, createDefinitionId(id)),
+    findWorkflowByName: async (name) => {
+      const wf = await repoContext.workflowRepo.findByName(name);
+      if (!wf) return null;
+      return { id: wf.id, name: wf.name };
+    },
+    findWorkflowById: async (id) => {
+      const all = await repoContext.workflowRepo.findAll();
+      const wf = all.find((w) => w.id === id);
+      if (!wf) return null;
+      return { id: wf.id, name: wf.name };
+    },
+    getReport: (name) => reportRegistry.get(name),
+  };
+}
+
+function buildGetDeps(repoContext: RepositoryContext): ReportGetDeps {
+  return {
+    findAllGlobal: () => repoContext.unifiedDataRepo.findAllGlobal(),
+    findAllForModel: (type, modelId) =>
+      repoContext.unifiedDataRepo.findAllForModel(type, modelId),
+    getContent: (type, modelId, dataName, version) =>
+      repoContext.unifiedDataRepo.getContent(type, modelId, dataName, version),
+    lookupDefinition: (idOrName) =>
+      findDefinitionByIdOrName(repoContext.definitionRepo, idOrName),
+    lookupDefinitionById: (type, id) =>
+      repoContext.definitionRepo.findById(type, createDefinitionId(id)),
+    findWorkflowByName: async (name) => {
+      const wf = await repoContext.workflowRepo.findByName(name);
+      if (!wf) return null;
+      return { id: wf.id, name: wf.name };
+    },
+    findWorkflowById: async (id) => {
+      const all = await repoContext.workflowRepo.findAll();
+      const wf = all.find((w) => w.id === id);
+      if (!wf) return null;
+      return { id: wf.id, name: wf.name };
+    },
+  };
+}
+
+/**
+ * Fetches and displays full report content for a selected summary.
+ */
+async function displayReportDetail(
+  summary: StoredReportSummary,
+  repoContext: RepositoryContext,
+  libCtx: LibSwampContext,
+  outputMode: OutputMode,
+): Promise<void> {
+  const getDeps = buildGetDeps(repoContext);
+  const renderer = createReportGetRenderer(outputMode);
+  await consumeStream(
+    reportGet(libCtx, getDeps, {
+      reportName: summary.reportName,
+      model: summary.workflowName ? undefined : summary.modelName,
+      workflow: summary.workflowName,
+      variant: summary.varySuffix,
+    }),
+    renderer.handlers(),
+  );
+}
+
+export const reportSearchCommand = new Command()
+  .name("search")
+  .description("Search stored report results across all models and workflows")
+  .arguments("[query:string]")
+  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option("--model <name:string>", "Filter to a specific model")
+  .option("--workflow <name:string>", "Filter to a specific workflow")
+  .option(
+    "--scope <scope:string>",
+    "Filter by report scope (method, model, workflow)",
+  )
+  .option(
+    "--label <label:string>",
+    "Filter by report label (repeatable)",
+    { collect: true },
+  )
+  .action(async function (options: AnyOptions, query?: string) {
+    const ctx = createContext(options as GlobalOptions, [
+      "report",
+      "search",
+    ]);
+    const effectiveMode = interactiveOutputMode(ctx);
+
+    const { repoContext } = await requireInitializedRepoReadOnly({
+      repoDir: options.repoDir ?? ".",
+      outputMode: effectiveMode,
+    });
+
+    const libCtx = createLibSwampContext({ logger: ctx.logger });
+
+    // Consume the search generator to get summaries
+    let searchResult;
+    try {
+      searchResult = await result(
+        reportSearch(libCtx, buildSearchDeps(repoContext), {
+          query,
+          model: options.model as string | undefined,
+          workflow: options.workflow as string | undefined,
+          scope: options.scope as string | undefined,
+          labels: options.label as string[] | undefined,
+        }),
+      );
+    } catch (err) {
+      const swampErr = err as SwampError;
+      throw new UserError(swampErr.message ?? String(err));
+    }
+
+    const summaries = searchResult.data.reports;
+
+    // For JSON mode with exactly one match, show full detail directly
+    if (effectiveMode === "json" && query && summaries.length === 1) {
+      await displayReportDetail(
+        summaries[0],
+        repoContext,
+        libCtx,
+        effectiveMode,
+      );
+      return;
+    }
+
+    const data: ReportSearchData = {
+      query: query ?? "",
+      results: summaries,
+    };
+
+    const selected = await renderReportSearch(data, effectiveMode);
+
+    if (selected) {
+      ctx.logger.debug`Selected report: ${selected.reportName}`;
+      await displayReportDetail(selected, repoContext, libCtx, effectiveMode);
+    } else {
+      ctx.logger.debug`Search cancelled`;
+    }
+
+    ctx.logger.debug("Report search command completed");
+  });

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -67,6 +67,27 @@ export const workflowRunCommand = new Command()
     "--driver <driver:string>",
     "Override execution driver (e.g. raw, docker)",
   )
+  .option("--skip-reports", "Skip all post-run reports", { default: false })
+  .option(
+    "--skip-report <name:string>",
+    "Skip a specific post-run report by name",
+    { collect: true },
+  )
+  .option(
+    "--skip-report-label <label:string>",
+    "Skip post-run reports with this label",
+    { collect: true },
+  )
+  .option(
+    "--report <name:string>",
+    "Run only this report (inclusion filter)",
+    { collect: true },
+  )
+  .option(
+    "--report-label <label:string>",
+    "Run only reports with this label (inclusion filter)",
+    { collect: true },
+  )
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(async function (options: AnyOptions, workflowIdOrName: string) {
     const ctx = createContext(options as GlobalOptions, ["workflow", "run"]);
@@ -169,6 +190,8 @@ export const workflowRunCommand = new Command()
         },
         createExecutionService: (wfRepo, rnRepo, dir) =>
           new WorkflowExecutionService(wfRepo, rnRepo, dir),
+        dataRepo: repoContext.unifiedDataRepo,
+        definitionRepo: repoContext.definitionRepo,
       };
 
       const libCtx = createLibSwampContext();
@@ -184,6 +207,11 @@ export const workflowRunCommand = new Command()
           runtimeTags,
           verbose: ctx.verbosity === "verbose",
           driver: options.driver as string | undefined,
+          skipAllReports: options.skipReports as boolean | undefined,
+          skipReportNames: options.skipReport as string[] | undefined,
+          skipReportLabels: options.skipReportLabel as string[] | undefined,
+          reportNames: options.report as string[] | undefined,
+          reportLabels: options.reportLabel as string[] | undefined,
         }),
         renderer.handlers(),
       );

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -18,9 +18,9 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { setColorEnabled, stripAnsiCode } from "@std/fmt/colors";
+import { setColorEnabled } from "@std/fmt/colors";
 import { isAbsolute, resolve } from "@std/path";
-import { parseLogLevel } from "@logtape/logtape";
+import { getLogger, parseLogLevel } from "@logtape/logtape";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
 import { VERSION, versionCommand } from "./commands/version.ts";
 import { modelCommand } from "./commands/model_create.ts";
@@ -38,6 +38,7 @@ import { authCommand } from "./commands/auth.ts";
 import { extensionCommand } from "./commands/extension.ts";
 import { summariseCommand } from "./commands/summarise.ts";
 import { datastoreCommand } from "./commands/datastore.ts";
+import { reportCommand } from "./commands/report.ts";
 import { createHelpCommand } from "./commands/help.ts";
 import { unknownCommandErrorHandler } from "./unknown_command_handler.ts";
 import {
@@ -54,6 +55,7 @@ import { UserModelLoader } from "../domain/models/user_model_loader.ts";
 import { UserVaultLoader } from "../domain/vaults/user_vault_loader.ts";
 import { UserDriverLoader } from "../domain/drivers/user_driver_loader.ts";
 import { UserDatastoreLoader } from "../domain/datastore/user_datastore_loader.ts";
+import { UserReportLoader } from "../domain/reports/user_report_loader.ts";
 
 // Import driver types barrel to trigger built-in driver registration
 import "../domain/drivers/driver_types.ts";
@@ -105,6 +107,10 @@ import { resolveDriversDir } from "./resolve_drivers_dir.ts";
 export { resolveDriversDir };
 import { resolveDatastoresDir } from "./resolve_datastores_dir.ts";
 export { resolveDatastoresDir };
+import { resolveReportsDir } from "./resolve_reports_dir.ts";
+export { resolveReportsDir };
+
+const logger = getLogger(["swamp", "cli"]);
 
 /**
  * Resolves the log level.
@@ -201,25 +207,17 @@ async function loadUserModels(
     const result = await loader.loadModels(absoluteModelsDir);
 
     // Log extension successes at debug level
-    if (Deno.env.get("SWAMP_DEBUG")) {
-      for (const file of result.extended) {
-        console.debug(`Extended model type from ${file}`);
-      }
+    for (const file of result.extended) {
+      logger.debug`Extended model type from ${file}`;
     }
 
     // Log failures as warnings (don't block CLI startup)
     for (const failure of result.failed) {
-      console.error(
-        `Warning: Failed to load user model ${failure.file}: ${
-          stripAnsiCode(failure.error)
-        }`,
-      );
+      logger.warn`Failed to load user model ${failure.file}: ${failure.error}`;
     }
   } catch (error) {
     // Not in a swamp repo or other error - log at debug level for troubleshooting
-    if (Deno.env.get("SWAMP_DEBUG")) {
-      console.debug(`Skipping user models: ${error}`);
-    }
+    logger.debug`Skipping user models: ${error}`;
   }
 }
 
@@ -241,25 +239,17 @@ async function loadUserVaults(
     const result = await loader.loadVaults(absoluteVaultsDir);
 
     // Log successes at debug level
-    if (Deno.env.get("SWAMP_DEBUG")) {
-      for (const file of result.loaded) {
-        console.debug(`Loaded user vault type from ${file}`);
-      }
+    for (const file of result.loaded) {
+      logger.debug`Loaded user vault type from ${file}`;
     }
 
     // Log failures as warnings (don't block CLI startup)
     for (const failure of result.failed) {
-      console.error(
-        `Warning: Failed to load user vault ${failure.file}: ${
-          stripAnsiCode(failure.error)
-        }`,
-      );
+      logger.warn`Failed to load user vault ${failure.file}: ${failure.error}`;
     }
   } catch (error) {
     // Not in a swamp repo or other error - log at debug level for troubleshooting
-    if (Deno.env.get("SWAMP_DEBUG")) {
-      console.debug(`Skipping user vaults: ${error}`);
-    }
+    logger.debug`Skipping user vaults: ${error}`;
   }
 }
 
@@ -278,25 +268,17 @@ async function loadUserDrivers(
     const result = await loader.loadDrivers(absoluteDriversDir);
 
     // Log successes at debug level
-    if (Deno.env.get("SWAMP_DEBUG")) {
-      for (const file of result.loaded) {
-        console.debug(`Loaded user driver type from ${file}`);
-      }
+    for (const file of result.loaded) {
+      logger.debug`Loaded user driver type from ${file}`;
     }
 
     // Log failures as warnings (don't block CLI startup)
     for (const failure of result.failed) {
-      console.error(
-        `Warning: Failed to load user driver ${failure.file}: ${
-          stripAnsiCode(failure.error)
-        }`,
-      );
+      logger.warn`Failed to load user driver ${failure.file}: ${failure.error}`;
     }
   } catch (error) {
     // Not in a swamp repo or other error - log at debug level for troubleshooting
-    if (Deno.env.get("SWAMP_DEBUG")) {
-      console.debug(`Skipping user drivers: ${error}`);
-    }
+    logger.debug`Skipping user drivers: ${error}`;
   }
 }
 
@@ -315,25 +297,47 @@ async function loadUserDatastores(
     const result = await loader.loadDatastores(absoluteDatastoresDir);
 
     // Log successes at debug level
-    if (Deno.env.get("SWAMP_DEBUG")) {
-      for (const file of result.loaded) {
-        console.debug(`Loaded user datastore type from ${file}`);
-      }
+    for (const file of result.loaded) {
+      logger.debug`Loaded user datastore type from ${file}`;
     }
 
     // Log failures as warnings (don't block CLI startup)
     for (const failure of result.failed) {
-      console.error(
-        `Warning: Failed to load user datastore ${failure.file}: ${
-          stripAnsiCode(failure.error)
-        }`,
-      );
+      logger
+        .warn`Failed to load user datastore ${failure.file}: ${failure.error}`;
     }
   } catch (error) {
     // Not in a swamp repo or other error - log at debug level for troubleshooting
-    if (Deno.env.get("SWAMP_DEBUG")) {
-      console.debug(`Skipping user datastores: ${error}`);
+    logger.debug`Skipping user datastores: ${error}`;
+  }
+}
+
+async function loadUserReports(
+  repoDir: string,
+  marker: RepoMarkerData | null,
+  denoRuntime: EmbeddedDenoRuntime,
+): Promise<void> {
+  try {
+    const reportsDir = resolveReportsDir(marker);
+    const absoluteReportsDir = isAbsolute(reportsDir)
+      ? reportsDir
+      : resolve(repoDir, reportsDir);
+
+    const loader = new UserReportLoader(denoRuntime, repoDir);
+    const result = await loader.loadReports(absoluteReportsDir);
+
+    // Log successes at debug level
+    for (const file of result.loaded) {
+      logger.debug`Loaded user report from ${file}`;
     }
+
+    // Log failures as warnings (don't block CLI startup)
+    for (const failure of result.failed) {
+      logger.warn`Failed to load user report ${failure.file}: ${failure.error}`;
+    }
+  } catch (error) {
+    // Not in a swamp repo or other error - log at debug level for troubleshooting
+    logger.debug`Skipping user reports: ${error}`;
   }
 }
 
@@ -497,6 +501,7 @@ export async function runCli(args: string[]): Promise<void> {
       loadUserVaults(repoDir, marker, denoRuntime),
       loadUserDrivers(repoDir, marker, denoRuntime),
       loadUserDatastores(repoDir, marker, denoRuntime),
+      loadUserReports(repoDir, marker, denoRuntime),
     ]);
   }
 
@@ -531,6 +536,7 @@ export async function runCli(args: string[]): Promise<void> {
           vaultsDir,
           driversDir: resolveDriversDir(marker),
           datastoresDir: resolveDatastoresDir(marker),
+          reportsDir: resolveReportsDir(marker),
           repoDir,
           denoRuntime,
         }),
@@ -609,7 +615,8 @@ export async function runCli(args: string[]): Promise<void> {
     .command("auth", authCommand)
     .command("extension", extensionCommand)
     .command("summarise", summariseCommand)
-    .command("datastore", datastoreCommand);
+    .command("datastore", datastoreCommand)
+    .command("report", reportCommand);
 
   // Register help command last — needs reference to the fully-built CLI tree
   cli.command("help", createHelpCommand(cli));

--- a/src/cli/resolve_extension_files.ts
+++ b/src/cli/resolve_extension_files.ts
@@ -36,6 +36,7 @@ import { resolveVaultsDir } from "./resolve_vaults_dir.ts";
 import { resolveWorkflowsDir } from "./resolve_workflows_dir.ts";
 import { resolveDriversDir } from "./resolve_drivers_dir.ts";
 import { resolveDatastoresDir } from "./resolve_datastores_dir.ts";
+import { resolveReportsDir } from "./resolve_reports_dir.ts";
 
 export interface ResolveExtensionFilesContext {
   repoDir: string;
@@ -59,6 +60,9 @@ export interface ResolvedExtensionFiles {
   datastoresDir: string;
   datastoreEntryPoints: string[];
   allDatastoreFiles: string[];
+  reportsDir: string;
+  reportEntryPoints: string[];
+  allReportFiles: string[];
   workflowFiles: Array<{ sourcePath: string; archiveName: string }>;
   additionalFilePaths: string[];
 }
@@ -95,6 +99,7 @@ export async function resolveExtensionFiles(
   const vaultsDir = resolve(repoDir, resolveVaultsDir(marker));
   const driversDir = resolve(repoDir, resolveDriversDir(marker));
   const datastoresDir = resolve(repoDir, resolveDatastoresDir(marker));
+  const reportsDir = resolve(repoDir, resolveReportsDir(marker));
 
   // 3. Collect model files from manifest
   const modelEntryPoints: string[] = [];
@@ -276,7 +281,31 @@ export async function resolveExtensionFiles(
     allDatastoreFiles.push(...datastoreImportResult.resolvedFiles);
   }
 
-  // 12. Validate additional files
+  // 12. Collect report files from manifest
+  const reportEntryPoints: string[] = [];
+  for (const reportRef of manifest.reports) {
+    const reportPath = resolve(reportsDir, reportRef);
+    try {
+      await Deno.stat(reportPath);
+    } catch {
+      throw new UserError(
+        `Report file not found: ${reportRef} (expected at ${reportPath})`,
+      );
+    }
+    reportEntryPoints.push(reportPath);
+  }
+
+  // 13. Resolve local imports for report entry points
+  const allReportFiles: string[] = [];
+  if (reportEntryPoints.length > 0) {
+    const reportImportResult = await resolveLocalImports(
+      reportEntryPoints,
+      reportsDir,
+    );
+    allReportFiles.push(...reportImportResult.resolvedFiles);
+  }
+
+  // 14. Validate additional files
   const additionalFilePaths: string[] = [];
   for (const af of manifest.additionalFiles) {
     const afPath = resolve(dirname(absoluteManifestPath), af);
@@ -305,6 +334,9 @@ export async function resolveExtensionFiles(
     datastoresDir,
     datastoreEntryPoints,
     allDatastoreFiles,
+    reportsDir,
+    reportEntryPoints,
+    allReportFiles,
     workflowFiles,
     additionalFilePaths,
   };

--- a/src/cli/resolve_reports_dir.ts
+++ b/src/cli/resolve_reports_dir.ts
@@ -1,0 +1,40 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { RepoMarkerData } from "../infrastructure/persistence/repo_marker_repository.ts";
+
+/**
+ * Resolves the reports directory path.
+ * Priority: SWAMP_REPORTS_DIR env var > .swamp.yaml config > default "extensions/reports"
+ */
+export function resolveReportsDir(marker: RepoMarkerData | null): string {
+  // Environment variable takes highest priority
+  const envReportsDir = Deno.env.get("SWAMP_REPORTS_DIR");
+  if (envReportsDir) {
+    return envReportsDir;
+  }
+
+  // Then .swamp.yaml config
+  if (marker?.reportsDir) {
+    return marker.reportsDir;
+  }
+
+  // Default
+  return "extensions/reports";
+}

--- a/src/domain/definitions/definition.ts
+++ b/src/domain/definitions/definition.ts
@@ -22,6 +22,10 @@ import {
   DriverConfigFieldSchema,
   DriverFieldSchema,
 } from "../drivers/driver_config.ts";
+import {
+  type ReportSelection,
+  ReportSelectionSchema,
+} from "../reports/report_selection.ts";
 
 /**
  * Branded type for Definition IDs.
@@ -159,6 +163,7 @@ export const DefinitionSchema = z.object({
   methods: z.record(z.string(), MethodDataSchema).default({}),
   inputs: InputsSchemaSchema,
   checks: CheckSelectionSchema,
+  reports: ReportSelectionSchema,
   driver: DriverFieldSchema,
   driverConfig: DriverConfigFieldSchema,
 });
@@ -190,6 +195,7 @@ export interface CreateDefinitionProps {
   methods?: Record<string, MethodData>;
   inputs?: InputsSchema;
   checks?: CheckSelection;
+  reports?: ReportSelection;
   driver?: string;
   driverConfig?: Record<string, unknown>;
 }
@@ -215,6 +221,7 @@ export class Definition {
     private _methods: Record<string, MethodData>,
     private _inputs: InputsSchema | undefined,
     private _checks: CheckSelection | undefined,
+    private _reports: ReportSelection | undefined,
     readonly driver: string | undefined,
     readonly driverConfig: Record<string, unknown> | undefined,
   ) {}
@@ -240,6 +247,7 @@ export class Definition {
       methods: props.methods ?? {},
       inputs: props.inputs,
       checks: props.checks,
+      reports: props.reports,
       driver: props.driver,
       driverConfig: props.driverConfig,
     });
@@ -255,6 +263,7 @@ export class Definition {
       validated.methods,
       validated.inputs,
       validated.checks,
+      validated.reports,
       validated.driver,
       validated.driverConfig,
     );
@@ -279,6 +288,7 @@ export class Definition {
       validated.methods,
       validated.inputs,
       validated.checks,
+      validated.reports,
       validated.driver,
       validated.driverConfig,
     );
@@ -309,6 +319,7 @@ export class Definition {
       structuredClone(original._methods),
       original._inputs ? structuredClone(original._inputs) : undefined,
       original._checks ? structuredClone(original._checks) : undefined,
+      original._reports ? structuredClone(original._reports) : undefined,
       original.driver,
       original.driverConfig
         ? structuredClone(original.driverConfig)
@@ -349,6 +360,13 @@ export class Definition {
    */
   get checkSelection(): CheckSelection | undefined {
     return this._checks ? structuredClone(this._checks) : undefined;
+  }
+
+  /**
+   * Returns a copy of the report selection (require/skip lists).
+   */
+  get reportSelection(): ReportSelection | undefined {
+    return this._reports ? structuredClone(this._reports) : undefined;
   }
 
   /**
@@ -434,6 +452,7 @@ export class Definition {
       methods: structuredClone(this._methods),
       inputs: this._inputs ? structuredClone(this._inputs) : undefined,
       checks: this._checks ? structuredClone(this._checks) : undefined,
+      reports: this._reports ? structuredClone(this._reports) : undefined,
       driver: this.driver,
       driverConfig: this.driverConfig
         ? structuredClone(this.driverConfig)

--- a/src/domain/definitions/definition_test.ts
+++ b/src/domain/definitions/definition_test.ts
@@ -231,6 +231,7 @@ Deno.test("Definition.toData returns correct structure", () => {
       properties: { name: { type: "string" } },
     },
     checks: undefined,
+    reports: undefined,
     driver: undefined,
     driverConfig: undefined,
   });

--- a/src/domain/extensions/extension_collective_validator.ts
+++ b/src/domain/extensions/extension_collective_validator.ts
@@ -21,7 +21,7 @@ import type { ExtensionContentMetadata } from "./extension_content.ts";
 
 /** A single content item whose collective doesn't match the extension's collective. */
 export interface CollectiveMismatch {
-  kind: "model" | "vault" | "workflow" | "driver" | "datastore";
+  kind: "model" | "vault" | "workflow" | "driver" | "datastore" | "report";
   identifier: string;
   fileName: string;
 }
@@ -97,6 +97,16 @@ export function validateContentCollectives(
         kind: "datastore",
         identifier: datastore.type,
         fileName: datastore.fileName,
+      });
+    }
+  }
+
+  for (const report of contentMetadata.reports) {
+    if (!report.name.startsWith(collectivePrefix)) {
+      mismatches.push({
+        kind: "report",
+        identifier: report.name,
+        fileName: report.fileName,
       });
     }
   }

--- a/src/domain/extensions/extension_collective_validator_test.ts
+++ b/src/domain/extensions/extension_collective_validator_test.ts
@@ -30,6 +30,7 @@ function makeMetadata(
     vaults: [],
     drivers: [],
     datastores: [],
+    reports: [],
     ...overrides,
   };
 }

--- a/src/domain/extensions/extension_content.ts
+++ b/src/domain/extensions/extension_content.ts
@@ -112,11 +112,21 @@ export interface ExtractedDatastore {
   configFields: ExtractedArgument[];
 }
 
-/** Content metadata extracted from all models, workflows, vaults, drivers, and datastores in an extension. */
+/** Metadata extracted from a single report TypeScript file. */
+export interface ExtractedReport {
+  fileName: string;
+  name: string;
+  description: string;
+  scope: string;
+  labels: string[];
+}
+
+/** Content metadata extracted from all models, workflows, vaults, drivers, datastores, and reports in an extension. */
 export interface ExtensionContentMetadata {
   models: ExtractedModel[];
   workflows: ExtractedWorkflow[];
   vaults: ExtractedVault[];
   drivers: ExtractedDriver[];
   datastores: ExtractedDatastore[];
+  reports: ExtractedReport[];
 }

--- a/src/domain/extensions/extension_content_extractor.ts
+++ b/src/domain/extensions/extension_content_extractor.ts
@@ -27,6 +27,7 @@ import type {
   ExtractedFile,
   ExtractedMethod,
   ExtractedModel,
+  ExtractedReport,
   ExtractedResource,
   ExtractedVault,
   ExtractedWorkflow,
@@ -53,12 +54,15 @@ export async function extractContentMetadata(
   driversDir = "",
   datastoreFiles: string[] = [],
   datastoresDir = "",
+  reportFiles: string[] = [],
+  reportsDir = "",
 ): Promise<ExtensionContentMetadata> {
   const models: ExtractedModel[] = [];
   const workflows: ExtractedWorkflow[] = [];
   const vaults: ExtractedVault[] = [];
   const drivers: ExtractedDriver[] = [];
   const datastores: ExtractedDatastore[] = [];
+  const reports: ExtractedReport[] = [];
 
   for (const filePath of modelFiles) {
     try {
@@ -124,7 +128,19 @@ export async function extractContentMetadata(
     }
   }
 
-  return { models, workflows, vaults, drivers, datastores };
+  for (const filePath of reportFiles) {
+    try {
+      const content = await Deno.readTextFile(filePath);
+      const report = extractReportFromSource(content, filePath, reportsDir);
+      if (report) {
+        reports.push(report);
+      }
+    } catch {
+      // Non-fatal: skip files that can't be read or parsed
+    }
+  }
+
+  return { models, workflows, vaults, drivers, datastores, reports };
 }
 
 /**
@@ -767,6 +783,56 @@ function extractDatastoreFromSource(
     description: descMatch ? (descMatch[1] ?? descMatch[2] ?? "") : "",
     hasConfigSchema,
     configFields,
+  };
+}
+
+/**
+ * Extracts report metadata from a TypeScript source file.
+ * Returns null if the file doesn't contain a recognizable report definition.
+ * Uses `execute` as the discriminator combined with `export const report`.
+ */
+function extractReportFromSource(
+  content: string,
+  filePath: string,
+  reportsDir: string,
+): ExtractedReport | null {
+  const reportMatch = content.match(/export\s+const\s+report\s*=\s*\{/);
+  if (!reportMatch || reportMatch.index === undefined) return null;
+
+  // Must contain execute to be a report file
+  if (!/execute/.test(content)) return null;
+
+  const reportStart = reportMatch.index + reportMatch[0].length;
+  const reportBody = extractBalancedBraces(content, reportStart);
+  if (!reportBody) return null;
+
+  const nameMatch = reportBody.match(/(?<![.\w])name:\s*["']([^"']+)["']/);
+  if (!nameMatch) return null;
+
+  const descMatch = reportBody.match(
+    /(?<![.\w])description:\s*(?:"([^"]*?)"|'([^']*?)')/,
+  );
+
+  const scopeMatch = reportBody.match(/(?<![.\w])scope:\s*["']([^"']+)["']/);
+
+  // Extract labels array
+  const labels: string[] = [];
+  const labelsMatch = reportBody.match(/(?<![.\w])labels:\s*\[([^\]]*)\]/);
+  if (labelsMatch) {
+    const labelsContent = labelsMatch[1];
+    const labelPattern = /["']([^"']+)["']/g;
+    let labelMatch;
+    while ((labelMatch = labelPattern.exec(labelsContent)) !== null) {
+      labels.push(labelMatch[1]);
+    }
+  }
+
+  return {
+    fileName: relative(reportsDir, filePath),
+    name: nameMatch[1],
+    description: descMatch ? (descMatch[1] ?? descMatch[2] ?? "") : "",
+    scope: scopeMatch ? scopeMatch[1] : "",
+    labels,
   };
 }
 

--- a/src/domain/extensions/extension_content_extractor_test.ts
+++ b/src/domain/extensions/extension_content_extractor_test.ts
@@ -30,6 +30,7 @@ Deno.test("extractContentMetadata returns empty for no inputs", async () => {
     vaults: [],
     drivers: [],
     datastores: [],
+    reports: [],
   });
 });
 

--- a/src/domain/extensions/extension_manifest.ts
+++ b/src/domain/extensions/extension_manifest.ts
@@ -44,6 +44,7 @@ const ExtensionManifestSchemaV1 = z.object({
   vaults: z.array(z.string()).optional(),
   drivers: z.array(z.string()).optional(),
   datastores: z.array(z.string()).optional(),
+  reports: z.array(z.string()).optional(),
   additionalFiles: z.array(z.string()).optional(),
   platforms: z.array(z.string().min(1)).optional(),
   labels: z.array(z.string().min(1)).optional(),
@@ -59,7 +60,8 @@ const ExtensionManifestSchemaV1 = z.object({
     (data.workflows && data.workflows.length > 0) ||
     (data.vaults && data.vaults.length > 0) ||
     (data.drivers && data.drivers.length > 0) ||
-    (data.datastores && data.datastores.length > 0),
+    (data.datastores && data.datastores.length > 0) ||
+    (data.reports && data.reports.length > 0),
   {
     message:
       "Extension must include at least one model, workflow, vault, driver, or datastore",
@@ -78,6 +80,7 @@ export interface ExtensionManifest {
   vaults: string[];
   drivers: string[];
   datastores: string[];
+  reports: string[];
   additionalFiles: string[];
   platforms: string[];
   labels: string[];
@@ -135,6 +138,7 @@ export function parseExtensionManifest(content: string): ExtensionManifest {
     vaults: result.data.vaults ?? [],
     drivers: result.data.drivers ?? [],
     datastores: result.data.datastores ?? [],
+    reports: result.data.reports ?? [],
     additionalFiles: result.data.additionalFiles ?? [],
     platforms: result.data.platforms ?? [],
     labels: result.data.labels ?? [],

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -292,6 +292,17 @@ export interface MethodContext {
   skipCheckLabels?: string[];
   /** Skip all pre-flight checks. */
   skipAllChecks?: boolean;
+
+  /** Report names to skip during post-run reports. */
+  skipReportNames?: string[];
+  /** Skip reports that have any of these labels. */
+  skipReportLabels?: string[];
+  /** Skip all post-run reports. */
+  skipAllReports?: boolean;
+  /** Only run these specific reports (inclusion filter). */
+  reportNames?: string[];
+  /** Only run reports matching these labels (inclusion filter). */
+  reportLabels?: string[];
 }
 
 /**
@@ -591,6 +602,12 @@ export interface ModelDefinition<
   checks?: Record<string, CheckDefinition>;
 
   /**
+   * Names of standalone reports that are defaults for this model type.
+   * Reports are registered independently via UserReportLoader.
+   */
+  reports?: string[];
+
+  /**
    * Ordered list of upgrade functions for migrating definitions between versions.
    * Each entry transforms attributes from the previous version to `toVersion`.
    * Must be ordered chronologically by `toVersion`.
@@ -686,6 +703,7 @@ export class ModelRegistry {
     type: string | ModelType,
     methods: Record<string, MethodDefinition>,
     checks?: Record<string, CheckDefinition>,
+    reports?: string[],
   ): void {
     const modelType = typeof type === "string" ? ModelType.create(type) : type;
     const key = modelType.normalized;
@@ -721,6 +739,14 @@ export class ModelRegistry {
       methods: { ...existing.methods, ...methods },
       ...(checks || existing.checks
         ? { checks: { ...(existing.checks ?? {}), ...(checks ?? {}) } }
+        : {}),
+      ...(reports || existing.reports
+        ? {
+          reports: [
+            ...(existing.reports ?? []),
+            ...(reports ?? []),
+          ],
+        }
         : {}),
     };
 

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -132,6 +132,7 @@ const UserModelSchema = z.object({
   methods: z.record(z.string(), UserMethodSchema),
   checks: z.record(z.string(), UserCheckSchema).optional(),
   upgrades: z.array(UserUpgradeSchema).optional(),
+  reports: z.array(z.string()).optional(),
 });
 
 /**
@@ -717,6 +718,7 @@ export class UserModelLoader {
       methods,
       ...(checks ? { checks } : {}),
       ...(upgrades && upgrades.length > 0 ? { upgrades } : {}),
+      ...(userModel.reports ? { reports: userModel.reports } : {}),
     };
   }
 

--- a/src/domain/reports/mod.ts
+++ b/src/domain/reports/mod.ts
@@ -1,0 +1,41 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+export type { ReportDefinition, ReportResult, ReportScope } from "./report.ts";
+export type {
+  MethodReportContext,
+  ModelReportContext,
+  ReportContext,
+  WorkflowReportContext,
+} from "./report_context.ts";
+export { ReportRegistry, reportRegistry } from "./report_registry.ts";
+export {
+  type ReportRef,
+  type ReportSelection,
+  ReportSelectionSchema,
+} from "./report_selection.ts";
+export {
+  executeReports,
+  filterReports,
+  type ReportEventCallback,
+  type ReportExecutionResult,
+  type ReportExecutionSummary,
+  type ReportFilterOptions,
+} from "./report_execution_service.ts";
+export { buildReportDataHandles } from "./report_data_handles.ts";

--- a/src/domain/reports/report.ts
+++ b/src/domain/reports/report.ts
@@ -1,0 +1,49 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ReportContext } from "./report_context.ts";
+
+/**
+ * The scope at which a report operates.
+ */
+export type ReportScope = "method" | "model" | "workflow";
+
+/**
+ * The result produced by a report execution.
+ */
+export interface ReportResult {
+  /** Human-readable markdown content. */
+  markdown: string;
+  /** Machine-readable structured data. */
+  json: Record<string, unknown>;
+}
+
+/**
+ * Definition of a report that can be registered and executed.
+ */
+export interface ReportDefinition {
+  /** Human-readable description of what the report produces. */
+  description: string;
+  /** The scope at which this report operates. */
+  scope: ReportScope;
+  /** Labels for filtering (e.g., ["cost", "finops"]). */
+  labels?: string[];
+  /** Execute the report and produce results. */
+  execute(context: ReportContext): Promise<ReportResult>;
+}

--- a/src/domain/reports/report_context.ts
+++ b/src/domain/reports/report_context.ts
@@ -1,0 +1,105 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { Logger } from "@logtape/logtape";
+import type { ModelType } from "../models/model_type.ts";
+import type { DataHandle } from "../models/model.ts";
+import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import type { DefinitionRepository } from "../definitions/repositories.ts";
+
+/**
+ * Base fields shared by all report contexts.
+ */
+interface BaseReportContext {
+  repoDir: string;
+  logger: Logger;
+  dataRepository: UnifiedDataRepository;
+  definitionRepository: DefinitionRepository;
+}
+
+/**
+ * Context provided to method-scope reports.
+ */
+export interface MethodReportContext extends BaseReportContext {
+  scope: "method";
+  modelType: ModelType;
+  modelId: string;
+  definition: {
+    id: string;
+    name: string;
+    version: number;
+    tags: Record<string, string>;
+  };
+  globalArgs: Record<string, unknown>;
+  methodArgs: Record<string, unknown>;
+  methodName: string;
+  executionStatus: "succeeded" | "failed";
+  dataHandles: DataHandle[];
+}
+
+/**
+ * Context provided to model-scope reports.
+ */
+export interface ModelReportContext extends BaseReportContext {
+  scope: "model";
+  modelType: ModelType;
+  modelId: string;
+  definition: {
+    id: string;
+    name: string;
+    version: number;
+    tags: Record<string, string>;
+  };
+  globalArgs: Record<string, unknown>;
+  methodArgs: Record<string, unknown>;
+  methodName: string;
+  executionStatus: "succeeded" | "failed";
+  dataHandles: DataHandle[];
+}
+
+/**
+ * Context provided to workflow-scope reports.
+ */
+export interface WorkflowReportContext extends BaseReportContext {
+  scope: "workflow";
+  workflowId: string;
+  workflowRunId: string;
+  workflowName: string;
+  workflowStatus: "succeeded" | "failed";
+  stepExecutions: Array<{
+    jobName: string;
+    stepName: string;
+    modelName: string;
+    modelType: string;
+    methodName: string;
+    status: "succeeded" | "failed" | "skipped";
+    dataHandles: DataHandle[];
+    methodArgs: Record<string, unknown>;
+    modelId: string;
+    globalArgs: Record<string, unknown>;
+  }>;
+}
+
+/**
+ * Discriminated union of all report context types.
+ */
+export type ReportContext =
+  | MethodReportContext
+  | ModelReportContext
+  | WorkflowReportContext;

--- a/src/domain/reports/report_data_handles.ts
+++ b/src/domain/reports/report_data_handles.ts
@@ -1,0 +1,67 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { Data } from "../data/data.ts";
+import type { DataHandle } from "../models/model.ts";
+import type { ModelType } from "../models/model_type.ts";
+
+/**
+ * Narrow interface for the data repository dependency.
+ * Avoids importing the infrastructure layer directly.
+ */
+interface DataRepository {
+  findAllForModel(type: ModelType, modelId: string): Promise<Data[]>;
+}
+
+/**
+ * Builds DataHandle[] from persisted data for a given model.
+ *
+ * This is the single source of truth for report data handles across all
+ * invocation paths (model run, standalone report, workflow post-run).
+ * By reading from the data repository, reports get full metadata
+ * (contentType, lifetime, etc.) rather than hollow reconstructions.
+ */
+export async function buildReportDataHandles(
+  dataRepo: DataRepository,
+  modelType: ModelType,
+  modelId: string,
+): Promise<DataHandle[]> {
+  const allData = await dataRepo.findAllForModel(modelType, modelId);
+  return allData
+    .filter((d) => d.lifecycle === "active")
+    .map((d) => ({
+      name: d.name,
+      specName: d.tags["specName"] ?? d.name,
+      kind: (d.tags["type"] === "file" ? "file" : "resource") as
+        | "resource"
+        | "file",
+      dataId: d.id,
+      version: d.version,
+      size: d.size ?? 0,
+      tags: d.tags,
+      metadata: {
+        contentType: d.contentType,
+        lifetime: d.lifetime,
+        garbageCollection: d.garbageCollection,
+        streaming: d.streaming,
+        tags: d.tags,
+        ownerDefinition: d.ownerDefinition,
+      } as DataHandle["metadata"],
+    }));
+}

--- a/src/domain/reports/report_data_handles_test.ts
+++ b/src/domain/reports/report_data_handles_test.ts
@@ -1,0 +1,132 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { buildReportDataHandles } from "./report_data_handles.ts";
+import { Data } from "../data/data.ts";
+import { ModelType } from "../models/model_type.ts";
+import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+
+function makeData(overrides: {
+  name?: string;
+  lifecycle?: "active" | "deleted";
+  tags?: Record<string, string>;
+  contentType?: string;
+  size?: number;
+}): Data {
+  return Data.create({
+    name: overrides.name ?? "my-resource",
+    contentType: overrides.contentType ?? "application/json",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: overrides.tags ?? { type: "resource", specName: "my-spec" },
+    ownerDefinition: { ownerType: "model-method", ownerRef: "test:run" },
+    lifecycle: overrides.lifecycle ?? "active",
+    size: overrides.size ?? 42,
+  });
+}
+
+function makeMockRepo(data: Data[]): UnifiedDataRepository {
+  return {
+    findAllForModel: () => Promise.resolve(data),
+  } as unknown as UnifiedDataRepository;
+}
+
+const modelType = ModelType.create("test/model");
+const modelId = "def-123";
+
+Deno.test("buildReportDataHandles - maps active data to DataHandle[]", async () => {
+  const data = makeData({
+    name: "my-resource",
+    tags: { type: "resource", specName: "my-spec" },
+    contentType: "application/json",
+    size: 100,
+  });
+  const repo = makeMockRepo([data]);
+
+  const handles = await buildReportDataHandles(repo, modelType, modelId);
+
+  assertEquals(handles.length, 1);
+  assertEquals(handles[0].name, "my-resource");
+  assertEquals(handles[0].specName, "my-spec");
+  assertEquals(handles[0].kind, "resource");
+  assertEquals(handles[0].version, 1);
+  assertEquals(handles[0].size, 100);
+  assertEquals(handles[0].metadata.contentType, "application/json");
+  assertEquals(handles[0].metadata.lifetime, "infinite");
+});
+
+Deno.test("buildReportDataHandles - filters out deleted data", async () => {
+  const active = makeData({ name: "active", lifecycle: "active" });
+  const deleted = makeData({ name: "deleted", lifecycle: "deleted" });
+  const repo = makeMockRepo([active, deleted]);
+
+  const handles = await buildReportDataHandles(repo, modelType, modelId);
+
+  assertEquals(handles.length, 1);
+  assertEquals(handles[0].name, "active");
+});
+
+Deno.test("buildReportDataHandles - sets kind to file when type tag is file", async () => {
+  const data = makeData({
+    tags: { type: "file", specName: "my-file" },
+  });
+  const repo = makeMockRepo([data]);
+
+  const handles = await buildReportDataHandles(repo, modelType, modelId);
+
+  assertEquals(handles[0].kind, "file");
+  assertEquals(handles[0].specName, "my-file");
+});
+
+Deno.test("buildReportDataHandles - falls back to name when specName tag is missing", async () => {
+  const data = makeData({
+    name: "fallback-name",
+    tags: { type: "resource" },
+  });
+  const repo = makeMockRepo([data]);
+
+  const handles = await buildReportDataHandles(repo, modelType, modelId);
+
+  assertEquals(handles[0].specName, "fallback-name");
+});
+
+Deno.test("buildReportDataHandles - returns empty array when no data exists", async () => {
+  const repo = makeMockRepo([]);
+
+  const handles = await buildReportDataHandles(repo, modelType, modelId);
+
+  assertEquals(handles, []);
+});
+
+Deno.test("buildReportDataHandles - defaults size to 0 when undefined", async () => {
+  const data = Data.create({
+    name: "no-size",
+    contentType: "application/json",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: { type: "resource" },
+    ownerDefinition: { ownerType: "model-method", ownerRef: "test:run" },
+  });
+  const repo = makeMockRepo([data]);
+
+  const handles = await buildReportDataHandles(repo, modelType, modelId);
+
+  assertEquals(handles[0].size, 0);
+});

--- a/src/domain/reports/report_execution_service.ts
+++ b/src/domain/reports/report_execution_service.ts
@@ -1,0 +1,364 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ReportDefinition, ReportScope } from "./report.ts";
+import type { ReportContext } from "./report_context.ts";
+import type { ReportRef, ReportSelection } from "./report_selection.ts";
+import type { ReportRegistry } from "./report_registry.ts";
+import type { DataHandle } from "../models/model.ts";
+import type { ModelType } from "../models/model_type.ts";
+import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { DefaultDataWriter } from "../models/data_writer.ts";
+
+/**
+ * Options for filtering which reports to execute.
+ */
+export interface ReportFilterOptions {
+  /** Skip all reports. */
+  skipAllReports?: boolean;
+  /** Skip specific reports by name. */
+  skipReportNames?: string[];
+  /** Skip reports matching these labels. */
+  skipReportLabels?: string[];
+  /** Only run these specific reports (inclusion filter). */
+  reportNames?: string[];
+  /** Only run reports matching these labels (inclusion filter). */
+  reportLabels?: string[];
+}
+
+/**
+ * Result of a single report execution.
+ */
+export interface ReportExecutionResult {
+  name: string;
+  scope: ReportScope;
+  success: boolean;
+  markdown?: string;
+  json?: Record<string, unknown>;
+  dataHandles?: DataHandle[];
+  error?: string;
+}
+
+/**
+ * Result of executing all applicable reports.
+ */
+export interface ReportExecutionSummary {
+  results: ReportExecutionResult[];
+  failures: number;
+}
+
+/**
+ * Gets the name from a ReportRef.
+ */
+function getReportRefName(ref: ReportRef): string {
+  return typeof ref === "string" ? ref : ref.name;
+}
+
+/**
+ * Gets the method scoping from a ReportRef (undefined = all methods).
+ */
+function getReportRefMethods(ref: ReportRef): string[] | undefined {
+  return typeof ref === "string" ? undefined : ref.methods;
+}
+
+/**
+ * Filters reports based on selection rules and CLI flags.
+ *
+ * Filtering logic:
+ * 1. Build candidate set from model-type defaults + selection.require
+ * 2. Definition/workflow-level skip always wins
+ * 3. Respect YAML method scoping
+ * 4. Required reports immune to CLI skip flags
+ * 5. Honor CLI: --skip-reports, --skip-report, --skip-report-label
+ * 6. Inclusion filters: --report, --report-label
+ *
+ * When `modelTypeReports` is provided (method/model scope), the candidate set
+ * is reports whose name appears in modelTypeReports OR in selection.require.
+ * When `modelTypeReports` is undefined (workflow scope), the candidate set
+ * is reports in selection.require only.
+ */
+export function filterReports(
+  reports: Array<{ name: string; report: ReportDefinition }>,
+  scope: ReportScope,
+  selection: ReportSelection | undefined,
+  filterOptions: ReportFilterOptions,
+  methodName?: string,
+  modelTypeReports?: string[],
+): Array<{ name: string; report: ReportDefinition }> {
+  const requiredRefs = selection?.require ?? [];
+  const requiredNames = new Set(requiredRefs.map(getReportRefName));
+
+  // Build the candidate set: model-type defaults + require
+  // When modelTypeReports is provided (method/model scope), candidates are
+  // reports in modelTypeReports OR in selection.require.
+  // When modelTypeReports is undefined (workflow scope), candidates are
+  // reports in selection.require only.
+  const candidateNames = new Set<string>(requiredNames);
+  if (modelTypeReports) {
+    for (const name of modelTypeReports) {
+      candidateNames.add(name);
+    }
+  }
+
+  if (filterOptions.skipAllReports) {
+    // Still allow required reports through
+    return reports.filter(({ name, report }) =>
+      report.scope === scope && requiredNames.has(name) &&
+      candidateNames.has(name)
+    );
+  }
+
+  const skippedNames = new Set(selection?.skip ?? []);
+
+  // Build method scoping map from required refs
+  const methodScopingMap = new Map<string, string[] | undefined>();
+  for (const ref of requiredRefs) {
+    methodScopingMap.set(getReportRefName(ref), getReportRefMethods(ref));
+  }
+
+  return reports.filter(({ name, report }) => {
+    // Only include reports matching the requested scope
+    if (report.scope !== scope) return false;
+
+    // Only include candidates (model-type defaults + require)
+    if (!candidateNames.has(name)) return false;
+
+    // Definition-level skip always wins
+    if (skippedNames.has(name)) return false;
+
+    // Respect method scoping from YAML
+    if (methodName && methodScopingMap.has(name)) {
+      const methods = methodScopingMap.get(name);
+      if (methods && !methods.includes(methodName)) return false;
+    }
+
+    // Required reports are immune to CLI skip flags
+    if (requiredNames.has(name)) return true;
+
+    // CLI skip by name
+    if (filterOptions.skipReportNames?.includes(name)) return false;
+
+    // CLI skip by label
+    if (
+      filterOptions.skipReportLabels &&
+      report.labels?.some((l) => filterOptions.skipReportLabels!.includes(l))
+    ) {
+      return false;
+    }
+
+    // Inclusion filters (narrow to subset)
+    if (filterOptions.reportNames && filterOptions.reportNames.length > 0) {
+      if (!filterOptions.reportNames.includes(name)) return false;
+    }
+    if (filterOptions.reportLabels && filterOptions.reportLabels.length > 0) {
+      if (
+        !report.labels?.some((l) => filterOptions.reportLabels!.includes(l))
+      ) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
+
+/**
+ * Sanitizes a report name for use as a data name component.
+ *
+ * Report names use the `@collective/name` scoped pattern, but data names
+ * reject `/`, `\`, `..`, and null bytes as path traversal risks.
+ * Follows the same pattern as `sanitizeVaultKey` in `data_writer.ts`.
+ */
+export function sanitizeReportNameForData(reportName: string): string {
+  return reportName
+    .replace(/@/g, "")
+    .replace(/[/\\]/g, "-")
+    .replace(/\.\./g, ".")
+    .replace(/\0/g, "");
+}
+
+/**
+ * Persists report results as data artifacts.
+ *
+ * Stores two artifacts per report:
+ * - Markdown: data name `report-{reportName}`, contentType `text/markdown`
+ * - JSON: data name `report-{reportName}-json`, contentType `application/json`
+ */
+async function persistReportData(
+  repo: UnifiedDataRepository,
+  modelType: ModelType,
+  modelId: string,
+  reportName: string,
+  scope: ReportScope,
+  markdown: string,
+  json: Record<string, unknown>,
+  varySuffix?: string,
+): Promise<DataHandle[]> {
+  const handles: DataHandle[] = [];
+  const tags: Record<string, string> = {
+    type: "report",
+    reportName,
+    reportScope: scope,
+    ...(varySuffix ? { varySuffix } : {}),
+  };
+
+  const sanitized = sanitizeReportNameForData(reportName);
+  const baseName = varySuffix
+    ? `report-${sanitized}-${varySuffix}`
+    : `report-${sanitized}`;
+
+  // Persist markdown artifact
+  const mdWriter = new DefaultDataWriter(
+    repo,
+    modelType,
+    modelId,
+    {
+      name: baseName,
+      specName: "report",
+      kind: "file",
+      contentType: "text/markdown",
+      lifetime: "30d",
+      garbageCollection: 5,
+      tags: { ...tags },
+    },
+  );
+  const mdHandle = await mdWriter.writeText(markdown);
+  handles.push(mdHandle);
+
+  // Persist JSON artifact
+  const jsonWriter = new DefaultDataWriter(
+    repo,
+    modelType,
+    modelId,
+    {
+      name: `${baseName}-json`,
+      specName: "report",
+      kind: "file",
+      contentType: "application/json",
+      lifetime: "30d",
+      garbageCollection: 5,
+      tags: { ...tags },
+    },
+  );
+  const jsonHandle = await jsonWriter.writeText(JSON.stringify(json, null, 2));
+  handles.push(jsonHandle);
+
+  return handles;
+}
+
+/**
+ * Event callback for report execution progress.
+ */
+export interface ReportEventCallback {
+  onReportStarted(reportName: string, scope: ReportScope): void;
+  onReportCompleted(
+    reportName: string,
+    scope: ReportScope,
+    markdown: string,
+    json: Record<string, unknown>,
+    dataHandles: DataHandle[],
+  ): void;
+  onReportFailed(reportName: string, scope: ReportScope, error: string): void;
+}
+
+/**
+ * Executes applicable reports and persists their results.
+ */
+export async function executeReports(
+  registry: ReportRegistry,
+  context: ReportContext,
+  modelType: ModelType,
+  modelId: string,
+  selection: ReportSelection | undefined,
+  filterOptions: ReportFilterOptions,
+  events?: ReportEventCallback,
+  methodName?: string,
+  modelTypeReports?: string[],
+  varySuffix?: string,
+): Promise<ReportExecutionSummary> {
+  const allReports = registry.getAll();
+  const applicable = filterReports(
+    allReports,
+    context.scope,
+    selection,
+    filterOptions,
+    methodName,
+    modelTypeReports,
+  );
+
+  if (applicable.length === 0) {
+    return { results: [], failures: 0 };
+  }
+
+  const results: ReportExecutionResult[] = [];
+  let failures = 0;
+
+  for (const { name, report } of applicable) {
+    events?.onReportStarted(name, report.scope);
+
+    try {
+      const result = await report.execute(context);
+
+      // Persist results
+      const dataHandles = await persistReportData(
+        context.dataRepository,
+        modelType,
+        modelId,
+        name,
+        report.scope,
+        result.markdown,
+        result.json,
+        varySuffix,
+      );
+
+      events?.onReportCompleted(
+        name,
+        report.scope,
+        result.markdown,
+        result.json,
+        dataHandles,
+      );
+
+      results.push({
+        name,
+        scope: report.scope,
+        success: true,
+        markdown: result.markdown,
+        json: result.json,
+        dataHandles,
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error
+        ? error.message
+        : String(error);
+
+      events?.onReportFailed(name, report.scope, errorMessage);
+
+      results.push({
+        name,
+        scope: report.scope,
+        success: false,
+        error: errorMessage,
+      });
+      failures++;
+    }
+  }
+
+  return { results, failures };
+}

--- a/src/domain/reports/report_execution_service_test.ts
+++ b/src/domain/reports/report_execution_service_test.ts
@@ -1,0 +1,731 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  executeReports,
+  filterReports,
+  sanitizeReportNameForData,
+} from "./report_execution_service.ts";
+import type { ReportDefinition } from "./report.ts";
+import type { ReportContext } from "./report_context.ts";
+import type { ReportSelection } from "./report_selection.ts";
+import type { ReportFilterOptions } from "./report_execution_service.ts";
+import { ReportRegistry } from "./report_registry.ts";
+import type { MethodReportContext } from "./report_context.ts";
+import { ModelType } from "../models/model_type.ts";
+import type { DataHandle } from "../models/model.ts";
+import { generateDataId } from "../data/mod.ts";
+
+function makeReport(
+  scope: "method" | "model" | "workflow" = "method",
+  labels?: string[],
+): ReportDefinition {
+  return {
+    description: `Test ${scope} report`,
+    scope,
+    labels,
+    execute(_context: ReportContext) {
+      return Promise.resolve({ markdown: "# Test", json: { test: true } });
+    },
+  };
+}
+
+function makeReportEntry(
+  name: string,
+  scope: "method" | "model" | "workflow" = "method",
+  labels?: string[],
+) {
+  return { name, report: makeReport(scope, labels) };
+}
+
+Deno.test("filterReports - returns model-type default reports when provided", () => {
+  const reports = [
+    makeReportEntry("a", "method"),
+    makeReportEntry("b", "method"),
+  ];
+  const result = filterReports(
+    reports,
+    "method",
+    undefined,
+    {},
+    undefined,
+    ["a", "b"],
+  );
+  assertEquals(result.length, 2);
+});
+
+Deno.test("filterReports - only model-type defaults are candidates", () => {
+  const reports = [
+    makeReportEntry("a", "method"),
+    makeReportEntry("b", "method"),
+    makeReportEntry("c", "method"),
+  ];
+  // Only "a" and "b" are model-type defaults, "c" should be excluded
+  const result = filterReports(
+    reports,
+    "method",
+    undefined,
+    {},
+    undefined,
+    ["a", "b"],
+  );
+  assertEquals(result.length, 2);
+  assertEquals(result.map((r) => r.name).sort(), ["a", "b"]);
+});
+
+Deno.test("filterReports - without modelTypeReports only require are candidates", () => {
+  const reports = [
+    makeReportEntry("a", "method"),
+    makeReportEntry("b", "method"),
+  ];
+  // No model-type defaults and no require = no candidates (workflow scope behavior)
+  const result = filterReports(reports, "method", undefined, {});
+  assertEquals(result.length, 0);
+});
+
+Deno.test("filterReports - require adds to candidates without modelTypeReports", () => {
+  const reports = [
+    makeReportEntry("a", "method"),
+    makeReportEntry("b", "method"),
+  ];
+  const selection: ReportSelection = {
+    require: ["a"],
+  };
+  // Only "a" is in require, so only "a" is a candidate
+  const result = filterReports(reports, "method", selection, {});
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "a");
+});
+
+Deno.test("filterReports - filters by scope", () => {
+  const reports = [
+    makeReportEntry("a", "method"),
+    makeReportEntry("b", "model"),
+    makeReportEntry("c", "workflow"),
+  ];
+  const result = filterReports(
+    reports,
+    "method",
+    undefined,
+    {},
+    undefined,
+    ["a", "b", "c"],
+  );
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "a");
+});
+
+Deno.test("filterReports - definition-level skip always wins", () => {
+  const reports = [
+    makeReportEntry("a", "method"),
+    makeReportEntry("b", "method"),
+  ];
+  const selection: ReportSelection = {
+    skip: ["a"],
+  };
+  const result = filterReports(
+    reports,
+    "method",
+    selection,
+    {},
+    undefined,
+    ["a", "b"],
+  );
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "b");
+});
+
+Deno.test("filterReports - definition-level skip wins over require", () => {
+  const reports = [
+    makeReportEntry("a", "method"),
+  ];
+  const selection: ReportSelection = {
+    require: ["a"],
+    skip: ["a"],
+  };
+  const result = filterReports(
+    reports,
+    "method",
+    selection,
+    {},
+    undefined,
+    ["a"],
+  );
+  assertEquals(result.length, 0);
+});
+
+Deno.test("filterReports - required reports immune to CLI skip flags", () => {
+  const reports = [
+    makeReportEntry("a", "method", ["cost"]),
+    makeReportEntry("b", "method", ["cost"]),
+  ];
+  const selection: ReportSelection = {
+    require: ["a"],
+  };
+  const filter: ReportFilterOptions = {
+    skipReportNames: ["a"],
+    skipReportLabels: ["cost"],
+  };
+  const result = filterReports(
+    reports,
+    "method",
+    selection,
+    filter,
+    undefined,
+    ["a", "b"],
+  );
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "a");
+});
+
+Deno.test("filterReports - skipAllReports still allows required", () => {
+  const reports = [
+    makeReportEntry("a", "method"),
+    makeReportEntry("b", "method"),
+  ];
+  const selection: ReportSelection = {
+    require: ["a"],
+  };
+  const filter: ReportFilterOptions = {
+    skipAllReports: true,
+  };
+  const result = filterReports(
+    reports,
+    "method",
+    selection,
+    filter,
+    undefined,
+    ["a", "b"],
+  );
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "a");
+});
+
+Deno.test("filterReports - CLI skip by name", () => {
+  const reports = [
+    makeReportEntry("a", "method"),
+    makeReportEntry("b", "method"),
+  ];
+  const filter: ReportFilterOptions = {
+    skipReportNames: ["a"],
+  };
+  const result = filterReports(
+    reports,
+    "method",
+    undefined,
+    filter,
+    undefined,
+    ["a", "b"],
+  );
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "b");
+});
+
+Deno.test("filterReports - CLI skip by label", () => {
+  const reports = [
+    makeReportEntry("a", "method", ["cost"]),
+    makeReportEntry("b", "method", ["audit"]),
+  ];
+  const filter: ReportFilterOptions = {
+    skipReportLabels: ["cost"],
+  };
+  const result = filterReports(
+    reports,
+    "method",
+    undefined,
+    filter,
+    undefined,
+    ["a", "b"],
+  );
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "b");
+});
+
+Deno.test("filterReports - inclusion filter by name", () => {
+  const reports = [
+    makeReportEntry("a", "method"),
+    makeReportEntry("b", "method"),
+    makeReportEntry("c", "method"),
+  ];
+  const filter: ReportFilterOptions = {
+    reportNames: ["b"],
+  };
+  const result = filterReports(
+    reports,
+    "method",
+    undefined,
+    filter,
+    undefined,
+    ["a", "b", "c"],
+  );
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "b");
+});
+
+Deno.test("filterReports - inclusion filter by label", () => {
+  const reports = [
+    makeReportEntry("a", "method", ["cost"]),
+    makeReportEntry("b", "method", ["audit"]),
+    makeReportEntry("c", "method", ["cost", "audit"]),
+  ];
+  const filter: ReportFilterOptions = {
+    reportLabels: ["cost"],
+  };
+  const result = filterReports(
+    reports,
+    "method",
+    undefined,
+    filter,
+    undefined,
+    ["a", "b", "c"],
+  );
+  assertEquals(result.length, 2);
+  assertEquals(result.map((r) => r.name).sort(), ["a", "c"]);
+});
+
+Deno.test("filterReports - method scoping from YAML", () => {
+  const reports = [
+    makeReportEntry("a", "method"),
+    makeReportEntry("b", "method"),
+  ];
+  const selection: ReportSelection = {
+    require: [
+      { name: "a", methods: ["create", "update"] },
+      "b",
+    ],
+  };
+  // Running "delete" method - "a" should be excluded, "b" included
+  const result = filterReports(
+    reports,
+    "method",
+    selection,
+    {},
+    "delete",
+    ["a", "b"],
+  );
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "b");
+});
+
+Deno.test("filterReports - method scoping includes matching method", () => {
+  const reports = [
+    makeReportEntry("a", "method"),
+  ];
+  const selection: ReportSelection = {
+    require: [{ name: "a", methods: ["create", "update"] }],
+  };
+  const result = filterReports(
+    reports,
+    "method",
+    selection,
+    {},
+    "create",
+    ["a"],
+  );
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "a");
+});
+
+Deno.test("filterReports - require adds reports beyond model-type defaults", () => {
+  const reports = [
+    makeReportEntry("a", "method"),
+    makeReportEntry("b", "method"),
+    makeReportEntry("c", "method"),
+  ];
+  const selection: ReportSelection = {
+    require: ["c"],
+  };
+  // Model-type defaults are "a" and "b", require adds "c"
+  const result = filterReports(
+    reports,
+    "method",
+    selection,
+    {},
+    undefined,
+    ["a", "b"],
+  );
+  assertEquals(result.length, 3);
+  assertEquals(result.map((r) => r.name).sort(), ["a", "b", "c"]);
+});
+
+Deno.test("filterReports - skip removes from model-type defaults", () => {
+  const reports = [
+    makeReportEntry("a", "method"),
+    makeReportEntry("b", "method"),
+  ];
+  const selection: ReportSelection = {
+    skip: ["a"],
+  };
+  const result = filterReports(
+    reports,
+    "method",
+    selection,
+    {},
+    undefined,
+    ["a", "b"],
+  );
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "b");
+});
+
+Deno.test("sanitizeReportNameForData - strips @ and replaces / with -", () => {
+  assertEquals(
+    sanitizeReportNameForData("@adam/cfgmgmt-workflow-summary"),
+    "adam-cfgmgmt-workflow-summary",
+  );
+});
+
+Deno.test("sanitizeReportNameForData - handles backslashes", () => {
+  assertEquals(
+    sanitizeReportNameForData("@org\\report"),
+    "org-report",
+  );
+});
+
+Deno.test("sanitizeReportNameForData - collapses double dots", () => {
+  assertEquals(
+    sanitizeReportNameForData("foo..bar"),
+    "foo.bar",
+  );
+});
+
+Deno.test("sanitizeReportNameForData - strips null bytes", () => {
+  assertEquals(
+    sanitizeReportNameForData("foo\0bar"),
+    "foobar",
+  );
+});
+
+Deno.test("sanitizeReportNameForData - passes through simple names unchanged", () => {
+  assertEquals(
+    sanitizeReportNameForData("cost-report"),
+    "cost-report",
+  );
+});
+
+// --- executeReports with varySuffix tests ---
+
+/**
+ * Creates a minimal in-memory data repository for testing report persistence.
+ */
+function createInMemoryDataRepo() {
+  const saved: Array<{
+    name: string;
+    tags: Record<string, string>;
+    content: string;
+  }> = [];
+
+  return {
+    repo: {
+      nextId: () => generateDataId(),
+      findByName: () => Promise.resolve(null),
+      listVersions: () => Promise.resolve([]),
+      save: (
+        _type: ModelType,
+        _modelId: string,
+        data: { name: string; tags: Record<string, string> },
+        content: Uint8Array,
+      ) => {
+        saved.push({
+          name: data.name,
+          tags: { ...data.tags },
+          content: new TextDecoder().decode(content),
+        });
+        return Promise.resolve({ version: 1 });
+      },
+      findAllForModel: () => Promise.resolve([]),
+      findAllGlobal: () => Promise.resolve([]),
+      findById: () => Promise.resolve(null),
+      append: () => Promise.resolve(),
+      stream: async function* () {},
+      getContent: () => Promise.resolve(null),
+      getPath: () => "",
+      getContentPath: () => "",
+      delete: () => Promise.resolve(),
+      deleteVersion: () => Promise.resolve(),
+      gc: () => Promise.resolve({ deleted: 0 }),
+    },
+    saved,
+  };
+}
+
+Deno.test("executeReports - varySuffix appends to data names", async () => {
+  const registry = new ReportRegistry();
+  registry.register("test-report", makeReport("method"));
+
+  const { repo, saved } = createInMemoryDataRepo();
+  const modelType = ModelType.create("test/model");
+
+  const context: MethodReportContext = {
+    scope: "method",
+    repoDir: "/tmp/test",
+    logger: {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      fatal: () => {},
+    } as unknown as MethodReportContext["logger"],
+    // deno-lint-ignore no-explicit-any
+    dataRepository: repo as any,
+    // deno-lint-ignore no-explicit-any
+    definitionRepository: {} as any,
+    modelType,
+    modelId: "test-id",
+    definition: { id: "test-id", name: "test", version: 1, tags: {} },
+    globalArgs: {},
+    methodArgs: {},
+    methodName: "run",
+    executionStatus: "succeeded",
+    dataHandles: [],
+  };
+
+  const selection: ReportSelection = { require: ["test-report"] };
+
+  await executeReports(
+    registry,
+    context,
+    modelType,
+    "test-id",
+    selection,
+    {},
+    undefined,
+    "run",
+    undefined,
+    "iteration-1",
+  );
+
+  // Should have saved 2 artifacts (markdown + json) with varySuffix in name
+  assertEquals(saved.length, 2);
+  assertStringIncludes(saved[0].name, "iteration-1");
+  assertStringIncludes(saved[1].name, "iteration-1");
+  assertEquals(saved[0].name, "report-test-report-iteration-1");
+  assertEquals(saved[1].name, "report-test-report-iteration-1-json");
+});
+
+Deno.test("executeReports - varySuffix included as tag", async () => {
+  const registry = new ReportRegistry();
+  registry.register("tag-test", makeReport("method"));
+
+  const { repo, saved } = createInMemoryDataRepo();
+  const modelType = ModelType.create("test/model");
+
+  const context: MethodReportContext = {
+    scope: "method",
+    repoDir: "/tmp/test",
+    logger: {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      fatal: () => {},
+    } as unknown as MethodReportContext["logger"],
+    // deno-lint-ignore no-explicit-any
+    dataRepository: repo as any,
+    // deno-lint-ignore no-explicit-any
+    definitionRepository: {} as any,
+    modelType,
+    modelId: "test-id",
+    definition: { id: "test-id", name: "test", version: 1, tags: {} },
+    globalArgs: {},
+    methodArgs: {},
+    methodName: "run",
+    executionStatus: "succeeded",
+    dataHandles: [],
+  };
+
+  await executeReports(
+    registry,
+    context,
+    modelType,
+    "test-id",
+    { require: ["tag-test"] },
+    {},
+    undefined,
+    "run",
+    undefined,
+    "dev",
+  );
+
+  assertEquals(saved[0].tags.varySuffix, "dev");
+  assertEquals(saved[1].tags.varySuffix, "dev");
+});
+
+Deno.test("executeReports - without varySuffix uses base name", async () => {
+  const registry = new ReportRegistry();
+  registry.register("no-vary", makeReport("method"));
+
+  const { repo, saved } = createInMemoryDataRepo();
+  const modelType = ModelType.create("test/model");
+
+  const context: MethodReportContext = {
+    scope: "method",
+    repoDir: "/tmp/test",
+    logger: {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      fatal: () => {},
+    } as unknown as MethodReportContext["logger"],
+    // deno-lint-ignore no-explicit-any
+    dataRepository: repo as any,
+    // deno-lint-ignore no-explicit-any
+    definitionRepository: {} as any,
+    modelType,
+    modelId: "test-id",
+    definition: { id: "test-id", name: "test", version: 1, tags: {} },
+    globalArgs: {},
+    methodArgs: {},
+    methodName: "run",
+    executionStatus: "succeeded",
+    dataHandles: [],
+  };
+
+  await executeReports(
+    registry,
+    context,
+    modelType,
+    "test-id",
+    { require: ["no-vary"] },
+    {},
+    undefined,
+    "run",
+  );
+
+  assertEquals(saved[0].name, "report-no-vary");
+  assertEquals(saved[1].name, "report-no-vary-json");
+  assertEquals(saved[0].tags.varySuffix, undefined);
+});
+
+Deno.test("executeReports - varySuffix with scoped report name sanitization", async () => {
+  const registry = new ReportRegistry();
+  registry.register("@adam/state-report", makeReport("method"));
+
+  const { repo, saved } = createInMemoryDataRepo();
+  const modelType = ModelType.create("test/model");
+
+  const context: MethodReportContext = {
+    scope: "method",
+    repoDir: "/tmp/test",
+    logger: {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      fatal: () => {},
+    } as unknown as MethodReportContext["logger"],
+    // deno-lint-ignore no-explicit-any
+    dataRepository: repo as any,
+    // deno-lint-ignore no-explicit-any
+    definitionRepository: {} as any,
+    modelType,
+    modelId: "test-id",
+    definition: { id: "test-id", name: "test", version: 1, tags: {} },
+    globalArgs: {},
+    methodArgs: {},
+    methodName: "run",
+    executionStatus: "succeeded",
+    dataHandles: [],
+  };
+
+  await executeReports(
+    registry,
+    context,
+    modelType,
+    "test-id",
+    { require: ["@adam/state-report"] },
+    {},
+    undefined,
+    "run",
+    undefined,
+    "2",
+  );
+
+  // @adam/state-report → sanitized to "adam-state-report", plus varySuffix "2"
+  assertEquals(saved[0].name, "report-adam-state-report-2");
+  assertEquals(saved[1].name, "report-adam-state-report-2-json");
+});
+
+Deno.test("executeReports - events include varySuffix data handles", async () => {
+  const registry = new ReportRegistry();
+  registry.register("event-test", makeReport("method"));
+
+  const { repo } = createInMemoryDataRepo();
+  const modelType = ModelType.create("test/model");
+
+  const context: MethodReportContext = {
+    scope: "method",
+    repoDir: "/tmp/test",
+    logger: {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      fatal: () => {},
+    } as unknown as MethodReportContext["logger"],
+    // deno-lint-ignore no-explicit-any
+    dataRepository: repo as any,
+    // deno-lint-ignore no-explicit-any
+    definitionRepository: {} as any,
+    modelType,
+    modelId: "test-id",
+    definition: { id: "test-id", name: "test", version: 1, tags: {} },
+    globalArgs: {},
+    methodArgs: {},
+    methodName: "run",
+    executionStatus: "succeeded",
+    dataHandles: [],
+  };
+
+  const completedHandles: DataHandle[][] = [];
+  const events = {
+    onReportStarted: () => {},
+    onReportCompleted: (
+      _name: string,
+      _scope: string,
+      _markdown: string,
+      _json: Record<string, unknown>,
+      dataHandles: DataHandle[],
+    ) => {
+      completedHandles.push(dataHandles);
+    },
+    onReportFailed: () => {},
+  };
+
+  await executeReports(
+    registry,
+    context,
+    modelType,
+    "test-id",
+    { require: ["event-test"] },
+    {},
+    events,
+    "run",
+    undefined,
+    "host-a",
+  );
+
+  assertEquals(completedHandles.length, 1);
+  const handles = completedHandles[0];
+  assertEquals(handles.length, 2);
+  assertStringIncludes(handles[0].name, "host-a");
+  assertStringIncludes(handles[1].name, "host-a");
+});

--- a/src/domain/reports/report_registry.ts
+++ b/src/domain/reports/report_registry.ts
@@ -1,0 +1,86 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ReportDefinition, ReportScope } from "./report.ts";
+
+/**
+ * Registry of all known report definitions.
+ */
+export class ReportRegistry {
+  private reports = new Map<string, ReportDefinition>();
+
+  /**
+   * Registers a report definition.
+   *
+   * @param name - Unique name for the report
+   * @param report - The report definition
+   * @throws If a report with the same name is already registered
+   */
+  register(name: string, report: ReportDefinition): void {
+    if (this.reports.has(name)) {
+      throw new Error(`Report already registered: ${name}`);
+    }
+    this.reports.set(name, report);
+  }
+
+  /**
+   * Gets a report definition by name.
+   */
+  get(name: string): ReportDefinition | undefined {
+    return this.reports.get(name);
+  }
+
+  /**
+   * Returns all registered reports.
+   */
+  getAll(): Array<{ name: string; report: ReportDefinition }> {
+    return Array.from(this.reports.entries()).map(([name, report]) => ({
+      name,
+      report,
+    }));
+  }
+
+  /**
+   * Returns all reports matching a specific scope.
+   */
+  getByScope(
+    scope: ReportScope,
+  ): Array<{ name: string; report: ReportDefinition }> {
+    return this.getAll().filter(({ report }) => report.scope === scope);
+  }
+
+  /**
+   * Checks if a report is registered.
+   */
+  has(name: string): boolean {
+    return this.reports.has(name);
+  }
+}
+
+/**
+ * Global report registry instance.
+ *
+ * Uses globalThis so that the same registry is shared across module
+ * boundaries (e.g., when extensions are loaded outside the bundle).
+ */
+const REPORT_REGISTRY_KEY = "__swampReportRegistry";
+// deno-lint-ignore no-explicit-any
+export const reportRegistry: ReportRegistry = (globalThis as any)[
+  REPORT_REGISTRY_KEY
+] ??= new ReportRegistry();

--- a/src/domain/reports/report_registry_test.ts
+++ b/src/domain/reports/report_registry_test.ts
@@ -1,0 +1,97 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import { ReportRegistry } from "./report_registry.ts";
+import type { ReportDefinition } from "./report.ts";
+import type { ReportContext } from "./report_context.ts";
+
+function makeReport(
+  scope: "method" | "model" | "workflow" = "method",
+  labels?: string[],
+): ReportDefinition {
+  return {
+    description: `Test ${scope} report`,
+    scope,
+    labels,
+    execute(_context: ReportContext) {
+      return Promise.resolve({ markdown: "# Test", json: { test: true } });
+    },
+  };
+}
+
+Deno.test("ReportRegistry - register and get", () => {
+  const registry = new ReportRegistry();
+  const report = makeReport();
+  registry.register("test-report", report);
+
+  assertEquals(registry.get("test-report"), report);
+  assertEquals(registry.has("test-report"), true);
+  assertEquals(registry.has("nonexistent"), false);
+  assertEquals(registry.get("nonexistent"), undefined);
+});
+
+Deno.test("ReportRegistry - duplicate registration throws", () => {
+  const registry = new ReportRegistry();
+  registry.register("test-report", makeReport());
+
+  assertThrows(
+    () => registry.register("test-report", makeReport()),
+    Error,
+    "Report already registered: test-report",
+  );
+});
+
+Deno.test("ReportRegistry - getAll returns all reports", () => {
+  const registry = new ReportRegistry();
+  registry.register("report-a", makeReport("method"));
+  registry.register("report-b", makeReport("model"));
+  registry.register("report-c", makeReport("workflow"));
+
+  const all = registry.getAll();
+  assertEquals(all.length, 3);
+  assertEquals(all.map((r) => r.name).sort(), [
+    "report-a",
+    "report-b",
+    "report-c",
+  ]);
+});
+
+Deno.test("ReportRegistry - getByScope filters by scope", () => {
+  const registry = new ReportRegistry();
+  registry.register("method-1", makeReport("method"));
+  registry.register("method-2", makeReport("method"));
+  registry.register("model-1", makeReport("model"));
+  registry.register("workflow-1", makeReport("workflow"));
+
+  const methodReports = registry.getByScope("method");
+  assertEquals(methodReports.length, 2);
+  assertEquals(
+    methodReports.map((r) => r.name).sort(),
+    ["method-1", "method-2"],
+  );
+
+  const modelReports = registry.getByScope("model");
+  assertEquals(modelReports.length, 1);
+  assertEquals(modelReports[0].name, "model-1");
+
+  const workflowReports = registry.getByScope("workflow");
+  assertEquals(workflowReports.length, 1);
+  assertEquals(workflowReports[0].name, "workflow-1");
+});

--- a/src/domain/reports/report_selection.ts
+++ b/src/domain/reports/report_selection.ts
@@ -1,0 +1,53 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { z } from "zod";
+
+/**
+ * A report reference: either a string (report name, applies to all methods)
+ * or an object with optional method scoping.
+ */
+const ReportRefSchema = z.union([
+  z.string(),
+  z.object({
+    name: z.string(),
+    methods: z.array(z.string()).optional(),
+  }),
+]);
+
+/**
+ * Schema for report selection in definition/workflow YAML.
+ */
+export const ReportSelectionSchema = z.object({
+  require: z.array(ReportRefSchema).optional(),
+  skip: z.array(z.string()).optional(),
+}).optional();
+
+/**
+ * A report reference: string shorthand or object with method scoping.
+ */
+export type ReportRef = string | { name: string; methods?: string[] };
+
+/**
+ * Report selection (require/skip) from a definition or workflow.
+ */
+export type ReportSelection = {
+  require?: ReportRef[];
+  skip?: string[];
+};

--- a/src/domain/reports/user_report_loader.ts
+++ b/src/domain/reports/user_report_loader.ts
@@ -1,0 +1,330 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { z } from "zod";
+import { dirname, join, resolve, toFileUrl } from "@std/path";
+import { getLogger } from "@logtape/logtape";
+import {
+  bundleExtension,
+  fixCjsEsmInterop,
+  installZodGlobal,
+  rewriteZodImports,
+  sanitizeDataUrlError,
+  uint8ArrayToBase64,
+} from "../models/bundle.ts";
+import { resolveLocalImports } from "../models/local_import_resolver.ts";
+import type { DenoRuntime } from "../runtime/deno_runtime.ts";
+import type { ReportContext } from "./report_context.ts";
+import type { ReportResult } from "./report.ts";
+import { reportRegistry } from "./report_registry.ts";
+import {
+  SWAMP_DATA_DIR,
+  SWAMP_SUBDIRS,
+} from "../../infrastructure/persistence/paths.ts";
+import { assertSafePath } from "../../infrastructure/persistence/safe_path.ts";
+
+const logger = getLogger(["swamp", "reports", "loader"]);
+
+/** Pattern for valid user report name: @collective/name or collective/name */
+const USER_REPORT_NAME_PATTERN = /^@?[a-z0-9_-]+\/[a-z0-9_-]+$/;
+
+/**
+ * Schema for validating user report exports.
+ */
+const UserReportSchema = z.object({
+  name: z.string().refine(
+    (n) => USER_REPORT_NAME_PATTERN.test(n),
+    {
+      message:
+        "Report name must match @collective/name or collective/name (e.g., @myorg/cost-report or myorg/cost-report)",
+    },
+  ),
+  description: z.string(),
+  scope: z.enum(["method", "model", "workflow"]),
+  labels: z.array(z.string()).optional(),
+  execute: z.custom<(ctx: ReportContext) => Promise<ReportResult>>(
+    (val) => typeof val === "function",
+  ),
+});
+
+/**
+ * Result of loading user report extensions from a directory.
+ */
+export interface ReportLoadResult {
+  loaded: string[];
+  failed: Array<{ file: string; error: string }>;
+}
+
+/**
+ * Loader for user-defined TypeScript report implementations.
+ *
+ * Users export a `report` object from TypeScript files that defines:
+ * - name: namespaced identifier (e.g., "@myorg/cost-report")
+ * - description: what the report produces
+ * - scope: "method" | "model" | "workflow"
+ * - labels: optional filtering labels
+ * - execute: function that produces ReportResult
+ *
+ * This loader validates the structure and registers reports with the global registry.
+ */
+export class UserReportLoader {
+  private readonly denoRuntime: DenoRuntime;
+  private readonly repoDir: string | null;
+
+  /**
+   * @param denoRuntime - Runtime manager for obtaining a deno binary path
+   * @param repoDir - Repository root for writing bundles to .swamp/report-bundles/
+   *                   (pass null to skip bundle caching)
+   */
+  constructor(denoRuntime: DenoRuntime, repoDir: string | null = null) {
+    this.denoRuntime = denoRuntime;
+    this.repoDir = repoDir;
+  }
+
+  /**
+   * Loads all user report implementations from the specified directory.
+   *
+   * @param reportsDir - The directory containing user report files
+   * @returns Result containing lists of loaded and failed files
+   */
+  async loadReports(reportsDir: string): Promise<ReportLoadResult> {
+    const result: ReportLoadResult = { loaded: [], failed: [] };
+
+    // Ensure swamp's Zod is available on globalThis before importing bundles.
+    installZodGlobal();
+
+    // Check if directory exists
+    try {
+      await Deno.stat(reportsDir);
+    } catch {
+      return result; // No user reports directory - not an error
+    }
+
+    // Ensure deno is available before bundling
+    const denoPath = await this.denoRuntime.ensureDeno();
+
+    const files = await this.discoverFiles(reportsDir);
+
+    for (const file of files) {
+      try {
+        const absolutePath = resolve(reportsDir, file);
+        const js = await this.bundleWithCache(
+          absolutePath,
+          file,
+          denoPath,
+          reportsDir,
+        );
+        const module = await this.importBundle(js, file);
+
+        if (!module.report) {
+          // Files without a report export are silently skipped (utility files)
+          continue;
+        }
+
+        const parsed = UserReportSchema.safeParse(module.report);
+        if (!parsed.success) {
+          result.failed.push({
+            file,
+            error: this.formatValidationError(parsed.error),
+          });
+          continue;
+        }
+
+        const userReport = parsed.data;
+
+        // Register with the report registry
+        if (reportRegistry.has(userReport.name)) {
+          result.failed.push({
+            file,
+            error: `Report name '${userReport.name}' is already registered`,
+          });
+          continue;
+        }
+
+        reportRegistry.register(userReport.name, {
+          description: userReport.description,
+          scope: userReport.scope,
+          labels: userReport.labels,
+          execute: userReport.execute,
+        });
+
+        result.loaded.push(file);
+      } catch (error) {
+        result.failed.push({ file, error: String(error) });
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Bundles a report file, using cached bundle from .swamp/report-bundles/ when possible.
+   */
+  private async bundleWithCache(
+    absolutePath: string,
+    relativePath: string,
+    denoPath: string,
+    boundaryDir: string,
+  ): Promise<string> {
+    if (this.repoDir) {
+      const bundlePath = join(
+        this.repoDir,
+        SWAMP_DATA_DIR,
+        SWAMP_SUBDIRS.reportBundles,
+        relativePath.replace(/\.ts$/, ".js"),
+      );
+
+      // Check mtime-based cache against all local dependencies.
+      // If the bundle exists but freshness cannot be determined (e.g. a
+      // dependency file is missing because the extension was pushed with an
+      // older swamp that had a single-line import regex), fall back to the
+      // cached bundle rather than attempting a re-bundle that will also fail.
+      let bundleExists = false;
+      try {
+        const bundleStat = await Deno.stat(bundlePath);
+        bundleExists = true;
+        if (bundleStat.mtime) {
+          const { resolvedFiles } = await resolveLocalImports(
+            [absolutePath],
+            boundaryDir,
+          );
+          const depStats = await Promise.all(
+            resolvedFiles.map((f) => Deno.stat(f)),
+          );
+          const newestSourceMtime = depStats.reduce<Date | null>(
+            (max, s) => {
+              if (!s.mtime) return max;
+              if (!max) return s.mtime;
+              return s.mtime > max ? s.mtime : max;
+            },
+            null,
+          );
+          if (newestSourceMtime && bundleStat.mtime > newestSourceMtime) {
+            logger.debug`Using cached report bundle for ${relativePath}`;
+            return await Deno.readTextFile(bundlePath);
+          }
+        }
+      } catch {
+        if (bundleExists) {
+          logger
+            .debug`Using cached report bundle for ${relativePath} (freshness check failed — missing dependency)`;
+          return await Deno.readTextFile(bundlePath);
+        }
+      }
+
+      // Bundle and write to cache
+      const js = await bundleExtension(absolutePath, denoPath);
+      const bundleBoundary = join(this.repoDir, SWAMP_DATA_DIR);
+      await assertSafePath(bundlePath, bundleBoundary);
+      await Deno.mkdir(dirname(bundlePath), { recursive: true });
+      await Deno.writeTextFile(bundlePath, js);
+      logger.debug`Wrote report bundle cache: ${bundlePath}`;
+      return js;
+    }
+
+    // No repo dir — just bundle without caching
+    return await bundleExtension(absolutePath, denoPath);
+  }
+
+  /**
+   * Imports bundled JavaScript and returns the module exports.
+   * Uses file URL import when a bundle file exists on disk, otherwise falls back to data URL.
+   */
+  private async importBundle(
+    js: string,
+    relativePath: string,
+  ): Promise<Record<string, unknown>> {
+    const rewritten = fixCjsEsmInterop(rewriteZodImports(js));
+
+    if (this.repoDir) {
+      const bundlePath = join(
+        this.repoDir,
+        SWAMP_DATA_DIR,
+        SWAMP_SUBDIRS.reportBundles,
+        relativePath.replace(/\.ts$/, ".js"),
+      );
+
+      try {
+        await Deno.stat(bundlePath);
+        let cachedJs = await Deno.readTextFile(bundlePath);
+        const fixed = fixCjsEsmInterop(rewriteZodImports(cachedJs));
+        if (fixed !== cachedJs) {
+          cachedJs = fixed;
+          await Deno.writeTextFile(bundlePath, cachedJs);
+        }
+        return await import(toFileUrl(bundlePath).href);
+      } catch (error) {
+        logger.debug`File URL import failed for ${relativePath}: ${
+          String(error).substring(0, 200)
+        }`;
+      }
+    }
+
+    // Fallback: import via base64 data URL (no file on disk)
+    try {
+      const encoded = uint8ArrayToBase64(
+        new TextEncoder().encode(rewritten),
+      );
+      return await import(
+        `data:application/javascript;base64,${encoded}`
+      );
+    } catch (error) {
+      throw new Error(sanitizeDataUrlError(error));
+    }
+  }
+
+  /**
+   * Formats a Zod validation error into a clear message.
+   */
+  private formatValidationError(error: z.ZodError): string {
+    return error.issues
+      .map((i) => {
+        const path = i.path.join(".");
+        return `${path}: ${i.message}`;
+      })
+      .join("; ");
+  }
+
+  /**
+   * Recursively discovers TypeScript files in the given directory.
+   * Returns relative paths. Excludes test files.
+   */
+  private async discoverFiles(
+    dir: string,
+    prefix = "",
+  ): Promise<string[]> {
+    const files: string[] = [];
+    for await (const entry of Deno.readDir(dir)) {
+      const relativePath = prefix ? join(prefix, entry.name) : entry.name;
+      if (entry.isDirectory) {
+        const nested = await this.discoverFiles(
+          join(dir, entry.name),
+          relativePath,
+        );
+        files.push(...nested);
+      } else if (
+        entry.isFile && entry.name.endsWith(".ts") &&
+        !entry.name.endsWith("_test.ts")
+      ) {
+        files.push(relativePath);
+      }
+    }
+    return files.sort();
+  }
+}

--- a/src/domain/workflows/execution_events.ts
+++ b/src/domain/workflows/execution_events.ts
@@ -76,4 +76,22 @@ export type WorkflowExecutionEvent =
     methodName: string;
     event: MethodExecutionEvent;
   }
+  | {
+    kind: "report_started";
+    reportName: string;
+    scope: string;
+  }
+  | {
+    kind: "report_completed";
+    reportName: string;
+    scope: string;
+    markdown: string;
+    json: Record<string, unknown>;
+  }
+  | {
+    kind: "report_failed";
+    reportName: string;
+    scope: string;
+    error: string;
+  }
   | { kind: "completed"; run: WorkflowRun };

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -81,6 +81,15 @@ import { SecretRedactor } from "../secrets/mod.ts";
 import { VaultService } from "../vaults/vault_service.ts";
 import { merge } from "../../infrastructure/stream/merge.ts";
 import { withEventBridge } from "../../infrastructure/stream/event_bridge.ts";
+import {
+  executeReports,
+  type ReportEventCallback,
+  type ReportFilterOptions,
+} from "../reports/report_execution_service.ts";
+import { reportRegistry } from "../reports/report_registry.ts";
+import type { MethodReportContext } from "../reports/report_context.ts";
+import { buildReportDataHandles } from "../reports/report_data_handles.ts";
+import { modelRegistry } from "../models/model.ts";
 /**
  * Context for step execution.
  */
@@ -115,6 +124,8 @@ export interface StepExecutionContext {
   driver?: string;
   /** Execution driver config override from workflow/CLI level */
   driverConfig?: Record<string, unknown>;
+  /** Report filter options for per-step report execution */
+  reportFilterOptions?: ReportFilterOptions;
 }
 
 /**
@@ -559,6 +570,131 @@ export class DefaultStepExecutor implements StepExecutor {
         { method: task.methodName, model: originalDefinition.name },
       );
 
+      // --- Per-step reports (method + model scope) ---
+      if (
+        reportRegistry.getAll().length > 0 && ctx.reportFilterOptions
+      ) {
+        const dataHandles = await buildReportDataHandles(
+          unifiedDataRepo,
+          modelType,
+          evaluatedDefinition.id,
+        );
+
+        // Compute vary suffix from forEach variable
+        let reportVarySuffix: string | undefined;
+        if (ctx.forEachVariable?.value !== undefined) {
+          const val = ctx.forEachVariable.value;
+          if (typeof val === "object" && val !== null && "key" in val) {
+            reportVarySuffix = String(
+              (val as Record<string, unknown>).key,
+            );
+          } else {
+            reportVarySuffix = String(val);
+          }
+        }
+
+        const reportEventCallbacks: ReportEventCallback = {
+          onReportStarted: (name, scope) => {
+            ctx.emitEvent?.({
+              kind: "report_started",
+              reportName: name,
+              scope,
+            });
+          },
+          onReportCompleted: (
+            name,
+            scope,
+            markdown,
+            json,
+            reportDataHandles,
+          ) => {
+            ctx.emitEvent?.({
+              kind: "report_completed",
+              reportName: name,
+              scope,
+              markdown,
+              json,
+            });
+            // Track report data artifacts alongside method artifacts
+            for (const handle of reportDataHandles) {
+              output.addDataArtifact({
+                dataId: handle.dataId,
+                name: handle.name,
+                version: handle.version,
+                tags: handle.tags,
+              });
+              savedArtifacts.push({
+                dataId: handle.dataId,
+                name: handle.name,
+                version: handle.version,
+                tags: handle.tags,
+              });
+            }
+          },
+          onReportFailed: (name, scope, error) => {
+            ctx.emitEvent?.({
+              kind: "report_failed",
+              reportName: name,
+              scope,
+              error,
+            });
+          },
+        };
+
+        // Look up model-type defaults for report filtering
+        const stepModelDef = modelRegistry.get(modelType);
+        const stepModelTypeReports = stepModelDef?.reports;
+
+        // Method-scope reports
+        const methodContext: MethodReportContext = {
+          scope: "method",
+          repoDir: ctx.repoDir,
+          logger: runLogger,
+          dataRepository: unifiedDataRepo,
+          definitionRepository: definitionRepo,
+          modelType,
+          modelId: evaluatedDefinition.id,
+          definition: {
+            id: evaluatedDefinition.id,
+            name: evaluatedDefinition.name,
+            version: evaluatedDefinition.version,
+            tags: evaluatedDefinition.tags,
+          },
+          globalArgs: evaluatedDefinition.globalArguments,
+          methodArgs: evaluatedDefinition.getMethodArguments(task.methodName),
+          methodName: task.methodName,
+          executionStatus: "succeeded",
+          dataHandles,
+        };
+
+        await executeReports(
+          reportRegistry,
+          methodContext,
+          modelType,
+          evaluatedDefinition.id,
+          originalDefinition.reportSelection,
+          ctx.reportFilterOptions,
+          reportEventCallbacks,
+          task.methodName,
+          stepModelTypeReports,
+          reportVarySuffix,
+        );
+
+        // Model-scope reports
+        await executeReports(
+          reportRegistry,
+          { ...methodContext, scope: "model" },
+          modelType,
+          evaluatedDefinition.id,
+          originalDefinition.reportSelection,
+          ctx.reportFilterOptions,
+          reportEventCallbacks,
+          task.methodName,
+          stepModelTypeReports,
+          reportVarySuffix,
+        );
+      }
+
       return {
         type: "model_method",
         model: task.modelIdOrName,
@@ -685,6 +821,7 @@ interface StepOptions {
   secretRedactor?: SecretRedactor;
   signal?: AbortSignal;
   driver?: string;
+  reportFilterOptions?: ReportFilterOptions;
 }
 
 /**
@@ -726,6 +863,8 @@ export class WorkflowExecutionService {
       /** Execution driver override (from CLI --driver flag) */
       driver?: string;
       signal?: AbortSignal;
+      /** Report filter options for per-step report execution */
+      reportFilterOptions?: ReportFilterOptions;
     },
   ): AsyncGenerator<WorkflowExecutionEvent> {
     // Look up workflow
@@ -829,6 +968,7 @@ export class WorkflowExecutionService {
       secretRedactor,
       signal: options?.signal,
       driver: options?.driver,
+      reportFilterOptions: options?.reportFilterOptions,
     };
 
     // Sort jobs topologically
@@ -1260,6 +1400,7 @@ export class WorkflowExecutionService {
           driverConfig: step.driverConfig ?? job.driverConfig ??
             workflow.driverConfig,
           emitEvent: push,
+          reportFilterOptions: options.reportFilterOptions,
         };
         return this.executor.execute(step, ctx);
       });

--- a/src/domain/workflows/workflow.ts
+++ b/src/domain/workflows/workflow.ts
@@ -28,6 +28,10 @@ import {
   DriverConfigFieldSchema,
   DriverFieldSchema,
 } from "../drivers/driver_config.ts";
+import {
+  type ReportSelection,
+  ReportSelectionSchema,
+} from "../reports/report_selection.ts";
 
 /**
  * Zod schema for Workflow aggregate root.
@@ -48,6 +52,7 @@ export const WorkflowSchema = z.object({
   inputs: InputsSchemaSchema,
   jobs: z.array(JobSchema).min(1),
   version: z.number().int().positive().default(1),
+  reports: ReportSelectionSchema,
   driver: DriverFieldSchema,
   driverConfig: DriverConfigFieldSchema,
 });
@@ -73,6 +78,7 @@ export interface CreateWorkflowProps {
   inputs?: InputsSchema;
   jobs?: Job[];
   version?: number;
+  reports?: ReportSelection;
   driver?: string;
   driverConfig?: Record<string, unknown>;
 }
@@ -96,6 +102,7 @@ export class Workflow {
     readonly inputs: InputsSchema | undefined,
     private _jobs: Job[],
     readonly version: number,
+    readonly reports: ReportSelection | undefined,
     readonly driver: string | undefined,
     readonly driverConfig: Record<string, unknown> | undefined,
   ) {}
@@ -118,6 +125,7 @@ export class Workflow {
       inputs: props.inputs,
       jobs: jobs.map((j) => j.toData()),
       version,
+      reports: props.reports,
       driver: props.driver,
       driverConfig: props.driverConfig,
     };
@@ -138,6 +146,7 @@ export class Workflow {
       data.inputs,
       jobs,
       data.version,
+      data.reports,
       data.driver,
       data.driverConfig,
     );
@@ -158,9 +167,17 @@ export class Workflow {
       validated.inputs,
       jobs,
       validated.version,
+      validated.reports,
       validated.driver,
       validated.driverConfig,
     );
+  }
+
+  /**
+   * Returns the report selection (require/skip lists).
+   */
+  get reportSelection(): ReportSelection | undefined {
+    return this.reports ? structuredClone(this.reports) : undefined;
   }
 
   /**
@@ -199,6 +216,7 @@ export class Workflow {
       inputs: this.inputs,
       jobs: this._jobs.map((j) => j.toData()) as JobData[],
       version: this.version,
+      reports: this.reports,
       driver: this.driver,
       driverConfig: this.driverConfig,
     };

--- a/src/domain/workflows/workflow_test.ts
+++ b/src/domain/workflows/workflow_test.ts
@@ -485,6 +485,60 @@ Deno.test("Workflow.fromData and toData roundtrip with driver", () => {
   assertEquals(restored.driverConfig, { image: "deno:latest" });
 });
 
+// Reports field tests
+
+Deno.test("Workflow.create creates workflow with reports", () => {
+  const workflow = Workflow.create({
+    name: "reported-workflow",
+    reports: { require: ["cost-report", { name: "audit", methods: ["run"] }] },
+    jobs: [createTestJob("job1")],
+  });
+
+  assertEquals(workflow.reports?.require?.length, 2);
+  assertEquals(workflow.reports?.require?.[0], "cost-report");
+  assertEquals(workflow.reportSelection?.require?.[1], {
+    name: "audit",
+    methods: ["run"],
+  });
+});
+
+Deno.test("Workflow.create defaults reports to undefined", () => {
+  const workflow = Workflow.create({ name: "no-reports-workflow" });
+  assertEquals(workflow.reports, undefined);
+  assertEquals(workflow.reportSelection, undefined);
+});
+
+Deno.test("Workflow.toData includes reports in output", () => {
+  const workflow = Workflow.create({
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "test-workflow",
+    reports: { require: ["cost-report"], skip: ["verbose-report"] },
+    jobs: [createTestJob("job1")],
+  });
+
+  const data = workflow.toData();
+  assertEquals(data.reports?.require, ["cost-report"]);
+  assertEquals(data.reports?.skip, ["verbose-report"]);
+});
+
+Deno.test("Workflow.fromData and toData roundtrip with reports", () => {
+  const original = Workflow.create({
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "roundtrip-reports",
+    reports: {
+      require: ["cost-report", { name: "audit", methods: ["sync"] }],
+      skip: ["debug-report"],
+    },
+    jobs: [createTestJob("deploy")],
+  });
+
+  const data = original.toData();
+  const restored = Workflow.fromData(data);
+
+  assertEquals(restored.reports?.require, original.reports?.require);
+  assertEquals(restored.reports?.skip, ["debug-report"]);
+});
+
 Deno.test("Workflow.fromData handles missing tags (backward compat)", () => {
   // Simulate legacy data without tags field — Zod .default({}) fills it in
   const data = {

--- a/src/infrastructure/assets/skill_assets.ts
+++ b/src/infrastructure/assets/skill_assets.ts
@@ -84,6 +84,14 @@ const BUNDLED_SKILLS: SkillInfo[] = [
     relativePath: "swamp-repo/references/troubleshooting.md",
     name: "swamp-repo",
   },
+  {
+    relativePath: "swamp-report/SKILL.md",
+    name: "swamp-report",
+  },
+  {
+    relativePath: "swamp-report/references/report-types.md",
+    name: "swamp-report",
+  },
   { relativePath: "swamp-workflow/SKILL.md", name: "swamp-workflow" },
   {
     relativePath: "swamp-workflow/references/data-chaining.md",

--- a/src/infrastructure/persistence/paths.ts
+++ b/src/infrastructure/persistence/paths.ts
@@ -72,6 +72,8 @@ export const SWAMP_SUBDIRS = {
   driverBundles: "driver-bundles",
   /** Cached datastore extension bundles */
   datastoreBundles: "datastore-bundles",
+  /** Cached report extension bundles */
+  reportBundles: "report-bundles",
   /** Audit command logs */
   audit: "audit",
   /** Legacy: resource definitions */

--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -41,6 +41,7 @@ export interface RepoMarkerData {
   vaultsDir?: string;
   driversDir?: string;
   datastoresDir?: string;
+  reportsDir?: string;
   repoId?: string;
   telemetryEndpoint?: string;
   telemetryDisabled?: boolean;

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -86,7 +86,30 @@ export {
 export {
   type DataArtifactView,
   type ModelMethodRunView,
+  type ModelReportView,
+  type ReportResultView,
 } from "./models/model_method_run_view.ts";
+
+// Report operations (top-level)
+export { reportDescribe, type ReportDescribeDeps } from "./reports/describe.ts";
+export {
+  reportSearch,
+  type ReportSearchDeps,
+  type ReportSearchInput,
+} from "./reports/search.ts";
+export {
+  reportGet,
+  type ReportGetDeps,
+  type ReportGetInput,
+} from "./reports/get.ts";
+export type {
+  ReportDefinitionDetail,
+  ReportDescribeEvent,
+  ReportGetEvent,
+  ReportSearchEvent,
+  StoredReportDetail,
+  StoredReportSummary,
+} from "./reports/report_views.ts";
 export {
   createModelGetDeps,
   modelGet,

--- a/src/libswamp/models/model_method_run_view.ts
+++ b/src/libswamp/models/model_method_run_view.ts
@@ -31,6 +31,37 @@ export interface DataArtifactView {
  * Read-model projection of a completed model method run.
  * Presentation-oriented view with computed fields (duration, artifacts).
  */
+/**
+ * Result of a single report execution for the view.
+ */
+export interface ReportResultView {
+  name: string;
+  scope?: string;
+  success: boolean;
+  markdown?: string;
+  json?: Record<string, unknown>;
+  error?: string;
+}
+
+/**
+ * Read-model projection of a completed model method run.
+ * Presentation-oriented view with computed fields (duration, artifacts).
+ */
+/**
+ * Read-model projection of a standalone report run (no method execution).
+ */
+export interface ModelReportView {
+  modelId: string;
+  modelName: string;
+  modelType: string;
+  status: "succeeded" | "failed";
+  reports: Record<string, ReportResultView>;
+}
+
+/**
+ * Read-model projection of a completed model method run.
+ * Presentation-oriented view with computed fields (duration, artifacts).
+ */
 export interface ModelMethodRunView {
   modelId: string;
   modelName: string;
@@ -41,4 +72,5 @@ export interface ModelMethodRunView {
   outputId: string;
   logFile?: string;
   dataArtifacts: DataArtifactView[];
+  reports?: Record<string, ReportResultView>;
 }

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -21,6 +21,16 @@ import { cancelled, type SwampError } from "../errors.ts";
 import { inputValidationFailed } from "../workflows/run.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { MethodExecutionEvent } from "../../domain/models/method_events.ts";
+import {
+  executeReports,
+  type ReportExecutionResult,
+} from "../../domain/reports/report_execution_service.ts";
+import { reportRegistry } from "../../domain/reports/report_registry.ts";
+import type {
+  MethodReportContext,
+  ModelReportContext,
+} from "../../domain/reports/report_context.ts";
+import type { ReportResultView } from "./model_method_run_view.ts";
 import type { Definition } from "../../domain/definitions/definition.ts";
 import type { InputsSchema } from "../../domain/definitions/definition.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
@@ -46,6 +56,7 @@ import { detectEnvVarUsageInDefinition } from "../../domain/models/env_var_detec
 import { withEventBridge } from "../../infrastructure/stream/event_bridge.ts";
 import type { MethodResult } from "../../domain/models/model.ts";
 import { getRunLogger } from "../../infrastructure/logging/logger.ts";
+import { buildReportDataHandles } from "../../domain/reports/report_data_handles.ts";
 
 /**
  * Events emitted by the libswamp model method run generator.
@@ -87,6 +98,24 @@ export type ModelMethodRunEvent =
     event: MethodExecutionEvent;
   }
   | { kind: "data_artifact_saved"; name: string; path: string }
+  | {
+    kind: "report_started";
+    reportName: string;
+    scope: string;
+  }
+  | {
+    kind: "report_completed";
+    reportName: string;
+    scope: string;
+    markdown: string;
+    json: Record<string, unknown>;
+  }
+  | {
+    kind: "report_failed";
+    reportName: string;
+    scope: string;
+    error: string;
+  }
   | { kind: "completed"; run: ModelMethodRunView }
   | { kind: "error"; error: SwampError };
 
@@ -143,6 +172,11 @@ export interface ModelMethodRunInput {
   skipCheckNames?: string[];
   skipCheckLabels?: string[];
   skipAllChecks?: boolean;
+  skipReportNames?: string[];
+  skipReportLabels?: string[];
+  skipAllReports?: boolean;
+  reportNames?: string[];
+  reportLabels?: string[];
   driver?: string;
 }
 
@@ -470,17 +504,156 @@ export async function* modelMethodRun(
     output.markSucceeded();
     await deps.outputRepo.save(modelType, input.methodName, output);
 
+    // --- Post-run reports ---
+    let reportResults: Record<string, ReportResultView> | undefined;
+    let reportFailures = 0;
+
+    if (!input.skipAllReports && reportRegistry.getAll().length > 0) {
+      const dataHandles = await buildReportDataHandles(
+        deps.dataRepo,
+        modelType,
+        evaluatedDefinition.id,
+      );
+
+      // Run method-scope reports
+      const methodContext: MethodReportContext = {
+        scope: "method",
+        repoDir: deps.repoDir,
+        logger: getRunLogger(definition.name, input.methodName),
+        dataRepository: deps.dataRepo,
+        definitionRepository: deps.definitionRepo,
+        modelType,
+        modelId: evaluatedDefinition.id,
+        definition: {
+          id: evaluatedDefinition.id,
+          name: evaluatedDefinition.name,
+          version: evaluatedDefinition.version,
+          tags: evaluatedDefinition.tags,
+        },
+        globalArgs: evaluatedDefinition.globalArguments,
+        methodArgs: evaluatedDefinition.getMethodArguments(input.methodName),
+        methodName: input.methodName,
+        executionStatus: "succeeded",
+        dataHandles,
+      };
+
+      const methodSummary = await executeReports(
+        reportRegistry,
+        methodContext,
+        modelType,
+        evaluatedDefinition.id,
+        definition.reportSelection,
+        {
+          skipAllReports: input.skipAllReports,
+          skipReportNames: input.skipReportNames,
+          skipReportLabels: input.skipReportLabels,
+          reportNames: input.reportNames,
+          reportLabels: input.reportLabels,
+        },
+        {
+          onReportStarted: () => {},
+          onReportCompleted: () => {},
+          onReportFailed: () => {},
+        },
+        input.methodName,
+        modelDef.reports,
+      );
+
+      // Yield report events and collect results
+      reportResults = {};
+      for (const result of methodSummary.results) {
+        yield {
+          kind: "report_started" as const,
+          reportName: result.name,
+          scope: result.scope,
+        };
+        if (result.success) {
+          yield {
+            kind: "report_completed" as const,
+            reportName: result.name,
+            scope: result.scope,
+            markdown: result.markdown!,
+            json: result.json!,
+          };
+        } else {
+          yield {
+            kind: "report_failed" as const,
+            reportName: result.name,
+            scope: result.scope,
+            error: result.error!,
+          };
+        }
+        reportResults[result.name] = toReportResultView(result);
+      }
+      reportFailures += methodSummary.failures;
+
+      // Run model-scope reports
+      const modelContext: ModelReportContext = {
+        ...methodContext,
+        scope: "model",
+      };
+
+      const modelSummary = await executeReports(
+        reportRegistry,
+        modelContext,
+        modelType,
+        evaluatedDefinition.id,
+        definition.reportSelection,
+        {
+          skipAllReports: input.skipAllReports,
+          skipReportNames: input.skipReportNames,
+          skipReportLabels: input.skipReportLabels,
+          reportNames: input.reportNames,
+          reportLabels: input.reportLabels,
+        },
+        {
+          onReportStarted: () => {},
+          onReportCompleted: () => {},
+          onReportFailed: () => {},
+        },
+        input.methodName,
+        modelDef.reports,
+      );
+
+      for (const result of modelSummary.results) {
+        yield {
+          kind: "report_started" as const,
+          reportName: result.name,
+          scope: result.scope,
+        };
+        if (result.success) {
+          yield {
+            kind: "report_completed" as const,
+            reportName: result.name,
+            scope: result.scope,
+            markdown: result.markdown!,
+            json: result.json!,
+          };
+        } else {
+          yield {
+            kind: "report_failed" as const,
+            reportName: result.name,
+            scope: result.scope,
+            error: result.error!,
+          };
+        }
+        reportResults[result.name] = toReportResultView(result);
+      }
+      reportFailures += modelSummary.failures;
+    }
+
     // --- Complete ---
     const view: ModelMethodRunView = {
       modelId: definition.id,
       modelName: definition.name,
       modelType: modelType.normalized,
       methodName: input.methodName,
-      status: "succeeded",
+      status: reportFailures > 0 ? "failed" : "succeeded",
       duration: output.durationMs,
       outputId: output.id,
       logFile: logFilePath,
       dataArtifacts,
+      reports: reportResults,
     };
     yield { kind: "completed", run: view };
   } finally {
@@ -546,5 +719,21 @@ export function methodExecutionFailed(cause: unknown): SwampError {
     code: "method_execution_failed",
     message,
     cause: cause instanceof Error ? cause : undefined,
+  };
+}
+
+/**
+ * Converts a ReportExecutionResult to a ReportResultView.
+ */
+export function toReportResultView(
+  result: ReportExecutionResult,
+): ReportResultView {
+  return {
+    name: result.name,
+    scope: result.scope,
+    success: result.success,
+    markdown: result.markdown,
+    json: result.json,
+    error: result.error,
   };
 }

--- a/src/libswamp/reports/describe.ts
+++ b/src/libswamp/reports/describe.ts
@@ -1,0 +1,57 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ReportDefinition } from "../../domain/reports/report.ts";
+import type { LibSwampContext } from "../context.ts";
+import { notFound } from "../errors.ts";
+import type { ReportDescribeEvent } from "./report_views.ts";
+
+/**
+ * Dependencies for the report describe operation.
+ */
+export interface ReportDescribeDeps {
+  getReport: (name: string) => ReportDefinition | undefined;
+}
+
+/**
+ * Looks up a report definition from the registry and yields its metadata.
+ */
+export async function* reportDescribe(
+  _ctx: LibSwampContext,
+  deps: ReportDescribeDeps,
+  reportName: string,
+): AsyncGenerator<ReportDescribeEvent> {
+  yield { kind: "resolving" };
+
+  const report = deps.getReport(reportName);
+  if (!report) {
+    yield { kind: "error", error: notFound("Report", reportName) };
+    return;
+  }
+
+  yield {
+    kind: "completed",
+    data: {
+      name: reportName,
+      description: report.description,
+      scope: report.scope,
+      labels: report.labels ?? [],
+    },
+  };
+}

--- a/src/libswamp/reports/describe_test.ts
+++ b/src/libswamp/reports/describe_test.ts
@@ -1,0 +1,87 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import { reportDescribe } from "./describe.ts";
+import type { ReportDescribeDeps } from "./describe.ts";
+import type { ReportDefinition } from "../../domain/reports/report.ts";
+
+const testReport: ReportDefinition = {
+  description: "A test cost report",
+  scope: "model",
+  labels: ["cost", "finops"],
+  execute: () => Promise.resolve({ markdown: "", json: {} }),
+};
+
+function makeDeps(
+  reports: Record<string, ReportDefinition> = {},
+): ReportDescribeDeps {
+  return {
+    getReport: (name) => reports[name],
+  };
+}
+
+Deno.test("reportDescribe - returns report definition details", async () => {
+  const ctx = createLibSwampContext();
+  const deps = makeDeps({ "cost-report": testReport });
+
+  const events = await collect(reportDescribe(ctx, deps, "cost-report"));
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "completed");
+  if (last.kind === "completed") {
+    assertEquals(last.data.name, "cost-report");
+    assertEquals(last.data.description, "A test cost report");
+    assertEquals(last.data.scope, "model");
+    assertEquals(last.data.labels, ["cost", "finops"]);
+  }
+});
+
+Deno.test("reportDescribe - returns empty labels when none defined", async () => {
+  const noLabelsReport: ReportDefinition = {
+    description: "No labels",
+    scope: "method",
+    execute: () => Promise.resolve({ markdown: "", json: {} }),
+  };
+  const ctx = createLibSwampContext();
+  const deps = makeDeps({ "simple-report": noLabelsReport });
+
+  const events = await collect(reportDescribe(ctx, deps, "simple-report"));
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "completed");
+  if (last.kind === "completed") {
+    assertEquals(last.data.labels, []);
+  }
+});
+
+Deno.test("reportDescribe - errors when report not found", async () => {
+  const ctx = createLibSwampContext();
+  const deps = makeDeps({});
+
+  const events = await collect(reportDescribe(ctx, deps, "missing-report"));
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "error");
+  if (last.kind === "error") {
+    assertEquals(last.error.code, "not_found");
+  }
+});

--- a/src/libswamp/reports/get.ts
+++ b/src/libswamp/reports/get.ts
@@ -1,0 +1,277 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { Data } from "../../domain/data/data.ts";
+import type { Definition } from "../../domain/definitions/definition.ts";
+import type { ModelType } from "../../domain/models/model_type.ts";
+import type { LibSwampContext } from "../context.ts";
+import { notFound, validationFailed } from "../errors.ts";
+import type { ReportGetEvent, StoredReportDetail } from "./report_views.ts";
+
+/**
+ * Input for the report get operation.
+ */
+export interface ReportGetInput {
+  reportName: string;
+  model?: string;
+  workflow?: string;
+  version?: number;
+  variant?: string;
+}
+
+/**
+ * Dependencies for the report get operation.
+ */
+export interface ReportGetDeps {
+  findAllGlobal: () => Promise<
+    Array<{ data: Data; modelType: ModelType; modelId: string }>
+  >;
+  findAllForModel: (type: ModelType, modelId: string) => Promise<Data[]>;
+  getContent: (
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ) => Promise<Uint8Array | null>;
+  lookupDefinition: (
+    idOrName: string,
+  ) => Promise<{ definition: Definition; type: ModelType } | null>;
+  lookupDefinitionById: (
+    type: ModelType,
+    id: string,
+  ) => Promise<Definition | null>;
+  findWorkflowByName: (
+    name: string,
+  ) => Promise<{ id: string; name: string } | null>;
+  findWorkflowById: (
+    id: string,
+  ) => Promise<{ id: string; name: string } | null>;
+}
+
+/**
+ * Checks whether a Data artifact is a markdown report with matching name.
+ */
+function isMatchingReport(data: Data, reportName: string): boolean {
+  return data.tags.type === "report" &&
+    data.contentType === "text/markdown" &&
+    data.tags.reportName === reportName;
+}
+
+/**
+ * Fetches a specific stored report's content.
+ */
+export async function* reportGet(
+  _ctx: LibSwampContext,
+  deps: ReportGetDeps,
+  input: ReportGetInput,
+): AsyncGenerator<ReportGetEvent> {
+  yield { kind: "resolving" };
+
+  // --- Find matching report data entries ---
+  let matches: Array<{
+    data: Data;
+    modelType: ModelType;
+    modelId: string;
+  }>;
+
+  if (input.model) {
+    const result = await deps.lookupDefinition(input.model);
+    if (!result) {
+      yield { kind: "error", error: notFound("Model", input.model) };
+      return;
+    }
+    const items = await deps.findAllForModel(
+      result.type,
+      result.definition.id,
+    );
+    matches = items
+      .filter((d) => isMatchingReport(d, input.reportName))
+      .map((d) => ({
+        data: d,
+        modelType: result.type,
+        modelId: result.definition.id,
+      }));
+  } else if (input.workflow) {
+    const wf = await deps.findWorkflowByName(input.workflow);
+    if (!wf) {
+      yield { kind: "error", error: notFound("Workflow", input.workflow) };
+      return;
+    }
+    const { ModelType: MT } = await import(
+      "../../domain/models/model_type.ts"
+    );
+    const workflowModelType = MT.create("workflow");
+    const items = await deps.findAllForModel(workflowModelType, wf.id);
+    matches = items
+      .filter((d) => isMatchingReport(d, input.reportName))
+      .map((d) => ({
+        data: d,
+        modelType: workflowModelType,
+        modelId: wf.id,
+      }));
+  } else {
+    // Global search
+    const all = await deps.findAllGlobal();
+    matches = all.filter((c) => isMatchingReport(c.data, input.reportName));
+  }
+
+  // Filter by variant when specified
+  if (input.variant) {
+    matches = matches.filter(
+      (m) => m.data.tags.varySuffix === input.variant,
+    );
+  }
+
+  if (matches.length === 0) {
+    yield {
+      kind: "error",
+      error: notFound("Report", input.reportName),
+    };
+    return;
+  }
+
+  // Ambiguity check: multiple models/workflows have this report
+  if (matches.length > 1 && !input.model && !input.workflow) {
+    const locations = new Set<string>();
+    for (const m of matches) {
+      if (m.modelType.normalized === "workflow") {
+        const wf = await deps.findWorkflowById(m.modelId);
+        locations.add(`workflow:${wf?.name ?? m.modelId}`);
+      } else {
+        const def = await deps.lookupDefinitionById(m.modelType, m.modelId);
+        locations.add(`model:${def?.name ?? m.modelId}`);
+      }
+    }
+    if (locations.size > 1) {
+      const locationList = [...locations].join(", ");
+      yield {
+        kind: "error",
+        error: validationFailed(
+          `Report "${input.reportName}" exists in multiple locations: ${locationList}. Use --model or --workflow to disambiguate.`,
+        ),
+      };
+      return;
+    }
+  }
+
+  // Ambiguity check: multiple variants on the same model
+  if (matches.length > 1 && !input.variant) {
+    const variants = new Set(
+      matches.map((m) => m.data.tags.varySuffix).filter(Boolean),
+    );
+    if (variants.size > 1) {
+      const variantList = [...variants].join(", ");
+      yield {
+        kind: "error",
+        error: validationFailed(
+          `Report "${input.reportName}" has multiple variants: ${variantList}. Use --variant to select one.`,
+        ),
+      };
+      return;
+    }
+  }
+
+  // Pick the best match (latest version or specific version)
+  let match = matches[0];
+  if (input.version) {
+    const versionMatch = matches.find(
+      (m) => m.data.version === input.version,
+    );
+    if (!versionMatch) {
+      yield {
+        kind: "error",
+        error: notFound(
+          "Report",
+          `"${input.reportName}" version ${input.version}`,
+        ),
+      };
+      return;
+    }
+    match = versionMatch;
+  } else {
+    // Pick latest by createdAt
+    matches.sort(
+      (a, b) => b.data.createdAt.getTime() - a.data.createdAt.getTime(),
+    );
+    match = matches[0];
+  }
+
+  const { data, modelType, modelId } = match;
+  const reportScope = data.tags.reportScope ?? "unknown";
+
+  // Resolve model name
+  let modelName = modelId;
+  if (modelType.normalized === "workflow") {
+    const wf = await deps.findWorkflowById(modelId);
+    if (wf) modelName = wf.name;
+  } else {
+    const def = await deps.lookupDefinitionById(modelType, modelId);
+    if (def) modelName = def.name;
+  }
+
+  // Resolve workflow name
+  let workflowName: string | undefined;
+  if (modelType.normalized === "workflow") {
+    const wf = await deps.findWorkflowById(modelId);
+    if (wf) workflowName = wf.name;
+  }
+
+  // Fetch markdown content
+  const rawMd = await deps.getContent(
+    modelType,
+    modelId,
+    data.name,
+    data.version,
+  );
+  const markdown = rawMd ? new TextDecoder().decode(rawMd) : "";
+
+  // Fetch paired JSON content
+  const jsonDataName = `${data.name}-json`;
+  const rawJson = await deps.getContent(
+    modelType,
+    modelId,
+    jsonDataName,
+    data.version,
+  );
+  let json: Record<string, unknown> = {};
+  if (rawJson) {
+    try {
+      json = JSON.parse(new TextDecoder().decode(rawJson));
+    } catch {
+      // Leave as empty if JSON parse fails
+    }
+  }
+
+  const detail: StoredReportDetail = {
+    reportName: input.reportName,
+    reportScope,
+    modelId,
+    modelName,
+    modelType: modelType.normalized,
+    version: data.version,
+    createdAt: data.createdAt.toISOString(),
+    workflowName,
+    varySuffix: data.tags.varySuffix || undefined,
+    dataName: data.name,
+    markdown,
+    json,
+  };
+
+  yield { kind: "completed", data: detail };
+}

--- a/src/libswamp/reports/get_test.ts
+++ b/src/libswamp/reports/get_test.ts
@@ -1,0 +1,315 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import { reportGet } from "./get.ts";
+import type { ReportGetDeps } from "./get.ts";
+import { Data } from "../../domain/data/data.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
+import { Definition } from "../../domain/definitions/definition.ts";
+
+function makeReportData(
+  name: string,
+  reportName: string,
+  scope: string,
+): Data {
+  return Data.create({
+    name,
+    contentType: "text/markdown",
+    lifetime: "30d",
+    garbageCollection: 5,
+    tags: { type: "report", reportName, reportScope: scope },
+    ownerDefinition: { ownerType: "model-method", ownerRef: "test" },
+    createdAt: new Date("2026-01-15T10:00:00Z"),
+  });
+}
+
+function makeDeps(
+  globalData: Array<{
+    data: Data;
+    modelType: ModelType;
+    modelId: string;
+  }> = [],
+): ReportGetDeps {
+  return {
+    findAllGlobal: () => Promise.resolve(globalData),
+    findAllForModel: (_type: ModelType, _modelId: string) =>
+      Promise.resolve([] as Data[]),
+    getContent: (
+      _type: ModelType,
+      _modelId: string,
+      dataName: string,
+    ) => {
+      if (dataName.endsWith("-json")) {
+        return Promise.resolve(
+          new TextEncoder().encode('{"status":"ok"}'),
+        );
+      }
+      return Promise.resolve(
+        new TextEncoder().encode("# Report\nAll good."),
+      );
+    },
+    lookupDefinition: () => Promise.resolve(null),
+    lookupDefinitionById: () => Promise.resolve(null),
+    findWorkflowByName: () => Promise.resolve(null),
+    findWorkflowById: () => Promise.resolve(null),
+  };
+}
+
+Deno.test("reportGet - returns stored report content", async () => {
+  const modelType = ModelType.create("aws/ec2");
+  const reportData = makeReportData("report-cost", "cost-report", "model");
+
+  const deps = makeDeps([
+    { data: reportData, modelType, modelId: "test-id" },
+  ]);
+
+  const ctx = createLibSwampContext();
+  const events = await collect(
+    reportGet(ctx, deps, { reportName: "cost-report" }),
+  );
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "completed");
+  if (last.kind === "completed") {
+    assertEquals(last.data.reportName, "cost-report");
+    assertEquals(last.data.reportScope, "model");
+    assertEquals(last.data.markdown, "# Report\nAll good.");
+    assertEquals(last.data.json, { status: "ok" });
+  }
+});
+
+Deno.test("reportGet - errors when report not found", async () => {
+  const deps = makeDeps([]);
+  const ctx = createLibSwampContext();
+
+  const events = await collect(
+    reportGet(ctx, deps, { reportName: "nonexistent" }),
+  );
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "error");
+  if (last.kind === "error") {
+    assertEquals(last.error.code, "not_found");
+  }
+});
+
+Deno.test("reportGet - errors on ambiguous report across models", async () => {
+  const modelType = ModelType.create("aws/ec2");
+  const report1 = makeReportData("report-cost", "cost-report", "model");
+  const report2 = makeReportData("report-cost", "cost-report", "model");
+
+  const def1 = Definition.create({ name: "model-a", type: "aws/ec2" });
+  const def2 = Definition.create({ name: "model-b", type: "aws/ec2" });
+
+  const deps: ReportGetDeps = {
+    ...makeDeps(),
+    findAllGlobal: () =>
+      Promise.resolve([
+        { data: report1, modelType, modelId: def1.id },
+        { data: report2, modelType, modelId: def2.id },
+      ]),
+    lookupDefinitionById: (_type: ModelType, id: string) => {
+      if (id === def1.id) return Promise.resolve(def1);
+      if (id === def2.id) return Promise.resolve(def2);
+      return Promise.resolve(null);
+    },
+  };
+
+  const ctx = createLibSwampContext();
+  const events = await collect(
+    reportGet(ctx, deps, { reportName: "cost-report" }),
+  );
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "error");
+  if (last.kind === "error") {
+    assertEquals(last.error.code, "validation_failed");
+  }
+});
+
+Deno.test("reportGet - resolves with --model when ambiguous", async () => {
+  const modelType = ModelType.create("aws/ec2");
+  const reportData = makeReportData("report-cost", "cost-report", "model");
+  const def = Definition.create({ name: "my-model", type: "aws/ec2" });
+
+  const deps: ReportGetDeps = {
+    ...makeDeps(),
+    lookupDefinition: (idOrName: string) => {
+      if (idOrName === "my-model") {
+        return Promise.resolve({ definition: def, type: modelType });
+      }
+      return Promise.resolve(null);
+    },
+    findAllForModel: () => Promise.resolve([reportData]),
+    getContent: (
+      _type: ModelType,
+      _modelId: string,
+      dataName: string,
+    ) => {
+      if (dataName.endsWith("-json")) {
+        return Promise.resolve(new TextEncoder().encode("{}"));
+      }
+      return Promise.resolve(
+        new TextEncoder().encode("# Scoped Report"),
+      );
+    },
+    lookupDefinitionById: (_type: ModelType, id: string) => {
+      if (id === def.id) return Promise.resolve(def);
+      return Promise.resolve(null);
+    },
+  };
+
+  const ctx = createLibSwampContext();
+  const events = await collect(
+    reportGet(ctx, deps, { reportName: "cost-report", model: "my-model" }),
+  );
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "completed");
+  if (last.kind === "completed") {
+    assertEquals(last.data.modelName, "my-model");
+    assertEquals(last.data.markdown, "# Scoped Report");
+  }
+});
+
+function makeVariantReportData(
+  name: string,
+  reportName: string,
+  scope: string,
+  varySuffix: string,
+): Data {
+  return Data.create({
+    name,
+    contentType: "text/markdown",
+    lifetime: "30d",
+    garbageCollection: 5,
+    tags: { type: "report", reportName, reportScope: scope, varySuffix },
+    ownerDefinition: { ownerType: "model-method", ownerRef: "test" },
+    createdAt: new Date("2026-01-15T10:00:00Z"),
+  });
+}
+
+Deno.test("reportGet - --variant filters to matching varySuffix", async () => {
+  const modelType = ModelType.create("aws/ec2");
+  const report1 = makeVariantReportData(
+    "report-scan-10.0.0.1",
+    "scan-report",
+    "method",
+    "10.0.0.1",
+  );
+  const report2 = makeVariantReportData(
+    "report-scan-10.0.0.2",
+    "scan-report",
+    "method",
+    "10.0.0.2",
+  );
+
+  const deps: ReportGetDeps = {
+    ...makeDeps(),
+    findAllGlobal: () =>
+      Promise.resolve([
+        { data: report1, modelType, modelId: "test-id" },
+        { data: report2, modelType, modelId: "test-id" },
+      ]),
+    lookupDefinitionById: () => Promise.resolve(null),
+  };
+
+  const ctx = createLibSwampContext();
+  const events = await collect(
+    reportGet(ctx, deps, {
+      reportName: "scan-report",
+      variant: "10.0.0.1",
+    }),
+  );
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "completed");
+  if (last.kind === "completed") {
+    assertEquals(last.data.reportName, "scan-report");
+    assertEquals(last.data.varySuffix, "10.0.0.1");
+  }
+});
+
+Deno.test("reportGet - ambiguity error suggests --variant for multiple variants", async () => {
+  const modelType = ModelType.create("aws/ec2");
+  const report1 = makeVariantReportData(
+    "report-scan-10.0.0.1",
+    "scan-report",
+    "method",
+    "10.0.0.1",
+  );
+  const report2 = makeVariantReportData(
+    "report-scan-10.0.0.2",
+    "scan-report",
+    "method",
+    "10.0.0.2",
+  );
+
+  const deps: ReportGetDeps = {
+    ...makeDeps(),
+    findAllGlobal: () =>
+      Promise.resolve([
+        { data: report1, modelType, modelId: "test-id" },
+        { data: report2, modelType, modelId: "test-id" },
+      ]),
+    lookupDefinitionById: () => Promise.resolve(null),
+  };
+
+  const ctx = createLibSwampContext();
+  const events = await collect(
+    reportGet(ctx, deps, { reportName: "scan-report" }),
+  );
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "error");
+  if (last.kind === "error") {
+    assertEquals(last.error.code, "validation_failed");
+    assertStringIncludes(last.error.message, "--variant");
+    assertStringIncludes(last.error.message, "10.0.0.1");
+    assertStringIncludes(last.error.message, "10.0.0.2");
+  }
+});
+
+Deno.test("reportGet - populates varySuffix in returned detail", async () => {
+  const modelType = ModelType.create("aws/ec2");
+  const reportData = makeVariantReportData(
+    "report-scan-10.0.0.1",
+    "scan-report",
+    "method",
+    "10.0.0.1",
+  );
+
+  const deps = makeDeps([
+    { data: reportData, modelType, modelId: "test-id" },
+  ]);
+
+  const ctx = createLibSwampContext();
+  const events = await collect(
+    reportGet(ctx, deps, { reportName: "scan-report" }),
+  );
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "completed");
+  if (last.kind === "completed") {
+    assertEquals(last.data.varySuffix, "10.0.0.1");
+  }
+});

--- a/src/libswamp/reports/report_views.ts
+++ b/src/libswamp/reports/report_views.ts
@@ -1,0 +1,71 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { SwampError } from "../errors.ts";
+
+/**
+ * Summary of a stored report (no content).
+ */
+export interface StoredReportSummary {
+  reportName: string;
+  reportScope: string;
+  modelId: string;
+  modelName: string;
+  modelType: string;
+  version: number;
+  createdAt: string;
+  workflowName?: string;
+  dataName: string;
+  varySuffix?: string;
+}
+
+/**
+ * Full stored report detail including content.
+ */
+export interface StoredReportDetail extends StoredReportSummary {
+  markdown: string;
+  json: Record<string, unknown>;
+}
+
+/**
+ * Report definition metadata from the registry.
+ */
+export interface ReportDefinitionDetail {
+  name: string;
+  description: string;
+  scope: string;
+  labels: string[];
+}
+
+// --- Event types ---
+
+export type ReportSearchEvent =
+  | { kind: "resolving" }
+  | { kind: "completed"; data: { reports: StoredReportSummary[] } }
+  | { kind: "error"; error: SwampError };
+
+export type ReportGetEvent =
+  | { kind: "resolving" }
+  | { kind: "completed"; data: StoredReportDetail }
+  | { kind: "error"; error: SwampError };
+
+export type ReportDescribeEvent =
+  | { kind: "resolving" }
+  | { kind: "completed"; data: ReportDefinitionDetail }
+  | { kind: "error"; error: SwampError };

--- a/src/libswamp/reports/search.ts
+++ b/src/libswamp/reports/search.ts
@@ -1,0 +1,201 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { Data } from "../../domain/data/data.ts";
+import type { Definition } from "../../domain/definitions/definition.ts";
+import type { ReportDefinition } from "../../domain/reports/report.ts";
+import type { ModelType } from "../../domain/models/model_type.ts";
+import type { LibSwampContext } from "../context.ts";
+import { notFound } from "../errors.ts";
+import type { ReportSearchEvent, StoredReportSummary } from "./report_views.ts";
+
+/**
+ * Input for the report search operation.
+ */
+export interface ReportSearchInput {
+  query?: string;
+  model?: string;
+  workflow?: string;
+  scope?: string;
+  labels?: string[];
+}
+
+/**
+ * Dependencies for the report search operation.
+ */
+export interface ReportSearchDeps {
+  findAllGlobal: () => Promise<
+    Array<{ data: Data; modelType: ModelType; modelId: string }>
+  >;
+  findAllForModel: (type: ModelType, modelId: string) => Promise<Data[]>;
+  lookupDefinition: (
+    idOrName: string,
+  ) => Promise<{ definition: Definition; type: ModelType } | null>;
+  lookupDefinitionById: (
+    type: ModelType,
+    id: string,
+  ) => Promise<Definition | null>;
+  findWorkflowByName: (
+    name: string,
+  ) => Promise<{ id: string; name: string } | null>;
+  findWorkflowById: (
+    id: string,
+  ) => Promise<{ id: string; name: string } | null>;
+  getReport: (name: string) => ReportDefinition | undefined;
+}
+
+/**
+ * Checks whether a Data artifact is a markdown report entry
+ * (skip the paired JSON artifacts).
+ */
+function isReportMarkdown(data: Data): boolean {
+  return data.tags.type === "report" &&
+    data.contentType === "text/markdown";
+}
+
+/**
+ * Searches stored report data across all models and workflows.
+ */
+export async function* reportSearch(
+  _ctx: LibSwampContext,
+  deps: ReportSearchDeps,
+  input: ReportSearchInput,
+): AsyncGenerator<ReportSearchEvent> {
+  yield { kind: "resolving" };
+
+  // --- Collect candidate report data entries ---
+  let candidates: Array<{
+    data: Data;
+    modelType: ModelType;
+    modelId: string;
+  }>;
+
+  if (input.model) {
+    const result = await deps.lookupDefinition(input.model);
+    if (!result) {
+      yield { kind: "error", error: notFound("Model", input.model) };
+      return;
+    }
+    const items = await deps.findAllForModel(
+      result.type,
+      result.definition.id,
+    );
+    candidates = items.map((d) => ({
+      data: d,
+      modelType: result.type,
+      modelId: result.definition.id,
+    }));
+  } else if (input.workflow) {
+    const wf = await deps.findWorkflowByName(input.workflow);
+    if (!wf) {
+      yield { kind: "error", error: notFound("Workflow", input.workflow) };
+      return;
+    }
+    const { ModelType: MT } = await import(
+      "../../domain/models/model_type.ts"
+    );
+    const workflowModelType = MT.create("workflow");
+    const items = await deps.findAllForModel(workflowModelType, wf.id);
+    candidates = items.map((d) => ({
+      data: d,
+      modelType: workflowModelType,
+      modelId: wf.id,
+    }));
+  } else {
+    candidates = await deps.findAllGlobal();
+  }
+
+  // Filter to report markdown entries
+  candidates = candidates.filter((c) => isReportMarkdown(c.data));
+
+  // Apply scope filter
+  if (input.scope) {
+    candidates = candidates.filter(
+      (c) => c.data.tags.reportScope === input.scope,
+    );
+  }
+
+  // Apply label filter — only include reports whose definition has all requested labels
+  if (input.labels && input.labels.length > 0) {
+    candidates = candidates.filter((c) => {
+      const reportName = c.data.tags.reportName;
+      if (!reportName) return false;
+      const def = deps.getReport(reportName);
+      if (!def || !def.labels) return false;
+      return input.labels!.every((l) => def.labels!.includes(l));
+    });
+  }
+
+  // Apply text query filter
+  if (input.query) {
+    const q = input.query.toLowerCase();
+    candidates = candidates.filter((c) => {
+      const reportName = c.data.tags.reportName ?? "";
+      const varySuffix = c.data.tags.varySuffix ?? "";
+      return reportName.toLowerCase().includes(q) ||
+        c.data.name.toLowerCase().includes(q) ||
+        varySuffix.toLowerCase().includes(q);
+    });
+  }
+
+  // Sort by createdAt descending
+  candidates.sort(
+    (a, b) => b.data.createdAt.getTime() - a.data.createdAt.getTime(),
+  );
+
+  // --- Build summary results ---
+  const reports: StoredReportSummary[] = [];
+
+  for (const { data, modelType, modelId } of candidates) {
+    const reportName = data.tags.reportName ?? data.name;
+    const reportScope = data.tags.reportScope ?? "unknown";
+
+    // Resolve model name
+    let modelName = modelId;
+    if (modelType.normalized === "workflow") {
+      const wf = await deps.findWorkflowById(modelId);
+      if (wf) modelName = wf.name;
+    } else {
+      const def = await deps.lookupDefinitionById(modelType, modelId);
+      if (def) modelName = def.name;
+    }
+
+    // Resolve workflow name for workflow-scoped reports
+    let workflowName: string | undefined;
+    if (modelType.normalized === "workflow") {
+      const wf = await deps.findWorkflowById(modelId);
+      if (wf) workflowName = wf.name;
+    }
+
+    reports.push({
+      reportName,
+      reportScope,
+      modelId,
+      modelName,
+      modelType: modelType.normalized,
+      version: data.version,
+      createdAt: data.createdAt.toISOString(),
+      workflowName,
+      dataName: data.name,
+      varySuffix: data.tags.varySuffix || undefined,
+    });
+  }
+
+  yield { kind: "completed", data: { reports } };
+}

--- a/src/libswamp/reports/search_test.ts
+++ b/src/libswamp/reports/search_test.ts
@@ -1,0 +1,274 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import { reportSearch } from "./search.ts";
+import type { ReportSearchDeps } from "./search.ts";
+import { Data } from "../../domain/data/data.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
+
+function makeReportData(
+  name: string,
+  reportName: string,
+  scope: string,
+  contentType = "text/markdown",
+): Data {
+  return Data.create({
+    name,
+    contentType,
+    lifetime: "30d",
+    garbageCollection: 5,
+    tags: { type: "report", reportName, reportScope: scope },
+    ownerDefinition: { ownerType: "model-method", ownerRef: "test" },
+    createdAt: new Date("2026-01-15T10:00:00Z"),
+  });
+}
+
+function makeDeps(
+  globalData: Array<{
+    data: Data;
+    modelType: ModelType;
+    modelId: string;
+  }> = [],
+): ReportSearchDeps {
+  return {
+    findAllGlobal: () => Promise.resolve(globalData),
+    findAllForModel: (_type: ModelType, _modelId: string) =>
+      Promise.resolve([] as Data[]),
+    lookupDefinition: () => Promise.resolve(null),
+    lookupDefinitionById: () => Promise.resolve(null),
+    findWorkflowByName: () => Promise.resolve(null),
+    findWorkflowById: () => Promise.resolve(null),
+    getReport: () => undefined,
+  };
+}
+
+Deno.test("reportSearch - returns empty when no reports exist", async () => {
+  const ctx = createLibSwampContext();
+  const deps = makeDeps([]);
+
+  const events = await collect(reportSearch(ctx, deps, {}));
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "completed");
+  if (last.kind === "completed") {
+    assertEquals(last.data.reports.length, 0);
+  }
+});
+
+Deno.test("reportSearch - finds markdown report entries", async () => {
+  const modelType = ModelType.create("aws/ec2");
+  const mdData = makeReportData("report-cost", "cost-report", "model");
+  const jsonData = makeReportData(
+    "report-cost-json",
+    "cost-report",
+    "model",
+    "application/json",
+  );
+
+  const deps = makeDeps([
+    { data: mdData, modelType, modelId: "test-id" },
+    { data: jsonData, modelType, modelId: "test-id" },
+  ]);
+
+  const ctx = createLibSwampContext();
+  const events = await collect(reportSearch(ctx, deps, {}));
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "completed");
+  if (last.kind === "completed") {
+    // Should only return markdown entries, not JSON pairs
+    assertEquals(last.data.reports.length, 1);
+    assertEquals(last.data.reports[0].reportName, "cost-report");
+    assertEquals(last.data.reports[0].reportScope, "model");
+  }
+});
+
+Deno.test("reportSearch - filters by scope", async () => {
+  const modelType = ModelType.create("aws/ec2");
+  const methodReport = makeReportData(
+    "report-method",
+    "method-report",
+    "method",
+  );
+  const modelReport = makeReportData(
+    "report-model",
+    "model-report",
+    "model",
+  );
+
+  const deps = makeDeps([
+    { data: methodReport, modelType, modelId: "test-id" },
+    { data: modelReport, modelType, modelId: "test-id" },
+  ]);
+
+  const ctx = createLibSwampContext();
+  const events = await collect(
+    reportSearch(ctx, deps, { scope: "method" }),
+  );
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "completed");
+  if (last.kind === "completed") {
+    assertEquals(last.data.reports.length, 1);
+    assertEquals(last.data.reports[0].reportName, "method-report");
+  }
+});
+
+Deno.test("reportSearch - filters by query", async () => {
+  const modelType = ModelType.create("aws/ec2");
+  const costReport = makeReportData("report-cost", "cost-report", "model");
+  const secReport = makeReportData(
+    "report-security",
+    "security-report",
+    "model",
+  );
+
+  const deps = makeDeps([
+    { data: costReport, modelType, modelId: "test-id" },
+    { data: secReport, modelType, modelId: "test-id" },
+  ]);
+
+  const ctx = createLibSwampContext();
+  const events = await collect(
+    reportSearch(ctx, deps, { query: "cost" }),
+  );
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "completed");
+  if (last.kind === "completed") {
+    assertEquals(last.data.reports.length, 1);
+    assertEquals(last.data.reports[0].reportName, "cost-report");
+  }
+});
+
+Deno.test("reportSearch - populates varySuffix from tags", async () => {
+  const modelType = ModelType.create("aws/ec2");
+  const data = Data.create({
+    name: "report-cost",
+    contentType: "text/markdown",
+    lifetime: "30d",
+    garbageCollection: 5,
+    tags: {
+      type: "report",
+      reportName: "cost-report",
+      reportScope: "model",
+      varySuffix: "10.0.0.1",
+    },
+    ownerDefinition: { ownerType: "model-method", ownerRef: "test" },
+    createdAt: new Date("2026-01-15T10:00:00Z"),
+  });
+
+  const deps = makeDeps([{ data, modelType, modelId: "test-id" }]);
+  const ctx = createLibSwampContext();
+  const events = await collect(reportSearch(ctx, deps, {}));
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "completed");
+  if (last.kind === "completed") {
+    assertEquals(last.data.reports[0].varySuffix, "10.0.0.1");
+  }
+});
+
+Deno.test("reportSearch - varySuffix is undefined when not in tags", async () => {
+  const modelType = ModelType.create("aws/ec2");
+  const data = makeReportData("report-cost", "cost-report", "model");
+
+  const deps = makeDeps([{ data, modelType, modelId: "test-id" }]);
+  const ctx = createLibSwampContext();
+  const events = await collect(reportSearch(ctx, deps, {}));
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "completed");
+  if (last.kind === "completed") {
+    assertEquals(last.data.reports[0].varySuffix, undefined);
+  }
+});
+
+Deno.test("reportSearch - query filter matches varySuffix", async () => {
+  const modelType = ModelType.create("aws/ec2");
+  const dataWithSuffix = Data.create({
+    name: "report-cost",
+    contentType: "text/markdown",
+    lifetime: "30d",
+    garbageCollection: 5,
+    tags: {
+      type: "report",
+      reportName: "cost-report",
+      reportScope: "model",
+      varySuffix: "10.0.0.1",
+    },
+    ownerDefinition: { ownerType: "model-method", ownerRef: "test" },
+    createdAt: new Date("2026-01-15T10:00:00Z"),
+  });
+  const dataWithout = makeReportData(
+    "report-security",
+    "security-report",
+    "model",
+  );
+
+  const deps = makeDeps([
+    { data: dataWithSuffix, modelType, modelId: "test-id" },
+    { data: dataWithout, modelType, modelId: "test-id" },
+  ]);
+
+  const ctx = createLibSwampContext();
+  const events = await collect(
+    reportSearch(ctx, deps, { query: "10.0.0.1" }),
+  );
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "completed");
+  if (last.kind === "completed") {
+    assertEquals(last.data.reports.length, 1);
+    assertEquals(last.data.reports[0].varySuffix, "10.0.0.1");
+  }
+});
+
+Deno.test("reportSearch - errors when model not found", async () => {
+  const deps = makeDeps([]);
+  const ctx = createLibSwampContext();
+
+  const events = await collect(
+    reportSearch(ctx, deps, { model: "nonexistent" }),
+  );
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "error");
+  if (last.kind === "error") {
+    assertEquals(last.error.code, "not_found");
+  }
+});
+
+Deno.test("reportSearch - errors when workflow not found", async () => {
+  const deps = makeDeps([]);
+  const ctx = createLibSwampContext();
+
+  const events = await collect(
+    reportSearch(ctx, deps, { workflow: "nonexistent" }),
+  );
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "error");
+  if (last.kind === "error") {
+    assertEquals(last.error.code, "not_found");
+  }
+});

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -32,6 +32,8 @@ import type {
   StepRunView,
   WorkflowRunView,
 } from "./workflow_run_view.ts";
+import type { ReportResultView } from "../models/model_method_run_view.ts";
+import { toReportResultView } from "../models/run.ts";
 import type {
   WorkflowRepository,
   WorkflowRunRepository,
@@ -45,6 +47,21 @@ import {
   type InputValidationError,
   InputValidationService,
 } from "../../domain/inputs/mod.ts";
+import {
+  executeReports,
+} from "../../domain/reports/report_execution_service.ts";
+import { reportRegistry } from "../../domain/reports/report_registry.ts";
+import type {
+  WorkflowReportContext,
+} from "../../domain/reports/report_context.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
+import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
+import { getWorkflowRunLogger } from "../../infrastructure/logging/logger.ts";
+import type { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import type { DefinitionRepository } from "../../domain/definitions/repositories.ts";
+import { YamlEvaluatedDefinitionRepository } from "../../infrastructure/persistence/yaml_evaluated_definition_repository.ts";
+import { buildReportDataHandles } from "../../domain/reports/report_data_handles.ts";
 
 /**
  * Events emitted by the libswamp workflow run generator.
@@ -98,6 +115,24 @@ export type WorkflowRunEvent =
     methodName: string;
     event: MethodExecutionEvent;
   }
+  | {
+    kind: "report_started";
+    reportName: string;
+    scope: string;
+  }
+  | {
+    kind: "report_completed";
+    reportName: string;
+    scope: string;
+    markdown: string;
+    json: Record<string, unknown>;
+  }
+  | {
+    kind: "report_failed";
+    reportName: string;
+    scope: string;
+    error: string;
+  }
   | { kind: "completed"; run: WorkflowRunView }
   | { kind: "error"; error: SwampError };
 
@@ -117,6 +152,8 @@ export interface WorkflowRunDeps {
     runRepo: WorkflowRunRepository,
     repoDir: string,
   ) => WorkflowExecutionService;
+  dataRepo?: UnifiedDataRepository;
+  definitionRepo?: DefinitionRepository;
 }
 
 /**
@@ -129,6 +166,11 @@ export interface WorkflowRunInput {
   runtimeTags?: Record<string, string>;
   verbose?: boolean;
   driver?: string;
+  skipAllReports?: boolean;
+  skipReportNames?: string[];
+  skipReportLabels?: string[];
+  reportNames?: string[];
+  reportLabels?: string[];
 }
 
 /**
@@ -268,6 +310,9 @@ function mapEvent(
     case "method_executing":
     case "method_output":
     case "method_event":
+    case "report_started":
+    case "report_completed":
+    case "report_failed":
       return event;
     default: {
       const _exhaustive: never = event;
@@ -337,7 +382,22 @@ export async function* workflowRun(
     deps.repoDir,
   );
 
+  // Track model info from events for post-run reports
+  const modelInfoByStep = new Map<
+    string,
+    { modelName: string; modelType: string; methodName: string }
+  >();
+  // Track step statuses from events
+  const stepStatuses = new Map<string, "succeeded" | "failed" | "skipped">();
+  // Track step job names
+  const stepJobNames = new Map<string, string>();
+
   try {
+    let completedEvent: WorkflowRunEvent | undefined;
+
+    // Collect per-step report results from execution service events
+    const perStepReportResults: ReportResultView[] = [];
+
     for await (
       const event of service.run(resolvedInput.workflowIdOrName, {
         lastEvaluated: resolvedInput.lastEvaluated,
@@ -345,9 +405,85 @@ export async function* workflowRun(
         runtimeTags: resolvedInput.runtimeTags,
         signal: ctx.signal,
         driver: resolvedInput.driver,
+        reportFilterOptions: {
+          skipAllReports: resolvedInput.skipAllReports,
+          skipReportNames: resolvedInput.skipReportNames,
+          skipReportLabels: resolvedInput.skipReportLabels,
+          reportNames: resolvedInput.reportNames,
+          reportLabels: resolvedInput.reportLabels,
+        },
       })
     ) {
-      yield mapEvent(event, deps, resolvedInput);
+      // Track model_resolved events for report context
+      if (event.kind === "model_resolved") {
+        const key = `${event.jobId}:${event.stepId}`;
+        modelInfoByStep.set(key, {
+          modelName: event.modelName,
+          modelType: event.modelType,
+          methodName: event.methodName,
+        });
+        stepJobNames.set(key, event.jobId);
+      }
+      if (event.kind === "step_completed") {
+        stepStatuses.set(`${event.jobId}:${event.stepId}`, "succeeded");
+      }
+      if (event.kind === "step_failed") {
+        stepStatuses.set(`${event.jobId}:${event.stepId}`, "failed");
+      }
+      if (event.kind === "step_skipped") {
+        stepStatuses.set(`${event.jobId}:${event.stepId}`, "skipped");
+      }
+
+      // Collect per-step report results from execution service events
+      if (event.kind === "report_completed") {
+        perStepReportResults.push({
+          name: event.reportName,
+          scope: event.scope,
+          success: true,
+          markdown: event.markdown,
+          json: event.json,
+        });
+      }
+      if (event.kind === "report_failed") {
+        perStepReportResults.push({
+          name: event.reportName,
+          scope: event.scope,
+          success: false,
+          error: event.error,
+        });
+      }
+
+      const mapped = mapEvent(event, deps, resolvedInput);
+
+      // Intercept the completed event to run reports first
+      if (mapped.kind === "completed") {
+        completedEvent = mapped;
+        continue;
+      }
+
+      yield mapped;
+    }
+
+    // Execute post-run reports (workflow-scope only) before yielding the completed event
+    if (completedEvent && completedEvent.kind === "completed") {
+      const reportResults: ReportResultView[] = [...perStepReportResults];
+      yield* executePostRunReports(
+        deps,
+        resolvedInput,
+        workflow,
+        completedEvent.run,
+        modelInfoByStep,
+        stepStatuses,
+        stepJobNames,
+        reportResults,
+      );
+      if (reportResults.length > 0) {
+        completedEvent = {
+          ...completedEvent,
+          run: { ...completedEvent.run, reports: reportResults },
+        };
+      }
+      yield completedEvent;
     }
   } catch (error) {
     if (
@@ -360,6 +496,159 @@ export async function* workflowRun(
       kind: "error",
       error: workflowExecutionFailed(error),
     };
+  }
+}
+
+/**
+ * Executes post-run reports (workflow-scope only) after a workflow completes.
+ *
+ * Method-scope and model-scope reports are now executed inline during
+ * `executeModelMethod()` in the execution service, where the forEach
+ * variable is in scope for computing vary suffixes.
+ */
+async function* executePostRunReports(
+  deps: WorkflowRunDeps,
+  input: WorkflowRunInput,
+  workflow: Workflow,
+  runView: WorkflowRunView,
+  modelInfoByStep: Map<
+    string,
+    { modelName: string; modelType: string; methodName: string }
+  >,
+  stepStatuses: Map<string, "succeeded" | "failed" | "skipped">,
+  stepJobNames: Map<string, string>,
+  reportResults: ReportResultView[],
+): AsyncGenerator<WorkflowRunEvent> {
+  // Reports require dataRepo and definitionRepo; skip if not provided
+  if (!deps.dataRepo || !deps.definitionRepo) {
+    return;
+  }
+
+  if (reportRegistry.getAll().length === 0) {
+    return;
+  }
+
+  const filterOptions = {
+    skipAllReports: input.skipAllReports,
+    skipReportNames: input.skipReportNames,
+    skipReportLabels: input.skipReportLabels,
+    reportNames: input.reportNames,
+    reportLabels: input.reportLabels,
+  };
+
+  const noopEvents = {
+    onReportStarted: () => {},
+    onReportCompleted: () => {},
+    onReportFailed: () => {},
+  };
+
+  // Build workflow-scope step executions context
+  const stepExecutions: WorkflowReportContext["stepExecutions"] = [];
+
+  // Prefer evaluated definitions (post-CEL) over raw definitions
+  const evaluatedDefRepo = new YamlEvaluatedDefinitionRepository(deps.repoDir);
+
+  for (const [key, info] of modelInfoByStep) {
+    const status = stepStatuses.get(key) ?? "failed";
+    const jobName = stepJobNames.get(key) ?? "";
+    // Extract step name from key (format: jobId:stepId)
+    const stepName = key.split(":")[1] ?? "";
+
+    // Look up the evaluated definition first, then fall back to raw
+    let lookupResult = await evaluatedDefRepo.findByNameGlobal(info.modelName);
+    if (!lookupResult) {
+      lookupResult = await findDefinitionByIdOrName(
+        deps.definitionRepo as YamlDefinitionRepository,
+        info.modelName,
+      );
+    }
+
+    if (!lookupResult || status === "skipped") {
+      stepExecutions.push({
+        jobName,
+        stepName,
+        modelName: info.modelName,
+        modelType: info.modelType,
+        methodName: info.methodName,
+        status: status as "succeeded" | "failed" | "skipped",
+        dataHandles: [],
+        methodArgs: {},
+        modelId: "",
+        globalArgs: {},
+      });
+      continue;
+    }
+
+    const { definition, type: modelType } = lookupResult;
+
+    // Build data handles from persisted data repository
+    const stepDataHandles = await buildReportDataHandles(
+      deps.dataRepo,
+      modelType,
+      definition.id,
+    );
+
+    stepExecutions.push({
+      jobName,
+      stepName,
+      modelName: info.modelName,
+      modelType: info.modelType,
+      methodName: info.methodName,
+      status: status as "succeeded" | "failed" | "skipped",
+      dataHandles: stepDataHandles,
+      methodArgs: definition.getMethodArguments(info.methodName),
+      modelId: definition.id,
+      globalArgs: definition.globalArguments,
+    });
+  }
+
+  // Workflow-scope reports
+  const wfContext: WorkflowReportContext = {
+    scope: "workflow",
+    repoDir: deps.repoDir,
+    logger: getWorkflowRunLogger(workflow.name),
+    dataRepository: deps.dataRepo,
+    definitionRepository: deps.definitionRepo,
+    workflowId: workflow.id,
+    workflowRunId: runView.id,
+    workflowName: workflow.name,
+    workflowStatus: runView.status === "succeeded" ? "succeeded" : "failed",
+    stepExecutions,
+  };
+
+  const wfSummary = await executeReports(
+    reportRegistry,
+    wfContext,
+    ModelType.create("workflow"),
+    workflow.id,
+    workflow.reportSelection,
+    filterOptions,
+    noopEvents,
+  );
+
+  for (const result of wfSummary.results) {
+    yield {
+      kind: "report_started",
+      reportName: result.name,
+      scope: result.scope,
+    };
+    if (result.success) {
+      yield {
+        kind: "report_completed",
+        reportName: result.name,
+        scope: result.scope,
+        markdown: result.markdown!,
+        json: result.json!,
+      };
+    } else {
+      yield {
+        kind: "report_failed",
+        reportName: result.name,
+        scope: result.scope,
+        error: result.error!,
+      };
+    }
+    reportResults.push(toReportResultView(result));
   }
 }
 

--- a/src/libswamp/workflows/run_test.ts
+++ b/src/libswamp/workflows/run_test.ts
@@ -650,6 +650,125 @@ Deno.test("inputValidationFailed returns correct error structure", () => {
   assertEquals(error.message, "Input validation failed:\n  name is required");
 });
 
+// --- Report event collection tests ---
+
+Deno.test("workflowRun collects report_completed events from execution service", async () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+  run.start();
+  run.complete();
+
+  const deps = createTestDeps(workflow, [
+    {
+      kind: "started",
+      runId: run.id,
+      workflowName: "test-workflow",
+      logPath: "/tmp/log",
+    },
+    { kind: "job_started", jobId: "job1" },
+    { kind: "step_started", jobId: "job1", stepId: "step1" },
+    {
+      kind: "model_resolved",
+      jobId: "job1",
+      stepId: "step1",
+      modelName: "my-model",
+      modelType: "command/shell",
+      methodName: "run",
+    },
+    {
+      kind: "report_started",
+      reportName: "test-report",
+      scope: "method",
+    },
+    {
+      kind: "report_completed",
+      reportName: "test-report",
+      scope: "method",
+      markdown: "# Report",
+      json: { status: "ok" },
+    },
+    { kind: "step_completed", jobId: "job1", stepId: "step1" },
+    { kind: "job_completed", jobId: "job1", status: "succeeded" },
+    { kind: "completed", run },
+  ]);
+
+  const ctx = createLibSwampContext();
+  const events = await collect(workflowRun(ctx, deps, {
+    workflowIdOrName: "test-workflow",
+  }));
+
+  // Report events should be forwarded
+  const reportStarted = events.find((e) => e.kind === "report_started");
+  assertEquals(reportStarted?.kind, "report_started");
+  if (reportStarted?.kind === "report_started") {
+    assertEquals(reportStarted.reportName, "test-report");
+  }
+
+  const reportCompleted = events.find((e) => e.kind === "report_completed");
+  assertEquals(reportCompleted?.kind, "report_completed");
+  if (reportCompleted?.kind === "report_completed") {
+    assertEquals(reportCompleted.reportName, "test-report");
+    assertEquals(reportCompleted.markdown, "# Report");
+  }
+
+  // Completed event should include per-step report results
+  const completed = events.find((e) => e.kind === "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.run.reports?.length, 1);
+    assertEquals(completed.run.reports![0].name, "test-report");
+    assertEquals(completed.run.reports![0].success, true);
+  }
+});
+
+Deno.test("workflowRun collects report_failed events from execution service", async () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+  run.start();
+  run.complete();
+
+  const deps = createTestDeps(workflow, [
+    {
+      kind: "started",
+      runId: run.id,
+      workflowName: "test-workflow",
+      logPath: "/tmp/log",
+    },
+    { kind: "job_started", jobId: "job1" },
+    { kind: "step_started", jobId: "job1", stepId: "step1" },
+    {
+      kind: "report_failed",
+      reportName: "broken-report",
+      scope: "method",
+      error: "report crashed",
+    },
+    { kind: "step_completed", jobId: "job1", stepId: "step1" },
+    { kind: "job_completed", jobId: "job1", status: "succeeded" },
+    { kind: "completed", run },
+  ]);
+
+  const ctx = createLibSwampContext();
+  const events = await collect(workflowRun(ctx, deps, {
+    workflowIdOrName: "test-workflow",
+  }));
+
+  // Report failed event should be forwarded
+  const reportFailed = events.find((e) => e.kind === "report_failed");
+  assertEquals(reportFailed?.kind, "report_failed");
+  if (reportFailed?.kind === "report_failed") {
+    assertEquals(reportFailed.reportName, "broken-report");
+    assertEquals(reportFailed.error, "report crashed");
+  }
+
+  // Completed event should include the failed report result
+  const completed = events.find((e) => e.kind === "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.run.reports?.length, 1);
+    assertEquals(completed.run.reports![0].name, "broken-report");
+    assertEquals(completed.run.reports![0].success, false);
+    assertEquals(completed.run.reports![0].error, "report crashed");
+  }
+});
+
 // --- Cancellation tests ---
 
 Deno.test("workflowRun yields cancelled error when abort signal fires during execution", async () => {

--- a/src/libswamp/workflows/workflow_run_view.ts
+++ b/src/libswamp/workflows/workflow_run_view.ts
@@ -17,6 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import type { ReportResultView } from "../models/model_method_run_view.ts";
+
 /**
  * Read-model projections of workflow run domain aggregates.
  * These are presentation-oriented views with computed fields (duration, path, artifacts).
@@ -73,4 +75,5 @@ export interface WorkflowRunView {
   jobs: JobRunView[];
   duration?: number;
   path?: string;
+  reports?: ReportResultView[];
 }

--- a/src/presentation/markdown_renderer.ts
+++ b/src/presentation/markdown_renderer.ts
@@ -1,0 +1,48 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Marked } from "marked";
+import TerminalRenderer from "marked-terminal";
+
+const terminalMarked = new Marked();
+terminalMarked.setOptions({
+  // deno-lint-ignore no-explicit-any
+  renderer: new (TerminalRenderer as any)(),
+});
+
+/**
+ * Renders markdown to terminal-formatted text with syntax highlighting.
+ * chalk (used by marked-terminal) auto-respects NO_COLOR env var.
+ */
+export function renderMarkdownToTerminal(markdown: string): string {
+  const result = terminalMarked.parse(markdown);
+  if (typeof result === "string") {
+    return result;
+  }
+  // marked can return a Promise when async extensions are used, but
+  // we don't use any, so this should always be sync.
+  return markdown;
+}
+
+/**
+ * Returns markdown as-is (plain text fallback).
+ */
+export function renderMarkdownPlain(markdown: string): string {
+  return markdown;
+}

--- a/src/presentation/markdown_renderer_test.ts
+++ b/src/presentation/markdown_renderer_test.ts
@@ -1,0 +1,42 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertStringIncludes } from "@std/assert";
+import {
+  renderMarkdownPlain,
+  renderMarkdownToTerminal,
+} from "./markdown_renderer.ts";
+
+Deno.test("renderMarkdownToTerminal - renders heading", () => {
+  const result = renderMarkdownToTerminal("# Hello World");
+  // Should contain the text (formatting may vary with NO_COLOR)
+  assertStringIncludes(result, "Hello World");
+});
+
+Deno.test("renderMarkdownToTerminal - renders bold text", () => {
+  const result = renderMarkdownToTerminal("This is **bold** text");
+  assertStringIncludes(result, "bold");
+});
+
+Deno.test("renderMarkdownPlain - returns markdown unchanged", () => {
+  const md = "# Hello\n\nSome **bold** text";
+  const result = renderMarkdownPlain(md);
+  assertStringIncludes(result, "# Hello");
+  assertStringIncludes(result, "**bold**");
+});

--- a/src/presentation/output/extension_push_output.ts
+++ b/src/presentation/output/extension_push_output.ts
@@ -60,6 +60,15 @@ export interface ResolvedDatastoreEntry {
   configFields?: ExtractedArgument[];
 }
 
+/** A report entry enriched with extracted metadata for the resolved display. */
+export interface ResolvedReportEntry {
+  name: string;
+  fileName: string;
+  description?: string;
+  scope?: string;
+  labels?: string[];
+}
+
 /** Data for showing resolved extension contents before push. */
 export interface ExtensionPushResolvedData {
   name: string;
@@ -72,6 +81,7 @@ export interface ExtensionPushResolvedData {
   vaults: ResolvedVaultEntry[];
   drivers: ResolvedDriverEntry[];
   datastores: ResolvedDatastoreEntry[];
+  reports: ResolvedReportEntry[];
   additionalFiles: string[];
   platforms: string[];
   labels: string[];
@@ -90,6 +100,7 @@ export interface ExtensionPushSuccessData {
   vaultCount: number;
   driverCount: number;
   datastoreCount: number;
+  reportCount: number;
 }
 
 /** Data for compilation error output. */
@@ -177,6 +188,13 @@ export function renderExtensionPushResolved(
             logger.info`      ${field.name}: ${field.type}${opt}`;
           }
         }
+      }
+    }
+    if (data.reports.length > 0) {
+      logger.info`Reports (${data.reports.length}):`;
+      for (const r of data.reports) {
+        const scopeLabel = r.scope ? ` [${r.scope}]` : "";
+        logger.info`  ${r.name}${scopeLabel} (${r.fileName})`;
       }
     }
     if (data.additionalFiles.length > 0) {
@@ -278,6 +296,7 @@ export function renderExtensionPush(
     if (data.datastoreCount > 0) {
       parts.push(`Datastores: ${data.datastoreCount}`);
     }
+    if (data.reportCount > 0) parts.push(`Reports: ${data.reportCount}`);
     parts.push(`Bundles: ${data.bundleCount}`);
     logger.info`${parts.join(", ")}`;
   }

--- a/src/presentation/output/extension_push_output_test.ts
+++ b/src/presentation/output/extension_push_output_test.ts
@@ -56,6 +56,7 @@ Deno.test("renderExtensionPushResolved outputs JSON in json mode", () => {
         vaults: [],
         drivers: [],
         datastores: [],
+        reports: [],
         additionalFiles: [],
         platforms: [],
         labels: [],
@@ -83,6 +84,7 @@ Deno.test("renderExtensionPush outputs JSON in json mode", () => {
         vaultCount: 0,
         driverCount: 0,
         datastoreCount: 0,
+        reportCount: 0,
       },
       "json",
     );

--- a/src/presentation/output/report_search_output.tsx
+++ b/src/presentation/output/report_search_output.tsx
@@ -1,0 +1,277 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+// deno-lint-ignore verbatim-module-syntax
+import React, { useCallback, useMemo, useState } from "react";
+import { Box, render, Text, useApp, useInput } from "ink";
+import type { OutputMode } from "./output.ts";
+import { Fzf, type FzfResultItem } from "fzf";
+import { suppressInkTtyErrors } from "./ink_lifecycle.ts";
+import { useScrollableList } from "./hooks/mod.ts";
+import type { StoredReportSummary } from "../../libswamp/mod.ts";
+
+/**
+ * Re-export for convenience.
+ */
+export type ReportSearchItem = StoredReportSummary;
+
+/**
+ * Data structure for report search results.
+ */
+export interface ReportSearchData {
+  query: string;
+  results: ReportSearchItem[];
+}
+
+/**
+ * Formats an ISO date string as a relative time (e.g., "2d ago").
+ */
+function formatRelativeTime(isoDate: string): string {
+  const diffMs = Date.now() - new Date(isoDate).getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHour = Math.floor(diffMin / 60);
+  if (diffHour < 24) return `${diffHour}h ago`;
+  const diffDay = Math.floor(diffHour / 24);
+  return `${diffDay}d ago`;
+}
+
+/**
+ * Renders report search in either interactive or JSON mode.
+ *
+ * @param data - The search data to render
+ * @param mode - The output mode (interactive or json)
+ * @returns A promise that resolves with the selected report in interactive mode, or undefined in JSON mode
+ */
+export async function renderReportSearch(
+  data: ReportSearchData,
+  mode: OutputMode,
+): Promise<ReportSearchItem | undefined> {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+    return undefined;
+  } else {
+    return await renderInteractiveReportSearch(data);
+  }
+}
+
+/**
+ * Renders an interactive report search UI.
+ *
+ * @param data - The initial search data (reports to search and optional initial query)
+ * @returns A promise that resolves with the selected report, or undefined if cancelled
+ */
+function renderInteractiveReportSearch(
+  data: ReportSearchData,
+): Promise<ReportSearchItem | undefined> {
+  return new Promise<ReportSearchItem | undefined>((resolve) => {
+    const cleanupTty = suppressInkTtyErrors();
+    const { waitUntilExit } = render(
+      <ReportSearchUI
+        reports={data.results}
+        initialQuery={data.query}
+        onSelect={(item) => {
+          cleanupTty();
+          resolve(item);
+        }}
+        onCancel={() => {
+          cleanupTty();
+          resolve(undefined);
+        }}
+      />,
+    );
+    waitUntilExit().catch(() => {});
+  });
+}
+
+interface ReportSearchUIProps {
+  reports: ReportSearchItem[];
+  initialQuery: string;
+  onSelect: (item: ReportSearchItem) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Interactive report search component using fzf for fuzzy matching.
+ */
+export function ReportSearchUI(
+  props: ReportSearchUIProps,
+): React.ReactElement {
+  const { reports, initialQuery, onSelect, onCancel } = props;
+  const { exit } = useApp();
+
+  const [query, setQuery] = useState(initialQuery);
+
+  // Create fzf instance for fuzzy searching
+  const fzf = useMemo(
+    () =>
+      new Fzf(reports, {
+        selector: (item) =>
+          `${item.reportName} ${item.modelName} ${item.reportScope} ${
+            item.workflowName ?? ""
+          } ${item.varySuffix ?? ""}`,
+      }),
+    [reports],
+  );
+
+  // Get filtered results
+  const results: FzfResultItem<ReportSearchItem>[] = fzf.find(query);
+
+  // Use shared scrollable list hook
+  const {
+    selectedIndex,
+    setSelectedIndex,
+    visibleItems: visibleResults,
+    scrollMetrics,
+  } = useScrollableList(results, 10, [query]);
+
+  const handleSelect = useCallback(() => {
+    if (results.length > 0 && selectedIndex < results.length) {
+      const selected = results[selectedIndex].item;
+      exit();
+      onSelect(selected);
+    }
+  }, [results, selectedIndex, exit, onSelect]);
+
+  const handleCancel = useCallback(() => {
+    exit();
+    onCancel();
+  }, [exit, onCancel]);
+
+  useInput((input, key) => {
+    if (key.escape || (key.ctrl && input === "c")) {
+      handleCancel();
+      return;
+    }
+
+    if (key.return) {
+      handleSelect();
+      return;
+    }
+
+    if (key.upArrow) {
+      setSelectedIndex((i) => Math.max(0, i - 1));
+      return;
+    }
+
+    if (key.downArrow) {
+      setSelectedIndex((i) => Math.min(results.length - 1, i + 1));
+      return;
+    }
+
+    if (key.backspace || key.delete) {
+      setQuery((q) => q.slice(0, -1));
+      return;
+    }
+
+    // Handle regular character input
+    if (input && !key.ctrl && !key.meta) {
+      setQuery((q) => q + input);
+    }
+  });
+
+  return (
+    <Box flexDirection="column">
+      {/* Search input */}
+      <Box>
+        <Text color="cyan" bold>
+          Search:{" "}
+        </Text>
+        <Text>{query}</Text>
+        <Text color="gray">|</Text>
+      </Box>
+
+      {/* Results count */}
+      <Box marginTop={1}>
+        <Text dimColor>
+          {results.length} / {reports.length} reports
+        </Text>
+      </Box>
+
+      {/* Results list */}
+      <Box flexDirection="column" marginTop={1}>
+        {scrollMetrics.hasMoreAbove && (
+          <Text dimColor>... {scrollMetrics.moreAboveCount} more above</Text>
+        )}
+        {visibleResults.map((result, index) => (
+          <ReportSearchResultItem
+            key={`${result.item.modelId}-${result.item.dataName}-${result.item.version}`}
+            item={result.item}
+            isSelected={index + scrollMetrics.moreAboveCount === selectedIndex}
+          />
+        ))}
+        {scrollMetrics.hasMoreBelow && (
+          <Text dimColor>
+            ... {scrollMetrics.moreBelowCount} more below
+          </Text>
+        )}
+        {results.length === 0 && (
+          <Text color="yellow">No matching reports found</Text>
+        )}
+      </Box>
+
+      {/* Help text */}
+      <Box marginTop={1}>
+        <Text dimColor>
+          Up/Down: Navigate | Enter: Select | Esc: Cancel
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+interface ReportSearchResultItemProps {
+  item: ReportSearchItem;
+  isSelected: boolean;
+}
+
+/**
+ * Component to display a single report search result item.
+ */
+function ReportSearchResultItem(
+  props: ReportSearchResultItemProps,
+): React.ReactElement {
+  const { item, isSelected } = props;
+  const source = item.workflowName ?? item.modelName;
+
+  return (
+    <Box flexDirection="column">
+      <Box gap={2}>
+        <Text color={isSelected ? "green" : undefined} bold={isSelected}>
+          {isSelected ? "> " : "  "}
+          {item.reportName}
+        </Text>
+        <Text color="cyan">{source}</Text>
+        <Text dimColor>{item.reportScope}</Text>
+        {item.varySuffix && <Text color="yellow">[{item.varySuffix}]</Text>}
+        <Text dimColor>v{item.version}</Text>
+        <Text dimColor>{formatRelativeTime(item.createdAt)}</Text>
+      </Box>
+      {isSelected && (
+        <Box marginLeft={4}>
+          <Text dimColor>
+            type: {item.modelType} | id: {item.modelId}
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/presentation/renderers/model_method_run.ts
+++ b/src/presentation/renderers/model_method_run.ts
@@ -22,6 +22,7 @@ import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
 import { getRunLogger } from "../../infrastructure/logging/logger.ts";
 import { UserError } from "../../domain/errors.ts";
+import { renderMarkdownToTerminal } from "../markdown_renderer.ts";
 
 export interface ModelMethodRunRenderOpts {
   modelName: string;
@@ -119,6 +120,24 @@ class LogModelMethodRunRenderer implements ModelMethodRunRenderer {
           { path: e.path, name: e.name },
         );
       },
+      report_started: () => {},
+      report_completed: (e) => {
+        const logger = getRunLogger(this.modelName, this.methodName);
+        const separator = "\u2500".repeat(60);
+        const parts = [
+          `Running report: "${e.reportName}"`,
+          `\u2500\u2500 Report: ${e.reportName} ${separator}`,
+          renderMarkdownToTerminal(e.markdown),
+          separator,
+        ];
+        logger.info(parts.join("\n"));
+      },
+      report_failed: (e) => {
+        getRunLogger(this.modelName, this.methodName).warn(
+          "Running report: {reportName} \u2192 \u2717 {error}",
+          { reportName: e.reportName, error: e.error },
+        );
+      },
       completed: (e) => {
         if (e.run.status === "failed") {
           this._failed = true;
@@ -168,6 +187,9 @@ class JsonModelMethodRunRenderer implements ModelMethodRunRenderer {
       method_output: () => {},
       method_event: () => {},
       data_artifact_saved: () => {},
+      report_started: () => {},
+      report_completed: () => {},
+      report_failed: () => {},
       completed: (e) => {
         if (e.run.status === "failed") this._failed = true;
         console.log(JSON.stringify(e.run, null, 2));

--- a/src/presentation/renderers/report_describe.ts
+++ b/src/presentation/renderers/report_describe.ts
@@ -1,0 +1,69 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { EventHandlers, ReportDescribeEvent } from "../../libswamp/mod.ts";
+import type { Renderer } from "../renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { UserError } from "../../domain/errors.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+
+class LogReportDescribeRenderer implements Renderer<ReportDescribeEvent> {
+  handlers(): EventHandlers<ReportDescribeEvent> {
+    return {
+      resolving: () => {},
+      completed: (e) => {
+        const d = e.data;
+        writeOutput(`Report: ${d.name}`);
+        writeOutput(`Description: ${d.description}`);
+        writeOutput(`Scope: ${d.scope}`);
+        if (d.labels.length > 0) {
+          writeOutput(`Labels: ${d.labels.join(", ")}`);
+        }
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonReportDescribeRenderer implements Renderer<ReportDescribeEvent> {
+  handlers(): EventHandlers<ReportDescribeEvent> {
+    return {
+      resolving: () => {},
+      completed: (e) => {
+        console.log(JSON.stringify(e.data, null, 2));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createReportDescribeRenderer(
+  mode: OutputMode,
+): Renderer<ReportDescribeEvent> {
+  switch (mode) {
+    case "json":
+      return new JsonReportDescribeRenderer();
+    case "log":
+      return new LogReportDescribeRenderer();
+  }
+}

--- a/src/presentation/renderers/report_describe_test.ts
+++ b/src/presentation/renderers/report_describe_test.ts
@@ -1,0 +1,95 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertStringIncludes } from "@std/assert";
+import { assertThrows } from "@std/assert";
+import { createReportDescribeRenderer } from "./report_describe.ts";
+import type { ReportDescribeEvent } from "../../libswamp/mod.ts";
+
+Deno.test("report describe log renderer - renders definition metadata", () => {
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: string) => output.push(msg);
+
+  try {
+    const renderer = createReportDescribeRenderer("log");
+    const handlers = renderer.handlers();
+    handlers.resolving({ kind: "resolving" });
+    handlers.completed({
+      kind: "completed",
+      data: {
+        name: "cost-report",
+        description: "Shows cost breakdown",
+        scope: "model",
+        labels: ["cost", "finops"],
+      },
+    });
+
+    const combined = output.join("\n");
+    assertStringIncludes(combined, "cost-report");
+    assertStringIncludes(combined, "Shows cost breakdown");
+    assertStringIncludes(combined, "model");
+    assertStringIncludes(combined, "cost, finops");
+  } finally {
+    console.log = origLog;
+  }
+});
+
+Deno.test("report describe json renderer - outputs JSON", () => {
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: string) => output.push(msg);
+
+  try {
+    const renderer = createReportDescribeRenderer("json");
+    const handlers = renderer.handlers();
+    handlers.resolving({ kind: "resolving" });
+    handlers.completed({
+      kind: "completed",
+      data: {
+        name: "cost-report",
+        description: "Shows cost breakdown",
+        scope: "model",
+        labels: ["cost"],
+      },
+    });
+
+    const parsed = JSON.parse(output[0]);
+    assertStringIncludes(parsed.name, "cost-report");
+  } finally {
+    console.log = origLog;
+  }
+});
+
+Deno.test("report describe renderer - throws on error", () => {
+  const renderer = createReportDescribeRenderer("log");
+  const handlers = renderer.handlers();
+  const errorEvent: ReportDescribeEvent = {
+    kind: "error",
+    error: { code: "not_found", message: "Report not found: foo" },
+  };
+  assertThrows(
+    () =>
+      handlers.error(
+        errorEvent as Extract<ReportDescribeEvent, { kind: "error" }>,
+      ),
+    Error,
+    "Report not found: foo",
+  );
+});

--- a/src/presentation/renderers/report_get.ts
+++ b/src/presentation/renderers/report_get.ts
@@ -1,0 +1,75 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { EventHandlers, ReportGetEvent } from "../../libswamp/mod.ts";
+import type { Renderer } from "../renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { UserError } from "../../domain/errors.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import { renderMarkdownToTerminal } from "../markdown_renderer.ts";
+
+class LogReportGetRenderer implements Renderer<ReportGetEvent> {
+  handlers(): EventHandlers<ReportGetEvent> {
+    return {
+      resolving: () => {},
+      completed: (e) => {
+        const r = e.data;
+        const separator = "\u2500".repeat(60);
+        const source = r.workflowName
+          ? `Workflow: ${r.workflowName}`
+          : `Model: ${r.modelName} (${r.modelType})`;
+        const varySuffixLabel = r.varySuffix
+          ? `  |  Variant: ${r.varySuffix}`
+          : "";
+        writeOutput(
+          `${separator}\n  ${r.reportName}  |  ${source}  |  Scope: ${r.reportScope}${varySuffixLabel}  |  v${r.version}  |  ${r.createdAt}\n${separator}`,
+        );
+        writeOutput(renderMarkdownToTerminal(r.markdown));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonReportGetRenderer implements Renderer<ReportGetEvent> {
+  handlers(): EventHandlers<ReportGetEvent> {
+    return {
+      resolving: () => {},
+      completed: (e) => {
+        console.log(JSON.stringify(e.data, null, 2));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createReportGetRenderer(
+  mode: OutputMode,
+): Renderer<ReportGetEvent> {
+  switch (mode) {
+    case "json":
+      return new JsonReportGetRenderer();
+    case "log":
+      return new LogReportGetRenderer();
+  }
+}

--- a/src/presentation/renderers/report_get_test.ts
+++ b/src/presentation/renderers/report_get_test.ts
@@ -1,0 +1,167 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
+import { createReportGetRenderer } from "./report_get.ts";
+import type { ReportGetEvent } from "../../libswamp/mod.ts";
+
+Deno.test("report get log renderer - renders report content", () => {
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: string) => output.push(msg);
+
+  try {
+    const renderer = createReportGetRenderer("log");
+    const handlers = renderer.handlers();
+    handlers.resolving({ kind: "resolving" });
+    handlers.completed({
+      kind: "completed",
+      data: {
+        reportName: "cost-report",
+        reportScope: "model",
+        modelId: "test-id",
+        modelName: "my-ec2",
+        modelType: "aws/ec2",
+        version: 1,
+        createdAt: "2026-01-15T10:00:00.000Z",
+        dataName: "report-cost",
+        markdown: "# Cost Report\nTotal: $42",
+        json: { total: 42 },
+      },
+    });
+
+    const combined = output.join("\n");
+    assertStringIncludes(combined, "cost-report");
+    assertStringIncludes(combined, "my-ec2");
+  } finally {
+    console.log = origLog;
+  }
+});
+
+Deno.test("report get json renderer - outputs JSON object", () => {
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: string) => output.push(msg);
+
+  try {
+    const renderer = createReportGetRenderer("json");
+    const handlers = renderer.handlers();
+    handlers.completed({
+      kind: "completed",
+      data: {
+        reportName: "cost-report",
+        reportScope: "model",
+        modelId: "test-id",
+        modelName: "my-ec2",
+        modelType: "aws/ec2",
+        version: 1,
+        createdAt: "2026-01-15T10:00:00.000Z",
+        dataName: "report-cost",
+        markdown: "# Cost Report",
+        json: { total: 42 },
+      },
+    });
+
+    const parsed = JSON.parse(output[0]);
+    assertStringIncludes(parsed.reportName, "cost-report");
+    assertStringIncludes(parsed.markdown, "# Cost Report");
+  } finally {
+    console.log = origLog;
+  }
+});
+
+Deno.test("report get log renderer - includes Variant when varySuffix present", () => {
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: string) => output.push(msg);
+
+  try {
+    const renderer = createReportGetRenderer("log");
+    const handlers = renderer.handlers();
+    handlers.completed({
+      kind: "completed",
+      data: {
+        reportName: "cost-report",
+        reportScope: "model",
+        modelId: "test-id",
+        modelName: "my-ec2",
+        modelType: "aws/ec2",
+        version: 1,
+        createdAt: "2026-01-15T10:00:00.000Z",
+        dataName: "report-cost",
+        varySuffix: "10.0.0.1",
+        markdown: "# Cost Report\nTotal: $42",
+        json: { total: 42 },
+      },
+    });
+
+    const combined = output.join("\n");
+    assertStringIncludes(combined, "Variant: 10.0.0.1");
+  } finally {
+    console.log = origLog;
+  }
+});
+
+Deno.test("report get log renderer - omits Variant when varySuffix absent", () => {
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: string) => output.push(msg);
+
+  try {
+    const renderer = createReportGetRenderer("log");
+    const handlers = renderer.handlers();
+    handlers.completed({
+      kind: "completed",
+      data: {
+        reportName: "cost-report",
+        reportScope: "model",
+        modelId: "test-id",
+        modelName: "my-ec2",
+        modelType: "aws/ec2",
+        version: 1,
+        createdAt: "2026-01-15T10:00:00.000Z",
+        dataName: "report-cost",
+        markdown: "# Cost Report\nTotal: $42",
+        json: { total: 42 },
+      },
+    });
+
+    const combined = output.join("\n");
+    assertEquals(combined.includes("Variant"), false);
+  } finally {
+    console.log = origLog;
+  }
+});
+
+Deno.test("report get renderer - throws on error", () => {
+  const renderer = createReportGetRenderer("log");
+  const handlers = renderer.handlers();
+  const errorEvent: ReportGetEvent = {
+    kind: "error",
+    error: { code: "not_found", message: "Report not found" },
+  };
+  assertThrows(
+    () =>
+      handlers.error(
+        errorEvent as Extract<ReportGetEvent, { kind: "error" }>,
+      ),
+    Error,
+    "Report not found",
+  );
+});

--- a/src/presentation/renderers/workflow_run.ts
+++ b/src/presentation/renderers/workflow_run.ts
@@ -29,6 +29,7 @@ import {
   getWorkflowRunLogger,
 } from "../../infrastructure/logging/logger.ts";
 import { UserError } from "../../domain/errors.ts";
+import { renderMarkdownToTerminal } from "../markdown_renderer.ts";
 
 export interface WorkflowRunRenderOpts {
   workflowName: string;
@@ -128,6 +129,24 @@ class LogWorkflowRunRenderer implements WorkflowRunRenderer {
             break;
         }
       },
+      report_started: () => {},
+      report_completed: (e) => {
+        const logger = getWorkflowRunLogger(this.workflowName);
+        const separator = "\u2500".repeat(60);
+        const parts = [
+          `Running report: "${e.reportName}"`,
+          `\u2500\u2500 Report: ${e.reportName} ${separator}`,
+          renderMarkdownToTerminal(e.markdown),
+          separator,
+        ];
+        logger.info(parts.join("\n"));
+      },
+      report_failed: (e) => {
+        getWorkflowRunLogger(this.workflowName).warn(
+          "Running report: {reportName} \u2192 \u2717 {error}",
+          { reportName: e.reportName, error: e.error },
+        );
+      },
       completed: (e) => {
         const wfLogger = getWorkflowRunLogger(this.workflowName);
         if (e.run.status === "failed") {
@@ -201,6 +220,9 @@ class JsonWorkflowRunRenderer implements WorkflowRunRenderer {
       method_executing: () => {},
       method_output: () => {},
       method_event: () => {},
+      report_started: () => {},
+      report_completed: () => {},
+      report_failed: () => {},
       completed: (e) => {
         if (e.run.status === "failed") this._failed = true;
         console.log(JSON.stringify(e.run, null, 2));


### PR DESCRIPTION
## Summary

- Add a reports system: user-defined TypeScript extensions in `extensions/reports/` that analyze model/workflow execution results and produce markdown + JSON output, automatically persisted as versioned data artifacts
- Three report scopes (method, model, workflow) with a three-level control model: model-type defaults, definition YAML `reports.require`/`reports.skip`, and CLI flags (`--report`, `--skip-report`, `--report-label`, `--skip-report-label`, `--skip-reports`)
- New CLI commands: `report describe`, `report get`, `report search` (with interactive fuzzy-search TUI)
- Integrate reports into model method runs and workflow runs, extension push/pull, and add a `swamp-report` skill
- Add markdown-to-terminal renderer for rich report output

## Test Plan

- Unit tests for all new domain modules (report registry, execution service, data handles, report selection)
- Unit tests for libswamp generators (describe, get, search) and presentation renderers
- Integration tests updated for architecture boundary and DDD layer rules
- All 3474 tests pass, `deno check`, `deno lint`, `deno fmt` clean
- Binary compiles successfully via `deno run compile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)