### PR TITLE
fix: remove stale symlink and repo index references from skill docs

### DIFF
--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -70,20 +70,23 @@ Correct flow: `swamp model create <type> <name> --json` → set global args with
 
 ## Repository Structure
 
-Swamp uses a dual-layer architecture:
-
-- **Data directory (`/.swamp/`)** - Internal storage organized by entity type
-- **Logical views (`/models/`)** - Human-friendly symlinked directories
+Model definitions are stored directly in the `models/` directory, organized by
+type:
 
 ```
-/models/{model-name}/
-  input.yaml → ../.swamp/definitions/{type}/{id}.yaml
-  resource.yaml → ../.swamp/data/{type}/{id}/{specName}/latest/raw  (type=resource)
-  outputs/ → ../.swamp/outputs/{type}/{id}/
-  files/ → ../.swamp/data/{type}/{id}/ (filtered by type=file)
+models/
+  {normalized-type}/
+    {model-id}.yaml
 ```
 
-Use `swamp repo index` to rebuild if symlinks become out of sync.
+Internal data (evaluated definitions, data artifacts, outputs) lives in
+`.swamp/`:
+
+```
+.swamp/definitions-evaluated/{normalized-type}/{model-id}.yaml
+.swamp/data/{normalized-type}/{model-id}/{data-name}/{version}/raw
+.swamp/outputs/{normalized-type}/{model-id}/{output-id}.yaml
+```
 
 ## Search for Model Types
 
@@ -269,8 +272,6 @@ edit directly with the Edit tool, then validate with
 
 - Interactive: `swamp model edit my-shell` (opens in system editor)
 - Stdin: `cat updated.yaml | swamp model edit my-shell --json`
-
-Run `swamp repo index` if search results seem stale after editing.
 
 ## Delete a Model
 

--- a/.claude/skills/swamp-model/references/troubleshooting.md
+++ b/.claude/skills/swamp-model/references/troubleshooting.md
@@ -332,8 +332,8 @@ swamp model output get <model-name> --json
 # 3. List model data
 swamp data list <model-name> --json
 
-# 4. Rebuild index if needed
-swamp repo index --json
+# 4. Check data directory directly
+ls -la .swamp/data/
 ```
 
 ### Cannot Find Previous Output

--- a/.claude/skills/swamp-repo/SKILL.md
+++ b/.claude/skills/swamp-repo/SKILL.md
@@ -342,8 +342,8 @@ development copy — your local version loads instead.
 - **Structure**: See [references/structure.md](references/structure.md) for
   complete directory layout reference
 - **Troubleshooting**: See
-  [references/troubleshooting.md](references/troubleshooting.md) for symlink
-  issues, index rebuild, and config problems
+  [references/troubleshooting.md](references/troubleshooting.md) for config
+  problems and recovery procedures
 - **Repository design**: See [design/repo.md](design/repo.md)
 - **Model structure**: See [design/models.md](design/models.md)
 - **Datastore design**: See [design/datastores.md](design/datastores.md)

--- a/.claude/skills/swamp-repo/references/structure.md
+++ b/.claude/skills/swamp-repo/references/structure.md
@@ -2,11 +2,9 @@
 
 ## Overview
 
-Swamp uses a **dual-layer architecture**:
-
-1. **Data Layer** (`.swamp/`) — Internal storage organized by entity type
-2. **Logical Views** (`models/`, `workflows/`, `vaults/`) — Human-friendly
-   symlinked directories
+Swamp stores entities as flat files in top-level directories (`models/`,
+`workflows/`, `vaults/`), with internal data (artifacts, outputs, runs) in
+`.swamp/`.
 
 ## Complete Directory Layout
 
@@ -64,25 +62,16 @@ my-swamp-repo/
 │   └── telemetry/               # Local telemetry data
 │       └── events.jsonl
 │
-├── models/                      # Logical view: models by name
-│   └── {model-name}/
-│       ├── input.yaml → ../.swamp/definitions/{type}/{id}.yaml
-│       ├── resource.yaml → ../.swamp/data/{type}/{id}/{spec}/latest/raw
-│       ├── outputs/ → ../.swamp/outputs/{type}/{id}/
-│       └── files/ → ../.swamp/data/{type}/{id}/ (filtered)
+├── models/                      # Model definitions by type
+│   └── {normalized-type}/
+│       └── {model-id}.yaml
 │
-├── workflows/                   # Logical view: workflows by name
-│   └── {workflow-name}/
-│       ├── workflow.yaml → ../.swamp/workflows/{id}.yaml
-│       └── runs/
-│           ├── latest → {most-recent-run}/
-│           └── {timestamp}/
-│               └── run.yaml → ../.swamp/workflow-runs/{id}/{run-id}.yaml
+├── workflows/                   # Workflow definitions (flat files)
+│   └── workflow-{uuid}.yaml
 │
-├── vaults/                      # Logical view: vaults by name
-│   └── {vault-name}/
-│       ├── vault.yaml → ../.swamp/vault/{type}/{id}.yaml
-│       └── secrets/ → ../.swamp/secrets/{type}/{vault-name}/ (local only)
+├── vaults/                      # Vault configurations by type
+│   └── {vault-type}/
+│       └── {vault-id}.yaml
 │
 ├── extensions/                  # Custom user extensions
 │   ├── models/                  # TypeScript model definitions
@@ -227,32 +216,6 @@ jobs:
         duration: 2000
 ```
 
-## Logical View Symlinks
-
-### models/{name}/
-
-| Symlink         | Target                                             |
-| --------------- | -------------------------------------------------- |
-| `input.yaml`    | `.swamp/definitions/{type}/{id}.yaml`              |
-| `resource.yaml` | `.swamp/data/{type}/{id}/{spec}/latest/raw`        |
-| `outputs/`      | `.swamp/outputs/{type}/{id}/`                      |
-| `files/`        | `.swamp/data/{type}/{id}/` (filtered by type=file) |
-
-### workflows/{name}/
-
-| Symlink              | Target                                    |
-| -------------------- | ----------------------------------------- |
-| `workflow.yaml`      | `.swamp/workflows/{id}.yaml`              |
-| `runs/latest`        | `runs/{most-recent-timestamp}/`           |
-| `runs/{ts}/run.yaml` | `.swamp/workflow-runs/{id}/{run-id}.yaml` |
-
-### vaults/{name}/
-
-| Symlink      | Target                                             |
-| ------------ | -------------------------------------------------- |
-| `vault.yaml` | `.swamp/vault/{type}/{id}.yaml`                    |
-| `secrets/`   | `.swamp/secrets/{type}/{vault-name}/` (local only) |
-
 ## File Ownership and Permissions
 
 ### Files to Never Commit
@@ -275,19 +238,4 @@ Auto-generated on `swamp repo init`:
 .swamp/telemetry/
 .swamp/secrets/keyfile
 .claude/
-```
-
-## Rebuilding the Index
-
-When symlinks become stale or broken:
-
-```bash
-# Verify current state
-swamp repo index --verify --json
-
-# Remove broken symlinks
-swamp repo index --prune --json
-
-# Full rebuild
-swamp repo index --json
 ```

--- a/.claude/skills/swamp-repo/references/troubleshooting.md
+++ b/.claude/skills/swamp-repo/references/troubleshooting.md
@@ -4,8 +4,6 @@
 
 - [Common Errors](#common-errors)
   - ["Not a swamp repository"](#not-a-swamp-repository)
-  - [Broken Symlinks](#broken-symlinks)
-  - [Index Out of Sync](#index-out-of-sync)
   - [Config File Issues](#config-file-issues)
   - [Skills Not Loading](#skills-not-loading)
 - [Recovery Procedures](#recovery-procedures)
@@ -41,62 +39,6 @@
    pwd
    ls -la .swamp/
    ```
-
-### Broken Symlinks
-
-**Symptom**: Commands fail with "file not found" or `ls` shows broken symlinks
-
-**Diagnose**:
-
-```bash
-# Check for broken symlinks
-swamp repo index --verify --json
-
-# Manual check
-find models/ -type l ! -exec test -e {} \; -print
-```
-
-**Solutions**:
-
-1. **Prune broken symlinks**:
-
-   ```bash
-   swamp repo index --prune --json
-   ```
-
-2. **Full rebuild**:
-
-   ```bash
-   swamp repo index --json
-   ```
-
-3. **Verify internal data still exists**:
-
-   ```bash
-   ls -la .swamp/definitions/
-   ls -la .swamp/data/
-   ```
-
-### Index Out of Sync
-
-**Symptom**: Search results don't match actual files, or recent changes aren't
-visible
-
-**Causes**:
-
-- Manual file edits without running `swamp repo index`
-- Interrupted operations
-- Git operations that modified `.swamp/` directly
-
-**Solution**:
-
-```bash
-# Rebuild the index
-swamp repo index --json
-```
-
-**Prevention**: After manual edits to `.swamp/` files, always run
-`swamp repo index`.
 
 ### Config File Issues
 
@@ -216,13 +158,7 @@ swamp model create <type> <name> --json
 
 Edit conflicting files in `.swamp/` to pick the correct version.
 
-**Step 2: Rebuild index**
-
-```bash
-swamp repo index --json
-```
-
-**Step 3: Validate all models**
+**Step 2: Validate all models**
 
 ```bash
 swamp model validate --json
@@ -262,9 +198,6 @@ swamp repo init --json
 
 # 4. Restore extensions
 cp -r extensions.backup/* extensions/
-
-# 5. Rebuild index
-swamp repo index --json
 ```
 
 **Note**: This loses all model data and workflow history. Only use as last

--- a/.claude/skills/swamp-vault/SKILL.md
+++ b/.claude/skills/swamp-vault/SKILL.md
@@ -39,15 +39,21 @@ Correct flow: `swamp vault create <type> <name> --json` → edit config if neede
 
 ## Repository Structure
 
-Vaults use the dual-layer architecture:
-
-- **Data directory (`/.swamp/vault/`)** - Internal storage by vault type
-- **Logical views (`/vaults/`)** - Human-friendly symlinked directories
+Vault configurations are stored directly in the `vaults/` directory, organized
+by type:
 
 ```
-/vaults/{vault-name}/
-  vault.yaml → ../.swamp/vault/{type}/{id}.yaml
-  secrets/ → ../.swamp/secrets/{type}/{vault-name}/ (local_encryption only)
+vaults/
+  {vault-type}/
+    {vault-id}.yaml
+```
+
+Encrypted secrets (local_encryption vaults only) live in `.swamp/`:
+
+```
+.swamp/secrets/local_encryption/{vault-name}/
+  .key          # Encryption key (NEVER commit)
+  {secret-key}  # Encrypted secret data
 ```
 
 ## Vault Types

--- a/.claude/skills/swamp-vault/references/troubleshooting.md
+++ b/.claude/skills/swamp-vault/references/troubleshooting.md
@@ -198,13 +198,3 @@ Vault names must:
 
 **Invalid names**: `MyVault`, `123-vault`, `vault_name`, `VAULT` **Valid
 names**: `dev-secrets`, `prod-vault`, `api-keys-v2`
-
-## Rebuilding Logical Views
-
-If vault symlinks are missing or broken:
-
-```bash
-swamp repo index --json
-```
-
-This rebuilds all logical views including `/vaults/{name}/` directories.

--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -45,21 +45,19 @@ run.
 
 ## Repository Structure
 
-Swamp uses a dual-layer architecture:
-
-- **Data directory (`/.swamp/`)** - Internal storage organized by entity type
-- **Logical views (`/workflows/`)** - Human-friendly symlinked directories
+Workflow files are stored directly in the `workflows/` directory:
 
 ```
-/workflows/{workflow-name}/
-  workflow.yaml → ../.swamp/workflows/{id}.yaml
-  runs/
-    latest → {most-recent-run}/
-    {timestamp}/
-      run.yaml → ../.swamp/workflow-runs/{id}/{run-id}.yaml
+workflows/
+  workflow-{uuid}.yaml
 ```
 
-Use `swamp repo index` to rebuild if symlinks become out of sync.
+Internal data (evaluated workflows, run records) lives in `.swamp/`:
+
+```
+.swamp/workflows-evaluated/{uuid}.yaml
+.swamp/workflow-runs/{workflow-id}/{run-id}.yaml
+```
 
 ## IMPORTANT: Always Get Schema First
 
@@ -187,8 +185,6 @@ then edit directly with the Edit tool, then validate with
 
 - Interactive: `swamp workflow edit my-workflow` (opens in system editor)
 - Stdin: `cat updated.yaml | swamp workflow edit my-workflow --json`
-
-Run `swamp repo index` if search results seem stale after editing.
 
 ## Delete a Workflow
 


### PR DESCRIPTION
## Summary

- Replaced outdated dual-layer symlink architecture descriptions with actual flat-file storage layout across all affected skill references (swamp-workflow, swamp-model, swamp-vault, swamp-repo)
- Removed all references to the nonexistent `swamp repo index` command (symlink indexing was replaced with `NoopRepoIndexService`)
- Removed stale troubleshooting sections (Broken Symlinks, Index Out of Sync, Rebuilding Logical Views)

Fixes #1130

## Test Plan

- [x] `deno fmt --check` — passes
- [x] `deno lint` — passes
- [x] `deno run test` — all 4192 tests pass
- [x] Verified no remaining `repo index`, `symlinked directories`, or `dual-layer` references in `.claude/skills/`
- [x] Confirmed actual storage paths match code: `YamlWorkflowRepository` (`workflows/workflow-{uuid}.yaml`), `YamlDefinitionRepository` (`models/{type}/{id}.yaml`), `YamlVaultConfigRepository` (`vaults/{type}/{id}.yaml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)