### PR TITLE
ci: add JSR publish workflow for @systeminit/swamp-lib

### DIFF
--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -12,31 +12,34 @@ concurrency:
   group: publish-client
   cancel-in-progress: false
 
-permissions:
-  contents: read
-  id-token: write
-
 jobs:
   publish:
     name: Publish to JSR
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
 
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           ref: main
+          fetch-depth: 0
 
       - name: Setup Deno
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: v2.x
 
       - name: Generate version
         id: version
         run: |
-          # Semantic version derived from date: MAJOR.YYYYMMDD.PATCH
+          # Version: 0.YYYYMMDD.N where N is the total commit count touching
+          # packages/client. This produces a monotonically increasing semver
+          # since N never resets (it's a lifetime count, not per-day).
           VERSION="0.$(date -u +%Y%m%d).$(git rev-list --count HEAD -- packages/client)"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Version: $VERSION"
@@ -45,7 +48,6 @@ jobs:
         working-directory: packages/client
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          # Update version in deno.json
           deno eval "
             const config = JSON.parse(await Deno.readTextFile('deno.json'));
             config.version = '${VERSION}';


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that publishes the `@systeminit/swamp-lib` client package to JSR when files in `packages/client/` change on merge to main.

- Uses Deno's OIDC token auth (no secrets needed — JSR trusts GitHub Actions)
- Auto-generates semver from date + commit count: `0.YYYYMMDD.N`
- Runs type check + tests before publishing
- Also supports `workflow_dispatch` for manual publishing

## Test plan

- [ ] Workflow triggers on merge with `packages/client/` changes
- [ ] Version stamp produces valid semver
- [ ] `deno publish` succeeds with OIDC auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)