### PR TITLE
docs: add report guidance to skills and generated CLAUDE.md

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -44,6 +44,10 @@ swamp model create @swamp/digitalocean/droplet my-droplet
   → creates my-droplet definition
 ```
 
+If the task is transforming/analyzing existing model output into a report,
+create a report extension instead (see `swamp-report` skill). Extension models
+are for new data sources and integrations.
+
 **Important:** Do not default to generic CLI types (like `command/shell`) for
 specific service integrations. If the user wants to manage S3 buckets, EC2
 instances, or other resources, create a dedicated model for that service rather
@@ -484,6 +488,7 @@ swamp model type describe @myorg/my-model --json  # Check schema
 | Manage secrets for models | `swamp-vault`    |
 | Repository structure      | `swamp-repo`     |
 | Manage model data         | `swamp-data`     |
+| Create reports for models | `swamp-report`   |
 
 ## References
 

--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -532,6 +532,14 @@ Data is owned by the creating model — see
 [references/data-ownership.md](references/data-ownership.md) for rules and
 validation.
 
+## Choosing the Right Approach
+
+| Task                                                  | Approach                                  |
+| ----------------------------------------------------- | ----------------------------------------- |
+| New API/service integration                           | Extension model (`swamp-extension-model`) |
+| Reusable data pipeline (reports, analysis, summaries) | Report extension (`swamp-report`)         |
+| Ad-hoc debugging or one-off data inspection           | Inline processing is fine                 |
+
 ## When to Use Other Skills
 
 | Need                            | Use Skill               |
@@ -541,6 +549,7 @@ validation.
 | Repository structure            | `swamp-repo`            |
 | Manage data lifecycle           | `swamp-data`            |
 | Create custom TypeScript models | `swamp-extension-model` |
+| Create reports for models       | `swamp-report`          |
 
 ## References
 

--- a/.claude/skills/swamp-report/SKILL.md
+++ b/.claude/skills/swamp-report/SKILL.md
@@ -9,6 +9,19 @@ Create and run reports that analyze model and workflow executions. Reports
 produce markdown (human-readable) and JSON (machine-readable) output. All
 commands support `--json` for machine-readable output.
 
+## When to Create a Report
+
+Create a report extension when you need a **repeatable pipeline** to transform,
+aggregate, or analyze model output — security reports, cost analysis, compliance
+checks, execution summaries, etc.
+
+Reports are the right choice when:
+
+- The analysis will be run more than once
+- The output should be stored and versioned alongside model data
+- Multiple models or workflows need the same analysis
+- The user asks for a "report", "analysis", "summary", or "audit"
+
 **Verify CLI syntax:** If unsure about exact flags or subcommands, run
 `swamp help model report` or `swamp help model method run` for the complete,
 up-to-date CLI schema.

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -574,6 +574,7 @@ This repository is managed with [swamp](https://github.com/systeminit/swamp).
 5. **Verify before destructive operations.** Always \`swamp model get <name> --json\` and verify resource IDs before running delete/stop/destroy methods.
 6. **Prefer fan-out methods over loops.** When operating on multiple targets, use a single method that handles all targets internally (factory pattern) rather than looping N separate \`swamp model method run\` calls against the same model. Multiple parallel calls against the same model contend on the per-model lock, causing timeouts. A single fan-out method acquires the lock once and produces all outputs in one execution. Check \`swamp model type describe\` for methods that accept filters or produce multiple outputs.
 7. **Extension npm deps are bundled, not lockfile-tracked.** Swamp's bundler inlines all npm packages (except zod) into extension bundles at bundle time. \`deno.lock\` and \`package.json\` do NOT cover extension model dependencies — this is by design. Always pin explicit versions in \`npm:\` import specifiers (e.g., \`npm:lodash-es@4.17.21\`).
+8. **Reports for reusable data pipelines.** When the task involves building a repeatable pipeline to transform, aggregate, or analyze model output (security reports, cost analysis, compliance checks, summaries), create a report extension. Use the \`swamp-report\` skill for guidance.
 
 ## Skills
 
@@ -584,6 +585,7 @@ essential context for working with this repository.
 - \`swamp-workflow\` - Work with workflows (creating, editing, running)
 - \`swamp-vault\` - Manage secrets and credentials
 - \`swamp-data\` - Manage model data lifecycle
+- \`swamp-report\` - Create and run reports for models and workflows
 - \`swamp-repo\` - Repository management
 - \`swamp-extension-model\` - Create custom TypeScript models
 - \`swamp-extension-driver\` - Create custom execution drivers


### PR DESCRIPTION
## Summary

Closes #662

Agents default to inline shell scripts (`python3 -c`, `deno eval`, complex `jq` pipelines) when they need to transform model output, instead of using the proper extension points. With reports now available, this PR updates skill documentation so agents automatically choose the right approach based on task intent:

- **Reusable pipeline** (reports, analysis, summaries) → report extension
- **Ad-hoc debugging / one-off inspection** → inline is fine

## Changes

- **`src/domain/repo/repo_service.ts`** — Added rule 8 ("Reports for reusable data pipelines") to the generated CLAUDE.md rules, and added `swamp-report` to the generated skills list (after `swamp-data`)
- **`.claude/skills/swamp-model/SKILL.md`** — Added a "Choosing the Right Approach" decision table before "When to Use Other Skills" that maps task type → approach (extension model, report extension, or inline), and added `swamp-report` to the skills cross-reference table
- **`.claude/skills/swamp-extension-model/SKILL.md`** — Added guidance in the decision flow that if the task is transforming/analyzing existing model output, a report extension is the right choice (not an extension model), and added `swamp-report` to the skills cross-reference table
- **`.claude/skills/swamp-report/SKILL.md`** — Added a "When to Create a Report" positioning section after the intro that defines when reports are the right choice (repeatable analysis, versioned output, multi-model analysis, user asks for report/summary/audit)

## Design choices

The key decision was keeping the guidance lightweight and distributed across skills rather than creating a centralized decision document. Each skill now contains just enough context to redirect agents to the right tool — the `swamp-model` skill has the top-level decision table, `swamp-extension-model` has a guard clause before its creation flow, and `swamp-report` has positioning criteria. This means agents get the right guidance regardless of which skill they load first.

We chose not to add any code changes or new CLI behavior — this is purely a documentation/guidance fix that steers agent behavior through better skill content.

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes  
- [x] `deno run test` — all 3475 tests pass
- [ ] Verify generated CLAUDE.md includes rule 8 and `swamp-report` skill by running `swamp init` in a test repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)