### PR TITLE
feat: add @si/issue-lifecycle extension model with label automation

### DIFF
--- a/.claude/skills/issue-lifecycle/SKILL.md
+++ b/.claude/skills/issue-lifecycle/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: issue-lifecycle
+description: >
+  Drive the @si/issue-lifecycle model for interactive issue triage and
+  plan iteration. Use when the user wants to triage a GitHub issue,
+  generate an implementation plan, or iterate on a plan with feedback.
+  Triggers on "triage issue", "triage #", "issue plan", "review plan",
+  "iterate plan", "approve plan", "issue lifecycle", "fix review issues",
+  "check CI", "ci status".
+---
+
+# Issue Lifecycle Skill
+
+Interactive triage and implementation planning for GitHub issues using the
+`@si/issue-lifecycle` extension model. This skill drives the model
+conversationally — the human steers, you execute.
+
+## Core Principle
+
+**Never auto-approve.** Always stop and show the plan to the human. Always ask
+for feedback. Only call `approve` when the human explicitly says to proceed.
+
+## Starting a New Triage
+
+When the user says something like "triage issue #850" or "triage
+systeminit/swamp#850":
+
+1. **Create the model instance** (if it doesn't already exist):
+   ```
+   swamp model create @si/issue-lifecycle issue-<N> \
+     --global-arg issueNumber=<N> --json
+   ```
+   The repo defaults to `systeminit/swamp`. Override with
+   `--global-arg repo=<owner/repo>` for other repositories.
+
+2. **Fetch the issue context**:
+   ```
+   swamp model method run issue-<N> start --json
+   ```
+
+3. **Read the issue context** from the model output, then **read the codebase**:
+   - Read `CLAUDE.md` and `design/*.md`
+   - Read relevant skills (especially `ddd/SKILL.md`)
+   - Explore source files related to the issue
+   - Trace code paths to understand the problem
+
+4. **Classify the issue** based on your analysis:
+   ```
+   swamp model method run issue-<N> triage \
+     --input type=<bug|feature|unclear> \
+     --input confidence=<high|medium|low> \
+     --input reasoning="<your analysis>" --json
+   ```
+
+5. **Generate an implementation plan**:
+   ```
+   swamp model method run issue-<N> plan \
+     --input summary="..." \
+     --input dddAnalysis="..." \
+     --input-file steps.json \
+     --input testingStrategy="..." \
+     --input-file potentialChallenges.json --json
+   ```
+
+6. **Show the plan to the human and ask for feedback.** Present it clearly:
+   - Summary
+   - Each step with files and risks
+   - Testing strategy
+   - Potential challenges
+   - Then ask: "Does this plan look right, or do you have feedback?"
+
+## Plan Iteration Loop
+
+When the human gives feedback (they almost always will on the first plan):
+
+1. **Call iterate** with both the feedback text and your revised plan:
+   ```
+   swamp model method run issue-<N> iterate \
+     --input feedback="<human's feedback>" \
+     --input summary="..." \
+     --input-file steps.json \
+     ... --json
+   ```
+
+2. **Show what changed** between the previous and new plan version. Be specific:
+   - "Reordered steps 2 and 3 based on your feedback"
+   - "Added regression analysis for module X"
+   - "Removed step 4 — you're right, that's already handled by..."
+
+3. **Ask for feedback again.** Keep iterating until the human says one of:
+   - "approve", "approved", "looks good", "ship it", "go", "LGTM"
+
+4. Only then call `approve`:
+   ```
+   swamp model method run issue-<N> approve --json
+   ```
+
+## Implementation & CI Flow
+
+After plan approval, when the human says to implement:
+
+1. **Do the implementation work** based on the approved plan
+2. **Create a PR** using the `github-pr` skill
+3. **Record the PR number**:
+   ```
+   swamp model method run issue-<N> implement \
+     --input prNumber=<N> --json
+   ```
+
+4. **Wait for CI to complete**, then fetch results:
+   ```
+   swamp model method run issue-<N> ci_status --json
+   ```
+
+5. **Show the CI results** to the human, grouped by reviewer and severity:
+   - Which checks passed/failed
+   - Review comments grouped by reviewer
+   - Comments sorted by severity (critical first)
+
+6. **When the human directs fixes**, parse their instruction:
+   - "fix the CRITICAL issues from adversarial review" ->
+     `targetReview: "claude-adversarial-review"`, `targetSeverity: "critical"`
+   - "address all the review comments" -> no filters
+   - "fix the test failures" -> `targetReview: "test"`
+
+   ```
+   swamp model method run issue-<N> fix \
+     --input directive="<human's instruction>" \
+     --input targetReview="<reviewer>" \
+     --input targetSeverity="<severity>" --json
+   ```
+
+7. **Make the fixes**, push, wait for CI, then call `ci_status` again
+8. **Loop until clean** or the human says to complete:
+   ```
+   swamp model method run issue-<N> complete --json
+   ```
+
+## Reviewing Plan History
+
+To review a specific plan version:
+
+```
+swamp model method run issue-<N> review --input version=<V> --json
+```
+
+To see all model data:
+
+```
+swamp model output search issue-<N> --json
+```
+
+## Resuming a Session
+
+If the human comes back to an in-progress issue, check the current state:
+
+```
+swamp model get issue-<N> --json
+```
+
+Then pick up from whatever phase the state shows. The full history of plans,
+feedback, and CI results is persisted in the model data.
+
+## Key Rules
+
+1. **Never skip the feedback loop.** Always show the plan. Always ask.
+2. **Never call approve without explicit human approval.**
+3. **Persist everything through the model.** Don't just have a conversation —
+   call the model methods so state survives context compression and sessions.
+4. **GitHub comments are automatic.** Every state transition posts to the issue.
+   You don't need to manually post comments.
+5. **Read the codebase thoroughly** before generating the plan. The plan should
+   reference specific files, functions, and test paths.
+6. **Use DDD analysis.** Every plan should identify domain concepts, entities,
+   and services affected by the change.

--- a/.claude/skills/swamp-issue/SKILL.md
+++ b/.claude/skills/swamp-issue/SKILL.md
@@ -18,8 +18,8 @@ non-interactive mode with `--title` and `--body` flags.
 
 | Command               | Labels                    | Template sections                                         |
 | --------------------- | ------------------------- | --------------------------------------------------------- |
-| `swamp issue bug`     | `bug`, `external`         | Title, description, steps to reproduce, environment       |
-| `swamp issue feature` | `enhancement`, `external` | Title, problem statement, proposed solution, alternatives |
+| `swamp issue bug`     | `bug`, `needs-triage`     | Title, description, steps to reproduce, environment       |
+| `swamp issue feature` | `feature`, `needs-triage` | Title, problem statement, proposed solution, alternatives |
 
 **Non-interactive examples:**
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ swamp
 /workflows/
 workflows-evaluated/
 resources/
+/models/
 
 plans/
 

--- a/extensions/models/README.md
+++ b/extensions/models/README.md
@@ -1,0 +1,227 @@
+# Issue Lifecycle Extension Model
+
+The `@si/issue-lifecycle` extension model moves GitHub issue triage and
+implementation planning out of GitHub Actions and into a local, interactive
+workflow. Every plan revision, feedback round, and CI result is stored as
+versioned, immutable data — the issue thread on GitHub becomes a live status
+dashboard.
+
+## Why
+
+The old flow: a `/triage` comment in GitHub triggers a CI action, Claude posts a
+plan as a comment, you push back in the comment thread, re-triage, wait for CI,
+repeat. Every round-trip goes through GitHub's API and Actions queue.
+
+The new flow: triage happens locally in a conversation with Claude. You push
+back directly. Plans are revised in seconds, not minutes. State is persisted in
+swamp's data store so you can walk away and resume later. GitHub gets a comment
+on every state change so the issue thread stays current.
+
+## State Machine
+
+```
+created ──[start]──> triaging
+triaging ──[triage]──> classified
+classified ──[plan]──> plan_generated
+plan_generated ──[iterate]──> plan_generated  (feedback loop)
+plan_generated ──[approve]──> approved
+approved ──[implement]──> implementing
+implementing ──[ci_status]──> ci_review
+ci_review ──[fix]──> implementing  (fix loop)
+ci_review ──[complete]──> done
+```
+
+Two iteration loops:
+
+1. **Plan loop** — generate a plan, get feedback, revise, repeat until approved
+2. **Fix loop** — check CI, direct fixes, push, check CI again until clean
+
+Pre-flight checks enforce valid transitions. You cannot approve without a plan.
+You cannot implement without approval.
+
+## Using with Claude Code (recommended)
+
+Tell Claude:
+
+```
+triage issue #850
+```
+
+The `issue-lifecycle` skill takes over. Claude creates the model instance,
+fetches the issue from GitHub, reads the codebase, classifies the issue,
+generates a plan, and shows it to you.
+
+From there, it's a conversation:
+
+```
+You:    The step ordering is wrong — CLI should come before parser changes.
+        What about regressions in the tokenizer?
+
+Claude: [revises plan, persists feedback]
+        Revised plan (v2):
+        1. Update CLI command ...
+        2. Add parser validation ...
+        3. Regression tests for tokenizer ...
+        Feedback?
+
+You:    Looks good. Approve it.
+
+Claude: [approves, posts full plan to GitHub issue]
+        Plan approved. Ready to implement?
+
+You:    Go.
+
+Claude: [implements, creates PR, records PR number]
+        PR #851 created. Checking CI...
+
+        CI Results:
+        - test: PASSED
+        - claude-review: CHANGES_REQUESTED (1 critical)
+        - adversarial-review: APPROVED
+
+You:    Fix the critical issue from claude-review.
+
+Claude: [persists fix directive, makes fix, pushes, checks CI again]
+        All checks passed. Ship it?
+
+You:    Done.
+
+Claude: [marks complete, posts to GitHub]
+```
+
+Every step posts a comment to the GitHub issue. Anyone watching sees:
+
+- "Triage started"
+- "Classified as bug (high confidence)"
+- "Plan revised (v2) — incorporated feedback round 1"
+- "Plan approved (v2)" with the full plan
+- "Implementation started — PR #851"
+- "CI results: 4 passed, 1 failed"
+- "Fixing: critical issue from claude-review"
+- "Complete — all checks passed"
+
+## Using via CLI (manual mode)
+
+If you want to drive the model directly without Claude:
+
+### Setup
+
+```bash
+# Create an instance for issue #850
+swamp model create @si/issue-lifecycle issue-850 \
+  --global-arg issueNumber=850 --json
+
+# Repo defaults to systeminit/swamp. Override for other repos:
+swamp model create @si/issue-lifecycle issue-850 \
+  --global-arg issueNumber=850 \
+  --global-arg repo=owner/repo --json
+```
+
+### Triage
+
+```bash
+# Fetch issue context from GitHub
+swamp model method run issue-850 start --json
+
+# Classify the issue
+swamp model method run issue-850 triage \
+  --input type=bug \
+  --input confidence=high \
+  --input reasoning="Parser fails on nested brackets" --json
+
+# Generate a plan
+swamp model method run issue-850 plan \
+  --input summary="Fix bracket parsing in tokenizer" \
+  --input dddAnalysis="Touches the Parser entity..." \
+  --input-file steps.json \
+  --input testingStrategy="Unit tests for tokenizer edge cases" \
+  --input-file potentialChallenges.json --json
+```
+
+### Plan iteration
+
+```bash
+# Review the current plan
+swamp model method run issue-850 review --json
+
+# Review a specific version
+swamp model method run issue-850 review --input version=1 --json
+
+# Submit feedback and a revised plan
+swamp model method run issue-850 iterate \
+  --input feedback="Step ordering is wrong" \
+  --input summary="..." \
+  --input-file steps.json \
+  --input testingStrategy="..." \
+  --input-file potentialChallenges.json --json
+
+# Approve when satisfied
+swamp model method run issue-850 approve --json
+```
+
+### Implementation & CI
+
+```bash
+# Record implementation start + PR number
+swamp model method run issue-850 implement --input prNumber=851 --json
+
+# Fetch CI results
+swamp model method run issue-850 ci_status --json
+
+# Direct fixes
+swamp model method run issue-850 fix \
+  --input directive="Fix the CRITICAL issues from adversarial review" \
+  --input targetReview=claude-adversarial-review \
+  --input targetSeverity=critical --json
+
+# Check CI again
+swamp model method run issue-850 ci_status --json
+
+# Mark done
+swamp model method run issue-850 complete --json
+```
+
+### Inspection
+
+```bash
+# See current state
+swamp model get issue-850 --json
+
+# See all stored data (plans, feedback, CI results)
+swamp model output search issue-850 --json
+```
+
+## Methods
+
+| Method      | Description                                   | State Transition                 |
+| ----------- | --------------------------------------------- | -------------------------------- |
+| `start`     | Fetch issue from GitHub                       | * -> triaging                    |
+| `triage`    | Classify as bug/feature/unclear               | triaging -> classified           |
+| `plan`      | Generate implementation plan                  | classified -> plan_generated     |
+| `review`    | Display current plan (read-only)              | no change                        |
+| `iterate`   | Revise plan with feedback                     | plan_generated -> plan_generated |
+| `approve`   | Lock the plan, post to GitHub                 | plan_generated -> approved       |
+| `implement` | Record PR number, signal implementation start | approved -> implementing         |
+| `ci_status` | Fetch CI check results and review comments    | implementing -> ci_review        |
+| `fix`       | Direct specific fixes from review feedback    | ci_review -> implementing        |
+| `complete`  | Mark lifecycle done                           | ci_review -> done                |
+
+## Data stored
+
+All data is versioned and immutable. Each `iterate` creates a new plan version
+and a new feedback version. You can review any prior version.
+
+| Resource         | What it stores                                |
+| ---------------- | --------------------------------------------- |
+| `state`          | Current phase, repo, issue number, PR number  |
+| `context`        | Issue title, body, labels, comments           |
+| `classification` | Bug/feature/unclear + reasoning               |
+| `plan`           | Implementation plan (versioned per iteration) |
+| `feedback`       | Human feedback (versioned per round)          |
+| `ciResults`      | CI check runs + review comments               |
+| `fixDirective`   | Human-directed fix instructions               |
+
+## Prerequisites
+
+- `gh` CLI installed and authenticated (`gh auth login`)
+- swamp initialized in the repository (`swamp init`)

--- a/extensions/models/_lib/issue_tracker.ts
+++ b/extensions/models/_lib/issue_tracker.ts
@@ -1,0 +1,387 @@
+// Swamp, an Automation Framework Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify it under the terms
+// of the GNU Affero General Public License version 3 as published by the Free
+// Software Foundation, with the Swamp Extension and Definition Exception (found in
+// the "COPYING-EXCEPTION" file).
+//
+// Swamp is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along
+// with Swamp. If not, see <https://www.gnu.org/licenses/>.
+
+import type { Phase } from "./schemas.ts";
+
+// ---------------------------------------------------------------------------
+// Issue Tracker Interface
+// ---------------------------------------------------------------------------
+
+/** Abstract interface for issue tracker operations. */
+export interface IssueTracker {
+  /** Fetch issue context (title, body, labels, comments). */
+  fetchIssue(
+    repo: string,
+    issueNumber: number,
+  ): Promise<{
+    title: string;
+    body: string;
+    labels: string[];
+    comments: { author: string; body: string; createdAt: string }[];
+  }>;
+
+  /** Post a comment on the issue. Best-effort — should not throw. */
+  postComment(
+    repo: string,
+    issueNumber: number,
+    body: string,
+  ): Promise<void>;
+
+  /** Set the lifecycle phase label, removing all other lifecycle labels. */
+  setPhaseLabel(
+    repo: string,
+    issueNumber: number,
+    phase: Phase,
+  ): Promise<void>;
+
+  /** Add labels to the issue. Best-effort. */
+  addLabels(
+    repo: string,
+    issueNumber: number,
+    labels: string[],
+  ): Promise<void>;
+
+  /** Remove labels from the issue. Best-effort. */
+  removeLabels(
+    repo: string,
+    issueNumber: number,
+    labels: string[],
+  ): Promise<void>;
+
+  /** Fetch PR check runs. */
+  fetchPrChecks(
+    repo: string,
+    prNumber: number,
+  ): Promise<
+    {
+      name: string;
+      status: "passed" | "failed" | "pending";
+    }[]
+  >;
+
+  /** Fetch PR reviews and their inline comments. */
+  fetchPrReviews(
+    repo: string,
+    prNumber: number,
+  ): Promise<
+    {
+      reviewer: string;
+      state: "APPROVED" | "CHANGES_REQUESTED" | "COMMENTED" | "PENDING";
+      body: string;
+      comments: {
+        path: string;
+        line?: number;
+        body: string;
+        severity?: string;
+      }[];
+    }[]
+  >;
+
+  /** Check that the tracker backend is available and authenticated. */
+  checkAvailability(): Promise<
+    { available: true } | { available: false; error: string }
+  >;
+}
+
+// ---------------------------------------------------------------------------
+// GitHub Issue Tracker Implementation
+// ---------------------------------------------------------------------------
+
+const PHASE_LABELS: Record<Phase, string> = {
+  created: "",
+  triaging: "lifecycle/triaging",
+  classified: "lifecycle/classified",
+  plan_generated: "lifecycle/plan-review",
+  approved: "lifecycle/approved",
+  implementing: "lifecycle/implementing",
+  ci_review: "lifecycle/ci-review",
+  done: "lifecycle/done",
+};
+
+const ALL_LIFECYCLE_LABELS = Object.values(PHASE_LABELS).filter(Boolean);
+
+/** Run a gh CLI command and return parsed JSON output. */
+async function ghJson(args: string[]): Promise<unknown> {
+  const cmd = new Deno.Command("gh", {
+    args,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const output = await cmd.output();
+  if (!output.success) {
+    throw new Error(
+      `gh ${args.join(" ")} failed: ${new TextDecoder().decode(output.stderr)}`,
+    );
+  }
+  return JSON.parse(new TextDecoder().decode(output.stdout));
+}
+
+/** Best-effort run a gh command. Swallows errors. */
+async function ghBestEffort(args: string[]): Promise<boolean> {
+  try {
+    const cmd = new Deno.Command("gh", {
+      args,
+      stdout: "null",
+      stderr: "piped",
+    });
+    const output = await cmd.output();
+    return output.success;
+  } catch {
+    return false;
+  }
+}
+
+export class GitHubIssueTracker implements IssueTracker {
+  async fetchIssue(repo: string, issueNumber: number) {
+    const issue = (await ghJson([
+      "issue",
+      "view",
+      String(issueNumber),
+      "--repo",
+      repo,
+      "--json",
+      "title,body,labels,comments",
+    ])) as {
+      title: string;
+      body: string;
+      labels: { name: string }[];
+      comments: {
+        author: { login: string };
+        body: string;
+        createdAt: string;
+      }[];
+    };
+
+    return {
+      title: issue.title,
+      body: issue.body,
+      labels: issue.labels.map((l) => l.name),
+      comments: issue.comments.map((c) => ({
+        author: c.author.login,
+        body: c.body,
+        createdAt: c.createdAt,
+      })),
+    };
+  }
+
+  async postComment(
+    repo: string,
+    issueNumber: number,
+    body: string,
+  ): Promise<void> {
+    await ghBestEffort([
+      "issue",
+      "comment",
+      String(issueNumber),
+      "--repo",
+      repo,
+      "--body",
+      body,
+    ]);
+  }
+
+  async setPhaseLabel(
+    repo: string,
+    issueNumber: number,
+    phase: Phase,
+  ): Promise<void> {
+    const targetLabel = PHASE_LABELS[phase];
+    const removeLabels = ALL_LIFECYCLE_LABELS.filter((l) => l !== targetLabel);
+    removeLabels.push("lifecycle/needs-info");
+
+    await this.removeLabels(repo, issueNumber, removeLabels);
+    if (targetLabel) {
+      await this.addLabels(repo, issueNumber, [targetLabel]);
+    }
+  }
+
+  async addLabels(
+    repo: string,
+    issueNumber: number,
+    labels: string[],
+  ): Promise<void> {
+    for (const label of labels) {
+      await ghBestEffort([
+        "issue",
+        "edit",
+        String(issueNumber),
+        "--repo",
+        repo,
+        "--add-label",
+        label,
+      ]);
+    }
+  }
+
+  async removeLabels(
+    repo: string,
+    issueNumber: number,
+    labels: string[],
+  ): Promise<void> {
+    for (const label of labels) {
+      await ghBestEffort([
+        "issue",
+        "edit",
+        String(issueNumber),
+        "--repo",
+        repo,
+        "--remove-label",
+        label,
+      ]);
+    }
+  }
+
+  async fetchPrChecks(repo: string, prNumber: number) {
+    const checksData = (await ghJson([
+      "pr",
+      "checks",
+      String(prNumber),
+      "--repo",
+      repo,
+      "--json",
+      "name,state,bucket",
+    ])) as { name: string; state: string; bucket: string }[];
+
+    return (Array.isArray(checksData) ? checksData : []).map((c) => ({
+      name: c.name,
+      status: c.bucket === "pass"
+        ? "passed" as const
+        : c.bucket === "fail"
+        ? "failed" as const
+        : "pending" as const,
+    }));
+  }
+
+  async fetchPrReviews(repo: string, prNumber: number) {
+    const reviewsRaw = (await ghJson([
+      "api",
+      `repos/${repo}/pulls/${prNumber}/reviews`,
+      "--jq",
+      ".",
+    ])) as {
+      user: { login: string };
+      state: string;
+      body: string;
+    }[];
+
+    const commentsRaw = (await ghJson([
+      "api",
+      `repos/${repo}/pulls/${prNumber}/comments`,
+      "--jq",
+      ".",
+    ])) as {
+      user: { login: string };
+      path: string;
+      line: number | null;
+      body: string;
+      pull_request_review_id: number;
+    }[];
+
+    const reviewMap = new Map<
+      string,
+      {
+        state: string;
+        body: string;
+        comments: {
+          path: string;
+          line?: number;
+          body: string;
+          severity?: string;
+        }[];
+      }
+    >();
+
+    for (const review of (Array.isArray(reviewsRaw) ? reviewsRaw : [])) {
+      reviewMap.set(review.user.login, {
+        state: review.state,
+        body: review.body,
+        comments: [],
+      });
+    }
+
+    for (const comment of (Array.isArray(commentsRaw) ? commentsRaw : [])) {
+      const reviewer = comment.user.login;
+      if (!reviewMap.has(reviewer)) {
+        reviewMap.set(reviewer, {
+          state: "COMMENTED",
+          body: "",
+          comments: [],
+        });
+      }
+
+      const severityMatch = comment.body.match(
+        /\*\*(?:severity|Severity)\s*:\s*(critical|high|medium|low|info)\*\*/i,
+      );
+
+      reviewMap.get(reviewer)!.comments.push({
+        path: comment.path,
+        line: comment.line ?? undefined,
+        body: comment.body,
+        severity: severityMatch ? severityMatch[1].toLowerCase() : undefined,
+      });
+    }
+
+    return Array.from(reviewMap.entries()).map(([reviewer, data]) => ({
+      reviewer,
+      state: data.state as
+        | "APPROVED"
+        | "CHANGES_REQUESTED"
+        | "COMMENTED"
+        | "PENDING",
+      body: data.body,
+      comments: data.comments,
+    }));
+  }
+
+  async checkAvailability(): Promise<
+    { available: true } | { available: false; error: string }
+  > {
+    try {
+      const which = new Deno.Command("which", {
+        args: ["gh"],
+        stdout: "null",
+        stderr: "null",
+      });
+      const { success } = await which.output();
+      if (!success) {
+        return { available: false, error: "gh CLI is not installed" };
+      }
+      const auth = new Deno.Command("gh", {
+        args: ["auth", "status"],
+        stdout: "null",
+        stderr: "null",
+      });
+      const authResult = await auth.output();
+      if (!authResult.success) {
+        return {
+          available: false,
+          error: "gh CLI is not authenticated. Run 'gh auth login'.",
+        };
+      }
+      return { available: true };
+    } catch {
+      return {
+        available: false,
+        error: "Failed to check gh CLI availability",
+      };
+    }
+  }
+}
+
+/** Create the default issue tracker instance. */
+export function createTracker(): IssueTracker {
+  return new GitHubIssueTracker();
+}

--- a/extensions/models/_lib/schemas.ts
+++ b/extensions/models/_lib/schemas.ts
@@ -1,0 +1,171 @@
+// Swamp, an Automation Framework Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify it under the terms
+// of the GNU Affero General Public License version 3 as published by the Free
+// Software Foundation, with the Swamp Extension and Definition Exception (found in
+// the "COPYING-EXCEPTION" file).
+//
+// Swamp is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along
+// with Swamp. If not, see <https://www.gnu.org/licenses/>.
+
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Global Arguments
+// ---------------------------------------------------------------------------
+
+export const GlobalArgsSchema = z.object({
+  repo: z.string().default("systeminit/swamp").describe(
+    "GitHub repository in owner/repo format",
+  ),
+  issueNumber: z.number().describe("GitHub issue number"),
+});
+
+// ---------------------------------------------------------------------------
+// Phases (state machine)
+// ---------------------------------------------------------------------------
+
+export const Phase = z.enum([
+  "created",
+  "triaging",
+  "classified",
+  "plan_generated",
+  "approved",
+  "implementing",
+  "ci_review",
+  "done",
+]);
+
+export type Phase = z.infer<typeof Phase>;
+
+/** Valid transitions: method name → allowed source phases */
+export const TRANSITIONS: Record<string, Phase[]> = {
+  start: [
+    "created",
+    "triaging",
+    "classified",
+    "plan_generated",
+    "approved",
+    "implementing",
+    "ci_review",
+  ],
+  triage: ["triaging"],
+  plan: ["classified"],
+  iterate: ["plan_generated"],
+  approve: ["plan_generated"],
+  implement: ["approved"],
+  ci_status: ["implementing"],
+  fix: ["ci_review"],
+  complete: ["ci_review"],
+};
+
+// ---------------------------------------------------------------------------
+// Resource Schemas
+// ---------------------------------------------------------------------------
+
+export const StateSchema = z.object({
+  phase: Phase,
+  issueNumber: z.number(),
+  repo: z.string(),
+  prNumber: z.number().optional(),
+  updatedAt: z.string(),
+});
+
+export type StateData = z.infer<typeof StateSchema>;
+
+export const ContextSchema = z.object({
+  title: z.string(),
+  body: z.string(),
+  labels: z.array(z.string()),
+  comments: z.array(
+    z.object({
+      author: z.string(),
+      body: z.string(),
+      createdAt: z.string(),
+    }),
+  ),
+  fetchedAt: z.string(),
+});
+
+export const ClassificationSchema = z.object({
+  type: z.enum(["bug", "feature", "unclear"]),
+  confidence: z.enum(["high", "medium", "low"]),
+  reasoning: z.string(),
+  clarifyingQuestions: z.array(z.string()).optional(),
+  classifiedAt: z.string(),
+});
+
+export const PlanStepSchema = z.object({
+  order: z.number(),
+  description: z.string(),
+  files: z.array(z.string()),
+  risks: z.string().optional(),
+});
+
+export const PlanSchema = z.object({
+  version: z.number(),
+  summary: z.string(),
+  dddAnalysis: z.string(),
+  steps: z.array(PlanStepSchema),
+  testingStrategy: z.string(),
+  potentialChallenges: z.array(z.string()),
+  feedbackIncorporated: z.array(z.string()),
+  generatedAt: z.string(),
+});
+
+export type PlanData = z.infer<typeof PlanSchema>;
+
+export const FeedbackSchema = z.object({
+  round: z.number(),
+  feedback: z.string(),
+  planVersionReviewed: z.number(),
+  submittedAt: z.string(),
+});
+
+export const CiResultsSchema = z.object({
+  prNumber: z.number(),
+  checkRuns: z.array(
+    z.object({
+      name: z.string(),
+      status: z.enum(["passed", "failed", "pending"]),
+    }),
+  ),
+  reviews: z.array(
+    z.object({
+      reviewer: z.string(),
+      state: z.enum([
+        "APPROVED",
+        "CHANGES_REQUESTED",
+        "COMMENTED",
+        "PENDING",
+      ]),
+      body: z.string(),
+      comments: z.array(
+        z.object({
+          path: z.string(),
+          line: z.number().optional(),
+          body: z.string(),
+          severity: z
+            .enum(["critical", "high", "medium", "low", "info"])
+            .optional(),
+        }),
+      ),
+    }),
+  ),
+  fetchedAt: z.string(),
+});
+
+export const FixDirectiveSchema = z.object({
+  round: z.number(),
+  directive: z.string(),
+  targetReview: z.string().optional(),
+  targetSeverity: z.string().optional(),
+  ciResultsVersion: z.number(),
+  submittedAt: z.string(),
+});

--- a/extensions/models/issue_lifecycle.ts
+++ b/extensions/models/issue_lifecycle.ts
@@ -1,0 +1,996 @@
+// Swamp, an Automation Framework Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify it under the terms
+// of the GNU Affero General Public License version 3 as published by the Free
+// Software Foundation, with the Swamp Extension and Definition Exception (found in
+// the "COPYING-EXCEPTION" file).
+//
+// Swamp is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along
+// with Swamp. If not, see <https://www.gnu.org/licenses/>.
+
+import { z } from "zod";
+import {
+  CiResultsSchema,
+  ClassificationSchema,
+  ContextSchema,
+  FeedbackSchema,
+  FixDirectiveSchema,
+  GlobalArgsSchema,
+  type PlanData,
+  PlanSchema,
+  PlanStepSchema,
+  type StateData,
+  StateSchema,
+  TRANSITIONS,
+} from "./_lib/schemas.ts";
+import { createTracker } from "./_lib/issue_tracker.ts";
+
+const tracker = createTracker();
+
+/** Read the current state from data repository (for checks). */
+async function readState(
+  dataRepository: {
+    getContent: (
+      type: string,
+      modelId: string,
+      dataName: string,
+    ) => Promise<Uint8Array | null>;
+  },
+  modelType: string,
+  modelId: string,
+): Promise<StateData | null> {
+  const content = await dataRepository.getContent(
+    modelType,
+    modelId,
+    "state-main",
+  );
+  if (!content) return null;
+  return JSON.parse(new TextDecoder().decode(content)) as StateData;
+}
+
+// ---------------------------------------------------------------------------
+// Model Definition
+// ---------------------------------------------------------------------------
+
+export const model = {
+  type: "@si/issue-lifecycle",
+  version: "2026.03.25.2",
+  globalArguments: GlobalArgsSchema,
+
+  resources: {
+    "state": {
+      description: "Current lifecycle phase and metadata",
+      schema: StateSchema,
+      lifetime: "infinite" as const,
+      garbageCollection: 10,
+    },
+    "context": {
+      description: "Issue context fetched from GitHub",
+      schema: ContextSchema,
+      lifetime: "infinite" as const,
+      garbageCollection: 5,
+    },
+    "classification": {
+      description: "Issue triage classification",
+      schema: ClassificationSchema,
+      lifetime: "infinite" as const,
+      garbageCollection: 5,
+    },
+    "plan": {
+      description: "Implementation plan (versioned across iterations)",
+      schema: PlanSchema,
+      lifetime: "infinite" as const,
+      garbageCollection: 20,
+    },
+    "feedback": {
+      description: "Human feedback on plan (versioned per round)",
+      schema: FeedbackSchema,
+      lifetime: "infinite" as const,
+      garbageCollection: 20,
+    },
+    "ciResults": {
+      description: "CI check results and review comments",
+      schema: CiResultsSchema,
+      lifetime: "infinite" as const,
+      garbageCollection: 10,
+    },
+    "fixDirective": {
+      description: "Human-directed fix instructions",
+      schema: FixDirectiveSchema,
+      lifetime: "infinite" as const,
+      garbageCollection: 20,
+    },
+  },
+
+  checks: {
+    "valid-transition": {
+      description:
+        "Validates that the method is allowed from the current lifecycle phase",
+      labels: ["policy"],
+      execute: async (context: {
+        methodName: string;
+        dataRepository: {
+          getContent: (
+            type: string,
+            modelId: string,
+            dataName: string,
+          ) => Promise<Uint8Array | null>;
+        };
+        modelType: string;
+        modelId: string;
+      }) => {
+        const allowed = TRANSITIONS[context.methodName];
+        if (!allowed) return { pass: true };
+
+        const state = await readState(
+          context.dataRepository,
+          context.modelType,
+          context.modelId,
+        );
+
+        if (!state) {
+          return context.methodName === "start" ? { pass: true } : {
+            pass: false,
+            errors: ["No lifecycle state found. Run 'start' first."],
+          };
+        }
+
+        if (!allowed.includes(state.phase)) {
+          return {
+            pass: false,
+            errors: [
+              `Method '${context.methodName}' cannot run in phase '${state.phase}'. ` +
+              `Allowed phases: ${allowed.join(", ")}`,
+            ],
+          };
+        }
+        return { pass: true };
+      },
+    },
+
+    "plan-exists": {
+      description: "Ensures a plan exists before approve can be called",
+      labels: ["policy"],
+      appliesTo: ["approve"],
+      execute: async (context: {
+        dataRepository: {
+          getContent: (
+            type: string,
+            modelId: string,
+            dataName: string,
+          ) => Promise<Uint8Array | null>;
+        };
+        modelType: string;
+        modelId: string;
+      }) => {
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          "plan-main",
+        );
+        if (!content) {
+          return {
+            pass: false,
+            errors: ["No plan exists. Generate a plan first."],
+          };
+        }
+        return { pass: true };
+      },
+    },
+
+    "plan-approved": {
+      description: "Ensures plan is approved before implement can be called",
+      labels: ["policy"],
+      appliesTo: ["implement"],
+      execute: async (context: {
+        dataRepository: {
+          getContent: (
+            type: string,
+            modelId: string,
+            dataName: string,
+          ) => Promise<Uint8Array | null>;
+        };
+        modelType: string;
+        modelId: string;
+      }) => {
+        const state = await readState(
+          context.dataRepository,
+          context.modelType,
+          context.modelId,
+        );
+        if (!state) {
+          return { pass: false, errors: ["No state found."] };
+        }
+        if (state.phase !== "approved") {
+          return {
+            pass: false,
+            errors: [
+              "Plan must be approved before implementation can begin.",
+            ],
+          };
+        }
+        return { pass: true };
+      },
+    },
+
+    "tracker-available": {
+      description:
+        "Checks that the issue tracker backend is available and authenticated",
+      labels: ["live"],
+      execute: async () => {
+        const result = await tracker.checkAvailability();
+        if (result.available) return { pass: true };
+        return { pass: false, errors: [result.error] };
+      },
+    },
+  },
+
+  methods: {
+    start: {
+      description: "Fetch issue context and begin lifecycle",
+      arguments: z.object({}),
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: { repo: string; issueNumber: number };
+          logger: {
+            info: (msg: string, props: Record<string, unknown>) => void;
+            warning: (msg: string, props: Record<string, unknown>) => void;
+          };
+          writeResource: (
+            specName: string,
+            instanceName: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
+        const { repo, issueNumber } = context.globalArgs;
+        const handles = [];
+
+        const issue = await tracker.fetchIssue(repo, issueNumber);
+
+        handles.push(
+          await context.writeResource("context", "context-main", {
+            title: issue.title,
+            body: issue.body,
+            labels: issue.labels,
+            comments: issue.comments,
+            fetchedAt: new Date().toISOString(),
+          }),
+        );
+
+        handles.push(
+          await context.writeResource("state", "state-main", {
+            phase: "triaging",
+            issueNumber,
+            repo,
+            updatedAt: new Date().toISOString(),
+          }),
+        );
+
+        context.logger.info("Fetched issue #{issueNumber}: {title}", {
+          issueNumber,
+          title: issue.title,
+        });
+
+        await tracker.postComment(
+          repo,
+          issueNumber,
+          `\u{1F50D} **Triage started** \u2014 fetching issue context`,
+        );
+        await tracker.setPhaseLabel(repo, issueNumber, "triaging");
+
+        return { dataHandles: handles };
+      },
+    },
+
+    triage: {
+      description: "Classify the issue based on context",
+      arguments: z.object({
+        type: z.enum(["bug", "feature", "unclear"]),
+        confidence: z.enum(["high", "medium", "low"]),
+        reasoning: z.string(),
+        clarifyingQuestions: z.array(z.string()).optional(),
+      }),
+      execute: async (
+        args: {
+          type: "bug" | "feature" | "unclear";
+          confidence: "high" | "medium" | "low";
+          reasoning: string;
+          clarifyingQuestions?: string[];
+        },
+        context: {
+          globalArgs: { repo: string; issueNumber: number };
+          logger: {
+            info: (msg: string, props: Record<string, unknown>) => void;
+            warning: (msg: string, props: Record<string, unknown>) => void;
+          };
+          writeResource: (
+            specName: string,
+            instanceName: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
+        const { repo, issueNumber } = context.globalArgs;
+        const handles = [];
+
+        handles.push(
+          await context.writeResource(
+            "classification",
+            "classification-main",
+            {
+              type: args.type,
+              confidence: args.confidence,
+              reasoning: args.reasoning,
+              clarifyingQuestions: args.clarifyingQuestions,
+              classifiedAt: new Date().toISOString(),
+            },
+          ),
+        );
+
+        handles.push(
+          await context.writeResource("state", "state-main", {
+            phase: "classified",
+            issueNumber,
+            repo,
+            updatedAt: new Date().toISOString(),
+          }),
+        );
+
+        context.logger.info(
+          "Classified as {type} ({confidence}): {reasoning}",
+          {
+            type: args.type,
+            confidence: args.confidence,
+            reasoning: args.reasoning,
+          },
+        );
+
+        await tracker.postComment(
+          repo,
+          issueNumber,
+          `\u{1F4CB} **Classified as ${args.type}** (${args.confidence}) \u2014 ${args.reasoning}`,
+        );
+        await tracker.setPhaseLabel(repo, issueNumber, "classified");
+
+        const typeLabels: Record<string, { add: string[]; remove: string[] }> =
+          {
+            bug: { add: ["bug"], remove: ["feature", "needs-triage"] },
+            feature: { add: ["feature"], remove: ["bug", "needs-triage"] },
+            unclear: {
+              add: ["lifecycle/needs-info"],
+              remove: ["needs-triage"],
+            },
+          };
+        const labelOps = typeLabels[args.type];
+        if (labelOps) {
+          await tracker.removeLabels(repo, issueNumber, labelOps.remove);
+          await tracker.addLabels(repo, issueNumber, labelOps.add);
+        }
+
+        return { dataHandles: handles };
+      },
+    },
+
+    plan: {
+      description: "Generate an initial implementation plan",
+      arguments: z.object({
+        summary: z.string(),
+        dddAnalysis: z.string(),
+        steps: z.array(PlanStepSchema),
+        testingStrategy: z.string(),
+        potentialChallenges: z.array(z.string()),
+      }),
+      execute: async (
+        args: {
+          summary: string;
+          dddAnalysis: string;
+          steps: {
+            order: number;
+            description: string;
+            files: string[];
+            risks?: string;
+          }[];
+          testingStrategy: string;
+          potentialChallenges: string[];
+        },
+        context: {
+          globalArgs: { repo: string; issueNumber: number };
+          logger: {
+            info: (msg: string, props: Record<string, unknown>) => void;
+            warning: (msg: string, props: Record<string, unknown>) => void;
+          };
+          writeResource: (
+            specName: string,
+            instanceName: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
+        const { repo, issueNumber } = context.globalArgs;
+        const handles = [];
+
+        handles.push(
+          await context.writeResource("plan", "plan-main", {
+            version: 1,
+            summary: args.summary,
+            dddAnalysis: args.dddAnalysis,
+            steps: args.steps,
+            testingStrategy: args.testingStrategy,
+            potentialChallenges: args.potentialChallenges,
+            feedbackIncorporated: [],
+            generatedAt: new Date().toISOString(),
+          }),
+        );
+
+        handles.push(
+          await context.writeResource("state", "state-main", {
+            phase: "plan_generated",
+            issueNumber,
+            repo,
+            updatedAt: new Date().toISOString(),
+          }),
+        );
+
+        context.logger.info("Plan v1 generated: {summary}", {
+          summary: args.summary,
+        });
+
+        await tracker.postComment(
+          repo,
+          issueNumber,
+          `\u{1F4DD} **Implementation plan generated** (v1) \u2014 ${args.summary}`,
+        );
+        await tracker.setPhaseLabel(repo, issueNumber, "plan_generated");
+
+        return { dataHandles: handles };
+      },
+    },
+
+    review: {
+      description: "Display the current plan (read-only)",
+      arguments: z.object({
+        version: z.number().optional().describe(
+          "Specific plan version to review",
+        ),
+      }),
+      execute: async (
+        args: { version?: number },
+        context: {
+          logger: {
+            info: (msg: string, props: Record<string, unknown>) => void;
+          };
+          readResource: (
+            instanceName: string,
+            version?: number,
+          ) => Promise<Record<string, unknown> | null>;
+        },
+      ) => {
+        const plan = await context.readResource!("plan-main", args.version) as
+          | PlanData
+          | null;
+        if (!plan) throw new Error("No plan exists yet. Run 'plan' first.");
+
+        const stepsText = plan.steps.map((s) =>
+          `  ${s.order}. ${s.description}`
+        ).join("\n");
+        context.logger.info(
+          "Plan v{version}:\n{summary}\n\nSteps:\n{steps}\n\nTesting: {testing}",
+          {
+            version: plan.version,
+            summary: plan.summary,
+            steps: stepsText,
+            testing: plan.testingStrategy,
+          },
+        );
+
+        return { dataHandles: [] };
+      },
+    },
+
+    iterate: {
+      description:
+        "Submit feedback and a revised plan incorporating all prior feedback",
+      arguments: z.object({
+        feedback: z.string().describe("Human feedback on the current plan"),
+        summary: z.string(),
+        dddAnalysis: z.string(),
+        steps: z.array(PlanStepSchema),
+        testingStrategy: z.string(),
+        potentialChallenges: z.array(z.string()),
+      }),
+      execute: async (
+        args: {
+          feedback: string;
+          summary: string;
+          dddAnalysis: string;
+          steps: {
+            order: number;
+            description: string;
+            files: string[];
+            risks?: string;
+          }[];
+          testingStrategy: string;
+          potentialChallenges: string[];
+        },
+        context: {
+          globalArgs: { repo: string; issueNumber: number };
+          logger: {
+            info: (msg: string, props: Record<string, unknown>) => void;
+            warning: (msg: string, props: Record<string, unknown>) => void;
+          };
+          writeResource: (
+            specName: string,
+            instanceName: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+          readResource: (
+            instanceName: string,
+            version?: number,
+          ) => Promise<Record<string, unknown> | null>;
+          dataRepository: {
+            findAllForModel: (
+              type: string,
+              modelId: string,
+            ) => Promise<{ name: string; version: number }[]>;
+            getContent: (
+              type: string,
+              modelId: string,
+              dataName: string,
+              version?: number,
+            ) => Promise<Uint8Array | null>;
+          };
+          modelType: string;
+          modelId: string;
+        },
+      ) => {
+        const { repo, issueNumber } = context.globalArgs;
+        const handles = [];
+
+        const currentPlan = await context.readResource!("plan-main") as
+          | PlanData
+          | null;
+        const currentVersion = currentPlan ? currentPlan.version : 0;
+
+        const allData = await context.dataRepository.findAllForModel(
+          context.modelType,
+          context.modelId,
+        );
+        const feedbackEntries = allData.filter((d) =>
+          d.name === "feedback-main"
+        );
+        const feedbackRound = feedbackEntries.length + 1;
+
+        const allFeedback: string[] = [];
+        for (const entry of feedbackEntries) {
+          const content = await context.dataRepository.getContent(
+            context.modelType,
+            context.modelId,
+            "feedback-main",
+            entry.version,
+          );
+          if (content) {
+            const fb = JSON.parse(new TextDecoder().decode(content));
+            allFeedback.push(fb.feedback as string);
+          }
+        }
+        allFeedback.push(args.feedback);
+
+        handles.push(
+          await context.writeResource("feedback", "feedback-main", {
+            round: feedbackRound,
+            feedback: args.feedback,
+            planVersionReviewed: currentVersion,
+            submittedAt: new Date().toISOString(),
+          }),
+        );
+
+        const newVersion = currentVersion + 1;
+        handles.push(
+          await context.writeResource("plan", "plan-main", {
+            version: newVersion,
+            summary: args.summary,
+            dddAnalysis: args.dddAnalysis,
+            steps: args.steps,
+            testingStrategy: args.testingStrategy,
+            potentialChallenges: args.potentialChallenges,
+            feedbackIncorporated: allFeedback,
+            generatedAt: new Date().toISOString(),
+          }),
+        );
+
+        handles.push(
+          await context.writeResource("state", "state-main", {
+            phase: "plan_generated",
+            issueNumber,
+            repo,
+            updatedAt: new Date().toISOString(),
+          }),
+        );
+
+        context.logger.info(
+          "Plan revised to v{version}, incorporated feedback round {round}",
+          { version: newVersion, round: feedbackRound },
+        );
+
+        await tracker.postComment(
+          repo,
+          issueNumber,
+          `\u{1F504} **Plan revised** (v${newVersion}) \u2014 incorporated feedback round ${feedbackRound}`,
+        );
+        await tracker.setPhaseLabel(repo, issueNumber, "plan_generated");
+
+        return { dataHandles: handles };
+      },
+    },
+
+    approve: {
+      description: "Approve the current plan and post it to the issue",
+      arguments: z.object({}),
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: { repo: string; issueNumber: number };
+          logger: {
+            info: (msg: string, props: Record<string, unknown>) => void;
+            warning: (msg: string, props: Record<string, unknown>) => void;
+          };
+          writeResource: (
+            specName: string,
+            instanceName: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+          readResource: (
+            instanceName: string,
+            version?: number,
+          ) => Promise<Record<string, unknown> | null>;
+        },
+      ) => {
+        const { repo, issueNumber } = context.globalArgs;
+        const handles = [];
+
+        handles.push(
+          await context.writeResource("state", "state-main", {
+            phase: "approved",
+            issueNumber,
+            repo,
+            updatedAt: new Date().toISOString(),
+          }),
+        );
+
+        const plan = await context.readResource!("plan-main") as
+          | PlanData
+          | null;
+        if (plan) {
+          const steps = plan.steps
+            .map((s) =>
+              `${s.order}. ${s.description}${
+                s.risks ? ` _(risk: ${s.risks})_` : ""
+              }`
+            )
+            .join("\n");
+          const files = plan.steps
+            .flatMap((s) => s.files)
+            .filter((f, i, a) => a.indexOf(f) === i)
+            .map((f) => `- \`${f}\``)
+            .join("\n");
+          const challenges = plan.potentialChallenges.map((c) => `- ${c}`).join(
+            "\n",
+          );
+
+          await tracker.postComment(
+            repo,
+            issueNumber,
+            [
+              "<!-- IMPLEMENTATION-PLAN -->",
+              `## Approved Implementation Plan (v${plan.version})`,
+              "",
+              `**Summary:** ${plan.summary}`,
+              "",
+              "### DDD Analysis",
+              plan.dddAnalysis,
+              "",
+              "### Implementation Steps",
+              steps,
+              "",
+              "### Files",
+              files,
+              "",
+              "### Testing Strategy",
+              plan.testingStrategy,
+              "",
+              "### Potential Challenges",
+              challenges,
+              "",
+              plan.feedbackIncorporated.length > 0
+                ? `_Incorporated ${plan.feedbackIncorporated.length} round(s) of feedback._`
+                : "",
+              "",
+              "_Approved via swamp @si/issue-lifecycle_",
+            ].join("\n"),
+          );
+        }
+
+        context.logger.info("Plan approved", {});
+        await tracker.setPhaseLabel(repo, issueNumber, "approved");
+
+        return { dataHandles: handles };
+      },
+    },
+
+    implement: {
+      description: "Signal that implementation has started and track the PR",
+      arguments: z.object({
+        prNumber: z.number().optional().describe(
+          "PR number if already created",
+        ),
+      }),
+      execute: async (
+        args: { prNumber?: number },
+        context: {
+          globalArgs: { repo: string; issueNumber: number };
+          logger: {
+            info: (msg: string, props: Record<string, unknown>) => void;
+            warning: (msg: string, props: Record<string, unknown>) => void;
+          };
+          writeResource: (
+            specName: string,
+            instanceName: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
+        const { repo, issueNumber } = context.globalArgs;
+
+        const stateHandle = await context.writeResource("state", "state-main", {
+          phase: "implementing",
+          issueNumber,
+          repo,
+          prNumber: args.prNumber,
+          updatedAt: new Date().toISOString(),
+        });
+
+        const prText = args.prNumber ? ` \u2014 PR #${args.prNumber}` : "";
+        context.logger.info("Implementation started{prText}", { prText });
+
+        await tracker.postComment(
+          repo,
+          issueNumber,
+          `\u{1F680} **Implementation started**${prText}`,
+        );
+        await tracker.setPhaseLabel(repo, issueNumber, "implementing");
+
+        return { dataHandles: [stateHandle] };
+      },
+    },
+
+    ci_status: {
+      description: "Fetch CI results and review comments for the PR",
+      arguments: z.object({}),
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: { repo: string; issueNumber: number };
+          logger: {
+            info: (msg: string, props: Record<string, unknown>) => void;
+            warning: (msg: string, props: Record<string, unknown>) => void;
+          };
+          writeResource: (
+            specName: string,
+            instanceName: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+          readResource: (
+            instanceName: string,
+            version?: number,
+          ) => Promise<Record<string, unknown> | null>;
+        },
+      ) => {
+        const { repo, issueNumber } = context.globalArgs;
+        const handles = [];
+
+        const state = await context.readResource!("state-main") as
+          | StateData
+          | null;
+        if (!state?.prNumber) {
+          throw new Error(
+            "No PR number recorded. Run 'implement' with --input prNumber=<N> first.",
+          );
+        }
+        const prNumber = state.prNumber;
+
+        const checkRuns = await tracker.fetchPrChecks(repo, prNumber);
+        const reviews = await tracker.fetchPrReviews(repo, prNumber);
+
+        handles.push(
+          await context.writeResource("ciResults", "ciResults-main", {
+            prNumber,
+            checkRuns,
+            reviews,
+            fetchedAt: new Date().toISOString(),
+          }),
+        );
+
+        handles.push(
+          await context.writeResource("state", "state-main", {
+            phase: "ci_review",
+            issueNumber,
+            repo,
+            prNumber,
+            updatedAt: new Date().toISOString(),
+          }),
+        );
+
+        const passed = checkRuns.filter((c) => c.status === "passed").length;
+        const failed = checkRuns.filter((c) => c.status === "failed").length;
+        context.logger.info("CI results: {passed} passed, {failed} failed", {
+          passed,
+          failed,
+        });
+
+        await tracker.postComment(
+          repo,
+          issueNumber,
+          `\u{1F52C} **CI results**: ${passed} passed, ${failed} failed`,
+        );
+        await tracker.setPhaseLabel(repo, issueNumber, "ci_review");
+
+        return { dataHandles: handles };
+      },
+    },
+
+    fix: {
+      description: "Direct specific fixes based on CI/review feedback",
+      arguments: z.object({
+        directive: z.string().describe(
+          'What to fix, e.g. "fix the CRITICAL issues from adversarial review"',
+        ),
+        targetReview: z.string().optional().describe(
+          "Filter to a specific reviewer",
+        ),
+        targetSeverity: z.string().optional().describe(
+          "Filter to a specific severity level",
+        ),
+      }),
+      execute: async (
+        args: {
+          directive: string;
+          targetReview?: string;
+          targetSeverity?: string;
+        },
+        context: {
+          globalArgs: { repo: string; issueNumber: number };
+          logger: {
+            info: (msg: string, props: Record<string, unknown>) => void;
+            warning: (msg: string, props: Record<string, unknown>) => void;
+          };
+          writeResource: (
+            specName: string,
+            instanceName: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+          readResource: (
+            instanceName: string,
+            version?: number,
+          ) => Promise<Record<string, unknown> | null>;
+          dataRepository: {
+            findAllForModel: (
+              type: string,
+              modelId: string,
+            ) => Promise<{ name: string; version: number }[]>;
+          };
+          modelType: string;
+          modelId: string;
+        },
+      ) => {
+        const { repo, issueNumber } = context.globalArgs;
+        const handles = [];
+
+        const state = await context.readResource!("state-main") as
+          | StateData
+          | null;
+
+        const allData = await context.dataRepository.findAllForModel(
+          context.modelType,
+          context.modelId,
+        );
+        const fixRound =
+          allData.filter((d) => d.name === "fixDirective-main").length + 1;
+        const ciEntries = allData.filter((d) => d.name === "ciResults-main");
+        const latestCiVersion = ciEntries.length > 0
+          ? Math.max(...ciEntries.map((e) => e.version))
+          : 0;
+
+        handles.push(
+          await context.writeResource("fixDirective", "fixDirective-main", {
+            round: fixRound,
+            directive: args.directive,
+            targetReview: args.targetReview,
+            targetSeverity: args.targetSeverity,
+            ciResultsVersion: latestCiVersion,
+            submittedAt: new Date().toISOString(),
+          }),
+        );
+
+        handles.push(
+          await context.writeResource("state", "state-main", {
+            phase: "implementing",
+            issueNumber,
+            repo,
+            prNumber: state?.prNumber,
+            updatedAt: new Date().toISOString(),
+          }),
+        );
+
+        context.logger.info("Fix directive recorded: {directive}", {
+          directive: args.directive,
+        });
+
+        await tracker.postComment(
+          repo,
+          issueNumber,
+          `\u{1F527} **Fixing**: ${args.directive}`,
+        );
+        await tracker.setPhaseLabel(repo, issueNumber, "implementing");
+
+        return { dataHandles: handles };
+      },
+    },
+
+    complete: {
+      description: "Mark the issue lifecycle as done",
+      arguments: z.object({}),
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: { repo: string; issueNumber: number };
+          logger: {
+            info: (msg: string, props: Record<string, unknown>) => void;
+            warning: (msg: string, props: Record<string, unknown>) => void;
+          };
+          writeResource: (
+            specName: string,
+            instanceName: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+          readResource: (
+            instanceName: string,
+            version?: number,
+          ) => Promise<Record<string, unknown> | null>;
+        },
+      ) => {
+        const { repo, issueNumber } = context.globalArgs;
+
+        const state = await context.readResource!("state-main") as
+          | StateData
+          | null;
+
+        const stateHandle = await context.writeResource("state", "state-main", {
+          phase: "done",
+          issueNumber,
+          repo,
+          prNumber: state?.prNumber,
+          updatedAt: new Date().toISOString(),
+        });
+
+        context.logger.info("Issue lifecycle complete", {});
+
+        await tracker.postComment(
+          repo,
+          issueNumber,
+          `\u{2705} **Complete** \u2014 all checks passed`,
+        );
+        await tracker.setPhaseLabel(repo, issueNumber, "done");
+
+        return { dataHandles: [stateHandle] };
+      },
+    },
+  },
+};

--- a/src/cli/commands/issue_bug.ts
+++ b/src/cli/commands/issue_bug.ts
@@ -187,7 +187,7 @@ export const issueBugCommand = new Command()
       issueCreate(libCtx, deps, {
         title,
         body,
-        labels: ["bug", "external"],
+        labels: ["bug", "needs-triage"],
         type: "bug",
       }),
       renderer.handlers(),

--- a/src/cli/commands/issue_feature.ts
+++ b/src/cli/commands/issue_feature.ts
@@ -186,7 +186,7 @@ export const issueFeatureCommand = new Command()
       issueCreate(libCtx, deps, {
         title,
         body,
-        labels: ["enhancement", "external"],
+        labels: ["feature", "needs-triage"],
         type: "feature",
       }),
       renderer.handlers(),

--- a/src/infrastructure/github/github_issue_service_test.ts
+++ b/src/infrastructure/github/github_issue_service_test.ts
@@ -43,10 +43,10 @@ Deno.test("issue URL parsing returns 0 for invalid URL", () => {
 
 Deno.test("getNewIssueUrl uses default repo with labels", () => {
   const service = new GitHubIssueService();
-  const url = service.getNewIssueUrl({ labels: ["bug", "external"] });
+  const url = service.getNewIssueUrl({ labels: ["bug", "needs-triage"] });
   assertEquals(
     url,
-    "https://github.com/systeminit/swamp/issues/new?labels=bug%2Cexternal",
+    "https://github.com/systeminit/swamp/issues/new?labels=bug%2Cneeds-triage",
   );
 });
 
@@ -54,11 +54,11 @@ Deno.test("getNewIssueUrl uses custom repo", () => {
   const service = new GitHubIssueService();
   const url = service.getNewIssueUrl({
     repo: "owner/other-repo",
-    labels: ["enhancement"],
+    labels: ["feature"],
   });
   assertEquals(
     url,
-    "https://github.com/owner/other-repo/issues/new?labels=enhancement",
+    "https://github.com/owner/other-repo/issues/new?labels=feature",
   );
 });
 


### PR DESCRIPTION
## Summary

- Add `@si/issue-lifecycle` extension model that drives GitHub issue triage and implementation planning as a local, interactive workflow
- Every phase transition persists state in swamp's data store, posts a comment to the GitHub issue, and sets the corresponding `lifecycle/*` label
- Extract `IssueTracker` interface to decouple the model from GitHub — swappable to Linear, Jira, etc. by implementing the interface
- Align `swamp issue bug/feature` CLI labels with the lifecycle pipeline (`needs-triage` instead of `external`, `feature` instead of `enhancement`)

## Flow

The model provides a structured state machine for issue triage:

```
created → triaging → classified → plan_generated → approved →
implementing → ci_review → done
```

Two human-controlled iteration loops:
1. **Plan loop** — generate plan → get feedback → revise → approve
2. **Fix loop** — check CI → direct fixes → push → check CI → complete

Every state change automatically:
- Posts a comment to the issue thread (visible to anyone watching)
- Swaps the `lifecycle/*` label (at-a-glance pipeline visibility)
- On classification, sets `bug`/`feature` label and removes `needs-triage`

## Architecture

```
extensions/models/
├── _lib/
│   ├── schemas.ts          # Zod schemas, types, phase transitions
│   └── issue_tracker.ts    # IssueTracker interface + GitHubIssueTracker
├── issue_lifecycle.ts      # Model definition (checks + methods)
└── README.md               # Full usage docs (CLI + Claude Code)
```

The `IssueTracker` interface abstracts: fetch issue, post comment, set/add/remove labels, fetch PR checks, fetch PR reviews, check availability. The `GitHubIssueTracker` implements all operations via the `gh` CLI.

## Label scheme

| Phase | Label |
|-------|-------|
| triaging | `lifecycle/triaging` |
| classified | `lifecycle/classified` |
| plan_generated | `lifecycle/plan-review` |
| approved | `lifecycle/approved` |
| implementing | `lifecycle/implementing` |
| ci_review | `lifecycle/ci-review` |
| done | `lifecycle/done` |
| unclear classification | `lifecycle/needs-info` |

## Test plan

- [x] `deno check` passes on all extension model files
- [x] `deno lint` and `deno fmt` clean
- [x] `github_issue_service_test.ts` updated and passing (label assertions)
- [x] Compiled binary verified: `swamp repo init` does NOT ship the extension model or skill to user repos
- [x] Labels audited: 12 labels total, all mapped to model phases or CLI commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)