### PR TITLE
fix: reject path traversal in extension push manifests (#946)

### DIFF
--- a/src/cli/resolve_extension_files.ts
+++ b/src/cli/resolve_extension_files.ts
@@ -27,6 +27,7 @@ import { RepoPath } from "../domain/repo/repo_path.ts";
 import { UserError } from "../domain/errors.ts";
 import {
   type ExtensionManifest,
+  isSafeRelativePath,
   parseExtensionManifest,
 } from "../domain/extensions/extension_manifest.ts";
 import { resolveLocalImports } from "../domain/extensions/extension_import_resolver.ts";
@@ -91,6 +92,29 @@ export async function resolveExtensionFiles(
   }
 
   const manifest = parseExtensionManifest(manifestContent);
+
+  // 1b. Defensive path traversal check (belt-and-suspenders with Zod schema)
+  const allManifestPaths = [
+    ...manifest.models.map((p) => ({ field: "models", path: p })),
+    ...manifest.workflows.map((p) => ({ field: "workflows", path: p })),
+    ...manifest.vaults.map((p) => ({ field: "vaults", path: p })),
+    ...manifest.drivers.map((p) => ({ field: "drivers", path: p })),
+    ...manifest.datastores.map((p) => ({ field: "datastores", path: p })),
+    ...manifest.reports.map((p) => ({ field: "reports", path: p })),
+    ...manifest.include.map((p) => ({ field: "include", path: p })),
+    ...manifest.additionalFiles.map((p) => ({
+      field: "additionalFiles",
+      path: p,
+    })),
+  ];
+  for (const { field, path } of allManifestPaths) {
+    if (!isSafeRelativePath(path)) {
+      throw new UserError(
+        `Manifest field '${field}' contains unsafe path: ${path}. ` +
+          `Paths must be relative and must not contain '..' components or start with '/'.`,
+      );
+    }
+  }
 
   // 2. Resolve models dir and vaults dir
   const repoPath = RepoPath.create(repoDir);

--- a/src/cli/resolve_extension_files_test.ts
+++ b/src/cli/resolve_extension_files_test.ts
@@ -293,3 +293,57 @@ Deno.test("resolveExtensionFiles returns empty vault arrays when no vaults in ma
     assertEquals(result.allVaultFiles, []);
   });
 });
+
+Deno.test("resolveExtensionFiles rejects path traversal in models", async () => {
+  await withTempRepo(async (dir) => {
+    const manifestPath = join(dir, "manifest.yaml");
+    await Deno.writeTextFile(
+      manifestPath,
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/myext",
+        version: "2026.03.03.1",
+        models: ["../../other/model.ts"],
+      }),
+    );
+
+    await assertRejects(
+      () =>
+        resolveExtensionFiles({
+          repoDir: dir,
+          manifestPath,
+          repoContext: stubRepoContext,
+          logger,
+        }),
+      UserError,
+      "must not contain '..'",
+    );
+  });
+});
+
+Deno.test("resolveExtensionFiles rejects absolute path in workflows", async () => {
+  await withTempRepo(async (dir) => {
+    const manifestPath = join(dir, "manifest.yaml");
+    await Deno.writeTextFile(
+      manifestPath,
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/myext",
+        version: "2026.03.03.1",
+        workflows: ["/etc/passwd"],
+      }),
+    );
+
+    await assertRejects(
+      () =>
+        resolveExtensionFiles({
+          repoDir: dir,
+          manifestPath,
+          repoContext: stubRepoContext,
+          logger,
+        }),
+      UserError,
+      "must not contain '..'",
+    );
+  });
+});

--- a/src/domain/extensions/extension_manifest.ts
+++ b/src/domain/extensions/extension_manifest.ts
@@ -25,6 +25,22 @@ import { UserError } from "../errors.ts";
 /** Scoped name pattern: @collective/name or @collective/name/subname/... */
 const SCOPED_NAME_PATTERN = /^@[a-z0-9_-]+\/[a-z0-9_-]+(\/[a-z0-9_-]+)*$/;
 
+/**
+ * Checks whether a relative path is safe for use in an extension manifest.
+ * Rejects absolute paths and paths containing '..' components, which would
+ * escape the base directory during archive creation.
+ */
+export function isSafeRelativePath(p: string): boolean {
+  if (p.startsWith("/")) return false;
+  const segments = p.split(/[/\\]/);
+  return !segments.includes("..");
+}
+
+const safePathString = z.string().refine(isSafeRelativePath, {
+  message:
+    "Path must be relative and must not contain '..' components or start with '/'",
+});
+
 const ExtensionManifestSchemaV1 = z.object({
   manifestVersion: z.literal(1),
   name: z.string().refine(
@@ -39,14 +55,14 @@ const ExtensionManifestSchemaV1 = z.object({
   }),
   description: z.string().optional(),
   repository: z.string().url().optional(),
-  workflows: z.array(z.string()).optional(),
-  models: z.array(z.string()).optional(),
-  vaults: z.array(z.string()).optional(),
-  drivers: z.array(z.string()).optional(),
-  datastores: z.array(z.string()).optional(),
-  reports: z.array(z.string()).optional(),
-  include: z.array(z.string()).optional(),
-  additionalFiles: z.array(z.string()).optional(),
+  workflows: z.array(safePathString).optional(),
+  models: z.array(safePathString).optional(),
+  vaults: z.array(safePathString).optional(),
+  drivers: z.array(safePathString).optional(),
+  datastores: z.array(safePathString).optional(),
+  reports: z.array(safePathString).optional(),
+  include: z.array(safePathString).optional(),
+  additionalFiles: z.array(safePathString).optional(),
   platforms: z.array(z.string().min(1)).optional(),
   labels: z.array(z.string().min(1)).optional(),
   releaseNotes: z.string().max(5000).optional(),

--- a/src/domain/extensions/extension_manifest_test.ts
+++ b/src/domain/extensions/extension_manifest_test.ts
@@ -19,7 +19,10 @@
 
 import { assertEquals, assertThrows } from "@std/assert";
 import { assertStringIncludes } from "@std/assert/string-includes";
-import { parseExtensionManifest } from "./extension_manifest.ts";
+import {
+  isSafeRelativePath,
+  parseExtensionManifest,
+} from "./extension_manifest.ts";
 
 Deno.test("parseExtensionManifest parses valid manifest with models", () => {
   const yaml = `
@@ -325,4 +328,113 @@ models:
   assertEquals(manifest.platforms, []);
   assertEquals(manifest.labels, []);
   assertEquals(manifest.dependencies, []);
+});
+
+// --- isSafeRelativePath unit tests ---
+
+Deno.test("isSafeRelativePath: accepts simple filename", () => {
+  assertEquals(isSafeRelativePath("foo.ts"), true);
+});
+
+Deno.test("isSafeRelativePath: accepts nested relative path", () => {
+  assertEquals(isSafeRelativePath("aws/ec2/instance.ts"), true);
+});
+
+Deno.test("isSafeRelativePath: rejects path with .. component", () => {
+  assertEquals(isSafeRelativePath("../foo.ts"), false);
+});
+
+Deno.test("isSafeRelativePath: rejects path with multiple .. components", () => {
+  assertEquals(isSafeRelativePath("../../workflows/foo.yaml"), false);
+});
+
+Deno.test("isSafeRelativePath: rejects path with .. in middle", () => {
+  assertEquals(isSafeRelativePath("foo/../bar.ts"), false);
+});
+
+Deno.test("isSafeRelativePath: rejects absolute path", () => {
+  assertEquals(isSafeRelativePath("/etc/passwd"), false);
+});
+
+Deno.test("isSafeRelativePath: rejects backslash path traversal", () => {
+  assertEquals(isSafeRelativePath("..\\foo.ts"), false);
+});
+
+// --- Manifest-level path traversal rejection tests ---
+
+Deno.test("parseExtensionManifest rejects path traversal in models", () => {
+  const yaml = `
+manifestVersion: 1
+name: "@myuser/myext"
+version: "2026.02.26.1"
+models:
+  - ../../other/model.ts
+`;
+  const error = assertThrows(() => parseExtensionManifest(yaml));
+  assertStringIncludes((error as Error).message, "must not contain '..'");
+});
+
+Deno.test("parseExtensionManifest rejects path traversal in workflows", () => {
+  const yaml = `
+manifestVersion: 1
+name: "@myuser/myext"
+version: "2026.02.26.1"
+workflows:
+  - ../../workflows/deploy.yaml
+`;
+  const error = assertThrows(() => parseExtensionManifest(yaml));
+  assertStringIncludes((error as Error).message, "must not contain '..'");
+});
+
+Deno.test("parseExtensionManifest rejects absolute path in models", () => {
+  const yaml = `
+manifestVersion: 1
+name: "@myuser/myext"
+version: "2026.02.26.1"
+models:
+  - /etc/passwd
+`;
+  const error = assertThrows(() => parseExtensionManifest(yaml));
+  assertStringIncludes((error as Error).message, "must not contain '..'");
+});
+
+Deno.test("parseExtensionManifest rejects path traversal in additionalFiles", () => {
+  const yaml = `
+manifestVersion: 1
+name: "@myuser/myext"
+version: "2026.02.26.1"
+models:
+  - foo.ts
+additionalFiles:
+  - ../../../secrets.txt
+`;
+  const error = assertThrows(() => parseExtensionManifest(yaml));
+  assertStringIncludes((error as Error).message, "must not contain '..'");
+});
+
+Deno.test("parseExtensionManifest rejects path traversal in include", () => {
+  const yaml = `
+manifestVersion: 1
+name: "@myuser/myext"
+version: "2026.02.26.1"
+models:
+  - foo.ts
+include:
+  - ../helpers.ts
+`;
+  const error = assertThrows(() => parseExtensionManifest(yaml));
+  assertStringIncludes((error as Error).message, "must not contain '..'");
+});
+
+Deno.test("parseExtensionManifest accepts valid nested paths in models", () => {
+  const yaml = `
+manifestVersion: 1
+name: "@myuser/myext"
+version: "2026.02.26.1"
+models:
+  - aws/ec2/instance.ts
+  - deploy_model.ts
+`;
+  const manifest = parseExtensionManifest(yaml);
+  assertEquals(manifest.models, ["aws/ec2/instance.ts", "deploy_model.ts"]);
 });


### PR DESCRIPTION
- Add path validation to the extension manifest Zod schema that rejects paths
containing `..` components or starting with `/` in all path arrays (models,
workflows, vaults, drivers, datastores, reports, include, additionalFiles)
- Add defensive belt-and-suspenders check in `resolveExtensionFiles` before
paths are resolved against the filesystem
- Document path safety constraints in `design/extension.md` and the
`swamp-extension-model` skill

Fixes #946

- 13 new unit tests in `extension_manifest_test.ts` covering `isSafeRelativePath`
and manifest-level rejection for traversal and absolute paths across all fields
- 2 new unit tests in `resolve_extension_files_test.ts` for the defensive check
- All existing tests continue to pass

Co-authored-by: Sean Escriva <webframp@users.noreply.github.com>
