### PR TITLE
ci: gate skill-review and skill-trigger-eval on .claude/ path changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,26 @@ permissions:
   id-token: write
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      skills: ${{ steps.filter.outputs.skills }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check for skill changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            skills:
+              - '.claude/skills/**'
+              - 'CLAUDE.md'
+              - 'scripts/review_skills.ts'
+              - 'scripts/eval_skill_triggers.ts'
+
   test:
     name: Lint, Test, and Format Check
     runs-on: ubuntu-latest
@@ -68,6 +88,8 @@ jobs:
 
   skill-review:
     name: Skill Review
+    needs: [changes]
+    if: needs.changes.outputs.skills == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -89,6 +111,8 @@ jobs:
 
   skill-trigger-eval:
     name: Skill Trigger Eval
+    needs: [changes]
+    if: needs.changes.outputs.skills == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -122,7 +146,9 @@ jobs:
     name: Claude Code Review
     needs: [test, deps-audit, skill-review]
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: |
+      !failure() && !cancelled() &&
+      github.event.pull_request.draft == false
     concurrency:
       group: claude-review-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -182,7 +208,9 @@ jobs:
     name: Adversarial Code Review
     needs: [test, deps-audit, skill-review]
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: |
+      !failure() && !cancelled() &&
+      github.event.pull_request.draft == false
     concurrency:
       group: claude-adversarial-review-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -317,6 +345,7 @@ jobs:
     # Only auto-merge PRs from the same repo (not forks) for security
     # Skip auto-merge if PR has the 'hold' label
     if: |
+      !failure() && !cancelled() &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       !contains(github.event.pull_request.labels.*.name, 'hold')
 


### PR DESCRIPTION
## Summary

- Add a `changes` job using `dorny/paths-filter` to detect whether skill-related
  files changed (`.claude/skills/**`, `CLAUDE.md`, or the review/eval scripts).
- Gate `skill-review` and `skill-trigger-eval` jobs behind
  `needs.changes.outputs.skills == 'true'` so they only run when relevant files
  are touched — avoids burning tessl and claude -p API credits on unrelated PRs.
- Add `!failure() && !cancelled()` conditions to `claude-review`,
  `claude-adversarial-review`, and `auto-merge` so they still run when the skill
  jobs are skipped (no skill changes) but still block when they actually fail.

## Test plan

- [ ] PR touching only `src/` files — skill-review and skill-trigger-eval skip
- [ ] PR touching `.claude/skills/` — both skill jobs run
- [ ] PR where skill-review fails — claude-review and auto-merge block
- [ ] PR where skill-review skips — claude-review and auto-merge proceed

🤖 Generated with [Claude Code](https://claude.com/claude-code)