### PR TITLE
fix: resolve all expressions in forEach step names to prevent duplicate name collisions

### DIFF
--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -1402,13 +1402,23 @@ export class WorkflowExecutionService {
             },
           };
 
-          // Evaluate step name (may contain ${{ self.env }})
+          // Evaluate ALL expressions in step name (may contain multiple
+          // like ${{ self.ep.attributes.show }}-${{ self.ep.attributes.rawTitle }})
           let expandedName = step.name;
-          const nameMatch = step.name.match(/\$\{\{\s*(.+?)\s*\}\}/);
-          if (nameMatch) {
-            const value = celEvaluator.evaluate(nameMatch[1], stepContext);
-            expandedName = step.name.replace(nameMatch[0], String(value));
-          } else if (!nameHasExpression) {
+          if (nameHasExpression) {
+            expandedName = step.name.replace(
+              /\$\{\{\s*(.+?)\s*\}\}/g,
+              (_match, expr) => {
+                try {
+                  return String(
+                    celEvaluator.evaluate(expr as string, stepContext),
+                  );
+                } catch {
+                  return _match as string;
+                }
+              },
+            );
+          } else {
             // Step name has no expression template — append item value for uniqueness
             if (
               item !== null && typeof item === "object"
@@ -1445,13 +1455,22 @@ export class WorkflowExecutionService {
             },
           };
 
-          // Evaluate step name
+          // Evaluate ALL expressions in step name
           let expandedName = step.name;
-          const nameMatch = step.name.match(/\$\{\{\s*(.+?)\s*\}\}/);
-          if (nameMatch) {
-            const evalValue = celEvaluator.evaluate(nameMatch[1], stepContext);
-            expandedName = step.name.replace(nameMatch[0], String(evalValue));
-          } else if (!nameHasExpression) {
+          if (nameHasExpression) {
+            expandedName = step.name.replace(
+              /\$\{\{\s*(.+?)\s*\}\}/g,
+              (_match, expr) => {
+                try {
+                  return String(
+                    celEvaluator.evaluate(expr as string, stepContext),
+                  );
+                } catch {
+                  return _match as string;
+                }
+              },
+            );
+          } else {
             // Step name has no expression template — append key for uniqueness
             expandedName = `${step.name}-${key}`;
           }


### PR DESCRIPTION
## Summary

- `expandForEachSteps()` used `.match()` (no `g` flag) to resolve step name expressions, only replacing the **first** `${{ }}`. Step names with multiple expressions (e.g. `dl-${{ self.ep.attributes.show }}-${{ self.ep.attributes.rawTitle }}`) produced duplicate names when items shared the same first field value.
- Duplicate names caused `TopologicalSortService.sort()` to throw `CyclicDependencyError` (the sort's `nodeMap` deduplicates by name, so `processed.size` never reaches `nodes.length`). The error was caught silently, leaving the job in "running" state.
- Fix: use `.replace()` with `g` flag to resolve ALL expressions in forEach step names. Applied to both array and object iteration branches.

## Test Plan

- [x] Verified with real `eztv-check` workflow in swamp-media — all 16 download steps now execute with fully-resolved unique names
- [x] All 30 existing execution_service tests pass
- [x] `deno check`, `deno lint`, `deno fmt` pass

Closes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)