### PR TITLE
fix: restore extension vault type auto-resolve in vault create

### DIFF
--- a/src/libswamp/vaults/create.ts
+++ b/src/libswamp/vaults/create.ts
@@ -26,6 +26,8 @@ import {
   vaultTypeRegistry,
 } from "../../domain/vaults/vault_type_registry.ts";
 import { RENAMED_VAULT_TYPES } from "../../domain/vaults/vault_service.ts";
+import { resolveVaultType } from "../../domain/extensions/extension_auto_resolver.ts";
+import { getAutoResolver } from "../../domain/extensions/auto_resolver_context.ts";
 import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -57,6 +59,7 @@ export interface VaultCreateInput {
 
 /** Dependencies for the vault create operation. */
 export interface VaultCreateDeps {
+  resolveExtensionVaultType: (type: string) => Promise<void>;
   getVaultTypeInfo: (type: string) => VaultTypeInfo | undefined;
   findByName: (name: string) => Promise<boolean>;
   save: (config: VaultConfig) => Promise<void>;
@@ -67,6 +70,11 @@ export interface VaultCreateDeps {
 export function createVaultCreateDeps(repoDir: string): VaultCreateDeps {
   const repo = new YamlVaultConfigRepository(repoDir);
   return {
+    resolveExtensionVaultType: async (type) => {
+      if (!vaultTypeRegistry.has(type) && type.startsWith("@")) {
+        await resolveVaultType(type, getAutoResolver());
+      }
+    },
     getVaultTypeInfo: (type) => vaultTypeRegistry.get(type),
     findByName: async (name) => {
       const existing = await repo.findByName(name);
@@ -104,6 +112,9 @@ export async function* vaultCreate(
   yield { kind: "creating" };
 
   ctx.logger.debug`Creating vault: type=${input.vaultType}, name=${input.name}`;
+
+  // Auto-resolve extension vault types if not already registered
+  await deps.resolveExtensionVaultType(input.vaultType);
 
   // Validate the vault type
   const typeInfo = deps.getVaultTypeInfo(input.vaultType);

--- a/src/libswamp/vaults/create_test.ts
+++ b/src/libswamp/vaults/create_test.ts
@@ -28,6 +28,7 @@ import {
 
 function makeDeps(overrides: Partial<VaultCreateDeps> = {}): VaultCreateDeps {
   return {
+    resolveExtensionVaultType: () => Promise.resolve(),
     getVaultTypeInfo: () =>
       ({
         type: "local_encryption",


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #821 (batch 3 migration) where `swamp vault create @org/custom-vault my-vault` fails with "Unknown vault type" instead of auto-resolving the extension type from the registry.

## What broke

The old `vault_create.ts` CLI handler had this auto-resolve step before checking the registry:

```typescript
if (!vaultTypeRegistry.has(vaultType) && vaultType.startsWith("@")) {
  await resolveVaultType(vaultType, getAutoResolver());
}
```

When the command was migrated to the libswamp generator pattern, this step was dropped. The generator's `deps.getVaultTypeInfo()` calls `vaultTypeRegistry.get()` directly — if the `@`-prefixed extension type isn't already registered, it immediately yields a `validation_failed` error.

## Fix

Added `resolveExtensionVaultType` to `VaultCreateDeps`:
- The dep calls `resolveVaultType()` from `extension_auto_resolver.ts` for `@`-prefixed types not yet in the registry
- The generator calls it before `deps.getVaultTypeInfo()`, restoring the original behavior
- Follows the same pattern as `ModelCreateDeps.resolveModelType` which auto-resolves extension model types

## Test plan

- [x] Existing vault create tests pass (4/4)
- [x] `deno check` — clean
- [x] `deno lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)