### PR TITLE
fix: scope extractModelType() to model export to avoid string literal false positives

### DIFF
--- a/src/domain/extensions/extension_content_extractor.ts
+++ b/src/domain/extensions/extension_content_extractor.ts
@@ -177,6 +177,10 @@ function extractModelFromSource(
 /**
  * Extracts the model type string.
  * Matches `ModelType.create("...")` or `type: "..."` patterns.
+ *
+ * Scopes the `type:` literal search to the `export const model = { ... }`
+ * object body to avoid false positives from string literals elsewhere in
+ * the file (e.g. embedded LLM prompts containing `type: "anime"`).
  */
 function extractModelType(content: string): string | null {
   // Match ModelType.create("type-name") or ModelType.create('type-name')
@@ -185,10 +189,16 @@ function extractModelType(content: string): string | null {
   );
   if (modelTypeMatch) return modelTypeMatch[1];
 
-  // Match type: "type-name" or type: 'type-name' in object literal
-  const typeLiteralMatch = content.match(
-    /type:\s*["']([^"']+)["']/,
-  );
+  // Scope the type: search to the model export object body to avoid matching
+  // type: patterns inside string literals elsewhere in the file.
+  const modelExportMatch = content.match(/export\s+const\s+model\s*=\s*\{/);
+  if (!modelExportMatch || modelExportMatch.index === undefined) return null;
+
+  const bodyStart = modelExportMatch.index + modelExportMatch[0].length;
+  const body = extractBalancedBraces(content, bodyStart);
+  if (!body) return null;
+
+  const typeLiteralMatch = body.match(/type:\s*["']([^"']+)["']/);
   if (typeLiteralMatch) return typeLiteralMatch[1];
 
   return null;

--- a/src/domain/extensions/extension_content_extractor_test.ts
+++ b/src/domain/extensions/extension_content_extractor_test.ts
@@ -1471,3 +1471,80 @@ Deno.test("extractContentMetadata: extracts methods from variable reference", as
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
+
+Deno.test("extractContentMetadata: ignores type: inside string literal before model export", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const modelsDir = join(tmpDir, "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+
+    const modelFile = join(modelsDir, "organizer.ts");
+    await Deno.writeTextFile(
+      modelFile,
+      [
+        'import { z } from "npm:zod@4";',
+        "",
+        "// A const string that contains type: before the model export",
+        'const PROMPT = "For Anime (type: \\"anime\\"):\\n" +',
+        '  "List episodes by season.";',
+        "",
+        "export const model = {",
+        '  type: "@keeb/mms/organizer",',
+        '  version: "2026.03.01.1",',
+        "  methods: {",
+        "    organize: {",
+        '      description: "Organize media",',
+        "      arguments: z.object({}),",
+        "      execute: async () => ({ dataHandles: [] }),",
+        "    },",
+        "  },",
+        "};",
+      ].join("\n"),
+    );
+
+    const result = await extractContentMetadata([modelFile], modelsDir, []);
+    assertEquals(result.models.length, 1);
+    assertEquals(result.models[0].type, "@keeb/mms/organizer");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extractContentMetadata: ignores type: inside template literal in method", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const modelsDir = join(tmpDir, "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+
+    const modelFile = join(modelsDir, "organizer2.ts");
+    await Deno.writeTextFile(
+      modelFile,
+      [
+        'import { z } from "npm:zod@4";',
+        "",
+        "export const model = {",
+        '  type: "@keeb/mms/organizer",',
+        '  version: "2026.03.01.1",',
+        "  methods: {",
+        "    organize: {",
+        '      description: "Organize media",',
+        "      arguments: z.object({}),",
+        "      execute: async () => {",
+        "        const prompt = `",
+        '**For Anime (type: "anime"):**',
+        "List episodes by season.`,",
+        "        return { dataHandles: [] };",
+        "      },",
+        "    },",
+        "  },",
+        "};",
+      ].join("\n"),
+    );
+
+    const result = await extractContentMetadata([modelFile], modelsDir, []);
+    assertEquals(result.models.length, 1);
+    assertEquals(result.models[0].type, "@keeb/mms/organizer");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Scopes the `type: "..."` regex fallback in `extractModelType()` to only search within the `export const model = { ... }` object body, preventing false positives from string literals elsewhere in the file (e.g. embedded LLM prompts containing `type: "anime"`)
- Adds two test cases covering string literals before the model export and template literals inside methods

Fixes #915

## Test Plan

- [x] New test: string literal containing `type: "anime"` before model export — correct type extracted
- [x] New test: template literal containing `type: "anime"` inside method — correct type extracted
- [x] All 37 content extractor tests pass
- [x] Full test suite passes (3682 tests)
- [x] `deno check`, `deno lint`, `deno fmt` clean
- [x] `deno run compile` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)