### PR TITLE
fix: prevent CLI hang after workflow run completes

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -43,4 +43,9 @@ if (import.meta.main) {
   } finally {
     await shutdownTracing();
   }
+
+  // Explicit exit so fire-and-forget promises (telemetry flush, background
+  // update check) can never keep the event loop alive after the CLI finishes.
+  // The error path already calls Deno.exit(1) in the catch block above.
+  Deno.exit(0);
 }

--- a/src/infrastructure/update/http_update_checker.ts
+++ b/src/infrastructure/update/http_update_checker.ts
@@ -108,6 +108,7 @@ export class HttpUpdateChecker implements UpdateChecker {
     const response = await fetch(url, {
       method: "HEAD",
       redirect: "manual",
+      signal: AbortSignal.timeout(5000),
     });
 
     // Check for redirect via Location header or S3 metadata


### PR DESCRIPTION
## Summary

- Add `AbortSignal.timeout(5000)` to the update checker's `fetch()` call — the
  missing timeout allowed an unreachable endpoint to keep Deno's event loop alive
  indefinitely after the CLI's main work finished.
- Add explicit `Deno.exit(0)` on the success path in `main.ts` as a safety net
  so no fire-and-forget promise can ever hang the process.

## Test Plan

- Existing update checker tests pass
- Full test suite passes (3748 tests)
- Verified the fix matches the timeout pattern already used in `HttpTelemetrySender`