### PR TITLE
fix: exclude datastore-bundles from DEFAULT_DATASTORE_SUBDIRS

### DIFF
--- a/src/domain/datastore/datastore_config.ts
+++ b/src/domain/datastore/datastore_config.ts
@@ -49,13 +49,18 @@ export const DEFAULT_DATASTORE_SUBDIRS = [
   "bundles",
   "vault-bundles",
   "driver-bundles",
-  "datastore-bundles",
   "report-bundles",
   "audit",
   "telemetry",
   "logs",
   "files",
 ] as const;
+
+// Note: "datastore-bundles" is intentionally excluded from the datastore tier.
+// The datastore loader runs during bootstrap BEFORE the DatastorePathResolver
+// exists, so datastore extension bundles must always remain in local .swamp/.
+// Including it here causes the setup migration to delete .swamp/datastore-bundles/
+// after copying to cache, breaking subsequent extension loading.
 
 /**
  * Filesystem-based datastore configuration.

--- a/src/infrastructure/persistence/default_datastore_path_resolver_test.ts
+++ b/src/infrastructure/persistence/default_datastore_path_resolver_test.ts
@@ -197,7 +197,8 @@ Deno.test("DefaultDatastorePathResolver - bundle subdirs are recognized as datas
   assertEquals(resolver.isDatastoreSubdir("bundles"), true);
   assertEquals(resolver.isDatastoreSubdir("vault-bundles"), true);
   assertEquals(resolver.isDatastoreSubdir("driver-bundles"), true);
-  assertEquals(resolver.isDatastoreSubdir("datastore-bundles"), true);
+  // datastore-bundles intentionally excluded — bootstrap ordering
+  assertEquals(resolver.isDatastoreSubdir("datastore-bundles"), false);
   assertEquals(resolver.isDatastoreSubdir("report-bundles"), true);
 });
 
@@ -222,9 +223,10 @@ Deno.test("DefaultDatastorePathResolver - resolvePath routes bundles to S3 cache
     resolver.resolvePath("driver-bundles", "bb22cc33", "driver.js"),
     "/home/user/.swamp/repos/abc/driver-bundles/bb22cc33/driver.js",
   );
+  // datastore-bundles stays local (bootstrap ordering — excluded from datastore tier)
   assertEquals(
     resolver.resolvePath("datastore-bundles", "dd44ee55", "ds.js"),
-    "/home/user/.swamp/repos/abc/datastore-bundles/dd44ee55/ds.js",
+    "/repo/.swamp/datastore-bundles/dd44ee55/ds.js",
   );
   assertEquals(
     resolver.resolvePath("report-bundles", "66778899", "report.js"),


### PR DESCRIPTION
## Summary

- Remove `datastore-bundles` from `DEFAULT_DATASTORE_SUBDIRS` to fix S3 datastore sync regression introduced in #1103

## Root Cause

PR #1103 added `datastore-bundles` to `DEFAULT_DATASTORE_SUBDIRS` alongside `driver-bundles` and `report-bundles`. This caused the S3 datastore setup migration to:

1. Copy `.swamp/datastore-bundles/` (containing S3 extension bundles) to the S3 cache
2. **Delete** `.swamp/datastore-bundles/` from local on successful migration

On subsequent commands, the datastore loader (which runs during bootstrap **before** the `DatastorePathResolver` exists and therefore always reads from local `.swamp/`) could no longer find the S3 extension bundles. This broke all S3 datastore operations — the extension failed to load, `resolveDatastoreConfig` couldn't resolve the S3 config, and sync operations failed silently.

## Why This Is Correct

The `UserDatastoreLoader` is explicitly excluded from resolver wiring due to bootstrap ordering — it loads datastore extensions that **configure** the resolver. So `datastore-bundles` must always remain in local `.swamp/`, never in the datastore tier. This mirrors the exclusion of `UserDatastoreLoader` from the resolver in #1103.

`driver-bundles` and `report-bundles` remain in the datastore tier because their loaders **do** receive the resolver and can find bundles in the cache path.

## Test Plan

- Updated resolver tests to verify `datastore-bundles` is NOT recognized as a datastore subdir and resolves to local `.swamp/` path
- All 4140 tests pass
- S3 datastore UAT failure from https://github.com/systeminit/swamp-uat/actions/runs/23987653347/job/69962141207 should be resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)