### PR TITLE
feat: multi-model skill trigger evaluation

### DIFF
--- a/.github/workflows/multi-model-eval.yml
+++ b/.github/workflows/multi-model-eval.yml
@@ -1,0 +1,57 @@
+name: Multi-Model Skill Trigger Eval
+
+on:
+  schedule:
+    # Run every Saturday at 08:00 UTC
+    - cron: "0 8 * * 6"
+  workflow_dispatch:
+    inputs:
+      models:
+        description: "Comma-separated model aliases to evaluate (or 'all')"
+        required: false
+        default: "all"
+
+jobs:
+  eval:
+    name: Eval (${{ matrix.model }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        model: [sonnet, opus, gpt-4.1, gemini-2.5-pro]
+    steps:
+      - name: Check if model is selected
+        id: check
+        run: |
+          MODELS="${{ github.event.inputs.models || 'all' }}"
+          if [ "$MODELS" = "all" ] || echo ",$MODELS," | grep -q ",${{ matrix.model }},"; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout code
+        if: steps.check.outputs.run == 'true'
+        uses: actions/checkout@v6
+
+      - name: Setup Deno
+        if: steps.check.outputs.run == 'true'
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Setup Node.js
+        if: steps.check.outputs.run == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Run skill trigger evals
+        if: steps.check.outputs.run == 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+        run: deno run eval-skill-triggers --model ${{ matrix.model }}

--- a/evals/promptfoo/generate_config.ts
+++ b/evals/promptfoo/generate_config.ts
@@ -22,11 +22,41 @@
  * files and SKILL.md frontmatter, using lightweight API calls (~193 calls)
  * instead of spawning Claude Code sessions.
  *
- * Usage: deno run --allow-read generate_config.ts > promptfooconfig.yaml
+ * Usage: deno run --allow-read generate_config.ts [--model <alias>]
+ *
+ * Supported model aliases: sonnet, opus, gpt-4.1, gemini-2.5-pro
+ * Default: sonnet
  */
 
+import { parseArgs } from "@std/cli/parse-args";
 import { join } from "@std/path";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+
+interface ProviderDefinition {
+  id: string;
+  apiKeyEnv: string;
+}
+
+const PROVIDER_REGISTRY: Record<string, ProviderDefinition> = {
+  "sonnet": {
+    id: "anthropic:messages:claude-sonnet-4-5",
+    apiKeyEnv: "ANTHROPIC_API_KEY",
+  },
+  "opus": {
+    id: "anthropic:messages:claude-opus-4-6",
+    apiKeyEnv: "ANTHROPIC_API_KEY",
+  },
+  "gpt-4.1": {
+    id: "openai:gpt-4.1",
+    apiKeyEnv: "OPENAI_API_KEY",
+  },
+  "gemini-2.5-pro": {
+    id: "google:gemini-2.5-pro",
+    apiKeyEnv: "GOOGLE_API_KEY",
+  },
+};
+
+const VALID_MODELS = Object.keys(PROVIDER_REGISTRY);
 
 const SKILLS_DIR = join(Deno.cwd(), ".claude", "skills");
 const SKILL_NAMES = [
@@ -98,6 +128,22 @@ interface PromptfooTest {
 }
 
 async function main(): Promise<void> {
+  const args = parseArgs(Deno.args, {
+    string: ["model"],
+    default: { model: "sonnet" },
+  });
+
+  const modelAlias = args.model;
+  if (!VALID_MODELS.includes(modelAlias)) {
+    console.error(
+      `Error: unknown model "${modelAlias}". Valid models: ${
+        VALID_MODELS.join(", ")
+      }`,
+    );
+    Deno.exit(1);
+  }
+
+  const provider = PROVIDER_REGISTRY[modelAlias];
   const tools: PromptfooTool[] = [];
   const tests: PromptfooTest[] = [];
 
@@ -190,17 +236,19 @@ async function main(): Promise<void> {
     }
   }
 
+  const systemMessage =
+    "You are a skill router for swamp, an AI-native automation framework. Your ONLY job is to route user requests to the correct skill by making a tool call. You MUST call exactly one tool for every request. NEVER respond with text. NEVER ask clarifying questions. Even if the request is vague or missing details, route it to the best-matching skill based on the topic and keywords. The skill itself will handle gathering any missing information from the user.";
+
   const config = {
-    description: "Swamp skill trigger routing evaluation",
+    description: `Swamp skill trigger routing evaluation (${modelAlias})`,
     prompts: ["{{query}}"],
     providers: [
       {
-        id: "anthropic:messages:claude-sonnet-4-5",
+        id: provider.id,
         config: {
           temperature: 0,
           max_tokens: 200,
-          systemMessage:
-            "You are a skill router for swamp, an AI-native automation framework. Your ONLY job is to route user requests to the correct skill by making a tool call. You MUST call exactly one tool for every request. NEVER respond with text. NEVER ask clarifying questions. Even if the request is vague or missing details, route it to the best-matching skill based on the topic and keywords. The skill itself will handle gathering any missing information from the user.",
+          systemMessage,
           tools,
         },
       },

--- a/evals/promptfoo/promptfooconfig.yaml
+++ b/evals/promptfoo/promptfooconfig.yaml
@@ -1,4 +1,4 @@
-description: Swamp skill trigger routing evaluation
+description: Swamp skill trigger routing evaluation (sonnet)
 prompts:
   - "{{query}}"
 providers:
@@ -60,11 +60,12 @@ providers:
           function:
             name: swamp-extension-model
             description: >-
-              Create user-defined TypeScript models for swamp — define Zod schemas, implement model interfaces, configure output specs — and publish extensions to the registry. Use when users want to
-              extend swamp with custom model types, create automation models, add new integrations, or publish any extension type (models, vaults, drivers, datastores). Triggers on "create model",
-              "new model type", "custom model", "extension model", "user model", "typescript model", "extend swamp", "build integration", "zod schema", "model plugin", "deno model",
-              "extensions/models", "model development", "implement model", "smoke test", "test extension", "verify model", "test against API", "before push test", "push extension", "publish
-              extension", "extension push", "release extension", "bump version", "publish to registry".
+              Create, test, and publish extension models for swamp — define Zod schemas, implement model interfaces, smoke test against live APIs, write manifest.yaml, and push extensions to the
+              registry. Use when creating models, writing manifest.yaml, publishing/pushing extensions, testing extensions, or preparing models for the registry. Covers all extension types (models,
+              vaults, drivers, datastores, reports). Triggers on "create model", "new model type", "custom model", "extension model", "user model", "typescript model", "extend swamp", "build
+              integration", "zod schema", "model plugin", "deno model", "extensions/models", "model development", "implement model", "smoke test", "test extension", "verify model", "test against API",
+              "before push test", "push extension", "publish extension", "extension push", "release extension", "bump version", "publish to registry", "test extension from another repo", "source
+              extension loading", "manifest", "manifest.yaml", "write manifest", "prepare for publishing".
             parameters:
               type: object
               properties:
@@ -124,10 +125,12 @@ providers:
           function:
             name: swamp-repo
             description: >-
-              Manage swamp repositories and datastores — initializing repos, upgrading swamp, syncing data, releasing stuck locks, and installing swamp in CI. Use when initializing repos, upgrading
-              swamp, starting the webapp, configuring datastores, or setting up swamp in CI/CD pipelines. Triggers on "repo", "repository", "init", "initialize", "swamp init", "setup swamp", "new
-              swamp project", "upgrade swamp", "webapp", "swamp webapp", "repository structure", ".swamp folder", "datastore", "datastore setup", "datastore status", "datastore sync", "datastore
-              lock", "s3 datastore", "filesystem datastore", "stuck lock", "lock release", "install swamp", "CI", "CI/CD", "GitHub Actions", "install in CI", "setup CI".
+              Manage swamp repositories, datastores, and extension sources — initializing repos, upgrading swamp, syncing data, releasing stuck locks, loading extensions from external paths, and
+              installing swamp in CI. Use when initializing repos, upgrading swamp, starting the webapp, configuring datastores, managing extension sources, or setting up swamp in CI/CD pipelines.
+              Triggers on "repo", "repository", "init", "initialize", "swamp init", "setup swamp", "new swamp project", "upgrade swamp", "webapp", "swamp webapp", "repository structure", ".swamp
+              folder", "datastore", "datastore setup", "datastore status", "datastore sync", "datastore lock", "s3 datastore", "filesystem datastore", "stuck lock", "lock release", "install swamp",
+              "CI", "CI/CD", "GitHub Actions", "install in CI", "setup CI", "extension source", "extension sources", ".swamp-sources.yaml", "load extensions from", "local extension source", "add
+              source", "source add", "source rm", "source list".
             parameters:
               type: object
               properties:
@@ -1073,6 +1076,104 @@ tests:
   - description: "[swamp-extension-model] SHOULD trigger: Help me create and test a CRUD extension model"
     vars:
       query: Help me create and test a CRUD extension model
+    assert:
+      - type: javascript
+        value: |-
+          const toolCalls = (context.prompt?.raw || '').includes('tool_use') ? [] : [];
+          try {
+            const calls = JSON.parse(output);
+            if (Array.isArray(calls)) {
+              return calls.some(c => c.function?.name === 'swamp-extension-model' || c.name === 'swamp-extension-model');
+            }
+          } catch {}
+          return String(output).includes('"swamp-extension-model"');
+  - description: "[swamp-extension-model] SHOULD trigger: Make a manifest.yaml so I can push my extension"
+    vars:
+      query: Make a manifest.yaml so I can push my extension
+    assert:
+      - type: javascript
+        value: |-
+          const toolCalls = (context.prompt?.raw || '').includes('tool_use') ? [] : [];
+          try {
+            const calls = JSON.parse(output);
+            if (Array.isArray(calls)) {
+              return calls.some(c => c.function?.name === 'swamp-extension-model' || c.name === 'swamp-extension-model');
+            }
+          } catch {}
+          return String(output).includes('"swamp-extension-model"');
+  - description: "[swamp-extension-model] SHOULD trigger: Publish my model to the registry"
+    vars:
+      query: Publish my model to the registry
+    assert:
+      - type: javascript
+        value: |-
+          const toolCalls = (context.prompt?.raw || '').includes('tool_use') ? [] : [];
+          try {
+            const calls = JSON.parse(output);
+            if (Array.isArray(calls)) {
+              return calls.some(c => c.function?.name === 'swamp-extension-model' || c.name === 'swamp-extension-model');
+            }
+          } catch {}
+          return String(output).includes('"swamp-extension-model"');
+  - description: "[swamp-extension-model] SHOULD trigger: Help me push this extension to swamp-club"
+    vars:
+      query: Help me push this extension to swamp-club
+    assert:
+      - type: javascript
+        value: |-
+          const toolCalls = (context.prompt?.raw || '').includes('tool_use') ? [] : [];
+          try {
+            const calls = JSON.parse(output);
+            if (Array.isArray(calls)) {
+              return calls.some(c => c.function?.name === 'swamp-extension-model' || c.name === 'swamp-extension-model');
+            }
+          } catch {}
+          return String(output).includes('"swamp-extension-model"');
+  - description: "[swamp-extension-model] SHOULD trigger: I need to write a manifest for my model"
+    vars:
+      query: I need to write a manifest for my model
+    assert:
+      - type: javascript
+        value: |-
+          const toolCalls = (context.prompt?.raw || '').includes('tool_use') ? [] : [];
+          try {
+            const calls = JSON.parse(output);
+            if (Array.isArray(calls)) {
+              return calls.some(c => c.function?.name === 'swamp-extension-model' || c.name === 'swamp-extension-model');
+            }
+          } catch {}
+          return String(output).includes('"swamp-extension-model"');
+  - description: "[swamp-extension-model] SHOULD trigger: Prepare my extension for publishing"
+    vars:
+      query: Prepare my extension for publishing
+    assert:
+      - type: javascript
+        value: |-
+          const toolCalls = (context.prompt?.raw || '').includes('tool_use') ? [] : [];
+          try {
+            const calls = JSON.parse(output);
+            if (Array.isArray(calls)) {
+              return calls.some(c => c.function?.name === 'swamp-extension-model' || c.name === 'swamp-extension-model');
+            }
+          } catch {}
+          return String(output).includes('"swamp-extension-model"');
+  - description: "[swamp-extension-model] SHOULD trigger: How do I swamp extension push my model?"
+    vars:
+      query: How do I swamp extension push my model?
+    assert:
+      - type: javascript
+        value: |-
+          const toolCalls = (context.prompt?.raw || '').includes('tool_use') ? [] : [];
+          try {
+            const calls = JSON.parse(output);
+            if (Array.isArray(calls)) {
+              return calls.some(c => c.function?.name === 'swamp-extension-model' || c.name === 'swamp-extension-model');
+            }
+          } catch {}
+          return String(output).includes('"swamp-extension-model"');
+  - description: "[swamp-extension-model] SHOULD trigger: I want to release a new version of my extension"
+    vars:
+      query: I want to release a new version of my extension
     assert:
       - type: javascript
         value: |-
@@ -2133,6 +2234,48 @@ tests:
             }
           } catch {}
           return !String(output).includes('"swamp-report"');
+  - description: "[swamp-report] SHOULD trigger: How do I read execution data in a report using dataHandles?"
+    vars:
+      query: How do I read execution data in a report using dataHandles?
+    assert:
+      - type: javascript
+        value: |-
+          const toolCalls = (context.prompt?.raw || '').includes('tool_use') ? [] : [];
+          try {
+            const calls = JSON.parse(output);
+            if (Array.isArray(calls)) {
+              return calls.some(c => c.function?.name === 'swamp-report' || c.name === 'swamp-report');
+            }
+          } catch {}
+          return String(output).includes('"swamp-report"');
+  - description: "[swamp-report] SHOULD trigger: Access dataRepository from report context to get model outpu"
+    vars:
+      query: Access dataRepository from report context to get model output
+    assert:
+      - type: javascript
+        value: |-
+          const toolCalls = (context.prompt?.raw || '').includes('tool_use') ? [] : [];
+          try {
+            const calls = JSON.parse(output);
+            if (Array.isArray(calls)) {
+              return calls.some(c => c.function?.name === 'swamp-report' || c.name === 'swamp-report');
+            }
+          } catch {}
+          return String(output).includes('"swamp-report"');
+  - description: "[swamp-report] SHOULD trigger: What methods does UnifiedDataRepository expose in reports?"
+    vars:
+      query: What methods does UnifiedDataRepository expose in reports?
+    assert:
+      - type: javascript
+        value: |-
+          const toolCalls = (context.prompt?.raw || '').includes('tool_use') ? [] : [];
+          try {
+            const calls = JSON.parse(output);
+            if (Array.isArray(calls)) {
+              return calls.some(c => c.function?.name === 'swamp-report' || c.name === 'swamp-report');
+            }
+          } catch {}
+          return String(output).includes('"swamp-report"');
   - description: "[swamp-troubleshooting] SHOULD trigger: Debug why my deploy-infra workflow is failing on the second "
     vars:
       query: Debug why my deploy-infra workflow is failing on the second step with error 'model not found'

--- a/scripts/eval_skill_triggers_promptfoo.ts
+++ b/scripts/eval_skill_triggers_promptfoo.ts
@@ -20,19 +20,32 @@
 /**
  * Runs skill trigger evaluations using promptfoo. This replaces the previous
  * approach that spawned hundreds of `claude -p` subprocesses with lightweight
- * Anthropic API calls via promptfoo's tool-call evaluation.
+ * API calls via promptfoo's tool-call evaluation.
  *
- * The promptfoo config at evals/promptfoo/promptfooconfig.yaml defines all
- * skill tools and test cases (generated from .claude/skills/<skill>/evals/trigger_evals.json).
+ * The promptfoo config is regenerated at eval time from
+ * .claude/skills/<skill>/evals/trigger_evals.json using evals/promptfoo/generate_config.ts.
  *
- * Usage: deno run eval-skill-triggers [--concurrency <n>] [--threshold <0.0-1.0>]
+ * Usage: deno run eval-skill-triggers [--model <alias>] [--concurrency <n>] [--threshold <0.0-1.0>]
+ *
+ * Supported models: sonnet (default), opus, gpt-4.1, gemini-2.5-pro
  *
  * Environment:
- *   ANTHROPIC_API_KEY - Required. Anthropic API key for running evals.
+ *   ANTHROPIC_API_KEY - Required for sonnet/opus models.
+ *   OPENAI_API_KEY    - Required for gpt-4.1 model.
+ *   GOOGLE_API_KEY    - Required for gemini-2.5-pro model.
  */
 
 import { parseArgs } from "@std/cli/parse-args";
 import { join } from "@std/path";
+
+const API_KEY_ENV: Record<string, string> = {
+  "sonnet": "ANTHROPIC_API_KEY",
+  "opus": "ANTHROPIC_API_KEY",
+  "gpt-4.1": "OPENAI_API_KEY",
+  "gemini-2.5-pro": "GOOGLE_API_KEY",
+};
+
+const VALID_MODELS = Object.keys(API_KEY_ENV);
 
 interface EvalStats {
   successes: number;
@@ -78,11 +91,53 @@ function findProjectRoot(): string {
   }
 }
 
+async function regenerateConfig(
+  projectRoot: string,
+  model: string,
+): Promise<void> {
+  const generatorPath = join(
+    projectRoot,
+    "evals",
+    "promptfoo",
+    "generate_config.ts",
+  );
+  const configPath = join(
+    projectRoot,
+    "evals",
+    "promptfoo",
+    "promptfooconfig.yaml",
+  );
+
+  const command = new Deno.Command("deno", {
+    args: ["run", "--allow-read", generatorPath, "--model", model],
+    cwd: projectRoot,
+    stdout: "piped",
+    stderr: "inherit",
+  });
+
+  const { code, stdout } = await command.output();
+  if (code !== 0) {
+    console.error(`Failed to regenerate promptfoo config for model ${model}`);
+    Deno.exit(1);
+  }
+
+  await Deno.writeFile(configPath, stdout);
+  console.log(`Regenerated promptfoo config for model: ${model}`);
+}
+
 async function main(): Promise<void> {
   const args = parseArgs(Deno.args, {
-    string: ["concurrency", "threshold"],
-    default: { concurrency: "20", threshold: "0.9" },
+    string: ["model", "concurrency", "threshold"],
+    default: { model: "sonnet", concurrency: "20", threshold: "0.9" },
   });
+
+  const model = args.model;
+  if (!VALID_MODELS.includes(model)) {
+    console.error(
+      `Error: unknown model "${model}". Valid models: ${VALID_MODELS.join(", ")}`,
+    );
+    Deno.exit(1);
+  }
 
   const concurrency = parseInt(args.concurrency);
   const passThreshold = parseFloat(args.threshold);
@@ -90,16 +145,30 @@ async function main(): Promise<void> {
   const configDir = join(projectRoot, "evals", "promptfoo");
   const resultsPath = join(configDir, "results.json");
 
-  if (!Deno.env.get("ANTHROPIC_API_KEY")) {
-    console.error(
-      "Error: ANTHROPIC_API_KEY environment variable is required.",
-    );
-    console.error("  export ANTHROPIC_API_KEY=sk-ant-...");
-    Deno.exit(1);
+  // Check for required API key — gracefully skip if missing
+  const requiredKeyEnv = API_KEY_ENV[model];
+  if (!Deno.env.get(requiredKeyEnv)) {
+    const message =
+      `Skipping ${model} eval: ${requiredKeyEnv} environment variable is not set.`;
+    console.warn(message);
+
+    // Write skip status to GitHub Actions summary
+    const summaryFile = Deno.env.get("GITHUB_STEP_SUMMARY");
+    if (summaryFile) {
+      let md = `## Skill Trigger Eval Results (${model})\n\n`;
+      md += `**Skipped** — \`${requiredKeyEnv}\` not configured.\n`;
+      await Deno.writeTextFile(summaryFile, md, { append: true });
+    }
+
+    // Exit 0 — missing key is not a failure
+    return;
   }
 
+  // Regenerate config for the selected model
+  await regenerateConfig(projectRoot, model);
+
   console.log(
-    `Running skill trigger evals (concurrency=${concurrency}, threshold=${passThreshold})…`,
+    `Running skill trigger evals for ${model} (concurrency=${concurrency}, threshold=${passThreshold})…`,
   );
 
   // Run promptfoo eval
@@ -141,7 +210,7 @@ async function main(): Promise<void> {
   );
 
   console.log(
-    `\nResults: ${stats.successes}/${total} passed (${(rate * 100).toFixed(1)}%)`,
+    `\nResults (${model}): ${stats.successes}/${total} passed (${(rate * 100).toFixed(1)}%)`,
   );
   console.log(
     `Tokens: ${stats.tokenUsage.total} (${stats.tokenUsage.prompt} prompt, ${stats.tokenUsage.completion} completion)`,
@@ -164,8 +233,9 @@ async function main(): Promise<void> {
   // Write GitHub Actions summary
   const summaryFile = Deno.env.get("GITHUB_STEP_SUMMARY");
   if (summaryFile) {
-    let md = "## Skill Trigger Eval Results\n\n";
+    let md = `## Skill Trigger Eval Results (${model})\n\n`;
     md += "| Metric | Value |\n|---|---|\n";
+    md += `| Model | ${model} |\n`;
     md += `| Total tests | ${total} |\n`;
     md += `| Passed | ${stats.successes} |\n`;
     md += `| Failed | ${stats.failures} |\n`;
@@ -192,12 +262,12 @@ async function main(): Promise<void> {
   // Check threshold
   if (rate < passThreshold) {
     console.error(
-      `\nFAIL: Pass rate ${(rate * 100).toFixed(1)}% is below ${(passThreshold * 100).toFixed(0)}% threshold`,
+      `\nFAIL (${model}): Pass rate ${(rate * 100).toFixed(1)}% is below ${(passThreshold * 100).toFixed(0)}% threshold`,
     );
     Deno.exit(1);
   }
 
-  console.log("\nAll skills passed trigger evals.");
+  console.log(`\nAll skills passed trigger evals for ${model}.`);
 }
 
 await main();


### PR DESCRIPTION
## Summary

- Add provider registry to `generate_config.ts` mapping model aliases (sonnet, opus, gpt-4.1, gemini-2.5-pro) to promptfoo provider IDs and API key env vars
- Add `--model` flag to both config generator and eval script for selecting which provider to evaluate
- Eval script regenerates promptfoo config at eval time, avoiding drift from checked-in YAML
- Gracefully skip evaluation when required API key is missing (warn + exit 0, not a failure)
- New `multi-model-eval.yml` workflow: runs Saturday 08:00 UTC on cron + manual `workflow_dispatch`, with a matrix strategy across all 4 models
- Per-model results reporting in console output and GitHub Actions step summary
- Existing Sonnet-only PR CI workflow remains unchanged

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno run test` — 4130 tests pass
- [x] `deno run compile` succeeds
- [x] Regenerated `promptfooconfig.yaml` with updated generator (default sonnet)
- [ ] Verify `workflow_dispatch` trigger works after `OPENAI_API_KEY` and `GOOGLE_API_KEY` secrets are configured

Closes #1054

🤖 Generated with [Claude Code](https://claude.com/claude-code)