### PR TITLE
feat: add .example() to all model CLI commands

### DIFF
--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -44,6 +44,11 @@ type AnyOptions = any;
 
 export const modelCreateCommand = new Command()
   .description("Create a new model definition")
+  .example("Create a model", "swamp model create aws-ec2 my-server")
+  .example(
+    "With global args",
+    "swamp model create aws-ec2 my-server --global-arg region=us-east-1",
+  )
   .arguments("<type:model_type> <name:string>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option(

--- a/src/cli/commands/model_delete.ts
+++ b/src/cli/commands/model_delete.ts
@@ -53,6 +53,8 @@ async function promptConfirmation(message: string): Promise<boolean> {
 export const modelDeleteCommand = new Command()
   .name("delete")
   .description("Delete a model and all related artifacts")
+  .example("Delete a model", "swamp model delete my-server")
+  .example("Force delete", "swamp model delete my-server --force")
   .arguments("<model_id_or_name:model_name>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option(

--- a/src/cli/commands/model_edit.ts
+++ b/src/cli/commands/model_edit.ts
@@ -39,6 +39,8 @@ type AnyOptions = any;
 export const modelEditCommand = new Command()
   .name("edit")
   .description("Edit a model definition file")
+  .example("Edit a model", "swamp model edit my-server")
+  .example("Interactive search", "swamp model edit")
   .arguments("[model_id_or_name:model_name]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   // @ts-expect-error - Cliffy custom type returns unknown instead of string

--- a/src/cli/commands/model_evaluate.ts
+++ b/src/cli/commands/model_evaluate.ts
@@ -40,6 +40,8 @@ type AnyOptions = any;
 export const modelEvaluateCommand = new Command()
   .name("evaluate")
   .description("Evaluate expressions in model definitions")
+  .example("Evaluate a model", "swamp model evaluate my-server")
+  .example("Evaluate all models", "swamp model evaluate --all")
   .arguments("[model_id_or_name:string]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("--all", "Evaluate all model definitions")

--- a/src/cli/commands/model_get.ts
+++ b/src/cli/commands/model_get.ts
@@ -34,6 +34,8 @@ type AnyOptions = any;
 export const modelGetCommand = new Command()
   .name("get")
   .description("Show details of a model definition")
+  .example("Show model details", "swamp model get my-server")
+  .example("JSON output", "swamp model get my-server --json")
   .arguments("<model_id_or_name:model_name>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   // @ts-expect-error - Cliffy custom type returns unknown instead of string

--- a/src/cli/commands/model_method_history_get.ts
+++ b/src/cli/commands/model_method_history_get.ts
@@ -34,6 +34,11 @@ type AnyOptions = any;
 export const modelMethodHistoryGetCommand = new Command()
   .name("get")
   .description("Show details of a model method run")
+  .example("Show run details by ID", "swamp model method history get abc123")
+  .example(
+    "Show latest run for a model",
+    "swamp model method history get my-server",
+  )
   .arguments("<output_id_or_model_name:string>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .action(async function (options: AnyOptions, outputIdOrModelName: string) {

--- a/src/cli/commands/model_method_history_logs.ts
+++ b/src/cli/commands/model_method_history_logs.ts
@@ -34,6 +34,11 @@ type AnyOptions = any;
 export const modelMethodHistoryLogsCommand = new Command()
   .name("logs")
   .description("Show logs for a model method run")
+  .example("Show run logs", "swamp model method history logs abc123")
+  .example(
+    "Tail last 50 lines",
+    "swamp model method history logs abc123 --tail 50",
+  )
   .arguments("<output_id_or_model_name:string>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("--tail <lines:number>", "Show only the last N lines")

--- a/src/cli/commands/model_method_history_search.ts
+++ b/src/cli/commands/model_method_history_search.ts
@@ -43,6 +43,8 @@ type AnyOptions = any;
 export const modelMethodHistorySearchCommand = new Command()
   .name("search")
   .description("Search model method run history")
+  .example("Browse all history", "swamp model method history search")
+  .example("Search by keyword", "swamp model method history search deploy")
   .arguments("[query:string]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .action(async function (options: AnyOptions, query?: string) {

--- a/src/cli/commands/model_output_data.ts
+++ b/src/cli/commands/model_output_data.ts
@@ -34,6 +34,15 @@ type AnyOptions = any;
 export const modelOutputDataCommand = new Command()
   .name("data")
   .description("Show data artifact content for a model output")
+  .example("Show output data", "swamp model output data abc123")
+  .example(
+    "Show specific field",
+    "swamp model output data abc123 --field status",
+  )
+  .example(
+    "Show specific version",
+    "swamp model output data abc123 --version 2",
+  )
   .arguments("<output_id:string>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("--field <name:string>", "Show only a specific field from the data")

--- a/src/cli/commands/model_output_get.ts
+++ b/src/cli/commands/model_output_get.ts
@@ -34,6 +34,8 @@ type AnyOptions = any;
 export const modelOutputGetCommand = new Command()
   .name("get")
   .description("Show details of a model output")
+  .example("Show output details by ID", "swamp model output get abc123")
+  .example("Show latest output for a model", "swamp model output get my-server")
   .arguments("<output_id_or_model_name:string>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .action(async function (options: AnyOptions, outputIdOrModelName: string) {

--- a/src/cli/commands/model_output_logs.ts
+++ b/src/cli/commands/model_output_logs.ts
@@ -34,6 +34,8 @@ type AnyOptions = any;
 export const modelOutputLogsCommand = new Command()
   .name("logs")
   .description("Show log artifact content for a model output")
+  .example("Show output logs", "swamp model output logs abc123")
+  .example("Tail last 100 lines", "swamp model output logs abc123 --tail 100")
   .arguments("<output_id:string>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("--tail <n:number>", "Show only last N lines")

--- a/src/cli/commands/model_output_search.ts
+++ b/src/cli/commands/model_output_search.ts
@@ -72,6 +72,8 @@ function createOutputFetchPreview(
 export const modelOutputSearchCommand = new Command()
   .name("search")
   .description("Search for model outputs")
+  .example("Browse all outputs", "swamp model output search")
+  .example("Search by keyword", "swamp model output search deploy")
   .arguments("[query:string]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .action(async function (options: AnyOptions, query?: string) {

--- a/src/cli/commands/model_search.ts
+++ b/src/cli/commands/model_search.ts
@@ -120,6 +120,8 @@ export async function modelSearchAction(
 export const modelSearchCommand = new Command()
   .name("search")
   .description("Search for model definitions")
+  .example("Browse all models", "swamp model search")
+  .example("Search by keyword", "swamp model search aws")
   .arguments("[query:string]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .action(modelSearchAction);

--- a/src/cli/commands/model_validate.ts
+++ b/src/cli/commands/model_validate.ts
@@ -37,6 +37,12 @@ type AnyOptions = any;
 export const modelValidateCommand = new Command()
   .name("validate")
   .description("Validate a model definition against its schema")
+  .example("Validate a model", "swamp model validate my-server")
+  .example("Validate all models", "swamp model validate")
+  .example(
+    "Filter by label",
+    "swamp model validate --label production",
+  )
   .arguments("[model_id_or_name:string]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option(


### PR DESCRIPTION
## Summary

- Add `.example()` usage examples to 14 CLI commands covering batches 5-6 from #993
- **Model core:** `model create` (2 examples), `model delete` (2), `model edit` (2), `model evaluate` (2), `model get` (2), `model search` (2), `model validate` (3)
- **Method history:** `model method history get` (2), `history logs` (2), `history search` (2)
- **Model output:** `model output data` (3), `output get` (2), `output logs` (2), `output search` (2)

Partial progress on #993

## Test Plan

- [x] `deno fmt` passes
- [x] `deno lint` passes
- [x] `deno check` passes
- [x] `deno run test` — all 3913 tests pass
- [x] `deno run compile` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)