### PR TITLE
docs: add data access patterns to report skill docs

### DIFF
--- a/.claude/skills/swamp-extension-model/references/api.md
+++ b/.claude/skills/swamp-extension-model/references/api.md
@@ -142,16 +142,29 @@ const handle = await streamWriter.finalize();
 
 Returned by `writeResource` and writer methods:
 
-| Field      | Description                          |
-| ---------- | ------------------------------------ |
-| `name`     | Data artifact name                   |
-| `specName` | The declared spec name               |
-| `kind`     | `"resource"` or `"file"`             |
-| `dataId`   | Unique ID for this data              |
-| `version`  | Version number of this write         |
-| `size`     | Size of the written content in bytes |
-| `tags`     | Tags from the writer options         |
-| `metadata` | Full metadata for the data artifact  |
+| Field      | Description                                |
+| ---------- | ------------------------------------------ |
+| `name`     | Data artifact name                         |
+| `specName` | The declared spec name                     |
+| `kind`     | `"resource"` or `"file"`                   |
+| `dataId`   | Unique ID for this data                    |
+| `version`  | Version number of this write               |
+| `size`     | Size of the written content in bytes       |
+| `tags`     | Tags from the writer options               |
+| `metadata` | Metadata for the data artifact (see below) |
+
+**`metadata` sub-fields:**
+
+| Field               | Type                      | Description                                              |
+| ------------------- | ------------------------- | -------------------------------------------------------- |
+| `contentType`       | `string`                  | MIME type (e.g. `"application/json"`)                    |
+| `lifetime`          | `Lifetime`                | TTL from the spec (e.g. `"7d"`, `"infinite"`)            |
+| `garbageCollection` | `GarbageCollectionPolicy` | Version retention count or duration                      |
+| `streaming`         | `boolean`                 | Whether the data was written as streaming                |
+| `tags`              | `Record<string, string>`  | Tags (e.g. `type`, `specName`, `modelName`)              |
+| `ownerDefinition`   | `OwnerDefinition`         | Owner type and ref (model-method, workflow-step, manual) |
+| `lifecycle`         | `"active" \| "deleted"`   | Current lifecycle state                                  |
+| `renamedTo`         | `string?`                 | New name if the data was renamed                         |
 
 **UserMethodResult:**
 

--- a/.claude/skills/swamp-report/SKILL.md
+++ b/.claude/skills/swamp-report/SKILL.md
@@ -122,6 +122,44 @@ const methodArgs = context.redactSensitiveArgs(context.methodArgs, "method");
 The helper is available on method and model scope contexts. It returns args
 unchanged if no schema is found, so it is safe to call unconditionally.
 
+### Reading Execution Data
+
+Reports can read data produced during method execution via `context.dataHandles`
+and `context.dataRepository`:
+
+```typescript
+execute: async (context) => {
+  const handle = context.dataHandles.find(h => h.specName === "state");
+  if (!handle) {
+    return { markdown: "No data produced.", json: {} };
+  }
+
+  // getContent returns raw bytes — parse JSON manually
+  const raw = await context.dataRepository.getContent(
+    context.modelType,
+    context.modelId,
+    handle.name,
+    handle.version,
+  );
+  if (!raw) {
+    return { markdown: "Data not found.", json: {} };
+  }
+  const attrs = JSON.parse(new TextDecoder().decode(raw));
+
+  return {
+    markdown: `# State Report\n\n- **Status**: ${attrs.status}\n`,
+    json: { status: attrs.status },
+  };
+},
+```
+
+Use `findByName()` when you need metadata (tags, version, content type) without
+the content itself. See
+[references/report-types.md](references/report-types.md#unifieddatarepository-methods)
+for the full API and
+[references/testing.md](references/testing.md#testing-reports-that-read-data)
+for testing patterns.
+
 ### Key Rules
 
 1. **Return both markdown and json** — every report must produce both

--- a/.claude/skills/swamp-report/evals/trigger_evals.json
+++ b/.claude/skills/swamp-report/evals/trigger_evals.json
@@ -61,5 +61,17 @@
     "query": "The report generation is timing out",
     "should_trigger": false,
     "note": "Debugging report execution issues → swamp-troubleshooting"
+  },
+  {
+    "query": "How do I read execution data in a report using dataHandles?",
+    "should_trigger": true
+  },
+  {
+    "query": "Access dataRepository from report context to get model output",
+    "should_trigger": true
+  },
+  {
+    "query": "What methods does UnifiedDataRepository expose in reports?",
+    "should_trigger": true
   }
 ]

--- a/.claude/skills/swamp-report/references/report-types.md
+++ b/.claude/skills/swamp-report/references/report-types.md
@@ -48,6 +48,7 @@ interface BaseReportContext {
   logger: Logger;
   dataRepository: UnifiedDataRepository;
   definitionRepository: DefinitionRepository;
+  swampSha?: string;
 }
 ```
 
@@ -65,9 +66,12 @@ interface MethodReportContext extends BaseReportContext {
     tags: Record<string, string>;
   };
   globalArgs: Record<string, unknown>;
+  methodArgs: Record<string, unknown>;
   methodName: string;
   executionStatus: "succeeded" | "failed";
+  errorMessage?: string;
   dataHandles: DataHandle[];
+  outputSpecs?: OutputSpecInfo[];
 }
 ```
 
@@ -93,6 +97,9 @@ interface WorkflowReportContext extends BaseReportContext {
     methodName: string;
     status: "succeeded" | "failed" | "skipped";
     dataHandles: DataHandle[];
+    methodArgs: Record<string, unknown>;
+    modelId: string;
+    globalArgs: Record<string, unknown>;
   }>;
 }
 ```
@@ -138,6 +145,68 @@ const ReportSelectionSchema = z.object({
 3. `require` makes reports immune to CLI skip flags
 4. CLI `--skip-report` / `--skip-report-label` apply to non-required reports
 5. CLI `--report` / `--report-label` narrow to a subset (inclusion filter)
+
+## UnifiedDataRepository Methods
+
+The `dataRepository` on all report contexts exposes these methods for reading
+execution data:
+
+| Method            | Signature                             | Returns              | Description                                     |
+| ----------------- | ------------------------------------- | -------------------- | ----------------------------------------------- |
+| `getContent`      | `(type, modelId, dataName, version?)` | `Uint8Array \| null` | Get raw content bytes                           |
+| `findByName`      | `(type, modelId, dataName, version?)` | `Data \| null`       | Get data metadata (tags, version, content type) |
+| `findAllForModel` | `(type, modelId)`                     | `Data[]`             | List all data for a model instance              |
+
+**Parameter mapping from report context:**
+
+| Parameter  | Value                                                         |
+| ---------- | ------------------------------------------------------------- |
+| `type`     | `context.modelType`                                           |
+| `modelId`  | `context.modelId`                                             |
+| `dataName` | `handle.name` from `context.dataHandles`                      |
+| `version`  | `handle.version` from `context.dataHandles` (omit for latest) |
+
+For workflow-scope reports, use `step.modelType`, `step.modelId`, and
+`step.dataHandles` from `context.stepExecutions`.
+
+**Note:** `findByName` returns metadata only — use `getContent` to read the
+actual data bytes, then parse as needed (e.g.
+`JSON.parse(new TextDecoder().decode(bytes))` for JSON resources).
+
+## DataHandle Structure
+
+The `dataHandles` array contains handles returned by `writeResource` /
+`createFileWriter` during method execution. See the
+[extension model API reference](../swamp-extension-model/references/api.md#datahandle-structure)
+for the full structure.
+
+**`metadata` sub-fields:**
+
+| Field               | Type                      | Description                                              |
+| ------------------- | ------------------------- | -------------------------------------------------------- |
+| `contentType`       | `string`                  | MIME type (e.g. `"application/json"`)                    |
+| `lifetime`          | `Lifetime`                | TTL from the spec (e.g. `"7d"`, `"infinite"`)            |
+| `garbageCollection` | `GarbageCollectionPolicy` | Version retention count or duration                      |
+| `streaming`         | `boolean`                 | Whether the data was written as streaming                |
+| `tags`              | `Record<string, string>`  | Tags (e.g. `type`, `specName`, `modelName`)              |
+| `ownerDefinition`   | `OwnerDefinition`         | Owner type and ref (model-method, workflow-step, manual) |
+| `lifecycle`         | `"active" \| "deleted"`   | Current lifecycle state                                  |
+| `renamedTo`         | `string?`                 | New name if the data was renamed                         |
+
+## OutputSpecInfo
+
+Lightweight description of a data output spec, available on method and model
+scope contexts via `outputSpecs`:
+
+```typescript
+interface OutputSpecInfo {
+  specName: string;
+  kind: "resource" | "file";
+  description?: string;
+  schema?: object;
+  contentType?: string;
+}
+```
 
 ## Data Persistence
 

--- a/.claude/skills/swamp-report/references/testing.md
+++ b/.claude/skills/swamp-report/references/testing.md
@@ -91,6 +91,66 @@ Deno.test("report reads model data", async () => {
 });
 ```
 
+## Testing Reports That Read Data
+
+Reports that read execution data via `getContent` need pre-seeded data
+artifacts. Use the `dataArtifacts` option and provide `content` as raw bytes:
+
+```typescript
+Deno.test("report reads execution data via getContent", async () => {
+  const stateData = { status: "active", instanceId: "i-abc123" };
+  const content = new TextEncoder().encode(JSON.stringify(stateData));
+  const { context } = createReportTestContext({
+    scope: "method",
+    modelType: "aws/ec2",
+    modelId: "my-ec2",
+    methodName: "create",
+    executionStatus: "succeeded",
+    dataHandles: [{
+      name: "state-current",
+      specName: "state",
+      kind: "resource",
+      dataId: "d1",
+      version: 1,
+      size: content.length,
+      tags: { type: "resource", specName: "state" },
+      metadata: {
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 5,
+        streaming: false,
+        tags: { type: "resource", specName: "state" },
+        ownerDefinition: { type: "model-method", ref: "create" },
+      },
+    }],
+    dataArtifacts: [{
+      modelType: "aws/ec2",
+      modelId: "my-ec2",
+      data: {
+        name: "state-current",
+        kind: "resource",
+        dataId: "d1",
+        version: 1,
+        size: content.length,
+        contentType: "application/json",
+      },
+      content,
+    }],
+  });
+
+  // Read raw bytes and parse — same pattern as live reports
+  const raw = await context.dataRepository.getContent(
+    "aws/ec2",
+    "my-ec2",
+    "state-current",
+    1,
+  );
+  const parsed = JSON.parse(new TextDecoder().decode(raw!));
+  assertEquals(parsed.status, "active");
+  assertEquals(parsed.instanceId, "i-abc123");
+});
+```
+
 ## Mocking External Calls
 
 Reports that call external APIs (e.g., pricing APIs, cost calculators) can use


### PR DESCRIPTION
## Summary

- Add "Reading Execution Data" section to report skill SKILL.md with concrete `getContent()` → `JSON.parse` example
- Document `UnifiedDataRepository` methods, `DataHandle.metadata` sub-fields, and `OutputSpecInfo` type in report-types.md
- Sync stale context types with source: `MethodReportContext` (add `methodArgs`, `errorMessage`, `outputSpecs`), `WorkflowReportContext` stepExecutions (add `methodArgs`, `modelId`, `globalArgs`), `BaseReportContext` (add `swampSha`)
- Document `DataHandle.metadata` sub-fields in extension model api.md
- Add testing example for reports that read execution data via `getContent`
- Add trigger evals for data access queries

Closes #1080

## Test plan

- [x] `deno fmt` — clean
- [x] `deno lint` — clean
- [x] `deno run test src/infrastructure/assets/skill_assets_test.ts` — 29/29 pass
- [x] `deno run test packages/testing/report_test_context_test.ts` — 19/19 pass
- [x] `npx tessl skill review .claude/skills/swamp-report` — 94%
- [x] `npx tessl skill review .claude/skills/swamp-extension-model` — 93%

🤖 Generated with [Claude Code](https://claude.com/claude-code)