### PR TITLE
feat: add .example() to all vault CLI commands

### DIFF
--- a/src/cli/commands/vault_create.ts
+++ b/src/cli/commands/vault_create.ts
@@ -53,6 +53,11 @@ async function promptVaultName(): Promise<string> {
 export const vaultCreateCommand = new Command()
   .name("create")
   .description("Create a new vault configuration")
+  .example("Create a vault", "swamp vault create env my-vault")
+  .example(
+    "With provider config",
+    `swamp vault create aws-secrets-manager my-vault --config '{"region":"us-east-1"}'`,
+  )
   .arguments("<type:string> [name:string]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option(

--- a/src/cli/commands/vault_describe.ts
+++ b/src/cli/commands/vault_describe.ts
@@ -34,6 +34,7 @@ type AnyOptions = any;
 export const vaultDescribeCommand = new Command()
   .name("describe")
   .description("Describe a vault configuration")
+  .example("Describe a vault", "swamp vault describe my-vault")
   .arguments("<vault_name_or_id:string>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("-t, --type <type:string>", "Vault type (optional, narrows search)")

--- a/src/cli/commands/vault_edit.ts
+++ b/src/cli/commands/vault_edit.ts
@@ -38,6 +38,8 @@ type AnyOptions = any;
 export const vaultEditCommand = new Command()
   .name("edit")
   .description("Edit a vault configuration file")
+  .example("Edit a vault", "swamp vault edit my-vault")
+  .example("Interactive search", "swamp vault edit")
   .arguments("[vault_name_or_id:string]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("-t, --type <type:string>", "Vault type (optional, narrows search)")

--- a/src/cli/commands/vault_get.ts
+++ b/src/cli/commands/vault_get.ts
@@ -35,6 +35,7 @@ type AnyOptions = any;
 export const vaultGetCommand = new Command()
   .name("get")
   .description("Show details of a vault configuration")
+  .example("Show vault details", "swamp vault get my-vault")
   .arguments("<vault_name_or_id:string> [extra:string]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("-t, --type <type:string>", "Vault type (optional, narrows search)")

--- a/src/cli/commands/vault_list_keys.ts
+++ b/src/cli/commands/vault_list_keys.ts
@@ -34,6 +34,8 @@ type AnyOptions = any;
 export const vaultListKeysCommand = new Command()
   .name("list-keys")
   .description("List all secret keys in a vault (without values)")
+  .example("List keys in a vault", "swamp vault list-keys my-vault")
+  .example("List all vault keys", "swamp vault list-keys")
   .arguments("[vault_name:string]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .action(async function (options: AnyOptions, vaultName?: string) {

--- a/src/cli/commands/vault_search.ts
+++ b/src/cli/commands/vault_search.ts
@@ -70,6 +70,8 @@ function createVaultFetchPreview(
 export const vaultSearchCommand = new Command()
   .name("search")
   .description("Search for vaults in the repository")
+  .example("Browse all vaults", "swamp vault search")
+  .example("Search by keyword", "swamp vault search aws")
   .arguments("[query:string]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .action(async function (options: AnyOptions, query?: string) {

--- a/src/cli/commands/vault_type_search.ts
+++ b/src/cli/commands/vault_type_search.ts
@@ -72,5 +72,7 @@ export async function vaultTypeSearchAction(
 export const vaultTypeSearchCommand = new Command()
   .name("search")
   .description("Search for vault types")
+  .example("Browse vault types", "swamp vault type-search")
+  .example("Search by keyword", "swamp vault type-search aws")
   .arguments("[query:string]")
   .action(vaultTypeSearchAction);


### PR DESCRIPTION
## Summary

- Add `.example()` usage examples to 7 CLI commands covering batch 7 from #993
- **Vault:** `vault create` (2 examples), `vault describe` (1), `vault edit` (2), `vault get` (1), `vault list-keys` (2), `vault search` (2), `vault type-search` (2)

Partial progress on #993

## Test Plan

- [x] `deno fmt` passes
- [x] `deno lint` passes
- [x] `deno check` passes
- [x] `deno run test` — all 3913 tests pass
- [x] `deno run compile` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)