### PR TITLE
feat: add extension adversarial review to extension skills

### DIFF
--- a/.claude/skills/swamp-extension-datastore/SKILL.md
+++ b/.claude/skills/swamp-extension-datastore/SKILL.md
@@ -190,6 +190,14 @@ swamp datastore status --json
 7. **Locking is required**: `createLock` must return a working `DistributedLock`
    — swamp acquires locks for all write operations
 
+## Extension Adversarial Review
+
+After writing or significantly modifying datastore code, and before running unit
+tests, read the
+[extension adversarial review](../swamp-extension-model/references/adversarial-review.md)
+and self-review against all applicable dimensions (universal + datastores).
+Present findings to the user before proceeding.
+
 ## Publishing
 
 Publishing is the same for all extension types. Before pushing:

--- a/.claude/skills/swamp-extension-driver/SKILL.md
+++ b/.claude/skills/swamp-extension-driver/SKILL.md
@@ -223,6 +223,14 @@ driver file — swamp silently skips files that fail to compile.
 7. **Output types**: Drivers return `"pending"` outputs (data to be persisted by
    swamp) or `"persisted"` outputs (already written by in-process drivers)
 
+## Extension Adversarial Review
+
+After writing or significantly modifying driver code, and before running unit
+tests, read the
+[extension adversarial review](../swamp-extension-model/references/adversarial-review.md)
+and self-review against all applicable dimensions (universal + drivers). Present
+findings to the user before proceeding.
+
 ## Publishing
 
 Publishing is the same for all extension types. Before pushing:

--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -227,57 +227,22 @@ files: {
 
 The execute function receives pre-validated `args` and a `context` object:
 
-```typescript
-execute: (async (args, context) => {
-  // args                   - Pre-validated method arguments
-  // context.globalArgs     - Global arguments
-  // context.definition     - { id, name, version, tags }
-  // context.methodName     - Name of the executing method
-  // context.repoDir        - Repository root path
-  // context.logger         - LogTape Logger
-  // context.dataRepository - For advanced data operations
-  // context.writeResource  - Write structured JSON data
-  // context.readResource   - Read stored JSON data by instance name
-  // context.createFileWriter - Create a writer for files
+- `args` — Pre-validated method arguments
+- `context.globalArgs` — Global arguments
+- `context.definition` — `{ id, name, version, tags }`
+- `context.methodName` — Name of the executing method
+- `context.repoDir` — Repository root path
+- `context.logger` — LogTape Logger
+- `context.writeResource(specName, instanceName, data)` — Write structured JSON
+- `context.readResource(instanceName, version?)` — Read stored JSON
+- `context.createFileWriter(specName, instanceName)` — Create file writer
+- `context.dataRepository` — Advanced data operations
 
-  const handle = await context.writeResource("result", "main", {
-    value: "processed",
-    timestamp: new Date().toISOString(),
-  });
+Return `{ dataHandles: [handle] }` from execute. Throw **before** writing data —
+failed executions should not persist incorrect data. The workflow engine catches
+exceptions and marks the step as failed.
 
-  return { dataHandles: [handle] };
-});
-```
-
-### Error Handling
-
-Models should throw when execution fails. Throw **before** writing data — failed
-executions should not persist incorrect or misleading data.
-
-```typescript
-execute: (async (args, context) => {
-  const result = await callExternalApi(args);
-
-  // Throw BEFORE writing data — don't persist failure data
-  if (result.status >= 400) {
-    throw new Error(`API request failed with status ${result.status}`);
-  }
-
-  const handle = await context.writeResource("result", "main", {
-    statusCode: result.status,
-    response: result.body,
-  });
-
-  return { dataHandles: [handle] };
-});
-```
-
-The workflow engine catches exceptions and marks the step as failed. Use
-`allowFailure: true` on a workflow step to continue execution after a failure.
-
-For detailed API documentation on `writeResource`, `createFileWriter`,
-`DataWriter`, `DataHandle`, and `dataRepository`, see
-[references/api.md](references/api.md).
+See [references/api.md](references/api.md) for detailed API documentation.
 
 ## Instance Names
 
@@ -300,34 +265,9 @@ one spec — see [Factory Models](#factory-models) below.
 ## Factory Models
 
 A single method execution can produce multiple dynamically-named resources from
-the same output spec. This is useful when a model discovers N items and needs to
-emit each as a separately-addressable resource.
-
-```typescript
-const handles = [];
-for (const subnet of subnets) {
-  const handle = await context.writeResource(
-    "subnet",
-    subnet.subnetId, // Dynamic instance name
-    subnet,
-  );
-  handles.push(handle);
-}
-return { dataHandles: handles };
-```
-
-**Discovering factory outputs in CEL:**
-
-```yaml
-# Get all subnets produced by the scanner
-allSubnets: ${{ data.findBySpec("my-scanner", "subnet") }}
-
-# Access a specific named instance
-subnetA: ${{ model.my-scanner.resource.subnet.subnet-aaa.attributes.cidr }}
-```
-
-See [references/scenarios.md](references/scenarios.md) for complete factory
-model examples.
+the same output spec by passing distinct instance names to `writeResource`. See
+[references/scenarios.md](references/scenarios.md#scenario-3-factory-model-for-discovery)
+for complete factory model examples with CEL discovery patterns.
 
 ## CRUD Lifecycle Models
 
@@ -457,28 +397,17 @@ Deno.test("run method writes expected resource", async () => {
 });
 ```
 
-For CRUD models, seed stored resources to test methods that read existing state:
+See [references/testing.md](references/testing.md) for CRUD lifecycle testing
+with `storedResources`, injectable client patterns, log assertions, and
+cancellation testing.
 
-```typescript
-const { context } = createModelTestContext({
-  storedResources: { "main": { instanceId: "i-abc123" } },
-});
-await model.methods.sync.execute({}, context);
-```
+## Extension Adversarial Review
 
-For models calling external APIs, use the injectable client pattern — accept an
-optional client parameter so tests can pass a stub:
-
-```typescript
-execute: (async (args, context) => {
-  const s3 = args._s3Client ??
-    new S3Client({ region: context.globalArgs.region });
-  // ...
-});
-```
-
-See [references/testing.md](references/testing.md) for the full guide including
-injectable client examples, log assertions, and cancellation testing.
+After writing or significantly modifying extension code, and before running unit
+tests or smoke tests, read
+[references/adversarial-review.md](references/adversarial-review.md) and
+self-review against all applicable dimensions. Present findings to the user
+before proceeding to testing.
 
 ## Publishing Extensions
 
@@ -516,44 +445,17 @@ troubleshooting, see [references/publishing.md](references/publishing.md).
 
 ## Key Rules
 
-1. **Export**: Use `export const model = { ... }` for new types or
+1. **Export**: `export const model = { ... }` for new types,
    `export const extension = { ... }` for extending existing types
-2. **Import**: `import { z } from "npm:zod@4";` is always required. Any
-   Deno-compatible import (`npm:`, `jsr:`, `https://`) can also be used — swamp
-   bundles all dependencies automatically. Extensions with a `deno.json` or
-   `package.json` can use bare specifiers instead (e.g., `from "zod"`). See
-   [references/examples.md](references/examples.md#using-external-dependencies)
-3. **Static imports only**: All imports must be static top-level imports.
-   Dynamic `import()` calls are not supported — the quality checker rejects them
-   during `extension push`.
-4. **Pin npm versions**: Always pin versions — either inline
-   (`npm:lodash-es@4.17.21`), via a `deno.json` import map, or in `package.json`
-   dependencies. See
-   [references/examples.md](references/examples.md#import-styles) for details.
-5. **Helper scripts**: Use `include` in the manifest for TypeScript files that
-   are executed via `Deno.Command` subprocess and shouldn't be bundled. See
-   [references/examples.md](references/examples.md#helper-scripts) for details.
-6. **Type naming**: Use `@<collective>/<name>` or `<collective>/<name>` format
-   (e.g., `@user/my-model` or `myorg/my-model`)
-7. **No type annotations**: Avoid TypeScript types in execute parameters
-8. **File naming**: Use snake_case (`my_model.ts`)
-9. **Version upgrades**: When bumping `version`, always add an `upgrades` entry
-   and prompt the user for the migration path. See
-   [references/upgrades.md](references/upgrades.md)
+2. **Import**: `import { z } from "npm:zod@4";` is always required
+3. **Static imports only**: Dynamic `import()` is rejected during push
+4. **Pin npm versions**: Always pin — inline, via `deno.json`, or `package.json`
+5. **No type annotations**: Avoid TypeScript types in execute parameters
+6. **File naming**: Use snake_case (`my_model.ts`)
+7. **Version upgrades**: When bumping `version`, always add an `upgrades` entry
 
-## Collective Rules
-
-User-defined models can use any collective except reserved ones (`swamp`, `si`):
-
-| Type                        | Valid? | Notes                       |
-| --------------------------- | ------ | --------------------------- |
-| `@user/my-model`            | ✅     | Valid collective            |
-| `@myorg/deploy`             | ✅     | Custom collective allowed   |
-| `myorg/my-model`            | ✅     | Non-@ format allowed        |
-| `digitalocean/app-platform` | ✅     | Non-@ multi-segment allowed |
-| `@user/aws/s3`              | ✅     | Nested paths allowed        |
-| `swamp/my-model`            | ❌     | Reserved collective         |
-| `si/my-model`               | ❌     | Reserved collective         |
+For import styles, helper scripts, collective naming rules, and version details,
+see [references/publishing.md](references/publishing.md).
 
 ## Verify
 
@@ -598,5 +500,8 @@ swamp model type describe @myorg/my-model --json  # Check schema
   [references/troubleshooting.md](references/troubleshooting.md)
 - **Version Upgrades**: See [references/upgrades.md](references/upgrades.md) for
   upgrade patterns, user prompt workflow, and migration examples
+- **Adversarial Review**: See
+  [references/adversarial-review.md](references/adversarial-review.md) for the
+  pre-push quality review checklist (credentials, logging, errors, idempotency)
 - **Docker execution**: See
   [references/docker-execution.md](references/docker-execution.md)

--- a/.claude/skills/swamp-extension-model/references/adversarial-review.md
+++ b/.claude/skills/swamp-extension-model/references/adversarial-review.md
@@ -1,0 +1,154 @@
+# Extension Adversarial Review
+
+After writing or significantly modifying extension code, review against each
+applicable dimension below before running tests or pushing. Present findings to
+the user before proceeding.
+
+## When to Run
+
+- After writing new extension code, before unit tests
+- After revising code in response to smoke test failures (review only changed
+  dimensions)
+- Before publishing with `swamp extension push`
+
+## Universal Dimensions
+
+These apply to **all** extension types (models, drivers, vaults, datastores).
+
+### 1. Credentials & Secrets
+
+- **API tokens, passwords, service-specific secrets**: Store in vault and mark
+  schema fields with `.meta({ sensitive: true })`. Use `sensitiveOutput: true`
+  on output specs that are entirely secret.
+- **Cloud provider credentials (AWS, GCP, Azure)**: Prefer environment-based
+  auth (IAM roles, instance profiles, env var credential chains) over vault
+  storage. Don't store what you don't need to.
+- **Best option**: Defer to the environment when possible. Only vault what can't
+  be sourced from env vars or provider-native auth mechanisms.
+- Config schemas should accept vault references for credential fields where
+  vaulting is appropriate.
+- Scope credentials narrowly — use read-only tokens when write access isn't
+  needed.
+
+### 2. Logging Quality
+
+- Every method should log at `info` level on entry (what it's about to do) and
+  completion (what it did).
+- Use structured placeholders:
+  `context.logger.info("Created {resource}", { resource: name })` — never string
+  interpolation.
+- Use appropriate levels:
+  - `debug` — internal state, intermediate values
+  - `info` — user-visible progress, state transitions
+  - `warning` — recoverable issues, degraded behavior
+  - `error` — failures that stop the operation
+- **Never log sensitive data** — API keys, tokens, passwords, secret values must
+  not appear in log messages or structured properties.
+
+### 3. Error Handling
+
+- **Throw before writing data**: If validation or an API call fails, throw
+  before calling `writeResource` or `createFileWriter`. The workflow engine
+  catches exceptions and marks the method as failed — partial writes create
+  inconsistent state.
+- Error messages must be descriptive and actionable: include the operation that
+  failed, the resource involved, and the error detail.
+- HTTP errors should include the status code and response body (or a summary).
+- Distinguish transient errors (429 Too Many Requests, 503 Service Unavailable,
+  network timeouts) from permanent errors (403 Forbidden, 404 Not Found) when
+  the distinction affects recovery.
+- Scope try/catch blocks narrowly — don't catch broadly and swallow errors.
+
+### 4. Testing Completeness
+
+- Unit tests use the appropriate test context (`createModelTestContext`,
+  `createDriverTestContext`, `assertVaultExportConformance`,
+  `assertDatastoreExportConformance`).
+- Cover both success and failure paths — test what happens when the API returns
+  an error, when a resource already exists, when input is invalid.
+- Use the injectable client pattern or mock primitives (`withMockedFetch`,
+  `withMockedCommand`) for code that calls external APIs.
+- Use `storedResources` to seed existing state for update/delete/sync method
+  tests.
+
+### 5. Idempotency & Resilience
+
+- **Create** methods should handle "already exists" gracefully — return the
+  existing resource rather than throwing.
+- **Delete** methods should handle "already gone" gracefully — succeed rather
+  than throw on 404.
+- Consider partial failure: if the method is interrupted mid-execution, what
+  state does it leave behind? Are there orphaned cloud resources or partial
+  writes?
+
+### 6. API Contracts
+
+- Validate or check external API responses before accessing fields — don't
+  assume the shape is correct.
+- Handle pagination for list endpoints that return paginated results.
+- Respect rate limits — honor `Retry-After` headers and use backoff when
+  appropriate.
+- Verify that URLs, HTTP methods, and request body schemas match the provider's
+  current documentation.
+
+### 7. Resource Management
+
+- Clean up network connections, file handles, and temporary files on all code
+  paths, including error paths.
+- Methods that create cloud resources should track resource IDs so they can be
+  referenced for later cleanup or deletion.
+
+## Type-Specific Dimensions
+
+### Models
+
+- **Schema strictness**: Zod schemas should use `z.object({...})` without
+  `.passthrough()` — passthrough prevents CEL expression validation.
+- **Lifetime & GC**: Every resource/file spec should have `lifetime` and
+  `garbageCollection` configured appropriately.
+- **CRUD completeness**: CRUD lifecycle models should have create, update,
+  delete, and sync methods.
+- **Pre-flight checks**: Mutating methods should have pre-flight checks with
+  labels (e.g., `"policy"`, `"live"`) for selective skipping.
+- **Instance names**: Instance names must be unique across specs within a method
+  execution.
+- **Data access**: Use `readResource` (not direct `dataRepository` access) for
+  reading back stored state in update/delete/sync methods.
+- **Version upgrades**: When bumping the model `version`, always add an
+  `upgrades` entry with migration logic.
+
+### Drivers
+
+- Return the correct output `kind` — `"pending"` for data that swamp should
+  persist, `"persisted"` for data already written by the driver.
+- Record `durationMs` accurately in execution results.
+- Forward logs to the host via `callbacks.onLog()`.
+- Handle the `initialize`/`shutdown` lifecycle correctly.
+- On error, set `status: "error"` with a useful error message.
+
+### Vaults
+
+- `get` must throw on missing keys — never return an empty string.
+- `put` must be idempotent — overwrite existing keys without error.
+- `list` must return key names only, never secret values.
+- `getName` must return the vault instance name passed to the constructor.
+
+### Datastores
+
+- `createLock` must return a working `DistributedLock` with all required methods
+  (`acquire`, `release`, `withLock`, `heartbeat`).
+- `withLock` must release the lock on both success and error paths.
+- `createVerifier` must return accurate health information with latency.
+- `resolveDatastorePath` must be deterministic for the same inputs.
+- Remote datastores must implement `resolveCachePath`.
+
+## What This Review Does NOT Check
+
+These are already covered by other gates:
+
+- **Formatting** — `deno fmt` (enforced by extension quality checker)
+- **Linting** — `deno lint` (enforced by extension quality checker)
+- **eval/Function usage** — extension safety analyzer
+- **File restrictions & sizes** — extension safety analyzer
+- **Collective consistency** — extension collective validator
+- **General logic & security** — CI adversarial review

--- a/.claude/skills/swamp-extension-model/references/publishing.md
+++ b/.claude/skills/swamp-extension-model/references/publishing.md
@@ -58,6 +58,35 @@ must be present with entries.
 - Reserved collectives (`@swamp`, `@si`) cannot be used
 - Allowed characters: lowercase letters, numbers, hyphens, underscores
 
+### Collective Validation
+
+| Type                        | Valid? | Notes                       |
+| --------------------------- | ------ | --------------------------- |
+| `@user/my-model`            | Yes    | Valid collective            |
+| `@myorg/deploy`             | Yes    | Custom collective allowed   |
+| `myorg/my-model`            | Yes    | Non-@ format allowed        |
+| `digitalocean/app-platform` | Yes    | Non-@ multi-segment allowed |
+| `@user/aws/s3`              | Yes    | Nested paths allowed        |
+| `swamp/my-model`            | No     | Reserved collective         |
+| `si/my-model`               | No     | Reserved collective         |
+
+### Import Rules
+
+- `import { z } from "npm:zod@4";` is always required
+- Any Deno-compatible import (`npm:`, `jsr:`, `https://`) can be used — swamp
+  bundles all dependencies automatically
+- Extensions with a `deno.json` or `package.json` can use bare specifiers (e.g.,
+  `from "zod"`)
+- All imports must be static top-level imports — dynamic `import()` calls are
+  rejected during push
+- Always pin npm versions — either inline (`npm:lodash-es@4.17.21`), via a
+  `deno.json` import map, or in `package.json` dependencies
+- Use `include` in the manifest for helper scripts executed via `Deno.Command`
+  that shouldn't be bundled
+
+See [examples.md](examples.md#import-styles) for import style examples and
+[examples.md](examples.md#helper-scripts) for helper script details.
+
 ### How Content Maps to Manifest
 
 - `models` paths resolve relative to `extensions/models/`

--- a/.claude/skills/swamp-extension-vault/SKILL.md
+++ b/.claude/skills/swamp-extension-vault/SKILL.md
@@ -202,6 +202,14 @@ swamp vault status --json
    `(name: string, config: Record<string, unknown>)` — the first arg is the
    vault instance name, the second is the parsed config
 
+## Extension Adversarial Review
+
+After writing or significantly modifying vault code, and before running unit
+tests, read the
+[extension adversarial review](../swamp-extension-model/references/adversarial-review.md)
+and self-review against all applicable dimensions (universal + vaults). Present
+findings to the user before proceeding.
+
 ## Publishing
 
 Publishing is the same for all extension types. Before pushing:

--- a/src/infrastructure/assets/skill_assets.ts
+++ b/src/infrastructure/assets/skill_assets.ts
@@ -162,6 +162,10 @@ const BUNDLED_SKILLS: SkillInfo[] = [
     name: "swamp-extension-model",
   },
   {
+    relativePath: "swamp-extension-model/references/adversarial-review.md",
+    name: "swamp-extension-model",
+  },
+  {
     relativePath: "swamp-model/references/execution-drivers.md",
     name: "swamp-model",
   },

--- a/src/infrastructure/assets/skill_assets_test.ts
+++ b/src/infrastructure/assets/skill_assets_test.ts
@@ -471,6 +471,23 @@ Deno.test("SkillAssets.copySkillsTo copies swamp-extension-datastore reference f
   });
 });
 
+Deno.test("SkillAssets.copySkillsTo copies swamp-extension-model adversarial-review file", async () => {
+  await withTempDir(async (dir) => {
+    const assets = new SkillAssets();
+    await assets.copySkillsTo(dir);
+
+    const adversarialPath = join(
+      dir,
+      "swamp-extension-model",
+      "references",
+      "adversarial-review.md",
+    );
+
+    const adversarialStat = await Deno.stat(adversarialPath);
+    assertEquals(adversarialStat.isFile, true);
+  });
+});
+
 Deno.test("SkillAssets includes swamp-extension-driver skill", () => {
   const assets = new SkillAssets();
   const names = assets.getSkillNames();


### PR DESCRIPTION
## Summary

- Add a shared adversarial review reference (`adversarial-review.md`) that all four extension skills cross-reference, covering 7 universal dimensions (credentials/secrets, logging, error handling, testing, idempotency, API contracts, resource management) plus type-specific checks for models, drivers, vaults, and datastores
- Credentials guidance is nuanced: cloud provider creds prefer env-based auth (IAM roles, instance profiles), API tokens go in vaults, and the best option is deferring to the environment when possible
- Refactor `swamp-extension-model/SKILL.md` from 614 to 507 lines by moving duplicated content to existing references (factory models → scenarios.md, unit testing → testing.md, collective/import rules → publishing.md)
- Register the new reference file in `BUNDLED_SKILLS` so it ships with `repo init` and `repo upgrade`

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno check` passes
- [x] All 3914 tests pass including new `skill_assets_test.ts` test for the adversarial review file
- [x] `deno run compile` succeeds with the new file embedded

🤖 Generated with [Claude Code](https://claude.com/claude-code)