### PR TITLE
fix: use correct swamp-club health endpoint path

### DIFF
--- a/extensions/models/_lib/swamp_club.ts
+++ b/extensions/models/_lib/swamp_club.ts
@@ -269,7 +269,7 @@ export async function createSwampClubClient(
 
   // Reachability check — verify the swamp-club URL is accessible before proceeding
   try {
-    const healthUrl = `${url}/api/v1/health`;
+    const healthUrl = `${url}/api/health`;
     const res = await fetch(healthUrl, {
       method: "GET",
       signal: AbortSignal.timeout(5_000),


### PR DESCRIPTION
## Summary

- The reachability check added in #1087 was hitting `/api/v1/health` which returns 404
- The correct endpoint is `/api/health` (returns 200)
- This caused `createSwampClubClient()` to return `null`, silently skipping all lifecycle posts to swamp.club

## Test plan

- [x] Verified `curl https://swamp.club/api/v1/health` → 404
- [x] Verified `curl https://swamp.club/api/health` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)