### PR TITLE
fix: correct CLI --driver flag priority in workflow execution

### DIFF
--- a/src/domain/drivers/driver_resolution.ts
+++ b/src/domain/drivers/driver_resolution.ts
@@ -35,18 +35,20 @@ export interface ResolvedDriverConfig {
 
 /**
  * Resolves the effective driver and config using precedence:
- *   step > job > workflow > definition > "raw"
+ *   cli > step > job > workflow > definition > "raw"
  *
  * The first non-undefined `driver` value wins. Its corresponding
  * `driverConfig` is used as-is (no merging across levels).
  */
 export function resolveDriverConfig(
+  cli?: DriverSource,
   step?: DriverSource,
   job?: DriverSource,
   workflow?: DriverSource,
   definition?: DriverSource,
 ): ResolvedDriverConfig {
   const sources: (DriverSource | undefined)[] = [
+    cli,
     step,
     job,
     workflow,

--- a/src/domain/drivers/driver_resolution_test.ts
+++ b/src/domain/drivers/driver_resolution_test.ts
@@ -20,14 +20,15 @@
 import { assertEquals } from "@std/assert";
 import { resolveDriverConfig } from "./driver_resolution.ts";
 
-Deno.test("resolveDriverConfig - defaults to raw when no sources", () => {
+Deno.test("resolveDriverConfig: defaults to raw when no sources", () => {
   const result = resolveDriverConfig();
   assertEquals(result.driver, "raw");
   assertEquals(result.driverConfig, undefined);
 });
 
-Deno.test("resolveDriverConfig - defaults to raw when all sources undefined", () => {
+Deno.test("resolveDriverConfig: defaults to raw when all sources undefined", () => {
   const result = resolveDriverConfig(
+    undefined,
     undefined,
     undefined,
     undefined,
@@ -36,8 +37,9 @@ Deno.test("resolveDriverConfig - defaults to raw when all sources undefined", ()
   assertEquals(result.driver, "raw");
 });
 
-Deno.test("resolveDriverConfig - definition driver wins over default", () => {
+Deno.test("resolveDriverConfig: definition driver wins over default", () => {
   const result = resolveDriverConfig(
+    undefined,
     undefined,
     undefined,
     undefined,
@@ -47,8 +49,9 @@ Deno.test("resolveDriverConfig - definition driver wins over default", () => {
   assertEquals(result.driverConfig, { image: "node:18" });
 });
 
-Deno.test("resolveDriverConfig - workflow driver wins over definition", () => {
+Deno.test("resolveDriverConfig: workflow driver wins over definition", () => {
   const result = resolveDriverConfig(
+    undefined,
     undefined,
     undefined,
     { driver: "docker", driverConfig: { image: "deno:latest" } },
@@ -58,8 +61,9 @@ Deno.test("resolveDriverConfig - workflow driver wins over definition", () => {
   assertEquals(result.driverConfig, { image: "deno:latest" });
 });
 
-Deno.test("resolveDriverConfig - job driver wins over workflow", () => {
+Deno.test("resolveDriverConfig: job driver wins over workflow", () => {
   const result = resolveDriverConfig(
+    undefined,
     undefined,
     { driver: "raw" },
     { driver: "docker" },
@@ -68,8 +72,9 @@ Deno.test("resolveDriverConfig - job driver wins over workflow", () => {
   assertEquals(result.driver, "raw");
 });
 
-Deno.test("resolveDriverConfig - step driver wins over all", () => {
+Deno.test("resolveDriverConfig: step driver wins over job", () => {
   const result = resolveDriverConfig(
+    undefined,
     { driver: "docker", driverConfig: { image: "step-image" } },
     { driver: "raw" },
     { driver: "raw" },
@@ -79,8 +84,45 @@ Deno.test("resolveDriverConfig - step driver wins over all", () => {
   assertEquals(result.driverConfig, { image: "step-image" });
 });
 
-Deno.test("resolveDriverConfig - skips sources without driver field", () => {
+Deno.test("resolveDriverConfig: cli driver wins over all others", () => {
   const result = resolveDriverConfig(
+    { driver: "raw" },
+    { driver: "docker", driverConfig: { image: "step-image" } },
+    { driver: "docker", driverConfig: { image: "job-image" } },
+    { driver: "docker", driverConfig: { image: "wf-image" } },
+    { driver: "docker", driverConfig: { image: "def-image" } },
+  );
+  assertEquals(result.driver, "raw");
+  assertEquals(result.driverConfig, undefined);
+});
+
+Deno.test("resolveDriverConfig: cli driver config is used when cli wins", () => {
+  const result = resolveDriverConfig(
+    { driver: "docker", driverConfig: { image: "cli-image" } },
+    { driver: "raw" },
+    { driver: "raw" },
+    { driver: "raw" },
+    { driver: "raw" },
+  );
+  assertEquals(result.driver, "docker");
+  assertEquals(result.driverConfig, { image: "cli-image" });
+});
+
+Deno.test("resolveDriverConfig: step wins when cli is undefined", () => {
+  const result = resolveDriverConfig(
+    undefined,
+    { driver: "docker", driverConfig: { image: "step-image" } },
+    { driver: "raw" },
+    { driver: "raw" },
+    { driver: "raw" },
+  );
+  assertEquals(result.driver, "docker");
+  assertEquals(result.driverConfig, { image: "step-image" });
+});
+
+Deno.test("resolveDriverConfig: skips sources without driver field", () => {
+  const result = resolveDriverConfig(
+    undefined,
     { driverConfig: { ignore: true } },
     undefined,
     { driver: "docker" },
@@ -89,8 +131,9 @@ Deno.test("resolveDriverConfig - skips sources without driver field", () => {
   assertEquals(result.driver, "docker");
 });
 
-Deno.test("resolveDriverConfig - uses driverConfig from winning level only", () => {
+Deno.test("resolveDriverConfig: uses driverConfig from winning level only", () => {
   const result = resolveDriverConfig(
+    undefined,
     undefined,
     { driver: "docker", driverConfig: { timeout: 30 } },
     { driver: "raw", driverConfig: { verbose: true } },

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -90,6 +90,7 @@ import { reportRegistry } from "../reports/report_registry.ts";
 import type { MethodReportContext } from "../reports/report_context.ts";
 import { modelRegistry } from "../models/model.ts";
 import { getTracer, SpanStatusCode } from "../../infrastructure/tracing/mod.ts";
+import { resolveDriverConfig } from "../drivers/driver_resolution.ts";
 /**
  * Context for step execution.
  */
@@ -1460,10 +1461,12 @@ export class WorkflowExecutionService {
           workflowTags: options.workflowTags,
           runtimeTags: options.runtimeTags,
           secretRedactor: options.secretRedactor,
-          driver: options.driver ?? step.driver ?? job.driver ??
-            workflow.driver,
-          driverConfig: step.driverConfig ?? job.driverConfig ??
-            workflow.driverConfig,
+          ...resolveDriverConfig(
+            { driver: options.driver },
+            { driver: step.driver, driverConfig: step.driverConfig },
+            { driver: job.driver, driverConfig: job.driverConfig },
+            { driver: workflow.driver, driverConfig: workflow.driverConfig },
+          ),
           emitEvent: push,
           reportFilterOptions: options.reportFilterOptions,
         };

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -1460,8 +1460,8 @@ export class WorkflowExecutionService {
           workflowTags: options.workflowTags,
           runtimeTags: options.runtimeTags,
           secretRedactor: options.secretRedactor,
-          driver: step.driver ?? job.driver ?? workflow.driver ??
-            options.driver,
+          driver: options.driver ?? step.driver ?? job.driver ??
+            workflow.driver,
           driverConfig: step.driverConfig ?? job.driverConfig ??
             workflow.driverConfig,
           emitEvent: push,


### PR DESCRIPTION
## Summary

- **Bug**: The CLI `--driver` flag was resolved as lowest priority (fallback), but the design doc (`design/execution-drivers.md`) specifies it should be highest priority
- **Fix**: Flipped `options.driver` to first position in the `??` chain in `execution_service.ts` so CLI overrides step/job/workflow driver settings
- **Contract**: Added `cli` parameter to `resolveDriverConfig()` in `driver_resolution.ts` to keep the resolution function's contract in sync with the design doc

## What was wrong

In `src/domain/workflows/execution_service.ts` (line 1463), the driver resolution was:

```ts
driver: step.driver ?? job.driver ?? workflow.driver ?? options.driver,
```

This made the CLI `--driver` flag a fallback — it only applied when step, job, and workflow didn't specify a driver.

## What it should be (per design doc)

```
1. CLI --driver flag        ← highest priority
2. Workflow step driver:
3. Workflow job driver:
4. Workflow-level driver:
5. Model definition driver:
6. Default: raw             ← lowest priority
```

## The fix

```ts
driver: options.driver ?? step.driver ?? job.driver ?? workflow.driver,
```

Also updated `resolveDriverConfig()` to accept a `cli` parameter as first in the resolution chain (`cli > step > job > workflow > definition > raw`), and added tests for CLI override behavior.

## Impact

Users passing `--driver` on the CLI will now correctly override any driver configuration set in workflow YAML files. Previously, a workflow step with `driver: docker` would silently ignore `--driver raw` from the CLI.

## Files changed

- `src/domain/workflows/execution_service.ts` — flip `??` chain priority
- `src/domain/drivers/driver_resolution.ts` — add `cli` parameter to resolution function
- `src/domain/drivers/driver_resolution_test.ts` — update existing tests + add CLI override tests

## Test plan

- [x] All 11 driver resolution tests pass (including 3 new CLI override tests)
- [x] Full test suite passes (3560 tests, 0 failures)
- [x] `deno check` — type checking clean
- [x] `deno lint` — no warnings
- [x] `deno fmt` — properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)