### PR TITLE
feat: add multi-arch Docker image build to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,3 +163,72 @@ jobs:
           repository: systeminit/swamp-uat
           event-type: run-uat
           client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
+
+  docker:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    needs: release
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Download Linux binaries from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p docker-build/linux-amd64 docker-build/linux-arm64
+          # Find the release tag (use latest release since we just created it)
+          LATEST_TAG=$(gh release view --json tagName -q .tagName)
+          echo "Downloading binaries from release ${LATEST_TAG}"
+          gh release download "${LATEST_TAG}" --pattern "swamp-linux-x86_64" --dir docker-build/linux-amd64
+          gh release download "${LATEST_TAG}" --pattern "swamp-linux-aarch64" --dir docker-build/linux-arm64
+          mv docker-build/linux-amd64/swamp-linux-x86_64 docker-build/linux-amd64/swamp
+          mv docker-build/linux-arm64/swamp-linux-aarch64 docker-build/linux-arm64/swamp
+          chmod +x docker-build/linux-amd64/swamp docker-build/linux-arm64/swamp
+          # Extract version from tag for Docker tagging
+          echo "docker_tag=${LATEST_TAG#v}" >> "$GITHUB_ENV"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Copy Dockerfile into build contexts
+        run: |
+          cp Dockerfile docker-build/linux-amd64/
+          cp Dockerfile docker-build/linux-arm64/
+
+      - name: Build and push (amd64)
+        uses: docker/build-push-action@v6
+        with:
+          context: docker-build/linux-amd64
+          platforms: linux/amd64
+          push: true
+          tags: systeminit/swamp:${{ env.docker_tag }}-amd64
+
+      - name: Build and push (arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: docker-build/linux-arm64
+          platforms: linux/arm64
+          push: true
+          tags: systeminit/swamp:${{ env.docker_tag }}-arm64
+
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            -t systeminit/swamp:${{ env.docker_tag }} \
+            systeminit/swamp:${{ env.docker_tag }}-amd64 \
+            systeminit/swamp:${{ env.docker_tag }}-arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM denoland/deno:latest
+COPY swamp /usr/local/bin/swamp
+RUN chmod +x /usr/local/bin/swamp
+WORKDIR /workspace
+ENTRYPOINT ["swamp"]


### PR DESCRIPTION
Build and push linux/amd64 and linux/arm64 Docker images to DockerHub
(systeminit/swamp) on each release, using pre-compiled binaries from
the GitHub Release. Based on denoland/deno for Deno runtime support.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>