### PR TITLE
feat: add --tool none for headless/CI init

### DIFF
--- a/src/cli/commands/repo_init.ts
+++ b/src/cli/commands/repo_init.ts
@@ -38,6 +38,7 @@ const aiToolType = new EnumType([
   "opencode",
   "codex",
   "kiro",
+  "none",
 ]);
 
 // Exported for reuse by repoCommand default action
@@ -81,7 +82,7 @@ export const repoInitCommand = new Command()
   .type("aiTool", aiToolType)
   .option(
     "-t, --tool <tool:aiTool>",
-    "AI coding tool to configure for (claude, cursor, opencode, codex, kiro)",
+    "AI coding tool to configure for (claude, cursor, opencode, codex, kiro, none)",
     { default: "claude" },
   )
   .action(repoInitAction);
@@ -135,7 +136,7 @@ export const repoCommand = new Command()
   .type("aiTool", aiToolType)
   .option(
     "-t, --tool <tool:aiTool>",
-    "AI coding tool to configure for (claude, cursor, opencode, codex, kiro)",
+    "AI coding tool to configure for (claude, cursor, opencode, codex, kiro, none)",
     { default: "claude" },
   )
   .action(repoInitAction)
@@ -149,7 +150,7 @@ export const repoCommand = new Command()
       .type("aiTool", aiToolType)
       .option(
         "-t, --tool <tool:aiTool>",
-        "AI coding tool to configure for (claude, cursor, opencode, codex, kiro)",
+        "AI coding tool to configure for (claude, cursor, opencode, codex, kiro, none)",
         { default: "claude" },
       )
       .action(repoInitAction),

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -55,7 +55,7 @@ const LEGACY_INSTRUCTIONS_SIGNATURE = "This repository is managed with [swamp]";
  */
 export type GitignoreAction = "created" | "updated" | "unchanged" | "skipped";
 
-const SKILL_DIRS: Record<AiTool, string> = {
+const SKILL_DIRS: Partial<Record<AiTool, string>> = {
   claude: ".claude/skills",
   cursor: ".cursor/skills",
   opencode: ".agents/skills",
@@ -63,7 +63,7 @@ const SKILL_DIRS: Record<AiTool, string> = {
   kiro: ".kiro/skills",
 };
 
-const INSTRUCTIONS_FILES: Record<AiTool, string> = {
+const INSTRUCTIONS_FILES: Partial<Record<AiTool, string>> = {
   claude: "CLAUDE.md",
   cursor: ".cursor/rules/swamp.mdc",
   opencode: "AGENTS.md",
@@ -71,7 +71,7 @@ const INSTRUCTIONS_FILES: Record<AiTool, string> = {
   kiro: ".kiro/steering/swamp-rules.md",
 };
 
-const GITIGNORE_TOOL_ENTRIES: Record<AiTool, string> = {
+const GITIGNORE_TOOL_ENTRIES: Partial<Record<AiTool, string>> = {
   claude: "# Claude Code configuration (managed by swamp)\n.claude/",
   cursor: "# Cursor skills (managed by swamp)\n.cursor/skills/",
   opencode: "# Agent skills (managed by swamp)\n.agents/skills/",
@@ -179,50 +179,56 @@ export class RepoService {
     // Create data directory structure
     await this.createDataDirectoryStructure(repoPath);
 
-    // Copy skills to tool-appropriate directory
-    const skillsDir = join(repoPath.value, SKILL_DIRS[tool]);
-    await this.skillAssets.copySkillsTo(skillsDir);
-    const skillsCopied = this.skillAssets.getSkillNames();
-
-    // Create instructions file if it doesn't exist
-    const instructionsFileCreated = await this
-      .createInstructionsFileIfNotExists(repoPath, tool);
-
-    // Create or update tool-specific settings
+    // Copy skills and create tool-specific files (skipped for --tool none)
+    let skillsCopied: string[] = [];
+    let instructionsFileCreated = false;
     let settingsCreated = false;
-    switch (tool) {
-      case "claude":
-        settingsCreated = isAlreadyInit
-          ? await this.updateClaudeSettings(repoPath)
-          : await this.createClaudeSettingsIfNotExists(repoPath);
-        break;
-      case "cursor":
-        settingsCreated = isAlreadyInit
-          ? await this.updateCursorHooks(repoPath)
-          : await this.createCursorHooksIfNotExists(repoPath);
-        break;
-      case "kiro": {
-        const s = isAlreadyInit
-          ? await this.updateKiroSettings(repoPath)
-          : await this.createKiroSettingsIfNotExists(repoPath);
-        const h = isAlreadyInit
-          ? await this.updateKiroHooks(repoPath)
-          : await this.createKiroHooksIfNotExists(repoPath);
-        const a = isAlreadyInit
-          ? await this.updateKiroAgentConfig(repoPath)
-          : await this.createKiroAgentConfigIfNotExists(repoPath);
-        settingsCreated = s || h || a;
-        break;
+
+    if (tool !== "none") {
+      // Copy skills to tool-appropriate directory
+      const skillsDir = join(repoPath.value, SKILL_DIRS[tool]!);
+      await this.skillAssets.copySkillsTo(skillsDir);
+      skillsCopied = this.skillAssets.getSkillNames();
+
+      // Create instructions file if it doesn't exist
+      instructionsFileCreated = await this
+        .createInstructionsFileIfNotExists(repoPath, tool);
+
+      // Create or update tool-specific settings
+      switch (tool) {
+        case "claude":
+          settingsCreated = isAlreadyInit
+            ? await this.updateClaudeSettings(repoPath)
+            : await this.createClaudeSettingsIfNotExists(repoPath);
+          break;
+        case "cursor":
+          settingsCreated = isAlreadyInit
+            ? await this.updateCursorHooks(repoPath)
+            : await this.createCursorHooksIfNotExists(repoPath);
+          break;
+        case "kiro": {
+          const s = isAlreadyInit
+            ? await this.updateKiroSettings(repoPath)
+            : await this.createKiroSettingsIfNotExists(repoPath);
+          const h = isAlreadyInit
+            ? await this.updateKiroHooks(repoPath)
+            : await this.createKiroHooksIfNotExists(repoPath);
+          const a = isAlreadyInit
+            ? await this.updateKiroAgentConfig(repoPath)
+            : await this.createKiroAgentConfigIfNotExists(repoPath);
+          settingsCreated = s || h || a;
+          break;
+        }
+        case "opencode":
+          settingsCreated = isAlreadyInit
+            ? await this.updateOpenCodePlugin(repoPath)
+            : await this.createOpenCodePluginIfNotExists(repoPath);
+          break;
+        case "codex":
+          break;
+        default:
+          assertNever(tool);
       }
-      case "opencode":
-        settingsCreated = isAlreadyInit
-          ? await this.updateOpenCodePlugin(repoPath)
-          : await this.createOpenCodePluginIfNotExists(repoPath);
-        break;
-      case "codex":
-        break;
-      default:
-        assertNever(tool);
     }
 
     // Always manage .gitignore on init
@@ -273,40 +279,46 @@ export class RepoService {
     );
     updatedMarker.tool = tool;
 
-    // Update skills in tool-appropriate directory
-    const skillsDir = join(repoPath.value, SKILL_DIRS[tool]);
-    await this.skillAssets.copySkillsTo(skillsDir);
-    const skillsUpdated = this.skillAssets.getSkillNames();
-
-    // Update instructions file (managed by swamp, kept in sync on upgrade)
-    const instructionsUpdated = await this.updateInstructionsFile(
-      repoPath,
-      tool,
-    );
-
-    // Update tool-specific settings
+    // Update skills and tool-specific files (skipped for --tool none)
+    let skillsUpdated: string[] = [];
+    let instructionsUpdated = false;
     let settingsUpdated = false;
-    switch (tool) {
-      case "claude":
-        settingsUpdated = await this.updateClaudeSettings(repoPath);
-        break;
-      case "cursor":
-        settingsUpdated = await this.updateCursorHooks(repoPath);
-        break;
-      case "kiro": {
-        const s = await this.updateKiroSettings(repoPath);
-        const h = await this.updateKiroHooks(repoPath);
-        const a = await this.updateKiroAgentConfig(repoPath);
-        settingsUpdated = s || h || a;
-        break;
+
+    if (tool !== "none") {
+      // Update skills in tool-appropriate directory
+      const skillsDir = join(repoPath.value, SKILL_DIRS[tool]!);
+      await this.skillAssets.copySkillsTo(skillsDir);
+      skillsUpdated = this.skillAssets.getSkillNames();
+
+      // Update instructions file (managed by swamp, kept in sync on upgrade)
+      instructionsUpdated = await this.updateInstructionsFile(
+        repoPath,
+        tool,
+      );
+
+      // Update tool-specific settings
+      switch (tool) {
+        case "claude":
+          settingsUpdated = await this.updateClaudeSettings(repoPath);
+          break;
+        case "cursor":
+          settingsUpdated = await this.updateCursorHooks(repoPath);
+          break;
+        case "kiro": {
+          const s = await this.updateKiroSettings(repoPath);
+          const h = await this.updateKiroHooks(repoPath);
+          const a = await this.updateKiroAgentConfig(repoPath);
+          settingsUpdated = s || h || a;
+          break;
+        }
+        case "opencode":
+          settingsUpdated = await this.updateOpenCodePlugin(repoPath);
+          break;
+        case "codex":
+          break;
+        default:
+          assertNever(tool);
       }
-      case "opencode":
-        settingsUpdated = await this.updateOpenCodePlugin(repoPath);
-        break;
-      case "codex":
-        break;
-      default:
-        assertNever(tool);
     }
 
     // Determine gitignore management: CLI flag > marker preference > default off
@@ -365,7 +377,7 @@ export class RepoService {
     repoPath: RepoPath,
     tool: AiTool,
   ): Promise<boolean> {
-    const filePath = join(repoPath.value, INSTRUCTIONS_FILES[tool]);
+    const filePath = join(repoPath.value, INSTRUCTIONS_FILES[tool]!);
 
     // For shared-file tools, always ensure the managed section exists
     // (merges into existing file or creates new one)
@@ -400,7 +412,7 @@ export class RepoService {
     repoPath: RepoPath,
     tool: AiTool,
   ): Promise<boolean> {
-    const filePath = join(repoPath.value, INSTRUCTIONS_FILES[tool]);
+    const filePath = join(repoPath.value, INSTRUCTIONS_FILES[tool]!);
     if (!this.usesSharedInstructionsFile(tool)) {
       return this.overwriteIfChanged(
         filePath,
@@ -552,6 +564,8 @@ export class RepoService {
       case "cursor":
       case "kiro":
         return false;
+      case "none":
+        return false;
       default:
         assertNever(tool);
     }
@@ -636,6 +650,8 @@ ${body}`;
       case "opencode":
       case "codex":
         return body;
+      case "none":
+        return body;
       default:
         assertNever(tool);
     }
@@ -717,14 +733,19 @@ ${body}`;
    * Generates the content between markers (not including the markers).
    */
   private generateGitignoreSectionBody(tool: AiTool): string {
-    return [
+    const lines = [
       "",
       "# Runtime data (not needed in version control)",
       ".swamp/",
-      "",
-      GITIGNORE_TOOL_ENTRIES[tool],
-      "",
-    ].join("\n");
+    ];
+
+    const toolEntry = GITIGNORE_TOOL_ENTRIES[tool];
+    if (toolEntry) {
+      lines.push("", toolEntry);
+    }
+
+    lines.push("");
+    return lines.join("\n");
   }
 
   /**

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -892,7 +892,7 @@ Deno.test("RepoService.init cursor instructions have MDC frontmatter", async () 
 });
 
 Deno.test("RepoService.init includes tool-specific gitignore entries", async () => {
-  const toolGitignoreEntries: Record<AiTool, string> = {
+  const toolGitignoreEntries: Partial<Record<AiTool, string>> = {
     claude: ".claude/",
     cursor: ".cursor/skills/",
     opencode: ".agents/skills/",
@@ -2034,5 +2034,75 @@ Deno.test("RepoService.upgrade with duplicate END markers throws clear error", a
       Error,
       "multiple swamp managed sections",
     );
+  });
+});
+
+// --tool none tests
+
+Deno.test("RepoService.init with tool none creates core structure but skips skills and instructions", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    const result = await service.init(repoPath, { tool: "none" });
+
+    // Core structure should exist
+    assertEquals(result.tool, "none");
+    const swampDir = join(tempDir, ".swamp");
+    const stat = await Deno.stat(swampDir);
+    assertEquals(stat.isDirectory, true);
+
+    // .swamp.yaml should exist with tool: none
+    const markerPath = join(tempDir, ".swamp.yaml");
+    const markerContent = await Deno.readTextFile(markerPath);
+    assertStringIncludes(markerContent, "tool: none");
+
+    // Models/workflows/vaults dirs should exist
+    for (const dir of ["models", "workflows", "vaults"]) {
+      const dirStat = await Deno.stat(join(tempDir, dir));
+      assertEquals(dirStat.isDirectory, true);
+    }
+
+    // No skills should be copied
+    assertEquals(result.skillsCopied, []);
+
+    // No instructions file should be created
+    assertEquals(result.instructionsFileCreated, false);
+
+    // No settings should be created
+    assertEquals(result.settingsCreated, false);
+
+    // .gitignore should have .swamp/ but no tool-specific entry
+    const gitignorePath = join(tempDir, ".gitignore");
+    const gitignoreContent = await Deno.readTextFile(gitignorePath);
+    assertStringIncludes(gitignoreContent, ".swamp/");
+    assertStringIncludes(
+      gitignoreContent,
+      "# BEGIN swamp managed section - DO NOT EDIT",
+    );
+    // Should not contain any tool-specific entries
+    assertEquals(gitignoreContent.includes(".claude/"), false);
+    assertEquals(gitignoreContent.includes(".cursor/"), false);
+    assertEquals(gitignoreContent.includes(".agents/"), false);
+    assertEquals(gitignoreContent.includes(".kiro/"), false);
+  });
+});
+
+Deno.test("RepoService.upgrade with tool none skips skills and instructions", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    // Init with none first
+    await service.init(repoPath, { tool: "none" });
+
+    // Upgrade
+    const upgradeService = new RepoService("0.2.0");
+    const result = await upgradeService.upgrade(repoPath, { tool: "none" });
+
+    assertEquals(result.tool, "none");
+    assertEquals(result.skillsUpdated, []);
+    assertEquals(result.instructionsUpdated, false);
+    assertEquals(result.settingsUpdated, false);
   });
 });

--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -27,7 +27,13 @@ import type { DatastoreConfigData } from "../../domain/datastore/datastore_confi
 /**
  * The AI coding tool to configure skills and instructions for.
  */
-export type AiTool = "claude" | "cursor" | "opencode" | "codex" | "kiro";
+export type AiTool =
+  | "claude"
+  | "cursor"
+  | "opencode"
+  | "codex"
+  | "kiro"
+  | "none";
 
 /**
  * Data structure for the .swamp.yaml marker file.


### PR DESCRIPTION
## Summary

- Adds `--tool none` option to `swamp repo init` and `swamp repo upgrade` for headless/CI environments where no AI coding tool is involved
- When `--tool none` is used, swamp creates the core repo structure (`.swamp/`, `models/`, `workflows/`, `vaults/`, `.swamp.yaml`, `.gitignore`) but skips all AI tool-specific files (skills, instructions, settings/hooks)
- The `.gitignore` managed section still includes `.swamp/` but omits tool-specific entries

## Use case

When setting up GitHub Actions or other CI pipelines to run swamp workflows directly, there's no appropriate `--tool` value today. Using `--tool claude` works but is semantically wrong — no AI agent is involved in CI execution. `--tool none` provides the correct option for these environments.

Closes #801

## Test plan

- [x] Added unit tests for `--tool none` init (verifies core structure created, no skills/instructions/settings)
- [x] Added unit tests for `--tool none` upgrade (verifies no skills/instructions/settings updated)
- [x] All 80 existing tests continue to pass
- [x] Type checking passes
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)