### PR TITLE
fix: add ensureTypeLoaded() before registry .get() calls for lazy types

### DIFF
--- a/src/cli/commands/report_describe.ts
+++ b/src/cli/commands/report_describe.ts
@@ -44,7 +44,10 @@ export const reportDescribeCommand = new Command()
 
     await reportRegistry.ensureLoaded();
     const deps: ReportDescribeDeps = {
-      getReport: (name) => reportRegistry.get(name),
+      getReport: async (name) => {
+        await reportRegistry.ensureTypeLoaded(name);
+        return reportRegistry.get(name);
+      },
     };
 
     const libCtx = createLibSwampContext({ logger: ctx.logger });

--- a/src/cli/commands/report_search.ts
+++ b/src/cli/commands/report_search.ts
@@ -69,7 +69,10 @@ async function buildSearchDeps(
       if (!wf) return null;
       return { id: wf.id, name: wf.name };
     },
-    getReport: (name) => reportRegistry.get(name),
+    getReport: async (name) => {
+      await reportRegistry.ensureTypeLoaded(name);
+      return reportRegistry.get(name);
+    },
   };
 }
 

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -105,6 +105,7 @@ async function resolveCustomProvider(
   config: CustomDatastoreConfig,
 ): Promise<DatastoreProvider> {
   await datastoreTypeRegistry.ensureLoaded();
+  await datastoreTypeRegistry.ensureTypeLoaded(config.type);
   const typeInfo = datastoreTypeRegistry.get(config.type);
   if (!typeInfo?.createProvider) {
     throw new UserError(

--- a/src/cli/resolve_datastore.ts
+++ b/src/cli/resolve_datastore.ts
@@ -212,6 +212,7 @@ export async function parseDatastoreEnvVar(
       await resolveDatastoreType(renamedTo, getAutoResolver());
       await maybeAutoUpdateSwampDatastore(renamedTo, repoDir ?? ".", null);
 
+      await datastoreTypeRegistry.ensureTypeLoaded(renamedTo);
       const typeInfo = datastoreTypeRegistry.get(renamedTo);
       if (typeInfo?.createProvider) {
         const config: Record<string, unknown> = { bucket };
@@ -258,6 +259,7 @@ export async function parseDatastoreEnvVar(
   }
 
   // Custom datastore type: value is JSON config
+  await datastoreTypeRegistry.ensureTypeLoaded(type);
   const typeInfo = datastoreTypeRegistry.get(type);
   if (!typeInfo) {
     const available = datastoreTypeRegistry.getAll().map((t) => t.type).join(
@@ -362,6 +364,7 @@ export async function resolveDatastoreConfig(
         marker ?? null,
       );
 
+      await datastoreTypeRegistry.ensureTypeLoaded(renamedTo);
       const typeInfo = datastoreTypeRegistry.get(renamedTo);
       if (typeInfo?.createProvider) {
         // Build config from the S3-specific YAML fields
@@ -432,6 +435,7 @@ export async function resolveDatastoreConfig(
     }
 
     // Custom datastore type from YAML config
+    await datastoreTypeRegistry.ensureTypeLoaded(dsType);
     const typeInfo = datastoreTypeRegistry.get(dsType);
     if (!typeInfo) {
       const available = datastoreTypeRegistry.getAll().map((t) => t.type).join(

--- a/src/domain/extensions/extension_auto_resolver.ts
+++ b/src/domain/extensions/extension_auto_resolver.ts
@@ -378,6 +378,8 @@ export async function resolveVaultType(
   type: string,
   resolver: ExtensionAutoResolver | null,
 ): Promise<boolean> {
+  // Try lazy loading first — the type may be indexed but not imported yet
+  await vaultTypeRegistry.ensureTypeLoaded(type);
   if (vaultTypeRegistry.has(type)) return true;
   if (!resolver) return false;
   if (!type.startsWith("@")) return false;
@@ -395,6 +397,8 @@ export async function resolveDatastoreType(
   type: string,
   resolver: ExtensionAutoResolver | null,
 ): Promise<boolean> {
+  // Try lazy loading first — the type may be indexed but not imported yet
+  await datastoreTypeRegistry.ensureTypeLoaded(type);
   if (datastoreTypeRegistry.has(type)) return true;
   if (!resolver) return false;
   if (!type.startsWith("@")) return false;

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -643,6 +643,7 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
         }
 
         // Look up a registered driver type
+        await driverTypeRegistry.ensureTypeLoaded(driverType);
         const driverInfo = driverTypeRegistry.get(driverType);
         if (!driverInfo) {
           throw new Error(

--- a/src/domain/vaults/vault_service.ts
+++ b/src/domain/vaults/vault_service.ts
@@ -73,6 +73,7 @@ export class VaultService {
         }
 
         // Auto-resolve missing vault types from trusted collectives
+        await vaultTypeRegistry.ensureTypeLoaded(vaultType);
         if (
           !vaultTypeRegistry.has(vaultType) && vaultType.startsWith("@")
         ) {

--- a/src/libswamp/datastores/setup.ts
+++ b/src/libswamp/datastores/setup.ts
@@ -244,6 +244,7 @@ export async function* datastoreSetupExtension(
       }
 
       // Look up the extension type in the registry
+      await datastoreTypeRegistry.ensureTypeLoaded(input.type);
       const typeInfo = datastoreTypeRegistry.get(input.type);
       if (!typeInfo?.createProvider) {
         yield {

--- a/src/libswamp/datastores/status.ts
+++ b/src/libswamp/datastores/status.ts
@@ -64,6 +64,7 @@ export async function createDatastoreStatusDeps(
     loadConfig: () => datastoreResolver.config(),
     verifyHealth: async (config: DatastoreConfig) => {
       if (isCustomDatastoreConfig(config)) {
+        await datastoreTypeRegistry.ensureTypeLoaded(config.type);
         const typeInfo = datastoreTypeRegistry.get(config.type);
         if (typeInfo?.createProvider) {
           const provider = typeInfo.createProvider(config.config);

--- a/src/libswamp/datastores/sync.ts
+++ b/src/libswamp/datastores/sync.ts
@@ -68,6 +68,7 @@ export async function createDatastoreSyncDeps(
   const config = datastoreResolver.config();
 
   if (isCustomDatastoreConfig(config)) {
+    await datastoreTypeRegistry.ensureTypeLoaded(config.type);
     const typeInfo = datastoreTypeRegistry.get(config.type);
     if (!typeInfo?.createProvider) {
       return makeUnsupportedDeps(

--- a/src/libswamp/reports/describe.ts
+++ b/src/libswamp/reports/describe.ts
@@ -28,14 +28,17 @@ import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
  * Dependencies for the report describe operation.
  */
 export interface ReportDescribeDeps {
-  getReport: (name: string) => ReportDefinition | undefined;
+  getReport: (name: string) => Promise<ReportDefinition | undefined>;
 }
 
 /** Wires real infrastructure into ReportDescribeDeps. */
 export async function createReportDescribeDeps(): Promise<ReportDescribeDeps> {
   await reportRegistry.ensureLoaded();
   return {
-    getReport: (name) => reportRegistry.get(name),
+    getReport: async (name) => {
+      await reportRegistry.ensureTypeLoaded(name);
+      return reportRegistry.get(name);
+    },
   };
 }
 
@@ -53,7 +56,7 @@ export async function* reportDescribe(
     (async function* () {
       yield { kind: "resolving" };
 
-      const report = deps.getReport(reportName);
+      const report = await deps.getReport(reportName);
       if (!report) {
         yield { kind: "error", error: notFound("Report", reportName) };
         return;

--- a/src/libswamp/reports/describe_test.ts
+++ b/src/libswamp/reports/describe_test.ts
@@ -35,7 +35,7 @@ function makeDeps(
   reports: Record<string, ReportDefinition> = {},
 ): ReportDescribeDeps {
   return {
-    getReport: (name) => reports[name],
+    getReport: (name) => Promise.resolve(reports[name]),
   };
 }
 

--- a/src/libswamp/reports/search.ts
+++ b/src/libswamp/reports/search.ts
@@ -68,7 +68,7 @@ export interface ReportSearchDeps {
   findWorkflowById: (
     id: string,
   ) => Promise<{ id: string; name: string } | null>;
-  getReport: (name: string) => ReportDefinition | undefined;
+  getReport: (name: string) => Promise<ReportDefinition | undefined>;
 }
 
 /** Wires real infrastructure into ReportSearchDeps. */
@@ -103,7 +103,10 @@ export async function createReportSearchDeps(
       if (!wf) return null;
       return { id: wf.id, name: wf.name };
     },
-    getReport: (name) => reportRegistry.get(name),
+    getReport: async (name) => {
+      await reportRegistry.ensureTypeLoaded(name);
+      return reportRegistry.get(name);
+    },
   };
 }
 
@@ -184,13 +187,17 @@ export async function* reportSearch(
 
       // Apply label filter — only include reports whose definition has all requested labels
       if (input.labels && input.labels.length > 0) {
-        candidates = candidates.filter((c) => {
+        const filtered: typeof candidates = [];
+        for (const c of candidates) {
           const reportName = c.data.tags.reportName;
-          if (!reportName) return false;
-          const def = deps.getReport(reportName);
-          if (!def || !def.labels) return false;
-          return input.labels!.every((l) => def.labels!.includes(l));
-        });
+          if (!reportName) continue;
+          const def = await deps.getReport(reportName);
+          if (!def || !def.labels) continue;
+          if (input.labels!.every((l) => def.labels!.includes(l))) {
+            filtered.push(c);
+          }
+        }
+        candidates = filtered;
       }
 
       // Apply text query filter

--- a/src/libswamp/reports/search_test.ts
+++ b/src/libswamp/reports/search_test.ts
@@ -57,7 +57,7 @@ function makeDeps(
     lookupDefinitionById: () => Promise.resolve(null),
     findWorkflowByName: () => Promise.resolve(null),
     findWorkflowById: () => Promise.resolve(null),
-    getReport: () => undefined,
+    getReport: () => Promise.resolve(undefined),
   };
 }
 

--- a/src/libswamp/vaults/create.ts
+++ b/src/libswamp/vaults/create.ts
@@ -75,6 +75,7 @@ export async function createVaultCreateDeps(
   const repo = new YamlVaultConfigRepository(repoDir);
   return {
     resolveExtensionVaultType: async (type) => {
+      await vaultTypeRegistry.ensureTypeLoaded(type);
       if (!vaultTypeRegistry.has(type) && type.startsWith("@")) {
         await resolveVaultType(type, getAutoResolver());
       }


### PR DESCRIPTION
## Summary

PR #1089 introduced lazy per-bundle loading for vault, datastore, driver, and report registries. This caused a regression: `get()` only returns fully-loaded types (from `this.types`), returning `undefined` for lazy entries (in `this.lazyTypes`) — but many consumer code paths call `get()` without first calling `ensureTypeLoaded()` to promote the lazy entry.

This broke 11 UATs:
- **Datastore (6 failures):** `Unknown datastore type "@swamp/s3-datastore"` / same for GCS
- **Vault (5 failures):** `Unknown vault type: @test/mock-vault` — vault create, vault put, and extension vault lifecycle all fail

### Root cause

The registries have two maps: `types` (fully loaded) and `lazyTypes` (indexed but not imported). After PR #1089:
- `has()` returns `true` for both maps — masking the problem in conditional checks
- `get()` only checks `types` — returning `undefined` for lazy entries
- `ensureLoaded()` only populates `lazyTypes` (builds the index), it does NOT promote entries to `types`
- `ensureTypeLoaded(type)` is required to import the specific bundle and move the entry from `lazyTypes` to `types`

The model registry was already correct — `resolveModelType()` in `extension_auto_resolver.ts` calls `await modelRegistry.ensureTypeLoaded(type)` before `get()`. The vault, datastore, driver, and report registries needed the same treatment.

### Changes

Added `await registry.ensureTypeLoaded(type)` before every `.get()` call across all four registries (15 files, 11 code paths):

| # | File | Function | Change |
|---|------|----------|--------|
| 1 | `extension_auto_resolver.ts` | `resolveVaultType()` | Added `ensureTypeLoaded` before `has()` check |
| 2 | `extension_auto_resolver.ts` | `resolveDatastoreType()` | Same pattern |
| 3 | `vault_service.ts` | `fromRepository()` | Added `ensureTypeLoaded` before `registerVault()` |
| 4 | `libswamp/vaults/create.ts` | `resolveExtensionVaultType` callback | Added `ensureTypeLoaded` before `has()` check |
| 5 | `libswamp/datastores/sync.ts` | `createDatastoreSyncDeps()` | Added `ensureTypeLoaded` before `.get()` |
| 6 | `libswamp/datastores/status.ts` | `verifyHealth` callback | Added `ensureTypeLoaded` before `.get()` |
| 7 | `libswamp/datastores/setup.ts` | `datastoreSetupExtension()` | Added `ensureTypeLoaded` before `.get()` |
| 8 | `cli/repo_context.ts` | `resolveCustomProvider()` | Added `ensureTypeLoaded` alongside existing `ensureLoaded()` |
| 9 | `cli/resolve_datastore.ts` | 4 locations in `parseDatastoreEnvVar` and `resolveDatastoreConfig` | Added `ensureTypeLoaded` before each `.get()` |
| 10 | `method_execution_service.ts` | Driver lookup ~L646 | Added `ensureTypeLoaded` before `.get()` |
| 11 | `reports/describe.ts` + `search.ts` | `getReport` callback | Made async with `ensureTypeLoaded` before `.get()`; updated interface, callers, CLI commands, and tests |

### Why `ensureLoaded()` alone is insufficient

After PR #1089, `ensureLoaded()` calls `buildIndex()` which only registers lazy entries via `registerLazy()`. It does **not** import bundles or populate `this.types`. Only `ensureTypeLoaded(type)` triggers the `typeLoader` to import the specific bundle and call `promoteFromLazy()`, moving the entry from `lazyTypes` to `types` where `get()` can find it.

## Test Plan

- `deno check` — all types pass
- `deno lint` — clean
- `deno fmt --check` — clean
- `deno run test` — 4174 tests pass, 0 failures
- Manual verification with compiled binary:
  - `swamp repo init` in /tmp directory
  - `swamp extension pull @swamp/aws-sm` — installed extension vault
  - `swamp vault create @swamp/aws-sm my-aws-vault --config '{"region":"us-east-1"}'` — **succeeded** (would have failed with "Unknown vault type" before fix)
  - `swamp extension pull @swamp/s3-datastore` — installed extension datastore
  - `swamp datastore setup extension @swamp/s3-datastore --config '{"bucket":"test","region":"us-east-1"}'` — **reached S3 access check** (would have failed with "not registered or has no provider" before fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)