### PR TITLE
fix: correct vault get storagePath to use vaults/ instead of .swamp/vault/

### DIFF
--- a/src/libswamp/vaults/get.ts
+++ b/src/libswamp/vaults/get.ts
@@ -18,10 +18,6 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
-import {
-  SWAMP_DATA_DIR,
-  SWAMP_SUBDIRS,
-} from "../../infrastructure/persistence/paths.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound, validationFailed } from "../errors.ts";
@@ -68,8 +64,7 @@ export function createVaultGetDeps(repoDir: string): VaultGetDeps {
     findByName: (name) => repo.findByName(name),
     findById: (type, id) => repo.findById(type, id),
     findAll: () => repo.findAll(),
-    storagePath: (config) =>
-      `${SWAMP_DATA_DIR}/${SWAMP_SUBDIRS.vault}/${config.type}/${config.id}.yaml`,
+    storagePath: (config) => `vaults/${config.type}/${config.id}.yaml`,
   };
 }
 

--- a/src/libswamp/vaults/get_test.ts
+++ b/src/libswamp/vaults/get_test.ts
@@ -21,6 +21,7 @@ import { assertEquals } from "@std/assert";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
+  createVaultGetDeps,
   type VaultConfigInfo,
   vaultGet,
   type VaultGetDeps,
@@ -121,4 +122,19 @@ Deno.test("vaultGet yields error with validation_failed when vault type does not
   const last = events[1] as Extract<VaultGetEvent, { kind: "error" }>;
   assertEquals(last.kind, "error");
   assertEquals(last.error.code, "validation_failed");
+});
+
+Deno.test("createVaultGetDeps: storagePath uses vaults/ not .swamp/vault/", () => {
+  const deps = createVaultGetDeps("/tmp/fake-repo");
+  const config: VaultConfigInfo = {
+    id: "abc-123",
+    name: "test-vault",
+    type: "local_encryption",
+    config: {},
+    createdAt: new Date(),
+  };
+  assertEquals(
+    deps.storagePath(config),
+    "vaults/local_encryption/abc-123.yaml",
+  );
 });


### PR DESCRIPTION
## Summary

- Fix `createVaultGetDeps` in `src/libswamp/vaults/get.ts` to construct `storagePath` as `vaults/{type}/{id}.yaml` instead of `.swamp/vault/{type}/{id}.yaml`
- Remove unused `SWAMP_DATA_DIR` and `SWAMP_SUBDIRS` imports
- Add unit test for `createVaultGetDeps.storagePath` to prevent regression

Fixes #1132

## Test Plan

- [x] New unit test `createVaultGetDeps: storagePath uses vaults/ not .swamp/vault/` passes
- [x] All existing vault get tests pass
- [x] Verified fix in scratch repo: `swamp vault get my-secrets --json` now shows `vaults/local_encryption/{id}.yaml`
- [x] `deno check`, `deno lint`, `deno fmt` all pass