### PR TITLE
fix: downgrade rebundle-failed log from info to debug

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release of swamp receives security updates. We recommend always
+running the most recent version.
+
+## Reporting a Vulnerability
+
+For most bugs — including crashes, unexpected behavior, and general defects —
+please [file a public issue](https://github.com/systeminit/swamp/issues/new). We
+prefer open issues so the community can track progress and discuss.
+
+If the vulnerability involves **secret or credential exposure, data
+exfiltration, or any issue where public disclosure could put users at risk**,
+please email [security@systeminit.com](mailto:security@systeminit.com) instead.
+
+### What to Include
+
+- **Executive Summary** — a brief description of the vulnerability
+- **Impact** — what an attacker could achieve by exploiting it
+- **Proof of Concept** — steps to reproduce or sample code
+- **Swamp Version** — the version affected
+- **Mitigation Steps** (optional) — any suggested fix or workaround
+
+### What to Expect
+
+- We will acknowledge your report within **72 hours**
+- We will work with you to understand and validate the issue
+- We will develop a fix and coordinate a disclosure timeline
+- We will credit you in the release notes (unless you prefer to remain
+  anonymous)
+
+## Scope
+
+The following are examples of issues that should be reported privately:
+
+- Secrets or credentials leaked through logs, data files, or error messages
+- Extension code that can exfiltrate data outside its intended boundary
+- Datastore credential mishandling
+- Dependency vulnerabilities that could expose user data
+
+Everything else — general bugs, feature requests, and non-sensitive defects —
+should be filed as a
+[public issue](https://github.com/systeminit/swamp/issues/new).

--- a/src/domain/datastore/user_datastore_loader.ts
+++ b/src/domain/datastore/user_datastore_loader.ts
@@ -276,7 +276,7 @@ export class UserDatastoreLoader {
               ? bundleError.message
               : String(bundleError);
             logger
-              .info`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
+              .debug`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
             // Touch the cache mtime so subsequent loads see it as fresh,
             // avoiding repeated failed rebundle attempts on every cold start.
             try {

--- a/src/domain/drivers/user_driver_loader.ts
+++ b/src/domain/drivers/user_driver_loader.ts
@@ -275,7 +275,7 @@ export class UserDriverLoader {
               ? bundleError.message
               : String(bundleError);
             logger
-              .info`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
+              .debug`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
             // Touch the cache mtime so subsequent loads see it as fresh,
             // avoiding repeated failed rebundle attempts on every cold start.
             try {

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -1111,7 +1111,7 @@ export class UserModelLoader {
               ? bundleError.message
               : String(bundleError);
             logger
-              .info`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
+              .debug`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
             // Touch the cache mtime so subsequent loads see it as fresh,
             // avoiding repeated failed rebundle attempts on every cold start.
             try {

--- a/src/domain/vaults/user_vault_loader.ts
+++ b/src/domain/vaults/user_vault_loader.ts
@@ -276,7 +276,7 @@ export class UserVaultLoader {
               ? bundleError.message
               : String(bundleError);
             logger
-              .info`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
+              .debug`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
             // Touch the cache mtime so subsequent loads see it as fresh,
             // avoiding repeated failed rebundle attempts on every cold start.
             try {


### PR DESCRIPTION
## Summary

- Downgrades the "Rebundle failed, using cached bundle" log message from `info` to `debug` across all four extension loaders (models, drivers, datastores, vaults)
- The message is not actionable for users since the cached bundle is used successfully — it just adds noise on first run with pulled extensions

## Test Plan

- `deno check` passes
- `deno lint` passes
- `deno run test` passes