### PR TITLE
docs: add API contract verification to extension model skill

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -430,6 +430,12 @@ Before pushing an extension, verify it works against the live API. Unit tests
 with mocked responses can't catch Content-Type mismatches, bundle caching bugs,
 or API validation quirks that only surface with real HTTP calls.
 
+**For models that call external APIs:** Before pushing, verify all API endpoints
+and request/response schemas against the provider's official REST API reference
+documentation. Cross-reference HTTP methods, request body schemas, response
+fields, and naming conventions. This catches contract mismatches that mocked
+tests cannot detect.
+
 Follow the smoke-test protocol in
 [references/smoke_testing.md](references/smoke_testing.md) to systematically
 test your model's methods against the real API. Start with safe read-only

--- a/.claude/skills/swamp-extension-model/references/smoke_testing.md
+++ b/.claude/skills/swamp-extension-model/references/smoke_testing.md
@@ -20,6 +20,27 @@ bugs, or API validation quirks that only surface with real HTTP calls.
 4. Verify vault credentials are configured:
    `swamp vault get <vault-name> --json`
 
+### Phase 0.5: API Contract Verification
+
+Before running any methods, verify the model's API calls against the provider's
+official REST API reference documentation. Mocked unit tests validate internal
+logic but cannot catch contract mismatches that only surface with real HTTP
+calls.
+
+For each endpoint the model calls, verify:
+
+1. **Endpoint URL pattern** — does the URL match the provider's documented path?
+2. **HTTP method** — does the model use the correct verb (GET vs POST vs PUT vs
+   PATCH vs DELETE)?
+3. **Request body** — does the body schema match what the API expects? Some
+   endpoints require an empty body, others require specific wrapper fields
+4. **Response schema** — does the model parse the fields the API actually
+   returns?
+5. **Field naming conventions** — does the model match the provider's convention
+   (camelCase vs snake_case vs PascalCase)?
+
+If any mismatch is found, fix the model source **before** proceeding to Phase 1.
+
 ### Phase 1: List methods (safe reads)
 
 - Run all `list`-kind methods — read-only, no side effects
@@ -123,6 +144,25 @@ Produce a summary table:
 
 These are the most frequent bugs caught by smoke testing (from real extension
 model development):
+
+### API contract mismatches
+
+**Symptom:** API returns unexpected errors (400, 404, 405) or silently ignores
+fields. Mocked unit tests pass but real API calls fail.
+
+**Cause:** The model's HTTP calls don't match the provider's actual REST API
+contract. Common examples:
+
+- Using POST when the API expects GET (or vice versa)
+- Sending a JSON body to an endpoint that requires an empty body
+- Using camelCase field names when the API expects snake_case
+- Missing required wrapper fields in the request body
+- Parsing response fields that don't exist or have different names
+
+**Fix:** Open the provider's official REST API reference documentation and
+cross-reference each endpoint the model calls. Verify the HTTP method, request
+body schema, and response schema match exactly. See Phase 0.5 in the protocol
+above for the full checklist.
 
 ### Content-Type mismatches (HTTP 415)
 


### PR DESCRIPTION
## Summary

Closes #855

Adds API contract verification guidance to the `swamp-extension-model` skill's smoke testing protocol. This addresses a real bug where a GCP IAM extension model shipped with `JSON.stringify({})` as the POST body to `serviceAccounts.getIamPolicy` — an endpoint that requires an empty body per GCP docs. Mocked unit tests passed because they validated internal logic, not the actual API contract.

### Changes

- **Phase 0.5: API Contract Verification** (`smoke_testing.md`) — New phase between Pre-flight and Phase 1 with a 5-item checklist: endpoint URL patterns, HTTP methods, request body schemas, response schemas, and field naming conventions
- **API contract mismatches failure pattern** (`smoke_testing.md`) — New entry in Common Failure Patterns covering wrong HTTP methods, incorrect request bodies, and field naming mismatches, with symptoms/causes/fix guidance
- **Contextual reminder** (`SKILL.md`) — Prompt in the Smoke Testing section reminding model authors to verify against provider REST API docs before pushing

### Why this is correct

The `swamp-extension-model` skill is what Claude follows when building extension models. By adding an API contract verification step to the skill, Claude will execute that step during model development — cross-referencing each endpoint URL, HTTP method, and request/response body against the provider's official docs. This catches the exact class of bug described in the issue (contract mismatches that mocked tests cannot detect) at the right point in the workflow (before push, after implementation).

### Impact

- Documentation-only change — no code, no runtime behavior changes
- Applies to all future extension model development that wraps REST APIs
- Zero risk of regression

## Test plan

- [ ] Verify markdown renders correctly in both files
- [ ] Verify the new Phase 0.5 flows logically between Pre-flight and Phase 1
- [ ] Verify the failure pattern follows the existing format (Symptom/Cause/Fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)