### PR TITLE
fix: upgrade @anthropic-ai/sdk to 0.81.0 (CVE-2026-34451)

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1526,6 +1526,13 @@
       "npm:zod@^4.3.6"
     ],
     "members": {
+      "evals/promptfoo": {
+        "packageJson": {
+          "dependencies": [
+            "npm:promptfoo@0.121.3"
+          ]
+        }
+      },
       "packages/testing": {
         "dependencies": [
           "jsr:@std/assert@1.0.19"

--- a/evals/promptfoo/package-lock.json
+++ b/evals/promptfoo/package-lock.json
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.80.0.tgz",
-      "integrity": "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
+      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"

--- a/evals/promptfoo/package.json
+++ b/evals/promptfoo/package.json
@@ -4,5 +4,8 @@
   "private": true,
   "dependencies": {
     "promptfoo": "0.121.3"
+  },
+  "overrides": {
+    "@anthropic-ai/sdk": "^0.81.0"
   }
 }


### PR DESCRIPTION
## Summary

- Override `@anthropic-ai/sdk` to `^0.81.0` in `evals/promptfoo/package.json` to fix a medium-severity path traversal vulnerability ([GHSA-5474-4w2j-mq4c](https://github.com/anthropics/anthropic-sdk-typescript/security/advisories/GHSA-5474-4w2j-mq4c))
- Regenerated `package-lock.json` — the resolved version moves from 0.80.0 → 0.81.0

## Test plan

- [x] `npm install` succeeds with 0 vulnerabilities
- [x] `deno check` passes
- [ ] CI passes

Closes https://github.com/systeminit/swamp/security/dependabot/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)