### PR TITLE
fix: suggest extension search/install when type describe fails

### DIFF
--- a/src/libswamp/types/describe.ts
+++ b/src/libswamp/types/describe.ts
@@ -18,7 +18,6 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { ModelDefinition } from "../../domain/models/model.ts";
-import { modelRegistry } from "../../domain/models/model.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
 import { resolveModelType } from "../../domain/extensions/extension_auto_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
@@ -54,14 +53,12 @@ export interface TypeDescribeDeps {
   resolveModelType: (
     type: ModelType,
   ) => Promise<ModelDefinition | undefined>;
-  getAvailableTypes: () => string[];
 }
 
 /** Wires real infrastructure into TypeDescribeDeps. */
 export function createTypeDescribeDeps(): TypeDescribeDeps {
   return {
     resolveModelType: (type) => resolveModelType(type, null),
-    getAvailableTypes: () => modelRegistry.types().map((t) => t.normalized),
   };
 }
 
@@ -79,12 +76,16 @@ export async function* typeDescribe(
 
       const definition = await deps.resolveModelType(modelType);
       if (!definition) {
-        const availableTypes = deps.getAvailableTypes().join(", ");
+        const searchTerm = deriveSearchTerm(modelType.normalized);
+        const installName = deriveInstallName(modelType.normalized);
         yield {
           kind: "error",
           error: notFound(
             "Model type",
-            `${modelType.raw}. Available types: ${availableTypes || "none"}`,
+            `${modelType.raw}\n\n` +
+              `This type may be available as an extension:\n` +
+              `  Search:  swamp extension search ${searchTerm}\n` +
+              `  Install: swamp extension pull ${installName}`,
           ),
         };
         return;
@@ -119,4 +120,28 @@ export async function* typeDescribe(
       };
     })(),
   );
+}
+
+/**
+ * Derives a search term from a normalized type by stripping the collective prefix.
+ * e.g., "@swamp/gcp/oauth2" → "gcp/oauth2", "swamp/echo" → "echo"
+ */
+function deriveSearchTerm(normalized: string): string {
+  let stripped = normalized;
+  if (stripped.startsWith("@")) {
+    stripped = stripped.slice(1);
+  }
+  const firstSlash = stripped.indexOf("/");
+  if (firstSlash !== -1) {
+    return stripped.slice(firstSlash + 1);
+  }
+  return stripped;
+}
+
+/**
+ * Derives an install name from a normalized type by ensuring the @ prefix.
+ * e.g., "swamp/echo" → "@swamp/echo", "@swamp/gcp/oauth2" → "@swamp/gcp/oauth2"
+ */
+function deriveInstallName(normalized: string): string {
+  return normalized.startsWith("@") ? normalized : `@${normalized}`;
 }

--- a/src/libswamp/types/describe_test.ts
+++ b/src/libswamp/types/describe_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { z } from "zod";
 import type { ModelDefinition } from "../../domain/models/model.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
@@ -54,7 +54,6 @@ function makeDeps(
 
   return {
     resolveModelType: () => Promise.resolve(modelDef),
-    getAvailableTypes: () => ["model/type"],
     ...overrides,
   };
 }
@@ -83,7 +82,6 @@ Deno.test("typeDescribe yields resolving then completed on happy path", async ()
 Deno.test("typeDescribe yields error with not_found when type not found", async () => {
   const deps = makeDeps({
     resolveModelType: () => Promise.resolve(undefined),
-    getAvailableTypes: () => ["model/type"],
   });
   const unknownType = ModelType.create("unknown/type");
   const events = await collect<TypeDescribeEvent>(
@@ -95,4 +93,35 @@ Deno.test("typeDescribe yields error with not_found when type not found", async 
   const last = events[1] as Extract<TypeDescribeEvent, { kind: "error" }>;
   assertEquals(last.kind, "error");
   assertEquals(last.error.code, "not_found");
+});
+
+Deno.test("typeDescribe error includes extension search hint", async () => {
+  const deps = makeDeps({
+    resolveModelType: () => Promise.resolve(undefined),
+  });
+  const unknownType = ModelType.create("@swamp/gcp/oauth2");
+  const events = await collect<TypeDescribeEvent>(
+    typeDescribe(createLibSwampContext(), deps, unknownType),
+  );
+
+  const last = events[1] as Extract<TypeDescribeEvent, { kind: "error" }>;
+  assertStringIncludes(last.error.message, "swamp extension search gcp/oauth2");
+  assertStringIncludes(
+    last.error.message,
+    "swamp extension pull @swamp/gcp/oauth2",
+  );
+});
+
+Deno.test("typeDescribe error derives correct search term for non-namespaced type", async () => {
+  const deps = makeDeps({
+    resolveModelType: () => Promise.resolve(undefined),
+  });
+  const unknownType = ModelType.create("docker/run");
+  const events = await collect<TypeDescribeEvent>(
+    typeDescribe(createLibSwampContext(), deps, unknownType),
+  );
+
+  const last = events[1] as Extract<TypeDescribeEvent, { kind: "error" }>;
+  assertStringIncludes(last.error.message, "swamp extension search run");
+  assertStringIncludes(last.error.message, "swamp extension pull @docker/run");
 });


### PR DESCRIPTION
## Summary

- When `swamp model type describe` fails because a type isn't installed, the error now includes actionable hints suggesting `swamp extension search` and `swamp extension pull` commands
- This breaks a common thrashing loop for AI agents that interpret "not found" as a name resolution failure rather than an installation gap
- Follows the established inline-hint pattern used by `notAuthenticated()` and datastore setup errors

Closes #1030

## Test Plan

- [x] New unit tests verify the error message includes search/install hints for both `@`-namespaced and non-namespaced types
- [x] Existing tests continue to pass (3939 tests, 0 failures)
- [x] `deno check`, `deno lint`, `deno fmt` all pass
- [x] UAT backward compatibility preserved ("not found" remains in the message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)