### PR TITLE
fix: address adversarial review findings for data query

### DIFF
--- a/src/cli/commands/data_query.ts
+++ b/src/cli/commands/data_query.ts
@@ -39,7 +39,19 @@ export const dataQueryCommand = new Command()
   .arguments("<predicate:string>")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
   .option("--limit <n:number>", "Maximum results", { default: 100 })
-  .option("--select <expr:string>", "CEL projection expression")
+  .option(
+    "--select <expr:string>",
+    "CEL expression to extract fields from matching records (e.g. data.name)",
+  )
+  .example("Filter by model", "swamp data query 'modelName == \"scanner\"'")
+  .example(
+    "Filter with size threshold",
+    "swamp data query 'size > 1048576'",
+  )
+  .example(
+    "Project a single field",
+    "swamp data query 'dataType == \"resource\"' --select data.name",
+  )
   .action(async function (options: AnyOptions, predicate: string) {
     const ctx = createContext(options as GlobalOptions, ["data", "query"]);
     const libCtx = createLibSwampContext();

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -123,4 +123,6 @@ export const serveCommand = new Command()
     Deno.addSignalListener("SIGTERM", shutdown);
 
     await server.finished;
+
+    repoContext.catalogStore?.close();
   });

--- a/src/domain/data/data_query_service.ts
+++ b/src/domain/data/data_query_service.ts
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { getLogger } from "@logtape/logtape";
 import { Environment } from "cel-js";
 import type {
   CatalogRow,
@@ -33,6 +34,8 @@ import {
   validateFieldReferences,
 } from "./query_predicate.ts";
 import { isTextContentType } from "./content_type.ts";
+
+const logger = getLogger(["swamp", "domain", "data", "query"]);
 
 export interface DataQueryOptions {
   limit?: number;
@@ -130,8 +133,11 @@ export class DataQueryService {
           results.push(record);
           if (results.length >= limit) break;
         }
-      } catch {
-        // Evaluation error on this row (e.g., type mismatch) — skip
+      } catch (error) {
+        logger
+          .debug`Query predicate skipped row ${row.model_name}/${row.data_name}: ${
+          String(error)
+        }`;
       }
     }
 

--- a/src/infrastructure/persistence/catalog_store.ts
+++ b/src/infrastructure/persistence/catalog_store.ts
@@ -53,6 +53,8 @@ export interface CatalogRow {
  * The catalog is local-only and excluded from datastore sync. It self-heals
  * by triggering a backfill when missing or not yet populated.
  */
+const ITERATE_PAGE_SIZE = 1000;
+
 export class CatalogStore {
   private readonly db: DatabaseSync;
 
@@ -139,13 +141,21 @@ export class CatalogStore {
   }
 
   /**
-   * Iterates over all catalog rows. Uses a generator so only one row
-   * is in memory at a time.
+   * Iterates over all catalog rows using paged queries.
+   * Fetches rows in batches of {@link ITERATE_PAGE_SIZE} to bound memory.
    */
   *iterate(): IterableIterator<CatalogRow> {
-    const stmt = this.db.prepare("SELECT * FROM catalog");
-    for (const row of stmt.all()) {
-      yield row as unknown as CatalogRow;
+    const stmt = this.db.prepare("SELECT * FROM catalog LIMIT ? OFFSET ?");
+    let offset = 0;
+    while (true) {
+      const rows = stmt.all(
+        ITERATE_PAGE_SIZE,
+        offset,
+      ) as unknown as CatalogRow[];
+      if (rows.length === 0) break;
+      yield* rows;
+      if (rows.length < ITERATE_PAGE_SIZE) break;
+      offset += ITERATE_PAGE_SIZE;
     }
   }
 

--- a/src/presentation/renderers/data_query.ts
+++ b/src/presentation/renderers/data_query.ts
@@ -177,17 +177,18 @@ function renderProjected(data: DataQueryData): string {
  */
 function renderJson(data: DataQueryData): void {
   if (data.projected) {
-    switch (data.projected.shape) {
-      case "scalar":
-        writeOutput(JSON.stringify(data.projected.values, null, 2));
-        break;
-      case "map":
-        writeOutput(JSON.stringify(data.projected.rows, null, 2));
-        break;
-      case "list":
-        writeOutput(JSON.stringify(data.projected.rows, null, 2));
-        break;
-    }
+    const results = data.projected.shape === "scalar"
+      ? data.projected.values
+      : data.projected.rows;
+    writeOutput(JSON.stringify(
+      {
+        results,
+        total: data.total,
+        limited: data.limited,
+      },
+      null,
+      2,
+    ));
   } else {
     writeOutput(JSON.stringify(data, null, 2));
   }


### PR DESCRIPTION
## Summary

Fixes three medium-severity findings from the adversarial review on #1029:

- **Paged iteration**: `CatalogStore.iterate()` now fetches rows in batches of 1000 via `LIMIT/OFFSET` instead of `stmt.all()` which loaded all rows into memory
- **Serve shutdown cleanup**: Close `CatalogStore` after `server.finished` so the SQLite connection isn't leaked for long-running processes
- **Debug logging**: Log skipped rows at debug level in `DataQueryService` instead of silently swallowing evaluation errors, visible with `--verbose`

Also incorporates UX review suggestions from the same PR: CLI examples, improved `--select` description, and JSON envelope for projected output.

## Test Plan

- All 3940 existing tests pass
- `deno fmt`, `deno lint`, `deno check` all clean
- Manual: `swamp data query 'size > 0' --verbose` shows debug output for type-mismatch rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>