### PR TITLE
fix: show step name in tree view for forEach-expanded steps

### DIFF
--- a/src/presentation/renderers/workflow_run_tree/components/job_line.tsx
+++ b/src/presentation/renderers/workflow_run_tree/components/job_line.tsx
@@ -72,9 +72,13 @@ export function JobLine(
     case "running": {
       if (runningSteps.length === 1) {
         const step = runningSteps[0];
-        const label = step.modelName && step.methodName
+        const modelMethod = step.modelName && step.methodName
           ? `${step.modelName} \u2192 ${step.methodName}`
-          : step.id;
+          : null;
+        const stepPrefix = modelMethod && step.id !== step.modelName
+          ? `${step.id}: `
+          : "";
+        const label = modelMethod ? `${stepPrefix}${modelMethod}` : step.id;
         const dur = elapsed > 0 ? ` (${formatDuration(elapsed)})` : "";
         statusInfo = (
           <Text dimColor>

--- a/src/presentation/renderers/workflow_run_tree/components/step_line.tsx
+++ b/src/presentation/renderers/workflow_run_tree/components/step_line.tsx
@@ -36,9 +36,13 @@ export function StepLine({ step, prefix }: StepLineProps) {
   const spinnerFrame = useSpinner();
   const elapsed = useElapsed(step.startedAt);
 
-  const label = step.modelName && step.methodName
+  const modelMethod = step.modelName && step.methodName
     ? `${step.modelName} \u2192 ${step.methodName}`
-    : step.id;
+    : null;
+  const stepPrefix = modelMethod && step.id !== step.modelName
+    ? `${step.id}: `
+    : "";
+  const label = modelMethod ? `${stepPrefix}${modelMethod}` : step.id;
 
   const duration = elapsed > 0 ? formatDuration(elapsed) : "";
 

--- a/src/presentation/renderers/workflow_run_tree/state.ts
+++ b/src/presentation/renderers/workflow_run_tree/state.ts
@@ -221,7 +221,8 @@ function graduateJob(job: JobState): ScrollbackItem {
   if (job.stepOrder.length === 1) {
     const step = job.steps.get(job.stepOrder[0]);
     if (step?.modelName && step?.methodName) {
-      singleStepLabel = `${step.modelName} \u2192 ${step.methodName}`;
+      const prefix = step.id !== step.modelName ? `${step.id}: ` : "";
+      singleStepLabel = `${prefix}${step.modelName} \u2192 ${step.methodName}`;
     }
   }
 

--- a/src/presentation/renderers/workflow_run_tree/state_test.ts
+++ b/src/presentation/renderers/workflow_run_tree/state_test.ts
@@ -190,7 +190,7 @@ Deno.test("treeReducer: job_completed graduates to scrollback and unblocks depen
   if (item.type === "job") {
     assertEquals(item.jobId, "provision");
     assertEquals(item.status, "succeeded");
-    assertEquals(item.singleStepLabel, "ec2-instance \u2192 create");
+    assertEquals(item.singleStepLabel, "step-1: ec2-instance \u2192 create");
   }
 
   // configure should now be waiting (provision dependency resolved)
@@ -482,4 +482,65 @@ Deno.test("treeReducer: batch action processes multiple events atomically", () =
   const step = job.steps.get("s1")!;
   assertEquals(step.modelName, "ec2");
   assertEquals(step.outputBuffer, ["Creating..."]);
+});
+
+Deno.test("treeReducer: singleStepLabel includes step name prefix for forEach-expanded steps", () => {
+  const state = reduce(
+    createInitialState("test"),
+    {
+      kind: "started",
+      runId: "run-1",
+      workflowName: "test",
+      jobs: [{ id: "test-job", stepCount: 1, dependsOn: [] }],
+    },
+    { kind: "job_started", jobId: "test-job" },
+    { kind: "step_started", jobId: "test-job", stepId: "test-alpine" },
+    {
+      kind: "model_resolved",
+      jobId: "test-job",
+      stepId: "test-alpine",
+      modelName: "tester",
+      modelType: "test/runner",
+      methodName: "smokeTest",
+    },
+    { kind: "step_completed", jobId: "test-job", stepId: "test-alpine" },
+    { kind: "job_completed", jobId: "test-job", status: "succeeded" },
+  );
+
+  const item = state.scrollback[0];
+  assertEquals(item.type, "job");
+  if (item.type === "job") {
+    assertEquals(item.singleStepLabel, "test-alpine: tester \u2192 smokeTest");
+  }
+});
+
+Deno.test("treeReducer: singleStepLabel omits prefix when stepId matches modelName", () => {
+  const state = reduce(
+    createInitialState("deploy"),
+    {
+      kind: "started",
+      runId: "run-1",
+      workflowName: "deploy",
+      jobs: [{ id: "provision", stepCount: 1, dependsOn: [] }],
+    },
+    { kind: "job_started", jobId: "provision" },
+    { kind: "step_started", jobId: "provision", stepId: "ec2-instance" },
+    {
+      kind: "model_resolved",
+      jobId: "provision",
+      stepId: "ec2-instance",
+      modelName: "ec2-instance",
+      modelType: "aws/ec2",
+      methodName: "create",
+    },
+    { kind: "step_completed", jobId: "provision", stepId: "ec2-instance" },
+    { kind: "job_completed", jobId: "provision", status: "succeeded" },
+  );
+
+  const item = state.scrollback[0];
+  assertEquals(item.type, "job");
+  if (item.type === "job") {
+    // No prefix when stepId matches modelName
+    assertEquals(item.singleStepLabel, "ec2-instance \u2192 create");
+  }
 });


### PR DESCRIPTION
## Summary

Fixes #867 — forEach-expanded steps in the workflow tree view now show the step name as a prefix when it differs from the model name.

**Before:**
```
test
  ├─ tester → smokeTest    ∴ 1.9s
  ├─ tester → smokeTest    ∴ 1.9s
  ├─ tester → smokeTest    ∴ 1.9s
```

**After:**
```
test
  ├─ test-alpine: tester → smokeTest    ∴ 1.9s
  ├─ test-discord: tester → smokeTest   ∴ 1.9s
  ├─ test-github: tester → smokeTest    ∴ 1.9s
```

### What changed

Three label construction sites in the tree view renderer were updated to prefix the step ID when `stepId !== modelName`:

- **`step_line.tsx`** — live expanded step labels
- **`job_line.tsx`** — inline single-running-step labels
- **`state.ts`** — graduated scrollback labels after job completion

### Why this is correct

- The domain layer already propagates the correct expanded step name (e.g., `test-alpine`) as the `stepId` through workflow events — this is purely a presentation fix
- The prefix is only added when `stepId !== modelName`, so non-forEach steps where the step name naturally matches the model name (e.g., `ec2-instance → create`) remain unchanged
- The `--json` output and report system already had the correct step names — this brings the tree view in line with those

### User impact

Users running workflows with `forEach` steps can now tell which iteration is which during live execution, without the workaround of creating N separate model instances per iteration.

## Test Plan

- Updated existing scrollback label assertion to account for the new prefix format
- Added test: forEach-expanded step with `stepId !== modelName` shows `"test-alpine: tester → smokeTest"`
- Added test: regular step with `stepId === modelName` shows `"ec2-instance → create"` (no prefix)
- All 39 tests in `workflow_run_tree/` pass
- Full `deno check`, `deno lint`, `deno fmt` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)