### PR TITLE
fix: omit empty argument sections in method-summary report

### DIFF
--- a/src/domain/reports/builtin/method_summary_report.ts
+++ b/src/domain/reports/builtin/method_summary_report.ts
@@ -147,11 +147,32 @@ export const methodSummaryReport: ReportDefinition = {
       ? redactSensitiveArgs(methodArgs, "method")
       : methodArgs;
 
-    lines.push("## Arguments", "");
-    lines.push("**Global Arguments**", "");
-    lines.push("```json", JSON.stringify(redactedGlobal, null, 2), "```", "");
-    lines.push("**Method Arguments**", "");
-    lines.push("```json", JSON.stringify(redactedMethod, null, 2), "```", "");
+    const globalEmpty = Object.keys(redactedGlobal).length === 0;
+    const methodEmpty = Object.keys(redactedMethod).length === 0;
+
+    if (globalEmpty && methodEmpty) {
+      lines.push("## Arguments", "", "No arguments.", "");
+    } else {
+      lines.push("## Arguments", "");
+      if (!globalEmpty) {
+        lines.push("**Global Arguments**", "");
+        lines.push(
+          "```json",
+          JSON.stringify(redactedGlobal, null, 2),
+          "```",
+          "",
+        );
+      }
+      if (!methodEmpty) {
+        lines.push("**Method Arguments**", "");
+        lines.push(
+          "```json",
+          JSON.stringify(redactedMethod, null, 2),
+          "```",
+          "",
+        );
+      }
+    }
 
     if (dataHandles.length > 0) {
       lines.push(...renderPointersMarkdown(definition.name, dataHandles));

--- a/src/domain/reports/builtin/method_summary_report_test.ts
+++ b/src/domain/reports/builtin/method_summary_report_test.ts
@@ -306,6 +306,54 @@ Deno.test("methodSummaryReport: multiple data handles grouped by specName", asyn
   assertEquals(items[2].specName, "logs");
 });
 
+Deno.test("methodSummaryReport: both args empty shows 'No arguments.'", async () => {
+  const ctx = makeMethodContext({
+    globalArgs: {},
+    methodArgs: {},
+    dataHandles: [],
+  });
+
+  const result = await methodSummaryReport.execute(ctx);
+
+  assertStringIncludes(result.markdown, "## Arguments");
+  assertStringIncludes(result.markdown, "No arguments.");
+  assertEquals(result.markdown.includes("**Global Arguments**"), false);
+  assertEquals(result.markdown.includes("**Method Arguments**"), false);
+  assertEquals(result.markdown.includes("```json\n{}"), false);
+
+  // JSON still contains both fields
+  assertEquals(result.json.globalArgs, {});
+  assertEquals(result.json.methodArgs, {});
+});
+
+Deno.test("methodSummaryReport: only globalArgs populated omits method args section", async () => {
+  const ctx = makeMethodContext({
+    globalArgs: { region: "us-west-2" },
+    methodArgs: {},
+  });
+
+  const result = await methodSummaryReport.execute(ctx);
+
+  assertStringIncludes(result.markdown, "**Global Arguments**");
+  assertStringIncludes(result.markdown, '"region": "us-west-2"');
+  assertEquals(result.markdown.includes("**Method Arguments**"), false);
+  assertEquals(result.markdown.includes("No arguments."), false);
+});
+
+Deno.test("methodSummaryReport: only methodArgs populated omits global args section", async () => {
+  const ctx = makeMethodContext({
+    globalArgs: {},
+    methodArgs: { force: true },
+  });
+
+  const result = await methodSummaryReport.execute(ctx);
+
+  assertStringIncludes(result.markdown, "**Method Arguments**");
+  assertStringIncludes(result.markdown, '"force": true');
+  assertEquals(result.markdown.includes("**Global Arguments**"), false);
+  assertEquals(result.markdown.includes("No arguments."), false);
+});
+
 Deno.test("methodSummaryReport: JSON output structure matches expected shape", async () => {
   const ctx = makeMethodContext({
     dataHandles: [


### PR DESCRIPTION
## Summary

- Conditionally omit empty argument sections in the `@swamp/method-summary` report markdown output instead of rendering noisy `{}` JSON blocks
- When both `globalArgs` and `methodArgs` are empty, shows "No arguments." instead of two empty code blocks
- When only one is empty, omits that section and shows only the populated one
- JSON output is unchanged -- `globalArgs` and `methodArgs` fields always appear for agent consumers

Closes #952

## Test Plan

- Added 3 new unit tests covering: both args empty, only global args populated, only method args populated
- All 12 method-summary report tests pass (9 existing + 3 new)
- Full test suite passes (3766 tests)
- `deno check`, `deno lint`, `deno fmt` all clean
- `deno run compile` succeeds