### PR TITLE
fix: remove auth requirement from extension version

### DIFF
--- a/src/cli/commands/extension_version.ts
+++ b/src/cli/commands/extension_version.ts
@@ -58,7 +58,7 @@ export const extensionVersionCommand = new Command()
       const extensionName = await resolveExtensionName(name, options.manifest);
 
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
-      const deps = await createExtensionVersionDeps();
+      const deps = createExtensionVersionDeps();
       const renderer = createExtensionVersionRenderer(cliCtx.outputMode);
 
       await consumeStream(

--- a/src/libswamp/extensions/version.ts
+++ b/src/libswamp/extensions/version.ts
@@ -18,11 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { CalVer } from "../../domain/models/calver.ts";
-import {
-  ExtensionApiClient,
-  type LatestVersionInfo,
-} from "../../infrastructure/http/extension_api_client.ts";
-import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
+import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
 import { resolveServerUrl } from "./pull.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -46,22 +42,27 @@ export interface ExtensionVersionInput {
   extensionName: string;
 }
 
+/** Version info resolved from the public extension metadata endpoint. */
+export interface LatestVersionInfo {
+  version: string;
+  publishedAt: string | null;
+}
+
 /** Dependencies for the extension version operation. */
 export interface ExtensionVersionDeps {
   getLatestVersion: (name: string) => Promise<LatestVersionInfo | null>;
 }
 
-/** Wires real infrastructure into ExtensionVersionDeps. */
-export async function createExtensionVersionDeps(): Promise<
-  ExtensionVersionDeps
-> {
-  const authRepo = new AuthRepository();
-  const creds = await authRepo.load();
-  const serverUrl = creds?.serverUrl ?? resolveServerUrl();
+/** Wires real infrastructure into ExtensionVersionDeps. No authentication required. */
+export function createExtensionVersionDeps(): ExtensionVersionDeps {
+  const serverUrl = resolveServerUrl();
   const client = new ExtensionApiClient(serverUrl);
-  const apiKey = creds?.apiKey;
   return {
-    getLatestVersion: (name: string) => client.getLatestVersion(name, apiKey),
+    getLatestVersion: async (name: string) => {
+      const info = await client.getExtension(name);
+      if (!info) return null;
+      return { version: info.latestVersion, publishedAt: null };
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

- `swamp extension version` unnecessarily required authentication while `extension pull` and `extension update` did not
- Switched from the authenticated `/api/v1/extensions/{name}/latest` endpoint to the public `/api/v1/extensions/{name}` endpoint (same one used by pull/update)
- Removed `AuthRepository` dependency, making `createExtensionVersionDeps` synchronous

## Follow-up needed (swamp-club server-side)

The `/api/v1/extensions/{name}/latest` endpoint currently returns 401 for unauthenticated requests. This endpoint is read-only and should be public like `/api/v1/extensions/{name}`. That would also restore the `publishedAt` field which the `/latest` endpoint provides but the public metadata endpoint does not. The log renderer never displayed `publishedAt`, but it shows as `null` in `--json` output until the server-side fix is made.

## Test plan

- [x] Unit tests pass (`deno run test src/libswamp/extensions/version_test.ts`)
- [x] Type checking passes (`deno check`)
- [x] Compiled binary and verified `swamp extension version @swamp/digitalocean` works without auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)