### PR TITLE
fix: pass API key in extension version command

### DIFF
--- a/src/cli/commands/extension_version.ts
+++ b/src/cli/commands/extension_version.ts
@@ -58,7 +58,7 @@ export const extensionVersionCommand = new Command()
       const extensionName = await resolveExtensionName(name, options.manifest);
 
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
-      const deps = createExtensionVersionDeps();
+      const deps = await createExtensionVersionDeps();
       const renderer = createExtensionVersionRenderer(cliCtx.outputMode);
 
       await consumeStream(

--- a/src/libswamp/extensions/version.ts
+++ b/src/libswamp/extensions/version.ts
@@ -22,6 +22,7 @@ import {
   ExtensionApiClient,
   type LatestVersionInfo,
 } from "../../infrastructure/http/extension_api_client.ts";
+import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
 import { resolveServerUrl } from "./pull.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -51,11 +52,16 @@ export interface ExtensionVersionDeps {
 }
 
 /** Wires real infrastructure into ExtensionVersionDeps. */
-export function createExtensionVersionDeps(): ExtensionVersionDeps {
-  const serverUrl = resolveServerUrl();
+export async function createExtensionVersionDeps(): Promise<
+  ExtensionVersionDeps
+> {
+  const authRepo = new AuthRepository();
+  const creds = await authRepo.load();
+  const serverUrl = creds?.serverUrl ?? resolveServerUrl();
   const client = new ExtensionApiClient(serverUrl);
+  const apiKey = creds?.apiKey;
   return {
-    getLatestVersion: (name: string) => client.getLatestVersion(name),
+    getLatestVersion: (name: string) => client.getLatestVersion(name, apiKey),
   };
 }
 


### PR DESCRIPTION
## Summary

- `createExtensionVersionDeps()` never loaded credentials, so `client.getLatestVersion()` was called without an API key — every `swamp extension version` invocation failed with 401
- Load credentials via `AuthRepository` and pass the `apiKey` into the closure, matching the existing pattern in `push.ts`

Fixes #1025

## Test Plan

- Existing unit tests pass (deps are injected, interface unchanged)
- Verified against reproduction: `swamp extension version @swamp/digitalocean --json` now returns version info instead of 401
- UAT gap filed: systeminit/swamp-uat#116

🤖 Generated with [Claude Code](https://claude.com/claude-code)