### PR TITLE
fix: improve error handling for extension sources and rebundle logging

### DIFF
--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -596,14 +596,10 @@ export async function runCli(args: string[]): Promise<void> {
   // Read extension sources (additional extension directories from
   // .swamp-sources.yaml). Resolved once and shared across all loaders.
   let resolvedSources: ResolvedSourceDirs[] = [];
-  try {
-    const sourcesConfig = await readSwampSources(repoDir);
-    if (sourcesConfig) {
-      const expanded = await expandSourcePaths(sourcesConfig, repoDir);
-      resolvedSources = await resolveSourceExtensionDirs(expanded);
-    }
-  } catch {
-    // Sources file missing or invalid — continue without sources
+  const sourcesConfig = await readSwampSources(repoDir);
+  if (sourcesConfig) {
+    const expanded = await expandSourcePaths(sourcesConfig, repoDir);
+    resolvedSources = await resolveSourceExtensionDirs(expanded);
   }
 
   // Configure lazy extension loaders on each registry.

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -77,18 +77,24 @@ import {
 
 /**
  * Resolves source workflow directories from `.swamp-sources.yaml`.
+ * Results are cached per repoDir to avoid re-reading and re-expanding on
+ * every call (multiple repo context functions call this per command).
  * Returns an empty array if no sources are configured or file doesn't exist.
  */
+const sourceWorkflowDirCache = new Map<string, string[]>();
 async function getSourceWorkflowDirs(repoDir: string): Promise<string[]> {
-  try {
-    const sourcesConfig = await readSwampSources(repoDir);
-    if (!sourcesConfig) return [];
-    const expanded = await expandSourcePaths(sourcesConfig, repoDir);
-    const resolved = await resolveSourceExtensionDirs(expanded);
-    return collectDirsForKind(resolved, "workflows");
-  } catch {
+  const cached = sourceWorkflowDirCache.get(repoDir);
+  if (cached) return cached;
+  const sourcesConfig = await readSwampSources(repoDir);
+  if (!sourcesConfig) {
+    sourceWorkflowDirCache.set(repoDir, []);
     return [];
   }
+  const expanded = await expandSourcePaths(sourcesConfig, repoDir);
+  const resolved = await resolveSourceExtensionDirs(expanded);
+  const dirs = collectDirsForKind(resolved, "workflows");
+  sourceWorkflowDirCache.set(repoDir, dirs);
+  return dirs;
 }
 
 /**

--- a/src/domain/datastore/user_datastore_loader.ts
+++ b/src/domain/datastore/user_datastore_loader.ts
@@ -272,8 +272,11 @@ export class UserDatastoreLoader {
         if (bundleExists) {
           try {
             const cached = await Deno.readTextFile(bundlePath);
+            const msg = bundleError instanceof Error
+              ? bundleError.message
+              : String(bundleError);
             logger
-              .warn`Rebundle failed for ${relativePath}, using cached bundle: ${bundleError}`;
+              .info`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
             // Touch the cache mtime so subsequent loads see it as fresh,
             // avoiding repeated failed rebundle attempts on every cold start.
             try {

--- a/src/domain/drivers/user_driver_loader.ts
+++ b/src/domain/drivers/user_driver_loader.ts
@@ -271,8 +271,11 @@ export class UserDriverLoader {
         if (bundleExists) {
           try {
             const cached = await Deno.readTextFile(bundlePath);
+            const msg = bundleError instanceof Error
+              ? bundleError.message
+              : String(bundleError);
             logger
-              .warn`Rebundle failed for ${relativePath}, using cached bundle: ${bundleError}`;
+              .info`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
             // Touch the cache mtime so subsequent loads see it as fresh,
             // avoiding repeated failed rebundle attempts on every cold start.
             try {

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -1107,8 +1107,11 @@ export class UserModelLoader {
         if (bundleExists) {
           try {
             const cached = await Deno.readTextFile(bundlePath);
+            const msg = bundleError instanceof Error
+              ? bundleError.message
+              : String(bundleError);
             logger
-              .warn`Rebundle failed for ${relativePath}, using cached bundle: ${bundleError}`;
+              .info`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
             // Touch the cache mtime so subsequent loads see it as fresh,
             // avoiding repeated failed rebundle attempts on every cold start.
             try {

--- a/src/domain/vaults/user_vault_loader.ts
+++ b/src/domain/vaults/user_vault_loader.ts
@@ -272,8 +272,11 @@ export class UserVaultLoader {
         if (bundleExists) {
           try {
             const cached = await Deno.readTextFile(bundlePath);
+            const msg = bundleError instanceof Error
+              ? bundleError.message
+              : String(bundleError);
             logger
-              .warn`Rebundle failed for ${relativePath}, using cached bundle: ${bundleError}`;
+              .info`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
             // Touch the cache mtime so subsequent loads see it as fresh,
             // avoiding repeated failed rebundle attempts on every cold start.
             try {

--- a/src/infrastructure/persistence/swamp_sources_repository.ts
+++ b/src/infrastructure/persistence/swamp_sources_repository.ts
@@ -136,12 +136,43 @@ export async function resolveSourceExtensionDirs(
     const sourceDir = source.path;
     const resolved: ResolvedSourceDirs = { sourcePath: sourceDir };
 
-    // Try to read the source's own .swamp.yaml for directory overrides
+    // Try to read the source's own .swamp.yaml for directory overrides.
+    // The YAML is from an external repo, so we only extract fields we need
+    // and validate they are strings before using them.
     let sourceMarker: RepoMarkerData | null = null;
     try {
       const markerPath = resolve(sourceDir, ".swamp.yaml");
       const content = await Deno.readTextFile(markerPath);
-      sourceMarker = parseYaml(content) as RepoMarkerData;
+      const raw = parseYaml(content);
+      if (raw && typeof raw === "object") {
+        const obj = raw as Record<string, unknown>;
+        sourceMarker = {
+          swampVersion: typeof obj.swampVersion === "string"
+            ? obj.swampVersion
+            : "",
+          initializedAt: typeof obj.initializedAt === "string"
+            ? obj.initializedAt
+            : "",
+          modelsDir: typeof obj.modelsDir === "string"
+            ? obj.modelsDir
+            : undefined,
+          workflowsDir: typeof obj.workflowsDir === "string"
+            ? obj.workflowsDir
+            : undefined,
+          vaultsDir: typeof obj.vaultsDir === "string"
+            ? obj.vaultsDir
+            : undefined,
+          driversDir: typeof obj.driversDir === "string"
+            ? obj.driversDir
+            : undefined,
+          datastoresDir: typeof obj.datastoresDir === "string"
+            ? obj.datastoresDir
+            : undefined,
+          reportsDir: typeof obj.reportsDir === "string"
+            ? obj.reportsDir
+            : undefined,
+        };
+      }
     } catch {
       // No marker file — use defaults
     }


### PR DESCRIPTION
## Summary

- **Rebundle logging**: Downgrade rebundle failure logs from `warn` to `info` and extract just the error message instead of dumping the full stack trace. Applied to all 4 loaders (models, vaults, drivers, datastores).
- **Silent error swallowing in `mod.ts`**: Remove the blanket `catch {}` around `.swamp-sources.yaml` loading that silently swallowed `UserError` from Zod validation failures (e.g., `only: [model]` missing the `s`). `readSwampSources()` already returns `null` for missing files, so the outer catch was only hiding real errors.
- **Duplicate source resolution in `repo_context.ts`**: Cache resolved source workflow dirs per `repoDir` so the three repo context functions (`requireInitializedRepoReadOnly`, `requireInitializedRepo`, `requireInitializedRepoUnlocked`) don't each re-read, re-expand globs, and re-stat directories. Also fixed the same silent `catch {}` bug.
- **Unsafe YAML cast in `swamp_sources_repository.ts`**: Replace `parseYaml(content) as RepoMarkerData` with field-by-field string validation when reading external source `.swamp.yaml` markers. Non-string values (e.g., `modelsDir: 42`) now fall back to defaults instead of flowing into `resolve()` with undefined behavior.

## Test Plan

- All 4121 existing tests pass
- `deno check`, `deno lint`, `deno fmt --check` all clean
- Verified rebundle failure path still works via existing `user_model_loader_test.ts` (45 tests)
- Verified source resolution via `swamp_sources_repository_test.ts` (13 tests) and `repo_context_test.ts` (21 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)