### PR TITLE
fix: promote race conditions to HIGH severity in adversarial review

### DIFF
--- a/.github/actions/adversarial-review/action.yml
+++ b/.github/actions/adversarial-review/action.yml
@@ -122,10 +122,11 @@ runs:
 
           - **CRITICAL**: Security vulnerabilities, data loss/corruption, or crashes in production paths.
             These BLOCK the merge.
-          - **HIGH**: Logic errors that produce wrong results, resource leaks, or unhandled failure modes
-            in common paths. These BLOCK the merge.
-          - **MEDIUM**: Edge cases in uncommon paths, minor race conditions, or API contract concerns.
-            These are warnings but do NOT block.
+          - **HIGH**: Logic errors that produce wrong results, resource leaks, race conditions that can
+            corrupt shared state or produce wrong results, or unhandled failure modes in common paths.
+            These BLOCK the merge.
+          - **MEDIUM**: Edge cases in uncommon paths, cosmetic concurrency issues (e.g. log interleaving,
+            progress bar flicker), or API contract concerns. These are warnings but do NOT block.
           - **LOW**: Theoretical issues that are unlikely in practice. Mention but do NOT block.
 
           After reviewing, submit your review using ONE of these commands:


### PR DESCRIPTION
## Summary

- Moved race conditions that can corrupt shared state or produce wrong results from MEDIUM to HIGH severity, making them merge-blocking
- Replaced the vague "minor race conditions" MEDIUM category with "cosmetic concurrency issues" (e.g. log interleaving, progress bar flicker)
- No functional code changes — only the severity classification prompt in the adversarial review action

## Motivation

The previous classification lumped all race conditions under MEDIUM ("minor race conditions"), giving the reviewer an easy escape hatch to let real concurrency bugs through without blocking the merge. The distinction should be: can it produce wrong results or corrupt state? If yes, it's HIGH and blocks.

## Test plan

- [ ] Verify CI passes (no code changes, only prompt wording)
- [ ] Confirm future adversarial reviews correctly classify data-corrupting race conditions as HIGH

🤖 Generated with [Claude Code](https://claude.com/claude-code)