### PR TITLE
fix: add success log with file count to per-model lock push

### DIFF
--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -696,7 +696,14 @@ export async function acquireModelLocks(
         try {
           await pushLock.acquire();
           logger.info`Pushing changes to datastore...`;
-          await customSyncService.pushChanged();
+          const pushed = await customSyncService.pushChanged();
+          if (pushed && pushed > 0) {
+            logger.info("Pushed {count} file(s) to datastore", {
+              count: pushed,
+            });
+          } else {
+            logger.info`Push complete, no changes`;
+          }
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);
           logger.error("Failed to push changes to datastore: {error}", {


### PR DESCRIPTION
## Summary

The flush function in `acquireModelLocks` logged `"Pushing changes to
datastore..."` but had no log after `pushChanged()` completed. This made
it impossible to tell from CI logs whether the push finished, how many
files were uploaded, or if zero changes were found.

Now logs one of:
- `Pushed N file(s) to datastore` — push completed with uploads
- `Push complete, no changes` — push ran but found nothing to upload
- (no log) — push didn't complete (process killed/timeout)
- `Failed to push changes to datastore: ...` — push error (existing)

Follow-up to #977 to help diagnose CI push behavior.

## Test Plan

- `deno check`, `deno lint`, `deno fmt` pass
- Log output verified by reading the code path