### PR TITLE
fix: calculate eval cost from token usage

### DIFF
--- a/scripts/eval_skill_triggers_promptfoo.ts
+++ b/scripts/eval_skill_triggers_promptfoo.ts
@@ -45,6 +45,14 @@ const API_KEY_ENV: Record<string, string> = {
   "gemini-2.5-pro": "GOOGLE_API_KEY",
 };
 
+// Per-million-token pricing for cost estimation
+const TOKEN_PRICING: Record<string, { prompt: number; completion: number }> = {
+  "sonnet": { prompt: 3.0, completion: 15.0 },
+  "opus": { prompt: 15.0, completion: 75.0 },
+  "gpt-4.1": { prompt: 2.0, completion: 8.0 },
+  "gemini-2.5-pro": { prompt: 1.25, completion: 10.0 },
+};
+
 const VALID_MODELS = Object.keys(API_KEY_ENV);
 
 interface EvalStats {
@@ -60,7 +68,6 @@ interface EvalStats {
 
 interface EvalResult {
   success: boolean;
-  cost?: number;
   testCase?: {
     description?: string;
     vars?: Record<string, string>;
@@ -204,10 +211,14 @@ async function main(): Promise<void> {
   const { stats } = data.results;
   const total = stats.successes + stats.failures;
   const rate = stats.successes / total;
-  const totalCost = data.results.results.reduce(
-    (sum, r) => sum + (r.cost ?? 0),
-    0,
-  );
+  // Calculate cost from aggregate token usage and model pricing.
+  // promptfoo does not populate per-result cost for Anthropic providers,
+  // so we compute it from the token counts directly.
+  const pricing = TOKEN_PRICING[model];
+  const totalCost = pricing
+    ? (stats.tokenUsage.prompt / 1_000_000) * pricing.prompt +
+      (stats.tokenUsage.completion / 1_000_000) * pricing.completion
+    : 0;
 
   console.log(
     `\nResults (${model}): ${stats.successes}/${total} passed (${(rate * 100).toFixed(1)}%)`,


### PR DESCRIPTION
## Summary

- Skill trigger eval cost was always reported as $0.00 because promptfoo's Anthropic provider doesn't populate per-result `cost` fields
- Compute estimated cost from aggregate `stats.tokenUsage` (prompt + completion tokens) using per-model pricing constants
- Adds pricing for all four supported models: sonnet, opus, gpt-4.1, gemini-2.5-pro

## Test Plan

- Verified the math: for the latest sonnet eval run (618,252 prompt + 18,041 completion tokens), cost would now show ~$2.12 instead of $0.00
- No functional changes to eval logic — only the cost reporting line

🤖 Generated with [Claude Code](https://claude.com/claude-code)