### PR TITLE
feat: improve extension model skill for publishing and collective guidance

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -1,12 +1,21 @@
 ---
 name: swamp-extension-model
-description: Create user-defined TypeScript models for swamp — define Zod schemas, implement model interfaces, configure output specs — and publish extensions to the registry. Use when users want to extend swamp with custom model types, create automation models, add new integrations, or publish any extension type (models, vaults, drivers, datastores). Triggers on "create model", "new model type", "custom model", "extension model", "user model", "typescript model", "extend swamp", "build integration", "zod schema", "model plugin", "deno model", "extensions/models", "model development", "implement model", "smoke test", "test extension", "verify model", "test against API", "before push test", "push extension", "publish extension", "extension push", "release extension", "bump version", "publish to registry", "test extension from another repo", "source extension loading".
+description: Create, test, and publish extension models for swamp — define Zod schemas, implement model interfaces, smoke test against live APIs, write manifest.yaml, and push extensions to the registry. Use when creating models, writing manifest.yaml, publishing/pushing extensions, testing extensions, or preparing models for the registry. Covers all extension types (models, vaults, drivers, datastores, reports). Triggers on "create model", "new model type", "custom model", "extension model", "user model", "typescript model", "extend swamp", "build integration", "zod schema", "model plugin", "deno model", "extensions/models", "model development", "implement model", "smoke test", "test extension", "verify model", "test against API", "before push test", "push extension", "publish extension", "extension push", "release extension", "bump version", "publish to registry", "test extension from another repo", "source extension loading", "manifest", "manifest.yaml", "write manifest", "prepare for publishing".
 ---
 
 # Swamp Extension Model
 
 Create TypeScript models in `extensions/models/*.ts` that swamp loads at
 startup.
+
+## Choosing a Collective Name
+
+Before creating a model, determine the collective name for the `type` field. Run
+`swamp auth whoami --json` to see available collectives. If multiple collectives
+are returned, **always ask the user** which one to use — never auto-select. Use
+`@collective/model-name` as the type from the start (e.g., `@keeb/ports`). Do
+not use placeholder prefixes like `@local/` — they will be rejected during
+`swamp extension push`.
 
 ## When to Create a Custom Model
 
@@ -438,7 +447,7 @@ before proceeding to testing.
 
 Extensions are published to the swamp registry via a `manifest.yaml` and the
 `swamp extension push` command. Extensions can contain models, workflows,
-vaults, drivers, and datastores.
+vaults, drivers, datastores, and reports.
 
 **Minimal manifest:**
 

--- a/.claude/skills/swamp-extension-model/evals/trigger_evals.json
+++ b/.claude/skills/swamp-extension-model/evals/trigger_evals.json
@@ -89,5 +89,40 @@
     "query": "Help me create and test a CRUD extension model",
     "should_trigger": true,
     "note": "create model + test extension triggers"
+  },
+  {
+    "query": "Make a manifest.yaml so I can push my extension",
+    "should_trigger": true,
+    "note": "manifest.yaml and push extension are triggers"
+  },
+  {
+    "query": "Publish my model to the registry",
+    "should_trigger": true,
+    "note": "publish extension and publish to registry are triggers"
+  },
+  {
+    "query": "Help me push this extension to swamp-club",
+    "should_trigger": true,
+    "note": "push extension is a trigger"
+  },
+  {
+    "query": "I need to write a manifest for my model",
+    "should_trigger": true,
+    "note": "write manifest and manifest are triggers"
+  },
+  {
+    "query": "Prepare my extension for publishing",
+    "should_trigger": true,
+    "note": "prepare for publishing is a trigger"
+  },
+  {
+    "query": "How do I swamp extension push my model?",
+    "should_trigger": true,
+    "note": "extension push is a trigger"
+  },
+  {
+    "query": "I want to release a new version of my extension",
+    "should_trigger": true,
+    "note": "release extension and bump version are triggers"
   }
 ]

--- a/.claude/skills/swamp-extension-model/references/publishing.md
+++ b/.claude/skills/swamp-extension-model/references/publishing.md
@@ -42,13 +42,14 @@ dependencies:
 | `vaults`          | No*      | Vault file paths relative to `extensions/vaults/`                                                |
 | `drivers`         | No*      | Driver file paths relative to `extensions/drivers/`                                              |
 | `datastores`      | No*      | Datastore file paths relative to `extensions/datastores/`                                        |
+| `reports`         | No*      | Report file paths relative to `extensions/reports/`                                              |
 | `additionalFiles` | No       | Extra files relative to the manifest location                                                    |
 | `platforms`       | No       | OS/architecture hints (e.g. `darwin-aarch64`, `linux-x86_64`)                                    |
 | `labels`          | No       | Categorization labels (e.g. `aws`, `kubernetes`, `security`)                                     |
 | `dependencies`    | No       | Other extensions this one depends on                                                             |
 
-*At least one of `models`, `workflows`, `vaults`, `drivers`, or `datastores`
-must be present with entries.
+*At least one of `models`, `workflows`, `vaults`, `drivers`, `datastores`, or
+`reports` must be present with entries.
 
 ### Name Rules
 
@@ -136,6 +137,18 @@ models:
   - dashboard.ts
 dependencies:
   - "@myorg/aws-core"
+```
+
+### Model + report
+
+```yaml
+manifestVersion: 1
+name: "@myorg/ports"
+version: "2026.03.01.1"
+models:
+  - ports.ts
+reports:
+  - port_whisperer.ts
 ```
 
 ## Pre-Push Checklist


### PR DESCRIPTION
## Summary

- Reframe `swamp-extension-model` skill description to surface **create, test, and publish** as equal phases — not just creation
- Add `manifest`, `manifest.yaml`, `write manifest`, `prepare for publishing` as trigger keywords so the skill loads for publishing tasks
- Add `reports` to the extension type list in the description
- Add **collective name guidance** to SKILL.md: run `swamp auth whoami --json` upfront, prompt user to choose a collective, use `@collective/model-name` from the start — prevents the `@local/` migration problem entirely
- Add `reports` to publishing.md field reference table, update the "at least one" footnote, add model+report manifest example
- Add 7 publishing-focused trigger eval test cases (the existing evals had zero publishing scenarios)

Skill review score: 93% (description 100%, content 85%)

Closes #1081

## Test plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `npx tessl skill review .claude/skills/swamp-extension-model` passes at 93%
- [ ] CI trigger eval tests validate the new publishing queries route correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)