### PR TITLE
feat: add smoke-test protocol for extension models

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swamp-extension-model
-description: Create user-defined TypeScript models for swamp — define Zod schemas, implement model interfaces, configure output specs. Use when users want to extend swamp with custom model types, create automation models, or add new integrations. Triggers on "create model", "new model type", "custom model", "extension model", "user model", "typescript model", "extend swamp", "build integration", "zod schema", "model plugin", "deno model", "extensions/models", "model development", "implement model".
+description: Create user-defined TypeScript models for swamp — define Zod schemas, implement model interfaces, configure output specs. Use when users want to extend swamp with custom model types, create automation models, or add new integrations. Triggers on "create model", "new model type", "custom model", "extension model", "user model", "typescript model", "extend swamp", "build integration", "zod schema", "model plugin", "deno model", "extensions/models", "model development", "implement model", "smoke test", "test extension", "verify model", "test against API", "before push test".
 ---
 
 # Swamp Extension Model
@@ -61,6 +61,7 @@ than wrapping CLI commands.
 | Check formatting    | `swamp extension fmt manifest.yaml --check --json`                   |
 | Push extension      | `swamp extension push manifest.yaml --json`                          |
 | Dry-run push        | `swamp extension push manifest.yaml --dry-run --json`                |
+| Smoke test model    | See [references/smoke_testing.md](references/smoke_testing.md)       |
 
 ## Quick Start
 
@@ -383,6 +384,17 @@ Swamp discovers models and extensions recursively:
 Files are classified by export name: `export const model` defines new types,
 `export const extension` adds methods to existing types.
 
+## Smoke Testing
+
+Before pushing an extension, verify it works against the live API. Unit tests
+with mocked responses can't catch Content-Type mismatches, bundle caching bugs,
+or API validation quirks that only surface with real HTTP calls.
+
+Follow the smoke-test protocol in
+[references/smoke_testing.md](references/smoke_testing.md) to systematically
+test your model's methods against the real API. Start with safe read-only
+methods (list, get), then run the full CRUD lifecycle.
+
 ## Publishing Extensions
 
 Extensions are published to the swamp registry via a `manifest.yaml` and the
@@ -484,6 +496,9 @@ swamp model type describe @myorg/my-model --json  # Check schema
   end-to-end scenarios (custom API, cloud CRUD, factory models)
 - **Publishing**: See [references/publishing.md](references/publishing.md) for
   manifest schema, push workflow, safety rules, and CalVer versioning
+- **Smoke Testing**: See
+  [references/smoke_testing.md](references/smoke_testing.md) for the pre-push
+  smoke-test protocol, CRUD lifecycle testing, and common failure patterns
 - **Troubleshooting**: See
   [references/troubleshooting.md](references/troubleshooting.md)
 - **Docker execution**: See

--- a/.claude/skills/swamp-extension-model/evals/trigger_evals.json
+++ b/.claude/skills/swamp-extension-model/evals/trigger_evals.json
@@ -64,5 +64,25 @@
     "query": "List all the data stored from running my models",
     "should_trigger": false,
     "note": "Viewing model data → swamp-data"
+  },
+  {
+    "query": "Smoke test my extension model against the live API",
+    "should_trigger": true
+  },
+  {
+    "query": "I need to test my extension before pushing it",
+    "should_trigger": true
+  },
+  {
+    "query": "Verify my model works against the real API",
+    "should_trigger": true
+  },
+  {
+    "query": "Run a before push test on my custom model",
+    "should_trigger": true
+  },
+  {
+    "query": "Test my extension model's CRUD lifecycle",
+    "should_trigger": true
   }
 ]

--- a/.claude/skills/swamp-extension-model/references/smoke_testing.md
+++ b/.claude/skills/swamp-extension-model/references/smoke_testing.md
@@ -1,0 +1,183 @@
+# Smoke-Test Protocol for Extension Models
+
+Systematically verify extension models against live APIs before pushing. Unit
+tests with mocked responses can't catch Content-Type mismatches, bundle caching
+bugs, or API validation quirks that only surface with real HTTP calls.
+
+## Protocol Phases
+
+### Phase 0: Pre-flight
+
+1. Read the extension model source to understand the API surface
+2. `swamp model get <name> --json` to see configured methods and resource specs
+3. Clear the **specific** bundle cache for the model under test:
+   ```bash
+   rm .swamp/bundles/<model-filename>.js
+   ```
+   For example, for `extensions/models/honeycomb.ts`, remove
+   `.swamp/bundles/honeycomb.ts.js`. Do **not** wipe the entire
+   `.swamp/bundles/` directory — other models have legitimate cached bundles.
+4. Verify vault credentials are configured:
+   `swamp vault get <vault-name> --json`
+
+### Phase 1: List methods (safe reads)
+
+- Run all `list`-kind methods — read-only, no side effects
+- Try each `resource_type` the model supports
+- **401/403 = expected signal** (endpoint works, token is scoped), not failure
+- Connection errors or 500s = **stop**, API config is broken
+
+```bash
+swamp model method run <name> list --json
+swamp model method run <name> list --arg resource_type=<type> --json
+```
+
+### Phase 2: Read methods
+
+- Run `read`/`get`-kind methods using resource names/IDs from list results
+- Verify response matches declared schema
+
+```bash
+swamp model method run <name> get --arg id=<id-from-list> --json
+```
+
+### Phase 3: Create lifecycle
+
+For each resource type supporting create:
+
+1. Use unique names: `smoke-test-{resource_type}-{timestamp}`
+2. Read model source to determine required fields beyond `name` (this is where
+   Claude's API understanding matters)
+3. Run create, verify with read/get
+4. **Track every created resource for cleanup**
+
+```bash
+swamp model method run <name> create \
+  --arg name=smoke-test-widget-1711100000 \
+  --arg <other-required-fields> \
+  --json
+```
+
+### Phase 4: Update lifecycle
+
+- Only run if create succeeded
+- Make a small change to verify the update path works
+
+```bash
+swamp model method run <name> update \
+  --arg id=<created-id> \
+  --arg description="smoke test update" \
+  --json
+```
+
+### Phase 5: Delete / cleanup (ALWAYS runs)
+
+- Delete **every** resource created in Phase 3, in reverse order
+- If delete fails (e.g., `delete_protected: true`), try the documented
+  workaround (update to remove protection first, then delete)
+- Verify deletion via read returning 404/not-found
+
+```bash
+swamp model method run <name> delete --arg id=<created-id> --json
+# Verify deletion
+swamp model method run <name> get --arg id=<created-id> --json
+```
+
+### Phase 6: Report
+
+Produce a summary table:
+
+| Method | Resource Type | Status | Notes                        |
+| ------ | ------------- | ------ | ---------------------------- |
+| list   | widget        | passed | 3 items returned             |
+| get    | widget        | passed | schema matches               |
+| create | widget        | passed | smoke-test-widget-1711100000 |
+| update | widget        | passed | description updated          |
+| delete | widget        | passed | verified 404                 |
+
+**Result classifications:**
+
+- **passed** — method succeeded as expected
+- **expected_error** — 401/403 (endpoint works, token scoped)
+- **failed** — unexpected error (real bug)
+- **skipped** — couldn't run (missing args, dependent create failed)
+
+**Flag specific bug categories:**
+
+- Content-Type errors (415)
+- Bundle cache issues (fix not reflected at runtime)
+- Missing required fields (422)
+- Read-only violations (405)
+
+## Protocol Rules
+
+1. **Never touch pre-existing resources** — only `smoke-test-*` named resources
+2. **Always clean up**, even on failure
+3. **Clear the specific model's bundle cache** (`.swamp/bundles/{filename}.js`)
+   before every smoke test run — don't wipe the entire bundles directory
+4. **Permission errors are signal, not failure** — 401/403 means the endpoint
+   works but the token is scoped
+5. **If unsure about required arguments, ask the user** rather than guessing
+
+## Common Failure Patterns
+
+These are the most frequent bugs caught by smoke testing (from real extension
+model development):
+
+### Content-Type mismatches (HTTP 415)
+
+**Symptom:** API returns 415 Unsupported Media Type.
+
+**Cause:** The model sends the wrong `Content-Type` header (or none at all).
+Many APIs require `application/json` explicitly.
+
+**Fix:** Check the API docs for the required Content-Type and set it in the
+fetch headers.
+
+### Stale bundle cache
+
+**Symptom:** A source fix isn't reflected at runtime — the model behaves as if
+the old code is still running.
+
+**Cause:** Swamp caches bundled model code in `.swamp/bundles/`. After editing
+the source, the stale cached bundle is still used.
+
+**Fix:** Remove the specific bundle:
+
+```bash
+rm .swamp/bundles/<model-filename>.js
+```
+
+### API validation quirks (HTTP 422)
+
+**Symptom:** API returns 422 Unprocessable Entity with validation errors.
+
+**Cause:** The API requires fields that aren't obvious from the primary docs
+(e.g., a `type` field, a specific enum value, or a nested object structure).
+
+**Fix:** Read the API's error response carefully — it usually lists the missing
+or invalid fields. Update the model's create/update method to include them.
+
+### Delete-protected defaults (HTTP 403/409)
+
+**Symptom:** Delete method fails with 403 Forbidden or 409 Conflict.
+
+**Cause:** The resource was created with delete protection enabled by default.
+
+**Fix:** Update the resource to disable delete protection first, then retry the
+delete:
+
+```bash
+swamp model method run <name> update --arg id=<id> --arg delete_protected=false --json
+swamp model method run <name> delete --arg id=<id> --json
+```
+
+### Read-only resource guards (HTTP 405)
+
+**Symptom:** Mutation method returns 405 Method Not Allowed.
+
+**Cause:** The resource type is read-only (e.g., AWS managed policies, system
+resources).
+
+**Fix:** Mark the resource as read-only in the model — remove create/update/
+delete methods for that resource type and only expose list/get.


### PR DESCRIPTION
## Summary

Adds a structured smoke-test protocol to the `swamp-extension-model` skill that guides Claude through systematically verifying extension models against live APIs before pushing. Closes #633.

- **New reference doc** (`references/smoke_testing.md`): A 7-phase protocol (pre-flight → list → read → create → update → delete/cleanup → report) with safety rules and a common failure patterns catalog
- **Updated SKILL.md**: New "Smoke Testing" section, quick reference table row, reference link, and 5 new trigger phrases in the frontmatter
- **Updated trigger evals**: 5 new eval entries to verify the skill activates on smoke-test queries

## Why this approach

Extension model developers were hitting real API bugs — Content-Type mismatches (415), stale bundle cache, API validation quirks (422), delete-protected defaults (403/409), and read-only resource guards (405) — that unit tests with mocked responses **cannot catch**. These bugs survived into pushes and were only discovered during manual smoke testing.

Rather than building new CLI infrastructure, this uses a skill-based approach: Claude reads the protocol and executes it using existing commands (`swamp model method run`, `swamp model get`, etc.). This means:

1. **Zero code changes to swamp** — purely skill content, no new commands or flags to maintain
2. **Claude adapts per-model** — reads the model source to understand required fields, API quirks, and resource types rather than relying on generic templates
3. **Safe by design** — only creates `smoke-test-*` named resources, always cleans up, never touches pre-existing resources
4. **Specific bundle cache clearing** — clears only `.swamp/bundles/{model-filename}.js`, not the entire bundles directory, so other models' cached bundles aren't disrupted

## UX flow

When a user says "smoke test my honeycomb extension" or "test my model before pushing":

1. Skill triggers via the new trigger phrases
2. Claude loads the smoke-test protocol from the reference doc
3. Executes phases 0-6 in order, using existing CLI commands
4. Produces a summary table with pass/fail/expected_error/skipped classifications
5. Flags any failures by bug category (415, 422, stale cache, etc.) with actionable fix guidance

The protocol treats 401/403 as **signal, not failure** — it means the endpoint works but the token is scoped. Connection errors and 500s are the real blockers.

## Test plan

- [ ] Verify skill triggers on "smoke test my extension model"
- [ ] Verify the reference doc loads when Claude needs smoke-test details
- [ ] Review protocol covers all 5 bug categories from issue #633 (Content-Type 415, stale bundle cache, API validation 422, delete-protected 403/409, read-only 405)
- [ ] Confirm existing trigger phrases still work (no regressions in trigger evals)
- [ ] Verify new trigger evals pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Blake Irvin <blakeirvin@me.com>