### PR TITLE
fix: coerce global argument types from CLI strings during model create

### DIFF
--- a/src/libswamp/models/create.ts
+++ b/src/libswamp/models/create.ts
@@ -33,6 +33,7 @@ import {
   toMethodDescribeData,
   zodToJsonSchema,
 } from "../types/schema_helpers.ts";
+import { coerceInputTypes } from "../../domain/inputs/input_coercion.ts";
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
@@ -150,6 +151,12 @@ export async function* modelCreate(
       const modelDef = deps.getModelDef(modelType);
       let globalArguments = input.globalArguments;
       if (globalArguments && modelDef?.globalArguments) {
+        // Coerce CLI string values to match schema types (e.g. "428" → 428)
+        const jsonSchema = zodToJsonSchema(modelDef.globalArguments);
+        globalArguments = coerceInputTypes(
+          globalArguments,
+          jsonSchema as Record<string, unknown>,
+        );
         const result = modelDef.globalArguments.safeParse(globalArguments);
         if (!result.success) {
           const issues = result.error.issues.map((i) =>

--- a/src/libswamp/models/create_test.ts
+++ b/src/libswamp/models/create_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
+import { z } from "zod";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
@@ -25,6 +26,7 @@ import {
   type ModelCreateDeps,
   type ModelCreateEvent,
 } from "./create.ts";
+import type { ModelDefinition } from "../../domain/models/model.ts";
 
 function makeDeps(overrides: Partial<ModelCreateDeps> = {}): ModelCreateDeps {
   return {
@@ -91,6 +93,51 @@ Deno.test("modelCreate: yields error for unknown model type", async () => {
   const last = events[1] as Extract<ModelCreateEvent, { kind: "error" }>;
   assertEquals(last.kind, "error");
   assertEquals(last.error.code, "validation_failed");
+});
+
+Deno.test("modelCreate: coerces string global arguments to match schema types", async () => {
+  const globalArgsSchema = z.object({
+    repo: z.string(),
+    issueNumber: z.number(),
+  });
+
+  const deps = makeDeps({
+    getModelDef: () => ({
+      type: { normalized: "test/typed-args" },
+      version: "1.0.0",
+      globalArguments: globalArgsSchema,
+      methods: {},
+      resources: {},
+    } as unknown as ModelDefinition),
+    createAndSave: (_type, _name, _version, globalArguments) => {
+      // Verify the number was coerced from string "428" to number 428
+      assertEquals(
+        (globalArguments as Record<string, unknown>)?.issueNumber,
+        428,
+      );
+      return Promise.resolve({
+        id: "def-1",
+        name: "my-model",
+      } as unknown as Awaited<
+        ReturnType<ModelCreateDeps["createAndSave"]>
+      >);
+    },
+  });
+
+  const events = await collect<ModelCreateEvent>(
+    modelCreate(createLibSwampContext(), deps, {
+      typeArg: "test/typed-args",
+      name: "my-model",
+      // CLI passes all values as strings from --global-arg key=value
+      globalArguments: { repo: "owner/repo", issueNumber: "428" },
+    }),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    ModelCreateEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
 });
 
 Deno.test("modelCreate: yields error when name already exists", async () => {


### PR DESCRIPTION
## Summary

- **Bug**: `swamp model create` with `--global-arg` fails when the model's globalArguments schema expects non-string types (number, boolean). The CLI always passes values as strings (e.g., `--global-arg issueNumber=428` → `{ issueNumber: "428" }`), and the Zod `safeParse` rejects them with `"expected number, received string"`.
- **Root cause**: The `modelCreate` generator in `src/libswamp/models/create.ts` validates global arguments directly via `safeParse` without first coercing string values to their schema-declared types. The method execution path (`modelMethodRun`) already applies `coerceInputTypes()` before validation — this was simply missed for global arguments during model creation.
- **Fix**: Apply the existing `coerceInputTypes()` function to global arguments before Zod validation, using the JSON schema derived from the Zod schema via `zodToJsonSchema()`. This is the same pattern used in `src/libswamp/models/run.ts:237`.

## Impact

Any extension model type that declares a numeric or boolean global argument is broken when created from the CLI. For example, `@si/issue-lifecycle` declares `issueNumber: z.number()` — creating an instance via `swamp model create @si/issue-lifecycle issue-428 --global-arg issueNumber=428` fails. This affects all CLI users; only programmatic callers passing native JS types would work.

## What changed

| File | Change |
|------|--------|
| `src/libswamp/models/create.ts` | Import `coerceInputTypes`, apply it to global args before `safeParse` |
| `src/libswamp/models/create_test.ts` | Add test: model with `z.number()` global arg succeeds when passed as string `"428"` |

## Test plan

- [x] New unit test verifies string `"428"` is coerced to number `428` and model creation succeeds
- [x] All existing `create_test.ts` tests pass (no regression)
- [x] `deno check`, `deno lint`, `deno fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)