### PR TITLE
feat: add supply chain attestations to Docker image builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,7 @@ jobs:
     needs: release
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - name: Checkout code
@@ -218,6 +219,8 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: systeminit/swamp:${{ env.docker_tag }}-amd64
+          provenance: mode=max
+          sbom: true
 
       - name: Build and push (arm64)
         uses: docker/build-push-action@v6
@@ -226,6 +229,8 @@ jobs:
           platforms: linux/arm64
           push: true
           tags: systeminit/swamp:${{ env.docker_tag }}-arm64
+          provenance: mode=max
+          sbom: true
 
       - name: Create and push multi-arch manifest
         run: |


### PR DESCRIPTION
## Summary

- Add **SLSA provenance** (`mode=max`) and **SBOM** generation to both amd64 and arm64 Docker image builds
- Add `id-token: write` permission to the docker job for OIDC-signed provenance

## Impact

Docker Hub will now receive full supply chain attestations alongside each image push:

- **Provenance** — cryptographically signed record of what was built, by which workflow, from which commit. Uses GitHub's OIDC token via Sigstore/Fulcio for signing.
- **SBOM** — SPDX software bill of materials generated by BuildKit's built-in scanner

This improves the Docker Hub security score and gives consumers verifiable proof of image origin.

## Why this is safe

The `id-token: write` permission only allows the job to request a short-lived OIDC token from GitHub's token endpoint. It cannot access repo contents, secrets, or the GitHub API. The token is scoped to the workflow run and expires immediately after.

## Test plan

- [ ] Verify CI passes
- [ ] After next release, confirm attestations are visible:
  ```
  docker buildx imagetools inspect systeminit/swamp:<tag> --format '{{json .Provenance}}'
  docker buildx imagetools inspect systeminit/swamp:<tag> --format '{{json .SBOM}}'
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)