### PR TITLE
fix: deduplicate findBySpec/findByTag across orphan model UUIDs

### DIFF
--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -611,8 +611,7 @@ export class ModelResolver {
                 latestVersion,
               );
               if (versionData && versionData.tags[tagKey] === tagValue) {
-                const dedupeKey =
-                  `${modelType.normalized}:${modelId}:${data.name}`;
+                const dedupeKey = `${tagModelName}:${data.name}`;
                 if (seen.has(dedupeKey)) continue;
                 seen.add(dedupeKey);
                 const record = dataToRecord(
@@ -660,10 +659,8 @@ export class ModelResolver {
               if (runId && versionData.tags["workflowRunId"] !== runId) {
                 continue;
               }
-              const dedupeKey =
-                `${modelType.normalized}:${modelId}:${data.name}`;
-              if (seen.has(dedupeKey)) continue;
-              seen.add(dedupeKey);
+              if (seen.has(data.name)) continue;
+              seen.add(data.name);
               const record = dataToRecord(
                 versionData,
                 modelType,

--- a/src/domain/expressions/model_resolver_test.ts
+++ b/src/domain/expressions/model_resolver_test.ts
@@ -353,6 +353,72 @@ Deno.test("data.findByTag() deduplicates when data exists under orphan coordinat
   });
 });
 
+Deno.test("data.findByTag() deduplicates when both old and new UUIDs have data for same name", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+
+    // Step 1: Create model and save data under its UUID
+    const originalModel = Definition.create({
+      name: "dup-model",
+      globalArguments: {},
+    });
+    await defRepo.save(type, originalModel);
+
+    const dataV1 = Data.create({
+      name: "tagged-item",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", env: "prod", modelName: "dup-model" },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      originalModel.id,
+      dataV1,
+      new TextEncoder().encode(JSON.stringify({ v: 1 })),
+    );
+
+    // Step 2: Delete and recreate model with new UUID
+    await defRepo.delete(type, originalModel.id);
+    const recreatedModel = Definition.create({
+      name: "dup-model",
+      globalArguments: {},
+    });
+    await defRepo.save(type, recreatedModel);
+
+    // Step 3: Save data with same name under new UUID
+    const dataV2 = Data.create({
+      name: "tagged-item",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", env: "prod", modelName: "dup-model" },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      recreatedModel.id,
+      dataV2,
+      new TextEncoder().encode(JSON.stringify({ v: 2 })),
+    );
+
+    // Step 4: Build context — both UUIDs have data for "tagged-item"
+    const resolver = new ModelResolver(defRepo, { repoDir, dataRepo });
+    const ctx = await resolver.buildContext();
+
+    assertExists(ctx.data);
+
+    // findByTag should return the record only once, not duplicated
+    const results = ctx.data.findByTag("env", "prod");
+    assertEquals(results.length, 1);
+    assertEquals(results[0].name, "tagged-item");
+  });
+});
+
 // ============================================================================
 // data.findBySpec() returns records matching specName tag
 // ============================================================================
@@ -409,6 +475,72 @@ Deno.test("data.findBySpec() returns records matching specName tag", async () =>
     assertEquals(results.length, 2);
     assertEquals(results.some((r) => r.name === "subnet-a"), true);
     assertEquals(results.some((r) => r.name === "subnet-b"), true);
+  });
+});
+
+Deno.test("data.findBySpec() deduplicates when both old and new UUIDs have data for same name", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const dataRepo = new FileSystemUnifiedDataRepository(repoDir);
+    const type = ModelType.create("test/model");
+
+    // Step 1: Create model and save data under its UUID
+    const originalModel = Definition.create({
+      name: "spec-model",
+      globalArguments: {},
+    });
+    await defRepo.save(type, originalModel);
+
+    const dataV1 = Data.create({
+      name: "subnet-a",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", specName: "subnet", modelName: "spec-model" },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      originalModel.id,
+      dataV1,
+      new TextEncoder().encode(JSON.stringify({ cidr: "10.0.1.0/24" })),
+    );
+
+    // Step 2: Delete and recreate model with new UUID
+    await defRepo.delete(type, originalModel.id);
+    const recreatedModel = Definition.create({
+      name: "spec-model",
+      globalArguments: {},
+    });
+    await defRepo.save(type, recreatedModel);
+
+    // Step 3: Save data with same name under new UUID
+    const dataV2 = Data.create({
+      name: "subnet-a",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", specName: "subnet", modelName: "spec-model" },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      recreatedModel.id,
+      dataV2,
+      new TextEncoder().encode(JSON.stringify({ cidr: "10.0.1.0/24-v2" })),
+    );
+
+    // Step 4: Build context — both UUIDs have data for "subnet-a"
+    const resolver = new ModelResolver(defRepo, { repoDir, dataRepo });
+    const ctx = await resolver.buildContext();
+
+    assertExists(ctx.data);
+
+    // findBySpec should return the record only once, not duplicated
+    const results = ctx.data.findBySpec("spec-model", "subnet");
+    assertEquals(results.length, 1);
+    assertEquals(results[0].name, "subnet-a");
   });
 });
 


### PR DESCRIPTION
## Summary

- Fix `findBySpec()` and `findByTag()` in `model_resolver.ts` to deduplicate by logical data identity instead of physical storage identity, preventing duplicate results when orphan recovery maps multiple model UUIDs to the same model name
- `findBySpec` dedup key: `data.name` (scoped to one model, names are unique)
- `findByTag` dedup key: `modelName:data.name` (spans all models, needs logical model name)
- Add tests covering the case where both old and new UUIDs have data for the same data name

## Test Plan

- [x] New unit tests: `findBySpec` and `findByTag` deduplication with data under both old and new UUIDs (model_resolver_test.ts)
- [x] Existing orphan dedup tests still pass
- [x] Full test suite passes (4142 tests)
- [x] Verified with reproduction scenario at `/tmp/swamp-repro-issue-1105/` — forEach now correctly returns 1 step instead of 2
- [x] `deno check`, `deno lint`, `deno fmt` all pass

Closes #1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)