### PR TITLE
fix: pin third-party actions and trust docker publisher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check for changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
         with:
           filters: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,7 @@ jobs:
           } >> /tmp/release_body.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: swamp ${{ steps.version.outputs.version }}
@@ -159,7 +159,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Trigger UAT
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           token: ${{ secrets.UAT_TRIGGER_TOKEN }}
           repository: systeminit/swamp-uat

--- a/scripts/audit_actions.ts
+++ b/scripts/audit_actions.ts
@@ -58,6 +58,7 @@ const TRUSTED_PUBLISHERS = new Set([
   "actions",
   "anthropics",
   "denoland",
+  "docker",
   "github",
 ]);
 


### PR DESCRIPTION
## Summary

- Pin `dorny/paths-filter`, `softprops/action-gh-release`, and `peter-evans/repository-dispatch` to full commit SHAs for supply chain security
- Add `docker` to `TRUSTED_PUBLISHERS` in `scripts/audit_actions.ts` so `docker/*` actions are accepted with tag-only pins

## Test Plan

- `deno fmt --check`, `deno lint`, and `deno run test` all pass
- CI security review should no longer flag unpinned third-party actions