### PR TITLE
refactor: replace /plan workflow with idempotent /triage command

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -142,7 +142,8 @@ jobs:
             - **Potential Challenges**: Risks, edge cases, or complications
 
             Reminders for the plan:
-            - Keep the blast radius small — only touch what is necessary
+            - Keep the blast radius small — only touch what is necessary. If the scope is large, recommend splitting into multiple PRs.
+            - Focus on WHAT needs to change and WHERE, not exact implementation details. The implementer will make design choices like formatting, heuristics, and UX. The plan should describe the problem and the approach, not prescribe every detail.
             - New `.ts`/`.tsx` files need the AGPLv3 license header (run `deno run license-headers`)
             - CLI commands must import from `src/libswamp/mod.ts`, never internal paths
             - Every command must support both `"log"` and `"json"` output modes


### PR DESCRIPTION
## Summary

- Replaces `issue-planner.yml` (`/plan` + `/plan-update`) with `issue-triage.yml` using a single `/triage` command
- Adds a triage phase that independently verifies issue claims against the codebase before planning — bugs are traced to confirm root cause, feature proposals are evaluated against the architecture
- Makes `/triage` idempotent: re-running it reads the full comment thread (operator feedback, additional context) and updates the existing triage in-place. No second command needed.
- Removes duplicated code style rules from the prompt (CLAUDE.md is the source of truth) and adds missing conventions: license headers, libswamp import rule, design docs, integration tests
- Updates README to reference `/triage` instead of removed `/plan` commands

## Test plan

- [ ] Comment `/triage` on a bug report — verify it traces through the code to confirm/deny the bug rather than trusting the author's diagnosis
- [ ] Comment `/triage` on a feature request with a proposed solution — verify it independently evaluates the proposal against the architecture
- [ ] Leave operator feedback as a regular comment, then `/triage` again — verify it reads the comment thread and updates the existing triage with a revision history entry
- [ ] Verify `/triage` on an unclear issue produces a "Needs Clarification" response with suggested questions
- [ ] Confirm the `<!-- IMPLEMENTATION-PLAN -->` marker is present for triage comment detection