### PR TITLE
fix: add missing ensureLoaded() calls for lazy extension registries

### DIFF
--- a/src/cli/commands/model_method_describe.ts
+++ b/src/cli/commands/model_method_describe.ts
@@ -27,6 +27,7 @@ import {
 import { createModelMethodDescribeRenderer } from "../../presentation/renderers/model_method_describe.ts";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -57,6 +58,8 @@ export const modelMethodDescribeCommand = new Command()
         repoDir: options.repoDir ?? ".",
         outputMode: cliCtx.outputMode,
       });
+
+      await modelRegistry.ensureLoaded();
 
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
       const deps = createModelMethodDescribeDeps(repoDir);

--- a/src/cli/commands/type_describe.ts
+++ b/src/cli/commands/type_describe.ts
@@ -27,6 +27,7 @@ import {
 import { createTypeDescribeRenderer } from "../../presentation/renderers/type_describe.ts";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
 
 // Re-export from libswamp for backward compatibility with existing importers
 export { toMethodDescribeData, zodToJsonSchema } from "../../libswamp/mod.ts";
@@ -48,6 +49,8 @@ export const typeDescribeCommand = new Command()
     cliCtx.logger.debug`Describing type: ${typeArg}`;
 
     const modelType = ModelType.create(typeArg);
+
+    await modelRegistry.ensureLoaded();
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
     const deps = createTypeDescribeDeps();

--- a/src/cli/commands/vault_type_search.ts
+++ b/src/cli/commands/vault_type_search.ts
@@ -31,6 +31,7 @@ import {
   interactiveOutputMode,
 } from "../context.ts";
 import { getVaultTypes } from "../../domain/vaults/vault_types.ts";
+import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -46,6 +47,8 @@ export async function vaultTypeSearchAction(
   const effectiveMode = interactiveOutputMode(ctx);
   const libCtx = createLibSwampContext();
   ctx.logger.debug`Searching vault types with query: ${query ?? "(none)"}`;
+
+  await vaultTypeRegistry.ensureLoaded();
 
   const deps: VaultTypeSearchDeps = {
     getVaultTypes: () => getVaultTypes(),

--- a/src/cli/completion_types.ts
+++ b/src/cli/completion_types.ts
@@ -130,7 +130,8 @@ export class ModelTypeType extends Type<string> {
     return value;
   }
 
-  override complete(): string[] {
+  override async complete(): Promise<string[]> {
+    await modelRegistry.ensureLoaded();
     return modelRegistry.types().map((t) => t.normalized);
   }
 }

--- a/src/cli/completion_types_test.ts
+++ b/src/cli/completion_types_test.ts
@@ -102,9 +102,9 @@ Deno.test("ModelTypeType.parse handles nested type paths", () => {
   assertEquals(result, "aws/ec2/instance");
 });
 
-Deno.test("ModelTypeType.complete returns registered model types", () => {
+Deno.test("ModelTypeType.complete returns registered model types", async () => {
   const type = new ModelTypeType();
-  const result = type.complete();
+  const result = await type.complete();
 
   // Should return an array of strings
   assertEquals(Array.isArray(result), true);
@@ -113,9 +113,9 @@ Deno.test("ModelTypeType.complete returns registered model types", () => {
   assertEquals(result.includes("command/shell"), true);
 });
 
-Deno.test("ModelTypeType.complete returns registered types", () => {
+Deno.test("ModelTypeType.complete returns registered types", async () => {
   const type = new ModelTypeType();
-  const result = type.complete();
+  const result = await type.complete();
 
   // Should include registered types (command/shell is built-in)
   assertEquals(result.includes("command/shell"), true);


### PR DESCRIPTION
## Summary

PR #1050 converted all type registries (`modelRegistry`, `vaultTypeRegistry`, etc.) from eager loading at CLI startup to lazy loading via `setLoader()` / `ensureLoaded()`. However, three commands and tab completion were missed, causing user-defined extensions from `extensions/models/` and `extensions/vaults/` to not be discovered.

**Fixes:**
- `model method describe` — added `modelRegistry.ensureLoaded()` before `createModelMethodDescribeDeps`
- `type describe` — added `modelRegistry.ensureLoaded()` before `createTypeDescribeDeps`
- `vault type-search` — added `vaultTypeRegistry.ensureLoaded()` before constructing deps
- `ModelTypeType.complete()` — made async with `ensureLoaded()` so extension types appear in tab completion

**Root cause:** Unlike `createModelCreateDeps()` which calls `ensureLoaded()` internally, `createModelMethodDescribeDeps()` and `createTypeDescribeDeps()` do not — so the CLI command must call it before invoking them.

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] All 4013 unit/integration tests pass
- [ ] UAT tests pass: `extension_vault_test.ts`, `extension_model_test.ts`, `method_describe_test.ts`, `broken_extensions_test.ts`, `vault_only_pull_test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)