### PR TITLE
fix: address OTel tracing PR review feedback

### DIFF
--- a/.claude/skills/swamp-troubleshooting/SKILL.md
+++ b/.claude/skills/swamp-troubleshooting/SKILL.md
@@ -6,7 +6,8 @@ description: >
   --help is insufficient. Use this skill whenever something is broken
   ("error", "failing", "not working", "crash", "timeout", "bug", "fix",
   "debug", "troubleshoot", "root cause", "stack trace", "isn't being found",
-  "giving me an error") OR when you need to understand how swamp works
+  "giving me an error", "slow", "performance", "latency") OR when you need
+  to understand how swamp works
   internally ("how does", "what happens when", "where is", "internals",
   "under the hood"). Applies even when the query mentions a specific domain
   (e.g., "vault expressions aren't resolving" or "how does extension push
@@ -132,7 +133,25 @@ Read ~/.swamp/source/src/cli/mod.ts
 Read ~/.swamp/source/src/domain/models/model_service.ts
 ```
 
-### 4. Diagnose the Issue
+### 4. Enable Tracing (Performance Issues)
+
+If the issue is about slowness, timeouts, or understanding execution flow,
+enable OpenTelemetry tracing:
+
+```bash
+# Quick: print spans to stderr
+OTEL_TRACES_EXPORTER=console swamp workflow run my-workflow
+
+# Visual: send to local Jaeger (docker run -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one)
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 swamp workflow run my-workflow
+```
+
+Traces show the full execution hierarchy with timing for every operation — CLI
+command → workflow → job → step → method → driver. See
+[references/tracing.md](references/tracing.md) for setup, span names, and
+diagnosing common issues.
+
+### 5. Diagnose the Issue
 
 Based on the error message or symptoms:
 
@@ -145,8 +164,10 @@ Based on the error message or symptoms:
 7. **Pre-flight check failures**: See
    [references/checks.md](references/checks.md) for skip flags, check selection
    errors, extension conflicts, and required check behavior
+8. **Slow operations**: Enable tracing — see
+   [references/tracing.md](references/tracing.md)
 
-### 5. Explain and Suggest Fixes
+### 6. Explain and Suggest Fixes
 
 After diagnosing:
 
@@ -174,6 +195,7 @@ After diagnosing:
 │   ├── infrastructure/
 │   │   ├── persistence/     # File-based storage
 │   │   ├── logging/         # LogTape configuration
+│   │   ├── tracing/         # OpenTelemetry tracing
 │   │   └── update/          # Self-update mechanism
 │   └── presentation/
 │       └── output/          # Terminal output rendering

--- a/.claude/skills/swamp-troubleshooting/references/tracing.md
+++ b/.claude/skills/swamp-troubleshooting/references/tracing.md
@@ -1,0 +1,137 @@
+# OpenTelemetry Tracing
+
+Swamp has native OpenTelemetry tracing for diagnosing slow or failing
+operations. Tracing is opt-in via environment variables and has zero overhead
+when disabled.
+
+## Quick Setup
+
+```bash
+# Local Jaeger (run once)
+docker run -d --name jaeger -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one:latest
+
+# Enable tracing for any swamp command
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 swamp workflow run my-workflow
+
+# View traces at http://localhost:16686 — search for service "swamp"
+```
+
+## When to Use Tracing
+
+Tracing is most useful when:
+
+- A workflow run is slow and you need to identify which step/method is the
+  bottleneck
+- Extension model methods are timing out and you need to see the full execution
+  timeline
+- Datastore sync (S3 pull/push) is slow and you want to measure lock acquisition
+  and transfer times
+- `data gc` is taking too long and you want to see how many entries are being
+  processed
+- Extension pull/push is failing and you want to see which network phase fails
+- You need to trace context across Docker container boundaries to connect
+  extension spans to the parent workflow
+
+## Configuration
+
+| Variable                      | Purpose                                | Default         |
+| ----------------------------- | -------------------------------------- | --------------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector URL (tracing off when unset) | _(unset = off)_ |
+| `OTEL_TRACES_EXPORTER`        | `otlp`, `console`, or `none`           | `otlp`          |
+| `OTEL_SERVICE_NAME`           | Service name in traces                 | `swamp`         |
+| `OTEL_EXPORTER_OTLP_HEADERS`  | Auth headers (`key=val,key=val`)       | _(none)_        |
+
+### Console Exporter (No Collector Needed)
+
+For quick debugging without running a collector:
+
+```bash
+OTEL_TRACES_EXPORTER=console swamp workflow run my-workflow
+```
+
+Spans are printed to stderr in a readable format showing traceId, parentId,
+name, duration, and attributes.
+
+### Cloud Providers
+
+```bash
+# Honeycomb
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://api.honeycomb.io
+export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=YOUR_API_KEY"
+
+# Grafana Cloud
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-us-east-0.grafana.net/otlp
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic YOUR_BASE64_TOKEN"
+```
+
+## What Gets Traced
+
+### Workflow Execution Hierarchy
+
+```
+swamp.cli "workflow run"
+  └─ swamp.workflow.run.command
+       └─ swamp.workflow.run "deploy"
+            ├─ swamp.workflow.evaluate
+            ├─ swamp.workflow.job "build"
+            │    ├─ swamp.workflow.step "compile" (20ms)
+            │    │    └─ swamp.model.method → swamp.driver.execute
+            │    └─ swamp.workflow.step "test" (parallel, 45ms)
+            │         └─ swamp.model.method → swamp.driver.execute
+            └─ swamp.workflow.job "deploy" (starts after build)
+                 └─ swamp.workflow.step "apply"
+                      └─ swamp.model.method → swamp.driver.execute
+```
+
+### All CLI Operations
+
+Every libswamp generator is traced. Key span names:
+
+- `swamp.model.method.run` — standalone model method execution
+- `swamp.data.gc` — garbage collection (attributes: entries expired, bytes
+  reclaimed)
+- `swamp.extension.pull` / `.push` — registry network operations
+- `swamp.datastore.sync` — S3 pull/push (attributes: direction, file count)
+- `swamp.lock.acquire` — distributed lock acquisition
+- `swamp.vault.put` / `.get` — secret storage/retrieval
+
+## Diagnosing Common Issues
+
+### Slow Workflow Runs
+
+1. Enable tracing and run the workflow
+2. In Jaeger, find the trace and look at the waterfall view
+3. Identify which `swamp.workflow.step` spans are longest
+4. Drill into `swamp.model.method` → `swamp.driver.execute` to see if the method
+   itself is slow or if it's lock/sync overhead
+
+### Slow Data GC
+
+Look at the `swamp.data.gc` span attributes:
+
+- `gc.entries_expired` — how many entries were processed
+- `gc.versions_deleted` — how many versions were cleaned up
+- `gc.bytes_reclaimed` — total bytes freed
+
+### Extension Pull/Push Failures
+
+The `swamp.extension.pull` and `swamp.extension.push` spans show the full
+network operation. Push has three phases (initiate → upload → confirm) — the
+span status and error message indicate which phase failed.
+
+### Lock Contention
+
+If `swamp.lock.acquire` spans are long, another process is holding the lock.
+Check with `swamp datastore lock status` to see the current holder.
+
+### Docker Driver Trace Propagation
+
+When using `driver: docker`, swamp automatically sets `TRACEPARENT` as a
+container environment variable. Extensions running in Docker that initialize
+their own OTel SDK can read this env var to connect their spans to the parent
+trace, creating a unified trace across process boundaries.
+
+## Design Reference
+
+See `design/tracing.md` for the full architecture, implementation files, and
+span attribute reference.

--- a/README.md
+++ b/README.md
@@ -289,6 +289,44 @@ Valid levels: `trace`, `debug`, `info`, `warning`, `error`, `fatal`.
 Priority order (highest to lowest): `-q` / `--log-level` flag →
 `SWAMP_LOG_LEVEL` env var → `.swamp.yaml` `logLevel` → default (`info`).
 
+## Tracing
+
+Swamp has native OpenTelemetry tracing for diagnosing slow or failing
+operations. Tracing is opt-in and has zero overhead when disabled.
+
+Set `OTEL_EXPORTER_OTLP_ENDPOINT` to enable:
+
+```bash
+# Send traces to a local Jaeger instance
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 swamp workflow run my-workflow
+
+# Quick debug: print spans to stderr (no collector needed)
+OTEL_TRACES_EXPORTER=console swamp workflow run my-workflow
+```
+
+Traces capture the full execution hierarchy — CLI command, workflow, job, step,
+model method, and driver execution — with automatic context propagation to
+in-process extensions and Docker containers via `TRACEPARENT`.
+
+### Local development
+
+Run Jaeger for a local trace UI:
+
+```bash
+docker run -d --name jaeger -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one:latest
+```
+
+Then open `http://localhost:16686` and search for the `swamp` service.
+
+### Configuration
+
+| Variable                      | Purpose                                | Default         |
+| ----------------------------- | -------------------------------------- | --------------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector URL (tracing off when unset) | _(unset = off)_ |
+| `OTEL_TRACES_EXPORTER`        | `otlp`, `console`, or `none`           | `otlp`          |
+| `OTEL_SERVICE_NAME`           | Service name in traces                 | `swamp`         |
+| `OTEL_EXPORTER_OTLP_HEADERS`  | Auth headers (`key=val,key=val`)       | _(none)_        |
+
 ## Telemetry
 
 Swamp collects anonymous usage telemetry to help us understand which commands

--- a/design/tracing.md
+++ b/design/tracing.md
@@ -1,0 +1,291 @@
+# Tracing
+
+Swamp has native OpenTelemetry (OTel) tracing that captures the full execution
+hierarchy from CLI command through workflow orchestration to individual model
+method and driver execution. Tracing is opt-in and has zero overhead when
+disabled — the `@opentelemetry/api` package returns no-op implementations when
+no provider is registered.
+
+## Configuration
+
+Tracing is controlled entirely through standard OTel environment variables. No
+CLI flags or configuration files are needed.
+
+| Variable                       | Purpose                                   | Default               |
+| ------------------------------ | ----------------------------------------- | --------------------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector URL (tracing off when unset)    | _(unset = off)_       |
+| `OTEL_TRACES_EXPORTER`        | Exporter: `otlp`, `console`, or `none`    | `otlp`                |
+| `OTEL_SERVICE_NAME`           | Service name in traces                    | `swamp`               |
+| `OTEL_EXPORTER_OTLP_HEADERS`  | Auth headers (comma-separated `key=val`)  | _(none)_              |
+
+### Enabling Tracing
+
+Set `OTEL_EXPORTER_OTLP_ENDPOINT` to point at an OTLP-compatible collector:
+
+```bash
+# Send traces to a local Jaeger instance
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+
+# Send traces to Honeycomb
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://api.honeycomb.io
+export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=your-api-key"
+
+# Debug: print spans to stderr
+export OTEL_TRACES_EXPORTER=console
+```
+
+When `OTEL_EXPORTER_OTLP_ENDPOINT` is unset and `OTEL_TRACES_EXPORTER` is not
+`console`, tracing is completely disabled. No SDK packages are loaded, no context
+manager is installed, and all tracer/span operations are no-ops.
+
+### Local Development
+
+Run Jaeger for a local trace UI:
+
+```bash
+docker run -d --name jaeger \
+  -p 16686:16686 \
+  -p 4318:4318 \
+  jaegertracing/all-in-one:latest
+```
+
+Then run any swamp command with tracing enabled:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 swamp workflow run my-workflow
+```
+
+Open `http://localhost:16686` and search for the `swamp` service.
+
+## Span Hierarchy
+
+Traces capture the full execution tree. A workflow run produces a hierarchy like:
+
+```
+swamp.cli "workflow run"
+  ├─ swamp.lock.acquire
+  ├─ swamp.datastore.sync (pull)
+  └─ swamp.workflow.run.command
+       └─ swamp.workflow.run "deploy"
+            ├─ swamp.workflow.evaluate
+            ├─ swamp.workflow.job "build"
+            │    ├─ swamp.workflow.step "compile"
+            │    │    └─ swamp.model.method "app.build"
+            │    │         └─ swamp.driver.execute "raw"
+            │    │              └─ (extension spans — automatic)
+            │    └─ swamp.workflow.step "test"
+            │         └─ swamp.model.method "app.test"
+            │              └─ swamp.driver.execute "docker"
+            │                   └─ (TRACEPARENT env var propagated)
+            └─ swamp.workflow.job "deploy"
+                 └─ swamp.workflow.step "apply"
+                      └─ swamp.model.method "ec2.create"
+                           └─ swamp.driver.execute "raw"
+```
+
+## Instrumentation Points
+
+### CLI Root Span
+
+Every CLI invocation creates a `swamp.cli` root span that encompasses the entire
+command lifecycle. Attributes include `swamp.command`, `swamp.subcommand`, and
+`swamp.version`.
+
+### Libswamp Generator Spans
+
+Every libswamp generator is wrapped with `withGeneratorSpan`, producing a span
+for the full duration of the operation. These spans use the naming convention
+`swamp.<domain>.<operation>`:
+
+| Domain       | Span Names                                                                      |
+| ------------ | ------------------------------------------------------------------------------- |
+| `auth`       | `swamp.auth.login`                                                              |
+| `audit`      | `swamp.audit.timeline`                                                          |
+| `data`       | `swamp.data.get`, `.list`, `.search`, `.versions`, `.rename`, `.gc`             |
+| `datastore`  | `swamp.datastore.setup`, `.status`, `.sync.command`, `.lock.status`, `.lock.release` |
+| `extension`  | `swamp.extension.pull`, `.push`, `.search`, `.update`, `.yank`, `.rm`, `.fmt`, `.list` |
+| `issue`      | `swamp.issue.create`                                                            |
+| `model`      | `swamp.model.create`, `.delete`, `.edit`, `.get`, `.search`, `.validate`        |
+| `model`      | `swamp.model.method.run`, `.method.describe`, `.method.history.logs`            |
+| `model`      | `swamp.model.output.search`, `.output.get`, `.output.logs`, `.output.data`     |
+| `report`     | `swamp.report.describe`, `.get`, `.search`                                      |
+| `repo`       | `swamp.repo.create`, `.upgrade`                                                 |
+| `source`     | `swamp.source.fetch`, `.clean`                                                  |
+| `telemetry`  | `swamp.telemetry.stats`                                                         |
+| `type`       | `swamp.type.describe`, `.search`                                                |
+| `update`     | `swamp.update.check`                                                            |
+| `vault`      | `swamp.vault.create`, `.describe`, `.edit`, `.get`, `.list_keys`, `.put`, `.search`, `.type_search` |
+| `workflow`   | `swamp.workflow.create`, `.delete`, `.edit`, `.get`, `.search`, `.validate`, `.schema` |
+| `workflow`   | `swamp.workflow.run.command`, `.history.get`, `.history.logs`, `.history.search`, `.run_search` |
+
+Generator spans automatically detect `kind: "error"` events and mark the span
+status as ERROR.
+
+### Domain-Layer Spans
+
+The workflow execution engine and method execution service create fine-grained
+spans for the execution hierarchy:
+
+| Span Name                   | Created By                         | Attributes                                     |
+| --------------------------- | ---------------------------------- | ---------------------------------------------- |
+| `swamp.workflow.run`        | `WorkflowExecutionService.run()`   | `workflow.name`, `workflow.id`, `workflow.run_id` |
+| `swamp.workflow.evaluate`   | `evaluateWorkflow()`               | `workflow.name`, `workflow.expressions_evaluated` |
+| `swamp.workflow.job`        | `runJob()`                         | `job.name`, `job.status`                       |
+| `swamp.workflow.step`       | `runStep()`                        | `step.name`, `job.name`, `step.task.type`      |
+| `swamp.model.method`        | `executeWorkflow()`                | `model.name`, `model.type`, `method.name`      |
+| `swamp.driver.execute`      | method execution service           | `driver.type`, `model.type`                    |
+
+### Infrastructure Spans
+
+| Span Name               | Created By                     | Attributes                              |
+| ------------------------ | ------------------------------ | --------------------------------------- |
+| `swamp.lock.acquire`    | `registerDatastoreSyncNamed()` | `lock.key`, `lock.label`                |
+| `swamp.datastore.sync`  | sync coordinator               | `sync.direction` (pull/push), `sync.file_count` |
+| `swamp.repo.init`       | `requireInitializedRepo()`     | _(none)_                                |
+
+## Context Propagation
+
+### In-Process (Automatic)
+
+The OTel SDK uses `AsyncLocalStorageContextManager` to propagate trace context
+through async call chains. When `tracer.startActiveSpan()` or
+`tracer.startSpan()` creates a span inside an active context, parent-child
+relationships are established automatically. This means:
+
+- Extensions running in-process (raw driver) inherit the active span context
+  automatically — their OTel-instrumented code creates child spans without any
+  manual wiring.
+- `yield*` delegation in async generators preserves context across generator
+  boundaries.
+
+### Cross-Process (Docker Driver)
+
+For out-of-process execution, W3C Trace Context headers are propagated:
+
+1. `injectTraceContext()` extracts `traceparent` and `tracestate` from the
+   current active context into a `Record<string, string>`.
+2. The `ExecutionRequest.traceHeaders` field carries these headers.
+3. The Docker driver passes them as container environment variables
+   (`TRACEPARENT`, `TRACESTATE`).
+4. Extensions running in Docker can read these env vars and connect their spans
+   to the parent trace.
+
+```
+HOST PROCESS                         DOCKER CONTAINER
+─────────────                        ────────────────
+
+active span context
+  │
+  ├─ injectTraceContext()
+  │   → { traceparent: "00-abc..." }
+  │
+  ├─ ExecutionRequest.traceHeaders
+  │
+  └─ docker run -e TRACEPARENT=00-abc...
+                                     TRACEPARENT env var
+                                       │
+                                       └─ Extension reads env var
+                                          and connects to parent trace
+```
+
+## SDK Initialization
+
+### Dynamic Loading
+
+All OTel SDK packages (`sdk-trace-base`, `exporter-trace-otlp-http`,
+`context-async-hooks`, `resources`, `semantic-conventions`) are loaded via
+dynamic `import()` only when tracing is enabled. The `@opentelemetry/api`
+package is statically imported because it is designed as a zero-cost no-op when
+no provider is registered.
+
+### Lifecycle
+
+```
+main.ts:
+  initTracing()          ← Check env vars, optionally load SDK
+    │
+    ├─ No endpoint?  → return (no-op)
+    │
+    └─ Endpoint set?
+         ├─ Create AsyncLocalStorageContextManager
+         ├─ Create BasicTracerProvider with Resource
+         ├─ Add BatchSpanProcessor with exporter
+         └─ Register as global provider
+    │
+  runCli(args)           ← All spans created during execution
+    │
+  shutdownTracing()      ← Flush pending spans, disable context manager
+```
+
+### Zero-Cost When Disabled
+
+When tracing is disabled:
+
+- `getTracer()` returns a no-op tracer
+- `tracer.startSpan()` returns a no-op span (all-zeros traceId)
+- `withSpan()` calls the wrapped function directly
+- `withGeneratorSpan()` iterates the wrapped generator directly
+- `injectTraceContext()` returns an empty object
+- No SDK packages are loaded, no async hooks are installed
+
+## Utilities
+
+### `withSpan(name, attributes, fn)`
+
+Wraps an async function with a span. Creates the span, sets it as active,
+executes the function, records errors, and ends the span in all code paths.
+Used for regular async methods (e.g., `executeWorkflow()`).
+
+### `withGeneratorSpan(name, attributes, generator)`
+
+Wraps an async generator with a span. The span starts when iteration begins and
+ends when the generator completes, throws, or is abandoned. Events with
+`kind: "error"` are detected and recorded as span errors. Used for all libswamp
+generators.
+
+### `getTracer()`
+
+Returns the swamp tracer from the global provider. Returns a no-op tracer when
+tracing is not initialized.
+
+### `injectTraceContext()` / `extractTraceContext(headers)`
+
+Inject/extract W3C Trace Context headers (`traceparent`, `tracestate`) for
+cross-process propagation.
+
+## Implementation Files
+
+### Infrastructure Layer
+
+| File                                            | Purpose                                       |
+| ----------------------------------------------- | --------------------------------------------- |
+| `src/infrastructure/tracing/mod.ts`             | Public API surface (re-exports)               |
+| `src/infrastructure/tracing/otel_init.ts`       | SDK bootstrap, dynamic loading, shutdown      |
+| `src/infrastructure/tracing/tracer.ts`          | `getTracer`, `withSpan`, `withGeneratorSpan`  |
+| `src/infrastructure/tracing/propagation.ts`     | W3C Trace Context inject/extract              |
+
+### Instrumented Domain Files
+
+| File                                                    | Spans Created                                     |
+| ------------------------------------------------------- | ------------------------------------------------- |
+| `main.ts`                                               | `initTracing()` / `shutdownTracing()` lifecycle   |
+| `src/cli/mod.ts`                                        | `swamp.cli` root span                             |
+| `src/cli/repo_context.ts`                               | `swamp.repo.init`                                 |
+| `src/domain/workflows/execution_service.ts`             | `swamp.workflow.run`, `.job`, `.step`, `.evaluate` |
+| `src/domain/models/method_execution_service.ts`         | `swamp.model.method`, `swamp.driver.execute`      |
+| `src/domain/drivers/docker_execution_driver.ts`         | Trace header propagation via env vars             |
+| `src/infrastructure/persistence/datastore_sync_coordinator.ts` | `swamp.lock.acquire`, `swamp.datastore.sync` |
+
+### Dependencies
+
+```json
+"@opentelemetry/api": "npm:@opentelemetry/api@^1.9.0",
+"@opentelemetry/sdk-trace-base": "npm:@opentelemetry/sdk-trace-base@^1.30.0",
+"@opentelemetry/exporter-trace-otlp-http": "npm:@opentelemetry/exporter-trace-otlp-http@^0.57.0",
+"@opentelemetry/context-async-hooks": "npm:@opentelemetry/context-async-hooks@^1.30.0",
+"@opentelemetry/resources": "npm:@opentelemetry/resources@^1.30.0",
+"@opentelemetry/semantic-conventions": "npm:@opentelemetry/semantic-conventions@^1.30.0"
+```
+
+Only `@opentelemetry/api` is statically imported. All other packages are
+dynamically loaded when tracing is enabled.

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -63,8 +63,7 @@ import {
 import type { DatastoreProvider } from "../domain/datastore/datastore_provider.ts";
 import { datastoreTypeRegistry } from "../domain/datastore/datastore_type_registry.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
-import { getTracer } from "../infrastructure/tracing/mod.ts";
-import { SpanStatusCode } from "@opentelemetry/api";
+import { withSpan } from "../infrastructure/tracing/mod.ts";
 
 /**
  * Resolves a DatastoreProvider for a custom datastore config.
@@ -244,12 +243,11 @@ export async function requireInitializedRepoReadOnly(
  * @returns The validated repo context
  * @throws UserError if not initialized
  */
-export async function requireInitializedRepo(
+export function requireInitializedRepo(
   options: RequireRepoOptions,
   factoryConfig?: Partial<Omit<RepositoryFactoryConfig, "repoDir">>,
 ): Promise<RepoValidationContext> {
-  const repoSpan = getTracer().startSpan("swamp.repo.init");
-  try {
+  return withSpan("swamp.repo.init", {}, async () => {
     const { repoDir, datastoreConfig, marker } = await resolveDatastoreForRepo(
       options.repoDir,
     );
@@ -349,21 +347,12 @@ export async function requireInitializedRepo(
       ...factoryConfig,
     });
 
-    repoSpan.setStatus({ code: SpanStatusCode.OK });
     return {
       repoDir: repoPath.value,
       repoContext,
       datastoreResolver,
     };
-  } catch (error) {
-    repoSpan.setStatus({
-      code: SpanStatusCode.ERROR,
-      message: error instanceof Error ? error.message : String(error),
-    });
-    throw error;
-  } finally {
-    repoSpan.end();
-  }
+  });
 }
 
 /**

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -89,8 +89,7 @@ import {
 import { reportRegistry } from "../reports/report_registry.ts";
 import type { MethodReportContext } from "../reports/report_context.ts";
 import { modelRegistry } from "../models/model.ts";
-import { getTracer } from "../../infrastructure/tracing/mod.ts";
-import { SpanStatusCode } from "@opentelemetry/api";
+import { getTracer, SpanStatusCode } from "../../infrastructure/tracing/mod.ts";
 /**
  * Context for step execution.
  */

--- a/src/infrastructure/assets/skill_assets.ts
+++ b/src/infrastructure/assets/skill_assets.ts
@@ -225,6 +225,10 @@ const BUNDLED_SKILLS: SkillInfo[] = [
     relativePath: "swamp-troubleshooting/references/checks.md",
     name: "swamp-troubleshooting",
   },
+  {
+    relativePath: "swamp-troubleshooting/references/tracing.md",
+    name: "swamp-troubleshooting",
+  },
 ];
 
 /**

--- a/src/infrastructure/persistence/datastore_sync_coordinator.ts
+++ b/src/infrastructure/persistence/datastore_sync_coordinator.ts
@@ -34,8 +34,7 @@
 
 import type { DistributedLock } from "../../domain/datastore/distributed_lock.ts";
 import { getSwampLogger } from "../logging/logger.ts";
-import { getTracer } from "../tracing/mod.ts";
-import { SpanStatusCode } from "@opentelemetry/api";
+import { getTracer, SpanStatusCode } from "../tracing/mod.ts";
 
 /**
  * Common interface for sync services compatible with the coordinator.

--- a/src/infrastructure/tracing/mod.ts
+++ b/src/infrastructure/tracing/mod.ts
@@ -18,5 +18,10 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 export { initTracing, shutdownTracing } from "./otel_init.ts";
-export { getTracer, withGeneratorSpan, withSpan } from "./tracer.ts";
+export {
+  getTracer,
+  SpanStatusCode,
+  withGeneratorSpan,
+  withSpan,
+} from "./tracer.ts";
 export { extractTraceContext, injectTraceContext } from "./propagation.ts";

--- a/src/infrastructure/tracing/otel_init.ts
+++ b/src/infrastructure/tracing/otel_init.ts
@@ -86,7 +86,7 @@ export async function initTracing(): Promise<void> {
     }
 
     const exporter = new OTLPTraceExporter({
-      url: `${endpoint}/v1/traces`,
+      url: `${endpoint!.replace(/\/+$/, "")}/v1/traces`,
       headers,
     });
     provider.addSpanProcessor(new BatchSpanProcessor(exporter));

--- a/src/infrastructure/tracing/tracer.ts
+++ b/src/infrastructure/tracing/tracer.ts
@@ -19,6 +19,7 @@
 
 import {
   type Attributes,
+  context,
   type Span,
   SpanStatusCode,
   trace,
@@ -26,6 +27,12 @@ import {
 } from "@opentelemetry/api";
 
 const TRACER_NAME = "swamp";
+
+/**
+ * Re-export SpanStatusCode so consumers don't need a direct
+ * `@opentelemetry/api` dependency.
+ */
+export { SpanStatusCode };
 
 /**
  * Returns the swamp tracer from the global tracer provider.
@@ -36,19 +43,9 @@ export function getTracer(): Tracer {
 }
 
 /**
- * Convenience wrapper around `tracer.startActiveSpan()`.
- *
- * Creates a span that is automatically set as the active span for the
- * duration of `fn`. Records errors and ends the span in `finally`.
- *
- * @param name - Span name (e.g. "swamp.workflow.run")
- * @param attributes - Span attributes
- * @param fn - Async function to execute within the span
- * @returns The return value of `fn`
- */
-/**
- * Wraps an async generator with a span. The span starts when iteration
- * begins and ends when the generator completes, errors, or is abandoned.
+ * Wraps an async generator with a span. The span is set as the active
+ * context so that child spans created during iteration are properly
+ * parented.
  *
  * Events with `kind: "error"` are detected and recorded on the span.
  */
@@ -57,16 +54,24 @@ export async function* withGeneratorSpan<T extends { kind: string }>(
   attributes: Attributes,
   generator: AsyncIterable<T>,
 ): AsyncGenerator<T> {
-  const span = getTracer().startSpan(name, { attributes });
+  const tracer = getTracer();
+  const span = tracer.startSpan(name, { attributes });
+  const ctx = trace.setSpan(context.active(), span);
+  let hasError = false;
   try {
-    for await (const event of generator) {
+    // Bind each iteration to the span's context so child spans are parented
+    const iterator = generator[Symbol.asyncIterator]();
+    while (true) {
+      const result = await context.with(ctx, () => iterator.next());
+      if (result.done) break;
+      const event = result.value;
       if (event.kind === "error") {
+        hasError = true;
         span.setStatus({ code: SpanStatusCode.ERROR });
       }
       yield event;
     }
-    // Only set OK if we didn't already set ERROR
-    if (span.isRecording()) {
+    if (!hasError) {
       span.setStatus({ code: SpanStatusCode.OK });
     }
   } catch (error) {

--- a/src/libswamp/data/gc.ts
+++ b/src/libswamp/data/gc.ts
@@ -26,8 +26,7 @@ import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistenc
 import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
-import { getTracer } from "../../infrastructure/tracing/mod.ts";
-import { SpanStatusCode } from "@opentelemetry/api";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 
 /** Preview item for a single expired data entry. */
 export interface DataGcPreviewItem {
@@ -111,37 +110,24 @@ export async function* dataGc(
   deps: DataGcDeps,
   input: DataGcInput,
 ): AsyncIterable<DataGcEvent> {
-  const gcSpan = getTracer().startSpan("swamp.data.gc", {
-    attributes: { "gc.dry_run": input.dryRun },
-  });
+  yield* withGeneratorSpan(
+    "swamp.data.gc",
+    { "gc.dry_run": input.dryRun },
+    (async function* () {
+      yield { kind: "collecting" } as const;
 
-  try {
-    yield { kind: "collecting" };
+      const result = await deps.deleteExpiredData({ dryRun: input.dryRun });
 
-    const result = await deps.deleteExpiredData({ dryRun: input.dryRun });
-
-    gcSpan.setAttribute("gc.entries_expired", result.dataEntriesExpired);
-    gcSpan.setAttribute("gc.versions_deleted", result.versionsDeleted);
-    gcSpan.setAttribute("gc.bytes_reclaimed", result.bytesReclaimed);
-    gcSpan.setStatus({ code: SpanStatusCode.OK });
-
-    yield {
-      kind: "completed",
-      data: {
-        dataEntriesExpired: result.dataEntriesExpired,
-        versionsDeleted: result.versionsDeleted,
-        bytesReclaimed: result.bytesReclaimed,
-        dryRun: result.dryRun,
-        expiredEntries: result.expiredEntries,
-      },
-    };
-  } catch (error) {
-    gcSpan.setStatus({
-      code: SpanStatusCode.ERROR,
-      message: error instanceof Error ? error.message : String(error),
-    });
-    throw error;
-  } finally {
-    gcSpan.end();
-  }
+      yield {
+        kind: "completed" as const,
+        data: {
+          dataEntriesExpired: result.dataEntriesExpired,
+          versionsDeleted: result.versionsDeleted,
+          bytesReclaimed: result.bytesReclaimed,
+          dryRun: result.dryRun,
+          expiredEntries: result.expiredEntries,
+        },
+      };
+    })(),
+  );
 }

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -31,8 +31,7 @@ import { resolveLocalImports } from "../../domain/models/local_import_resolver.t
 import type { Logger } from "@logtape/logtape";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
-import { getTracer } from "../../infrastructure/tracing/mod.ts";
-import { SpanStatusCode } from "@opentelemetry/api";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 
 export const DEFAULT_SERVER_URL = "https://swamp.club";
 const SCOPED_NAME_PATTERN = /^@[a-z0-9_-]+\/[a-z0-9_-]+(\/[a-z0-9_-]+)*$/;
@@ -958,45 +957,36 @@ export async function* extensionPull(
   deps: ExtensionPullDeps,
   input: ExtensionPullInput,
 ): AsyncIterable<ExtensionPullEvent> {
-  const pullSpan = getTracer().startSpan("swamp.extension.pull", {
-    attributes: { "extension.name": input.ref.name },
-  });
+  yield* withGeneratorSpan(
+    "swamp.extension.pull",
+    { "extension.name": input.ref.name },
+    (async function* () {
+      yield { kind: "installing" } as const;
 
-  try {
-    yield { kind: "installing" };
+      const installCtx: InstallContext = {
+        getExtension: deps.getExtension,
+        downloadArchive: deps.downloadArchive,
+        getChecksum: deps.getChecksum,
+        logger: ctx.logger,
+        modelsDir: deps.modelsDir,
+        workflowsDir: deps.workflowsDir,
+        vaultsDir: deps.vaultsDir,
+        driversDir: deps.driversDir,
+        datastoresDir: deps.datastoresDir,
+        reportsDir: deps.reportsDir,
+        repoDir: deps.repoDir,
+        force: input.force,
+        alreadyPulled: deps.alreadyPulled,
+        depth: deps.depth,
+      };
 
-    const installCtx: InstallContext = {
-      getExtension: deps.getExtension,
-      downloadArchive: deps.downloadArchive,
-      getChecksum: deps.getChecksum,
-      logger: ctx.logger,
-      modelsDir: deps.modelsDir,
-      workflowsDir: deps.workflowsDir,
-      vaultsDir: deps.vaultsDir,
-      driversDir: deps.driversDir,
-      datastoresDir: deps.datastoresDir,
-      reportsDir: deps.reportsDir,
-      repoDir: deps.repoDir,
-      force: input.force,
-      alreadyPulled: deps.alreadyPulled,
-      depth: deps.depth,
-    };
-
-    // Let ConflictError propagate — CLI catches it for the two-phase prompt flow
-    const result = await installExtension(input.ref, installCtx);
-    if (result) {
-      pullSpan.setStatus({ code: SpanStatusCode.OK });
-      yield { kind: "completed", data: result };
-    }
-  } catch (error) {
-    pullSpan.setStatus({
-      code: SpanStatusCode.ERROR,
-      message: error instanceof Error ? error.message : String(error),
-    });
-    throw error;
-  } finally {
-    pullSpan.end();
-  }
+      // Let ConflictError propagate — CLI catches it for the two-phase prompt flow
+      const result = await installExtension(input.ref, installCtx);
+      if (result) {
+        yield { kind: "completed" as const, data: result };
+      }
+    })(),
+  );
 }
 
 /** Wires real infrastructure into ExtensionPullDeps. */

--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -34,8 +34,7 @@ import type { ExtensionManifest } from "../../domain/extensions/extension_manife
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notAuthenticated, validationFailed } from "../errors.ts";
-import { getTracer } from "../../infrastructure/tracing/mod.ts";
-import { SpanStatusCode } from "@opentelemetry/api";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 
 // ── Data types ────────────────────────────────────────────────────────
 
@@ -637,130 +636,105 @@ export async function* extensionPush(
   deps: ExtensionPushExecuteDeps,
   input: ExtensionPushExecuteInput,
 ): AsyncIterable<ExtensionPushEvent> {
-  const pushSpan = getTracer().startSpan("swamp.extension.push", {
-    attributes: { "extension.name": input.manifest.name },
-  });
+  yield* withGeneratorSpan(
+    "swamp.extension.push",
+    { "extension.name": input.manifest.name },
+    (async function* () {
+      const credentials = await deps.loadCredentials();
+      if (!credentials) {
+        yield { kind: "error" as const, error: notAuthenticated() };
+        return;
+      }
 
-  try {
-    const credentials = await deps.loadCredentials();
-    if (!credentials) {
-      pushSpan.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: "Not authenticated",
-      });
-      pushSpan.end();
-      yield { kind: "error", error: notAuthenticated() };
-      return;
-    }
-
-    const releaseNotes = input.releaseNotes ?? input.manifest.releaseNotes;
-    const pushMetadata = {
-      name: input.manifest.name,
-      version: input.manifest.version,
-      description: input.manifest.description ?? "",
-      dependencies: input.manifest.dependencies,
-      platforms: input.manifest.platforms,
-      labels: input.manifest.labels,
-      repository: input.manifest.repository || undefined,
-      ...(releaseNotes ? { releaseNotes } : {}),
-    };
-
-    // Phase 1: Initiate
-    yield { kind: "pushing", phase: "initiate" };
-    ctx.logger.debug("Initiating push...");
-    let initResult: { uploadUrl: string };
-    try {
-      initResult = await deps.initiatePush(
-        credentials.serverUrl,
-        pushMetadata,
-        credentials.apiKey,
-      );
-    } catch (error) {
-      pushSpan.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: "initiate failed",
-      });
-      pushSpan.end();
-      yield {
-        kind: "error",
-        error: validationFailed(
-          error instanceof Error ? error.message : String(error),
-        ),
+      const releaseNotes = input.releaseNotes ?? input.manifest.releaseNotes;
+      const pushMetadata = {
+        name: input.manifest.name,
+        version: input.manifest.version,
+        description: input.manifest.description ?? "",
+        dependencies: input.manifest.dependencies,
+        platforms: input.manifest.platforms,
+        labels: input.manifest.labels,
+        repository: input.manifest.repository || undefined,
+        ...(releaseNotes ? { releaseNotes } : {}),
       };
-      return;
-    }
 
-    // Phase 2: Upload archive
-    yield { kind: "pushing", phase: "upload" };
-    ctx.logger.debug("Uploading archive...");
-    try {
-      await deps.uploadArchive(initResult.uploadUrl, input.archiveBytes);
-    } catch (error) {
-      pushSpan.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: "upload failed",
-      });
-      pushSpan.end();
-      yield {
-        kind: "error",
-        error: validationFailed(
-          error instanceof Error ? error.message : String(error),
-        ),
+      // Phase 1: Initiate
+      yield { kind: "pushing" as const, phase: "initiate" as const };
+      ctx.logger.debug("Initiating push...");
+      let initResult: { uploadUrl: string };
+      try {
+        initResult = await deps.initiatePush(
+          credentials.serverUrl,
+          pushMetadata,
+          credentials.apiKey,
+        );
+      } catch (error) {
+        yield {
+          kind: "error" as const,
+          error: validationFailed(
+            error instanceof Error ? error.message : String(error),
+          ),
+        };
+        return;
+      }
+
+      // Phase 2: Upload archive
+      yield { kind: "pushing" as const, phase: "upload" as const };
+      ctx.logger.debug("Uploading archive...");
+      try {
+        await deps.uploadArchive(initResult.uploadUrl, input.archiveBytes);
+      } catch (error) {
+        yield {
+          kind: "error" as const,
+          error: validationFailed(
+            error instanceof Error ? error.message : String(error),
+          ),
+        };
+        return;
+      }
+
+      // Phase 3: Confirm
+      yield { kind: "pushing" as const, phase: "confirm" as const };
+      ctx.logger.debug("Confirming push...");
+      let confirmResult: {
+        name: string;
+        version: string;
+        extensionId: string;
       };
-      return;
-    }
+      try {
+        confirmResult = await deps.confirmPush(
+          credentials.serverUrl,
+          { ...pushMetadata, contentMetadata: input.contentMetadata },
+          credentials.apiKey,
+        );
+      } catch (error) {
+        yield {
+          kind: "error" as const,
+          error: validationFailed(
+            error instanceof Error ? error.message : String(error),
+          ),
+        };
+        return;
+      }
 
-    // Phase 3: Confirm
-    yield { kind: "pushing", phase: "confirm" };
-    ctx.logger.debug("Confirming push...");
-    let confirmResult: { name: string; version: string; extensionId: string };
-    try {
-      confirmResult = await deps.confirmPush(
-        credentials.serverUrl,
-        { ...pushMetadata, contentMetadata: input.contentMetadata },
-        credentials.apiKey,
-      );
-    } catch (error) {
-      pushSpan.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: "confirm failed",
-      });
-      pushSpan.end();
       yield {
-        kind: "error",
-        error: validationFailed(
-          error instanceof Error ? error.message : String(error),
-        ),
+        kind: "completed" as const,
+        data: {
+          name: confirmResult.name,
+          version: confirmResult.version,
+          extensionId: confirmResult.extensionId,
+          archiveSize: input.archiveBytes.length,
+          modelCount: input.counts.models,
+          workflowCount: input.counts.workflows,
+          bundleCount: input.counts.bundles,
+          vaultCount: input.counts.vaults,
+          driverCount: input.counts.drivers,
+          datastoreCount: input.counts.datastores,
+          reportCount: input.counts.reports,
+        },
       };
-      return;
-    }
-
-    pushSpan.setStatus({ code: SpanStatusCode.OK });
-    pushSpan.end();
-    yield {
-      kind: "completed",
-      data: {
-        name: confirmResult.name,
-        version: confirmResult.version,
-        extensionId: confirmResult.extensionId,
-        archiveSize: input.archiveBytes.length,
-        modelCount: input.counts.models,
-        workflowCount: input.counts.workflows,
-        bundleCount: input.counts.bundles,
-        vaultCount: input.counts.vaults,
-        driverCount: input.counts.drivers,
-        datastoreCount: input.counts.datastores,
-        reportCount: input.counts.reports,
-      },
-    };
-  } catch (error) {
-    pushSpan.setStatus({
-      code: SpanStatusCode.ERROR,
-      message: error instanceof Error ? error.message : String(error),
-    });
-    pushSpan.end();
-    throw error;
-  }
+    })(),
+  );
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────


### PR DESCRIPTION
- Fix `withGeneratorSpan` to set span as active context so child spans are
properly parented (was producing flat traces instead of hierarchies)
- Refactor 3 generators (data/gc, extensions/pull, extensions/push) from manual
`getTracer().startSpan()` to `withGeneratorSpan` for consistency
- Contain `@opentelemetry/api` dependency — re-export `SpanStatusCode` from
tracing module, remove 4 direct OTel imports across layers
- Fix OK-after-ERROR bug — track error state with boolean instead of
`span.isRecording()` which doesn't reflect status changes
- Refactor `requireInitializedRepo` from manual span to `withSpan` wrapper
- Fix trailing-slash in OTLP endpoint URL
- Add `design/tracing.md` design doc covering configuration, span hierarchy,
context propagation, and implementation files
- Add `swamp-troubleshooting/references/tracing.md` skill reference for
diagnosing slow operations with OTel tracing
- Update troubleshooting skill to trigger on "slow", "performance", "latency"
- Register tracing skill reference in `skill_assets.ts` for repo init/upgrade

- [x] `deno check` — 0 type errors
- [x] `deno lint` — 0 issues
- [x] `deno fmt --check` — 0 formatting issues
- [x] `deno run test` — 3510 passed, 0 failed
- [x] Smoke test: workflow run with `OTEL_EXPORTER_OTLP_ENDPOINT` produces
correct parent-child span hierarchy in Jaeger
