### PR TITLE
feat: add hidden vault list alias for vault search

### DIFF
--- a/src/cli/commands/hidden_aliases_test.ts
+++ b/src/cli/commands/hidden_aliases_test.ts
@@ -65,6 +65,27 @@ Deno.test("workflow history list is registered as a hidden subcommand", async ()
   );
 });
 
+Deno.test("vault list is registered as a hidden subcommand", async () => {
+  const { vaultCommand } = await import("./vault.ts");
+
+  // getCommand with second arg true includes hidden commands
+  const listCmd = vaultCommand.getCommand("list", true);
+  assertEquals(
+    listCmd !== undefined,
+    true,
+    "list command should be registered",
+  );
+
+  // Verify it's hidden: not in getCommands() (which excludes hidden)
+  const visibleCommands = vaultCommand.getCommands();
+  const visibleList = visibleCommands.find((c) => c.getName() === "list");
+  assertEquals(
+    visibleList,
+    undefined,
+    "list should not appear in visible commands",
+  );
+});
+
 Deno.test("vault type list is registered as a hidden subcommand", async () => {
   const { vaultTypeCommand } = await import("./vault.ts");
 

--- a/src/cli/commands/vault.ts
+++ b/src/cli/commands/vault.ts
@@ -23,7 +23,7 @@ import {
   vaultTypeSearchCommand,
 } from "./vault_type_search.ts";
 import { vaultCreateCommand } from "./vault_create.ts";
-import { vaultSearchCommand } from "./vault_search.ts";
+import { vaultSearchAction, vaultSearchCommand } from "./vault_search.ts";
 import { vaultGetCommand } from "./vault_get.ts";
 import { vaultDescribeCommand } from "./vault_describe.ts";
 import { vaultEditCommand } from "./vault_edit.ts";
@@ -67,4 +67,15 @@ export const vaultCommand = new Command()
   .command("describe", vaultDescribeCommand)
   .command("edit", vaultEditCommand)
   .command("put", vaultPutCommand)
-  .command("list-keys", vaultListKeysCommand);
+  .command("list-keys", vaultListKeysCommand)
+  .command(
+    "list",
+    new Command()
+      .description("Alias for vault search")
+      .hidden()
+      .arguments("[query:string]")
+      .option("--repo-dir <dir:string>", "Repository directory", {
+        default: ".",
+      })
+      .action(vaultSearchAction),
+  );

--- a/src/cli/commands/vault_search.ts
+++ b/src/cli/commands/vault_search.ts
@@ -67,6 +67,56 @@ function createVaultFetchPreview(
   };
 }
 
+export async function vaultSearchAction(
+  options: AnyOptions,
+  query?: string,
+): Promise<void> {
+  const ctx = createContext(options as GlobalOptions, ["vault", "search"]);
+  const effectiveMode = interactiveOutputMode(ctx);
+  const libCtx = createLibSwampContext();
+  ctx.logger.debug`Searching vaults with query: ${query ?? "(none)"}`;
+
+  const { repoContext } = await requireInitializedRepoReadOnly({
+    repoDir: options.repoDir ?? ".",
+    outputMode: effectiveMode,
+  });
+
+  const deps: VaultSearchDeps = {
+    findAllVaults: () => repoContext.vaultConfigRepo.findAll(),
+  };
+
+  const repoDir = options.repoDir ?? ".";
+  const fetchPreview = effectiveMode === "log"
+    ? createVaultFetchPreview(repoDir)
+    : undefined;
+
+  const renderer = createVaultSearchRenderer(effectiveMode, fetchPreview);
+  await consumeStream(
+    vaultSearch(libCtx, deps, { query }),
+    renderer.handlers(),
+  );
+
+  const selected = renderer.selectedItem();
+  if (selected) {
+    ctx.logger.debug`Selected vault: ${selected.name}`;
+    // In JSON mode, still display the full vault describe output after auto-select
+    if (effectiveMode === "json") {
+      const describeRenderer = createVaultDescribeRenderer(effectiveMode);
+      const describeDeps = createVaultDescribeDeps(repoDir);
+      await consumeStream(
+        vaultDescribe(libCtx, describeDeps, selected.name),
+        describeRenderer.handlers(),
+      );
+    }
+    // In interactive mode, the scrollback from the picker already contains
+    // the vault detail, so no additional vaultDescribe call is needed.
+  } else {
+    ctx.logger.debug`Search cancelled`;
+  }
+
+  ctx.logger.debug("Vault search command completed");
+}
+
 export const vaultSearchCommand = new Command()
   .name("search")
   .description("Search for vaults in the repository")
@@ -74,49 +124,4 @@ export const vaultSearchCommand = new Command()
   .example("Search by keyword", "swamp vault search aws")
   .arguments("[query:string]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
-  .action(async function (options: AnyOptions, query?: string) {
-    const ctx = createContext(options as GlobalOptions, ["vault", "search"]);
-    const effectiveMode = interactiveOutputMode(ctx);
-    const libCtx = createLibSwampContext();
-    ctx.logger.debug`Searching vaults with query: ${query ?? "(none)"}`;
-
-    const { repoContext } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
-      outputMode: effectiveMode,
-    });
-
-    const deps: VaultSearchDeps = {
-      findAllVaults: () => repoContext.vaultConfigRepo.findAll(),
-    };
-
-    const repoDir = options.repoDir ?? ".";
-    const fetchPreview = effectiveMode === "log"
-      ? createVaultFetchPreview(repoDir)
-      : undefined;
-
-    const renderer = createVaultSearchRenderer(effectiveMode, fetchPreview);
-    await consumeStream(
-      vaultSearch(libCtx, deps, { query }),
-      renderer.handlers(),
-    );
-
-    const selected = renderer.selectedItem();
-    if (selected) {
-      ctx.logger.debug`Selected vault: ${selected.name}`;
-      // In JSON mode, still display the full vault describe output after auto-select
-      if (effectiveMode === "json") {
-        const describeRenderer = createVaultDescribeRenderer(effectiveMode);
-        const describeDeps = createVaultDescribeDeps(repoDir);
-        await consumeStream(
-          vaultDescribe(libCtx, describeDeps, selected.name),
-          describeRenderer.handlers(),
-        );
-      }
-      // In interactive mode, the scrollback from the picker already contains
-      // the vault detail, so no additional vaultDescribe call is needed.
-    } else {
-      ctx.logger.debug`Search cancelled`;
-    }
-
-    ctx.logger.debug("Vault search command completed");
-  });
+  .action(vaultSearchAction);


### PR DESCRIPTION
## Summary

- Adds `swamp vault list` as a hidden alias for `swamp vault search`, matching the existing pattern used by `model list`, `vault type list`, and `workflow history list`
- Extracts `vaultSearchAction` as an exported function from `vault_search.ts` so the alias can reuse it
- Adds test coverage in `hidden_aliases_test.ts`

Closes #1049

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] All 3941 tests pass (`deno run test`)
- [x] `deno run compile` succeeds
- [x] New test in `hidden_aliases_test.ts` verifies `vault list` is registered and hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)