### PR TITLE
fix: consolidate MethodReportContext construction through a single factory

### DIFF
--- a/src/domain/reports/report_context.ts
+++ b/src/domain/reports/report_context.ts
@@ -136,3 +136,68 @@ export type ReportContext =
   | MethodReportContext
   | ModelReportContext
   | WorkflowReportContext;
+
+/**
+ * Common dependencies shared across all MethodReportContext construction sites.
+ * These come from the runtime environment (repositories, logging, repo path).
+ */
+export interface CommonReportContextDeps {
+  repoDir: string;
+  logger: Logger;
+  dataRepository: UnifiedDataRepository;
+  definitionRepository: DefinitionRepository;
+  swampSha?: string;
+}
+
+/**
+ * Per-invocation data specific to a single method execution.
+ */
+export interface MethodReportInvocation {
+  modelType: ModelType;
+  modelId: string;
+  definition: {
+    id: string;
+    name: string;
+    version: number;
+    tags: Record<string, string>;
+  };
+  globalArgs: Record<string, unknown>;
+  methodArgs: Record<string, unknown>;
+  methodName: string;
+  executionStatus: "succeeded" | "failed";
+  errorMessage?: string;
+  dataHandles: DataHandle[];
+  outputSpecs?: OutputSpecInfo[];
+}
+
+/**
+ * Single factory for MethodReportContext construction. All production sites
+ * must route through this function — the architecture guard test in
+ * report_context_arch_test.ts enforces this.
+ *
+ * Note: `redactSensitiveArgs` is deliberately absent from both input types.
+ * It is injected after construction by the report execution service.
+ */
+export function buildMethodReportContext(
+  common: CommonReportContextDeps,
+  invocation: MethodReportInvocation,
+): MethodReportContext {
+  return {
+    scope: "method",
+    repoDir: common.repoDir,
+    logger: common.logger,
+    dataRepository: common.dataRepository,
+    definitionRepository: common.definitionRepository,
+    swampSha: common.swampSha,
+    modelType: invocation.modelType,
+    modelId: invocation.modelId,
+    definition: invocation.definition,
+    globalArgs: invocation.globalArgs,
+    methodArgs: invocation.methodArgs,
+    methodName: invocation.methodName,
+    executionStatus: invocation.executionStatus,
+    errorMessage: invocation.errorMessage,
+    dataHandles: invocation.dataHandles,
+    outputSpecs: invocation.outputSpecs,
+  };
+}

--- a/src/domain/reports/report_context_arch_test.ts
+++ b/src/domain/reports/report_context_arch_test.ts
@@ -1,0 +1,68 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+// Architecture guard: production MethodReportContext construction must go
+// through buildMethodReportContext. This test walks src/ and fails if a new
+// inline MethodReportContext object literal appears outside the allowed files.
+// If this test fails, route the construction through buildMethodReportContext
+// in src/domain/reports/report_context.ts.
+
+import { assertEquals } from "@std/assert";
+import { walk } from "@std/fs";
+import { relative } from "@std/path";
+
+const REPO_ROOT = new URL("../../..", import.meta.url).pathname;
+const SRC_ROOT = `${REPO_ROOT}src`;
+
+const ALLOWED_FILES: ReadonlySet<string> = new Set([
+  // The factory itself.
+  "src/domain/reports/report_context.ts",
+]);
+
+// Matches `MethodReportContext = {` literal assignments.
+const INLINE_LITERAL = /\bMethodReportContext\s*=\s*\{/;
+
+Deno.test("architecture: no inline MethodReportContext literals outside factory and tests", async () => {
+  const offenders: string[] = [];
+
+  for await (
+    const entry of walk(SRC_ROOT, {
+      exts: [".ts"],
+      includeDirs: false,
+      followSymlinks: false,
+    })
+  ) {
+    const rel = relative(REPO_ROOT, entry.path);
+    if (rel.endsWith("_test.ts")) continue;
+    if (ALLOWED_FILES.has(rel)) continue;
+
+    const text = await Deno.readTextFile(entry.path);
+    if (INLINE_LITERAL.test(text)) {
+      offenders.push(rel);
+    }
+  }
+
+  assertEquals(
+    offenders,
+    [],
+    `Found inline MethodReportContext literals in production code:\n  ${
+      offenders.join("\n  ")
+    }\n\nRoute construction through buildMethodReportContext in src/domain/reports/report_context.ts.`,
+  );
+});

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -93,7 +93,7 @@ import {
   type ReportFilterOptions,
 } from "../reports/report_execution_service.ts";
 import { reportRegistry } from "../reports/report_registry.ts";
-import type { MethodReportContext } from "../reports/report_context.ts";
+import { buildMethodReportContext } from "../reports/report_context.ts";
 import { modelRegistry } from "../models/model.ts";
 import { getTracer, SpanStatusCode } from "../../infrastructure/tracing/mod.ts";
 import { resolveDriverConfig } from "../drivers/driver_resolution.ts";
@@ -724,28 +724,31 @@ export class DefaultStepExecutor implements StepExecutor {
         ];
 
         // Method-scope reports
-        const methodContext: MethodReportContext = {
-          scope: "method",
-          repoDir: ctx.repoDir,
-          logger: runLogger,
-          dataRepository: unifiedDataRepo,
-          definitionRepository: definitionRepo,
-          swampSha: ctx.swampSha,
-          modelType,
-          modelId: evaluatedDefinition.id,
-          definition: {
-            id: evaluatedDefinition.id,
-            name: evaluatedDefinition.name,
-            version: evaluatedDefinition.version,
-            tags: evaluatedDefinition.tags,
+        const methodContext = buildMethodReportContext(
+          {
+            repoDir: ctx.repoDir,
+            logger: runLogger,
+            dataRepository: unifiedDataRepo,
+            definitionRepository: definitionRepo,
+            swampSha: ctx.swampSha,
           },
-          globalArgs: reportGlobalArgs,
-          methodArgs: reportMethodArgs,
-          methodName: task.methodName,
-          executionStatus: "succeeded",
-          dataHandles,
-          outputSpecs: buildOutputSpecs(modelDef),
-        };
+          {
+            modelType,
+            modelId: evaluatedDefinition.id,
+            definition: {
+              id: evaluatedDefinition.id,
+              name: evaluatedDefinition.name,
+              version: evaluatedDefinition.version,
+              tags: evaluatedDefinition.tags,
+            },
+            globalArgs: reportGlobalArgs,
+            methodArgs: reportMethodArgs,
+            methodName: task.methodName,
+            executionStatus: "succeeded",
+            dataHandles,
+            outputSpecs: buildOutputSpecs(modelDef),
+          },
+        );
 
         await executeReports(
           reportRegistry,
@@ -823,29 +826,32 @@ export class DefaultStepExecutor implements StepExecutor {
         if (
           reportRegistry.getAll().length > 0 && ctx.reportFilterOptions
         ) {
-          const failedMethodContext: MethodReportContext = {
-            scope: "method",
-            repoDir: ctx.repoDir,
-            logger: runLogger,
-            dataRepository: unifiedDataRepo,
-            definitionRepository: definitionRepo,
-            swampSha: ctx.swampSha,
-            modelType,
-            modelId: evaluatedDefinition.id,
-            definition: {
-              id: evaluatedDefinition.id,
-              name: evaluatedDefinition.name,
-              version: evaluatedDefinition.version,
-              tags: evaluatedDefinition.tags,
+          const failedMethodContext = buildMethodReportContext(
+            {
+              repoDir: ctx.repoDir,
+              logger: runLogger,
+              dataRepository: unifiedDataRepo,
+              definitionRepository: definitionRepo,
+              swampSha: ctx.swampSha,
             },
-            globalArgs: reportGlobalArgs,
-            methodArgs: reportMethodArgs,
-            methodName: task.methodName,
-            executionStatus: "failed",
-            errorMessage,
-            dataHandles: [],
-            outputSpecs: buildOutputSpecs(modelDef),
-          };
+            {
+              modelType,
+              modelId: evaluatedDefinition.id,
+              definition: {
+                id: evaluatedDefinition.id,
+                name: evaluatedDefinition.name,
+                version: evaluatedDefinition.version,
+                tags: evaluatedDefinition.tags,
+              },
+              globalArgs: reportGlobalArgs,
+              methodArgs: reportMethodArgs,
+              methodName: task.methodName,
+              executionStatus: "failed",
+              errorMessage,
+              dataHandles: [],
+              outputSpecs: buildOutputSpecs(modelDef),
+            },
+          );
 
           const stepModelDef = modelRegistry.get(modelType);
           const stepModelTypeReports = [

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -27,9 +27,9 @@ import {
 } from "../../domain/reports/report_execution_service.ts";
 import { reportRegistry } from "../../domain/reports/report_registry.ts";
 import { BUILTIN_METHOD_REPORTS } from "../../domain/reports/builtin/mod.ts";
-import type {
-  MethodReportContext,
-  ModelReportContext,
+import {
+  buildMethodReportContext,
+  type ModelReportContext,
 } from "../../domain/reports/report_context.ts";
 import { buildOutputSpecs } from "../../domain/models/output_spec_builder.ts";
 import type { ReportResultView } from "./model_method_run_view.ts";
@@ -470,29 +470,32 @@ export async function* modelMethodRun(
           // Run method-summary report for failed executions so JSON consumers
           // see structured error output (not just the raw error event).
           if (!input.skipAllReports && reportRegistry.getAll().length > 0) {
-            const failedMethodContext: MethodReportContext = {
-              scope: "method",
-              repoDir: deps.repoDir,
-              logger: getRunLogger(definition.name, input.methodName),
-              dataRepository: deps.dataRepo,
-              definitionRepository: deps.definitionRepo,
-              swampSha: input.swampSha,
-              modelType,
-              modelId: evaluatedDefinition.id,
-              definition: {
-                id: evaluatedDefinition.id,
-                name: evaluatedDefinition.name,
-                version: evaluatedDefinition.version,
-                tags: evaluatedDefinition.tags,
+            const failedMethodContext = buildMethodReportContext(
+              {
+                repoDir: deps.repoDir,
+                logger: getRunLogger(definition.name, input.methodName),
+                dataRepository: deps.dataRepo,
+                definitionRepository: deps.definitionRepo,
+                swampSha: input.swampSha,
               },
-              globalArgs: reportGlobalArgs,
-              methodArgs: reportMethodArgs,
-              methodName: input.methodName,
-              executionStatus: "failed",
-              errorMessage,
-              dataHandles: [],
-              outputSpecs: buildOutputSpecs(modelDef),
-            };
+              {
+                modelType,
+                modelId: evaluatedDefinition.id,
+                definition: {
+                  id: evaluatedDefinition.id,
+                  name: evaluatedDefinition.name,
+                  version: evaluatedDefinition.version,
+                  tags: evaluatedDefinition.tags,
+                },
+                globalArgs: reportGlobalArgs,
+                methodArgs: reportMethodArgs,
+                methodName: input.methodName,
+                executionStatus: "failed",
+                errorMessage,
+                dataHandles: [],
+                outputSpecs: buildOutputSpecs(modelDef),
+              },
+            );
 
             const failedSummary = await executeReports(
               reportRegistry,
@@ -615,28 +618,31 @@ export async function* modelMethodRun(
           const dataHandles = execResult.dataHandles ?? [];
 
           // Run method-scope reports
-          const methodContext: MethodReportContext = {
-            scope: "method",
-            repoDir: deps.repoDir,
-            logger: getRunLogger(definition.name, input.methodName),
-            dataRepository: deps.dataRepo,
-            definitionRepository: deps.definitionRepo,
-            swampSha: input.swampSha,
-            modelType,
-            modelId: evaluatedDefinition.id,
-            definition: {
-              id: evaluatedDefinition.id,
-              name: evaluatedDefinition.name,
-              version: evaluatedDefinition.version,
-              tags: evaluatedDefinition.tags,
+          const methodContext = buildMethodReportContext(
+            {
+              repoDir: deps.repoDir,
+              logger: getRunLogger(definition.name, input.methodName),
+              dataRepository: deps.dataRepo,
+              definitionRepository: deps.definitionRepo,
+              swampSha: input.swampSha,
             },
-            globalArgs: reportGlobalArgs,
-            methodArgs: reportMethodArgs,
-            methodName: input.methodName,
-            executionStatus: "succeeded",
-            dataHandles,
-            outputSpecs: buildOutputSpecs(modelDef),
-          };
+            {
+              modelType,
+              modelId: evaluatedDefinition.id,
+              definition: {
+                id: evaluatedDefinition.id,
+                name: evaluatedDefinition.name,
+                version: evaluatedDefinition.version,
+                tags: evaluatedDefinition.tags,
+              },
+              globalArgs: reportGlobalArgs,
+              methodArgs: reportMethodArgs,
+              methodName: input.methodName,
+              executionStatus: "succeeded",
+              dataHandles,
+              outputSpecs: buildOutputSpecs(modelDef),
+            },
+          );
 
           const methodSummary = await executeReports(
             reportRegistry,


### PR DESCRIPTION
## Summary

Extracts a `buildMethodReportContext()` factory function and routes all 4 production construction sites through it, eliminating the same class of recurring regression that #35 fixed for `MethodContext`.

- Adds `CommonReportContextDeps` and `MethodReportInvocation` input types + `buildMethodReportContext()` factory in `src/domain/reports/report_context.ts`
- Replaces 4 inline `MethodReportContext` constructions: 2 in `src/libswamp/models/run.ts` (success + error paths) and 2 in `src/domain/workflows/execution_service.ts` (workflow success + error paths)
- Adds architecture guard test (`report_context_arch_test.ts`) that fails if new inline literals appear in production code

Closes #84

## Test Plan

- [x] `deno check` — type-checks all modified files
- [x] `deno lint` + `deno fmt` — clean
- [x] `deno run test` — 4342 passed (4 pre-existing failures in `extension_push_test.ts`)
- [x] Architecture guard test passes — no inline `MethodReportContext` literals in production code
- [x] Compiled binary: direct model run success path produces correct `@swamp/method-summary` report
- [x] Compiled binary: direct model run error path (`exit 1`) produces correct failed report with error message
- [x] Compiled binary: 2-step workflow success path produces correct per-step reports + workflow summary
- [x] Compiled binary: 2-step workflow with failing step produces correct failed report via workflow error path

🤖 Generated with [Claude Code](https://claude.com/claude-code)