### PR TITLE
fix: forward driver onLog output as method_output events

### DIFF
--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -650,7 +650,14 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
           "model.type": context.modelType.normalized,
         }, () =>
           driver.execute(executionRequest, {
-            onLog: (line) => context.logger?.info(line),
+            onLog: (line) => {
+              context.logger?.info(line);
+              context.onEvent?.({
+                type: "output",
+                stream: "stdout",
+                line,
+              });
+            },
           }));
 
         if (driverResult.status === "error") {


### PR DESCRIPTION
## Summary

Out-of-process execution drivers (Tensorlake, Docker, etc.) emit log lines via `callbacks.onLog`, but these were only forwarded to the logger — not through the `onEvent` stream. This meant WebSocket clients using `swamp serve` never received `method_output` events from these drivers.

Now `onLog` also emits `MethodExecutionEvent { type: "output" }` so the output appears in the event stream alongside in-process output.

## Test plan

- [x] Tensorlake driver output appears in WebSocket event stream
- [x] Existing forEach tests pass (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)