### PR TITLE
docs: update vault and datastore skill testing refs with conformance suites

### DIFF
--- a/.claude/skills/swamp-extension-datastore/references/testing.md
+++ b/.claude/skills/swamp-extension-datastore/references/testing.md
@@ -1,12 +1,81 @@
-# Unit Testing Datastore Providers
+# Testing Datastore Extensions
 
-The `@systeminit/swamp-testing` package provides `createDatastoreTestContext()`
-for unit testing datastore provider implementations without real storage
-backends.
+The `@systeminit/swamp-testing` package provides conformance suites and test
+doubles for datastore extensions.
 
 Install: `deno add jsr:@systeminit/swamp-testing`
 
-## createDatastoreTestContext Options
+## Export Conformance
+
+One call replaces all structural boilerplate tests (metadata, config schema,
+method existence on provider/lock/verifier):
+
+```typescript
+import { assertDatastoreExportConformance } from "@systeminit/swamp-testing";
+import { datastore } from "./s3.ts";
+
+Deno.test("datastore export conforms", () => {
+  assertDatastoreExportConformance(datastore, {
+    validConfigs: [{ bucket: "my-bucket", region: "us-east-1" }],
+    invalidConfigs: [{}, { bucket: "AB" }],
+  });
+});
+```
+
+This verifies: type matches naming pattern, name/description are non-empty,
+configSchema accepts/rejects configs, createProvider returns a DatastoreProvider
+with createLock/createVerifier/resolveDatastorePath, lock has all required
+methods, verifier has verify().
+
+## Lock Conformance
+
+Test the full DistributedLock contract against your implementation:
+
+```typescript
+import { assertLockConformance } from "@systeminit/swamp-testing";
+
+Deno.test("lock contract", async () => {
+  const lock = provider.createLock("/test/path");
+  await assertLockConformance(lock);
+});
+```
+
+Tests: acquire/release lifecycle, withLock executes and releases, withLock
+releases on error, inspect when held/not held, forceRelease with correct/wrong
+nonce, release is idempotent.
+
+Works with both real backends and mocked clients (e.g., `createMockS3Client`).
+
+## Verifier Conformance
+
+```typescript
+import { assertVerifierConformance } from "@systeminit/swamp-testing";
+
+Deno.test("verifier contract", async () => {
+  const verifier = provider.createVerifier();
+  await assertVerifierConformance(verifier);
+});
+```
+
+Validates: verify() returns a result with healthy (boolean), message (string),
+latencyMs (non-negative number), datastoreType (string).
+
+## In-Memory Test Double
+
+For testing code that _consumes_ a datastore (not the datastore itself):
+
+```typescript
+import { createDatastoreTestContext } from "@systeminit/swamp-testing";
+
+Deno.test("lock behavior", async () => {
+  const { provider, isLockHeld } = createDatastoreTestContext();
+  const lock = provider.createLock("/ds");
+
+  await lock.acquire();
+  assertEquals(isLockHeld(), true);
+  await lock.release();
+});
+```
 
 | Option             | Default                       | Description                      |
 | ------------------ | ----------------------------- | -------------------------------- |
@@ -16,88 +85,13 @@ Install: `deno add jsr:@systeminit/swamp-testing`
 | `lockAcquireFails` | `false`                       | Make lock acquire reject         |
 | `withSyncService`  | `false`                       | Enable `createSyncService`       |
 
-## Inspection Helpers
-
-```typescript
-const {
-  provider, // DatastoreProvider to pass to code under test
-  getLockOperations, // () => LockOperation[]
-  getSyncOperations, // () => SyncOperation[]
-  isLockHeld, // () => boolean
-} = createDatastoreTestContext();
-```
-
-## Testing Lock Behavior
-
-```typescript
-import { createDatastoreTestContext } from "@systeminit/swamp-testing";
-import { assertEquals } from "@std/assert";
-
-Deno.test("withLock executes callback under lock", async () => {
-  const { provider, isLockHeld } = createDatastoreTestContext();
-  const lock = provider.createLock("/ds");
-
-  let heldDuring = false;
-  await lock.withLock(async () => {
-    heldDuring = isLockHeld();
-    await Promise.resolve();
-  });
-
-  assertEquals(heldDuring, true);
-  assertEquals(isLockHeld(), false);
-});
-```
-
-## Testing Health Checks
-
-```typescript
-Deno.test("verifier reports healthy", async () => {
-  const { provider } = createDatastoreTestContext();
-  const result = await provider.createVerifier().verify();
-  assertEquals(result.healthy, true);
-});
-
-Deno.test("verifier reports unhealthy", async () => {
-  const { provider } = createDatastoreTestContext({
-    healthResult: { healthy: false, message: "Unreachable" },
-  });
-  const result = await provider.createVerifier().verify();
-  assertEquals(result.healthy, false);
-});
-```
-
-## Testing Sync Services
-
-```typescript
-Deno.test("sync service pulls and pushes", async () => {
-  const { provider, getSyncOperations } = createDatastoreTestContext({
-    withSyncService: true,
-  });
-
-  const sync = provider.createSyncService!("/repo", "/cache");
-  await sync.pullChanged();
-  await sync.pushChanged();
-
-  assertEquals(getSyncOperations().length, 2);
-});
-```
-
-## Testing Lock Failure Handling
-
-```typescript
-import { assertRejects } from "@std/assert";
-
-Deno.test("handles lock acquisition failure", async () => {
-  const { provider } = createDatastoreTestContext({ lockAcquireFails: true });
-  const lock = provider.createLock("/ds");
-  await assertRejects(() => lock.acquire(), Error);
-});
-```
-
 ## In-Repo Extensions
 
 Import directly from the testing package source:
 
 ```typescript
-import { createDatastoreTestContext } from "../../packages/testing/mod.ts";
+import {
+  assertDatastoreExportConformance,
+  assertLockConformance,
+} from "../../packages/testing/mod.ts";
 ```

--- a/.claude/skills/swamp-extension-vault/references/testing.md
+++ b/.claude/skills/swamp-extension-vault/references/testing.md
@@ -1,53 +1,63 @@
-# Unit Testing Vault Providers
+# Testing Vault Extensions
 
-The `@systeminit/swamp-testing` package provides `createVaultTestContext()` for
-unit testing code that interacts with vault providers without real secret
-storage.
+The `@systeminit/swamp-testing` package provides conformance suites and test
+doubles for vault extensions.
 
 Install: `deno add jsr:@systeminit/swamp-testing`
 
-## createVaultTestContext Options
+## Export Conformance
 
-| Option           | Default        | Description                           |
-| ---------------- | -------------- | ------------------------------------- |
-| `name`           | `"test-vault"` | Vault provider name                   |
-| `secrets`        | `{}`           | Pre-seed secrets for `get()` calls    |
-| `throwOnMissing` | `true`         | Reject on missing keys vs return `""` |
-
-## Inspection Helpers
+One call replaces all structural boilerplate tests (metadata, config schema,
+method existence):
 
 ```typescript
-const {
-  vault, // VaultProvider to pass to code under test
-  getStoredSecrets, // () => Record<string, string>
-  getOperations, // () => VaultOperation[]
-  getOperationsByMethod, // (method) => VaultOperation[]
-} = createVaultTestContext();
-```
-
-## Testing Vault Provider Implementations
-
-Test your `VaultProvider` implementation directly:
-
-```typescript
-import { assertEquals } from "@std/assert";
+import { assertVaultExportConformance } from "@systeminit/swamp-testing";
 import { vault } from "./my_vault.ts";
 
-Deno.test("stores and retrieves secrets", async () => {
-  const provider = vault.createProvider("test", {});
-  await provider.put("api-key", "sk-123");
-  assertEquals(await provider.get("api-key"), "sk-123");
+Deno.test("vault export conforms", () => {
+  assertVaultExportConformance(vault, {
+    validConfigs: [{ region: "us-east-1" }],
+    invalidConfigs: [{}, { region: "" }],
+  });
 });
 ```
 
-## Testing Code That Reads From Vaults
+This verifies: type matches naming pattern, name/description are non-empty,
+configSchema accepts valid and rejects invalid configs, createProvider returns
+an object with get/put/list/getName.
 
-Pre-seed secrets to test code that depends on vault values:
+## Behavioral Conformance
+
+Test the full VaultProvider contract against a real or mocked provider:
+
+```typescript
+import { assertVaultConformance } from "@systeminit/swamp-testing";
+
+Deno.test("vault contract", async () => {
+  const provider = vault.createProvider("test", { region: "us-east-1" });
+  await assertVaultConformance(provider);
+});
+```
+
+Tests: put/get roundtrip, get-missing rejects, put overwrites, list includes
+stored keys, getName returns non-empty string. Test keys are prefixed with
+`swamp-conformance-test-` and cleaned up automatically.
+
+Options:
+
+| Option      | Default                     | Description             |
+| ----------- | --------------------------- | ----------------------- |
+| `keyPrefix` | `"swamp-conformance-test-"` | Namespace for test keys |
+| `cleanup`   | `true`                      | Delete test keys after  |
+
+## In-Memory Test Double
+
+For testing code that _consumes_ a vault (not the vault itself):
 
 ```typescript
 import { createVaultTestContext } from "@systeminit/swamp-testing";
 
-Deno.test("model reads API key from vault", async () => {
+Deno.test("code reads from vault", async () => {
   const { vault, getOperations } = createVaultTestContext({
     secrets: { "api-key": "sk-test-123" },
   });
@@ -55,22 +65,6 @@ Deno.test("model reads API key from vault", async () => {
   const key = await vault.get("api-key");
   assertEquals(key, "sk-test-123");
   assertEquals(getOperations().length, 1);
-  assertEquals(getOperations()[0].method, "get");
-});
-```
-
-## Verifying Side Effects
-
-Use `getStoredSecrets()` to verify what was written:
-
-```typescript
-Deno.test("rotation writes new secret", async () => {
-  const { vault, getStoredSecrets } = createVaultTestContext({
-    secrets: { "api-key": "old-value" },
-  });
-
-  await vault.put("api-key", "new-value");
-  assertEquals(getStoredSecrets()["api-key"], "new-value");
 });
 ```
 
@@ -79,5 +73,5 @@ Deno.test("rotation writes new secret", async () => {
 Import directly from the testing package source:
 
 ```typescript
-import { createVaultTestContext } from "../../packages/testing/mod.ts";
+import { assertVaultExportConformance } from "../../packages/testing/mod.ts";
 ```


### PR DESCRIPTION
## Summary

- Update vault and datastore skill `references/testing.md` to lead with conformance suites (the primary value for extension authors) instead of test doubles
- Add examples for `assertVaultExportConformance`, `assertVaultConformance`, `assertDatastoreExportConformance`, `assertLockConformance`, and `assertVerifierConformance`

Follow-up to #963.

## Test Plan

- [x] Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)