### PR TITLE
feat: auto-assign issue to current user during lifecycle start

### DIFF
--- a/.claude/skills/issue-lifecycle/references/triage.md
+++ b/.claude/skills/issue-lifecycle/references/triage.md
@@ -49,6 +49,16 @@ writes the title, body, type, status, and comments to the `context` resource. If
 the issue doesn't exist in swamp-club, `start` fails loudly — create the issue
 there first.
 
+### Auto-assignment
+
+`start` automatically assigns the issue to you in swamp-club. It reads your
+username from local auth (`~/.config/swamp/auth.json`, written by
+`swamp auth login`), resolves it to a userId via the eligible-assignees
+endpoint, and PATCHes the issue's assignees. Existing assignees are preserved
+(additive). If assignment fails for any reason (missing credentials, lookup
+error, API failure), `start` still succeeds — it logs a warning and continues
+with triage.
+
 ## 3. Read the Issue Context and Codebase
 
 Read the model output, then explore the codebase.

--- a/extensions/models/README.md
+++ b/extensions/models/README.md
@@ -130,7 +130,7 @@ swamp model output search issue-42 --json
 
 | Method               | Description                                     | State Transition                 |
 | -------------------- | ----------------------------------------------- | -------------------------------- |
-| `start`              | Fetch issue from swamp-club                     | \* -> triaging                   |
+| `start`              | Fetch issue from swamp-club, auto-assign to you | \* -> triaging                   |
 | `triage`             | Classify as bug/feature/security                | triaging -> classified           |
 | `plan`               | Generate implementation plan                    | classified -> plan_generated     |
 | `review`             | Display current plan (read-only)                | no change                        |

--- a/extensions/models/_lib/swamp_club.ts
+++ b/extensions/models/_lib/swamp_club.ts
@@ -31,6 +31,11 @@ export interface LifecycleEntryParams {
   isVerbose?: boolean;
 }
 
+export interface EligibleAssignee {
+  userId: string;
+  username: string;
+}
+
 export interface FetchedIssue {
   number: number;
   type: IssueType;
@@ -38,6 +43,7 @@ export interface FetchedIssue {
   title: string;
   body: string;
   comments: { author: string; body: string; createdAt: string }[];
+  assignees: { userId: string; username: string }[];
 }
 
 /**
@@ -105,6 +111,10 @@ export class SwampClubClient {
             body?: string;
             createdAt?: string;
           }[];
+          assignees?: {
+            userId?: string;
+            username?: string;
+          }[];
         };
       };
       const issue = data?.issue;
@@ -120,6 +130,10 @@ export class SwampClubClient {
           body: c.body ?? "",
           createdAt: c.createdAt ?? "",
         })),
+        assignees: (issue.assignees ?? []).filter(
+          (a): a is { userId: string; username: string } =>
+            typeof a.userId === "string" && typeof a.username === "string",
+        ),
       };
     } catch (err) {
       this.log("swamp-club fetch issue error: {error}", {
@@ -175,6 +189,59 @@ export class SwampClubClient {
     await this.patchIssue({ type });
   }
 
+  /**
+   * Fetch the list of eligible assignees. Returns null on any error
+   * (401/403/network) — callers should treat failure as a warning, not a gate.
+   */
+  async fetchEligibleAssignees(): Promise<EligibleAssignee[] | null> {
+    try {
+      const url = `${this.baseUrl}/api/v1/lab/assignees`;
+      const res = await fetch(url, {
+        method: "GET",
+        headers: {
+          "Authorization": `Bearer ${this.#apiKey}`,
+        },
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        this.log("swamp-club fetch assignees failed: {status} {text}", {
+          status: res.status,
+          text,
+        });
+        return null;
+      }
+      const data = await res.json() as {
+        assignees?: { userId?: string; username?: string }[];
+      };
+      return (data.assignees ?? []).filter(
+        (a): a is EligibleAssignee =>
+          typeof a.userId === "string" && typeof a.username === "string",
+      );
+    } catch (err) {
+      this.log("swamp-club fetch assignees error: {error}", {
+        error: String(err),
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Resolve a username to a userId via the eligible-assignees endpoint.
+   * Returns null if the lookup fails or the username is not found.
+   */
+  async resolveUserId(username: string): Promise<string | null> {
+    const assignees = await this.fetchEligibleAssignees();
+    if (!assignees) return null;
+    const match = assignees.find((a) => a.username === username);
+    return match?.userId ?? null;
+  }
+
+  /** Update the issue's assignees. Best-effort (same as other PATCH helpers). */
+  async updateAssignees(userIds: string[]): Promise<void> {
+    await this.patchIssue({ assignees: userIds });
+  }
+
   /** PATCH the issue with a partial set of fields. Best-effort. */
   private async patchIssue(
     patch: Record<string, unknown>,
@@ -207,10 +274,11 @@ export class SwampClubClient {
 
 /**
  * Load credentials from ~/.config/swamp/auth.json (or $XDG_CONFIG_HOME/swamp/auth.json).
- * Returns { serverUrl, apiKey } or null if the file doesn't exist.
+ * Returns { serverUrl, apiKey, username? } or null if the file doesn't exist.
+ * Username is optional — older auth.json files and env-var auth may not have it.
  */
-async function loadAuthFile(): Promise<
-  { serverUrl: string; apiKey: string } | null
+export async function loadAuthFile(): Promise<
+  { serverUrl: string; apiKey: string; username?: string } | null
 > {
   try {
     const xdg = Deno.env.get("XDG_CONFIG_HOME");
@@ -227,11 +295,13 @@ async function loadAuthFile(): Promise<
     const creds = JSON.parse(content) as {
       serverUrl?: string;
       apiKey?: string;
+      username?: string;
     };
     if (creds.apiKey) {
       return {
         serverUrl: creds.serverUrl ?? "https://swamp.club",
         apiKey: creds.apiKey,
+        username: creds.username || undefined,
       };
     }
     return null;

--- a/extensions/models/issue_lifecycle.ts
+++ b/extensions/models/issue_lifecycle.ts
@@ -34,7 +34,7 @@ import {
   StateSchema,
   TRANSITIONS,
 } from "./_lib/schemas.ts";
-import { createSwampClubClient } from "./_lib/swamp_club.ts";
+import { createSwampClubClient, loadAuthFile } from "./_lib/swamp_club.ts";
 
 /** Global args type for the issue-lifecycle model. */
 type GlobalArgs = {
@@ -70,7 +70,7 @@ async function readState(
 
 export const model = {
   type: "@swamp/issue-lifecycle",
-  version: "2026.04.09.1",
+  version: "2026.04.12.1",
   globalArguments: GlobalArgsSchema,
 
   upgrades: [
@@ -116,6 +116,15 @@ export const model = {
         "link_pr now accepts pr_failed as source phase for recovery. " +
         "implement now accepts pr_failed for rework scenarios. " +
         "complete now accepts releasing for backwards compatibility.",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.12.1",
+      description:
+        "Auto-assign issue to the authenticated user during start(). " +
+        "Reads username from local auth, resolves userId via the " +
+        "eligible-assignees endpoint, and PATCHes the issue's assignees. " +
+        "Best-effort — assignment failures are warnings, never errors.",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
   ],
@@ -478,6 +487,48 @@ export const model = {
           payload: { issueNumber },
           isVerbose: false,
         });
+
+        // Auto-assign the issue to the current authenticated user.
+        // All failures are warnings — assignment must never break the triage flow.
+        const authFile = await loadAuthFile();
+        const authUsername = authFile?.username;
+        if (!authUsername) {
+          context.logger.warning(
+            "Cannot determine your username — issue will not be auto-assigned. " +
+              "Run `swamp auth login` to enable auto-assignment.",
+            {},
+          );
+        } else {
+          const resolvedUserId = await sc.resolveUserId(authUsername);
+          if (!resolvedUserId) {
+            context.logger.warning(
+              "Could not resolve your swamp-club identity — issue will not be auto-assigned.",
+              {},
+            );
+          } else {
+            const existingIds = issue.assignees.map((a) => a.userId);
+            if (existingIds.includes(resolvedUserId)) {
+              context.logger.info(
+                "Already assigned to {username}",
+                { username: authUsername },
+              );
+            } else {
+              await sc.updateAssignees([...existingIds, resolvedUserId]);
+              await sc.postLifecycleEntry({
+                step: "assigned",
+                targetStatus: "open",
+                summary: `Assigned to ${authUsername}`,
+                emoji: "\u{1F464}",
+                payload: { username: authUsername, userId: resolvedUserId },
+                isVerbose: false,
+              });
+              context.logger.info(
+                "Auto-assigned issue to {username}",
+                { username: authUsername },
+              );
+            }
+          }
+        }
 
         return { dataHandles: handles };
       },

--- a/extensions/models/issue_lifecycle_test.ts
+++ b/extensions/models/issue_lifecycle_test.ts
@@ -319,8 +319,8 @@ Deno.test("model: exposes the new link_pr method definition", () => {
   );
 });
 
-Deno.test("model: version bumped to 2026.04.09.1", () => {
-  assertEquals(model.version, "2026.04.09.1");
+Deno.test("model: version bumped to 2026.04.12.1", () => {
+  assertEquals(model.version, "2026.04.12.1");
 });
 
 // ---------------------------------------------------------------------------
@@ -500,4 +500,386 @@ Deno.test("model: exposes pr_failed method definition", () => {
 
 Deno.test("model: exposes ship method definition", () => {
   assertEquals("ship" in model.methods, true);
+});
+
+// ---------------------------------------------------------------------------
+// start() auto-assignment tests
+// ---------------------------------------------------------------------------
+
+interface FetchStubRoute {
+  urlIncludes: string;
+  method?: string;
+  response: { status: number; body: unknown };
+}
+
+/**
+ * Build a test context for start() with a fetch stub and optional fake auth.json.
+ * The fetch stub intercepts all HTTP calls (health check, issue GET, assignees
+ * GET, issue PATCH). The fake auth.json provides a username for loadAuthFile().
+ */
+async function buildStartTestContext(
+  issueNumber: number,
+  opts: {
+    routes: FetchStubRoute[];
+    authUsername?: string;
+    /** If provided, written to auth.json alongside the username */
+    authApiKey?: string;
+  },
+): Promise<{
+  context: Parameters<typeof model.methods.start.execute>[1];
+  writes: RecordedWrite[];
+  warnings: string[];
+  patchBodies: unknown[];
+  restore: () => Promise<void>;
+}> {
+  const writes: RecordedWrite[] = [];
+  const warnings: string[] = [];
+  const patchBodies: unknown[] = [];
+  const tempDir = await Deno.makeTempDir({ prefix: "issue_lifecycle_test_" });
+
+  const original = {
+    SWAMP_API_KEY: Deno.env.get("SWAMP_API_KEY"),
+    SWAMP_CLUB_URL: Deno.env.get("SWAMP_CLUB_URL"),
+    HOME: Deno.env.get("HOME"),
+    XDG_CONFIG_HOME: Deno.env.get("XDG_CONFIG_HOME"),
+  };
+  const originalFetch = globalThis.fetch;
+
+  // Write fake auth.json if credentials are provided
+  if (opts.authUsername || opts.authApiKey) {
+    const configDir = `${tempDir}/swamp`;
+    await Deno.mkdir(configDir, { recursive: true });
+    const authData: Record<string, string> = {
+      serverUrl: "https://fake.swamp.club",
+      apiKey: opts.authApiKey ?? "swamp_fake_key",
+      apiKeyId: "fake-key-id",
+    };
+    if (opts.authUsername) {
+      authData.username = opts.authUsername;
+    }
+    await Deno.writeTextFile(
+      `${configDir}/auth.json`,
+      JSON.stringify(authData),
+    );
+  }
+
+  // Set env so createSwampClubClient uses auth.json (not SWAMP_API_KEY)
+  Deno.env.delete("SWAMP_API_KEY");
+  Deno.env.delete("SWAMP_CLUB_URL");
+  Deno.env.set("HOME", tempDir);
+  Deno.env.set("XDG_CONFIG_HOME", tempDir);
+
+  // Install fetch stub
+  globalThis.fetch = ((
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.toString()
+      : input.url;
+    const method = init?.method ?? "GET";
+
+    // Capture PATCH bodies for assertion
+    if (method === "PATCH" && init?.body) {
+      patchBodies.push(JSON.parse(init.body as string));
+    }
+
+    for (const route of opts.routes) {
+      if (
+        url.includes(route.urlIncludes) &&
+        (route.method === undefined || route.method === method)
+      ) {
+        return Promise.resolve(
+          new Response(JSON.stringify(route.response.body), {
+            status: route.response.status,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+    }
+    // Default: 404
+    return Promise.resolve(new Response("Not Found", { status: 404 }));
+  }) as typeof fetch;
+
+  const restore = async () => {
+    globalThis.fetch = originalFetch;
+    for (const [k, v] of Object.entries(original)) {
+      if (v === undefined) {
+        Deno.env.delete(k);
+      } else {
+        Deno.env.set(k, v);
+      }
+    }
+    await Deno.remove(tempDir, { recursive: true });
+  };
+
+  const context = {
+    globalArgs: { issueNumber },
+    logger: {
+      info: () => {},
+      warning: (msg: string, _props: Record<string, unknown>) => {
+        warnings.push(msg);
+      },
+    },
+    writeResource: (
+      specName: string,
+      instanceName: string,
+      data: Record<string, unknown>,
+    ) => {
+      writes.push({ specName, instanceName, data });
+      return Promise.resolve({ name: instanceName });
+    },
+  };
+
+  return { context, writes, warnings, patchBodies, restore };
+}
+
+/** Standard routes for a successful start() + assignment flow. */
+function happyRoutes(opts: {
+  issueNumber: number;
+  issueAssignees?: { userId: string; username: string }[];
+  eligibleAssignees: { userId: string; username: string }[];
+}): FetchStubRoute[] {
+  return [
+    {
+      urlIncludes: "/api/health",
+      response: { status: 200, body: { ok: true } },
+    },
+    {
+      urlIncludes: `/api/v1/lab/issues/${opts.issueNumber}`,
+      method: "GET",
+      response: {
+        status: 200,
+        body: {
+          issue: {
+            number: opts.issueNumber,
+            type: "feature",
+            status: "open",
+            title: "Test issue",
+            body: "Test body",
+            comments: [],
+            assignees: opts.issueAssignees ?? [],
+          },
+        },
+      },
+    },
+    {
+      urlIncludes: `/api/v1/lab/issues/${opts.issueNumber}`,
+      method: "PATCH",
+      response: { status: 200, body: { issue: {} } },
+    },
+    {
+      urlIncludes: "/api/v1/lab/assignees",
+      method: "GET",
+      response: {
+        status: 200,
+        body: { assignees: opts.eligibleAssignees },
+      },
+    },
+    {
+      urlIncludes: `/api/v1/lab/issues/${opts.issueNumber}/lifecycle`,
+      method: "POST",
+      response: { status: 200, body: {} },
+    },
+  ];
+}
+
+Deno.test("start: auto-assigns the current user on happy path", async () => {
+  const { context, writes, patchBodies, restore } = await buildStartTestContext(
+    99,
+    {
+      authUsername: "alice",
+      routes: happyRoutes({
+        issueNumber: 99,
+        eligibleAssignees: [
+          { userId: "user-alice-id", username: "alice" },
+          { userId: "user-bob-id", username: "bob" },
+        ],
+      }),
+    },
+  );
+  try {
+    await model.methods.start.execute({}, context);
+
+    // Core start behavior: writes context + state
+    const contextWrite = writes.find((w) => w.specName === "context");
+    assertEquals(contextWrite !== undefined, true);
+    const stateWrite = writes.find((w) => w.specName === "state");
+    assertEquals(stateWrite !== undefined, true);
+    assertEquals(stateWrite!.data.phase, "triaging");
+
+    // Assignment: PATCH with alice's userId
+    assertEquals(patchBodies.length >= 1, true);
+    const assignPatch = patchBodies.find(
+      (b: unknown) => typeof b === "object" && b !== null && "assignees" in b,
+    ) as { assignees: string[] } | undefined;
+    assertEquals(assignPatch !== undefined, true);
+    assertEquals(assignPatch!.assignees, ["user-alice-id"]);
+  } finally {
+    await restore();
+  }
+});
+
+Deno.test("start: preserves pre-existing assignees (additive merge)", async () => {
+  const { context, patchBodies, restore } = await buildStartTestContext(99, {
+    authUsername: "charlie",
+    routes: happyRoutes({
+      issueNumber: 99,
+      issueAssignees: [
+        { userId: "user-alice-id", username: "alice" },
+        { userId: "user-bob-id", username: "bob" },
+      ],
+      eligibleAssignees: [
+        { userId: "user-alice-id", username: "alice" },
+        { userId: "user-bob-id", username: "bob" },
+        { userId: "user-charlie-id", username: "charlie" },
+      ],
+    }),
+  });
+  try {
+    await model.methods.start.execute({}, context);
+
+    const assignPatch = patchBodies.find(
+      (b: unknown) => typeof b === "object" && b !== null && "assignees" in b,
+    ) as { assignees: string[] } | undefined;
+    assertEquals(assignPatch !== undefined, true);
+    assertEquals(assignPatch!.assignees, [
+      "user-alice-id",
+      "user-bob-id",
+      "user-charlie-id",
+    ]);
+  } finally {
+    await restore();
+  }
+});
+
+Deno.test("start: skips PATCH when already assigned (idempotent)", async () => {
+  const { context, patchBodies, restore } = await buildStartTestContext(99, {
+    authUsername: "alice",
+    routes: happyRoutes({
+      issueNumber: 99,
+      issueAssignees: [{ userId: "user-alice-id", username: "alice" }],
+      eligibleAssignees: [{ userId: "user-alice-id", username: "alice" }],
+    }),
+  });
+  try {
+    await model.methods.start.execute({}, context);
+
+    // No assignees PATCH should have been made
+    const assignPatch = patchBodies.find(
+      (b: unknown) => typeof b === "object" && b !== null && "assignees" in b,
+    );
+    assertEquals(assignPatch, undefined);
+  } finally {
+    await restore();
+  }
+});
+
+Deno.test("start: warns and skips assignment when no username in auth", async () => {
+  // Provide an auth.json with apiKey but no username — simulates older auth
+  // files or env-var-only auth where username was never stored.
+  const routes = happyRoutes({
+    issueNumber: 99,
+    eligibleAssignees: [],
+  });
+  const { context, writes, warnings, patchBodies, restore } =
+    await buildStartTestContext(99, {
+      // authUsername is deliberately omitted — no username in auth.json
+      authApiKey: "swamp_fake_no_username",
+      routes,
+    });
+  try {
+    // start() should still succeed (not throw)
+    await model.methods.start.execute({}, context);
+
+    // Core behavior still works
+    const stateWrite = writes.find((w) => w.specName === "state");
+    assertEquals(stateWrite !== undefined, true);
+    assertEquals(stateWrite!.data.phase, "triaging");
+
+    // No assignees PATCH
+    const assignPatch = patchBodies.find(
+      (b: unknown) => typeof b === "object" && b !== null && "assignees" in b,
+    );
+    assertEquals(assignPatch, undefined);
+
+    // Warning was logged
+    assertEquals(warnings.length >= 1, true);
+  } finally {
+    await restore();
+  }
+});
+
+Deno.test("start: warns and skips assignment when assignees endpoint returns 403", async () => {
+  const routes = happyRoutes({
+    issueNumber: 99,
+    eligibleAssignees: [],
+  });
+  // Override the assignees route to return 403
+  const assigneesIdx = routes.findIndex((r) =>
+    r.urlIncludes.includes("assignees")
+  );
+  routes[assigneesIdx] = {
+    urlIncludes: "/api/v1/lab/assignees",
+    method: "GET",
+    response: { status: 403, body: { error: "Forbidden" } },
+  };
+
+  const { context, writes, patchBodies, restore } = await buildStartTestContext(
+    99,
+    {
+      authUsername: "alice",
+      routes,
+    },
+  );
+  try {
+    await model.methods.start.execute({}, context);
+
+    // Core behavior still works
+    const stateWrite = writes.find((w) => w.specName === "state");
+    assertEquals(stateWrite !== undefined, true);
+
+    // No assignees PATCH
+    const assignPatch = patchBodies.find(
+      (b: unknown) => typeof b === "object" && b !== null && "assignees" in b,
+    );
+    assertEquals(assignPatch, undefined);
+  } finally {
+    await restore();
+  }
+});
+
+Deno.test("start: succeeds even when PATCH fails", async () => {
+  const routes = happyRoutes({
+    issueNumber: 99,
+    eligibleAssignees: [{ userId: "user-alice-id", username: "alice" }],
+  });
+  // Override the PATCH route to return 500
+  const patchIdx = routes.findIndex(
+    (r) =>
+      r.urlIncludes.includes("/api/v1/lab/issues/99") && r.method === "PATCH",
+  );
+  routes[patchIdx] = {
+    urlIncludes: "/api/v1/lab/issues/99",
+    method: "PATCH",
+    response: { status: 500, body: { error: "Internal Server Error" } },
+  };
+
+  const { context, writes, restore } = await buildStartTestContext(99, {
+    authUsername: "alice",
+    routes,
+  });
+  try {
+    // start() should still succeed — assignment is best-effort
+    await model.methods.start.execute({}, context);
+
+    // Core behavior still works
+    const stateWrite = writes.find((w) => w.specName === "state");
+    assertEquals(stateWrite !== undefined, true);
+    assertEquals(stateWrite!.data.phase, "triaging");
+  } finally {
+    await restore();
+  }
 });


### PR DESCRIPTION
## Summary

- Wire auto-assignment into the `start()` method of the `@swamp/issue-lifecycle` extension model
- When triage begins, reads the current user's username from local auth (`~/.config/swamp/auth.json`), resolves it to a userId via the eligible-assignees endpoint, and PATCHes the issue's assignees additively
- All assignment failures are best-effort warnings — the triage flow never breaks
- Bumps model version to `2026.04.12.1`

## Changes

- **`extensions/models/_lib/swamp_club.ts`**: Export `loadAuthFile` (now returns optional `username`); add `fetchEligibleAssignees()`, `resolveUserId()`, `updateAssignees()` to `SwampClubClient`; extend `FetchedIssue` with `assignees` field
- **`extensions/models/issue_lifecycle.ts`**: Wire assignment block into `start()` after context/state writes; add version upgrade entry
- **`extensions/models/issue_lifecycle_test.ts`**: 6 new unit tests with fetch stub infrastructure covering happy path, additive merge, idempotent, missing username, 403 on lookup, PATCH failure
- **`extensions/models/README.md`**: Update `start` description in methods table
- **`.claude/skills/issue-lifecycle/references/triage.md`**: Add auto-assignment documentation section

## Test Plan

- [x] All 28 extension model tests pass (6 new + 22 existing)
- [x] Full test suite: 4292 passed, 0 failed
- [x] `deno check` — clean
- [x] `deno lint` — clean
- [x] `deno fmt` — clean
- [x] `deno run compile` — binary built
- [x] Changes synced to `systeminit/swamp-extensions` and `systeminit/swamp-club`

Closes swamp-club#86

🤖 Generated with [Claude Code](https://claude.ai/claude-code)