### PR TITLE
fix: invalidate extension catalog when source directories change

### DIFF
--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -69,6 +69,19 @@ const logger = getLogger(["swamp", "models", "loader"]);
 const BUNDLE_LAYOUT_VERSION = "namespaced-v1";
 
 /**
+ * Builds a stable fingerprint from the set of directories passed to buildIndex.
+ * When sources change (added/removed via `swamp extension source add/rm`),
+ * the fingerprint changes and triggers a catalog invalidation.
+ */
+function sourceDirsFingerprint(
+  modelsDir: string,
+  additionalDirs?: string[],
+): string {
+  const dirs = [modelsDir, ...(additionalDirs ?? [])];
+  return dirs.sort().join("\n");
+}
+
+/**
  * Plain object result returned by user methods before conversion.
  * User models must use context.writeResource() / context.createFileWriter() to produce data.
  */
@@ -511,6 +524,24 @@ export class UserModelLoader {
       catalog.invalidate("model");
     }
 
+    // Force a full rescan if the set of extension source directories has
+    // changed (e.g. user ran `swamp extension source add`). Without this,
+    // the catalog's "populated" flag causes buildIndex to skip the full
+    // import path, so models from newly added sources are never discovered
+    // (#1107).
+    const currentSourceFingerprint = sourceDirsFingerprint(
+      modelsDir,
+      options?.additionalDirs,
+    );
+    if (
+      catalog.isPopulated("model") &&
+      catalog.getSourceDirsFingerprint() !== currentSourceFingerprint
+    ) {
+      logger
+        .warn`Extension source dirs changed — invalidating catalog for full rescan`;
+      catalog.invalidate("model");
+    }
+
     // If catalog is already populated, register lazy entries from it
     // and do a lightweight mtime check for staleness.
     if (catalog.isPopulated("model")) {
@@ -564,6 +595,7 @@ export class UserModelLoader {
     catalog.markPopulated("model");
     catalog.setLayoutVersion(BUNDLE_LAYOUT_VERSION);
     catalog.setDatastoreBasePath(currentBasePath);
+    catalog.setSourceDirsFingerprint(currentSourceFingerprint);
 
     // Migrate old flat-layout bundle files into namespaced subdirectories.
     if (this.repoDir) {

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -2568,3 +2568,97 @@ Deno.test("UserModelLoader: accepts optional DatastorePathResolver", () => {
   const loaderWithoutResolver = new UserModelLoader(testDenoRuntime, "/repo");
   assertNotEquals(loaderWithoutResolver, undefined);
 });
+
+Deno.test("buildIndex: invalidates catalog when source dirs change (#1107)", async () => {
+  const ts = Date.now();
+  const modelCodeA = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "@user/source-a-${ts}",
+  version: "2026.04.05.1",
+  methods: {
+    run: {
+      description: "Run",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+  const modelCodeB = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "@user/source-b-${ts}",
+  version: "2026.04.05.1",
+  methods: {
+    run: {
+      description: "Run",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+  const repoDir = await Deno.makeTempDir({
+    prefix: "swamp_source_dirs_repo_",
+  });
+  const modelsDir = await Deno.makeTempDir({
+    prefix: "swamp_source_dirs_models_",
+  });
+  const sourceDirB = await Deno.makeTempDir({
+    prefix: "swamp_source_dirs_extra_",
+  });
+  const dbPath = join(repoDir, ".swamp", "_extension_catalog.db");
+
+  try {
+    // Write model A in the primary dir, model B in the extra source dir
+    await Deno.writeTextFile(join(modelsDir, "model_a.ts"), modelCodeA);
+    await Deno.writeTextFile(join(sourceDirB, "model_b.ts"), modelCodeB);
+
+    // First buildIndex — only primary dir, no additional sources
+    const catalog1 = new ExtensionCatalogStore(dbPath);
+    const loader1 = new UserModelLoader(testDenoRuntime, repoDir);
+    await loader1.buildIndex(modelsDir, catalog1);
+    catalog1.close();
+
+    // Model A should be registered, model B should not
+    assertEquals(
+      modelRegistry.has(`@user/source-a-${ts}`),
+      true,
+      "model A should be registered after first buildIndex",
+    );
+    assertEquals(
+      modelRegistry.has(`@user/source-b-${ts}`),
+      false,
+      "model B should NOT be registered (not in any source dir yet)",
+    );
+
+    // Second buildIndex — now include the extra source dir
+    const catalog2 = new ExtensionCatalogStore(dbPath);
+    const loader2 = new UserModelLoader(testDenoRuntime, repoDir);
+    const result = await loader2.buildIndex(modelsDir, catalog2, {
+      additionalDirs: [sourceDirB],
+    });
+    catalog2.close();
+
+    // Model B should now be discovered and registered
+    assertEquals(
+      modelRegistry.has(`@user/source-b-${ts}`),
+      true,
+      "model B should be registered after source dir was added",
+    );
+    assertEquals(
+      result.failed.length,
+      0,
+      `expected no failures, got: ${JSON.stringify(result.failed)}`,
+    );
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+    await Deno.remove(modelsDir, { recursive: true });
+    await Deno.remove(sourceDirB, { recursive: true });
+  }
+});

--- a/src/infrastructure/persistence/extension_catalog_store.ts
+++ b/src/infrastructure/persistence/extension_catalog_store.ts
@@ -285,6 +285,30 @@ export class ExtensionCatalogStore {
   }
 
   /**
+   * Returns the stored source directories fingerprint, or undefined if not set.
+   * Used to detect when extension sources have been added or removed,
+   * triggering a full rescan so new source models are discovered.
+   */
+  getSourceDirsFingerprint(): string | undefined {
+    const stmt = this.db.prepare(
+      "SELECT value FROM bundle_meta WHERE key = 'source_dirs_fingerprint'",
+    );
+    const row = stmt.get() as { value: string } | undefined;
+    return row?.value;
+  }
+
+  /**
+   * Stores a fingerprint of the current source directories. Set after a
+   * successful catalog population so subsequent runs can detect source changes.
+   */
+  setSourceDirsFingerprint(fingerprint: string): void {
+    const stmt = this.db.prepare(
+      "INSERT OR REPLACE INTO bundle_meta (key, value) VALUES ('source_dirs_fingerprint', ?)",
+    );
+    stmt.run(fingerprint);
+  }
+
+  /**
    * Closes the database connection.
    */
   close(): void {


### PR DESCRIPTION
## Summary

- When a new extension source is added after the catalog is already populated, models from that source are never discovered because `buildIndex` trusts the stale catalog. This stores a fingerprint of the configured source directories in the catalog's `bundle_meta` table and invalidates the catalog when the fingerprint changes, triggering a full rescan.
- Follows the existing pattern used for bundle layout version (#1065) and datastore base path (#1100) invalidation.

Closes #1107

## Test Plan

- Added `buildIndex: invalidates catalog when source dirs change (#1107)` test that bootstraps a catalog with one model dir, then calls `buildIndex` again with a new `additionalDirs` entry and verifies the new source's model is discovered
- All 67 existing `user_model_loader_test.ts` tests pass
- All 18 `extension_catalog_store_test.ts` tests pass
- `deno check`, `deno lint`, `deno fmt --check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>