### PR TITLE
fix: resolve ETXTBSY error when running swamp update on Linux

### DIFF
--- a/src/infrastructure/update/http_update_checker.ts
+++ b/src/infrastructure/update/http_update_checker.ts
@@ -46,6 +46,48 @@ async function removeQuarantine(path: string): Promise<void> {
 }
 
 /**
+ * Replace a binary at `targetPath` with the file at `sourcePath`.
+ *
+ * On Linux, overwriting a running binary fails with ETXTBSY because the kernel
+ * prevents writing to an inode with active text mappings. The standard fix is
+ * to remove the directory entry first (the running process keeps its fd open),
+ * then move the new file into place.
+ *
+ * Strategy:
+ * 1. Try `Deno.rename()` — atomic, no ETXTBSY (operates on directory entries).
+ * 2. If rename fails with EXDEV (cross-filesystem), fall back to
+ *    `Deno.remove()` + `Deno.copyFile()`.
+ */
+async function replaceBinary(
+  sourcePath: string,
+  targetPath: string,
+): Promise<void> {
+  try {
+    // Unlink first to release the inode on Linux
+    try {
+      await Deno.remove(targetPath);
+    } catch (error) {
+      // NotFound is fine — target may not exist yet
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+    await Deno.rename(sourcePath, targetPath);
+  } catch (error) {
+    // EXDEV: source and target on different filesystems — rename won't work
+    const code = error instanceof Error
+      ? (error as Error & { code?: string }).code
+      : undefined;
+    if (code === "EXDEV") {
+      // Target already removed above, so copyFile won't hit ETXTBSY
+      await Deno.copyFile(sourcePath, targetPath);
+    } else {
+      throw error;
+    }
+  }
+}
+
+/**
  * HTTP adapter implementing UpdateChecker.
  * Checks artifacts.systeminit.com for the latest swamp binary.
  */
@@ -192,8 +234,8 @@ export class HttpUpdateChecker implements UpdateChecker {
         await removeQuarantine(extractedBinary);
       }
 
-      // Replace the current binary
-      await Deno.copyFile(extractedBinary, binaryPath);
+      // Replace the current binary (unlink-then-rename to avoid ETXTBSY on Linux)
+      await replaceBinary(extractedBinary, binaryPath);
       await Deno.chmod(binaryPath, 0o755);
 
       // Also clear quarantine on the final path (in case copyFile propagates it)

--- a/src/libswamp/models/create.ts
+++ b/src/libswamp/models/create.ts
@@ -33,7 +33,7 @@ import {
   toMethodDescribeData,
   zodToJsonSchema,
 } from "../types/schema_helpers.ts";
-import { coerceInputTypes } from "../../domain/inputs/input_coercion.ts";
+import { coerceInputTypes } from "../../domain/inputs/mod.ts";
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**


### PR DESCRIPTION
## Summary

- Fix `swamp update` failing on Linux with `ETXTBSY` ("Text file busy") by replacing `Deno.copyFile()` with an unlink-then-rename pattern
- Fix import consistency in `create.ts` (use `mod.ts` instead of internal path)

Fixes #854

## Problem

On Linux, the kernel prevents overwriting a file whose inode has active text (code) mappings. When `swamp update` downloads a new binary and calls `Deno.copyFile()` to replace the running executable, the kernel rejects it with `ETXTBSY (os error 26)`. This affects **all Linux users** — not a specific circumstance.

macOS does not enforce ETXTBSY for copyFile operations, which is why this was never caught during development.

## Fix

Added a `replaceBinary()` helper in `src/infrastructure/update/http_update_checker.ts` that uses the standard pattern for self-updating binaries on Linux (same approach as rustup, gh, etc.):

1. **`Deno.remove(targetPath)`** — removes the directory entry. The running process keeps its file descriptor open (standard POSIX behavior).
2. **`Deno.rename(sourcePath, targetPath)`** — atomic, operates on directory entries, no ETXTBSY.
3. **Fallback**: if rename fails with `EXDEV` (cross-filesystem, e.g. `/tmp` → `/home`), falls back to `Deno.copyFile()` — safe because the target was already unlinked in step 1.

The macOS quarantine (`xattr`) handling is preserved and runs after the binary is in its final location regardless of which replacement path was taken.

## Confidence: 95%

**Why 95% and not 100%:**
- Cannot reproduce the actual ETXTBSY scenario on macOS — the fix is based on well-understood POSIX semantics and the exact pattern the issue reporter suggested
- Verified that Deno surfaces `error.code === "EXDEV"` for cross-filesystem rename failures
- The unlink-then-rename pattern is the industry standard for self-updating binaries on Linux

**Why high confidence:**
- The logic is simple: remove directory entry, then move file — two well-understood syscalls
- Failure modes are identical to before (permission errors propagate the same way)
- macOS behavior is unchanged (the unlink+rename is a no-op improvement there)
- All existing tests pass

## Files changed

| File | Change |
|------|--------|
| `src/infrastructure/update/http_update_checker.ts` | Add `replaceBinary()` helper, replace `Deno.copyFile()` call |
| `src/libswamp/models/create.ts` | Import `coerceInputTypes` from `mod.ts` for consistency with `run.ts` |

## Test plan

- [x] `deno check` passes
- [x] `deno lint` and `deno fmt` clean
- [x] All existing update tests pass
- [x] Verified Deno error shape: `error.code` is a string property (`"EXDEV"`, `"ENOENT"`, etc.)
- [ ] Linux user validates `swamp update` works (needs reporter verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)