### PR TITLE
feat: add post-execution data inspection guidance to skills

### DIFF
--- a/.claude/skills/swamp-data-query/SKILL.md
+++ b/.claude/skills/swamp-data-query/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swamp-data-query
-description: Query swamp data artifacts using CEL predicates — find, filter, and extract data across all models. Use when searching for data by field values, filtering by attributes or tags, extracting specific fields from data records, or answering questions about what data exists. Triggers on "data query", "query data", "find data", "search data where", "filter data", "which data has", "data with", "select from data", "data.query", "context.queryData", "CEL predicate", "data predicate".
+description: Query swamp data artifacts using CEL predicates — find, filter, and extract data across all models. Use when searching for data by field values, filtering by attributes or tags, extracting specific fields from data records, answering questions about what data exists, or exploring results after running a model method. Triggers on "data query", "query data", "find data", "search data where", "filter data", "which data has", "data with", "select from data", "data.query", "context.queryData", "CEL predicate", "data predicate", "inspect results", "method output", "factory results", "browse artifacts", "what did method produce".
 ---
 
 # Swamp Data Query

--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -407,6 +407,11 @@ swamp model method run my-deploy create --skip-check valid-region
 swamp model method run my-deploy create --skip-check-label live
 ```
 
+**Data versioning:** Running a method multiple times creates new data versions
+(v1, v2, ...), never overwrites. Each run's artifacts are preserved. Use
+`swamp data get <name> <spec> --version <N>` to access a specific version, or
+see the **swamp-data** skill for version history and cleanup.
+
 Pre-flight checks run automatically before mutating methods (`create`, `update`,
 `delete`, `action`). Read-only methods (`sync`, `get`, etc.) do not trigger
 checks.
@@ -451,6 +456,24 @@ Use `swamp model output search`, `output get`, `output logs`, and `output data`
 to inspect method execution results. See
 [references/outputs.md](references/outputs.md) for commands and output shapes.
 
+### Inspecting Factory Method Results
+
+When a factory method produces multiple data artifacts, use `swamp data query`
+(from the **swamp-data-query** skill) to explore them:
+
+```bash
+# List all artifacts from a model
+swamp data query 'modelName == "my-scanner"' --select '{"name": name, "version": version}'
+
+# Filter by spec name and extract fields
+swamp data query 'modelName == "my-scanner" && specName == "result"' \
+    --select '{"host": attributes.hostname, "status": attributes.status}'
+```
+
+For single-output inspection, `swamp model output get <name> --json` is
+sufficient. For browsing N artifacts, `data query` with `--select` is the
+primary pattern.
+
 ## Workflow Example
 
 1. **Search** for the right type: `swamp model type search "shell" --json`
@@ -492,6 +515,7 @@ validation.
 | Manage secrets                  | `swamp-vault`           |
 | Repository structure            | `swamp-repo`            |
 | Manage data lifecycle           | `swamp-data`            |
+| Explore/query method results    | `swamp-data-query`      |
 | Create custom TypeScript models | `swamp-extension-model` |
 | Create reports for models       | `swamp-report`          |
 | Understand swamp internals      | `swamp-troubleshooting` |


### PR DESCRIPTION
## Summary

Closes #1093

- Add "Inspecting Factory Method Results" subsection to swamp-model skill showing `data query` as the primary pattern for exploring N artifacts from factory methods
- Add data versioning note near "Run Methods" explaining re-runs create new versions, never overwrite
- Add `swamp-data-query` to the "When to Use Other Skills" table in swamp-model skill
- Broaden swamp-data-query trigger keywords to include post-execution discovery terms ("inspect results", "method output", "factory results", "browse artifacts", "what did method produce")

## Test Plan

- [x] `deno fmt --check` passes on both modified files
- [x] Verified `data query` syntax examples match swamp-data-query skill documentation
- [x] Confirmed new trigger keywords don't overlap with swamp-data or swamp-model triggers
- Documentation-only change — no runtime code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)