### PR TITLE
refactor: extract resolveForEachStepName helper to DRY up forEach expansion

### DIFF
--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -966,6 +966,53 @@ interface StepOptions {
 }
 
 /**
+ * Result of resolving a forEach step name template.
+ */
+export interface ResolvedStepName {
+  /** The resolved step name. */
+  name: string;
+  /** Whether any expression evaluation failed during resolution. */
+  hadEvalFailure: boolean;
+}
+
+/**
+ * Resolves a forEach step name template by evaluating `${{ }}` expressions,
+ * or falls back to appending a suffix when no expressions are present.
+ *
+ * When expression evaluation fails, the raw expression is preserved and the
+ * fallbackSuffix is appended to ensure uniqueness across iterations.
+ */
+export function resolveForEachStepName(
+  template: string,
+  hasExpression: boolean,
+  stepContext: Record<string, unknown>,
+  celEvaluator: CelEvaluator,
+  fallbackSuffix: string,
+): ResolvedStepName {
+  if (hasExpression) {
+    let hadEvalFailure = false;
+    const resolved = template.replace(
+      /\$\{\{\s*(.+?)\s*\}\}/g,
+      (_match, expr) => {
+        try {
+          return String(
+            celEvaluator.evaluate(expr as string, stepContext),
+          );
+        } catch {
+          hadEvalFailure = true;
+          return _match as string;
+        }
+      },
+    );
+    return {
+      name: hadEvalFailure ? `${resolved}-${fallbackSuffix}` : resolved,
+      hadEvalFailure,
+    };
+  }
+  return { name: `${template}-${fallbackSuffix}`, hadEvalFailure: false };
+}
+
+/**
  * Domain service for workflow execution.
  */
 export class WorkflowExecutionService {
@@ -1417,48 +1464,37 @@ export class WorkflowExecutionService {
             },
           };
 
-          // Evaluate ALL expressions in step name (may contain multiple
-          // like ${{ self.ep.attributes.show }}-${{ self.ep.attributes.rawTitle }})
-          let expandedName = step.name;
-          if (nameHasExpression) {
-            let hadEvalFailure = false;
-            expandedName = step.name.replace(
-              /\$\{\{\s*(.+?)\s*\}\}/g,
-              (_match, expr) => {
-                try {
-                  return String(
-                    celEvaluator.evaluate(expr as string, stepContext),
-                  );
-                } catch {
-                  hadEvalFailure = true;
-                  return _match as string;
-                }
-              },
+          // Resolve step name expressions or fall back to a unique suffix.
+          // For the expression-failure path, always use index for uniqueness.
+          // For the no-expression path, use item value for primitives, index for objects.
+          const fallbackSuffix = nameHasExpression
+            ? String(index)
+            : (item !== null && typeof item === "object")
+            ? String(index)
+            : String(item);
+          if (
+            !nameHasExpression && item !== null && typeof item === "object"
+          ) {
+            getLogger(["swamp", "workflows"]).warn(
+              "forEach step '{stepName}' uses index-based naming because item is an object. " +
+                "Consider adding a ${{{{ self.{itemName}.<field> }}}} expression to the step name for better observability.",
+              { stepName: step.name, itemName },
             );
-            if (hadEvalFailure) {
-              expandedName = `${expandedName}-${index}`;
-              getLogger(["swamp", "workflows"]).warn(
-                "forEach step '{stepName}' has expression(s) that failed to evaluate for item at index {index}. " +
-                  "Appending index to prevent duplicate names. " +
-                  "Check that the expression references valid properties on self.{itemName}.",
-                { stepName: step.name, index, itemName },
-              );
-            }
-          } else {
-            // Step name has no expression template — append item value for uniqueness
-            if (
-              item !== null && typeof item === "object"
-            ) {
-              // Objects/arrays stringify to "[object Object]" which causes duplicate names
-              expandedName = `${step.name}-${index}`;
-              getLogger(["swamp", "workflows"]).warn(
-                "forEach step '{stepName}' uses index-based naming because item is an object. " +
-                  "Consider adding a ${{{{ self.{itemName}.<field> }}}} expression to the step name for better observability.",
-                { stepName: step.name, itemName },
-              );
-            } else {
-              expandedName = `${step.name}-${String(item)}`;
-            }
+          }
+          const { name: expandedName, hadEvalFailure } = resolveForEachStepName(
+            step.name,
+            nameHasExpression,
+            stepContext,
+            celEvaluator,
+            fallbackSuffix,
+          );
+          if (hadEvalFailure) {
+            getLogger(["swamp", "workflows"]).warn(
+              "forEach step '{stepName}' has expression(s) that failed to evaluate for item at index {index}. " +
+                "Appending index to prevent duplicate names. " +
+                "Check that the expression references valid properties on self.{itemName}.",
+              { stepName: step.name, index, itemName },
+            );
           }
 
           expandedSteps.push({
@@ -1481,35 +1517,21 @@ export class WorkflowExecutionService {
             },
           };
 
-          // Evaluate ALL expressions in step name
-          let expandedName = step.name;
-          if (nameHasExpression) {
-            let hadEvalFailure = false;
-            expandedName = step.name.replace(
-              /\$\{\{\s*(.+?)\s*\}\}/g,
-              (_match, expr) => {
-                try {
-                  return String(
-                    celEvaluator.evaluate(expr as string, stepContext),
-                  );
-                } catch {
-                  hadEvalFailure = true;
-                  return _match as string;
-                }
-              },
+          // Resolve step name expressions or fall back to key suffix
+          const { name: expandedName, hadEvalFailure } = resolveForEachStepName(
+            step.name,
+            nameHasExpression,
+            stepContext,
+            celEvaluator,
+            key,
+          );
+          if (hadEvalFailure) {
+            getLogger(["swamp", "workflows"]).warn(
+              "forEach step '{stepName}' has expression(s) that failed to evaluate for key '{key}'. " +
+                "Appending key to prevent duplicate names. " +
+                "Check that the expression references valid properties on self.{itemName}.",
+              { stepName: step.name, key, itemName },
             );
-            if (hadEvalFailure) {
-              expandedName = `${expandedName}-${key}`;
-              getLogger(["swamp", "workflows"]).warn(
-                "forEach step '{stepName}' has expression(s) that failed to evaluate for key '{key}'. " +
-                  "Appending key to prevent duplicate names. " +
-                  "Check that the expression references valid properties on self.{itemName}.",
-                { stepName: step.name, key, itemName },
-              );
-            }
-          } else {
-            // Step name has no expression template — append key for uniqueness
-            expandedName = `${step.name}-${key}`;
           }
 
           expandedSteps.push({

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -20,6 +20,7 @@
 import { assertEquals, assertNotEquals, assertRejects } from "@std/assert";
 import {
   DefaultStepExecutor,
+  resolveForEachStepName,
   type StepExecutionContext,
   type StepExecutor,
   WorkflowExecutionService,
@@ -40,6 +41,7 @@ import type {
   WorkflowRunRepository,
 } from "./repositories.ts";
 import type { WorkflowRun } from "./workflow_run.ts";
+import { CelEvaluator } from "../../infrastructure/cel/cel_evaluator.ts";
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   const dir = await Deno.makeTempDir({ prefix: "swamp-test-" });
@@ -2323,4 +2325,116 @@ Deno.test("expandForEachSteps: does not append index when expression evaluates s
       true,
     );
   });
+});
+
+// --- resolveForEachStepName tests ---
+
+function makeStepContext(
+  vars: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    self: {
+      id: "test-id",
+      name: "test",
+      ...vars,
+    },
+  };
+}
+
+Deno.test("resolveForEachStepName: resolves single expression in template", () => {
+  const cel = new CelEvaluator();
+  const ctx = makeStepContext({ item: "hello" });
+  const result = resolveForEachStepName(
+    "step-${{ self.item }}",
+    true,
+    ctx,
+    cel,
+    "fallback",
+  );
+  assertEquals(result.name, "step-hello");
+  assertEquals(result.hadEvalFailure, false);
+});
+
+Deno.test("resolveForEachStepName: resolves multiple expressions in template", () => {
+  const cel = new CelEvaluator();
+  const ctx = makeStepContext({ show: "MyShow", title: "Episode1" });
+  const result = resolveForEachStepName(
+    "dl-${{ self.show }}-${{ self.title }}",
+    true,
+    ctx,
+    cel,
+    "0",
+  );
+  assertEquals(result.name, "dl-MyShow-Episode1");
+  assertEquals(result.hadEvalFailure, false);
+});
+
+Deno.test("resolveForEachStepName: appends fallback suffix when expression fails", () => {
+  const cel = new CelEvaluator();
+  const ctx = makeStepContext();
+  const result = resolveForEachStepName(
+    "step-${{ self.missing.deep.field }}",
+    true,
+    ctx,
+    cel,
+    "0",
+  );
+  assertEquals(result.name, "step-${{ self.missing.deep.field }}-0");
+  assertEquals(result.hadEvalFailure, true);
+});
+
+Deno.test("resolveForEachStepName: appends fallback suffix when no expressions", () => {
+  const cel = new CelEvaluator();
+  const ctx = makeStepContext();
+  const result = resolveForEachStepName(
+    "download",
+    false,
+    ctx,
+    cel,
+    "my-key",
+  );
+  assertEquals(result.name, "download-my-key");
+  assertEquals(result.hadEvalFailure, false);
+});
+
+Deno.test("resolveForEachStepName: uses numeric fallback suffix for index-based naming", () => {
+  const cel = new CelEvaluator();
+  const ctx = makeStepContext();
+  const result = resolveForEachStepName(
+    "process",
+    false,
+    ctx,
+    cel,
+    "3",
+  );
+  assertEquals(result.name, "process-3");
+  assertEquals(result.hadEvalFailure, false);
+});
+
+Deno.test("resolveForEachStepName: resolves expression with object property access", () => {
+  const cel = new CelEvaluator();
+  const ctx = makeStepContext({ ep: { attributes: { show: "Futurama" } } });
+  const result = resolveForEachStepName(
+    "dl-${{ self.ep.attributes.show }}",
+    true,
+    ctx,
+    cel,
+    "0",
+  );
+  assertEquals(result.name, "dl-Futurama");
+  assertEquals(result.hadEvalFailure, false);
+});
+
+Deno.test("resolveForEachStepName: mixed resolved and failed expressions appends suffix", () => {
+  const cel = new CelEvaluator();
+  const ctx = makeStepContext({ item: "resolved" });
+  const result = resolveForEachStepName(
+    "${{ self.item }}-${{ self.nonexistent.deep }}",
+    true,
+    ctx,
+    cel,
+    "0",
+  );
+  assertEquals(result.name, "resolved-${{ self.nonexistent.deep }}-0");
+  assertEquals(result.hadEvalFailure, true);
 });


### PR DESCRIPTION
## Summary

- Extracted `resolveForEachStepName()` helper to eliminate duplicated `${{ }}` expression resolution logic across the array and object iteration branches in `expandForEachSteps()`
- Both branches now call the shared helper, which evaluates all expressions via CEL with graceful fallback for failures, or appends a fallback suffix when no expressions are present
- Added 7 unit tests covering single/multiple expression resolution, failing expression fallback, fallback suffix appending, nested object property access, and mixed resolved/failed expressions

## Test Plan

- [x] 7 new `resolveForEachStepName` unit tests pass
- [x] All 30 existing `execution_service` tests pass (no behavioral changes)
- [x] Full test suite passes (3892 tests)
- [x] `deno check`, `deno lint`, `deno fmt` pass
- [x] `deno run compile` succeeds

Fixes #978

🤖 Generated with [Claude Code](https://claude.com/claude-code)