### PR TITLE
fix: always include array fields in extension search JSON output

### DIFF
--- a/src/presentation/renderers/extension_search.tsx
+++ b/src/presentation/renderers/extension_search.tsx
@@ -53,12 +53,7 @@ class JsonExtensionSearchRenderer implements ExtensionSearchRenderer {
           query: e.data.query,
           extensions: e.data.results.map((ext) => {
             const { platforms, labels, contentTypes, ...rest } = ext;
-            return {
-              ...rest,
-              ...(platforms.length > 0 ? { platforms } : {}),
-              ...(labels.length > 0 ? { labels } : {}),
-              ...(contentTypes.length > 0 ? { contentTypes } : {}),
-            };
+            return { ...rest, platforms, labels, contentTypes };
           }),
           meta: e.data.meta,
         };


### PR DESCRIPTION
## Summary

- Fix regression where `extension search --json` conditionally omitted `platforms`, `labels`, and `contentTypes` fields when they were empty arrays
- Consumers (including swamp-uat) expect these fields to always be present as arrays, causing `ZodError: expected array, received undefined` schema validation failures
- The conditional pattern was inherited from the old `extension_search_output.tsx` and carried over during the renderer pattern port in #833

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — no lint errors
- [x] Verified JSON output now always includes `platforms`, `labels`, and `contentTypes` as arrays

🤖 Generated with [Claude Code](https://claude.com/claude-code)