### PR TITLE
feat: require filing unrelated issues found during triage

### DIFF
--- a/.claude/skills/issue-lifecycle/SKILL.md
+++ b/.claude/skills/issue-lifecycle/SKILL.md
@@ -444,3 +444,7 @@ feedback, and CI results is persisted in the model data.
    reference specific files, functions, and test paths.
 6. **Use DDD analysis.** Every plan should identify domain concepts, entities,
    and services affected by the change.
+7. **File unrelated issues immediately.** If you discover a bug, code smell, or
+   problem during investigation that is NOT related to the current issue, file
+   it as a new GitHub issue in swamp using the `swamp-issue` skill. Do not try
+   to fix it in the current work span — keep the scope focused.


### PR DESCRIPTION
## Summary

- Adds Key Rule 7 to the issue-lifecycle skill: issues discovered during investigation that are NOT related to the current work must be filed as separate GitHub issues using the `swamp-issue` skill
- Prevents scope creep and ensures incidental findings get tracked rather than derailing the current fix (e.g., the `coordsMap` staleness edge case in #966)

## Context

This is the final piece from the #974 retro. Combined with the reproduction step added in #996, the skill now covers all four proposals:

1. **Production reproduction / debug-first** → reproduction step (step 5)
2. **Challenge the symptom** → reproduction step's requirement to document discrepancies (step 5d)
3. **File unrelated issues** → this PR (Key Rule 7)

Closes #974

## Test Plan

- Skill markdown change only — no code changes
- Verified the rule is correctly numbered and formatted in the Key Rules section

🤖 Generated with [Claude Code](https://claude.com/claude-code)