### PR TITLE
feat: route extension issues to swamp-extensions repo

### DIFF
--- a/.claude/skills/swamp-issue/SKILL.md
+++ b/.claude/skills/swamp-issue/SKILL.md
@@ -26,6 +26,8 @@ non-interactive mode with `--title` and `--body` flags.
 ```bash
 swamp issue bug --title "CLI crashes on empty input" --body "When running..." --json
 swamp issue feature --title "Add dark mode" --body "I'd like..." --json
+swamp issue bug --repo systeminit/swamp-extensions --title "@swamp/aws-ec2: describe fails for stopped instances" --body "..." --json
+swamp issue feature --repo systeminit/swamp-extensions --title "@swamp/aws-s3: add bucket lifecycle rules" --body "..." --json
 ```
 
 **Output shape** (both commands with `--json`):
@@ -42,12 +44,40 @@ swamp issue feature --title "Add dark mode" --body "I'd like..." --json
 **Verify submission:** Check the returned `url` or run `gh issue view <number>`
 to confirm the issue was created.
 
+## Extension Issue Routing
+
+When an issue relates to an official swamp extension (`@swamp/*` or `@si/*`
+collective), route it to the extensions repository using
+`--repo
+systeminit/swamp-extensions`. If the issue is about the swamp CLI,
+runtime, workflow engine, or core framework, omit `--repo` (defaults to
+`systeminit/swamp`).
+
+**Indicators that an issue is extension-related:**
+
+- The user mentions a specific extension by name (e.g., `@swamp/aws-ec2`)
+- The problem occurs during a model method that belongs to an extension
+- The feature request is about adding or improving an extension model capability
+- Error messages reference extension model code or types
+
+**Indicators that an issue is core swamp:**
+
+- CLI crash or incorrect output unrelated to a specific extension
+- Workflow engine, DAG execution, or scheduling issues
+- Vault, datastore, or driver framework bugs
+- General UX or configuration issues
+
+When in doubt, ask the user whether the problem is with swamp itself or with a
+specific extension.
+
 ## Workflow
 
 1. Gather details from the user (bug reproduction steps or feature context)
-2. Verify syntax with `swamp help issue`
-3. Run the appropriate command (`swamp issue bug` or `swamp issue feature`)
-4. Verify with the returned URL
+2. **Determine target repository:** If the issue involves an official extension
+   (`@swamp/*` or `@si/*`), use `--repo systeminit/swamp-extensions`
+3. Verify syntax with `swamp help issue`
+4. Run the appropriate command (`swamp issue bug` or `swamp issue feature`)
+5. Verify with the returned URL
 
 ## Requirements
 

--- a/.claude/skills/swamp-issue/references/formatting.md
+++ b/.claude/skills/swamp-issue/references/formatting.md
@@ -34,3 +34,36 @@ Provide a summary of the implementation plan:
 >
 > The approach would intercept execution at the method call boundary and display
 > the planned actions without making external calls.
+
+## Extension Issues
+
+When filing an issue for an official extension, prefix the title with the
+extension name:
+
+**Format:** `@collective/extension-name: brief description`
+
+**Example bug:**
+
+> **Title:**
+> `@swamp/aws-ec2: describe method returns empty attributes for stopped instances`
+>
+> This bug affects the `@swamp/aws-ec2` extension's `describe` method. When an
+> EC2 instance is in a stopped state, the method returns an empty attributes map
+> instead of the instance metadata.
+>
+> The fix would involve updating the attribute mapping in the describe method to
+> handle stopped-state API responses, which return a subset of fields.
+
+**Example feature:**
+
+> **Title:** `@swamp/aws-s3: add support for bucket lifecycle rules`
+>
+> This feature would add a `lifecycle` method to the `@swamp/aws-s3` extension
+> model. Changes would be needed in:
+>
+> - New `lifecycle` method definition in the extension model
+> - S3 lifecycle rule API integration
+> - Output type definitions for lifecycle configuration
+>
+> The approach would follow the existing pattern used by the `policy` method for
+> bucket policy management.

--- a/src/cli/commands/issue_bug.ts
+++ b/src/cli/commands/issue_bug.ts
@@ -117,6 +117,10 @@ export const issueBugCommand = new Command()
     "-b, --body <body:string>",
     "Bug description (requires --title, skips editor entirely)",
   )
+  .option(
+    "-r, --repo <repo:string>",
+    "Target GitHub repository (e.g., systeminit/swamp-extensions)",
+  )
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, ["issue", "bug"]);
     ctx.logger.debug`Submitting bug report`;
@@ -190,6 +194,7 @@ export const issueBugCommand = new Command()
         body,
         labels: ["bug", "needs-triage"],
         type: "bug",
+        repo: options.repo,
       }),
       renderer.handlers(),
     );

--- a/src/cli/commands/issue_feature.ts
+++ b/src/cli/commands/issue_feature.ts
@@ -116,6 +116,10 @@ export const issueFeatureCommand = new Command()
     "-b, --body <body:string>",
     "Feature description (requires --title, skips editor entirely)",
   )
+  .option(
+    "-r, --repo <repo:string>",
+    "Target GitHub repository (e.g., systeminit/swamp-extensions)",
+  )
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, ["issue", "feature"]);
     ctx.logger.debug`Submitting feature request`;
@@ -189,6 +193,7 @@ export const issueFeatureCommand = new Command()
         body,
         labels: ["feature", "needs-triage"],
         type: "feature",
+        repo: options.repo,
       }),
       renderer.handlers(),
     );

--- a/src/libswamp/issues/create.ts
+++ b/src/libswamp/issues/create.ts
@@ -52,6 +52,7 @@ export interface IssueCreateInput {
   body: string;
   labels: string[];
   type: "bug" | "feature";
+  repo?: string;
 }
 
 /** Dependencies for the issue create operation. */
@@ -60,6 +61,7 @@ export interface IssueCreateDeps {
     title: string;
     body: string;
     labels: string[];
+    repo?: string;
   }) => Promise<
     | { method: "created"; url: string; number: number }
     | { method: "url"; url: string; body: string; labels: string[] }
@@ -90,6 +92,7 @@ export async function* issueCreate(
         title: input.title,
         body: input.body,
         labels: input.labels,
+        repo: input.repo,
       });
 
       const data: IssueCreateData = result.method === "created"

--- a/src/libswamp/issues/create_test.ts
+++ b/src/libswamp/issues/create_test.ts
@@ -91,3 +91,56 @@ Deno.test("issueCreate: yields completed with url method", async () => {
   assertEquals(completed.data.title, "Test feature");
   assertEquals(completed.data.type, "feature");
 });
+
+Deno.test("issueCreate: threads repo through to createIssue", async () => {
+  let capturedRepo: string | undefined;
+  const deps = makeDeps({
+    createIssue: (opts) => {
+      capturedRepo = opts.repo;
+      return Promise.resolve({
+        method: "created" as const,
+        url: "https://github.com/systeminit/swamp-extensions/issues/1",
+        number: 1,
+      });
+    },
+  });
+
+  const events = await collect<IssueCreateEvent>(
+    issueCreate(createLibSwampContext(), deps, {
+      title: "Extension bug",
+      body: "Test body",
+      labels: ["bug"],
+      type: "bug",
+      repo: "systeminit/swamp-extensions",
+    }),
+  );
+
+  assertEquals(capturedRepo, "systeminit/swamp-extensions");
+  assertEquals(events.length, 1);
+  assertEquals(events[0].kind, "completed");
+});
+
+Deno.test("issueCreate: repo is undefined when not provided", async () => {
+  let capturedRepo: string | undefined = "should-be-undefined";
+  const deps = makeDeps({
+    createIssue: (opts) => {
+      capturedRepo = opts.repo;
+      return Promise.resolve({
+        method: "created" as const,
+        url: "https://github.com/systeminit/swamp/issues/2",
+        number: 2,
+      });
+    },
+  });
+
+  await collect<IssueCreateEvent>(
+    issueCreate(createLibSwampContext(), deps, {
+      title: "Core bug",
+      body: "Test body",
+      labels: ["bug"],
+      type: "bug",
+    }),
+  );
+
+  assertEquals(capturedRepo, undefined);
+});


### PR DESCRIPTION
## Summary

- Adds `--repo` flag to `swamp issue bug` and `swamp issue feature` commands, threading it through `IssueCreateInput` → `IssueCreateDeps` → `GitHubIssueService` (which already supported the parameter)
- Updates the `swamp-issue` skill to automatically detect when an issue relates to an official extension (`@swamp/*` or `@si/*`) and route it to `systeminit/swamp-extensions`
- Adds formatting conventions for extension issues (title prefix with extension name)
- Also created `feature` and `needs-triage` labels in `systeminit/swamp-extensions` to match the labels applied by the issue commands

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] All 3942 tests pass including 2 new tests for repo threading
- [x] `deno run compile` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)