### PR TITLE
fix: eliminate shell injection in command/shell vault secrets via env var injection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,39 @@ jobs:
       - name: Review skills
         run: deno run --allow-read --allow-run --allow-env=GITHUB_STEP_SUMMARY --allow-write scripts/review_skills.ts
 
+  skill-trigger-eval:
+    name: Skill Trigger Eval
+    runs-on: ubuntu-latest
+    # Only run when skill files or the eval framework change
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'skill-eval') ||
+      github.event_name == 'schedule'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install Claude CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run skill trigger evals
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          EVAL_RUNS: "3"
+          EVAL_WORKERS: "5"
+          EVAL_TIMEOUT: "30"
+        run: deno run eval-skill-triggers
+
   claude-review:
     # NOTE: For this to block merges, enable branch protection on main with:
     # "Require a pull request before merging" + "Require approving reviews"

--- a/design/expressions.md
+++ b/design/expressions.md
@@ -196,24 +196,34 @@ attributes:
 
 ### Shell Safety
 
-When vault secrets are injected into the `run` field of a `command/shell` model via CEL
-string concatenation, shell metacharacters in the secret value are automatically escaped so
-that the value is always treated as **literal data**, never as shell syntax.
+When vault secrets are used in the `run` field of a `command/shell` model, the
+shell model passes secret values via **environment variables** instead of
+embedding them in the command string. This prevents all shell metacharacter
+injection — the shell never parses secret content as syntax.
 
-Specifically, `$` and `` ` `` are escaped so that `$(cmd)` and `` `cmd` `` in a secret
-value do not trigger command substitution:
+Internally, vault secrets are replaced with unique sentinel tokens during CEL
+evaluation. At the shell model boundary, sentinels are replaced with
+double-quoted environment variable references (`"${__SWAMP_VAULT_N}"`), and the
+raw secret values are passed through the process environment. Shell variable
+expansion happens after command parsing, so metacharacters in the secret value
+are always treated as literal data.
 
 ```yaml
-# Secret value: $(cat /etc/passwd)
-# Shell receives: \$(cat /etc/passwd)  → outputs literally: $(cat /etc/passwd)
-attributes:
-  run: '"echo " + vault.get(''my-vault'', ''SECRET'') + '' done'''
+# Secret value: pass;rm -rf /
+# Shell receives: echo "${__SWAMP_VAULT_0}"  (with env __SWAMP_VAULT_0="pass;rm -rf /")
+# Output: pass;rm -rf /  (literal, no injection)
+globalArguments:
+  run: "echo ${{ vault.get('my-vault', 'SECRET') }}"
 ```
 
 This means:
-- `$VAR_NAME` in a secret is **not** expanded as a shell variable — it appears literally.
-- `$(cmd)` and `` `cmd` `` in a secret are **not** executed — they appear literally.
-- Prices, connection strings, and other data containing `$` are safe to store and use.
+- `;`, `|`, `&`, `(`, `)`, `<`, `>` in a secret do **not** split or redirect commands.
+- `$VAR_NAME` and `$(cmd)` in a secret are **not** expanded or executed.
+- `` `cmd` `` in a secret is **not** executed.
+- `!` in a secret does **not** trigger bash history expansion.
+- All current and future shell metacharacters are handled — no character blocklist.
+- Non-shell contexts (extension models, API calls) receive exact raw secret values
+  with no escaping artifacts.
 
 ## Environment Variables
 

--- a/integration/cel_data_access_test.ts
+++ b/integration/cel_data_access_test.ts
@@ -603,12 +603,19 @@ Deno.test("CEL Data Access: access environment variables", async () => {
       );
 
       // Resolve runtime expressions (env + vault) — this is the runtime phase
-      const resolved = await evalService.resolveRuntimeExpressionsInDefinition(
-        result.definition,
-      );
+      const runtimeResult = await evalService
+        .resolveRuntimeExpressionsInDefinition(
+          result.definition,
+        );
 
-      assertEquals(resolved.globalArguments.from_env, "test-value");
-      assertEquals(resolved.globalArguments.number_as_string, "42");
+      assertEquals(
+        runtimeResult.definition.globalArguments.from_env,
+        "test-value",
+      );
+      assertEquals(
+        runtimeResult.definition.globalArguments.number_as_string,
+        "42",
+      );
     } finally {
       Deno.env.delete("CEL_TEST_VAR");
       Deno.env.delete("CEL_TEST_NUMBER");

--- a/integration/definition_lifecycle_test.ts
+++ b/integration/definition_lifecycle_test.ts
@@ -784,11 +784,15 @@ Deno.test("Definition Lifecycle: environment variable expressions", async () => 
       );
 
       // Resolve runtime expressions (env + vault) — this is the runtime phase
-      const resolved = await evalService.resolveRuntimeExpressionsInDefinition(
-        result.definition,
-      );
+      const runtimeResult = await evalService
+        .resolveRuntimeExpressionsInDefinition(
+          result.definition,
+        );
 
-      assertEquals(resolved.globalArguments.from_env, "env-value-123");
+      assertEquals(
+        runtimeResult.definition.globalArguments.from_env,
+        "env-value-123",
+      );
     } finally {
       Deno.env.delete("TEST_ENV_VAR");
     }

--- a/integration/vault_cel_integration_test.ts
+++ b/integration/vault_cel_integration_test.ts
@@ -725,13 +725,12 @@ Deno.test("Vault CEL: handles secrets with special characters", async () => {
       "--json",
     ]);
 
-    // Store secret with special characters
-    // Note: $ and ` are escaped with a \\ prefix so that after CEL evaluation
-    // the shell receives \$ and \` (literal characters, no command substitution).
-    // Backslashes, quotes, and newlines are also escaped for CEL string safety.
+    // Store secret with special characters.
+    // Shell metacharacters ($, `, ;, |, &, etc.) are passed through as-is —
+    // shell safety is handled by the shell model via env var injection.
     const specialSecret = "p@ssw0rd!#$%^&*()_+-=[]{}|;:.<>?/";
-    // After escaping, $ becomes \$ so the resolved CEL value includes the backslash
-    const expectedResolved = "p@ssw0rd!#\\$%^&*()_+-=[]{}|;:.<>?/";
+    // Secret is returned as the exact raw value — no escaping artifacts
+    const expectedResolved = "p@ssw0rd!#$%^&*()_+-=[]{}|;:.<>?/";
     const vaultServiceForPut = await VaultService.fromRepository(repoDir);
     await vaultServiceForPut.put(
       "special-chars-vault",

--- a/src/domain/expressions/expression_evaluation_service.ts
+++ b/src/domain/expressions/expression_evaluation_service.ts
@@ -41,6 +41,7 @@ import {
 } from "./model_resolver.ts";
 import { CyclicDependencyError } from "./errors.ts";
 import type { SecretRedactor } from "../secrets/mod.ts";
+import { VaultSecretBag } from "../vaults/vault_secret_bag.ts";
 import {
   CyclicDependencyError as TopoCyclicError,
   type GraphNode,
@@ -83,6 +84,16 @@ export function containsEnvExpression(celExpression: string): boolean {
 export function containsRuntimeExpression(celExpression: string): boolean {
   return containsVaultExpression(celExpression) ||
     containsEnvExpression(celExpression);
+}
+
+/**
+ * Result of resolving runtime expressions in a definition.
+ * Includes the resolved definition and a VaultSecretBag containing
+ * sentinel-to-value mappings for any vault secrets encountered.
+ */
+export interface RuntimeResolutionResult {
+  definition: Definition;
+  secretBag: VaultSecretBag;
 }
 
 /**
@@ -409,14 +420,20 @@ export class ExpressionEvaluationService {
    * Resolves remaining runtime expressions (vault and env) in an already-evaluated definition.
    * This is the runtime phase — vault secrets and env variables are resolved here and never persisted.
    *
+   * Vault secrets are replaced with sentinel tokens. The returned VaultSecretBag
+   * maps sentinels to raw values, allowing the caller to resolve them appropriately:
+   * - Non-shell contexts: VaultSecretBag.resolveDeep() for raw values
+   * - Shell commands: VaultSecretBag.resolveForShell() for env var injection
+   *
    * @param definition - The definition (may contain remaining ${{ vault.get(...) }} or ${{ env.* }} expressions)
    * @param redactor - Optional SecretRedactor to register resolved secret values for redaction
-   * @returns A new definition with all runtime expressions resolved
+   * @returns The definition with sentinels and the VaultSecretBag for resolving them
    */
   async resolveRuntimeExpressionsInDefinition(
     definition: Definition,
     redactor?: SecretRedactor,
-  ): Promise<Definition> {
+  ): Promise<RuntimeResolutionResult> {
+    const secretBag = new VaultSecretBag();
     const definitionData = definition.toData();
     const expressions = extractExpressions(definitionData);
 
@@ -426,23 +443,29 @@ export class ExpressionEvaluationService {
     );
 
     if (runtimeExpressions.length === 0) {
-      return definition;
+      return { definition, secretBag };
     }
 
-    return await this.resolveRuntimeInExpressions(
+    const resolvedDefinition = await this.resolveRuntimeInExpressions(
       definitionData,
       runtimeExpressions,
       redactor,
+      secretBag,
     );
+
+    return { definition: resolvedDefinition, secretBag };
   }
 
   /**
    * Resolves remaining runtime expressions (vault and env) in arbitrary data.
    * This is the runtime phase — vault secrets and env variables are resolved here and never persisted.
    *
+   * When vault secrets are present, sentinels are resolved to raw values inline
+   * (no VaultSecretBag is returned). This is appropriate for non-shell data contexts.
+   *
    * @param data - The data (may contain remaining runtime expressions)
    * @param redactor - Optional SecretRedactor to register resolved secret values for redaction
-   * @returns The data with all runtime expressions resolved
+   * @returns The data with all runtime expressions resolved (sentinels replaced with raw values)
    */
   async resolveRuntimeExpressionsInData(
     data: unknown,
@@ -457,6 +480,7 @@ export class ExpressionEvaluationService {
       return data;
     }
 
+    const secretBag = new VaultSecretBag();
     const evaluatedValues = new Map<string, unknown>();
     for (const expr of runtimeExpressions) {
       // Resolve vault references first (if any), then evaluate the full CEL
@@ -465,6 +489,7 @@ export class ExpressionEvaluationService {
         resolvedCelExpr = await this.modelResolver.resolveVaultExpressions(
           expr.celExpression,
           redactor,
+          secretBag,
         );
       }
       const value = this.celEvaluator.evaluate(resolvedCelExpr, {
@@ -474,16 +499,31 @@ export class ExpressionEvaluationService {
       evaluatedValues.set(expr.raw, value);
     }
 
-    return replaceExpressions(data, evaluatedValues);
+    // For the data path, resolve sentinels to raw values immediately
+    // since there's no shell context to worry about.
+    const resolved = replaceExpressions(data, evaluatedValues);
+    if (!secretBag.isEmpty) {
+      return secretBag.resolveDeep(resolved);
+    }
+    return resolved;
   }
 
   /**
    * @deprecated Use resolveRuntimeExpressionsInDefinition instead.
    */
-  resolveVaultExpressionsInDefinition(
+  async resolveVaultExpressionsInDefinition(
     definition: Definition,
   ): Promise<Definition> {
-    return this.resolveRuntimeExpressionsInDefinition(definition);
+    const result = await this.resolveRuntimeExpressionsInDefinition(definition);
+    // Legacy callers expect raw values, so resolve sentinels immediately
+    if (!result.secretBag.isEmpty) {
+      const data = result.definition.toData();
+      const resolved = result.secretBag.resolveDeep(data);
+      return DefinitionClass.fromData(
+        resolved as ReturnType<Definition["toData"]>,
+      );
+    }
+    return result.definition;
   }
 
   /**
@@ -495,11 +535,13 @@ export class ExpressionEvaluationService {
 
   /**
    * Internal: resolves runtime expressions in definition data and returns a new Definition.
+   * Vault secrets are replaced with sentinel tokens stored in the secretBag.
    */
   private async resolveRuntimeInExpressions(
     definitionData: ReturnType<Definition["toData"]>,
     runtimeExpressions: ExpressionLocation[],
     redactor?: SecretRedactor,
+    secretBag?: VaultSecretBag,
   ): Promise<Definition> {
     const evaluatedValues = new Map<string, unknown>();
     for (const expr of runtimeExpressions) {
@@ -509,6 +551,7 @@ export class ExpressionEvaluationService {
         resolvedCelExpr = await this.modelResolver.resolveVaultExpressions(
           expr.celExpression,
           redactor,
+          secretBag,
         );
       }
       const value = this.celEvaluator.evaluate(resolvedCelExpr, {

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -27,6 +27,7 @@ import type { Data } from "../data/data.ts";
 import { ModelNotFoundError } from "./errors.ts";
 import { VaultService } from "../vaults/vault_service.ts";
 import type { SecretRedactor } from "../secrets/mod.ts";
+import type { VaultSecretBag } from "../vaults/vault_secret_bag.ts";
 
 /**
  * Builds env context from Deno environment variables.
@@ -809,13 +810,20 @@ export class ModelResolver {
   /**
    * Resolves vault expressions in a string by evaluating vault.get() calls.
    *
+   * Secret values are replaced with sentinel tokens in the CEL expression.
+   * The sentinel-to-value mapping is stored in the provided VaultSecretBag,
+   * allowing callers to resolve sentinels later — either to raw values
+   * (non-shell contexts) or to environment variable references (shell commands).
+   *
    * @param value - The string that may contain vault expressions
    * @param redactor - Optional SecretRedactor to register resolved secret values for redaction
-   * @returns The string with vault expressions resolved to actual secret values
+   * @param secretBag - VaultSecretBag to store sentinel-to-value mappings
+   * @returns The string with vault.get() calls replaced by sentinel tokens wrapped as CEL strings
    */
   async resolveVaultExpressions(
     value: string,
     redactor?: SecretRedactor,
+    secretBag?: VaultSecretBag,
   ): Promise<string> {
     // Pattern to match vault.get(vaultName, secretKey) expressions
     // Handles both quoted and unquoted arguments
@@ -837,23 +845,28 @@ export class ModelResolver {
       try {
         const secretValue = await vaultService.get(vaultName, secretKey);
         redactor?.addSecret(secretValue);
-        // Escape special characters to prevent CEL parsing issues and injection attacks.
-        // For $ and `, we use a \\X prefix (two backslashes + char) so that:
-        //   - CEL sees \\ → produces one \, then the char is a plain literal
-        //   - Shell receives \$ or \` → literal character, no command substitution
-        const escapedValue = secretValue
-          .replace(/\\/g, "\\\\")
-          .replace(/\$/g, "\\\\$") // $ → \\$ so CEL produces \$, shell treats as literal $
-          .replace(/`/g, "\\\\`") // ` → \\` so CEL produces \`, shell treats as literal `
-          .replace(/"/g, '\\"')
-          .replace(/'/g, "\\'")
-          .replace(/\n/g, "\\n")
-          .replace(/\r/g, "\\r")
-          .replace(/\t/g, "\\t");
-        // Replace the entire vault.get(...) call with the escaped secret value wrapped in quotes for CEL
-        resolvedValue = resolvedValue.split(fullMatch).join(
-          `"${escapedValue}"`,
-        );
+
+        let celReplacement: string;
+        if (secretBag) {
+          // Sentinel-based resolution: secret value goes into the bag,
+          // sentinel token goes into the CEL expression.
+          const sentinel = secretBag.addSecret(secretValue);
+          celReplacement = `"${sentinel}"`;
+        } else {
+          // Legacy fallback: escape for CEL string safety only.
+          // No shell-specific escaping — shell safety is handled by the
+          // shell model via VaultSecretBag.resolveForShell().
+          const escapedValue = secretValue
+            .replace(/\\/g, "\\\\")
+            .replace(/"/g, '\\"')
+            .replace(/'/g, "\\'")
+            .replace(/\n/g, "\\n")
+            .replace(/\r/g, "\\r")
+            .replace(/\t/g, "\\t");
+          celReplacement = `"${escapedValue}"`;
+        }
+
+        resolvedValue = resolvedValue.split(fullMatch).join(celReplacement);
       } catch (error) {
         throw new Error(
           `Failed to resolve vault expression ${fullMatch}: ${

--- a/src/domain/models/command/shell/shell_model.ts
+++ b/src/domain/models/command/shell/shell_model.ts
@@ -95,11 +95,28 @@ async function executeCommand(
     context.redactor?.hasSecrets ? context.redactor.redact(text) : text;
 
   try {
+    // Resolve vault secrets via environment variables to prevent shell injection.
+    // The unresolved run field contains sentinel tokens for vault secrets.
+    // We replace sentinels with "${__SWAMP_VAULT_N}" env var references and
+    // pass the raw secret values through the process environment, so the shell
+    // never parses secret content as syntax.
+    let shellCommand = args.run;
+    let shellEnv = args.env ?? {};
+    const secretBag = context.vaultSecrets;
+    if (secretBag && !secretBag.isEmpty && context.unresolvedMethodArgs) {
+      const unresolvedRun = context.unresolvedMethodArgs.run;
+      if (typeof unresolvedRun === "string") {
+        const resolved = secretBag.resolveForShell(unresolvedRun);
+        shellCommand = resolved.command;
+        shellEnv = { ...shellEnv, ...resolved.env };
+      }
+    }
+
     const result = await executeProcess({
       command: "sh",
-      args: ["-c", args.run],
+      args: ["-c", shellCommand],
       cwd: args.workingDir,
-      env: args.env,
+      env: Object.keys(shellEnv).length > 0 ? shellEnv : undefined,
       timeoutMs: args.timeout,
       logger: context.logger,
       redactor: context.redactor,

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -231,9 +231,23 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
     method: MethodDefinition,
     context: MethodContext,
   ): Promise<MethodResult> {
-    // Validate per-method arguments against the method's schema
+    // Get raw method arguments (may contain vault sentinel tokens)
     const rawMethodArgs = definition.getMethodArguments(context.methodName);
-    const methodArgs = coerceMethodArgs(rawMethodArgs, method.arguments);
+
+    // Resolve vault sentinels to raw values for method args and global args.
+    // This ensures extension models receive exact secret values with no escaping.
+    const secretBag = context.vaultSecrets;
+    const resolvedMethodArgs = secretBag && !secretBag.isEmpty
+      ? secretBag.resolveDeep(rawMethodArgs) as Record<string, unknown>
+      : rawMethodArgs;
+    const resolvedGlobalArgs = secretBag && !secretBag.isEmpty
+      ? secretBag.resolveDeep(
+        definition.globalArguments,
+      ) as Record<string, unknown>
+      : definition.globalArguments;
+
+    // Validate per-method arguments against the method's schema
+    const methodArgs = coerceMethodArgs(resolvedMethodArgs, method.arguments);
     const argsResult = method.arguments.safeParse(methodArgs);
 
     if (!argsResult.success) {
@@ -249,8 +263,7 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
     // accesses a field with an unresolved ${{ ... }} expression.
     // This allows methods that don't need certain fields to succeed while
     // failing fast with a helpful message if they do.
-    const rawGlobalArgs = definition.globalArguments;
-    const globalArgsProxy = new Proxy(rawGlobalArgs, {
+    const globalArgsProxy = new Proxy(resolvedGlobalArgs, {
       get(target, prop, receiver) {
         const value = Reflect.get(target, prop, receiver);
         if (
@@ -274,6 +287,9 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
         version: definition.version,
         tags: definition.tags,
       },
+      // Store unresolved args (with sentinels) so the shell model can
+      // resolve vault secrets via env vars instead of command string injection
+      unresolvedMethodArgs: rawMethodArgs,
     };
 
     // Execute the method with pre-validated args
@@ -317,6 +333,21 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
         context.modelType,
         currentDefinition,
       );
+    }
+
+    // Resolve vault sentinels in globalArguments before validation.
+    // Sentinels must be replaced with raw values so Zod schemas (e.g., url(),
+    // regex()) validate against actual secret values, not sentinel tokens.
+    const secretBag = context.vaultSecrets;
+    if (secretBag && !secretBag.isEmpty) {
+      const rawGlobal = currentDefinition.globalArguments;
+      const resolvedGlobal = secretBag.resolveDeep(rawGlobal) as Record<
+        string,
+        unknown
+      >;
+      for (const [key, value] of Object.entries(resolvedGlobal)) {
+        currentDefinition.setGlobalArgument(key, value);
+      }
     }
 
     // Validate globalArguments against schema (after upgrade and runtime resolution).

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -22,6 +22,7 @@ import type { CloudControlClient } from "@aws-sdk/client-cloudcontrol";
 import type { Logger } from "@logtape/logtape";
 import { ModelType } from "./model_type.ts";
 import type { VaultService } from "../vaults/vault_service.ts";
+import type { VaultSecretBag } from "../vaults/vault_secret_bag.ts";
 import type { SecretRedactor } from "../secrets/mod.ts";
 import type { MethodExecutionEvent } from "./method_events.ts";
 import { CalVer } from "./calver.ts";
@@ -303,6 +304,19 @@ export interface MethodContext {
   reportNames?: string[];
   /** Only run reports matching these labels (inclusion filter). */
   reportLabels?: string[];
+
+  /**
+   * Vault secret bag containing sentinel-to-value mappings from runtime
+   * expression resolution. Used by the shell model to pass secrets via
+   * environment variables instead of embedding them in command strings.
+   */
+  vaultSecrets?: VaultSecretBag;
+
+  /**
+   * Pre-resolution method arguments containing sentinel tokens.
+   * Used by the shell model to resolve vault secrets for shell safety.
+   */
+  unresolvedMethodArgs?: Record<string, unknown>;
 }
 
 /**

--- a/src/domain/vaults/vault_expression_test.ts
+++ b/src/domain/vaults/vault_expression_test.ts
@@ -192,14 +192,16 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
     assertEquals(result, '"p@ss\\\'w0rd"');
   });
 
-  await t.step("should escape backticks in secret values", async () => {
+  await t.step("should pass backticks through in secret values", async () => {
     const resolver = createResolverWithMockVault({
       "backtick-secret": "value`with`backticks",
     });
     const result = await resolver.resolveVaultExpressions(
       "vault.get(test-vault, backtick-secret)",
     );
-    assertEquals(result, '"value\\\\`with\\\\`backticks"');
+    // Backticks have no special meaning in CEL strings — passed through as-is.
+    // Shell safety is handled by the shell model via VaultSecretBag.resolveForShell().
+    assertEquals(result, '"value`with`backticks"');
   });
 
   await t.step(
@@ -254,8 +256,12 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
     assertStringIncludes(error.message, "vault.get(test-vault, missing-key)");
   });
 
+  // The following tests verify that $ and ` are passed through as-is in CEL strings.
+  // These characters have no special meaning in CEL. Shell safety is now handled
+  // by VaultSecretBag.resolveForShell() in the shell model, not by escaping here.
+
   await t.step(
-    "should escape $ in secret values to prevent shell variable expansion",
+    "should pass $ through in secret values (CEL-safe)",
     async () => {
       const resolver = createResolverWithMockVault({
         "dollar-amp": "my$&secret",
@@ -263,12 +269,12 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
       const result = await resolver.resolveVaultExpressions(
         "vault.get(test-vault, dollar-amp)",
       );
-      assertEquals(result, '"my\\\\$&secret"');
+      assertEquals(result, '"my$&secret"');
     },
   );
 
   await t.step(
-    "should escape $` pattern in secret values",
+    "should pass $` pattern through in secret values",
     async () => {
       const resolver = createResolverWithMockVault({
         "dollar-backtick": "prefix$`suffix",
@@ -276,12 +282,12 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
       const result = await resolver.resolveVaultExpressions(
         "vault.get(test-vault, dollar-backtick)",
       );
-      assertEquals(result, '"prefix\\\\$\\\\`suffix"');
+      assertEquals(result, '"prefix$`suffix"');
     },
   );
 
   await t.step(
-    "should escape $' pattern in secret values",
+    "should pass $' pattern through and escape single quote for CEL",
     async () => {
       const resolver = createResolverWithMockVault({
         "dollar-quote": "prefix$'suffix",
@@ -289,12 +295,12 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
       const result = await resolver.resolveVaultExpressions(
         "vault.get(test-vault, dollar-quote)",
       );
-      assertEquals(result, '"prefix\\\\$\\\'suffix"');
+      assertEquals(result, '"prefix$\\\'suffix"');
     },
   );
 
   await t.step(
-    "should escape $$ pattern in secret values",
+    "should pass $$ pattern through in secret values",
     async () => {
       const resolver = createResolverWithMockVault({
         "dollar-dollar": "cost: $$100",
@@ -302,12 +308,12 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
       const result = await resolver.resolveVaultExpressions(
         "vault.get(test-vault, dollar-dollar)",
       );
-      assertEquals(result, '"cost: \\\\$\\\\$100"');
+      assertEquals(result, '"cost: $$100"');
     },
   );
 
   await t.step(
-    "should escape numbered dollar patterns in secret values",
+    "should pass numbered dollar patterns through in secret values",
     async () => {
       const resolver = createResolverWithMockVault({
         "dollar-numbers": "$1$2$3",
@@ -315,12 +321,12 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
       const result = await resolver.resolveVaultExpressions(
         "vault.get(test-vault, dollar-numbers)",
       );
-      assertEquals(result, '"\\\\$1\\\\$2\\\\$3"');
+      assertEquals(result, '"$1$2$3"');
     },
   );
 
   await t.step(
-    "should escape multiple dollar and backtick patterns in same secret",
+    "should pass multiple dollar and backtick patterns through",
     async () => {
       const resolver = createResolverWithMockVault({
         "multi-dollar": "a]$&b$`c$'d$$e$1f",
@@ -328,15 +334,13 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
       const result = await resolver.resolveVaultExpressions(
         "vault.get(test-vault, multi-dollar)",
       );
-      assertEquals(
-        result,
-        '"a]\\\\$&b\\\\$\\\\`c\\\\$\\\'d\\\\$\\\\$e\\\\$1f"',
-      );
+      // Only ' is escaped (CEL safety), $ and ` pass through
+      assertEquals(result, '"a]$&b$`c$\\\'d$$e$1f"');
     },
   );
 
   await t.step(
-    "should escape $ to prevent shell command substitution",
+    "should pass $() through in secret values (shell safety via env vars)",
     async () => {
       const resolver = createResolverWithMockVault({
         "cmd-secret": "$(echo injected)",
@@ -344,12 +348,12 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
       const result = await resolver.resolveVaultExpressions(
         "vault.get(test-vault, cmd-secret)",
       );
-      assertEquals(result, '"\\\\$(echo injected)"');
+      assertEquals(result, '"$(echo injected)"');
     },
   );
 
   await t.step(
-    "should escape backticks to prevent shell command substitution",
+    "should pass backtick commands through in secret values (shell safety via env vars)",
     async () => {
       const resolver = createResolverWithMockVault({
         "backtick-cmd": "`echo injected`",
@@ -357,7 +361,7 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
       const result = await resolver.resolveVaultExpressions(
         "vault.get(test-vault, backtick-cmd)",
       );
-      assertEquals(result, '"\\\\`echo injected\\\\`"');
+      assertEquals(result, '"`echo injected`"');
     },
   );
 

--- a/src/domain/vaults/vault_secret_bag.ts
+++ b/src/domain/vaults/vault_secret_bag.ts
@@ -1,0 +1,110 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * VaultSecretBag is a value object that maps sentinel tokens to raw secret values.
+ *
+ * During vault expression resolution, secret values are replaced with unique
+ * sentinel tokens (safe alphanumeric strings). The bag tracks the mapping so
+ * that sentinels can be resolved later — either to raw values (for non-shell
+ * contexts) or to environment variable references (for shell commands).
+ */
+export class VaultSecretBag {
+  private readonly secrets = new Map<string, string>();
+  private counter = 0;
+  private readonly prefix: string;
+
+  /** Pattern that matches any sentinel produced by this bag or any other. */
+  static readonly SENTINEL_PATTERN = /__SWAMP_VSEC_[0-9a-f]{8}_\d+__/g;
+
+  constructor() {
+    this.prefix = crypto.getRandomValues(new Uint8Array(4))
+      .reduce((s, b) => s + b.toString(16).padStart(2, "0"), "");
+  }
+
+  /**
+   * Adds a secret and returns a unique sentinel token.
+   * The sentinel is alphanumeric + underscores, safe in CEL strings and shell.
+   */
+  addSecret(value: string): string {
+    const sentinel = `__SWAMP_VSEC_${this.prefix}_${this.counter++}__`;
+    this.secrets.set(sentinel, value);
+    return sentinel;
+  }
+
+  /** Whether this bag contains any secrets. */
+  get isEmpty(): boolean {
+    return this.secrets.size === 0;
+  }
+
+  /**
+   * Replaces all sentinel tokens in a string with their raw secret values.
+   * Use this for non-shell contexts where the value should be literal.
+   */
+  resolveRaw(str: string): string {
+    let result = str;
+    for (const [sentinel, value] of this.secrets) {
+      result = result.split(sentinel).join(value);
+    }
+    return result;
+  }
+
+  /**
+   * Recursively replaces all sentinel tokens in a data structure with raw values.
+   */
+  resolveDeep(data: unknown): unknown {
+    if (typeof data === "string") {
+      return this.resolveRaw(data);
+    }
+    if (Array.isArray(data)) {
+      return data.map((item) => this.resolveDeep(item));
+    }
+    if (data !== null && typeof data === "object") {
+      const result: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(data)) {
+        result[key] = this.resolveDeep(value);
+      }
+      return result;
+    }
+    return data;
+  }
+
+  /**
+   * Replaces sentinel tokens in a shell command string with double-quoted
+   * environment variable references, and returns the env var map.
+   *
+   * Shell variable expansion happens after command parsing, so metacharacters
+   * in the secret value are never interpreted as shell syntax.
+   */
+  resolveForShell(
+    command: string,
+  ): { command: string; env: Record<string, string> } {
+    const env: Record<string, string> = {};
+    let result = command;
+    let envIdx = 0;
+    for (const [sentinel, value] of this.secrets) {
+      if (result.includes(sentinel)) {
+        const envName = `__SWAMP_VAULT_${envIdx++}`;
+        result = result.split(sentinel).join(`"\${${envName}}"`);
+        env[envName] = value;
+      }
+    }
+    return { command: result, env };
+  }
+}

--- a/src/domain/vaults/vault_secret_bag_test.ts
+++ b/src/domain/vaults/vault_secret_bag_test.ts
@@ -1,0 +1,160 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { VaultSecretBag } from "./vault_secret_bag.ts";
+
+Deno.test("VaultSecretBag", async (t) => {
+  await t.step("addSecret: returns unique sentinel tokens", () => {
+    const bag = new VaultSecretBag();
+    const s1 = bag.addSecret("secret1");
+    const s2 = bag.addSecret("secret2");
+    assertEquals(s1 !== s2, true);
+    assertEquals(s1.startsWith("__SWAMP_VSEC_"), true);
+    assertEquals(s1.endsWith("__"), true);
+    assertEquals(s2.startsWith("__SWAMP_VSEC_"), true);
+  });
+
+  await t.step("addSecret: sentinel matches pattern", () => {
+    const bag = new VaultSecretBag();
+    const sentinel = bag.addSecret("test");
+    const matches = sentinel.match(VaultSecretBag.SENTINEL_PATTERN);
+    assertEquals(matches !== null, true);
+    assertEquals(matches![0], sentinel);
+  });
+
+  await t.step("isEmpty: true when no secrets added", () => {
+    const bag = new VaultSecretBag();
+    assertEquals(bag.isEmpty, true);
+  });
+
+  await t.step("isEmpty: false after adding a secret", () => {
+    const bag = new VaultSecretBag();
+    bag.addSecret("test");
+    assertEquals(bag.isEmpty, false);
+  });
+
+  await t.step("resolveRaw: replaces sentinel with raw value", () => {
+    const bag = new VaultSecretBag();
+    const sentinel = bag.addSecret("my-secret-value");
+    assertEquals(
+      bag.resolveRaw(`prefix ${sentinel} suffix`),
+      "prefix my-secret-value suffix",
+    );
+  });
+
+  await t.step("resolveRaw: replaces multiple sentinels", () => {
+    const bag = new VaultSecretBag();
+    const s1 = bag.addSecret("val1");
+    const s2 = bag.addSecret("val2");
+    assertEquals(bag.resolveRaw(`${s1}-${s2}`), "val1-val2");
+  });
+
+  await t.step("resolveRaw: preserves strings without sentinels", () => {
+    const bag = new VaultSecretBag();
+    bag.addSecret("unused");
+    assertEquals(bag.resolveRaw("no sentinels here"), "no sentinels here");
+  });
+
+  await t.step("resolveRaw: handles secrets with shell metacharacters", () => {
+    const bag = new VaultSecretBag();
+    const sentinel = bag.addSecret("pass;rm -rf /");
+    assertEquals(bag.resolveRaw(sentinel), "pass;rm -rf /");
+  });
+
+  await t.step("resolveDeep: resolves strings in nested objects", () => {
+    const bag = new VaultSecretBag();
+    const s1 = bag.addSecret("secret-value");
+    const s2 = bag.addSecret("other-value");
+    const data = {
+      simple: s1,
+      nested: { deep: s2 },
+      array: [s1, "plain"],
+      number: 42,
+      bool: true,
+      nullVal: null,
+    };
+    const resolved = bag.resolveDeep(data);
+    assertEquals(resolved, {
+      simple: "secret-value",
+      nested: { deep: "other-value" },
+      array: ["secret-value", "plain"],
+      number: 42,
+      bool: true,
+      nullVal: null,
+    });
+  });
+
+  await t.step(
+    "resolveForShell: replaces sentinel with env var reference",
+    () => {
+      const bag = new VaultSecretBag();
+      const sentinel = bag.addSecret("my-password");
+      const result = bag.resolveForShell(`echo ${sentinel}`);
+      assertEquals(result.command, 'echo "${__SWAMP_VAULT_0}"');
+      assertEquals(result.env, { __SWAMP_VAULT_0: "my-password" });
+    },
+  );
+
+  await t.step("resolveForShell: handles multiple secrets", () => {
+    const bag = new VaultSecretBag();
+    const s1 = bag.addSecret("user");
+    const s2 = bag.addSecret("pass");
+    const cmd = "echo " + s1 + ":" + s2;
+    const result = bag.resolveForShell(cmd);
+    assertEquals(
+      result.command,
+      'echo "${__SWAMP_VAULT_0}":"${__SWAMP_VAULT_1}"',
+    );
+    assertEquals(result.env, {
+      __SWAMP_VAULT_0: "user",
+      __SWAMP_VAULT_1: "pass",
+    });
+  });
+
+  await t.step(
+    "resolveForShell: secret with shell metacharacters goes to env",
+    () => {
+      const bag = new VaultSecretBag();
+      const sentinel = bag.addSecret("pass;rm -rf /|cat /etc/passwd&whoami");
+      const result = bag.resolveForShell(`echo ${sentinel}`);
+      assertEquals(result.command, 'echo "${__SWAMP_VAULT_0}"');
+      assertEquals(
+        result.env.__SWAMP_VAULT_0,
+        "pass;rm -rf /|cat /etc/passwd&whoami",
+      );
+    },
+  );
+
+  await t.step("resolveForShell: skips secrets not in command", () => {
+    const bag = new VaultSecretBag();
+    bag.addSecret("unused-secret");
+    const s2 = bag.addSecret("used-secret");
+    const result = bag.resolveForShell(`echo ${s2}`);
+    assertEquals(result.command, 'echo "${__SWAMP_VAULT_0}"');
+    assertEquals(Object.keys(result.env).length, 1);
+  });
+
+  await t.step("resolveForShell: no secrets returns original command", () => {
+    const bag = new VaultSecretBag();
+    const result = bag.resolveForShell("echo hello world");
+    assertEquals(result.command, "echo hello world");
+    assertEquals(result.env, {});
+  });
+});

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -325,16 +325,19 @@ export class DefaultStepExecutor implements StepExecutor {
     const evaluatedDefRepo = new YamlEvaluatedDefinitionRepository(ctx.repoDir);
     await evaluatedDefRepo.save(modelType, evaluatedDefinition);
 
-    // Resolve runtime expressions (vault and env) at runtime (never persisted)
+    // Resolve runtime expressions (vault and env) at runtime (never persisted).
+    // Vault secrets become sentinel tokens; the secretBag maps sentinels to raw values.
     const evalService = new ExpressionEvaluationService(
       new YamlDefinitionRepository(ctx.repoDir),
       ctx.repoDir,
     );
-    evaluatedDefinition = await evalService
+    const runtimeResult = await evalService
       .resolveRuntimeExpressionsInDefinition(
         evaluatedDefinition,
         ctx.secretRedactor,
       );
+    evaluatedDefinition = runtimeResult.definition;
+    const secretBag = runtimeResult.secretBag;
 
     // Validate method exists on the model
     const method = modelDef.methods[task.methodName];
@@ -451,6 +454,7 @@ export class DefaultStepExecutor implements StepExecutor {
           dataOutputOverrides: stepDataOutputOverrides,
           vaultService,
           redactor: ctx.secretRedactor,
+          vaultSecrets: secretBag,
           driver: ctx.driver ?? evaluatedDefinition.driver,
           driverConfig: ctx.driverConfig ?? evaluatedDefinition.driverConfig,
           onEvent: ctx.emitEvent

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -345,9 +345,12 @@ export async function* modelMethodRun(
       }
     }
 
-    // Resolve runtime expressions (vault and env)
-    evaluatedDefinition = await evaluationService
+    // Resolve runtime expressions (vault and env).
+    // Vault secrets become sentinel tokens; the secretBag maps sentinels to raw values.
+    const runtimeResult = await evaluationService
       .resolveRuntimeExpressionsInDefinition(evaluatedDefinition, redactor);
+    evaluatedDefinition = runtimeResult.definition;
+    const secretBag = runtimeResult.secretBag;
 
     // --- Execute ---
     yield {
@@ -404,6 +407,7 @@ export async function* modelMethodRun(
               runtimeTags: input.runtimeTags,
               vaultService,
               redactor,
+              vaultSecrets: secretBag,
               skipCheckNames: input.skipCheckNames,
               skipCheckLabels: input.skipCheckLabels,
               skipAllChecks: input.skipAllChecks,

--- a/src/libswamp/models/run_test.ts
+++ b/src/libswamp/models/run_test.ts
@@ -34,6 +34,7 @@ import { Definition } from "../../domain/definitions/definition.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import type { ModelDefinition } from "../../domain/models/model.ts";
 import { z } from "zod";
+import { VaultSecretBag } from "../../domain/vaults/vault_secret_bag.ts";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 
 await initializeLogging({});
@@ -120,7 +121,10 @@ function createFakeEvaluationService(): any {
         hadExpressions: false,
       }),
     resolveRuntimeExpressionsInDefinition: (def: Definition) =>
-      Promise.resolve(def),
+      Promise.resolve({
+        definition: def,
+        secretBag: new VaultSecretBag(),
+      }),
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes #430 — vault secrets with shell metacharacters (`;`, `|`, `&`, `!`, `$()`, etc.) were interpreted as shell syntax when used in `command/shell` model `run` fields, enabling arbitrary command execution.

**Root cause:** Shell-specific escaping lived in `resolveVaultExpressions` (serves ALL models) — the wrong layer for a shell-only problem. It was also incomplete (missed `;`, `|`, `&`, `!`) and corrupted non-shell values (`$100` → `\$100`).

**Fix:** Move shell safety to the shell model using environment variable injection:

- Vault secrets become sentinel tokens during CEL evaluation (safe alphanumeric strings)
- `VaultSecretBag` value object maps sentinels → raw values
- Shell model replaces sentinels with `"${__SWAMP_VAULT_N}"` env var refs, passes raw values via process environment
- All other models get exact raw values via `resolveDeep()` — no escaping artifacts

Shell variable expansion happens after command parsing, so secret content is never parsed as shell syntax. This eliminates the **entire class** of shell injection bugs — no character blocklist to maintain.

### User impact

- **No breaking changes** — same YAML syntax, same output
- **Shell commands:** injection-proof for all metacharacters (current and future)
- **Non-shell models:** strictly better — no more `\$` / `` \` `` corruption
- **Existing definitions on disk:** untouched (expressions stored, not values)

### Files changed

| File | Change |
|------|--------|
| `src/domain/vaults/vault_secret_bag.ts` | New `VaultSecretBag` value object |
| `src/domain/vaults/vault_secret_bag_test.ts` | Tests for VaultSecretBag |
| `src/domain/expressions/model_resolver.ts` | Sentinel-based vault resolution, CEL-only escaping |
| `src/domain/expressions/expression_evaluation_service.ts` | Returns `RuntimeResolutionResult` with secretBag |
| `src/domain/models/model.ts` | Added `vaultSecrets` and `unresolvedMethodArgs` to MethodContext |
| `src/domain/models/method_execution_service.ts` | Resolves sentinels before Zod validation and method execution |
| `src/domain/models/command/shell/shell_model.ts` | Env var injection for vault secrets in `run` field |
| `src/libswamp/models/run.ts` | Threads secretBag through execution |
| `src/domain/workflows/execution_service.ts` | Threads secretBag through workflow execution |
| `design/expressions.md` | Updated Shell Safety documentation |
| Tests | Updated expected values, added new test cases |

## Test plan

- [x] All 3476 unit tests pass
- [x] Type checking (`deno check`) clean
- [x] Lint (`deno lint`) clean
- [x] Manual verification: secrets with `;`, `|`, `$`, `&` all treated as literal in shell commands
- [x] Binary compiled and tested end-to-end
- [x] Integration tests in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Walter Heck <walterheck@helixiora.com>