### PR TITLE
feat: add .example() to auth and utility CLI commands

### DIFF
--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -142,6 +142,9 @@ export const auditRecordCommand = new Command()
 export const auditCommand = new Command()
   .name("audit")
   .description("View audit timeline of swamp vs direct CLI commands")
+  .example("View audit timeline", "swamp audit")
+  .example("Last 4 hours", "swamp audit --hours 4")
+  .example("Include all commands", "swamp audit --all")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("--hours <hours:number>", "Number of hours to analyze", {
     default: 24,

--- a/src/cli/commands/auth_login.ts
+++ b/src/cli/commands/auth_login.ts
@@ -41,6 +41,15 @@ type AnyOptions = any;
 export const authLoginCommand = new Command()
   .name("login")
   .description("Authenticate with a swamp-club server")
+  .example("Login via browser", "swamp auth login")
+  .example(
+    "Login to custom server",
+    "swamp auth login --server https://registry.example.com",
+  )
+  .example(
+    "Non-interactive login",
+    "swamp auth login --username alice --password secret --no-browser",
+  )
   .option(
     "--server <url:string>",
     "Server URL (env: SWAMP_CLUB_URL)",

--- a/src/cli/commands/auth_logout.ts
+++ b/src/cli/commands/auth_logout.ts
@@ -34,6 +34,7 @@ type AnyOptions = any;
 export const authLogoutCommand = new Command()
   .name("logout")
   .description("Remove stored authentication credentials")
+  .example("Remove stored credentials", "swamp auth logout")
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, ["auth", "logout"]);
     cliCtx.logger.debug("Executing auth logout command");

--- a/src/cli/commands/auth_whoami.ts
+++ b/src/cli/commands/auth_whoami.ts
@@ -33,6 +33,7 @@ type AnyOptions = any;
 export const authWhoamiCommand = new Command()
   .name("whoami")
   .description("Show current authenticated identity")
+  .example("Show current identity", "swamp auth whoami")
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, ["auth", "whoami"]);
     cliCtx.logger.debug("Executing auth whoami command");

--- a/src/cli/commands/completion.ts
+++ b/src/cli/commands/completion.ts
@@ -46,4 +46,6 @@ import { CompletionsCommand } from "@cliffy/command/completions";
  * Note: Model and workflow name completions are directory-dependent.
  * They return names from the current working directory's swamp repository.
  */
-export const completionCommand = new CompletionsCommand();
+export const completionCommand = new CompletionsCommand()
+  .example("Generate zsh completions", "swamp completions zsh")
+  .example("Generate bash completions", "swamp completions bash");

--- a/src/cli/commands/summarise.ts
+++ b/src/cli/commands/summarise.ts
@@ -40,6 +40,9 @@ export const summariseCommand = new Command()
   .description(
     "Show a high-level overview of repo activity (method executions, workflows, data)",
   )
+  .example("Show recent activity", "swamp summarise")
+  .example("Activity from the last day", "swamp summarise --since 1d")
+  .example("Activity from the last hour", "swamp summarise --since 1h")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("--since <duration:string>", "Time window (e.g. 1h, 1d, 7d, 1w)", {
     default: "7d",

--- a/src/cli/commands/telemetry_stats.ts
+++ b/src/cli/commands/telemetry_stats.ts
@@ -32,6 +32,8 @@ import { VERSION } from "./version.ts";
 export const telemetryStatsCommand = new Command()
   .name("stats")
   .description("View telemetry usage statistics")
+  .example("View usage statistics", "swamp telemetry stats")
+  .example("Last 7 days", "swamp telemetry stats --days 7")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("--days <days:number>", "Number of days to analyze", { default: 2 })
   .action(async function (options) {


### PR DESCRIPTION
## Summary

- Add `.example()` usage examples to 7 CLI commands covering auth (batch 1) and utility (batch 13) from #993
- Auth: `auth login` (3 examples), `auth logout` (1), `auth whoami` (1)
- Utility: `completions` (2), `summarise` (3), `telemetry stats` (2), `audit` (3)

Closes partially #993

## Test Plan

- [x] `deno fmt` passes
- [x] `deno lint` passes
- [x] `deno check` passes
- [x] `deno run test` — all 3913 tests pass
- [x] `deno run compile` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)