### PR TITLE
fix: address review feedback on S3 datastore extension migration

### DIFF
--- a/src/cli/commands/datastore_setup.ts
+++ b/src/cli/commands/datastore_setup.ts
@@ -96,7 +96,7 @@ const datastoreSetupExtensionCommand = new Command()
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option(
     "--config <config:string>",
-    "JSON configuration for the datastore extension",
+    'JSON config object for the extension (e.g., \'{"bucket":"name","region":"us-east-1"}\')',
     { required: true },
   )
   .option("--skip-migration", "Skip migrating existing data")
@@ -111,9 +111,15 @@ const datastoreSetupExtensionCommand = new Command()
     const renamedTo = RENAMED_DATASTORE_TYPES[type];
     const resolvedType = renamedTo ?? type;
 
-    // Auto-resolve the extension if needed
+    // Auto-resolve the extension if needed — catch network errors so
+    // the registry check below produces a clean UserError instead of
+    // an opaque stack trace.
     if (resolvedType.startsWith("@")) {
-      await resolveDatastoreType(resolvedType, getAutoResolver());
+      try {
+        await resolveDatastoreType(resolvedType, getAutoResolver());
+      } catch {
+        // Fall through to the registry check which has a user-friendly error
+      }
     }
 
     if (!datastoreTypeRegistry.has(resolvedType)) {
@@ -153,8 +159,24 @@ const datastoreSetupExtensionCommand = new Command()
     );
   });
 
+const datastoreSetupS3DeprecatedCommand = new Command()
+  .description(
+    "(Removed) Use: swamp datastore setup extension @swamp/s3-datastore --config '{...}'",
+  )
+  .arguments("[...args:string]")
+  .action(() => {
+    throw new UserError(
+      `The "datastore setup s3" command has been removed.\n\n` +
+        `S3 datastores are now provided by the @swamp/s3-datastore extension.\n` +
+        `Use the new generic command instead:\n\n` +
+        `  swamp datastore setup extension @swamp/s3-datastore \\\n` +
+        `    --config '{"bucket":"my-bucket","region":"us-east-1"}'`,
+    );
+  });
+
 /** Configure a datastore for this repository. */
 export const datastoreSetupCommand = new Command()
   .description("Configure a datastore for this repository")
   .command("filesystem", datastoreSetupFilesystemCommand)
-  .command("extension", datastoreSetupExtensionCommand);
+  .command("extension", datastoreSetupExtensionCommand)
+  .command("s3", datastoreSetupS3DeprecatedCommand);

--- a/src/domain/datastore/datastore_sync_service.ts
+++ b/src/domain/datastore/datastore_sync_service.ts
@@ -20,8 +20,8 @@
 /**
  * Interface for datastore synchronization services.
  *
- * Extracted from S3CacheSyncService to allow user-defined datastores
- * to provide their own sync implementations.
+ * Extension datastores implement this interface to provide
+ * bidirectional sync between a local cache and a remote backend.
  */
 export interface DatastoreSyncService {
   /** Pull changed files from the remote datastore to the local cache. */

--- a/src/infrastructure/persistence/datastore_sync_coordinator.ts
+++ b/src/infrastructure/persistence/datastore_sync_coordinator.ts
@@ -38,7 +38,7 @@ import { getTracer, SpanStatusCode } from "../tracing/mod.ts";
 
 /**
  * Common interface for sync services compatible with the coordinator.
- * Both S3CacheSyncService and DatastoreSyncService satisfy this.
+ * Any DatastoreSyncService implementation satisfies this.
  */
 export interface SyncableService {
   pullChanged(): Promise<number | void>;

--- a/src/libswamp/datastores/setup.ts
+++ b/src/libswamp/datastores/setup.ts
@@ -289,12 +289,6 @@ export async function* datastoreSetupExtension(
         return;
       }
 
-      // Update .swamp.yaml with extension datastore config
-      await deps.updateRepoConfig(input.repoDir, {
-        type: input.type,
-        config: input.config,
-      });
-
       // Migrate existing data if the extension supports sync
       const errors: string[] = [];
       let filesCopied = 0;
@@ -345,6 +339,16 @@ export async function* datastoreSetupExtension(
             migrationResult.directoriesMigrated,
           );
         }
+      }
+
+      // Update .swamp.yaml only after migration succeeds (or is skipped).
+      // This avoids leaving the config pointing at an extension datastore
+      // when data never made it to the remote.
+      if (errors.length === 0) {
+        await deps.updateRepoConfig(input.repoDir, {
+          type: input.type,
+          config: input.config,
+        });
       }
 
       yield {


### PR DESCRIPTION
## Summary

Addresses review feedback from #930.

- **`setup s3` breadcrumb**: Users with `swamp datastore setup s3` muscle memory now get a clear migration message instead of "Unknown subcommand"
- **`--config` flag hint**: Description now shows example JSON structure for discoverability
- **Silent auto-resolve failure**: `resolveDatastoreType` network errors are caught so the registry check produces a clean `UserError` instead of an opaque stack trace
- **Config-before-migration ordering**: `updateRepoConfig` now runs *after* successful migration, avoiding `.swamp.yaml` pointing at an extension datastore when data never made it to the remote
- **Stale comments**: Removed `S3CacheSyncService` references from `datastore_sync_service.ts` and `datastore_sync_coordinator.ts`

### Not addressed (tracked, not regressions)

- **`datastore status` backend details**: Bucket/prefix/region no longer shown for S3. This is inherent to the generic extension interface — the provider doesn't expose backend-specific fields. Worth tracking for future improvement but not a regression (custom datastores never had this).
- **`resolveCachePath` "unknown" fallback**: Pre-existing pattern (old S3 code had the same `repoId ?? "unknown"` fallback). Not a regression from this PR.

## Test plan

- [x] `deno check` — clean
- [x] `deno lint` — clean
- [x] `deno fmt` — clean
- [x] All 10 setup tests pass (4 filesystem + 6 extension)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)