### PR TITLE
fix: pin Deno Docker image and pass release version via job outputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
   release:
     name: Build and Release
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     # Only run on merged PRs (not closed without merge) or manual trigger
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
 
@@ -180,18 +182,17 @@ jobs:
       - name: Download Linux binaries from release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ needs.release.outputs.version }}
         run: |
           mkdir -p docker-build/linux-amd64 docker-build/linux-arm64
-          # Find the release tag (use latest release since we just created it)
-          LATEST_TAG=$(gh release view --json tagName -q .tagName)
-          echo "Downloading binaries from release ${LATEST_TAG}"
-          gh release download "${LATEST_TAG}" --pattern "swamp-linux-x86_64" --dir docker-build/linux-amd64
-          gh release download "${LATEST_TAG}" --pattern "swamp-linux-aarch64" --dir docker-build/linux-arm64
+          RELEASE_TAG="v${RELEASE_VERSION}"
+          echo "Downloading binaries from release ${RELEASE_TAG}"
+          gh release download "${RELEASE_TAG}" --pattern "swamp-linux-x86_64" --dir docker-build/linux-amd64
+          gh release download "${RELEASE_TAG}" --pattern "swamp-linux-aarch64" --dir docker-build/linux-arm64
           mv docker-build/linux-amd64/swamp-linux-x86_64 docker-build/linux-amd64/swamp
           mv docker-build/linux-arm64/swamp-linux-aarch64 docker-build/linux-arm64/swamp
           chmod +x docker-build/linux-amd64/swamp docker-build/linux-arm64/swamp
-          # Extract version from tag for Docker tagging
-          echo "docker_tag=${LATEST_TAG#v}" >> "$GITHUB_ENV"
+          echo "docker_tag=${RELEASE_VERSION}" >> "$GITHUB_ENV"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:latest
+FROM denoland/deno:2.7.5
 COPY swamp /usr/local/bin/swamp
 RUN chmod +x /usr/local/bin/swamp
 WORKDIR /workspace


### PR DESCRIPTION
## Summary

- **Pin Dockerfile base image** to `denoland/deno:2.7.5` instead of `:latest` for reproducible, deterministic builds
- **Pass version via job outputs** from the `release` job to the `docker` job instead of querying `gh release view`, which could theoretically return a different release

## Impact

These changes make the release pipeline more deterministic:

1. **Reproducible Docker builds** — Pinning the Deno base image means the same Dockerfile produces the same image regardless of when it's built. Previously, `:latest` meant builds could silently pick up a new Deno version with breaking changes or security issues.

2. **Correct version propagation** — The docker job now receives the exact version from the release job that created it via `needs.release.outputs.version`. Previously, `gh release view` returned the repo's latest release, which could be wrong if a manual release was created between jobs.

## Why this is correct

- The `release` job already computes the version in the `version` step — we simply expose it as a job output
- The `docker` job already declares `needs: release`, so the output is guaranteed to be available
- No behavioral change in the happy path; this only eliminates edge-case failure modes

Addresses review feedback from #882.

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Confirm release workflow still builds and pushes Docker images correctly on next merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)