### PR TITLE
fix: allow scoped @collective/name in workflow and definition names

### DIFF
--- a/src/domain/definitions/definition.ts
+++ b/src/domain/definitions/definition.ts
@@ -149,12 +149,19 @@ export const DefinitionSchema = z.object({
   ),
   id: z.string().uuid(),
   name: z.string().min(1).refine(
-    (name) =>
-      !name.includes("..") && !name.includes("/") && !name.includes("\\") &&
-      !name.includes("\0"),
+    (name) => {
+      if (name.includes("..") || name.includes("\\") || name.includes("\0")) {
+        return false;
+      }
+      if (name.includes("/")) {
+        // Allow '/' only in scoped @collective/name extension names
+        return /^@[a-z0-9_-]+\/[a-z0-9_-]+(\/[a-z0-9_-]+)*$/.test(name);
+      }
+      return true;
+    },
     {
       message:
-        "Definition name must not contain '..', '/', '\\', or null bytes (path traversal)",
+        "Definition name must not contain '..', '\\', or null bytes (path traversal). '/' is only allowed in scoped @collective/name patterns.",
     },
   ),
   version: z.number().int().positive(),

--- a/src/domain/definitions/definition_test.ts
+++ b/src/domain/definitions/definition_test.ts
@@ -140,6 +140,33 @@ Deno.test("Definition.create throws on name with null bytes", () => {
   );
 });
 
+// Scoped @collective/name tests
+
+Deno.test("Definition.create accepts scoped @collective/name", () => {
+  const def = Definition.create({ name: "@john/pod-inventory" });
+  assertEquals(def.name, "@john/pod-inventory");
+});
+
+Deno.test("Definition.create accepts scoped name with multiple segments", () => {
+  const def = Definition.create({ name: "@swamp/aws/ec2" });
+  assertEquals(def.name, "@swamp/aws/ec2");
+});
+
+Deno.test("Definition.create rejects malformed scoped names", () => {
+  assertThrows(
+    () => Definition.create({ name: "@/" }),
+    Error,
+  );
+  assertThrows(
+    () => Definition.create({ name: "@scope/" }),
+    Error,
+  );
+  assertThrows(
+    () => Definition.create({ name: "@UPPER/case" }),
+    Error,
+  );
+});
+
 Deno.test("Definition.create throws on invalid version", () => {
   assertThrows(
     () => Definition.create({ name: "test", version: 0 }),

--- a/src/domain/workflows/workflow.ts
+++ b/src/domain/workflows/workflow.ts
@@ -39,12 +39,19 @@ import {
 export const WorkflowSchema = z.object({
   id: z.string().uuid(),
   name: z.string().min(1).refine(
-    (name) =>
-      !name.includes("..") && !name.includes("/") && !name.includes("\\") &&
-      !name.includes("\0"),
+    (name) => {
+      if (name.includes("..") || name.includes("\\") || name.includes("\0")) {
+        return false;
+      }
+      if (name.includes("/")) {
+        // Allow '/' only in scoped @collective/name extension names
+        return /^@[a-z0-9_-]+\/[a-z0-9_-]+(\/[a-z0-9_-]+)*$/.test(name);
+      }
+      return true;
+    },
     {
       message:
-        "Workflow name must not contain '..', '/', '\\', or null bytes (path traversal)",
+        "Workflow name must not contain '..', '\\', or null bytes (path traversal). '/' is only allowed in scoped @collective/name patterns.",
     },
   ),
   description: z.string().optional(),

--- a/src/domain/workflows/workflow_test.ts
+++ b/src/domain/workflows/workflow_test.ts
@@ -439,6 +439,33 @@ Deno.test("Workflow.create rejects path traversal even without jobs", () => {
   );
 });
 
+// Scoped @collective/name tests
+
+Deno.test("Workflow.create accepts scoped @collective/name", () => {
+  const workflow = Workflow.create({ name: "@john/pod-inventory" });
+  assertEquals(workflow.name, "@john/pod-inventory");
+});
+
+Deno.test("Workflow.create accepts scoped name with multiple segments", () => {
+  const workflow = Workflow.create({ name: "@swamp/aws/ec2" });
+  assertEquals(workflow.name, "@swamp/aws/ec2");
+});
+
+Deno.test("Workflow.create rejects malformed scoped names", () => {
+  assertThrows(
+    () => Workflow.create({ name: "@/" }),
+    Error,
+  );
+  assertThrows(
+    () => Workflow.create({ name: "@scope/" }),
+    Error,
+  );
+  assertThrows(
+    () => Workflow.create({ name: "@UPPER/case" }),
+    Error,
+  );
+});
+
 // Driver field tests
 
 Deno.test("Workflow.create defaults driver to undefined", () => {


### PR DESCRIPTION
## Summary

Extension workflows using scoped names like `@john/pod-inventory` were rejected
at load time with a path traversal error because the `WorkflowSchema` and
`DefinitionSchema` name validation unconditionally rejected any name containing
`/`. The `/` in scoped `@collective/name` patterns is a namespace separator, not
a path traversal vector.

**Root cause:** The Zod refinement on the `name` field in both `WorkflowSchema`
(`src/domain/workflows/workflow.ts:41-44`) and `DefinitionSchema`
(`src/domain/definitions/definition.ts:151-154`) used a flat blocklist:

```typescript
!name.includes("..") && !name.includes("/") && !name.includes("\\") && !name.includes("\0")
```

This blocked all `/` characters, including legitimate ones in scoped extension
names like `@john/pod-inventory` or `@swamp/aws/ec2`.

**Fix:** Updated the inline validation in both schemas to allow `/` only when
the full name matches the established `SCOPED_NAME_PATTERN`
(`^@[a-z0-9_-]+\/[a-z0-9_-]+(\/[a-z0-9_-]+)*$`), which is the same regex used
in `extension_manifest.ts`. Unscoped names containing `/` (e.g. `a/b`,
`/etc/passwd`) are still rejected. The `data_metadata.ts` validation is
intentionally unchanged — data artifact names are internal and should not use
scoped patterns.

**Changes:**
- `src/domain/workflows/workflow.ts` — Updated name validation refinement
- `src/domain/definitions/definition.ts` — Updated name validation refinement
- `src/domain/workflows/workflow_test.ts` — Added tests for scoped name
  acceptance and malformed scoped name rejection
- `src/domain/definitions/definition_test.ts` — Same test additions

**Verified end-to-end:** compiled binary, `swamp repo init`, `swamp extension
pull @john/k8s`, `swamp workflow search pod` — all 13 workflows load without
warnings.

## Test Plan

- [x] Existing path traversal rejection tests pass (`..'`, unscoped `/`, `\`, null bytes)
- [x] New tests: scoped `@collective/name` accepted (`@john/pod-inventory`, `@swamp/aws/ec2`)
- [x] New tests: malformed scoped names rejected (`@/`, `@scope/`, `@UPPER/case`)
- [x] Full test suite: 3592 tests pass
- [x] `deno check`, `deno lint`, `deno fmt` all clean
- [x] E2E: compiled binary, pulled `@john/k8s`, all 13 workflows load correctly

Fixes #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)