### PR TITLE
fix: complete reports integration across extension push, pull, and search

### DIFF
--- a/integration/extension_push_test.ts
+++ b/integration/extension_push_test.ts
@@ -166,7 +166,7 @@ Deno.test("extension push with invalid manifest (no models or workflows) gives c
     assertEquals(code === 0, false);
     assertStringIncludes(
       stderr,
-      "at least one model, workflow, vault, driver, or datastore",
+      "at least one model, workflow, vault, driver, datastore, or report",
     );
   } finally {
     await Deno.remove(tmpDir, { recursive: true });

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -945,6 +945,7 @@ export async function installExtension(
       absoluteVaultsDir,
       absoluteDriversDir,
       absoluteDatastoresDir,
+      absoluteReportsDir,
     );
 
     // Update upstream_extensions.json

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -237,6 +237,7 @@ export const extensionPushCommand = new Command()
           ...vaultEntryPoints,
           ...driverEntryPoints,
           ...datastoreEntryPoints,
+          ...reportEntryPoints,
         ];
         let hasBare = false;
         for (const ep of allEntryPoints) {
@@ -325,7 +326,7 @@ export const extensionPushCommand = new Command()
         reportsDir,
       );
       ctx.logger
-        .debug`Extracted content metadata: ${contentMetadata.models.length} models, ${contentMetadata.workflows.length} workflows, ${contentMetadata.vaults.length} vaults, ${contentMetadata.drivers.length} drivers, ${contentMetadata.datastores.length} datastores`;
+        .debug`Extracted content metadata: ${contentMetadata.models.length} models, ${contentMetadata.workflows.length} workflows, ${contentMetadata.vaults.length} vaults, ${contentMetadata.drivers.length} drivers, ${contentMetadata.datastores.length} datastores, ${contentMetadata.reports.length} reports`;
     } catch {
       ctx.logger.debug`Content metadata extraction failed, skipping`;
     }
@@ -346,7 +347,7 @@ export const extensionPushCommand = new Command()
         );
         throw new UserError(
           "Extension content uses collectives that don't match the extension package. " +
-            "All model types, vault types, workflow names, driver types, and datastore types must use the same collective as the extension.",
+            "All model types, vault types, workflow names, driver types, datastore types, and report names must use the same collective as the extension.",
         );
       }
     }
@@ -577,7 +578,7 @@ export const extensionPushCommand = new Command()
     for (const entryPoint of reportEntryPoints) {
       const entryName = relative(reportsDir, entryPoint).replace(/\.ts$/, "");
       try {
-        const js = await bundleExtension(entryPoint, denoPath);
+        const js = await bundleExtension(entryPoint, denoPath, bundleOptions);
         reportBundles.set(entryName, js);
         ctx.logger.debug`Bundled report ${entryName} (${js.length} bytes)`;
       } catch (error) {

--- a/src/cli/commands/extension_search.ts
+++ b/src/cli/commands/extension_search.ts
@@ -66,7 +66,7 @@ export const extensionSearchCommand = new Command()
   .option("--label <label:string>", "Filter by label", { collect: true })
   .option(
     "--content-type <contentType:string>",
-    "Filter by content type (models, workflows, vaults, datastores, drivers)",
+    "Filter by content type (models, workflows, vaults, datastores, drivers, reports)",
     { collect: true },
   )
   .option(
@@ -113,6 +113,7 @@ export const extensionSearchCommand = new Command()
       "vaults",
       "datastores",
       "drivers",
+      "reports",
     ];
     for (const ct of options.contentType ?? []) {
       if (!validContentTypes.includes(ct)) {

--- a/src/domain/extensions/extension_collective_validator.ts
+++ b/src/domain/extensions/extension_collective_validator.ts
@@ -33,11 +33,11 @@ export interface CollectiveValidationResult {
 }
 
 /**
- * Validates that all content items (models, vaults, workflows, drivers, datastores) in an extension
+ * Validates that all content items (models, vaults, workflows, drivers, datastores, reports) in an extension
  * use the same collective as the extension package itself.
  *
  * For example, if the extension is `@stack72/my-extension`, all model types,
- * vault types, workflow names, driver types, and datastore types must start with `@stack72/`.
+ * vault types, workflow names, driver types, datastore types, and report names must start with `@stack72/`.
  */
 export function validateContentCollectives(
   extensionName: string,

--- a/src/domain/extensions/extension_manifest.ts
+++ b/src/domain/extensions/extension_manifest.ts
@@ -64,7 +64,7 @@ const ExtensionManifestSchemaV1 = z.object({
     (data.reports && data.reports.length > 0),
   {
     message:
-      "Extension must include at least one model, workflow, vault, driver, or datastore",
+      "Extension must include at least one model, workflow, vault, driver, datastore, or report",
   },
 );
 

--- a/src/domain/extensions/extension_manifest_test.ts
+++ b/src/domain/extensions/extension_manifest_test.ts
@@ -200,7 +200,7 @@ version: "2026.02.26.1"
   const error = assertThrows(() => parseExtensionManifest(yaml));
   assertStringIncludes(
     (error as Error).message,
-    "at least one model, workflow, vault, driver, or datastore",
+    "at least one model, workflow, vault, driver, datastore, or report",
   );
 });
 


### PR DESCRIPTION
## Summary

PR #790 added reports as a top-level extension primitive, but several extension system paths were not updated to handle them consistently with other extension types. This PR fixes bugs and consistency gaps across push, pull, and search.

### Bug fixes

- **Report bundles compiled without `bundleOptions`** — Reports using bare specifiers or deno.json import maps would fail to compile during `extension push` because `bundleOptions` (denoConfigPath/packageJsonDir) was not passed to `bundleExtension()`. All other extension types correctly received these options.
- **Reports excluded from bare specifier detection** — When determining whether a `package.json` is needed for bundling, report entry points were not checked. If a report was the only file using bare specifiers, `packageJsonDir` would never be set, causing a bundling failure.
- **`validateSourceCompleteness` skipped reports on pull** — After pulling an extension, source completeness validation checked models, vaults, drivers, and datastores but not reports. Missing report dependencies would go unwarned.
- **`--content-type reports` rejected by CLI** — The `extension search` command had a hardcoded content type validation list that didn't include `"reports"`, so `swamp extension search --content-type reports` would error.

### Consistency fixes

- Manifest validation error message now includes "report" as a valid extension type
- Collective validation error messages and docstrings now mention reports
- Content metadata debug log now includes report count
- Help text for `--content-type` flag lists reports

## Test plan

- [x] `deno run test src/domain/extensions/extension_manifest_test.ts` — passes with updated error message
- [x] `deno run test src/domain/extensions/extension_collective_validator_test.ts` — passes
- [x] `deno run test src/domain/extensions/extension_content_extractor_test.ts` — passes
- [x] `deno check` on all modified files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)