### PR TITLE
fix: accept secret value as separate argument in vault put

### DIFF
--- a/src/cli/commands/vault_put.ts
+++ b/src/cli/commands/vault_put.ts
@@ -83,7 +83,8 @@ export function resolveKeyValue(
 
   return {
     error: `Invalid argument format: ${argument}\n\n` +
-      `Provide the value inline or via stdin:\n` +
+      `Provide the value as a separate argument, inline, or via stdin:\n` +
+      `  swamp vault put <vault> ${argument} <value>\n` +
       `  swamp vault put <vault> ${argument}=<value>\n` +
       `  echo "<value>" | swamp vault put <vault> ${argument}`,
   };
@@ -109,13 +110,14 @@ type AnyOptions = any;
 export const vaultPutCommand = new Command()
   .name("put")
   .description("Store a secret in a vault")
-  .arguments("<vault_name:string> <key_value:string>")
+  .arguments("<vault_name:string> <key:string> [value:string]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("-f, --force", "Skip confirmation prompt when overwriting")
   .action(async function (
     options: AnyOptions,
     vaultName: string,
-    keyValue: string,
+    keyOrKeyValue: string,
+    valueArg: string | undefined,
   ) {
     const cliCtx = createContext(options as GlobalOptions, ["vault", "put"]);
     cliCtx.logger.debug`Storing secret in vault: ${vaultName}`;
@@ -125,44 +127,52 @@ export const vaultPutCommand = new Command()
       outputMode: cliCtx.outputMode,
     });
 
-    // Parse KEY=VALUE argument, or KEY with value from stdin/interactive prompt.
-    const parsed = parseKeyValue(keyValue);
+    // Resolve key and value from arguments.
+    // Priority: explicit value arg > KEY=VALUE format > stdin > interactive prompt.
     let key: string;
     let value: string;
     let stdinContent: string | null = null;
 
-    if (parsed) {
-      key = parsed.key;
-      value = parsed.value;
-    } else if (!isStdinTty()) {
-      stdinContent = await readStdin();
-      const resolved = resolveKeyValue(keyValue, stdinContent);
-      if ("error" in resolved) {
-        throw new UserError(resolved.error);
-      }
-      key = resolved.key;
-      value = resolved.value;
-    } else if (cliCtx.outputMode === "log") {
-      key = keyValue;
-      if (key.length === 0) {
-        throw new UserError("Key cannot be empty");
-      }
-      try {
-        value = await readSecretFromTty(`Enter value for ${key}: `);
-      } catch (err) {
-        if (err instanceof Error && err.message === "Cancelled.") {
-          renderVaultPutCancelled(cliCtx.outputMode);
-          return;
-        }
-        throw err;
-      }
+    if (valueArg !== undefined) {
+      // 3-arg form: swamp vault put <vault> <key> <value>
+      key = keyOrKeyValue;
+      value = valueArg;
     } else {
-      const resolved = resolveKeyValue(keyValue, null);
-      if ("error" in resolved) {
-        throw new UserError(resolved.error);
+      // 2-arg form: try KEY=VALUE, then stdin, then interactive prompt.
+      const parsed = parseKeyValue(keyOrKeyValue);
+      if (parsed) {
+        key = parsed.key;
+        value = parsed.value;
+      } else if (!isStdinTty()) {
+        stdinContent = await readStdin();
+        const resolved = resolveKeyValue(keyOrKeyValue, stdinContent);
+        if ("error" in resolved) {
+          throw new UserError(resolved.error);
+        }
+        key = resolved.key;
+        value = resolved.value;
+      } else if (cliCtx.outputMode === "log") {
+        key = keyOrKeyValue;
+        if (key.length === 0) {
+          throw new UserError("Key cannot be empty");
+        }
+        try {
+          value = await readSecretFromTty(`Enter value for ${key}: `);
+        } catch (err) {
+          if (err instanceof Error && err.message === "Cancelled.") {
+            renderVaultPutCancelled(cliCtx.outputMode);
+            return;
+          }
+          throw err;
+        }
+      } else {
+        const resolved = resolveKeyValue(keyOrKeyValue, null);
+        if ("error" in resolved) {
+          throw new UserError(resolved.error);
+        }
+        key = resolved.key;
+        value = resolved.value;
       }
-      key = resolved.key;
-      value = resolved.value;
     }
     cliCtx.logger.debug`Parsed key: ${key}`;
 

--- a/src/cli/commands/vault_put_test.ts
+++ b/src/cli/commands/vault_put_test.ts
@@ -97,10 +97,11 @@ Deno.test("resolveKeyValue - error when no = and no stdin", () => {
   assertEquals("error" in result, true);
 });
 
-Deno.test("resolveKeyValue - error message includes both usage formats", () => {
+Deno.test("resolveKeyValue - error message includes all usage formats", () => {
   const result = resolveKeyValue("MY_KEY", null);
   assertEquals("error" in result, true);
   if ("error" in result) {
+    assertEquals(result.error.includes("MY_KEY <value>"), true);
     assertEquals(result.error.includes("MY_KEY=<value>"), true);
     assertEquals(result.error.includes("echo"), true);
   }


### PR DESCRIPTION
## Summary

- Changed `vault put` argument signature from `<vault_name> <key_value>` to `<vault_name> <key> [value]` so users can pass the secret as a separate positional argument
- When 3 args given, treats arg2 as key and arg3 as value directly (no `KEY=VALUE` parsing needed)
- When 2 args given, maintains full backward compatibility: `KEY=VALUE` format, stdin piping, and interactive prompt all still work
- Updated error message to mention all three input methods including the new 3-arg form

## Test Plan

- [x] All 3564 existing tests pass
- [x] Updated test for new error message format (now mentions `<key> <value>` form)
- [x] `deno check`, `deno lint`, `deno fmt` all clean
- [ ] Manual test: `swamp vault put <vault> KEY value` works
- [ ] Manual test: `swamp vault put <vault> KEY=value` still works (backward compat)
- [ ] Manual test: `echo "value" | swamp vault put <vault> KEY` still works

Closes #880

Co-authored-by: Blake Irvin <bixu@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)