### PR TITLE
feat: add documentation staleness checks to issue-lifecycle skill

### DIFF
--- a/.claude/skills/issue-lifecycle/SKILL.md
+++ b/.claude/skills/issue-lifecycle/SKILL.md
@@ -88,7 +88,14 @@ systeminit/swamp#850":
      --input-file /tmp/plan.yaml --json
    ```
 
-6. **Show the plan to the human**, then **run adversarial review** (see below).
+6. **Check for documentation impact.** Before presenting the plan, evaluate
+   whether the change affects anything described in `design/*.md` or
+   `.claude/skills/`. If so, include explicit plan steps to update those files.
+   Common triggers: new domain concepts, changed CLI commands or flags, new
+   extension patterns, modified architectural decisions, renamed types or
+   methods referenced in skill examples.
+
+7. **Show the plan to the human**, then **run adversarial review** (see below).
 
 ## Adversarial Plan Review
 
@@ -111,6 +118,12 @@ Re-read the plan, then critically evaluate it across these dimensions:
   unnecessary abstractions or indirections?
 - **Correctness**: Will this actually solve the problem? Are there logical gaps?
   Does the approach match established patterns in the codebase?
+- **Documentation**: Does this change introduce or modify domain concepts, CLI
+  commands, extension patterns, or architectural decisions that should be
+  reflected in `design/*.md` or `.claude/skills/`? If a design doc describes
+  behavior this plan changes, the plan must include a step to update it. If a
+  skill references CLI commands or examples affected by this change, the plan
+  must include a step to update the skill. Flag any gaps as findings.
 
 ### Step 2: Verify against the codebase
 
@@ -122,6 +135,10 @@ For each plan step, **read the actual code**:
 - Check for conflicts with existing patterns or naming conventions
 - Verify that proposed test paths and test patterns match the codebase
 - Look for code that already does what a step proposes (duplication risk)
+- Check if design docs in `design/` describe behavior being changed — flag stale
+  docs
+- Check if skills in `.claude/skills/` reference commands, flags, or examples
+  affected by the plan — flag stale skills
 
 ### Step 3: Record findings
 
@@ -152,7 +169,8 @@ Each finding must have:
 
 - `id`: Sequential identifier (ADV-1, ADV-2, ...)
 - `severity`: critical, high, medium, or low
-- `category`: architecture, scope, risk, testing, complexity, or correctness
+- `category`: architecture, scope, risk, testing, complexity, correctness, or
+  documentation
 - `description`: Clear explanation of the concern
 
 **Critical/high findings block approval.** Medium/low are shown as warnings.


### PR DESCRIPTION
## Summary

- Adds a **documentation impact check** as a new planning step (step 6) in the issue-lifecycle skill, requiring plans to evaluate whether changes affect `design/*.md` or `.claude/skills/` and include update steps if so
- Adds **"Documentation"** as a new adversarial review dimension alongside architecture, scope, risk, testing, complexity, and correctness
- Adds **stale doc/skill verification** to the codebase verification checklist, so the adversarial reviewer actively checks referenced design docs and skills against planned changes
- Adds **`documentation`** as a valid finding category for adversarial review findings

## Why

Design docs and skills drift out of sync with the codebase when PRs change behavior without updating the documentation that describes it. This is hard to catch after the fact because the people making changes have the context at planning time but not later. By embedding the check into the issue-lifecycle adversarial review — which already blocks approval on unresolved findings — we catch documentation gaps before code is written, when the fix is cheap.

## Impact

Every issue triaged through the issue-lifecycle model will now have documentation impact evaluated at two points:
1. **Planning** — the plan must include doc/skill update steps if the change warrants them
2. **Adversarial review** — gaps are flagged as findings that block approval if severity is high/critical

This is a skill-only change with no code changes. It modifies the instructions that guide Claude's behavior during issue triage and plan review.

## Test plan

- [ ] Triage a test issue that changes CLI behavior and verify the plan includes a skill update step
- [ ] Triage a test issue that changes domain concepts and verify the adversarial review flags missing design doc updates
- [ ] Triage a trivial bug fix and verify no false-positive documentation findings are raised

🤖 Generated with [Claude Code](https://claude.com/claude-code)