### PR TITLE
fix: model and workflow commands ignore datastore cache path

### DIFF
--- a/src/cli/commands/model_delete.ts
+++ b/src/cli/commands/model_delete.ts
@@ -66,13 +66,13 @@ export const modelDeleteCommand = new Command()
     const cliCtx = createContext(options as GlobalOptions, ["model", "delete"]);
     cliCtx.logger.debug`Deleting model: ${modelIdOrName}`;
 
-    const { repoDir } = await requireInitializedRepo({
+    const { repoDir, datastoreResolver } = await requireInitializedRepo({
       repoDir: options.repoDir ?? ".",
       outputMode: cliCtx.outputMode,
     });
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createModelDeleteDeps(repoDir);
+    const deps = createModelDeleteDeps(repoDir, datastoreResolver);
     const force = !!options.force;
 
     // Phase 1: Preview — gather what will be affected

--- a/src/cli/commands/model_evaluate.ts
+++ b/src/cli/commands/model_evaluate.ts
@@ -54,13 +54,13 @@ export const modelEvaluateCommand = new Command()
 
       // If --all flag or no argument, evaluate all definitions (global lock)
       if (options.all || !modelIdOrName) {
-        const { repoDir } = await requireInitializedRepo({
+        const { repoDir, datastoreResolver } = await requireInitializedRepo({
           repoDir: options.repoDir ?? ".",
           outputMode: cliCtx.outputMode,
         });
 
         const ctx = createLibSwampContext({ logger: cliCtx.logger });
-        const deps = createModelEvaluateDeps(repoDir);
+        const deps = createModelEvaluateDeps(repoDir, datastoreResolver);
         const renderer = createModelEvaluateRenderer(cliCtx.outputMode);
 
         await consumeStream(
@@ -71,7 +71,7 @@ export const modelEvaluateCommand = new Command()
       }
 
       // Single model evaluation — use per-model lock
-      const { repoDir, repoContext, datastoreConfig } =
+      const { repoDir, repoContext, datastoreConfig, datastoreResolver } =
         await requireInitializedRepoUnlocked({
           repoDir: options.repoDir ?? ".",
           outputMode: cliCtx.outputMode,
@@ -94,7 +94,7 @@ export const modelEvaluateCommand = new Command()
       ], repoDir);
 
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
-      const deps = createModelEvaluateDeps(repoDir);
+      const deps = createModelEvaluateDeps(repoDir, datastoreResolver);
       const renderer = createModelEvaluateRenderer(cliCtx.outputMode);
 
       try {

--- a/src/cli/commands/model_method_history_get.ts
+++ b/src/cli/commands/model_method_history_get.ts
@@ -50,13 +50,15 @@ export const modelMethodHistoryGetCommand = new Command()
     ]);
     cliCtx.logger.debug`Getting method run: ${outputIdOrModelName}`;
 
-    const { repoDir } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
-      outputMode: cliCtx.outputMode,
-    });
+    const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
+      {
+        repoDir: options.repoDir ?? ".",
+        outputMode: cliCtx.outputMode,
+      },
+    );
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createModelOutputGetDeps(repoDir);
+    const deps = createModelOutputGetDeps(repoDir, datastoreResolver);
 
     const renderer = createModelOutputGetRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/cli/commands/model_method_history_logs.ts
+++ b/src/cli/commands/model_method_history_logs.ts
@@ -51,13 +51,15 @@ export const modelMethodHistoryLogsCommand = new Command()
     ]);
     cliCtx.logger.debug`Getting logs for method run: ${outputIdOrModelName}`;
 
-    const { repoDir } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
-      outputMode: cliCtx.outputMode,
-    });
+    const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
+      {
+        repoDir: options.repoDir ?? ".",
+        outputMode: cliCtx.outputMode,
+      },
+    );
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createModelMethodHistoryLogsDeps(repoDir);
+    const deps = createModelMethodHistoryLogsDeps(repoDir, datastoreResolver);
 
     const renderer = createModelMethodHistoryLogsRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/cli/commands/model_output_data.ts
+++ b/src/cli/commands/model_output_data.ts
@@ -62,13 +62,15 @@ export const modelOutputDataCommand = new Command()
     ]);
     cliCtx.logger.debug`Getting data for output: ${outputIdArg}`;
 
-    const { repoDir } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
-      outputMode: cliCtx.outputMode,
-    });
+    const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
+      {
+        repoDir: options.repoDir ?? ".",
+        outputMode: cliCtx.outputMode,
+      },
+    );
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createModelOutputDataDeps(repoDir);
+    const deps = createModelOutputDataDeps(repoDir, datastoreResolver);
 
     const renderer = createModelOutputDataRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/cli/commands/model_output_get.ts
+++ b/src/cli/commands/model_output_get.ts
@@ -46,13 +46,15 @@ export const modelOutputGetCommand = new Command()
     ]);
     cliCtx.logger.debug`Getting output: ${outputIdOrModelName}`;
 
-    const { repoDir } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
-      outputMode: cliCtx.outputMode,
-    });
+    const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
+      {
+        repoDir: options.repoDir ?? ".",
+        outputMode: cliCtx.outputMode,
+      },
+    );
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createModelOutputGetDeps(repoDir);
+    const deps = createModelOutputGetDeps(repoDir, datastoreResolver);
 
     const renderer = createModelOutputGetRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/cli/commands/model_output_logs.ts
+++ b/src/cli/commands/model_output_logs.ts
@@ -47,13 +47,15 @@ export const modelOutputLogsCommand = new Command()
     ]);
     cliCtx.logger.debug`Getting logs for output: ${outputIdArg}`;
 
-    const { repoDir } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
-      outputMode: cliCtx.outputMode,
-    });
+    const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
+      {
+        repoDir: options.repoDir ?? ".",
+        outputMode: cliCtx.outputMode,
+      },
+    );
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createModelOutputLogsDeps(repoDir);
+    const deps = createModelOutputLogsDeps(repoDir, datastoreResolver);
 
     const renderer = createModelOutputLogsRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/cli/commands/model_validate.ts
+++ b/src/cli/commands/model_validate.ts
@@ -65,7 +65,7 @@ export const modelValidateCommand = new Command()
       const method = options.method as string | undefined;
       const hasCheckOptions = (labels && labels.length > 0) || method;
 
-      const { repoDir } = hasCheckOptions
+      const { repoDir, datastoreResolver } = hasCheckOptions
         ? await requireInitializedRepo({
           repoDir: options.repoDir ?? ".",
           outputMode: cliCtx.outputMode,
@@ -76,7 +76,11 @@ export const modelValidateCommand = new Command()
         });
 
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
-      const deps = createModelValidateDeps(repoDir, { labels, method });
+      const deps = createModelValidateDeps(
+        repoDir,
+        { labels, method },
+        datastoreResolver,
+      );
 
       const renderer = createModelValidateRenderer(cliCtx.outputMode);
       await consumeStream(

--- a/src/cli/commands/workflow_delete.ts
+++ b/src/cli/commands/workflow_delete.ts
@@ -66,13 +66,13 @@ export const workflowDeleteCommand = new Command()
     ]);
     cliCtx.logger.debug`Deleting workflow: ${workflowIdOrName}`;
 
-    const { repoDir } = await requireInitializedRepo({
+    const { repoDir, datastoreResolver } = await requireInitializedRepo({
       repoDir: options.repoDir ?? ".",
       outputMode: cliCtx.outputMode,
     });
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createWorkflowDeleteDeps(repoDir);
+    const deps = createWorkflowDeleteDeps(repoDir, datastoreResolver);
 
     // Phase 1: Preview
     let preview;

--- a/src/cli/commands/workflow_evaluate.ts
+++ b/src/cli/commands/workflow_evaluate.ts
@@ -73,13 +73,13 @@ export const workflowEvaluateCommand = new Command()
 
       // If --all flag or no argument, evaluate all workflows (global lock)
       if (options.all || !workflowIdOrName) {
-        const { repoDir } = await requireInitializedRepo({
+        const { repoDir, datastoreResolver } = await requireInitializedRepo({
           repoDir: options.repoDir ?? ".",
           outputMode: cliCtx.outputMode,
         });
 
         const ctx = createLibSwampContext({ logger: cliCtx.logger });
-        const deps = createWorkflowEvaluateDeps(repoDir);
+        const deps = createWorkflowEvaluateDeps(repoDir, datastoreResolver);
         const renderer = createWorkflowEvaluateRenderer(cliCtx.outputMode);
 
         await consumeStream(
@@ -133,6 +133,7 @@ export const workflowEvaluateCommand = new Command()
 
       let flushModelLocks: (() => Promise<void>) | null = null;
       let repoDir: string;
+      let datastoreResolver = unlocked.datastoreResolver;
 
       if (modelRefs !== null && modelRefs.length > 0) {
         // Resolve model references to { modelType, modelId }
@@ -172,13 +173,14 @@ export const workflowEvaluateCommand = new Command()
           outputMode: cliCtx.outputMode,
         });
         repoDir = globalResult.repoDir;
+        datastoreResolver = globalResult.datastoreResolver;
       } else {
         // No model references
         repoDir = unlocked.repoDir;
       }
 
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
-      const deps = createWorkflowEvaluateDeps(repoDir);
+      const deps = createWorkflowEvaluateDeps(repoDir, datastoreResolver);
       const renderer = createWorkflowEvaluateRenderer(cliCtx.outputMode);
 
       try {

--- a/src/cli/commands/workflow_history_get.ts
+++ b/src/cli/commands/workflow_history_get.ts
@@ -46,13 +46,15 @@ export const workflowHistoryGetCommand = new Command()
     ]);
     cliCtx.logger.debug`Getting latest run for workflow: ${workflowIdOrName}`;
 
-    const { repoDir } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
-      outputMode: cliCtx.outputMode,
-    });
+    const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
+      {
+        repoDir: options.repoDir ?? ".",
+        outputMode: cliCtx.outputMode,
+      },
+    );
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createWorkflowHistoryGetDeps(repoDir);
+    const deps = createWorkflowHistoryGetDeps(repoDir, datastoreResolver);
 
     const renderer = createWorkflowHistoryGetRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/cli/commands/workflow_history_logs.ts
+++ b/src/cli/commands/workflow_history_logs.ts
@@ -49,13 +49,15 @@ export const workflowHistoryLogsCommand = new Command()
     );
     cliCtx.logger.debug`Getting logs for workflow run: ${runIdOrWorkflow}`;
 
-    const { repoDir } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
-      outputMode: cliCtx.outputMode,
-    });
+    const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
+      {
+        repoDir: options.repoDir ?? ".",
+        outputMode: cliCtx.outputMode,
+      },
+    );
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createWorkflowHistoryLogsDeps(repoDir);
+    const deps = createWorkflowHistoryLogsDeps(repoDir, datastoreResolver);
 
     const renderer = createWorkflowHistoryLogsRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/libswamp/models/delete.ts
+++ b/src/libswamp/models/delete.ts
@@ -26,6 +26,8 @@ import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_
 import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
+import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
+import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import { createModelOutputId } from "../../domain/models/model_output.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -95,11 +97,22 @@ export interface ModelDeleteDeps {
 }
 
 /** Wires real infrastructure into ModelDeleteDeps. */
-export function createModelDeleteDeps(repoDir: string): ModelDeleteDeps {
+export function createModelDeleteDeps(
+  repoDir: string,
+  datastoreResolver?: DatastorePathResolver,
+): ModelDeleteDeps {
+  const dsPath = (subdir: string): string | undefined =>
+    datastoreResolver?.resolvePath(subdir);
   const definitionRepo = new YamlDefinitionRepository(repoDir);
   const workflowRepo = new YamlWorkflowRepository(repoDir);
-  const unifiedDataRepo = new FileSystemUnifiedDataRepository(repoDir);
-  const outputRepo = new YamlOutputRepository(repoDir);
+  const unifiedDataRepo = new FileSystemUnifiedDataRepository(
+    repoDir,
+    dsPath(SWAMP_SUBDIRS.data),
+  );
+  const outputRepo = new YamlOutputRepository(
+    repoDir,
+    dsPath(SWAMP_SUBDIRS.outputs),
+  );
   return {
     lookupDefinition: (idOrName) =>
       findDefinitionByIdOrName(definitionRepo, idOrName),

--- a/src/libswamp/models/evaluate.ts
+++ b/src/libswamp/models/evaluate.ts
@@ -28,6 +28,8 @@ import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { YamlEvaluatedDefinitionRepository } from "../../infrastructure/persistence/yaml_evaluated_definition_repository.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
+import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError } from "../errors.ts";
 
@@ -82,15 +84,26 @@ export interface ModelEvaluateDeps {
 }
 
 /** Wires real infrastructure into ModelEvaluateDeps. */
-export function createModelEvaluateDeps(repoDir: string): ModelEvaluateDeps {
+export function createModelEvaluateDeps(
+  repoDir: string,
+  datastoreResolver?: DatastorePathResolver,
+): ModelEvaluateDeps {
+  const dsPath = (subdir: string): string | undefined =>
+    datastoreResolver?.resolvePath(subdir);
   const definitionRepo = new YamlDefinitionRepository(repoDir);
-  const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+  const dataRepo = new FileSystemUnifiedDataRepository(
+    repoDir,
+    dsPath(SWAMP_SUBDIRS.data),
+  );
   const evaluationService = new ExpressionEvaluationService(
     definitionRepo,
     repoDir,
     { dataRepo },
   );
-  const evaluatedDefRepo = new YamlEvaluatedDefinitionRepository(repoDir);
+  const evaluatedDefRepo = new YamlEvaluatedDefinitionRepository(
+    repoDir,
+    dsPath(SWAMP_SUBDIRS.definitionsEvaluated),
+  );
 
   return {
     lookupDefinition: (idOrName) =>

--- a/src/libswamp/models/method_history_logs.ts
+++ b/src/libswamp/models/method_history_logs.ts
@@ -33,6 +33,8 @@ import { readLogFile } from "../../presentation/output/log_file_reader.ts";
 import { toRelativePath } from "../../infrastructure/persistence/paths.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
+import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
+import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
@@ -106,9 +108,15 @@ export interface ModelMethodHistoryLogsDeps {
 /** Wires real infrastructure into ModelMethodHistoryLogsDeps. */
 export function createModelMethodHistoryLogsDeps(
   repoDir: string,
+  datastoreResolver?: DatastorePathResolver,
 ): ModelMethodHistoryLogsDeps {
+  const dsPath = (subdir: string): string | undefined =>
+    datastoreResolver?.resolvePath(subdir);
   const definitionRepo = new YamlDefinitionRepository(repoDir);
-  const outputRepo = new YamlOutputRepository(repoDir);
+  const outputRepo = new YamlOutputRepository(
+    repoDir,
+    dsPath(SWAMP_SUBDIRS.outputs),
+  );
   return {
     isPartialId,
     matchOutputByPartialId: async (idPrefix: string) => {

--- a/src/libswamp/models/output_data.ts
+++ b/src/libswamp/models/output_data.ts
@@ -30,6 +30,8 @@ import {
 import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
+import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
@@ -100,10 +102,19 @@ export interface ModelOutputDataDeps {
 /** Wires real infrastructure into ModelOutputDataDeps. */
 export function createModelOutputDataDeps(
   repoDir: string,
+  datastoreResolver?: DatastorePathResolver,
 ): ModelOutputDataDeps {
-  const outputRepo = new YamlOutputRepository(repoDir);
+  const dsPath = (subdir: string): string | undefined =>
+    datastoreResolver?.resolvePath(subdir);
+  const outputRepo = new YamlOutputRepository(
+    repoDir,
+    dsPath(SWAMP_SUBDIRS.outputs),
+  );
   const definitionRepo = new YamlDefinitionRepository(repoDir);
-  const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+  const dataRepo = new FileSystemUnifiedDataRepository(
+    repoDir,
+    dsPath(SWAMP_SUBDIRS.data),
+  );
   return {
     isPartialId,
     matchOutputByPartialId: async (idPrefix: string) => {

--- a/src/libswamp/models/output_get.ts
+++ b/src/libswamp/models/output_get.ts
@@ -29,6 +29,8 @@ import {
 } from "../../domain/models/model_lookup.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
+import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
+import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound } from "../errors.ts";
@@ -143,9 +145,17 @@ export interface ModelOutputGetDeps {
 }
 
 /** Wires real infrastructure into ModelOutputGetDeps. */
-export function createModelOutputGetDeps(repoDir: string): ModelOutputGetDeps {
+export function createModelOutputGetDeps(
+  repoDir: string,
+  datastoreResolver?: DatastorePathResolver,
+): ModelOutputGetDeps {
+  const dsPath = (subdir: string): string | undefined =>
+    datastoreResolver?.resolvePath(subdir);
   const definitionRepo = new YamlDefinitionRepository(repoDir);
-  const outputRepo = new YamlOutputRepository(repoDir);
+  const outputRepo = new YamlOutputRepository(
+    repoDir,
+    dsPath(SWAMP_SUBDIRS.outputs),
+  );
   return {
     findAllOutputsGlobal: () => outputRepo.findAllGlobal(),
     findDefinitionByIdOrName: (idOrName) =>

--- a/src/libswamp/models/output_logs.ts
+++ b/src/libswamp/models/output_logs.ts
@@ -25,6 +25,8 @@ import {
 } from "../../domain/models/model_lookup.ts";
 import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
+import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
@@ -77,9 +79,18 @@ export interface ModelOutputLogsDeps {
 /** Wires real infrastructure into ModelOutputLogsDeps. */
 export function createModelOutputLogsDeps(
   repoDir: string,
+  datastoreResolver?: DatastorePathResolver,
 ): ModelOutputLogsDeps {
-  const outputRepo = new YamlOutputRepository(repoDir);
-  const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+  const dsPath = (subdir: string): string | undefined =>
+    datastoreResolver?.resolvePath(subdir);
+  const outputRepo = new YamlOutputRepository(
+    repoDir,
+    dsPath(SWAMP_SUBDIRS.outputs),
+  );
+  const dataRepo = new FileSystemUnifiedDataRepository(
+    repoDir,
+    dsPath(SWAMP_SUBDIRS.data),
+  );
   return {
     isPartialId,
     matchOutputByPartialId: async (idPrefix: string) => {

--- a/src/libswamp/models/validate.ts
+++ b/src/libswamp/models/validate.ts
@@ -28,6 +28,8 @@ import {
 } from "../../domain/models/validation_service.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
+import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
@@ -114,9 +116,15 @@ export interface ModelValidateDeps {
 export function createModelValidateDeps(
   repoDir: string,
   options?: { labels?: string[]; method?: string },
+  datastoreResolver?: DatastorePathResolver,
 ): ModelValidateDeps {
+  const dsPath = (subdir: string): string | undefined =>
+    datastoreResolver?.resolvePath(subdir);
   const definitionRepo = new YamlDefinitionRepository(repoDir);
-  const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+  const dataRepo = new FileSystemUnifiedDataRepository(
+    repoDir,
+    dsPath(SWAMP_SUBDIRS.data),
+  );
   const validationService = new DefaultModelValidationService();
 
   const checkContext: CheckValidationContext = {

--- a/src/libswamp/workflows/delete.ts
+++ b/src/libswamp/workflows/delete.ts
@@ -25,6 +25,8 @@ import {
 import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
 import { YamlEvaluatedWorkflowRepository } from "../../infrastructure/persistence/yaml_evaluated_workflow_repository.ts";
+import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
+import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound, validationFailed } from "../errors.ts";
@@ -76,10 +78,22 @@ export interface WorkflowDeleteDeps {
 }
 
 /** Wires real infrastructure into WorkflowDeleteDeps. */
-export function createWorkflowDeleteDeps(repoDir: string): WorkflowDeleteDeps {
+export function createWorkflowDeleteDeps(
+  repoDir: string,
+  datastoreResolver?: DatastorePathResolver,
+): WorkflowDeleteDeps {
+  const dsPath = (subdir: string): string | undefined =>
+    datastoreResolver?.resolvePath(subdir);
   const workflowRepo = new YamlWorkflowRepository(repoDir);
-  const workflowRunRepo = new YamlWorkflowRunRepository(repoDir);
-  const evaluatedWorkflowRepo = new YamlEvaluatedWorkflowRepository(repoDir);
+  const workflowRunRepo = new YamlWorkflowRunRepository(
+    repoDir,
+    undefined,
+    dsPath(SWAMP_SUBDIRS.workflowRuns),
+  );
+  const evaluatedWorkflowRepo = new YamlEvaluatedWorkflowRepository(
+    repoDir,
+    dsPath(SWAMP_SUBDIRS.workflowsEvaluated),
+  );
   return {
     findById: (id) => workflowRepo.findById(id),
     findByName: (name) => workflowRepo.findByName(name),

--- a/src/libswamp/workflows/evaluate.ts
+++ b/src/libswamp/workflows/evaluate.ts
@@ -40,6 +40,8 @@ import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_wo
 import { YamlEvaluatedWorkflowRepository } from "../../infrastructure/persistence/yaml_evaluated_workflow_repository.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
+import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError } from "../errors.ts";
 
@@ -97,11 +99,20 @@ export interface WorkflowEvaluateDeps {
 /** Wires real infrastructure into WorkflowEvaluateDeps. */
 export function createWorkflowEvaluateDeps(
   repoDir: string,
+  datastoreResolver?: DatastorePathResolver,
 ): WorkflowEvaluateDeps {
+  const dsPath = (subdir: string): string | undefined =>
+    datastoreResolver?.resolvePath(subdir);
   const workflowRepo = new YamlWorkflowRepository(repoDir);
   const definitionRepo = new YamlDefinitionRepository(repoDir);
-  const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
-  const evaluatedWorkflowRepo = new YamlEvaluatedWorkflowRepository(repoDir);
+  const dataRepo = new FileSystemUnifiedDataRepository(
+    repoDir,
+    dsPath(SWAMP_SUBDIRS.data),
+  );
+  const evaluatedWorkflowRepo = new YamlEvaluatedWorkflowRepository(
+    repoDir,
+    dsPath(SWAMP_SUBDIRS.workflowsEvaluated),
+  );
   const modelResolver = new ModelResolver(definitionRepo, {
     repoDir,
     dataRepo,

--- a/src/libswamp/workflows/history_get.ts
+++ b/src/libswamp/workflows/history_get.ts
@@ -26,6 +26,8 @@ import {
 } from "../../domain/workflows/workflow_id.ts";
 import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
+import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
+import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound } from "../errors.ts";
@@ -48,9 +50,16 @@ export interface WorkflowHistoryGetDeps {
 /** Wires real infrastructure into WorkflowHistoryGetDeps. */
 export function createWorkflowHistoryGetDeps(
   repoDir: string,
+  datastoreResolver?: DatastorePathResolver,
 ): WorkflowHistoryGetDeps {
+  const dsPath = (subdir: string): string | undefined =>
+    datastoreResolver?.resolvePath(subdir);
   const workflowRepo = new YamlWorkflowRepository(repoDir);
-  const runRepo = new YamlWorkflowRunRepository(repoDir);
+  const runRepo = new YamlWorkflowRunRepository(
+    repoDir,
+    undefined,
+    dsPath(SWAMP_SUBDIRS.workflowRuns),
+  );
   return {
     findWorkflow: async (idOrName) =>
       await workflowRepo.findByName(idOrName) ??

--- a/src/libswamp/workflows/history_logs.ts
+++ b/src/libswamp/workflows/history_logs.ts
@@ -28,6 +28,8 @@ import { readLogFile } from "../../presentation/output/log_file_reader.ts";
 import { toRelativePath } from "../../infrastructure/persistence/paths.ts";
 import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
+import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
+import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
@@ -92,8 +94,15 @@ export interface WorkflowHistoryLogsDeps {
 /** Wires real infrastructure into WorkflowHistoryLogsDeps. */
 export function createWorkflowHistoryLogsDeps(
   repoDir: string,
+  datastoreResolver?: DatastorePathResolver,
 ): WorkflowHistoryLogsDeps {
-  const runRepo = new YamlWorkflowRunRepository(repoDir);
+  const dsPath = (subdir: string): string | undefined =>
+    datastoreResolver?.resolvePath(subdir);
+  const runRepo = new YamlWorkflowRunRepository(
+    repoDir,
+    undefined,
+    dsPath(SWAMP_SUBDIRS.workflowRuns),
+  );
   const workflowRepo = new YamlWorkflowRepository(repoDir);
   return {
     isPartialId,


### PR DESCRIPTION
## Summary

Extends the datastore path fix from #1017 to 11 additional command factories that construct datastore-tier repositories (`outputs`, `workflow-runs`, `definitions-evaluated`, `workflows-evaluated`, `data`) without passing the resolved base directory from the datastore resolver.

**Root cause:** Same as #1017 — each `createDeps` factory constructed repositories with only `repoDir`, causing them to always read from `.swamp/<subdir>/` instead of the resolved datastore cache path (e.g. `~/.swamp/repos/<repoId>/<subdir>/`).

### Model commands fixed (7 factories)

| Factory | Affected repos |
|---------|---------------|
| `createModelDeleteDeps` | `FileSystemUnifiedDataRepository`, `YamlOutputRepository` |
| `createModelEvaluateDeps` | `FileSystemUnifiedDataRepository`, `YamlEvaluatedDefinitionRepository` |
| `createModelValidateDeps` | `FileSystemUnifiedDataRepository` |
| `createModelOutputGetDeps` | `YamlOutputRepository` |
| `createModelOutputDataDeps` | `YamlOutputRepository`, `FileSystemUnifiedDataRepository` |
| `createModelOutputLogsDeps` | `YamlOutputRepository`, `FileSystemUnifiedDataRepository` |
| `createModelMethodHistoryLogsDeps` | `YamlOutputRepository` |

### Workflow commands fixed (4 factories)

| Factory | Affected repos |
|---------|---------------|
| `createWorkflowDeleteDeps` | `YamlWorkflowRunRepository`, `YamlEvaluatedWorkflowRepository` |
| `createWorkflowEvaluateDeps` | `FileSystemUnifiedDataRepository`, `YamlEvaluatedWorkflowRepository` |
| `createWorkflowHistoryGetDeps` | `YamlWorkflowRunRepository` |
| `createWorkflowHistoryLogsDeps` | `YamlWorkflowRunRepository` |

### User impact

Any user with an extension datastore (S3, custom) would see incorrect or missing results from these commands:
- **model output get/data/logs** — no outputs or stale outputs
- **model method history logs/get** — no history or stale history  
- **model evaluate** — CEL expressions evaluated against stale data, evaluated defs written to wrong path
- **model validate** — validated against stale data
- **model delete** — missed data artifacts and outputs during cleanup
- **workflow history get/logs** — no runs or stale runs
- **workflow evaluate** — stale data for CEL expressions, evaluated workflows written to wrong path
- **workflow delete** — missed run records during cleanup

Users with only the default local datastore are not affected.

### Fix

Same pattern as #1017: added optional `datastoreResolver` parameter to each `createDeps` factory. CLI commands now destructure `datastoreResolver` from `requireInitializedRepo*` and pass it through.

## Test Plan

- [x] `deno check` — full project type-checks
- [x] `deno lint` — 957 files clean
- [x] `deno fmt` — formatted
- [x] `deno run test` — 3913 tests pass
- [x] `deno run compile` — binary compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)