### PR TITLE
fix: prevent repeated failed rebundle attempts and TOCTOU on cache fallback

### DIFF
--- a/src/domain/datastore/user_datastore_loader.ts
+++ b/src/domain/datastore/user_datastore_loader.ts
@@ -251,9 +251,20 @@ export class UserDatastoreLoader {
         return js;
       } catch (bundleError) {
         if (bundleExists) {
-          logger
-            .warn`Rebundle failed for ${relativePath}, using cached bundle: ${bundleError}`;
-          return await Deno.readTextFile(bundlePath);
+          try {
+            const cached = await Deno.readTextFile(bundlePath);
+            logger
+              .warn`Rebundle failed for ${relativePath}, using cached bundle: ${bundleError}`;
+            // Touch the cache mtime so subsequent loads see it as fresh,
+            // avoiding repeated failed rebundle attempts on every cold start.
+            try {
+              const now = new Date();
+              await Deno.utime(bundlePath, now, now);
+            } catch { /* ignore — worst case we retry next load */ }
+            return cached;
+          } catch {
+            // Cache file was removed between stat and read — treat as no cache.
+          }
         }
         throw bundleError;
       }

--- a/src/domain/drivers/user_driver_loader.ts
+++ b/src/domain/drivers/user_driver_loader.ts
@@ -250,9 +250,20 @@ export class UserDriverLoader {
         return js;
       } catch (bundleError) {
         if (bundleExists) {
-          logger
-            .warn`Rebundle failed for ${relativePath}, using cached bundle: ${bundleError}`;
-          return await Deno.readTextFile(bundlePath);
+          try {
+            const cached = await Deno.readTextFile(bundlePath);
+            logger
+              .warn`Rebundle failed for ${relativePath}, using cached bundle: ${bundleError}`;
+            // Touch the cache mtime so subsequent loads see it as fresh,
+            // avoiding repeated failed rebundle attempts on every cold start.
+            try {
+              const now = new Date();
+              await Deno.utime(bundlePath, now, now);
+            } catch { /* ignore — worst case we retry next load */ }
+            return cached;
+          } catch {
+            // Cache file was removed between stat and read — treat as no cache.
+          }
         }
         throw bundleError;
       }

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -473,9 +473,20 @@ export class UserModelLoader {
         return js;
       } catch (bundleError) {
         if (bundleExists) {
-          logger
-            .warn`Rebundle failed for ${relativePath}, using cached bundle: ${bundleError}`;
-          return await Deno.readTextFile(bundlePath);
+          try {
+            const cached = await Deno.readTextFile(bundlePath);
+            logger
+              .warn`Rebundle failed for ${relativePath}, using cached bundle: ${bundleError}`;
+            // Touch the cache mtime so subsequent loads see it as fresh,
+            // avoiding repeated failed rebundle attempts on every cold start.
+            try {
+              const now = new Date();
+              await Deno.utime(bundlePath, now, now);
+            } catch { /* ignore — worst case we retry next load */ }
+            return cached;
+          } catch {
+            // Cache file was removed between stat and read — treat as no cache.
+          }
         }
         throw bundleError;
       }

--- a/src/domain/vaults/user_vault_loader.ts
+++ b/src/domain/vaults/user_vault_loader.ts
@@ -257,9 +257,20 @@ export class UserVaultLoader {
         return js;
       } catch (bundleError) {
         if (bundleExists) {
-          logger
-            .warn`Rebundle failed for ${relativePath}, using cached bundle: ${bundleError}`;
-          return await Deno.readTextFile(bundlePath);
+          try {
+            const cached = await Deno.readTextFile(bundlePath);
+            logger
+              .warn`Rebundle failed for ${relativePath}, using cached bundle: ${bundleError}`;
+            // Touch the cache mtime so subsequent loads see it as fresh,
+            // avoiding repeated failed rebundle attempts on every cold start.
+            try {
+              const now = new Date();
+              await Deno.utime(bundlePath, now, now);
+            } catch { /* ignore — worst case we retry next load */ }
+            return cached;
+          } catch {
+            // Cache file was removed between stat and read — treat as no cache.
+          }
         }
         throw bundleError;
       }


### PR DESCRIPTION
## Summary

- When a rebundle fails for pulled extensions with bare specifiers, touch the cached bundle's mtime so subsequent loads short-circuit at the freshness check instead of re-invoking the Deno bundler on every cold start
- Fix a pre-existing TOCTOU race where the cache file could be deleted between the initial `Deno.stat()` and the fallback `Deno.readTextFile()`
- Applied consistently to all 4 extension loaders: models, vaults, drivers, and datastores

## Problem

PR #876 changed extension loaders to attempt rebundling before falling back to cached bundles, fixing a bug where stale caches were served even when source files had changed. However, CI review identified a performance regression:

For **pulled extensions with bare specifiers** (e.g. `from "zod"` resolved via a project's `deno.json`), repos without the import map can't rebundle. The old code detected bare specifiers upfront and returned the cache immediately. The new code attempts `bundleExtension()`, which invokes the Deno bundler, waits for it to fail, then falls back — adding seconds of latency **per extension on every load**.

This is because the cache file's mtime was never updated after a fallback, so the next mtime check would see the cache as stale again and trigger the same failed rebundle cycle.

## User Impact

Users with many pulled extensions using bare specifiers (e.g. `@swamp/hetzner-cloud` with 11 models) would see significantly slower cold starts — the Deno bundler would be invoked and fail 11 times on every `swamp` command, adding potentially 10+ seconds of startup latency.

## Fix

**Mtime touch**: After falling back to the cached bundle on rebundle failure, `Deno.utime()` touches the cache file's mtime. The next load sees the cache as "fresh" and returns it immediately at the mtime check — no bundler invocation.

- First load with stale bare-specifier bundle: tries rebundle → fails → falls back → touches cache (one-time cost)
- Subsequent loads: mtime check sees cache as fresh → returns immediately (no cost)  
- If source changes again later: mtime check detects newer source → tries rebundle again

**TOCTOU fix**: The `bundleExists` flag was set via `Deno.stat()` early in the method, but the fallback `Deno.readTextFile()` runs in a later catch block. If the bundle is deleted between the stat and the read (e.g. concurrent garbage collection), `readTextFile` would throw unhandled. The fallback read is now wrapped in a try/catch — if the file is gone, it falls through to throw the original `bundleError`.

## Test plan

- [x] `deno check` passes on all 4 loaders
- [x] `deno lint` passes on all 4 loaders
- [x] `deno fmt` passes
- [x] 3562 unit tests pass
- [x] Verified pulled extensions with bare specifiers still load (`@swamp/hetzner-cloud` — 11 models in a repo without `deno.json`)
- [x] Verified stale bundles are replaced when source changes and `deno.json` is present (local dev scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)