### PR TITLE
fix: restore modelId to method-summary report JSON output

### DIFF
--- a/src/domain/reports/builtin/method_summary_report.ts
+++ b/src/domain/reports/builtin/method_summary_report.ts
@@ -163,6 +163,7 @@ export const methodSummaryReport: ReportDefinition = {
     const json: Record<string, unknown> = {
       status: executionStatus,
       ...(errorMessage ? { error: errorMessage } : {}),
+      modelId: definition.id,
       modelName: definition.name,
       modelType: modelType.normalized,
       methodName,

--- a/src/domain/reports/builtin/method_summary_report_test.ts
+++ b/src/domain/reports/builtin/method_summary_report_test.ts
@@ -100,6 +100,7 @@ Deno.test("methodSummaryReport: succeeded method with data handles shows narrati
 
   // JSON checks
   assertEquals(result.json.status, "succeeded");
+  assertEquals(result.json.modelId, "def-123");
   assertEquals(result.json.modelName, "my-server");
   assertEquals(result.json.modelType, "server");
   assertEquals(result.json.methodName, "deploy");
@@ -329,6 +330,7 @@ Deno.test("methodSummaryReport: JSON output structure matches expected shape", a
   // Verify all expected keys exist
   const expectedKeys = [
     "status",
+    "modelId",
     "modelName",
     "modelType",
     "methodName",


### PR DESCRIPTION
## Summary

- Restores the `modelId` (UUID) field to the `@swamp/method-summary` report JSON output, which was accidentally dropped in PR #944 during a refactor
- Adds test coverage verifying `modelId` is present and correct in JSON output

Fixes #954

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] All 9 method-summary report tests pass, including updated JSON structure test
- [x] `deno run compile` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)