### PR TITLE
feat: add sanitized CLI args to swamp.cli root span

### DIFF
--- a/design/tracing.md
+++ b/design/tracing.md
@@ -88,8 +88,10 @@ swamp.cli "workflow run"
 ### CLI Root Span
 
 Every CLI invocation creates a `swamp.cli` root span that encompasses the entire
-command lifecycle. Attributes include `swamp.command`, `swamp.subcommand`, and
-`swamp.version`.
+command lifecycle. Attributes include `swamp.command`, `swamp.subcommand`,
+`swamp.version`, `swamp.args` (sanitized positional arguments),
+`swamp.option_keys` (command-specific option names), and `swamp.global_options`
+(global flags like `--json`, `--verbose`).
 
 ### Libswamp Generator Spans
 

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -634,6 +634,9 @@ export async function runCli(args: string[]): Promise<void> {
       "swamp.command": commandInfo.command,
       "swamp.subcommand": commandInfo.subcommand ?? "",
       "swamp.version": VERSION,
+      "swamp.args": commandInfo.args.join(" "),
+      "swamp.option_keys": commandInfo.optionKeys.join(" "),
+      "swamp.global_options": commandInfo.globalOptions.join(" "),
     }, async () => {
       await cli.parse(args);
     });


### PR DESCRIPTION
## Summary

User feedback from a Honeycomb trace viewer: the `swamp.cli` root span shows
`swamp.command` and `swamp.subcommand`, but there's no way to tell _what_ was
passed to the command without digging into child spans or logs. Adding the
sanitized arguments to the root span makes traces immediately useful for
filtering and debugging.

## What changed

The `swamp.cli` root span now includes three additional attributes:

| Attribute | Example value | Description |
|-----------|--------------|-------------|
| `swamp.args` | `run <REDACTED> validate` | Positional args with user-identifiable values redacted |
| `swamp.option_keys` | `--filter --limit` | Command-specific option names (values stripped) |
| `swamp.global_options` | `--json --verbose` | Global flags |

### Privacy / redaction

No new sanitization code was needed. The existing `extractCommandInfo()` function
in `src/cli/telemetry_integration.ts` already applies per-command redaction via
`ARG_SCHEMAS`:

- **Categorical** values (model types, method names) are recorded as-is — these
  are system-defined and safe to expose
- **User-identifiable** values (model names, paths, queries) are replaced with
  `<REDACTED>`
- Commands without a schema default to **redacting all positional args**

This change simply surfaces data that was already being computed but not attached
to the span.

### Design doc

Updated `design/tracing.md` to document the new attributes on the CLI root span.

## Test plan

- [x] `deno check` passes
- [x] All 23 telemetry integration tests pass (`src/cli/telemetry_integration_test.ts`)
- [ ] Manual verification: run a command with `OTEL_TRACES_EXPORTER=console` and
  confirm the new attributes appear on the `swamp.cli` span

🤖 Generated with [Claude Code](https://claude.com/claude-code)