### PR TITLE
fix: add CI installation docs to prevent hallucinated install URLs

### DIFF
--- a/.claude/skills/swamp-repo/SKILL.md
+++ b/.claude/skills/swamp-repo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swamp-repo
-description: Manage swamp repositories and datastores — initializing repos, upgrading swamp, syncing data, releasing stuck locks. Use when initializing repos, upgrading swamp, starting the webapp, or configuring datastores. Triggers on "repo", "repository", "init", "initialize", "swamp init", "setup swamp", "new swamp project", "upgrade swamp", "webapp", "swamp webapp", "repository structure", ".swamp folder", "datastore", "datastore setup", "datastore status", "datastore sync", "datastore lock", "s3 datastore", "filesystem datastore", "stuck lock", "lock release".
+description: Manage swamp repositories and datastores — initializing repos, upgrading swamp, syncing data, releasing stuck locks, and installing swamp in CI. Use when initializing repos, upgrading swamp, starting the webapp, configuring datastores, or setting up swamp in CI/CD pipelines. Triggers on "repo", "repository", "init", "initialize", "swamp init", "setup swamp", "new swamp project", "upgrade swamp", "webapp", "swamp webapp", "repository structure", ".swamp folder", "datastore", "datastore setup", "datastore status", "datastore sync", "datastore lock", "s3 datastore", "filesystem datastore", "stuck lock", "lock release", "install swamp", "CI", "CI/CD", "GitHub Actions", "install in CI", "setup CI".
 ---
 
 # Swamp Repository Skill
@@ -271,6 +271,9 @@ export SWAMP_DATASTORE='@myorg/my-store:{"key":"val"}'
 
 ## References
 
+- **CI/CD integration**: See
+  [references/ci-integration.md](references/ci-integration.md) for installing
+  swamp in CI, GitHub Actions examples, and version pinning
 - **Structure**: See [references/structure.md](references/structure.md) for
   complete directory layout reference
 - **Troubleshooting**: See

--- a/.claude/skills/swamp-repo/evals/trigger_evals.json
+++ b/.claude/skills/swamp-repo/evals/trigger_evals.json
@@ -30,6 +30,14 @@
   },
   { "query": "Check the datastore status and health", "should_trigger": true },
   {
+    "query": "How do I install swamp in a GitHub Actions CI pipeline?",
+    "should_trigger": true
+  },
+  {
+    "query": "Create a GitHub Actions workflow that runs swamp on every PR",
+    "should_trigger": true
+  },
+  {
     "query": "Create a custom model type for AWS Lambda",
     "should_trigger": false,
     "note": "Building custom model types → swamp-extension-model"

--- a/.claude/skills/swamp-repo/references/ci-integration.md
+++ b/.claude/skills/swamp-repo/references/ci-integration.md
@@ -1,0 +1,74 @@
+# CI/CD Integration
+
+## Installing Swamp in CI
+
+The canonical install command is:
+
+```bash
+curl -fsSL https://swamp.club/install.sh | sh
+```
+
+### Installer Options
+
+| Flag                        | Description            | Default                                     |
+| --------------------------- | ---------------------- | ------------------------------------------- |
+| `-d, --destination=<DEST>`  | Installation directory | `$HOME/bin` (or `/usr/local/bin` with sudo) |
+| `-V, --version=<VERSION>`   | Release version        | `stable`                                    |
+| `-p, --platform=<PLATFORM>` | Platform override      | Auto-detected                               |
+
+### Pin a specific version
+
+```bash
+curl -fsSL https://swamp.club/install.sh | sh -s -- -V 20260320.184735.0
+```
+
+## GitHub Actions Example
+
+```yaml
+name: Swamp CI
+on:
+  pull_request:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install swamp
+        run: curl -fsSL https://swamp.club/install.sh | sh
+
+      - name: Add swamp to PATH
+        run: echo "$HOME/bin" >> "$GITHUB_PATH"
+
+      - name: Run workflow
+        run: swamp workflow run my-workflow --json
+```
+
+### With S3 datastore in CI
+
+```yaml
+- name: Run workflow with S3 datastore
+  env:
+    SWAMP_DATASTORE: s3:my-bucket/my-prefix
+    AWS_REGION: us-east-1
+  run: swamp workflow run my-workflow --json
+```
+
+### With version pinning
+
+```yaml
+- name: Install swamp (pinned)
+  run: curl -fsSL https://swamp.club/install.sh | sh -s -- -V 20260320.184735.0
+```
+
+## IMPORTANT
+
+- **NEVER fabricate installer URLs.** The only official installer is
+  `https://swamp.club/install.sh`. There is no `https://get.swamp.club` or any
+  other install endpoint.
+- **NEVER invent a `setup-swamp` GitHub Action** — none exists. Use the curl
+  installer shown above.
+- The installer auto-detects platform (linux/darwin, x86_64/aarch64).
+- The default install destination is `$HOME/bin` — add it to `$GITHUB_PATH` in
+  GitHub Actions.

--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -467,6 +467,9 @@ End-to-end workflow creation:
 
 ## References
 
+- **CI/CD integration**: See `swamp-repo` skill's
+  [references/ci-integration.md](../swamp-repo/references/ci-integration.md) for
+  installing swamp in CI and GitHub Actions examples
 - **Nested workflows**: See
   [references/nested-workflows.md](references/nested-workflows.md) for full
   examples of workflows calling other workflows, forEach with workflows, and

--- a/.claude/skills/swamp-workflow/evals/trigger_evals.json
+++ b/.claude/skills/swamp-workflow/evals/trigger_evals.json
@@ -64,5 +64,10 @@
     "query": "Generate a cost report for workflow executions",
     "should_trigger": false,
     "note": "Creating/running reports → swamp-report"
+  },
+  {
+    "query": "How do I install swamp in CI to run workflows on every PR?",
+    "should_trigger": false,
+    "note": "CI installation → swamp-repo"
   }
 ]

--- a/src/infrastructure/assets/skill_assets.ts
+++ b/src/infrastructure/assets/skill_assets.ts
@@ -85,6 +85,10 @@ const BUNDLED_SKILLS: SkillInfo[] = [
     name: "swamp-repo",
   },
   {
+    relativePath: "swamp-repo/references/ci-integration.md",
+    name: "swamp-repo",
+  },
+  {
     relativePath: "swamp-report/SKILL.md",
     name: "swamp-report",
   },

--- a/src/infrastructure/assets/skill_assets_test.ts
+++ b/src/infrastructure/assets/skill_assets_test.ts
@@ -275,6 +275,15 @@ Deno.test("SkillAssets.copySkillsTo copies swamp-repo reference files", async ()
 
     const troubleshootingStat = await Deno.stat(troubleshootingPath);
     assertEquals(troubleshootingStat.isFile, true);
+
+    const ciIntegrationPath = join(
+      dir,
+      "swamp-repo",
+      "references",
+      "ci-integration.md",
+    );
+    const ciIntegrationStat = await Deno.stat(ciIntegrationPath);
+    assertEquals(ciIntegrationStat.isFile, true);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #800

Claude was fabricating installer URLs (e.g. `https://get.swamp.club`) when users asked for help setting up swamp in CI pipelines, because no skill documentation included the canonical install method.

- Add `ci-integration.md` reference to `swamp-repo` skill with the correct install URL (`https://swamp.club/install.sh`), installer options, GitHub Actions examples, and explicit warnings against fabricating URLs
- Register `ci-integration.md` in `BUNDLED_SKILLS` so `repo init` and `repo upgrade` distribute it to user repos
- Update `swamp-repo` skill description with CI/CD trigger keywords so CI-related queries route to the right skill
- Add cross-reference from `swamp-workflow` to the `swamp-repo` CI docs
- Add trigger eval test cases for CI-related queries (2 positive in swamp-repo, 1 negative in swamp-workflow)
- Add test coverage for `ci-integration.md` in `skill_assets_test.ts`

## Test plan

- [x] `deno run test src/infrastructure/assets/skill_assets_test.ts` — verifies ci-integration.md is copied by repo init/upgrade
- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt --check` — formatting passes
- [ ] CI skill trigger evals validate new test cases route correctly

Co-authored-by: Blake Irvin <bixu@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)