### PR TITLE
fix: centralize S3 connection config to fix missing endpoint/forcePathStyle

### DIFF
--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -330,13 +330,7 @@ export function requireInitializedRepo(
       await ensureDir(datastoreConfig.cachePath);
 
       // Share a single S3Client for both lock and sync service
-      const s3 = new S3Client({
-        bucket: datastoreConfig.bucket,
-        prefix: datastoreConfig.prefix,
-        region: datastoreConfig.region,
-        endpoint: datastoreConfig.endpoint,
-        forcePathStyle: datastoreConfig.forcePathStyle,
-      });
+      const s3 = new S3Client(datastoreConfig);
 
       const lock = new S3Lock(s3);
       const syncService = new S3CacheSyncService(s3, datastoreConfig.cachePath);
@@ -475,11 +469,7 @@ export function createModelLock(
     return provider.createLock(config.datastorePath, { lockKey });
   }
   if (config.type === "s3") {
-    const s3 = new S3Client({
-      bucket: config.bucket,
-      prefix: config.prefix,
-      region: config.region,
-    });
+    const s3 = new S3Client(config);
     return new S3Lock(s3, { lockKey });
   }
   return new FileLock(config.path, { lockKey });
@@ -649,11 +639,7 @@ export async function acquireModelLocks(
   // For S3 datastores, create a shared sync service for model-scoped pulls
   let s3SyncService: S3CacheSyncService | undefined;
   if (!isCustomDatastoreConfig(config) && config.type === "s3") {
-    const s3 = new S3Client({
-      bucket: config.bucket,
-      prefix: config.prefix,
-      region: config.region,
-    });
+    const s3 = new S3Client(config);
     s3SyncService = new S3CacheSyncService(s3, config.cachePath);
   }
 
@@ -836,11 +822,7 @@ export function createDatastoreLock(config: DatastoreConfig): DistributedLock {
     return provider.createLock(config.datastorePath);
   }
   if (config.type === "s3") {
-    const s3 = new S3Client({
-      bucket: config.bucket,
-      prefix: config.prefix,
-      region: config.region,
-    });
+    const s3 = new S3Client(config);
     return new S3Lock(s3);
   }
   return new FileLock(config.path);

--- a/src/domain/datastore/datastore_config.ts
+++ b/src/domain/datastore/datastore_config.ts
@@ -69,11 +69,12 @@ export interface FilesystemDatastoreConfig {
 }
 
 /**
- * S3-based datastore configuration.
- * Data is cached locally and synced to S3.
+ * Value object: S3 connection parameters.
+ *
+ * Centralizes the fields needed to connect to an S3-compatible object store
+ * so that adding a new connection parameter requires updating only this type.
  */
-export interface S3DatastoreConfig {
-  readonly type: "s3";
+export interface S3ConnectionConfig {
   /** S3 bucket name */
   readonly bucket: string;
   /** Key prefix within the bucket */
@@ -84,6 +85,14 @@ export interface S3DatastoreConfig {
   readonly endpoint?: string;
   /** Use path-style addressing (bucket in path, not subdomain). Default: false. */
   readonly forcePathStyle?: boolean;
+}
+
+/**
+ * S3-based datastore configuration.
+ * Data is cached locally and synced to S3.
+ */
+export interface S3DatastoreConfig extends S3ConnectionConfig {
+  readonly type: "s3";
   /** Local cache directory path (defaults to ~/.swamp/repos/{repoId}/) */
   readonly cachePath: string;
   /** Which subdirectories belong to the datastore (defaults to DEFAULT_DATASTORE_SUBDIRS) */

--- a/src/infrastructure/persistence/s3_client.ts
+++ b/src/infrastructure/persistence/s3_client.ts
@@ -30,16 +30,7 @@ import {
   PutObjectCommand,
   S3Client as AwsS3Client,
 } from "@aws-sdk/client-s3";
-
-export interface S3ClientConfig {
-  bucket: string;
-  prefix?: string;
-  region?: string;
-  /** Custom S3-compatible endpoint URL (e.g., https://nyc3.digitaloceanspaces.com) */
-  endpoint?: string;
-  /** Use path-style addressing (bucket in path, not subdomain). Default: false. */
-  forcePathStyle?: boolean;
-}
+import type { S3ConnectionConfig } from "../../domain/datastore/datastore_config.ts";
 
 export interface S3ListResult {
   keys: string[];
@@ -55,7 +46,7 @@ export class S3Client {
   private readonly bucket: string;
   private readonly prefix: string;
 
-  constructor(config: S3ClientConfig) {
+  constructor(config: S3ConnectionConfig) {
     this.client = new AwsS3Client({
       region: config.region,
       ...(config.endpoint ? { endpoint: config.endpoint } : {}),

--- a/src/infrastructure/persistence/s3_client_test.ts
+++ b/src/infrastructure/persistence/s3_client_test.ts
@@ -1,0 +1,61 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertExists } from "@std/assert";
+import type { S3ConnectionConfig } from "../../domain/datastore/datastore_config.ts";
+import type { S3DatastoreConfig } from "../../domain/datastore/datastore_config.ts";
+import { S3Client } from "./s3_client.ts";
+
+Deno.test("S3Client: accepts S3ConnectionConfig", () => {
+  const config: S3ConnectionConfig = {
+    bucket: "my-bucket",
+    prefix: "my-prefix",
+    region: "us-west-2",
+    endpoint: "https://nyc3.digitaloceanspaces.com",
+    forcePathStyle: true,
+  };
+
+  const client = new S3Client(config);
+  assertExists(client);
+});
+
+Deno.test("S3Client: accepts S3DatastoreConfig via structural subtyping", () => {
+  const config: S3DatastoreConfig = {
+    type: "s3",
+    bucket: "my-bucket",
+    prefix: "my-prefix",
+    region: "us-west-2",
+    endpoint: "https://nyc3.digitaloceanspaces.com",
+    forcePathStyle: true,
+    cachePath: "/tmp/cache",
+  };
+
+  // S3DatastoreConfig extends S3ConnectionConfig, so this compiles
+  const client = new S3Client(config);
+  assertExists(client);
+});
+
+Deno.test("S3Client: accepts minimal config with only bucket", () => {
+  const config: S3ConnectionConfig = {
+    bucket: "my-bucket",
+  };
+
+  const client = new S3Client(config);
+  assertExists(client);
+});

--- a/src/infrastructure/persistence/s3_datastore_verifier.ts
+++ b/src/infrastructure/persistence/s3_datastore_verifier.ts
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import type { S3ConnectionConfig } from "../../domain/datastore/datastore_config.ts";
 import type {
   DatastoreHealthResult,
   DatastoreVerifier,
@@ -33,21 +34,9 @@ export class S3DatastoreVerifier implements DatastoreVerifier {
   private readonly s3: S3Client;
   private readonly bucket: string;
 
-  constructor(
-    bucket: string,
-    prefix?: string,
-    region?: string,
-    endpoint?: string,
-    forcePathStyle?: boolean,
-  ) {
-    this.bucket = bucket;
-    this.s3 = new S3Client({
-      bucket,
-      prefix,
-      region,
-      endpoint,
-      forcePathStyle,
-    });
+  constructor(config: S3ConnectionConfig) {
+    this.bucket = config.bucket;
+    this.s3 = new S3Client(config);
   }
 
   async verify(): Promise<DatastoreHealthResult> {

--- a/src/libswamp/datastores/setup.ts
+++ b/src/libswamp/datastores/setup.ts
@@ -22,6 +22,7 @@ import { join } from "@std/path";
 import {
   type FilesystemDatastoreConfig,
   getDatastoreDirectories,
+  type S3ConnectionConfig,
 } from "../../domain/datastore/datastore_config.ts";
 import {
   migrateDatastore,
@@ -85,18 +86,10 @@ export interface DatastoreSetupDeps {
     path: string,
   ) => Promise<{ healthy: boolean; message: string }>;
   verifyS3: (
-    bucket: string,
-    prefix?: string,
-    region?: string,
-    endpoint?: string,
-    forcePathStyle?: boolean,
+    config: S3ConnectionConfig,
   ) => Promise<{ healthy: boolean; message: string }>;
   checkS3DatastoreExists: (
-    bucket: string,
-    prefix?: string,
-    region?: string,
-    endpoint?: string,
-    forcePathStyle?: boolean,
+    config: S3ConnectionConfig,
   ) => Promise<boolean>;
   ensureDir: (path: string) => Promise<void>;
   getDatastoreDirectories: (config: {
@@ -124,12 +117,8 @@ export interface DatastoreSetupDeps {
     datastoreConfig: Record<string, unknown>,
   ) => Promise<void>;
   pushAllToS3: (
-    bucket: string,
-    prefix: string | undefined,
-    region: string | undefined,
+    config: S3ConnectionConfig,
     cachePath: string,
-    endpoint?: string,
-    forcePathStyle?: boolean,
   ) => Promise<number>;
   getSwampDataDir: () => string;
   getCachePath: (repoId: string) => string;
@@ -274,14 +263,17 @@ export async function* datastoreSetupS3(
         return;
       }
 
+      // Build connection config once from input
+      const s3Conn: S3ConnectionConfig = {
+        bucket: input.bucket,
+        prefix: input.prefix,
+        region: input.region,
+        endpoint: input.endpoint,
+        forcePathStyle: input.forcePathStyle,
+      };
+
       // Verify S3 bucket is accessible
-      const health = await deps.verifyS3(
-        input.bucket,
-        input.prefix,
-        input.region,
-        input.endpoint,
-        input.forcePathStyle,
-      );
+      const health = await deps.verifyS3(s3Conn);
       if (!health.healthy) {
         yield {
           kind: "error",
@@ -294,13 +286,7 @@ export async function* datastoreSetupS3(
       }
 
       // Check if this S3 location already has datastore data
-      const exists = await deps.checkS3DatastoreExists(
-        input.bucket,
-        input.prefix,
-        input.region,
-        input.endpoint,
-        input.forcePathStyle,
-      );
+      const exists = await deps.checkS3DatastoreExists(s3Conn);
       if (exists) {
         const prefixStr = input.prefix ?? "";
         yield {
@@ -354,14 +340,7 @@ export async function* datastoreSetupS3(
         // Push cache to S3
         ctx.logger.debug`Pushing data to S3...`;
         try {
-          filesPushed = await deps.pushAllToS3(
-            input.bucket,
-            input.prefix,
-            input.region,
-            cachePath,
-            input.endpoint,
-            input.forcePathStyle,
-          );
+          filesPushed = await deps.pushAllToS3(s3Conn, cachePath);
           ctx.logger.debug`Pushed ${filesPushed} file(s) to S3`;
         } catch (error) {
           errors.push(
@@ -455,36 +434,12 @@ export function createDatastoreSetupDeps(
       const verifier = new FilesystemDatastoreVerifier(path);
       return await verifier.verify();
     },
-    verifyS3: async (
-      bucket: string,
-      prefix?: string,
-      region?: string,
-      endpoint?: string,
-      forcePathStyle?: boolean,
-    ) => {
-      const verifier = new S3DatastoreVerifier(
-        bucket,
-        prefix,
-        region,
-        endpoint,
-        forcePathStyle,
-      );
+    verifyS3: async (config) => {
+      const verifier = new S3DatastoreVerifier(config);
       return await verifier.verify();
     },
-    checkS3DatastoreExists: async (
-      bucket: string,
-      prefix?: string,
-      region?: string,
-      endpoint?: string,
-      forcePathStyle?: boolean,
-    ) => {
-      const s3 = new S3Client({
-        bucket,
-        prefix,
-        region,
-        endpoint,
-        forcePathStyle,
-      });
+    checkS3DatastoreExists: async (config) => {
+      const s3 = new S3Client(config);
       try {
         await s3.getObject(".datastore-index.json");
         return true;
@@ -529,21 +484,8 @@ export function createDatastoreSetupDeps(
         await markerRepo.write(repoPath, marker);
       }
     },
-    pushAllToS3: async (
-      bucket: string,
-      prefix: string | undefined,
-      region: string | undefined,
-      cachePath: string,
-      endpoint?: string,
-      forcePathStyle?: boolean,
-    ) => {
-      const s3 = new S3Client({
-        bucket,
-        prefix,
-        region,
-        endpoint,
-        forcePathStyle,
-      });
+    pushAllToS3: async (config, cachePath) => {
+      const s3 = new S3Client(config);
       const syncService = new S3CacheSyncService(s3, cachePath);
       return await syncService.pushAll();
     },

--- a/src/libswamp/datastores/status.ts
+++ b/src/libswamp/datastores/status.ts
@@ -83,13 +83,7 @@ export function createDatastoreStatusDeps(
         const verifier = new FilesystemDatastoreVerifier(config.path);
         return await verifier.verify();
       } else {
-        const verifier = new S3DatastoreVerifier(
-          config.bucket,
-          config.prefix,
-          config.region,
-          config.endpoint,
-          config.forcePathStyle,
-        );
+        const verifier = new S3DatastoreVerifier(config);
         return await verifier.verify();
       }
     },

--- a/src/libswamp/datastores/sync.ts
+++ b/src/libswamp/datastores/sync.ts
@@ -118,13 +118,7 @@ export function createDatastoreSyncDeps(
     );
   }
 
-  const s3 = new S3Client({
-    bucket: config.bucket,
-    prefix: config.prefix,
-    region: config.region,
-    endpoint: config.endpoint,
-    forcePathStyle: config.forcePathStyle,
-  });
+  const s3 = new S3Client(config);
   const syncService = new S3CacheSyncService(s3, config.cachePath);
 
   return {


### PR DESCRIPTION
## Summary

- Introduce `S3ConnectionConfig` value object in the domain layer to
  centralize S3 connection parameters (bucket, prefix, region, endpoint,
  forcePathStyle) in one type
- `S3DatastoreConfig` now extends `S3ConnectionConfig`, eliminating field
  duplication
- Fix bug where `createModelLock`, `acquireModelLocks`, and
  `createDatastoreLock` silently dropped `endpoint` and `forcePathStyle`,
  breaking S3-compatible object stores (DigitalOcean Spaces, MinIO, etc.)
  for per-model locking and breakglass commands
- Replace primitive-obsession signatures on `S3DatastoreVerifier` and
  `DatastoreSetupDeps` with `S3ConnectionConfig`, so adding a new
  connection parameter only requires updating one type

## Test Plan

- [x] New tests: S3Client accepts S3ConnectionConfig, S3DatastoreConfig
  (structural subtyping), and minimal config
- [x] Existing setup, sync, and repo_context tests pass unchanged
- [x] Full test suite passes (3685 tests)
- [x] `deno check`, `deno lint`, `deno fmt` clean
- [x] `deno run compile` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)