### PR TITLE
fix: populate ownerDefinition.workflowRunId in data writer factories

### DIFF
--- a/integration/cross_model_data_access_test.ts
+++ b/integration/cross_model_data_access_test.ts
@@ -210,6 +210,95 @@ Deno.test("cross-model data access: model with no data returns empty array", asy
   });
 });
 
+Deno.test("cross-model data access: workflowRunId scoping returns only matching data", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const sourceType = ModelType.create("test/source");
+
+    const sourceDef = Definition.create({
+      name: "scoped-source",
+      globalArguments: {},
+    });
+    await defRepo.save(sourceType, sourceDef);
+
+    const runId1 = crypto.randomUUID();
+    const runId2 = crypto.randomUUID();
+    const definitionHash = await computeDefinitionHash({
+      type: "model-method",
+      ref: `${sourceDef.id}:create`,
+    });
+
+    // Write data scoped to workflow run 1
+    const data1 = Data.create({
+      name: "episode-run1",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { type: "resource", specName: "episode", workflowRunId: runId1 },
+      ownerDefinition: {
+        definitionHash,
+        ownerType: "model-method",
+        ownerRef: sourceDef.id,
+        workflowRunId: runId1,
+      },
+    });
+    await dataRepo.save(
+      sourceType,
+      sourceDef.id,
+      data1,
+      new TextEncoder().encode(JSON.stringify({ title: "from run 1" })),
+    );
+
+    // Write data scoped to workflow run 2
+    const data2 = Data.create({
+      name: "episode-run2",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: { type: "resource", specName: "episode", workflowRunId: runId2 },
+      ownerDefinition: {
+        definitionHash,
+        ownerType: "model-method",
+        ownerRef: sourceDef.id,
+        workflowRunId: runId2,
+      },
+    });
+    await dataRepo.save(
+      sourceType,
+      sourceDef.id,
+      data2,
+      new TextEncoder().encode(JSON.stringify({ title: "from run 2" })),
+    );
+
+    const service = new DataAccessService(defRepo, dataRepo);
+
+    // Scoped to run 1 — should return only run 1's data
+    const run1Records = await service.readModelData(
+      "scoped-source",
+      "episode",
+      runId1,
+    );
+    assertEquals(run1Records.length, 1);
+    assertEquals(run1Records[0].attributes, { title: "from run 1" });
+
+    // Scoped to run 2 — should return only run 2's data
+    const run2Records = await service.readModelData(
+      "scoped-source",
+      "episode",
+      runId2,
+    );
+    assertEquals(run2Records.length, 1);
+    assertEquals(run2Records[0].attributes, { title: "from run 2" });
+
+    // No scope — should return both
+    const allRecords = await service.readModelData("scoped-source", "episode");
+    assertEquals(allRecords.length, 2);
+  });
+});
+
 Deno.test("cross-model data access: orphan recovery reads content from old UUID path", async () => {
   await withTempDir(async (repoDir) => {
     await setupRepoDir(repoDir);

--- a/src/domain/models/data_writer.ts
+++ b/src/domain/models/data_writer.ts
@@ -578,6 +578,9 @@ export function createResourceWriter(
       ownerDefinition: {
         ownerType: "model-method",
         ownerRef: modelId,
+        ...(tagOverrides?.["workflowRunId"]
+          ? { workflowRunId: tagOverrides["workflowRunId"] }
+          : {}),
       },
     };
 
@@ -856,6 +859,9 @@ export function createFileWriterFactory(
       ownerDefinition: {
         ownerType: "model-method",
         ownerRef: modelId,
+        ...(tagOverrides?.["workflowRunId"]
+          ? { workflowRunId: tagOverrides["workflowRunId"] }
+          : {}),
       },
     };
 

--- a/src/domain/models/data_writer_test.ts
+++ b/src/domain/models/data_writer_test.ts
@@ -257,6 +257,69 @@ Deno.test("createFileWriterFactory: runtime tags override definition tags", asyn
   assertEquals(handle.tags["env"], "prod");
 });
 
+Deno.test("createResourceWriter: populates ownerDefinition.workflowRunId from tagOverrides", async () => {
+  const repo = createMockRepo();
+  const workflowRunId = "6be8c3b8-ff3f-4e23-b998-fd9456d84d0a";
+  const tagOverrides = {
+    source: "step-output",
+    workflow: "my-wf",
+    workflowRunId,
+  };
+
+  const { writeResource } = createResourceWriter(
+    repo,
+    modelType,
+    modelId,
+    testResources,
+    tagOverrides,
+  );
+
+  const handle = await writeResource("item", "test-item", { value: "hello" });
+  assertEquals(handle.metadata.ownerDefinition.workflowRunId, workflowRunId);
+  assertEquals(handle.metadata.ownerDefinition.ownerType, "model-method");
+  assertEquals(handle.metadata.ownerDefinition.ownerRef, modelId);
+});
+
+Deno.test("createResourceWriter: omits ownerDefinition.workflowRunId when not in tagOverrides", async () => {
+  const repo = createMockRepo();
+  const tagOverrides = { source: "step-output", workflow: "my-wf" };
+
+  const { writeResource } = createResourceWriter(
+    repo,
+    modelType,
+    modelId,
+    testResources,
+    tagOverrides,
+  );
+
+  const handle = await writeResource("item", "test-item", { value: "hello" });
+  assertEquals(handle.metadata.ownerDefinition.workflowRunId, undefined);
+});
+
+Deno.test("createFileWriterFactory: populates ownerDefinition.workflowRunId from tagOverrides", async () => {
+  const repo = createMockRepo();
+  const workflowRunId = "6be8c3b8-ff3f-4e23-b998-fd9456d84d0a";
+  const tagOverrides = {
+    source: "step-output",
+    workflow: "my-wf",
+    workflowRunId,
+  };
+
+  const { createFileWriter } = createFileWriterFactory(
+    repo,
+    modelType,
+    modelId,
+    testFiles,
+    tagOverrides,
+  );
+
+  const writer = createFileWriter("log", "test-log");
+  const handle = await writer.writeText("log content");
+  assertEquals(handle.metadata.ownerDefinition.workflowRunId, workflowRunId);
+  assertEquals(handle.metadata.ownerDefinition.ownerType, "model-method");
+  assertEquals(handle.metadata.ownerDefinition.ownerRef, modelId);
+});
+
 Deno.test("createResourceWriter: rejects reserved data name 'latest'", async () => {
   const repo = createMockRepo();
   const { writeResource } = createResourceWriter(


### PR DESCRIPTION
## Summary

- PR #1060 added workflow-run scoping to `readModelData` but the read filter checks `ownerDefinition.workflowRunId`, which was never populated by the data writer — only `tags.workflowRunId` was set via `tagOverrides`
- Extract `workflowRunId` from `tagOverrides` into `ownerDefinition` in both `createResourceWriter` and `createFileWriterFactory` so cross-model reads within workflows return the correct scoped data

Closes #1066

## Test Plan

- Unit tests: 3 new tests in `data_writer_test.ts` verifying `ownerDefinition.workflowRunId` is populated (resource writer) / omitted (no workflow) / populated (file writer)
- Integration test: new test in `cross_model_data_access_test.ts` verifying `readModelData` returns only workflow-run-scoped data
- Manual verification: reproduced the bug in a scratch repo, confirmed consumer step now finds source data (`recordCount: 1` vs `0` before fix)