### PR TITLE
fix: zodToJsonSchema fallback for z.record(), z.uuid(), z.iso.datetime()

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -69,11 +69,15 @@ than wrapping CLI commands.
 // extensions/models/my_model.ts
 import { z } from "npm:zod@4";
 
-const GlobalArgsSchema = z.object({ message: z.string() });
+const GlobalArgsSchema = z.object({
+  message: z.string(),
+  metadata: z.record(z.string(), z.unknown()).default({}),
+});
 
 const OutputSchema = z.object({
+  id: z.uuid(),
   message: z.string(),
-  timestamp: z.string(),
+  timestamp: z.iso.datetime(),
 });
 
 export const model = {
@@ -94,6 +98,7 @@ export const model = {
       arguments: z.object({}),
       execute: async (args, context) => {
         const handle = await context.writeResource("result", "main", {
+          id: crypto.randomUUID(),
           message: context.globalArgs.message.toUpperCase(),
           timestamp: new Date().toISOString(),
         });
@@ -117,6 +122,26 @@ export const model = {
 | `methods`         | Yes      | Object of method definitions with `arguments` Zod |
 | `checks`          | No       | Pre-flight checks run before mutating methods     |
 | `reports`         | No       | Inline report definitions (see `swamp-report`)    |
+
+## Supported Zod Types
+
+All standard Zod types work in `globalArguments`, method `arguments`, and
+resource `schema` definitions:
+
+| Zod Type                            | JSON Schema Output                             | Use Case        |
+| ----------------------------------- | ---------------------------------------------- | --------------- |
+| `z.string()`                        | `{ type: "string" }`                           | Text fields     |
+| `z.number()`                        | `{ type: "number" }`                           | Numeric values  |
+| `z.boolean()`                       | `{ type: "boolean" }`                          | Flags           |
+| `z.uuid()`                          | `{ type: "string", format: "uuid" }`           | Resource IDs    |
+| `z.iso.datetime()`                  | `{ type: "string", format: "date-time" }`      | Timestamps      |
+| `z.enum(["a", "b"])`                | `{ type: "string", enum: [...] }`              | Fixed choices   |
+| `z.object({ ... })`                 | `{ type: "object", ... }`                      | Structured data |
+| `z.array(z.string())`               | `{ type: "array", items: ... }`                | Lists           |
+| `z.record(z.string(), z.unknown())` | `{ type: "object", additionalProperties: {} }` | Key-value maps  |
+
+All types support `.optional()`, `.default()`, `.describe()`, and
+`.meta({ sensitive: true })` modifiers.
 
 ## Resources & Files
 

--- a/src/cli/commands/type_search.ts
+++ b/src/cli/commands/type_search.ts
@@ -32,17 +32,10 @@ import {
 import { UserError } from "../../domain/errors.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
-import { z } from "zod";
+import { zodToJsonSchema } from "../../libswamp/mod.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
-
-/**
- * Converts a Zod schema to JSON Schema format.
- */
-function zodToJsonSchema(schema: z.ZodTypeAny): object {
-  return z.toJSONSchema(schema);
-}
 
 /**
  * Gets all registered types as TypeSearchItem array.

--- a/src/libswamp/types/schema_helpers.ts
+++ b/src/libswamp/types/schema_helpers.ts
@@ -50,10 +50,134 @@ export interface MethodDescribeData {
 }
 
 /**
+ * Internal interface for accessing Zod v4's internal definition structure.
+ */
+interface ZodDef {
+  type: string;
+  innerType?: z.ZodTypeAny;
+  element?: z.ZodTypeAny;
+  shape?: Record<string, z.ZodTypeAny>;
+  valueType?: z.ZodTypeAny;
+  options?: z.ZodTypeAny[];
+  schema?: z.ZodTypeAny;
+  values?: readonly string[];
+  value?: unknown;
+  defaultValue?: unknown;
+}
+
+/**
+ * Gets the definition type from a Zod schema (Zod v4 compatible).
+ */
+function getSchemaType(schema: z.ZodTypeAny): string {
+  const def = (schema as unknown as { _def: ZodDef })._def;
+  return def?.type ?? "";
+}
+
+/**
+ * Gets the definition from a Zod schema.
+ */
+function getSchemaDef(schema: z.ZodTypeAny): ZodDef {
+  return (schema as unknown as { _def: ZodDef })._def;
+}
+
+/**
+ * Unwraps optional, nullable, default, and effects wrapper types.
+ */
+function unwrapSchema(schema: z.ZodTypeAny): z.ZodTypeAny {
+  const schemaType = getSchemaType(schema);
+  const def = getSchemaDef(schema);
+
+  const wrapperTypes = ["optional", "nullable", "default"];
+  if (wrapperTypes.includes(schemaType) && def.innerType) {
+    return unwrapSchema(def.innerType);
+  }
+  if (schemaType === "effects" && def.schema) {
+    return unwrapSchema(def.schema);
+  }
+  return schema;
+}
+
+/**
+ * Manually converts a Zod schema to JSON Schema format.
+ * This is a fallback for when Zod's built-in toJSONSchema() crashes
+ * on types like z.record(z.unknown()), z.uuid(), or z.iso.datetime().
+ */
+function manualZodToJsonSchema(schema: z.ZodTypeAny): object {
+  const unwrapped = unwrapSchema(schema);
+  const schemaType = getSchemaType(unwrapped);
+  const def = getSchemaDef(unwrapped);
+
+  switch (schemaType) {
+    case "unknown":
+      return {};
+    case "string": {
+      const result: Record<string, unknown> = { type: "string" };
+      // Check for format metadata (uuid, datetime, etc.)
+      const zodInternals = unwrapped as unknown as {
+        _zod?: { format?: string };
+      };
+      if (zodInternals._zod?.format) {
+        result.format = zodInternals._zod.format;
+      }
+      return result;
+    }
+    case "number":
+      return { type: "number" };
+    case "boolean":
+      return { type: "boolean" };
+    case "record": {
+      const additionalProperties = def.valueType
+        ? manualZodToJsonSchema(def.valueType)
+        : {};
+      return { type: "object", additionalProperties };
+    }
+    case "object": {
+      const result: Record<string, unknown> = { type: "object" };
+      if (def.shape) {
+        const properties: Record<string, object> = {};
+        const required: string[] = [];
+        for (const [key, value] of Object.entries(def.shape)) {
+          properties[key] = manualZodToJsonSchema(value);
+          if (getSchemaType(value) !== "optional") {
+            required.push(key);
+          }
+        }
+        result.properties = properties;
+        if (required.length > 0) {
+          result.required = required;
+        }
+      }
+      return result;
+    }
+    case "array": {
+      const items = def.element ? manualZodToJsonSchema(def.element) : {};
+      return { type: "array", items };
+    }
+    case "enum": {
+      if (def.values) {
+        return { type: "string", enum: [...def.values] };
+      }
+      return { type: "string" };
+    }
+    case "literal": {
+      return { type: typeof def.value, const: def.value };
+    }
+    default:
+      // Safe fallback for any unrecognized type
+      return {};
+  }
+}
+
+/**
  * Converts a Zod schema to JSON Schema format.
+ * Falls back to a manual converter if Zod's built-in toJSONSchema() fails.
  */
 export function zodToJsonSchema(schema: z.ZodTypeAny): object {
-  return z.toJSONSchema(schema);
+  try {
+    return z.toJSONSchema(schema);
+  } catch {
+    return manualZodToJsonSchema(schema);
+  }
 }
 
 /**

--- a/src/libswamp/types/schema_helpers_test.ts
+++ b/src/libswamp/types/schema_helpers_test.ts
@@ -1,0 +1,85 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { z } from "zod";
+import { zodToJsonSchema } from "./schema_helpers.ts";
+
+Deno.test("zodToJsonSchema: handles z.record(z.unknown())", () => {
+  const schema = z.record(z.string(), z.unknown());
+  const result = zodToJsonSchema(schema);
+  const json = result as Record<string, unknown>;
+  assertEquals(json.type, "object");
+  assertEquals(typeof json.additionalProperties, "object");
+});
+
+Deno.test("zodToJsonSchema: handles z.uuid()", () => {
+  const schema = z.uuid();
+  const result = zodToJsonSchema(schema);
+  const json = result as Record<string, unknown>;
+  assertEquals(json.type, "string");
+});
+
+Deno.test("zodToJsonSchema: handles z.iso.datetime()", () => {
+  const schema = z.iso.datetime();
+  const result = zodToJsonSchema(schema);
+  const json = result as Record<string, unknown>;
+  assertEquals(json.type, "string");
+});
+
+Deno.test("zodToJsonSchema: handles nested combination with problematic types", () => {
+  const schema = z.object({
+    data: z.record(z.string(), z.unknown()),
+    id: z.uuid().optional(),
+  });
+  const result = zodToJsonSchema(schema);
+  const json = result as Record<string, unknown>;
+  assertEquals(json.type, "object");
+  const properties = json.properties as Record<string, Record<string, unknown>>;
+  assertEquals(properties.data.type, "object");
+});
+
+Deno.test("zodToJsonSchema: handles standard z.string()", () => {
+  const result = zodToJsonSchema(z.string()) as Record<string, unknown>;
+  assertEquals(result.type, "string");
+});
+
+Deno.test("zodToJsonSchema: handles standard z.number()", () => {
+  const result = zodToJsonSchema(z.number()) as Record<string, unknown>;
+  assertEquals(result.type, "number");
+});
+
+Deno.test("zodToJsonSchema: handles standard z.object()", () => {
+  const schema = z.object({ name: z.string(), age: z.number() });
+  const result = zodToJsonSchema(schema) as Record<string, unknown>;
+  assertEquals(result.type, "object");
+  const properties = result.properties as Record<
+    string,
+    Record<string, unknown>
+  >;
+  assertEquals(properties.name.type, "string");
+  assertEquals(properties.age.type, "number");
+});
+
+Deno.test("zodToJsonSchema: handles z.enum()", () => {
+  const schema = z.enum(["a", "b", "c"]);
+  const result = zodToJsonSchema(schema) as Record<string, unknown>;
+  // Zod's toJSONSchema may succeed for enum, but verify it works either way
+  assertEquals(Array.isArray(result.enum), true);
+});


### PR DESCRIPTION
## Summary

- Add manual fallback converter in `zodToJsonSchema()` that catches crashes from
Zod v4's `toJSONSchema()` on `z.record(z.unknown())`, `z.uuid()`, and
`z.iso.datetime()` — unblocking extension authors from using these types in
`globalArguments` and method schemas
- Remove duplicate `zodToJsonSchema` function in `type_search.ts`, importing
from `libswamp/mod.ts` instead
- Update extension-model skill with a "Supported Zod Types" reference table and
Quick Start examples using `z.uuid()`, `z.iso.datetime()`, and `z.record()`

Fixes #830

## Test plan

- [x] New `schema_helpers_test.ts` with 8 test cases covering crash cases
    (`z.record`, `z.uuid`, `z.iso.datetime`), nested combinations, and
    existing working types
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] Full test suite passes (3511 tests)
- [x] `deno run compile` succeeds

Co-authored-by: Raymond Masciarella <rmasciarella@acrlabs.io>