### PR TITLE
feat: document stdin and interactive input in vault put help text

### DIFF
--- a/src/cli/commands/vault_put.ts
+++ b/src/cli/commands/vault_put.ts
@@ -109,8 +109,34 @@ type AnyOptions = any;
 
 export const vaultPutCommand = new Command()
   .name("put")
-  .description("Store a secret in a vault")
+  .description(
+    `Store a secret in a vault.
+
+The value can be provided in several ways:
+  - As a third argument:   swamp vault put <vault> <key> <value>
+  - Inline with KEY=VALUE: swamp vault put <vault> KEY=VALUE
+  - Piped via stdin:       echo "val" | swamp vault put <vault> <key>
+  - Interactive prompt:    swamp vault put <vault> <key>  (prompts with hidden input)
+
+Piping via stdin is recommended for scripts and CI to avoid exposing secrets in the process argument list.`,
+  )
   .arguments("<vault_name:string> <key:string> [value:string]")
+  .example(
+    "Inline KEY=VALUE",
+    "swamp vault put my-vault API_KEY=sk-1234567890",
+  )
+  .example(
+    "Pipe from stdin (recommended for scripts)",
+    'echo "$SECRET" | swamp vault put my-vault API_KEY',
+  )
+  .example(
+    "Interactive prompt (value is hidden)",
+    "swamp vault put my-vault API_KEY",
+  )
+  .example(
+    "Overwrite existing secret",
+    "swamp vault put my-vault API_KEY=new-value --force",
+  )
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("-f, --force", "Skip confirmation prompt when overwriting")
   .action(async function (


### PR DESCRIPTION
## Summary

- Expand `swamp vault put --help` description to document all four value input methods: explicit argument, KEY=VALUE inline, piped stdin, and interactive prompt
- Add `.example()` entries showing each usage pattern
- Recommend stdin piping for scripts/CI to avoid process-list secret exposure

Closes #992

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] All 16 existing `vault_put_test.ts` tests pass
- [x] `swamp vault put --help` renders the new description and examples correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)