### PR TITLE
fix: add deterministic ORDER BY to paged catalog iteration

### DIFF
--- a/src/infrastructure/persistence/catalog_store.ts
+++ b/src/infrastructure/persistence/catalog_store.ts
@@ -53,7 +53,7 @@ export interface CatalogRow {
  * The catalog is local-only and excluded from datastore sync. It self-heals
  * by triggering a backfill when missing or not yet populated.
  */
-const ITERATE_PAGE_SIZE = 1000;
+export const ITERATE_PAGE_SIZE = 1000;
 
 export class CatalogStore {
   private readonly db: DatabaseSync;
@@ -145,7 +145,9 @@ export class CatalogStore {
    * Fetches rows in batches of {@link ITERATE_PAGE_SIZE} to bound memory.
    */
   *iterate(): IterableIterator<CatalogRow> {
-    const stmt = this.db.prepare("SELECT * FROM catalog LIMIT ? OFFSET ?");
+    const stmt = this.db.prepare(
+      "SELECT * FROM catalog ORDER BY rowid LIMIT ? OFFSET ?",
+    );
     let offset = 0;
     while (true) {
       const rows = stmt.all(

--- a/src/infrastructure/persistence/catalog_store_test.ts
+++ b/src/infrastructure/persistence/catalog_store_test.ts
@@ -19,7 +19,11 @@
 
 import { assertEquals } from "@std/assert";
 import { join } from "@std/path";
-import { type CatalogRow, CatalogStore } from "./catalog_store.ts";
+import {
+  type CatalogRow,
+  CatalogStore,
+  ITERATE_PAGE_SIZE,
+} from "./catalog_store.ts";
 
 function makeTempDbPath(): string {
   const dir = Deno.makeTempDirSync({ prefix: "swamp-catalog-test-" });
@@ -153,6 +157,33 @@ Deno.test("CatalogStore: empty catalog iterates zero rows", () => {
   const store = new CatalogStore(dbPath);
   const rows = [...store.iterate()];
   assertEquals(rows.length, 0);
+  store.close();
+});
+
+Deno.test("CatalogStore: iterate paginates across page boundaries", () => {
+  const dbPath = makeTempDbPath();
+  const store = new CatalogStore(dbPath);
+
+  const totalRows = ITERATE_PAGE_SIZE + 1;
+  for (let i = 0; i < totalRows; i++) {
+    store.upsert(
+      makeRow({
+        model_id: `model-${String(i).padStart(5, "0")}`,
+        data_name: `data-${String(i).padStart(5, "0")}`,
+      }),
+    );
+  }
+
+  assertEquals(store.count(), totalRows);
+
+  const rows = [...store.iterate()];
+  assertEquals(rows.length, totalRows);
+
+  // Verify deterministic ordering — rows come back in rowid order
+  for (let i = 0; i < totalRows; i++) {
+    assertEquals(rows[i].model_id, `model-${String(i).padStart(5, "0")}`);
+  }
+
   store.close();
 });
 


### PR DESCRIPTION
## Summary

- Add explicit `ORDER BY rowid` to the paged `LIMIT/OFFSET` query in `CatalogStore.iterate()` so pagination is deterministic across page boundaries
- Export `ITERATE_PAGE_SIZE` and add a pagination boundary test that inserts 1001 rows, verifying all rows are returned in correct order across two page fetches

Addresses review feedback on #1035.

## Test Plan

- All 3941 existing tests pass
- New `"iterate paginates across page boundaries"` test verifies multi-batch iteration with 1001 rows
- `deno fmt`, `deno lint`, `deno check` all clean