### PR TITLE
ci: upgrade actions/checkout and setup-node to v6, node to 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       ci: ${{ steps.filter.outputs.ci }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check for changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Deno
         uses: denoland/setup-deno@v2
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Deno
         uses: denoland/setup-deno@v2
@@ -118,7 +118,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Deno
         uses: denoland/setup-deno@v2
@@ -126,9 +126,9 @@ jobs:
           deno-version: v2.x
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: Review skills
         run: deno run --allow-read --allow-run --allow-env=GITHUB_STEP_SUMMARY --allow-write scripts/review_skills.ts
@@ -142,7 +142,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Deno
         uses: denoland/setup-deno@v2
@@ -150,9 +150,9 @@ jobs:
           deno-version: v2.x
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: Install Claude CLI
         run: npm install -g @anthropic-ai/claude-code
@@ -186,7 +186,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Claude Code Review
         uses: anthropics/claude-code-action@v1
@@ -269,7 +269,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Adversarial Code Review
         uses: anthropics/claude-code-action@v1
@@ -416,7 +416,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: CLI UX Review
         uses: anthropics/claude-code-action@v1
@@ -542,7 +542,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: CI Security Review
         uses: anthropics/claude-code-action@v1
@@ -718,7 +718,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Merge PR
         run: gh pr merge --squash --delete-branch "$PR_NUMBER"

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Add reaction to acknowledge
         run: |

--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 
@@ -176,7 +176,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 

--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run actionlint
         uses: rhysd/actionlint@393031adb9afb225ee52ae2ccd7a5af5525e03e8 # v1.7.11


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` from v4 to v6 across all 6 workflow files (16 occurrences)
- Upgrade `actions/setup-node` from v4 to v6 in `ci.yml` (2 occurrences)
- Bump `node-version` from 22 to 24 in `ci.yml` (2 occurrences: skill-review, skill-trigger-eval jobs)

## Breaking Change Analysis

### actions/checkout v4 → v6

| Change | Version | Impact |
|--------|---------|--------|
| Node 20 → 24 runtime | v5 | None — GitHub-hosted runners handle automatically |
| Credentials stored in `$RUNNER_TEMP` instead of `.git/config` | v6 | None — no workflows parse `.git/config` directly |
| No input/output API changes | — | Drop-in replacement |

### actions/setup-node v4 → v6

| Change | Version | Impact |
|--------|---------|--------|
| `always-auth` input removed | v6 | None — not used in any workflow |
| Auto-caching enabled for npm by default | v5 | None — no `packageManager` field in `package.json` |
| Auto-caching narrowed to npm only | v6 | None — no explicit caching configured |
| `devEngines.runtime` precedence over `engines.node` | v6.3 | None — we use explicit `node-version`, not `node-version-file` |

### Node 22 → 24

Node 24 is the current LTS. Used only for `npm install -g @anthropic-ai/claude-code` and skill review scripts — no compatibility concerns.

## Why this is correct

Both upgrades were verified to be safe for our specific usage patterns:
- All runners are GitHub-hosted (no self-hosted runner version concerns)
- No workflows use `always-auth`, `packageManager` in `package.json`, custom mirrors, or `.git/config` parsing
- `setup-node` usage is minimal — just installing a Node version for npm CLI usage

## Test plan

- [ ] CI passes on this PR (self-validating — these workflows run on the PR itself)
- [ ] Verify checkout step succeeds across all jobs
- [ ] Verify skill-review and skill-trigger-eval jobs install Node 24 and run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)