### PR TITLE
feat: add native OpenTelemetry tracing across all CLI operations

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -38,7 +38,13 @@
     "fast-json-patch": "npm:fast-json-patch@^3.1.1",
     "fast-check": "npm:fast-check@^3.22.0",
     "marked": "npm:marked@^14.0.0",
-    "marked-terminal": "npm:marked-terminal@^7.3.0"
+    "marked-terminal": "npm:marked-terminal@^7.3.0",
+    "@opentelemetry/api": "npm:@opentelemetry/api@^1.9.0",
+    "@opentelemetry/sdk-trace-base": "npm:@opentelemetry/sdk-trace-base@^1.30.0",
+    "@opentelemetry/exporter-trace-otlp-http": "npm:@opentelemetry/exporter-trace-otlp-http@^0.57.0",
+    "@opentelemetry/context-async-hooks": "npm:@opentelemetry/context-async-hooks@^1.30.0",
+    "@opentelemetry/resources": "npm:@opentelemetry/resources@^1.30.0",
+    "@opentelemetry/semantic-conventions": "npm:@opentelemetry/semantic-conventions@^1.30.0"
   },
   "compilerOptions": {
     "jsx": "react",

--- a/deno.lock
+++ b/deno.lock
@@ -19,6 +19,12 @@
     "npm:@aws-sdk/client-cloudcontrol@^3.1014.0": "3.1014.0",
     "npm:@aws-sdk/client-s3@^3.1013.0": "3.1013.0",
     "npm:@marcbachmann/cel-js@7.5.1": "7.5.1",
+    "npm:@opentelemetry/api@^1.9.0": "1.9.0",
+    "npm:@opentelemetry/context-async-hooks@^1.30.0": "1.30.1_@opentelemetry+api@1.9.0",
+    "npm:@opentelemetry/exporter-trace-otlp-http@0.57": "0.57.2_@opentelemetry+api@1.9.0",
+    "npm:@opentelemetry/resources@^1.30.0": "1.30.1_@opentelemetry+api@1.9.0",
+    "npm:@opentelemetry/sdk-trace-base@^1.30.0": "1.30.1_@opentelemetry+api@1.9.0",
+    "npm:@opentelemetry/semantic-conventions@^1.30.0": "1.40.0",
     "npm:@types/node@24.0.7": "24.0.7",
     "npm:@types/react@^18.3.28": "18.3.28",
     "npm:fast-check@^3.22.0": "3.23.2",
@@ -677,6 +683,134 @@
     "@marcbachmann/cel-js@7.5.1": {
       "integrity": "sha512-3X+TKpt/xyPsVSU3R2bVeZQCOW5L29y+EVDOmOp2xnyD7bifNM/UypBaqs2Z6oC075p+tKtjPUT1kUwnyY7cQg==",
       "bin": true
+    },
+    "@opentelemetry/api-logs@0.57.2": {
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+      "dependencies": [
+        "@opentelemetry/api"
+      ]
+    },
+    "@opentelemetry/api@1.9.0": {
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
+    },
+    "@opentelemetry/context-async-hooks@1.30.1_@opentelemetry+api@1.9.0": {
+      "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
+      "dependencies": [
+        "@opentelemetry/api"
+      ]
+    },
+    "@opentelemetry/core@1.30.1_@opentelemetry+api@1.9.0": {
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "dependencies": [
+        "@opentelemetry/api",
+        "@opentelemetry/semantic-conventions@1.28.0"
+      ]
+    },
+    "@opentelemetry/exporter-trace-otlp-http@0.57.2_@opentelemetry+api@1.9.0": {
+      "integrity": "sha512-sB/gkSYFu+0w2dVQ0PWY9fAMl172PKMZ/JrHkkW8dmjCL0CYkmXeE+ssqIL/yBUTPOvpLIpenX5T9RwXRBW/3g==",
+      "dependencies": [
+        "@opentelemetry/api",
+        "@opentelemetry/core",
+        "@opentelemetry/otlp-exporter-base",
+        "@opentelemetry/otlp-transformer",
+        "@opentelemetry/resources",
+        "@opentelemetry/sdk-trace-base"
+      ]
+    },
+    "@opentelemetry/otlp-exporter-base@0.57.2_@opentelemetry+api@1.9.0": {
+      "integrity": "sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==",
+      "dependencies": [
+        "@opentelemetry/api",
+        "@opentelemetry/core",
+        "@opentelemetry/otlp-transformer"
+      ]
+    },
+    "@opentelemetry/otlp-transformer@0.57.2_@opentelemetry+api@1.9.0": {
+      "integrity": "sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==",
+      "dependencies": [
+        "@opentelemetry/api",
+        "@opentelemetry/api-logs",
+        "@opentelemetry/core",
+        "@opentelemetry/resources",
+        "@opentelemetry/sdk-logs",
+        "@opentelemetry/sdk-metrics",
+        "@opentelemetry/sdk-trace-base",
+        "protobufjs"
+      ]
+    },
+    "@opentelemetry/resources@1.30.1_@opentelemetry+api@1.9.0": {
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "dependencies": [
+        "@opentelemetry/api",
+        "@opentelemetry/core",
+        "@opentelemetry/semantic-conventions@1.28.0"
+      ]
+    },
+    "@opentelemetry/sdk-logs@0.57.2_@opentelemetry+api@1.9.0": {
+      "integrity": "sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==",
+      "dependencies": [
+        "@opentelemetry/api",
+        "@opentelemetry/api-logs",
+        "@opentelemetry/core",
+        "@opentelemetry/resources"
+      ]
+    },
+    "@opentelemetry/sdk-metrics@1.30.1_@opentelemetry+api@1.9.0": {
+      "integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
+      "dependencies": [
+        "@opentelemetry/api",
+        "@opentelemetry/core",
+        "@opentelemetry/resources"
+      ]
+    },
+    "@opentelemetry/sdk-trace-base@1.30.1_@opentelemetry+api@1.9.0": {
+      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+      "dependencies": [
+        "@opentelemetry/api",
+        "@opentelemetry/core",
+        "@opentelemetry/resources",
+        "@opentelemetry/semantic-conventions@1.28.0"
+      ]
+    },
+    "@opentelemetry/semantic-conventions@1.28.0": {
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+    },
+    "@opentelemetry/semantic-conventions@1.40.0": {
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="
+    },
+    "@protobufjs/aspromise@1.1.2": {
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "@protobufjs/base64@1.1.2": {
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen@2.0.4": {
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter@1.1.0": {
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "@protobufjs/fetch@1.1.0": {
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": [
+        "@protobufjs/aspromise",
+        "@protobufjs/inquire"
+      ]
+    },
+    "@protobufjs/float@1.0.2": {
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "@protobufjs/inquire@1.1.0": {
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "@protobufjs/path@1.1.2": {
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "@protobufjs/pool@1.1.0": {
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "@protobufjs/utf8@1.1.0": {
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@sindresorhus/is@4.6.0": {
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
@@ -1378,6 +1512,9 @@
     "js-tokens@4.0.0": {
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
+    "long@5.3.2": {
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
+    },
     "loose-envify@1.4.0": {
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dependencies": [
@@ -1448,6 +1585,24 @@
     },
     "path-expression-matcher@1.2.0": {
       "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ=="
+    },
+    "protobufjs@7.5.4": {
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "dependencies": [
+        "@protobufjs/aspromise",
+        "@protobufjs/base64",
+        "@protobufjs/codegen",
+        "@protobufjs/eventemitter",
+        "@protobufjs/fetch",
+        "@protobufjs/float",
+        "@protobufjs/inquire",
+        "@protobufjs/path",
+        "@protobufjs/pool",
+        "@protobufjs/utf8",
+        "@types/node",
+        "long"
+      ],
+      "scripts": true
     },
     "pure-rand@6.1.0": {
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="
@@ -1643,6 +1798,12 @@
       "npm:@aws-sdk/client-cloudcontrol@^3.1014.0",
       "npm:@aws-sdk/client-s3@^3.1013.0",
       "npm:@marcbachmann/cel-js@7.5.1",
+      "npm:@opentelemetry/api@^1.9.0",
+      "npm:@opentelemetry/context-async-hooks@^1.30.0",
+      "npm:@opentelemetry/exporter-trace-otlp-http@0.57",
+      "npm:@opentelemetry/resources@^1.30.0",
+      "npm:@opentelemetry/sdk-trace-base@^1.30.0",
+      "npm:@opentelemetry/semantic-conventions@^1.30.0",
       "npm:@types/react@^18.3.28",
       "npm:fast-check@^3.22.0",
       "npm:fast-json-patch@^3.1.1",

--- a/integration/ddd_layer_rules_test.ts
+++ b/integration/ddd_layer_rules_test.ts
@@ -58,6 +58,13 @@ function isLoggingImport(filePath: string, importPath: string): boolean {
   return importsLayer(filePath, importPath, "infrastructure/logging");
 }
 
+/**
+ * Check if an import is a tracing import (cross-cutting concern, not a real violation).
+ */
+function isTracingImport(filePath: string, importPath: string): boolean {
+  return importsLayer(filePath, importPath, "infrastructure/tracing");
+}
+
 // Ratchet counts: current number of known violations.
 // If someone fixes a violation, the count decreases and the test still passes.
 // If someone adds a new violation, the count increases and the test fails.
@@ -81,8 +88,9 @@ Deno.test(
 
       for (const imp of imports) {
         if (importsLayer(entry.path, imp, "infrastructure")) {
-          // Logging is a cross-cutting concern, not an infrastructure dependency
+          // Logging and tracing are cross-cutting concerns, not infrastructure dependencies
           if (isLoggingImport(entry.path, imp)) continue;
+          if (isTracingImport(entry.path, imp)) continue;
           violations.push(relative(ROOT, entry.path));
           break; // Count each file only once
         }
@@ -126,8 +134,9 @@ Deno.test(
 
       for (const imp of imports) {
         if (importsLayer(entry.path, imp, "infrastructure")) {
-          // Logging is a cross-cutting concern, not an infrastructure dependency
+          // Logging and tracing are cross-cutting concerns, not infrastructure dependencies
           if (isLoggingImport(entry.path, imp)) continue;
+          if (isTracingImport(entry.path, imp)) continue;
           violations.push(relative(ROOT, entry.path));
           break; // Count each file only once
         }

--- a/main.ts
+++ b/main.ts
@@ -22,8 +22,13 @@ import { initializeLogging } from "./src/infrastructure/logging/logger.ts";
 import { renderError } from "./src/presentation/output/error_output.ts";
 import { flushDatastoreSync } from "./src/infrastructure/persistence/datastore_sync_coordinator.ts";
 import { getOutputModeFromArgs } from "./src/cli/context.ts";
+import {
+  initTracing,
+  shutdownTracing,
+} from "./src/infrastructure/tracing/mod.ts";
 
 if (import.meta.main) {
+  await initTracing();
   try {
     await runCli(Deno.args);
   } catch (error) {
@@ -34,5 +39,7 @@ if (import.meta.main) {
     });
     renderError(error);
     Deno.exit(1);
+  } finally {
+    await shutdownTracing();
   }
 }

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -93,6 +93,7 @@ import { Platform } from "../domain/update/platform.ts";
 import { renderUpdateNotification } from "../presentation/output/update_notification_output.ts";
 import { getOutputModeFromArgs } from "./context.ts";
 import { flushDatastoreSync } from "../infrastructure/persistence/datastore_sync_coordinator.ts";
+import { withSpan } from "../infrastructure/tracing/mod.ts";
 
 // Import models barrel to trigger self-registration
 import "../domain/models/models.ts";
@@ -628,7 +629,13 @@ export async function runCli(args: string[]): Promise<void> {
   cli.command("help", createHelpCommand(cli));
 
   try {
-    await cli.parse(args);
+    await withSpan("swamp.cli", {
+      "swamp.command": commandInfo.command,
+      "swamp.subcommand": commandInfo.subcommand ?? "",
+      "swamp.version": VERSION,
+    }, async () => {
+      await cli.parse(args);
+    });
 
     // Flush datastore sync (push to S3 + release lock)
     await flushDatastoreSync();

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -63,6 +63,8 @@ import {
 import type { DatastoreProvider } from "../domain/datastore/datastore_provider.ts";
 import { datastoreTypeRegistry } from "../domain/datastore/datastore_type_registry.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+import { getTracer } from "../infrastructure/tracing/mod.ts";
+import { SpanStatusCode } from "@opentelemetry/api";
 
 /**
  * Resolves a DatastoreProvider for a custom datastore config.
@@ -246,107 +248,122 @@ export async function requireInitializedRepo(
   options: RequireRepoOptions,
   factoryConfig?: Partial<Omit<RepositoryFactoryConfig, "repoDir">>,
 ): Promise<RepoValidationContext> {
-  const { repoDir, datastoreConfig, marker } = await resolveDatastoreForRepo(
-    options.repoDir,
-  );
+  const repoSpan = getTracer().startSpan("swamp.repo.init");
+  try {
+    const { repoDir, datastoreConfig, marker } = await resolveDatastoreForRepo(
+      options.repoDir,
+    );
 
-  const repoPath = RepoPath.create(repoDir);
+    const repoPath = RepoPath.create(repoDir);
 
-  const workflowsDirRel = resolveWorkflowsDir(marker);
-  const workflowsDir = isAbsolute(workflowsDirRel)
-    ? workflowsDirRel
-    : resolve(repoPath.value, workflowsDirRel);
+    const workflowsDirRel = resolveWorkflowsDir(marker);
+    const workflowsDir = isAbsolute(workflowsDirRel)
+      ? workflowsDirRel
+      : resolve(repoPath.value, workflowsDirRel);
 
-  const datastoreResolver = new DefaultDatastorePathResolver(
-    repoPath.value,
-    datastoreConfig,
-  );
+    const datastoreResolver = new DefaultDatastorePathResolver(
+      repoPath.value,
+      datastoreConfig,
+    );
 
-  // Verify datastore is accessible
-  if (isCustomDatastoreConfig(datastoreConfig)) {
-    const provider = resolveCustomProvider(datastoreConfig);
-    const lock = provider.createLock(datastoreConfig.datastorePath);
+    // Verify datastore is accessible
+    if (isCustomDatastoreConfig(datastoreConfig)) {
+      const provider = resolveCustomProvider(datastoreConfig);
+      const lock = provider.createLock(datastoreConfig.datastorePath);
 
-    // If the custom provider supports sync, register sync service too
-    const syncService = datastoreConfig.cachePath
-      ? provider.createSyncService?.(repoPath.value, datastoreConfig.cachePath)
-      : undefined;
+      // If the custom provider supports sync, register sync service too
+      const syncService = datastoreConfig.cachePath
+        ? provider.createSyncService?.(
+          repoPath.value,
+          datastoreConfig.cachePath,
+        )
+        : undefined;
 
-    if (datastoreConfig.cachePath) {
+      if (datastoreConfig.cachePath) {
+        await ensureDir(datastoreConfig.cachePath);
+      }
+
+      await registerDatastoreSync({
+        service: syncService,
+        lock,
+        label: datastoreConfig.type,
+      });
+    } else if (datastoreConfig.type === "filesystem") {
+      try {
+        const stat = await Deno.stat(datastoreConfig.path);
+        if (!stat.isDirectory) {
+          throw new UserError(
+            `Datastore path is not a directory: ${datastoreConfig.path}`,
+          );
+        }
+      } catch (error) {
+        if (error instanceof Deno.errors.NotFound) {
+          // Directory doesn't exist yet - that's OK, it will be created
+        } else if (error instanceof UserError) {
+          throw error;
+        } else {
+          throw new UserError(
+            `Cannot access datastore at ${datastoreConfig.path}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
+
+      // Wait for any held per-model locks to be released before acquiring global lock.
+      // This prevents the global lock from racing with in-progress per-model operations.
+      await waitForPerModelLocks(datastoreConfig.path);
+
+      // Wire file-based lock for filesystem datastores
+      const lock = new FileLock(datastoreConfig.path);
+      await registerDatastoreSync({ lock });
+    } else {
+      // S3: Ensure local cache directory exists
       await ensureDir(datastoreConfig.cachePath);
+
+      // Share a single S3Client for both lock and sync service
+      const s3 = new S3Client({
+        bucket: datastoreConfig.bucket,
+        prefix: datastoreConfig.prefix,
+        region: datastoreConfig.region,
+      });
+
+      const lock = new S3Lock(s3);
+      const syncService = new S3CacheSyncService(s3, datastoreConfig.cachePath);
+      await registerDatastoreSync({ service: syncService, lock, label: "S3" });
     }
 
-    await registerDatastoreSync({
-      service: syncService,
-      lock,
-      label: datastoreConfig.type,
-    });
-  } else if (datastoreConfig.type === "filesystem") {
-    try {
-      const stat = await Deno.stat(datastoreConfig.path);
-      if (!stat.isDirectory) {
-        throw new UserError(
-          `Datastore path is not a directory: ${datastoreConfig.path}`,
-        );
-      }
-    } catch (error) {
-      if (error instanceof Deno.errors.NotFound) {
-        // Directory doesn't exist yet - that's OK, it will be created
-      } else if (error instanceof UserError) {
-        throw error;
-      } else {
-        throw new UserError(
-          `Cannot access datastore at ${datastoreConfig.path}: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
-      }
-    }
+    // Compute top-level directories for definitions, workflows, and vaults
+    const definitionsDir = join(repoPath.value, "models");
+    const yamlWorkflowsDir = join(repoPath.value, "workflows");
+    const vaultsDir = join(repoPath.value, "vaults");
 
-    // Wait for any held per-model locks to be released before acquiring global lock.
-    // This prevents the global lock from racing with in-progress per-model operations.
-    await waitForPerModelLocks(datastoreConfig.path);
-
-    // Wire file-based lock for filesystem datastores
-    const lock = new FileLock(datastoreConfig.path);
-    await registerDatastoreSync({ lock });
-  } else {
-    // S3: Ensure local cache directory exists
-    await ensureDir(datastoreConfig.cachePath);
-
-    // Share a single S3Client for both lock and sync service
-    const s3 = new S3Client({
-      bucket: datastoreConfig.bucket,
-      prefix: datastoreConfig.prefix,
-      region: datastoreConfig.region,
+    // Create repository context with the validated directory and datastore resolver
+    const repoContext = createRepositoryContext({
+      repoDir: repoPath.value,
+      workflowsDir,
+      definitionsDir,
+      yamlWorkflowsDir,
+      vaultsDir,
+      datastoreResolver,
+      ...factoryConfig,
     });
 
-    const lock = new S3Lock(s3);
-    const syncService = new S3CacheSyncService(s3, datastoreConfig.cachePath);
-    await registerDatastoreSync({ service: syncService, lock, label: "S3" });
+    repoSpan.setStatus({ code: SpanStatusCode.OK });
+    return {
+      repoDir: repoPath.value,
+      repoContext,
+      datastoreResolver,
+    };
+  } catch (error) {
+    repoSpan.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  } finally {
+    repoSpan.end();
   }
-
-  // Compute top-level directories for definitions, workflows, and vaults
-  const definitionsDir = join(repoPath.value, "models");
-  const yamlWorkflowsDir = join(repoPath.value, "workflows");
-  const vaultsDir = join(repoPath.value, "vaults");
-
-  // Create repository context with the validated directory and datastore resolver
-  const repoContext = createRepositoryContext({
-    repoDir: repoPath.value,
-    workflowsDir,
-    definitionsDir,
-    yamlWorkflowsDir,
-    vaultsDir,
-    datastoreResolver,
-    ...factoryConfig,
-  });
-
-  return {
-    repoDir: repoPath.value,
-    repoContext,
-    datastoreResolver,
-  };
 }
 
 /**

--- a/src/domain/drivers/docker_execution_driver.ts
+++ b/src/domain/drivers/docker_execution_driver.ts
@@ -118,7 +118,7 @@ export class DockerExecutionDriver implements ExecutionDriver {
 
     const run = request.methodArgs.run as string;
     const containerName = `swamp-${crypto.randomUUID().slice(0, 8)}`;
-    const args = this.buildCommandArgs(containerName, run);
+    const args = this.buildCommandArgs(containerName, run, request);
 
     try {
       const command = new Deno.Command(this.config.command, {
@@ -290,7 +290,7 @@ export class DockerExecutionDriver implements ExecutionDriver {
 
       // Build docker args for bundle mode
       const containerName = `swamp-${crypto.randomUUID().slice(0, 8)}`;
-      const args = this.buildBundleArgs(containerName, tempDir);
+      const args = this.buildBundleArgs(containerName, tempDir, request);
 
       const command = new Deno.Command(this.config.command, {
         args,
@@ -472,8 +472,12 @@ export class DockerExecutionDriver implements ExecutionDriver {
   /**
    * Builds the docker run argument array for command mode.
    */
-  buildCommandArgs(containerName: string, commandString: string): string[] {
-    const args = this.buildCommonArgs(containerName);
+  buildCommandArgs(
+    containerName: string,
+    commandString: string,
+    request?: ExecutionRequest,
+  ): string[] {
+    const args = this.buildCommonArgs(containerName, request);
     args.push(this.config.image);
     args.push("sh", "-c", commandString);
     return args;
@@ -482,8 +486,12 @@ export class DockerExecutionDriver implements ExecutionDriver {
   /**
    * Builds the docker run argument array for bundle mode.
    */
-  buildBundleArgs(containerName: string, tempDir: string): string[] {
-    const args = this.buildCommonArgs(containerName);
+  buildBundleArgs(
+    containerName: string,
+    tempDir: string,
+    request?: ExecutionRequest,
+  ): string[] {
+    const args = this.buildCommonArgs(containerName, request);
 
     // Mount the workspace with bundle, request, and runner
     args.push("-v", `${tempDir}:/swamp:ro`);
@@ -498,7 +506,10 @@ export class DockerExecutionDriver implements ExecutionDriver {
   /**
    * Builds the common docker run arguments shared by both modes.
    */
-  private buildCommonArgs(containerName: string): string[] {
+  private buildCommonArgs(
+    containerName: string,
+    request?: ExecutionRequest,
+  ): string[] {
     const args: string[] = ["run", "--rm", "--name", containerName];
 
     if (this.config.network) {
@@ -518,6 +529,12 @@ export class DockerExecutionDriver implements ExecutionDriver {
     if (this.config.env) {
       for (const [key, value] of Object.entries(this.config.env)) {
         args.push("-e", `${key}=${value}`);
+      }
+    }
+    // Propagate W3C Trace Context headers as environment variables
+    if (request?.traceHeaders) {
+      for (const [key, value] of Object.entries(request.traceHeaders)) {
+        args.push("-e", `${key.toUpperCase().replace(/-/g, "_")}=${value}`);
       }
     }
     if (this.config.extraArgs) {

--- a/src/domain/drivers/execution_driver.ts
+++ b/src/domain/drivers/execution_driver.ts
@@ -48,6 +48,8 @@ export interface ExecutionRequest {
   fileSpecs?: Record<string, unknown>;
   /** Optional bundled module for out-of-process execution. */
   bundle?: Uint8Array;
+  /** W3C Trace Context headers for distributed tracing propagation. */
+  traceHeaders?: Record<string, string>;
 }
 
 /**

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -46,6 +46,10 @@ import type { Data } from "../data/data.ts";
 import type { DriverOutput } from "../drivers/execution_driver.ts";
 import { RawExecutionDriver } from "../drivers/raw_execution_driver.ts";
 import { driverTypeRegistry } from "../drivers/driver_type_registry.ts";
+import {
+  injectTraceContext,
+  withSpan,
+} from "../../infrastructure/tracing/mod.ts";
 
 /**
  * Maximum depth for recursive follow-up action processing.
@@ -311,471 +315,485 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
     return result;
   }
 
-  async executeWorkflow(
+  executeWorkflow(
     definition: Definition,
     modelDef: ModelDefinition,
     methodName: string,
     context: MethodContext,
   ): Promise<MethodResult> {
-    const method = modelDef.methods[methodName];
-    if (!method) {
-      throw new Error(`Method '${methodName}' not found in model`);
-    }
-
-    // Upgrade definition if needed
-    const upgradeService = new DefinitionUpgradeService();
-    const upgradeResult = upgradeService.upgrade(definition, modelDef);
-    const currentDefinition = upgradeResult.definition;
-
-    // Persist upgraded definition if it was upgraded
-    if (upgradeResult.upgraded && context.definitionRepository) {
-      await context.definitionRepository.save(
-        context.modelType,
-        currentDefinition,
-      );
-    }
-
-    // Resolve vault sentinels in globalArguments before validation.
-    // Sentinels must be replaced with raw values so Zod schemas (e.g., url(),
-    // regex()) validate against actual secret values, not sentinel tokens.
-    const secretBag = context.vaultSecrets;
-    if (secretBag && !secretBag.isEmpty) {
-      const rawGlobal = currentDefinition.globalArguments;
-      const resolvedGlobal = secretBag.resolveDeep(rawGlobal) as Record<
-        string,
-        unknown
-      >;
-      for (const [key, value] of Object.entries(resolvedGlobal)) {
-        currentDefinition.setGlobalArgument(key, value);
-      }
-    }
-
-    // Validate globalArguments against schema (after upgrade and runtime resolution).
-    // GlobalArguments may contain unevaluated ${{ inputs.* }} expressions when
-    // the user didn't provide those inputs (e.g., running "delete" without
-    // create-time inputs). Strip unresolved fields before Zod validation so
-    // methods that don't need them can proceed. A Proxy on context.globalArgs
-    // will throw a clear error if the method actually accesses an unresolved field.
-    if (modelDef.globalArguments) {
-      const rawGlobalArgs = currentDefinition.globalArguments;
-
-      // Identify globalArg fields with unresolved expressions (inputs,
-      // model resource/file refs, or any other ${{ ... }} that wasn't evaluated)
-      let hasUnresolved = false;
-      const resolvedGlobalArgs: Record<string, unknown> = {};
-      for (const [key, value] of Object.entries(rawGlobalArgs)) {
-        if (typeof value === "string" && containsExpression(value)) {
-          hasUnresolved = true;
-        } else {
-          resolvedGlobalArgs[key] = value;
-        }
+    return withSpan("swamp.model.method", {
+      "model.name": definition.name,
+      "model.type": context.modelType.normalized,
+      "method.name": methodName,
+    }, async () => {
+      const method = modelDef.methods[methodName];
+      if (!method) {
+        throw new Error(`Method '${methodName}' not found in model`);
       }
 
-      if (hasUnresolved) {
-        // Validate only the resolved fields — unresolved fields are guarded
-        // by a Proxy that throws when the method actually accesses them
-        const coercedGlobalArgs = coerceMethodArgs(
-          resolvedGlobalArgs,
-          modelDef.globalArguments,
+      // Upgrade definition if needed
+      const upgradeService = new DefinitionUpgradeService();
+      const upgradeResult = upgradeService.upgrade(definition, modelDef);
+      const currentDefinition = upgradeResult.definition;
+
+      // Persist upgraded definition if it was upgraded
+      if (upgradeResult.upgraded && context.definitionRepository) {
+        await context.definitionRepository.save(
+          context.modelType,
+          currentDefinition,
         );
-        // Apply coerced values for resolved fields
-        for (const [key, value] of Object.entries(coercedGlobalArgs)) {
-          currentDefinition.setGlobalArgument(key, value);
-        }
-      } else {
-        const coercedGlobalArgs = coerceMethodArgs(
-          rawGlobalArgs,
-          modelDef.globalArguments,
-        );
-        const globalArgsResult = modelDef.globalArguments.safeParse(
-          coercedGlobalArgs,
-        );
-        if (!globalArgsResult.success) {
-          throw new Error(
-            `Global arguments validation failed: ${
-              formatZodError(globalArgsResult.error)
-            }`,
-          );
-        }
-        // Update definition with parsed values so methods receive correct types
-        const parsedGlobalArgs = globalArgsResult.data as Record<
+      }
+
+      // Resolve vault sentinels in globalArguments before validation.
+      // Sentinels must be replaced with raw values so Zod schemas (e.g., url(),
+      // regex()) validate against actual secret values, not sentinel tokens.
+      const secretBag = context.vaultSecrets;
+      if (secretBag && !secretBag.isEmpty) {
+        const rawGlobal = currentDefinition.globalArguments;
+        const resolvedGlobal = secretBag.resolveDeep(rawGlobal) as Record<
           string,
           unknown
         >;
-        for (const [key, value] of Object.entries(parsedGlobalArgs)) {
+        for (const [key, value] of Object.entries(resolvedGlobal)) {
           currentDefinition.setGlobalArgument(key, value);
         }
       }
-    }
 
-    // Infer method kind for lifecycle checks
-    const methodKind = inferMethodKind(methodName, method);
+      // Validate globalArguments against schema (after upgrade and runtime resolution).
+      // GlobalArguments may contain unevaluated ${{ inputs.* }} expressions when
+      // the user didn't provide those inputs (e.g., running "delete" without
+      // create-time inputs). Strip unresolved fields before Zod validation so
+      // methods that don't need them can proceed. A Proxy on context.globalArgs
+      // will throw a clear error if the method actually accesses an unresolved field.
+      if (modelDef.globalArguments) {
+        const rawGlobalArgs = currentDefinition.globalArguments;
 
-    // Run pre-flight checks for mutating methods
-    if (modelDef.checks && isMutatingKind(methodKind)) {
-      const defChecks = currentDefinition.checkSelection;
-      const requiredCheckNames = new Set(defChecks?.require ?? []);
-      const skippedCheckNames = new Set(defChecks?.skip ?? []);
-
-      const applicableChecks = Object.entries(modelDef.checks).filter(
-        ([name, check]) => {
-          // Definition-level skip always wins
-          if (skippedCheckNames.has(name)) return false;
-          // Respect appliesTo for all checks (including required)
-          if (check.appliesTo && !check.appliesTo.includes(methodName)) {
-            return false;
+        // Identify globalArg fields with unresolved expressions (inputs,
+        // model resource/file refs, or any other ${{ ... }} that wasn't evaluated)
+        let hasUnresolved = false;
+        const resolvedGlobalArgs: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(rawGlobalArgs)) {
+          if (typeof value === "string" && containsExpression(value)) {
+            hasUnresolved = true;
+          } else {
+            resolvedGlobalArgs[key] = value;
           }
-          // Required checks are immune to CLI skip flags
-          if (requiredCheckNames.has(name)) return true;
-          // Non-required: honor CLI skip flags
-          if (context.skipAllChecks) return false;
-          if (context.skipCheckNames?.includes(name)) return false;
-          if (
-            context.skipCheckLabels &&
-            check.labels?.some((l) => context.skipCheckLabels!.includes(l))
-          ) {
-            return false;
-          }
-          return true;
-        },
-      );
+        }
 
-      if (applicableChecks.length > 0) {
-        context.logger.info(
-          `Running ${applicableChecks.length} pre-flight check(s)`,
+        if (hasUnresolved) {
+          // Validate only the resolved fields — unresolved fields are guarded
+          // by a Proxy that throws when the method actually accesses them
+          const coercedGlobalArgs = coerceMethodArgs(
+            resolvedGlobalArgs,
+            modelDef.globalArguments,
+          );
+          // Apply coerced values for resolved fields
+          for (const [key, value] of Object.entries(coercedGlobalArgs)) {
+            currentDefinition.setGlobalArgument(key, value);
+          }
+        } else {
+          const coercedGlobalArgs = coerceMethodArgs(
+            rawGlobalArgs,
+            modelDef.globalArguments,
+          );
+          const globalArgsResult = modelDef.globalArguments.safeParse(
+            coercedGlobalArgs,
+          );
+          if (!globalArgsResult.success) {
+            throw new Error(
+              `Global arguments validation failed: ${
+                formatZodError(globalArgsResult.error)
+              }`,
+            );
+          }
+          // Update definition with parsed values so methods receive correct types
+          const parsedGlobalArgs = globalArgsResult.data as Record<
+            string,
+            unknown
+          >;
+          for (const [key, value] of Object.entries(parsedGlobalArgs)) {
+            currentDefinition.setGlobalArgument(key, value);
+          }
+        }
+      }
+
+      // Infer method kind for lifecycle checks
+      const methodKind = inferMethodKind(methodName, method);
+
+      // Run pre-flight checks for mutating methods
+      if (modelDef.checks && isMutatingKind(methodKind)) {
+        const defChecks = currentDefinition.checkSelection;
+        const requiredCheckNames = new Set(defChecks?.require ?? []);
+        const skippedCheckNames = new Set(defChecks?.skip ?? []);
+
+        const applicableChecks = Object.entries(modelDef.checks).filter(
+          ([name, check]) => {
+            // Definition-level skip always wins
+            if (skippedCheckNames.has(name)) return false;
+            // Respect appliesTo for all checks (including required)
+            if (check.appliesTo && !check.appliesTo.includes(methodName)) {
+              return false;
+            }
+            // Required checks are immune to CLI skip flags
+            if (requiredCheckNames.has(name)) return true;
+            // Non-required: honor CLI skip flags
+            if (context.skipAllChecks) return false;
+            if (context.skipCheckNames?.includes(name)) return false;
+            if (
+              context.skipCheckLabels &&
+              check.labels?.some((l) => context.skipCheckLabels!.includes(l))
+            ) {
+              return false;
+            }
+            return true;
+          },
         );
 
-        const failures: Array<{ checkName: string; errors: string[] }> = [];
+        if (applicableChecks.length > 0) {
+          context.logger.info(
+            `Running ${applicableChecks.length} pre-flight check(s)`,
+          );
 
-        for (const [checkName, check] of applicableChecks) {
-          try {
-            const checkResult = await check.execute({
-              ...context,
-              methodName,
-              globalArgs: currentDefinition.globalArguments,
-              definition: {
-                id: currentDefinition.id,
-                name: currentDefinition.name,
-                version: currentDefinition.version,
-                tags: currentDefinition.tags,
-              },
-            });
-            if (!checkResult || typeof checkResult.pass !== "boolean") {
+          const failures: Array<{ checkName: string; errors: string[] }> = [];
+
+          for (const [checkName, check] of applicableChecks) {
+            try {
+              const checkResult = await check.execute({
+                ...context,
+                methodName,
+                globalArgs: currentDefinition.globalArguments,
+                definition: {
+                  id: currentDefinition.id,
+                  name: currentDefinition.name,
+                  version: currentDefinition.version,
+                  tags: currentDefinition.tags,
+                },
+              });
+              if (!checkResult || typeof checkResult.pass !== "boolean") {
+                failures.push({
+                  checkName,
+                  errors: [
+                    "Check returned invalid result (expected { pass: boolean })",
+                  ],
+                });
+              } else if (!checkResult.pass) {
+                failures.push({
+                  checkName,
+                  errors: checkResult.errors ?? ["Check failed"],
+                });
+              }
+            } catch (error) {
               failures.push({
                 checkName,
                 errors: [
-                  "Check returned invalid result (expected { pass: boolean })",
+                  error instanceof Error ? error.message : String(error),
                 ],
               });
-            } else if (!checkResult.pass) {
-              failures.push({
-                checkName,
-                errors: checkResult.errors ?? ["Check failed"],
-              });
-            }
-          } catch (error) {
-            failures.push({
-              checkName,
-              errors: [
-                error instanceof Error ? error.message : String(error),
-              ],
-            });
-          }
-        }
-
-        if (failures.length > 0) {
-          const lines = [
-            `Pre-flight checks failed for "${currentDefinition.name}" → ${methodName}:`,
-          ];
-          for (const failure of failures) {
-            lines.push(`  ${failure.checkName}:`);
-            for (const err of failure.errors) {
-              lines.push(`    - ${err}`);
             }
           }
-          throw new UserError(lines.join("\n"));
-        }
-      }
-    }
 
-    // Fast-fail: reject read/update on deleted resources.
-    // Only check declared resource data (tagged with specName matching a
-    // declared resource spec). Block only when ALL declared resource data
-    // is deleted — old historical data entries should not cause false positives.
-    if (methodKind === "read" || methodKind === "update") {
-      const resources = modelDef.resources ?? {};
-      if (Object.keys(resources).length > 0) {
-        const existingData = await context.dataRepository.findAllForModel(
-          context.modelType,
-          context.modelId,
-        );
-        const resourceData = filterDeclaredResourceData(
-          existingData,
-          resources,
-        );
-        if (
-          resourceData.length > 0 && resourceData.every((d) => d.isDeleted)
-        ) {
-          const deleted = resourceData[0];
-          let deletedAt = "unknown";
-          try {
-            const content = await context.dataRepository.getContent(
-              context.modelType,
-              context.modelId,
-              deleted.name,
-            );
-            if (content) {
-              const marker = JSON.parse(
-                new TextDecoder().decode(content),
-              );
-              if (marker.deletedAt) {
-                deletedAt = marker.deletedAt;
+          if (failures.length > 0) {
+            const lines = [
+              `Pre-flight checks failed for "${currentDefinition.name}" → ${methodName}:`,
+            ];
+            for (const failure of failures) {
+              lines.push(`  ${failure.checkName}:`);
+              for (const err of failure.errors) {
+                lines.push(`    - ${err}`);
               }
             }
-          } catch {
-            // Use default "unknown" timestamp
+            throw new UserError(lines.join("\n"));
           }
-          throw new UserError(
-            `Resource '${deleted.name}' was deleted at ${deletedAt} — run a 'create' method to re-create it first`,
+        }
+      }
+
+      // Fast-fail: reject read/update on deleted resources.
+      // Only check declared resource data (tagged with specName matching a
+      // declared resource spec). Block only when ALL declared resource data
+      // is deleted — old historical data entries should not cause false positives.
+      if (methodKind === "read" || methodKind === "update") {
+        const resources = modelDef.resources ?? {};
+        if (Object.keys(resources).length > 0) {
+          const existingData = await context.dataRepository.findAllForModel(
+            context.modelType,
+            context.modelId,
+          );
+          const resourceData = filterDeclaredResourceData(
+            existingData,
+            resources,
+          );
+          if (
+            resourceData.length > 0 && resourceData.every((d) => d.isDeleted)
+          ) {
+            const deleted = resourceData[0];
+            let deletedAt = "unknown";
+            try {
+              const content = await context.dataRepository.getContent(
+                context.modelType,
+                context.modelId,
+                deleted.name,
+              );
+              if (content) {
+                const marker = JSON.parse(
+                  new TextDecoder().decode(content),
+                );
+                if (marker.deletedAt) {
+                  deletedAt = marker.deletedAt;
+                }
+              }
+            } catch {
+              // Use default "unknown" timestamp
+            }
+            throw new UserError(
+              `Resource '${deleted.name}' was deleted at ${deletedAt} — run a 'create' method to re-create it first`,
+            );
+          }
+        }
+      }
+
+      // Resolve the execution driver
+      const driverType = context.driver ?? "raw";
+      const definitionHash = await currentDefinition.computeHash();
+
+      const executionRequest:
+        import("../drivers/execution_driver.ts").ExecutionRequest = {
+          protocolVersion: 1,
+          modelType: context.modelType.normalized,
+          modelId: context.modelId,
+          methodName,
+          globalArgs: currentDefinition.globalArguments,
+          methodArgs: currentDefinition.getMethodArguments(methodName),
+          definitionMeta: {
+            id: currentDefinition.id,
+            name: currentDefinition.name,
+            version: currentDefinition.version,
+            tags: currentDefinition.tags,
+          },
+          resourceSpecs: modelDef.resources
+            ? Object.fromEntries(
+              Object.entries(modelDef.resources).map(([name, spec]) => [
+                name,
+                { description: spec.description },
+              ]),
+            )
+            : undefined,
+          fileSpecs: modelDef.files
+            ? Object.fromEntries(
+              Object.entries(modelDef.files).map(([name, spec]) => [
+                name,
+                { contentType: spec.contentType },
+              ]),
+            )
+            : undefined,
+          traceHeaders: injectTraceContext(),
+        };
+
+      let currentHandles: DataHandle[];
+      let result: MethodResult;
+      let executionContext: MethodContext = context;
+
+      if (driverType === "raw") {
+        // Use the raw in-process driver
+        const driver = new RawExecutionDriver(
+          this,
+          currentDefinition,
+          method,
+          modelDef,
+          context,
+          methodName,
+        );
+        const driverResult = await withSpan("swamp.driver.execute", {
+          "driver.type": "raw",
+          "model.type": context.modelType.normalized,
+        }, () => driver.execute(executionRequest));
+
+        if (driverResult.outputs.some((o) => o.kind === "pending")) {
+          throw new Error(
+            "Raw driver unexpectedly produced pending outputs — " +
+              "this is a bug; raw driver should only produce persisted outputs",
           );
         }
-      }
-    }
+        currentHandles = await processDriverOutputs(driverResult.outputs);
+        result = {
+          dataHandles: currentHandles,
+          followUpActions: driverResult
+            .followUpActions as FollowUpAction[] | undefined,
+        };
+        // Use the driver's context with writers for follow-up actions
+        executionContext = driver.contextWithWriters ?? context;
+      } else {
+        // Populate bundle only for out-of-process drivers (raw driver doesn't use it)
+        if (modelDef.bundleSourceFactory) {
+          executionRequest.bundle = new TextEncoder().encode(
+            await modelDef.bundleSourceFactory(),
+          );
+        }
 
-    // Resolve the execution driver
-    const driverType = context.driver ?? "raw";
-    const definitionHash = await currentDefinition.computeHash();
+        // Look up a registered driver type
+        const driverInfo = driverTypeRegistry.get(driverType);
+        if (!driverInfo) {
+          throw new Error(
+            `Unknown execution driver '${driverType}'. ` +
+              `Available drivers: ${
+                driverTypeRegistry.getAll().map((d) => d.type).join(", ")
+              }`,
+          );
+        }
+        if (!driverInfo.createDriver) {
+          throw new Error(
+            `Execution driver '${driverType}' does not have a createDriver factory.`,
+          );
+        }
+        const driver = driverInfo.createDriver(context.driverConfig ?? {});
+        const driverResult = await withSpan("swamp.driver.execute", {
+          "driver.type": driverType,
+          "model.type": context.modelType.normalized,
+        }, () =>
+          driver.execute(executionRequest, {
+            onLog: (line) => context.logger?.info(line),
+          }));
 
-    const executionRequest:
-      import("../drivers/execution_driver.ts").ExecutionRequest = {
-        protocolVersion: 1,
-        modelType: context.modelType.normalized,
-        modelId: context.modelId,
-        methodName,
-        globalArgs: currentDefinition.globalArguments,
-        methodArgs: currentDefinition.getMethodArguments(methodName),
-        definitionMeta: {
-          id: currentDefinition.id,
-          name: currentDefinition.name,
-          version: currentDefinition.version,
-          tags: currentDefinition.tags,
-        },
-        resourceSpecs: modelDef.resources
-          ? Object.fromEntries(
-            Object.entries(modelDef.resources).map(([name, spec]) => [
-              name,
-              { description: spec.description },
-            ]),
-          )
-          : undefined,
-        fileSpecs: modelDef.files
-          ? Object.fromEntries(
-            Object.entries(modelDef.files).map(([name, spec]) => [
-              name,
-              { contentType: spec.contentType },
-            ]),
-          )
-          : undefined,
-      };
+        if (driverResult.status === "error") {
+          throw new Error(driverResult.error ?? "Driver execution failed");
+        }
 
-    let currentHandles: DataHandle[];
-    let result: MethodResult;
-    let executionContext: MethodContext = context;
-
-    if (driverType === "raw") {
-      // Use the raw in-process driver
-      const driver = new RawExecutionDriver(
-        this,
-        currentDefinition,
-        method,
-        modelDef,
-        context,
-        methodName,
-      );
-      const driverResult = await driver.execute(executionRequest);
-
-      if (driverResult.outputs.some((o) => o.kind === "pending")) {
-        throw new Error(
-          "Raw driver unexpectedly produced pending outputs — " +
-            "this is a bug; raw driver should only produce persisted outputs",
-        );
-      }
-      currentHandles = await processDriverOutputs(driverResult.outputs);
-      result = {
-        dataHandles: currentHandles,
-        followUpActions: driverResult
-          .followUpActions as FollowUpAction[] | undefined,
-      };
-      // Use the driver's context with writers for follow-up actions
-      executionContext = driver.contextWithWriters ?? context;
-    } else {
-      // Populate bundle only for out-of-process drivers (raw driver doesn't use it)
-      if (modelDef.bundleSourceFactory) {
-        executionRequest.bundle = new TextEncoder().encode(
-          await modelDef.bundleSourceFactory(),
-        );
-      }
-
-      // Look up a registered driver type
-      const driverInfo = driverTypeRegistry.get(driverType);
-      if (!driverInfo) {
-        throw new Error(
-          `Unknown execution driver '${driverType}'. ` +
-            `Available drivers: ${
-              driverTypeRegistry.getAll().map((d) => d.type).join(", ")
-            }`,
-        );
-      }
-      if (!driverInfo.createDriver) {
-        throw new Error(
-          `Execution driver '${driverType}' does not have a createDriver factory.`,
-        );
-      }
-      const driver = driverInfo.createDriver(context.driverConfig ?? {});
-      const driverResult = await driver.execute(executionRequest, {
-        onLog: (line) => context.logger?.info(line),
-      });
-
-      if (driverResult.status === "error") {
-        throw new Error(driverResult.error ?? "Driver execution failed");
-      }
-
-      const resources = modelDef.resources ?? {};
-      const files = modelDef.files ?? {};
-      currentHandles = await processDriverOutputs(driverResult.outputs, {
-        dataRepository: context.dataRepository,
-        modelType: context.modelType,
-        modelId: context.modelId,
-        resources,
-        files,
-        tagOverrides: context.tagOverrides,
-        definitionTags: currentDefinition.tags,
-        runtimeTags: context.runtimeTags,
-        definitionName: currentDefinition.name,
-        vaultService: context.vaultService,
-        methodName,
-      });
-      result = { dataHandles: currentHandles };
-    }
-
-    // Collect artifact refs from handles (data is already persisted)
-    const storedArtifacts: DataArtifactRef[] = currentHandles.map((h) => ({
-      dataId: h.dataId,
-      name: h.name,
-      version: h.version,
-      tags: h.tags,
-    }));
-
-    // Create ModelOutput if output repository is available
-    if (context.outputRepository) {
-      const output = ModelOutput.create({
-        definitionId: currentDefinition.id,
-        methodName,
-        status: "running",
-        provenance: {
-          definitionHash,
-          modelVersion: modelDef.version,
-          triggeredBy: "manual",
-        },
-        artifacts: { dataArtifacts: storedArtifacts },
-      });
-      output.markSucceeded();
-      await context.outputRepository.save(modelDef.type, methodName, output);
-    }
-
-    // Write deletion markers after a successful delete method.
-    // Only mark declared resource data — untagged or non-resource data is left alone.
-    // Markers include the last known active state so that data.latest() still
-    // resolves original attributes after deletion (enables idempotent workflow re-runs).
-    if (methodKind === "delete") {
-      const resources = modelDef.resources ?? {};
-      if (Object.keys(resources).length > 0) {
-        const existingData = await context.dataRepository.findAllForModel(
-          context.modelType,
-          context.modelId,
-        );
-        const resourceData = filterDeclaredResourceData(
-          existingData,
+        const resources = modelDef.resources ?? {};
+        const files = modelDef.files ?? {};
+        currentHandles = await processDriverOutputs(driverResult.outputs, {
+          dataRepository: context.dataRepository,
+          modelType: context.modelType,
+          modelId: context.modelId,
           resources,
-        );
-        for (const data of resourceData) {
-          if (!data.isDeleted) {
-            // Read last known active state to preserve in tombstone
-            let lastKnownState: Record<string, unknown> = {};
-            if (data.contentType === "application/json") {
-              try {
-                const activeContent = await context.dataRepository.getContent(
-                  context.modelType,
-                  context.modelId,
-                  data.name,
-                );
-                if (activeContent) {
-                  lastKnownState = JSON.parse(
-                    new TextDecoder().decode(activeContent),
-                  ) as Record<string, unknown>;
+          files,
+          tagOverrides: context.tagOverrides,
+          definitionTags: currentDefinition.tags,
+          runtimeTags: context.runtimeTags,
+          definitionName: currentDefinition.name,
+          vaultService: context.vaultService,
+          methodName,
+        });
+        result = { dataHandles: currentHandles };
+      }
+
+      // Collect artifact refs from handles (data is already persisted)
+      const storedArtifacts: DataArtifactRef[] = currentHandles.map((h) => ({
+        dataId: h.dataId,
+        name: h.name,
+        version: h.version,
+        tags: h.tags,
+      }));
+
+      // Create ModelOutput if output repository is available
+      if (context.outputRepository) {
+        const output = ModelOutput.create({
+          definitionId: currentDefinition.id,
+          methodName,
+          status: "running",
+          provenance: {
+            definitionHash,
+            modelVersion: modelDef.version,
+            triggeredBy: "manual",
+          },
+          artifacts: { dataArtifacts: storedArtifacts },
+        });
+        output.markSucceeded();
+        await context.outputRepository.save(modelDef.type, methodName, output);
+      }
+
+      // Write deletion markers after a successful delete method.
+      // Only mark declared resource data — untagged or non-resource data is left alone.
+      // Markers include the last known active state so that data.latest() still
+      // resolves original attributes after deletion (enables idempotent workflow re-runs).
+      if (methodKind === "delete") {
+        const resources = modelDef.resources ?? {};
+        if (Object.keys(resources).length > 0) {
+          const existingData = await context.dataRepository.findAllForModel(
+            context.modelType,
+            context.modelId,
+          );
+          const resourceData = filterDeclaredResourceData(
+            existingData,
+            resources,
+          );
+          for (const data of resourceData) {
+            if (!data.isDeleted) {
+              // Read last known active state to preserve in tombstone
+              let lastKnownState: Record<string, unknown> = {};
+              if (data.contentType === "application/json") {
+                try {
+                  const activeContent = await context.dataRepository.getContent(
+                    context.modelType,
+                    context.modelId,
+                    data.name,
+                  );
+                  if (activeContent) {
+                    lastKnownState = JSON.parse(
+                      new TextDecoder().decode(activeContent),
+                    ) as Record<string, unknown>;
+                  }
+                } catch {
+                  // Not valid JSON or read error — proceed with empty state
                 }
-              } catch {
-                // Not valid JSON or read error — proceed with empty state
               }
-            }
 
-            const marker = data.withDeletionMarker({
-              version: data.version + 1,
-            });
-            const markerContent = new TextEncoder().encode(JSON.stringify({
-              ...lastKnownState,
-              deletedAt: new Date().toISOString(),
-              deletedByMethod: methodName,
-            }));
-            await context.dataRepository.save(
-              context.modelType,
-              context.modelId,
-              marker,
-              markerContent,
-            );
+              const marker = data.withDeletionMarker({
+                version: data.version + 1,
+              });
+              const markerContent = new TextEncoder().encode(JSON.stringify({
+                ...lastKnownState,
+                deletedAt: new Date().toISOString(),
+                deletedByMethod: methodName,
+              }));
+              await context.dataRepository.save(
+                context.modelType,
+                context.modelId,
+                marker,
+                markerContent,
+              );
 
-            // Append deletion marker as a data handle so it surfaces
-            // in the method response as a data artifact.
-            currentHandles.push({
-              name: data.name,
-              specName: data.tags["specName"] ?? data.name,
-              kind: "resource",
-              dataId: marker.id,
-              version: marker.version,
-              size: markerContent.byteLength,
-              tags: { ...marker.tags },
-              metadata: {
-                contentType: marker.contentType,
-                lifetime: marker.lifetime,
-                garbageCollection: marker.garbageCollection,
-                streaming: marker.streaming,
+              // Append deletion marker as a data handle so it surfaces
+              // in the method response as a data artifact.
+              currentHandles.push({
+                name: data.name,
+                specName: data.tags["specName"] ?? data.name,
+                kind: "resource",
+                dataId: marker.id,
+                version: marker.version,
+                size: markerContent.byteLength,
                 tags: { ...marker.tags },
-                ownerDefinition: marker.ownerDefinition,
-                lifecycle: marker.lifecycle,
-              },
-            });
+                metadata: {
+                  contentType: marker.contentType,
+                  lifetime: marker.lifetime,
+                  garbageCollection: marker.garbageCollection,
+                  streaming: marker.streaming,
+                  tags: { ...marker.tags },
+                  ownerDefinition: marker.ownerDefinition,
+                  lifecycle: marker.lifecycle,
+                },
+              });
+            }
           }
         }
       }
-    }
 
-    // Process follow-up actions
-    if (result.followUpActions && currentHandles.length > 0) {
-      const finalResult = await this.processFollowUpActions(
-        currentDefinition,
-        modelDef,
-        executionContext,
-        result.followUpActions,
-        currentHandles,
-        0,
-      );
-      currentHandles = finalResult.dataHandles;
-    }
+      // Process follow-up actions
+      if (result.followUpActions && currentHandles.length > 0) {
+        const finalResult = await this.processFollowUpActions(
+          currentDefinition,
+          modelDef,
+          executionContext,
+          result.followUpActions,
+          currentHandles,
+          0,
+        );
+        currentHandles = finalResult.dataHandles;
+      }
 
-    return {
-      ...result,
-      dataHandles: currentHandles,
-    };
+      return {
+        ...result,
+        dataHandles: currentHandles,
+      };
+    }); // end withSpan
   }
 
   /**

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -89,6 +89,8 @@ import {
 import { reportRegistry } from "../reports/report_registry.ts";
 import type { MethodReportContext } from "../reports/report_context.ts";
 import { modelRegistry } from "../models/model.ts";
+import { getTracer } from "../../infrastructure/tracing/mod.ts";
+import { SpanStatusCode } from "@opentelemetry/api";
 /**
  * Context for step execution.
  */
@@ -865,144 +867,165 @@ export class WorkflowExecutionService {
       reportFilterOptions?: ReportFilterOptions;
     },
   ): AsyncGenerator<WorkflowExecutionEvent> {
-    // Look up workflow
-    let workflow = await this.lookupWorkflow(idOrName);
-    if (!workflow) {
-      throw new Error(`Workflow not found: ${idOrName}`);
-    }
+    const tracer = getTracer();
+    const runSpan = tracer.startSpan("swamp.workflow.run", {
+      attributes: { "workflow.name": idOrName },
+    });
 
-    let expressionContext: ExpressionContext | undefined;
+    try {
+      // Look up workflow
+      let workflow = await this.lookupWorkflow(idOrName);
+      if (!workflow) {
+        throw new Error(`Workflow not found: ${idOrName}`);
+      }
 
-    if (options?.lastEvaluated) {
-      // Load previously evaluated workflow from cache
-      const evaluatedWorkflowRepo = new YamlEvaluatedWorkflowRepository(
-        this.repoDir,
-      );
-      const lastEvaluated = await evaluatedWorkflowRepo.findByName(
-        workflow.name,
-      );
-      if (!lastEvaluated) {
-        throw new UserError(
-          `No previously evaluated workflow found for "${workflow.name}".\n\n` +
-            `Evaluate the workflow first to generate evaluated data:\n` +
-            `  swamp workflow evaluate ${workflow.name}`,
+      let expressionContext: ExpressionContext | undefined;
+
+      if (options?.lastEvaluated) {
+        // Load previously evaluated workflow from cache
+        const evaluatedWorkflowRepo = new YamlEvaluatedWorkflowRepository(
+          this.repoDir,
         );
-      }
-      // Use the fully evaluated workflow (forEach expanded, expressions resolved)
-      workflow = lastEvaluated;
+        const lastEvaluated = await evaluatedWorkflowRepo.findByName(
+          workflow.name,
+        );
+        if (!lastEvaluated) {
+          throw new UserError(
+            `No previously evaluated workflow found for "${workflow.name}".\n\n` +
+              `Evaluate the workflow first to generate evaluated data:\n` +
+              `  swamp workflow evaluate ${workflow.name}`,
+          );
+        }
+        // Use the fully evaluated workflow (forEach expanded, expressions resolved)
+        workflow = lastEvaluated;
 
-      // Build a minimal expression context so step outputs can be tracked
-      // and deferred expressions (e.g. model.previous.resource.*) can be
-      // evaluated at step execution time.
-      expressionContext = {
-        model: {},
-        env: buildEnvContext(),
-      };
-      if (options?.inputs) {
-        expressionContext.inputs = options.inputs;
-      }
-    } else {
-      // Build expression context and evaluate workflow
-      expressionContext = await this.modelResolver.buildContext();
+        // Build a minimal expression context so step outputs can be tracked
+        // and deferred expressions (e.g. model.previous.resource.*) can be
+        // evaluated at step execution time.
+        expressionContext = {
+          model: {},
+          env: buildEnvContext(),
+        };
+        if (options?.inputs) {
+          expressionContext.inputs = options.inputs;
+        }
+      } else {
+        // Build expression context and evaluate workflow
+        expressionContext = await this.modelResolver.buildContext();
 
-      // Add workflow inputs to context
-      if (options?.inputs) {
-        expressionContext.inputs = options.inputs;
-      }
+        // Add workflow inputs to context
+        if (options?.inputs) {
+          expressionContext.inputs = options.inputs;
+        }
 
-      workflow = this.evaluateWorkflow(
-        workflow,
-        expressionContext,
-      );
-      const evaluatedWorkflowRepo = new YamlEvaluatedWorkflowRepository(
-        this.repoDir,
-      );
-      await evaluatedWorkflowRepo.save(workflow);
-    }
-
-    // Create workflow run with merged tags (runtime tags take precedence)
-    const mergedTags: Record<string, string> = {
-      ...(workflow.tags ?? {}),
-      ...(options?.runtimeTags ?? {}),
-    };
-    const run = WorkflowRun.create(workflow, mergedTags);
-
-    // Create secret redactor — populated during vault resolution, used by log sink and data writers
-    const secretRedactor = new SecretRedactor();
-
-    // Register run file sink target for the workflow log output
-    const workflowLogPath = join(
-      swampPath(this.repoDir, SWAMP_SUBDIRS.workflowRuns),
-      workflow.id,
-      `workflow-run-${run.id}.log`,
-    );
-    const workflowLogCategory: string[] = [];
-    const workflowLogBoundary = swampPath(this.repoDir);
-    await runFileSink.register(
-      workflowLogCategory,
-      workflowLogPath,
-      secretRedactor,
-      workflowLogBoundary,
-    );
-    run.setLogFile(workflowLogPath);
-
-    // Start execution
-    run.start();
-    yield {
-      kind: "started",
-      runId: run.id,
-      workflowName: workflow.name,
-      logPath: workflowLogPath,
-    };
-
-    await this.saveRun(workflow.id, run);
-
-    const stepOpts: StepOptions = {
-      lastEvaluated: options?.lastEvaluated,
-      workflowNestingDepth: options?.workflowNestingDepth,
-      ancestorWorkflowIds: options?.ancestorWorkflowIds,
-      workflowTags: workflow.tags,
-      runtimeTags: options?.runtimeTags,
-      secretRedactor,
-      signal: options?.signal,
-      driver: options?.driver,
-      reportFilterOptions: options?.reportFilterOptions,
-    };
-
-    // Sort jobs topologically
-    const jobNodes: GraphNode[] = workflow.jobs.map((job) => ({
-      name: job.name,
-      weight: job.weight,
-      dependencies: job.getDependencyNames(),
-    }));
-
-    const sortedJobs = this.sortService.sort(jobNodes);
-
-    // Execute jobs level by level
-    for (const level of sortedJobs.levels) {
-      // Merge parallel job generators within each level
-      const jobStreams = level.map((jobName) =>
-        this.runJob(
+        workflow = this.evaluateWorkflow(
           workflow,
-          run,
-          jobName,
           expressionContext,
-          stepOpts,
-        )
-      );
-      for await (const event of merge(jobStreams, options?.signal)) {
-        yield event;
+        );
+        const evaluatedWorkflowRepo = new YamlEvaluatedWorkflowRepository(
+          this.repoDir,
+        );
+        await evaluatedWorkflowRepo.save(workflow);
       }
+
+      // Create workflow run with merged tags (runtime tags take precedence)
+      const mergedTags: Record<string, string> = {
+        ...(workflow.tags ?? {}),
+        ...(options?.runtimeTags ?? {}),
+      };
+      const run = WorkflowRun.create(workflow, mergedTags);
+
+      // Create secret redactor — populated during vault resolution, used by log sink and data writers
+      const secretRedactor = new SecretRedactor();
+
+      // Register run file sink target for the workflow log output
+      const workflowLogPath = join(
+        swampPath(this.repoDir, SWAMP_SUBDIRS.workflowRuns),
+        workflow.id,
+        `workflow-run-${run.id}.log`,
+      );
+      const workflowLogCategory: string[] = [];
+      const workflowLogBoundary = swampPath(this.repoDir);
+      await runFileSink.register(
+        workflowLogCategory,
+        workflowLogPath,
+        secretRedactor,
+        workflowLogBoundary,
+      );
+      run.setLogFile(workflowLogPath);
+
+      // Enrich span with resolved workflow metadata
+      runSpan.setAttribute("workflow.id", workflow.id);
+      runSpan.setAttribute("workflow.run_id", run.id);
+
+      // Start execution
+      run.start();
+      yield {
+        kind: "started",
+        runId: run.id,
+        workflowName: workflow.name,
+        logPath: workflowLogPath,
+      };
+
       await this.saveRun(workflow.id, run);
+
+      const stepOpts: StepOptions = {
+        lastEvaluated: options?.lastEvaluated,
+        workflowNestingDepth: options?.workflowNestingDepth,
+        ancestorWorkflowIds: options?.ancestorWorkflowIds,
+        workflowTags: workflow.tags,
+        runtimeTags: options?.runtimeTags,
+        secretRedactor,
+        signal: options?.signal,
+        driver: options?.driver,
+        reportFilterOptions: options?.reportFilterOptions,
+      };
+
+      // Sort jobs topologically
+      const jobNodes: GraphNode[] = workflow.jobs.map((job) => ({
+        name: job.name,
+        weight: job.weight,
+        dependencies: job.getDependencyNames(),
+      }));
+
+      const sortedJobs = this.sortService.sort(jobNodes);
+
+      // Execute jobs level by level
+      for (const level of sortedJobs.levels) {
+        // Merge parallel job generators within each level
+        const jobStreams = level.map((jobName) =>
+          this.runJob(
+            workflow,
+            run,
+            jobName,
+            expressionContext,
+            stepOpts,
+          )
+        );
+        for await (const event of merge(jobStreams, options?.signal)) {
+          yield event;
+        }
+        await this.saveRun(workflow.id, run);
+      }
+
+      // Complete workflow
+      run.complete();
+      yield { kind: "completed", run };
+      await this.saveRun(workflow.id, run);
+
+      // Unregister workflow log file sink
+      runFileSink.unregister(workflowLogCategory);
+
+      runSpan.setStatus({ code: SpanStatusCode.OK });
+    } catch (error) {
+      runSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    } finally {
+      runSpan.end();
     }
-
-    // Complete workflow
-    run.complete();
-    yield { kind: "completed", run };
-    await this.saveRun(workflow.id, run);
-
-    // Unregister workflow log file sink
-    runFileSink.unregister(workflowLogCategory);
   }
 
   /**
@@ -1035,123 +1058,145 @@ export class WorkflowExecutionService {
     expressionContext: ExpressionContext | undefined,
     options: StepOptions,
   ): AsyncGenerator<WorkflowExecutionEvent> {
-    const job = workflow.getJob(jobName);
-    if (!job) {
-      throw new Error(`Job not found: ${jobName}`);
-    }
+    const tracer = getTracer();
+    const jobSpan = tracer.startSpan("swamp.workflow.job", {
+      attributes: { "job.name": jobName },
+    });
 
-    const jobRun = run.getJob(jobName);
-    if (!jobRun) {
-      throw new Error(`Job run not found: ${jobName}`);
-    }
+    try {
+      const job = workflow.getJob(jobName);
+      if (!job) {
+        throw new Error(`Job not found: ${jobName}`);
+      }
 
-    // Check if job's trigger condition is met
-    const shouldRun = this.shouldJobRun(job, run);
-    if (!shouldRun) {
-      jobRun.skip();
-      yield { kind: "job_skipped", jobId: jobName };
-      return;
-    }
+      const jobRun = run.getJob(jobName);
+      if (!jobRun) {
+        throw new Error(`Job run not found: ${jobName}`);
+      }
 
-    // Start job
-    jobRun.start();
-    yield { kind: "job_started", jobId: jobName };
+      // Check if job's trigger condition is met
+      const shouldRun = this.shouldJobRun(job, run);
+      if (!shouldRun) {
+        jobRun.skip();
+        jobSpan.setAttribute("job.status", "skipped");
+        yield { kind: "job_skipped", jobId: jobName };
+        return;
+      }
 
-    // Expand forEach steps if we have expression context
-    let expandedStepsMap: Map<string, ExpandedStep[]> | undefined;
-    if (expressionContext && !options.lastEvaluated) {
-      expandedStepsMap = this.expandForEachSteps(job, expressionContext);
-    }
+      // Start job
+      jobRun.start();
+      yield { kind: "job_started", jobId: jobName };
 
-    // Build step graph nodes from explicit dependencies
-    const stepNodes: GraphNode[] = job.steps.map((step) => ({
-      name: step.name,
-      weight: step.weight,
-      dependencies: step.getDependencyNames(),
-    }));
+      // Expand forEach steps if we have expression context
+      let expandedStepsMap: Map<string, ExpandedStep[]> | undefined;
+      if (expressionContext && !options.lastEvaluated) {
+        expandedStepsMap = this.expandForEachSteps(job, expressionContext);
+      }
 
-    // If we have expanded steps, update the graph nodes
-    let effectiveNodes = stepNodes;
-    if (expandedStepsMap) {
-      effectiveNodes = [];
-      for (const node of stepNodes) {
-        const expanded = expandedStepsMap.get(node.name);
-        if (expanded && expanded.length > 0) {
-          // Create nodes for each expanded step
-          for (const exp of expanded) {
-            effectiveNodes.push({
-              name: exp.expandedName,
-              weight: node.weight,
-              // Map dependencies to all expanded step names
-              dependencies: node.dependencies.flatMap((dep) => {
-                const depExpanded = expandedStepsMap!.get(dep);
-                return depExpanded && depExpanded.length > 0
-                  ? depExpanded.map((d) => d.expandedName)
-                  : [dep];
-              }),
-            });
+      // Build step graph nodes from explicit dependencies
+      const stepNodes: GraphNode[] = job.steps.map((step) => ({
+        name: step.name,
+        weight: step.weight,
+        dependencies: step.getDependencyNames(),
+      }));
+
+      // If we have expanded steps, update the graph nodes
+      let effectiveNodes = stepNodes;
+      if (expandedStepsMap) {
+        effectiveNodes = [];
+        for (const node of stepNodes) {
+          const expanded = expandedStepsMap.get(node.name);
+          if (expanded && expanded.length > 0) {
+            // Create nodes for each expanded step
+            for (const exp of expanded) {
+              effectiveNodes.push({
+                name: exp.expandedName,
+                weight: node.weight,
+                // Map dependencies to all expanded step names
+                dependencies: node.dependencies.flatMap((dep) => {
+                  const depExpanded = expandedStepsMap!.get(dep);
+                  return depExpanded && depExpanded.length > 0
+                    ? depExpanded.map((d) => d.expandedName)
+                    : [dep];
+                }),
+              });
+            }
+          } else if (!expanded || expanded.length === 0) {
+            // Skip steps that expanded to empty (e.g., empty array)
+            continue;
+          } else {
+            effectiveNodes.push(node);
           }
-        } else if (!expanded || expanded.length === 0) {
-          // Skip steps that expanded to empty (e.g., empty array)
-          continue;
-        } else {
-          effectiveNodes.push(node);
         }
       }
-    }
 
-    const sortedSteps = this.sortService.sort(effectiveNodes);
+      const sortedSteps = this.sortService.sort(effectiveNodes);
 
-    // Execute steps level by level
-    let jobFailed = false;
-    for (const level of sortedSteps.levels) {
-      if (jobFailed) break;
+      // Execute steps level by level
+      let jobFailed = false;
+      for (const level of sortedSteps.levels) {
+        if (jobFailed) break;
 
-      // Merge parallel step generators within each level
-      const stepStreams = level.map((stepName) => {
-        // Find the expanded step info if applicable
-        let forEachVar: { name: string; value: unknown } | undefined;
-        let originalStep: Step | undefined;
+        // Merge parallel step generators within each level
+        const stepStreams = level.map((stepName) => {
+          // Find the expanded step info if applicable
+          let forEachVar: { name: string; value: unknown } | undefined;
+          let originalStep: Step | undefined;
 
-        if (expandedStepsMap) {
-          for (const [, expanded] of expandedStepsMap) {
-            const found = expanded.find((e) => e.expandedName === stepName);
-            if (found) {
-              forEachVar = found.forEachVar;
-              originalStep = found.step;
-              break;
+          if (expandedStepsMap) {
+            for (const [, expanded] of expandedStepsMap) {
+              const found = expanded.find((e) => e.expandedName === stepName);
+              if (found) {
+                forEachVar = found.forEachVar;
+                originalStep = found.step;
+                break;
+              }
             }
           }
-        }
 
-        return this.runStep(
-          workflow,
-          run,
-          job,
-          jobRun,
-          stepName,
-          originalStep,
-          forEachVar,
-          expressionContext,
-          options,
-        );
-      });
+          return this.runStep(
+            workflow,
+            run,
+            job,
+            jobRun,
+            stepName,
+            originalStep,
+            forEachVar,
+            expressionContext,
+            options,
+          );
+        });
 
-      for await (const event of merge(stepStreams, options.signal)) {
-        yield event;
-        if (event.kind === "step_failed" && !event.allowedFailure) {
-          jobFailed = true;
+        for await (const event of merge(stepStreams, options.signal)) {
+          yield event;
+          if (event.kind === "step_failed" && !event.allowedFailure) {
+            jobFailed = true;
+          }
         }
       }
-    }
 
-    // Complete job
-    if (jobFailed) {
-      jobRun.fail();
-    } else {
-      jobRun.succeed();
+      // Complete job
+      if (jobFailed) {
+        jobRun.fail();
+        jobSpan.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: "Job failed",
+        });
+      } else {
+        jobRun.succeed();
+        jobSpan.setStatus({ code: SpanStatusCode.OK });
+      }
+      jobSpan.setAttribute("job.status", jobRun.status);
+      yield { kind: "job_completed", jobId: jobName, status: jobRun.status };
+    } catch (error) {
+      jobSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    } finally {
+      jobSpan.end();
     }
-    yield { kind: "job_completed", jobId: jobName, status: jobRun.status };
   }
 
   /**
@@ -1302,11 +1347,20 @@ export class WorkflowExecutionService {
     expressionContext: ExpressionContext | undefined,
     options: StepOptions,
   ): AsyncGenerator<WorkflowExecutionEvent> {
+    const stepSpan = getTracer().startSpan("swamp.workflow.step", {
+      attributes: {
+        "step.name": stepName,
+        "job.name": job.name,
+      },
+    });
+
     // For forEach-expanded steps, use the original step but create a dynamic step run
     const step = originalStep ?? job.getStep(stepName);
     if (!step) {
+      stepSpan.end();
       throw new Error(`Step not found: ${stepName}`);
     }
+    stepSpan.setAttribute("step.task.type", step.task.data.type);
 
     // For forEach-expanded steps, we need to dynamically create the step run
     let stepRun = jobRun.getStep(stepName);
@@ -1316,6 +1370,7 @@ export class WorkflowExecutionService {
       stepRun = jobRun.getStep(stepName);
     }
     if (!stepRun) {
+      stepSpan.end();
       throw new Error(`Step run not found: ${stepName}`);
     }
 
@@ -1325,6 +1380,8 @@ export class WorkflowExecutionService {
       const shouldRun = this.shouldStepRun(step, jobRun);
       if (!shouldRun) {
         stepRun.skip();
+        stepSpan.setAttribute("step.status", "skipped");
+        stepSpan.end();
         yield { kind: "step_skipped", jobId: job.name, stepId: stepName };
         return;
       }
@@ -1475,6 +1532,7 @@ export class WorkflowExecutionService {
       }
 
       stepRun.succeed(output);
+      stepSpan.setStatus({ code: SpanStatusCode.OK });
       yield {
         kind: "step_completed",
         jobId: job.name,
@@ -1490,6 +1548,10 @@ export class WorkflowExecutionService {
       if (isAllowed) {
         stepRun.markAllowedFailure();
       }
+      stepSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: errorMessage,
+      });
       yield {
         kind: "step_failed",
         jobId: job.name,
@@ -1499,6 +1561,8 @@ export class WorkflowExecutionService {
       };
       // Do not re-throw: merge() continues draining all step generators
       // (allSettled semantics). The job generator tracks failure via step_failed events.
+    } finally {
+      stepSpan.end();
     }
   }
 
@@ -1681,58 +1745,78 @@ export class WorkflowExecutionService {
     workflow: Workflow,
     context: ExpressionContext,
   ): Workflow {
-    const celEvaluator = new CelEvaluator();
-    const workflowData = workflow.toData();
-    const expressions = extractExpressions(workflowData);
+    const evalSpan = getTracer().startSpan("swamp.workflow.evaluate", {
+      attributes: { "workflow.name": workflow.name },
+    });
 
-    if (expressions.length === 0) {
-      return workflow;
-    }
+    try {
+      const celEvaluator = new CelEvaluator();
+      const workflowData = workflow.toData();
+      const expressions = extractExpressions(workflowData);
 
-    // Collect forEach.in expressions to skip during evaluation
-    const forEachInExpressions = new Set<string>();
-    for (const job of workflow.jobs) {
-      for (const step of job.steps) {
-        if (step.forEach) {
-          const match = step.forEach.in.match(/\$\{\{\s*(.+?)\s*\}\}/);
-          if (match) {
-            forEachInExpressions.add(step.forEach.in);
+      if (expressions.length === 0) {
+        return workflow;
+      }
+
+      // Collect forEach.in expressions to skip during evaluation
+      const forEachInExpressions = new Set<string>();
+      for (const job of workflow.jobs) {
+        for (const step of job.steps) {
+          if (step.forEach) {
+            const match = step.forEach.in.match(/\$\{\{\s*(.+?)\s*\}\}/);
+            if (match) {
+              forEachInExpressions.add(step.forEach.in);
+            }
           }
         }
       }
+
+      // Evaluate CEL-only expressions; skip runtime (vault, env), self.*, and forEach.in expressions
+      const evaluatedValues = new Map<string, unknown>();
+      for (const expr of expressions) {
+        if (containsRuntimeExpression(expr.celExpression)) {
+          continue;
+        }
+        // Skip self.* expressions — they reference forEach variables resolved at runtime
+        if (expr.celExpression.match(/\bself\./)) {
+          continue;
+        }
+        // Skip forEach.in expressions — they must remain as strings for forEach expansion
+        if (forEachInExpressions.has(expr.raw)) {
+          continue;
+        }
+        // Skip task.inputs expressions that depend on step outputs (resource, file, execution, data, file.contents).
+        // These are evaluated at step execution time when upstream step outputs are available.
+        if (
+          isTaskInputsPath(expr.path) &&
+          hasStepOutputDependency(expr.celExpression)
+        ) {
+          continue;
+        }
+
+        const value = celEvaluator.evaluate(expr.celExpression, context);
+        evaluatedValues.set(expr.raw, value);
+      }
+
+      // Replace only CEL-only expressions with evaluated values
+      const evaluatedData = replaceExpressions(workflowData, evaluatedValues);
+
+      // Create new Workflow from evaluated data
+      const result = Workflow.fromData(evaluatedData as WorkflowInput);
+      evalSpan.setAttribute(
+        "workflow.expressions_evaluated",
+        evaluatedValues.size,
+      );
+      evalSpan.setStatus({ code: SpanStatusCode.OK });
+      return result;
+    } catch (error) {
+      evalSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    } finally {
+      evalSpan.end();
     }
-
-    // Evaluate CEL-only expressions; skip runtime (vault, env), self.*, and forEach.in expressions
-    const evaluatedValues = new Map<string, unknown>();
-    for (const expr of expressions) {
-      if (containsRuntimeExpression(expr.celExpression)) {
-        continue;
-      }
-      // Skip self.* expressions — they reference forEach variables resolved at runtime
-      if (expr.celExpression.match(/\bself\./)) {
-        continue;
-      }
-      // Skip forEach.in expressions — they must remain as strings for forEach expansion
-      if (forEachInExpressions.has(expr.raw)) {
-        continue;
-      }
-      // Skip task.inputs expressions that depend on step outputs (resource, file, execution, data, file.contents).
-      // These are evaluated at step execution time when upstream step outputs are available.
-      if (
-        isTaskInputsPath(expr.path) &&
-        hasStepOutputDependency(expr.celExpression)
-      ) {
-        continue;
-      }
-
-      const value = celEvaluator.evaluate(expr.celExpression, context);
-      evaluatedValues.set(expr.raw, value);
-    }
-
-    // Replace only CEL-only expressions with evaluated values
-    const evaluatedData = replaceExpressions(workflowData, evaluatedValues);
-
-    // Create new Workflow from evaluated data
-    return Workflow.fromData(evaluatedData as WorkflowInput);
   }
 }

--- a/src/infrastructure/persistence/datastore_sync_coordinator.ts
+++ b/src/infrastructure/persistence/datastore_sync_coordinator.ts
@@ -34,6 +34,8 @@
 
 import type { DistributedLock } from "../../domain/datastore/distributed_lock.ts";
 import { getSwampLogger } from "../logging/logger.ts";
+import { getTracer } from "../tracing/mod.ts";
+import { SpanStatusCode } from "@opentelemetry/api";
 
 /**
  * Common interface for sync services compatible with the coordinator.
@@ -132,17 +134,35 @@ export async function registerDatastoreSyncNamed(
 
   // Acquire distributed lock if provided
   if (lock) {
-    await lock.acquire();
+    const lockSpan = getTracer().startSpan("swamp.lock.acquire", {
+      attributes: { "lock.key": key, "lock.label": label },
+    });
+    try {
+      await lock.acquire();
+      lockSpan.setStatus({ code: SpanStatusCode.OK });
+    } catch (error) {
+      lockSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    } finally {
+      lockSpan.end();
+    }
     installSignalHandler();
   }
 
   // Pull changed files if a sync service is registered
   if (service) {
+    const syncSpan = getTracer().startSpan("swamp.datastore.sync", {
+      attributes: { "sync.direction": "pull", "sync.label": label },
+    });
     const logger = getSwampLogger(["datastore", "sync"]);
     try {
       logger.info("Syncing from {label}...", { label });
       const pulled = await service.pullChanged();
       if (pulled && pulled > 0) {
+        syncSpan.setAttribute("sync.file_count", pulled);
         logger.info("Synced {count} file(s) from {label}", {
           count: pulled,
           label,
@@ -150,8 +170,10 @@ export async function registerDatastoreSyncNamed(
       } else {
         logger.info("{label} sync complete, already up to date", { label });
       }
+      syncSpan.setStatus({ code: SpanStatusCode.OK });
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
+      syncSpan.setStatus({ code: SpanStatusCode.ERROR, message: msg });
       logger.error("Failed to pull changes from {label}: {error}", {
         label,
         error: msg,
@@ -159,6 +181,8 @@ export async function registerDatastoreSyncNamed(
       throw new Error(
         `${label} sync failed: could not pull changes: ${msg}`,
       );
+    } finally {
+      syncSpan.end();
     }
   }
 }
@@ -191,12 +215,16 @@ export async function flushDatastoreSyncNamed(key: string): Promise<void> {
   entries.delete(key);
 
   if (entry.service) {
+    const syncSpan = getTracer().startSpan("swamp.datastore.sync", {
+      attributes: { "sync.direction": "push", "sync.label": entry.label },
+    });
     const logger = getSwampLogger(["datastore", "sync"]);
     const label = entry.label;
     try {
       logger.info("Pushing changes to {label}...", { label });
       const pushed = await entry.service.pushChanged();
       if (pushed && pushed > 0) {
+        syncSpan.setAttribute("sync.file_count", pushed);
         logger.info("Pushed {count} file(s) to {label}", {
           count: pushed,
           label,
@@ -204,11 +232,18 @@ export async function flushDatastoreSyncNamed(key: string): Promise<void> {
       } else {
         logger.info("{label} push complete, no changes", { label });
       }
+      syncSpan.setStatus({ code: SpanStatusCode.OK });
     } catch (error) {
+      syncSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: error instanceof Error ? error.message : String(error),
+      });
       logger.warn("Failed to push changes to {label}: {error}", {
         label,
         error: error instanceof Error ? error.message : String(error),
       });
+    } finally {
+      syncSpan.end();
     }
   }
 

--- a/src/infrastructure/tracing/mod.ts
+++ b/src/infrastructure/tracing/mod.ts
@@ -1,0 +1,22 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+export { initTracing, shutdownTracing } from "./otel_init.ts";
+export { getTracer, withGeneratorSpan, withSpan } from "./tracer.ts";
+export { extractTraceContext, injectTraceContext } from "./propagation.ts";

--- a/src/infrastructure/tracing/otel_init.ts
+++ b/src/infrastructure/tracing/otel_init.ts
@@ -1,0 +1,114 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/** Handle to the provider so we can flush on shutdown. */
+let providerRef: { shutdown(): Promise<void> } | undefined;
+
+/**
+ * Initializes OpenTelemetry tracing if `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
+ *
+ * All SDK packages are dynamically imported so they impose zero cost when
+ * tracing is disabled. `@opentelemetry/api` is statically imported because it
+ * returns no-op implementations by default.
+ */
+export async function initTracing(): Promise<void> {
+  const endpoint = Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
+  const exporterKind = Deno.env.get("OTEL_TRACES_EXPORTER") ?? "otlp";
+
+  if (!endpoint && exporterKind !== "console") {
+    // No endpoint configured and not console mode — tracing stays disabled.
+    return;
+  }
+
+  // Dynamic imports — only loaded when tracing is actually enabled.
+  const [
+    { BasicTracerProvider, BatchSpanProcessor, ConsoleSpanExporter },
+    { AsyncLocalStorageContextManager },
+    { Resource },
+    { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION },
+    contextApi,
+  ] = await Promise.all([
+    import("@opentelemetry/sdk-trace-base"),
+    import("@opentelemetry/context-async-hooks"),
+    import("@opentelemetry/resources"),
+    import("@opentelemetry/semantic-conventions"),
+    import("@opentelemetry/api"),
+  ]);
+
+  // Register AsyncLocalStorage-based context manager
+  const contextManager = new AsyncLocalStorageContextManager();
+  contextApi.context.setGlobalContextManager(contextManager);
+
+  const serviceName = Deno.env.get("OTEL_SERVICE_NAME") ?? "swamp";
+
+  const resource = new Resource({
+    [ATTR_SERVICE_NAME]: serviceName,
+    [ATTR_SERVICE_VERSION]: Deno.env.get("SWAMP_VERSION") ?? "dev",
+  });
+
+  const provider = new BasicTracerProvider({ resource });
+
+  if (exporterKind === "console") {
+    provider.addSpanProcessor(
+      new BatchSpanProcessor(new ConsoleSpanExporter()),
+    );
+  } else {
+    // OTLP/HTTP exporter
+    const { OTLPTraceExporter } = await import(
+      "@opentelemetry/exporter-trace-otlp-http"
+    );
+
+    const headers: Record<string, string> = {};
+    const rawHeaders = Deno.env.get("OTEL_EXPORTER_OTLP_HEADERS");
+    if (rawHeaders) {
+      for (const pair of rawHeaders.split(",")) {
+        const eqIdx = pair.indexOf("=");
+        if (eqIdx > 0) {
+          headers[pair.slice(0, eqIdx).trim()] = pair.slice(eqIdx + 1).trim();
+        }
+      }
+    }
+
+    const exporter = new OTLPTraceExporter({
+      url: `${endpoint}/v1/traces`,
+      headers,
+    });
+    provider.addSpanProcessor(new BatchSpanProcessor(exporter));
+  }
+
+  // Register as global tracer provider
+  provider.register();
+
+  providerRef = provider;
+}
+
+/**
+ * Flushes pending spans and shuts down the tracer provider.
+ * No-op when tracing was not initialized.
+ */
+export async function shutdownTracing(): Promise<void> {
+  if (providerRef) {
+    await providerRef.shutdown();
+    providerRef = undefined;
+
+    // Disable the global context manager
+    const contextApi = await import("@opentelemetry/api");
+    contextApi.context.disable();
+  }
+}

--- a/src/infrastructure/tracing/otel_init_test.ts
+++ b/src/infrastructure/tracing/otel_init_test.ts
@@ -1,0 +1,83 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { trace } from "@opentelemetry/api";
+import { initTracing, shutdownTracing } from "./otel_init.ts";
+
+Deno.test("initTracing: no-op when OTEL_EXPORTER_OTLP_ENDPOINT is not set", async () => {
+  // Ensure env var is not set
+  const original = Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
+  const originalExporter = Deno.env.get("OTEL_TRACES_EXPORTER");
+  try {
+    Deno.env.delete("OTEL_EXPORTER_OTLP_ENDPOINT");
+    Deno.env.delete("OTEL_TRACES_EXPORTER");
+
+    await initTracing();
+
+    // Tracer should return a no-op tracer (no provider registered)
+    const tracer = trace.getTracer("test");
+    const span = tracer.startSpan("test-span");
+    // No-op spans have an invalid (all-zeros) span context
+    const ctx = span.spanContext();
+    assertEquals(ctx.traceId, "00000000000000000000000000000000");
+    span.end();
+
+    await shutdownTracing();
+  } finally {
+    if (original) Deno.env.set("OTEL_EXPORTER_OTLP_ENDPOINT", original);
+    if (originalExporter) {
+      Deno.env.set("OTEL_TRACES_EXPORTER", originalExporter);
+    }
+  }
+});
+
+Deno.test("initTracing: initializes when OTEL_TRACES_EXPORTER=console", async () => {
+  const originalEndpoint = Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
+  const originalExporter = Deno.env.get("OTEL_TRACES_EXPORTER");
+  try {
+    Deno.env.delete("OTEL_EXPORTER_OTLP_ENDPOINT");
+    Deno.env.set("OTEL_TRACES_EXPORTER", "console");
+
+    await initTracing();
+
+    const tracer = trace.getTracer("test");
+    const span = tracer.startSpan("test-span");
+    const ctx = span.spanContext();
+    // When initialized, trace ID should not be all zeros
+    assertEquals(ctx.traceId !== "00000000000000000000000000000000", true);
+    span.end();
+
+    await shutdownTracing();
+  } finally {
+    if (originalEndpoint) {
+      Deno.env.set("OTEL_EXPORTER_OTLP_ENDPOINT", originalEndpoint);
+    }
+    if (originalExporter) {
+      Deno.env.set("OTEL_TRACES_EXPORTER", originalExporter);
+    } else {
+      Deno.env.delete("OTEL_TRACES_EXPORTER");
+    }
+  }
+});
+
+Deno.test("shutdownTracing: no-op when tracing was not initialized", async () => {
+  // Should not throw
+  await shutdownTracing();
+});

--- a/src/infrastructure/tracing/propagation.ts
+++ b/src/infrastructure/tracing/propagation.ts
@@ -1,0 +1,51 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { context, propagation } from "@opentelemetry/api";
+
+/**
+ * Carrier that implements the TextMapSetter/Getter interfaces for
+ * a plain Record<string, string>.
+ */
+type HeaderCarrier = Record<string, string>;
+
+/**
+ * Extracts W3C Trace Context (`traceparent`/`tracestate`) from the current
+ * active context and returns them as a plain object.
+ *
+ * Returns an empty object when tracing is not initialized (propagation API
+ * returns no-op implementations).
+ */
+export function injectTraceContext(): HeaderCarrier {
+  const carrier: HeaderCarrier = {};
+  propagation.inject(context.active(), carrier);
+  return carrier;
+}
+
+/**
+ * Reconstructs an OTel context from W3C Trace Context headers.
+ *
+ * This is useful for receiving trace context from an external caller
+ * (e.g. a parent process that set TRACEPARENT).
+ */
+export function extractTraceContext(
+  headers: HeaderCarrier,
+): ReturnType<typeof context.active> {
+  return propagation.extract(context.active(), headers);
+}

--- a/src/infrastructure/tracing/propagation_test.ts
+++ b/src/infrastructure/tracing/propagation_test.ts
@@ -1,0 +1,35 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { extractTraceContext, injectTraceContext } from "./propagation.ts";
+
+Deno.test("injectTraceContext: returns empty object when tracing is not initialized", () => {
+  const headers = injectTraceContext();
+  // Without an active span/provider, propagation injects nothing
+  assertEquals(typeof headers, "object");
+  assertEquals(Object.keys(headers).length, 0);
+});
+
+Deno.test("extractTraceContext: returns a context object", () => {
+  const ctx = extractTraceContext({ traceparent: "00-abc-def-01" });
+  // Should return a context (even if the traceparent is not parseable by
+  // the no-op propagator, the function should not throw)
+  assertEquals(typeof ctx, "object");
+});

--- a/src/infrastructure/tracing/tracer.ts
+++ b/src/infrastructure/tracing/tracer.ts
@@ -1,0 +1,113 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import {
+  type Attributes,
+  type Span,
+  SpanStatusCode,
+  trace,
+  type Tracer,
+} from "@opentelemetry/api";
+
+const TRACER_NAME = "swamp";
+
+/**
+ * Returns the swamp tracer from the global tracer provider.
+ * Returns a no-op tracer when tracing is not initialized.
+ */
+export function getTracer(): Tracer {
+  return trace.getTracer(TRACER_NAME);
+}
+
+/**
+ * Convenience wrapper around `tracer.startActiveSpan()`.
+ *
+ * Creates a span that is automatically set as the active span for the
+ * duration of `fn`. Records errors and ends the span in `finally`.
+ *
+ * @param name - Span name (e.g. "swamp.workflow.run")
+ * @param attributes - Span attributes
+ * @param fn - Async function to execute within the span
+ * @returns The return value of `fn`
+ */
+/**
+ * Wraps an async generator with a span. The span starts when iteration
+ * begins and ends when the generator completes, errors, or is abandoned.
+ *
+ * Events with `kind: "error"` are detected and recorded on the span.
+ */
+export async function* withGeneratorSpan<T extends { kind: string }>(
+  name: string,
+  attributes: Attributes,
+  generator: AsyncIterable<T>,
+): AsyncGenerator<T> {
+  const span = getTracer().startSpan(name, { attributes });
+  try {
+    for await (const event of generator) {
+      if (event.kind === "error") {
+        span.setStatus({ code: SpanStatusCode.ERROR });
+      }
+      yield event;
+    }
+    // Only set OK if we didn't already set ERROR
+    if (span.isRecording()) {
+      span.setStatus({ code: SpanStatusCode.OK });
+    }
+  } catch (error) {
+    span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  } finally {
+    span.end();
+  }
+}
+
+export function withSpan<T>(
+  name: string,
+  attributes: Attributes,
+  fn: (span: Span) => Promise<T>,
+): Promise<T> {
+  const tracer = getTracer();
+  return tracer.startActiveSpan(name, { attributes }, (span) => {
+    return fn(span).then(
+      (result) => {
+        span.setStatus({ code: SpanStatusCode.OK });
+        span.end();
+        return result;
+      },
+      (error) => {
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: error instanceof Error ? error.message : String(error),
+        });
+        if (error instanceof Error) {
+          span.addEvent("exception", {
+            "exception.type": error.name,
+            "exception.message": error.message,
+            "exception.stacktrace": error.stack ?? "",
+          });
+        }
+        span.end();
+        throw error;
+      },
+    );
+  });
+}

--- a/src/infrastructure/tracing/tracer_test.ts
+++ b/src/infrastructure/tracing/tracer_test.ts
@@ -1,0 +1,57 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects } from "@std/assert";
+import { getTracer, withSpan } from "./tracer.ts";
+
+Deno.test("getTracer: returns a tracer instance", () => {
+  const tracer = getTracer();
+  // Should have startSpan method
+  assertEquals(typeof tracer.startSpan, "function");
+  assertEquals(typeof tracer.startActiveSpan, "function");
+});
+
+Deno.test("withSpan: returns the result of the wrapped function", async () => {
+  const result = await withSpan(
+    "test.span",
+    { "test.key": "value" },
+    () => Promise.resolve(42),
+  );
+  assertEquals(result, 42);
+});
+
+Deno.test("withSpan: propagates errors from the wrapped function", async () => {
+  await assertRejects(
+    () =>
+      withSpan(
+        "test.error.span",
+        {},
+        () => Promise.reject(new Error("test error")),
+      ),
+    Error,
+    "test error",
+  );
+});
+
+Deno.test("withSpan: handles non-Error throws", async () => {
+  await assertRejects(
+    () =>
+      withSpan("test.string.throw", {}, () => Promise.reject("string error")),
+  );
+});

--- a/src/libswamp/audit/timeline.ts
+++ b/src/libswamp/audit/timeline.ts
@@ -26,6 +26,7 @@ import { JsonlAuditRepository } from "../../infrastructure/persistence/jsonl_aud
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Data structure for the audit timeline output.
  */
@@ -66,33 +67,39 @@ export async function* auditTimeline(
   deps: AuditTimelineDeps,
   input: AuditTimelineInput,
 ): AsyncIterable<AuditTimelineEvent> {
-  ctx.logger.debug`Fetching audit timeline`;
+  yield* withGeneratorSpan(
+    "swamp.audit.timeline",
+    {},
+    (async function* () {
+      ctx.logger.debug`Fetching audit timeline`;
 
-  // Check if the configured tool supports audit hooks
-  if (input.tool === "codex") {
-    yield {
-      kind: "completed",
-      data: { status: "tool_not_supported", tool: input.tool },
-    };
-    return;
-  }
+      // Check if the configured tool supports audit hooks
+      if (input.tool === "codex") {
+        yield {
+          kind: "completed",
+          data: { status: "tool_not_supported", tool: input.tool },
+        };
+        return;
+      }
 
-  const timeline = await deps.getTimeline({
-    hours: input.hours,
-    showAll: input.showAll,
-    sessionId: input.sessionId,
-  });
+      const timeline = await deps.getTimeline({
+        hours: input.hours,
+        showAll: input.showAll,
+        sessionId: input.sessionId,
+      });
 
-  if (
-    timeline.entries.length === 0 && timeline.totalSwamp === 0 &&
-    timeline.totalDirect === 0
-  ) {
-    yield { kind: "completed", data: { status: "no_data" } };
-    return;
-  }
+      if (
+        timeline.entries.length === 0 && timeline.totalSwamp === 0 &&
+        timeline.totalDirect === 0
+      ) {
+        yield { kind: "completed", data: { status: "no_data" } };
+        return;
+      }
 
-  yield {
-    kind: "completed",
-    data: { status: "timeline", timeline },
-  };
+      yield {
+        kind: "completed",
+        data: { status: "timeline", timeline },
+      };
+    })(),
+  );
 }

--- a/src/libswamp/auth/login.ts
+++ b/src/libswamp/auth/login.ts
@@ -31,6 +31,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { validationFailed } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** Data returned on successful authentication. */
 export interface AuthLoginData {
   username: string;
@@ -197,90 +198,96 @@ export async function* authLogin(
   deps: AuthLoginDeps,
   input: AuthLoginInput,
 ): AsyncIterable<AuthLoginEvent> {
-  ctx.logger.debug`Executing auth login`;
+  yield* withGeneratorSpan(
+    "swamp.auth.login",
+    {},
+    (async function* () {
+      ctx.logger.debug`Executing auth login`;
 
-  let sessionToken: string;
-  let knownUsername: string | undefined;
+      let sessionToken: string;
+      let knownUsername: string | undefined;
 
-  if (input.useBrowserFlow) {
-    // Browser flow
-    const state = crypto.randomUUID();
-    const deviceCode = deps.generateDeviceCode();
-    const server = deps.startCallbackServer(state, input.serverUrl);
+      if (input.useBrowserFlow) {
+        // Browser flow
+        const state = crypto.randomUUID();
+        const deviceCode = deps.generateDeviceCode();
+        const server = deps.startCallbackServer(state, input.serverUrl);
 
-    const callbackUrl = `http://localhost:${server.port}/callback`;
-    const loginUrl = `${input.serverUrl}/login?cli_callback=${
-      encodeURIComponent(callbackUrl)
-    }&state=${encodeURIComponent(state)}&device_code=${
-      encodeURIComponent(deviceCode)
-    }`;
+        const callbackUrl = `http://localhost:${server.port}/callback`;
+        const loginUrl = `${input.serverUrl}/login?cli_callback=${
+          encodeURIComponent(callbackUrl)
+        }&state=${encodeURIComponent(state)}&device_code=${
+          encodeURIComponent(deviceCode)
+        }`;
 
-    yield { kind: "opening_browser" };
-    const browserError = await deps.openBrowser(loginUrl);
-    if (browserError) {
-      yield { kind: "browser_open_failed", message: browserError };
-    }
+        yield { kind: "opening_browser" };
+        const browserError = await deps.openBrowser(loginUrl);
+        if (browserError) {
+          yield { kind: "browser_open_failed", message: browserError };
+        }
 
-    yield { kind: "device_verification", deviceCode };
-    yield { kind: "waiting_for_auth" };
+        yield { kind: "device_verification", deviceCode };
+        yield { kind: "waiting_for_auth" };
 
-    try {
-      sessionToken = await server.token;
-    } finally {
-      await server.shutdown();
-    }
-  } else {
-    // Stdin flow
-    let username = input.username;
-    let password = input.password;
-    if (!username || !password) {
-      const creds = await deps.readCredentials();
-      username = username ?? creds.username;
-      password = password ?? creds.password;
-    }
+        try {
+          sessionToken = await server.token;
+        } finally {
+          await server.shutdown();
+        }
+      } else {
+        // Stdin flow
+        let username = input.username;
+        let password = input.password;
+        if (!username || !password) {
+          const creds = await deps.readCredentials();
+          username = username ?? creds.username;
+          password = password ?? creds.password;
+        }
 
-    if (!username || !password) {
+        if (!username || !password) {
+          yield {
+            kind: "error",
+            error: validationFailed("Username and password are required."),
+          };
+          return;
+        }
+
+        const result = await deps.signIn(input.serverUrl, username, password);
+        sessionToken = result.token;
+        knownUsername = result.username;
+      }
+
+      yield { kind: "securing_session" };
+
+      const host = deps.getHostname().slice(0, 14);
+      const keyName = `cli-${host}-${Date.now()}`;
+      ctx.logger.debug`Creating API key: ${keyName}`;
+      const apiKey = await deps.createApiKey(
+        input.serverUrl,
+        sessionToken,
+        keyName,
+      );
+      const identity = await deps.whoami(input.serverUrl, apiKey.key);
+      const username = identity.username ?? knownUsername ?? "unknown";
+
+      await deps.saveCredentials({
+        serverUrl: input.serverUrl,
+        apiKey: apiKey.key,
+        apiKeyId: apiKey.id,
+        username,
+        ...(identity.collectives ? { collectives: identity.collectives } : {}),
+      });
+
       yield {
-        kind: "error",
-        error: validationFailed("Username and password are required."),
+        kind: "completed",
+        data: {
+          username,
+          email: identity.email,
+          name: identity.name,
+          serverUrl: input.serverUrl,
+          apiKey: apiKey.key,
+        },
       };
-      return;
-    }
-
-    const result = await deps.signIn(input.serverUrl, username, password);
-    sessionToken = result.token;
-    knownUsername = result.username;
-  }
-
-  yield { kind: "securing_session" };
-
-  const host = deps.getHostname().slice(0, 14);
-  const keyName = `cli-${host}-${Date.now()}`;
-  ctx.logger.debug`Creating API key: ${keyName}`;
-  const apiKey = await deps.createApiKey(
-    input.serverUrl,
-    sessionToken,
-    keyName,
+    })(),
   );
-  const identity = await deps.whoami(input.serverUrl, apiKey.key);
-  const username = identity.username ?? knownUsername ?? "unknown";
-
-  await deps.saveCredentials({
-    serverUrl: input.serverUrl,
-    apiKey: apiKey.key,
-    apiKeyId: apiKey.id,
-    username,
-    ...(identity.collectives ? { collectives: identity.collectives } : {}),
-  });
-
-  yield {
-    kind: "completed",
-    data: {
-      username,
-      email: identity.email,
-      name: identity.name,
-      serverUrl: input.serverUrl,
-      apiKey: apiKey.key,
-    },
-  };
 }

--- a/src/libswamp/data/gc.ts
+++ b/src/libswamp/data/gc.ts
@@ -26,6 +26,8 @@ import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistenc
 import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
+import { getTracer } from "../../infrastructure/tracing/mod.ts";
+import { SpanStatusCode } from "@opentelemetry/api";
 
 /** Preview item for a single expired data entry. */
 export interface DataGcPreviewItem {
@@ -109,18 +111,37 @@ export async function* dataGc(
   deps: DataGcDeps,
   input: DataGcInput,
 ): AsyncIterable<DataGcEvent> {
-  yield { kind: "collecting" };
+  const gcSpan = getTracer().startSpan("swamp.data.gc", {
+    attributes: { "gc.dry_run": input.dryRun },
+  });
 
-  const result = await deps.deleteExpiredData({ dryRun: input.dryRun });
+  try {
+    yield { kind: "collecting" };
 
-  yield {
-    kind: "completed",
-    data: {
-      dataEntriesExpired: result.dataEntriesExpired,
-      versionsDeleted: result.versionsDeleted,
-      bytesReclaimed: result.bytesReclaimed,
-      dryRun: result.dryRun,
-      expiredEntries: result.expiredEntries,
-    },
-  };
+    const result = await deps.deleteExpiredData({ dryRun: input.dryRun });
+
+    gcSpan.setAttribute("gc.entries_expired", result.dataEntriesExpired);
+    gcSpan.setAttribute("gc.versions_deleted", result.versionsDeleted);
+    gcSpan.setAttribute("gc.bytes_reclaimed", result.bytesReclaimed);
+    gcSpan.setStatus({ code: SpanStatusCode.OK });
+
+    yield {
+      kind: "completed",
+      data: {
+        dataEntriesExpired: result.dataEntriesExpired,
+        versionsDeleted: result.versionsDeleted,
+        bytesReclaimed: result.bytesReclaimed,
+        dryRun: result.dryRun,
+        expiredEntries: result.expiredEntries,
+      },
+    };
+  } catch (error) {
+    gcSpan.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  } finally {
+    gcSpan.end();
+  }
 }

--- a/src/libswamp/data/get.ts
+++ b/src/libswamp/data/get.ts
@@ -31,6 +31,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound, validationFailed } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Data structure for the data get output.
  */
@@ -209,42 +210,48 @@ export async function* dataGet(
   deps: DataGetDeps,
   input: DataGetInput,
 ): AsyncIterable<DataGetEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.data.get",
+    { "data.name": input.dataName },
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const { workflowName, modelIdOrName, dataName, version, repoDir } = input;
+      const { workflowName, modelIdOrName, dataName, version, repoDir } = input;
 
-  // Validate arguments
-  if (workflowName && modelIdOrName && dataName) {
-    yield {
-      kind: "error",
-      error: validationFailed(
-        "Too many arguments. Usage: swamp data get --workflow <name> <data_name>",
-      ),
-    };
-    return;
-  }
-  if (!modelIdOrName && !workflowName) {
-    yield {
-      kind: "error",
-      error: validationFailed(
-        "Either a model name or --workflow is required.",
-      ),
-    };
-    return;
-  }
+      // Validate arguments
+      if (workflowName && modelIdOrName && dataName) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            "Too many arguments. Usage: swamp data get --workflow <name> <data_name>",
+          ),
+        };
+        return;
+      }
+      if (!modelIdOrName && !workflowName) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            "Either a model name or --workflow is required.",
+          ),
+        };
+        return;
+      }
 
-  if (workflowName) {
-    yield* workflowScopedGet(deps, input, workflowName, repoDir, version);
-  } else {
-    yield* modelScopedGet(
-      deps,
-      modelIdOrName!,
-      dataName,
-      version,
-      repoDir,
-      input.includeContent,
-    );
-  }
+      if (workflowName) {
+        yield* workflowScopedGet(deps, input, workflowName, repoDir, version);
+      } else {
+        yield* modelScopedGet(
+          deps,
+          modelIdOrName!,
+          dataName,
+          version,
+          repoDir,
+          input.includeContent,
+        );
+      }
+    })(),
+  );
 }
 
 async function* workflowScopedGet(

--- a/src/libswamp/data/list.ts
+++ b/src/libswamp/data/list.ts
@@ -29,6 +29,7 @@ import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** Data item in the list. */
 export interface DataListItem {
   id: string;
@@ -367,31 +368,37 @@ export async function* dataList(
   deps: DataListDeps,
   input: DataListInput,
 ): AsyncIterable<DataListEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.data.list",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  if (input.modelIdOrName && input.workflowName) {
-    yield {
-      kind: "error",
-      error: validationFailed(
-        "Cannot specify both a model and --workflow. Use one or the other.",
-      ),
-    };
-    return;
-  }
+      if (input.modelIdOrName && input.workflowName) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            "Cannot specify both a model and --workflow. Use one or the other.",
+          ),
+        };
+        return;
+      }
 
-  if (!input.modelIdOrName && !input.workflowName) {
-    yield {
-      kind: "error",
-      error: validationFailed(
-        "Either a model name or --workflow is required.",
-      ),
-    };
-    return;
-  }
+      if (!input.modelIdOrName && !input.workflowName) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            "Either a model name or --workflow is required.",
+          ),
+        };
+        return;
+      }
 
-  if (input.workflowName) {
-    yield* workflowScopedList(deps, input);
-  } else {
-    yield* modelScopedList(deps, input);
-  }
+      if (input.workflowName) {
+        yield* workflowScopedList(deps, input);
+      } else {
+        yield* modelScopedList(deps, input);
+      }
+    })(),
+  );
 }

--- a/src/libswamp/data/rename.ts
+++ b/src/libswamp/data/rename.ts
@@ -27,6 +27,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { validationFailed } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Data structure for the data rename output.
  */
@@ -79,51 +80,57 @@ export async function* dataRename(
   deps: DataRenameDeps,
   input: DataRenameInput,
 ): AsyncIterable<DataRenameEvent> {
-  yield { kind: "renaming" };
+  yield* withGeneratorSpan(
+    "swamp.data.rename",
+    { "data.old_name": input.oldName, "data.new_name": input.newName },
+    (async function* () {
+      yield { kind: "renaming" };
 
-  ctx.logger
-    .debug`Renaming data: model=${input.modelIdOrName}, ${input.oldName} -> ${input.newName}`;
+      ctx.logger
+        .debug`Renaming data: model=${input.modelIdOrName}, ${input.oldName} -> ${input.newName}`;
 
-  // Validate names are different
-  if (input.oldName === input.newName) {
-    yield {
-      kind: "error",
-      error: validationFailed(
-        "Old name and new name must be different.",
-      ),
-    };
-    return;
-  }
+      // Validate names are different
+      if (input.oldName === input.newName) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            "Old name and new name must be different.",
+          ),
+        };
+        return;
+      }
 
-  let result: RenameResult;
-  try {
-    result = await deps.rename(
-      input.modelIdOrName,
-      input.oldName,
-      input.newName,
-    );
-  } catch (error) {
-    yield {
-      kind: "error",
-      error: validationFailed(
-        error instanceof Error ? error.message : String(error),
-      ),
-    };
-    return;
-  }
+      let result: RenameResult;
+      try {
+        result = await deps.rename(
+          input.modelIdOrName,
+          input.oldName,
+          input.newName,
+        );
+      } catch (error) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            error instanceof Error ? error.message : String(error),
+          ),
+        };
+        return;
+      }
 
-  const data: DataRenameData = {
-    oldName: result.oldName,
-    newName: result.newName,
-    modelId: result.modelId,
-    modelName: result.modelName,
-    modelType: result.modelType,
-    copiedVersion: result.copiedVersion,
-    newVersion: result.newVersion,
-    warning:
-      `Any workflows or models that produce data under "${result.oldName}" ` +
-      `will overwrite the forward reference. Update them to use "${result.newName}" instead.`,
-  };
+      const data: DataRenameData = {
+        oldName: result.oldName,
+        newName: result.newName,
+        modelId: result.modelId,
+        modelName: result.modelName,
+        modelType: result.modelType,
+        copiedVersion: result.copiedVersion,
+        newVersion: result.newVersion,
+        warning:
+          `Any workflows or models that produce data under "${result.oldName}" ` +
+          `will overwrite the forward reference. Update them to use "${result.newName}" instead.`,
+      };
 
-  yield { kind: "completed", data };
+      yield { kind: "completed", data };
+    })(),
+  );
 }

--- a/src/libswamp/data/search.ts
+++ b/src/libswamp/data/search.ts
@@ -22,6 +22,7 @@ import type { SwampError } from "../errors.ts";
 import { validationFailed } from "../errors.ts";
 import { UserError } from "../../domain/errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * A single data search result item.
  */
@@ -256,74 +257,81 @@ export async function* dataSearch(
   deps: DataSearchDeps,
   input: DataSearchInput,
 ): AsyncGenerator<DataSearchEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.data.search",
+    { "search.query": input.query ?? "" },
+    (async function* () {
+      yield { kind: "resolving" };
 
-  // Validate model if provided
-  if (input.model) {
-    const modelResult = await deps.findDefinitionByIdOrName(input.model);
-    if (!modelResult) {
+      // Validate model if provided
+      if (input.model) {
+        const modelResult = await deps.findDefinitionByIdOrName(input.model);
+        if (!modelResult) {
+          yield {
+            kind: "error",
+            error: validationFailed(`Model not found: ${input.model}`),
+          };
+          return;
+        }
+      }
+
+      // Fetch and convert all data
+      const allResults = await deps.findAllGlobal();
+      const items: DataSearchItem[] = [];
+
+      for (const { data, modelType, modelId } of allResults) {
+        let modelName = modelId;
+        const definition = await deps.findDefinitionById(modelType, modelId);
+        if (definition) {
+          modelName = definition.name;
+        }
+
+        items.push({
+          id: data.id,
+          name: data.name,
+          version: data.version,
+          contentType: data.contentType,
+          type: data.type,
+          lifetime: data.lifetime,
+          ownerType: data.ownerDefinition.ownerType,
+          ownerRef: data.ownerDefinition.ownerRef,
+          modelId,
+          modelName,
+          modelType: modelType.normalized,
+          streaming: data.streaming,
+          size: data.size ?? 0,
+          createdAt: data.createdAt.toISOString(),
+          tags: data.tags,
+          workflowTag: data.tags.workflow,
+          stepTag: data.tags.step,
+        });
+      }
+
+      // Apply filters
+      const filtered = filterData(items, input);
+
+      // Sort by createdAt descending
+      filtered.sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      );
+
+      // Apply limit
+      const limit = input.limit ?? 50;
+      const total = filtered.length;
+      const limited = total > limit;
+      const results = filtered.slice(0, limit);
+
       yield {
-        kind: "error",
-        error: validationFailed(`Model not found: ${input.model}`),
+        kind: "completed",
+        data: {
+          query: input.query ?? "",
+          filters: buildFilters(input),
+          results,
+          total,
+          limited,
+        },
       };
-      return;
-    }
-  }
-
-  // Fetch and convert all data
-  const allResults = await deps.findAllGlobal();
-  const items: DataSearchItem[] = [];
-
-  for (const { data, modelType, modelId } of allResults) {
-    let modelName = modelId;
-    const definition = await deps.findDefinitionById(modelType, modelId);
-    if (definition) {
-      modelName = definition.name;
-    }
-
-    items.push({
-      id: data.id,
-      name: data.name,
-      version: data.version,
-      contentType: data.contentType,
-      type: data.type,
-      lifetime: data.lifetime,
-      ownerType: data.ownerDefinition.ownerType,
-      ownerRef: data.ownerDefinition.ownerRef,
-      modelId,
-      modelName,
-      modelType: modelType.normalized,
-      streaming: data.streaming,
-      size: data.size ?? 0,
-      createdAt: data.createdAt.toISOString(),
-      tags: data.tags,
-      workflowTag: data.tags.workflow,
-      stepTag: data.tags.step,
-    });
-  }
-
-  // Apply filters
-  const filtered = filterData(items, input);
-
-  // Sort by createdAt descending
-  filtered.sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    })(),
   );
-
-  // Apply limit
-  const limit = input.limit ?? 50;
-  const total = filtered.length;
-  const limited = total > limit;
-  const results = filtered.slice(0, limit);
-
-  yield {
-    kind: "completed",
-    data: {
-      query: input.query ?? "",
-      filters: buildFilters(input),
-      results,
-      total,
-      limited,
-    },
-  };
 }

--- a/src/libswamp/data/versions.ts
+++ b/src/libswamp/data/versions.ts
@@ -25,6 +25,7 @@ import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistenc
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** Version information for a single data entry. */
 export interface DataVersionInfo {
   version: number;
@@ -100,65 +101,71 @@ export async function* dataVersions(
   deps: DataVersionsDeps,
   input: DataVersionsInput,
 ): AsyncIterable<DataVersionsEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.data.versions",
+    { "data.name": input.dataName },
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const result = await deps.lookupDefinition(input.modelIdOrName);
-  if (!result) {
-    yield { kind: "error", error: notFound("Model", input.modelIdOrName) };
-    return;
-  }
-  const { definition, type: modelType } = result;
+      const result = await deps.lookupDefinition(input.modelIdOrName);
+      if (!result) {
+        yield { kind: "error", error: notFound("Model", input.modelIdOrName) };
+        return;
+      }
+      const { definition, type: modelType } = result;
 
-  const versionNumbers = await deps.listVersions(
-    modelType,
-    definition.id,
-    input.dataName,
+      const versionNumbers = await deps.listVersions(
+        modelType,
+        definition.id,
+        input.dataName,
+      );
+
+      if (versionNumbers.length === 0) {
+        yield {
+          kind: "error",
+          error: notFound(
+            "Data",
+            `"${input.dataName}" for model "${input.modelIdOrName}"`,
+          ),
+        };
+        return;
+      }
+
+      const versions: DataVersionInfo[] = [];
+      const latestVersion = Math.max(...versionNumbers);
+
+      for (const version of versionNumbers) {
+        const data = await deps.findByName(
+          modelType,
+          definition.id,
+          input.dataName,
+          version,
+        );
+        if (data) {
+          versions.push({
+            version: data.version,
+            createdAt: data.createdAt.toISOString(),
+            size: data.size,
+            checksum: data.checksum,
+            isLatest: version === latestVersion,
+          });
+        }
+      }
+
+      // Sort versions descending (newest first)
+      versions.sort((a, b) => b.version - a.version);
+
+      yield {
+        kind: "completed",
+        data: {
+          dataName: input.dataName,
+          modelId: definition.id,
+          modelName: definition.name,
+          modelType: modelType.normalized,
+          versions,
+          total: versions.length,
+        },
+      };
+    })(),
   );
-
-  if (versionNumbers.length === 0) {
-    yield {
-      kind: "error",
-      error: notFound(
-        "Data",
-        `"${input.dataName}" for model "${input.modelIdOrName}"`,
-      ),
-    };
-    return;
-  }
-
-  const versions: DataVersionInfo[] = [];
-  const latestVersion = Math.max(...versionNumbers);
-
-  for (const version of versionNumbers) {
-    const data = await deps.findByName(
-      modelType,
-      definition.id,
-      input.dataName,
-      version,
-    );
-    if (data) {
-      versions.push({
-        version: data.version,
-        createdAt: data.createdAt.toISOString(),
-        size: data.size,
-        checksum: data.checksum,
-        isLatest: version === latestVersion,
-      });
-    }
-  }
-
-  // Sort versions descending (newest first)
-  versions.sort((a, b) => b.version - a.version);
-
-  yield {
-    kind: "completed",
-    data: {
-      dataName: input.dataName,
-      modelId: definition.id,
-      modelName: definition.name,
-      modelType: modelType.normalized,
-      versions,
-      total: versions.length,
-    },
-  };
 }

--- a/src/libswamp/datastores/lock.ts
+++ b/src/libswamp/datastores/lock.ts
@@ -28,6 +28,7 @@ import { relative } from "@std/path";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 export type { LockInfo } from "../../domain/datastore/distributed_lock.ts";
 
 // ── Lock status ────────────────────────────────────────────────────────
@@ -71,35 +72,41 @@ export async function* datastoreLockStatus(
   deps: DatastoreLockStatusDeps,
   input: DatastoreLockStatusInput,
 ): AsyncIterable<DatastoreLockStatusEvent> {
-  ctx.logger.debug`Checking global lock status`;
+  yield* withGeneratorSpan(
+    "swamp.datastore.lock.status",
+    {},
+    (async function* () {
+      ctx.logger.debug`Checking global lock status`;
 
-  const info = await deps.inspectGlobalLock();
+      const info = await deps.inspectGlobalLock();
 
-  // Scan for per-model locks (filesystem only) — yield these first
-  if (input.isFilesystemDatastore) {
-    const modelLocks = await deps.scanModelLocks();
-    for (const ml of modelLocks) {
+      // Scan for per-model locks (filesystem only) — yield these first
+      if (input.isFilesystemDatastore) {
+        const modelLocks = await deps.scanModelLocks();
+        for (const ml of modelLocks) {
+          yield {
+            kind: "model_lock",
+            data: {
+              held: true,
+              info: ml.info,
+              datastoreType: input.datastoreType,
+              lockScope: `${ml.modelType}/${ml.modelId}`,
+            },
+          };
+        }
+      }
+
+      // Yield the global status as the final completed event
       yield {
-        kind: "model_lock",
+        kind: "completed",
         data: {
-          held: true,
-          info: ml.info,
+          held: info !== null,
+          info: info ?? undefined,
           datastoreType: input.datastoreType,
-          lockScope: `${ml.modelType}/${ml.modelId}`,
         },
       };
-    }
-  }
-
-  // Yield the global status as the final completed event
-  yield {
-    kind: "completed",
-    data: {
-      held: info !== null,
-      info: info ?? undefined,
-      datastoreType: input.datastoreType,
-    },
-  };
+    })(),
+  );
 }
 
 // ── Lock release ───────────────────────────────────────────────────────
@@ -130,46 +137,52 @@ export async function* datastoreLockRelease(
   deps: DatastoreLockReleaseDeps,
   _input: DatastoreLockReleaseInput = {},
 ): AsyncIterable<DatastoreLockReleaseEvent> {
-  ctx.logger.debug`Checking lock before force-release`;
+  yield* withGeneratorSpan(
+    "swamp.datastore.lock.release",
+    {},
+    (async function* () {
+      ctx.logger.debug`Checking lock before force-release`;
 
-  const info = await deps.inspectLock();
+      const info = await deps.inspectLock();
 
-  if (!info) {
-    yield {
-      kind: "completed",
-      data: {
-        released: false,
-        reason: "no lock held",
-      },
-    };
-    return;
-  }
+      if (!info) {
+        yield {
+          kind: "completed",
+          data: {
+            released: false,
+            reason: "no lock held",
+          },
+        };
+        return;
+      }
 
-  // Re-verify the lock holder hasn't changed between inspect and delete.
-  // forceRelease() re-reads the nonce immediately before deleting to
-  // minimise the TOCTOU window.
-  const released = await deps.forceRelease(info.nonce!);
-  if (!released) {
-    yield {
-      kind: "completed",
-      data: {
-        released: false,
-        reason:
-          "lock holder changed — aborting to avoid breaking an active lock",
-      },
-    };
-    return;
-  }
+      // Re-verify the lock holder hasn't changed between inspect and delete.
+      // forceRelease() re-reads the nonce immediately before deleting to
+      // minimise the TOCTOU window.
+      const released = await deps.forceRelease(info.nonce!);
+      if (!released) {
+        yield {
+          kind: "completed",
+          data: {
+            released: false,
+            reason:
+              "lock holder changed — aborting to avoid breaking an active lock",
+          },
+        };
+        return;
+      }
 
-  ctx.logger.debug`Lock force-released`;
+      ctx.logger.debug`Lock force-released`;
 
-  yield {
-    kind: "completed",
-    data: {
-      released: true,
-      previousHolder: info,
-    },
-  };
+      yield {
+        kind: "completed",
+        data: {
+          released: true,
+          previousHolder: info,
+        },
+      };
+    })(),
+  );
 }
 
 // ── Factory functions ─────────────────────────────────────────────────

--- a/src/libswamp/datastores/setup.ts
+++ b/src/libswamp/datastores/setup.ts
@@ -39,6 +39,7 @@ import { S3DatastoreVerifier } from "../../infrastructure/persistence/s3_datasto
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** Output data for datastore setup operations. */
 export interface DatastoreSetupData {
   type: string;
@@ -133,102 +134,111 @@ export async function* datastoreSetupFilesystem(
   deps: DatastoreSetupDeps,
   input: DatastoreSetupFilesystemInput,
 ): AsyncIterable<DatastoreSetupEvent> {
-  yield { kind: "validating" };
+  yield* withGeneratorSpan(
+    "swamp.datastore.setup",
+    { "datastore.type": "filesystem" },
+    (async function* () {
+      yield { kind: "validating" };
 
-  try {
-    await deps.requireUpgradedRepo(input.repoDir);
-  } catch (err) {
-    yield {
-      kind: "error",
-      error: {
-        code: "validation_failed",
-        message: err instanceof Error ? err.message : String(err),
-      },
-    };
-    return;
-  }
+      try {
+        await deps.requireUpgradedRepo(input.repoDir);
+      } catch (err) {
+        yield {
+          kind: "error",
+          error: {
+            code: "validation_failed",
+            message: err instanceof Error ? err.message : String(err),
+          },
+        };
+        return;
+      }
 
-  // Validate target path is accessible
-  await deps.ensureDir(input.datastorePath);
-  const health = await deps.verifyPath(input.datastorePath);
-  if (!health.healthy) {
-    yield {
-      kind: "error",
-      error: {
-        code: "validation_failed",
-        message: `Datastore path is not accessible: ${health.message}`,
-      },
-    };
-    return;
-  }
+      // Validate target path is accessible
+      await deps.ensureDir(input.datastorePath);
+      const health = await deps.verifyPath(input.datastorePath);
+      if (!health.healthy) {
+        yield {
+          kind: "error",
+          error: {
+            code: "validation_failed",
+            message: `Datastore path is not accessible: ${health.message}`,
+          },
+        };
+        return;
+      }
 
-  // Create datastore subdirectory structure
-  const directories = deps.getDatastoreDirectories({
-    type: "filesystem",
-    directories: input.directories,
-  });
-  for (const subdir of directories) {
-    await deps.ensureDir(`${input.datastorePath}/${subdir}`);
-  }
+      // Create datastore subdirectory structure
+      const directories = deps.getDatastoreDirectories({
+        type: "filesystem",
+        directories: input.directories,
+      });
+      for (const subdir of directories) {
+        await deps.ensureDir(`${input.datastorePath}/${subdir}`);
+      }
 
-  // Migrate existing data
-  let filesCopied = 0;
-  let bytesCopied = 0;
-  let directoriesMigrated: string[] = [];
-  const errors: string[] = [];
+      // Migrate existing data
+      let filesCopied = 0;
+      let bytesCopied = 0;
+      let directoriesMigrated: string[] = [];
+      const errors: string[] = [];
 
-  if (!input.skipMigration) {
-    yield { kind: "migrating" };
-    ctx.logger.debug`Migrating data to ${input.datastorePath}...`;
-    const sourceDir = `${input.repoDir}/.swamp`;
-    const config = { type: "filesystem" as const, path: input.datastorePath };
-    const result = await deps.migrateData(
-      sourceDir,
-      input.datastorePath,
-      config,
-    );
-    filesCopied = result.filesCopied;
-    bytesCopied = result.bytesCopied;
-    directoriesMigrated = result.directoriesMigrated;
-    errors.push(...result.errors);
+      if (!input.skipMigration) {
+        yield { kind: "migrating" };
+        ctx.logger.debug`Migrating data to ${input.datastorePath}...`;
+        const sourceDir = `${input.repoDir}/.swamp`;
+        const config = {
+          type: "filesystem" as const,
+          path: input.datastorePath,
+        };
+        const result = await deps.migrateData(
+          sourceDir,
+          input.datastorePath,
+          config,
+        );
+        filesCopied = result.filesCopied;
+        bytesCopied = result.bytesCopied;
+        directoriesMigrated = result.directoriesMigrated;
+        errors.push(...result.errors);
 
-    // Verify migration
-    const verification = await deps.verifyMigration(
-      sourceDir,
-      input.datastorePath,
-      config,
-    );
-    if (!verification.valid) {
-      errors.push(
-        `Migration verification: source has ${verification.sourceCount} files, destination has ${verification.destCount}`,
-      );
-    }
+        // Verify migration
+        const verification = await deps.verifyMigration(
+          sourceDir,
+          input.datastorePath,
+          config,
+        );
+        if (!verification.valid) {
+          errors.push(
+            `Migration verification: source has ${verification.sourceCount} files, destination has ${verification.destCount}`,
+          );
+        }
 
-    // Clean up migrated directories from .swamp/ on success
-    if (errors.length === 0 && directoriesMigrated.length > 0) {
-      await deps.cleanupSourceDirs(sourceDir, directoriesMigrated);
-    }
-  }
+        // Clean up migrated directories from .swamp/ on success
+        if (errors.length === 0 && directoriesMigrated.length > 0) {
+          await deps.cleanupSourceDirs(sourceDir, directoriesMigrated);
+        }
+      }
 
-  // Update .swamp.yaml with new datastore config
-  const collapsedPath = deps.collapseEnvVars(input.datastorePath);
-  await deps.updateRepoConfig(input.repoDir, {
-    type: "filesystem",
-    path: collapsedPath,
-    directories: input.directories ?? undefined,
-  });
+      // Update .swamp.yaml with new datastore config
+      const collapsedPath = deps.collapseEnvVars(input.datastorePath);
+      await deps.updateRepoConfig(input.repoDir, {
+        type: "filesystem",
+        path: collapsedPath,
+        directories: input.directories ?? undefined,
+      });
 
-  yield {
-    kind: "completed",
-    data: {
-      type: "filesystem",
-      path: input.datastorePath,
-      filesCopied,
-      bytesCopied,
-      directoriesMigrated,
-      errors,
-    },
-  };
+      yield {
+        kind: "completed",
+        data: {
+          type: "filesystem",
+          path: input.datastorePath,
+          filesCopied,
+          bytesCopied,
+          directoriesMigrated,
+          errors,
+        },
+      };
+    })(),
+  );
 }
 
 /** Sets up an S3 datastore. */
@@ -237,134 +247,140 @@ export async function* datastoreSetupS3(
   deps: DatastoreSetupDeps,
   input: DatastoreSetupS3Input,
 ): AsyncIterable<DatastoreSetupEvent> {
-  yield { kind: "validating" };
+  yield* withGeneratorSpan(
+    "swamp.datastore.setup",
+    { "datastore.type": "s3" },
+    (async function* () {
+      yield { kind: "validating" };
 
-  try {
-    await deps.requireUpgradedRepo(input.repoDir);
-  } catch (err) {
-    yield {
-      kind: "error",
-      error: {
-        code: "validation_failed",
-        message: err instanceof Error ? err.message : String(err),
-      },
-    };
-    return;
-  }
+      try {
+        await deps.requireUpgradedRepo(input.repoDir);
+      } catch (err) {
+        yield {
+          kind: "error",
+          error: {
+            code: "validation_failed",
+            message: err instanceof Error ? err.message : String(err),
+          },
+        };
+        return;
+      }
 
-  // Verify S3 bucket is accessible
-  const health = await deps.verifyS3(
-    input.bucket,
-    input.prefix,
-    input.region,
-  );
-  if (!health.healthy) {
-    yield {
-      kind: "error",
-      error: {
-        code: "validation_failed",
-        message: `S3 bucket is not accessible: ${health.message}`,
-      },
-    };
-    return;
-  }
-
-  // Check if this S3 location already has datastore data
-  const exists = await deps.checkS3DatastoreExists(
-    input.bucket,
-    input.prefix,
-    input.region,
-  );
-  if (exists) {
-    const prefixStr = input.prefix ?? "";
-    yield {
-      kind: "error",
-      error: {
-        code: "already_exists",
-        message:
-          `S3 location s3://${input.bucket}/${prefixStr} already contains a datastore. ` +
-          `If you want to share this datastore, configure it in .swamp.yaml directly:\n\n` +
-          `  datastore:\n` +
-          `    type: s3\n` +
-          `    bucket: ${input.bucket}\n` +
-          (input.prefix ? `    prefix: ${input.prefix}\n` : "") +
-          (input.region ? `    region: ${input.region}\n` : "") +
-          `\nThen run 'swamp datastore sync --pull' to populate the local cache.`,
-      },
-    };
-    return;
-  }
-
-  // Update .swamp.yaml with S3 datastore config
-  await deps.updateRepoConfig(input.repoDir, {
-    type: "s3",
-    bucket: input.bucket,
-    prefix: input.prefix,
-    region: input.region,
-  });
-
-  // Migrate existing data to S3
-  let filesPushed = 0;
-  const errors: string[] = [];
-
-  if (!input.skipMigration) {
-    yield { kind: "migrating" };
-
-    // Compute cache path
-    const cachePath = deps.getCachePath(input.repoId ?? "unknown");
-    const sourceDir = `${input.repoDir}/.swamp`;
-    const config = { type: "filesystem" as const, path: cachePath };
-
-    // Migrate local .swamp/ to cache, then push to S3
-    const migrationResult = await deps.migrateData(
-      sourceDir,
-      cachePath,
-      config,
-    );
-    errors.push(...migrationResult.errors);
-
-    // Push cache to S3
-    ctx.logger.debug`Pushing data to S3...`;
-    try {
-      filesPushed = await deps.pushAllToS3(
+      // Verify S3 bucket is accessible
+      const health = await deps.verifyS3(
         input.bucket,
         input.prefix,
         input.region,
-        cachePath,
       );
-      ctx.logger.debug`Pushed ${filesPushed} file(s) to S3`;
-    } catch (error) {
-      errors.push(
-        `Failed to push to S3: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-    }
+      if (!health.healthy) {
+        yield {
+          kind: "error",
+          error: {
+            code: "validation_failed",
+            message: `S3 bucket is not accessible: ${health.message}`,
+          },
+        };
+        return;
+      }
 
-    // Clean up migrated directories from local .swamp/ on success
-    if (
-      errors.length === 0 && migrationResult.filesCopied > 0 &&
-      migrationResult.directoriesMigrated.length > 0
-    ) {
-      await deps.cleanupSourceDirs(
-        sourceDir,
-        migrationResult.directoriesMigrated,
+      // Check if this S3 location already has datastore data
+      const exists = await deps.checkS3DatastoreExists(
+        input.bucket,
+        input.prefix,
+        input.region,
       );
-    }
-  }
+      if (exists) {
+        const prefixStr = input.prefix ?? "";
+        yield {
+          kind: "error",
+          error: {
+            code: "already_exists",
+            message:
+              `S3 location s3://${input.bucket}/${prefixStr} already contains a datastore. ` +
+              `If you want to share this datastore, configure it in .swamp.yaml directly:\n\n` +
+              `  datastore:\n` +
+              `    type: s3\n` +
+              `    bucket: ${input.bucket}\n` +
+              (input.prefix ? `    prefix: ${input.prefix}\n` : "") +
+              (input.region ? `    region: ${input.region}\n` : "") +
+              `\nThen run 'swamp datastore sync --pull' to populate the local cache.`,
+          },
+        };
+        return;
+      }
 
-  yield {
-    kind: "completed",
-    data: {
-      type: "s3",
-      bucket: input.bucket,
-      prefix: input.prefix,
-      filesCopied: filesPushed,
-      bytesCopied: 0,
-      directoriesMigrated: [],
-      errors,
-    },
-  };
+      // Update .swamp.yaml with S3 datastore config
+      await deps.updateRepoConfig(input.repoDir, {
+        type: "s3",
+        bucket: input.bucket,
+        prefix: input.prefix,
+        region: input.region,
+      });
+
+      // Migrate existing data to S3
+      let filesPushed = 0;
+      const errors: string[] = [];
+
+      if (!input.skipMigration) {
+        yield { kind: "migrating" };
+
+        // Compute cache path
+        const cachePath = deps.getCachePath(input.repoId ?? "unknown");
+        const sourceDir = `${input.repoDir}/.swamp`;
+        const config = { type: "filesystem" as const, path: cachePath };
+
+        // Migrate local .swamp/ to cache, then push to S3
+        const migrationResult = await deps.migrateData(
+          sourceDir,
+          cachePath,
+          config,
+        );
+        errors.push(...migrationResult.errors);
+
+        // Push cache to S3
+        ctx.logger.debug`Pushing data to S3...`;
+        try {
+          filesPushed = await deps.pushAllToS3(
+            input.bucket,
+            input.prefix,
+            input.region,
+            cachePath,
+          );
+          ctx.logger.debug`Pushed ${filesPushed} file(s) to S3`;
+        } catch (error) {
+          errors.push(
+            `Failed to push to S3: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+
+        // Clean up migrated directories from local .swamp/ on success
+        if (
+          errors.length === 0 && migrationResult.filesCopied > 0 &&
+          migrationResult.directoriesMigrated.length > 0
+        ) {
+          await deps.cleanupSourceDirs(
+            sourceDir,
+            migrationResult.directoriesMigrated,
+          );
+        }
+      }
+
+      yield {
+        kind: "completed",
+        data: {
+          type: "s3",
+          bucket: input.bucket,
+          prefix: input.prefix,
+          filesCopied: filesPushed,
+          bytesCopied: 0,
+          directoriesMigrated: [],
+          errors,
+        },
+      };
+    })(),
+  );
 }
 
 const TOP_LEVEL_DIRS = ["models", "workflows", "vaults"] as const;

--- a/src/libswamp/datastores/status.ts
+++ b/src/libswamp/datastores/status.ts
@@ -29,6 +29,7 @@ import type { DatastorePathResolver } from "../../domain/datastore/datastore_pat
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Data structure for the datastore status output.
  */
@@ -100,34 +101,40 @@ export async function* datastoreStatus(
   ctx: LibSwampContext,
   deps: DatastoreStatusDeps,
 ): AsyncIterable<DatastoreStatusEvent> {
-  ctx.logger.debug`Executing datastore status`;
+  yield* withGeneratorSpan(
+    "swamp.datastore.status",
+    {},
+    (async function* () {
+      ctx.logger.debug`Executing datastore status`;
 
-  const config = deps.loadConfig();
-  const directories = deps.getDirectories(config);
-  const { healthy, message, latencyMs } = await deps.verifyHealth(config);
+      const config = deps.loadConfig();
+      const directories = deps.getDirectories(config);
+      const { healthy, message, latencyMs } = await deps.verifyHealth(config);
 
-  const data: DatastoreStatusData = {
-    type: config.type,
-    path: !isCustomDatastoreConfig(config) && config.type === "filesystem"
-      ? config.path
-      : undefined,
-    bucket: !isCustomDatastoreConfig(config) && config.type === "s3"
-      ? config.bucket
-      : undefined,
-    prefix: !isCustomDatastoreConfig(config) && config.type === "s3"
-      ? config.prefix
-      : undefined,
-    region: !isCustomDatastoreConfig(config) && config.type === "s3"
-      ? config.region
-      : undefined,
-    healthy,
-    message,
-    latencyMs,
-    directories,
-    exclude: config.exclude,
-  };
+      const data: DatastoreStatusData = {
+        type: config.type,
+        path: !isCustomDatastoreConfig(config) && config.type === "filesystem"
+          ? config.path
+          : undefined,
+        bucket: !isCustomDatastoreConfig(config) && config.type === "s3"
+          ? config.bucket
+          : undefined,
+        prefix: !isCustomDatastoreConfig(config) && config.type === "s3"
+          ? config.prefix
+          : undefined,
+        region: !isCustomDatastoreConfig(config) && config.type === "s3"
+          ? config.region
+          : undefined,
+        healthy,
+        message,
+        latencyMs,
+        directories,
+        exclude: config.exclude,
+      };
 
-  ctx.logger.debug`Datastore status complete`;
+      ctx.logger.debug`Datastore status complete`;
 
-  yield { kind: "completed", data };
+      yield { kind: "completed", data };
+    })(),
+  );
 }

--- a/src/libswamp/datastores/sync.ts
+++ b/src/libswamp/datastores/sync.ts
@@ -25,6 +25,7 @@ import { S3Client } from "../../infrastructure/persistence/s3_client.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Data structure for the datastore sync output.
  */
@@ -174,45 +175,51 @@ export async function* datastoreSync(
   deps: DatastoreSyncDeps,
   input: DatastoreSyncInput,
 ): AsyncIterable<DatastoreSyncEvent> {
-  ctx.logger.debug`Executing datastore sync in ${input.mode} mode`;
+  yield* withGeneratorSpan(
+    "swamp.datastore.sync.command",
+    {},
+    (async function* () {
+      ctx.logger.debug`Executing datastore sync in ${input.mode} mode`;
 
-  const validation = await deps.validateSyncSupport();
-  if (!validation.supported) {
-    yield {
-      kind: "error",
-      error: {
-        code: "sync_not_supported",
-        message: validation.errorMessage ??
-          `Datastore type "${validation.type}" does not support sync.`,
-      },
-    };
-    return;
-  }
+      const validation = await deps.validateSyncSupport();
+      if (!validation.supported) {
+        yield {
+          kind: "error",
+          error: {
+            code: "sync_not_supported",
+            message: validation.errorMessage ??
+              `Datastore type "${validation.type}" does not support sync.`,
+          },
+        };
+        return;
+      }
 
-  yield { kind: "syncing", mode: input.mode };
+      yield { kind: "syncing", mode: input.mode };
 
-  if (input.mode === "push") {
-    const result = await deps.pushSync();
-    yield {
-      kind: "completed",
-      data: { mode: "push", filesPushed: result.filesPushed },
-    };
-  } else if (input.mode === "pull") {
-    const result = await deps.pullSync();
-    yield {
-      kind: "completed",
-      data: { mode: "pull", filesPulled: result.filesPulled },
-    };
-  } else {
-    const result = await deps.fullSync();
-    yield {
-      kind: "completed",
-      data: {
-        mode: "sync",
-        filesPulled: result.filesPulled,
-        filesPushed: result.filesPushed,
-        errors: result.errors,
-      },
-    };
-  }
+      if (input.mode === "push") {
+        const result = await deps.pushSync();
+        yield {
+          kind: "completed",
+          data: { mode: "push", filesPushed: result.filesPushed },
+        };
+      } else if (input.mode === "pull") {
+        const result = await deps.pullSync();
+        yield {
+          kind: "completed",
+          data: { mode: "pull", filesPulled: result.filesPulled },
+        };
+      } else {
+        const result = await deps.fullSync();
+        yield {
+          kind: "completed",
+          data: {
+            mode: "sync",
+            filesPulled: result.filesPulled,
+            filesPushed: result.filesPushed,
+            errors: result.errors,
+          },
+        };
+      }
+    })(),
+  );
 }

--- a/src/libswamp/extensions/fmt.ts
+++ b/src/libswamp/extensions/fmt.ts
@@ -26,6 +26,7 @@ import { EmbeddedDenoRuntime } from "../../infrastructure/runtime/embedded_deno_
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** Data for a check-only run. */
 export interface ExtensionFmtCheckData {
   mode: "check";
@@ -103,40 +104,46 @@ export async function* extensionFmt(
   deps: ExtensionFmtDeps,
   input: ExtensionFmtInput,
 ): AsyncIterable<ExtensionFmtEvent> {
-  ctx.logger.debug`Executing extension fmt`;
+  yield* withGeneratorSpan(
+    "swamp.extension.fmt",
+    {},
+    (async function* () {
+      ctx.logger.debug`Executing extension fmt`;
 
-  if (input.tsFiles.length === 0) {
-    yield { kind: "no_files" };
-    return;
-  }
+      if (input.tsFiles.length === 0) {
+        yield { kind: "no_files" };
+        return;
+      }
 
-  if (input.check) {
-    const result = await deps.checkQuality(input.tsFiles);
-    yield {
-      kind: "completed",
-      data: {
-        mode: "check",
-        passed: result.passed,
-        issues: result.issues,
-      },
-    };
-    return;
-  }
+      if (input.check) {
+        const result = await deps.checkQuality(input.tsFiles);
+        yield {
+          kind: "completed",
+          data: {
+            mode: "check",
+            passed: result.passed,
+            issues: result.issues,
+          },
+        };
+        return;
+      }
 
-  // Auto-fix mode
-  const fmtOutput = await deps.runFmt(input.tsFiles);
-  const lintOutput = await deps.runLint(input.tsFiles);
-  const remaining = await deps.checkQuality(input.tsFiles);
+      // Auto-fix mode
+      const fmtOutput = await deps.runFmt(input.tsFiles);
+      const lintOutput = await deps.runLint(input.tsFiles);
+      const remaining = await deps.checkQuality(input.tsFiles);
 
-  yield {
-    kind: "completed",
-    data: {
-      mode: "fix",
-      fileCount: input.tsFiles.length,
-      fmtOutput,
-      lintOutput,
-      remainingIssues: remaining.issues,
-      passed: remaining.passed,
-    },
-  };
+      yield {
+        kind: "completed",
+        data: {
+          mode: "fix",
+          fileCount: input.tsFiles.length,
+          fmtOutput,
+          lintOutput,
+          remainingIssues: remaining.issues,
+          passed: remaining.passed,
+        },
+      };
+    })(),
+  );
 }

--- a/src/libswamp/extensions/list.ts
+++ b/src/libswamp/extensions/list.ts
@@ -26,6 +26,7 @@ import { readUpstreamExtensions } from "../../infrastructure/persistence/upstrea
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** A single extension entry for list output. */
 export interface ExtensionListEntry {
   name: string;
@@ -76,18 +77,24 @@ export async function* extensionList(
   _ctx: LibSwampContext,
   deps: ExtensionListDeps,
 ): AsyncIterable<ExtensionListEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.extension.list",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const upstreamData = await deps.readUpstreamExtensions();
+      const upstreamData = await deps.readUpstreamExtensions();
 
-  const entries: ExtensionListEntry[] = Object.entries(upstreamData)
-    .map(([name, entry]) => ({
-      name,
-      version: entry.version,
-      pulledAt: entry.pulledAt ?? "",
-      files: entry.files ?? [],
-    }))
-    .sort((a, b) => a.name.localeCompare(b.name));
+      const entries: ExtensionListEntry[] = Object.entries(upstreamData)
+        .map(([name, entry]) => ({
+          name,
+          version: entry.version,
+          pulledAt: entry.pulledAt ?? "",
+          files: entry.files ?? [],
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name));
 
-  yield { kind: "completed", data: { extensions: entries } };
+      yield { kind: "completed", data: { extensions: entries } };
+    })(),
+  );
 }

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -31,6 +31,8 @@ import { resolveLocalImports } from "../../domain/models/local_import_resolver.t
 import type { Logger } from "@logtape/logtape";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
+import { getTracer } from "../../infrastructure/tracing/mod.ts";
+import { SpanStatusCode } from "@opentelemetry/api";
 
 export const DEFAULT_SERVER_URL = "https://swamp.club";
 const SCOPED_NAME_PATTERN = /^@[a-z0-9_-]+\/[a-z0-9_-]+(\/[a-z0-9_-]+)*$/;
@@ -956,29 +958,44 @@ export async function* extensionPull(
   deps: ExtensionPullDeps,
   input: ExtensionPullInput,
 ): AsyncIterable<ExtensionPullEvent> {
-  yield { kind: "installing" };
+  const pullSpan = getTracer().startSpan("swamp.extension.pull", {
+    attributes: { "extension.name": input.ref.name },
+  });
 
-  const installCtx: InstallContext = {
-    getExtension: deps.getExtension,
-    downloadArchive: deps.downloadArchive,
-    getChecksum: deps.getChecksum,
-    logger: ctx.logger,
-    modelsDir: deps.modelsDir,
-    workflowsDir: deps.workflowsDir,
-    vaultsDir: deps.vaultsDir,
-    driversDir: deps.driversDir,
-    datastoresDir: deps.datastoresDir,
-    reportsDir: deps.reportsDir,
-    repoDir: deps.repoDir,
-    force: input.force,
-    alreadyPulled: deps.alreadyPulled,
-    depth: deps.depth,
-  };
+  try {
+    yield { kind: "installing" };
 
-  // Let ConflictError propagate — CLI catches it for the two-phase prompt flow
-  const result = await installExtension(input.ref, installCtx);
-  if (result) {
-    yield { kind: "completed", data: result };
+    const installCtx: InstallContext = {
+      getExtension: deps.getExtension,
+      downloadArchive: deps.downloadArchive,
+      getChecksum: deps.getChecksum,
+      logger: ctx.logger,
+      modelsDir: deps.modelsDir,
+      workflowsDir: deps.workflowsDir,
+      vaultsDir: deps.vaultsDir,
+      driversDir: deps.driversDir,
+      datastoresDir: deps.datastoresDir,
+      reportsDir: deps.reportsDir,
+      repoDir: deps.repoDir,
+      force: input.force,
+      alreadyPulled: deps.alreadyPulled,
+      depth: deps.depth,
+    };
+
+    // Let ConflictError propagate — CLI catches it for the two-phase prompt flow
+    const result = await installExtension(input.ref, installCtx);
+    if (result) {
+      pullSpan.setStatus({ code: SpanStatusCode.OK });
+      yield { kind: "completed", data: result };
+    }
+  } catch (error) {
+    pullSpan.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  } finally {
+    pullSpan.end();
   }
 }
 

--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -34,6 +34,8 @@ import type { ExtensionManifest } from "../../domain/extensions/extension_manife
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notAuthenticated, validationFailed } from "../errors.ts";
+import { getTracer } from "../../infrastructure/tracing/mod.ts";
+import { SpanStatusCode } from "@opentelemetry/api";
 
 // ── Data types ────────────────────────────────────────────────────────
 
@@ -635,95 +637,130 @@ export async function* extensionPush(
   deps: ExtensionPushExecuteDeps,
   input: ExtensionPushExecuteInput,
 ): AsyncIterable<ExtensionPushEvent> {
-  const credentials = await deps.loadCredentials();
-  if (!credentials) {
-    yield { kind: "error", error: notAuthenticated() };
-    return;
-  }
+  const pushSpan = getTracer().startSpan("swamp.extension.push", {
+    attributes: { "extension.name": input.manifest.name },
+  });
 
-  const releaseNotes = input.releaseNotes ?? input.manifest.releaseNotes;
-  const pushMetadata = {
-    name: input.manifest.name,
-    version: input.manifest.version,
-    description: input.manifest.description ?? "",
-    dependencies: input.manifest.dependencies,
-    platforms: input.manifest.platforms,
-    labels: input.manifest.labels,
-    repository: input.manifest.repository || undefined,
-    ...(releaseNotes ? { releaseNotes } : {}),
-  };
-
-  // Phase 1: Initiate
-  yield { kind: "pushing", phase: "initiate" };
-  ctx.logger.debug("Initiating push...");
-  let initResult: { uploadUrl: string };
   try {
-    initResult = await deps.initiatePush(
-      credentials.serverUrl,
-      pushMetadata,
-      credentials.apiKey,
-    );
-  } catch (error) {
-    yield {
-      kind: "error",
-      error: validationFailed(
-        error instanceof Error ? error.message : String(error),
-      ),
-    };
-    return;
-  }
+    const credentials = await deps.loadCredentials();
+    if (!credentials) {
+      pushSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: "Not authenticated",
+      });
+      pushSpan.end();
+      yield { kind: "error", error: notAuthenticated() };
+      return;
+    }
 
-  // Phase 2: Upload archive
-  yield { kind: "pushing", phase: "upload" };
-  ctx.logger.debug("Uploading archive...");
-  try {
-    await deps.uploadArchive(initResult.uploadUrl, input.archiveBytes);
-  } catch (error) {
-    yield {
-      kind: "error",
-      error: validationFailed(
-        error instanceof Error ? error.message : String(error),
-      ),
+    const releaseNotes = input.releaseNotes ?? input.manifest.releaseNotes;
+    const pushMetadata = {
+      name: input.manifest.name,
+      version: input.manifest.version,
+      description: input.manifest.description ?? "",
+      dependencies: input.manifest.dependencies,
+      platforms: input.manifest.platforms,
+      labels: input.manifest.labels,
+      repository: input.manifest.repository || undefined,
+      ...(releaseNotes ? { releaseNotes } : {}),
     };
-    return;
-  }
 
-  // Phase 3: Confirm
-  yield { kind: "pushing", phase: "confirm" };
-  ctx.logger.debug("Confirming push...");
-  let confirmResult: { name: string; version: string; extensionId: string };
-  try {
-    confirmResult = await deps.confirmPush(
-      credentials.serverUrl,
-      { ...pushMetadata, contentMetadata: input.contentMetadata },
-      credentials.apiKey,
-    );
-  } catch (error) {
+    // Phase 1: Initiate
+    yield { kind: "pushing", phase: "initiate" };
+    ctx.logger.debug("Initiating push...");
+    let initResult: { uploadUrl: string };
+    try {
+      initResult = await deps.initiatePush(
+        credentials.serverUrl,
+        pushMetadata,
+        credentials.apiKey,
+      );
+    } catch (error) {
+      pushSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: "initiate failed",
+      });
+      pushSpan.end();
+      yield {
+        kind: "error",
+        error: validationFailed(
+          error instanceof Error ? error.message : String(error),
+        ),
+      };
+      return;
+    }
+
+    // Phase 2: Upload archive
+    yield { kind: "pushing", phase: "upload" };
+    ctx.logger.debug("Uploading archive...");
+    try {
+      await deps.uploadArchive(initResult.uploadUrl, input.archiveBytes);
+    } catch (error) {
+      pushSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: "upload failed",
+      });
+      pushSpan.end();
+      yield {
+        kind: "error",
+        error: validationFailed(
+          error instanceof Error ? error.message : String(error),
+        ),
+      };
+      return;
+    }
+
+    // Phase 3: Confirm
+    yield { kind: "pushing", phase: "confirm" };
+    ctx.logger.debug("Confirming push...");
+    let confirmResult: { name: string; version: string; extensionId: string };
+    try {
+      confirmResult = await deps.confirmPush(
+        credentials.serverUrl,
+        { ...pushMetadata, contentMetadata: input.contentMetadata },
+        credentials.apiKey,
+      );
+    } catch (error) {
+      pushSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: "confirm failed",
+      });
+      pushSpan.end();
+      yield {
+        kind: "error",
+        error: validationFailed(
+          error instanceof Error ? error.message : String(error),
+        ),
+      };
+      return;
+    }
+
+    pushSpan.setStatus({ code: SpanStatusCode.OK });
+    pushSpan.end();
     yield {
-      kind: "error",
-      error: validationFailed(
-        error instanceof Error ? error.message : String(error),
-      ),
+      kind: "completed",
+      data: {
+        name: confirmResult.name,
+        version: confirmResult.version,
+        extensionId: confirmResult.extensionId,
+        archiveSize: input.archiveBytes.length,
+        modelCount: input.counts.models,
+        workflowCount: input.counts.workflows,
+        bundleCount: input.counts.bundles,
+        vaultCount: input.counts.vaults,
+        driverCount: input.counts.drivers,
+        datastoreCount: input.counts.datastores,
+        reportCount: input.counts.reports,
+      },
     };
-    return;
+  } catch (error) {
+    pushSpan.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    pushSpan.end();
+    throw error;
   }
-
-  yield {
-    kind: "completed",
-    data: {
-      name: confirmResult.name,
-      version: confirmResult.version,
-      extensionId: confirmResult.extensionId,
-      archiveSize: input.archiveBytes.length,
-      modelCount: input.counts.models,
-      workflowCount: input.counts.workflows,
-      bundleCount: input.counts.bundles,
-      vaultCount: input.counts.vaults,
-      driverCount: input.counts.drivers,
-      datastoreCount: input.counts.datastores,
-      reportCount: input.counts.reports,
-    },
-  };
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────

--- a/src/libswamp/extensions/rm.ts
+++ b/src/libswamp/extensions/rm.ts
@@ -26,6 +26,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 const LOCK_RETRY_COUNT = 10;
 const LOCK_RETRY_DELAY_MS = 100;
 
@@ -258,56 +259,62 @@ export async function* extensionRm(
   deps: ExtensionRmDeps,
   input: ExtensionRmInput,
 ): AsyncIterable<ExtensionRmEvent> {
-  yield { kind: "deleting" };
+  yield* withGeneratorSpan(
+    "swamp.extension.rm",
+    {},
+    (async function* () {
+      yield { kind: "deleting" };
 
-  const upstreamData = await deps.readUpstreamExtensions(deps.modelsDir);
-  const entry = upstreamData[input.extensionName];
+      const upstreamData = await deps.readUpstreamExtensions(deps.modelsDir);
+      const entry = upstreamData[input.extensionName];
 
-  if (!entry || !entry.files) {
-    yield {
-      kind: "error",
-      error: notFound("Extension", input.extensionName),
-    };
-    return;
-  }
-
-  let filesDeleted = 0;
-  let filesSkipped = 0;
-  const parentDirs: string[] = [];
-
-  for (const filePath of entry.files) {
-    const absolutePath = join(deps.repoDir, filePath);
-    try {
-      await deps.removeFile(absolutePath);
-      filesDeleted++;
-      parentDirs.push(dirname(absolutePath));
-      ctx.logger.debug("  deleted {file}", { file: filePath });
-    } catch (error) {
-      if (error instanceof Deno.errors.NotFound) {
-        filesSkipped++;
-        ctx.logger.debug("  skipped {file} (already missing)", {
-          file: filePath,
-        });
-      } else {
-        throw error;
+      if (!entry || !entry.files) {
+        yield {
+          kind: "error",
+          error: notFound("Extension", input.extensionName),
+        };
+        return;
       }
-    }
-  }
 
-  const dirsRemoved = await pruneEmptyDirs(parentDirs, deps.repoDir, deps);
+      let filesDeleted = 0;
+      let filesSkipped = 0;
+      const parentDirs: string[] = [];
 
-  await deps.removeUpstreamExtension(deps.modelsDir, input.extensionName);
+      for (const filePath of entry.files) {
+        const absolutePath = join(deps.repoDir, filePath);
+        try {
+          await deps.removeFile(absolutePath);
+          filesDeleted++;
+          parentDirs.push(dirname(absolutePath));
+          ctx.logger.debug("  deleted {file}", { file: filePath });
+        } catch (error) {
+          if (error instanceof Deno.errors.NotFound) {
+            filesSkipped++;
+            ctx.logger.debug("  skipped {file} (already missing)", {
+              file: filePath,
+            });
+          } else {
+            throw error;
+          }
+        }
+      }
 
-  yield {
-    kind: "completed",
-    data: {
-      name: input.extensionName,
-      version: entry.version,
-      filesDeleted,
-      filesSkipped,
-      dirsRemoved,
-    },
-  };
+      const dirsRemoved = await pruneEmptyDirs(parentDirs, deps.repoDir, deps);
+
+      await deps.removeUpstreamExtension(deps.modelsDir, input.extensionName);
+
+      yield {
+        kind: "completed",
+        data: {
+          name: input.extensionName,
+          version: entry.version,
+          filesDeleted,
+          filesSkipped,
+          dirsRemoved,
+        },
+      };
+    })(),
+  );
 }
 
 /** Wires real infrastructure into ExtensionRmDeps. */

--- a/src/libswamp/extensions/search.ts
+++ b/src/libswamp/extensions/search.ts
@@ -20,6 +20,7 @@
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** A single extension entry in search results. */
 export interface ExtensionSearchItem {
   name: string;
@@ -95,34 +96,40 @@ export async function* extensionSearch(
   deps: ExtensionSearchDeps,
   input: ExtensionSearchInput,
 ): AsyncGenerator<ExtensionSearchEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.extension.search",
+    { "search.query": input.query ?? "" },
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const response = await deps.searchExtensions({
-    q: input.query,
-    collective: input.collective,
-    platform: input.platform,
-    label: input.label,
-    contentType: input.contentType,
-    sort: input.sort,
-    perPage: input.perPage,
-    page: input.page,
-  });
+      const response = await deps.searchExtensions({
+        q: input.query,
+        collective: input.collective,
+        platform: input.platform,
+        label: input.label,
+        contentType: input.contentType,
+        sort: input.sort,
+        perPage: input.perPage,
+        page: input.page,
+      });
 
-  yield {
-    kind: "completed",
-    data: {
-      query: input.query ?? "",
-      results: response.extensions.map((ext) => ({
-        name: ext.name,
-        description: ext.description,
-        latestVersion: ext.latestVersion,
-        platforms: ext.platforms,
-        labels: ext.labels,
-        contentTypes: ext.contentTypes ?? [],
-        createdAt: ext.createdAt,
-        updatedAt: ext.updatedAt,
-      })),
-      meta: response.meta,
-    },
-  };
+      yield {
+        kind: "completed",
+        data: {
+          query: input.query ?? "",
+          results: response.extensions.map((ext) => ({
+            name: ext.name,
+            description: ext.description,
+            latestVersion: ext.latestVersion,
+            platforms: ext.platforms,
+            labels: ext.labels,
+            contentTypes: ext.contentTypes ?? [],
+            createdAt: ext.createdAt,
+            updatedAt: ext.updatedAt,
+          })),
+          meta: response.meta,
+        },
+      };
+    })(),
+  );
 }

--- a/src/libswamp/extensions/update.ts
+++ b/src/libswamp/extensions/update.ts
@@ -29,6 +29,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { validationFailed } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 const DEFAULT_SERVER_URL = "https://swamp.club";
 
 function resolveServerUrl(): string {
@@ -96,102 +97,110 @@ export async function* extensionUpdate(
   deps: ExtensionUpdateDeps,
   input: ExtensionUpdateInput,
 ): AsyncIterable<ExtensionUpdateEvent> {
-  ctx.logger.debug`Executing extension update`;
+  yield* withGeneratorSpan(
+    "swamp.extension.update",
+    {},
+    (async function* () {
+      ctx.logger.debug`Executing extension update`;
 
-  const upstream = await deps.readUpstreamExtensions();
-  const installedNames = Object.keys(upstream);
+      const upstream = await deps.readUpstreamExtensions();
+      const installedNames = Object.keys(upstream);
 
-  if (installedNames.length === 0) {
-    yield { kind: "no_extensions" };
-    return;
-  }
-
-  // Validate specific extension exists
-  let targetNames: string[];
-  if (input.extensionName) {
-    if (!upstream[input.extensionName]) {
-      yield { kind: "extension_not_installed", name: input.extensionName };
-      yield {
-        kind: "error",
-        error: validationFailed(
-          `Extension ${input.extensionName} is not installed. Use 'swamp extension pull ${input.extensionName}' to install it.`,
-        ),
-      };
-      return;
-    }
-    targetNames = [input.extensionName];
-  } else {
-    targetNames = installedNames;
-  }
-
-  // Check each extension for updates
-  const statuses: ExtensionUpdateStatus[] = [];
-  for (const name of targetNames) {
-    yield { kind: "checking", name };
-    const installedVersion = upstream[name].version;
-
-    const extInfo = await deps.getExtension(name);
-    if (!extInfo) {
-      statuses.push({
-        status: "not_found",
-        name,
-        installedVersion,
-        error: `Failed to fetch registry info for ${name}.`,
-      });
-      continue;
-    }
-
-    statuses.push(
-      checkExtensionVersion(name, installedVersion, extInfo.latestVersion),
-    );
-  }
-
-  // Check-only mode
-  if (input.checkOnly) {
-    yield {
-      kind: "completed",
-      data: buildUpdateResult(statuses),
-      mode: "check",
-    };
-    return;
-  }
-
-  // Update mode
-  const finalStatuses: ExtensionUpdateStatus[] = [];
-  for (const s of statuses) {
-    if (s.status === "update_available") {
-      yield {
-        kind: "updating",
-        name: s.name,
-        from: s.installedVersion,
-        to: s.latestVersion,
-      };
-
-      try {
-        await deps.installExtension(s.name, s.latestVersion);
-        finalStatuses.push({
-          status: "updated",
-          name: s.name,
-          previousVersion: s.installedVersion,
-          newVersion: s.latestVersion,
-        });
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        finalStatuses.push({
-          status: "failed",
-          name: s.name,
-          installedVersion: s.installedVersion,
-          error: `Update failed: ${message}`,
-        });
+      if (installedNames.length === 0) {
+        yield { kind: "no_extensions" };
+        return;
       }
-    } else {
-      finalStatuses.push(s);
-    }
-  }
 
-  yield {
-    kind: "completed",
-    data: buildUpdateResult(finalStatuses),
-    mode: "update",
-  };
+      // Validate specific extension exists
+      let targetNames: string[];
+      if (input.extensionName) {
+        if (!upstream[input.extensionName]) {
+          yield { kind: "extension_not_installed", name: input.extensionName };
+          yield {
+            kind: "error",
+            error: validationFailed(
+              `Extension ${input.extensionName} is not installed. Use 'swamp extension pull ${input.extensionName}' to install it.`,
+            ),
+          };
+          return;
+        }
+        targetNames = [input.extensionName];
+      } else {
+        targetNames = installedNames;
+      }
+
+      // Check each extension for updates
+      const statuses: ExtensionUpdateStatus[] = [];
+      for (const name of targetNames) {
+        yield { kind: "checking", name };
+        const installedVersion = upstream[name].version;
+
+        const extInfo = await deps.getExtension(name);
+        if (!extInfo) {
+          statuses.push({
+            status: "not_found",
+            name,
+            installedVersion,
+            error: `Failed to fetch registry info for ${name}.`,
+          });
+          continue;
+        }
+
+        statuses.push(
+          checkExtensionVersion(name, installedVersion, extInfo.latestVersion),
+        );
+      }
+
+      // Check-only mode
+      if (input.checkOnly) {
+        yield {
+          kind: "completed",
+          data: buildUpdateResult(statuses),
+          mode: "check",
+        };
+        return;
+      }
+
+      // Update mode
+      const finalStatuses: ExtensionUpdateStatus[] = [];
+      for (const s of statuses) {
+        if (s.status === "update_available") {
+          yield {
+            kind: "updating",
+            name: s.name,
+            from: s.installedVersion,
+            to: s.latestVersion,
+          };
+
+          try {
+            await deps.installExtension(s.name, s.latestVersion);
+            finalStatuses.push({
+              status: "updated",
+              name: s.name,
+              previousVersion: s.installedVersion,
+              newVersion: s.latestVersion,
+            });
+          } catch (error) {
+            const message = error instanceof Error
+              ? error.message
+              : String(error);
+            finalStatuses.push({
+              status: "failed",
+              name: s.name,
+              installedVersion: s.installedVersion,
+              error: `Update failed: ${message}`,
+            });
+          }
+        } else {
+          finalStatuses.push(s);
+        }
+      }
+
+      yield {
+        kind: "completed",
+        data: buildUpdateResult(finalStatuses),
+        mode: "update",
+      };
+    })(),
+  );
 }

--- a/src/libswamp/extensions/yank.ts
+++ b/src/libswamp/extensions/yank.ts
@@ -23,6 +23,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notAuthenticated, validationFailed } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 const SCOPED_NAME_PATTERN = /^@[a-z0-9_-]+\/[a-z0-9_-]+(\/[a-z0-9_-]+)*$/;
 const DEFAULT_SERVER_URL = "https://swamp.club";
 
@@ -128,31 +129,37 @@ export async function* extensionYank(
   deps: ExtensionYankDeps,
   input: ExtensionYankInput,
 ): AsyncIterable<ExtensionYankEvent> {
-  ctx.logger.debug`Executing extension yank`;
+  yield* withGeneratorSpan(
+    "swamp.extension.yank",
+    {},
+    (async function* () {
+      ctx.logger.debug`Executing extension yank`;
 
-  // Re-validate credentials (self-contained)
-  const credentials = await deps.loadCredentials();
-  if (!credentials) {
-    yield { kind: "error", error: notAuthenticated() };
-    return;
-  }
+      // Re-validate credentials (self-contained)
+      const credentials = await deps.loadCredentials();
+      if (!credentials) {
+        yield { kind: "error", error: notAuthenticated() };
+        return;
+      }
 
-  await deps.yankExtension(
-    credentials.serverUrl,
-    input.extensionName,
-    input.version,
-    input.reason,
-    credentials.apiKey,
+      await deps.yankExtension(
+        credentials.serverUrl,
+        input.extensionName,
+        input.version,
+        input.reason,
+        credentials.apiKey,
+      );
+
+      ctx.logger.debug`Yanked extension ${input.extensionName}`;
+
+      yield {
+        kind: "completed",
+        data: {
+          name: input.extensionName,
+          version: input.version,
+          reason: input.reason,
+        },
+      };
+    })(),
   );
-
-  ctx.logger.debug`Yanked extension ${input.extensionName}`;
-
-  yield {
-    kind: "completed",
-    data: {
-      name: input.extensionName,
-      version: input.version,
-      reason: input.reason,
-    },
-  };
 }

--- a/src/libswamp/issues/create.ts
+++ b/src/libswamp/issues/create.ts
@@ -21,6 +21,7 @@ import { GitHubIssueService } from "../../infrastructure/github/github_issue_ser
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Data structure for the issue create output.
  */
@@ -79,30 +80,36 @@ export async function* issueCreate(
   deps: IssueCreateDeps,
   input: IssueCreateInput,
 ): AsyncIterable<IssueCreateEvent> {
-  ctx.logger.debug`Creating ${input.type} issue: ${input.title}`;
+  yield* withGeneratorSpan(
+    "swamp.issue.create",
+    {},
+    (async function* () {
+      ctx.logger.debug`Creating ${input.type} issue: ${input.title}`;
 
-  const result = await deps.createIssue({
-    title: input.title,
-    body: input.body,
-    labels: input.labels,
-  });
+      const result = await deps.createIssue({
+        title: input.title,
+        body: input.body,
+        labels: input.labels,
+      });
 
-  const data: IssueCreateData = result.method === "created"
-    ? {
-      method: "created",
-      url: result.url,
-      number: result.number,
-      type: input.type,
-      title: input.title,
-    }
-    : {
-      method: "url",
-      url: result.url,
-      type: input.type,
-      title: input.title,
-      body: result.body,
-      labels: result.labels,
-    };
+      const data: IssueCreateData = result.method === "created"
+        ? {
+          method: "created",
+          url: result.url,
+          number: result.number,
+          type: input.type,
+          title: input.title,
+        }
+        : {
+          method: "url",
+          url: result.url,
+          type: input.type,
+          title: input.title,
+          body: result.body,
+          labels: result.labels,
+        };
 
-  yield { kind: "completed", data };
+      yield { kind: "completed", data };
+    })(),
+  );
 }

--- a/src/libswamp/models/create.ts
+++ b/src/libswamp/models/create.ts
@@ -34,6 +34,7 @@ import {
   zodToJsonSchema,
 } from "../types/schema_helpers.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Data structure for the model create output.
  */
@@ -110,87 +111,94 @@ export async function* modelCreate(
   deps: ModelCreateDeps,
   input: ModelCreateInput,
 ): AsyncIterable<ModelCreateEvent> {
-  yield { kind: "creating" };
+  yield* withGeneratorSpan(
+    "swamp.model.create",
+    { "model.type": input.typeArg, "model.name": input.name },
+    (async function* () {
+      yield { kind: "creating" };
 
-  ctx.logger.debug`Creating model: type=${input.typeArg}, name=${input.name}`;
+      ctx.logger
+        .debug`Creating model: type=${input.typeArg}, name=${input.name}`;
 
-  // Validate and resolve the model type
-  const modelType = ModelType.create(input.typeArg);
-  const resolvedDef = await deps.resolveModelType(input.typeArg);
-  if (!resolvedDef) {
-    const availableTypes = deps.listAvailableTypes().join(", ");
-    yield {
-      kind: "error",
-      error: validationFailed(
-        `Unknown model type: ${input.typeArg}. Available types: ${
-          availableTypes || "none"
-        }`,
-      ),
-    };
-    return;
-  }
-
-  // Check name uniqueness
-  const exists = await deps.findByNameGlobal(input.name);
-  if (exists) {
-    yield {
-      kind: "error",
-      error: alreadyExists("Model", input.name),
-    };
-    return;
-  }
-
-  // Validate global arguments against model schema if present
-  const modelDef = deps.getModelDef(modelType);
-  let globalArguments = input.globalArguments;
-  if (globalArguments && modelDef?.globalArguments) {
-    const result = modelDef.globalArguments.safeParse(globalArguments);
-    if (!result.success) {
-      const issues = result.error.issues.map((i) =>
-        `  ${i.path.join(".")}: ${i.message}`
-      ).join("\n");
-      yield {
-        kind: "error",
-        error: validationFailed(
-          `Invalid global arguments for type '${modelType.normalized}':\n${issues}`,
-        ),
-      };
-      return;
-    }
-    globalArguments = result.data as Record<string, unknown>;
-  }
-
-  // Create and save the definition
-  const definition = await deps.createAndSave(
-    modelType,
-    input.name,
-    modelDef?.version,
-    globalArguments,
-  );
-
-  ctx.logger.debug`Created definition with ID: ${definition.id}`;
-
-  const data: ModelCreateData = {
-    id: definition.id,
-    type: modelType.normalized,
-    name: definition.name,
-    path: deps.getPath(modelType, definition.id),
-    version: modelDef?.version,
-    globalArguments: modelDef?.globalArguments
-      ? zodToJsonSchema(modelDef.globalArguments)
-      : undefined,
-    methods: modelDef
-      ? Object.entries(modelDef.methods).map(
-        ([name, method]) =>
-          toMethodDescribeData(
-            name,
-            method,
-            modelDef.resources,
-            modelDef.files,
+      // Validate and resolve the model type
+      const modelType = ModelType.create(input.typeArg);
+      const resolvedDef = await deps.resolveModelType(input.typeArg);
+      if (!resolvedDef) {
+        const availableTypes = deps.listAvailableTypes().join(", ");
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `Unknown model type: ${input.typeArg}. Available types: ${
+              availableTypes || "none"
+            }`,
           ),
-      )
-      : undefined,
-  };
+        };
+        return;
+      }
 
-  yield { kind: "completed", data };
+      // Check name uniqueness
+      const exists = await deps.findByNameGlobal(input.name);
+      if (exists) {
+        yield {
+          kind: "error",
+          error: alreadyExists("Model", input.name),
+        };
+        return;
+      }
+
+      // Validate global arguments against model schema if present
+      const modelDef = deps.getModelDef(modelType);
+      let globalArguments = input.globalArguments;
+      if (globalArguments && modelDef?.globalArguments) {
+        const result = modelDef.globalArguments.safeParse(globalArguments);
+        if (!result.success) {
+          const issues = result.error.issues.map((i) =>
+            `  ${i.path.join(".")}: ${i.message}`
+          ).join("\n");
+          yield {
+            kind: "error",
+            error: validationFailed(
+              `Invalid global arguments for type '${modelType.normalized}':\n${issues}`,
+            ),
+          };
+          return;
+        }
+        globalArguments = result.data as Record<string, unknown>;
+      }
+
+      // Create and save the definition
+      const definition = await deps.createAndSave(
+        modelType,
+        input.name,
+        modelDef?.version,
+        globalArguments,
+      );
+
+      ctx.logger.debug`Created definition with ID: ${definition.id}`;
+
+      const data: ModelCreateData = {
+        id: definition.id,
+        type: modelType.normalized,
+        name: definition.name,
+        path: deps.getPath(modelType, definition.id),
+        version: modelDef?.version,
+        globalArguments: modelDef?.globalArguments
+          ? zodToJsonSchema(modelDef.globalArguments)
+          : undefined,
+        methods: modelDef
+          ? Object.entries(modelDef.methods).map(
+            ([name, method]) =>
+              toMethodDescribeData(
+                name,
+                method,
+                modelDef.resources,
+                modelDef.files,
+              ),
+          )
+          : undefined,
+      };
+
+      yield { kind: "completed", data };
+    })(),
+  );
 }

--- a/src/libswamp/models/delete.ts
+++ b/src/libswamp/models/delete.ts
@@ -31,6 +31,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound, validationFailed } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** Preview data returned before confirmation. */
 export interface ModelDeletePreview {
   id: string;
@@ -188,85 +189,91 @@ export async function* modelDelete(
   deps: ModelDeleteDeps,
   input: ModelDeleteInput,
 ): AsyncIterable<ModelDeleteEvent> {
-  yield { kind: "deleting" };
+  yield* withGeneratorSpan(
+    "swamp.model.delete",
+    { "model.id_or_name": input.modelIdOrName },
+    (async function* () {
+      yield { kind: "deleting" };
 
-  const result = await deps.lookupDefinition(input.modelIdOrName);
-  if (!result) {
-    yield { kind: "error", error: notFound("Model", input.modelIdOrName) };
-    return;
-  }
-  const { definition, type: modelType } = result;
+      const result = await deps.lookupDefinition(input.modelIdOrName);
+      if (!result) {
+        yield { kind: "error", error: notFound("Model", input.modelIdOrName) };
+        return;
+      }
+      const { definition, type: modelType } = result;
 
-  // Check workflow references
-  const allWorkflows = await deps.findAllWorkflows();
-  const referencingWorkflows = findWorkflowsReferencingModel(
-    allWorkflows,
-    definition.id,
-    definition.name,
+      // Check workflow references
+      const allWorkflows = await deps.findAllWorkflows();
+      const referencingWorkflows = findWorkflowsReferencingModel(
+        allWorkflows,
+        definition.id,
+        definition.name,
+      );
+      if (referencingWorkflows.length > 0) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `Model '${definition.name}' is referenced by workflow(s): ${
+              referencingWorkflows.join(", ")
+            }. ` +
+              `Remove the model from these workflows before deleting.`,
+          ),
+        };
+        return;
+      }
+
+      // Check data artifacts
+      const dataArtifacts = await deps.findDataArtifacts(
+        modelType,
+        definition.id,
+      );
+      if (dataArtifacts.length > 0 && !input.force) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `Model '${definition.name}' has ${dataArtifacts.length} associated data artifact(s). ` +
+              `Delete the data first, or use --force to delete all.`,
+          ),
+        };
+        return;
+      }
+
+      const definitionPath = deps.getDefinitionPath(modelType, definition.id);
+
+      // Delete outputs
+      const outputs = await deps.findOutputs(modelType, definition.id);
+      let outputsDeleted = 0;
+      for (const output of outputs) {
+        ctx.logger.debug`Deleting output: ${output.id}`;
+        await deps.deleteOutput(modelType, output.methodName, output.id);
+        outputsDeleted++;
+      }
+
+      // Delete data artifacts
+      let dataDeleted = false;
+      for (const data of dataArtifacts) {
+        ctx.logger.debug`Deleting data artifact: ${data.name}`;
+        await deps.deleteData(modelType, definition.id, data.name);
+        dataDeleted = true;
+      }
+
+      // Delete definition
+      ctx.logger.debug`Deleting definition: ${definition.id}`;
+      await deps.deleteDefinition(modelType, definition.id);
+
+      yield {
+        kind: "completed",
+        data: {
+          id: definition.id,
+          name: definition.name,
+          type: modelType.normalized,
+          inputPath: definitionPath,
+          resourceDeleted: false,
+          outputsDeleted,
+          evaluatedInputDeleted: false,
+          dataDeleted,
+        },
+      };
+    })(),
   );
-  if (referencingWorkflows.length > 0) {
-    yield {
-      kind: "error",
-      error: validationFailed(
-        `Model '${definition.name}' is referenced by workflow(s): ${
-          referencingWorkflows.join(", ")
-        }. ` +
-          `Remove the model from these workflows before deleting.`,
-      ),
-    };
-    return;
-  }
-
-  // Check data artifacts
-  const dataArtifacts = await deps.findDataArtifacts(
-    modelType,
-    definition.id,
-  );
-  if (dataArtifacts.length > 0 && !input.force) {
-    yield {
-      kind: "error",
-      error: validationFailed(
-        `Model '${definition.name}' has ${dataArtifacts.length} associated data artifact(s). ` +
-          `Delete the data first, or use --force to delete all.`,
-      ),
-    };
-    return;
-  }
-
-  const definitionPath = deps.getDefinitionPath(modelType, definition.id);
-
-  // Delete outputs
-  const outputs = await deps.findOutputs(modelType, definition.id);
-  let outputsDeleted = 0;
-  for (const output of outputs) {
-    ctx.logger.debug`Deleting output: ${output.id}`;
-    await deps.deleteOutput(modelType, output.methodName, output.id);
-    outputsDeleted++;
-  }
-
-  // Delete data artifacts
-  let dataDeleted = false;
-  for (const data of dataArtifacts) {
-    ctx.logger.debug`Deleting data artifact: ${data.name}`;
-    await deps.deleteData(modelType, definition.id, data.name);
-    dataDeleted = true;
-  }
-
-  // Delete definition
-  ctx.logger.debug`Deleting definition: ${definition.id}`;
-  await deps.deleteDefinition(modelType, definition.id);
-
-  yield {
-    kind: "completed",
-    data: {
-      id: definition.id,
-      name: definition.name,
-      type: modelType.normalized,
-      inputPath: definitionPath,
-      resourceDeleted: false,
-      outputsDeleted,
-      evaluatedInputDeleted: false,
-      dataDeleted,
-    },
-  };
 }

--- a/src/libswamp/models/edit.ts
+++ b/src/libswamp/models/edit.ts
@@ -33,6 +33,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound, validationFailed } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Data structure for the model edit output.
  */
@@ -107,100 +108,106 @@ export async function* modelEdit(
   deps: ModelEditDeps,
   input: ModelEditInput,
 ): AsyncIterable<ModelEditEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.model.edit",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const { modelIdOrName, stdinContent } = input;
+      const { modelIdOrName, stdinContent } = input;
 
-  // Look up the model definition
-  let definition: Definition | null = null;
-  let modelType: ModelType | null = null;
-  let filePath: string | null = null;
+      // Look up the model definition
+      let definition: Definition | null = null;
+      let modelType: ModelType | null = null;
+      let filePath: string | null = null;
 
-  ctx.logger.debug`Looking up model: ${modelIdOrName}`;
-  try {
-    const result = await deps.lookupDefinition(modelIdOrName);
-    if (result) {
-      definition = result.definition;
-      modelType = result.type;
-      filePath = deps.getDefinitionPath(modelType, definition.id);
-    }
-  } catch (error) {
-    ctx.logger
-      .debug`Model lookup failed, will try symlink fallback: ${error}`;
-  }
+      ctx.logger.debug`Looking up model: ${modelIdOrName}`;
+      try {
+        const result = await deps.lookupDefinition(modelIdOrName);
+        if (result) {
+          definition = result.definition;
+          modelType = result.type;
+          filePath = deps.getDefinitionPath(modelType, definition.id);
+        }
+      } catch (error) {
+        ctx.logger
+          .debug`Model lookup failed, will try symlink fallback: ${error}`;
+      }
 
-  // If normal lookup didn't find the model, try symlink fallback
-  if (!filePath) {
-    const resolvedPath = await deps.resolveSymlink(modelIdOrName);
-    if (resolvedPath) {
-      ctx.logger
-        .debug`Using symlink fallback for broken model: ${resolvedPath}`;
-      filePath = resolvedPath;
-    } else {
-      yield { kind: "error", error: notFound("Model", modelIdOrName) };
-      return;
-    }
-  }
+      // If normal lookup didn't find the model, try symlink fallback
+      if (!filePath) {
+        const resolvedPath = await deps.resolveSymlink(modelIdOrName);
+        if (resolvedPath) {
+          ctx.logger
+            .debug`Using symlink fallback for broken model: ${resolvedPath}`;
+          filePath = resolvedPath;
+        } else {
+          yield { kind: "error", error: notFound("Model", modelIdOrName) };
+          return;
+        }
+      }
 
-  ctx.logger.debug`Using file path: ${filePath}`;
+      ctx.logger.debug`Using file path: ${filePath}`;
 
-  // Stdin update mode
-  if (stdinContent !== undefined && stdinContent !== null) {
-    ctx.logger.debug`Reading model content from stdin`;
+      // Stdin update mode
+      if (stdinContent !== undefined && stdinContent !== null) {
+        ctx.logger.debug`Reading model content from stdin`;
 
-    if (!definition || !modelType) {
-      yield {
-        kind: "error",
-        error: validationFailed(
-          "Cannot update model from stdin: the model's YAML is broken and must be fixed in an editor first",
-        ),
-      };
-      return;
-    }
+        if (!definition || !modelType) {
+          yield {
+            kind: "error",
+            error: validationFailed(
+              "Cannot update model from stdin: the model's YAML is broken and must be fixed in an editor first",
+            ),
+          };
+          return;
+        }
 
-    try {
-      const updated = await deps.updateFromStdin(
-        definition,
-        modelType,
-        stdinContent,
-      );
+        try {
+          const updated = await deps.updateFromStdin(
+            definition,
+            modelType,
+            stdinContent,
+          );
+
+          yield {
+            kind: "completed",
+            data: {
+              path: filePath,
+              status: "updated",
+              name: updated.name,
+              type: modelType.normalized,
+              editType: "definition",
+            },
+          };
+        } catch (error) {
+          yield {
+            kind: "error",
+            error: validationFailed(
+              `Invalid model YAML from stdin: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            ),
+          };
+        }
+        return;
+      }
+
+      // Editor mode
+      ctx.logger.debug`Opening file: ${filePath}`;
+      const result = await deps.openEditor(filePath);
 
       yield {
         kind: "completed",
         data: {
           path: filePath,
-          status: "updated",
-          name: updated.name,
-          type: modelType.normalized,
+          editor: result.editor,
+          status: "opened",
+          name: definition?.name ?? modelIdOrName,
+          type: modelType?.normalized ?? "unknown",
           editType: "definition",
         },
       };
-    } catch (error) {
-      yield {
-        kind: "error",
-        error: validationFailed(
-          `Invalid model YAML from stdin: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        ),
-      };
-    }
-    return;
-  }
-
-  // Editor mode
-  ctx.logger.debug`Opening file: ${filePath}`;
-  const result = await deps.openEditor(filePath);
-
-  yield {
-    kind: "completed",
-    data: {
-      path: filePath,
-      editor: result.editor,
-      status: "opened",
-      name: definition?.name ?? modelIdOrName,
-      type: modelType?.normalized ?? "unknown",
-      editType: "definition",
-    },
-  };
+    })(),
+  );
 }

--- a/src/libswamp/models/get.ts
+++ b/src/libswamp/models/get.ts
@@ -32,6 +32,7 @@ import {
   zodToJsonSchema,
 } from "../types/schema_helpers.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Data structure for the model get output.
  */
@@ -76,40 +77,46 @@ export async function* modelGet(
   deps: ModelGetDeps,
   modelIdOrName: string,
 ): AsyncIterable<ModelGetEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.model.get",
+    { "model.id_or_name": modelIdOrName },
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const result = await deps.lookupDefinition(modelIdOrName);
-  if (!result) {
-    yield { kind: "error", error: notFound("Model", modelIdOrName) };
-    return;
-  }
+      const result = await deps.lookupDefinition(modelIdOrName);
+      if (!result) {
+        yield { kind: "error", error: notFound("Model", modelIdOrName) };
+        return;
+      }
 
-  const { definition, type: modelType } = result;
-  const modelDef = deps.getModelDef(modelType);
+      const { definition, type: modelType } = result;
+      const modelDef = deps.getModelDef(modelType);
 
-  const data: ModelGetData = {
-    id: definition.id,
-    name: definition.name,
-    type: modelType.normalized,
-    version: definition.version,
-    tags: definition.tags,
-    globalArguments: definition.globalArguments,
-    typeVersion: modelDef?.version,
-    globalArgumentsSchema: modelDef?.globalArguments
-      ? zodToJsonSchema(modelDef.globalArguments)
-      : undefined,
-    methods: modelDef
-      ? Object.entries(modelDef.methods).map(
-        ([name, method]) =>
-          toMethodDescribeData(
-            name,
-            method,
-            modelDef.resources,
-            modelDef.files,
-          ),
-      )
-      : undefined,
-  };
+      const data: ModelGetData = {
+        id: definition.id,
+        name: definition.name,
+        type: modelType.normalized,
+        version: definition.version,
+        tags: definition.tags,
+        globalArguments: definition.globalArguments,
+        typeVersion: modelDef?.version,
+        globalArgumentsSchema: modelDef?.globalArguments
+          ? zodToJsonSchema(modelDef.globalArguments)
+          : undefined,
+        methods: modelDef
+          ? Object.entries(modelDef.methods).map(
+            ([name, method]) =>
+              toMethodDescribeData(
+                name,
+                method,
+                modelDef.resources,
+                modelDef.files,
+              ),
+          )
+          : undefined,
+      };
 
-  yield { kind: "completed", data };
+      yield { kind: "completed", data };
+    })(),
+  );
 }

--- a/src/libswamp/models/method_describe.ts
+++ b/src/libswamp/models/method_describe.ts
@@ -31,6 +31,7 @@ import {
   toMethodDescribeData,
 } from "../types/schema_helpers.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Data structure for the model method describe output.
  */
@@ -75,54 +76,60 @@ export async function* modelMethodDescribe(
   modelIdOrName: string,
   methodName: string,
 ): AsyncIterable<ModelMethodDescribeEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.model.method.describe",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const result = await deps.lookupDefinition(modelIdOrName);
-  if (!result) {
-    yield { kind: "error", error: notFound("Model", modelIdOrName) };
-    return;
-  }
+      const result = await deps.lookupDefinition(modelIdOrName);
+      if (!result) {
+        yield { kind: "error", error: notFound("Model", modelIdOrName) };
+        return;
+      }
 
-  const { definition, type: modelType } = result;
-  const modelDef = await deps.resolveModelType(modelType);
-  if (!modelDef) {
-    yield {
-      kind: "error",
-      error: notFound("Model type", modelType.normalized),
-    };
-    return;
-  }
+      const { definition, type: modelType } = result;
+      const modelDef = await deps.resolveModelType(modelType);
+      if (!modelDef) {
+        yield {
+          kind: "error",
+          error: notFound("Model type", modelType.normalized),
+        };
+        return;
+      }
 
-  const method = modelDef.methods[methodName];
-  if (!method) {
-    const availableMethods = Object.keys(modelDef.methods).join(", ");
-    yield {
-      kind: "error",
-      error: {
-        code: "unknown_method",
-        message:
-          `Unknown method '${methodName}' for type '${modelType.normalized}'. Available methods: ${
-            availableMethods || "none"
-          }`,
-      },
-    };
-    return;
-  }
+      const method = modelDef.methods[methodName];
+      if (!method) {
+        const availableMethods = Object.keys(modelDef.methods).join(", ");
+        yield {
+          kind: "error",
+          error: {
+            code: "unknown_method",
+            message:
+              `Unknown method '${methodName}' for type '${modelType.normalized}'. Available methods: ${
+                availableMethods || "none"
+              }`,
+          },
+        };
+        return;
+      }
 
-  const methodData = toMethodDescribeData(
-    methodName,
-    method,
-    modelDef.resources,
-    modelDef.files,
+      const methodData = toMethodDescribeData(
+        methodName,
+        method,
+        modelDef.resources,
+        modelDef.files,
+      );
+
+      yield {
+        kind: "completed",
+        data: {
+          modelName: definition.name,
+          modelType: modelType.normalized,
+          version: modelDef.version,
+          method: methodData,
+        },
+      };
+    })(),
   );
-
-  yield {
-    kind: "completed",
-    data: {
-      modelName: definition.name,
-      modelType: modelType.normalized,
-      version: modelDef.version,
-      method: methodData,
-    },
-  };
 }

--- a/src/libswamp/models/method_history_logs.ts
+++ b/src/libswamp/models/method_history_logs.ts
@@ -36,6 +36,7 @@ import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_outp
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** Log file data. */
 export interface LogData {
   lines: string[];
@@ -154,110 +155,117 @@ export async function* modelMethodHistoryLogs(
   deps: ModelMethodHistoryLogsDeps,
   input: ModelMethodHistoryLogsInput,
 ): AsyncIterable<ModelMethodHistoryLogsEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.model.method.history.logs",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  let output: ModelOutput | undefined;
+      let output: ModelOutput | undefined;
 
-  if (deps.isPartialId(input.outputIdOrModelName)) {
-    const result = await deps.matchOutputByPartialId(
-      input.outputIdOrModelName,
-    );
+      if (deps.isPartialId(input.outputIdOrModelName)) {
+        const result = await deps.matchOutputByPartialId(
+          input.outputIdOrModelName,
+        );
 
-    if (result.status === "found" && result.match) {
-      output = result.match;
-    } else if (result.status === "ambiguous" && result.matches) {
-      yield {
-        kind: "error",
-        error: validationFailed(
-          `Ambiguous ID prefix "${input.outputIdOrModelName}" matches:\n` +
-            result.matches.map((m) => `  ${m.id}`).join("\n"),
-        ),
-      };
-      return;
-    }
-    // not_found: fall through to model name lookup
-  }
+        if (result.status === "found" && result.match) {
+          output = result.match;
+        } else if (result.status === "ambiguous" && result.matches) {
+          yield {
+            kind: "error",
+            error: validationFailed(
+              `Ambiguous ID prefix "${input.outputIdOrModelName}" matches:\n` +
+                result.matches.map((m) => `  ${m.id}`).join("\n"),
+            ),
+          };
+          return;
+        }
+        // not_found: fall through to model name lookup
+      }
 
-  if (!output) {
-    const definitionResult = await deps.findDefinition(
-      input.outputIdOrModelName,
-    );
+      if (!output) {
+        const definitionResult = await deps.findDefinition(
+          input.outputIdOrModelName,
+        );
 
-    if (!definitionResult) {
-      yield {
-        kind: "error",
-        error: {
-          code: "not_found",
-          message: `No method run or model found: ${input.outputIdOrModelName}`,
-          details: {
-            entityType: "Method run or model",
-            idOrName: input.outputIdOrModelName,
+        if (!definitionResult) {
+          yield {
+            kind: "error",
+            error: {
+              code: "not_found",
+              message:
+                `No method run or model found: ${input.outputIdOrModelName}`,
+              details: {
+                entityType: "Method run or model",
+                idOrName: input.outputIdOrModelName,
+              },
+            },
+          };
+          return;
+        }
+
+        const latestOutput = await deps.findLatestOutput(
+          definitionResult.type,
+          definitionResult.definition.id,
+        );
+        if (!latestOutput) {
+          yield {
+            kind: "error",
+            error: notFound(
+              "Run",
+              `for model: ${definitionResult.definition.name}`,
+            ),
+          };
+          return;
+        }
+
+        output = latestOutput;
+      }
+
+      // Read log file
+      if (!output.logFile) {
+        const modelName = await deps.getModelName(output.definitionId);
+        yield {
+          kind: "completed",
+          data: {
+            type: "no_log_file",
+            info: {
+              outputId: output.id,
+              modelName,
+              methodName: output.methodName,
+            },
           },
-        },
-      };
-      return;
-    }
+        };
+        return;
+      }
 
-    const latestOutput = await deps.findLatestOutput(
-      definitionResult.type,
-      definitionResult.definition.id,
-    );
-    if (!latestOutput) {
+      const logData = await deps.readLogFile(output.logFile, {
+        tail: input.tail,
+      });
+      const displayPath = deps.toRelativePath(input.repoDir, output.logFile);
+
+      if (logData.lines.length === 0) {
+        yield {
+          kind: "completed",
+          data: {
+            type: "empty_log",
+            info: {
+              outputId: output.id,
+              methodName: output.methodName,
+              path: displayPath,
+            },
+          },
+        };
+        return;
+      }
+
       yield {
-        kind: "error",
-        error: notFound(
-          "Run",
-          `for model: ${definitionResult.definition.name}`,
-        ),
+        kind: "completed",
+        data: {
+          type: "log",
+          log: { ...logData, path: displayPath },
+        },
       };
-      return;
-    }
-
-    output = latestOutput;
-  }
-
-  // Read log file
-  if (!output.logFile) {
-    const modelName = await deps.getModelName(output.definitionId);
-    yield {
-      kind: "completed",
-      data: {
-        type: "no_log_file",
-        info: {
-          outputId: output.id,
-          modelName,
-          methodName: output.methodName,
-        },
-      },
-    };
-    return;
-  }
-
-  const logData = await deps.readLogFile(output.logFile, {
-    tail: input.tail,
-  });
-  const displayPath = deps.toRelativePath(input.repoDir, output.logFile);
-
-  if (logData.lines.length === 0) {
-    yield {
-      kind: "completed",
-      data: {
-        type: "empty_log",
-        info: {
-          outputId: output.id,
-          methodName: output.methodName,
-          path: displayPath,
-        },
-      },
-    };
-    return;
-  }
-
-  yield {
-    kind: "completed",
-    data: {
-      type: "log",
-      log: { ...logData, path: displayPath },
-    },
-  };
+    })(),
+  );
 }

--- a/src/libswamp/models/output_data.ts
+++ b/src/libswamp/models/output_data.ts
@@ -33,6 +33,7 @@ import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistenc
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** Data payload for the completed event. */
 export interface ModelOutputDataData {
   outputId: string;
@@ -142,187 +143,194 @@ export async function* modelOutputData(
   deps: ModelOutputDataDeps,
   input: ModelOutputDataInput,
 ): AsyncIterable<ModelOutputDataEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.model.output.data",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  if (!deps.isPartialId(input.outputIdArg)) {
-    yield {
-      kind: "error",
-      error: validationFailed(
-        `Invalid output ID format: ${input.outputIdArg}. ` +
-          `Expected a UUID or partial ID (3+ hex characters).`,
-      ),
-    };
-    return;
-  }
+      if (!deps.isPartialId(input.outputIdArg)) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `Invalid output ID format: ${input.outputIdArg}. ` +
+              `Expected a UUID or partial ID (3+ hex characters).`,
+          ),
+        };
+        return;
+      }
 
-  const result = await deps.matchOutputByPartialId(input.outputIdArg);
+      const result = await deps.matchOutputByPartialId(input.outputIdArg);
 
-  if (result.status === "not_found") {
-    yield {
-      kind: "error",
-      error: notFound("Output", input.outputIdArg),
-    };
-    return;
-  }
+      if (result.status === "not_found") {
+        yield {
+          kind: "error",
+          error: notFound("Output", input.outputIdArg),
+        };
+        return;
+      }
 
-  if (result.status === "ambiguous" && result.matches) {
-    yield {
-      kind: "error",
-      error: validationFailed(
-        `Ambiguous ID prefix "${input.outputIdArg}" matches:\n` +
-          result.matches.map((m) => `  ${m.id}`).join("\n"),
-      ),
-    };
-    return;
-  }
+      if (result.status === "ambiguous" && result.matches) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `Ambiguous ID prefix "${input.outputIdArg}" matches:\n` +
+              result.matches.map((m) => `  ${m.id}`).join("\n"),
+          ),
+        };
+        return;
+      }
 
-  const { output, type } = result.match!;
+      const { output, type } = result.match!;
 
-  // Find the data artifact
-  let dataArtifact: DataArtifactRef | undefined;
-  if (input.name) {
-    dataArtifact = output.artifacts.dataArtifacts.find(
-      (a) => a.name === input.name,
-    );
-    if (!dataArtifact) {
-      const availableNames = output.artifacts.dataArtifacts
-        .map((a) => a.name)
-        .join(", ");
+      // Find the data artifact
+      let dataArtifact: DataArtifactRef | undefined;
+      if (input.name) {
+        dataArtifact = output.artifacts.dataArtifacts.find(
+          (a) => a.name === input.name,
+        );
+        if (!dataArtifact) {
+          const availableNames = output.artifacts.dataArtifacts
+            .map((a) => a.name)
+            .join(", ");
+          yield {
+            kind: "error",
+            error: notFound(
+              "Data artifact",
+              `"${input.name}". Available: ${availableNames || "(none)"}`,
+            ),
+          };
+          return;
+        }
+      } else {
+        dataArtifact = output.artifacts.dataArtifacts.find(
+          (a) => a.tags.type === "data",
+        ) ?? output.artifacts.dataArtifacts[0];
+      }
+
+      if (!dataArtifact) {
+        yield {
+          kind: "error",
+          error: notFound(
+            "Data artifacts",
+            `Output ${output.id} has no data artifacts. ` +
+              `Status: ${output.status}, Method: ${output.methodName}`,
+          ),
+        };
+        return;
+      }
+
+      // Get the definition
+      const definition = await deps.findDefinition(type, output.definitionId);
+      if (!definition) {
+        yield {
+          kind: "error",
+          error: notFound(
+            "Definition",
+            `${output.definitionId} for output ${output.id}`,
+          ),
+        };
+        return;
+      }
+
+      // Get the version
+      const version = input.version ?? dataArtifact.version;
+
+      // Find the data
+      const data = await deps.findDataByName(
+        type,
+        definition.id,
+        dataArtifact.name,
+        version,
+      );
+
+      if (!data) {
+        yield {
+          kind: "error",
+          error: notFound(
+            "Data",
+            `"${dataArtifact.name}" (v${version}) for model "${definition.name}"`,
+          ),
+        };
+        return;
+      }
+
+      // Get the raw content
+      const content = await deps.getContent(
+        type,
+        definition.id,
+        dataArtifact.name,
+        version,
+      );
+
+      if (!content) {
+        yield {
+          kind: "error",
+          error: notFound(
+            "Data content",
+            `"${dataArtifact.name}" (v${version})`,
+          ),
+        };
+        return;
+      }
+
+      // Try to parse as JSON if content type is JSON
+      let displayData: unknown;
+      const isJson = data.contentType === "application/json";
+
+      if (isJson) {
+        try {
+          const text = new TextDecoder().decode(content);
+          displayData = JSON.parse(text);
+        } catch {
+          displayData = new TextDecoder().decode(content);
+        }
+      } else {
+        displayData = new TextDecoder().decode(content);
+      }
+
+      // If a specific field is requested, extract it
+      if (input.field) {
+        if (typeof displayData !== "object" || displayData === null) {
+          yield {
+            kind: "error",
+            error: validationFailed(
+              `Cannot extract field "${input.field}": data is not a JSON object`,
+            ),
+          };
+          return;
+        }
+        const fieldValue =
+          (displayData as Record<string, unknown>)[input.field];
+        if (fieldValue === undefined) {
+          const availableFields = Object.keys(displayData as object).join(", ");
+          yield {
+            kind: "error",
+            error: notFound(
+              "Field",
+              `"${input.field}" in data artifact. Available fields: ${
+                availableFields || "(none)"
+              }`,
+            ),
+          };
+          return;
+        }
+        displayData = fieldValue;
+      }
+
       yield {
-        kind: "error",
-        error: notFound(
-          "Data artifact",
-          `"${input.name}". Available: ${availableNames || "(none)"}`,
-        ),
+        kind: "completed",
+        data: {
+          outputId: output.id,
+          methodName: output.methodName,
+          dataId: data.id,
+          dataName: data.name,
+          version: data.version,
+          contentType: data.contentType,
+          field: input.field ?? null,
+          data: displayData,
+        },
       };
-      return;
-    }
-  } else {
-    dataArtifact = output.artifacts.dataArtifacts.find(
-      (a) => a.tags.type === "data",
-    ) ?? output.artifacts.dataArtifacts[0];
-  }
-
-  if (!dataArtifact) {
-    yield {
-      kind: "error",
-      error: notFound(
-        "Data artifacts",
-        `Output ${output.id} has no data artifacts. ` +
-          `Status: ${output.status}, Method: ${output.methodName}`,
-      ),
-    };
-    return;
-  }
-
-  // Get the definition
-  const definition = await deps.findDefinition(type, output.definitionId);
-  if (!definition) {
-    yield {
-      kind: "error",
-      error: notFound(
-        "Definition",
-        `${output.definitionId} for output ${output.id}`,
-      ),
-    };
-    return;
-  }
-
-  // Get the version
-  const version = input.version ?? dataArtifact.version;
-
-  // Find the data
-  const data = await deps.findDataByName(
-    type,
-    definition.id,
-    dataArtifact.name,
-    version,
+    })(),
   );
-
-  if (!data) {
-    yield {
-      kind: "error",
-      error: notFound(
-        "Data",
-        `"${dataArtifact.name}" (v${version}) for model "${definition.name}"`,
-      ),
-    };
-    return;
-  }
-
-  // Get the raw content
-  const content = await deps.getContent(
-    type,
-    definition.id,
-    dataArtifact.name,
-    version,
-  );
-
-  if (!content) {
-    yield {
-      kind: "error",
-      error: notFound(
-        "Data content",
-        `"${dataArtifact.name}" (v${version})`,
-      ),
-    };
-    return;
-  }
-
-  // Try to parse as JSON if content type is JSON
-  let displayData: unknown;
-  const isJson = data.contentType === "application/json";
-
-  if (isJson) {
-    try {
-      const text = new TextDecoder().decode(content);
-      displayData = JSON.parse(text);
-    } catch {
-      displayData = new TextDecoder().decode(content);
-    }
-  } else {
-    displayData = new TextDecoder().decode(content);
-  }
-
-  // If a specific field is requested, extract it
-  if (input.field) {
-    if (typeof displayData !== "object" || displayData === null) {
-      yield {
-        kind: "error",
-        error: validationFailed(
-          `Cannot extract field "${input.field}": data is not a JSON object`,
-        ),
-      };
-      return;
-    }
-    const fieldValue = (displayData as Record<string, unknown>)[input.field];
-    if (fieldValue === undefined) {
-      const availableFields = Object.keys(displayData as object).join(", ");
-      yield {
-        kind: "error",
-        error: notFound(
-          "Field",
-          `"${input.field}" in data artifact. Available fields: ${
-            availableFields || "(none)"
-          }`,
-        ),
-      };
-      return;
-    }
-    displayData = fieldValue;
-  }
-
-  yield {
-    kind: "completed",
-    data: {
-      outputId: output.id,
-      methodName: output.methodName,
-      dataId: data.id,
-      dataName: data.name,
-      version: data.version,
-      contentType: data.contentType,
-      field: input.field ?? null,
-      data: displayData,
-    },
-  };
 }

--- a/src/libswamp/models/output_get.ts
+++ b/src/libswamp/models/output_get.ts
@@ -33,6 +33,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Data structure for provenance information.
  */
@@ -167,13 +168,19 @@ export async function* modelOutputGet(
   deps: ModelOutputGetDeps,
   outputIdOrModelName: string,
 ): AsyncIterable<ModelOutputGetEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.model.output.get",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  if (deps.isPartialId(outputIdOrModelName)) {
-    yield* lookupByPartialId(deps, outputIdOrModelName);
-  } else {
-    yield* lookupByModelName(deps, outputIdOrModelName);
-  }
+      if (deps.isPartialId(outputIdOrModelName)) {
+        yield* lookupByPartialId(deps, outputIdOrModelName);
+      } else {
+        yield* lookupByModelName(deps, outputIdOrModelName);
+      }
+    })(),
+  );
 }
 
 async function* lookupByPartialId(

--- a/src/libswamp/models/output_logs.ts
+++ b/src/libswamp/models/output_logs.ts
@@ -28,6 +28,7 @@ import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistenc
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** Data payload for the completed event. */
 export interface ModelOutputLogsData {
   outputId: string;
@@ -114,93 +115,101 @@ export async function* modelOutputLogs(
   deps: ModelOutputLogsDeps,
   input: ModelOutputLogsInput,
 ): AsyncIterable<ModelOutputLogsEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.model.output.logs",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  if (!deps.isPartialId(input.outputIdArg)) {
-    yield {
-      kind: "error",
-      error: validationFailed(
-        `Invalid output ID format: ${input.outputIdArg}. ` +
-          `Expected a UUID or partial ID (3+ hex characters).`,
-      ),
-    };
-    return;
-  }
-
-  const result = await deps.matchOutputByPartialId(input.outputIdArg);
-
-  if (result.status === "not_found") {
-    yield {
-      kind: "error",
-      error: notFound("Output", input.outputIdArg),
-    };
-    return;
-  }
-
-  if (result.status === "ambiguous" && result.matches) {
-    yield {
-      kind: "error",
-      error: validationFailed(
-        `Ambiguous ID prefix "${input.outputIdArg}" matches:\n` +
-          result.matches.map((m) => `  ${m.id}`).join("\n"),
-      ),
-    };
-    return;
-  }
-
-  const { output, type } = result.match!;
-
-  // Get log IDs from artifacts (find all artifacts with type "log")
-  const logArtifacts = output.artifacts.dataArtifacts.filter(
-    (a) => a.tags.type === "log",
-  );
-  if (logArtifacts.length === 0) {
-    yield {
-      kind: "error",
-      error: notFound(
-        "Log artifacts",
-        `Output ${output.id} has no log artifacts. ` +
-          `Status: ${output.status}, Method: ${output.methodName}`,
-      ),
-    };
-    return;
-  }
-
-  // Fetch and collect log lines
-  const allEntries: string[] = [];
-
-  for (const artifact of logArtifacts) {
-    const dataResult = await deps.findDataByName(
-      type,
-      output.definitionId,
-      artifact.name,
-    );
-    if (dataResult) {
-      const content = await deps.getContent(
-        type,
-        output.definitionId,
-        artifact.name,
-      );
-      if (content) {
-        const text = new TextDecoder().decode(content);
-        const lines = text.split("\n").filter((line) => line.length > 0);
-        allEntries.push(...lines);
+      if (!deps.isPartialId(input.outputIdArg)) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `Invalid output ID format: ${input.outputIdArg}. ` +
+              `Expected a UUID or partial ID (3+ hex characters).`,
+          ),
+        };
+        return;
       }
-    }
-  }
 
-  // Apply --tail if specified
-  const entriesToShow = input.tail ? allEntries.slice(-input.tail) : allEntries;
+      const result = await deps.matchOutputByPartialId(input.outputIdArg);
 
-  yield {
-    kind: "completed",
-    data: {
-      outputId: output.id,
-      methodName: output.methodName,
-      logArtifacts: logArtifacts.map((a) => a.name),
-      lines: entriesToShow,
-      totalLines: allEntries.length,
-      showingLines: entriesToShow.length,
-    },
-  };
+      if (result.status === "not_found") {
+        yield {
+          kind: "error",
+          error: notFound("Output", input.outputIdArg),
+        };
+        return;
+      }
+
+      if (result.status === "ambiguous" && result.matches) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `Ambiguous ID prefix "${input.outputIdArg}" matches:\n` +
+              result.matches.map((m) => `  ${m.id}`).join("\n"),
+          ),
+        };
+        return;
+      }
+
+      const { output, type } = result.match!;
+
+      // Get log IDs from artifacts (find all artifacts with type "log")
+      const logArtifacts = output.artifacts.dataArtifacts.filter(
+        (a) => a.tags.type === "log",
+      );
+      if (logArtifacts.length === 0) {
+        yield {
+          kind: "error",
+          error: notFound(
+            "Log artifacts",
+            `Output ${output.id} has no log artifacts. ` +
+              `Status: ${output.status}, Method: ${output.methodName}`,
+          ),
+        };
+        return;
+      }
+
+      // Fetch and collect log lines
+      const allEntries: string[] = [];
+
+      for (const artifact of logArtifacts) {
+        const dataResult = await deps.findDataByName(
+          type,
+          output.definitionId,
+          artifact.name,
+        );
+        if (dataResult) {
+          const content = await deps.getContent(
+            type,
+            output.definitionId,
+            artifact.name,
+          );
+          if (content) {
+            const text = new TextDecoder().decode(content);
+            const lines = text.split("\n").filter((line) => line.length > 0);
+            allEntries.push(...lines);
+          }
+        }
+      }
+
+      // Apply --tail if specified
+      const entriesToShow = input.tail
+        ? allEntries.slice(-input.tail)
+        : allEntries;
+
+      yield {
+        kind: "completed",
+        data: {
+          outputId: output.id,
+          methodName: output.methodName,
+          logArtifacts: logArtifacts.map((a) => a.name),
+          lines: entriesToShow,
+          totalLines: allEntries.length,
+          showingLines: entriesToShow.length,
+        },
+      };
+    })(),
+  );
 }

--- a/src/libswamp/models/output_search.ts
+++ b/src/libswamp/models/output_search.ts
@@ -20,6 +20,7 @@
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * A single model output search result item.
  */
@@ -88,40 +89,50 @@ export async function* modelOutputSearch(
   deps: ModelOutputSearchDeps,
   input: ModelOutputSearchInput,
 ): AsyncGenerator<ModelOutputSearchEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.model.output.search",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const allResults = await deps.findAllOutputsGlobal();
-  const items: ModelOutputSearchItem[] = [];
+      const allResults = await deps.findAllOutputsGlobal();
+      const items: ModelOutputSearchItem[] = [];
 
-  for (const { output, type } of allResults) {
-    let modelName: string | undefined;
-    const definition = await deps.findDefinitionById(type, output.definitionId);
-    if (definition) {
-      modelName = definition.name;
-    }
+      for (const { output, type } of allResults) {
+        let modelName: string | undefined;
+        const definition = await deps.findDefinitionById(
+          type,
+          output.definitionId,
+        );
+        if (definition) {
+          modelName = definition.name;
+        }
 
-    items.push({
-      id: output.id,
-      definitionId: output.definitionId,
-      modelName,
-      type: type.normalized,
-      methodName: output.methodName,
-      status: output.status,
-      startedAt: output.startedAt.toISOString(),
-      durationMs: output.durationMs,
-    });
-  }
+        items.push({
+          id: output.id,
+          definitionId: output.definitionId,
+          modelName,
+          type: type.normalized,
+          methodName: output.methodName,
+          status: output.status,
+          startedAt: output.startedAt.toISOString(),
+          durationMs: output.durationMs,
+        });
+      }
 
-  // Sort by startedAt descending (most recent first)
-  items.sort(
-    (a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+      // Sort by startedAt descending (most recent first)
+      items.sort(
+        (a, b) =>
+          new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+      );
+
+      yield {
+        kind: "completed",
+        data: {
+          query: input.query ?? "",
+          results: items,
+        },
+      };
+    })(),
   );
-
-  yield {
-    kind: "completed",
-    data: {
-      query: input.query ?? "",
-      results: items,
-    },
-  };
 }

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -57,6 +57,7 @@ import { detectEnvVarUsageInDefinition } from "../../domain/models/env_var_detec
 import { withEventBridge } from "../../infrastructure/stream/event_bridge.ts";
 import type { MethodResult } from "../../domain/models/model.ts";
 import { getRunLogger } from "../../infrastructure/logging/logger.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 
 /**
  * Events emitted by the libswamp model method run generator.
@@ -188,483 +189,492 @@ export async function* modelMethodRun(
   deps: ModelMethodRunDeps,
   input: ModelMethodRunInput,
 ): AsyncGenerator<ModelMethodRunEvent> {
-  // --- Validate inputs phase ---
-  yield { kind: "validating_inputs" };
+  yield* withGeneratorSpan(
+    "swamp.model.method.run",
+    {
+      "model.id_or_name": input.modelIdOrName,
+      "method.name": input.methodName,
+    },
+    (async function* () {
+      // --- Validate inputs phase ---
+      yield { kind: "validating_inputs" };
 
-  // --- Resolve model ---
-  yield { kind: "resolving_model", modelIdOrName: input.modelIdOrName };
+      // --- Resolve model ---
+      yield { kind: "resolving_model", modelIdOrName: input.modelIdOrName };
 
-  const lookupResult = await deps.lookupDefinition(input.modelIdOrName);
-  if (!lookupResult) {
-    yield { kind: "error", error: modelNotFound(input.modelIdOrName) };
-    return;
-  }
-  const { definition, type: modelType } = lookupResult;
+      const lookupResult = await deps.lookupDefinition(input.modelIdOrName);
+      if (!lookupResult) {
+        yield { kind: "error", error: modelNotFound(input.modelIdOrName) };
+        return;
+      }
+      const { definition, type: modelType } = lookupResult;
 
-  // Get model definition from registry (may auto-resolve if async)
-  const modelDef = await Promise.resolve(deps.getModelDef(modelType));
-  if (!modelDef) {
-    yield { kind: "error", error: unknownModelType(modelType.normalized) };
-    return;
-  }
+      // Get model definition from registry (may auto-resolve if async)
+      const modelDef = await Promise.resolve(deps.getModelDef(modelType));
+      if (!modelDef) {
+        yield { kind: "error", error: unknownModelType(modelType.normalized) };
+        return;
+      }
 
-  // Validate method exists
-  const method = modelDef.methods[input.methodName];
-  if (!method) {
-    const availableMethods = Object.keys(modelDef.methods).join(", ");
-    yield {
-      kind: "error",
-      error: unknownMethod(
-        input.methodName,
-        modelType.normalized,
-        availableMethods,
-      ),
-    };
-    return;
-  }
-
-  // Coerce and validate inputs against model's input schema
-  const inputs = { ...input.inputs };
-  if (definition.inputs) {
-    const coercedInputs = coerceInputTypes(inputs, definition.inputs);
-    Object.assign(inputs, coercedInputs);
-
-    const validationService = new InputValidationService();
-    const inputsWithDefaults = validationService.applyDefaults(
-      inputs,
-      definition.inputs,
-    );
-
-    // Build effective schema: only require inputs referenced by the method's arguments
-    const referencedInputs = extractInputReferences(
-      definition.getMethodArguments(input.methodName),
-    );
-    const originalRequired = definition.inputs.required ?? [];
-    const effectiveRequired = originalRequired.filter((name) =>
-      referencedInputs.has(name)
-    );
-    const effectiveSchema: InputsSchema = {
-      ...definition.inputs,
-      required: effectiveRequired,
-    };
-
-    const validationResult = validationService.validate(
-      inputsWithDefaults,
-      effectiveSchema,
-    );
-    if (!validationResult.valid) {
-      yield {
-        kind: "error",
-        error: inputValidationFailed(validationResult.errors),
-      };
-      return;
-    }
-    Object.assign(inputs, inputsWithDefaults);
-  }
-
-  yield {
-    kind: "model_resolved",
-    modelName: definition.name,
-    modelType: modelType.normalized,
-    methodName: input.methodName,
-  };
-
-  // --- Check for env var usage and warn ---
-  const envVarUsages = detectEnvVarUsageInDefinition(definition);
-  if (envVarUsages.length > 0) {
-    yield {
-      kind: "env_var_warning",
-      modelName: definition.name,
-      envVars: envVarUsages,
-      message:
-        "Data stored under this model will vary depending on these environment variables at runtime. Consider using separate models per environment, or vault.get() for sensitive values.",
-    };
-  }
-
-  // --- Set up logging ---
-  const runLog = await deps.createRunLog(
-    modelType,
-    input.methodName,
-    definition.id,
-  );
-  const { logFilePath, redactor } = runLog;
-
-  try {
-    // --- Evaluate expressions ---
-    yield {
-      kind: "evaluating_expressions",
-      lastEvaluated: input.lastEvaluated,
-    };
-
-    const evaluationService = deps.createEvaluationService();
-    let evaluatedDefinition = definition;
-
-    if (input.lastEvaluated) {
-      const lastEval = await deps.loadEvaluatedDefinition(
-        modelType,
-        definition.name,
-      );
-      if (!lastEval) {
+      // Validate method exists
+      const method = modelDef.methods[input.methodName];
+      if (!method) {
+        const availableMethods = Object.keys(modelDef.methods).join(", ");
         yield {
           kind: "error",
-          error: noEvaluatedDefinition(definition.name),
+          error: unknownMethod(
+            input.methodName,
+            modelType.normalized,
+            availableMethods,
+          ),
         };
         return;
       }
-      evaluatedDefinition = lastEval;
-    } else {
-      if (
-        evaluationService.hasDefinitionExpressions(definition) ||
-        Object.keys(inputs).length > 0
-      ) {
-        const evalResult = await evaluationService.evaluateDefinition(
-          definition,
-          modelType,
+
+      // Coerce and validate inputs against model's input schema
+      const inputs = { ...input.inputs };
+      if (definition.inputs) {
+        const coercedInputs = coerceInputTypes(inputs, definition.inputs);
+        Object.assign(inputs, coercedInputs);
+
+        const validationService = new InputValidationService();
+        const inputsWithDefaults = validationService.applyDefaults(
           inputs,
+          definition.inputs,
         );
-        evaluatedDefinition = evalResult.definition;
+
+        // Build effective schema: only require inputs referenced by the method's arguments
+        const referencedInputs = extractInputReferences(
+          definition.getMethodArguments(input.methodName),
+        );
+        const originalRequired = definition.inputs.required ?? [];
+        const effectiveRequired = originalRequired.filter((name) =>
+          referencedInputs.has(name)
+        );
+        const effectiveSchema: InputsSchema = {
+          ...definition.inputs,
+          required: effectiveRequired,
+        };
+
+        const validationResult = validationService.validate(
+          inputsWithDefaults,
+          effectiveSchema,
+        );
+        if (!validationResult.valid) {
+          yield {
+            kind: "error",
+            error: inputValidationFailed(validationResult.errors),
+          };
+          return;
+        }
+        Object.assign(inputs, inputsWithDefaults);
       }
-      await deps.saveEvaluatedDefinition(modelType, evaluatedDefinition);
-    }
 
-    // Merge override inputs into method arguments
-    const definitionInputKeys = definition.inputs
-      ? Object.keys(
-        (definition.inputs as { properties?: Record<string, unknown> })
-          .properties || {},
-      )
-      : [];
-    const overrideInputs = Object.fromEntries(
-      Object.entries(inputs).filter(([key]) =>
-        !definitionInputKeys.includes(key)
-      ),
-    );
-    if (Object.keys(overrideInputs).length > 0) {
-      for (const [key, value] of Object.entries(overrideInputs)) {
-        evaluatedDefinition.setMethodArgument(input.methodName, key, value);
+      yield {
+        kind: "model_resolved",
+        modelName: definition.name,
+        modelType: modelType.normalized,
+        methodName: input.methodName,
+      };
+
+      // --- Check for env var usage and warn ---
+      const envVarUsages = detectEnvVarUsageInDefinition(definition);
+      if (envVarUsages.length > 0) {
+        yield {
+          kind: "env_var_warning",
+          modelName: definition.name,
+          envVars: envVarUsages,
+          message:
+            "Data stored under this model will vary depending on these environment variables at runtime. Consider using separate models per environment, or vault.get() for sensitive values.",
+        };
       }
-    }
 
-    // Capture pre-vault args for report context (so vault secrets stay as expressions)
-    const reportGlobalArgs = evaluatedDefinition.globalArguments;
-    const reportMethodArgs = evaluatedDefinition.getMethodArguments(
-      input.methodName,
-    );
-
-    // Resolve runtime expressions (vault and env).
-    // Vault secrets become sentinel tokens; the secretBag maps sentinels to raw values.
-    const runtimeResult = await evaluationService
-      .resolveRuntimeExpressionsInDefinition(evaluatedDefinition, redactor);
-    evaluatedDefinition = runtimeResult.definition;
-    const secretBag = runtimeResult.secretBag;
-
-    // --- Execute ---
-    yield {
-      kind: "executing",
-      modelName: definition.name,
-      methodName: input.methodName,
-    };
-
-    // Create ModelOutput for tracking
-    const definitionHash = await definition.computeHash();
-    const output = ModelOutput.create({
-      definitionId: definition.id,
-      methodName: input.methodName,
-      provenance: {
-        definitionHash,
-        modelVersion: modelDef.version,
-        triggeredBy: "manual",
-      },
-    });
-    output.markRunning();
-    output.setLogFile(logFilePath);
-    await deps.outputRepo.save(modelType, input.methodName, output);
-
-    const vaultService = await deps.createVaultService();
-    const executionService = deps.createExecutionService();
-
-    let execResult: MethodResult;
-    try {
-      execResult = yield* withEventBridge<
-        ModelMethodRunEvent,
-        MethodResult
-      >(
-        (push) =>
-          executionService.executeWorkflow(
-            evaluatedDefinition,
-            modelDef,
-            input.methodName,
-            {
-              signal: ctx.signal,
-              repoDir: deps.repoDir,
-              modelType,
-              modelId: evaluatedDefinition.id,
-              globalArgs: evaluatedDefinition.globalArguments,
-              definition: {
-                id: evaluatedDefinition.id,
-                name: evaluatedDefinition.name,
-                version: evaluatedDefinition.version,
-                tags: evaluatedDefinition.tags,
-              },
-              methodName: input.methodName,
-              logger: getRunLogger(definition.name, input.methodName),
-              dataRepository: deps.dataRepo,
-              definitionRepository: deps.definitionRepo,
-              runtimeTags: input.runtimeTags,
-              vaultService,
-              redactor,
-              vaultSecrets: secretBag,
-              skipCheckNames: input.skipCheckNames,
-              skipCheckLabels: input.skipCheckLabels,
-              skipAllChecks: input.skipAllChecks,
-              driver: input.driver,
-              onEvent: (event: MethodExecutionEvent) => {
-                if (event.type === "output") {
-                  push({
-                    kind: "method_output",
-                    modelName: definition.name,
-                    methodName: input.methodName,
-                    stream: event.stream,
-                    line: event.line,
-                  });
-                } else {
-                  push({
-                    kind: "method_event",
-                    modelName: definition.name,
-                    methodName: input.methodName,
-                    event,
-                  });
-                }
-              },
-            },
-          ),
+      // --- Set up logging ---
+      const runLog = await deps.createRunLog(
+        modelType,
+        input.methodName,
+        definition.id,
       );
-    } catch (error) {
-      // Mark output as failed and save
-      const errorMessage = error instanceof Error
-        ? error.message
-        : String(error);
-      const errorStack = error instanceof Error ? error.stack : undefined;
-      output.markFailed({ message: errorMessage, stack: errorStack });
-      await deps.outputRepo.save(modelType, input.methodName, output);
+      const { logFilePath, redactor } = runLog;
 
-      if (
-        error instanceof DOMException && error.name === "AbortError"
-      ) {
-        yield { kind: "error", error: cancelled(error) };
-        return;
-      }
+      try {
+        // --- Evaluate expressions ---
+        yield {
+          kind: "evaluating_expressions",
+          lastEvaluated: input.lastEvaluated,
+        };
 
-      yield { kind: "error", error: methodExecutionFailed(error) };
-      return;
-    }
+        const evaluationService = deps.createEvaluationService();
+        let evaluatedDefinition = definition;
 
-    // --- Process data artifacts ---
-    const dataArtifacts: DataArtifactView[] = [];
-    if (execResult.dataHandles && execResult.dataHandles.length > 0) {
-      for (const handle of execResult.dataHandles) {
-        const dataPath = deps.dataRepo.getPath(
-          modelType,
-          definition.id,
-          handle.name,
-          handle.version,
-        );
-
-        output.addDataArtifact({
-          dataId: handle.dataId,
-          name: handle.name,
-          version: handle.version,
-          tags: handle.tags,
-        });
-
-        // Parse content if JSON for display
-        let attributes: Record<string, unknown> | undefined;
-        if (handle.metadata.contentType === "application/json") {
-          try {
-            const content = await deps.dataRepo.getContent(
+        if (input.lastEvaluated) {
+          const lastEval = await deps.loadEvaluatedDefinition(
+            modelType,
+            definition.name,
+          );
+          if (!lastEval) {
+            yield {
+              kind: "error",
+              error: noEvaluatedDefinition(definition.name),
+            };
+            return;
+          }
+          evaluatedDefinition = lastEval;
+        } else {
+          if (
+            evaluationService.hasDefinitionExpressions(definition) ||
+            Object.keys(inputs).length > 0
+          ) {
+            const evalResult = await evaluationService.evaluateDefinition(
+              definition,
               modelType,
-              evaluatedDefinition.id,
-              handle.name,
-              handle.version,
+              inputs,
             );
-            if (content) {
-              const text = new TextDecoder().decode(content);
-              attributes = JSON.parse(text) as Record<string, unknown>;
-            }
-          } catch {
-            // Not valid JSON, skip attributes
+            evaluatedDefinition = evalResult.definition;
+          }
+          await deps.saveEvaluatedDefinition(modelType, evaluatedDefinition);
+        }
+
+        // Merge override inputs into method arguments
+        const definitionInputKeys = definition.inputs
+          ? Object.keys(
+            (definition.inputs as { properties?: Record<string, unknown> })
+              .properties || {},
+          )
+          : [];
+        const overrideInputs = Object.fromEntries(
+          Object.entries(inputs).filter(([key]) =>
+            !definitionInputKeys.includes(key)
+          ),
+        );
+        if (Object.keys(overrideInputs).length > 0) {
+          for (const [key, value] of Object.entries(overrideInputs)) {
+            evaluatedDefinition.setMethodArgument(input.methodName, key, value);
           }
         }
 
-        dataArtifacts.push({
-          id: handle.dataId,
-          name: handle.name,
-          path: dataPath,
-          attributes,
+        // Capture pre-vault args for report context (so vault secrets stay as expressions)
+        const reportGlobalArgs = evaluatedDefinition.globalArguments;
+        const reportMethodArgs = evaluatedDefinition.getMethodArguments(
+          input.methodName,
+        );
+
+        // Resolve runtime expressions (vault and env).
+        // Vault secrets become sentinel tokens; the secretBag maps sentinels to raw values.
+        const runtimeResult = await evaluationService
+          .resolveRuntimeExpressionsInDefinition(evaluatedDefinition, redactor);
+        evaluatedDefinition = runtimeResult.definition;
+        const secretBag = runtimeResult.secretBag;
+
+        // --- Execute ---
+        yield {
+          kind: "executing",
+          modelName: definition.name,
+          methodName: input.methodName,
+        };
+
+        // Create ModelOutput for tracking
+        const definitionHash = await definition.computeHash();
+        const output = ModelOutput.create({
+          definitionId: definition.id,
+          methodName: input.methodName,
+          provenance: {
+            definitionHash,
+            modelVersion: modelDef.version,
+            triggeredBy: "manual",
+          },
         });
-        yield {
-          kind: "data_artifact_saved",
-          name: handle.name,
-          path: dataPath,
-        };
-      }
-    }
+        output.markRunning();
+        output.setLogFile(logFilePath);
+        await deps.outputRepo.save(modelType, input.methodName, output);
 
-    // Mark output as succeeded and save
-    output.markSucceeded();
-    await deps.outputRepo.save(modelType, input.methodName, output);
+        const vaultService = await deps.createVaultService();
+        const executionService = deps.createExecutionService();
 
-    // --- Post-run reports ---
-    let reportResults: Record<string, ReportResultView> | undefined;
-    let reportFailures = 0;
+        let execResult: MethodResult;
+        try {
+          execResult = yield* withEventBridge<
+            ModelMethodRunEvent,
+            MethodResult
+          >(
+            (push) =>
+              executionService.executeWorkflow(
+                evaluatedDefinition,
+                modelDef,
+                input.methodName,
+                {
+                  signal: ctx.signal,
+                  repoDir: deps.repoDir,
+                  modelType,
+                  modelId: evaluatedDefinition.id,
+                  globalArgs: evaluatedDefinition.globalArguments,
+                  definition: {
+                    id: evaluatedDefinition.id,
+                    name: evaluatedDefinition.name,
+                    version: evaluatedDefinition.version,
+                    tags: evaluatedDefinition.tags,
+                  },
+                  methodName: input.methodName,
+                  logger: getRunLogger(definition.name, input.methodName),
+                  dataRepository: deps.dataRepo,
+                  definitionRepository: deps.definitionRepo,
+                  runtimeTags: input.runtimeTags,
+                  vaultService,
+                  redactor,
+                  vaultSecrets: secretBag,
+                  skipCheckNames: input.skipCheckNames,
+                  skipCheckLabels: input.skipCheckLabels,
+                  skipAllChecks: input.skipAllChecks,
+                  driver: input.driver,
+                  onEvent: (event: MethodExecutionEvent) => {
+                    if (event.type === "output") {
+                      push({
+                        kind: "method_output",
+                        modelName: definition.name,
+                        methodName: input.methodName,
+                        stream: event.stream,
+                        line: event.line,
+                      });
+                    } else {
+                      push({
+                        kind: "method_event",
+                        modelName: definition.name,
+                        methodName: input.methodName,
+                        event,
+                      });
+                    }
+                  },
+                },
+              ),
+          );
+        } catch (error) {
+          // Mark output as failed and save
+          const errorMessage = error instanceof Error
+            ? error.message
+            : String(error);
+          const errorStack = error instanceof Error ? error.stack : undefined;
+          output.markFailed({ message: errorMessage, stack: errorStack });
+          await deps.outputRepo.save(modelType, input.methodName, output);
 
-    if (!input.skipAllReports && reportRegistry.getAll().length > 0) {
-      const dataHandles = execResult.dataHandles ?? [];
+          if (
+            error instanceof DOMException && error.name === "AbortError"
+          ) {
+            yield { kind: "error", error: cancelled(error) };
+            return;
+          }
 
-      // Run method-scope reports
-      const methodContext: MethodReportContext = {
-        scope: "method",
-        repoDir: deps.repoDir,
-        logger: getRunLogger(definition.name, input.methodName),
-        dataRepository: deps.dataRepo,
-        definitionRepository: deps.definitionRepo,
-        modelType,
-        modelId: evaluatedDefinition.id,
-        definition: {
-          id: evaluatedDefinition.id,
-          name: evaluatedDefinition.name,
-          version: evaluatedDefinition.version,
-          tags: evaluatedDefinition.tags,
-        },
-        globalArgs: reportGlobalArgs,
-        methodArgs: reportMethodArgs,
-        methodName: input.methodName,
-        executionStatus: "succeeded",
-        dataHandles,
-      };
-
-      const methodSummary = await executeReports(
-        reportRegistry,
-        methodContext,
-        modelType,
-        evaluatedDefinition.id,
-        definition.reportSelection,
-        {
-          skipAllReports: input.skipAllReports,
-          skipReportNames: input.skipReportNames,
-          skipReportLabels: input.skipReportLabels,
-          reportNames: input.reportNames,
-          reportLabels: input.reportLabels,
-        },
-        {
-          onReportStarted: () => {},
-          onReportCompleted: () => {},
-          onReportFailed: () => {},
-        },
-        input.methodName,
-        [...BUILTIN_METHOD_REPORTS, ...(modelDef.reports ?? [])],
-      );
-
-      // Yield report events and collect results
-      reportResults = {};
-      for (const result of methodSummary.results) {
-        yield {
-          kind: "report_started" as const,
-          reportName: result.name,
-          scope: result.scope,
-        };
-        if (result.success) {
-          yield {
-            kind: "report_completed" as const,
-            reportName: result.name,
-            scope: result.scope,
-            markdown: result.markdown!,
-            json: result.json!,
-          };
-        } else {
-          yield {
-            kind: "report_failed" as const,
-            reportName: result.name,
-            scope: result.scope,
-            error: result.error!,
-          };
+          yield { kind: "error", error: methodExecutionFailed(error) };
+          return;
         }
-        reportResults[result.name] = toReportResultView(result);
-      }
-      reportFailures += methodSummary.failures;
 
-      // Run model-scope reports
-      const modelContext: ModelReportContext = {
-        ...methodContext,
-        scope: "model",
-      };
+        // --- Process data artifacts ---
+        const dataArtifacts: DataArtifactView[] = [];
+        if (execResult.dataHandles && execResult.dataHandles.length > 0) {
+          for (const handle of execResult.dataHandles) {
+            const dataPath = deps.dataRepo.getPath(
+              modelType,
+              definition.id,
+              handle.name,
+              handle.version,
+            );
 
-      const modelSummary = await executeReports(
-        reportRegistry,
-        modelContext,
-        modelType,
-        evaluatedDefinition.id,
-        definition.reportSelection,
-        {
-          skipAllReports: input.skipAllReports,
-          skipReportNames: input.skipReportNames,
-          skipReportLabels: input.skipReportLabels,
-          reportNames: input.reportNames,
-          reportLabels: input.reportLabels,
-        },
-        {
-          onReportStarted: () => {},
-          onReportCompleted: () => {},
-          onReportFailed: () => {},
-        },
-        input.methodName,
-        [...BUILTIN_METHOD_REPORTS, ...(modelDef.reports ?? [])],
-      );
+            output.addDataArtifact({
+              dataId: handle.dataId,
+              name: handle.name,
+              version: handle.version,
+              tags: handle.tags,
+            });
 
-      for (const result of modelSummary.results) {
-        yield {
-          kind: "report_started" as const,
-          reportName: result.name,
-          scope: result.scope,
-        };
-        if (result.success) {
-          yield {
-            kind: "report_completed" as const,
-            reportName: result.name,
-            scope: result.scope,
-            markdown: result.markdown!,
-            json: result.json!,
-          };
-        } else {
-          yield {
-            kind: "report_failed" as const,
-            reportName: result.name,
-            scope: result.scope,
-            error: result.error!,
-          };
+            // Parse content if JSON for display
+            let attributes: Record<string, unknown> | undefined;
+            if (handle.metadata.contentType === "application/json") {
+              try {
+                const content = await deps.dataRepo.getContent(
+                  modelType,
+                  evaluatedDefinition.id,
+                  handle.name,
+                  handle.version,
+                );
+                if (content) {
+                  const text = new TextDecoder().decode(content);
+                  attributes = JSON.parse(text) as Record<string, unknown>;
+                }
+              } catch {
+                // Not valid JSON, skip attributes
+              }
+            }
+
+            dataArtifacts.push({
+              id: handle.dataId,
+              name: handle.name,
+              path: dataPath,
+              attributes,
+            });
+            yield {
+              kind: "data_artifact_saved",
+              name: handle.name,
+              path: dataPath,
+            };
+          }
         }
-        reportResults[result.name] = toReportResultView(result);
-      }
-      reportFailures += modelSummary.failures;
-    }
 
-    // --- Complete ---
-    const view: ModelMethodRunView = {
-      modelId: definition.id,
-      modelName: definition.name,
-      modelType: modelType.normalized,
-      methodName: input.methodName,
-      status: reportFailures > 0 ? "failed" : "succeeded",
-      duration: output.durationMs,
-      outputId: output.id,
-      logFile: logFilePath,
-      dataArtifacts,
-      reports: reportResults,
-    };
-    yield { kind: "completed", run: view };
-  } finally {
-    runLog.cleanup();
-  }
+        // Mark output as succeeded and save
+        output.markSucceeded();
+        await deps.outputRepo.save(modelType, input.methodName, output);
+
+        // --- Post-run reports ---
+        let reportResults: Record<string, ReportResultView> | undefined;
+        let reportFailures = 0;
+
+        if (!input.skipAllReports && reportRegistry.getAll().length > 0) {
+          const dataHandles = execResult.dataHandles ?? [];
+
+          // Run method-scope reports
+          const methodContext: MethodReportContext = {
+            scope: "method",
+            repoDir: deps.repoDir,
+            logger: getRunLogger(definition.name, input.methodName),
+            dataRepository: deps.dataRepo,
+            definitionRepository: deps.definitionRepo,
+            modelType,
+            modelId: evaluatedDefinition.id,
+            definition: {
+              id: evaluatedDefinition.id,
+              name: evaluatedDefinition.name,
+              version: evaluatedDefinition.version,
+              tags: evaluatedDefinition.tags,
+            },
+            globalArgs: reportGlobalArgs,
+            methodArgs: reportMethodArgs,
+            methodName: input.methodName,
+            executionStatus: "succeeded",
+            dataHandles,
+          };
+
+          const methodSummary = await executeReports(
+            reportRegistry,
+            methodContext,
+            modelType,
+            evaluatedDefinition.id,
+            definition.reportSelection,
+            {
+              skipAllReports: input.skipAllReports,
+              skipReportNames: input.skipReportNames,
+              skipReportLabels: input.skipReportLabels,
+              reportNames: input.reportNames,
+              reportLabels: input.reportLabels,
+            },
+            {
+              onReportStarted: () => {},
+              onReportCompleted: () => {},
+              onReportFailed: () => {},
+            },
+            input.methodName,
+            [...BUILTIN_METHOD_REPORTS, ...(modelDef.reports ?? [])],
+          );
+
+          // Yield report events and collect results
+          reportResults = {};
+          for (const result of methodSummary.results) {
+            yield {
+              kind: "report_started" as const,
+              reportName: result.name,
+              scope: result.scope,
+            };
+            if (result.success) {
+              yield {
+                kind: "report_completed" as const,
+                reportName: result.name,
+                scope: result.scope,
+                markdown: result.markdown!,
+                json: result.json!,
+              };
+            } else {
+              yield {
+                kind: "report_failed" as const,
+                reportName: result.name,
+                scope: result.scope,
+                error: result.error!,
+              };
+            }
+            reportResults[result.name] = toReportResultView(result);
+          }
+          reportFailures += methodSummary.failures;
+
+          // Run model-scope reports
+          const modelContext: ModelReportContext = {
+            ...methodContext,
+            scope: "model",
+          };
+
+          const modelSummary = await executeReports(
+            reportRegistry,
+            modelContext,
+            modelType,
+            evaluatedDefinition.id,
+            definition.reportSelection,
+            {
+              skipAllReports: input.skipAllReports,
+              skipReportNames: input.skipReportNames,
+              skipReportLabels: input.skipReportLabels,
+              reportNames: input.reportNames,
+              reportLabels: input.reportLabels,
+            },
+            {
+              onReportStarted: () => {},
+              onReportCompleted: () => {},
+              onReportFailed: () => {},
+            },
+            input.methodName,
+            [...BUILTIN_METHOD_REPORTS, ...(modelDef.reports ?? [])],
+          );
+
+          for (const result of modelSummary.results) {
+            yield {
+              kind: "report_started" as const,
+              reportName: result.name,
+              scope: result.scope,
+            };
+            if (result.success) {
+              yield {
+                kind: "report_completed" as const,
+                reportName: result.name,
+                scope: result.scope,
+                markdown: result.markdown!,
+                json: result.json!,
+              };
+            } else {
+              yield {
+                kind: "report_failed" as const,
+                reportName: result.name,
+                scope: result.scope,
+                error: result.error!,
+              };
+            }
+            reportResults[result.name] = toReportResultView(result);
+          }
+          reportFailures += modelSummary.failures;
+        }
+
+        // --- Complete ---
+        const view: ModelMethodRunView = {
+          modelId: definition.id,
+          modelName: definition.name,
+          modelType: modelType.normalized,
+          methodName: input.methodName,
+          status: reportFailures > 0 ? "failed" : "succeeded",
+          duration: output.durationMs,
+          outputId: output.id,
+          logFile: logFilePath,
+          dataArtifacts,
+          reports: reportResults,
+        };
+        yield { kind: "completed", run: view };
+      } finally {
+        runLog.cleanup();
+      }
+    })(),
+  );
 }
 
 /**

--- a/src/libswamp/models/search.ts
+++ b/src/libswamp/models/search.ts
@@ -20,6 +20,7 @@
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * A single model search result item.
  */
@@ -72,22 +73,28 @@ export async function* modelSearch(
   deps: ModelSearchDeps,
   input: ModelSearchInput,
 ): AsyncGenerator<ModelSearchEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.model.search",
+    { "search.query": input.query ?? "" },
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const allResults = await deps.findAllGlobal();
-  const results: ModelSearchItem[] = allResults.map(
-    ({ definition, type }) => ({
-      id: definition.id,
-      name: definition.name,
-      type: type.normalized,
-    }),
+      const allResults = await deps.findAllGlobal();
+      const results: ModelSearchItem[] = allResults.map(
+        ({ definition, type }) => ({
+          id: definition.id,
+          name: definition.name,
+          type: type.normalized,
+        }),
+      );
+
+      yield {
+        kind: "completed",
+        data: {
+          query: input.query ?? "",
+          results,
+        },
+      };
+    })(),
   );
-
-  yield {
-    kind: "completed",
-    data: {
-      query: input.query ?? "",
-      results,
-    },
-  };
 }

--- a/src/libswamp/models/validate.ts
+++ b/src/libswamp/models/validate.ts
@@ -32,6 +32,7 @@ import type { ModelType } from "../../domain/models/model_type.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** Validation result for a single check. */
 export interface ValidationItemData {
   name: string;
@@ -285,11 +286,17 @@ export async function* modelValidate(
   deps: ModelValidateDeps,
   input: ModelValidateInput,
 ): AsyncIterable<ModelValidateEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.model.validate",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  if (!input.modelIdOrName) {
-    yield* validateAll(deps);
-  } else {
-    yield* validateSingle(deps, input.modelIdOrName);
-  }
+      if (!input.modelIdOrName) {
+        yield* validateAll(deps);
+      } else {
+        yield* validateSingle(deps, input.modelIdOrName);
+      }
+    })(),
+  );
 }

--- a/src/libswamp/repo/init.ts
+++ b/src/libswamp/repo/init.ts
@@ -28,6 +28,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { validationFailed } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Data structure for the repo init output.
  */
@@ -77,42 +78,48 @@ export async function* repoInit(
   deps: RepoInitDeps,
   input: RepoInitInput,
 ): AsyncIterable<RepoInitEvent> {
-  yield { kind: "initializing" };
+  yield* withGeneratorSpan(
+    "swamp.repo.create",
+    {},
+    (async function* () {
+      yield { kind: "initializing" };
 
-  ctx.logger.debug`Initializing repository at: ${input.path}`;
+      ctx.logger.debug`Initializing repository at: ${input.path}`;
 
-  const repoPath = RepoPath.create(input.path);
+      const repoPath = RepoPath.create(input.path);
 
-  let result: RepoInitResult;
-  try {
-    result = await deps.init(repoPath, {
-      force: input.force,
-      tool: input.tool as AiTool,
-    });
-  } catch (error) {
-    yield {
-      kind: "error",
-      error: validationFailed(
-        error instanceof Error ? error.message : String(error),
-      ),
-    };
-    return;
-  }
+      let result: RepoInitResult;
+      try {
+        result = await deps.init(repoPath, {
+          force: input.force,
+          tool: input.tool as AiTool,
+        });
+      } catch (error) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            error instanceof Error ? error.message : String(error),
+          ),
+        };
+        return;
+      }
 
-  ctx.logger.debug`Repository initialized: ${result.path}`;
+      ctx.logger.debug`Repository initialized: ${result.path}`;
 
-  const data: RepoInitData = {
-    path: result.path,
-    version: result.version,
-    initializedAt: result.initializedAt,
-    skillsCopied: result.skillsCopied,
-    instructionsFileCreated: result.instructionsFileCreated,
-    settingsCreated: result.settingsCreated,
-    gitignoreAction: result.gitignoreAction,
-    tool: result.tool,
-  };
+      const data: RepoInitData = {
+        path: result.path,
+        version: result.version,
+        initializedAt: result.initializedAt,
+        skillsCopied: result.skillsCopied,
+        instructionsFileCreated: result.instructionsFileCreated,
+        settingsCreated: result.settingsCreated,
+        gitignoreAction: result.gitignoreAction,
+        tool: result.tool,
+      };
 
-  yield { kind: "completed", data };
+      yield { kind: "completed", data };
+    })(),
+  );
 }
 
 // --- Repo Upgrade ---
@@ -167,41 +174,47 @@ export async function* repoUpgrade(
   deps: RepoUpgradeDeps,
   input: RepoUpgradeInput,
 ): AsyncIterable<RepoUpgradeEvent> {
-  yield { kind: "upgrading" };
+  yield* withGeneratorSpan(
+    "swamp.repo.upgrade",
+    {},
+    (async function* () {
+      yield { kind: "upgrading" };
 
-  ctx.logger.debug`Upgrading repository at: ${input.path}`;
+      ctx.logger.debug`Upgrading repository at: ${input.path}`;
 
-  const repoPath = RepoPath.create(input.path);
+      const repoPath = RepoPath.create(input.path);
 
-  let result: RepoUpgradeResult;
-  try {
-    result = await deps.upgrade(repoPath, {
-      tool: input.tool as AiTool | undefined,
-      includeGitignore: input.includeGitignore,
-    });
-  } catch (error) {
-    yield {
-      kind: "error",
-      error: validationFailed(
-        error instanceof Error ? error.message : String(error),
-      ),
-    };
-    return;
-  }
+      let result: RepoUpgradeResult;
+      try {
+        result = await deps.upgrade(repoPath, {
+          tool: input.tool as AiTool | undefined,
+          includeGitignore: input.includeGitignore,
+        });
+      } catch (error) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            error instanceof Error ? error.message : String(error),
+          ),
+        };
+        return;
+      }
 
-  ctx.logger.debug`Repository upgraded: ${result.path}`;
+      ctx.logger.debug`Repository upgraded: ${result.path}`;
 
-  const data: RepoUpgradeData = {
-    path: result.path,
-    previousVersion: result.previousVersion,
-    newVersion: result.newVersion,
-    upgradedAt: result.upgradedAt,
-    skillsUpdated: result.skillsUpdated,
-    instructionsUpdated: result.instructionsUpdated,
-    settingsUpdated: result.settingsUpdated,
-    gitignoreAction: result.gitignoreAction,
-    tool: result.tool,
-  };
+      const data: RepoUpgradeData = {
+        path: result.path,
+        previousVersion: result.previousVersion,
+        newVersion: result.newVersion,
+        upgradedAt: result.upgradedAt,
+        skillsUpdated: result.skillsUpdated,
+        instructionsUpdated: result.instructionsUpdated,
+        settingsUpdated: result.settingsUpdated,
+        gitignoreAction: result.gitignoreAction,
+        tool: result.tool,
+      };
 
-  yield { kind: "completed", data };
+      yield { kind: "completed", data };
+    })(),
+  );
 }

--- a/src/libswamp/reports/describe.ts
+++ b/src/libswamp/reports/describe.ts
@@ -22,6 +22,7 @@ import type { LibSwampContext } from "../context.ts";
 import { notFound } from "../errors.ts";
 import type { ReportDescribeEvent } from "./report_views.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Dependencies for the report describe operation.
  */
@@ -37,21 +38,27 @@ export async function* reportDescribe(
   deps: ReportDescribeDeps,
   reportName: string,
 ): AsyncGenerator<ReportDescribeEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.report.describe",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const report = deps.getReport(reportName);
-  if (!report) {
-    yield { kind: "error", error: notFound("Report", reportName) };
-    return;
-  }
+      const report = deps.getReport(reportName);
+      if (!report) {
+        yield { kind: "error", error: notFound("Report", reportName) };
+        return;
+      }
 
-  yield {
-    kind: "completed",
-    data: {
-      name: reportName,
-      description: report.description,
-      scope: report.scope,
-      labels: report.labels ?? [],
-    },
-  };
+      yield {
+        kind: "completed",
+        data: {
+          name: reportName,
+          description: report.description,
+          scope: report.scope,
+          labels: report.labels ?? [],
+        },
+      };
+    })(),
+  );
 }

--- a/src/libswamp/reports/get.ts
+++ b/src/libswamp/reports/get.ts
@@ -24,6 +24,7 @@ import type { LibSwampContext } from "../context.ts";
 import { notFound, validationFailed } from "../errors.ts";
 import type { ReportGetEvent, StoredReportDetail } from "./report_views.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Input for the report get operation.
  */
@@ -81,197 +82,203 @@ export async function* reportGet(
   deps: ReportGetDeps,
   input: ReportGetInput,
 ): AsyncGenerator<ReportGetEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.report.get",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  // --- Find matching report data entries ---
-  let matches: Array<{
-    data: Data;
-    modelType: ModelType;
-    modelId: string;
-  }>;
+      // --- Find matching report data entries ---
+      let matches: Array<{
+        data: Data;
+        modelType: ModelType;
+        modelId: string;
+      }>;
 
-  if (input.model) {
-    const result = await deps.lookupDefinition(input.model);
-    if (!result) {
-      yield { kind: "error", error: notFound("Model", input.model) };
-      return;
-    }
-    const items = await deps.findAllForModel(
-      result.type,
-      result.definition.id,
-    );
-    matches = items
-      .filter((d) => isMatchingReport(d, input.reportName))
-      .map((d) => ({
-        data: d,
-        modelType: result.type,
-        modelId: result.definition.id,
-      }));
-  } else if (input.workflow) {
-    const wf = await deps.findWorkflowByName(input.workflow);
-    if (!wf) {
-      yield { kind: "error", error: notFound("Workflow", input.workflow) };
-      return;
-    }
-    const { ModelType: MT } = await import(
-      "../../domain/models/model_type.ts"
-    );
-    const workflowModelType = MT.create("workflow");
-    const items = await deps.findAllForModel(workflowModelType, wf.id);
-    matches = items
-      .filter((d) => isMatchingReport(d, input.reportName))
-      .map((d) => ({
-        data: d,
-        modelType: workflowModelType,
-        modelId: wf.id,
-      }));
-  } else {
-    // Global search
-    const all = await deps.findAllGlobal();
-    matches = all.filter((c) => isMatchingReport(c.data, input.reportName));
-  }
-
-  // Filter by variant when specified
-  if (input.variant) {
-    matches = matches.filter(
-      (m) => m.data.tags.varySuffix === input.variant,
-    );
-  }
-
-  if (matches.length === 0) {
-    yield {
-      kind: "error",
-      error: notFound("Report", input.reportName),
-    };
-    return;
-  }
-
-  // Ambiguity check: multiple models/workflows have this report
-  if (matches.length > 1 && !input.model && !input.workflow) {
-    const locations = new Set<string>();
-    for (const m of matches) {
-      if (m.modelType.normalized === "workflow") {
-        const wf = await deps.findWorkflowById(m.modelId);
-        locations.add(`workflow:${wf?.name ?? m.modelId}`);
+      if (input.model) {
+        const result = await deps.lookupDefinition(input.model);
+        if (!result) {
+          yield { kind: "error", error: notFound("Model", input.model) };
+          return;
+        }
+        const items = await deps.findAllForModel(
+          result.type,
+          result.definition.id,
+        );
+        matches = items
+          .filter((d) => isMatchingReport(d, input.reportName))
+          .map((d) => ({
+            data: d,
+            modelType: result.type,
+            modelId: result.definition.id,
+          }));
+      } else if (input.workflow) {
+        const wf = await deps.findWorkflowByName(input.workflow);
+        if (!wf) {
+          yield { kind: "error", error: notFound("Workflow", input.workflow) };
+          return;
+        }
+        const { ModelType: MT } = await import(
+          "../../domain/models/model_type.ts"
+        );
+        const workflowModelType = MT.create("workflow");
+        const items = await deps.findAllForModel(workflowModelType, wf.id);
+        matches = items
+          .filter((d) => isMatchingReport(d, input.reportName))
+          .map((d) => ({
+            data: d,
+            modelType: workflowModelType,
+            modelId: wf.id,
+          }));
       } else {
-        const def = await deps.lookupDefinitionById(m.modelType, m.modelId);
-        locations.add(`model:${def?.name ?? m.modelId}`);
+        // Global search
+        const all = await deps.findAllGlobal();
+        matches = all.filter((c) => isMatchingReport(c.data, input.reportName));
       }
-    }
-    if (locations.size > 1) {
-      const locationList = [...locations].join(", ");
-      yield {
-        kind: "error",
-        error: validationFailed(
-          `Report "${input.reportName}" exists in multiple locations: ${locationList}. Use --model or --workflow to disambiguate.`,
-        ),
+
+      // Filter by variant when specified
+      if (input.variant) {
+        matches = matches.filter(
+          (m) => m.data.tags.varySuffix === input.variant,
+        );
+      }
+
+      if (matches.length === 0) {
+        yield {
+          kind: "error",
+          error: notFound("Report", input.reportName),
+        };
+        return;
+      }
+
+      // Ambiguity check: multiple models/workflows have this report
+      if (matches.length > 1 && !input.model && !input.workflow) {
+        const locations = new Set<string>();
+        for (const m of matches) {
+          if (m.modelType.normalized === "workflow") {
+            const wf = await deps.findWorkflowById(m.modelId);
+            locations.add(`workflow:${wf?.name ?? m.modelId}`);
+          } else {
+            const def = await deps.lookupDefinitionById(m.modelType, m.modelId);
+            locations.add(`model:${def?.name ?? m.modelId}`);
+          }
+        }
+        if (locations.size > 1) {
+          const locationList = [...locations].join(", ");
+          yield {
+            kind: "error",
+            error: validationFailed(
+              `Report "${input.reportName}" exists in multiple locations: ${locationList}. Use --model or --workflow to disambiguate.`,
+            ),
+          };
+          return;
+        }
+      }
+
+      // Ambiguity check: multiple variants on the same model
+      if (matches.length > 1 && !input.variant) {
+        const variants = new Set(
+          matches.map((m) => m.data.tags.varySuffix).filter(Boolean),
+        );
+        if (variants.size > 1) {
+          const variantList = [...variants].join(", ");
+          yield {
+            kind: "error",
+            error: validationFailed(
+              `Report "${input.reportName}" has multiple variants: ${variantList}. Use --variant to select one.`,
+            ),
+          };
+          return;
+        }
+      }
+
+      // Pick the best match (latest version or specific version)
+      let match = matches[0];
+      if (input.version) {
+        const versionMatch = matches.find(
+          (m) => m.data.version === input.version,
+        );
+        if (!versionMatch) {
+          yield {
+            kind: "error",
+            error: notFound(
+              "Report",
+              `"${input.reportName}" version ${input.version}`,
+            ),
+          };
+          return;
+        }
+        match = versionMatch;
+      } else {
+        // Pick latest by createdAt
+        matches.sort(
+          (a, b) => b.data.createdAt.getTime() - a.data.createdAt.getTime(),
+        );
+        match = matches[0];
+      }
+
+      const { data, modelType, modelId } = match;
+      const reportScope = data.tags.reportScope ?? "unknown";
+
+      // Resolve model name
+      let modelName = modelId;
+      if (modelType.normalized === "workflow") {
+        const wf = await deps.findWorkflowById(modelId);
+        if (wf) modelName = wf.name;
+      } else {
+        const def = await deps.lookupDefinitionById(modelType, modelId);
+        if (def) modelName = def.name;
+      }
+
+      // Resolve workflow name
+      let workflowName: string | undefined;
+      if (modelType.normalized === "workflow") {
+        const wf = await deps.findWorkflowById(modelId);
+        if (wf) workflowName = wf.name;
+      }
+
+      // Fetch markdown content
+      const rawMd = await deps.getContent(
+        modelType,
+        modelId,
+        data.name,
+        data.version,
+      );
+      const markdown = rawMd ? new TextDecoder().decode(rawMd) : "";
+
+      // Fetch paired JSON content
+      const jsonDataName = `${data.name}-json`;
+      const rawJson = await deps.getContent(
+        modelType,
+        modelId,
+        jsonDataName,
+        data.version,
+      );
+      let json: Record<string, unknown> = {};
+      if (rawJson) {
+        try {
+          json = JSON.parse(new TextDecoder().decode(rawJson));
+        } catch {
+          // Leave as empty if JSON parse fails
+        }
+      }
+
+      const detail: StoredReportDetail = {
+        reportName: input.reportName,
+        reportScope,
+        modelId,
+        modelName,
+        modelType: modelType.normalized,
+        version: data.version,
+        createdAt: data.createdAt.toISOString(),
+        workflowName,
+        varySuffix: data.tags.varySuffix || undefined,
+        dataName: data.name,
+        markdown,
+        json,
       };
-      return;
-    }
-  }
 
-  // Ambiguity check: multiple variants on the same model
-  if (matches.length > 1 && !input.variant) {
-    const variants = new Set(
-      matches.map((m) => m.data.tags.varySuffix).filter(Boolean),
-    );
-    if (variants.size > 1) {
-      const variantList = [...variants].join(", ");
-      yield {
-        kind: "error",
-        error: validationFailed(
-          `Report "${input.reportName}" has multiple variants: ${variantList}. Use --variant to select one.`,
-        ),
-      };
-      return;
-    }
-  }
-
-  // Pick the best match (latest version or specific version)
-  let match = matches[0];
-  if (input.version) {
-    const versionMatch = matches.find(
-      (m) => m.data.version === input.version,
-    );
-    if (!versionMatch) {
-      yield {
-        kind: "error",
-        error: notFound(
-          "Report",
-          `"${input.reportName}" version ${input.version}`,
-        ),
-      };
-      return;
-    }
-    match = versionMatch;
-  } else {
-    // Pick latest by createdAt
-    matches.sort(
-      (a, b) => b.data.createdAt.getTime() - a.data.createdAt.getTime(),
-    );
-    match = matches[0];
-  }
-
-  const { data, modelType, modelId } = match;
-  const reportScope = data.tags.reportScope ?? "unknown";
-
-  // Resolve model name
-  let modelName = modelId;
-  if (modelType.normalized === "workflow") {
-    const wf = await deps.findWorkflowById(modelId);
-    if (wf) modelName = wf.name;
-  } else {
-    const def = await deps.lookupDefinitionById(modelType, modelId);
-    if (def) modelName = def.name;
-  }
-
-  // Resolve workflow name
-  let workflowName: string | undefined;
-  if (modelType.normalized === "workflow") {
-    const wf = await deps.findWorkflowById(modelId);
-    if (wf) workflowName = wf.name;
-  }
-
-  // Fetch markdown content
-  const rawMd = await deps.getContent(
-    modelType,
-    modelId,
-    data.name,
-    data.version,
+      yield { kind: "completed", data: detail };
+    })(),
   );
-  const markdown = rawMd ? new TextDecoder().decode(rawMd) : "";
-
-  // Fetch paired JSON content
-  const jsonDataName = `${data.name}-json`;
-  const rawJson = await deps.getContent(
-    modelType,
-    modelId,
-    jsonDataName,
-    data.version,
-  );
-  let json: Record<string, unknown> = {};
-  if (rawJson) {
-    try {
-      json = JSON.parse(new TextDecoder().decode(rawJson));
-    } catch {
-      // Leave as empty if JSON parse fails
-    }
-  }
-
-  const detail: StoredReportDetail = {
-    reportName: input.reportName,
-    reportScope,
-    modelId,
-    modelName,
-    modelType: modelType.normalized,
-    version: data.version,
-    createdAt: data.createdAt.toISOString(),
-    workflowName,
-    varySuffix: data.tags.varySuffix || undefined,
-    dataName: data.name,
-    markdown,
-    json,
-  };
-
-  yield { kind: "completed", data: detail };
 }

--- a/src/libswamp/reports/search.ts
+++ b/src/libswamp/reports/search.ts
@@ -25,6 +25,7 @@ import type { LibSwampContext } from "../context.ts";
 import { notFound } from "../errors.ts";
 import type { ReportSearchEvent, StoredReportSummary } from "./report_views.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Input for the report search operation.
  */
@@ -77,125 +78,131 @@ export async function* reportSearch(
   deps: ReportSearchDeps,
   input: ReportSearchInput,
 ): AsyncGenerator<ReportSearchEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.report.search",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  // --- Collect candidate report data entries ---
-  let candidates: Array<{
-    data: Data;
-    modelType: ModelType;
-    modelId: string;
-  }>;
+      // --- Collect candidate report data entries ---
+      let candidates: Array<{
+        data: Data;
+        modelType: ModelType;
+        modelId: string;
+      }>;
 
-  if (input.model) {
-    const result = await deps.lookupDefinition(input.model);
-    if (!result) {
-      yield { kind: "error", error: notFound("Model", input.model) };
-      return;
-    }
-    const items = await deps.findAllForModel(
-      result.type,
-      result.definition.id,
-    );
-    candidates = items.map((d) => ({
-      data: d,
-      modelType: result.type,
-      modelId: result.definition.id,
-    }));
-  } else if (input.workflow) {
-    const wf = await deps.findWorkflowByName(input.workflow);
-    if (!wf) {
-      yield { kind: "error", error: notFound("Workflow", input.workflow) };
-      return;
-    }
-    const { ModelType: MT } = await import(
-      "../../domain/models/model_type.ts"
-    );
-    const workflowModelType = MT.create("workflow");
-    const items = await deps.findAllForModel(workflowModelType, wf.id);
-    candidates = items.map((d) => ({
-      data: d,
-      modelType: workflowModelType,
-      modelId: wf.id,
-    }));
-  } else {
-    candidates = await deps.findAllGlobal();
-  }
+      if (input.model) {
+        const result = await deps.lookupDefinition(input.model);
+        if (!result) {
+          yield { kind: "error", error: notFound("Model", input.model) };
+          return;
+        }
+        const items = await deps.findAllForModel(
+          result.type,
+          result.definition.id,
+        );
+        candidates = items.map((d) => ({
+          data: d,
+          modelType: result.type,
+          modelId: result.definition.id,
+        }));
+      } else if (input.workflow) {
+        const wf = await deps.findWorkflowByName(input.workflow);
+        if (!wf) {
+          yield { kind: "error", error: notFound("Workflow", input.workflow) };
+          return;
+        }
+        const { ModelType: MT } = await import(
+          "../../domain/models/model_type.ts"
+        );
+        const workflowModelType = MT.create("workflow");
+        const items = await deps.findAllForModel(workflowModelType, wf.id);
+        candidates = items.map((d) => ({
+          data: d,
+          modelType: workflowModelType,
+          modelId: wf.id,
+        }));
+      } else {
+        candidates = await deps.findAllGlobal();
+      }
 
-  // Filter to report markdown entries
-  candidates = candidates.filter((c) => isReportMarkdown(c.data));
+      // Filter to report markdown entries
+      candidates = candidates.filter((c) => isReportMarkdown(c.data));
 
-  // Apply scope filter
-  if (input.scope) {
-    candidates = candidates.filter(
-      (c) => c.data.tags.reportScope === input.scope,
-    );
-  }
+      // Apply scope filter
+      if (input.scope) {
+        candidates = candidates.filter(
+          (c) => c.data.tags.reportScope === input.scope,
+        );
+      }
 
-  // Apply label filter — only include reports whose definition has all requested labels
-  if (input.labels && input.labels.length > 0) {
-    candidates = candidates.filter((c) => {
-      const reportName = c.data.tags.reportName;
-      if (!reportName) return false;
-      const def = deps.getReport(reportName);
-      if (!def || !def.labels) return false;
-      return input.labels!.every((l) => def.labels!.includes(l));
-    });
-  }
+      // Apply label filter — only include reports whose definition has all requested labels
+      if (input.labels && input.labels.length > 0) {
+        candidates = candidates.filter((c) => {
+          const reportName = c.data.tags.reportName;
+          if (!reportName) return false;
+          const def = deps.getReport(reportName);
+          if (!def || !def.labels) return false;
+          return input.labels!.every((l) => def.labels!.includes(l));
+        });
+      }
 
-  // Apply text query filter
-  if (input.query) {
-    const q = input.query.toLowerCase();
-    candidates = candidates.filter((c) => {
-      const reportName = c.data.tags.reportName ?? "";
-      const varySuffix = c.data.tags.varySuffix ?? "";
-      return reportName.toLowerCase().includes(q) ||
-        c.data.name.toLowerCase().includes(q) ||
-        varySuffix.toLowerCase().includes(q);
-    });
-  }
+      // Apply text query filter
+      if (input.query) {
+        const q = input.query.toLowerCase();
+        candidates = candidates.filter((c) => {
+          const reportName = c.data.tags.reportName ?? "";
+          const varySuffix = c.data.tags.varySuffix ?? "";
+          return reportName.toLowerCase().includes(q) ||
+            c.data.name.toLowerCase().includes(q) ||
+            varySuffix.toLowerCase().includes(q);
+        });
+      }
 
-  // Sort by createdAt descending
-  candidates.sort(
-    (a, b) => b.data.createdAt.getTime() - a.data.createdAt.getTime(),
+      // Sort by createdAt descending
+      candidates.sort(
+        (a, b) => b.data.createdAt.getTime() - a.data.createdAt.getTime(),
+      );
+
+      // --- Build summary results ---
+      const reports: StoredReportSummary[] = [];
+
+      for (const { data, modelType, modelId } of candidates) {
+        const reportName = data.tags.reportName ?? data.name;
+        const reportScope = data.tags.reportScope ?? "unknown";
+
+        // Resolve model name
+        let modelName = modelId;
+        if (modelType.normalized === "workflow") {
+          const wf = await deps.findWorkflowById(modelId);
+          if (wf) modelName = wf.name;
+        } else {
+          const def = await deps.lookupDefinitionById(modelType, modelId);
+          if (def) modelName = def.name;
+        }
+
+        // Resolve workflow name for workflow-scoped reports
+        let workflowName: string | undefined;
+        if (modelType.normalized === "workflow") {
+          const wf = await deps.findWorkflowById(modelId);
+          if (wf) workflowName = wf.name;
+        }
+
+        reports.push({
+          reportName,
+          reportScope,
+          modelId,
+          modelName,
+          modelType: modelType.normalized,
+          version: data.version,
+          createdAt: data.createdAt.toISOString(),
+          workflowName,
+          dataName: data.name,
+          varySuffix: data.tags.varySuffix || undefined,
+        });
+      }
+
+      yield { kind: "completed", data: { reports } };
+    })(),
   );
-
-  // --- Build summary results ---
-  const reports: StoredReportSummary[] = [];
-
-  for (const { data, modelType, modelId } of candidates) {
-    const reportName = data.tags.reportName ?? data.name;
-    const reportScope = data.tags.reportScope ?? "unknown";
-
-    // Resolve model name
-    let modelName = modelId;
-    if (modelType.normalized === "workflow") {
-      const wf = await deps.findWorkflowById(modelId);
-      if (wf) modelName = wf.name;
-    } else {
-      const def = await deps.lookupDefinitionById(modelType, modelId);
-      if (def) modelName = def.name;
-    }
-
-    // Resolve workflow name for workflow-scoped reports
-    let workflowName: string | undefined;
-    if (modelType.normalized === "workflow") {
-      const wf = await deps.findWorkflowById(modelId);
-      if (wf) workflowName = wf.name;
-    }
-
-    reports.push({
-      reportName,
-      reportScope,
-      modelId,
-      modelName,
-      modelType: modelType.normalized,
-      version: data.version,
-      createdAt: data.createdAt.toISOString(),
-      workflowName,
-      dataName: data.name,
-      varySuffix: data.tags.varySuffix || undefined,
-    });
-  }
-
-  yield { kind: "completed", data: { reports } };
 }

--- a/src/libswamp/source/clean.ts
+++ b/src/libswamp/source/clean.ts
@@ -24,6 +24,7 @@ import { JsonSourceMetadataRepository } from "../../infrastructure/source/json_s
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Data structure for the source clean output.
  */
@@ -53,9 +54,15 @@ export async function* sourceClean(
   ctx: LibSwampContext,
   deps: SourceCleanDeps,
 ): AsyncIterable<SourceCleanEvent> {
-  ctx.logger.debug`Cleaning source`;
+  yield* withGeneratorSpan(
+    "swamp.source.clean",
+    {},
+    (async function* () {
+      ctx.logger.debug`Cleaning source`;
 
-  const result = await deps.clean();
+      const result = await deps.clean();
 
-  yield { kind: "completed", data: result };
+      yield { kind: "completed", data: result };
+    })(),
+  );
 }

--- a/src/libswamp/source/fetch.ts
+++ b/src/libswamp/source/fetch.ts
@@ -24,6 +24,7 @@ import { JsonSourceMetadataRepository } from "../../infrastructure/source/json_s
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Data structure for the source fetch output.
  */
@@ -60,11 +61,17 @@ export async function* sourceFetch(
   deps: SourceFetchDeps,
   input: SourceFetchInput,
 ): AsyncIterable<SourceFetchEvent> {
-  ctx.logger.debug`Fetching source version: ${input.version}`;
+  yield* withGeneratorSpan(
+    "swamp.source.fetch",
+    {},
+    (async function* () {
+      ctx.logger.debug`Fetching source version: ${input.version}`;
 
-  yield { kind: "fetching" };
+      yield { kind: "fetching" };
 
-  const result = await deps.fetch(input.version);
+      const result = await deps.fetch(input.version);
 
-  yield { kind: "completed", data: result };
+      yield { kind: "completed", data: result };
+    })(),
+  );
 }

--- a/src/libswamp/telemetry/stats.ts
+++ b/src/libswamp/telemetry/stats.ts
@@ -25,6 +25,7 @@ import { JsonTelemetryRepository } from "../../infrastructure/persistence/json_t
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** Data payload for the completed event. */
 export interface TelemetryStatsData extends TelemetryStats {}
 
@@ -60,14 +61,20 @@ export async function* telemetryStats(
   deps: TelemetryStatsDeps,
   input: TelemetryStatsInput,
 ): AsyncIterable<TelemetryStatsEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.telemetry.stats",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const stats = await deps.getStats(input.days);
+      const stats = await deps.getStats(input.days);
 
-  if (stats.totalInvocations === 0) {
-    yield { kind: "completed", data: null };
-    return;
-  }
+      if (stats.totalInvocations === 0) {
+        yield { kind: "completed", data: null };
+        return;
+      }
 
-  yield { kind: "completed", data: stats };
+      yield { kind: "completed", data: stats };
+    })(),
+  );
 }

--- a/src/libswamp/types/describe.ts
+++ b/src/libswamp/types/describe.ts
@@ -30,6 +30,7 @@ import {
   zodToJsonSchema,
 } from "./schema_helpers.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Data structure for the type describe output.
  */
@@ -70,46 +71,52 @@ export async function* typeDescribe(
   deps: TypeDescribeDeps,
   modelType: ModelType,
 ): AsyncIterable<TypeDescribeEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.type.describe",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const definition = await deps.resolveModelType(modelType);
-  if (!definition) {
-    const availableTypes = deps.getAvailableTypes().join(", ");
-    yield {
-      kind: "error",
-      error: notFound(
-        "Model type",
-        `${modelType.raw}. Available types: ${availableTypes || "none"}`,
-      ),
-    };
-    return;
-  }
+      const definition = await deps.resolveModelType(modelType);
+      if (!definition) {
+        const availableTypes = deps.getAvailableTypes().join(", ");
+        yield {
+          kind: "error",
+          error: notFound(
+            "Model type",
+            `${modelType.raw}. Available types: ${availableTypes || "none"}`,
+          ),
+        };
+        return;
+      }
 
-  const globalArguments = definition.globalArguments
-    ? zodToJsonSchema(definition.globalArguments)
-    : undefined;
+      const globalArguments = definition.globalArguments
+        ? zodToJsonSchema(definition.globalArguments)
+        : undefined;
 
-  const methods: MethodDescribeData[] = Object.entries(definition.methods)
-    .map(
-      ([name, method]) =>
-        toMethodDescribeData(
-          name,
-          method,
-          definition.resources,
-          definition.files,
-        ),
-    );
+      const methods: MethodDescribeData[] = Object.entries(definition.methods)
+        .map(
+          ([name, method]) =>
+            toMethodDescribeData(
+              name,
+              method,
+              definition.resources,
+              definition.files,
+            ),
+        );
 
-  yield {
-    kind: "completed",
-    data: {
-      type: {
-        raw: modelType.raw,
-        normalized: modelType.normalized,
-      },
-      version: definition.version,
-      globalArguments,
-      methods,
-    },
-  };
+      yield {
+        kind: "completed",
+        data: {
+          type: {
+            raw: modelType.raw,
+            normalized: modelType.normalized,
+          },
+          version: definition.version,
+          globalArguments,
+          methods,
+        },
+      };
+    })(),
+  );
 }

--- a/src/libswamp/types/search.ts
+++ b/src/libswamp/types/search.ts
@@ -20,6 +20,7 @@
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * A single type search result item.
  */
@@ -67,19 +68,25 @@ export async function* typeSearch(
   deps: TypeSearchDeps,
   input: TypeSearchInput,
 ): AsyncGenerator<TypeSearchEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.type.search",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const types = deps.getRegisteredTypes();
-  const results: TypeSearchItem[] = types.map((t) => ({
-    raw: t.raw,
-    normalized: t.normalized,
-  }));
+      const types = deps.getRegisteredTypes();
+      const results: TypeSearchItem[] = types.map((t) => ({
+        raw: t.raw,
+        normalized: t.normalized,
+      }));
 
-  yield {
-    kind: "completed",
-    data: {
-      query: input.query ?? "",
-      results,
-    },
-  };
+      yield {
+        kind: "completed",
+        data: {
+          query: input.query ?? "",
+          results,
+        },
+      };
+    })(),
+  );
 }

--- a/src/libswamp/update/check.ts
+++ b/src/libswamp/update/check.ts
@@ -26,6 +26,7 @@ import { HttpUpdateChecker } from "../../infrastructure/update/http_update_check
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Data structure for the update check/install output.
  */
@@ -67,13 +68,19 @@ export async function* updateCheck(
   deps: UpdateCheckDeps,
   input: UpdateCheckInput,
 ): AsyncIterable<UpdateCheckEvent> {
-  ctx.logger.debug`Checking for updates (checkOnly=${input.checkOnly})`;
+  yield* withGeneratorSpan(
+    "swamp.update.check",
+    {},
+    (async function* () {
+      ctx.logger.debug`Checking for updates (checkOnly=${input.checkOnly})`;
 
-  yield { kind: "checking" };
+      yield { kind: "checking" };
 
-  const result = input.checkOnly
-    ? await deps.check(input.platform)
-    : await deps.update(input.platform);
+      const result = input.checkOnly
+        ? await deps.check(input.platform)
+        : await deps.update(input.platform);
 
-  yield { kind: "completed", data: result };
+      yield { kind: "completed", data: result };
+    })(),
+  );
 }

--- a/src/libswamp/vaults/create.ts
+++ b/src/libswamp/vaults/create.ts
@@ -33,6 +33,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { alreadyExists, validationFailed } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Data structure for the vault create output.
  */
@@ -109,107 +110,114 @@ export async function* vaultCreate(
   deps: VaultCreateDeps,
   input: VaultCreateInput,
 ): AsyncIterable<VaultCreateEvent> {
-  yield { kind: "creating" };
+  yield* withGeneratorSpan(
+    "swamp.vault.create",
+    {},
+    (async function* () {
+      yield { kind: "creating" };
 
-  ctx.logger.debug`Creating vault: type=${input.vaultType}, name=${input.name}`;
+      ctx.logger
+        .debug`Creating vault: type=${input.vaultType}, name=${input.name}`;
 
-  // Auto-resolve extension vault types if not already registered
-  await deps.resolveExtensionVaultType(input.vaultType);
+      // Auto-resolve extension vault types if not already registered
+      await deps.resolveExtensionVaultType(input.vaultType);
 
-  // Validate the vault type
-  const typeInfo = deps.getVaultTypeInfo(input.vaultType);
-  if (!typeInfo) {
-    const renamed = RENAMED_VAULT_TYPES[input.vaultType.toLowerCase()];
-    if (renamed) {
-      yield {
-        kind: "error",
-        error: validationFailed(
-          `The type '${input.vaultType}' has been renamed to '${renamed}'. Use type '${renamed}' instead.`,
-        ),
-      };
-      return;
-    }
-    const availableTypes = deps.listAvailableTypes().join(", ");
-    yield {
-      kind: "error",
-      error: validationFailed(
-        `Unknown vault type: ${input.vaultType}. Available types: ${availableTypes}. Use 'swamp vault type search' to see available types.`,
-      ),
-    };
-    return;
-  }
-
-  // Validate vault name format
-  if (!/^[a-z][a-z0-9-]*$/.test(input.name)) {
-    yield {
-      kind: "error",
-      error: validationFailed(
-        `Invalid vault name: ${input.name}. Vault names must start with a lowercase letter and contain only lowercase letters, numbers, and hyphens.`,
-      ),
-    };
-    return;
-  }
-
-  // Check name uniqueness
-  const exists = await deps.findByName(input.name);
-  if (exists) {
-    yield {
-      kind: "error",
-      error: alreadyExists("Vault", input.name),
-    };
-    return;
-  }
-
-  // Resolve provider configuration
-  let providerConfig: Record<string, unknown>;
-
-  if (!typeInfo.isBuiltIn && typeInfo.createProvider) {
-    // Extension vault type: use provided config, defaulting to {}
-    providerConfig = input.config ?? {};
-
-    // Validate against configSchema if provided
-    if (typeInfo.configSchema) {
-      const result = typeInfo.configSchema.safeParse(providerConfig);
-      if (!result.success) {
+      // Validate the vault type
+      const typeInfo = deps.getVaultTypeInfo(input.vaultType);
+      if (!typeInfo) {
+        const renamed = RENAMED_VAULT_TYPES[input.vaultType.toLowerCase()];
+        if (renamed) {
+          yield {
+            kind: "error",
+            error: validationFailed(
+              `The type '${input.vaultType}' has been renamed to '${renamed}'. Use type '${renamed}' instead.`,
+            ),
+          };
+          return;
+        }
+        const availableTypes = deps.listAvailableTypes().join(", ");
         yield {
           kind: "error",
           error: validationFailed(
-            `Invalid config for vault type '${input.vaultType}': ${result.error.message}`,
+            `Unknown vault type: ${input.vaultType}. Available types: ${availableTypes}. Use 'swamp vault type search' to see available types.`,
           ),
         };
         return;
       }
-    }
-  } else if (input.config) {
-    // Built-in type with explicit config
-    providerConfig = input.config;
-  } else {
-    // Built-in vault type: resolve defaults
-    providerConfig = resolveBuiltInProviderConfig(
-      input.vaultType,
-      input.repoDir,
-    );
-  }
 
-  // Create and save
-  const vaultId = createVaultConfigId(crypto.randomUUID());
-  const vaultConfig = VaultConfig.create(
-    vaultId,
-    input.name,
-    input.vaultType,
-    providerConfig,
+      // Validate vault name format
+      if (!/^[a-z][a-z0-9-]*$/.test(input.name)) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `Invalid vault name: ${input.name}. Vault names must start with a lowercase letter and contain only lowercase letters, numbers, and hyphens.`,
+          ),
+        };
+        return;
+      }
+
+      // Check name uniqueness
+      const exists = await deps.findByName(input.name);
+      if (exists) {
+        yield {
+          kind: "error",
+          error: alreadyExists("Vault", input.name),
+        };
+        return;
+      }
+
+      // Resolve provider configuration
+      let providerConfig: Record<string, unknown>;
+
+      if (!typeInfo.isBuiltIn && typeInfo.createProvider) {
+        // Extension vault type: use provided config, defaulting to {}
+        providerConfig = input.config ?? {};
+
+        // Validate against configSchema if provided
+        if (typeInfo.configSchema) {
+          const result = typeInfo.configSchema.safeParse(providerConfig);
+          if (!result.success) {
+            yield {
+              kind: "error",
+              error: validationFailed(
+                `Invalid config for vault type '${input.vaultType}': ${result.error.message}`,
+              ),
+            };
+            return;
+          }
+        }
+      } else if (input.config) {
+        // Built-in type with explicit config
+        providerConfig = input.config;
+      } else {
+        // Built-in vault type: resolve defaults
+        providerConfig = resolveBuiltInProviderConfig(
+          input.vaultType,
+          input.repoDir,
+        );
+      }
+
+      // Create and save
+      const vaultId = createVaultConfigId(crypto.randomUUID());
+      const vaultConfig = VaultConfig.create(
+        vaultId,
+        input.name,
+        input.vaultType,
+        providerConfig,
+      );
+      await deps.save(vaultConfig);
+
+      ctx.logger.debug`Vault created: ${input.name}`;
+
+      const data: VaultCreateData = {
+        id: vaultId,
+        name: input.name,
+        type: input.vaultType,
+        typeName: typeInfo.name,
+        config: providerConfig,
+      };
+
+      yield { kind: "completed", data };
+    })(),
   );
-  await deps.save(vaultConfig);
-
-  ctx.logger.debug`Vault created: ${input.name}`;
-
-  const data: VaultCreateData = {
-    id: vaultId,
-    name: input.name,
-    type: input.vaultType,
-    typeName: typeInfo.name,
-    config: providerConfig,
-  };
-
-  yield { kind: "completed", data };
 }

--- a/src/libswamp/vaults/describe.ts
+++ b/src/libswamp/vaults/describe.ts
@@ -23,6 +23,7 @@ import type { SwampError } from "../errors.ts";
 import { notFound, validationFailed } from "../errors.ts";
 import type { VaultConfigInfo } from "./get.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Data structure for vault describe output (full config data).
  */
@@ -63,49 +64,55 @@ export async function* vaultDescribe(
   vaultNameOrId: string,
   vaultType?: string,
 ): AsyncIterable<VaultDescribeEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.vault.describe",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  // Try to find by name first
-  let config = await deps.findByName(vaultNameOrId);
+      // Try to find by name first
+      let config = await deps.findByName(vaultNameOrId);
 
-  // If not found by name, try to find by ID
-  if (!config) {
-    if (vaultType) {
-      config = await deps.findById(vaultType, vaultNameOrId);
-    } else {
-      const allVaults = await deps.findAll();
-      config = allVaults.find((v) => v.id === vaultNameOrId) ?? null;
-    }
-  }
+      // If not found by name, try to find by ID
+      if (!config) {
+        if (vaultType) {
+          config = await deps.findById(vaultType, vaultNameOrId);
+        } else {
+          const allVaults = await deps.findAll();
+          config = allVaults.find((v) => v.id === vaultNameOrId) ?? null;
+        }
+      }
 
-  // If type was specified, verify it matches
-  if (config && vaultType && config.type !== vaultType) {
-    yield {
-      kind: "error",
-      error: validationFailed(
-        `Vault '${vaultNameOrId}' found but has type '${config.type}', not '${vaultType}'`,
-      ),
-    };
-    return;
-  }
+      // If type was specified, verify it matches
+      if (config && vaultType && config.type !== vaultType) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `Vault '${vaultNameOrId}' found but has type '${config.type}', not '${vaultType}'`,
+          ),
+        };
+        return;
+      }
 
-  if (!config) {
-    const typeHint = vaultType ? ` of type '${vaultType}'` : "";
-    yield {
-      kind: "error",
-      error: notFound("Vault", `${vaultNameOrId}${typeHint}`),
-    };
-    return;
-  }
+      if (!config) {
+        const typeHint = vaultType ? ` of type '${vaultType}'` : "";
+        yield {
+          kind: "error",
+          error: notFound("Vault", `${vaultNameOrId}${typeHint}`),
+        };
+        return;
+      }
 
-  yield {
-    kind: "completed",
-    data: {
-      id: config.id,
-      name: config.name,
-      type: config.type,
-      config: config.config,
-      createdAt: config.createdAt.toISOString(),
-    },
-  };
+      yield {
+        kind: "completed",
+        data: {
+          id: config.id,
+          name: config.name,
+          type: config.type,
+          config: config.config,
+          createdAt: config.createdAt.toISOString(),
+        },
+      };
+    })(),
+  );
 }

--- a/src/libswamp/vaults/edit.ts
+++ b/src/libswamp/vaults/edit.ts
@@ -27,6 +27,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound, validationFailed } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** Minimal vault config shape needed by the generator. */
 export interface VaultEditConfigInfo {
   id: string;
@@ -103,74 +104,80 @@ export async function* vaultEdit(
   deps: VaultEditDeps,
   input: VaultEditInput,
 ): AsyncIterable<VaultEditEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.vault.edit",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const { vaultNameOrId, vaultType } = input;
+      const { vaultNameOrId, vaultType } = input;
 
-  ctx.logger.debug`Looking up vault: ${vaultNameOrId}`;
+      ctx.logger.debug`Looking up vault: ${vaultNameOrId}`;
 
-  // Try to find by name first
-  let config = await deps.findByName(vaultNameOrId);
+      // Try to find by name first
+      let config = await deps.findByName(vaultNameOrId);
 
-  // If not found by name, try to find by ID
-  if (!config) {
-    if (vaultType) {
-      config = await deps.findById(vaultType, vaultNameOrId);
-    } else {
-      const allVaults = await deps.findAll();
-      config = allVaults.find((v) => v.id === vaultNameOrId) ?? null;
-    }
-  }
+      // If not found by name, try to find by ID
+      if (!config) {
+        if (vaultType) {
+          config = await deps.findById(vaultType, vaultNameOrId);
+        } else {
+          const allVaults = await deps.findAll();
+          config = allVaults.find((v) => v.id === vaultNameOrId) ?? null;
+        }
+      }
 
-  // If type was specified, verify it matches
-  if (config && vaultType && config.type !== vaultType) {
-    yield {
-      kind: "error",
-      error: validationFailed(
-        `Vault '${vaultNameOrId}' found but has type '${config.type}', not '${vaultType}'`,
-      ),
-    };
-    return;
-  }
+      // If type was specified, verify it matches
+      if (config && vaultType && config.type !== vaultType) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `Vault '${vaultNameOrId}' found but has type '${config.type}', not '${vaultType}'`,
+          ),
+        };
+        return;
+      }
 
-  if (!config) {
-    const typeHint = vaultType ? ` of type '${vaultType}'` : "";
-    yield {
-      kind: "error",
-      error: notFound("Vault", `${vaultNameOrId}${typeHint}`),
-    };
-    return;
-  }
+      if (!config) {
+        const typeHint = vaultType ? ` of type '${vaultType}'` : "";
+        yield {
+          kind: "error",
+          error: notFound("Vault", `${vaultNameOrId}${typeHint}`),
+        };
+        return;
+      }
 
-  ctx.logger
-    .debug`Found vault: id=${config.id}, name=${config.name}, type=${config.type}`;
+      ctx.logger
+        .debug`Found vault: id=${config.id}, name=${config.name}, type=${config.type}`;
 
-  const filePath = deps.getVaultPath(config);
+      const filePath = deps.getVaultPath(config);
 
-  // Check if file exists
-  const exists = await deps.fileExists(filePath);
-  if (!exists) {
-    yield {
-      kind: "error",
-      error: notFound(
-        "Vault configuration file",
-        filePath,
-      ),
-    };
-    return;
-  }
+      // Check if file exists
+      const exists = await deps.fileExists(filePath);
+      if (!exists) {
+        yield {
+          kind: "error",
+          error: notFound(
+            "Vault configuration file",
+            filePath,
+          ),
+        };
+        return;
+      }
 
-  ctx.logger.debug`Opening file: ${filePath}`;
-  const result = await deps.openEditor(filePath);
+      ctx.logger.debug`Opening file: ${filePath}`;
+      const result = await deps.openEditor(filePath);
 
-  yield {
-    kind: "completed",
-    data: {
-      path: filePath,
-      editor: result.editor,
-      status: "opened",
-      name: config.name,
-      type: config.type,
-    },
-  };
+      yield {
+        kind: "completed",
+        data: {
+          path: filePath,
+          editor: result.editor,
+          status: "opened",
+          name: config.name,
+          type: config.type,
+        },
+      };
+    })(),
+  );
 }

--- a/src/libswamp/vaults/get.ts
+++ b/src/libswamp/vaults/get.ts
@@ -26,6 +26,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound, validationFailed } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Data structure for the vault get output.
  */
@@ -79,49 +80,55 @@ export async function* vaultGet(
   vaultNameOrId: string,
   vaultType?: string,
 ): AsyncIterable<VaultGetEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.vault.get",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  // Try to find by name first
-  let config = await deps.findByName(vaultNameOrId);
+      // Try to find by name first
+      let config = await deps.findByName(vaultNameOrId);
 
-  // If not found by name, try to find by ID
-  if (!config) {
-    if (vaultType) {
-      config = await deps.findById(vaultType, vaultNameOrId);
-    } else {
-      const allVaults = await deps.findAll();
-      config = allVaults.find((v) => v.id === vaultNameOrId) ?? null;
-    }
-  }
+      // If not found by name, try to find by ID
+      if (!config) {
+        if (vaultType) {
+          config = await deps.findById(vaultType, vaultNameOrId);
+        } else {
+          const allVaults = await deps.findAll();
+          config = allVaults.find((v) => v.id === vaultNameOrId) ?? null;
+        }
+      }
 
-  // If type was specified, verify it matches
-  if (config && vaultType && config.type !== vaultType) {
-    yield {
-      kind: "error",
-      error: validationFailed(
-        `Vault '${vaultNameOrId}' found but has type '${config.type}', not '${vaultType}'`,
-      ),
-    };
-    return;
-  }
+      // If type was specified, verify it matches
+      if (config && vaultType && config.type !== vaultType) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `Vault '${vaultNameOrId}' found but has type '${config.type}', not '${vaultType}'`,
+          ),
+        };
+        return;
+      }
 
-  if (!config) {
-    const typeHint = vaultType ? ` of type '${vaultType}'` : "";
-    yield {
-      kind: "error",
-      error: notFound("Vault", `${vaultNameOrId}${typeHint}`),
-    };
-    return;
-  }
+      if (!config) {
+        const typeHint = vaultType ? ` of type '${vaultType}'` : "";
+        yield {
+          kind: "error",
+          error: notFound("Vault", `${vaultNameOrId}${typeHint}`),
+        };
+        return;
+      }
 
-  const data: VaultGetData = {
-    id: config.id,
-    name: config.name,
-    type: config.type,
-    config: config.config,
-    createdAt: config.createdAt.toISOString(),
-    storagePath: deps.storagePath(config),
-  };
+      const data: VaultGetData = {
+        id: config.id,
+        name: config.name,
+        type: config.type,
+        config: config.config,
+        createdAt: config.createdAt.toISOString(),
+        storagePath: deps.storagePath(config),
+      };
 
-  yield { kind: "completed", data };
+      yield { kind: "completed", data };
+    })(),
+  );
 }

--- a/src/libswamp/vaults/list_keys.ts
+++ b/src/libswamp/vaults/list_keys.ts
@@ -22,6 +22,7 @@ import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** Data payload for the completed event. */
 export interface VaultListKeysData {
   vaultName: string;
@@ -71,54 +72,60 @@ export async function* vaultListKeys(
   deps: VaultListKeysDeps,
   input: VaultListKeysInput,
 ): AsyncIterable<VaultListKeysEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.vault.list_keys",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  if (!input.vaultName) {
-    yield {
-      kind: "error",
-      error: validationFailed(
-        "Missing required argument: vault_name\n\n" +
-          "Usage: swamp vault list-keys <vault_name>\n\n" +
-          "Use 'swamp vault search' to see available vaults.",
-      ),
-    };
-    return;
-  }
+      if (!input.vaultName) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            "Missing required argument: vault_name\n\n" +
+              "Usage: swamp vault list-keys <vault_name>\n\n" +
+              "Use 'swamp vault search' to see available vaults.",
+          ),
+        };
+        return;
+      }
 
-  const vaultConfig = await deps.findVaultByName(input.vaultName);
-  if (!vaultConfig) {
-    const allVaults = await deps.findAllVaults();
-    if (allVaults.length === 0) {
+      const vaultConfig = await deps.findVaultByName(input.vaultName);
+      if (!vaultConfig) {
+        const allVaults = await deps.findAllVaults();
+        if (allVaults.length === 0) {
+          yield {
+            kind: "error",
+            error: notFound(
+              "Vault",
+              `'${input.vaultName}'. No vaults are configured.\n` +
+                `Create a vault using: swamp vault create <type> ${input.vaultName}`,
+            ),
+          };
+        } else {
+          const vaultNames = allVaults.map((v) => v.name).join(", ");
+          yield {
+            kind: "error",
+            error: notFound(
+              "Vault",
+              `'${input.vaultName}'. Available vaults: ${vaultNames}`,
+            ),
+          };
+        }
+        return;
+      }
+
+      const secretKeys = await deps.listKeys(input.vaultName);
+
       yield {
-        kind: "error",
-        error: notFound(
-          "Vault",
-          `'${input.vaultName}'. No vaults are configured.\n` +
-            `Create a vault using: swamp vault create <type> ${input.vaultName}`,
-        ),
+        kind: "completed",
+        data: {
+          vaultName: input.vaultName,
+          vaultType: vaultConfig.type,
+          secretKeys,
+          count: secretKeys.length,
+        },
       };
-    } else {
-      const vaultNames = allVaults.map((v) => v.name).join(", ");
-      yield {
-        kind: "error",
-        error: notFound(
-          "Vault",
-          `'${input.vaultName}'. Available vaults: ${vaultNames}`,
-        ),
-      };
-    }
-    return;
-  }
-
-  const secretKeys = await deps.listKeys(input.vaultName);
-
-  yield {
-    kind: "completed",
-    data: {
-      vaultName: input.vaultName,
-      vaultType: vaultConfig.type,
-      secretKeys,
-      count: secretKeys.length,
-    },
-  };
+    })(),
+  );
 }

--- a/src/libswamp/vaults/put.ts
+++ b/src/libswamp/vaults/put.ts
@@ -25,6 +25,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** Minimal vault config shape needed by the generator. */
 export interface VaultPutConfigInfo {
   id: string;
@@ -162,36 +163,42 @@ export async function* vaultPut(
   deps: VaultPutDeps,
   input: VaultPutInput,
 ): AsyncIterable<VaultPutEvent> {
-  yield { kind: "storing" };
+  yield* withGeneratorSpan(
+    "swamp.vault.put",
+    {},
+    (async function* () {
+      yield { kind: "storing" };
 
-  const config = await deps.findVault(input.vaultName);
-  if (!config) {
-    yield {
-      kind: "error",
-      error: notFound("Vault", input.vaultName),
-    };
-    return;
-  }
+      const config = await deps.findVault(input.vaultName);
+      if (!config) {
+        yield {
+          kind: "error",
+          error: notFound("Vault", input.vaultName),
+        };
+        return;
+      }
 
-  await deps.putSecret(input.vaultName, input.key, input.value);
-  ctx.logger.debug`Secret stored successfully`;
+      await deps.putSecret(input.vaultName, input.key, input.value);
+      ctx.logger.debug`Secret stored successfully`;
 
-  await deps.publishSecretUpdated(
-    config.id,
-    config.type,
-    config.name,
-    input.key,
+      await deps.publishSecretUpdated(
+        config.id,
+        config.type,
+        config.name,
+        input.key,
+      );
+      ctx.logger.debug`Emitted VaultSecretUpdated event`;
+
+      yield {
+        kind: "completed",
+        data: {
+          vaultName: input.vaultName,
+          secretKey: input.key,
+          vaultType: config.type,
+          overwritten: input.overwritten,
+          timestamp: new Date().toISOString(),
+        },
+      };
+    })(),
   );
-  ctx.logger.debug`Emitted VaultSecretUpdated event`;
-
-  yield {
-    kind: "completed",
-    data: {
-      vaultName: input.vaultName,
-      secretKey: input.key,
-      vaultType: config.type,
-      overwritten: input.overwritten,
-      timestamp: new Date().toISOString(),
-    },
-  };
 }

--- a/src/libswamp/vaults/search.ts
+++ b/src/libswamp/vaults/search.ts
@@ -20,6 +20,7 @@
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * A single vault search result item.
  */
@@ -75,21 +76,27 @@ export async function* vaultSearch(
   deps: VaultSearchDeps,
   input: VaultSearchInput,
 ): AsyncGenerator<VaultSearchEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.vault.search",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const configs = await deps.findAllVaults();
-  const results: VaultSearchItem[] = configs.map((c) => ({
-    id: c.id,
-    name: c.name,
-    type: c.type,
-    createdAt: c.createdAt.toISOString(),
-  }));
+      const configs = await deps.findAllVaults();
+      const results: VaultSearchItem[] = configs.map((c) => ({
+        id: c.id,
+        name: c.name,
+        type: c.type,
+        createdAt: c.createdAt.toISOString(),
+      }));
 
-  yield {
-    kind: "completed",
-    data: {
-      query: input.query ?? "",
-      results,
-    },
-  };
+      yield {
+        kind: "completed",
+        data: {
+          query: input.query ?? "",
+          results,
+        },
+      };
+    })(),
+  );
 }

--- a/src/libswamp/vaults/type_search.ts
+++ b/src/libswamp/vaults/type_search.ts
@@ -20,6 +20,7 @@
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * A single vault type search result item.
  */
@@ -71,20 +72,26 @@ export async function* vaultTypeSearch(
   deps: VaultTypeSearchDeps,
   input: VaultTypeSearchInput,
 ): AsyncGenerator<VaultTypeSearchEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.vault.type_search",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const types = deps.getVaultTypes();
-  const results: VaultTypeSearchItem[] = types.map((t) => ({
-    type: t.type,
-    name: t.name,
-    description: t.description,
-  }));
+      const types = deps.getVaultTypes();
+      const results: VaultTypeSearchItem[] = types.map((t) => ({
+        type: t.type,
+        name: t.name,
+        description: t.description,
+      }));
 
-  yield {
-    kind: "completed",
-    data: {
-      query: input.query ?? "",
-      results,
-    },
-  };
+      yield {
+        kind: "completed",
+        data: {
+          query: input.query ?? "",
+          results,
+        },
+      };
+    })(),
+  );
 }

--- a/src/libswamp/workflows/create.ts
+++ b/src/libswamp/workflows/create.ts
@@ -27,6 +27,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { alreadyExists } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Data structures for the workflow create output.
  */
@@ -84,58 +85,64 @@ export async function* workflowCreate(
   deps: WorkflowCreateDeps,
   input: WorkflowCreateInput,
 ): AsyncIterable<WorkflowCreateEvent> {
-  yield { kind: "creating" };
+  yield* withGeneratorSpan(
+    "swamp.workflow.create",
+    { "workflow.name": input.name },
+    (async function* () {
+      yield { kind: "creating" };
 
-  ctx.logger.debug`Creating workflow: name=${input.name}`;
+      ctx.logger.debug`Creating workflow: name=${input.name}`;
 
-  // Check name uniqueness
-  const existing = await deps.findByName(input.name);
-  if (existing) {
-    yield {
-      kind: "error",
-      error: alreadyExists("Workflow", input.name),
-    };
-    return;
-  }
+      // Check name uniqueness
+      const existing = await deps.findByName(input.name);
+      if (existing) {
+        yield {
+          kind: "error",
+          error: alreadyExists("Workflow", input.name),
+        };
+        return;
+      }
 
-  // Create workflow with a default job (schema requires at least one job)
-  const defaultJob = Job.create({
-    name: "main",
-    description: "Main job (edit or replace)",
-    steps: [
-      Step.create({
-        name: "example",
-        description: "Example step (edit or replace)",
-        task: StepTask.model("example-model", "run"),
-      }),
-    ],
-  });
+      // Create workflow with a default job (schema requires at least one job)
+      const defaultJob = Job.create({
+        name: "main",
+        description: "Main job (edit or replace)",
+        steps: [
+          Step.create({
+            name: "example",
+            description: "Example step (edit or replace)",
+            task: StepTask.model("example-model", "run"),
+          }),
+        ],
+      });
 
-  const workflow = Workflow.create({
-    name: input.name,
-    jobs: [defaultJob],
-  });
+      const workflow = Workflow.create({
+        name: input.name,
+        jobs: [defaultJob],
+      });
 
-  await deps.save(workflow);
+      await deps.save(workflow);
 
-  ctx.logger.debug`Created workflow with ID: ${workflow.id}`;
+      ctx.logger.debug`Created workflow with ID: ${workflow.id}`;
 
-  const jobs: WorkflowCreateJobData[] = workflow.jobs.map((job) => ({
-    name: job.name,
-    description: job.description ?? "",
-    steps: job.steps.map((step) => ({
-      name: step.name,
-      description: step.description ?? "",
-      taskType: step.task.data.type,
-    })),
-  }));
+      const jobs: WorkflowCreateJobData[] = workflow.jobs.map((job) => ({
+        name: job.name,
+        description: job.description ?? "",
+        steps: job.steps.map((step) => ({
+          name: step.name,
+          description: step.description ?? "",
+          taskType: step.task.data.type,
+        })),
+      }));
 
-  const data: WorkflowCreateData = {
-    id: workflow.id,
-    name: workflow.name,
-    path: deps.getPath(workflow.id),
-    jobs,
-  };
+      const data: WorkflowCreateData = {
+        id: workflow.id,
+        name: workflow.name,
+        path: deps.getPath(workflow.id),
+        jobs,
+      };
 
-  yield { kind: "completed", data };
+      yield { kind: "completed", data };
+    })(),
+  );
 }

--- a/src/libswamp/workflows/delete.ts
+++ b/src/libswamp/workflows/delete.ts
@@ -29,6 +29,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound, validationFailed } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -152,38 +153,44 @@ export async function* workflowDelete(
   deps: WorkflowDeleteDeps,
   input: WorkflowDeleteInput,
 ): AsyncIterable<WorkflowDeleteEvent> {
-  yield { kind: "deleting" };
+  yield* withGeneratorSpan(
+    "swamp.workflow.delete",
+    { "workflow.id_or_name": input.workflowIdOrName },
+    (async function* () {
+      yield { kind: "deleting" };
 
-  const workflow = await findWorkflow(deps, input.workflowIdOrName);
-  if (!workflow) {
-    yield {
-      kind: "error",
-      error: notFound("Workflow", input.workflowIdOrName),
-    };
-    return;
-  }
+      const workflow = await findWorkflow(deps, input.workflowIdOrName);
+      if (!workflow) {
+        yield {
+          kind: "error",
+          error: notFound("Workflow", input.workflowIdOrName),
+        };
+        return;
+      }
 
-  const workflowPath = deps.getPath(workflow.id);
+      const workflowPath = deps.getPath(workflow.id);
 
-  // Delete runs
-  ctx.logger.debug`Deleting workflow runs`;
-  const runsDeleted = await deps.deleteRuns(workflow.id);
+      // Delete runs
+      ctx.logger.debug`Deleting workflow runs`;
+      const runsDeleted = await deps.deleteRuns(workflow.id);
 
-  // Delete evaluated workflow
-  ctx.logger.debug`Deleting evaluated workflow`;
-  await deps.deleteEvaluated(workflow.id);
+      // Delete evaluated workflow
+      ctx.logger.debug`Deleting evaluated workflow`;
+      await deps.deleteEvaluated(workflow.id);
 
-  // Delete workflow
-  ctx.logger.debug`Deleting workflow: ${workflow.id}`;
-  await deps.deleteWorkflow(workflow.id);
+      // Delete workflow
+      ctx.logger.debug`Deleting workflow: ${workflow.id}`;
+      await deps.deleteWorkflow(workflow.id);
 
-  yield {
-    kind: "completed",
-    data: {
-      id: workflow.id,
-      name: workflow.name,
-      workflowPath,
-      runsDeleted,
-    },
-  };
+      yield {
+        kind: "completed",
+        data: {
+          id: workflow.id,
+          name: workflow.name,
+          workflowPath,
+          runsDeleted,
+        },
+      };
+    })(),
+  );
 }

--- a/src/libswamp/workflows/edit.ts
+++ b/src/libswamp/workflows/edit.ts
@@ -33,6 +33,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound, validationFailed } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * UUID v4 regex pattern for detecting if an argument is a UUID.
  */
@@ -124,124 +125,130 @@ export async function* workflowEdit(
   deps: WorkflowEditDeps,
   input: WorkflowEditInput,
 ): AsyncIterable<WorkflowEditEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.workflow.edit",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const { workflowIdOrName, stdinContent } = input;
+      const { workflowIdOrName, stdinContent } = input;
 
-  let workflow: Workflow | null = null;
-  let filePath: string | null = null;
+      let workflow: Workflow | null = null;
+      let filePath: string | null = null;
 
-  if (isUuid(workflowIdOrName)) {
-    ctx.logger.debug`Looking up by ID: ${workflowIdOrName}`;
-    try {
-      const id: WorkflowId = createWorkflowId(workflowIdOrName);
-      workflow = await deps.findById(id);
-    } catch (error) {
-      ctx.logger
-        .debug`Workflow lookup by ID failed, will try symlink fallback: ${error}`;
-    }
+      if (isUuid(workflowIdOrName)) {
+        ctx.logger.debug`Looking up by ID: ${workflowIdOrName}`;
+        try {
+          const id: WorkflowId = createWorkflowId(workflowIdOrName);
+          workflow = await deps.findById(id);
+        } catch (error) {
+          ctx.logger
+            .debug`Workflow lookup by ID failed, will try symlink fallback: ${error}`;
+        }
 
-    if (workflow) {
-      filePath = deps.getPath(workflow.id);
-    } else {
-      yield {
-        kind: "error",
-        error: notFound("Workflow", workflowIdOrName),
-      };
-      return;
-    }
-  } else {
-    ctx.logger.debug`Looking up by name: ${workflowIdOrName}`;
-    try {
-      workflow = await deps.findByName(workflowIdOrName);
-    } catch (error) {
-      ctx.logger
-        .debug`Workflow lookup by name failed, will try symlink fallback: ${error}`;
-    }
-
-    if (workflow) {
-      filePath = deps.getPath(workflow.id);
-    } else {
-      const resolvedPath = await deps.resolveSymlink(workflowIdOrName);
-      if (resolvedPath) {
-        ctx.logger
-          .debug`Using symlink fallback for broken workflow: ${resolvedPath}`;
-        filePath = resolvedPath;
+        if (workflow) {
+          filePath = deps.getPath(workflow.id);
+        } else {
+          yield {
+            kind: "error",
+            error: notFound("Workflow", workflowIdOrName),
+          };
+          return;
+        }
       } else {
-        yield {
-          kind: "error",
-          error: notFound("Workflow", workflowIdOrName),
-        };
+        ctx.logger.debug`Looking up by name: ${workflowIdOrName}`;
+        try {
+          workflow = await deps.findByName(workflowIdOrName);
+        } catch (error) {
+          ctx.logger
+            .debug`Workflow lookup by name failed, will try symlink fallback: ${error}`;
+        }
+
+        if (workflow) {
+          filePath = deps.getPath(workflow.id);
+        } else {
+          const resolvedPath = await deps.resolveSymlink(workflowIdOrName);
+          if (resolvedPath) {
+            ctx.logger
+              .debug`Using symlink fallback for broken workflow: ${resolvedPath}`;
+            filePath = resolvedPath;
+          } else {
+            yield {
+              kind: "error",
+              error: notFound("Workflow", workflowIdOrName),
+            };
+            return;
+          }
+        }
+      }
+
+      // If the primary path doesn't exist but we found the workflow,
+      // it's an extension workflow — try to find its actual source file.
+      if (filePath && workflow) {
+        const exists = await deps.fileExists(filePath);
+        if (!exists) {
+          const resolvedPath = await deps.resolveSymlink(workflow.name);
+          if (resolvedPath) {
+            filePath = resolvedPath;
+          }
+        }
+      }
+
+      ctx.logger.debug`Using file path: ${filePath}`;
+
+      // Stdin update mode
+      if (stdinContent !== undefined && stdinContent !== null) {
+        ctx.logger.debug`Reading workflow content from stdin`;
+
+        if (!workflow) {
+          yield {
+            kind: "error",
+            error: validationFailed(
+              "Cannot update workflow from stdin: the workflow's YAML is broken and must be fixed in an editor first",
+            ),
+          };
+          return;
+        }
+
+        try {
+          const updated = await deps.updateFromStdin(workflow, stdinContent);
+
+          yield {
+            kind: "completed",
+            data: {
+              path: filePath,
+              status: "updated",
+              name: updated.name,
+              id: updated.id,
+            },
+          };
+        } catch (error) {
+          yield {
+            kind: "error",
+            error: validationFailed(
+              `Invalid workflow YAML from stdin: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            ),
+          };
+        }
         return;
       }
-    }
-  }
 
-  // If the primary path doesn't exist but we found the workflow,
-  // it's an extension workflow — try to find its actual source file.
-  if (filePath && workflow) {
-    const exists = await deps.fileExists(filePath);
-    if (!exists) {
-      const resolvedPath = await deps.resolveSymlink(workflow.name);
-      if (resolvedPath) {
-        filePath = resolvedPath;
-      }
-    }
-  }
-
-  ctx.logger.debug`Using file path: ${filePath}`;
-
-  // Stdin update mode
-  if (stdinContent !== undefined && stdinContent !== null) {
-    ctx.logger.debug`Reading workflow content from stdin`;
-
-    if (!workflow) {
-      yield {
-        kind: "error",
-        error: validationFailed(
-          "Cannot update workflow from stdin: the workflow's YAML is broken and must be fixed in an editor first",
-        ),
-      };
-      return;
-    }
-
-    try {
-      const updated = await deps.updateFromStdin(workflow, stdinContent);
+      // Editor mode
+      ctx.logger.debug`Opening file: ${filePath}`;
+      const result = await deps.openEditor(filePath);
 
       yield {
         kind: "completed",
         data: {
           path: filePath,
-          status: "updated",
-          name: updated.name,
-          id: updated.id,
+          editor: result.editor,
+          status: "opened",
+          name: workflow?.name ?? workflowIdOrName,
+          id: workflow?.id ?? "unknown",
         },
       };
-    } catch (error) {
-      yield {
-        kind: "error",
-        error: validationFailed(
-          `Invalid workflow YAML from stdin: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        ),
-      };
-    }
-    return;
-  }
-
-  // Editor mode
-  ctx.logger.debug`Opening file: ${filePath}`;
-  const result = await deps.openEditor(filePath);
-
-  yield {
-    kind: "completed",
-    data: {
-      path: filePath,
-      editor: result.editor,
-      status: "opened",
-      name: workflow?.name ?? workflowIdOrName,
-      id: workflow?.id ?? "unknown",
-    },
-  };
+    })(),
+  );
 }

--- a/src/libswamp/workflows/get.ts
+++ b/src/libswamp/workflows/get.ts
@@ -27,6 +27,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Data structure for the workflow get output.
  */
@@ -87,33 +88,39 @@ export async function* workflowGet(
   deps: WorkflowGetDeps,
   workflowIdOrName: string,
 ): AsyncIterable<WorkflowGetEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.workflow.get",
+    { "workflow.id_or_name": workflowIdOrName },
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const workflow = await deps.findWorkflow(workflowIdOrName);
+      const workflow = await deps.findWorkflow(workflowIdOrName);
 
-  if (!workflow) {
-    yield { kind: "error", error: notFound("Workflow", workflowIdOrName) };
-    return;
-  }
+      if (!workflow) {
+        yield { kind: "error", error: notFound("Workflow", workflowIdOrName) };
+        return;
+      }
 
-  const data: WorkflowGetData = {
-    id: workflow.id,
-    name: workflow.name,
-    description: workflow.description,
-    version: workflow.version,
-    jobs: workflow.jobs.map((job) => ({
-      name: job.name,
-      description: job.description,
-      steps: job.steps.map((step) => ({
-        name: step.name,
-        description: step.description,
-        task: step.task.toData(),
-      })),
-    })),
-    path: deps.getWorkflowPath(workflow.id),
-  };
+      const data: WorkflowGetData = {
+        id: workflow.id,
+        name: workflow.name,
+        description: workflow.description,
+        version: workflow.version,
+        jobs: workflow.jobs.map((job) => ({
+          name: job.name,
+          description: job.description,
+          steps: job.steps.map((step) => ({
+            name: step.name,
+            description: step.description,
+            task: step.task.toData(),
+          })),
+        })),
+        path: deps.getWorkflowPath(workflow.id),
+      };
 
-  yield { kind: "completed", data };
+      yield { kind: "completed", data };
+    })(),
+  );
 }
 
 /** Checks if a string looks like a UUID. */

--- a/src/libswamp/workflows/history_get.ts
+++ b/src/libswamp/workflows/history_get.ts
@@ -32,6 +32,7 @@ import { notFound } from "../errors.ts";
 import type { WorkflowRunView } from "./workflow_run_view.ts";
 import { toRunData } from "./run.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 export type WorkflowHistoryGetEvent =
   | { kind: "resolving" }
   | { kind: "completed"; data: WorkflowRunView }
@@ -66,25 +67,34 @@ export async function* workflowHistoryGet(
   deps: WorkflowHistoryGetDeps,
   workflowIdOrName: string,
 ): AsyncIterable<WorkflowHistoryGetEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.workflow.history.get",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const workflow = await deps.findWorkflow(workflowIdOrName);
-  if (!workflow) {
-    yield { kind: "error", error: notFound("Workflow", workflowIdOrName) };
-    return;
-  }
+      const workflow = await deps.findWorkflow(workflowIdOrName);
+      if (!workflow) {
+        yield { kind: "error", error: notFound("Workflow", workflowIdOrName) };
+        return;
+      }
 
-  const latestRun = await deps.findLatestRun(workflow.id);
-  if (!latestRun) {
-    yield {
-      kind: "error",
-      error: notFound("Workflow run", `no runs for workflow: ${workflow.name}`),
-    };
-    return;
-  }
+      const latestRun = await deps.findLatestRun(workflow.id);
+      if (!latestRun) {
+        yield {
+          kind: "error",
+          error: notFound(
+            "Workflow run",
+            `no runs for workflow: ${workflow.name}`,
+          ),
+        };
+        return;
+      }
 
-  const path = deps.getRunPath(workflow.id, latestRun.id);
-  const data = toRunData(latestRun, path);
+      const path = deps.getRunPath(workflow.id, latestRun.id);
+      const data = toRunData(latestRun, path);
 
-  yield { kind: "completed", data };
+      yield { kind: "completed", data };
+    })(),
+  );
 }

--- a/src/libswamp/workflows/history_logs.ts
+++ b/src/libswamp/workflows/history_logs.ts
@@ -31,6 +31,7 @@ import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** Log file data. */
 export interface LogData {
   lines: string[];
@@ -129,99 +130,105 @@ export async function* workflowHistoryLogs(
   deps: WorkflowHistoryLogsDeps,
   input: WorkflowHistoryLogsInput,
 ): AsyncIterable<WorkflowHistoryLogsEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.workflow.history.logs",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  let run: WorkflowRun | undefined;
+      let run: WorkflowRun | undefined;
 
-  // Try partial ID matching first if input looks like an ID
-  if (deps.isPartialId(input.runIdOrWorkflow)) {
-    const result = await deps.matchRunByPartialId(input.runIdOrWorkflow);
+      // Try partial ID matching first if input looks like an ID
+      if (deps.isPartialId(input.runIdOrWorkflow)) {
+        const result = await deps.matchRunByPartialId(input.runIdOrWorkflow);
 
-    if (result.status === "found" && result.match) {
-      run = result.match;
-    } else if (result.status === "ambiguous" && result.matches) {
-      yield {
-        kind: "error",
-        error: validationFailed(
-          `Ambiguous ID prefix "${input.runIdOrWorkflow}" matches:\n` +
-            result.matches.map((m) => `  ${m.id}`).join("\n"),
-        ),
-      };
-      return;
-    }
-    // not_found: fall through to workflow name lookup
-  }
+        if (result.status === "found" && result.match) {
+          run = result.match;
+        } else if (result.status === "ambiguous" && result.matches) {
+          yield {
+            kind: "error",
+            error: validationFailed(
+              `Ambiguous ID prefix "${input.runIdOrWorkflow}" matches:\n` +
+                result.matches.map((m) => `  ${m.id}`).join("\n"),
+            ),
+          };
+          return;
+        }
+        // not_found: fall through to workflow name lookup
+      }
 
-  // If not found as run ID, try as workflow name and get latest run
-  if (!run) {
-    const workflow = await deps.findWorkflow(input.runIdOrWorkflow);
+      // If not found as run ID, try as workflow name and get latest run
+      if (!run) {
+        const workflow = await deps.findWorkflow(input.runIdOrWorkflow);
 
-    if (!workflow) {
-      yield {
-        kind: "error",
-        error: {
-          code: "not_found",
-          message:
-            `No workflow run or workflow found: ${input.runIdOrWorkflow}`,
-          details: {
-            entityType: "Workflow run or workflow",
-            idOrName: input.runIdOrWorkflow,
+        if (!workflow) {
+          yield {
+            kind: "error",
+            error: {
+              code: "not_found",
+              message:
+                `No workflow run or workflow found: ${input.runIdOrWorkflow}`,
+              details: {
+                entityType: "Workflow run or workflow",
+                idOrName: input.runIdOrWorkflow,
+              },
+            },
+          };
+          return;
+        }
+
+        const latestRun = await deps.findLatestRun(workflow.id);
+        if (!latestRun) {
+          yield {
+            kind: "error",
+            error: notFound("Run", `for workflow: ${workflow.name}`),
+          };
+          return;
+        }
+
+        run = latestRun;
+      }
+
+      // Read log file
+      if (!run.logFile) {
+        yield {
+          kind: "completed",
+          data: {
+            type: "no_log_file",
+            info: {
+              runId: run.id,
+              workflowName: run.workflowName,
+            },
           },
-        },
-      };
-      return;
-    }
+        };
+        return;
+      }
 
-    const latestRun = await deps.findLatestRun(workflow.id);
-    if (!latestRun) {
+      const logData = await deps.readLogFile(run.logFile, { tail: input.tail });
+      const displayPath = deps.toRelativePath(input.repoDir, run.logFile);
+
+      if (logData.lines.length === 0) {
+        yield {
+          kind: "completed",
+          data: {
+            type: "empty_log",
+            info: {
+              runId: run.id,
+              workflowName: run.workflowName,
+              path: displayPath,
+            },
+          },
+        };
+        return;
+      }
+
       yield {
-        kind: "error",
-        error: notFound("Run", `for workflow: ${workflow.name}`),
+        kind: "completed",
+        data: {
+          type: "log",
+          log: { ...logData, path: displayPath },
+        },
       };
-      return;
-    }
-
-    run = latestRun;
-  }
-
-  // Read log file
-  if (!run.logFile) {
-    yield {
-      kind: "completed",
-      data: {
-        type: "no_log_file",
-        info: {
-          runId: run.id,
-          workflowName: run.workflowName,
-        },
-      },
-    };
-    return;
-  }
-
-  const logData = await deps.readLogFile(run.logFile, { tail: input.tail });
-  const displayPath = deps.toRelativePath(input.repoDir, run.logFile);
-
-  if (logData.lines.length === 0) {
-    yield {
-      kind: "completed",
-      data: {
-        type: "empty_log",
-        info: {
-          runId: run.id,
-          workflowName: run.workflowName,
-          path: displayPath,
-        },
-      },
-    };
-    return;
-  }
-
-  yield {
-    kind: "completed",
-    data: {
-      type: "log",
-      log: { ...logData, path: displayPath },
-    },
-  };
+    })(),
+  );
 }

--- a/src/libswamp/workflows/history_search.ts
+++ b/src/libswamp/workflows/history_search.ts
@@ -21,6 +21,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import type { WorkflowRunSearchItem } from "./run_search.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * Re-export the shared item type for history search consumers.
  */
@@ -77,48 +78,56 @@ export async function* workflowHistorySearch(
   deps: WorkflowHistorySearchDeps,
   input: WorkflowHistorySearchInput,
 ): AsyncGenerator<WorkflowHistorySearchEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.workflow.history.search",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const allWorkflows = await deps.findAllWorkflows();
+      const allWorkflows = await deps.findAllWorkflows();
 
-  // Fetch all runs for all workflows in parallel
-  const runsPerWorkflow = await Promise.all(
-    allWorkflows.map((workflow) => deps.findAllRunsByWorkflowId(workflow.id)),
+      // Fetch all runs for all workflows in parallel
+      const runsPerWorkflow = await Promise.all(
+        allWorkflows.map((workflow) =>
+          deps.findAllRunsByWorkflowId(workflow.id)
+        ),
+      );
+      const allRuns = runsPerWorkflow.flat();
+
+      // Sort by startedAt descending (most recent first)
+      allRuns.sort((a, b) => {
+        const aTime = a.startedAt?.getTime() ?? 0;
+        const bTime = b.startedAt?.getTime() ?? 0;
+        return bTime - aTime;
+      });
+
+      // Convert to search items
+      const results: WorkflowHistorySearchItem[] = allRuns.map((run) => {
+        const startTime = run.startedAt?.getTime();
+        const endTime = run.completedAt?.getTime();
+        const tags = run.tags && Object.keys(run.tags).length > 0
+          ? { ...run.tags }
+          : undefined;
+
+        return {
+          runId: run.id,
+          workflowId: run.workflowId,
+          workflowName: run.workflowName,
+          status: run.status,
+          startedAt: run.startedAt?.toISOString(),
+          completedAt: run.completedAt?.toISOString(),
+          duration: startTime && endTime ? endTime - startTime : undefined,
+          tags,
+        };
+      });
+
+      yield {
+        kind: "completed",
+        data: {
+          query: input.query ?? "",
+          results,
+        },
+      };
+    })(),
   );
-  const allRuns = runsPerWorkflow.flat();
-
-  // Sort by startedAt descending (most recent first)
-  allRuns.sort((a, b) => {
-    const aTime = a.startedAt?.getTime() ?? 0;
-    const bTime = b.startedAt?.getTime() ?? 0;
-    return bTime - aTime;
-  });
-
-  // Convert to search items
-  const results: WorkflowHistorySearchItem[] = allRuns.map((run) => {
-    const startTime = run.startedAt?.getTime();
-    const endTime = run.completedAt?.getTime();
-    const tags = run.tags && Object.keys(run.tags).length > 0
-      ? { ...run.tags }
-      : undefined;
-
-    return {
-      runId: run.id,
-      workflowId: run.workflowId,
-      workflowName: run.workflowName,
-      status: run.status,
-      startedAt: run.startedAt?.toISOString(),
-      completedAt: run.completedAt?.toISOString(),
-      duration: startTime && endTime ? endTime - startTime : undefined,
-      tags,
-    };
-  });
-
-  yield {
-    kind: "completed",
-    data: {
-      query: input.query ?? "",
-      results,
-    },
-  };
 }

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -63,6 +63,7 @@ import type { UnifiedDataRepository } from "../../infrastructure/persistence/uni
 import type { DefinitionRepository } from "../../domain/definitions/repositories.ts";
 import { YamlEvaluatedDefinitionRepository } from "../../infrastructure/persistence/yaml_evaluated_definition_repository.ts";
 import type { DataHandle } from "../../domain/models/model.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 
 /**
  * Events emitted by the libswamp workflow run generator.
@@ -330,183 +331,192 @@ export async function* workflowRun(
   deps: WorkflowRunDeps,
   input: WorkflowRunInput,
 ): AsyncGenerator<WorkflowRunEvent> {
-  let resolvedInput = input;
+  yield* withGeneratorSpan(
+    "swamp.workflow.run.command",
+    { "workflow.id_or_name": input.workflowIdOrName },
+    (async function* () {
+      let resolvedInput = input;
 
-  yield { kind: "validating_inputs" };
+      yield { kind: "validating_inputs" };
 
-  // Look up workflow
-  const workflow = await deps.lookupWorkflow(
-    deps.workflowRepo,
-    input.workflowIdOrName,
-  );
-  if (!workflow) {
-    yield {
-      kind: "error",
-      error: workflowNotFound(input.workflowIdOrName),
-    };
-    return;
-  }
-
-  // Coerce and validate inputs
-  if (workflow.inputs && !input.lastEvaluated) {
-    const coercedInputs = coerceInputTypes(
-      input.inputs ?? {},
-      workflow.inputs,
-    );
-    const validationService = new InputValidationService();
-    const inputsWithDefaults = validationService.applyDefaults(
-      coercedInputs,
-      workflow.inputs,
-    );
-    const result = validationService.validate(
-      inputsWithDefaults,
-      workflow.inputs,
-    );
-    if (!result.valid) {
-      yield { kind: "error", error: inputValidationFailed(result.errors) };
-      return;
-    }
-    resolvedInput = { ...input, inputs: inputsWithDefaults };
-  } else if (workflow.inputs) {
-    // lastEvaluated: still coerce types but skip validation
-    resolvedInput = {
-      ...input,
-      inputs: coerceInputTypes(input.inputs ?? {}, workflow.inputs),
-    };
-  }
-
-  yield { kind: "evaluating_workflow" };
-
-  const service = deps.createExecutionService(
-    deps.workflowRepo,
-    deps.runRepo,
-    deps.repoDir,
-  );
-
-  // Track model info from events for post-run reports
-  const modelInfoByStep = new Map<
-    string,
-    { modelName: string; modelType: string; methodName: string }
-  >();
-  // Track step statuses from events
-  const stepStatuses = new Map<string, "succeeded" | "failed" | "skipped">();
-  // Track step job names
-  const stepJobNames = new Map<string, string>();
-  // Track per-step data handles from step_completed events
-  const dataHandlesByStep = new Map<string, DataHandle[]>();
-
-  try {
-    let completedEvent: WorkflowRunEvent | undefined;
-
-    // Collect per-step report results from execution service events
-    const perStepReportResults: ReportResultView[] = [];
-
-    for await (
-      const event of service.run(resolvedInput.workflowIdOrName, {
-        lastEvaluated: resolvedInput.lastEvaluated,
-        inputs: resolvedInput.inputs,
-        runtimeTags: resolvedInput.runtimeTags,
-        signal: ctx.signal,
-        driver: resolvedInput.driver,
-        reportFilterOptions: {
-          skipAllReports: resolvedInput.skipAllReports,
-          skipReportNames: resolvedInput.skipReportNames,
-          skipReportLabels: resolvedInput.skipReportLabels,
-          reportNames: resolvedInput.reportNames,
-          reportLabels: resolvedInput.reportLabels,
-        },
-      })
-    ) {
-      // Track model_resolved events for report context
-      if (event.kind === "model_resolved") {
-        const key = `${event.jobId}:${event.stepId}`;
-        modelInfoByStep.set(key, {
-          modelName: event.modelName,
-          modelType: event.modelType,
-          methodName: event.methodName,
-        });
-        stepJobNames.set(key, event.jobId);
-      }
-      if (event.kind === "step_completed") {
-        stepStatuses.set(`${event.jobId}:${event.stepId}`, "succeeded");
-        if (event.dataHandles) {
-          dataHandlesByStep.set(
-            `${event.jobId}:${event.stepId}`,
-            event.dataHandles,
-          );
-        }
-      }
-      if (event.kind === "step_failed") {
-        stepStatuses.set(`${event.jobId}:${event.stepId}`, "failed");
-      }
-      if (event.kind === "step_skipped") {
-        stepStatuses.set(`${event.jobId}:${event.stepId}`, "skipped");
-      }
-
-      // Collect per-step report results from execution service events
-      if (event.kind === "report_completed") {
-        perStepReportResults.push({
-          name: event.reportName,
-          scope: event.scope,
-          success: true,
-          markdown: event.markdown,
-          json: event.json,
-        });
-      }
-      if (event.kind === "report_failed") {
-        perStepReportResults.push({
-          name: event.reportName,
-          scope: event.scope,
-          success: false,
-          error: event.error,
-        });
-      }
-
-      const mapped = mapEvent(event, deps, resolvedInput);
-
-      // Intercept the completed event to run reports first
-      if (mapped.kind === "completed") {
-        completedEvent = mapped;
-        continue;
-      }
-
-      yield mapped;
-    }
-
-    // Execute post-run reports (workflow-scope only) before yielding the completed event
-    if (completedEvent && completedEvent.kind === "completed") {
-      const reportResults: ReportResultView[] = [...perStepReportResults];
-      yield* executePostRunReports(
-        deps,
-        resolvedInput,
-        workflow,
-        completedEvent.run,
-        modelInfoByStep,
-        stepStatuses,
-        stepJobNames,
-        reportResults,
-        dataHandlesByStep,
+      // Look up workflow
+      const workflow = await deps.lookupWorkflow(
+        deps.workflowRepo,
+        input.workflowIdOrName,
       );
-      if (reportResults.length > 0) {
-        completedEvent = {
-          ...completedEvent,
-          run: { ...completedEvent.run, reports: reportResults },
+      if (!workflow) {
+        yield {
+          kind: "error",
+          error: workflowNotFound(input.workflowIdOrName),
+        };
+        return;
+      }
+
+      // Coerce and validate inputs
+      if (workflow.inputs && !input.lastEvaluated) {
+        const coercedInputs = coerceInputTypes(
+          input.inputs ?? {},
+          workflow.inputs,
+        );
+        const validationService = new InputValidationService();
+        const inputsWithDefaults = validationService.applyDefaults(
+          coercedInputs,
+          workflow.inputs,
+        );
+        const result = validationService.validate(
+          inputsWithDefaults,
+          workflow.inputs,
+        );
+        if (!result.valid) {
+          yield { kind: "error", error: inputValidationFailed(result.errors) };
+          return;
+        }
+        resolvedInput = { ...input, inputs: inputsWithDefaults };
+      } else if (workflow.inputs) {
+        // lastEvaluated: still coerce types but skip validation
+        resolvedInput = {
+          ...input,
+          inputs: coerceInputTypes(input.inputs ?? {}, workflow.inputs),
         };
       }
-      yield completedEvent;
-    }
-  } catch (error) {
-    if (
-      error instanceof DOMException && error.name === "AbortError"
-    ) {
-      yield { kind: "error", error: cancelled(error) };
-      return;
-    }
-    yield {
-      kind: "error",
-      error: workflowExecutionFailed(error),
-    };
-  }
+
+      yield { kind: "evaluating_workflow" };
+
+      const service = deps.createExecutionService(
+        deps.workflowRepo,
+        deps.runRepo,
+        deps.repoDir,
+      );
+
+      // Track model info from events for post-run reports
+      const modelInfoByStep = new Map<
+        string,
+        { modelName: string; modelType: string; methodName: string }
+      >();
+      // Track step statuses from events
+      const stepStatuses = new Map<
+        string,
+        "succeeded" | "failed" | "skipped"
+      >();
+      // Track step job names
+      const stepJobNames = new Map<string, string>();
+      // Track per-step data handles from step_completed events
+      const dataHandlesByStep = new Map<string, DataHandle[]>();
+
+      try {
+        let completedEvent: WorkflowRunEvent | undefined;
+
+        // Collect per-step report results from execution service events
+        const perStepReportResults: ReportResultView[] = [];
+
+        for await (
+          const event of service.run(resolvedInput.workflowIdOrName, {
+            lastEvaluated: resolvedInput.lastEvaluated,
+            inputs: resolvedInput.inputs,
+            runtimeTags: resolvedInput.runtimeTags,
+            signal: ctx.signal,
+            driver: resolvedInput.driver,
+            reportFilterOptions: {
+              skipAllReports: resolvedInput.skipAllReports,
+              skipReportNames: resolvedInput.skipReportNames,
+              skipReportLabels: resolvedInput.skipReportLabels,
+              reportNames: resolvedInput.reportNames,
+              reportLabels: resolvedInput.reportLabels,
+            },
+          })
+        ) {
+          // Track model_resolved events for report context
+          if (event.kind === "model_resolved") {
+            const key = `${event.jobId}:${event.stepId}`;
+            modelInfoByStep.set(key, {
+              modelName: event.modelName,
+              modelType: event.modelType,
+              methodName: event.methodName,
+            });
+            stepJobNames.set(key, event.jobId);
+          }
+          if (event.kind === "step_completed") {
+            stepStatuses.set(`${event.jobId}:${event.stepId}`, "succeeded");
+            if (event.dataHandles) {
+              dataHandlesByStep.set(
+                `${event.jobId}:${event.stepId}`,
+                event.dataHandles,
+              );
+            }
+          }
+          if (event.kind === "step_failed") {
+            stepStatuses.set(`${event.jobId}:${event.stepId}`, "failed");
+          }
+          if (event.kind === "step_skipped") {
+            stepStatuses.set(`${event.jobId}:${event.stepId}`, "skipped");
+          }
+
+          // Collect per-step report results from execution service events
+          if (event.kind === "report_completed") {
+            perStepReportResults.push({
+              name: event.reportName,
+              scope: event.scope,
+              success: true,
+              markdown: event.markdown,
+              json: event.json,
+            });
+          }
+          if (event.kind === "report_failed") {
+            perStepReportResults.push({
+              name: event.reportName,
+              scope: event.scope,
+              success: false,
+              error: event.error,
+            });
+          }
+
+          const mapped = mapEvent(event, deps, resolvedInput);
+
+          // Intercept the completed event to run reports first
+          if (mapped.kind === "completed") {
+            completedEvent = mapped;
+            continue;
+          }
+
+          yield mapped;
+        }
+
+        // Execute post-run reports (workflow-scope only) before yielding the completed event
+        if (completedEvent && completedEvent.kind === "completed") {
+          const reportResults: ReportResultView[] = [...perStepReportResults];
+          yield* executePostRunReports(
+            deps,
+            resolvedInput,
+            workflow,
+            completedEvent.run,
+            modelInfoByStep,
+            stepStatuses,
+            stepJobNames,
+            reportResults,
+            dataHandlesByStep,
+          );
+          if (reportResults.length > 0) {
+            completedEvent = {
+              ...completedEvent,
+              run: { ...completedEvent.run, reports: reportResults },
+            };
+          }
+          yield completedEvent;
+        }
+      } catch (error) {
+        if (
+          error instanceof DOMException && error.name === "AbortError"
+        ) {
+          yield { kind: "error", error: cancelled(error) };
+          return;
+        }
+        yield {
+          kind: "error",
+          error: workflowExecutionFailed(error),
+        };
+      }
+    })(),
+  );
 }
 
 /**

--- a/src/libswamp/workflows/run_search.ts
+++ b/src/libswamp/workflows/run_search.ts
@@ -21,6 +21,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { parseDuration } from "../data/search.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * A single workflow run search result item.
  */
@@ -91,91 +92,99 @@ export async function* workflowRunSearch(
   deps: WorkflowRunSearchDeps,
   input: WorkflowRunSearchInput,
 ): AsyncGenerator<WorkflowRunSearchEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.workflow.run_search",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const allWorkflows = await deps.findAllWorkflows();
+      const allWorkflows = await deps.findAllWorkflows();
 
-  // Fetch all runs for all workflows in parallel
-  const runsPerWorkflow = await Promise.all(
-    allWorkflows.map((workflow) => deps.findAllRunsByWorkflowId(workflow.id)),
+      // Fetch all runs for all workflows in parallel
+      const runsPerWorkflow = await Promise.all(
+        allWorkflows.map((workflow) =>
+          deps.findAllRunsByWorkflowId(workflow.id)
+        ),
+      );
+      const allRuns = runsPerWorkflow.flat();
+
+      // Sort by startedAt descending (most recent first)
+      allRuns.sort((a, b) => {
+        const aTime = a.startedAt?.getTime() ?? 0;
+        const bTime = b.startedAt?.getTime() ?? 0;
+        return bTime - aTime;
+      });
+
+      // Convert to search items
+      let results: WorkflowRunSearchItem[] = allRuns.map((run) => {
+        const startTime = run.startedAt?.getTime();
+        const endTime = run.completedAt?.getTime();
+        const tags = run.tags && Object.keys(run.tags).length > 0
+          ? { ...run.tags }
+          : undefined;
+
+        return {
+          runId: run.id,
+          workflowId: run.workflowId,
+          workflowName: run.workflowName,
+          status: run.status,
+          startedAt: run.startedAt?.toISOString(),
+          completedAt: run.completedAt?.toISOString(),
+          duration: startTime && endTime ? endTime - startTime : undefined,
+          tags,
+        };
+      });
+
+      // Apply filters
+      if (input.since) {
+        const durationMs = parseDuration(input.since);
+        const cutoff = Date.now() - durationMs;
+        results = results.filter((r) => {
+          if (!r.startedAt) return false;
+          return new Date(r.startedAt).getTime() >= cutoff;
+        });
+      }
+
+      if (input.status) {
+        const status = input.status.toLowerCase();
+        results = results.filter((r) => r.status.toLowerCase() === status);
+      }
+
+      if (input.workflow) {
+        const name = input.workflow.toLowerCase();
+        results = results.filter(
+          (r) => r.workflowName.toLowerCase() === name,
+        );
+      }
+
+      if (input.tags) {
+        const tagEntries = Object.entries(input.tags);
+        results = results.filter((r) =>
+          tagEntries.every(([k, v]) => r.tags?.[k] === v)
+        );
+      }
+
+      if (input.query) {
+        const q = input.query.toLowerCase();
+        results = results.filter(
+          (r) =>
+            r.workflowName.toLowerCase().includes(q) ||
+            r.runId.toLowerCase().includes(q) ||
+            r.status.toLowerCase().includes(q),
+        );
+      }
+
+      if (input.limit !== undefined) {
+        results = results.slice(0, input.limit);
+      }
+
+      yield {
+        kind: "completed",
+        data: {
+          query: input.query ?? "",
+          results,
+        },
+      };
+    })(),
   );
-  const allRuns = runsPerWorkflow.flat();
-
-  // Sort by startedAt descending (most recent first)
-  allRuns.sort((a, b) => {
-    const aTime = a.startedAt?.getTime() ?? 0;
-    const bTime = b.startedAt?.getTime() ?? 0;
-    return bTime - aTime;
-  });
-
-  // Convert to search items
-  let results: WorkflowRunSearchItem[] = allRuns.map((run) => {
-    const startTime = run.startedAt?.getTime();
-    const endTime = run.completedAt?.getTime();
-    const tags = run.tags && Object.keys(run.tags).length > 0
-      ? { ...run.tags }
-      : undefined;
-
-    return {
-      runId: run.id,
-      workflowId: run.workflowId,
-      workflowName: run.workflowName,
-      status: run.status,
-      startedAt: run.startedAt?.toISOString(),
-      completedAt: run.completedAt?.toISOString(),
-      duration: startTime && endTime ? endTime - startTime : undefined,
-      tags,
-    };
-  });
-
-  // Apply filters
-  if (input.since) {
-    const durationMs = parseDuration(input.since);
-    const cutoff = Date.now() - durationMs;
-    results = results.filter((r) => {
-      if (!r.startedAt) return false;
-      return new Date(r.startedAt).getTime() >= cutoff;
-    });
-  }
-
-  if (input.status) {
-    const status = input.status.toLowerCase();
-    results = results.filter((r) => r.status.toLowerCase() === status);
-  }
-
-  if (input.workflow) {
-    const name = input.workflow.toLowerCase();
-    results = results.filter(
-      (r) => r.workflowName.toLowerCase() === name,
-    );
-  }
-
-  if (input.tags) {
-    const tagEntries = Object.entries(input.tags);
-    results = results.filter((r) =>
-      tagEntries.every(([k, v]) => r.tags?.[k] === v)
-    );
-  }
-
-  if (input.query) {
-    const q = input.query.toLowerCase();
-    results = results.filter(
-      (r) =>
-        r.workflowName.toLowerCase().includes(q) ||
-        r.runId.toLowerCase().includes(q) ||
-        r.status.toLowerCase().includes(q),
-    );
-  }
-
-  if (input.limit !== undefined) {
-    results = results.slice(0, input.limit);
-  }
-
-  yield {
-    kind: "completed",
-    data: {
-      query: input.query ?? "",
-      results,
-    },
-  };
 }

--- a/src/libswamp/workflows/schema.ts
+++ b/src/libswamp/workflows/schema.ts
@@ -29,6 +29,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { zodToJsonSchema } from "../types/schema_helpers.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** Schema data for all workflow-related Zod schemas. */
 export interface WorkflowSchemaData {
   workflow: object;
@@ -48,16 +49,22 @@ export type WorkflowSchemaEvent =
 export async function* workflowSchema(
   _ctx: LibSwampContext,
 ): AsyncIterable<WorkflowSchemaEvent> {
-  yield {
-    kind: "completed",
-    data: {
-      workflow: zodToJsonSchema(WorkflowSchema),
-      job: zodToJsonSchema(JobSchema),
-      jobDependency: zodToJsonSchema(JobDependencySchema),
-      step: zodToJsonSchema(StepSchema),
-      stepDependency: zodToJsonSchema(StepDependencySchema),
-      stepTask: zodToJsonSchema(StepTaskSchema),
-      triggerCondition: zodToJsonSchema(TriggerConditionSchema),
-    },
-  };
+  yield* withGeneratorSpan(
+    "swamp.workflow.schema",
+    {},
+    (async function* () {
+      yield {
+        kind: "completed",
+        data: {
+          workflow: zodToJsonSchema(WorkflowSchema),
+          job: zodToJsonSchema(JobSchema),
+          jobDependency: zodToJsonSchema(JobDependencySchema),
+          step: zodToJsonSchema(StepSchema),
+          stepDependency: zodToJsonSchema(StepDependencySchema),
+          stepTask: zodToJsonSchema(StepTaskSchema),
+          triggerCondition: zodToJsonSchema(TriggerConditionSchema),
+        },
+      };
+    })(),
+  );
 }

--- a/src/libswamp/workflows/search.ts
+++ b/src/libswamp/workflows/search.ts
@@ -20,6 +20,7 @@
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
  * A single workflow search result item.
  */
@@ -75,21 +76,27 @@ export async function* workflowSearch(
   deps: WorkflowSearchDeps,
   input: WorkflowSearchInput,
 ): AsyncGenerator<WorkflowSearchEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.workflow.search",
+    { "search.query": input.query ?? "" },
+    (async function* () {
+      yield { kind: "resolving" };
 
-  const allWorkflows = await deps.findAllWorkflows();
-  const results: WorkflowSearchItem[] = allWorkflows.map((w) => ({
-    id: w.id,
-    name: w.name,
-    description: w.description,
-    jobCount: w.jobs.length,
-  }));
+      const allWorkflows = await deps.findAllWorkflows();
+      const results: WorkflowSearchItem[] = allWorkflows.map((w) => ({
+        id: w.id,
+        name: w.name,
+        description: w.description,
+        jobCount: w.jobs.length,
+      }));
 
-  yield {
-    kind: "completed",
-    data: {
-      query: input.query ?? "",
-      results,
-    },
-  };
+      yield {
+        kind: "completed",
+        data: {
+          query: input.query ?? "",
+          results,
+        },
+      };
+    })(),
+  );
 }

--- a/src/libswamp/workflows/validate.ts
+++ b/src/libswamp/workflows/validate.ts
@@ -27,6 +27,7 @@ import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** UUID v4 regex pattern for detecting if an argument is a UUID. */
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -195,11 +196,17 @@ export async function* workflowValidate(
   deps: WorkflowValidateDeps,
   input: WorkflowValidateInput,
 ): AsyncIterable<WorkflowValidateEvent> {
-  yield { kind: "resolving" };
+  yield* withGeneratorSpan(
+    "swamp.workflow.validate",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
 
-  if (!input.workflowIdOrName) {
-    yield* validateAll(deps);
-  } else {
-    yield* validateSingle(deps, input.workflowIdOrName);
-  }
+      if (!input.workflowIdOrName) {
+        yield* validateAll(deps);
+      } else {
+        yield* validateSingle(deps, input.workflowIdOrName);
+      }
+    })(),
+  );
 }


### PR DESCRIPTION
Add native OTel tracing using AsyncLocalStorage-based implicit context propagation. Traces capture the full execution hierarchy from CLI command through workflow orchestration to individual model method and driver execution. Context propagates automatically to in-process extensions and via TRACEPARENT env vars to Docker containers.

Infrastructure:
- Add @opentelemetry/api and SDK packages to deno.json
- Create src/infrastructure/tracing/ with init, tracer, and propagation
- initTracing()/shutdownTracing() lifecycle in main.ts
- withSpan() for async functions, withGeneratorSpan() for async generators
- Zero overhead when disabled — OTel API returns no-op implementations

Execution hierarchy spans:
- swamp.cli → swamp.workflow.run → swamp.workflow.job → swamp.workflow.step
- swamp.model.method → swamp.driver.execute (raw and docker)
- swamp.workflow.evaluate for expression evaluation
- swamp.lock.acquire and swamp.datastore.sync for infrastructure

Cross-process propagation:
- Add traceHeaders to ExecutionRequest interface
- Inject W3C traceparent via injectTraceContext() in method execution
- Docker driver passes trace headers as container env vars

Comprehensive generator instrumentation:
- 64 libswamp generators wrapped with withGeneratorSpan
- Covers all domains: model, workflow, data, vault, extension, datastore, repo, report, source, auth, audit, telemetry, type, update, issue
- Error events automatically set span ERROR status

Configuration via standard OTel env vars:
- OTEL_EXPORTER_OTLP_ENDPOINT — collector URL (tracing off when unset)
- OTEL_TRACES_EXPORTER — otlp or console
- OTEL_SERVICE_NAME — defaults to "swamp"
- OTEL_EXPORTER_OTLP_HEADERS — auth headers

Closes #677, closes #679