### PR TITLE
feat: add withMockedFetch and withMockedCommand to swamp-testing

### DIFF
--- a/packages/testing/datastore_conformance.ts
+++ b/packages/testing/datastore_conformance.ts
@@ -287,22 +287,29 @@ export async function assertLockConformance(
   try {
     const info = await lock.inspect();
     assertExists(info, "lock must be held after acquire");
+    assertExists(
+      info!.nonce,
+      "lock info must include a nonce for forceRelease conformance",
+    );
+    assertEquals(
+      typeof info!.nonce,
+      "string",
+      "lock info nonce must be a string",
+    );
 
-    if (info && info.nonce) {
-      const released = await lock.forceRelease(info.nonce);
-      assertEquals(
-        released,
-        true,
-        "forceRelease with correct nonce must return true",
-      );
+    const released = await lock.forceRelease(info!.nonce!);
+    assertEquals(
+      released,
+      true,
+      "forceRelease with correct nonce must return true",
+    );
 
-      const infoAfterForce = await lock.inspect();
-      assertEquals(
-        infoAfterForce,
-        null,
-        "lock must be released after forceRelease",
-      );
-    }
+    const infoAfterForce = await lock.inspect();
+    assertEquals(
+      infoAfterForce,
+      null,
+      "lock must be released after forceRelease",
+    );
   } finally {
     // Ensure cleanup even if forceRelease didn't work
     try {
@@ -320,6 +327,13 @@ export async function assertLockConformance(
       released,
       false,
       "forceRelease with wrong nonce must return false",
+    );
+
+    // Verify lock is still held after wrong-nonce forceRelease
+    const stillHeld = await lock.inspect();
+    assertExists(
+      stillHeld,
+      "lock must remain held after wrong-nonce forceRelease",
     );
   } finally {
     await lock.release();

--- a/packages/testing/datastore_test_context.ts
+++ b/packages/testing/datastore_test_context.ts
@@ -86,7 +86,7 @@ export function createDatastoreTestContext(
 ): DatastoreTestContextResult {
   const lockOperations: LockOperation[] = [];
   const syncOperations: SyncOperation[] = [];
-  let lockHeld = false;
+  const heldLocks = new Map<string, boolean>();
 
   const datastorePath = options?.datastorePath ?? "/tmp/swamp-test-datastore";
   const cachePath = options?.cachePath;
@@ -120,7 +120,7 @@ export function createDatastoreTestContext(
             new Error(`Failed to acquire lock "${lockKey}"`),
           );
         }
-        lockHeld = true;
+        heldLocks.set(lockKey, true);
         return Promise.resolve();
       },
 
@@ -130,7 +130,7 @@ export function createDatastoreTestContext(
           lockKey,
           timestamp: Date.now(),
         });
-        lockHeld = false;
+        heldLocks.set(lockKey, false);
         return Promise.resolve();
       },
 
@@ -143,11 +143,11 @@ export function createDatastoreTestContext(
         if (lockAcquireFails) {
           throw new Error(`Failed to acquire lock "${lockKey}"`);
         }
-        lockHeld = true;
+        heldLocks.set(lockKey, true);
         try {
           return await fn();
         } finally {
-          lockHeld = false;
+          heldLocks.set(lockKey, false);
         }
       },
 
@@ -157,7 +157,7 @@ export function createDatastoreTestContext(
           lockKey,
           timestamp: Date.now(),
         });
-        if (!lockHeld) {
+        if (!heldLocks.get(lockKey)) {
           return Promise.resolve(null);
         }
         return Promise.resolve({
@@ -176,8 +176,8 @@ export function createDatastoreTestContext(
           lockKey,
           timestamp: Date.now(),
         });
-        if (lockHeld && expectedNonce === nonce) {
-          lockHeld = false;
+        if (heldLocks.get(lockKey) && expectedNonce === nonce) {
+          heldLocks.set(lockKey, false);
           return Promise.resolve(true);
         }
         return Promise.resolve(false);
@@ -237,6 +237,6 @@ export function createDatastoreTestContext(
     provider,
     getLockOperations: () => [...lockOperations],
     getSyncOperations: () => [...syncOperations],
-    isLockHeld: () => lockHeld,
+    isLockHeld: () => [...heldLocks.values()].some((held) => held),
   };
 }

--- a/packages/testing/mock_command.ts
+++ b/packages/testing/mock_command.ts
@@ -1,0 +1,173 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/** A recorded command execution for inspection. */
+export interface CapturedCommandCall {
+  command: string;
+  args: string[];
+  timestamp: number;
+}
+
+/** Result from withMockedCommand — includes the callback result and captured calls. */
+export interface MockCommandResult<T> {
+  result: T;
+  calls: CapturedCommandCall[];
+}
+
+/** The output shape returned by a command handler. */
+export interface CommandOutput {
+  stdout: string | Uint8Array;
+  stderr?: string | Uint8Array;
+  code: number;
+}
+
+/**
+ * A command handler that receives the command name and args, returns output.
+ * Can be async.
+ */
+export type CommandHandler = (
+  command: string,
+  args: string[],
+) => CommandOutput | Promise<CommandOutput>;
+
+/**
+ * Runs a callback with `Deno.Command` replaced by a mock.
+ *
+ * The mock can be:
+ * - A **CommandOutput array** — outputs are returned sequentially, one per command
+ * - A **handler function** — receives the command and args, returns output
+ *
+ * All command executions are recorded and returned for inspection.
+ * The original `Deno.Command` is always restored, even if the callback throws.
+ *
+ * **Simple mode** — sequential responses:
+ * ```typescript
+ * import { withMockedCommand } from "@systeminit/swamp-testing";
+ *
+ * const { result, calls } = await withMockedCommand([
+ *   { stdout: "sk-test-123", code: 0 },
+ * ], async () => {
+ *   const provider = vault.createProvider("test", { op_vault: "Eng" });
+ *   return await provider.get("api-key");
+ * });
+ *
+ * assertEquals(result, "sk-test-123");
+ * assertEquals(calls[0].command, "op");
+ * ```
+ *
+ * **Handler mode** — dynamic responses:
+ * ```typescript
+ * const { calls } = await withMockedCommand((cmd, args) => {
+ *   if (cmd === "op" && args.includes("read")) {
+ *     return { stdout: "sk-test-123", code: 0 };
+ *   }
+ *   return { stderr: "not found", code: 1 };
+ * }, async () => {
+ *   const provider = vault.createProvider("test", { op_vault: "Eng" });
+ *   await assertVaultConformance(provider);
+ * });
+ * ```
+ */
+export async function withMockedCommand<T>(
+  handlerOrOutputs: CommandHandler | CommandOutput[],
+  fn: () => T | Promise<T>,
+): Promise<MockCommandResult<T>> {
+  const calls: CapturedCommandCall[] = [];
+  let callIndex = 0;
+
+  const isSequential = Array.isArray(handlerOrOutputs);
+  const outputs = isSequential ? handlerOrOutputs : null;
+  const handler = isSequential ? null : handlerOrOutputs;
+
+  const OriginalCommand = Deno.Command;
+
+  function toBytes(value: string | Uint8Array | undefined): Uint8Array {
+    if (value === undefined) return new Uint8Array();
+    if (value instanceof Uint8Array) return value;
+    return new TextEncoder().encode(value);
+  }
+
+  // @ts-ignore: replacing Deno.Command for testing
+  Deno.Command = class MockCommand {
+    #command: string;
+    #args: string[];
+
+    constructor(
+      command: string | URL,
+      options?: { args?: string[]; [key: string]: unknown },
+    ) {
+      this.#command = command.toString();
+      this.#args = (options?.args as string[]) ?? [];
+    }
+
+    output(): Promise<Deno.CommandOutput> {
+      calls.push({
+        command: this.#command,
+        args: this.#args,
+        timestamp: Date.now(),
+      });
+
+      const getOutput = async (): Promise<CommandOutput> => {
+        if (outputs) {
+          if (callIndex >= outputs.length) {
+            throw new Error(
+              `withMockedCommand: no more outputs (got ${
+                callIndex + 1
+              } calls, ` +
+                `only ${outputs.length} outputs queued). ` +
+                `Last call: ${this.#command} ${this.#args.join(" ")}`,
+            );
+          }
+          return outputs[callIndex++];
+        }
+        return await handler!(this.#command, this.#args);
+      };
+
+      return getOutput().then((out) => ({
+        code: out.code,
+        signal: null,
+        success: out.code === 0,
+        stdout: toBytes(out.stdout),
+        stderr: toBytes(out.stderr),
+      })) as Promise<Deno.CommandOutput>;
+    }
+
+    spawn(): Deno.ChildProcess {
+      throw new Error(
+        "withMockedCommand: spawn() is not supported in mock mode. " +
+          "Use output() instead.",
+      );
+    }
+
+    outputSync(): Deno.CommandOutput {
+      throw new Error(
+        "withMockedCommand: outputSync() is not supported in mock mode. " +
+          "Use output() instead.",
+      );
+    }
+  };
+
+  try {
+    const result = await fn();
+    return { result, calls };
+  } finally {
+    // @ts-ignore: restoring original Deno.Command
+    Deno.Command = OriginalCommand;
+  }
+}

--- a/packages/testing/mock_command_test.ts
+++ b/packages/testing/mock_command_test.ts
@@ -1,0 +1,174 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects } from "@std/assert";
+import { withMockedCommand } from "./mock_command.ts";
+
+// --- Sequential mode ---
+
+Deno.test("withMockedCommand: sequential mode returns outputs in order", async () => {
+  const { result, calls } = await withMockedCommand([
+    { stdout: "first", code: 0 },
+    { stdout: "second", code: 0 },
+  ], async () => {
+    const c1 = new Deno.Command("echo", { args: ["first"] });
+    const c2 = new Deno.Command("echo", { args: ["second"] });
+    const o1 = await c1.output();
+    const o2 = await c2.output();
+    return {
+      first: new TextDecoder().decode(o1.stdout),
+      second: new TextDecoder().decode(o2.stdout),
+    };
+  });
+
+  assertEquals(result.first, "first");
+  assertEquals(result.second, "second");
+  assertEquals(calls.length, 2);
+  assertEquals(calls[0].command, "echo");
+  assertEquals(calls[0].args, ["first"]);
+  assertEquals(calls[1].args, ["second"]);
+});
+
+Deno.test("withMockedCommand: sequential mode throws when exhausted", async () => {
+  await assertRejects(
+    () =>
+      withMockedCommand([
+        { stdout: "ok", code: 0 },
+      ], async () => {
+        const c1 = new Deno.Command("cmd1");
+        await c1.output();
+        const c2 = new Deno.Command("cmd2");
+        await c2.output();
+      }),
+    Error,
+    "no more outputs",
+  );
+});
+
+// --- Handler mode ---
+
+Deno.test("withMockedCommand: handler mode routes by command", async () => {
+  const { result } = await withMockedCommand((cmd, args) => {
+    if (cmd === "op" && args.includes("read")) {
+      return { stdout: "secret-value", code: 0 };
+    }
+    return { stdout: "", stderr: "unknown command", code: 1 };
+  }, async () => {
+    const c = new Deno.Command("op", { args: ["read", "op://vault/key"] });
+    const out = await c.output();
+    return new TextDecoder().decode(out.stdout);
+  });
+
+  assertEquals(result, "secret-value");
+});
+
+Deno.test("withMockedCommand: handler receives full args", async () => {
+  const { calls } = await withMockedCommand(() => {
+    return { stdout: "", code: 0 };
+  }, async () => {
+    const c = new Deno.Command("git", {
+      args: ["commit", "-m", "test message"],
+    });
+    await c.output();
+  });
+
+  assertEquals(calls[0].command, "git");
+  assertEquals(calls[0].args, ["commit", "-m", "test message"]);
+});
+
+// --- Exit code and stderr ---
+
+Deno.test("withMockedCommand: non-zero exit code sets success=false", async () => {
+  const { result } = await withMockedCommand([
+    { stdout: "", stderr: "not found", code: 1 },
+  ], async () => {
+    const c = new Deno.Command("failing-cmd");
+    const out = await c.output();
+    return {
+      success: out.success,
+      code: out.code,
+      stderr: new TextDecoder().decode(out.stderr),
+    };
+  });
+
+  assertEquals(result.success, false);
+  assertEquals(result.code, 1);
+  assertEquals(result.stderr, "not found");
+});
+
+Deno.test("withMockedCommand: zero exit code sets success=true", async () => {
+  const { result } = await withMockedCommand([
+    { stdout: "ok", code: 0 },
+  ], async () => {
+    const c = new Deno.Command("succeeding-cmd");
+    const out = await c.output();
+    return out.success;
+  });
+
+  assertEquals(result, true);
+});
+
+// --- Restore ---
+
+Deno.test("withMockedCommand: restores original Deno.Command after success", async () => {
+  const OriginalCommand = Deno.Command;
+  await withMockedCommand([], () => {});
+  assertEquals(Deno.Command, OriginalCommand);
+});
+
+Deno.test("withMockedCommand: restores original Deno.Command after error", async () => {
+  const OriginalCommand = Deno.Command;
+  try {
+    await withMockedCommand([], () => {
+      throw new Error("test error");
+    });
+  } catch {
+    // expected
+  }
+  assertEquals(Deno.Command, OriginalCommand);
+});
+
+// --- Return value ---
+
+Deno.test("withMockedCommand: returns callback result", async () => {
+  const { result } = await withMockedCommand([
+    { stdout: "42", code: 0 },
+  ], async () => {
+    const c = new Deno.Command("echo", { args: ["42"] });
+    const out = await c.output();
+    return parseInt(new TextDecoder().decode(out.stdout));
+  });
+
+  assertEquals(result, 42);
+});
+
+// --- Uint8Array input ---
+
+Deno.test("withMockedCommand: accepts Uint8Array stdout", async () => {
+  const bytes = new Uint8Array([0x48, 0x65, 0x6c, 0x6c, 0x6f]);
+  const { result } = await withMockedCommand([
+    { stdout: bytes, code: 0 },
+  ], async () => {
+    const c = new Deno.Command("binary-cmd");
+    const out = await c.output();
+    return out.stdout;
+  });
+
+  assertEquals(result, bytes);
+});

--- a/packages/testing/mock_fetch.ts
+++ b/packages/testing/mock_fetch.ts
@@ -1,0 +1,146 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/** A recorded fetch call for inspection. */
+export interface CapturedFetchCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string | null;
+  timestamp: number;
+}
+
+/** Result from withMockedFetch — includes the callback result and captured calls. */
+export interface MockFetchResult<T> {
+  result: T;
+  calls: CapturedFetchCall[];
+}
+
+/**
+ * A fetch handler that receives a Request and returns a Response.
+ * Can be async.
+ */
+export type FetchHandler = (
+  request: Request,
+) => Response | Promise<Response>;
+
+/**
+ * Runs a callback with `globalThis.fetch` replaced by a mock.
+ *
+ * The mock can be:
+ * - A **Response array** — responses are returned sequentially, one per call
+ * - A **handler function** — receives the Request and returns a Response
+ *
+ * All fetch calls are recorded and returned for inspection.
+ * The original `fetch` is always restored, even if the callback throws.
+ *
+ * **Simple mode** — sequential responses:
+ * ```typescript
+ * import { withMockedFetch } from "@systeminit/swamp-testing";
+ *
+ * const { result, calls } = await withMockedFetch([
+ *   Response.json({ SecretString: "sk-test-123" }),
+ * ], async () => {
+ *   const provider = vault.createProvider("test", { region: "us-east-1" });
+ *   return await provider.get("my-key");
+ * });
+ *
+ * assertEquals(result, "sk-test-123");
+ * assertEquals(calls.length, 1);
+ * ```
+ *
+ * **Handler mode** — dynamic responses:
+ * ```typescript
+ * const { calls } = await withMockedFetch(async (req) => {
+ *   const body = await req.json();
+ *   if (body.SecretId) {
+ *     return Response.json({ SecretString: "value" });
+ *   }
+ *   return Response.json({ SecretList: [] });
+ * }, async () => {
+ *   const provider = vault.createProvider("test", { region: "us-east-1" });
+ *   await assertVaultConformance(provider);
+ * });
+ * ```
+ */
+export async function withMockedFetch<T>(
+  handlerOrResponses: FetchHandler | Response[],
+  fn: () => T | Promise<T>,
+): Promise<MockFetchResult<T>> {
+  const calls: CapturedFetchCall[] = [];
+  let callIndex = 0;
+
+  const isSequential = Array.isArray(handlerOrResponses);
+  const responses = isSequential ? handlerOrResponses : null;
+  const handler = isSequential ? null : handlerOrResponses;
+
+  const originalFetch = globalThis.fetch;
+
+  const mockFetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    // Normalize to a Request object
+    const request = input instanceof Request ? input : new Request(input, init);
+
+    // Capture the call
+    const headers: Record<string, string> = {};
+    request.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+
+    let body: string | null = null;
+    try {
+      body = await request.clone().text();
+    } catch {
+      // Body may not be readable
+    }
+
+    calls.push({
+      url: request.url,
+      method: request.method,
+      headers,
+      body,
+      timestamp: Date.now(),
+    });
+
+    // Return response
+    if (responses) {
+      if (callIndex >= responses.length) {
+        throw new Error(
+          `withMockedFetch: no more responses (got ${callIndex + 1} calls, ` +
+            `only ${responses.length} responses queued). ` +
+            `Last call: ${request.method} ${request.url}`,
+        );
+      }
+      return responses[callIndex++].clone();
+    }
+
+    return await handler!(request);
+  };
+
+  globalThis.fetch = mockFetch as typeof fetch;
+
+  try {
+    const result = await fn();
+    return { result, calls };
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}

--- a/packages/testing/mock_fetch_test.ts
+++ b/packages/testing/mock_fetch_test.ts
@@ -1,0 +1,137 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects } from "@std/assert";
+import { withMockedFetch } from "./mock_fetch.ts";
+
+// --- Sequential mode ---
+
+Deno.test("withMockedFetch: sequential mode returns responses in order", async () => {
+  const { result, calls } = await withMockedFetch([
+    Response.json({ value: "first" }),
+    Response.json({ value: "second" }),
+  ], async () => {
+    const r1 = await fetch("https://api.example.com/one");
+    const r2 = await fetch("https://api.example.com/two");
+    return {
+      first: await r1.json(),
+      second: await r2.json(),
+    };
+  });
+
+  assertEquals(result.first.value, "first");
+  assertEquals(result.second.value, "second");
+  assertEquals(calls.length, 2);
+  assertEquals(calls[0].url, "https://api.example.com/one");
+  assertEquals(calls[1].url, "https://api.example.com/two");
+});
+
+Deno.test("withMockedFetch: sequential mode throws when exhausted", async () => {
+  await assertRejects(
+    () =>
+      withMockedFetch([
+        Response.json({ ok: true }),
+      ], async () => {
+        await fetch("https://api.example.com/one");
+        await fetch("https://api.example.com/two"); // no response queued
+      }),
+    Error,
+    "no more responses",
+  );
+});
+
+// --- Handler mode ---
+
+Deno.test("withMockedFetch: handler mode routes by URL", async () => {
+  const { result } = await withMockedFetch((req) => {
+    if (req.url.includes("/secrets")) {
+      return Response.json({ secret: "sk-123" });
+    }
+    return Response.json({ error: "not found" }, { status: 404 });
+  }, async () => {
+    const r = await fetch("https://api.example.com/secrets");
+    return await r.json();
+  });
+
+  assertEquals(result.secret, "sk-123");
+});
+
+Deno.test("withMockedFetch: handler receives request body", async () => {
+  const { calls } = await withMockedFetch(async (req) => {
+    const body = await req.json();
+    return Response.json({ echo: body.message });
+  }, async () => {
+    await fetch("https://api.example.com/echo", {
+      method: "POST",
+      body: JSON.stringify({ message: "hello" }),
+    });
+  });
+
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0].method, "POST");
+  assertEquals(calls[0].body, '{"message":"hello"}');
+});
+
+// --- Call recording ---
+
+Deno.test("withMockedFetch: captures headers", async () => {
+  const { calls } = await withMockedFetch([
+    Response.json({}),
+  ], async () => {
+    await fetch("https://api.example.com/test", {
+      headers: { "Authorization": "Bearer token123" },
+    });
+  });
+
+  assertEquals(calls[0].headers["authorization"], "Bearer token123");
+});
+
+// --- Restore ---
+
+Deno.test("withMockedFetch: restores original fetch after success", async () => {
+  const originalFetch = globalThis.fetch;
+  await withMockedFetch([], () => {});
+  assertEquals(globalThis.fetch, originalFetch);
+});
+
+Deno.test("withMockedFetch: restores original fetch after error", async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    await withMockedFetch([], () => {
+      throw new Error("test error");
+    });
+  } catch {
+    // expected
+  }
+  assertEquals(globalThis.fetch, originalFetch);
+});
+
+// --- Return value ---
+
+Deno.test("withMockedFetch: returns callback result", async () => {
+  const { result } = await withMockedFetch([
+    Response.json({ val: 42 }),
+  ], async () => {
+    const r = await fetch("https://api.example.com/number");
+    const data = await r.json();
+    return data.val as number;
+  });
+
+  assertEquals(result, 42);
+});

--- a/packages/testing/mod.ts
+++ b/packages/testing/mod.ts
@@ -155,3 +155,22 @@ export type {
   TestDefinitionRepository,
   WorkflowReportContext,
 } from "./report_types.ts";
+
+// --- Mocking ---
+
+export { withMockedFetch } from "./mock_fetch.ts";
+
+export type {
+  CapturedFetchCall,
+  FetchHandler,
+  MockFetchResult,
+} from "./mock_fetch.ts";
+
+export { withMockedCommand } from "./mock_command.ts";
+
+export type {
+  CapturedCommandCall,
+  CommandHandler,
+  CommandOutput,
+  MockCommandResult,
+} from "./mock_command.ts";

--- a/packages/testing/report_test_context.ts
+++ b/packages/testing/report_test_context.ts
@@ -187,7 +187,9 @@ export function createReportTestContext(
         a.data.name === dataName &&
         (version === undefined || a.data.version === version)
       );
-      return Promise.resolve(match?.content ?? null);
+      return Promise.resolve(
+        match?.content ? new Uint8Array(match.content) : null,
+      );
     },
 
     findAllForModel(

--- a/packages/testing/vault_conformance.ts
+++ b/packages/testing/vault_conformance.ts
@@ -18,11 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 // deno-lint-ignore-file no-import-prefix
-import {
-  assertEquals,
-  assertExists,
-  assertStringIncludes,
-} from "jsr:@std/assert@1.0.19";
+import { assertEquals, assertExists } from "jsr:@std/assert@1.0.19";
 import type { VaultProvider } from "./vault_types.ts";
 
 /**
@@ -219,17 +215,25 @@ export async function assertVaultConformance(
     await provider.put(testKey2, "conformance-value-2");
     createdKeys.push(testKey2);
 
+    // re-read first key to confirm second write didn't clobber it
+    const value1AfterKey2 = await provider.get(testKey1);
+    assertEquals(
+      value1AfterKey2,
+      "conformance-value-updated",
+      "get(key1) must still return key1's value after writing key2",
+    );
+
     // list includes stored keys
     const keys = await provider.list();
     assertEquals(Array.isArray(keys), true, "list() must return an array");
-    assertStringIncludes(
-      keys.join(","),
-      testKey1,
+    assertEquals(
+      keys.includes(testKey1),
+      true,
       `list() must include "${testKey1}"`,
     );
-    assertStringIncludes(
-      keys.join(","),
-      testKey2,
+    assertEquals(
+      keys.includes(testKey2),
+      true,
       `list() must include "${testKey2}"`,
     );
 

--- a/src/domain/datastore/testing_package_compat_test.ts
+++ b/src/domain/datastore/testing_package_compat_test.ts
@@ -49,7 +49,10 @@ function _checkDistributedLockFields(lock: TestingDistributedLock) {
   const _forceRelease: ReturnType<CanonicalDistributedLock["forceRelease"]> =
     lock.forceRelease("nonce");
 
-  void [_acquire, _release, _inspect, _forceRelease];
+  // withLock — verify it exists and returns a Promise
+  const _withLock: Promise<void> = lock.withLock(() => Promise.resolve());
+
+  void [_acquire, _release, _inspect, _forceRelease, _withLock];
 }
 
 // DatastoreVerifier: verify method signature matches.

--- a/src/domain/drivers/testing_package_compat_test.ts
+++ b/src/domain/drivers/testing_package_compat_test.ts
@@ -100,7 +100,11 @@ function _checkExecutionResultFields(result: TestingExecutionResult) {
   const _followUpActions: CanonicalExecutionResult["followUpActions"] =
     result.followUpActions;
 
-  void [_status, _error, _logs, _durationMs, _followUpActions];
+  // outputs field — uses DriverOutput with DataHandle (branded DataId)
+  // so verify the array exists, not full assignability
+  const _outputs: TestingExecutionResult["outputs"] = result.outputs;
+
+  void [_status, _error, _logs, _durationMs, _followUpActions, _outputs];
 }
 
 // ExecutionDriver: verify interface shape.
@@ -108,8 +112,10 @@ function _checkExecutionDriverFields(driver: TestingExecutionDriver) {
   const _type: CanonicalExecutionDriver["type"] = driver.type;
   const _initialize: CanonicalExecutionDriver["initialize"] = driver.initialize;
   const _shutdown: CanonicalExecutionDriver["shutdown"] = driver.shutdown;
+  // execute is the most important method — verify it exists
+  const _execute: TestingExecutionDriver["execute"] = driver.execute;
 
-  void [_type, _initialize, _shutdown];
+  void [_type, _initialize, _shutdown, _execute];
 }
 
 Deno.test("testing package driver types: compile-time compatibility check", () => {


### PR DESCRIPTION
## Summary

Add two runtime mock primitives that test extension code on the exact same code path as production — no injection or alternative paths needed:

- **`withMockedFetch(handler|responses[], fn)`** — replaces `globalThis.fetch` for the callback's duration. Covers any HTTP-based SDK (AWS, Azure, GCP, REST APIs).
- **`withMockedCommand(handler|outputs[], fn)`** — replaces `Deno.Command` for the callback's duration. Covers any CLI-tool-wrapping extension (1password's `op`, etc.).

Both support two modes:
- **Sequential** — pass an array of canned responses, consumed one per call
- **Handler** — pass a function that routes dynamically based on the request/command

All calls are recorded for inspection after the test.

### Example: testing an AWS vault extension

```typescript
await withMockedFetch(async (req) => {
  const body = await req.json();
  if (body.SecretId) return Response.json({ SecretString: "sk-123" });
  return Response.json({ SecretList: [] });
}, async () => {
  // This is the EXACT production code path — real SecretsManagerClient,
  // real SDK, just intercepted at the fetch boundary
  const provider = vault.createProvider("test", { region: "us-east-1" });
  await assertVaultConformance(provider);
});
```

### Also fixes review issues from #963

- `vault_conformance`: use `keys.includes()` instead of `assertStringIncludes` on joined keys
- `vault_conformance`: re-read key1 after writing key2 to detect single-variable clobbering
- `datastore_test_context`: use per-lock `Map` instead of shared `lockHeld` boolean
- `datastore_conformance`: require `nonce` in `LockInfo`, verify lock still held after wrong-nonce `forceRelease`
- `report_test_context`: clone `Uint8Array` in `getContent` to prevent mutation
- Driver compat test: verify `execute` method and `outputs` field
- Datastore compat test: verify `withLock` method

115 tests pass (97 existing + 18 new mock tests).

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] `deno run test packages/testing/` — 115 tests pass
- [x] Compat tests pass with new assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)