### PR TITLE
fix: workflow get/validate/evaluate/edit find extension workflows

### DIFF
--- a/src/cli/commands/workflow_edit.ts
+++ b/src/cli/commands/workflow_edit.ts
@@ -89,7 +89,7 @@ export const workflowEditCommand = new Command()
     }
 
     const stdinContent = await readStdin();
-    const deps = createWorkflowEditDeps(repoDir);
+    const deps = createWorkflowEditDeps(repoDir, repoContext.workflowRepo);
 
     const renderer = createWorkflowEditRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/cli/commands/workflow_evaluate.ts
+++ b/src/cli/commands/workflow_evaluate.ts
@@ -73,13 +73,18 @@ export const workflowEvaluateCommand = new Command()
 
       // If --all flag or no argument, evaluate all workflows (global lock)
       if (options.all || !workflowIdOrName) {
-        const { repoDir, datastoreResolver } = await requireInitializedRepo({
-          repoDir: options.repoDir ?? ".",
-          outputMode: cliCtx.outputMode,
-        });
+        const { repoDir, repoContext, datastoreResolver } =
+          await requireInitializedRepo({
+            repoDir: options.repoDir ?? ".",
+            outputMode: cliCtx.outputMode,
+          });
 
         const ctx = createLibSwampContext({ logger: cliCtx.logger });
-        const deps = createWorkflowEvaluateDeps(repoDir, datastoreResolver);
+        const deps = createWorkflowEvaluateDeps(
+          repoDir,
+          repoContext.workflowRepo,
+          datastoreResolver,
+        );
         const renderer = createWorkflowEvaluateRenderer(cliCtx.outputMode);
 
         await consumeStream(
@@ -184,7 +189,11 @@ export const workflowEvaluateCommand = new Command()
       }
 
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
-      const deps = createWorkflowEvaluateDeps(repoDir, datastoreResolver);
+      const deps = createWorkflowEvaluateDeps(
+        repoDir,
+        workflowRepo,
+        datastoreResolver,
+      );
       const renderer = createWorkflowEvaluateRenderer(cliCtx.outputMode);
 
       try {

--- a/src/cli/commands/workflow_get.ts
+++ b/src/cli/commands/workflow_get.ts
@@ -42,13 +42,13 @@ export const workflowGetCommand = new Command()
     const cliCtx = createContext(options as GlobalOptions, ["workflow", "get"]);
     cliCtx.logger.debug`Getting workflow: ${workflowIdOrName}`;
 
-    const { repoDir } = await requireInitializedRepoReadOnly({
+    const { repoContext } = await requireInitializedRepoReadOnly({
       repoDir: options.repoDir ?? ".",
       outputMode: cliCtx.outputMode,
     });
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createWorkflowGetDeps(repoDir);
+    const deps = createWorkflowGetDeps(repoContext.workflowRepo);
 
     const renderer = createWorkflowGetRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/cli/commands/workflow_validate.ts
+++ b/src/cli/commands/workflow_validate.ts
@@ -43,13 +43,13 @@ export const workflowValidateCommand = new Command()
       "workflow",
       "validate",
     ]);
-    const { repoDir } = await requireInitializedRepoReadOnly({
+    const { repoContext } = await requireInitializedRepoReadOnly({
       repoDir: options.repoDir ?? ".",
       outputMode: cliCtx.outputMode,
     });
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createWorkflowValidateDeps(repoDir);
+    const deps = createWorkflowValidateDeps(repoContext.workflowRepo);
 
     const renderer = createWorkflowValidateRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/libswamp/workflows/edit.ts
+++ b/src/libswamp/workflows/edit.ts
@@ -27,7 +27,7 @@ import {
   createWorkflowId,
   type WorkflowId,
 } from "../../domain/workflows/workflow_id.ts";
-import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
+import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 import { EditorService } from "../../infrastructure/editor/editor_service.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -81,13 +81,15 @@ export interface WorkflowEditDeps {
 }
 
 /** Wires real infrastructure into WorkflowEditDeps. */
-export function createWorkflowEditDeps(repoDir: string): WorkflowEditDeps {
-  const repo = new YamlWorkflowRepository(repoDir);
+export function createWorkflowEditDeps(
+  repoDir: string,
+  workflowRepo: WorkflowRepository,
+): WorkflowEditDeps {
   const editorService = new EditorService();
   return {
-    findById: (id) => repo.findById(id),
-    findByName: (name) => repo.findByName(name),
-    getPath: (id) => repo.getPath(id),
+    findById: (id) => workflowRepo.findById(id),
+    findByName: (name) => workflowRepo.findByName(name),
+    getPath: (id) => workflowRepo.getPath(id),
     resolveSymlink: async (name) => {
       const symlinkPath = join(repoDir, "workflows", name, "workflow.yaml");
       try {
@@ -113,7 +115,7 @@ export function createWorkflowEditDeps(repoDir: string): WorkflowEditDeps {
       const yamlData = parseYaml(content) as WorkflowData;
       yamlData.id = workflow.id;
       const updated = Workflow.fromData(yamlData);
-      await repo.save(updated);
+      await workflowRepo.save(updated);
       return updated;
     },
   };

--- a/src/libswamp/workflows/evaluate.ts
+++ b/src/libswamp/workflows/evaluate.ts
@@ -36,7 +36,7 @@ import { hasStepOutputDependency } from "../../domain/expressions/dependency_ext
 import type { ExpressionContext } from "../../domain/expressions/model_resolver.ts";
 import { ModelResolver } from "../../domain/expressions/model_resolver.ts";
 import { CelEvaluator } from "../../infrastructure/cel/cel_evaluator.ts";
-import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
+import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 import { YamlEvaluatedWorkflowRepository } from "../../infrastructure/persistence/yaml_evaluated_workflow_repository.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
@@ -99,11 +99,11 @@ export interface WorkflowEvaluateDeps {
 /** Wires real infrastructure into WorkflowEvaluateDeps. */
 export function createWorkflowEvaluateDeps(
   repoDir: string,
+  workflowRepo: WorkflowRepository,
   datastoreResolver?: DatastorePathResolver,
 ): WorkflowEvaluateDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
-  const workflowRepo = new YamlWorkflowRepository(repoDir);
   const definitionRepo = new YamlDefinitionRepository(repoDir);
   const dataRepo = new FileSystemUnifiedDataRepository(
     repoDir,

--- a/src/libswamp/workflows/get.ts
+++ b/src/libswamp/workflows/get.ts
@@ -22,7 +22,7 @@ import {
   createWorkflowId,
   type WorkflowId,
 } from "../../domain/workflows/workflow_id.ts";
-import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
+import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound } from "../errors.ts";
@@ -69,8 +69,9 @@ const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 /** Wires real infrastructure into WorkflowGetDeps. */
-export function createWorkflowGetDeps(repoDir: string): WorkflowGetDeps {
-  const workflowRepo = new YamlWorkflowRepository(repoDir);
+export function createWorkflowGetDeps(
+  workflowRepo: WorkflowRepository,
+): WorkflowGetDeps {
   return {
     findWorkflow: async (idOrName) => {
       if (isUuid(idOrName)) {

--- a/src/libswamp/workflows/validate.ts
+++ b/src/libswamp/workflows/validate.ts
@@ -22,7 +22,7 @@ import type { WorkflowValidationResult } from "../../domain/workflows/validation
 import {
   DefaultWorkflowValidationService,
 } from "../../domain/workflows/validation_service.ts";
-import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
+import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
@@ -82,14 +82,13 @@ export interface WorkflowValidateDeps {
 
 /** Wires real infrastructure into WorkflowValidateDeps. */
 export function createWorkflowValidateDeps(
-  repoDir: string,
+  workflowRepo: WorkflowRepository,
 ): WorkflowValidateDeps {
-  const repo = new YamlWorkflowRepository(repoDir);
   const validationService = new DefaultWorkflowValidationService();
   return {
-    findWorkflowById: (id) => repo.findById(createWorkflowId(id)),
-    findWorkflowByName: (name) => repo.findByName(name),
-    findAllWorkflows: () => repo.findAll(),
+    findWorkflowById: (id) => workflowRepo.findById(createWorkflowId(id)),
+    findWorkflowByName: (name) => workflowRepo.findByName(name),
+    findAllWorkflows: () => workflowRepo.findAll(),
     validate: (workflow) => validationService.validate(workflow),
   };
 }


### PR DESCRIPTION
## Summary

- The `createWorkflow*Deps` factory functions in `src/libswamp/workflows/` hardcoded `YamlWorkflowRepository`, which only searches local YAML workflows. Extension workflows pulled via `swamp extension pull` were invisible to `workflow get`, `validate`, `evaluate`, and `edit` — even though `workflow search` and `workflow run` found them correctly.
- Changed each factory to accept a `WorkflowRepository` parameter (the `CompositeWorkflowRepository` from `repoContext`) instead of instantiating `YamlWorkflowRepository` directly. Updated the four CLI commands to pass `repoContext.workflowRepo`.

Closes #1095

## Test Plan

- [x] All 4131 existing tests pass
- [x] `deno check`, `deno lint`, `deno fmt` pass
- [x] Verified with compiled binary: `swamp extension pull @webframp/aws-ops` then `swamp workflow get @webframp/investigate-outage` and `swamp workflow validate @webframp/investigate-outage` both succeed (previously returned "Workflow not found")
- [x] Filed UAT coverage gap: systeminit/swamp-uat#120

🤖 Generated with [Claude Code](https://claude.com/claude-code)