### PR TITLE
fix: preserve vault CEL expressions during model type upgrades

### DIFF
--- a/src/domain/models/definition_upgrade_service_test.ts
+++ b/src/domain/models/definition_upgrade_service_test.ts
@@ -267,3 +267,28 @@ Deno.test("DefinitionUpgradeService - legacy numeric typeVersion coerced to unde
   assertEquals(result.definition.globalArguments.priority, "low");
   assertEquals(result.definition.typeVersion, "2025.06.01.1");
 });
+
+Deno.test("DefinitionUpgradeService: vault expression strings pass through unchanged", () => {
+  const service = new DefinitionUpgradeService();
+  const vaultExpr = '${{ vault.get("myvault", "my-api-key") }}';
+  const definition = Definition.create({
+    name: "test-def",
+    type: "test/upgradeable",
+    typeVersion: "2025.01.15.1",
+    globalArguments: { apiKey: vaultExpr, label: "prod" },
+  });
+
+  const modelDef = createModelDef("2025.06.01.1", [
+    {
+      toVersion: "2025.06.01.1",
+      description: "Add region field",
+      upgradeAttributes: (old) => ({ ...old, region: "us-east-1" }),
+    },
+  ]);
+
+  const result = service.upgrade(definition, modelDef);
+
+  assertEquals(result.upgraded, true);
+  assertEquals(result.definition.globalArguments.apiKey, vaultExpr);
+  assertEquals(result.definition.globalArguments.region, "us-east-1");
+});

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -336,12 +336,27 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
       const upgradeResult = upgradeService.upgrade(definition, modelDef);
       const currentDefinition = upgradeResult.definition;
 
-      // Persist upgraded definition if it was upgraded
+      // Persist upgraded definition if it was upgraded.
+      // IMPORTANT: The in-memory definition may have vault sentinel tokens
+      // (from runtime expression resolution). Sentinels are per-process random
+      // strings that become meaningless once the process exits. We must re-read
+      // the original definition from disk (which has vault CEL expressions
+      // intact), apply the upgrade to that copy, and persist it.
       if (upgradeResult.upgraded && context.definitionRepository) {
-        await context.definitionRepository.save(
+        const originalDefinition = await context.definitionRepository.findById(
           context.modelType,
-          currentDefinition,
+          definition.id,
         );
+        if (originalDefinition) {
+          const diskUpgrade = upgradeService.upgrade(
+            originalDefinition,
+            modelDef,
+          );
+          await context.definitionRepository.save(
+            context.modelType,
+            diskUpgrade.definition,
+          );
+        }
       }
 
       // Resolve vault sentinels in globalArguments before validation.

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -35,6 +35,7 @@ import { type DataId, generateDataId } from "../data/data_id.ts";
 import { Data } from "../data/data.ts";
 import { UserError } from "../errors.ts";
 import { getLogger } from "@logtape/logtape";
+import { VaultSecretBag } from "../vaults/vault_secret_bag.ts";
 
 /**
  * Test model that mimics the echo model's write method.
@@ -2524,3 +2525,96 @@ Deno.test("executeWorkflow - check returning invalid result treated as failure",
     "invalid result",
   );
 });
+
+Deno.test(
+  "executeWorkflow: upgrade persists original vault expressions, not sentinel tokens",
+  async () => {
+    const service = new DefaultMethodExecutionService();
+
+    // Model at version 2 with an upgrade from version 1
+    const model: ModelDefinition = {
+      type: ModelType.create("test/vault-upgrade"),
+      version: "2026.04.12.2",
+      globalArguments: z.object({ apiKey: z.string() }),
+      resources: {
+        status: {
+          description: "Status",
+          schema: z.object({ ok: z.boolean() }),
+          lifetime: "infinite",
+          garbageCollection: 5,
+        },
+      },
+      methods: {
+        check: {
+          description: "Check",
+          arguments: z.object({}),
+          execute: async (_args, context) => {
+            const handle = await context.writeResource!(
+              "status",
+              "main",
+              { ok: true },
+            );
+            return { dataHandles: [handle] };
+          },
+        },
+      },
+      upgrades: [
+        {
+          toVersion: "2026.04.12.2",
+          description: "No-op upgrade",
+          upgradeAttributes: (old) => old,
+        },
+      ],
+    };
+
+    const vaultExpression = '${{ vault.get("myvault", "my-api-key") }}';
+
+    // Simulate post-runtime-resolution: the in-memory definition has sentinel
+    // tokens in place of vault expressions (as happens in run.ts after
+    // resolveRuntimeExpressionsInDefinition).
+    const secretBag = new VaultSecretBag();
+    const sentinel = secretBag.addSecret("sk-test-secret-12345");
+
+    const definition = Definition.create({
+      name: "test-vault-def",
+      type: "test/vault-upgrade",
+      typeVersion: "2026.04.12.1",
+      globalArguments: { apiKey: sentinel },
+    });
+
+    // The "on-disk" definition has the original vault expression.
+    const originalDefinition = Definition.create({
+      id: definition.id,
+      name: "test-vault-def",
+      type: "test/vault-upgrade",
+      typeVersion: "2026.04.12.1",
+      globalArguments: { apiKey: vaultExpression },
+    });
+
+    // Track what gets saved to the definition repository.
+    let savedDefinition: Definition | null = null;
+    const mockDefRepo: DefinitionRepository = {
+      ...createMockDefinitionRepo(),
+      findById: () => Promise.resolve(originalDefinition),
+      save: (_type, def) => {
+        savedDefinition = def;
+        return Promise.resolve();
+      },
+    };
+
+    const { context } = createTestContext({
+      modelType: model.type,
+      definitionRepository: mockDefRepo,
+      vaultSecrets: secretBag,
+    });
+
+    await service.executeWorkflow(definition, model, "check", context);
+
+    // The persisted definition must have the original vault expression,
+    // not the sentinel token.
+    assertEquals(savedDefinition !== null, true);
+    const saved = savedDefinition as unknown as Definition;
+    assertEquals(saved.globalArguments.apiKey, vaultExpression);
+    assertEquals(saved.typeVersion, "2026.04.12.2");
+  },
+);


### PR DESCRIPTION
## Summary

- Fix upgrade persistence in `executeWorkflow` to re-read the original definition from the repository before persisting, preventing vault sentinel tokens from leaking into model YAML
- When a model type version bump triggers an upgrade, the in-memory definition has already had vault expressions resolved to per-process sentinel tokens — persisting those sentinels corrupts the YAML and breaks all subsequent runs
- The fix re-reads the on-disk definition (which has vault CEL expressions intact), applies the upgrade to that copy, and persists it

Closes swamp-club#91

## Test Plan

- [x] Reproduced the bug in `/tmp/swamp-repro-issue-91` — confirmed sentinel `__SWAMP_VSEC_*` was written to YAML after version bump
- [x] Verified the fix: vault expression survives upgrade and resolves correctly on subsequent runs
- [x] Added unit test: `executeWorkflow: upgrade persists original vault expressions, not sentinel tokens`
- [x] Added unit test: `DefinitionUpgradeService: vault expression strings pass through unchanged`
- [x] All 4304 tests pass (1 pre-existing flaky failure in `whoami_test.ts`)
- [x] Type checking, linting, and formatting pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)