### PR TITLE
fix: add remaining ensureLoaded() calls missed in #1056

### DIFF
--- a/src/cli/commands/model_validate.ts
+++ b/src/cli/commands/model_validate.ts
@@ -30,6 +30,7 @@ import {
   modelValidate,
 } from "../../libswamp/mod.ts";
 import { createModelValidateRenderer } from "../../presentation/renderers/model_validate.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -75,6 +76,7 @@ export const modelValidateCommand = new Command()
           outputMode: cliCtx.outputMode,
         });
 
+      await modelRegistry.ensureLoaded();
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
       const deps = createModelValidateDeps(
         repoDir,

--- a/src/domain/vaults/vault_service.ts
+++ b/src/domain/vaults/vault_service.ts
@@ -52,6 +52,7 @@ export class VaultService {
     repoDir: string,
     vaultsDir?: string,
   ): Promise<VaultService> {
+    await vaultTypeRegistry.ensureLoaded();
     const vaultService = new VaultService();
     try {
       const effectiveVaultsDir = vaultsDir ?? join(repoDir, "vaults");


### PR DESCRIPTION
## Summary

- Add `vaultTypeRegistry.ensureLoaded()` at the top of `VaultService.fromRepository()` — fixes 5 extension vault integration test failures where user-defined vault types weren't found because the registry was empty
- Add `modelRegistry.ensureLoaded()` in the `model validate` command handler before `createModelValidateDeps()` — fixes 1 extension model test failure where `model validate` couldn't find extension model types

These are the remaining 6 regression failures from the lazy extension loading change (#1050), following the initial fix in #1056 which resolved 4 of 10.

## Test Plan

- All 4013 tests pass locally (0 failures)
- The 6 previously failing integration tests now pass:
  - `extension_vault_test.ts` (5 tests): vault lifecycle, model method run with vault secrets, workflow run with vault secrets, built-in and user-defined vaults coexist, two instances of same type
  - `extension_model_test.ts` (1 test): model validate step

🤖 Generated with [Claude Code](https://claude.com/claude-code)