### PR TITLE
docs: guide agents to extend models instead of CLI fallback

### DIFF
--- a/.claude/skills/swamp-extension-driver/SKILL.md
+++ b/.claude/skills/swamp-extension-driver/SKILL.md
@@ -20,6 +20,8 @@ startup.
 
 ## Quick Start
 
+1. Create the driver file:
+
 ```typescript
 // extensions/drivers/my-driver/mod.ts
 import { z } from "npm:zod@4";
@@ -93,6 +95,12 @@ export const driver = {
   },
 };
 ```
+
+2. Verify it loaded: `swamp model type search --json` — your driver type should
+   appear in the output. If it doesn't, see [Verify](#verify) below.
+
+3. Test with a model: create a definition with `driver: "@myorg/my-driver"` and
+   run a method to confirm end-to-end execution.
 
 ## Export Contract
 
@@ -176,16 +184,21 @@ no merging across levels.
 
 After creating your driver:
 
-1. Check registration: `swamp model type search --json` — your driver type
-   should be loadable
+1. Check registration: `swamp model type search --json` — look for your driver
+   type in the output. If it appears, the driver loaded successfully.
 2. Test with a model: create a definition with `driver: "@myorg/my-driver"` and
-   run a method
-3. If the driver isn't found, delete stale bundles and retry:
+   run a method. A `"status": "success"` in the output confirms end-to-end
+   execution works.
+3. If the driver doesn't appear in step 1 or the method fails in step 2, delete
+   stale bundles and retry:
 
 ```bash
 rm -rf .swamp/driver-bundles/
 swamp model method run my-instance run --json
 ```
+
+If it still fails after clearing bundles, check for TypeScript errors in your
+driver file — swamp silently skips files that fail to compile.
 
 ## Discovery & Loading
 

--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -11,42 +11,31 @@ startup.
 ## When to Create a Custom Model
 
 **Create an extension model when no built-in or community type exists for your
-use case.**
+use case.** Before creating one:
 
-Before creating a custom model, always check both local types and community
-extensions:
-
-1. Search local types: `swamp model type search <query>`
-2. Search community extensions: `swamp extension search <query>`
+1. `swamp model type search <query>` — check local types
+2. `swamp extension search <query>` — check community extensions
 3. If a community extension exists, install it instead of building from scratch
-4. Only create a custom model if nothing exists locally or in the community
+4. Only create a custom model if nothing exists
 
-Note: Extensions from trusted collectives (`@swamp/*`, `@si/*`, and your
-membership collectives) auto-resolve on first use — no manual `extension pull`
-needed. Just reference the type and swamp installs the extension automatically.
-Use `swamp extension trust list` to see which collectives are trusted, and
-`swamp extension trust add <name>` to trust additional collectives.
-
-Extension models let you:
-
-- Integrate with any API or service (AWS S3, Stripe, custom APIs, etc.)
-- Define any automation logic you need
-- Create reusable components for your workflows
-
-**Example decision flow:**
-
-```
-User wants to work with DigitalOcean droplets
-swamp model type search droplet → no local results
-swamp model create @swamp/digitalocean/droplet my-droplet
-  → auto-resolves @swamp/digitalocean from registry
-  → installs and hot-loads 32 models
-  → creates my-droplet definition
-```
+Trusted collectives (`@swamp/*`, `@si/*`, membership collectives) auto-resolve
+on first use — no manual `extension pull` needed. Use
+`swamp extension trust list` to see trusted collectives.
 
 If the task is transforming/analyzing existing model output into a report,
 create a report extension instead (see `swamp-report` skill). Extension models
 are for new data sources and integrations.
+
+**When a model type exists but is missing a method:**
+
+If the model type covers your domain but doesn't have the method you need:
+
+1. Confirm the type exists: `swamp model type describe <type> --json`
+2. Verify the method is missing from the output
+3. Add the method via `export const extension` — see
+   [Extending Existing Model Types](#extending-existing-model-types) below
+4. Do not fall back to CLI tools (`gh`, `aws`, `curl`) when the domain model
+   already exists
 
 **Important:** Do not default to generic CLI types (like `command/shell`) for
 specific service integrations. If the user wants to manage S3 buckets, EC2
@@ -332,21 +321,12 @@ sync pattern with workflow examples.
 
 ### Optional Patterns for Cloud/API Models
 
-Two patterns are common for models that manage real cloud resources. Neither is
-required — ask the user whether they want them when creating a new extension
-model.
+Ask the user whether they want these when creating a new extension model:
 
 - **[Polling to completion](references/examples.md#polling-to-completion)** —
-  When the provider's API is async, poll until the resource is fully provisioned
-  before returning. Useful when downstream models depend on attributes that
-  aren't populated until ready (IPs, ARNs, endpoints). Not needed when the API
-  returns complete state synchronously.
-
-- **[Idempotent creates](references/examples.md#idempotent-creates)** — Check
-  `context.readResource()` for existing state before creating, to avoid
-  duplicates on workflow re-runs. Useful for non-idempotent APIs (droplets, EC2
-  instances). Not needed when the API is naturally idempotent (tags, S3 buckets)
-  or you intentionally want multiple instances.
+  poll async APIs until the resource is fully provisioned
+- **[Idempotent creates](references/examples.md#idempotent-creates)** — check
+  for existing state before creating to avoid duplicates on re-runs
 
 ## Pre-flight Checks
 

--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -537,6 +537,7 @@ validation.
 | Task                                                  | Approach                                  |
 | ----------------------------------------------------- | ----------------------------------------- |
 | New API/service integration                           | Extension model (`swamp-extension-model`) |
+| Existing model missing a method                       | Extend it (`swamp-extension-model`)       |
 | Reusable data pipeline (reports, analysis, summaries) | Report extension (`swamp-report`)         |
 | Ad-hoc debugging or one-off data inspection           | Inline processing is fine                 |
 

--- a/.claude/skills/swamp-report/SKILL.md
+++ b/.claude/skills/swamp-report/SKILL.md
@@ -278,13 +278,14 @@ Failed reports appear as `{ "_error": "error message" }`.
 
 ## When to Use Other Skills
 
-| Need                      | Use Skill               |
-| ------------------------- | ----------------------- |
-| Work with models          | `swamp-model`           |
-| Create/run workflows      | `swamp-workflow`        |
-| Create custom model types | `swamp-extension-model` |
-| Manage model data         | `swamp-data`            |
-| Repository structure      | `swamp-repo`            |
+| Need                         | Use Skill               |
+| ---------------------------- | ----------------------- |
+| Work with models             | `swamp-model`           |
+| Create/run workflows         | `swamp-workflow`        |
+| Create custom model types    | `swamp-extension-model` |
+| Extend model with new method | `swamp-extension-model` |
+| Manage model data            | `swamp-data`            |
+| Repository structure         | `swamp-repo`            |
 
 ## References
 

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -568,7 +568,7 @@ This repository is managed with [swamp](https://github.com/systeminit/swamp).
 ## Rules
 
 1. **Search before you build.** When automating AWS, APIs, or any external service: (a) search local types with \`swamp model type search <query>\`, (b) search community extensions with \`swamp extension search <query>\`, (c) if a community extension exists, install it with \`swamp extension pull <package>\` instead of building from scratch, (d) only create a custom extension model in \`extensions/models/\` if nothing exists. Use the \`swamp-extension-model\` skill for guidance. The \`command/shell\` model is ONLY for ad-hoc one-off shell commands, NEVER for wrapping CLI tools or building integrations.
-2. **Extend, don't be clever.** Don't work around a missing capability with shell scripts or multi-step hacks. Add a method to the extension model. One method, one purpose.
+2. **Extend, don't be clever.** When a model covers the domain but lacks the method you need, extend it with \`export const extension\` — don't bypass it with shell scripts, CLI tools, or multi-step hacks. One method, one purpose. Use \`swamp model type describe <type> --json\` to check available methods.
 3. **Use the data model.** Once data exists in a model (via \`lookup\`, \`start\`, \`sync\`, etc.), reference it with CEL expressions. Don't re-fetch data that's already available.
 4. **CEL expressions everywhere.** Wire models together with CEL expressions. Always prefer \`data.latest("<name>", "<dataName>").attributes.<field>\` over the deprecated \`model.<name>.resource.<spec>.<instance>.attributes.<field>\` pattern.
 5. **Verify before destructive operations.** Always \`swamp model get <name> --json\` and verify resource IDs before running delete/stop/destroy methods.


### PR DESCRIPTION
## Summary

- Strengthened Rule 2 in generated CLAUDE.md (`generateInstructionsBody()`) to explicitly call out CLI tools (`gh`, `aws`, `curl`) as an anti-pattern alongside shell scripts, and point agents to `export const extension` and `swamp model type describe` to check available methods
- Added "model exists but method missing" decision flow to `swamp-extension-model` skill, routing agents to extend existing models via `export const extension` instead of falling back to CLI tools
- Added "Existing model missing a method" row to the `swamp-model` skill's "Choosing the Right Approach" table
- Added "Extend model with new method" row to the `swamp-report` skill's "When to Use Other Skills" table
- Improved `swamp-extension-driver` skill verification section (tessl review: 94% → 100%)
- Tightened `swamp-extension-model` skill verbosity to stay under 500 lines (tessl review: 93% → 100%)

Closes #667

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno run test` — all 3475 tests pass
- [x] `deno run compile` succeeds
- [x] `npx tessl skill review .claude/skills/swamp-extension-model` — 100%
- [x] `npx tessl skill review .claude/skills/swamp-extension-driver` — 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)