### PR TITLE
fix: prevent orphaned lock on Ctrl-C by closing heartbeat/release race

### DIFF
--- a/src/infrastructure/persistence/file_lock.ts
+++ b/src/infrastructure/persistence/file_lock.ts
@@ -36,6 +36,25 @@ import type {
 import { LockTimeoutError } from "../../domain/datastore/distributed_lock.ts";
 import { getSwampLogger } from "../logging/logger.ts";
 
+/**
+ * Check if a process with the given PID is no longer running.
+ * Uses signal 0 (no-op) to test process existence.
+ * Returns false (not dead) on any error other than NotFound,
+ * so TTL-based detection remains the fallback.
+ */
+function isProcessDead(pid: number): boolean {
+  try {
+    Deno.kill(pid, "SIGCONT");
+    return false; // Process exists
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return true; // Process does not exist
+    }
+    // PermissionDenied or other error — can't determine, fall back to TTL
+    return false;
+  }
+}
+
 const DEFAULT_TTL_MS = 30_000;
 const DEFAULT_RETRY_INTERVAL_MS = 1_000;
 const DEFAULT_MAX_WAIT_MS = 60_000;
@@ -70,6 +89,7 @@ export class FileLock implements DistributedLock {
   private readonly maxWaitMs: number;
   private heartbeatId: number | undefined;
   private held = false;
+  private releasing = false;
   private nonce: string | undefined;
 
   constructor(basePath: string, options?: LockOptions) {
@@ -83,6 +103,7 @@ export class FileLock implements DistributedLock {
 
   async acquire(): Promise<void> {
     const startTime = Date.now();
+    this.releasing = false;
 
     await ensureDir(dirname(this.lockPath));
 
@@ -127,8 +148,9 @@ export class FileLock implements DistributedLock {
       // fencing in extend() ensures the old holder self-revokes.
       const existing = await this.readLockFile();
       if (existing) {
-        const acquiredAt = new Date(existing.acquiredAt).getTime();
-        if (Date.now() - acquiredAt > existing.ttlMs) {
+        const isStale = isProcessDead(existing.pid) ||
+          Date.now() - new Date(existing.acquiredAt).getTime() > existing.ttlMs;
+        if (isStale) {
           try {
             await Deno.remove(this.lockPath);
           } catch {
@@ -144,6 +166,9 @@ export class FileLock implements DistributedLock {
   }
 
   async release(): Promise<void> {
+    // Set releasing flag BEFORE stopping heartbeat so any in-flight
+    // extend() sees it and skips writing — prevents orphaned lock files.
+    this.releasing = true;
     this.stopHeartbeat();
 
     if (!this.held) return;
@@ -197,7 +222,7 @@ export class FileLock implements DistributedLock {
   }
 
   private async extend(): Promise<void> {
-    if (!this.held || !this.nonce) return;
+    if (!this.held || !this.nonce || this.releasing) return;
 
     // Verify we still own the lock before extending (fencing).
     // If another process acquired the lock (e.g., after we were paused
@@ -208,6 +233,10 @@ export class FileLock implements DistributedLock {
       this.stopHeartbeat();
       return;
     }
+
+    // Re-check releasing flag after the async read — release() may have
+    // been called while we were reading the lock file.
+    if (this.releasing) return;
 
     const info = buildLockInfo(this.ttlMs, this.nonce);
     const content = JSON.stringify(info, null, 2);

--- a/src/infrastructure/persistence/file_lock_test.ts
+++ b/src/infrastructure/persistence/file_lock_test.ts
@@ -198,6 +198,61 @@ Deno.test("FileLock - forceRelease returns false when no lock exists", async () 
   });
 });
 
+Deno.test("FileLock - stale lock from dead process is immediately acquired", async () => {
+  await withTempDir(async (dir) => {
+    // Simulate a lock held by a non-existent process with a fresh timestamp
+    // (i.e., TTL has NOT expired, but the process is dead)
+    const staleLockInfo: LockInfo = {
+      holder: "dead@host",
+      hostname: "host",
+      pid: 2147483647, // Very high PID — extremely unlikely to exist
+      acquiredAt: new Date().toISOString(), // Fresh timestamp — TTL not expired
+      ttlMs: 60_000, // Long TTL
+    };
+    const lockPath = `${dir}/.datastore.lock`;
+    await Deno.writeTextFile(lockPath, JSON.stringify(staleLockInfo, null, 2));
+
+    // New lock should detect the dead PID and acquire immediately
+    const lock = new FileLock(dir, { ttlMs: 5000, maxWaitMs: 2000 });
+    await lock.acquire();
+
+    const info = await lock.inspect();
+    assertEquals(info !== null, true);
+    assertEquals(info!.pid, Deno.pid);
+
+    await lock.release();
+  });
+});
+
+Deno.test("FileLock - lock held by live process is not stolen via PID check", async () => {
+  await withTempDir(async (dir) => {
+    // Simulate a lock held by the current process (which is definitely alive)
+    // with a fresh timestamp — should NOT be considered stale
+    const lockInfo: LockInfo = {
+      holder: "me@host",
+      hostname: "host",
+      pid: Deno.pid, // Current process — definitely alive
+      acquiredAt: new Date().toISOString(),
+      ttlMs: 60_000,
+      nonce: "existing-nonce",
+    };
+    const lockPath = `${dir}/.datastore.lock`;
+    await Deno.writeTextFile(lockPath, JSON.stringify(lockInfo, null, 2));
+
+    // New lock should NOT be able to acquire — process is alive and TTL not expired
+    const lock = new FileLock(dir, {
+      ttlMs: 60_000,
+      retryIntervalMs: 50,
+      maxWaitMs: 300,
+    });
+
+    await assertRejects(
+      () => lock.acquire(),
+      LockTimeoutError,
+    );
+  });
+});
+
 Deno.test("FileLock - custom lock key", async () => {
   await withTempDir(async (dir) => {
     const lock = new FileLock(dir, {

--- a/src/infrastructure/persistence/s3_lock.ts
+++ b/src/infrastructure/persistence/s3_lock.ts
@@ -80,6 +80,7 @@ export class S3Lock implements DistributedLock {
   private readonly maxWaitMs: number;
   private heartbeatId: number | undefined;
   private held = false;
+  private releasing = false;
   private nonce: string | undefined;
 
   constructor(s3: S3Client, options?: LockOptions) {
@@ -93,6 +94,7 @@ export class S3Lock implements DistributedLock {
 
   async acquire(): Promise<void> {
     const startTime = Date.now();
+    this.releasing = false;
 
     const nonce = crypto.randomUUID();
 
@@ -141,6 +143,9 @@ export class S3Lock implements DistributedLock {
   }
 
   async release(): Promise<void> {
+    // Set releasing flag BEFORE stopping heartbeat so any in-flight
+    // extend() sees it and skips writing — prevents orphaned lock files.
+    this.releasing = true;
     this.stopHeartbeat();
 
     if (!this.held) return;
@@ -185,7 +190,7 @@ export class S3Lock implements DistributedLock {
   }
 
   private async extend(): Promise<void> {
-    if (!this.held || !this.nonce) return;
+    if (!this.held || !this.nonce || this.releasing) return;
 
     // Verify we still own the lock before extending (fencing).
     // If another process acquired the lock (e.g., after we were paused
@@ -196,6 +201,10 @@ export class S3Lock implements DistributedLock {
       this.stopHeartbeat();
       return;
     }
+
+    // Re-check releasing flag after the async read — release() may have
+    // been called while we were reading the lock.
+    if (this.releasing) return;
 
     const info = buildLockInfo(this.ttlMs, this.nonce);
     const body = encodeLockInfo(info);

--- a/src/infrastructure/persistence/s3_lock_test.ts
+++ b/src/infrastructure/persistence/s3_lock_test.ts
@@ -248,6 +248,23 @@ Deno.test("S3Lock - custom lock key", async () => {
   await lock.release();
 });
 
+Deno.test("S3Lock - release cleans up lock even during heartbeat", async () => {
+  const mock = createMockS3Client();
+  const lock = new S3Lock(mock, { ttlMs: 5000 });
+
+  await lock.acquire();
+  assertEquals(mock.storage.has(".datastore.lock"), true);
+
+  // Release should clean up — the releasing flag prevents extend() from
+  // recreating the lock after release() deletes it
+  await lock.release();
+  assertEquals(mock.storage.has(".datastore.lock"), false);
+
+  // Wait briefly to ensure no heartbeat recreates the lock
+  await new Promise((r) => setTimeout(r, 100));
+  assertEquals(mock.storage.has(".datastore.lock"), false);
+});
+
 Deno.test("S3Lock - times out when stale lock cannot be deleted", async () => {
   const mock = createMockS3Client();
 


### PR DESCRIPTION
## Summary

Fixes #928 — lock not released when `extension pull` (or any command) is interrupted with Ctrl-C.

**Root cause:** Race condition between the heartbeat `extend()` method and `release()` in `FileLock`/`S3Lock`. When Ctrl-C fires, the SIGINT handler calls `release()` which deletes the lock file, but if `extend()` was mid-flight it would recreate the lock file after deletion. `Deno.exit(130)` then runs before `extend()`'s post-write cleanup can execute, leaving an orphaned lock.

**Fix:**
- Add a `releasing` flag checked by `extend()` between its async read and write — if set, `extend()` returns without writing, preventing the orphan
- Add PID-based stale lock detection (`Deno.kill(pid, "SIGCONT")`) to `FileLock` — when a lock holder's process is dead, the lock is immediately reclaimed instead of waiting ~30s for TTL expiry

## Test plan

- [x] New test: stale lock from dead process is immediately acquired (FileLock)
- [x] New test: lock held by live process is not stolen via PID check (FileLock)
- [x] New test: release cleans up lock even during heartbeat (S3Lock)
- [x] All 3733 existing tests pass
- [x] `deno check`, `deno lint`, `deno fmt` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)