### PR TITLE
fix: bundle smoke_testing.md in skill assets for repo init/upgrade

### DIFF
--- a/src/infrastructure/assets/skill_assets.ts
+++ b/src/infrastructure/assets/skill_assets.ts
@@ -150,6 +150,10 @@ const BUNDLED_SKILLS: SkillInfo[] = [
     name: "swamp-extension-model",
   },
   {
+    relativePath: "swamp-extension-model/references/smoke_testing.md",
+    name: "swamp-extension-model",
+  },
+  {
     relativePath: "swamp-model/references/execution-drivers.md",
     name: "swamp-model",
   },

--- a/src/infrastructure/assets/skill_assets_test.ts
+++ b/src/infrastructure/assets/skill_assets_test.ts
@@ -374,6 +374,23 @@ Deno.test("SkillAssets.copySkillsTo copies swamp-extension-model checks file", a
   });
 });
 
+Deno.test("SkillAssets.copySkillsTo copies swamp-extension-model smoke_testing file", async () => {
+  await withTempDir(async (dir) => {
+    const assets = new SkillAssets();
+    await assets.copySkillsTo(dir);
+
+    const smokePath = join(
+      dir,
+      "swamp-extension-model",
+      "references",
+      "smoke_testing.md",
+    );
+
+    const smokeStat = await Deno.stat(smokePath);
+    assertEquals(smokeStat.isFile, true);
+  });
+});
+
 Deno.test("SkillAssets.copySkillsTo copies swamp-workflow nested-workflows file", async () => {
   await withTempDir(async (dir) => {
     const assets = new SkillAssets();


### PR DESCRIPTION

## Summary

- The smoke-test protocol reference (`smoke_testing.md`) added in #633 was not included in the `BUNDLED_SKILLS` manifest in `skill_assets.ts`
- This meant `swamp repo init` and `swamp repo upgrade` would not copy the smoke-testing guide to user repositories
- Users who initialized or upgraded repos after #633 would be missing the smoke-test protocol documentation for extension models

## Changes

- **`src/infrastructure/assets/skill_assets.ts`** — Added `swamp-extension-model/references/smoke_testing.md` entry to `BUNDLED_SKILLS` array
- **`src/infrastructure/assets/skill_assets_test.ts`** — Added test verifying the smoke_testing.md file is correctly copied during `copySkillsTo`

## Impact

Without this fix, the smoke-test skill reference is only available when running swamp from source. Users running the compiled binary who `repo init` or `repo upgrade` would never receive the `smoke_testing.md` file in their `.claude/skills/swamp-extension-model/references/` directory, making the smoke-test protocol invisible to their AI coding assistants.

## Why this is correct

Every reference file in `.claude/skills/` that a skill's `SKILL.md` links to must have a corresponding entry in the `BUNDLED_SKILLS` array — this is how the compiled binary knows which files to embed and distribute. The existing pattern for all other `swamp-extension-model` references (`examples.md`, `troubleshooting.md`, `scenarios.md`, `api.md`, `publishing.md`, `checks.md`, `docker-execution.md`) confirms this is the correct approach.

## Test plan

- [x] `deno run test src/infrastructure/assets/skill_assets_test.ts` — all 28 tests pass
- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt --check` — formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)