### PR TITLE
fix: preserve data artifacts in workflow runs when model methods fail

### DIFF
--- a/src/domain/drivers/raw_execution_driver.ts
+++ b/src/domain/drivers/raw_execution_driver.ts
@@ -147,31 +147,54 @@ export class RawExecutionDriver implements ExecutionDriver {
       createFileWriter,
     };
 
-    const result = await this.executor.execute(
-      this.definition,
-      this.method,
-      this.contextWithWriters,
-    );
+    try {
+      const result = await this.executor.execute(
+        this.definition,
+        this.method,
+        this.contextWithWriters,
+      );
 
-    const durationMs = performance.now() - start;
-    const writerHandles = [
-      ...getResourceHandles(),
-      ...getFileHandles(),
-    ];
-    const handles = result.dataHandles?.length
-      ? result.dataHandles
-      : writerHandles;
-    const outputs = handles.map((handle) => ({
-      kind: "persisted" as const,
-      handle,
-    }));
+      const durationMs = performance.now() - start;
+      const writerHandles = [
+        ...getResourceHandles(),
+        ...getFileHandles(),
+      ];
+      const handles = result.dataHandles?.length
+        ? result.dataHandles
+        : writerHandles;
+      const outputs = handles.map((handle) => ({
+        kind: "persisted" as const,
+        handle,
+      }));
 
-    return {
-      status: "success",
-      outputs,
-      logs,
-      durationMs,
-      followUpActions: result.followUpActions,
-    };
+      return {
+        status: "success",
+        outputs,
+        logs,
+        durationMs,
+        followUpActions: result.followUpActions,
+      };
+    } catch (error) {
+      // Collect handles for data that was already written to disk before the
+      // throw. Without this, data produced by a method that writes-then-throws
+      // (e.g. code-review verdict=FAIL) would be invisible to workflow queries.
+      const durationMs = performance.now() - start;
+      const writerHandles = [
+        ...getResourceHandles(),
+        ...getFileHandles(),
+      ];
+      const outputs = writerHandles.map((handle) => ({
+        kind: "persisted" as const,
+        handle,
+      }));
+
+      return {
+        status: "error",
+        error: error instanceof Error ? error.message : String(error),
+        outputs,
+        logs,
+        durationMs,
+      };
+    }
   }
 }

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -613,7 +613,20 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
               "this is a bug; raw driver should only produce persisted outputs",
           );
         }
+        // Process outputs first — even on error, data may have been written
+        // to disk before the method threw (e.g. code-review writes log then
+        // throws on verdict=FAIL). Handles must survive the error path.
         currentHandles = await processDriverOutputs(driverResult.outputs);
+
+        if (driverResult.status === "error") {
+          const err = new Error(
+            driverResult.error ?? "Method execution failed",
+          );
+          (err as unknown as Record<string, unknown>).dataHandles =
+            currentHandles;
+          throw err;
+        }
+
         result = {
           dataHandles: currentHandles,
           followUpActions: driverResult

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -413,6 +413,15 @@ export class DefaultStepExecutor implements StepExecutor {
     const resources: Record<string, Record<string, DataRecord>> = {};
     const files: Record<string, Record<string, FileDataRecord>> = {};
 
+    // Declared outside try so the catch block can record artifacts written
+    // before a throw (e.g. model writes data then throws on verdict=FAIL).
+    const savedArtifacts: Array<{
+      dataId: string;
+      name: string;
+      version: number;
+      tags: Record<string, string>;
+    }> = [];
+
     try {
       runLogger.debug("Executing method {method}", {
         method: task.methodName,
@@ -525,12 +534,6 @@ export class DefaultStepExecutor implements StepExecutor {
       );
 
       // Extract artifact info from dataHandles (already persisted by DataWriter)
-      const savedArtifacts: Array<{
-        dataId: string;
-        name: string;
-        version: number;
-        tags: Record<string, string>;
-      }> = [];
       if (result.dataHandles && result.dataHandles.length > 0) {
         for (const handle of result.dataHandles) {
           const artifactRef = {
@@ -756,6 +759,24 @@ export class DefaultStepExecutor implements StepExecutor {
         dataHandles: result.dataHandles ?? [],
       };
     } catch (error) {
+      // Recover data handles written before the throw (e.g. model wrote data
+      // then threw on verdict=FAIL). The driver attaches them to the error.
+      const errorHandles = (error as Record<string, unknown>).dataHandles as
+        | import("../models/model.ts").DataHandle[]
+        | undefined;
+      if (errorHandles && errorHandles.length > 0) {
+        for (const handle of errorHandles) {
+          const artifactRef = {
+            dataId: handle.dataId,
+            name: handle.name,
+            version: handle.version,
+            tags: handle.tags,
+          };
+          output.addDataArtifact(artifactRef);
+          savedArtifacts.push(artifactRef);
+        }
+      }
+
       // Mark output as failed and save
       const errorMessage = error instanceof Error
         ? error.message
@@ -868,6 +889,11 @@ export class DefaultStepExecutor implements StepExecutor {
         );
       }
 
+      // Attach saved artifacts to the error so the outer step loop can
+      // record them in the step run even though the step failed.
+      if (savedArtifacts.length > 0) {
+        (error as Record<string, unknown>).dataArtifacts = savedArtifacts;
+      }
       throw error;
     }
   }
@@ -1783,6 +1809,22 @@ export class WorkflowExecutionService {
         dataHandles: stepDataHandles,
       };
     } catch (error) {
+      // Record data artifacts that were written before the throw so they
+      // survive in the workflow run record for later data get --workflow.
+      const errorArtifacts = (error as Record<string, unknown>).dataArtifacts as
+        | Array<{
+          dataId: string;
+          name: string;
+          version: number;
+          tags: Record<string, string>;
+        }>
+        | undefined;
+      if (errorArtifacts) {
+        for (const artifact of errorArtifacts) {
+          stepRun.addDataArtifact(artifact);
+        }
+      }
+
       const errorMessage = error instanceof Error
         ? error.message
         : String(error);


### PR DESCRIPTION
## Summary

Fixes #986 — `swamp data get --workflow` returns "Data not found" for data that
exists on disk and is accessible via direct model lookup.

### The Problem

When a model method writes data to disk and then throws an error, the data
artifacts are lost from the workflow run record. For example, the
`@swamp/ci/code-review` model:

1. Writes the review log via `logWriter.finalize()` → **persisted to disk**
2. Writes the review result via `context.writeResource()` → **persisted to disk**
3. Checks `if (verdict === "fail")` → **throws** `Error("Code review standard failed...")`
4. `return { dataHandles: [resultHandle, logHandle] }` → **never reached**

Because the `return` is never reached, `RawExecutionDriver` propagates the throw
without collecting the handles that `getResourceHandles()`/`getFileHandles()`
already tracked. The workflow run record is saved with `status: failed` and
**no `dataArtifacts`**, making the data invisible to `data get --workflow`.

### The Fix

Three changes to preserve data artifacts through the error chain:

1. **`RawExecutionDriver`** — catch the throw, collect already-persisted handles
   from the writer closures (`getResourceHandles()`/`getFileHandles()`), return
   an error result with outputs attached (same pattern the Docker driver uses).

2. **`MethodExecutionService`** — process raw driver outputs *before* checking
   error status so handles survive the error path. Attach handles to the thrown
   error.

3. **`WorkflowExecutionService`** — hoist `savedArtifacts` above the try block,
   extract handles from caught errors, record them in both the `ModelOutput` and
   the `StepRun` before re-throwing.

### Why This Affects Only `RawExecutionDriver`

The Docker driver doesn't have this issue — it returns pending outputs for the
caller to persist and never creates writers directly. The raw driver is the only
driver that creates `createResourceWriter`/`createFileWriterFactory`, lets the
model write directly to disk, then collects handles afterward. When the model
throws between writing and returning, the handles were lost.

## Test Plan

- All 3903 existing tests pass
- Compiled binary and verified against
  `/Users/stack72/code/systeminit/swamp-git-server/swamp-repo`:
  - `swamp data get code-review log-swamp-git-server-standard-c4aedca` → data
    exists on disk (1079 bytes)
  - Confirmed workflow run record has `status: failed` with no `dataArtifacts`
    (the bug)
  - Traced the exact throw in `code_review.js:419` (writes data, then throws on
    verdict=FAIL)
- `deno check`, `deno lint`, `deno fmt` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)