### PR TITLE
fix: resolve ternary CEL expressions with partial inputs (#814)

### DIFF
--- a/integration/workflow_partial_inputs_test.ts
+++ b/integration/workflow_partial_inputs_test.ts
@@ -167,3 +167,88 @@ Deno.test("Workflow: succeeds with partial inputs when globalArguments reference
     assertEquals(output.jobs[0].steps[0].status, "succeeded");
   });
 });
+
+// Regression test for issue #814.
+//
+// A ternary expression in methods.execute.arguments.run must resolve correctly
+// when the condition input is provided but one branch input is absent.
+//
+// The ternary is placed in methods.execute.arguments.run (not globalArguments)
+// because the shell model reads args.run directly — this gives a clear pass/fail
+// signal without being dependent on any model-specific globalArgs access.
+//
+// Before the fix: expression is skipped (regex pre-check treats all referenced
+// inputs as required), shell executes the raw "${{ ... }}" string → exit code 1.
+// After the fix: CEL short-circuits the ternary and resolves to "echo 100.64.0.1".
+Deno.test("Workflow: ternary expression resolves when condition input provided and one branch input absent", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const workflowRepo = new YamlWorkflowRepository(repoDir);
+
+    const model = Definition.create({
+      name: "transport-host-model",
+      inputs: {
+        properties: {
+          transport: { type: "string" },
+          lan_host: { type: "string" },
+          tailnet_host: { type: "string" },
+        },
+        required: ["transport", "tailnet_host"],
+      },
+      globalArguments: {},
+      methods: {
+        execute: {
+          arguments: {
+            run:
+              '${{ "echo " + (inputs.transport == "lan" ? inputs.lan_host : inputs.tailnet_host) }}',
+          },
+        },
+      },
+    });
+    await definitionRepo.save(SHELL_MODEL_TYPE, model);
+
+    const workflow = Workflow.create({
+      name: "ternary-transport-workflow",
+      jobs: [
+        Job.create({
+          name: "run-job",
+          steps: [
+            Step.create({
+              name: "run-step",
+              task: StepTask.model("transport-host-model", "execute", {
+                transport: "wan",
+                tailnet_host: "100.64.0.1",
+                // lan_host deliberately absent — only the wan branch is needed
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    const result = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "ternary-transport-workflow",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Workflow should succeed with ternary expression. stderr: ${result.stderr}`,
+    );
+
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.status, "succeeded");
+    assertEquals(output.jobs[0].steps[0].status, "succeeded");
+  });
+});

--- a/src/domain/expressions/expression_evaluation_service.ts
+++ b/src/domain/expressions/expression_evaluation_service.ts
@@ -25,7 +25,6 @@ import { CelEvaluator } from "../../infrastructure/cel/cel_evaluator.ts";
 import {
   containsExpression,
   extractExpressions,
-  extractInputReferencesFromCel,
   replaceExpressions,
 } from "./expression_parser.ts";
 import type { ExpressionLocation } from "./expression.ts";
@@ -215,9 +214,6 @@ export class ExpressionEvaluationService {
 
     // Evaluate CEL-only expressions; skip runtime expressions (vault, env)
     // Runtime expressions are resolved at runtime only, never persisted
-    const providedInputKeys = inputValues
-      ? new Set(Object.keys(inputValues))
-      : new Set<string>();
     const evaluatedValues = new Map<string, unknown>();
     for (const expr of expressions) {
       if (containsRuntimeExpression(expr.celExpression)) {
@@ -225,47 +221,39 @@ export class ExpressionEvaluationService {
         continue;
       }
 
-      // Skip expressions that reference inputs not provided by the user.
-      // This allows methods that don't need certain inputs to run without
-      // those inputs being provided (e.g., delete doesn't need create-time inputs).
-      const inputRefs = extractInputReferencesFromCel(expr.celExpression);
-      let hasMissing = false;
-      if (inputRefs.size > 0) {
-        for (const ref of inputRefs) {
-          if (!providedInputKeys.has(ref)) {
-            hasMissing = true;
+      // Skip expressions referencing model resource/file data that isn't
+      // available in context (e.g., referenced model was never executed).
+      // Unlike inputs, model data is never conditionally accessed in CEL —
+      // member access on a missing model ref is always an error.
+      let hasMissingModelDep = false;
+      const deps = extractDependencies(expr.celExpression);
+      for (const dep of deps) {
+        if (dep.type === "resource" || dep.type === "file") {
+          const modelData = ctx.model[dep.modelRef];
+          if (
+            !modelData ||
+            (dep.type === "resource" && !modelData.resource) ||
+            (dep.type === "file" && !modelData.file)
+          ) {
+            hasMissingModelDep = true;
             break;
           }
         }
       }
 
-      // Skip expressions referencing model resource/file data that isn't
-      // available in context (e.g., referenced model was never executed).
-      // This mirrors the inputs skip above — the raw expression is preserved
-      // so the Proxy on globalArgs will throw if the method actually needs it.
-      if (!hasMissing) {
-        const deps = extractDependencies(expr.celExpression);
-        for (const dep of deps) {
-          if (dep.type === "resource" || dep.type === "file") {
-            const modelData = ctx.model[dep.modelRef];
-            if (
-              !modelData ||
-              (dep.type === "resource" && !modelData.resource) ||
-              (dep.type === "file" && !modelData.file)
-            ) {
-              hasMissing = true;
-              break;
-            }
-          }
-        }
-      }
-
-      if (hasMissing) {
+      if (hasMissingModelDep) {
         continue;
       }
 
-      const value = this.celEvaluator.evaluate(expr.celExpression, ctx);
-      evaluatedValues.set(expr.raw, value);
+      try {
+        const value = this.celEvaluator.evaluate(expr.celExpression, ctx);
+        evaluatedValues.set(expr.raw, value);
+      } catch {
+        // Leave unresolved — CEL threw because an input referenced directly
+        // (not inside a conditional branch) is absent from context.
+        // The Proxy on globalArgs will surface a clear error if the method
+        // actually needs the unresolved value.
+      }
     }
 
     // Replace only the CEL-only expressions with evaluated values

--- a/src/domain/expressions/expression_evaluation_service_test.ts
+++ b/src/domain/expressions/expression_evaluation_service_test.ts
@@ -17,12 +17,25 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { Definition } from "../definitions/definition.ts";
+import { ModelType } from "../models/model_type.ts";
+import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import {
   containsEnvExpression,
   containsRuntimeExpression,
   containsVaultExpression,
+  ExpressionEvaluationService,
 } from "./expression_evaluation_service.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-eval-service-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
 
 // ============================================================================
 // containsVaultExpression
@@ -125,4 +138,85 @@ Deno.test("containsRuntimeExpression returns false for model/self/inputs", () =>
   );
   assertEquals(containsRuntimeExpression("self.name"), false);
   assertEquals(containsRuntimeExpression("inputs.param"), false);
+});
+
+// ============================================================================
+// evaluateDefinition — ternary expression regression (#814)
+// ============================================================================
+
+// Regression test for issue #814: a ternary in globalArguments must resolve
+// when the condition input is provided, even if one branch input is absent.
+// Before the fix the regex pre-check treated all referenced inputs as required,
+// so the whole expression was skipped and the globalArgument stayed as a raw
+// ${{ }} string.
+Deno.test("evaluateDefinition: ternary in globalArguments resolves when condition input provided and one branch input absent", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const service = new ExpressionEvaluationService(definitionRepo, repoDir);
+    const type = ModelType.create("command/shell");
+
+    const definition = Definition.create({
+      name: "transport-model",
+      inputs: {
+        properties: {
+          transport: { type: "string" },
+          lan_host: { type: "string" },
+          tailnet_host: { type: "string" },
+        },
+        required: ["transport", "tailnet_host"],
+      },
+      globalArguments: {
+        host:
+          '${{ inputs.transport == "lan" ? inputs.lan_host : inputs.tailnet_host }}',
+      },
+      methods: { exec: { arguments: { run: "echo hello" } } },
+    });
+
+    const result = await service.evaluateDefinition(
+      definition,
+      type,
+      { transport: "wan", tailnet_host: "100.64.0.1" }, // lan_host deliberately absent
+    );
+
+    assertEquals(result.definition.globalArguments.host, "100.64.0.1");
+  });
+});
+
+// Confirms the original #653 fix still works: a directly-referenced missing
+// input leaves the expression unresolved rather than throwing.
+Deno.test("evaluateDefinition: directly-missing input in globalArguments stays unresolved", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const service = new ExpressionEvaluationService(definitionRepo, repoDir);
+    const type = ModelType.create("command/shell");
+
+    const definition = Definition.create({
+      name: "factory-model",
+      inputs: {
+        properties: {
+          instanceName: { type: "string" },
+          cidrBlock: { type: "string" },
+        },
+        required: ["instanceName", "cidrBlock"],
+      },
+      globalArguments: {
+        run: '${{ "echo " + inputs.instanceName }}',
+        unusedArg: "${{ inputs.cidrBlock }}",
+      },
+      methods: { execute: { arguments: { run: "echo fallback" } } },
+    });
+
+    const result = await service.evaluateDefinition(
+      definition,
+      type,
+      { instanceName: "test-instance" }, // cidrBlock deliberately absent
+    );
+
+    // run is resolved, unusedArg stays as a raw expression
+    assertEquals(result.definition.globalArguments.run, "echo test-instance");
+    assertStringIncludes(
+      result.definition.globalArguments.unusedArg as string,
+      "${{",
+    );
+  });
 });

--- a/src/domain/expressions/expression_parser_test.ts
+++ b/src/domain/expressions/expression_parser_test.ts
@@ -23,6 +23,7 @@ import {
   extractCelExpression,
   extractExpressions,
   extractInputReferences,
+  extractInputReferencesFromCel,
   isTaskInputsPath,
   replaceExpressions,
 } from "./expression_parser.ts";
@@ -371,5 +372,18 @@ Deno.test("extractInputReferences handles mixed dot and bracket notation", () =>
   assertEquals(
     extractInputReferences(data),
     new Set(["region", "drop-name"]),
+  );
+});
+
+// Documents why extractInputReferencesFromCel must not be used as a skip gate
+// for expression evaluation. It reports all inputs in ALL branches of a ternary,
+// regardless of which branch CEL would actually evaluate at runtime.
+// This was the root cause of the #814 regression introduced in #655.
+Deno.test("extractInputReferencesFromCel: returns all branch inputs in ternary regardless of which branch runs", () => {
+  assertEquals(
+    extractInputReferencesFromCel(
+      `inputs.transport == "lan" ? inputs.lan_host : inputs.tailnet_host`,
+    ),
+    new Set(["transport", "lan_host", "tailnet_host"]),
   );
 });

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -47,7 +47,6 @@ import type { MethodExecutionEvent } from "../models/method_events.ts";
 import { ModelOutput } from "../models/model_output.ts";
 import {
   extractExpressions,
-  extractInputReferencesFromCel,
   isTaskInputsPath,
   replaceExpressions,
 } from "../expressions/expression_parser.ts";
@@ -743,11 +742,6 @@ export class DefaultStepExecutor implements StepExecutor {
       return definition;
     }
 
-    // Build set of provided input keys for selective skipping
-    const providedInputKeys = context.inputs
-      ? new Set(Object.keys(context.inputs))
-      : new Set<string>();
-
     // Evaluate CEL-only expressions; skip runtime expressions (vault, env)
     const evaluatedValues = new Map<string, unknown>();
     for (const expr of expressions) {
@@ -755,45 +749,39 @@ export class DefaultStepExecutor implements StepExecutor {
         continue;
       }
 
-      // Skip expressions that reference inputs not provided by the caller.
-      // This allows methods that don't need certain inputs to run without
-      // those inputs being provided (e.g., delete doesn't need create-time inputs).
-      const inputRefs = extractInputReferencesFromCel(expr.celExpression);
-      let hasMissing = false;
-      if (inputRefs.size > 0) {
-        for (const ref of inputRefs) {
-          if (!providedInputKeys.has(ref)) {
-            hasMissing = true;
+      // Skip expressions referencing model resource/file data that isn't
+      // available in context (e.g., referenced model was never executed).
+      // Unlike inputs, model data is never conditionally accessed in CEL —
+      // member access on a missing model ref is always an error.
+      let hasMissingModelDep = false;
+      const deps = extractDependencies(expr.celExpression);
+      for (const dep of deps) {
+        if (dep.type === "resource" || dep.type === "file") {
+          const modelData = context.model[dep.modelRef];
+          if (
+            !modelData ||
+            (dep.type === "resource" && !modelData.resource) ||
+            (dep.type === "file" && !modelData.file)
+          ) {
+            hasMissingModelDep = true;
             break;
           }
         }
       }
 
-      // Skip expressions referencing model resource/file data that isn't
-      // available in context (e.g., referenced model was never executed).
-      if (!hasMissing) {
-        const deps = extractDependencies(expr.celExpression);
-        for (const dep of deps) {
-          if (dep.type === "resource" || dep.type === "file") {
-            const modelData = context.model[dep.modelRef];
-            if (
-              !modelData ||
-              (dep.type === "resource" && !modelData.resource) ||
-              (dep.type === "file" && !modelData.file)
-            ) {
-              hasMissing = true;
-              break;
-            }
-          }
-        }
-      }
-
-      if (hasMissing) {
+      if (hasMissingModelDep) {
         continue;
       }
 
-      const value = celEvaluator.evaluate(expr.celExpression, context);
-      evaluatedValues.set(expr.raw, value);
+      try {
+        const value = celEvaluator.evaluate(expr.celExpression, context);
+        evaluatedValues.set(expr.raw, value);
+      } catch {
+        // Leave unresolved — CEL threw because an input referenced directly
+        // (not inside a conditional branch) is absent from context.
+        // The Proxy on globalArgs will surface a clear error if the method
+        // actually needs the unresolved value.
+      }
     }
 
     // Replace only CEL-only expressions with evaluated values

--- a/src/infrastructure/cel/cel_evaluator_test.ts
+++ b/src/infrastructure/cel/cel_evaluator_test.ts
@@ -904,3 +904,23 @@ Deno.test("CelEvaluator data.version() converts CEL int (bigint) to number for c
   );
   assertEquals(v1Vary, "first");
 });
+
+// Regression tests for issue #814: ternary expressions must short-circuit
+// so that a missing branch input does not cause evaluation to fail.
+
+Deno.test("CelEvaluator: ternary short-circuits — missing other-branch input does not throw", () => {
+  const evaluator = new CelEvaluator();
+  const result = evaluator.evaluate(
+    `inputs.transport == "lan" ? inputs.lan_host : inputs.tailnet_host`,
+    { inputs: { transport: "wan", tailnet_host: "100.64.0.1" } },
+  );
+  assertEquals(result, "100.64.0.1");
+});
+
+Deno.test("CelEvaluator: directly-missing input throws InvalidExpressionError", () => {
+  const evaluator = new CelEvaluator();
+  assertThrows(
+    () => evaluator.evaluate("inputs.cidrBlock", { inputs: {} }),
+    InvalidExpressionError,
+  );
+});


### PR DESCRIPTION
## Summary

Fixes a regression introduced in PR #655 where CEL expressions containing ternary operators would be incorrectly skipped during workflow execution when any input referenced in *any branch* of the ternary was absent — even if that branch would never be evaluated at runtime.

## Root Cause

PR #655 added a skip-guard to `evaluateDefinitionExpressions()` and `evaluateDefinition()` to fix issue #653 (factory model delete steps failing with `No such key: cidrBlock`). The guard used `extractInputReferencesFromCel()` — a regex scan — to detect all `inputs.*` references and skip evaluation if any were absent.

This is semantically incorrect for conditional expressions. Given:

```
inputs.transport == "lan" ? inputs.lan_host : inputs.tailnet_host
```

The regex reports `transport`, `lan_host`, and `tailnet_host` as all required. If `lan_host` is absent (because `transport` is `"wan"`), the entire expression is skipped — leaving `globalArguments.host` as a raw `${{ }}` string. The shell model then tries to execute that literal string and fails with exit code 1.

## Fix

Replace the inputs regex pre-check with try-catch around the CEL evaluation call.

CEL natively short-circuits ternaries — it only evaluates the taken branch. So:
- A missing input in a non-taken ternary branch: **no error** → expression resolves correctly ✓
- A missing input referenced directly (the #653 case): **CEL throws** → caught, expression left unresolved ✓

The model resource/file dependency pre-check (checking whether a prior step's output is available in context) is retained unchanged — that is a structural availability check, not an input presence check, and is always correct to guard.

## User Impact

**Who is affected:** Any workflow step whose model definition uses a ternary (or other conditional CEL expression) in `globalArguments` or `methods.<name>.arguments`, where only the inputs for the taken branch are provided.

**Symptom:** The workflow step fails with a non-zero exit code because the shell executes a literal `${{ ... }}` string rather than the resolved command.

**Breaking change:** No. This is a bug fix. Existing workflows that worked before #655 will now work correctly again. The factory model delete pattern fixed by #653 continues to work — directly-referenced missing inputs are still left unresolved via try-catch.

## Changes

| File | Change |
|------|--------|
| `src/domain/workflows/execution_service.ts` | Remove `providedInputKeys` / regex skip block; wrap `celEvaluator.evaluate()` in try-catch; rename `hasMissing` → `hasMissingModelDep` for clarity |
| `src/domain/expressions/expression_evaluation_service.ts` | Identical fix for the CLI evaluation path |
| `src/infrastructure/cel/cel_evaluator_test.ts` | Two new tests proving CEL ternary short-circuit and direct-missing-input throw behaviour |
| `src/domain/expressions/expression_parser_test.ts` | Documents why `extractInputReferencesFromCel` must not be used as a skip gate |
| `src/domain/expressions/expression_evaluation_service_test.ts` | Two model-agnostic unit tests for `evaluateDefinition()` with ternary in `globalArguments` |
| `integration/workflow_partial_inputs_test.ts` | End-to-end ternary test through the shell model execution path |

## Test Plan

- [x] `deno lint` — clean
- [x] `deno fmt --check` — clean
- [x] `deno run test` — 3484 passed, 0 failed
- [x] `deno run compile` — binary builds successfully
- [x] Manual repro: `workflow run issue-814-ternary` → `succeeded` (regression fixed)
- [x] Manual repro: `workflow run issue-653-partial-inputs` → `succeeded` (#653 fix preserved)
- [x] New CEL unit tests: ternary short-circuits, direct missing input throws
- [x] New model-agnostic unit tests: `globalArguments` ternary resolves correctly
- [x] New integration test: end-to-end ternary in method arguments

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)