### PR TITLE
fix: add env var detection warning to workflow step execution

### DIFF
--- a/packages/client/protocol.ts
+++ b/packages/client/protocol.ts
@@ -96,6 +96,14 @@ export type WorkflowRunEvent =
     methodName: string;
   }
   | {
+    kind: "env_var_warning";
+    jobId: string;
+    stepId: string;
+    modelName: string;
+    envVars: Array<{ path: string; envVar: string }>;
+    message: string;
+  }
+  | {
     kind: "method_executing";
     jobId: string;
     stepId: string;

--- a/src/domain/workflows/execution_events.ts
+++ b/src/domain/workflows/execution_events.ts
@@ -19,6 +19,7 @@
 
 import type { MethodExecutionEvent } from "../models/method_events.ts";
 import type { DataHandle } from "../models/model.ts";
+import type { EnvVarUsageDetail } from "../models/validation_service.ts";
 // deno-lint-ignore verbatim-module-syntax
 import { WorkflowRun } from "./workflow_run.ts";
 
@@ -73,6 +74,14 @@ export type WorkflowExecutionEvent =
     modelName: string;
     modelType: string;
     methodName: string;
+  }
+  | {
+    kind: "env_var_warning";
+    jobId: string;
+    stepId: string;
+    modelName: string;
+    envVars: EnvVarUsageDetail[];
+    message: string;
   }
   | {
     kind: "method_executing";

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -43,6 +43,7 @@ import { getAutoResolver } from "../extensions/auto_resolver_context.ts";
 import { DefaultMethodExecutionService } from "../models/method_execution_service.ts";
 import { DefaultModelValidationService } from "../models/validation_service.ts";
 import { buildOutputSpecs } from "../models/output_spec_builder.ts";
+import { detectEnvVarUsageInDefinition } from "../models/env_var_detector.ts";
 import type { Definition } from "../definitions/definition.ts";
 import { findDefinitionByIdOrName } from "../models/model_lookup.ts";
 import type { MethodExecutionEvent } from "../models/method_events.ts";
@@ -229,6 +230,20 @@ export class DefaultStepExecutor implements StepExecutor {
       modelType: modelType.normalized,
       methodName: task.methodName,
     });
+
+    // --- Check for env var usage and warn ---
+    const envVarUsages = detectEnvVarUsageInDefinition(originalDefinition);
+    if (envVarUsages.length > 0) {
+      ctx.emitEvent?.({
+        kind: "env_var_warning",
+        jobId: ctx.jobName,
+        stepId: ctx.stepName,
+        modelName: originalDefinition.name,
+        envVars: envVarUsages,
+        message:
+          "Data stored under this model will vary depending on these environment variables at runtime. Consider using separate models per environment, or vault.get() for sensitive values.",
+      });
+    }
 
     // Get the model definition from registry (auto-resolve if needed)
     const modelDef = await resolveModelType(modelType, getAutoResolver());

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -24,6 +24,7 @@ import type {
   WorkflowExecutionService,
 } from "../../domain/workflows/execution_service.ts";
 import type { MethodExecutionEvent } from "../../domain/models/method_events.ts";
+import type { EnvVarUsageDetail } from "../../domain/models/validation_service.ts";
 import type { Workflow } from "../../domain/workflows/workflow.ts";
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
 import type { StepRun } from "../../domain/workflows/workflow_run.ts";
@@ -107,6 +108,14 @@ export type WorkflowRunEvent =
     modelName: string;
     modelType: string;
     methodName: string;
+  }
+  | {
+    kind: "env_var_warning";
+    jobId: string;
+    stepId: string;
+    modelName: string;
+    envVars: EnvVarUsageDetail[];
+    message: string;
   }
   | {
     kind: "method_executing";
@@ -339,6 +348,7 @@ function mapEvent(
     case "step_skipped":
     case "step_failed":
     case "model_resolved":
+    case "env_var_warning":
     case "method_executing":
     case "method_output":
     case "method_event":

--- a/src/presentation/renderers/workflow_run.ts
+++ b/src/presentation/renderers/workflow_run.ts
@@ -102,6 +102,21 @@ class LogWorkflowRunRenderer implements WorkflowRunRenderer {
           { name: e.modelName, type: e.modelType },
         );
       },
+      env_var_warning: (e) => {
+        const logger = getWorkflowRunLogger(
+          this.workflowName,
+          e.jobId,
+          e.stepId,
+        );
+        logger.warn("Environment variables detected in model definition");
+        for (const detail of e.envVars) {
+          logger.warn("  {path} uses {envVar}", {
+            path: detail.path,
+            envVar: detail.envVar,
+          });
+        }
+        logger.warn(e.message);
+      },
       method_executing: (e) => {
         getRunLogger(e.modelName, e.methodName).info(
           "Executing method {method}",
@@ -229,6 +244,7 @@ class JsonWorkflowRunRenderer implements WorkflowRunRenderer {
       step_skipped: () => {},
       step_failed: () => {},
       model_resolved: () => {},
+      env_var_warning: () => {},
       method_executing: () => {},
       method_output: () => {},
       method_event: () => {},

--- a/src/presentation/renderers/workflow_run_tree/renderer.tsx
+++ b/src/presentation/renderers/workflow_run_tree/renderer.tsx
@@ -76,6 +76,7 @@ export class InkWorkflowRunRenderer implements WorkflowRunRenderer {
       step_skipped: forward,
       step_failed: forward,
       model_resolved: forward,
+      env_var_warning: forward,
       method_executing: forward,
       method_output: forward,
       method_event: forward,

--- a/src/presentation/renderers/workflow_run_tree/state.ts
+++ b/src/presentation/renderers/workflow_run_tree/state.ts
@@ -469,6 +469,7 @@ function treeReducerSingle(
       return { ...state, jobs };
     }
 
+    case "env_var_warning":
     case "method_executing":
       return state;
 


### PR DESCRIPTION
## Summary

Follow-up to #964 (which closed #947). The previous PR explicitly scoped out
env var detection in the workflow path — this PR adds it.

When a model definition contains `${{ env.VAR }}` expressions, both direct CLI
execution and workflow step execution now emit the same warning:

```
WRN Environment variables detected in model definition
WRN   "globalArguments.endpoint" uses "API_ENDPOINT"
WRN Data stored under this model will vary depending on these environment
    variables at runtime. Consider using separate models per environment,
    or vault.get() for sensitive values.
```

### Changes

- Add `env_var_warning` event to `WorkflowExecutionEvent` and `WorkflowRunEvent`
- Call `detectEnvVarUsageInDefinition` in `executeModelMethod` after model resolution
- Handle `env_var_warning` in all three workflow renderers (log, JSON, tree)
- Add `env_var_warning` to client protocol `WorkflowRunEvent`

## Test Plan

- **3867 passed, 0 failed** — full test suite
- `deno check`, `deno lint`, `deno fmt` clean
- Smoke tested with compiled binary:
  - Direct CLI `model method run` with `${{ env.API_ENDPOINT }}` in definition → warning shown ✅
  - `workflow run` with same model → identical warning now shown (previously missing) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)