### PR TITLE
fix: detect duplicate node names in topological sort instead of false cyclic dependency

### DIFF
--- a/src/domain/workflows/topological_sort_service.ts
+++ b/src/domain/workflows/topological_sort_service.ts
@@ -49,6 +49,16 @@ export class CyclicDependencyError extends Error {
 }
 
 /**
+ * Error thrown when duplicate node names are found in the input.
+ */
+export class DuplicateNodeNameError extends Error {
+  constructor(readonly duplicates: string[]) {
+    super(`Duplicate node names: ${duplicates.join(", ")}`);
+    this.name = "DuplicateNodeNameError";
+  }
+}
+
+/**
  * Domain service for topological sorting with weighted tie-breaking.
  *
  * Uses Kahn's algorithm to produce a deterministic order:
@@ -69,6 +79,19 @@ export class TopologicalSortService {
    * @throws CyclicDependencyError if a cycle is detected
    */
   sort(nodes: GraphNode[]): TopologicalSortResult {
+    // Detect duplicate node names before processing
+    const seen = new Set<string>();
+    const duplicates = new Set<string>();
+    for (const node of nodes) {
+      if (seen.has(node.name)) {
+        duplicates.add(node.name);
+      }
+      seen.add(node.name);
+    }
+    if (duplicates.size > 0) {
+      throw new DuplicateNodeNameError([...duplicates].sort());
+    }
+
     // Build adjacency list and in-degree map
     const inDegree = new Map<string, number>();
     const dependents = new Map<string, string[]>();

--- a/src/domain/workflows/topological_sort_service_test.ts
+++ b/src/domain/workflows/topological_sort_service_test.ts
@@ -20,6 +20,7 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import {
   CyclicDependencyError,
+  DuplicateNodeNameError,
   type GraphNode,
   TopologicalSortService,
 } from "./topological_sort_service.ts";
@@ -231,6 +232,47 @@ Deno.test("CyclicDependencyError contains cycle path", () => {
     if (error instanceof CyclicDependencyError) {
       // Cycle should contain all three nodes
       assertEquals(error.cycle.length >= 3, true);
+    } else {
+      throw error;
+    }
+  }
+});
+
+Deno.test("sort: detects duplicate node names", () => {
+  const nodes: GraphNode[] = [
+    { name: "a", weight: 0, dependencies: [] },
+    { name: "a", weight: 0, dependencies: [] },
+  ];
+
+  try {
+    service.sort(nodes);
+    throw new Error("Expected DuplicateNodeNameError");
+  } catch (error) {
+    if (error instanceof DuplicateNodeNameError) {
+      assertEquals(error.duplicates, ["a"]);
+      assertEquals(error.message, "Duplicate node names: a");
+    } else {
+      throw error;
+    }
+  }
+});
+
+Deno.test("sort: lists all duplicate names sorted alphabetically", () => {
+  const nodes: GraphNode[] = [
+    { name: "charlie", weight: 0, dependencies: [] },
+    { name: "alpha", weight: 0, dependencies: [] },
+    { name: "charlie", weight: 0, dependencies: [] },
+    { name: "alpha", weight: 0, dependencies: [] },
+    { name: "bravo", weight: 0, dependencies: [] },
+  ];
+
+  try {
+    service.sort(nodes);
+    throw new Error("Expected DuplicateNodeNameError");
+  } catch (error) {
+    if (error instanceof DuplicateNodeNameError) {
+      assertEquals(error.duplicates, ["alpha", "charlie"]);
+      assertEquals(error.name, "DuplicateNodeNameError");
     } else {
       throw error;
     }

--- a/src/domain/workflows/validation_service.ts
+++ b/src/domain/workflows/validation_service.ts
@@ -21,6 +21,7 @@ import type { Workflow } from "./workflow.ts";
 import { WorkflowSchema } from "./workflow.ts";
 import {
   CyclicDependencyError,
+  DuplicateNodeNameError,
   type GraphNode,
   TopologicalSortService,
 } from "./topological_sort_service.ts";
@@ -263,6 +264,12 @@ export class DefaultWorkflowValidationService
           error.message,
         );
       }
+      if (error instanceof DuplicateNodeNameError) {
+        return WorkflowValidationResult.fail(
+          "No cyclic job dependencies",
+          error.message,
+        );
+      }
       throw error;
     }
   }
@@ -294,7 +301,10 @@ export class DefaultWorkflowValidationService
           ),
         );
       } catch (error) {
-        if (error instanceof CyclicDependencyError) {
+        if (
+          error instanceof CyclicDependencyError ||
+          error instanceof DuplicateNodeNameError
+        ) {
           results.push(
             WorkflowValidationResult.fail(
               `No cyclic step dependencies in job '${job.name}'`,


### PR DESCRIPTION
## Summary

- When forEach expansion produces duplicate step names, the topological sort misreports a phantom cyclic dependency with an empty cycle path. This adds upfront duplicate name detection (`DuplicateNodeNameError`) before running Kahn's algorithm, and updates `validation_service.ts` to catch the new error at both job-level and step-level validation sites.

Closes #1106

## Test Plan

- Added 2 unit tests for duplicate detection in `topological_sort_service_test.ts` (duplicate pair, multiple duplicates)
- All 19 topological sort tests pass
- All 14 validation service tests pass
- Full test suite (4143 tests) passes
- `deno check`, `deno lint`, `deno fmt --check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)