### PR TITLE
fix: use libswamp public API import in CLI module

### DIFF
--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -383,7 +383,7 @@ export function resolveTelemetryEndpoint(
   return DEFAULT_TELEMETRY_ENDPOINT;
 }
 
-import { resolveTrustedCollectives } from "../libswamp/extensions/trust.ts";
+import { resolveTrustedCollectives } from "../libswamp/mod.ts";
 
 interface TelemetryContext {
   service: TelemetryService;


### PR DESCRIPTION
- Fix internal libswamp import path in src/cli/mod.ts to use the public libswamp/mod.ts barrel export instead of importing directly from src/libswamp/extensions/trust.ts
- This aligns with the libswamp design rule that CLI code must only import from libswamp/mod.ts, never from internal module paths

- deno check passes on the modified file
- CI passes
