### PR TITLE
docs: document include manifest field, loader pre-check, and helper scripts

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -468,10 +468,13 @@ troubleshooting, see [references/publishing.md](references/publishing.md).
    (`npm:lodash-es@4.17.21`), via a `deno.json` import map, or in `package.json`
    dependencies. See
    [references/examples.md](references/examples.md#import-styles) for details.
-5. **Type naming**: Use `@<collective>/<name>` or `<collective>/<name>` format
+5. **Helper scripts**: Use `include` in the manifest for TypeScript files that
+   are executed via `Deno.Command` subprocess and shouldn't be bundled. See
+   [references/examples.md](references/examples.md#helper-scripts) for details.
+6. **Type naming**: Use `@<collective>/<name>` or `<collective>/<name>` format
    (e.g., `@user/my-model` or `myorg/my-model`)
-6. **No type annotations**: Avoid TypeScript types in execute parameters
-7. **File naming**: Use snake_case (`my_model.ts`)
+7. **No type annotations**: Avoid TypeScript types in execute parameters
+8. **File naming**: Use snake_case (`my_model.ts`)
 
 ## Collective Rules
 

--- a/.claude/skills/swamp-extension-model/references/examples.md
+++ b/.claude/skills/swamp-extension-model/references/examples.md
@@ -15,6 +15,7 @@
 - [AWS Model with Pre-flight Credential Check](#aws-model-with-pre-flight-credential-check)
 - [Using External Dependencies](#using-external-dependencies)
 - [Extending Existing Model Types](#extending-existing-model-types)
+- [Helper Scripts](#helper-scripts)
 
 ## Using External Dependencies
 
@@ -1491,3 +1492,72 @@ extensions/models/
     health_check.ts       # export const model (new type)
   shell_audit.ts          # export const extension (extends command/shell)
 ```
+
+## Helper Scripts
+
+When a model needs to shell out to a helper script that has dependencies swamp
+can't bundle (e.g., native modules), use the `include` manifest field. Include
+files are shipped alongside models but never bundled.
+
+### Manifest
+
+```yaml
+manifestVersion: 1
+name: "@myorg/homekit"
+version: "2026.03.24.1"
+models:
+  - homekit.ts
+include:
+  - homekit_discover.ts
+```
+
+### Model (shells out to helper)
+
+```typescript
+// extensions/models/homekit.ts
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "@myorg/homekit",
+  version: "2026.03.24.1",
+  globalArguments: z.object({}),
+  methods: {
+    discover: {
+      description: "Discover HomeKit devices via mDNS",
+      arguments: z.object({}),
+      outputSpec: [{
+        name: "devices",
+        type: "resource",
+        description: "Discovered devices",
+      }],
+      execute: async (_args: unknown, context: { repoDir: string }) => {
+        const scriptPath =
+          `${context.repoDir}/extensions/models/homekit_discover.ts`;
+        const cmd = new Deno.Command("deno", {
+          args: ["run", "--allow-net", scriptPath],
+          stdout: "piped",
+        });
+        const output = await cmd.output();
+        return { devices: new TextDecoder().decode(output.stdout) };
+      },
+    },
+  },
+};
+```
+
+### Helper (not a model, not bundled)
+
+```typescript
+// extensions/models/homekit_discover.ts
+// This file does NOT export const model — swamp won't try to bundle it.
+import { HAPController } from "npm:hap-controller@1.0.0";
+
+const browser = new HAPController();
+const devices = await browser.discover();
+console.log(JSON.stringify(devices));
+```
+
+The loader skips files that don't declare `export const model` or
+`export const extension`, so the helper is never bundled — even without the
+`include` manifest field. The `include` field is needed to ship the helper in
+the extension archive when publishing.

--- a/.claude/skills/swamp-extension-model/references/publishing.md
+++ b/.claude/skills/swamp-extension-model/references/publishing.md
@@ -143,15 +143,20 @@ swamp extension push manifest.yaml --repo-dir /path/to/repo --json
    the extension uses bare specifiers, it is used for bundling. `deno.json` is
    also used for quality checks; `package.json` projects use default lint/fmt
    rules.
-5. **Safety analysis** — scans all files for disallowed patterns and limits
-6. **Quality checks** — runs `deno fmt --check` and `deno lint` (using the
-   project's `deno.json` config if present, otherwise default rules)
-7. **Bundle TypeScript** — compiles each entry point (models, vaults, drivers,
-   datastores) to standalone JS. If a `deno.json` is present, the import map
-   governs dependency resolution.
-8. **Version check** — verifies version doesn't already exist (offers to bump)
-9. **Build archive** — creates tar.gz with all content types and their bundles
-10. **Upload** — three-phase push: initiate, upload archive, confirm
+5. **Resolve include files** — collects files from the manifest's `include`
+   field (if present). These are copied to the archive alongside model sources
+   but not bundled or quality-checked.
+6. **Safety analysis** — scans all files (including `include` files) for
+   disallowed patterns and limits
+7. **Quality checks** — runs `deno fmt --check` and `deno lint` on model, vault,
+   driver, datastore, and report files (using the project's `deno.json` config
+   if present, otherwise default rules). Include files are excluded.
+8. **Bundle TypeScript** — compiles each entry point (models, vaults, drivers,
+   datastores) to standalone JS. Include files are not bundled. If a `deno.json`
+   is present, the import map governs dependency resolution.
+9. **Version check** — verifies version doesn't already exist (offers to bump)
+10. **Build archive** — creates tar.gz with all content types and their bundles
+11. **Upload** — three-phase push: initiate, upload archive, confirm
 
 ## Extension Formatting
 

--- a/design/extension.md
+++ b/design/extension.md
@@ -53,6 +53,10 @@ what the extension contains and how it should be packaged.
 - `drivers`: Array of relative paths to TypeScript driver files.
 - `datastores`: Array of relative paths to TypeScript datastore files.
 - `reports`: Array of relative paths to TypeScript report files.
+- `include`: Array of relative paths (from `modelsDir`) to TypeScript files that
+  should be included in the archive alongside models but not bundled. Used for
+  helper scripts that are executed via `Deno.Command` subprocess rather than
+  imported directly.
 - `additionalFiles`: Array of paths to non-model files to include (README,
   config, etc.).
 - `platforms`: Array of platform identifiers the extension supports (e.g.,
@@ -121,6 +125,20 @@ extension.tar.gz
 Source TypeScript files are included preserving their relative directory
 structure from the models directory. Local imports are resolved recursively —
 if `connection.ts` imports `./helpers.ts`, both files are included.
+
+Files listed in the manifest's `include` field are also copied to `models/` in
+the archive, preserving their relative paths from `modelsDir`. Include files are
+not bundled — they are raw TypeScript files intended to be executed as
+subprocesses or used as standalone utilities.
+
+### Loader pre-check
+
+At runtime, loaders discover `.ts` files in their respective directories and
+attempt to bundle each one. Before bundling, the loader reads the source and
+checks for the expected named export (`export const model`, `export const vault`,
+etc.). Files that don't declare the expected export are skipped — no bundling
+attempted, no error. This avoids failing on helper scripts with unbundleable
+dependencies (e.g., native modules used via `Deno.Command` subprocess).
 
 ### Bundles
 


### PR DESCRIPTION
## Summary

Documents the `include` manifest field and loader pre-check behaviour introduced in #849.

## Changes

### `design/extension.md`
- Added `include` to manifest Optional Fields section with description
- Added explanation of include files in the Models section (copied to archive under `models/`, not bundled)
- Added new "Loader pre-check" section explaining how loaders skip files without the expected export

### `swamp-extension-model/SKILL.md`
- Added Key Rule 5: "Helper scripts" — use `include` for files executed via `Deno.Command` subprocess, links to examples

### `swamp-extension-model/references/examples.md`
- Added "Helper Scripts" to table of contents
- Added complete example showing: manifest with `include`, model that shells out to helper, helper script with native deps that isn't bundled

### `swamp-extension-model/references/publishing.md`
- Updated "What Happens During Push" steps to include:
  - Step 5: Resolve include files
  - Step 6: Safety analysis now explicitly includes `include` files
  - Step 7: Quality checks explicitly exclude `include` files
  - Step 8: Bundle step notes include files are not bundled

🤖 Generated with [Claude Code](https://claude.com/claude-code)