### PR TITLE
refactor: split issue-lifecycle skill into progressive disclosure references

### DIFF
--- a/.claude/skills/issue-lifecycle/SKILL.md
+++ b/.claude/skills/issue-lifecycle/SKILL.md
@@ -20,392 +20,38 @@ conversationally — the human steers, you execute.
 **Never auto-approve.** Always stop and show the plan to the human. Always ask
 for feedback. Only call `approve` when the human explicitly says to proceed.
 
-## Starting a New Triage
+## Lifecycle Phases
 
-When the user says something like "triage issue #850" or "triage
-systeminit/swamp#850":
+Each phase has detailed instructions in a reference file. Read only the
+reference you need for the current phase.
 
-1. **Create the model instance** (if it doesn't already exist):
-   ```
-   swamp model create @si/issue-lifecycle issue-<N> \
-     --global-arg issueNumber=<N> --json
-   ```
-   The repo defaults to `systeminit/swamp`. Override with
-   `--global-arg repo=<owner/repo>` for other repositories.
+### Phase 1: Triage (steps 1–5)
 
-2. **Fetch the issue context**:
-   ```
-   swamp model method run issue-<N> start
-   ```
+Read [references/triage.md](references/triage.md) when starting a new triage or
+resuming an issue in the `triaging` phase. Covers: creating the model instance,
+fetching issue context, reading the codebase, classifying the issue, and
+reproducing bugs.
 
-3. **Read the issue context** from the model output, then **read the codebase**:
-   - Read `CLAUDE.md` and `design/*.md`
-   - Read relevant skills (especially `ddd/SKILL.md`)
-   - Explore source files related to the issue
-   - Trace code paths to understand the problem
-   - **Check for regression signals**: If the issue describes a bug, use
-     `git log` on the affected files to see if they were recently changed. Check
-     if the described behavior worked in a prior version. This informs whether
-     to classify as `bug` or `regression`.
+### Phase 2: Planning (steps 6–9)
 
-4. **Classify the issue** based on your analysis:
-   ```
-   swamp model method run issue-<N> triage \
-     --input type=<bug|feature|regression|unclear> \
-     --input confidence=<high|medium|low> \
-     --input reasoning="<your analysis>"
-   ```
+Read [references/planning.md](references/planning.md) after triage is complete.
+Covers: generating the implementation plan, checking documentation impact,
+assessing UAT coverage gaps, and presenting to the human.
 
-   **Classification guidance:**
-   - `bug` — something is broken or behaving incorrectly
-   - `feature` — a request for new functionality or enhancement
-   - `regression` — a bug where something **previously worked** but is now
-     broken. Look for signals like: "this used to work", "stopped working
-     after", "worked in version X", references to recent changes that broke
-     existing behavior, or git history showing the affected code was recently
-     modified. Regressions get both `bug` and `regression` labels.
-   - `unclear` — not enough information to classify confidently
+### Phase 3: Adversarial Review & Iteration
 
-5. **Reproduce the bug** (bugs and regressions only — skip for features):
+Read [references/adversarial-review.md](references/adversarial-review.md)
+**immediately after every `plan` or `iterate` call — no exceptions.** Planning
+and adversarial review are always paired: you never present a plan without
+running the review first. Covers: challenging the plan across 7 dimensions,
+verifying against the codebase, recording findings, presenting to the human, and
+the iteration loop until approval.
 
-   Before planning a fix, reproduce the issue in an isolated scratch repo to
-   confirm the failure mode and understand it firsthand.
+### Phase 4: Implementation & CI
 
-   a. **Ensure swamp is up to date:**
-   ```
-   swamp update
-   ```
-
-   b. **Create a scratch repo:**
-   ```
-   mkdir -p /tmp/swamp-repro-issue-<N>
-   cd /tmp/swamp-repro-issue-<N>
-   swamp repo init
-   ```
-
-   c. **Build a minimal reproduction.** Based on the issue description and your
-   codebase analysis, create the simplest set of models and/or workflows that
-   trigger the bug. Use an Agent (subagent) to do this — give it the issue
-   context, the error description, and tell it to create and run a swamp
-   scenario that reproduces the problem. The agent should:
-   - Create model definitions and workflow YAML files
-   - Create any required input data
-   - Run the workflow or model method that triggers the issue
-   - Capture the exact error output or incorrect behavior
-
-   d. **Document what you observed.** Before moving to planning, record:
-   - The exact commands that reproduce the issue
-   - The actual output/error (copy it verbatim)
-   - The expected output/behavior
-   - Any differences from what the issue originally described
-
-   e. **Keep the scratch repo.** You'll reuse it in the verification step after
-   the fix is implemented. The path `/tmp/swamp-repro-issue-<N>` must survive
-   until verification is complete.
-
-   If the bug **cannot be reproduced**, note that in the plan. It may mean the
-   issue description is incomplete, the bug is environment-specific, or the
-   underlying code has already changed. Ask the human how to proceed.
-
-6. **Generate an implementation plan**:
-
-   First, write a single YAML file (e.g. `/tmp/plan.yaml`) containing both
-   `steps` and `potentialChallenges` as top-level keys. The CLI only supports
-   one `--input-file` flag per invocation, and the file must be a YAML object
-   (not a bare array).
-
-   ```yaml
-   # /tmp/plan.yaml
-   steps:
-     - order: 1
-       description: "Add the new schema types"
-       files:
-         - src/domain/schemas.ts
-       risks: "May need migration"
-     - order: 2
-       description: "Update the service layer"
-       files:
-         - src/domain/service.ts
-         - src/domain/service_test.ts
-   potentialChallenges:
-     - "Backwards compatibility with existing data"
-     - "Test coverage for edge cases"
-   ```
-
-   Then run the method. The `--input` flags handle scalar values, and
-   `--input-file` handles the structured data:
-
-   ```
-   swamp model method run issue-<N> plan \
-     --input summary="..." \
-     --input dddAnalysis="..." \
-     --input testingStrategy="..." \
-     --input-file /tmp/plan.yaml
-   ```
-
-7. **Check for documentation impact.** Before presenting the plan, evaluate
-   whether the change affects anything described in `design/*.md` or
-   `.claude/skills/`. If so, include explicit plan steps to update those files.
-   Common triggers: new domain concepts, changed CLI commands or flags, new
-   extension patterns, modified architectural decisions, renamed types or
-   methods referenced in skill examples.
-
-8. **Show the plan to the human**, then **run adversarial review** (see below).
-
-## Adversarial Plan Review
-
-After **every** `plan` or `iterate` call, you MUST run an adversarial review
-before the human can approve. This is automatic — do not skip it.
-
-### Step 1: Challenge the plan
-
-Re-read the plan, then critically evaluate it across these dimensions:
-
-- **Architecture**: Does this follow DDD principles? Are domain boundaries
-  correct? Is this the right abstraction level? Are there better patterns?
-- **Scope**: Is this doing too much or too little? Does it match the issue? Is
-  there scope creep? Are there unnecessary changes?
-- **Risk**: Are all failure modes identified? What about edge cases, race
-  conditions, backwards compatibility? What could go wrong that isn't listed?
-- **Testing**: Is the testing strategy sufficient? Are edge cases covered? Are
-  there integration test gaps? Is there over-reliance on unit tests?
-- **Complexity**: Is this over-engineered? Could it be simpler? Are there
-  unnecessary abstractions or indirections?
-- **Correctness**: Will this actually solve the problem? Are there logical gaps?
-  Does the approach match established patterns in the codebase?
-- **Documentation**: Does this change introduce or modify domain concepts, CLI
-  commands, extension patterns, or architectural decisions that should be
-  reflected in `design/*.md` or `.claude/skills/`? If a design doc describes
-  behavior this plan changes, the plan must include a step to update it. If a
-  skill references CLI commands or examples affected by this change, the plan
-  must include a step to update the skill. Flag any gaps as findings.
-
-### Step 2: Verify against the codebase
-
-For each plan step, **read the actual code**:
-
-- Read every file referenced in the plan steps — verify they exist
-- Confirm functions, classes, and types exist where claimed
-- Grep for related code the plan might have missed
-- Check for conflicts with existing patterns or naming conventions
-- Verify that proposed test paths and test patterns match the codebase
-- Look for code that already does what a step proposes (duplication risk)
-- Check if design docs in `design/` describe behavior being changed — flag stale
-  docs
-- Check if skills in `.claude/skills/` reference commands, flags, or examples
-  affected by the plan — flag stale skills
-
-### Step 3: Record findings
-
-Write findings to a YAML file (e.g. `/tmp/findings.yaml`) as a YAML object with
-a `findings` key:
-
-```yaml
-# /tmp/findings.yaml
-findings:
-  - id: ADV-1
-    severity: high
-    category: architecture
-    description: "The plan adds a new service but doesn't define its domain boundary"
-  - id: ADV-2
-    severity: medium
-    category: testing
-    description: "No integration tests planned for the new API endpoint"
-```
-
-Then record them:
-
-```
-swamp model method run issue-<N> adversarial_review \
-  --input-file /tmp/findings.yaml
-```
-
-Each finding must have:
-
-- `id`: Sequential identifier (ADV-1, ADV-2, ...)
-- `severity`: critical, high, medium, or low
-- `category`: architecture, scope, risk, testing, complexity, correctness, or
-  documentation
-- `description`: Clear explanation of the concern
-
-**Critical/high findings block approval.** Medium/low are shown as warnings.
-
-### Step 4: Present to the human
-
-Show findings grouped by severity:
-
-1. Critical findings (blockers)
-2. High findings (blockers)
-3. Medium findings (warnings)
-4. Low findings (warnings)
-
-If there are blocking findings, say:
-
-> "The adversarial review found N blocking issue(s) that need to be addressed
-> before approval. Here's what needs to change: ..."
-
-If no blocking findings, say:
-
-> "Adversarial review passed — no blocking findings. N warning(s) noted. Ready
-> for your approval when you are."
-
-## Plan Iteration Loop
-
-When the human gives feedback OR adversarial findings need addressing:
-
-1. **Call iterate** with both the feedback text and your revised plan. Write the
-   revised `steps` and `potentialChallenges` to a YAML file (same format as the
-   `plan` step above), then run:
-
-   ```
-   swamp model method run issue-<N> iterate \
-     --input feedback="<human's feedback or adversarial findings>" \
-     --input summary="..." \
-     --input dddAnalysis="..." \
-     --input testingStrategy="..." \
-     --input-file /tmp/plan.yaml
-   ```
-
-2. **Resolve addressed findings**. Write resolutions to a YAML file:
-
-   ```yaml
-   # /tmp/resolutions.yaml
-   resolutions:
-     - findingId: ADV-1
-       resolutionNote: "Added domain boundary definition in step 2"
-     - findingId: ADV-2
-       resolutionNote: "Added integration test step covering the new endpoint"
-   ```
-
-   ```
-   swamp model method run issue-<N> resolve_findings \
-     --input-file /tmp/resolutions.yaml
-   ```
-
-3. **Re-run adversarial review** on the new plan version. The review must be
-   current with the latest plan version — stale reviews block approval.
-
-4. **Show what changed** between the previous and new plan version. Be specific:
-   - "Reordered steps 2 and 3 based on your feedback"
-   - "Added regression analysis for module X"
-   - "Removed step 4 — you're right, that's already handled by..."
-
-5. **Ask for feedback again.** Keep iterating until:
-   - All critical/high adversarial findings are resolved, AND
-   - The human says: "approve", "approved", "looks good", "ship it", "go",
-     "LGTM"
-
-6. Only then call `approve`:
-   ```
-   swamp model method run issue-<N> approve
-   ```
-
-**The `approve` method will fail** if critical/high findings are unresolved or
-if the adversarial review is stale (wrong plan version). This is enforced by the
-`adversarial-review-clear` pre-flight check.
-
-## Implementation & CI Flow
-
-After plan approval, when the human says to implement:
-
-1. **Do the implementation work** based on the approved plan
-
-2. **Verify the fix against the reproduction** (bugs and regressions only):
-
-   If a reproduction was created in step 5, reuse it to confirm the fix works.
-
-   a. **Recompile swamp** with the fix:
-   ```
-   deno run compile
-   ```
-   This produces a `./swamp` binary in the repo root.
-
-   b. **Re-run the reproduction scenario** in the scratch repo using the locally
-   compiled binary — **not** the `swamp` on PATH:
-   ```
-   cd /tmp/swamp-repro-issue-<N>
-   /path/to/repo/swamp <same commands from reproduction>
-   ```
-   Use the absolute path to the compiled binary (e.g.
-   `/Users/.../swamp/.claude/worktrees/issue-lifecycle/swamp`).
-
-   c. **Confirm the fix.** The previously failing scenario should now succeed.
-   If it still fails, the fix is incomplete — go back to step 1.
-
-   d. **Report verification results** to the human before creating the PR:
-   - "Verified: reproduction scenario now passes" or
-   - "Verification failed: <what still breaks>"
-
-3. **Create a PR** using the `github-pr` skill
-4. **Record the PR number**:
-   ```
-   swamp model method run issue-<N> implement \
-     --input prNumber=<N>
-   ```
-
-5. **Wait 3 minutes for CI to start.** Use `sleep 180` — CI takes at least this
-   long, so there's no point polling earlier.
-
-6. **Poll for CI results in a loop.** You MUST implement an explicit polling
-   loop — do not check once and assume done. The loop works like this:
-
-   ```
-   repeat:
-     call ci_status
-     parse the output — look at EVERY check's status
-     if ANY check is "pending", "queued", or "in_progress":
-       tell the human: "CI still running — N of M checks complete. Waiting 60s..."
-       sleep 60
-       go back to repeat
-     else:
-       all checks are conclusive (passed/failed) — exit the loop
-   ```
-
-   The ci_status command:
-   ```
-   swamp model method run issue-<N> ci_status
-   ```
-
-   **Do NOT exit this loop early.** A single ci_status call that shows some
-   checks passed does not mean CI is done — other checks may still be running.
-   You must confirm that **every** check has a conclusive status (passed or
-   failed) before proceeding. The human can always interrupt the loop (e.g.
-   "stop", "pause") — respect that immediately. But the agent must never exit
-   the loop on its own.
-
-7. **Show the CI results** to the human, grouped by reviewer and severity:
-   - Which checks passed/failed
-   - Review comments grouped by reviewer
-   - Comments sorted by severity (critical first)
-
-8. **If everything is green and approved**, the PR will auto-merge. Call
-   `complete` immediately — no need to ask the human:
-   ```
-   swamp model method run issue-<N> complete
-   ```
-
-9. **If there are failures or review comments**, present them and wait for the
-   human's direction. Parse their instruction:
-   - "fix the CRITICAL issues from adversarial review" ->
-     `targetReview: "claude-adversarial-review"`, `targetSeverity: "critical"`
-   - "address all the review comments" -> no filters
-   - "fix the test failures" -> `targetReview: "test"`
-
-   ```
-   swamp model method run issue-<N> fix \
-     --input directive="<human's instruction>" \
-     --input targetReview="<reviewer>" \
-     --input targetSeverity="<severity>"
-   ```
-
-10. **After pushing fixes, loop back to step 5.** Wait 3 minutes, poll for CI,
-    show results. Repeat until clean or the human says to stop.
-
-**IMPORTANT:** Do not break out of this loop voluntarily. The human should never
-have to manually check CI or come back to ask "what happened?" — the skill stays
-in the conversation and drives through to completion. If the human wants to
-break out (e.g. "I'll come back to this later", "pause", "stop"), respect that
-immediately — but it must be their decision, never yours.
+Read [references/implementation.md](references/implementation.md) after plan
+approval. Covers: doing the work, verifying fixes against the reproduction,
+creating the PR, CI polling loop, handling failures, and completing the issue.
 
 ## Reviewing Plan History
 
@@ -429,8 +75,8 @@ If the human comes back to an in-progress issue, check the current state:
 swamp model get issue-<N> --json
 ```
 
-Then pick up from whatever phase the state shows. The full history of plans,
-feedback, and CI results is persisted in the model data.
+Then read the reference file for whatever phase the state shows and pick up from
+there.
 
 ## Key Rules
 

--- a/.claude/skills/issue-lifecycle/references/adversarial-review.md
+++ b/.claude/skills/issue-lifecycle/references/adversarial-review.md
@@ -1,0 +1,158 @@
+# Adversarial Review & Plan Iteration
+
+Read this after generating or iterating on a plan. After **every** `plan` or
+`iterate` call, you MUST run an adversarial review before the human can approve.
+
+## Step 1: Challenge the Plan
+
+Re-read the plan, then critically evaluate it across these dimensions:
+
+- **Architecture**: Does this follow DDD principles? Are domain boundaries
+  correct? Is this the right abstraction level? Are there better patterns?
+- **Scope**: Is this doing too much or too little? Does it match the issue? Is
+  there scope creep? Are there unnecessary changes?
+- **Risk**: Are all failure modes identified? What about edge cases, race
+  conditions, backwards compatibility? What could go wrong that isn't listed?
+- **Testing**: Is the testing strategy sufficient? Are edge cases covered? Are
+  there integration test gaps? Is there over-reliance on unit tests? Was the UAT
+  assessment thorough — are there end-to-end CLI or adversarial test gaps that
+  should be filed in `systeminit/swamp-uat`?
+- **Complexity**: Is this over-engineered? Could it be simpler? Are there
+  unnecessary abstractions or indirections?
+- **Correctness**: Will this actually solve the problem? Are there logical gaps?
+  Does the approach match established patterns in the codebase?
+- **Documentation**: Does this change introduce or modify domain concepts, CLI
+  commands, extension patterns, or architectural decisions that should be
+  reflected in `design/*.md` or `.claude/skills/`? If a design doc describes
+  behavior this plan changes, the plan must include a step to update it. If a
+  skill references CLI commands or examples affected by this change, the plan
+  must include a step to update the skill. Flag any gaps as findings.
+
+## Step 2: Verify Against the Codebase
+
+For each plan step, **read the actual code**:
+
+- Read every file referenced in the plan steps — verify they exist
+- Confirm functions, classes, and types exist where claimed
+- Grep for related code the plan might have missed
+- Check for conflicts with existing patterns or naming conventions
+- Verify that proposed test paths and test patterns match the codebase
+- Look for code that already does what a step proposes (duplication risk)
+- Check if design docs in `design/` describe behavior being changed — flag stale
+  docs
+- Check if skills in `.claude/skills/` reference commands, flags, or examples
+  affected by the plan — flag stale skills
+
+## Step 3: Record Findings
+
+Write findings to a YAML file (e.g. `/tmp/findings.yaml`) as a YAML object with
+a `findings` key:
+
+```yaml
+# /tmp/findings.yaml
+findings:
+  - id: ADV-1
+    severity: high
+    category: architecture
+    description: "The plan adds a new service but doesn't define its domain boundary"
+  - id: ADV-2
+    severity: medium
+    category: testing
+    description: "No integration tests planned for the new API endpoint"
+```
+
+Then record them:
+
+```
+swamp model method run issue-<N> adversarial_review \
+  --input-file /tmp/findings.yaml
+```
+
+Each finding must have:
+
+- `id`: Sequential identifier (ADV-1, ADV-2, ...)
+- `severity`: critical, high, medium, or low
+- `category`: architecture, scope, risk, testing, complexity, correctness, or
+  documentation
+- `description`: Clear explanation of the concern
+
+**Critical/high findings block approval.** Medium/low are shown as warnings.
+
+## Step 4: Present to the Human
+
+Show findings grouped by severity:
+
+1. Critical findings (blockers)
+2. High findings (blockers)
+3. Medium findings (warnings)
+4. Low findings (warnings)
+
+If there are blocking findings, say:
+
+> "The adversarial review found N blocking issue(s) that need to be addressed
+> before approval. Here's what needs to change: ..."
+
+If no blocking findings, say:
+
+> "Adversarial review passed — no blocking findings. N warning(s) noted. Ready
+> for your approval when you are."
+
+## Plan Iteration Loop
+
+When the human gives feedback OR adversarial findings need addressing:
+
+1. **Call iterate** with both the feedback text and your revised plan. Write the
+   revised `steps` and `potentialChallenges` to a YAML file (same format as the
+   `plan` step), then run:
+
+   ```
+   swamp model method run issue-<N> iterate \
+     --input feedback="<human's feedback or adversarial findings>" \
+     --input summary="..." \
+     --input dddAnalysis="..." \
+     --input testingStrategy="..." \
+     --input-file /tmp/plan.yaml
+   ```
+
+2. **Resolve addressed findings**. Write resolutions to a YAML file:
+
+   ```yaml
+   # /tmp/resolutions.yaml
+   resolutions:
+     - findingId: ADV-1
+       resolutionNote: "Added domain boundary definition in step 2"
+     - findingId: ADV-2
+       resolutionNote: "Added integration test step covering the new endpoint"
+   ```
+
+   ```
+   swamp model method run issue-<N> resolve_findings \
+     --input-file /tmp/resolutions.yaml
+   ```
+
+3. **Re-run adversarial review** on the new plan version. The review must be
+   current with the latest plan version — stale reviews block approval.
+
+4. **Show what changed** between the previous and new plan version. Be specific:
+   - "Reordered steps 2 and 3 based on your feedback"
+   - "Added regression analysis for module X"
+   - "Removed step 4 — you're right, that's already handled by..."
+
+5. **Ask for feedback again.** Keep iterating until:
+   - All critical/high adversarial findings are resolved, AND
+   - The human says: "approve", "approved", "looks good", "ship it", "go",
+     "LGTM"
+
+6. Only then call `approve`:
+   ```
+   swamp model method run issue-<N> approve
+   ```
+
+**The `approve` method will fail** if critical/high findings are unresolved or
+if the adversarial review is stale (wrong plan version). This is enforced by the
+`adversarial-review-clear` pre-flight check.
+
+## Next Phase
+
+Plan is approved. Read [implementation.md](implementation.md) when the human
+says to implement.

--- a/.claude/skills/issue-lifecycle/references/implementation.md
+++ b/.claude/skills/issue-lifecycle/references/implementation.md
@@ -1,0 +1,127 @@
+# Implementation & CI Flow
+
+Read this after the plan is approved and the human says to implement.
+
+## 1. Do the Implementation Work
+
+Follow the approved plan step by step.
+
+## 2. Verify the Fix Against the Reproduction
+
+**Bugs and regressions only — skip for features.**
+
+If a reproduction was created during triage, reuse it to confirm the fix works.
+
+a. **Recompile swamp** with the fix:
+
+```
+deno run compile
+```
+
+This produces a `./swamp` binary in the repo root.
+
+b. **Re-run the reproduction scenario** in the scratch repo using the locally
+compiled binary — **not** the `swamp` on PATH:
+
+```
+cd /tmp/swamp-repro-issue-<N>
+/path/to/repo/swamp <same commands from reproduction>
+```
+
+Use the absolute path to the compiled binary (e.g.
+`/Users/.../swamp/.claude/worktrees/issue-lifecycle/swamp`).
+
+c. **Confirm the fix.** The previously failing scenario should now succeed. If
+it still fails, the fix is incomplete — go back to step 1.
+
+d. **Report verification results** to the human before creating the PR:
+
+- "Verified: reproduction scenario now passes" or
+- "Verification failed: <what still breaks>"
+
+## 3. Create a PR
+
+Use the `github-pr` skill.
+
+## 4. Record the PR Number
+
+```
+swamp model method run issue-<N> implement \
+  --input prNumber=<N>
+```
+
+## 5. Wait for CI to Start
+
+Use `sleep 180` — CI takes at least 3 minutes, so there's no point polling
+earlier.
+
+## 6. Poll for CI Results
+
+You MUST implement an explicit polling loop — do not check once and assume done:
+
+```
+repeat:
+  call ci_status
+  parse the output — look at EVERY check's status
+  if ANY check is "pending", "queued", or "in_progress":
+    tell the human: "CI still running — N of M checks complete. Waiting 60s..."
+    sleep 60
+    go back to repeat
+  else:
+    all checks are conclusive (passed/failed) — exit the loop
+```
+
+The ci_status command:
+
+```
+swamp model method run issue-<N> ci_status
+```
+
+**Do NOT exit this loop early.** A single ci_status call that shows some checks
+passed does not mean CI is done — other checks may still be running. You must
+confirm that **every** check has a conclusive status (passed or failed) before
+proceeding. The human can always interrupt the loop (e.g. "stop", "pause") —
+respect that immediately. But the agent must never exit the loop on its own.
+
+## 7. Show CI Results
+
+Show results to the human, grouped by reviewer and severity:
+
+- Which checks passed/failed
+- Review comments grouped by reviewer
+- Comments sorted by severity (critical first)
+
+## 8. If Everything is Green and Approved
+
+The PR will auto-merge. Call `complete` immediately — no need to ask the human:
+
+```
+swamp model method run issue-<N> complete
+```
+
+## 9. If There Are Failures or Review Comments
+
+Present them and wait for the human's direction. Parse their instruction:
+
+- "fix the CRITICAL issues from adversarial review" →
+  `targetReview: "claude-adversarial-review"`, `targetSeverity: "critical"`
+- "address all the review comments" → no filters
+- "fix the test failures" → `targetReview: "test"`
+
+```
+swamp model method run issue-<N> fix \
+  --input directive="<human's instruction>" \
+  --input targetReview="<reviewer>" \
+  --input targetSeverity="<severity>"
+```
+
+## 10. After Pushing Fixes
+
+Loop back to step 5. Wait 3 minutes, poll for CI, show results. Repeat until
+clean or the human says to stop.
+
+**IMPORTANT:** Do not break out of this loop voluntarily. The human should never
+have to manually check CI or come back to ask "what happened?" — the skill stays
+in the conversation and drives through to completion. If the human wants to
+break out (e.g. "I'll come back to this later", "pause", "stop"), respect that
+immediately — but it must be their decision, never yours.

--- a/.claude/skills/issue-lifecycle/references/planning.md
+++ b/.claude/skills/issue-lifecycle/references/planning.md
@@ -1,0 +1,91 @@
+# Planning Phase
+
+Steps 6–9 of the issue lifecycle. Read this after triage is complete and you're
+ready to generate an implementation plan.
+
+## 6. Generate an Implementation Plan
+
+Write a single YAML file (e.g. `/tmp/plan.yaml`) containing both `steps` and
+`potentialChallenges` as top-level keys. The CLI only supports one
+`--input-file` flag per invocation, and the file must be a YAML object (not a
+bare array).
+
+```yaml
+# /tmp/plan.yaml
+steps:
+  - order: 1
+    description: "Add the new schema types"
+    files:
+      - src/domain/schemas.ts
+    risks: "May need migration"
+  - order: 2
+    description: "Update the service layer"
+    files:
+      - src/domain/service.ts
+      - src/domain/service_test.ts
+potentialChallenges:
+  - "Backwards compatibility with existing data"
+  - "Test coverage for edge cases"
+```
+
+Then run the method. The `--input` flags handle scalar values, and
+`--input-file` handles the structured data:
+
+```
+swamp model method run issue-<N> plan \
+  --input summary="..." \
+  --input dddAnalysis="..." \
+  --input testingStrategy="..." \
+  --input-file /tmp/plan.yaml
+```
+
+## 7. Check for Documentation Impact
+
+Before presenting the plan, evaluate whether the change affects anything
+described in `design/*.md` or `.claude/skills/`. If so, include explicit plan
+steps to update those files. Common triggers: new domain concepts, changed CLI
+commands or flags, new extension patterns, modified architectural decisions,
+renamed types or methods referenced in skill examples.
+
+## 8. Assess User Acceptance Testing (UAT) Impact
+
+Evaluate whether the change requires end-to-end UAT coverage in the
+`systeminit/swamp-uat` repo. That repo has two categories of tests:
+
+- **CLI UAT tests** (`tests/cli/`) — verify CLI commands, flags, and output from
+  a user's perspective. File paths mirror CLI command paths (e.g.
+  `swamp model create` → `tests/cli/model/create_test.ts`).
+- **Adversarial tests** (`tests/cli/adversarial/`) — verify robustness under
+  edge conditions: concurrency, resource exhaustion, security boundaries, state
+  corruption, process lifecycle.
+
+First, check if existing UAT coverage exists:
+
+```
+gh api repos/systeminit/swamp-uat/contents/tests/cli --jq '.[].name'
+```
+
+Then assess:
+
+- If the change **is purely internal** (refactors, internal API changes) or
+  already covered by unit/integration tests in the swamp repo → no UAT action
+  needed. State this when presenting the plan.
+- If the change **affects user-facing CLI behavior** (commands, flags, output
+  formats) and no existing CLI UAT test covers it → flag this to the human.
+- If the change **affects robustness, error handling, or edge-case behavior**
+  (concurrency, large inputs, process signals, security boundaries) and no
+  existing adversarial test covers it → flag this to the human.
+- If the human agrees a UAT gap exists, file an issue in `swamp-uat`:
+  ```
+  gh issue create --repo systeminit/swamp-uat \
+    --title "UAT: <describe the missing test scenario>" \
+    --body "<reproduction steps, expected behavior, which CLI commands to test>"
+  ```
+  Use the label `cli` for CLI UAT gaps or `adversarial` for adversarial test
+  gaps.
+- Include UAT assessment findings when presenting the plan to the human.
+
+## 9. Present the Plan
+
+Show the plan to the human, then run adversarial review (see
+[adversarial-review.md](adversarial-review.md)).

--- a/.claude/skills/issue-lifecycle/references/triage.md
+++ b/.claude/skills/issue-lifecycle/references/triage.md
@@ -1,0 +1,107 @@
+# Triage Phase
+
+Steps 1–5 of the issue lifecycle. Read this when starting a new triage or
+resuming an issue in the `triaging` phase.
+
+## 1. Create the Model Instance
+
+If it doesn't already exist:
+
+```
+swamp model create @si/issue-lifecycle issue-<N> \
+  --global-arg issueNumber=<N> --json
+```
+
+The repo defaults to `systeminit/swamp`. Override with
+`--global-arg repo=<owner/repo>` for other repositories.
+
+## 2. Fetch the Issue Context
+
+```
+swamp model method run issue-<N> start
+```
+
+## 3. Read the Issue Context and Codebase
+
+Read the model output, then explore the codebase:
+
+- Read `CLAUDE.md` and `design/*.md`
+- Read relevant skills (especially `ddd/SKILL.md`)
+- Explore source files related to the issue
+- Trace code paths to understand the problem
+- **Check for regression signals**: If the issue describes a bug, use `git log`
+  on the affected files to see if they were recently changed. Check if the
+  described behavior worked in a prior version. This informs whether to classify
+  as `bug` or `regression`.
+
+## 4. Classify the Issue
+
+```
+swamp model method run issue-<N> triage \
+  --input type=<bug|feature|regression|unclear> \
+  --input confidence=<high|medium|low> \
+  --input reasoning="<your analysis>"
+```
+
+**Classification guidance:**
+
+- `bug` — something is broken or behaving incorrectly
+- `feature` — a request for new functionality or enhancement
+- `regression` — a bug where something **previously worked** but is now broken.
+  Look for signals like: "this used to work", "stopped working after", "worked
+  in version X", references to recent changes that broke existing behavior, or
+  git history showing the affected code was recently modified. Regressions get
+  both `bug` and `regression` labels.
+- `unclear` — not enough information to classify confidently
+
+## 5. Reproduce the Bug
+
+**Bugs and regressions only — skip for features.**
+
+Before planning a fix, reproduce the issue in an isolated scratch repo to
+confirm the failure mode and understand it firsthand.
+
+a. **Ensure swamp is up to date:**
+
+```
+swamp update
+```
+
+b. **Create a scratch repo:**
+
+```
+mkdir -p /tmp/swamp-repro-issue-<N>
+cd /tmp/swamp-repro-issue-<N>
+swamp repo init
+```
+
+c. **Build a minimal reproduction.** Based on the issue description and your
+codebase analysis, create the simplest set of models and/or workflows that
+trigger the bug. Use an Agent (subagent) to do this — give it the issue context,
+the error description, and tell it to create and run a swamp scenario that
+reproduces the problem. The agent should:
+
+- Create model definitions and workflow YAML files
+- Create any required input data
+- Run the workflow or model method that triggers the issue
+- Capture the exact error output or incorrect behavior
+
+d. **Document what you observed.** Before moving to planning, record:
+
+- The exact commands that reproduce the issue
+- The actual output/error (copy it verbatim)
+- The expected output/behavior
+- Any differences from what the issue originally described
+
+e. **Keep the scratch repo.** You'll reuse it in the verification step after the
+fix is implemented. The path `/tmp/swamp-repro-issue-<N>` must survive until
+verification is complete.
+
+If the bug **cannot be reproduced**, note that in the plan. It may mean the
+issue description is incomplete, the bug is environment-specific, or the
+underlying code has already changed. Ask the human how to proceed.
+
+## Next Phase
+
+Triage is complete. Read [planning.md](planning.md) to generate the
+implementation plan.


### PR DESCRIPTION
## Summary

The issue-lifecycle `SKILL.md` had grown to 489 lines — approaching the 500-line
limit recommended by the skill-creator best practices. This PR restructures it
using the **progressive disclosure** pattern:

- **`SKILL.md` (94 lines)** — Lean orchestration guide with the core principle,
  phase overview pointing to references, key rules, and resume/review commands.
  This is all that loads into context when the skill triggers.
- **`references/triage.md` (106 lines)** — Steps 1–5: create model instance,
  fetch issue context, read codebase, classify the issue, reproduce bugs.
- **`references/planning.md` (91 lines)** — Steps 6–9: generate implementation
  plan, check documentation impact, assess UAT coverage, present to human.
- **`references/adversarial-review.md` (158 lines)** — Challenge the plan across
  7 dimensions, verify against codebase, record findings, present to human,
  iteration loop until approval.
- **`references/implementation.md` (127 lines)** — Implement the fix, verify
  against reproduction, create PR, CI polling loop, handle failures, complete.

### Why this structure

1. **Context efficiency** — Instead of loading all 489 lines on every trigger,
   Claude now loads ~94 lines and then reads only the reference relevant to the
   current phase. A triage-only session saves ~400 lines of context.

2. **Phase isolation** — Each reference is self-contained for its phase, with
   "Next Phase" pointers at the end linking to the next file. This creates a
   clear chain: triage → planning → adversarial-review → implementation.

3. **Strong coupling where needed** — The planning→adversarial-review pairing
   uses emphatic language in SKILL.md ("immediately after every `plan` or
   `iterate` call — no exceptions") and `planning.md` step 9 directly links to
   `adversarial-review.md`. The `approve` model method also has a server-side
   guardrail that rejects stale reviews.

### New: UAT assessment step

Adds step 8 in the planning phase that evaluates whether changes need end-to-end
user acceptance test coverage in the `systeminit/swamp-uat` repo. Distinguishes
between two test categories:

- **CLI UAT tests** (`tests/cli/`) — verify commands, flags, and output from a
  user's perspective
- **Adversarial tests** (`tests/cli/adversarial/`) — verify robustness under
  edge conditions (concurrency, resource exhaustion, security, state corruption)

When a gap is identified and the human agrees, the skill files an issue in
`systeminit/swamp-uat` via `gh issue create --repo`.

## Test Plan

- [x] `deno fmt` passes
- [x] `deno lint` passes
- [x] `deno run test` passes (3913 tests)
- [ ] Verify skill still triggers correctly on "triage issue #N"
- [ ] Verify phase references load correctly during a full triage flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)