### PR TITLE
fix: use dynamic alignment for method error indent in summarise renderer

### DIFF
--- a/src/presentation/renderers/summarise.ts
+++ b/src/presentation/renderers/summarise.ts
@@ -70,11 +70,14 @@ function renderMethodExecutions(
   for (const model of models) {
     writeOutput(`  Model: ${bold(model.modelName)} ${dim(`(${model.type})`)}`);
 
+    const maxMethod = Math.max(...model.methods.map((m) => m.method.length));
+
     for (const method of model.methods) {
+      const label = method.method.padEnd(maxMethod + 3);
       const parts: string[] = [];
       if (method.succeeded > 0) parts.push(green(`\u2713 ${method.succeeded}`));
       if (method.failed > 0) parts.push(red(`\u2717 ${method.failed}`));
-      writeOutput(`    ${method.method}   ${parts.join("  ")}`);
+      writeOutput(`    ${label}${parts.join("  ")}`);
 
       if (verbose) {
         for (const run of method.runs) {
@@ -98,7 +101,9 @@ function renderMethodExecutions(
           .find((r) => r.status === "failed" && r.error);
         if (lastFailed?.error) {
           writeOutput(
-            `             ${red(`last error: "${lastFailed.error}"`)}`,
+            `    ${"".padEnd(maxMethod + 3)}${
+              red(`last error: "${lastFailed.error}"`)
+            }`,
           );
         }
       }

--- a/src/presentation/renderers/summarise_test.ts
+++ b/src/presentation/renderers/summarise_test.ts
@@ -1,0 +1,269 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import { stripAnsiCode } from "@std/fmt/colors";
+import { consumeStream } from "../../libswamp/mod.ts";
+import type { SummariseEvent } from "../../libswamp/mod.ts";
+import type { ActivitySummary } from "../../domain/summary/summary_types.ts";
+import { createSummariseRenderer } from "./summarise.ts";
+import { UserError } from "../../domain/errors.ts";
+
+async function* toStream(
+  events: SummariseEvent[],
+): AsyncGenerator<SummariseEvent> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+function makeSummary(
+  overrides: Partial<ActivitySummary> = {},
+): ActivitySummary {
+  return {
+    since: "2026-01-01T00:00:00Z",
+    methodExecutions: [],
+    workflows: [],
+    data: {
+      totalItems: 0,
+      totalVersions: 0,
+      uniqueModels: 0,
+      byModelType: [],
+    },
+    ...overrides,
+  };
+}
+
+Deno.test("renderMethodExecutions: error line aligns dynamically with short method name", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const summary = makeSummary({
+      methodExecutions: [{
+        modelName: "test-model",
+        type: "@test/type",
+        succeeded: 0,
+        failed: 1,
+        total: 1,
+        methods: [{
+          method: "run",
+          succeeded: 0,
+          failed: 1,
+          total: 1,
+          runs: [{
+            id: "r1",
+            definitionId: "d1",
+            startedAt: "2026-01-01T00:00:00Z",
+            status: "failed",
+            error: "something broke",
+            triggeredBy: "cli",
+          }],
+        }],
+      }],
+    });
+
+    const renderer = createSummariseRenderer("log", "normal");
+    await consumeStream(
+      toStream([{
+        kind: "completed",
+        data: { status: "summary", summary, sinceLabel: "24 hours" },
+      }]),
+      renderer.handlers(),
+    );
+
+    const plain = logs.map(stripAnsiCode);
+    // Find the method row and the error row
+    const methodRow = plain.find((l) => l.includes("run"));
+    const errorRow = plain.find((l) => l.includes("last error"));
+    assertEquals(methodRow !== undefined, true, "should have method row");
+    assertEquals(errorRow !== undefined, true, "should have error row");
+
+    // Both should start with 4-space indent and the error text should start
+    // at the same column as the status indicators on the method row
+    const methodIndent = methodRow!.indexOf("run");
+    const methodStatusCol = methodRow!.indexOf("\u2717");
+    // The error row uses "".padEnd(maxMethod + 3) after 4 spaces of indent,
+    // so its content starts at the same column as the status column
+    const errorContentCol = errorRow!.indexOf("last error");
+    assertEquals(
+      errorContentCol,
+      methodStatusCol,
+      "error text should align with status column",
+    );
+    assertEquals(methodIndent, 4, "method name should be at 4-space indent");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderMethodExecutions: error line aligns with longest method name", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const summary = makeSummary({
+      methodExecutions: [{
+        modelName: "test-model",
+        type: "@test/type",
+        succeeded: 1,
+        failed: 1,
+        total: 2,
+        methods: [
+          {
+            method: "a_very_long_method_name",
+            succeeded: 1,
+            failed: 0,
+            total: 1,
+            runs: [{
+              id: "r1",
+              definitionId: "d1",
+              startedAt: "2026-01-01T00:00:00Z",
+              status: "succeeded",
+              triggeredBy: "cli",
+            }],
+          },
+          {
+            method: "run",
+            succeeded: 0,
+            failed: 1,
+            total: 1,
+            runs: [{
+              id: "r2",
+              definitionId: "d1",
+              startedAt: "2026-01-01T00:00:00Z",
+              status: "failed",
+              error: "something broke",
+              triggeredBy: "cli",
+            }],
+          },
+        ],
+      }],
+    });
+
+    const renderer = createSummariseRenderer("log", "normal");
+    await consumeStream(
+      toStream([{
+        kind: "completed",
+        data: { status: "summary", summary, sinceLabel: "24 hours" },
+      }]),
+      renderer.handlers(),
+    );
+
+    const plain = logs.map(stripAnsiCode);
+    const longMethodRow = plain.find((l) =>
+      l.includes("a_very_long_method_name")
+    );
+    const shortMethodRow = plain.find((l) =>
+      l.includes("run") && !l.includes("a_very_long_method_name") &&
+      !l.includes("last error") && !l.includes("Executions")
+    );
+    const errorRow = plain.find((l) => l.includes("last error"));
+
+    assertEquals(
+      longMethodRow !== undefined,
+      true,
+      "should have long method row",
+    );
+    assertEquals(
+      shortMethodRow !== undefined,
+      true,
+      "should have short method row",
+    );
+    assertEquals(errorRow !== undefined, true, "should have error row");
+
+    // Status indicators should all start at the same column
+    const longMethodStatusCol = longMethodRow!.indexOf("\u2713");
+    const shortMethodStatusCol = shortMethodRow!.indexOf("\u2717");
+    const errorContentCol = errorRow!.indexOf("last error");
+
+    assertEquals(
+      longMethodStatusCol,
+      shortMethodStatusCol,
+      "status columns should align across methods",
+    );
+    assertEquals(
+      errorContentCol,
+      shortMethodStatusCol,
+      "error text should align with status column",
+    );
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("SummariseRenderer: error throws UserError", () => {
+  const renderer = createSummariseRenderer("log", "normal");
+  const handlers = renderer.handlers();
+  assertThrows(
+    () =>
+      handlers.error({
+        kind: "error",
+        error: { code: "test", message: "boom" },
+      }),
+    UserError,
+    "boom",
+  );
+});
+
+Deno.test("SummariseRenderer: no_activity does not write to console output", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createSummariseRenderer("log", "normal");
+    await consumeStream(
+      toStream([{
+        kind: "completed",
+        data: { status: "no_activity", sinceLabel: "24 hours" },
+      }]),
+      renderer.handlers(),
+    );
+    // no_activity messages go through the logger, not writeOutput/console.log
+    assertEquals(logs.length, 0);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("JsonSummariseRenderer: completed outputs JSON", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const summary = makeSummary();
+    const renderer = createSummariseRenderer("json", "normal");
+    await consumeStream(
+      toStream([{
+        kind: "completed",
+        data: { status: "summary", summary, sinceLabel: "24 hours" },
+      }]),
+      renderer.handlers(),
+    );
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.since, "2026-01-01T00:00:00Z");
+  } finally {
+    console.log = originalLog;
+  }
+});


### PR DESCRIPTION
## Summary

- Replace hardcoded 13-space indent for method error lines in `renderMethodExecutions` with dynamic `padEnd` alignment computed from method name lengths
- Method name rows now also use `padEnd` so status columns align across methods with different name lengths
- Matches the dynamic alignment pattern already used in `renderWorkflowRuns`

Fixes #955

## Test Plan

- Added `summarise_test.ts` with 5 tests covering:
  - Error line aligns dynamically with a single short method name
  - Error line aligns with the longest method name when multiple methods exist
  - Status columns align across methods of different lengths
  - Error event throws `UserError`
  - JSON renderer outputs valid JSON
- `deno check` -- passes
- `deno lint` -- passes
- `deno fmt` -- passes
- `deno run test` -- 3768 tests pass, 0 failures
- `deno run compile` -- compiles successfully