### PR TITLE
docs: add version upgrade guidance to swamp-extension-model skill

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -111,17 +111,32 @@ export const model = {
 
 ## Model Structure
 
-| Field             | Required | Description                                       |
-| ----------------- | -------- | ------------------------------------------------- |
-| `type`            | Yes      | Unique identifier (`@collective/name`)            |
-| `version`         | Yes      | CalVer version (`YYYY.MM.DD.MICRO`)               |
-| `globalArguments` | No       | Zod schema for global arguments                   |
-| `resources`       | No       | Resource output specs (JSON data with Zod schema) |
-| `files`           | No       | File output specs (binary/text with content type) |
-| `inputsSchema`    | No       | Zod schema for runtime inputs                     |
-| `methods`         | Yes      | Object of method definitions with `arguments` Zod |
-| `checks`          | No       | Pre-flight checks run before mutating methods     |
-| `reports`         | No       | Inline report definitions (see `swamp-report`)    |
+| Field             | Required | Description                                                              |
+| ----------------- | -------- | ------------------------------------------------------------------------ |
+| `type`            | Yes      | Unique identifier (`@collective/name`)                                   |
+| `version`         | Yes      | CalVer version (`YYYY.MM.DD.MICRO`)                                      |
+| `globalArguments` | No       | Zod schema for global arguments                                          |
+| `resources`       | No       | Resource output specs (JSON data with Zod schema)                        |
+| `files`           | No       | File output specs (binary/text with content type)                        |
+| `inputsSchema`    | No       | Zod schema for runtime inputs                                            |
+| `methods`         | Yes      | Object of method definitions with `arguments` Zod                        |
+| `checks`          | No       | Pre-flight checks run before mutating methods                            |
+| `reports`         | No       | Inline report definitions (see `swamp-report`)                           |
+| `upgrades`        | No       | Version upgrade chain ([references/upgrades.md](references/upgrades.md)) |
+
+## Version Upgrades
+
+When bumping `version`, always add an `upgrades` entry so existing instances
+migrate. **Prompt the user** to confirm:
+
+1. Did the `globalArguments` schema change?
+2. If yes: what fields were added/renamed/removed and what defaults to use?
+3. If no: add a no-op upgrade (`upgradeAttributes: (old) => old`)
+
+The last upgrade's `toVersion` must equal the model's current `version`.
+Upgrades run lazily at method execution time and persist after first run.
+
+See [references/upgrades.md](references/upgrades.md) for patterns and examples.
 
 ## Supported Zod Types
 
@@ -475,6 +490,9 @@ troubleshooting, see [references/publishing.md](references/publishing.md).
    (e.g., `@user/my-model` or `myorg/my-model`)
 7. **No type annotations**: Avoid TypeScript types in execute parameters
 8. **File naming**: Use snake_case (`my_model.ts`)
+9. **Version upgrades**: When bumping `version`, always add an `upgrades` entry
+   and prompt the user for the migration path. See
+   [references/upgrades.md](references/upgrades.md)
 
 ## Collective Rules
 
@@ -529,5 +547,7 @@ swamp model type describe @myorg/my-model --json  # Check schema
   smoke-test protocol, CRUD lifecycle testing, and common failure patterns
 - **Troubleshooting**: See
   [references/troubleshooting.md](references/troubleshooting.md)
+- **Version Upgrades**: See [references/upgrades.md](references/upgrades.md) for
+  upgrade patterns, user prompt workflow, and migration examples
 - **Docker execution**: See
   [references/docker-execution.md](references/docker-execution.md)

--- a/.claude/skills/swamp-extension-model/references/examples.md
+++ b/.claude/skills/swamp-extension-model/references/examples.md
@@ -16,6 +16,7 @@
 - [Using External Dependencies](#using-external-dependencies)
 - [Extending Existing Model Types](#extending-existing-model-types)
 - [Helper Scripts](#helper-scripts)
+- [Model with Version Upgrades](#model-with-version-upgrades)
 
 ## Using External Dependencies
 
@@ -1561,3 +1562,79 @@ The loader skips files that don't declare `export const model` or
 `export const extension`, so the helper is never bundled — even without the
 `include` manifest field. The `include` field is needed to ship the helper in
 the extension archive when publishing.
+
+## Model with Version Upgrades
+
+A notifier model that evolves through three versions, demonstrating how to
+maintain an upgrade chain for existing instances.
+
+```typescript
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "@acme/notifier",
+  version: "2026.02.09.1",
+
+  globalArguments: z.object({
+    content: z.string().min(1),
+    priority: z.enum(["low", "medium", "high"]),
+  }),
+
+  resources: {
+    "result": {
+      description: "Notification result",
+      schema: z.object({
+        sent: z.boolean(),
+        content: z.string(),
+        priority: z.string(),
+      }),
+      lifetime: "infinite" as const,
+      garbageCollection: 10,
+    },
+  },
+
+  // Upgrade chain: each entry migrates from the previous version.
+  // The last toVersion must match the model's current version.
+  upgrades: [
+    {
+      toVersion: "2025.06.01.1",
+      description: "Add priority field with default 'medium'",
+      upgradeAttributes: (old) => ({
+        ...old,
+        priority: "medium",
+      }),
+    },
+    {
+      toVersion: "2026.02.09.1",
+      description: "Rename 'message' to 'content'",
+      upgradeAttributes: (old) => {
+        const { message, ...rest } = old;
+        return { ...rest, content: message };
+      },
+    },
+  ],
+
+  methods: {
+    send: {
+      description: "Send a notification",
+      arguments: z.object({}),
+      execute: async (args, context) => {
+        const globalArgs = context.globalArgs;
+        const handle = await context.writeResource("result", "main", {
+          sent: true,
+          content: globalArgs.content,
+          priority: globalArgs.priority,
+        });
+        return { dataHandles: [handle] };
+      },
+    },
+  },
+};
+```
+
+An instance created at version `2025.01.15.1` with `{ message: "hello" }` will
+automatically migrate when any method runs:
+
+1. Upgrade to `2025.06.01.1`: `{ message: "hello", priority: "medium" }`
+2. Upgrade to `2026.02.09.1`: `{ content: "hello", priority: "medium" }`
+3. Definition persisted with `typeVersion: "2026.02.09.1"`

--- a/.claude/skills/swamp-extension-model/references/upgrades.md
+++ b/.claude/skills/swamp-extension-model/references/upgrades.md
@@ -1,0 +1,152 @@
+# Version Upgrades
+
+## Table of Contents
+
+- [User Prompt Workflow](#user-prompt-workflow)
+- [How Upgrades Work](#how-upgrades-work)
+- [Upgrade Entry Structure](#upgrade-entry-structure)
+- [Common Patterns](#common-patterns)
+- [Multi-Step Upgrade Chain](#multi-step-upgrade-chain)
+- [Rules](#rules)
+- [Without Upgrades](#without-upgrades)
+
+## User Prompt Workflow
+
+When bumping a model's `version`, **always prompt the user** before writing the
+upgrade. Claude cannot reliably determine whether or how the schema changed.
+
+1. Ask: "Did the `globalArguments` schema change between versions?"
+2. If **yes**: ask what fields were added, renamed, removed, or changed type —
+   and what default values to use for new/changed fields
+3. If **no**: add a no-op upgrade (see below) — still required to bump
+   `typeVersion` on existing instances
+4. Write the `upgrades` entry based on the user's answers
+
+## How Upgrades Work
+
+Upgrades are **lazy** — they run at method execution time, not at load time:
+
+1. User runs a method on an instance with an old `typeVersion`
+2. `DefinitionUpgradeService` filters the model's `upgrades` array to entries
+   with `toVersion > definition.typeVersion`
+3. Applicable upgrades run in order, each transforming `globalArguments`
+4. The upgraded definition is persisted with the new `typeVersion`
+5. The upgrade only runs once — subsequent method calls skip it
+
+## Upgrade Entry Structure
+
+```typescript
+{
+  toVersion: string,        // CalVer target version (YYYY.MM.DD.MICRO)
+  description: string,      // Human-readable summary of the change
+  upgradeAttributes: (old: Record<string, unknown>) => Record<string, unknown>,
+}
+```
+
+## Common Patterns
+
+### No-op upgrade (version bump, no schema change)
+
+```typescript
+upgrades: [
+  {
+    toVersion: "2026.03.25.2",
+    description: "Version bump, no schema changes",
+    upgradeAttributes: (old) => old,
+  },
+],
+```
+
+### Add a new field with default
+
+```typescript
+{
+  toVersion: "2026.03.25.1",
+  description: "Add priority field with default 'medium'",
+  upgradeAttributes: (old) => ({ ...old, priority: "medium" }),
+}
+```
+
+### Rename a field
+
+```typescript
+{
+  toVersion: "2026.03.25.1",
+  description: "Rename 'message' to 'content'",
+  upgradeAttributes: (old) => {
+    const { message, ...rest } = old;
+    return { ...rest, content: message };
+  },
+}
+```
+
+### Remove a field
+
+```typescript
+{
+  toVersion: "2026.03.25.1",
+  description: "Remove deprecated 'legacyFlag' field",
+  upgradeAttributes: (old) => {
+    const { legacyFlag: _, ...rest } = old;
+    return rest;
+  },
+}
+```
+
+## Multi-Step Upgrade Chain
+
+A model evolving through multiple versions builds up a chain. Each entry handles
+one version transition:
+
+```typescript
+export const model = {
+  type: "acme/notifier",
+  version: "2026.02.09.1",
+  globalArguments: z.object({
+    content: z.string().min(1),
+    priority: z.enum(["low", "medium", "high"]),
+  }),
+  upgrades: [
+    {
+      toVersion: "2025.06.01.1",
+      description: "Add priority field with default 'medium'",
+      upgradeAttributes: (old) => ({ ...old, priority: "medium" }),
+    },
+    {
+      toVersion: "2026.02.09.1",
+      description: "Rename 'message' to 'content'",
+      upgradeAttributes: (old) => {
+        const { message, ...rest } = old;
+        return { ...rest, content: message };
+      },
+    },
+  ],
+  methods: {/* ... */},
+};
+```
+
+An instance at `2025.01.15.1` with `{ message: "hello" }` would:
+
+1. Apply upgrade to `2025.06.01.1`: `{ message: "hello", priority: "medium" }`
+2. Apply upgrade to `2026.02.09.1`: `{ content: "hello", priority: "medium" }`
+3. Persist with `typeVersion: "2026.02.09.1"`
+
+An instance already at `2025.06.01.1` would only apply step 2.
+
+## Rules
+
+- Upgrades must be ordered chronologically by `toVersion`
+- The last upgrade's `toVersion` **must** equal the model's current `version`
+- Upgrade functions are pure transforms (old args in, new args out)
+- Upgrades are forward-only — there is no downgrade path
+- The registry validates these rules at startup and throws on violations
+
+## Without Upgrades
+
+If a model bumps `version` without adding an `upgrades` entry:
+
+- Existing instances keep their old `typeVersion` forever
+- Methods still execute if the schema is compatible (no new required fields)
+- But `typeVersion` never updates, making it impossible to tell which instances
+  have been migrated
+- Future upgrades that chain from the new version will skip these instances

--- a/design/models.md
+++ b/design/models.md
@@ -84,12 +84,12 @@ export const model = {
     {
       toVersion: "2025.06.01.1",
       description: "Add priority field with default 'medium'",
-      upgradeGlobalArguments: (old) => ({ ...old, priority: "medium" }),
+      upgradeAttributes: (old) => ({ ...old, priority: "medium" }),
     },
     {
       toVersion: "2026.02.09.1",
       description: "Rename 'message' to 'content'",
-      upgradeGlobalArguments: (old) => {
+      upgradeAttributes: (old) => {
         const { message, ...rest } = old;
         return { ...rest, content: message };
       },


### PR DESCRIPTION
docs: add version upgrade guidance to swamp-extension-model skill

## Summary

The `swamp-extension-model` skill had no documentation about the `upgrades` field on model definitions. This meant that when a model's version was bumped, existing instantiated models would be left stuck at their old `typeVersion` with no migration path — users (and Claude) had no idea they needed to add upgrade entries.

## What changed

- **skill.md**: Added `upgrades` row to the Model Structure table, a new "Version Upgrades" section with a user prompt workflow, Key Rule 9 requiring upgrades when bumping version, and a reference link
- **references/upgrades.md** (new): Detailed reference covering the user prompt workflow, how lazy upgrades work, common patterns (no-op, add field, rename, remove), multi-step chain example, rules, and consequences of skipping upgrades
- **references/examples.md**: Added a complete "Model with Version Upgrades" example showing a notifier model evolving through three versions
- **design/models.md**: Fixed `upgradeGlobalArguments` → `upgradeAttributes` to match the actual code interface (`VersionUpgrade` in `model.ts` and `UserUpgradeSchema` in `user_model_loader.ts`)

## Impact

The key behavioral change is that Claude is now instructed to **prompt the user** about schema changes when bumping a version, rather than guessing or silently skipping the upgrade. This ensures existing model instances get proper migration entries.

## Why this is correct

- The `upgradeAttributes` function name matches what the code validates (`user_model_loader.ts:106` and `model.ts:558`)
- The upgrade chain mechanics match `DefinitionUpgradeService` behavior (lazy execution at method run time, filtered by `toVersion > typeVersion`, persisted after first run)
- Examples follow skill conventions (no type annotations in execute parameters, snake_case file naming)
- skill.md stays under 560 lines (553), following skill-creator progressive disclosure guidelines — detailed content lives in the reference file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
