### PR TITLE
fix: resolve all model types before single-model validation

### DIFF
--- a/src/libswamp/models/validate.ts
+++ b/src/libswamp/models/validate.ts
@@ -270,6 +270,13 @@ async function* validateSingle(
     return;
   }
 
+  // Ensure all model types in the repo are resolved so cross-type
+  // expression references can be validated (matches validateAll behavior)
+  const allDefinitions = await deps.findAllDefinitions();
+  for (const { type } of allDefinitions) {
+    await deps.resolveModelType(type);
+  }
+
   const outcome = await deps.validateModel(definition, modelDef, modelType);
   const validations = toValidationItemData(outcome.results);
   const warnings = toValidationWarningData(outcome.warnings);

--- a/src/libswamp/models/validate_test.ts
+++ b/src/libswamp/models/validate_test.ts
@@ -138,6 +138,47 @@ Deno.test("modelValidate all yields error when no models exist", async () => {
   assertEquals(events[1].kind, "error");
 });
 
+Deno.test("modelValidate single model resolves all model types for cross-type references", async () => {
+  const targetType = ModelType.create("@keeb/mms/dedup");
+  const otherType = ModelType.create("@keeb/mms/organizer");
+  const targetDef = Definition.create({
+    id: "00000000-0000-4000-8000-000000000001",
+    name: "dedup",
+    version: 1,
+  });
+  const otherDef = Definition.create({
+    id: "00000000-0000-4000-8000-000000000002",
+    name: "organizer",
+    version: 1,
+  });
+
+  const resolvedTypes: string[] = [];
+  const deps = makeDeps({
+    lookupDefinition: () =>
+      Promise.resolve({ definition: targetDef, type: targetType }),
+    findAllDefinitions: () =>
+      Promise.resolve([
+        { definition: targetDef, type: targetType },
+        { definition: otherDef, type: otherType },
+      ]),
+    resolveModelType: (type) => {
+      resolvedTypes.push(type.normalized);
+      return Promise.resolve({});
+    },
+  });
+
+  await collect<ModelValidateEvent>(
+    modelValidate(createLibSwampContext(), deps, {
+      modelIdOrName: "dedup",
+    }),
+  );
+
+  // The target type is resolved once for the target model, then all types
+  // (including the target again) are resolved to populate the registry
+  assertEquals(resolvedTypes.includes(targetType.normalized), true);
+  assertEquals(resolvedTypes.includes(otherType.normalized), true);
+});
+
 Deno.test("modelValidate single model propagates warnings", async () => {
   const deps = makeDeps({
     validateModel: () =>


### PR DESCRIPTION
## Summary

- `validateSingle()` only resolved the target model's extension type, so cross-model CEL references to a different extension type failed with "Unknown model type"
- `validateAll()` worked because it resolved every type as a side effect of iterating all definitions
- Fix: resolve all model types in the repo before running validation in `validateSingle()`, matching `validateAll()` behavior

Closes #1091

## Test Plan

- Added unit test verifying `validateSingle` resolves all model types (including cross-type) before validation
- All existing validate tests pass (7/7)
- Full type check passes
- Formatting and linting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)