### PR TITLE
feat: add .example() to data and datastore CLI commands

### DIFF
--- a/src/cli/commands/data_gc.ts
+++ b/src/cli/commands/data_gc.ts
@@ -53,6 +53,8 @@ type AnyOptions = any;
 export const dataGcCommand = new Command()
   .name("gc")
   .description("Run garbage collection on data (lifecycle and versions)")
+  .example("Preview what would be collected", "swamp data gc --dry-run")
+  .example("Run garbage collection", "swamp data gc --force")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("--dry-run", "Show what would be deleted without deleting")
   .option("-f, --force", "Skip confirmation prompt")

--- a/src/cli/commands/data_get.ts
+++ b/src/cli/commands/data_get.ts
@@ -34,6 +34,16 @@ type AnyOptions = any;
 export const dataGetCommand = new Command()
   .name("get")
   .description("Get data by model and name, or by workflow")
+  .example("Get latest data", "swamp data get my-server system-info")
+  .example(
+    "Get a specific version",
+    "swamp data get my-server system-info --version 2",
+  )
+  .example("Get workflow data", "swamp data get --workflow deploy --run latest")
+  .example(
+    "Metadata only",
+    "swamp data get my-server system-info --no-content",
+  )
   .arguments("[model_id_or_name:model_name] [data_name:string]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("--version <version:number>", "Specific version (defaults to latest)")

--- a/src/cli/commands/data_list.ts
+++ b/src/cli/commands/data_list.ts
@@ -34,6 +34,9 @@ type AnyOptions = any;
 export const dataListCommand = new Command()
   .name("list")
   .description("List all data for a model or workflow, grouped by type")
+  .example("List all data for a model", "swamp data list my-server")
+  .example("Filter by type", "swamp data list my-server --type output")
+  .example("List workflow run data", "swamp data list --workflow deploy")
   .arguments("[model_id_or_name:model_name]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option(

--- a/src/cli/commands/data_rename.ts
+++ b/src/cli/commands/data_rename.ts
@@ -31,6 +31,10 @@ import { requireInitializedRepo } from "../repo_context.ts";
 export const dataRenameCommand = new Command()
   .name("rename")
   .description("Rename a data instance with backwards-compatible forwarding")
+  .example(
+    "Rename with forwarding",
+    "swamp data rename my-server old-name new-name",
+  )
   .arguments("<model_id_or_name:string> <old_name:string> <new_name:string>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .action(

--- a/src/cli/commands/data_search.ts
+++ b/src/cli/commands/data_search.ts
@@ -164,6 +164,9 @@ async function displayDataDetail(
 export const dataSearchCommand = new Command()
   .name("search")
   .description("Search for data across all models")
+  .example("Interactive search", "swamp data search")
+  .example("Search with query", "swamp data search cpu-metrics")
+  .example("Search within a model", "swamp data search --model my-server")
   .arguments("[query:string]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option(

--- a/src/cli/commands/data_versions.ts
+++ b/src/cli/commands/data_versions.ts
@@ -34,6 +34,7 @@ type AnyOptions = any;
 export const dataVersionsCommand = new Command()
   .name("versions")
   .description("List all versions of specific data")
+  .example("List all versions", "swamp data versions my-server system-info")
   .arguments("<model_id_or_name:model_name> <data_name:string>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .action(

--- a/src/cli/commands/datastore_lock.ts
+++ b/src/cli/commands/datastore_lock.ts
@@ -47,6 +47,7 @@ type AnyOptions = any;
  */
 const datastoreLockStatusCommand = new Command()
   .description("Show who holds the datastore lock")
+  .example("Check lock status", "swamp datastore lock status")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, [
@@ -82,6 +83,14 @@ const datastoreLockStatusCommand = new Command()
  */
 const datastoreLockReleaseCommand = new Command()
   .description("Force-release a stuck datastore lock")
+  .example(
+    "Release stuck datastore lock",
+    "swamp datastore lock release --force",
+  )
+  .example(
+    "Release a model lock",
+    "swamp datastore lock release --force --model aws-ec2/my-server",
+  )
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("--force", "Required to confirm force release", { required: true })
   .option(

--- a/src/cli/commands/datastore_setup.ts
+++ b/src/cli/commands/datastore_setup.ts
@@ -45,6 +45,14 @@ type AnyOptions = any;
 
 const datastoreSetupFilesystemCommand = new Command()
   .description("Set up a filesystem datastore")
+  .example(
+    "Set up filesystem datastore",
+    "swamp datastore setup filesystem --path ~/swamp-data",
+  )
+  .example(
+    "Custom subdirectories",
+    "swamp datastore setup filesystem --path /data --directories models,outputs",
+  )
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("--path <path:string>", "Path for the datastore directory", {
     required: true,
@@ -91,6 +99,10 @@ const datastoreSetupFilesystemCommand = new Command()
 const datastoreSetupExtensionCommand = new Command()
   .description(
     "Set up an extension-provided datastore (e.g., @swamp/s3-datastore)",
+  )
+  .example(
+    "Set up S3 datastore",
+    `swamp datastore setup extension @swamp/s3-datastore --config '{"bucket":"my-bucket","region":"us-east-1"}'`,
   )
   .arguments("<type:string>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })

--- a/src/cli/commands/datastore_status.ts
+++ b/src/cli/commands/datastore_status.ts
@@ -36,6 +36,7 @@ type AnyOptions = any;
  */
 export const datastoreStatusCommand = new Command()
   .description("Show datastore configuration and health")
+  .example("Show datastore health", "swamp datastore status")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, [

--- a/src/cli/commands/datastore_sync.ts
+++ b/src/cli/commands/datastore_sync.ts
@@ -39,6 +39,9 @@ type AnyOptions = any;
  */
 export const datastoreSyncCommand = new Command()
   .description("Sync local cache with S3 datastore")
+  .example("Full sync", "swamp datastore sync")
+  .example("Pull only", "swamp datastore sync --pull")
+  .example("Push only", "swamp datastore sync --push")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("--pull", "Pull-only mode (fetch all remote data to local cache)")
   .option("--push", "Push-only mode (upload all local cache data to S3)")


### PR DESCRIPTION
## Summary

- Add `.example()` usage examples to 12 CLI commands covering batches 2-3 from #993
- **Data:** `data gc` (2 examples), `data get` (4), `data list` (3), `data rename` (1), `data search` (3), `data versions` (1)
- **Datastore:** `datastore setup filesystem` (2), `datastore setup extension` (1), `datastore status` (1), `datastore sync` (3), `datastore lock status` (1), `datastore lock release` (2)

Partial progress on #993

## Test Plan

- [x] `deno fmt` passes
- [x] `deno lint` passes
- [x] `deno check` passes
- [x] `deno run test` — all 3913 tests pass
- [x] `deno run compile` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)