### PR TITLE
fix: restore extensions key in extension search JSON output

### DIFF
--- a/src/presentation/renderers/extension_search.tsx
+++ b/src/presentation/renderers/extension_search.tsx
@@ -51,7 +51,7 @@ class JsonExtensionSearchRenderer implements ExtensionSearchRenderer {
       completed: (e) => {
         const output = {
           query: e.data.query,
-          results: e.data.results.map((ext) => {
+          extensions: e.data.results.map((ext) => {
             const { platforms, labels, contentTypes, ...rest } = ext;
             return {
               ...rest,


### PR DESCRIPTION
PR #833 inadvertently renamed the top-level JSON key from "extensions" to "results" in the extension search --json output, breaking the JSON contract for downstream consumers.