### PR TITLE
fix: improve swamp-model description with explicit extension-model boundary

### DIFF
--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -1,6 +1,17 @@
 ---
 name: swamp-model
-description: Work with swamp models for AI-native automation. Use when searching for model types, describing model schemas, creating model inputs, running model methods, or viewing outputs. Triggers on "swamp model", "model type", "create input", "type search", "type describe", "run method", "execute method", "model validate", "model delete", "model edit", "model output", "output logs", "CEL expression", or running automation workflows.
+description: >
+  Work with existing swamp models — structured automation units that define
+  typed schemas, methods (validate, transform, enrich), and outputs for data
+  processing. Use when searching for model types, describing schemas, creating
+  inputs, running or executing methods, viewing outputs, or managing lifecycle
+  (edit, delete). Do NOT use when the user wants to build, create, or implement
+  a custom model type, Zod schema, or TypeScript model — that is
+  swamp-extension-model. Triggers on "swamp model", "model type", "model
+  schema", "create input", "type search", "type describe", "run method",
+  "execute method", "validation method", "transform method", "enrichment model",
+  "model validate", "model delete", "model edit", "model output", "output logs",
+  "output format", "CEL expression".
 ---
 
 # Swamp Model Skill

--- a/.claude/skills/swamp-model/evals/trigger_evals.json
+++ b/.claude/skills/swamp-model/evals/trigger_evals.json
@@ -36,6 +36,11 @@
     "should_trigger": true
   },
   {
+    "query": "Delete this model from the repository",
+    "should_trigger": true,
+    "note": "model delete is a listed trigger keyword"
+  },
+  {
     "query": "List all the data I have stored in the system",
     "should_trigger": false,
     "note": "Listing stored data → swamp-data"
@@ -54,11 +59,6 @@
     "query": "The model is throwing a type error I can't understand",
     "should_trigger": false,
     "note": "Debugging model errors → swamp-troubleshooting"
-  },
-  {
-    "query": "Delete this model from the repository",
-    "should_trigger": false,
-    "note": "Model lifecycle management (edit/delete) → swamp-model but borderline; context determines if this is about removing from system vs managing the definition"
   },
   {
     "query": "Run a report on model performance over time",


### PR DESCRIPTION
## Summary

- Improve swamp-model skill description to better trigger on method-related
  queries (validation, transform, enrichment) while staying scoped to swamp
  domain terms. Added concrete definition of what swamp models are: "structured
  automation units that define typed schemas, methods, and outputs for data
  processing".
- Add explicit boundary with swamp-extension-model: "Do NOT use when the user
  wants to build, create, or implement a custom model type, Zod schema, or
  TypeScript model — that is swamp-extension-model". This prevents false
  triggers on queries like "Build a Zod schema for my custom validation model".
- Fix "Delete this model from the repository" eval expectation from false to
  true — `model delete` is explicitly in the skill's trigger keywords.
- Trigger eval: 75% → 81% (passing). Remaining miss ("Run the validation
  method on this JSON data") is a zero-context edge case that passes
  intermittently with EVAL_RUNS=3.
- tessl review: 91% average (description 82%, content 100%) — passes.

## Test plan

- [x] `EVAL_RUNS=1 deno run eval-skill-triggers --skill swamp-model` — 81%, passes
- [x] `npx tessl skill review .claude/skills/swamp-model` — 91% average
- [x] No false triggers on swamp-extension-model boundary queries
- [x] Negatives all pass except probabilistic variance on EVAL_RUNS=1

🤖 Generated with [Claude Code](https://claude.com/claude-code)