### PR TITLE
fix: address lazy loading followups

### DIFF
--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -777,7 +777,11 @@ export class ModelRegistry {
     if (!promise) {
       const loader = this.typeLoader;
       promise = loader(key).then(() => {
-        this.lazyTypes.delete(key);
+        // promoteFromLazy() already deleted the lazy entry during
+        // the loader call, so no lazyTypes cleanup needed here.
+        // Prune the resolved promise — it's no longer needed since
+        // the type is now fully registered in this.models.
+        this.typeLoadPromises.delete(key);
       }).catch((err) => {
         this.typeLoadPromises.delete(key);
         throw err;

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -483,9 +483,12 @@ export class UserModelLoader {
       return result;
     }
 
-    // Catalog not populated — full import to bootstrap
+    // Catalog not populated — full import to bootstrap.
+    // skipAlreadyRegistered avoids failures when a user extension
+    // shadows a built-in type name during first-run bootstrap.
     const fullResult = await this.loadModels(modelsDir, {
       additionalDirs: options?.additionalDirs,
+      skipAlreadyRegistered: true,
     });
 
     // Populate catalog from the now-loaded registry
@@ -689,6 +692,11 @@ export class UserModelLoader {
         // runs during the first-run catalog bootstrap. Any mismatches are
         // corrected on subsequent runs when the mtime scan detects the
         // file as new (not in catalog) and does a proper bundle import.
+        //
+        // Classification: extension takes priority over model, matching
+        // the loader's own if/else if logic (line ~347). In practice
+        // these exports are mutually exclusive — a file exports one or
+        // the other, never both.
         const typeMatch = source.match(
           /type\s*:\s*["']([^"']+)["']/,
         );


### PR DESCRIPTION
## Summary

Fixes three issues identified in post-merge review of #1063 (lazy per-bundle loading):

- **`skipAlreadyRegistered` missing on bootstrap path** — `buildIndex()` full-import fallback now passes `skipAlreadyRegistered: true`, preventing failures when user extensions shadow built-in type names during first-run catalog bootstrap.
- **`typeLoadPromises` never pruned on success** — Resolved promises are now deleted from the map in the `.then()` handler. Removes the dead `lazyTypes.delete(key)` call that duplicated `promoteFromLazy()` cleanup.
- **Classification comment in `populateCatalogFromDir`** — Added clarifying comment explaining that extension-takes-priority matches the loader's own `if/else if` semantics and that the exports are mutually exclusive by design.

## Test Plan

- All 4047 existing tests pass (including 51 model registry + 45 user model loader tests)
- `deno check`, `deno lint`, `deno fmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)