### PR TITLE
feat: document skills as first-class extension content type

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -488,6 +488,17 @@ swamp model type search --json              # Model should appear
 swamp model type describe @myorg/my-model --json  # Check schema
 ```
 
+## Bundling Skills with Extensions
+
+Extensions can include skills — markdown guidance documents that teach agents
+how to use the extension's models effectively. Skills are declared in
+`manifest.yaml` and extracted to the user's tool-specific skill directory on
+pull.
+
+See [references/skills.md](references/skills.md) for the full guide: directory
+structure, SKILL.md format, manifest declaration, validation rules, and
+publishing workflow.
+
 ## When to Use Other Skills
 
 | Need                       | Use Skill               |
@@ -527,3 +538,6 @@ swamp model type describe @myorg/my-model --json  # Check schema
   pre-push quality review checklist (credentials, logging, errors, idempotency)
 - **Docker execution**: See
   [references/docker-execution.md](references/docker-execution.md)
+- **Bundling Skills**: See [references/skills.md](references/skills.md) for
+  packaging skills with extensions (directory structure, frontmatter,
+  validation, manifest declaration)

--- a/.claude/skills/swamp-extension-model/references/skills.md
+++ b/.claude/skills/swamp-extension-model/references/skills.md
@@ -1,0 +1,211 @@
+# Bundling Skills with Extensions
+
+Extensions can include **skills** — markdown guidance documents that teach
+agents and humans how to use the extension's models effectively within a
+specific organizational context.
+
+Skills are passive — swamp never executes them. It registers metadata at install
+time, surfaces descriptions for agent discovery, and serves content via the
+tool's skill directory. The agent or human decides when to load and follow them.
+
+## When to Bundle Skills
+
+Bundle skills when your extension's models support workflows that benefit from
+opinionated guidance. Common cases:
+
+- **Workflow templates** — step-by-step processes built on top of generic models
+  (e.g., a story creation template for a Redmine model)
+- **Organizational conventions** — naming standards, approval checklists,
+  security review steps
+- **Domain-specific instructions** — how to use model methods in combination for
+  a particular use case
+
+A skills-only extension needs no TypeScript, no `deno.json`, no tests — just a
+manifest and markdown files.
+
+## Skill Directory Structure
+
+Each skill is a directory containing a required `SKILL.md` and optional
+supporting files:
+
+```
+.claude/skills/<skill-name>/
+├── SKILL.md              # Required — uppercase
+├── references/           # Optional — detailed docs loaded on demand
+│   └── *.md
+└── evals/                # Optional — trigger evaluation test cases
+    └── trigger_evals.json
+```
+
+## SKILL.md Format
+
+SKILL.md must have YAML frontmatter with `name` and `description`:
+
+```markdown
+---
+name: create-story
+description: >
+  Use when creating a Redmine story issue with the @webframp/redmine model.
+  Triggers on "create story", "new story", "story template".
+---
+
+# Create Story
+
+Step-by-step instructions for creating a story...
+```
+
+**Frontmatter rules:**
+
+| Field         | Required | Constraints                               |
+| ------------- | -------- | ----------------------------------------- |
+| `name`        | Yes      | Letters, numbers, hyphens only. Max 64 ch |
+| `description` | Yes      | Max 1024 characters                       |
+
+No other frontmatter fields are required (optional `license` is allowed).
+
+**Body guidelines:**
+
+- Keep under 500 lines — split detailed content into `references/` files
+- Use imperative form ("Use this for…", "To create…")
+- The `description` is the primary trigger mechanism — include what the skill
+  does AND specific trigger phrases/contexts
+
+## Progressive Disclosure
+
+Skills load in three tiers to manage context efficiently:
+
+1. **Metadata** (name + description) — always in context (~100 words)
+2. **SKILL.md body** — loaded when the skill triggers (<5k words)
+3. **References** — loaded on demand by the agent as needed (unlimited)
+
+Keep only core workflow and selection guidance in SKILL.md. Move
+variant-specific details, API references, and lengthy examples into
+`references/`.
+
+## Manifest Declaration
+
+Declare skills in `manifest.yaml` as a flat list of directory names:
+
+```yaml
+manifestVersion: 1
+name: "@myorg/redmine-workflow"
+version: "2026.04.14.1"
+description: "Workflow skills for @webframp/redmine"
+skills:
+  - create-story
+  - create-task
+  - hypothesis-task
+dependencies:
+  - "@webframp/redmine"
+```
+
+Each entry is a skill directory name resolved from:
+
+1. **Project-local skill directory** — e.g., `.claude/skills/create-story/`
+2. **Global skill directory** — e.g., `~/.claude/skills/create-story/`
+
+The tool determines the skill directory path:
+
+| Tool     | Skill Directory   |
+| -------- | ----------------- |
+| Claude   | `.claude/skills/` |
+| Cursor   | `.cursor/skills/` |
+| Opencode | `.agents/skills/` |
+| Codex    | `.agents/skills/` |
+| Kiro     | `.kiro/skills/`   |
+
+## Validation Rules
+
+During `swamp extension push`, skills are validated:
+
+| Check                | Requirement                                    |
+| -------------------- | ---------------------------------------------- |
+| `SKILL.md` exists    | Each skill directory must contain a `SKILL.md` |
+| Valid frontmatter    | YAML frontmatter with `name` and `description` |
+| Individual file size | Max 500 KB per file                            |
+| Total skill content  | Max 2 MB across all skills in the extension    |
+
+Errors block the push. Warnings (e.g., presence of a `scripts/` directory) are
+surfaced but don't block.
+
+## Archive Structure
+
+Skills are archived under `extension/skills/` in the tar.gz:
+
+```
+extension.tar.gz
+└── extension/
+    ├── manifest.yaml
+    └── skills/
+        ├── create-story/
+        │   ├── SKILL.md
+        │   └── references/
+        │       └── templates.md
+        └── create-task/
+            └── SKILL.md
+```
+
+## Installation (Pull)
+
+When a user runs `swamp extension pull @myorg/redmine-workflow`, skills are
+extracted to the tool-specific skill directory. For Claude, this means:
+
+```
+.claude/skills/create-story/
+.claude/skills/create-task/
+.claude/skills/hypothesis-task/
+```
+
+Skill directories are tracked in `.swamp/upstream_extensions.json` for cleanup
+on uninstall.
+
+## Separation of Concerns
+
+Skills enable a clean split between generic integrations and opinionated
+workflows:
+
+```
+@webframp/redmine                    ← generic model, anyone can use
+@myorg/redmine-workflow              ← org-specific skills, depends on @webframp/redmine
+@corp/redmine-security-review        ← another org's skill pack, same model
+```
+
+Use `dependencies` in the manifest to declare that your skills-only extension
+requires a model extension.
+
+## Example: Skills-Only Extension
+
+A minimal extension that bundles two workflow skills:
+
+**Directory layout:**
+
+```
+.claude/skills/
+├── create-story/
+│   └── SKILL.md
+└── hypothesis-task/
+    ├── SKILL.md
+    └── references/
+        └── hypothesis-format.md
+manifest.yaml
+```
+
+**manifest.yaml:**
+
+```yaml
+manifestVersion: 1
+name: "@myorg/redmine-workflow"
+version: "2026.04.14.1"
+description: "Story and hypothesis workflow skills for Redmine"
+skills:
+  - create-story
+  - hypothesis-task
+dependencies:
+  - "@webframp/redmine"
+```
+
+**Push:**
+
+```bash
+swamp extension push manifest.yaml
+```

--- a/.claude/skills/swamp-extension-publish/SKILL.md
+++ b/.claude/skills/swamp-extension-publish/SKILL.md
@@ -108,7 +108,7 @@ Confirm `manifest.yaml` exists and is structurally valid.
 
 - Missing `manifestVersion` → add `manifestVersion: 1`
 - Invalid name → use `@collective/extension-name` format
-- No content arrays → add at least one of `models`, `workflows`, etc.
+- No content arrays → add at least one of `models`, `workflows`, `skills`, etc.
 - Missing files → create the files or fix the paths
 
 See [references/publishing.md](references/publishing.md) for the full manifest

--- a/.claude/skills/swamp-extension-publish/references/publishing.md
+++ b/.claude/skills/swamp-extension-publish/references/publishing.md
@@ -59,13 +59,14 @@ dependencies:
 | `drivers`         | No*      | Driver file paths relative to `extensions/drivers/`                                              |
 | `datastores`      | No*      | Datastore file paths relative to `extensions/datastores/`                                        |
 | `reports`         | No*      | Report file paths relative to `extensions/reports/`                                              |
+| `skills`          | No*      | Skill directory names resolved from the tool's skill directory (e.g., `.claude/skills/`)         |
 | `additionalFiles` | No       | Extra files relative to the manifest location                                                    |
 | `platforms`       | No       | OS/architecture hints (e.g. `darwin-aarch64`, `linux-x86_64`)                                    |
 | `labels`          | No       | Categorization labels (e.g. `aws`, `kubernetes`, `security`)                                     |
 | `dependencies`    | No       | Other extensions this one depends on                                                             |
 
-*At least one of `models`, `workflows`, `vaults`, `drivers`, `datastores`, or
-`reports` must be present with entries.
+*At least one of `models`, `workflows`, `vaults`, `drivers`, `datastores`,
+`reports`, or `skills` must be present with entries.
 
 ### Name Rules
 
@@ -334,16 +335,16 @@ swamp extension version --manifest manifest.yaml --json
 
 ## Common Errors and Fixes
 
-| Error                           | Fix                                                                     |
-| ------------------------------- | ----------------------------------------------------------------------- |
-| "Not a swamp repository"        | Run `swamp repo init --json` in the extension directory                 |
-| "Not authenticated"             | Run `swamp auth login` first                                            |
-| "collective does not match"     | Manifest `name` must use `@your-username/...`                           |
-| "CalVer format" error           | Use `YYYY.MM.DD.MICRO` (e.g., `2026.02.26.1`)                           |
-| "at least one model, workflow…" | Add a `models`, `workflows`, `vaults`, `drivers`, or `datastores` array |
-| "Model file not found"          | Check path is relative to `extensions/models/`                          |
-| "Workflow file not found"       | Check path is relative to `workflows/`                                  |
-| "eval() or new Function()"      | Remove dynamic code execution from your models                          |
-| "Version already exists"        | Bump the MICRO component or let CLI auto-bump                           |
-| "Missing manifestVersion"       | Add `manifestVersion: 1` to your manifest                               |
-| "Bundle compilation failed"     | Fix TypeScript errors in your model files                               |
+| Error                           | Fix                                                                               |
+| ------------------------------- | --------------------------------------------------------------------------------- |
+| "Not a swamp repository"        | Run `swamp repo init --json` in the extension directory                           |
+| "Not authenticated"             | Run `swamp auth login` first                                                      |
+| "collective does not match"     | Manifest `name` must use `@your-username/...`                                     |
+| "CalVer format" error           | Use `YYYY.MM.DD.MICRO` (e.g., `2026.02.26.1`)                                     |
+| "at least one model, workflow…" | Add a `models`, `workflows`, `vaults`, `drivers`, `datastores`, or `skills` array |
+| "Model file not found"          | Check path is relative to `extensions/models/`                                    |
+| "Workflow file not found"       | Check path is relative to `workflows/`                                            |
+| "eval() or new Function()"      | Remove dynamic code execution from your models                                    |
+| "Version already exists"        | Bump the MICRO component or let CLI auto-bump                                     |
+| "Missing manifestVersion"       | Add `manifestVersion: 1` to your manifest                                         |
+| "Bundle compilation failed"     | Fix TypeScript errors in your model files                                         |

--- a/design/extension.md
+++ b/design/extension.md
@@ -45,8 +45,8 @@ what the extension contains and how it should be packaged.
 - `manifestVersion`: Must be `1` (the only supported version).
 - `name`: Scoped name (`@collective/name`).
 - `version`: CalVer version string.
-- At least one of `models`, `workflows`, `vaults`, `drivers`, `datastores`, or
-  `reports` must be present.
+- At least one of `models`, `workflows`, `vaults`, `drivers`, `datastores`,
+  `reports`, or `skills` must be present.
 
 ### Path Safety
 
@@ -66,6 +66,10 @@ containing `..` or starting with `/`.
 - `drivers`: Array of relative paths to TypeScript driver files.
 - `datastores`: Array of relative paths to TypeScript datastore files.
 - `reports`: Array of relative paths to TypeScript report files.
+- `skills`: Array of skill directory names resolved from the tool's skill
+  directory (e.g., `.claude/skills/`). Each directory must contain a `SKILL.md`
+  with YAML frontmatter declaring `name` and `description`. Skills are passive
+  markdown guidance documents — swamp never executes them.
 - `include`: Array of relative paths (from `modelsDir`) to TypeScript files that
   should be included in the archive alongside models but not bundled. Used for
   helper scripts that are executed via `Deno.Command` subprocess rather than

--- a/integration/extension_push_test.ts
+++ b/integration/extension_push_test.ts
@@ -167,7 +167,7 @@ Deno.test("extension push with invalid manifest (no models or workflows) gives c
     assertEquals(code === 0, false);
     assertStringIncludes(
       stderr,
-      "at least one model, workflow, vault, driver, datastore, or report",
+      "at least one model, workflow, vault, driver, datastore, report, or skill",
     );
   } finally {
     await Deno.remove(tmpDir, { recursive: true });

--- a/src/domain/extensions/extension_manifest.ts
+++ b/src/domain/extensions/extension_manifest.ts
@@ -79,10 +79,11 @@ const ExtensionManifestSchemaV1 = z.object({
     (data.vaults && data.vaults.length > 0) ||
     (data.drivers && data.drivers.length > 0) ||
     (data.datastores && data.datastores.length > 0) ||
-    (data.reports && data.reports.length > 0),
+    (data.reports && data.reports.length > 0) ||
+    (data.skills && data.skills.length > 0),
   {
     message:
-      "Extension must include at least one model, workflow, vault, driver, datastore, or report",
+      "Extension must include at least one model, workflow, vault, driver, datastore, report, or skill",
   },
 );
 

--- a/src/domain/extensions/extension_manifest_test.ts
+++ b/src/domain/extensions/extension_manifest_test.ts
@@ -194,7 +194,7 @@ vaults:
   assertEquals(manifest.workflows, []);
 });
 
-Deno.test("parseExtensionManifest rejects no models, workflows, vaults, drivers, or datastores", () => {
+Deno.test("parseExtensionManifest rejects no models, workflows, vaults, drivers, datastores, or skills", () => {
   const yaml = `
 manifestVersion: 1
 name: "@myuser/myext"
@@ -203,7 +203,7 @@ version: "2026.02.26.1"
   const error = assertThrows(() => parseExtensionManifest(yaml));
   assertStringIncludes(
     (error as Error).message,
-    "at least one model, workflow, vault, driver, datastore, or report",
+    "at least one model, workflow, vault, driver, datastore, report, or skill",
   );
 });
 


### PR DESCRIPTION
## Summary

- Add `skills` to the manifest `.refine()` constraint so skills-only extensions are valid (previously rejected with "must include at least one model, workflow...")
- Add `references/skills.md` to `swamp-extension-model` skill documenting how to bundle skills with extensions — directory structure, SKILL.md format, manifest declaration, validation rules, archive structure, and push/pull workflow
- Update `swamp-extension-publish` skill docs to include skills in the constraint footnote, field table, and troubleshooting row
- Update `design/extension.md` to document the skills manifest field
- Fix unit and integration tests to match updated error message

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] `deno run test` passes (4344 passed, 0 failed)
- [x] `deno run compile` succeeds

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)