### PR TITLE
fix: resolve [object Object] in report data artifact names

### DIFF
--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -458,7 +458,7 @@ export class DefaultStepExecutor implements StepExecutor {
                   `Vary dimension '${key}' not found in step inputs for spec '${override.specName}'`,
                 );
               }
-              return String(val);
+              return coerceToSuffix(val);
             });
             resolvedVarySuffix = varyValues.join("-");
           }
@@ -636,14 +636,7 @@ export class DefaultStepExecutor implements StepExecutor {
         // Compute vary suffix from forEach variable
         let reportVarySuffix: string | undefined;
         if (ctx.forEachVariable?.value !== undefined) {
-          const val = ctx.forEachVariable.value;
-          if (typeof val === "object" && val !== null && "key" in val) {
-            reportVarySuffix = String(
-              (val as Record<string, unknown>).key,
-            );
-          } else {
-            reportVarySuffix = String(val);
-          }
+          reportVarySuffix = coerceToSuffix(ctx.forEachVariable.value);
         }
 
         const reportEventCallbacks: ReportEventCallback = {
@@ -1015,6 +1008,34 @@ export interface ResolvedStepName {
   name: string;
   /** Whether any expression evaluation failed during resolution. */
   hadEvalFailure: boolean;
+}
+
+/** Maximum length for a coerced suffix before truncation. */
+const MAX_SUFFIX_LENGTH = 64;
+
+/**
+ * Safely converts an unknown value to a string suitable for use as a data
+ * artifact name suffix. For objects, tries common identifier properties
+ * (`key`, `name`, `id`) before falling back to a truncated JSON representation.
+ */
+export function coerceToSuffix(val: unknown): string {
+  if (val === undefined || val === null) {
+    return "";
+  }
+  if (typeof val !== "object") {
+    return String(val);
+  }
+  const obj = val as Record<string, unknown>;
+  for (const prop of ["key", "name", "id"]) {
+    if (prop in obj && obj[prop] !== undefined && obj[prop] !== null) {
+      return String(obj[prop]);
+    }
+  }
+  const json = JSON.stringify(val);
+  if (json.length <= MAX_SUFFIX_LENGTH) {
+    return json;
+  }
+  return json.slice(0, MAX_SUFFIX_LENGTH);
 }
 
 /**

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -19,6 +19,7 @@
 
 import { assertEquals, assertNotEquals, assertRejects } from "@std/assert";
 import {
+  coerceToSuffix,
   DefaultStepExecutor,
   resolveForEachStepName,
   type StepExecutionContext,
@@ -2437,4 +2438,55 @@ Deno.test("resolveForEachStepName: mixed resolved and failed expressions appends
   );
   assertEquals(result.name, "resolved-${{ self.nonexistent.deep }}-0");
   assertEquals(result.hadEvalFailure, true);
+});
+
+// --- coerceToSuffix tests ---
+
+Deno.test("coerceToSuffix: returns string for primitive values", () => {
+  assertEquals(coerceToSuffix("hello"), "hello");
+  assertEquals(coerceToSuffix(42), "42");
+  assertEquals(coerceToSuffix(true), "true");
+});
+
+Deno.test("coerceToSuffix: returns empty string for null and undefined", () => {
+  assertEquals(coerceToSuffix(null), "");
+  assertEquals(coerceToSuffix(undefined), "");
+});
+
+Deno.test("coerceToSuffix: uses key property from object", () => {
+  assertEquals(coerceToSuffix({ key: "my-key", value: "stuff" }), "my-key");
+});
+
+Deno.test("coerceToSuffix: uses name property from object without key", () => {
+  assertEquals(coerceToSuffix({ name: "my-name", id: "123" }), "my-name");
+});
+
+Deno.test("coerceToSuffix: uses id property from object without key or name", () => {
+  assertEquals(coerceToSuffix({ id: "abc-123", other: "data" }), "abc-123");
+});
+
+Deno.test("coerceToSuffix: falls back to JSON.stringify for object without known properties", () => {
+  const val = { foo: "bar", baz: 1 };
+  assertEquals(coerceToSuffix(val), JSON.stringify(val));
+});
+
+Deno.test("coerceToSuffix: truncates long JSON.stringify output", () => {
+  const val = { data: "x".repeat(100) };
+  const result = coerceToSuffix(val);
+  assertEquals(result.length, 64);
+  assertEquals(result, JSON.stringify(val).slice(0, 64));
+});
+
+Deno.test("coerceToSuffix: prefers key over name and id", () => {
+  assertEquals(
+    coerceToSuffix({ key: "k", name: "n", id: "i" }),
+    "k",
+  );
+});
+
+Deno.test("coerceToSuffix: skips null/undefined properties", () => {
+  assertEquals(
+    coerceToSuffix({ key: null, name: undefined, id: "fallback-id" }),
+    "fallback-id",
+  );
 });


### PR DESCRIPTION
## Summary

- Extract a `coerceToSuffix` helper that safely converts unknown forEach values to string suffixes, trying `key` → `name` → `id` properties before falling back to truncated `JSON.stringify`
- Fix `reportVarySuffix` computation (line 636) and `resolvedVarySuffix` computation (line 451) to use the new helper instead of raw `String(val)`
- Add 9 unit tests covering all value shapes: primitives, null/undefined, objects with key/name/id, objects without known properties, long JSON truncation, property priority, and null property skipping

## Test Plan

- All 4130 existing tests pass
- 9 new `coerceToSuffix` unit tests added and passing
- Compiled binary and verified fix in scratch repo (`/tmp/swamp-verify-1084`): forEach over array of objects `[{"name": "foo"}, {"name": "bar"}]` now produces `report-swamp-method-summary-foo` and `report-swamp-method-summary-bar` instead of `report-swamp-method-summary-[object Object]`
- Confirmed zero occurrences of `[object Object]` in output data artifacts

Closes #1084