### PR TITLE
fix: quote --allowedTools in issue-triage workflow

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -161,7 +161,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
             --model claude-opus-4-5-20251101
-            --allowedTools Read,Glob,Grep,Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh api --method POST:*/reactions),Bash(gh api --method PATCH:*/comments/*)
+            --allowedTools 'Read,Glob,Grep,Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh api --method POST:*/reactions),Bash(gh api --method PATCH:*/comments/*)'
 
       - name: Add completion reaction
         if: success()


### PR DESCRIPTION
## Summary

- Fix `/triage` command failure caused by `shell-quote` parsing of unquoted `Bash(...)` patterns in `claude_args`
- Wraps the `--allowedTools` value in single quotes so spaces and parentheses are preserved as a single token

## Root Cause

`claude-code-action` uses `shell-quote` to parse `claude_args`. The `Bash(...)` patterns added in #852 contain spaces (e.g. `Bash(gh api --method POST:*/reactions)`), which caused:
1. Parentheses treated as shell operators and stripped
2. Space-splitting broke patterns into separate tokens
3. `--method` parsed as a standalone CLI flag, corrupting the entire argument structure
4. Claude Code crashed with exit code 1

Confirmed by workflow logs from the failed #902 triage — allowed tools were `["Read", "Glob", "Grep", "Bash", "gh", "issue", "api"]` instead of the intended patterns.

Fixes #904

## Test plan

- [ ] Re-run `/triage` on #902 after merge and verify it completes successfully
- [ ] Verify the workflow logs show the correct `Bash(...)` patterns in `allowedTools`

🤖 Generated with [Claude Code](https://claude.com/claude-code)