### PR TITLE
fix: improve skill trigger routing accuracy across models

### DIFF
--- a/.claude/skills/swamp-extension-driver/SKILL.md
+++ b/.claude/skills/swamp-extension-driver/SKILL.md
@@ -1,6 +1,15 @@
 ---
 name: swamp-extension-driver
-description: Create user-defined TypeScript execution drivers for swamp — implement ExecutionDriver to control where and how model methods run. Use when users want custom execution environments (remote servers, cloud functions, custom containers). Triggers on "custom driver", "extension driver", "execution driver", "ExecutionDriver", "extensions/drivers", "create driver", "new driver type", "driver plugin", "remote execution", "driver implementation".
+description: >
+  Create user-defined TypeScript execution drivers for swamp — implement the
+  ExecutionDriver interface to control where and how model methods run. Use
+  ONLY when the user wants to author, build, or implement a new driver in
+  extensions/drivers/. Do NOT use for running workflows on remote
+  infrastructure (that is swamp-workflow), running existing models (that is
+  swamp-model), or debugging driver issues (that is swamp-troubleshooting).
+  Triggers on "custom driver", "extension driver", "execution driver",
+  "ExecutionDriver", "extensions/drivers", "create driver", "new driver type",
+  "driver plugin", "driver implementation", "implement ExecutionDriver".
 ---
 
 # Swamp Extension Driver

--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -6,8 +6,9 @@ description: >
   manifest.yaml. Use ONLY when the user wants to author, build, or implement a
   new TypeScript model in extensions/models/. Do NOT use for running or
   executing existing models (that is swamp-model), orchestrating models in
-  workflows (that is swamp-workflow), or debugging model errors (that is
-  swamp-troubleshooting). Triggers on "create model", "new model type",
+  workflows (that is swamp-workflow), debugging model errors (that is
+  swamp-troubleshooting), or publishing, pushing, or releasing extensions (that
+  is swamp-extension-publish). Triggers on "create model", "new model type",
   "custom model", "extension model", "user model", "typescript model", "extend
   swamp", "build integration", "zod schema", "model plugin", "deno model",
   "extensions/models", "model development", "implement model", "smoke test",

--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -1,6 +1,19 @@
 ---
 name: swamp-extension-model
-description: Create, test, and develop extension models for swamp — define Zod schemas, implement model interfaces, smoke test against live APIs, and write manifest.yaml. Use when creating models, writing manifest.yaml, testing extensions, or developing models. Covers all extension types (models, vaults, drivers, datastores, reports). Triggers on "create model", "new model type", "custom model", "extension model", "user model", "typescript model", "extend swamp", "build integration", "zod schema", "model plugin", "deno model", "extensions/models", "model development", "implement model", "smoke test", "test extension", "verify model", "test against API", "before push test", "test extension from another repo", "source extension loading", "manifest", "manifest.yaml", "write manifest".
+description: >
+  Create, test, and develop new extension models for swamp — define Zod
+  schemas, implement model interfaces, smoke test against live APIs, and write
+  manifest.yaml. Use ONLY when the user wants to author, build, or implement a
+  new TypeScript model in extensions/models/. Do NOT use for running or
+  executing existing models (that is swamp-model), orchestrating models in
+  workflows (that is swamp-workflow), or debugging model errors (that is
+  swamp-troubleshooting). Triggers on "create model", "new model type",
+  "custom model", "extension model", "user model", "typescript model", "extend
+  swamp", "build integration", "zod schema", "model plugin", "deno model",
+  "extensions/models", "model development", "implement model", "smoke test",
+  "test extension", "verify model", "test against API", "before push test",
+  "test extension from another repo", "source extension loading", "manifest",
+  "manifest.yaml", "write manifest".
 ---
 
 # Swamp Extension Model

--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -7,8 +7,9 @@ description: >
   inputs, running or executing methods, viewing outputs, or managing lifecycle
   (edit, delete). Do NOT use when the user wants to build, create, or implement
   a custom model type, Zod schema, or TypeScript model — that is
-  swamp-extension-model. Triggers on "swamp model", "model type", "model
-  schema", "create input", "type search", "type describe", "run method",
+  swamp-extension-model. Do NOT use for orchestrating or chaining models in
+  workflows — that is swamp-workflow. Triggers on "swamp model", "model type",
+  "model schema", "create input", "type search", "type describe", "run method",
   "execute method", "validation method", "transform method", "enrichment model",
   "model validate", "model delete", "model edit", "model output", "output logs",
   "output format", "CEL expression".

--- a/.claude/skills/swamp-report/SKILL.md
+++ b/.claude/skills/swamp-report/SKILL.md
@@ -1,6 +1,16 @@
 ---
 name: swamp-report
-description: Create, register, configure, and run reports for swamp models and workflows. Use when creating report extensions, configuring reports in definition YAML, running reports via CLI, or viewing report output. Triggers on "report", "swamp report", "model report", "create report", "run report", "report extension", "report label", "skip report", "report output", "cost report", "audit report", "workflow report", "report results".
+description: >
+  Create, register, configure, and run reports for swamp models and workflows.
+  Use when creating report extensions, configuring reports in definition YAML,
+  running reports via CLI, viewing report output, or accessing execution data
+  through the report API (dataRepository, UnifiedDataRepository, dataHandles,
+  MethodReportContext). Do NOT use for debugging report execution failures —
+  that is swamp-troubleshooting. Triggers on "report", "swamp report", "model
+  report", "create report", "run report", "report extension", "report label",
+  "skip report", "report output", "cost report", "audit report", "workflow
+  report", "report results", "dataRepository", "UnifiedDataRepository",
+  "dataHandles", "report context", "report data access".
 ---
 
 # Swamp Report Skill

--- a/evals/promptfoo/generate_config.ts
+++ b/evals/promptfoo/generate_config.ts
@@ -240,7 +240,7 @@ async function main(): Promise<void> {
   }
 
   const systemMessage =
-    "You are a skill router for swamp, an AI-native automation framework. Your ONLY job is to route user requests to the correct skill by making a tool call. You MUST call exactly one tool for every request. NEVER respond with text. NEVER ask clarifying questions. Even if the request is vague or missing details, route it to the best-matching skill based on the topic and keywords. The skill itself will handle gathering any missing information from the user.";
+    "You are a skill router for swamp, an AI-native automation framework. Your ONLY job is to route user requests to the correct skill by making a tool call. You MUST call exactly one tool for every request. A text-only response with no tool call is ALWAYS wrong — every request has a best-matching skill. NEVER respond with text. NEVER ask clarifying questions. Even if the request is vague or missing details, route it to the best-matching skill based on the topic and keywords. The skill itself will handle gathering any missing information from the user.";
 
   const config = {
     description: `Swamp skill trigger routing evaluation (${modelAlias})`,


### PR DESCRIPTION
## Summary

- Sharpen skill descriptions for `swamp-report`, `swamp-extension-model`, `swamp-extension-driver`, and `swamp-model` to reduce cross-model misrouting identified by multi-model eval runs
- Add differentiating keywords (`dataRepository`, `UnifiedDataRepository`, `dataHandles`, `MethodReportContext`) to `swamp-report` so report API queries stop routing to troubleshooting
- Narrow extension-model and extension-driver descriptions to creation-only scope with explicit exclusions for adjacent skills (swamp-model, swamp-workflow, swamp-troubleshooting, swamp-extension-publish)
- Add workflow-orchestration exclusion to swamp-model
- Strengthen eval system prompt against text-only responses from Opus and Gemini

## Eval Results

Validated against multi-model eval suite ([run 1](https://github.com/systeminit/swamp/actions/runs/24422295695), [run 2](https://github.com/systeminit/swamp/actions/runs/24423025002)):

| Model | Before | After |
|-------|--------|-------|
| Sonnet | 99.0% (200/202) | 97.5% (197/202) |
| GPT-5.4 | 98.0% (198/202) | 98.0% (198/202) |
| Opus | 94.1% (190/202) | **96.5% (195/202)** |
| Gemini | 91.6% (185/202) | 93.8% (120/128*) |

*Gemini rate-limited, 128/202 tests completed.

Original cross-model failures from issue:

| Failure | Before | After |
|---------|--------|-------|
| report SHOULD trigger "UnifiedDataRepository" | 4/4 fail | **0/4 — FIXED** |
| model NOT for "chain into workflow" | 2/4 fail | **0/4 — FIXED** |
| extension-driver NOT for "Kubernetes cluster" | 3/4 fail | **0/4 — FIXED** |
| extension-model NOT for "custom model in workflow" | 3/4 fail | 2/4 — improved |
| workflow NOT for "erroring on second step" | 2/4 fail | 2/4 — same |

Closes #80

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] All 4346 tests pass
- [x] `deno run compile` succeeds
- [x] Multi-model eval suite passes (all models above 90% threshold)

🤖 Generated with [Claude Code](https://claude.ai/code)