### PR TITLE
fix: ensure lazy types are loaded before reading version in save() paths

### DIFF
--- a/src/infrastructure/persistence/yaml_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository.ts
@@ -247,6 +247,7 @@ export class YamlDefinitionRepository implements DefinitionRepository {
     const data = definition.toData();
     // Ensure type metadata is always present in persisted YAML
     data.type = type.normalized;
+    await modelRegistry.ensureTypeLoaded(type);
     const modelDef = modelRegistry.get(type);
     data.typeVersion = modelDef?.version ?? data.typeVersion;
     // Remove undefined values since YAML can't stringify them

--- a/src/infrastructure/persistence/yaml_evaluated_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_definition_repository.ts
@@ -243,6 +243,7 @@ export class YamlEvaluatedDefinitionRepository {
     const data = definition.toData();
     // Ensure type metadata is always present in persisted YAML
     data.type = type.normalized;
+    await modelRegistry.ensureTypeLoaded(type);
     const modelDef = modelRegistry.get(type);
     data.typeVersion = modelDef?.version ?? data.typeVersion;
     // Remove undefined values since YAML can't stringify them


### PR DESCRIPTION
## Summary

- Add `await modelRegistry.ensureTypeLoaded(type)` before `modelRegistry.get(type)` in `YamlDefinitionRepository.save()` and `YamlEvaluatedDefinitionRepository.save()`
- Without this, lazy-registered types (catalog-known but not yet imported) cause `get()` to return `undefined`, silently persisting a stale `typeVersion` to disk
- Follows the established fix pattern from `libswamp/models/get.ts:76` and `validation_service.ts:706`

Closes swamp-club#90 (follow-up to swamp-club#89)

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] All 4305 tests pass
- [x] Filed systeminit/swamp-uat#136 for missing UAT coverage of typeVersion persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)