### PR TITLE
ci: upgrade dorny/paths-filter v3→v4 for Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Check for changes
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |


### PR DESCRIPTION
## Summary

- Upgrade `dorny/paths-filter` from v3 (Node 20) to v4.0.1 (Node 24)
- Pinned to commit SHA `fbd0ab8f3e69293af611ebaee6363fc25e6d187d` per existing convention
- Eliminates the "Node.js 20 actions are deprecated" warning for this action

## Impact

Drop-in replacement. v4 has no breaking changes to inputs/outputs — the only change is the Node runtime upgrade from 20 to 24. An optional `predicate-quantifier` input was added but defaults to `'some'` (matching existing behavior).

The remaining `setup-bun` Node 20 warning comes from `anthropics/claude-code-action` and is outside our control.

## Test plan

- [ ] CI passes — the `Detect Changes` job uses this action to filter which jobs run
- [ ] Verify path filtering still correctly detects changes to skills, code, core, ux, and ci paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)