### PR TITLE
fix: consolidate MethodContext construction through a single factory

### DIFF
--- a/integration/workflow_query_data_context_test.ts
+++ b/integration/workflow_query_data_context_test.ts
@@ -1,0 +1,208 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+// Integration test for the full queryData chain on the workflow path:
+// buildMethodContext -> RawExecutionDriver -> derived queryData ->
+// real DataQueryService -> real CatalogStore. A regression in any of these
+// layers would surface here. See lab issue #35.
+
+import { assertEquals, assertExists } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { getLogger } from "@logtape/logtape";
+import { z } from "zod";
+
+import { buildMethodContext } from "../src/domain/models/method_context.ts";
+import {
+  type MethodExecutor,
+  RawExecutionDriver,
+} from "../src/domain/drivers/raw_execution_driver.ts";
+import { Definition } from "../src/domain/definitions/definition.ts";
+import { Data } from "../src/domain/data/data.ts";
+import { ModelType } from "../src/domain/models/model_type.ts";
+import type {
+  MethodContext,
+  MethodDefinition,
+  ModelDefinition,
+} from "../src/domain/models/model.ts";
+import type { DataRecord } from "../src/domain/data/data_record.ts";
+import type { ExecutionRequest } from "../src/domain/drivers/execution_driver.ts";
+import { FileSystemUnifiedDataRepository } from "../src/infrastructure/persistence/unified_data_repository.ts";
+import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
+import { CatalogStore } from "../src/infrastructure/persistence/catalog_store.ts";
+import { DataQueryService } from "../src/domain/data/data_query_service.ts";
+
+const TEST_MODEL_TYPE = ModelType.create("test/query_data_ctx");
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-queryctx-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+async function setupRepoDir(dir: string): Promise<void> {
+  await ensureDir(join(dir, ".swamp", "data"));
+  await ensureDir(join(dir, "models"));
+}
+
+function createMockRequest(): ExecutionRequest {
+  return {
+    protocolVersion: 1,
+    modelType: TEST_MODEL_TYPE.normalized,
+    modelId: "def-query-ctx",
+    methodName: "run",
+    globalArgs: {},
+    methodArgs: {},
+    definitionMeta: {
+      id: "def-query-ctx",
+      name: "query-ctx-model",
+      version: 1,
+      tags: {},
+    },
+  };
+}
+
+Deno.test("queryData chain: factory + driver derive working queryData from dataQueryService", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+
+    // Real infrastructure: catalog store, data repo, query service.
+    const catalogStore = new CatalogStore(
+      join(repoDir, ".swamp", "data", "_catalog.db"),
+    );
+    try {
+      const dataRepo = new FileSystemUnifiedDataRepository(
+        repoDir,
+        undefined,
+        catalogStore,
+      );
+      const definitionRepo = new YamlDefinitionRepository(repoDir);
+      const dataQueryService = new DataQueryService(catalogStore, dataRepo);
+
+      // Seed one data record the query should match.
+      const seedModel = Definition.create({
+        name: "seed_source",
+        type: TEST_MODEL_TYPE.normalized,
+      });
+      await definitionRepo.save(TEST_MODEL_TYPE, seedModel);
+      const seedData = Data.create({
+        name: "seeded_row",
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        tags: { type: "resource" },
+        ownerDefinition: {
+          ownerType: "model-method",
+          ownerRef: `${TEST_MODEL_TYPE.normalized}:seed`,
+        },
+      });
+      await dataRepo.save(
+        TEST_MODEL_TYPE,
+        seedModel.id,
+        seedData,
+        new TextEncoder().encode(JSON.stringify({ sentinel: "expected" })),
+      );
+
+      // Build a minimal execution target: one method that calls queryData.
+      const definition = Definition.create({
+        name: "query-ctx-model",
+        type: TEST_MODEL_TYPE.normalized,
+      });
+      const method: MethodDefinition = {
+        description: "run",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({}),
+      };
+      const modelDef: ModelDefinition = {
+        type: TEST_MODEL_TYPE,
+        version: "2026.01.01.1",
+        globalArguments: z.object({}),
+        resources: {},
+        methods: { run: method },
+      };
+
+      // Exercises the fix: context.queryData must exist and return seeded rows.
+      let queryResult: DataRecord[] | unknown[] | undefined;
+      const executor: MethodExecutor = {
+        execute: async (_def, _m, context) => {
+          queryResult = await context.queryData!(
+            'attributes.sentinel == "expected"',
+            undefined,
+          );
+          return {};
+        },
+      };
+
+      const context: MethodContext = buildMethodContext(
+        {
+          dataRepository: dataRepo,
+          definitionRepository: definitionRepo,
+          dataQueryService,
+        },
+        {
+          signal: new AbortController().signal,
+          repoDir,
+          modelType: TEST_MODEL_TYPE,
+          modelId: definition.id,
+          globalArgs: {},
+          definition: {
+            id: definition.id,
+            name: definition.name,
+            version: definition.version,
+            tags: definition.tags,
+          },
+          methodName: "run",
+          logger: getLogger(["test", "queryctx"]),
+        },
+      );
+
+      // The factory alone does not populate queryData — the driver derives it.
+      assertEquals(context.queryData, undefined);
+      assertExists(context.dataQueryService);
+
+      const driver = new RawExecutionDriver(
+        executor,
+        definition,
+        method,
+        modelDef,
+        context,
+        "run",
+      );
+      const result = await driver.execute(createMockRequest());
+
+      assertEquals(result.status, "success");
+      assertExists(queryResult);
+      assertEquals(
+        (queryResult as DataRecord[]).length >= 1,
+        true,
+        "expected seeded row to be returned by context.queryData",
+      );
+      const seededRow = (queryResult as DataRecord[]).find(
+        (r) => r.name === "seeded_row",
+      );
+      assertExists(seededRow);
+      assertEquals(seededRow.attributes.sentinel, "expected");
+    } finally {
+      catalogStore.close();
+    }
+  });
+});

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -190,14 +190,10 @@ export const modelMethodRunCommand = new Command()
         dataRepo: repoContext.unifiedDataRepo,
         definitionRepo: repoContext.definitionRepo,
         outputRepo: repoContext.outputRepo,
-        queryData:
-          ((dqs) => (predicate: string, select?: string) =>
-            dqs.query(predicate, { select }))(
-              new DataQueryService(
-                repoContext.catalogStore,
-                repoContext.unifiedDataRepo,
-              ),
-            ),
+        dataQueryService: new DataQueryService(
+          repoContext.catalogStore,
+          repoContext.unifiedDataRepo,
+        ),
         createRunLog: async (modelType, method, definitionId) => {
           const redactor = new SecretRedactor();
           const timestamp = new Date().toISOString().replace(/[:.]/g, "-");

--- a/src/domain/drivers/raw_execution_driver.ts
+++ b/src/domain/drivers/raw_execution_driver.ts
@@ -139,8 +139,15 @@ export class RawExecutionDriver implements ExecutionDriver {
     const readModelData = (modelName: string, specName?: string) =>
       dataAccessService.readModelData(modelName, specName);
 
-    // queryData passes through directly — no hidden scoping
-    const queryData = this.context.queryData;
+    // Prefer an explicitly-set queryData (test fixtures), otherwise derive
+    // a binding from dataQueryService. Production callers supply only
+    // dataQueryService; the driver owns the single queryData binding.
+    const dataQueryService = this.context.dataQueryService;
+    const queryData = this.context.queryData ??
+      (dataQueryService
+        ? (predicate: string, select?: string) =>
+          dataQueryService.query(predicate, { select })
+        : undefined);
 
     this.contextWithWriters = {
       ...this.context,

--- a/src/domain/drivers/raw_execution_driver_test.ts
+++ b/src/domain/drivers/raw_execution_driver_test.ts
@@ -34,6 +34,7 @@ import type { UnifiedDataRepository } from "../../infrastructure/persistence/uni
 import type { DefinitionRepository } from "../definitions/repositories.ts";
 import { type DataId, generateDataId } from "../data/data_id.ts";
 import { getLogger } from "@logtape/logtape";
+import type { DataQueryService } from "../data/data_query_service.ts";
 
 const TEST_MODEL_TYPE = ModelType.create("test/raw-driver");
 
@@ -356,4 +357,87 @@ Deno.test("RawExecutionDriver: leaves queryData unscoped when no workflowRunId",
   await driver.execute(createMockRequest());
 
   assertEquals(capturedPredicate, "model_name == 'source'");
+});
+
+Deno.test("RawExecutionDriver: derives queryData from dataQueryService when not set", async () => {
+  let capturedPredicate = "";
+  let capturedSelect: string | undefined;
+
+  const executor: MethodExecutor = {
+    execute: async (_def, _method, context) => {
+      await context.queryData!("model_name == 'source'", "attributes.foo");
+      return {};
+    },
+  };
+
+  const context = createMockContext();
+  context.definitionRepository = {
+    findByNameGlobal: () => Promise.resolve(null),
+    findAll: () => Promise.resolve([]),
+    findAllGlobal: () => Promise.resolve([]),
+  } as unknown as DefinitionRepository;
+  context.dataQueryService = {
+    query: (predicate: string, opts?: { select?: string }) => {
+      capturedPredicate = predicate;
+      capturedSelect = opts?.select;
+      return Promise.resolve([]);
+    },
+  } as unknown as DataQueryService;
+
+  const driver = new RawExecutionDriver(
+    executor,
+    testDefinition,
+    testMethod,
+    testModelDef,
+    context,
+    "test",
+  );
+
+  await driver.execute(createMockRequest());
+
+  assertEquals(capturedPredicate, "model_name == 'source'");
+  assertEquals(capturedSelect, "attributes.foo");
+});
+
+Deno.test("RawExecutionDriver: explicit queryData wins over dataQueryService derivation", async () => {
+  let usedExplicit = false;
+  let usedDerived = false;
+
+  const executor: MethodExecutor = {
+    execute: async (_def, _method, context) => {
+      await context.queryData!("true", undefined);
+      return {};
+    },
+  };
+
+  const context = createMockContext();
+  context.definitionRepository = {
+    findByNameGlobal: () => Promise.resolve(null),
+    findAll: () => Promise.resolve([]),
+    findAllGlobal: () => Promise.resolve([]),
+  } as unknown as DefinitionRepository;
+  context.queryData = () => {
+    usedExplicit = true;
+    return Promise.resolve([]);
+  };
+  context.dataQueryService = {
+    query: () => {
+      usedDerived = true;
+      return Promise.resolve([]);
+    },
+  } as unknown as DataQueryService;
+
+  const driver = new RawExecutionDriver(
+    executor,
+    testDefinition,
+    testMethod,
+    testModelDef,
+    context,
+    "test",
+  );
+
+  await driver.execute(createMockRequest());
+
+  assertEquals(usedExplicit, true);
+  assertEquals(usedDerived, false);
 });

--- a/src/domain/models/method_context.ts
+++ b/src/domain/models/method_context.ts
@@ -1,0 +1,122 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+// Production MethodContext construction must go through buildMethodContext.
+// Test fixtures may construct MethodContext inline so each test declares
+// exactly what it exercises. See method_context_arch_test.ts for enforcement.
+
+import type { MethodContext } from "./model.ts";
+
+/**
+ * Startup-scoped dependencies shared across every method invocation in a
+ * single execution context. A host (CLI, server, workflow runner) constructs
+ * these once and feeds them to `buildMethodContext` for each method call.
+ *
+ * Field types are reused from MethodContext via indexed access so this file
+ * does not add any new infrastructure imports to the domain layer.
+ */
+export interface CommonMethodContextDeps {
+  dataRepository: MethodContext["dataRepository"];
+  definitionRepository: MethodContext["definitionRepository"];
+  outputRepository?: MethodContext["outputRepository"];
+  vaultService?: MethodContext["vaultService"];
+  redactor?: MethodContext["redactor"];
+  dataQueryService?: MethodContext["dataQueryService"];
+  cloudControlClientFactory?: MethodContext["cloudControlClientFactory"];
+}
+
+/**
+ * Per-invocation overlay describing the model and method being executed.
+ * Populated fresh for each call into `buildMethodContext`.
+ */
+export interface MethodInvocationContext {
+  signal: MethodContext["signal"];
+  repoDir: MethodContext["repoDir"];
+  modelType: MethodContext["modelType"];
+  modelId: MethodContext["modelId"];
+  globalArgs: MethodContext["globalArgs"];
+  definition: MethodContext["definition"];
+  methodName: MethodContext["methodName"];
+  logger: MethodContext["logger"];
+  runtimeTags?: MethodContext["runtimeTags"];
+  tagOverrides?: MethodContext["tagOverrides"];
+  dataOutputOverrides?: MethodContext["dataOutputOverrides"];
+  onEvent?: MethodContext["onEvent"];
+  skipCheckNames?: MethodContext["skipCheckNames"];
+  skipCheckLabels?: MethodContext["skipCheckLabels"];
+  skipAllChecks?: MethodContext["skipAllChecks"];
+  skipReportNames?: MethodContext["skipReportNames"];
+  skipReportLabels?: MethodContext["skipReportLabels"];
+  skipAllReports?: MethodContext["skipAllReports"];
+  reportNames?: MethodContext["reportNames"];
+  reportLabels?: MethodContext["reportLabels"];
+  driver?: MethodContext["driver"];
+  driverConfig?: MethodContext["driverConfig"];
+  vaultSecrets?: MethodContext["vaultSecrets"];
+  unresolvedMethodArgs?: MethodContext["unresolvedMethodArgs"];
+}
+
+/**
+ * Assembles a `MethodContext` from startup-scoped dependencies and
+ * per-invocation overlay. This is the single production entry point for
+ * MethodContext construction — every method execution path (manual runs,
+ * workflow steps, pre-flight check validation) routes through here.
+ *
+ * `queryData` is intentionally not an input. The RawExecutionDriver derives
+ * it from `dataQueryService` at execution time, with a fallback for test
+ * fixtures that set `queryData` directly.
+ */
+export function buildMethodContext(
+  common: CommonMethodContextDeps,
+  invocation: MethodInvocationContext,
+): MethodContext {
+  return {
+    signal: invocation.signal,
+    repoDir: invocation.repoDir,
+    modelType: invocation.modelType,
+    modelId: invocation.modelId,
+    globalArgs: invocation.globalArgs,
+    definition: invocation.definition,
+    methodName: invocation.methodName,
+    logger: invocation.logger,
+    dataRepository: common.dataRepository,
+    definitionRepository: common.definitionRepository,
+    outputRepository: common.outputRepository,
+    vaultService: common.vaultService,
+    redactor: common.redactor,
+    dataQueryService: common.dataQueryService,
+    cloudControlClientFactory: common.cloudControlClientFactory,
+    runtimeTags: invocation.runtimeTags,
+    tagOverrides: invocation.tagOverrides,
+    dataOutputOverrides: invocation.dataOutputOverrides,
+    onEvent: invocation.onEvent,
+    skipCheckNames: invocation.skipCheckNames,
+    skipCheckLabels: invocation.skipCheckLabels,
+    skipAllChecks: invocation.skipAllChecks,
+    skipReportNames: invocation.skipReportNames,
+    skipReportLabels: invocation.skipReportLabels,
+    skipAllReports: invocation.skipAllReports,
+    reportNames: invocation.reportNames,
+    reportLabels: invocation.reportLabels,
+    driver: invocation.driver,
+    driverConfig: invocation.driverConfig,
+    vaultSecrets: invocation.vaultSecrets,
+    unresolvedMethodArgs: invocation.unresolvedMethodArgs,
+  };
+}

--- a/src/domain/models/method_context_arch_test.ts
+++ b/src/domain/models/method_context_arch_test.ts
@@ -1,0 +1,74 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+// Architecture guard: production MethodContext construction must go through
+// buildMethodContext. This test walks src/ and fails if a new inline
+// MethodContext object literal appears outside the allowed files. If this
+// test fails, route the construction through buildMethodContext in
+// src/domain/models/method_context.ts.
+
+import { assertEquals } from "@std/assert";
+import { walk } from "@std/fs";
+import { relative } from "@std/path";
+
+const REPO_ROOT = new URL("../../..", import.meta.url).pathname;
+const SRC_ROOT = `${REPO_ROOT}src`;
+
+const ALLOWED_FILES: ReadonlySet<string> = new Set([
+  // The factory itself.
+  "src/domain/models/method_context.ts",
+  // The interface declaration uses `MethodContext["logger"]` typeof lookups.
+  "src/domain/models/model.ts",
+  // Spread-based enrichment overlays `globalArgs`/`unresolvedMethodArgs` onto
+  // an already-built context during method execution. Not a new construction
+  // site — inherits every field the factory populated.
+  "src/domain/models/method_execution_service.ts",
+]);
+
+// Matches `: MethodContext = {` and `MethodContext = {` literal assignments.
+const INLINE_LITERAL = /\bMethodContext\s*=\s*\{/;
+
+Deno.test("architecture: no inline MethodContext literals outside factory and tests", async () => {
+  const offenders: string[] = [];
+
+  for await (
+    const entry of walk(SRC_ROOT, {
+      exts: [".ts"],
+      includeDirs: false,
+      followSymlinks: false,
+    })
+  ) {
+    const rel = relative(REPO_ROOT, entry.path);
+    if (rel.endsWith("_test.ts")) continue;
+    if (ALLOWED_FILES.has(rel)) continue;
+
+    const text = await Deno.readTextFile(entry.path);
+    if (INLINE_LITERAL.test(text)) {
+      offenders.push(rel);
+    }
+  }
+
+  assertEquals(
+    offenders,
+    [],
+    `Found inline MethodContext literals in production code:\n  ${
+      offenders.join("\n  ")
+    }\n\nRoute construction through buildMethodContext in src/domain/models/method_context.ts.`,
+  );
+});

--- a/src/domain/models/method_context_test.ts
+++ b/src/domain/models/method_context_test.ts
@@ -1,0 +1,192 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStrictEquals } from "@std/assert";
+import { getLogger } from "@logtape/logtape";
+
+import {
+  buildMethodContext,
+  type CommonMethodContextDeps,
+  type MethodInvocationContext,
+} from "./method_context.ts";
+import { ModelType } from "./model_type.ts";
+import type { DataQueryService } from "../data/data_query_service.ts";
+import type { DefinitionRepository } from "../definitions/repositories.ts";
+import type { OutputRepository } from "./repositories.ts";
+import type { VaultService } from "../vaults/vault_service.ts";
+import type { SecretRedactor } from "../secrets/mod.ts";
+import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+
+function makeCommon(
+  overrides: Partial<CommonMethodContextDeps> = {},
+): CommonMethodContextDeps {
+  const dataRepository = {} as UnifiedDataRepository;
+  const definitionRepository = {} as DefinitionRepository;
+  return {
+    dataRepository,
+    definitionRepository,
+    ...overrides,
+  };
+}
+
+function makeInvocation(
+  overrides: Partial<MethodInvocationContext> = {},
+): MethodInvocationContext {
+  return {
+    signal: new AbortController().signal,
+    repoDir: "/tmp/test-repo",
+    modelType: ModelType.create("test/model"),
+    modelId: "model-id-1",
+    globalArgs: { foo: "bar" },
+    definition: {
+      id: "def-1",
+      name: "test-model",
+      version: 1,
+      tags: {},
+    },
+    methodName: "run",
+    logger: getLogger(["test"]),
+    ...overrides,
+  };
+}
+
+Deno.test("buildMethodContext: passes through required common deps", () => {
+  const dataRepository = {} as UnifiedDataRepository;
+  const definitionRepository = {} as DefinitionRepository;
+
+  const ctx = buildMethodContext(
+    { dataRepository, definitionRepository },
+    makeInvocation(),
+  );
+
+  assertStrictEquals(ctx.dataRepository, dataRepository);
+  assertStrictEquals(ctx.definitionRepository, definitionRepository);
+});
+
+Deno.test("buildMethodContext: passes through optional common deps", () => {
+  const outputRepository = {} as OutputRepository;
+  const vaultService = {} as VaultService;
+  const redactor = {} as SecretRedactor;
+  const dataQueryService = {} as DataQueryService;
+
+  const ctx = buildMethodContext(
+    makeCommon({
+      outputRepository,
+      vaultService,
+      redactor,
+      dataQueryService,
+    }),
+    makeInvocation(),
+  );
+
+  assertStrictEquals(ctx.outputRepository, outputRepository);
+  assertStrictEquals(ctx.vaultService, vaultService);
+  assertStrictEquals(ctx.redactor, redactor);
+  assertStrictEquals(ctx.dataQueryService, dataQueryService);
+});
+
+Deno.test("buildMethodContext: omitted optional common deps flow through as undefined", () => {
+  const ctx = buildMethodContext(makeCommon(), makeInvocation());
+
+  assertEquals(ctx.outputRepository, undefined);
+  assertEquals(ctx.vaultService, undefined);
+  assertEquals(ctx.redactor, undefined);
+  assertEquals(ctx.dataQueryService, undefined);
+  assertEquals(ctx.cloudControlClientFactory, undefined);
+});
+
+Deno.test("buildMethodContext: passes through invocation overlay fields", () => {
+  const modelType = ModelType.create("test/model");
+  const signal = new AbortController().signal;
+  const logger = getLogger(["test"]);
+  const onEvent = () => {};
+
+  const ctx = buildMethodContext(
+    makeCommon(),
+    {
+      signal,
+      repoDir: "/tmp/foo",
+      modelType,
+      modelId: "m1",
+      globalArgs: { a: 1 },
+      definition: { id: "d1", name: "n1", version: 2, tags: { t: "v" } },
+      methodName: "go",
+      logger,
+      runtimeTags: { run: "tag" },
+      tagOverrides: { source: "test" },
+      dataOutputOverrides: [{ specName: "out" }],
+      onEvent,
+      skipCheckNames: ["a"],
+      skipCheckLabels: ["b"],
+      skipAllChecks: true,
+      skipReportNames: ["r1"],
+      skipReportLabels: ["r2"],
+      skipAllReports: false,
+      reportNames: ["only"],
+      reportLabels: ["label"],
+      driver: "raw",
+      driverConfig: { k: "v" },
+      vaultSecrets: { list: () => [] } as unknown as MethodInvocationContext[
+        "vaultSecrets"
+      ],
+      unresolvedMethodArgs: { arg: "sentinel" },
+    },
+  );
+
+  assertStrictEquals(ctx.signal, signal);
+  assertEquals(ctx.repoDir, "/tmp/foo");
+  assertStrictEquals(ctx.modelType, modelType);
+  assertEquals(ctx.modelId, "m1");
+  assertEquals(ctx.globalArgs, { a: 1 });
+  assertEquals(ctx.definition, {
+    id: "d1",
+    name: "n1",
+    version: 2,
+    tags: { t: "v" },
+  });
+  assertEquals(ctx.methodName, "go");
+  assertStrictEquals(ctx.logger, logger);
+  assertEquals(ctx.runtimeTags, { run: "tag" });
+  assertEquals(ctx.tagOverrides, { source: "test" });
+  assertEquals(ctx.dataOutputOverrides, [{ specName: "out" }]);
+  assertStrictEquals(ctx.onEvent, onEvent);
+  assertEquals(ctx.skipCheckNames, ["a"]);
+  assertEquals(ctx.skipCheckLabels, ["b"]);
+  assertEquals(ctx.skipAllChecks, true);
+  assertEquals(ctx.skipReportNames, ["r1"]);
+  assertEquals(ctx.skipReportLabels, ["r2"]);
+  assertEquals(ctx.skipAllReports, false);
+  assertEquals(ctx.reportNames, ["only"]);
+  assertEquals(ctx.reportLabels, ["label"]);
+  assertEquals(ctx.driver, "raw");
+  assertEquals(ctx.driverConfig, { k: "v" });
+  assertEquals(ctx.unresolvedMethodArgs, { arg: "sentinel" });
+});
+
+Deno.test("buildMethodContext: queryData is not populated by the factory", () => {
+  // queryData is derived at the driver boundary from dataQueryService.
+  // Factory output has no queryData of its own — the field is left
+  // undefined so the driver can bind it consistently.
+  const ctx = buildMethodContext(
+    makeCommon({ dataQueryService: {} as DataQueryService }),
+    makeInvocation(),
+  );
+
+  assertEquals(ctx.queryData, undefined);
+});

--- a/src/domain/models/validation_service.ts
+++ b/src/domain/models/validation_service.ts
@@ -20,9 +20,11 @@
 import type { z } from "zod";
 import type { MethodContext, ModelDefinition } from "./model.ts";
 import { modelRegistry } from "./model.ts";
+import { buildMethodContext } from "./method_context.ts";
 import type { Definition } from "../definitions/definition.ts";
 import { DefinitionSchema } from "../definitions/definition.ts";
 import type { DefinitionRepository } from "../definitions/repositories.ts";
+import type { DataQueryService } from "../data/data_query_service.ts";
 import {
   extractExpressions,
   stripExpressionFields,
@@ -231,6 +233,7 @@ export interface CheckValidationContext {
   repoDir: string;
   dataRepository: MethodContext["dataRepository"];
   definitionRepository: DefinitionRepository;
+  dataQueryService?: DataQueryService;
   labels?: string[];
   method?: string;
 }
@@ -375,32 +378,37 @@ export class DefaultModelValidationService implements ModelValidationService {
       }
 
       try {
-        const context: MethodContext = {
-          signal: new AbortController().signal,
-          repoDir: checkContext.repoDir,
-          modelType: modelDef.type,
-          modelId: definition.id,
-          globalArgs: definition.globalArguments,
-          definition: {
-            id: definition.id,
-            name: definition.name,
-            version: definition.version,
-            tags: definition.tags,
+        const context = buildMethodContext(
+          {
+            dataRepository: checkContext.dataRepository,
+            definitionRepository: checkContext.definitionRepository,
+            dataQueryService: checkContext.dataQueryService,
           },
-          methodName: checkContext.method ?? "",
-          logger: {
-            debug() {},
-            info() {},
-            warn() {},
-            error() {},
-            fatal() {},
-            with() {
-              return this;
+          {
+            signal: new AbortController().signal,
+            repoDir: checkContext.repoDir,
+            modelType: modelDef.type,
+            modelId: definition.id,
+            globalArgs: definition.globalArguments,
+            definition: {
+              id: definition.id,
+              name: definition.name,
+              version: definition.version,
+              tags: definition.tags,
             },
-          } as unknown as MethodContext["logger"],
-          dataRepository: checkContext.dataRepository,
-          definitionRepository: checkContext.definitionRepository,
-        };
+            methodName: checkContext.method ?? "",
+            logger: {
+              debug() {},
+              info() {},
+              warn() {},
+              error() {},
+              fatal() {},
+              with() {
+                return this;
+              },
+            } as unknown as MethodContext["logger"],
+          },
+        );
 
         const checkResult = await check.execute(context);
         if (!checkResult || typeof checkResult.pass !== "boolean") {

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -44,6 +44,7 @@ import { BUILTIN_METHOD_REPORTS } from "../reports/builtin/mod.ts";
 import { getAutoResolver } from "../extensions/auto_resolver_context.ts";
 import { DefaultMethodExecutionService } from "../models/method_execution_service.ts";
 import { DefaultModelValidationService } from "../models/validation_service.ts";
+import { buildMethodContext } from "../models/method_context.ts";
 import { buildOutputSpecs } from "../models/output_spec_builder.ts";
 import { detectEnvVarUsageInDefinition } from "../models/env_var_detector.ts";
 import type { Definition } from "../definitions/definition.ts";
@@ -208,6 +209,10 @@ export class DefaultStepExecutor implements StepExecutor {
       ctx.repoDir,
       ctx.dataBaseDir,
       ctx.catalogStore,
+    );
+    const dataQueryService = new DataQueryService(
+      ctx.catalogStore,
+      unifiedDataRepo,
     );
     const outputRepo = new YamlOutputRepository(ctx.repoDir);
     const executionService = new DefaultMethodExecutionService();
@@ -484,58 +489,63 @@ export class DefaultStepExecutor implements StepExecutor {
         evaluatedDefinition,
         modelDef,
         task.methodName,
-        {
-          signal: ctx.signal,
-          repoDir: ctx.repoDir,
-          modelType,
-          modelId: evaluatedDefinition.id,
-          globalArgs: evaluatedDefinition.globalArguments,
-          definition: {
-            id: evaluatedDefinition.id,
-            name: evaluatedDefinition.name,
-            version: evaluatedDefinition.version,
-            tags: evaluatedDefinition.tags,
+        buildMethodContext(
+          {
+            dataRepository: unifiedDataRepo,
+            definitionRepository: definitionRepo,
+            vaultService,
+            redactor: ctx.secretRedactor,
+            dataQueryService,
           },
-          methodName: task.methodName,
-          logger: runLogger,
-          dataRepository: unifiedDataRepo,
-          definitionRepository: definitionRepo,
-          tagOverrides: workflowTagOverrides,
-          runtimeTags: ctx.runtimeTags,
-          dataOutputOverrides: stepDataOutputOverrides,
-          vaultService,
-          redactor: ctx.secretRedactor,
-          vaultSecrets: secretBag,
-          driver: ctx.driver ?? evaluatedDefinition.driver,
-          driverConfig: ctx.driverConfig ?? evaluatedDefinition.driverConfig,
-          skipCheckNames: ctx.skipCheckNames,
-          skipCheckLabels: ctx.skipCheckLabels,
-          skipAllChecks: ctx.skipAllChecks,
-          onEvent: ctx.emitEvent
-            ? (event: MethodExecutionEvent) => {
-              if (event.type === "output") {
-                ctx.emitEvent!({
-                  kind: "method_output",
-                  jobId: ctx.jobName,
-                  stepId: ctx.stepName,
-                  modelName: originalDefinition.name,
-                  methodName: task.methodName,
-                  stream: event.stream,
-                  line: event.line,
-                });
-              } else {
-                ctx.emitEvent!({
-                  kind: "method_event",
-                  jobId: ctx.jobName,
-                  stepId: ctx.stepName,
-                  modelName: originalDefinition.name,
-                  methodName: task.methodName,
-                  event,
-                });
+          {
+            signal: ctx.signal,
+            repoDir: ctx.repoDir,
+            modelType,
+            modelId: evaluatedDefinition.id,
+            globalArgs: evaluatedDefinition.globalArguments,
+            definition: {
+              id: evaluatedDefinition.id,
+              name: evaluatedDefinition.name,
+              version: evaluatedDefinition.version,
+              tags: evaluatedDefinition.tags,
+            },
+            methodName: task.methodName,
+            logger: runLogger,
+            tagOverrides: workflowTagOverrides,
+            runtimeTags: ctx.runtimeTags,
+            dataOutputOverrides: stepDataOutputOverrides,
+            vaultSecrets: secretBag,
+            driver: ctx.driver ?? evaluatedDefinition.driver,
+            driverConfig: ctx.driverConfig ?? evaluatedDefinition.driverConfig,
+            skipCheckNames: ctx.skipCheckNames,
+            skipCheckLabels: ctx.skipCheckLabels,
+            skipAllChecks: ctx.skipAllChecks,
+            onEvent: ctx.emitEvent
+              ? (event: MethodExecutionEvent) => {
+                if (event.type === "output") {
+                  ctx.emitEvent!({
+                    kind: "method_output",
+                    jobId: ctx.jobName,
+                    stepId: ctx.stepName,
+                    modelName: originalDefinition.name,
+                    methodName: task.methodName,
+                    stream: event.stream,
+                    line: event.line,
+                  });
+                } else {
+                  ctx.emitEvent!({
+                    kind: "method_event",
+                    jobId: ctx.jobName,
+                    stepId: ctx.stepName,
+                    modelName: originalDefinition.name,
+                    methodName: task.methodName,
+                    event,
+                  });
+                }
               }
-            }
-            : undefined,
-        },
+              : undefined,
+          },
+        ),
       );
 
       // Extract artifact info from dataHandles (already persisted by DataWriter)

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -2605,3 +2605,81 @@ Deno.test("coerceToSuffix: skips null/undefined properties", () => {
     "fallback-id",
   );
 });
+
+// Regression test for lab issue #35: workflow-path MethodContext must carry
+// dataQueryService (and therefore a derived queryData) so extension methods
+// invoked as workflow steps can call context.queryData. Guards the factory
+// call site in DefaultStepExecutor.executeModelMethod.
+Deno.test("DefaultStepExecutor wires dataQueryService into MethodContext", async () => {
+  const { z } = await import("zod");
+  const { ModelType } = await import("../models/model_type.ts");
+  const { modelRegistry } = await import("../models/model.ts");
+  const { Definition } = await import("../definitions/definition.ts");
+  const { YamlDefinitionRepository } = await import(
+    "../../infrastructure/persistence/yaml_definition_repository.ts"
+  );
+  const { initializeLogging } = await import(
+    "../../infrastructure/logging/logger.ts"
+  );
+  await initializeLogging({});
+
+  await withTempDir(async (tempDir) => {
+    const typeName = `@test-issue35/capture-${crypto.randomUUID().slice(0, 8)}`;
+    const modelType = ModelType.create(typeName);
+    let capturedDataQueryService: unknown;
+    let capturedQueryData: unknown;
+
+    modelRegistry.register({
+      type: modelType,
+      version: "2026.01.01.1",
+      globalArguments: z.object({}),
+      resources: {},
+      methods: {
+        run: {
+          description: "captures context for regression assertions",
+          arguments: z.object({}),
+          execute: (_args, context) => {
+            capturedDataQueryService = context.dataQueryService;
+            capturedQueryData = context.queryData;
+            return Promise.resolve({});
+          },
+        },
+      },
+    });
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    try {
+      const definitionRepo = new YamlDefinitionRepository(tempDir);
+      const instance = Definition.create({
+        name: "capture-instance",
+        type: modelType.normalized,
+      });
+      await definitionRepo.save(modelType, instance);
+
+      const step = Step.create({
+        name: "capture-step",
+        task: StepTask.model("capture-instance", "run"),
+      });
+      const ctx: StepExecutionContext = {
+        workflowId: createWorkflowId("00000000-0000-0000-0000-000000000000"),
+        workflowRunId: "00000000-0000-0000-0000-000000000000",
+        workflowName: "regression",
+        jobName: "job1",
+        stepName: "capture-step",
+        repoDir: tempDir,
+        signal: new AbortController().signal,
+        step,
+        catalogStore,
+      };
+
+      const executor = new DefaultStepExecutor();
+      await executor.execute(step, ctx);
+
+      assertNotEquals(capturedDataQueryService, undefined);
+      assertNotEquals(capturedQueryData, undefined);
+      assertEquals(typeof capturedQueryData, "function");
+    } finally {
+      catalogStore.close();
+    }
+  });
+});

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -44,7 +44,8 @@ import type { OutputRepository } from "../../domain/models/repositories.ts";
 import type { VaultService } from "../../domain/vaults/vault_service.ts";
 import type { ExpressionEvaluationService } from "../../domain/expressions/expression_evaluation_service.ts";
 import type { SecretRedactor } from "../../domain/secrets/mod.ts";
-import type { DataRecord } from "../../domain/data/data_record.ts";
+import type { DataQueryService } from "../../domain/data/data_query_service.ts";
+import { buildMethodContext } from "../../domain/models/method_context.ts";
 import type {
   DataArtifactView,
   ModelMethodRunView,
@@ -156,11 +157,8 @@ export interface ModelMethodRunDeps {
   dataRepo: UnifiedDataRepository;
   definitionRepo: YamlDefinitionRepository;
   outputRepo: OutputRepository;
-  /** Pre-built query function for context.queryData(). */
-  queryData: (
-    predicate: string,
-    select?: string,
-  ) => Promise<DataRecord[] | unknown[]>;
+  /** Data query service — the driver derives context.queryData from this. */
+  dataQueryService: DataQueryService;
   createRunLog: (
     modelType: ModelType,
     methodName: string,
@@ -410,50 +408,54 @@ export async function* modelMethodRun(
                 evaluatedDefinition,
                 modelDef,
                 input.methodName,
-                {
-                  signal: ctx.signal,
-                  repoDir: deps.repoDir,
-                  modelType,
-                  modelId: evaluatedDefinition.id,
-                  globalArgs: evaluatedDefinition.globalArguments,
-                  definition: {
-                    id: evaluatedDefinition.id,
-                    name: evaluatedDefinition.name,
-                    version: evaluatedDefinition.version,
-                    tags: evaluatedDefinition.tags,
+                buildMethodContext(
+                  {
+                    dataRepository: deps.dataRepo,
+                    definitionRepository: deps.definitionRepo,
+                    vaultService,
+                    redactor,
+                    dataQueryService: deps.dataQueryService,
                   },
-                  methodName: input.methodName,
-                  logger: getRunLogger(definition.name, input.methodName),
-                  dataRepository: deps.dataRepo,
-                  definitionRepository: deps.definitionRepo,
-                  runtimeTags: input.runtimeTags,
-                  vaultService,
-                  redactor,
-                  vaultSecrets: secretBag,
-                  skipCheckNames: input.skipCheckNames,
-                  skipCheckLabels: input.skipCheckLabels,
-                  skipAllChecks: input.skipAllChecks,
-                  driver: input.driver,
-                  onEvent: (event: MethodExecutionEvent) => {
-                    if (event.type === "output") {
-                      push({
-                        kind: "method_output",
-                        modelName: definition.name,
-                        methodName: input.methodName,
-                        stream: event.stream,
-                        line: event.line,
-                      });
-                    } else {
-                      push({
-                        kind: "method_event",
-                        modelName: definition.name,
-                        methodName: input.methodName,
-                        event,
-                      });
-                    }
+                  {
+                    signal: ctx.signal,
+                    repoDir: deps.repoDir,
+                    modelType,
+                    modelId: evaluatedDefinition.id,
+                    globalArgs: evaluatedDefinition.globalArguments,
+                    definition: {
+                      id: evaluatedDefinition.id,
+                      name: evaluatedDefinition.name,
+                      version: evaluatedDefinition.version,
+                      tags: evaluatedDefinition.tags,
+                    },
+                    methodName: input.methodName,
+                    logger: getRunLogger(definition.name, input.methodName),
+                    runtimeTags: input.runtimeTags,
+                    vaultSecrets: secretBag,
+                    skipCheckNames: input.skipCheckNames,
+                    skipCheckLabels: input.skipCheckLabels,
+                    skipAllChecks: input.skipAllChecks,
+                    driver: input.driver,
+                    onEvent: (event: MethodExecutionEvent) => {
+                      if (event.type === "output") {
+                        push({
+                          kind: "method_output",
+                          modelName: definition.name,
+                          methodName: input.methodName,
+                          stream: event.stream,
+                          line: event.line,
+                        });
+                      } else {
+                        push({
+                          kind: "method_event",
+                          modelName: definition.name,
+                          methodName: input.methodName,
+                          event,
+                        });
+                      }
+                    },
                   },
-                  queryData: deps.queryData,
-                },
+                ),
               ),
           );
         } catch (error) {

--- a/src/libswamp/models/run_test.ts
+++ b/src/libswamp/models/run_test.ts
@@ -36,6 +36,7 @@ import type { ModelDefinition } from "../../domain/models/model.ts";
 import { z } from "zod";
 import { VaultSecretBag } from "../../domain/vaults/vault_secret_bag.ts";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import type { DataQueryService } from "../../domain/data/data_query_service.ts";
 
 await initializeLogging({});
 
@@ -165,7 +166,9 @@ function createTestDeps(
     dataRepo: createFakeDataRepo(),
     definitionRepo: createFakeDefinitionRepo(),
     outputRepo: createFakeOutputRepo(),
-    queryData: () => Promise.resolve([]),
+    dataQueryService: {
+      query: () => Promise.resolve([]),
+    } as unknown as DataQueryService,
     createRunLog: () =>
       Promise.resolve({
         logFilePath: "/tmp/test.log",

--- a/src/libswamp/models/validate.ts
+++ b/src/libswamp/models/validate.ts
@@ -30,6 +30,7 @@ import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
 import { createCatalogStore } from "../../infrastructure/persistence/repository_factory.ts";
+import { DataQueryService } from "../../domain/data/data_query_service.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
 import type { LibSwampContext } from "../context.ts";
@@ -122,17 +123,20 @@ export function createModelValidateDeps(
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
   const definitionRepo = new YamlDefinitionRepository(repoDir);
+  const catalogStore = createCatalogStore(repoDir, datastoreResolver);
   const dataRepo = new FileSystemUnifiedDataRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
-    createCatalogStore(repoDir, datastoreResolver),
+    catalogStore,
   );
+  const dataQueryService = new DataQueryService(catalogStore, dataRepo);
   const validationService = new DefaultModelValidationService();
 
   const checkContext: CheckValidationContext = {
     repoDir,
     dataRepository: dataRepo,
     definitionRepository: definitionRepo,
+    dataQueryService,
     labels: options?.labels,
     method: options?.method,
   };

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -127,14 +127,10 @@ export async function createModelMethodRunDeps(
     dataRepo: repoContext.unifiedDataRepo,
     definitionRepo: repoContext.definitionRepo,
     outputRepo: repoContext.outputRepo,
-    queryData:
-      ((dqs) => (predicate: string, select?: string) =>
-        dqs.query(predicate, { select }))(
-          new DataQueryService(
-            repoContext.catalogStore,
-            repoContext.unifiedDataRepo,
-          ),
-        ),
+    dataQueryService: new DataQueryService(
+      repoContext.catalogStore,
+      repoContext.unifiedDataRepo,
+    ),
     createRunLog: async (modelType, method, definitionId) => {
       const redactor = new SecretRedactor();
       const timestamp = new Date().toISOString().replace(/[:.]/g, "-");


### PR DESCRIPTION
## Summary

Fixes swamp-club lab issue **#35**.

Three production paths — manual `swamp model method run`, workflow steps, and pre-flight check validation — each hand-built a `MethodContext` literal independently. New fields added to one site silently missed the others, producing a recurring class of regression (see #947, #1145, #1148). The latest symptom: workflow steps that invoke a model calling `context.queryData` crashed with `"not a function"` because the workflow path omitted the field the manual path had just gained in #1145.

This PR:

- **Extracts `buildMethodContext`** in `src/domain/models/method_context.ts` as the single production entry point. `CommonMethodContextDeps` carries startup-scoped deps; `MethodInvocationContext` carries the per-call overlay. Field types come from `MethodContext[...]` indexed accesses so the factory adds no new infrastructure imports to the domain layer.
- **Routes all three production construction sites through the factory:**
  - `src/libswamp/models/run.ts` (manual)
  - `src/domain/workflows/execution_service.ts` — `DefaultStepExecutor.executeModelMethod` (workflow step)
  - `src/domain/models/validation_service.ts` — `DefaultModelValidationService.validateChecks` (pre-flight checks)
- **Collapses `queryData`/`dataQueryService` redundancy at the driver boundary.** `RawExecutionDriver` now derives `context.queryData` from `context.dataQueryService` with a `??` fallback, so production callers supply only `dataQueryService` while existing test fixtures that set `queryData` directly continue to work unchanged. `ModelMethodRunDeps` loses its `queryData` field; the CLI and serve deps pass `dataQueryService` instead. `CheckValidationContext` gains an optional `dataQueryService` so pre-flight checks can query data too.
- **Guards against future regressions** with `method_context_arch_test.ts`, which walks `src/` and fails on any new inline `MethodContext = {` literal outside tests, the factory, and the `MethodContext` interface declaration.

### Scope expansion

This PR deliberately bundles the bug fix, the three-site consolidation, and the queryData/dataQueryService dedup in one change, per issue-lifecycle discussion. The goal was a one-shot fix for the recurring regression class — not a follow-up trail. A separate issue (lab #84) was filed for the parallel divergence in `MethodReportContext`, which is out of scope here.

## Test plan

- [x] 5 new factory unit tests in `method_context_test.ts` — field pass-through for all required and optional `MethodContext` fields, including the invariant that the factory does not populate `queryData`.
- [x] 2 new driver tests in `raw_execution_driver_test.ts` — (1) explicit `queryData` wins over the derived binding; (2) derivation from `dataQueryService` works when `queryData` is unset, with the correct predicate and `select` pass-through.
- [x] New workflow-path unit regression in `execution_service_test.ts` — registers a capturing model, runs `DefaultStepExecutor` against a real `StepExecutionContext`, asserts the captured `MethodContext` has `dataQueryService` set and a callable `queryData`.
- [x] New integration test `integration/workflow_query_data_context_test.ts` — seeds a real `FileSystemUnifiedDataRepository` + `CatalogStore`, builds a `MethodContext` via the factory, runs an inline `MethodExecutor` through `RawExecutionDriver` against the predicate `attributes.sentinel == \"expected\"`, and verifies the seeded row comes back with attributes intact.
- [x] New architecture guard `method_context_arch_test.ts` — walks `src/`, fails on any new inline `MethodContext = {` literal outside the allowlist.
- [x] `deno check` — clean
- [x] `deno lint` — 1025 files, clean
- [x] `deno fmt --check` — 1039 files, clean
- [x] `deno run test` — **4296 passed, 0 failed** (DDD layer ratchet still at 25 — the factory reuses `MethodContext[...]` indexed types and adds no new infrastructure imports)
- [x] `deno run compile` — binary built

🤖 Generated with [Claude Code](https://claude.com/claude-code)