### PR TITLE
fix: suppress ANSI escape codes in deno fmt/lint subprocess output

### DIFF
--- a/src/domain/extensions/extension_quality_checker.ts
+++ b/src/domain/extensions/extension_quality_checker.ts
@@ -264,6 +264,7 @@ export async function checkExtensionQuality(
       : ["fmt", "--check", "--no-config", ...tsFiles],
     stdout: "piped",
     stderr: "piped",
+    env: { ...Deno.env.toObject(), NO_COLOR: "1" },
   });
   const fmtOutput = await fmtCommand.output();
   if (!fmtOutput.success) {
@@ -280,6 +281,7 @@ export async function checkExtensionQuality(
       : ["lint", "--no-config", ...tsFiles],
     stdout: "piped",
     stderr: "piped",
+    env: { ...Deno.env.toObject(), NO_COLOR: "1" },
   });
   const lintOutput = await lintCommand.output();
   if (!lintOutput.success) {

--- a/src/domain/extensions/extension_quality_checker_test.ts
+++ b/src/domain/extensions/extension_quality_checker_test.ts
@@ -327,6 +327,35 @@ Deno.test("checkExtensionQuality uses deno.json config when denoConfigPath provi
   );
 });
 
+Deno.test("checkExtensionQuality: fmt output contains no ANSI escape codes", async () => {
+  await withTempFiles(
+    { "model.ts": "export const x=1;" },
+    async (_dir, paths) => {
+      const result = await checkExtensionQuality(paths, DENO_PATH);
+      assertEquals(result.passed, false);
+      const fmtIssue = result.issues.find((i) => i.check === "fmt");
+      assertEquals(fmtIssue !== undefined, true);
+      // ANSI escape codes start with ESC (\x1b) followed by [
+      assertEquals(fmtIssue!.output.includes("\x1b["), false);
+    },
+  );
+});
+
+Deno.test("checkExtensionQuality: lint output contains no ANSI escape codes", async () => {
+  await withTempFiles(
+    {
+      "model.ts": "// deno-lint-ignore no-explicit-any\nexport const x = 1;\n",
+    },
+    async (_dir, paths) => {
+      const result = await checkExtensionQuality(paths, DENO_PATH);
+      assertEquals(result.passed, false);
+      const lintIssue = result.issues.find((i) => i.check === "lint");
+      assertEquals(lintIssue !== undefined, true);
+      assertEquals(lintIssue!.output.includes("\x1b["), false);
+    },
+  );
+});
+
 Deno.test("stripCommentsAndStrings removes single-line comments", () => {
   const result = stripCommentsAndStrings('code(); // import("pkg")');
   assertEquals(result.includes("import"), false);

--- a/src/libswamp/extensions/fmt.ts
+++ b/src/libswamp/extensions/fmt.ts
@@ -76,6 +76,7 @@ export async function createExtensionFmtDeps(): Promise<ExtensionFmtDeps> {
         args: ["fmt", "--no-config", ...files],
         stdout: "piped",
         stderr: "piped",
+        env: { ...Deno.env.toObject(), NO_COLOR: "1" },
       });
       const output = await command.output();
       return (
@@ -88,6 +89,7 @@ export async function createExtensionFmtDeps(): Promise<ExtensionFmtDeps> {
         args: ["lint", "--fix", "--no-config", ...files],
         stdout: "piped",
         stderr: "piped",
+        env: { ...Deno.env.toObject(), NO_COLOR: "1" },
       });
       const output = await command.output();
       return (


### PR DESCRIPTION
## Summary

Fixes raw ANSI escape sequences leaking into log output when `swamp extension fmt` runs `deno fmt` and `deno lint` as subprocesses.

- **Root cause:** `Deno.Command` inherits the parent TTY environment, causing deno to emit color codes even when stdout/stderr are piped and captured as strings.
- **Fix:** Add `env: { ...Deno.env.toObject(), NO_COLOR: "1" }` to all four subprocess invocations that capture deno fmt/lint output, suppressing ANSI codes while preserving `PATH` and other required environment variables.

**Affected locations:**
| File | Function | Invocation |
|------|----------|------------|
| `src/domain/extensions/extension_quality_checker.ts` | `checkExtensionQuality` | `deno fmt --check` |
| `src/domain/extensions/extension_quality_checker.ts` | `checkExtensionQuality` | `deno lint` |
| `src/libswamp/extensions/fmt.ts` | `createExtensionFmtDeps` | `deno fmt` (fix mode) |
| `src/libswamp/extensions/fmt.ts` | `createExtensionFmtDeps` | `deno lint --fix` |

**User impact:** Extension authors running `swamp extension fmt` on a system with a color-capable terminal will now see clean, readable error messages instead of output like `\x1b[1m\x1b[31merror\x1b[0m`.

## Test plan

- [x] Two new unit tests in `extension_quality_checker_test.ts` assert that fmt and lint issue output contains no ANSI escape sequences (`\x1b[`)
- [x] All 28 existing `extension_quality_checker_test.ts` tests pass
- [x] Full test suite: 3549 passed, 3 failed (all 3 failures are pre-existing network connectivity tests hitting `swamp.club`, unrelated to this change)
- [x] `deno check` clean
- [x] `deno lint` clean
- [x] `deno fmt` clean

Fixes #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)