### PR TITLE
fix: handle array-typed JSON Schema type fields in renderers

### DIFF
--- a/src/presentation/renderers/model_get.ts
+++ b/src/presentation/renderers/model_get.ts
@@ -30,15 +30,31 @@ import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import { UserError } from "../../domain/errors.ts";
 
 interface JsonSchemaProperty {
-  type?: string;
+  type?: string | string[];
   enum?: string[];
   description?: string;
 }
 
 interface JsonSchemaObject {
-  type?: string;
+  type?: string | string[];
   properties?: Record<string, JsonSchemaProperty>;
   required?: string[];
+}
+
+/**
+ * Formats a JSON Schema `type` field into a human-readable string.
+ * Handles both single types (`"string"`) and nullable/union arrays
+ * (`["string", "null"]`) produced by `zodToJsonSchema` for optional
+ * or nullable Zod types.
+ */
+export function formatSchemaType(
+  type: string | string[] | undefined,
+): string | undefined {
+  if (type === undefined) return undefined;
+  if (Array.isArray(type)) {
+    return type.join(" | ");
+  }
+  return type;
 }
 
 /**
@@ -54,7 +70,8 @@ export function formatSchemaAttributes(
   const required = new Set(s.required ?? []);
   return Object.entries(s.properties).map(([name, prop]) => {
     const parts = [name];
-    if (prop.type) parts.push(dim(`(${prop.type})`));
+    const formatted = formatSchemaType(prop.type);
+    if (formatted) parts.push(dim(`(${formatted})`));
     if (prop.enum) parts.push(dim(`[${prop.enum.join(", ")}]`));
     if (required.has(name)) parts.push(dim("*required"));
     return `${indent}${parts.join(" ")}`;

--- a/src/presentation/renderers/model_get_test.ts
+++ b/src/presentation/renderers/model_get_test.ts
@@ -21,7 +21,11 @@ import { assertEquals, assertThrows } from "@std/assert";
 import { consumeStream } from "../../libswamp/mod.ts";
 import type { ModelGetEvent } from "../../libswamp/mod.ts";
 import { UserError } from "../../domain/errors.ts";
-import { createModelGetRenderer } from "./model_get.ts";
+import {
+  createModelGetRenderer,
+  formatSchemaAttributes,
+  formatSchemaType,
+} from "./model_get.ts";
 
 const testData = {
   id: "def-1",
@@ -101,4 +105,50 @@ Deno.test("createModelGetRenderer - factory returns correct type per mode", () =
   const jsonRenderer = createModelGetRenderer("json");
   assertEquals(typeof logRenderer.handlers, "function");
   assertEquals(typeof jsonRenderer.handlers, "function");
+});
+
+Deno.test("formatSchemaType: returns undefined for undefined input", () => {
+  assertEquals(formatSchemaType(undefined), undefined);
+});
+
+Deno.test("formatSchemaType: returns string unchanged for string input", () => {
+  assertEquals(formatSchemaType("string"), "string");
+  assertEquals(formatSchemaType("number"), "number");
+  assertEquals(formatSchemaType("object"), "object");
+});
+
+Deno.test("formatSchemaType: joins array types with pipe separator", () => {
+  assertEquals(formatSchemaType(["string", "null"]), "string | null");
+  assertEquals(
+    formatSchemaType(["string", "number", "null"]),
+    "string | number | null",
+  );
+});
+
+Deno.test("formatSchemaType: handles single-element arrays", () => {
+  assertEquals(formatSchemaType(["string"]), "string");
+});
+
+Deno.test("formatSchemaType: handles empty arrays", () => {
+  assertEquals(formatSchemaType([]), "");
+});
+
+Deno.test("formatSchemaAttributes: renders array-typed properties correctly", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      name: { type: "string" },
+      nickname: { type: ["string", "null"] },
+    },
+    required: ["name"],
+  };
+  const lines = formatSchemaAttributes(schema, "  ");
+  assertEquals(lines.length, 2);
+  // The first line should contain 'name' and '(string)' and '*required'
+  assertEquals(lines[0].includes("name"), true);
+  assertEquals(lines[0].includes("(string)"), true);
+  assertEquals(lines[0].includes("*required"), true);
+  // The second line should contain 'nickname' and '(string | null)'
+  assertEquals(lines[1].includes("nickname"), true);
+  assertEquals(lines[1].includes("(string | null)"), true);
 });

--- a/src/presentation/renderers/model_search.tsx
+++ b/src/presentation/renderers/model_search.tsx
@@ -34,7 +34,11 @@ import {
   type PickerResult,
   renderInteractivePicker,
 } from "./components/search_picker.tsx";
-import { formatMethodLines, formatSchemaAttributes } from "./model_get.ts";
+import {
+  formatMethodLines,
+  formatSchemaAttributes,
+  formatSchemaType,
+} from "./model_get.ts";
 
 const INDENT_2 = "  ";
 const INDENT_4 = "    ";
@@ -235,7 +239,7 @@ function renderMethodArguments(schema: object): React.ReactElement | null {
   const s = schema as {
     properties?: Record<
       string,
-      { type?: string; enum?: string[]; description?: string }
+      { type?: string | string[]; enum?: string[]; description?: string }
     >;
     required?: string[];
   };
@@ -248,15 +252,18 @@ function renderMethodArguments(schema: object): React.ReactElement | null {
   return (
     <Box flexDirection="column" marginLeft={2}>
       <Text color="cyan">Arguments:</Text>
-      {entries.map(([name, prop]) => (
-        <Text key={name}>
-          {INDENT_4}
-          {name}
-          {prop.type ? <Text dimColor>({prop.type})</Text> : null}
-          {prop.enum ? <Text dimColor>[{prop.enum.join(", ")}]</Text> : null}
-          {required.has(name) ? <Text dimColor>*required</Text> : null}
-        </Text>
-      ))}
+      {entries.map(([name, prop]) => {
+        const formatted = formatSchemaType(prop.type);
+        return (
+          <Text key={name}>
+            {INDENT_4}
+            {name}
+            {formatted ? <Text dimColor>({formatted})</Text> : null}
+            {prop.enum ? <Text dimColor>[{prop.enum.join(", ")}]</Text> : null}
+            {required.has(name) ? <Text dimColor>*required</Text> : null}
+          </Text>
+        );
+      })}
     </Box>
   );
 }

--- a/src/presentation/renderers/type_search.tsx
+++ b/src/presentation/renderers/type_search.tsx
@@ -31,7 +31,7 @@ import type { SearchRenderer } from "./search_renderer.ts";
 import type { OutputMode } from "../output/output.ts";
 import { UserError } from "../../domain/errors.ts";
 import { renderInteractivePicker } from "./components/search_picker.tsx";
-import { formatMethodLines } from "./model_get.ts";
+import { formatMethodLines, formatSchemaType } from "./model_get.ts";
 
 const INDENT_4 = "    ";
 
@@ -216,7 +216,7 @@ function renderMethodArguments(schema: object): React.ReactElement | null {
   const s = schema as {
     properties?: Record<
       string,
-      { type?: string; enum?: string[]; description?: string }
+      { type?: string | string[]; enum?: string[]; description?: string }
     >;
     required?: string[];
   };
@@ -229,15 +229,18 @@ function renderMethodArguments(schema: object): React.ReactElement | null {
   return (
     <Box flexDirection="column" marginLeft={2}>
       <Text color="cyan">Arguments:</Text>
-      {entries.map(([name, prop]) => (
-        <Text key={name}>
-          {INDENT_4}
-          {name}
-          {prop.type ? <Text dimColor>({prop.type})</Text> : null}
-          {prop.enum ? <Text dimColor>[{prop.enum.join(", ")}]</Text> : null}
-          {required.has(name) ? <Text dimColor>*required</Text> : null}
-        </Text>
-      ))}
+      {entries.map(([name, prop]) => {
+        const formatted = formatSchemaType(prop.type);
+        return (
+          <Text key={name}>
+            {INDENT_4}
+            {name}
+            {formatted ? <Text dimColor>({formatted})</Text> : null}
+            {prop.enum ? <Text dimColor>[{prop.enum.join(", ")}]</Text> : null}
+            {required.has(name) ? <Text dimColor>*required</Text> : null}
+          </Text>
+        );
+      })}
     </Box>
   );
 }


### PR DESCRIPTION
## Summary

- Add `formatSchemaType` helper that normalizes JSON Schema `type` fields from arrays (e.g. `["string", "null"]`) into readable pipe-separated strings (e.g. `string | null`)
- Update `JsonSchemaProperty.type` to accept `string | string[]` in `model_get.ts`, `type_search.tsx`, and `model_search.tsx`
- Add unit tests for `formatSchemaType` and `formatSchemaAttributes` with array-typed properties

Fixes #951

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] All 3776 tests pass (`deno run test`)
- [x] `deno run compile` succeeds
- [x] New unit tests cover: undefined input, string passthrough, array joining with pipe separator, single-element arrays, empty arrays, and end-to-end `formatSchemaAttributes` with array-typed properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)