### PR TITLE
feat: add retrievalCommand to JSON dataProduced

### DIFF
--- a/src/domain/reports/builtin/method_summary_report.ts
+++ b/src/domain/reports/builtin/method_summary_report.ts
@@ -176,6 +176,8 @@ export const methodSummaryReport: ReportDefinition = {
         kind: h.kind,
         specName: h.specName,
         version: h.version,
+        retrievalCommand:
+          `swamp data get ${definition.name} ${h.name} --version ${h.version}`,
       })),
     };
 

--- a/src/domain/reports/builtin/method_summary_report_test.ts
+++ b/src/domain/reports/builtin/method_summary_report_test.ts
@@ -113,6 +113,10 @@ Deno.test("methodSummaryReport: succeeded method with data handles shows narrati
   assertEquals(items[0].name, "output.json");
   assertEquals(items[0].kind, "file");
   assertEquals(items[0].specName, "output");
+  assertEquals(
+    items[0].retrievalCommand,
+    "swamp data get my-server output.json --version 1",
+  );
 });
 
 Deno.test("methodSummaryReport: failed method status", async () => {
@@ -344,6 +348,6 @@ Deno.test("methodSummaryReport: JSON output structure matches expected shape", a
   assertEquals(items.length, 1);
   assertEquals(
     Object.keys(items[0]).sort(),
-    ["kind", "name", "specName", "version"],
+    ["kind", "name", "retrievalCommand", "specName", "version"],
   );
 });


### PR DESCRIPTION
## Summary

- Adds a version-pinned `retrievalCommand` field back to each `dataProduced` entry in the method-summary report JSON output
- Restores backwards compatibility for scripts that relied on `jq '.dataProduced[].retrievalCommand'` (regression from #944)
- The command format matches the existing markdown table: `swamp data get <modelName> <dataName> --version <version>`

## Test Plan

- [x] Updated existing test to verify `retrievalCommand` content matches expected format
- [x] Updated JSON structure shape test to include `retrievalCommand` in expected keys
- [x] All 3763 tests pass
- [x] `deno check`, `deno lint`, `deno fmt` all pass

Closes #953

🤖 Generated with [Claude Code](https://claude.com/claude-code)