### PR TITLE
fix: support nested paths in report names

### DIFF
--- a/.claude/skills/swamp-report/SKILL.md
+++ b/.claude/skills/swamp-report/SKILL.md
@@ -79,9 +79,9 @@ export const report = {
 
 ### Name Conventions
 
-Report names must follow the `@collective/name` pattern (e.g.,
-`@myorg/cost-report`). This matches the same collective conventions used by
-models, drivers, vaults, and datastores.
+Report names follow the `@collective/name` pattern with optional nested path
+segments (e.g., `@myorg/cost-report` or `@myorg/aws/cost-report`). This matches
+the same naming convention used by models, drivers, vaults, and datastores.
 
 ### Report Scopes
 

--- a/design/reports.md
+++ b/design/reports.md
@@ -116,9 +116,11 @@ export const report = {
 
 ### Name Convention
 
-Report names follow the `@collective/name` pattern (e.g.,
-`@myorg/cost-report`). The collective must match the extension's collective
-when distributed via `extension push`.
+Report names follow the `@collective/name` pattern with optional nested path
+segments (e.g., `@myorg/cost-report` or `@myorg/aws/cost-report`). This matches
+the same naming convention used by models and other extension types. The
+collective must match the extension's collective when distributed via
+`extension push`.
 
 ### Loader Validation
 
@@ -126,7 +128,7 @@ when distributed via `extension push`.
 (excluding `_test.ts`), bundles each with Deno (zod externalized), and
 validates the export against a Zod schema requiring:
 
-- `name` — matches `@collective/name` or `collective/name`
+- `name` — matches `@collective/name[/subname/...]` or `collective/name[/subname/...]`
 - `description` — non-empty string
 - `scope` — one of `"method"`, `"model"`, `"workflow"`
 - `labels` — optional `string[]`

--- a/src/domain/reports/report_execution_service_test.ts
+++ b/src/domain/reports/report_execution_service_test.ts
@@ -420,6 +420,13 @@ Deno.test("sanitizeReportNameForData - passes through simple names unchanged", (
   );
 });
 
+Deno.test("sanitizeReportNameForData - handles nested path report names", () => {
+  assertEquals(
+    sanitizeReportNameForData("@webframp/aws/cost-report"),
+    "webframp-aws-cost-report",
+  );
+});
+
 // --- executeReports with varySuffix tests ---
 
 /**

--- a/src/domain/reports/user_report_loader.ts
+++ b/src/domain/reports/user_report_loader.ts
@@ -41,8 +41,8 @@ import { assertSafePath } from "../../infrastructure/persistence/safe_path.ts";
 
 const logger = getLogger(["swamp", "reports", "loader"]);
 
-/** Pattern for valid user report name: @collective/name or collective/name */
-const USER_REPORT_NAME_PATTERN = /^@?[a-z0-9_-]+\/[a-z0-9_-]+$/;
+/** Pattern for valid user report name: @collective/name[/subname/...] or collective/name[/subname/...] */
+const USER_REPORT_NAME_PATTERN = /^@?[a-z0-9_-]+\/[a-z0-9_-]+(\/[a-z0-9_-]+)*$/;
 
 /**
  * Schema for validating user report exports.
@@ -52,7 +52,7 @@ const UserReportSchema = z.object({
     (n) => USER_REPORT_NAME_PATTERN.test(n),
     {
       message:
-        "Report name must match @collective/name or collective/name (e.g., @myorg/cost-report or myorg/cost-report)",
+        "Report name must match @collective/name or collective/name with optional nested segments (e.g., @myorg/cost-report or @myorg/aws/cost-report)",
     },
   ),
   description: z.string(),


### PR DESCRIPTION
## Summary

- Update `USER_REPORT_NAME_PATTERN` regex in `user_report_loader.ts` to allow
  nested path segments (e.g., `@collective/namespace/name`), matching the
  `SCOPED_NAME_PATTERN` used by models, definitions, and workflows
- Add test for `sanitizeReportNameForData` with nested path report names
- Update design docs and skill documentation to reflect the new pattern

Closes #940

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno run test` passes (3748 tests, 0 failures)
- [x] New `sanitizeReportNameForData` test verifies `@webframp/aws/cost-report` sanitizes to `webframp-aws-cost-report`
- [ ] Verify end-to-end: `extension pull` + report loading with nested path name (reporter has published `@webframp/aws/cost-report` for testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)