### PR TITLE
fix: ensure datastore extensions are loaded before auto-resolve in config resolution

### DIFF
--- a/src/cli/resolve_datastore.ts
+++ b/src/cli/resolve_datastore.ts
@@ -207,7 +207,8 @@ export async function parseDatastoreEnvVar(
       const bucket = slashIdx === -1 ? value : value.slice(0, slashIdx);
       const prefix = slashIdx === -1 ? undefined : value.slice(slashIdx + 1);
 
-      // Auto-resolve the extension if not already loaded
+      // Ensure lazy-loaded extensions are loaded before auto-resolve
+      await datastoreTypeRegistry.ensureLoaded();
       await resolveDatastoreType(renamedTo, getAutoResolver());
       await maybeAutoUpdateSwampDatastore(renamedTo, repoDir ?? ".", null);
 
@@ -247,7 +248,10 @@ export async function parseDatastoreEnvVar(
     type = renamedTo;
   }
 
-  // Auto-resolve extension types
+  // Ensure lazy-loaded extensions are loaded before auto-resolve
+  await datastoreTypeRegistry.ensureLoaded();
+
+  // Auto-resolve extension types (only fires if type is genuinely missing)
   if (type.startsWith("@")) {
     await resolveDatastoreType(type, getAutoResolver());
     await maybeAutoUpdateSwampDatastore(type, repoDir ?? ".", null);
@@ -349,7 +353,8 @@ export async function resolveDatastoreConfig(
           `Update your .swamp.yaml to use the new name.`,
       );
 
-      // Auto-resolve the extension if not already loaded
+      // Ensure lazy-loaded extensions are loaded before auto-resolve
+      await datastoreTypeRegistry.ensureLoaded();
       await resolveDatastoreType(renamedTo, getAutoResolver());
       await maybeAutoUpdateSwampDatastore(
         renamedTo,
@@ -414,7 +419,13 @@ export async function resolveDatastoreConfig(
       };
     }
 
-    // Auto-resolve extension types
+    // Ensure lazy-loaded extension datastores are loaded before checking
+    // the registry. Without this, the registry appears empty after PR #1050's
+    // lazy loading change, causing the auto-resolver to fire unnecessarily
+    // and write progress JSON to stdout — corrupting --json output.
+    await datastoreTypeRegistry.ensureLoaded();
+
+    // Auto-resolve extension types (only fires if type is genuinely missing)
     if (dsType.startsWith("@")) {
       await resolveDatastoreType(dsType, getAutoResolver());
       await maybeAutoUpdateSwampDatastore(dsType, repoDir ?? ".", marker);


### PR DESCRIPTION
## Summary

- `resolveDatastoreConfig()` calls `resolveDatastoreType()` which checks the datastore type registry. After PR #1050's lazy loading change, the registry is empty at this point because `ensureLoaded()` hasn't been called yet.
- This causes the auto-resolver to fire unnecessarily, writing progress JSON (`{"event":"auto_resolve","status":"searching","type":"@swamp/s3-datastore"}`) to stdout — corrupting `--json` output for any command that uses an extension-based datastore (S3, GCS).
- Adds `ensureLoaded()` calls before auto-resolve checks in all three code paths within `resolveDatastoreConfig()` and `parseDatastoreEnvVar()`.

The rogue JSON was 74 chars for S3 (position 75) and 75 chars for GCS (position 76), matching the 1-char difference between `@swamp/s3-datastore` and `@swamp/gcs-datastore`.

## Test Plan

- All 4020 unit tests pass
- `deno check`, `deno lint`, `deno fmt` all clean
- Binary recompiled successfully
- Fixes datastore UAT failures: `status_test.ts:14`, `sync_test.ts:19`, `sync_test.ts:96` on both S3 and GCS backends (CI run: https://github.com/systeminit/swamp-uat/actions/runs/23912975675)

🤖 Generated with [Claude Code](https://claude.com/claude-code)