### PR TITLE
fix: detect transitive dep changes and surface rebundle errors in bundle cache

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -515,9 +515,10 @@ the model registry is wired up initially.
 1. On first `ensureLoaded()` call, the model registry's loader runs
    `buildIndex()` which:
    - Checks the catalog's `populated` flag
-   - If populated: scans source directories, compares mtimes against catalog
-     entries, rebundles only changed files, then registers lazy entries for all
-     types from the catalog (no bundle imports)
+   - If populated: scans source directories, compares entry-point mtimes
+     against catalog entries and checks transitive dependency mtimes against
+     cached bundle files, rebundles only changed files, then registers lazy
+     entries for all types from the catalog (no bundle imports)
    - If not populated (first run or DB deleted): falls back to the existing
      full-import path, then populates the catalog from the loaded registry
 

--- a/src/domain/datastore/user_datastore_loader.ts
+++ b/src/domain/datastore/user_datastore_loader.ts
@@ -24,6 +24,7 @@ import {
   bundleExtension,
   fixCjsEsmInterop,
   installZodGlobal,
+  isExpectedBundleFailure,
   rewriteZodImports,
   sanitizeDataUrlError,
   uint8ArrayToBase64,
@@ -275,14 +276,25 @@ export class UserDatastoreLoader {
             const msg = bundleError instanceof Error
               ? bundleError.message
               : String(bundleError);
-            logger
-              .debug`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
-            // Touch the cache mtime so subsequent loads see it as fresh,
-            // avoiding repeated failed rebundle attempts on every cold start.
-            try {
-              const now = new Date();
-              await Deno.utime(bundlePath, now, now);
-            } catch { /* ignore — worst case we retry next load */ }
+            const expected = isExpectedBundleFailure(
+              absolutePath,
+              this.repoDir ?? undefined,
+            );
+            if (expected) {
+              logger
+                .debug`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
+              // Touch the cache mtime so subsequent loads see it as fresh,
+              // avoiding repeated failed rebundle attempts on every cold
+              // start. Only for expected failures (pulled extensions without
+              // project config) where retrying would always fail.
+              try {
+                const now = new Date();
+                await Deno.utime(bundlePath, now, now);
+              } catch { /* ignore — worst case we retry next load */ }
+            } else {
+              logger
+                .warn`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
+            }
             return cached;
           } catch {
             // Cache file was removed between stat and read — treat as no cache.

--- a/src/domain/drivers/user_driver_loader.ts
+++ b/src/domain/drivers/user_driver_loader.ts
@@ -24,6 +24,7 @@ import {
   bundleExtension,
   fixCjsEsmInterop,
   installZodGlobal,
+  isExpectedBundleFailure,
   rewriteZodImports,
   sanitizeDataUrlError,
   uint8ArrayToBase64,
@@ -274,14 +275,25 @@ export class UserDriverLoader {
             const msg = bundleError instanceof Error
               ? bundleError.message
               : String(bundleError);
-            logger
-              .debug`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
-            // Touch the cache mtime so subsequent loads see it as fresh,
-            // avoiding repeated failed rebundle attempts on every cold start.
-            try {
-              const now = new Date();
-              await Deno.utime(bundlePath, now, now);
-            } catch { /* ignore — worst case we retry next load */ }
+            const expected = isExpectedBundleFailure(
+              absolutePath,
+              this.repoDir ?? undefined,
+            );
+            if (expected) {
+              logger
+                .debug`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
+              // Touch the cache mtime so subsequent loads see it as fresh,
+              // avoiding repeated failed rebundle attempts on every cold
+              // start. Only for expected failures (pulled extensions without
+              // project config) where retrying would always fail.
+              try {
+                const now = new Date();
+                await Deno.utime(bundlePath, now, now);
+              } catch { /* ignore — worst case we retry next load */ }
+            } else {
+              logger
+                .warn`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
+            }
             return cached;
           } catch {
             // Cache file was removed between stat and read — treat as no cache.

--- a/src/domain/models/bundle.ts
+++ b/src/domain/models/bundle.ts
@@ -19,7 +19,7 @@
 
 import { getLogger } from "@logtape/logtape";
 import { stripAnsiCode } from "@std/fmt/colors";
-import { join } from "@std/path";
+import { dirname, join, resolve } from "@std/path";
 import * as zodModule from "zod";
 
 const logger = getLogger(["swamp", "models", "bundle"]);
@@ -193,6 +193,52 @@ export function sourceHasBareSpecifiers(source: string): boolean {
     return true;
   }
   return false;
+}
+
+/**
+ * Determines whether a bundle failure is "expected" — i.e. a pulled extension
+ * whose source contains bare specifiers but has no project config (deno.json /
+ * deno.jsonc) to resolve them. In this case the failure is a known limitation,
+ * not a user error, and the cached bundle should be used silently.
+ *
+ * Returns false (unexpected failure) when:
+ * - A deno.json is available (bundling should have succeeded)
+ * - The source has no bare specifiers (failure is not config-related)
+ *
+ * @param absolutePath - Absolute path to the source .ts file
+ * @param repoDir - Repository root, used as the upward-search boundary
+ */
+export function isExpectedBundleFailure(
+  absolutePath: string,
+  repoDir?: string,
+): boolean {
+  // Walk up from the source file looking for deno.json / deno.jsonc.
+  // If found, the project config should have resolved specifiers — failure
+  // is unexpected.
+  let dir = dirname(absolutePath);
+  const root = resolve("/");
+  while (dir !== root) {
+    if (repoDir && resolve(dir) === resolve(repoDir)) break;
+    for (const name of ["deno.json", "deno.jsonc"]) {
+      try {
+        Deno.statSync(join(dir, name));
+        return false; // Config found — failure is unexpected
+      } catch {
+        // Not found — keep walking
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  // No config found — check if source actually needs one.
+  try {
+    const source = Deno.readTextFileSync(absolutePath);
+    return sourceHasBareSpecifiers(source);
+  } catch {
+    return false; // Can't read source — treat as unexpected
+  }
 }
 
 /**

--- a/src/domain/models/bundle_test.ts
+++ b/src/domain/models/bundle_test.ts
@@ -24,6 +24,7 @@ import {
   bundleExtension,
   fixCjsEsmInterop,
   installZodGlobal,
+  isExpectedBundleFailure,
   rewriteZodImports,
   sanitizeDataUrlError,
   sourceHasBareSpecifiers,
@@ -461,4 +462,53 @@ export type Status = "running" | "stopped";
     // Should return a minimal module instead of throwing
     assertEquals(js, "export {};\n");
   });
+});
+
+// --- isExpectedBundleFailure unit tests ---
+
+Deno.test("isExpectedBundleFailure: returns true for bare specifiers without deno.json", async () => {
+  const repoDir = await Deno.makeTempDir({ prefix: "swamp_expected_test_" });
+  const extDir = repoDir + "/extensions/models/myext";
+  await Deno.mkdir(extDir, { recursive: true });
+  try {
+    const source = `import { z } from "zod";\nexport const x = z;`;
+    const filePath = extDir + "/model.ts";
+    await Deno.writeTextFile(filePath, source);
+    // No deno.json anywhere — bare specifier + no config = expected failure
+    assertEquals(isExpectedBundleFailure(filePath, repoDir), true);
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+  }
+});
+
+Deno.test("isExpectedBundleFailure: returns false when deno.json exists", async () => {
+  const repoDir = await Deno.makeTempDir({ prefix: "swamp_expected_test_" });
+  // Simulate realistic layout: source in a subdirectory, deno.json alongside it
+  const extDir = repoDir + "/extensions/models/myext";
+  await Deno.mkdir(extDir, { recursive: true });
+  try {
+    const source = `import { z } from "zod";\nexport const x = z;`;
+    const filePath = extDir + "/model.ts";
+    await Deno.writeTextFile(filePath, source);
+    await Deno.writeTextFile(extDir + "/deno.json", "{}");
+    // deno.json exists — failure is unexpected even with bare specifiers
+    assertEquals(isExpectedBundleFailure(filePath, repoDir), false);
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+  }
+});
+
+Deno.test("isExpectedBundleFailure: returns false for npm-only imports without deno.json", async () => {
+  const repoDir = await Deno.makeTempDir({ prefix: "swamp_expected_test_" });
+  const extDir = repoDir + "/extensions/models/myext";
+  await Deno.mkdir(extDir, { recursive: true });
+  try {
+    const source = `import { z } from "npm:zod@4";\nexport const x = z;`;
+    const filePath = extDir + "/model.ts";
+    await Deno.writeTextFile(filePath, source);
+    // No bare specifiers — failure is unexpected regardless of deno.json
+    assertEquals(isExpectedBundleFailure(filePath, repoDir), false);
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+  }
 });

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -24,6 +24,7 @@ import {
   bundleExtension,
   fixCjsEsmInterop,
   installZodGlobal,
+  isExpectedBundleFailure,
   rewriteZodImports,
   sanitizeDataUrlError,
   uint8ArrayToBase64,
@@ -877,12 +878,49 @@ export class UserModelLoader {
           continue;
         }
 
-        // Check mtime
+        // Check entry point mtime
         try {
           const stat = await Deno.stat(absolutePath);
           const sourceMtime = stat.mtime?.toISOString() ?? "";
           if (sourceMtime !== catalogEntry.source_mtime) {
             stale.push({ absolutePath, relativePath, baseDir: dir });
+            continue;
+          }
+
+          // Entry point is fresh — check transitive dependencies against
+          // the cached bundle file's mtime. This catches edits to imported
+          // .ts files that don't touch the entry point.
+          const bundlePath = this.getBundlePath(relativePath, dir);
+          if (bundlePath) {
+            try {
+              const bundleStat = await Deno.stat(bundlePath);
+              if (bundleStat.mtime) {
+                const { resolvedFiles } = await resolveLocalImports(
+                  [absolutePath],
+                  dir,
+                );
+                const depStats = await Promise.all(
+                  resolvedFiles.map((f) => Deno.stat(f)),
+                );
+                const newestDepMtime = depStats.reduce<Date | null>(
+                  (max, s) => {
+                    if (!s.mtime) return max;
+                    if (!max) return s.mtime;
+                    return s.mtime > max ? s.mtime : max;
+                  },
+                  null,
+                );
+                if (
+                  newestDepMtime && newestDepMtime >= bundleStat.mtime
+                ) {
+                  stale.push({ absolutePath, relativePath, baseDir: dir });
+                }
+              }
+            } catch {
+              // Bundle file missing or dep stat failed — mark as stale
+              // to trigger a rebundle.
+              stale.push({ absolutePath, relativePath, baseDir: dir });
+            }
           }
         } catch {
           stale.push({ absolutePath, relativePath, baseDir: dir });
@@ -1110,14 +1148,27 @@ export class UserModelLoader {
             const msg = bundleError instanceof Error
               ? bundleError.message
               : String(bundleError);
-            logger
-              .debug`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
-            // Touch the cache mtime so subsequent loads see it as fresh,
-            // avoiding repeated failed rebundle attempts on every cold start.
-            try {
-              const now = new Date();
-              await Deno.utime(bundlePath, now, now);
-            } catch { /* ignore — worst case we retry next load */ }
+            const expected = isExpectedBundleFailure(
+              absolutePath,
+              this.repoDir,
+            );
+            if (expected) {
+              logger
+                .debug`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
+              // Touch the cache mtime so subsequent loads see it as fresh,
+              // avoiding repeated failed rebundle attempts on every cold
+              // start. Only for expected failures (pulled extensions without
+              // project config) where retrying would always fail.
+              try {
+                const now = new Date();
+                await Deno.utime(bundlePath, now, now);
+              } catch { /* ignore — worst case we retry next load */ }
+            } else {
+              logger
+                .warn`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
+              // Do NOT touch the cache mtime — the next run should retry
+              // bundling so the user sees the error again until fixed.
+            }
             return cached;
           } catch {
             // Cache file was removed between stat and read — treat as no cache.

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -17,11 +17,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  assertEquals,
+  assertNotEquals,
+  assertStringIncludes,
+} from "@std/assert";
 import { dirname, join } from "@std/path";
 import { UserModelLoader } from "./user_model_loader.ts";
 import { modelRegistry } from "./model.ts";
 import { bundleNamespace } from "../../infrastructure/persistence/paths.ts";
+import { ExtensionCatalogStore } from "../../infrastructure/persistence/extension_catalog_store.ts";
 import type { DataHandle, DataWriter, MethodContext } from "./model.ts";
 import type { ModelType } from "./model_type.ts";
 import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
@@ -2372,4 +2377,164 @@ export function helper() { return "helper"; }
       }
     },
   );
+});
+
+Deno.test("UserModelLoader buildIndex detects transitive dependency changes", async () => {
+  const ts = Date.now();
+  const helperCode = `export const greeting = "hello";`;
+  const modelCode = `
+import { z } from "npm:zod@4";
+import { greeting } from "./helper.ts";
+
+export const model = {
+  type: "@user/dep-stale-${ts}",
+  version: "2026.02.09.1",
+  methods: {
+    run: {
+      description: "Run",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [], greeting }),
+    },
+  },
+};
+`;
+
+  const repoDir = await Deno.makeTempDir({ prefix: "swamp_stale_dep_repo_" });
+  const modelsDir = await Deno.makeTempDir({
+    prefix: "swamp_stale_dep_models_",
+  });
+  const dbPath = join(repoDir, ".swamp", "_extension_catalog.db");
+
+  try {
+    // Write initial files
+    await Deno.writeTextFile(join(modelsDir, "helper.ts"), helperCode);
+    await Deno.writeTextFile(join(modelsDir, "model.ts"), modelCode);
+
+    // First buildIndex — bootstraps the catalog from a full import
+    const catalog1 = new ExtensionCatalogStore(dbPath);
+    const loader1 = new UserModelLoader(testDenoRuntime, repoDir);
+    await loader1.buildIndex(modelsDir, catalog1);
+    catalog1.close();
+
+    // Read the cached bundle content
+    const ns = bundleNamespace(modelsDir, repoDir);
+    const bundlePath = join(repoDir, ".swamp", "bundles", ns, "model.js");
+    const cachedBundle1 = await Deno.readTextFile(bundlePath);
+
+    // Wait so mtime differs
+    await new Promise((r) => setTimeout(r, 1100));
+
+    // Modify only the dependency (not the entry point)
+    await Deno.writeTextFile(
+      join(modelsDir, "helper.ts"),
+      `export const greeting = "goodbye";`,
+    );
+
+    // Second buildIndex — catalog is populated, should detect dep change
+    const catalog2 = new ExtensionCatalogStore(dbPath);
+    const loader2 = new UserModelLoader(testDenoRuntime, repoDir);
+    const result = await loader2.buildIndex(modelsDir, catalog2);
+    catalog2.close();
+
+    // The bundle should have been regenerated with the new dependency content
+    const cachedBundle2 = await Deno.readTextFile(bundlePath);
+    assertNotEquals(
+      cachedBundle1,
+      cachedBundle2,
+      "Bundle should be regenerated when transitive dependency changes",
+    );
+    // model.ts should appear in the loaded list (it was rebundled)
+    assertEquals(result.loaded.length > 0, true);
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+    await Deno.remove(modelsDir, { recursive: true });
+  }
+});
+
+Deno.test("UserModelLoader bundleWithCache preserves cached bundle on unexpected failure", async () => {
+  const ts = Date.now();
+  // Model that imports a nonexistent npm package — will fail to bundle.
+  // Uses npm: prefix (not a bare specifier) so isExpectedBundleFailure
+  // returns false — this is an "unexpected" failure path.
+  const brokenModelCode = `
+import { z } from "npm:zod@4";
+import { something } from "npm:nonexistent-package-xyz-swamp-test-${ts}@999";
+
+export const model = {
+  type: "@user/broken-${ts}",
+  version: "2026.02.09.1",
+  methods: {
+    run: {
+      description: "Run",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+  // A valid model to produce the initial cached bundle
+  const validModelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "@user/broken-${ts}",
+  version: "2026.02.09.1",
+  methods: {
+    run: {
+      description: "Run",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+  const repoDir = await Deno.makeTempDir({
+    prefix: "swamp_mtime_test_repo_",
+  });
+  const modelsDir = await Deno.makeTempDir({
+    prefix: "swamp_mtime_test_models_",
+  });
+
+  try {
+    // Write valid model, load to produce cached bundle
+    await Deno.writeTextFile(join(modelsDir, "model.ts"), validModelCode);
+    const loader1 = new UserModelLoader(testDenoRuntime, repoDir);
+    await loader1.loadModels(modelsDir);
+
+    const ns = bundleNamespace(modelsDir, repoDir);
+    const bundlePath = join(repoDir, ".swamp", "bundles", ns, "model.js");
+    const cachedBundle1 = await Deno.readTextFile(bundlePath);
+
+    // Wait so mtime differs
+    await new Promise((r) => setTimeout(r, 1100));
+
+    // Replace with broken model (no bare specifiers, no deno.json →
+    // unexpected failure)
+    await Deno.writeTextFile(join(modelsDir, "model.ts"), brokenModelCode);
+
+    // Load again — should fall back to cached bundle.
+    // The broken code should NOT appear in the bundle.
+    const loader2 = new UserModelLoader(testDenoRuntime, repoDir);
+    await loader2.loadModels(modelsDir);
+
+    const cachedBundle2 = await Deno.readTextFile(bundlePath);
+
+    // The bundle content should be preserved (old valid bundle, not broken)
+    assertEquals(
+      cachedBundle1,
+      cachedBundle2,
+      "Bundle content should be preserved on unexpected failure",
+    );
+    // Verify the bundle doesn't contain the broken import
+    assertEquals(
+      cachedBundle2.includes("nonexistent-package"),
+      false,
+      "Bundle should not contain broken import from failed rebundle",
+    );
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+    await Deno.remove(modelsDir, { recursive: true });
+  }
 });

--- a/src/domain/vaults/user_vault_loader.ts
+++ b/src/domain/vaults/user_vault_loader.ts
@@ -24,6 +24,7 @@ import {
   bundleExtension,
   fixCjsEsmInterop,
   installZodGlobal,
+  isExpectedBundleFailure,
   rewriteZodImports,
   sanitizeDataUrlError,
   uint8ArrayToBase64,
@@ -275,14 +276,25 @@ export class UserVaultLoader {
             const msg = bundleError instanceof Error
               ? bundleError.message
               : String(bundleError);
-            logger
-              .debug`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
-            // Touch the cache mtime so subsequent loads see it as fresh,
-            // avoiding repeated failed rebundle attempts on every cold start.
-            try {
-              const now = new Date();
-              await Deno.utime(bundlePath, now, now);
-            } catch { /* ignore — worst case we retry next load */ }
+            const expected = isExpectedBundleFailure(
+              absolutePath,
+              this.repoDir ?? undefined,
+            );
+            if (expected) {
+              logger
+                .debug`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
+              // Touch the cache mtime so subsequent loads see it as fresh,
+              // avoiding repeated failed rebundle attempts on every cold
+              // start. Only for expected failures (pulled extensions without
+              // project config) where retrying would always fail.
+              try {
+                const now = new Date();
+                await Deno.utime(bundlePath, now, now);
+              } catch { /* ignore — worst case we retry next load */ }
+            } else {
+              logger
+                .warn`Rebundle failed for ${relativePath}, using cached bundle: ${msg}`;
+            }
             return cached;
           } catch {
             // Cache file was removed between stat and read — treat as no cache.


### PR DESCRIPTION
## Summary

- **findStaleFiles() now checks transitive dependency mtimes** — when an entry point appears fresh in the catalog, resolves its local imports via `resolveLocalImports()` and compares their mtimes against the cached bundle file. This catches edits to imported `.ts` files that don't touch the entry point itself.
- **bundleWithCache() surfaces real errors instead of silently falling back** — distinguishes expected failures (pulled extensions without project config + bare specifiers) from unexpected failures (user extensions with real errors). Unexpected failures log at warn level and don't touch the bundle mtime, so subsequent runs retry bundling.
- **Adds `isExpectedBundleFailure()` shared helper** in `bundle.ts` to avoid duplicating the deno.json discovery + bare-specifier check across all 4 extension loaders (models, drivers, vaults, datastores).
- **Updates design/extension.md** to document the transitive dependency checking in `buildIndex()`.

Closes #1094

## Test Plan

- Added unit test: `buildIndex detects transitive dependency changes` — verifies the catalog path correctly triggers rebundling when only an imported file changes
- Added unit test: `bundleWithCache preserves cached bundle on unexpected failure` — verifies fallback returns old valid bundle content without contamination from broken source
- Added unit tests for `isExpectedBundleFailure()` — covers bare specifiers without config (expected), deno.json present (unexpected), npm-only imports (unexpected)
- Verified fix against compiled binary in scratch repo: transitive dep changes detected and rebundled; rebundle failures surfaced at warn level with mtime preserved
- All 4136 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)