### PR TITLE
fix: resolve datastore sync path mismatch for remote datastores

### DIFF
--- a/packages/testing/datastore_types.ts
+++ b/packages/testing/datastore_types.ts
@@ -68,8 +68,8 @@ export interface DatastoreVerifier {
 
 /** Interface for datastore synchronization services. */
 export interface DatastoreSyncService {
-  pullChanged(): Promise<void>;
-  pushChanged(): Promise<void>;
+  pullChanged(): Promise<number | void>;
+  pushChanged(): Promise<number | void>;
 }
 
 /**

--- a/src/domain/datastore/datastore_sync_service.ts
+++ b/src/domain/datastore/datastore_sync_service.ts
@@ -25,7 +25,7 @@
  */
 export interface DatastoreSyncService {
   /** Pull changed files from the remote datastore to the local cache. */
-  pullChanged(): Promise<void>;
+  pullChanged(): Promise<number | void>;
   /** Push changed files from the local cache to the remote datastore. */
-  pushChanged(): Promise<void>;
+  pushChanged(): Promise<number | void>;
 }

--- a/src/infrastructure/persistence/default_datastore_path_resolver.ts
+++ b/src/infrastructure/persistence/default_datastore_path_resolver.ts
@@ -52,8 +52,12 @@ export class DefaultDatastorePathResolver implements DatastorePathResolver {
 
     // Determine the base path for the datastore
     if (isCustomDatastoreConfig(datastoreConfig)) {
-      // Custom: path was eagerly resolved during config resolution
-      this.datastoreBasePath = datastoreConfig.datastorePath;
+      // For remote datastores with a local cache (e.g. S3), use the cache
+      // path so reads/writes go to the same directory the sync service
+      // pushes from and pulls to.  Fall back to datastorePath for custom
+      // datastores that don't use a separate cache.
+      this.datastoreBasePath = datastoreConfig.cachePath ??
+        datastoreConfig.datastorePath;
     } else {
       this.datastoreBasePath = datastoreConfig.path;
     }

--- a/src/infrastructure/persistence/default_datastore_path_resolver_test.ts
+++ b/src/infrastructure/persistence/default_datastore_path_resolver_test.ts
@@ -147,6 +147,38 @@ Deno.test("DefaultDatastorePathResolver - default config (no external datastore)
   );
 });
 
+Deno.test("DefaultDatastorePathResolver - custom datastore prefers cachePath over datastorePath", () => {
+  const config: DatastoreConfig = {
+    type: "s3",
+    config: { bucket: "my-bucket" },
+    datastorePath: "/repo/.swamp",
+    cachePath: "/home/user/.swamp/repos/abc",
+  };
+  const resolver = new DefaultDatastorePathResolver("/repo", config);
+  // Data should go to cachePath so the sync service can find it
+  assertEquals(
+    resolver.datastorePath("data"),
+    "/home/user/.swamp/repos/abc/data",
+  );
+  assertEquals(
+    resolver.resolvePath("data", "foo"),
+    "/home/user/.swamp/repos/abc/data/foo",
+  );
+});
+
+Deno.test("DefaultDatastorePathResolver - custom datastore falls back to datastorePath without cachePath", () => {
+  const config: DatastoreConfig = {
+    type: "custom",
+    config: {},
+    datastorePath: "/shared/datastore",
+  };
+  const resolver = new DefaultDatastorePathResolver("/repo", config);
+  assertEquals(
+    resolver.datastorePath("data"),
+    "/shared/datastore/data",
+  );
+});
+
 Deno.test("DefaultDatastorePathResolver - config returns the stored config", () => {
   const config: DatastoreConfig = {
     type: "filesystem",

--- a/src/libswamp/datastores/sync.ts
+++ b/src/libswamp/datastores/sync.ts
@@ -93,17 +93,21 @@ export function createDatastoreSyncDeps(
       validateSyncSupport: () =>
         Promise.resolve({ supported: true, type: config.type }),
       pushSync: async () => {
-        await syncService.pushChanged();
-        return { filesPushed: 0 };
+        const count = await syncService.pushChanged();
+        return { filesPushed: typeof count === "number" ? count : 0 };
       },
       pullSync: async () => {
-        await syncService.pullChanged();
-        return { filesPulled: 0 };
+        const count = await syncService.pullChanged();
+        return { filesPulled: typeof count === "number" ? count : 0 };
       },
       fullSync: async () => {
-        await syncService.pullChanged();
-        await syncService.pushChanged();
-        return { filesPulled: 0, filesPushed: 0, errors: [] };
+        const pulled = await syncService.pullChanged();
+        const pushed = await syncService.pushChanged();
+        return {
+          filesPulled: typeof pulled === "number" ? pulled : 0,
+          filesPushed: typeof pushed === "number" ? pushed : 0,
+          errors: [],
+        };
       },
     };
   }


### PR DESCRIPTION
## Summary

Fixes a bug where data written during workflow execution with S3 (or other
remote) datastores was never pushed to the remote, making it invisible to
other machines pulling from the same datastore.

## Root Cause

For custom datastores with a local cache (e.g. `@swamp/s3-datastore`), there
are two path values in `CustomDatastoreConfig`:

| Field | S3 provider resolves to | Used by |
|-------|------------------------|---------|
| `datastorePath` | `{repoDir}/.swamp` | `DefaultDatastorePathResolver` — base for all data reads/writes |
| `cachePath` | `~/.swamp/repos/unknown` | `S3CacheSyncService` — directory scanned for push, target for pull |

These are **different directories**. The consequence:

1. **CI writes data** to `{repoDir}/.swamp/data/...` (via the path resolver
   using `datastorePath`)
2. **Push scans** `~/.swamp/repos/unknown/` (via the sync service using
   `cachePath`) — finds no files — pushes nothing to S3
3. **Local pull** downloads from S3 to `~/.swamp/repos/unknown/` — but the
   path resolver reads from `{repoDir}/.swamp/` — data is invisible

The S3 provider's `resolveCachePath()` comment even says *"return a sensible
default that core will override"*, but the `??` fallback in config resolution
never triggers because the provider returns a string (not `undefined`).

## The Fix

**`DefaultDatastorePathResolver`** now uses `cachePath ?? datastorePath` as
the base path for custom datastores. This ensures data reads/writes go to
the same directory the sync service pushes from and pulls to. When no
`cachePath` is configured, it falls back to the original `datastorePath`
behavior.

Additionally, `DatastoreSyncService.pullChanged()`/`pushChanged()` now
return `Promise<number | void>` instead of `Promise<void>`, and
`createDatastoreSyncDeps` passes through real file counts instead of
hardcoding zero. This fixes misleading output like `"Pulled 0 files"` and
`"already up to date"` even when files were actually transferred.

## Files Changed

- **`src/infrastructure/persistence/default_datastore_path_resolver.ts`** —
  Use `cachePath ?? datastorePath` for remote datastores
- **`src/infrastructure/persistence/default_datastore_path_resolver_test.ts`** —
  Add tests for cachePath preference and fallback
- **`src/domain/datastore/datastore_sync_service.ts`** — Return
  `Promise<number | void>` from sync methods
- **`src/libswamp/datastores/sync.ts`** — Pass through real counts from sync
  service instead of hardcoding 0
- **`packages/testing/datastore_types.ts`** — Match updated interface

> **Note:** The `@swamp/s3-datastore` extension also needs a matching update
> to return actual file counts from `pullChanged()`/`pushChanged()`. That
> change lives in `swamp-extensions/datastore/s3/` (separate repo).

## Test Plan

- All 7734 unit tests pass (2 pre-existing date-sensitive failures in
  `update_notification_service_test.ts`, unrelated)
- New tests verify `cachePath` is preferred over `datastorePath` for custom
  datastores, and that `datastorePath` is used as fallback when no
  `cachePath` exists
- Manual verification: built binary, ran `swamp datastore sync`, confirmed
  data from S3 is now visible via `swamp data search`
- Full round-trip (CI push → local pull) requires deploying the fixed binary
  to CI and running a workflow