### PR TITLE
fix: strengthen adversarial review to trace existing execution paths

### DIFF
--- a/.claude/skills/issue-lifecycle/references/adversarial-review.md
+++ b/.claude/skills/issue-lifecycle/references/adversarial-review.md
@@ -38,6 +38,11 @@ For each plan step, **read the actual code**:
 - Check for conflicts with existing patterns or naming conventions
 - Verify that proposed test paths and test patterns match the codebase
 - Look for code that already does what a step proposes (duplication risk)
+- **Trace existing execution paths**: When the plan adds a new entry point to an
+  existing capability (e.g. a new way to run workflows, execute model methods,
+  acquire locks), find how existing callers invoke that capability and verify
+  the plan routes through the same shared code path. New entry points that
+  reimplement existing logic are a high-severity finding.
 - Check if design docs in `design/` describe behavior being changed — flag stale
   docs
 - Check if skills in `.claude/skills/` reference commands, flags, or examples

--- a/extensions/models/_lib/schemas.ts
+++ b/extensions/models/_lib/schemas.ts
@@ -173,6 +173,7 @@ export const AdversarialFindingSchema = z.object({
     "testing",
     "complexity",
     "correctness",
+    "documentation",
   ]),
   description: z.string(),
   resolved: z.boolean().default(false),


### PR DESCRIPTION
## Summary

Addresses #1016 — the adversarial review missed that `ScheduledExecutionService` was creating a divergent workflow execution path instead of using the shared `executeWorkflowWithLocks` code path.

Rather than adding a brittle "divergence check" category (which would create a growing reactive checklist), this strengthens the existing "Verify Against the Codebase" step with a general principle: when a plan adds a new entry point to an existing capability, trace how existing callers invoke it and verify the new path uses the same shared code path.

Also fixes a schema/skill mismatch: the skill instructions listed "documentation" as a review dimension but the `AdversarialFindingSchema` enum didn't include it, so documentation findings couldn't actually be filed.

**Changes:**
- Add "Trace existing execution paths" bullet to adversarial review Step 2
- Add `"documentation"` to `AdversarialFindingSchema` category enum

## Test Plan

- Verified `deno check` passes on `extensions/models/_lib/schemas.ts`
- Verified `deno fmt --check` passes on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)