### PR TITLE
feat: unify data access on data query, teach helpers as shortcuts

### DIFF
--- a/.claude/skills/swamp-data/SKILL.md
+++ b/.claude/skills/swamp-data/SKILL.md
@@ -11,6 +11,33 @@ machine-readable output.
 **Verify CLI syntax:** If unsure about exact flags or subcommands, run
 `swamp help data` for the complete, up-to-date CLI schema.
 
+## Query is the primitive; get/list/search/versions are shortcuts
+
+`swamp data query` is the general data-access command — it takes any CEL
+predicate over artifact metadata and content, with optional projections via
+`--select`. The `get`, `list`, `search`, and `versions` subcommands are
+shortcuts for common queries. **Prefer the shortcut when your intent matches** —
+`swamp data get my-model state` reads more clearly than the equivalent
+predicate. Reach for `swamp data query` directly when you need a multi-field
+predicate, a projection, or history beyond a single version.
+
+### CLI shortcut mapping
+
+| Shortcut                              | Underlying query                                                                            |
+| ------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `swamp data get <m> <n>`              | `swamp data query 'modelName == "<m>" && name == "<n>"' --select content`                   |
+| `swamp data get <m> <n> --version 2`  | `swamp data query 'modelName == "<m>" && name == "<n>" && version == 2' --select content`   |
+| `swamp data list <m>`                 | `swamp data query 'modelName == "<m>"'`                                                     |
+| `swamp data list <m> --type resource` | `swamp data query 'modelName == "<m>" && dataType == "resource"'`                           |
+| `swamp data list --workflow <w>`      | `swamp data query 'workflowName == "<w>"'`                                                  |
+| `swamp data list --run <id>`          | `swamp data query 'workflowRunId == "<id>"'`                                                |
+| `swamp data versions <m> <n>`         | `swamp data query 'modelName == "<m>" && name == "<n>" && version >= 0' --select 'version'` |
+| `swamp data search --tag env=prod`    | `swamp data query 'tags.env == "prod"'`                                                     |
+
+The shortcut and the equivalent query run through the same catalog and return
+the same `DataRecord` shape. See the `swamp-data-query` skill for the full list
+of queryable fields and predicate operators.
+
 ## Quick Reference
 
 | Task                   | Command                                               |
@@ -51,11 +78,18 @@ swamp data query 'modelName == "scanner"' --select '{"name": name, "os": attribu
 
 # By content
 swamp data query 'attributes.status == "failed"' --select 'name'
+
+# History — all versions of a specific data item
+swamp data query 'modelName == "my-model" && name == "state" && version >= 0' --select 'version'
+
+# Interactive mode — TUI with live autocomplete, no predicate needed
+swamp data query
 ```
 
 ## List Model Data
 
-View all data items for a model, grouped by tag type.
+View all data items for a model, grouped by tag type. Shortcut for
+`swamp data query 'modelName == "<model>"'`.
 
 ```bash
 swamp data list my-model --json
@@ -69,7 +103,9 @@ full output shape.
 
 ## Get Specific Data
 
-Retrieve the latest version of a specific data item.
+Retrieve the latest version of a specific data item. Shortcut for
+`swamp data query 'modelName == "<model>" && name == "<name>"' --select content`
+(omit `--select content` to return metadata only).
 
 ```bash
 swamp data get my-model execution-log --json
@@ -103,7 +139,8 @@ swamp data get --workflow test-data-fetch output --version 2 --json
 
 ## View Version History
 
-See all versions of a specific data item.
+See all versions of a specific data item. Shortcut for
+`swamp data query 'modelName == "<model>" && name == "<name>" && version >= 0'`.
 
 ```bash
 swamp data versions my-model state --json
@@ -238,10 +275,8 @@ Data is stored in the `.swamp/data/` directory:
   examples from all data commands
 - **Examples**: See [references/examples.md](references/examples.md) for data
   query patterns, CEL expressions, and GC scenarios
+- **Expressions**: See [references/expressions.md](references/expressions.md)
+  for CEL expression patterns and the `data.*` namespace shortcut mapping
 - **Troubleshooting**: See
   [references/troubleshooting.md](references/troubleshooting.md) for common
   errors and fixes
-- **Data design**: See [design/models.md](design/models.md) for data lifecycle
-  details
-- **Expressions**: See [design/expressions.md](design/expressions.md) for CEL
-  syntax

--- a/.claude/skills/swamp-data/references/examples.md
+++ b/.claude/skills/swamp-data/references/examples.md
@@ -37,39 +37,37 @@
 
 ## Cross-Model Data References
 
-### Preferred: model.* Expressions
+### Use the `data.*` namespace
 
-Always prefer `model.*` expressions over `data.latest()` for referencing other
-models' data. The `model.*` expression provides:
-
-- In-memory updates during workflow execution
-- Type-safe attribute access
-- Clear dependency tracking
+Reference cross-model data with the `data.*` namespace. `data.query()` is the
+underlying primitive; the shortcut helpers (`data.latest`, `data.version`,
+`data.findByTag`, `data.findBySpec`, `data.listVersions`) read more clearly when
+your intent matches a shortcut — prefer them when they fit and reach for
+`data.query()` when you need a multi-field predicate or a projection. See
+[references/expressions.md](expressions.md) for the full shortcut mapping table.
 
 ```yaml
-# PREFERRED: Cross-model resource reference
+# Shortcut — single-model-and-name lookup reads clearly as data.latest()
 globalArguments:
-  vpcId: ${{ model.my-vpc.resource.vpc.main.attributes.VpcId }}
-  subnetId: ${{ model.public-subnet.resource.subnet.primary.attributes.SubnetId }}
+  vpcId: ${{ data.latest("my-vpc", "main").attributes.VpcId }}
+  subnetId: ${{ data.latest("public-subnet", "primary").attributes.SubnetId }}
 
-# For command/shell models
+# For command/shell models, the output spec is always named "result"
 globalArguments:
-  imageId: ${{ model.ami-lookup.resource.result.result.attributes.stdout }}
+  imageId: ${{ data.latest("ami-lookup", "result").attributes.stdout }}
 ```
 
-### When to Use data.latest()
+The `model.*.resource` / `model.*.file` patterns are deprecated and will be
+removed in a future release.
 
-Use `data.latest()` only when you need:
-
-- A snapshot from workflow start (not live updates)
-- Dynamic model name lookup
+### Specific versions and queries
 
 ```yaml
-# Snapshot at workflow start
-oldValue: ${{ data.latest("my-model", "state").attributes.value }}
-
-# Rollback scenario — get previous version
+# Specific version — reach for data.version() when you need history
 previousConfig: ${{ data.version("my-model", "config", 1).attributes.setting }}
+
+# Multi-field predicate — reach for data.query() when no shortcut fits
+prodFailures: ${{ data.query('modelName == "scanner" && tags.env == "prod" && attributes.status == "failed"') }}
 ```
 
 ## Data Discovery Patterns
@@ -116,10 +114,10 @@ jobs:
 
 ```yaml
 # Known instance name from factory model
-subnetA: ${{ model.subnet-scanner.resource.subnet.subnet-aaa.attributes.cidr }}
+subnetA: ${{ data.latest("subnet-scanner", "subnet-aaa").attributes.cidr }}
 
 # Single-instance model — use descriptive instance name
-vpcId: ${{ model.my-vpc.resource.vpc.main.attributes.VpcId }}
+vpcId: ${{ data.latest("my-vpc", "main").attributes.VpcId }}
 ```
 
 ## Version Management

--- a/.claude/skills/swamp-data/references/expressions.md
+++ b/.claude/skills/swamp-data/references/expressions.md
@@ -24,13 +24,37 @@ body: ${{ file.contents("my-model", "content") }}
 
 ## Data Namespace Functions
 
+`data.query('<predicate>', '<select>?')` is the general primitive. The functions
+below are shortcuts for common predicates — prefer them when your intent
+matches, because the short form reads more clearly. Reach for `data.query()`
+directly when you need a multi-field predicate, a projection, tag filters beyond
+a single key, or history beyond a single version.
+
 | Function                                     | Description                               |
 | -------------------------------------------- | ----------------------------------------- |
+| `data.query(predicate, select?)`             | General query with full CEL predicate     |
 | `data.version(modelName, dataName, version)` | Get specific version of data              |
 | `data.latest(modelName, dataName)`           | Get latest version of data                |
 | `data.listVersions(modelName, dataName)`     | Get array of available version numbers    |
 | `data.findByTag(tagKey, tagValue)`           | Find all data matching a tag              |
 | `data.findBySpec(modelName, specName)`       | Find all data from a specific output spec |
+
+### CEL shortcut mapping
+
+Every shortcut is equivalent to a specific `data.query()` call. Results have the
+same `DataRecord[]` shape — anything that works on a shortcut result works on a
+query result.
+
+| Shortcut                      | Underlying query                                                           |
+| ----------------------------- | -------------------------------------------------------------------------- |
+| `data.latest("m", "n")`       | `data.query('modelName == "m" && name == "n"')[0]`                         |
+| `data.version("m", "n", 2)`   | `data.query('modelName == "m" && name == "n" && version == 2')[0]`         |
+| `data.listVersions("m", "n")` | `data.query('modelName == "m" && name == "n" && version >= 0', 'version')` |
+| `data.findByTag("k", "v")`    | `data.query('tags.k == "v"')`                                              |
+| `data.findBySpec("m", "s")`   | `data.query('modelName == "m" && specName == "s"')`                        |
+
+See the `swamp-data-query` skill for the full list of queryable fields and
+predicate operators.
 
 **DataRecord structure** returned by these functions:
 
@@ -65,6 +89,13 @@ workflowData: ${{ data.findByTag("workflow", "my-workflow") }}
 
 # Find all instances from a factory model's output spec
 subnets: ${{ data.findBySpec("my-scanner", "subnet") }}
+
+# Query with a multi-field predicate — reach for data.query() when no
+# shortcut fits
+failures: ${{ data.query('modelName == "scanner" && dataType == "resource" && attributes.status == "failed"') }}
+
+# Query with a projection — extract specific fields from every match
+manifest: ${{ data.query('tags.role == "manifest"', '{"name": name, "version": version, "at": createdAt}') }}
 ```
 
 **Key rules:**

--- a/.claude/skills/swamp-model/references/data-chaining.md
+++ b/.claude/skills/swamp-model/references/data-chaining.md
@@ -5,9 +5,14 @@ capturing output for use in other models. For JSON output, use `jq` in the
 command to extract specific fields, then access the result via
 `data.latest("model-name", "result").attributes.stdout`.
 
-> **Note:** `data.latest()` is the preferred accessor for all cross-model data.
-> The `model.*.resource` pattern is deprecated and will be removed in a future
-> release. Existing examples below show both patterns for reference.
+> **Note:** The `data.*` namespace is the current accessor for cross-model data.
+> `data.query()` is the underlying primitive; the shortcut helpers
+> (`data.latest`, `data.version`, `data.findByTag`, `data.findBySpec`,
+> `data.listVersions`) read more clearly when your intent matches, so prefer a
+> shortcut if it fits and reach for `data.query()` when you need a multi-field
+> predicate or a projection. The `model.*.resource` pattern is deprecated and
+> will be removed in a future release. Existing examples below show both
+> patterns for reference.
 
 ## command/shell Data Attributes
 

--- a/.claude/skills/swamp-model/references/examples.md
+++ b/.claude/skills/swamp-model/references/examples.md
@@ -214,13 +214,15 @@ dryRun: true
 
 ## Cross-Model Data References
 
-### Preferred: data.latest() Expressions
+### Use the `data.*` namespace
 
-Always use `data.latest()` for referencing other models' data. It reads directly
-from disk on every call, so it always reflects the latest state:
+Use `data.*` expressions to reference other models' data. `data.query()` is the
+underlying primitive; the shortcut helpers read more clearly when your intent
+matches, so prefer a shortcut if it fits and reach for `data.query()` when you
+need a multi-field predicate or a projection.
 
 ```yaml
-# CORRECT: data.latest() — always reads fresh data from disk
+# Shortcut — reads most clearly for a single-model-and-name lookup
 globalArguments:
   vpcId: ${{ data.latest("my-vpc", "main").attributes.VpcId }}
 
@@ -229,16 +231,16 @@ globalArguments:
   vpcId: ${{ model.my-vpc.resource.vpc.main.attributes.VpcId }}
 ```
 
-### Why data.latest() is Preferred
+### Why `data.*` vs `model.*.resource`
 
-| Feature                   | `data.latest()` | `model.*.resource` |
-| ------------------------- | --------------- | ------------------ |
-| Always fresh (no cache)   | Yes (sync disk) | Yes (eager load)   |
-| Supports vary dimensions  | Yes             | No                 |
-| Clear dependency tracking | Yes             | Yes                |
-| Future-proof              | Yes (canonical) | No (deprecated)    |
+| Feature                   | `data.*` namespace | `model.*.resource` |
+| ------------------------- | ------------------ | ------------------ |
+| Always fresh (no cache)   | Yes (sync disk)    | Yes (eager load)   |
+| Supports vary dimensions  | Yes                | No                 |
+| Clear dependency tracking | Yes                | Yes                |
+| Future-proof              | Yes                | No (deprecated)    |
 
-### Other data.* Functions
+### data.* functions
 
 ```yaml
 # Specific version (rollback scenario)
@@ -252,7 +254,13 @@ allSubnets: ${{ data.findBySpec("scanner", "subnet") }}
 
 # Find by tag
 prodResources: ${{ data.findByTag("env", "prod") }}
+
+# Multi-field predicate — reach for data.query() when no shortcut fits
+prodFailures: ${{ data.query('modelName == "scanner" && tags.env == "prod" && attributes.status == "failed"') }}
 ```
+
+See the `swamp-data` skill's references/expressions.md for the full shortcut
+mapping table.
 
 ### Self-References
 

--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -542,9 +542,9 @@ End-to-end workflow creation:
   installing swamp in CI and GitHub Actions examples
 - **Nested workflows**: See
   [references/nested-workflows.md](references/nested-workflows.md) for when to
-  split a workflow into parent + child (including the async-list-into-forEach
-  pattern), full examples of workflows calling other workflows, forEach with
-  workflows, and nesting limitations
+  split a workflow into parent + child (reusable sub-processes, shape-validated
+  handoffs, independent cadence), full examples of workflows calling other
+  workflows, forEach with workflows, and nesting limitations
 - **Expressions, forEach, and data tracking**: See
   [references/expressions-and-foreach.md](references/expressions-and-foreach.md)
   for forEach iteration patterns, CEL expressions, environment variables, and

--- a/.claude/skills/swamp-workflow/references/data-chaining.md
+++ b/.claude/skills/swamp-workflow/references/data-chaining.md
@@ -68,31 +68,40 @@ globalArguments:
 
 Use `dependsOn` to ensure step B runs after step A when B references A's output.
 
-## Choosing `data.latest()` vs `model.*` Expressions
+## Choosing Data Accessors vs `model.*` Expressions
 
 Model instance definitions use CEL expressions to reference other models' data.
-**`data.latest()` is the preferred (canonical) accessor.** The
-`model.*.resource` and `model.*.file` patterns are deprecated and will be
-removed in a future release.
+The `data.*` namespace is the current accessor; `model.*.resource` and
+`model.*.file` are deprecated and will be removed in a future release.
 
-| Expression                            | Sees current-run data?                 | Sees prior-run data? | Status         |
-| ------------------------------------- | -------------------------------------- | -------------------- | -------------- |
-| `data.latest("<name>", "<spec>")`     | **Yes** — sync disk read on every call | **Yes**              | **Preferred**  |
-| `data.version("<name>", "<spec>", N)` | **Yes** — sync disk read               | **Yes**              | **Preferred**  |
-| `model.<name>.resource.<spec>`        | **Yes** — eagerly populated            | **Yes**              | **Deprecated** |
+Inside the `data.*` namespace, `data.query()` is the primitive and the other
+helpers (`data.latest`, `data.version`, `data.findByTag`, `data.findBySpec`,
+`data.listVersions`) are shortcuts for common predicates. Prefer a shortcut when
+your intent matches — `data.latest("m", "n")` reads more clearly than the
+equivalent predicate. Reach for `data.query()` when you need a multi-field
+predicate, a projection, or history access.
+
+| Expression                            | Sees current-run data?       | Sees prior-run data? | Status         |
+| ------------------------------------- | ---------------------------- | -------------------- | -------------- |
+| `data.query('<predicate>')`           | **Yes** — sync catalog query | **Yes**              | **Primary**    |
+| `data.latest("<name>", "<spec>")`     | **Yes** — shortcut for query | **Yes**              | **Shortcut**   |
+| `data.version("<name>", "<spec>", N)` | **Yes** — shortcut for query | **Yes**              | **Shortcut**   |
+| `model.<name>.resource.<spec>`        | **Yes** — eagerly populated  | **Yes**              | **Deprecated** |
 
 ### When to use each
 
-**Use `data.latest()` / `data.version()`** for all cases:
+**Use a shortcut (`data.latest` / `data.version` / `data.findBySpec` / etc.)**
+when your access pattern fits a shortcut. This covers the majority of
+cross-model data reads: "give me the latest X/Y", "give me version 2 of X/Y",
+"give me every instance from spec S".
 
-- Intra-workflow chaining (step B reads step A's output in the same run)
-- Cross-workflow chaining (workflow B reads data from prior workflow A run)
-- Data always reflects the latest on-disk state (no stale cache)
-- Supports vary dimensions for environment isolation
+**Use `data.query()` directly** when you need a predicate beyond a single
+model+name pair — for example, "every failed resource tagged env=prod", "every
+record across workflows tagged role=manifest", or a projection that extracts
+just specific fields.
 
 **Avoid `model.*.resource` / `model.*.file`** — these patterns are deprecated
-and will emit a warning. They still work for backward compatibility but should
-be migrated to `data.latest()`.
+and will emit a warning. Migrate to `data.latest()` or `data.query()`.
 
 Use explicit `dependsOn` to control step ordering.
 

--- a/.claude/skills/swamp-workflow/references/expressions-and-foreach.md
+++ b/.claude/skills/swamp-workflow/references/expressions-and-foreach.md
@@ -74,23 +74,38 @@ With `--input '{"tags": {"env": "prod", "team": "platform"}}'`, creates steps:
 | `self.{item}.key`   | Key name (object iteration)    |
 | `self.{item}.value` | Value (object iteration)       |
 
-### forEach.in Cannot Await Promises
+### forEach.in with Data Helpers
 
-`forEach.in` is evaluated **synchronously**. Async CEL functions that return a
-Promise — `data.latest()`, `data.findByTag()`, `data.findBySpec()` — do not
-resolve in this position and the step fails with
-`forEach.in must evaluate to an array or object, got: object`.
+`forEach.in` awaits async CEL expressions during expansion, so it accepts data
+helpers directly. A common pattern is iterating over every instance produced by
+a factory model:
 
-Only these shapes work directly in `forEach.in`:
+```yaml
+jobs:
+  - name: process-all
+    steps:
+      - name: process-${{ self.instance.name }}
+        forEach:
+          item: instance
+          in: ${{ data.findBySpec("my-factory", "instance") }}
+        task:
+          type: model_method
+          modelIdOrName: processor
+          methodName: run
+          inputs:
+            target: ${{ self.instance.name }}
+```
 
-- `${{ inputs.<name> }}` — workflow inputs (pre-resolved before expansion)
-- Static literals
+Any async data helper works here — `data.findByTag()`, `data.findBySpec()`,
+`data.latest()`, `data.query()`. The evaluator resolves the Promise before
+walking the items.
 
-To iterate over a list produced by `data.latest()` (or any async source), split
-into a parent + child workflow and let the parent's `task.inputs` resolve the
-list — task inputs ARE awaited. See
+If you want a **typed boundary** between the producer of the list and the
+consumer that iterates it — for shape validation, reusable sub-processes, or
+independent cadence — split into a parent + child workflow and pass the list
+through `task.inputs`. See
 [nested-workflows.md § When to Use Nested Workflows](nested-workflows.md#when-to-use-nested-workflows)
-for the canonical pattern.
+for the full pattern.
 
 ### forEach with Vary Dimensions
 

--- a/.claude/skills/swamp-workflow/references/nested-workflows.md
+++ b/.claude/skills/swamp-workflow/references/nested-workflows.md
@@ -17,20 +17,21 @@ for the child workflow to complete before continuing.
 Reach for a child workflow when a flat workflow can't express the shape you
 need. The cases that come up in practice:
 
-### 1. forEach over an async list (`data.latest()`, `data.findByTag()`, etc.)
+### 1. Reusable sub-process invoked from multiple parents
 
-`forEach.in` is evaluated **synchronously** at expansion time. CEL expressions
-that return a `Promise` — `data.latest()`, `data.findByTag()`,
-`data.findBySpec()` — never resolve in this position, and forEach fails with
-`forEach.in must evaluate to an array or object, got: object` (the "object" is
-the unresolved Promise).
+When the same sequence of steps runs from a cron parent, a manual run, and
+another workflow, extract it into a child workflow with a typed input schema.
+Duplicating steps across workflows is the wrong trade — the child gives you one
+validated entry point.
 
-Task `inputs:` ARE awaited for both `model_method` and `workflow` tasks. Move
-the async call into the parent's `task.inputs` and let the child iterate over a
-plain `inputs.<name>`:
+### 2. Shape-validated handoff of computed data
+
+When a parent produces a list (or other structured value) that a child should
+iterate over, passing it through `task.inputs` with an input schema catches
+shape drift at the boundary rather than deep inside the child:
 
 ```yaml
-# parent — task.inputs awaits data.latest() before invoking child
+# parent — resolve the list and pass it through a typed input
 - name: download
   task:
     type: workflow
@@ -54,7 +55,7 @@ jobs:
       - name: download-${{ self.ep.show }}
         forEach:
           item: ep
-          in: ${{ inputs.episodes }} # already resolved — sync eval is fine
+          in: ${{ inputs.episodes }}
         task:
           type: model_method
           modelIdOrName: transmission
@@ -64,15 +65,11 @@ jobs:
             protocol: torrent
 ```
 
-The child's input schema validates the boundary, so shape drift between producer
-and consumer is caught at invoke time.
-
-### 2. Reusable sub-process invoked from multiple parents
-
-When the same sequence of steps runs from a cron parent, a manual run, and
-another workflow, extract it into a child workflow with a typed input schema.
-Duplicating steps across workflows is the wrong trade — the child gives you one
-validated entry point.
+This is a design choice about validation and contract, not a workaround.
+`forEach.in` can call `data.findBySpec()`, `data.findByTag()`, `data.query()`,
+and the other data helpers directly in a flat workflow — the evaluator awaits
+async data helpers. Reach for a child workflow when the typed boundary itself is
+valuable.
 
 ### 3. Independent cadence or isolation
 

--- a/deno.json
+++ b/deno.json
@@ -18,6 +18,7 @@
     "eval-skill-triggers": "deno run --allow-read --allow-run --allow-env --allow-write --allow-net scripts/eval_skill_triggers_promptfoo.ts"
   },
   "imports": {
+    "@cliffy/table": "jsr:@cliffy/table@^1.0.0",
     "@std/assert": "jsr:@std/assert@^1.0.18",
     "@std/fmt": "jsr:@std/fmt@^1.0.9",
     "@std/cli": "jsr:@std/cli@^1.0.27",

--- a/deno.lock
+++ b/deno.lock
@@ -4,6 +4,7 @@
     "jsr:@cliffy/command@1": "1.0.0",
     "jsr:@cliffy/flags@1.0.0": "1.0.0",
     "jsr:@cliffy/internal@1.0.0": "1.0.0",
+    "jsr:@cliffy/table@1": "1.0.0",
     "jsr:@cliffy/table@1.0.0": "1.0.0",
     "jsr:@logtape/logtape@^2.0.2": "2.0.4",
     "jsr:@logtape/pretty@^2.0.2": "2.0.2",
@@ -11,8 +12,10 @@
     "jsr:@std/assert@^1.0.18": "1.0.19",
     "jsr:@std/cli@^1.0.27": "1.0.27",
     "jsr:@std/fmt@^1.0.9": "1.0.9",
+    "jsr:@std/fs@*": "1.0.23",
     "jsr:@std/fs@^1.0.22": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/path@*": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@std/semver@^1.0.8": "1.0.8",
     "jsr:@std/text@^1.0.17": "1.0.17",
@@ -46,7 +49,7 @@
       "dependencies": [
         "jsr:@cliffy/flags",
         "jsr:@cliffy/internal",
-        "jsr:@cliffy/table",
+        "jsr:@cliffy/table@1.0.0",
         "jsr:@std/fmt",
         "jsr:@std/semver",
         "jsr:@std/text"
@@ -98,7 +101,7 @@
       "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
       "dependencies": [
         "jsr:@std/internal",
-        "jsr:@std/path"
+        "jsr:@std/path@^1.1.4"
       ]
     },
     "@std/internal@1.0.12": {
@@ -1487,6 +1490,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@cliffy/command@1",
+      "jsr:@cliffy/table@1",
       "jsr:@logtape/logtape@^2.0.2",
       "jsr:@logtape/pretty@^2.0.2",
       "jsr:@std/assert@^1.0.18",

--- a/design/data-query.md
+++ b/design/data-query.md
@@ -1,8 +1,8 @@
 # Data Query
 
-Data query provides a unified interface for finding data artifacts across models
-using CEL predicates. Queries filter on artifact metadata (model name, spec name,
-tags, version, etc.) and optionally on JSON content.
+Data query is the general interface for finding data artifacts across models
+using CEL predicates. Queries filter on artifact metadata (model name, spec
+name, tags, version, etc.) and optionally on JSON content.
 
 The query interface is available in three places:
 
@@ -12,6 +12,42 @@ The query interface is available in three places:
   implementations
 
 All three accept the same CEL predicate syntax and operate on the same fields.
+
+## Query is the primitive; helpers are shortcuts
+
+Every `swamp data` read subcommand and every `data.*` CEL helper resolves
+against the same catalog that `data query` walks. The shortcuts exist because
+they read more clearly when your intent matches. **Prefer the shortcut when
+it fits** — `data.latest("m", "n")` is easier to understand than the
+equivalent predicate. Reach for `data query` / `data.query()` directly when
+you need a multi-field predicate, a projection, tag filters beyond a single
+key, or history access beyond a single version.
+
+### CLI shortcuts
+
+| Shortcut                              | Underlying query                                                                             |
+| ------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `swamp data get <m> <n>`              | `swamp data query 'modelName == "<m>" && name == "<n>"' --select content`                    |
+| `swamp data get <m> <n> --version 2`  | `swamp data query 'modelName == "<m>" && name == "<n>" && version == 2' --select content`   |
+| `swamp data list <m>`                 | `swamp data query 'modelName == "<m>"'`                                                      |
+| `swamp data list <m> --type resource` | `swamp data query 'modelName == "<m>" && dataType == "resource"'`                            |
+| `swamp data list --workflow <w>`      | `swamp data query 'workflowName == "<w>"'`                                                   |
+| `swamp data list --run <id>`          | `swamp data query 'workflowRunId == "<id>"'`                                                 |
+| `swamp data versions <m> <n>`         | `swamp data query 'modelName == "<m>" && name == "<n>" && version >= 0' --select 'version'` |
+| `swamp data search --tag env=prod`    | `swamp data query 'tags.env == "prod"'`                                                      |
+
+### CEL shortcuts
+
+| Shortcut                      | Underlying query                                                           |
+| ----------------------------- | -------------------------------------------------------------------------- |
+| `data.latest("m", "n")`       | `data.query('modelName == "m" && name == "n"')[0]`                         |
+| `data.version("m", "n", 2)`   | `data.query('modelName == "m" && name == "n" && version == 2')[0]`         |
+| `data.listVersions("m", "n")` | `data.query('modelName == "m" && name == "n" && version >= 0', 'version')` |
+| `data.findByTag("k", "v")`    | `data.query('tags.k == "v"')`                                              |
+| `data.findBySpec("m", "s")`   | `data.query('modelName == "m" && specName == "s"')`                        |
+
+Results from any shortcut are structurally identical to the equivalent
+`data.query()` call — same `DataRecord[]` type, same fields, same semantics.
 
 ## DataRecord
 

--- a/design/expressions.md
+++ b/design/expressions.md
@@ -37,8 +37,7 @@ attributes:
   message: ${{ model.foo.definition.attributes.message }}
 ```
 
-Or the data output of the same model (using the preferred `data.latest()`
-accessor):
+Or the data output of the same model:
 
 ```yaml
 id: 0bc79a8f-d9d2-4ec5-a37f-8d88bbb3ee27
@@ -48,6 +47,14 @@ tags: {}
 attributes:
   message: ${{ data.latest('foo', 'result').attributes.message }}
 ```
+
+`data.latest()` is a shortcut for the equivalent `data.query()` call. The
+general primitive is `data.query('<CEL predicate>')`, which takes any
+predicate over the full set of queryable fields. Reach for it when a
+shortcut doesn't express what you need — for example, a multi-field
+predicate, a projection, tag filters beyond a single key, or history access
+beyond a single version. See [data-query.md](./data-query.md) for the
+primitive, the full field set, and the shortcut mapping table.
 
 You can refer to your own model with `self`, for things like name, version,
 tags, and a model's other attributes.
@@ -91,12 +98,17 @@ dynamic configuration without modifying definition files.
 
 ## Data Versioning
 
-`data.latest()` is the **canonical accessor** for model data. It reads directly
-from disk on every call, so it always reflects the latest on-disk state with no
-cache staleness. The `model.*.resource` and `model.*.file` patterns are
-**deprecated** and will be removed in a future release.
+Data is immutable and versioned. The following CEL shortcuts cover the common
+read patterns; each is a convenience form of `data.query()` (see
+[data-query.md](./data-query.md) for the shortcut-to-query mapping). Prefer
+a shortcut when it matches your intent — `data.latest("m", "n")` reads more
+clearly than the equivalent predicate. Reach for `data.query()` directly when
+you need something the shortcuts don't express.
 
-Data is immutable and versioned. Use the following CEL functions to access data:
+These accessors read directly from disk on every call, so they always reflect
+the latest on-disk state with no cache staleness. The `model.*.resource` and
+`model.*.file` patterns are **deprecated** and will be removed in a future
+release.
 
 ### data.latest(modelName, dataName)
 
@@ -177,37 +189,59 @@ attributes:
 ### data.findBySpec(modelName, specName)
 
 Returns all data records for a model that match a given output spec name.
-Commonly used in `task.inputs` to pass variable-length output into a step.
-
-**Workflow run scoping:** When called inside a workflow run, `findBySpec` only
-returns data produced during the current run. This prevents stale data from
-previous runs leaking into iteration. Outside a workflow context, it returns all
-data globally. The same run-scoping applies to `context.readModelData()` and
-`context.queryData()` in extension model methods (see `design/data-query.md`).
-
-**Async limitation:** `data.findBySpec()` is async and cannot be used directly in
-`forEach.in` (which is evaluated synchronously). To iterate over findBySpec
-results, resolve the call in a parent workflow's `task.inputs` and pass the array
-to a child workflow. See
-`.claude/skills/swamp-workflow/references/nested-workflows.md`.
+Shortcut for `data.query('modelName == "..." && specName == "..."')`.
+Commonly used in `task.inputs` or `forEach.in` to iterate over variable-length
+output.
 
 ```yaml
-# In task.inputs — resolves the async call before passing to the step:
-inputs:
-  episodes: ${{ data.findBySpec("dedup-model", "episode") }}
+# Iterate over every episode produced by the dedup-model:
+- name: download-${{ self.ep.name }}
+  forEach:
+    item: ep
+    in: ${{ data.findBySpec("dedup-model", "episode") }}
+  task:
+    type: model_method
+    modelIdOrName: transmission
+    methodName: add
+    inputs:
+      uri: ${{ self.ep.magnet }}
 ```
+
+Results are **not** run-scoped — `findBySpec` returns every matching record
+in the catalog. Add a `workflowRunId` predicate via `data.query()` when you
+want to scope to the current run.
 
 ### data.findByTag(tagKey, tagValue)
 
-Returns all data records across all models with a matching tag. This function is
-**not** run-scoped — it always returns all matching data globally. Use it when
-you need cross-run data access.
+Returns all data records across all models with a matching tag. Shortcut for
+`data.query('tags.key == "value"')`. Not run-scoped — always returns all
+matching data globally.
 
 ```yaml
 # Find all data tagged with env=prod across all models:
 inputs:
   prodData: ${{ data.findByTag("env", "prod") }}
 ```
+
+### data.query(predicate, select?)
+
+`data.query()` is the underlying primitive. Use it when the shortcuts don't
+express what you need. It takes a CEL predicate over every queryable field
+(see [data-query.md](./data-query.md) for the full set) and an optional
+`select` projection. For example:
+
+```yaml
+# Every failed resource for a model tagged with env=prod:
+inputs:
+  failures: ${{ data.query('modelName == "scanner" && dataType == "resource" && tags.env == "prod" && attributes.status == "failed"') }}
+
+# Project specific fields out of every result across all models:
+inputs:
+  manifest: ${{ data.query('tags.role == "manifest"', '{"name": name, "version": version, "at": createdAt}') }}
+```
+
+`data.query()` results have the same `DataRecord[]` shape as the shortcuts
+— anything you can do with a shortcut result, you can do with a query result.
 
 ## Sensitive Data
 

--- a/integration/cel_data_access_test.ts
+++ b/integration/cel_data_access_test.ts
@@ -260,10 +260,11 @@ Deno.test("CEL Data Access: access latest resource via model.X.resource.specName
 Deno.test("CEL Data Access: access specific version via data.version()", async () => {
   await withTempDir(async (repoDir) => {
     await setupRepoDir(repoDir);
+    const catalog = new CatalogStore(join(repoDir, "_catalog.db"));
     const dataRepo = new FileSystemUnifiedDataRepository(
       repoDir,
       undefined,
-      new CatalogStore(join(repoDir, "_catalog.db")),
+      catalog,
     );
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const type = ModelType.create("test/model");
@@ -282,7 +283,7 @@ Deno.test("CEL Data Access: access specific version via data.version()", async (
       contentType: "application/json",
       lifetime: "infinite",
       garbageCollection: 100,
-      tags: { type: "audit" },
+      tags: { type: "audit", modelName: "versioned_model" },
       ownerDefinition: owner,
     });
 
@@ -301,9 +302,11 @@ Deno.test("CEL Data Access: access specific version via data.version()", async (
     }
 
     // Build context
+    const dqs = new DataQueryService(catalog, dataRepo);
     const modelResolver = new ModelResolver(definitionRepo, {
       repoDir,
       dataRepo,
+      dataQueryService: dqs,
     });
     const context = await modelResolver.buildContext();
 
@@ -397,10 +400,11 @@ Deno.test("CEL Data Access: access data via data.latest()", async () => {
 Deno.test("CEL Data Access: list all versions via data.listVersions()", async () => {
   await withTempDir(async (repoDir) => {
     await setupRepoDir(repoDir);
+    const catalog = new CatalogStore(join(repoDir, "_catalog.db"));
     const dataRepo = new FileSystemUnifiedDataRepository(
       repoDir,
       undefined,
-      new CatalogStore(join(repoDir, "_catalog.db")),
+      catalog,
     );
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const type = ModelType.create("test/model");
@@ -417,7 +421,7 @@ Deno.test("CEL Data Access: list all versions via data.listVersions()", async ()
       contentType: "text/plain",
       lifetime: "infinite",
       garbageCollection: 100,
-      tags: { type: "log" },
+      tags: { type: "log", modelName: "list_versions_model" },
       ownerDefinition: owner,
     });
 
@@ -431,9 +435,11 @@ Deno.test("CEL Data Access: list all versions via data.listVersions()", async ()
       );
     }
 
+    const dqs = new DataQueryService(catalog, dataRepo);
     const modelResolver = new ModelResolver(definitionRepo, {
       repoDir,
       dataRepo,
+      dataQueryService: dqs,
     });
     const context = await modelResolver.buildContext();
 

--- a/integration/data_expression_test.ts
+++ b/integration/data_expression_test.ts
@@ -152,10 +152,11 @@ Deno.test("Integration: model.X.resource.specName accesses latest version of res
 Deno.test("Integration: data.version() retrieves specific version", async () => {
   await withTempDir(async (repoDir) => {
     await setupRepoDir(repoDir);
+    const catalog = new CatalogStore(join(repoDir, "_catalog.db"));
     const dataRepo = new FileSystemUnifiedDataRepository(
       repoDir,
       undefined,
-      new CatalogStore(join(repoDir, "_catalog.db")),
+      catalog,
     );
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const type = ModelType.create("test/model");
@@ -177,7 +178,7 @@ Deno.test("Integration: data.version() retrieves specific version", async () => 
       contentType: "application/json",
       lifetime: "infinite",
       garbageCollection: 10,
-      tags: { type: "output" },
+      tags: { type: "output", modelName: "my-model" },
       ownerDefinition: owner,
     });
 
@@ -195,6 +196,7 @@ Deno.test("Integration: data.version() retrieves specific version", async () => 
     const modelResolver = new ModelResolver(definitionRepo, {
       repoDir,
       dataRepo,
+      dataQueryService: new DataQueryService(catalog, dataRepo),
     });
     const context = await modelResolver.buildContext();
 
@@ -340,10 +342,11 @@ Deno.test("Integration: data.latest() retrieves latest version", async () => {
 Deno.test("Integration: data.listVersions() returns sorted version numbers", async () => {
   await withTempDir(async (repoDir) => {
     await setupRepoDir(repoDir);
+    const catalog = new CatalogStore(join(repoDir, "_catalog.db"));
     const dataRepo = new FileSystemUnifiedDataRepository(
       repoDir,
       undefined,
-      new CatalogStore(join(repoDir, "_catalog.db")),
+      catalog,
     );
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const type = ModelType.create("test/model");
@@ -361,7 +364,7 @@ Deno.test("Integration: data.listVersions() returns sorted version numbers", asy
       contentType: "application/json",
       lifetime: "infinite",
       garbageCollection: 100,
-      tags: { type: "log" },
+      tags: { type: "log", modelName: "my-model" },
       ownerDefinition: owner,
     });
 
@@ -378,6 +381,7 @@ Deno.test("Integration: data.listVersions() returns sorted version numbers", asy
     const modelResolver = new ModelResolver(definitionRepo, {
       repoDir,
       dataRepo,
+      dataQueryService: new DataQueryService(catalog, dataRepo),
     });
     const context = await modelResolver.buildContext();
 
@@ -537,10 +541,11 @@ Deno.test("Integration: data.findByTag() returns matching records", async () => 
 Deno.test("Integration: model can have multiple named data items with mixed types", async () => {
   await withTempDir(async (repoDir) => {
     await setupRepoDir(repoDir);
+    const catalog = new CatalogStore(join(repoDir, "_catalog.db"));
     const dataRepo = new FileSystemUnifiedDataRepository(
       repoDir,
       undefined,
-      new CatalogStore(join(repoDir, "_catalog.db")),
+      catalog,
     );
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const type = ModelType.create("test/model");
@@ -560,7 +565,7 @@ Deno.test("Integration: model can have multiple named data items with mixed type
       contentType: "application/json",
       lifetime: "infinite",
       garbageCollection: 5,
-      tags: { type: "resource" },
+      tags: { type: "resource", modelName: "my-command" },
       ownerDefinition: owner,
     });
     await dataRepo.save(
@@ -576,7 +581,7 @@ Deno.test("Integration: model can have multiple named data items with mixed type
       contentType: "text/plain",
       lifetime: "infinite",
       garbageCollection: 5,
-      tags: { type: "file" },
+      tags: { type: "file", modelName: "my-command" },
       ownerDefinition: owner,
     });
     await dataRepo.save(
@@ -591,7 +596,7 @@ Deno.test("Integration: model can have multiple named data items with mixed type
       contentType: "text/plain",
       lifetime: "infinite",
       garbageCollection: 5,
-      tags: { type: "file" },
+      tags: { type: "file", modelName: "my-command" },
       ownerDefinition: owner,
     });
     await dataRepo.save(
@@ -604,6 +609,7 @@ Deno.test("Integration: model can have multiple named data items with mixed type
     const modelResolver = new ModelResolver(definitionRepo, {
       repoDir,
       dataRepo,
+      dataQueryService: new DataQueryService(catalog, dataRepo),
     });
     const context = await modelResolver.buildContext();
 

--- a/integration/data_versioning_test.ts
+++ b/integration/data_versioning_test.ts
@@ -541,10 +541,11 @@ Deno.test("Data Versioning: access specific version via data.version()", async (
 Deno.test("Data Versioning: listVersions returns all versions in order", async () => {
   await withTempDir(async (repoDir) => {
     await setupRepoDir(repoDir);
+    const catalog = new CatalogStore(join(repoDir, "_catalog.db"));
     const dataRepo = new FileSystemUnifiedDataRepository(
       repoDir,
       undefined,
-      new CatalogStore(join(repoDir, "_catalog.db")),
+      catalog,
     );
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const type = ModelType.create("test/model");
@@ -563,7 +564,7 @@ Deno.test("Data Versioning: listVersions returns all versions in order", async (
       contentType: "application/json",
       lifetime: "infinite",
       garbageCollection: 100,
-      tags: { type: "audit" },
+      tags: { type: "audit", modelName: "list-versions-model" },
       ownerDefinition: owner,
     });
 
@@ -581,6 +582,7 @@ Deno.test("Data Versioning: listVersions returns all versions in order", async (
     const modelResolver = new ModelResolver(definitionRepo, {
       repoDir,
       dataRepo,
+      dataQueryService: new DataQueryService(catalog, dataRepo),
     });
     const context = await modelResolver.buildContext();
 

--- a/integration/vary_test.ts
+++ b/integration/vary_test.ts
@@ -367,10 +367,11 @@ Deno.test("Vary: each varied data name has independent versioning", async () => 
 Deno.test("Vary: CEL data.version() with vary resolves specific version", async () => {
   await withTempDir(async (repoDir) => {
     await setupRepoDir(repoDir);
+    const catalog = new CatalogStore(join(repoDir, "_catalog.db"));
     const dataRepo = new FileSystemUnifiedDataRepository(
       repoDir,
       undefined,
-      new CatalogStore(join(repoDir, "_catalog.db")),
+      catalog,
     );
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const type = ModelType.create("test/model");
@@ -387,7 +388,7 @@ Deno.test("Vary: CEL data.version() with vary resolves specific version", async 
       contentType: "application/json",
       lifetime: "infinite",
       garbageCollection: 10,
-      tags: { type: "resource" },
+      tags: { type: "resource", modelName: "scanner" },
       ownerDefinition: owner,
     });
 
@@ -408,6 +409,7 @@ Deno.test("Vary: CEL data.version() with vary resolves specific version", async 
     const modelResolver = new ModelResolver(definitionRepo, {
       repoDir,
       dataRepo,
+      dataQueryService: new DataQueryService(catalog, dataRepo),
     });
     const context = await modelResolver.buildContext();
 
@@ -432,10 +434,11 @@ Deno.test("Vary: CEL data.version() with vary resolves specific version", async 
 Deno.test("Vary: CEL data.listVersions() with vary lists correct versions", async () => {
   await withTempDir(async (repoDir) => {
     await setupRepoDir(repoDir);
+    const catalog = new CatalogStore(join(repoDir, "_catalog.db"));
     const dataRepo = new FileSystemUnifiedDataRepository(
       repoDir,
       undefined,
-      new CatalogStore(join(repoDir, "_catalog.db")),
+      catalog,
     );
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const type = ModelType.create("test/model");
@@ -452,7 +455,7 @@ Deno.test("Vary: CEL data.listVersions() with vary lists correct versions", asyn
       contentType: "application/json",
       lifetime: "infinite",
       garbageCollection: 10,
-      tags: { type: "resource" },
+      tags: { type: "resource", modelName: "scanner" },
       ownerDefinition: owner,
     });
 
@@ -468,6 +471,7 @@ Deno.test("Vary: CEL data.listVersions() with vary lists correct versions", asyn
     const modelResolver = new ModelResolver(definitionRepo, {
       repoDir,
       dataRepo,
+      dataQueryService: new DataQueryService(catalog, dataRepo),
     });
     const context = await modelResolver.buildContext();
 

--- a/src/cli/commands/data_query.ts
+++ b/src/cli/commands/data_query.ts
@@ -28,7 +28,6 @@ import { createDataQueryRenderer } from "../../presentation/renderers/data_query
 import { renderInteractiveQuery } from "../../presentation/renderers/data_query_tui.tsx";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
-import { DataQueryService } from "../../domain/data/data_query_service.ts";
 import { UserError } from "../../domain/errors.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -41,7 +40,10 @@ export const dataQueryCommand = new Command()
   )
   .arguments("[predicate:string]")
   .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
-  .option("--limit <n:number>", "Maximum results", { default: 100 })
+  .option(
+    "--limit <n:number>",
+    "Maximum results (unlimited when omitted)",
+  )
   .option(
     "--select <expr:string>",
     "CEL expression to extract fields from matching records (e.g. data.name)",
@@ -73,10 +75,7 @@ export const dataQueryCommand = new Command()
       );
     }
 
-    const queryService = new DataQueryService(
-      repoContext.catalogStore,
-      repoContext.unifiedDataRepo,
-    );
+    const queryService = repoContext.dataQueryService;
 
     const deps: DataQueryDeps = {
       query: (pred, opts) => queryService.query(pred, opts),
@@ -113,7 +112,7 @@ export const dataQueryCommand = new Command()
       dataQuery(libCtx, deps, {
         predicate,
         select: options.select as string | undefined,
-        limit: (options.limit as number) ?? 100,
+        limit: options.limit as number | undefined,
       }),
       renderer.handlers(),
     );

--- a/src/domain/data/data_query_service.ts
+++ b/src/domain/data/data_query_service.ts
@@ -28,10 +28,13 @@ import type { DataRecord } from "./data_record.ts";
 import {
   type ASTNode,
   collectRootIdentifiers,
+  HISTORY_OPT_IN_FIELDS,
   referencesAttributes,
   referencesContent,
   validateFieldReferences,
 } from "./query_predicate.ts";
+import type { ModelType } from "../models/model_type.ts";
+import type { Data } from "./data.ts";
 import { fromRow } from "./data_record_mapper.ts";
 import type { VaultService } from "../vaults/vault_service.ts";
 import type { SecretRedactor } from "../secrets/mod.ts";
@@ -138,15 +141,31 @@ export class DataQueryService {
     predicate: string,
     options?: DataQueryOptions,
   ): DataRecord[] | unknown[] {
-    const limit = options?.limit ?? 100;
+    // No default limit — an unspecified limit returns every matching row.
+    // Callers that need a cap pass one explicitly.
+    const limit = options?.limit ?? Infinity;
 
-    // Parse and get callable evaluator
-    const parsed = this.queryEnv.parse(predicate);
-    const filterAst = parsed.ast as ASTNode;
-
-    // Validate field references in the filter predicate
-    const rootIds = collectRootIdentifiers(filterAst);
+    // Parse and validate the caller's predicate first. Parsing on the raw
+    // input means parse errors point at what the caller actually wrote.
+    const userParsed = this.queryEnv.parse(predicate);
+    const userAst = userParsed.ast as ASTNode;
+    const rootIds = collectRootIdentifiers(userAst);
     validateFieldReferences(rootIds);
+
+    // Implicit latest-only: unless the predicate references `version` or
+    // `isLatest` at root, restrict results to rows where is_latest is true.
+    // Callers opt into history by mentioning either field (e.g. `version ==
+    // 2`, `version >= 0`, `isLatest == false`). String literals like
+    // `name == "version-report"` do not trigger the opt-out because
+    // collectRootIdentifiers walks the AST rather than the source text.
+    const opensHistory = rootIds.some((id) => HISTORY_OPT_IN_FIELDS.has(id));
+    const effectivePredicate = opensHistory
+      ? predicate
+      : `(${predicate}) && isLatest == true`;
+    const parsed = opensHistory
+      ? userParsed
+      : this.queryEnv.parse(effectivePredicate);
+    const filterAst = parsed.ast as ASTNode;
 
     // Parse select expression if provided
     let selectParsed: ((ctx: Record<string, unknown>) => unknown) | undefined;
@@ -210,63 +229,119 @@ export class DataQueryService {
 
   private async backfillAsync(): Promise<void> {
     const allData = await this.dataRepo.findAllGlobal();
-    for (const { data, modelType, modelId } of allData) {
-      if (data.isRenamed || data.isDeleted) continue;
-      this.catalogStore.upsert({
-        type_normalized: modelType.normalized,
-        model_id: modelId,
-        data_name: data.name,
-        id: data.id,
-        version: data.version,
-        model_name: data.tags["modelName"] ?? "",
-        spec_name: data.tags["specName"] ?? "",
-        data_type: data.tags["type"] ?? "",
-        content_type: data.contentType,
-        lifetime: data.lifetime,
-        owner_type: data.ownerDefinition.ownerType,
-        streaming: data.streaming ? 1 : 0,
-        size: data.size ?? 0,
-        created_at: data.createdAt.toISOString(),
-        tags: JSON.stringify(data.tags),
-        owner_ref: data.ownerDefinition.ownerRef,
-        workflow_run_id: data.ownerDefinition.workflowRunId ?? "",
-        workflow_name: data.ownerDefinition.workflowName ?? "",
-        job_name: data.ownerDefinition.jobName ?? "",
-        step_name: data.ownerDefinition.stepName ?? "",
-        source: data.ownerDefinition.source ?? "",
-      });
+    // Gather every (row, isLatest) we want to write, THEN commit them to
+    // SQLite in one batch. Historical metadata.yaml reads are async and
+    // slow; interleaving them with individual SQLite writes would hold the
+    // database in a partially-populated state across many fsyncs and, on
+    // large repos, produces "database is locked" under contention.
+    const rows: CatalogRow[] = [];
+    for (const { data: latest, modelType, modelId } of allData) {
+      if (latest.isRenamed || latest.isDeleted) continue;
+      const versions = await this.dataRepo.listVersions(
+        modelType,
+        modelId,
+        latest.name,
+      );
+      if (versions.length === 0) continue;
+      const maxVersion = Math.max(...versions);
+      for (const version of versions) {
+        try {
+          const data = version === latest.version
+            ? latest
+            : await this.dataRepo.findByName(
+              modelType,
+              modelId,
+              latest.name,
+              version,
+            );
+          if (!data) continue;
+          if (data.isRenamed || data.isDeleted) continue;
+          rows.push(
+            this.toCatalogRow(data, modelType, modelId, version === maxVersion),
+          );
+        } catch (error) {
+          // Skip individual corrupted versions rather than abort the entire
+          // backfill — a half-populated catalog left behind would force
+          // every subsequent query to retry from scratch.
+          logger
+            .debug`Skipping ${modelType.normalized}/${modelId}/${latest.name}@${version} during backfill: ${
+            String(error)
+          }`;
+        }
+      }
     }
+    this.catalogStore.bulkReplaceAll(rows);
     this.catalogStore.markPopulated();
   }
 
   private backfillSync(): void {
     const allData = this.dataRepo.findAllGlobalSync();
-    for (const { data, modelType, modelId } of allData) {
-      if (data.isRenamed || data.isDeleted) continue;
-      this.catalogStore.upsert({
-        type_normalized: modelType.normalized,
-        model_id: modelId,
-        data_name: data.name,
-        id: data.id,
-        version: data.version,
-        model_name: data.tags["modelName"] ?? "",
-        spec_name: data.tags["specName"] ?? "",
-        data_type: data.tags["type"] ?? "",
-        content_type: data.contentType,
-        lifetime: data.lifetime,
-        owner_type: data.ownerDefinition.ownerType,
-        streaming: data.streaming ? 1 : 0,
-        size: data.size ?? 0,
-        created_at: data.createdAt.toISOString(),
-        tags: JSON.stringify(data.tags),
-        owner_ref: data.ownerDefinition.ownerRef,
-        workflow_run_id: data.ownerDefinition.workflowRunId ?? "",
-        workflow_name: data.ownerDefinition.workflowName ?? "",
-        job_name: data.ownerDefinition.jobName ?? "",
-        step_name: data.ownerDefinition.stepName ?? "",
-        source: data.ownerDefinition.source ?? "",
-      });
+    const rows: CatalogRow[] = [];
+    for (const { data: latest, modelType, modelId } of allData) {
+      if (latest.isRenamed || latest.isDeleted) continue;
+      const versions = this.dataRepo.listVersionsSync(
+        modelType,
+        modelId,
+        latest.name,
+      );
+      if (versions.length === 0) continue;
+      const maxVersion = Math.max(...versions);
+      for (const version of versions) {
+        try {
+          const data = version === latest.version
+            ? latest
+            : this.dataRepo.findByNameSync(
+              modelType,
+              modelId,
+              latest.name,
+              version,
+            );
+          if (!data) continue;
+          if (data.isRenamed || data.isDeleted) continue;
+          rows.push(
+            this.toCatalogRow(data, modelType, modelId, version === maxVersion),
+          );
+        } catch (error) {
+          logger
+            .debug`Skipping ${modelType.normalized}/${modelId}/${latest.name}@${version} during backfill: ${
+            String(error)
+          }`;
+        }
+      }
     }
+    this.catalogStore.bulkReplaceAll(rows);
     this.catalogStore.markPopulated();
+  }
+
+  private toCatalogRow(
+    data: Data,
+    modelType: ModelType,
+    modelId: string,
+    isLatest: boolean,
+  ): CatalogRow {
+    return {
+      type_normalized: modelType.normalized,
+      model_id: modelId,
+      data_name: data.name,
+      id: data.id,
+      version: data.version,
+      is_latest: isLatest ? 1 : 0,
+      model_name: data.tags["modelName"] ?? "",
+      spec_name: data.tags["specName"] ?? "",
+      data_type: data.tags["type"] ?? "",
+      content_type: data.contentType,
+      lifetime: data.lifetime,
+      owner_type: data.ownerDefinition.ownerType,
+      streaming: data.streaming ? 1 : 0,
+      size: data.size ?? 0,
+      created_at: data.createdAt.toISOString(),
+      tags: JSON.stringify(data.tags),
+      owner_ref: data.ownerDefinition.ownerRef,
+      workflow_run_id: data.ownerDefinition.workflowRunId ?? "",
+      workflow_name: data.ownerDefinition.workflowName ?? "",
+      job_name: data.ownerDefinition.jobName ?? "",
+      step_name: data.ownerDefinition.stepName ?? "",
+      source: data.ownerDefinition.source ?? "",
+    };
   }
 }

--- a/src/domain/data/data_query_service_test.ts
+++ b/src/domain/data/data_query_service_test.ts
@@ -37,6 +37,7 @@ function makeRow(overrides: Partial<CatalogRow> = {}): CatalogRow {
     data_name: "my-data",
     id: "00000000-0000-1000-8000-000000000001",
     version: 1,
+    is_latest: 1,
     model_name: "ingest",
     spec_name: "result",
     data_type: "resource",
@@ -416,5 +417,126 @@ Deno.test("DataQueryService: backfill triggers on unpopulated catalog", async ()
   assertEquals(results.length, 1);
   assertEquals(results[0].modelName, "ingest");
   assertEquals(catalog.isPopulated(), true);
+  catalog.close();
+});
+
+// ============================================================================
+// Implicit isLatest injection
+// ============================================================================
+
+function seedVersions(catalog: CatalogStore): void {
+  // Three versions of "my-data"; version 3 is the current latest.
+  catalog.upsert(
+    makeRow({ version: 1, is_latest: 0, id: "u1", size: 100 }),
+  );
+  catalog.upsert(
+    makeRow({ version: 2, is_latest: 0, id: "u2", size: 200 }),
+  );
+  catalog.upsert(
+    makeRow({ version: 3, is_latest: 1, id: "u3", size: 300 }),
+  );
+}
+
+Deno.test("DataQueryService: predicate without version or isLatest returns latest only", () => {
+  const { catalog, service } = setupTest();
+  seedVersions(catalog);
+
+  const results = service.querySync('modelName == "ingest"') as DataRecord[];
+  assertEquals(results.length, 1);
+  assertEquals(results[0].version, 3);
+  assertEquals(results[0].isLatest, true);
+  catalog.close();
+});
+
+Deno.test("DataQueryService: predicate referencing version opts into history", () => {
+  const { catalog, service } = setupTest();
+  seedVersions(catalog);
+
+  const all = service.querySync("version >= 0") as DataRecord[];
+  assertEquals(all.length, 3);
+  assertEquals(all.map((r) => r.version).sort(), [1, 2, 3]);
+
+  const exact = service.querySync("version == 2") as DataRecord[];
+  assertEquals(exact.length, 1);
+  assertEquals(exact[0].version, 2);
+  assertEquals(exact[0].isLatest, false);
+
+  const range = service.querySync("version > 1") as DataRecord[];
+  assertEquals(range.length, 2);
+  assertEquals(range.map((r) => r.version).sort(), [2, 3]);
+  catalog.close();
+});
+
+Deno.test("DataQueryService: isLatest in predicate composes with version filter", () => {
+  const { catalog, service } = setupTest();
+  seedVersions(catalog);
+
+  // "the latest row, but only if its version number is > 1"
+  const results = service.querySync(
+    "isLatest == true && version > 1",
+  ) as DataRecord[];
+  assertEquals(results.length, 1);
+  assertEquals(results[0].version, 3);
+  catalog.close();
+});
+
+Deno.test("DataQueryService: string literal containing 'version' does not opt into history", () => {
+  const { catalog, service } = setupTest();
+  // Two distinct data items so we can tell injection is working.
+  catalog.upsert(
+    makeRow({
+      data_name: "version-report",
+      version: 1,
+      is_latest: 0,
+      id: "vr1",
+    }),
+  );
+  catalog.upsert(
+    makeRow({
+      data_name: "version-report",
+      version: 2,
+      is_latest: 1,
+      id: "vr2",
+    }),
+  );
+
+  const results = service.querySync(
+    'name == "version-report"',
+  ) as DataRecord[];
+  assertEquals(results.length, 1);
+  assertEquals(results[0].version, 2);
+  catalog.close();
+});
+
+Deno.test("DataQueryService: explicit isLatest == false returns non-latest versions", () => {
+  const { catalog, service } = setupTest();
+  seedVersions(catalog);
+
+  const results = service.querySync("isLatest == false") as DataRecord[];
+  assertEquals(results.length, 2);
+  assertEquals(results.map((r) => r.version).sort(), [1, 2]);
+  catalog.close();
+});
+
+Deno.test("DataQueryService: select version projection with history opt-in", () => {
+  const { catalog, service } = setupTest();
+  seedVersions(catalog);
+
+  const versions = service.querySync("version >= 0", {
+    select: "version",
+  }) as number[];
+  assertEquals(versions.slice().sort((a, b) => a - b), [1, 2, 3]);
+  catalog.close();
+});
+
+Deno.test("DataQueryService: select version without history opt-in returns latest only", () => {
+  const { catalog, service } = setupTest();
+  seedVersions(catalog);
+
+  // Projection alone is NOT enough to opt into history.
+  const versions = service.querySync('modelName == "ingest"', {
+    select: "version",
+  }) as number[];
+  assertEquals(versions, [3]);
   catalog.close();
 });

--- a/src/domain/data/data_record.ts
+++ b/src/domain/data/data_record.ts
@@ -30,6 +30,7 @@ export interface DataRecord {
   id: string;
   name: string;
   version: number;
+  isLatest: boolean;
   createdAt: string;
   attributes: Record<string, unknown>;
   tags: Record<string, string>;

--- a/src/domain/data/data_record_mapper.ts
+++ b/src/domain/data/data_record_mapper.ts
@@ -115,6 +115,7 @@ export function fromRow(
       ModelType.create(row.type_normalized),
       row.model_id,
       row.data_name,
+      row.version,
     );
   }
 
@@ -136,6 +137,7 @@ export function fromRow(
     id: row.id,
     name: row.data_name,
     version: row.version,
+    isLatest: row.is_latest === 1,
     createdAt: row.created_at,
     attributes,
     tags,
@@ -160,8 +162,11 @@ export function fromRow(
 
 /**
  * Converts a Data entity to a DataRecord asynchronously.
- * Used by data.version() and data.listVersions() which remain file-system-based
- * because the catalog only stores the latest version per item.
+ * Used by helpers that hold a Data entity loaded outside the catalog path.
+ *
+ * Callers that know whether the version is currently the latest for its
+ * (type, model, name) triple should pass `isLatest`. When omitted, the
+ * record reports `isLatest: false`.
  */
 export async function fromData(
   data: Data,
@@ -172,6 +177,7 @@ export async function fromData(
     version?: number;
     modelName?: string;
     dataName?: string;
+    isLatest?: boolean;
   } = {},
 ): Promise<DataRecord | null> {
   const resolvedVersion = options.version ?? data.version;
@@ -202,6 +208,7 @@ export async function fromData(
     id: data.id,
     name: data.name,
     version: resolvedVersion,
+    isLatest: options.isLatest ?? false,
     createdAt: data.createdAt.toISOString(),
     attributes,
     tags: { ...data.tags },

--- a/src/domain/data/data_record_mapper_test.ts
+++ b/src/domain/data/data_record_mapper_test.ts
@@ -33,6 +33,7 @@ function createRow(overrides?: Partial<CatalogRow>): CatalogRow {
     data_name: "test-data",
     id: "data-id-1",
     version: 1,
+    is_latest: 1,
     model_name: "test-model",
     spec_name: "test-spec",
     data_type: "resource",

--- a/src/domain/data/query_predicate.ts
+++ b/src/domain/data/query_predicate.ts
@@ -24,6 +24,7 @@ export const QUERY_FIELDS = new Set([
   "id",
   "name",
   "version",
+  "isLatest",
   "createdAt",
   "attributes",
   "tags",
@@ -44,6 +45,13 @@ export const QUERY_FIELDS = new Set([
   "stepName",
   "source",
 ]);
+
+/**
+ * Fields whose presence in a predicate causes the query service to skip
+ * the implicit `isLatest == true` injection. A caller that mentions either
+ * field is opting into explicit version/latest handling.
+ */
+export const HISTORY_OPT_IN_FIELDS = new Set(["version", "isLatest"]);
 
 /** CEL built-in identifiers that may appear as root `id` nodes. */
 export const CEL_BUILTINS = new Set([

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -27,7 +27,6 @@ import type { Data } from "../data/data.ts";
 import type { DataRecord } from "../data/data_record.ts";
 import type { DataQueryService } from "../data/data_query_service.ts";
 import { isTextContentType } from "../data/content_type.ts";
-import { fromData } from "../data/data_record_mapper.ts";
 import { ModelNotFoundError } from "./errors.ts";
 import { VaultService } from "../vaults/vault_service.ts";
 import type { SecretRedactor } from "../secrets/mod.ts";
@@ -136,8 +135,9 @@ export interface ModelData {
  */
 export interface DataNamespace {
   /**
-   * Get a specific version of data. Remains file-system-based because
-   * the catalog only stores the latest version per item.
+   * Get a specific version of data. Delegates to catalog query with an
+   * explicit `version == N` predicate (which opts out of the implicit
+   * latest-only filter).
    */
   version(
     modelName: string,
@@ -146,7 +146,8 @@ export interface DataNamespace {
   ): Promise<DataRecord | null>;
 
   /**
-   * Get the latest version of data. Delegates to catalog query.
+   * Get the latest version of data. Delegates to catalog query — the
+   * implicit `isLatest == true` injection handles latest-only filtering.
    */
   latest(
     modelName: string,
@@ -154,7 +155,9 @@ export interface DataNamespace {
   ): Promise<DataRecord | null>;
 
   /**
-   * List all version numbers for a data item. Remains file-system-based.
+   * List all version numbers for a data item, ascending. Stays synchronous
+   * (via the sync catalog query path) so it can be used in sync CEL
+   * contexts that don't go through the async evaluator.
    */
   listVersions(modelName: string, dataName: string): number[];
 
@@ -531,46 +534,36 @@ export class ModelResolver {
       }
     }
 
-    // Create data namespace — most functions delegate to DataQueryService
-    const dataRepo = this.dataRepo;
+    // Create data namespace — every helper delegates to DataQueryService.
+    // The query service owns the implicit `isLatest == true` injection, so
+    // helpers compose predicates as if the catalog exposed history directly.
+    //
+    // Most helpers are async because the query path resolves vault
+    // references in result attributes. Callers in sync CEL contexts (e.g.
+    // `forEach.in`) must go through `CelEvaluator.evaluateAsync`, which
+    // cel-js natively propagates Promises through.
     context.data = {
-      // version() and listVersions() remain file-system-based because the
-      // catalog only stores the latest version per item.
       version: async (
         modelName: string,
         dataName: string,
         version: number,
       ): Promise<DataRecord | null> => {
-        if (!dataRepo) return null;
-        const allCoords = coordsMap.get(modelName);
-        if (!allCoords) return null;
-        for (const { modelType, modelId } of allCoords) {
-          const data = dataRepo.findByNameSync(
-            modelType,
-            modelId,
-            dataName,
-            version,
-          );
-          if (data) {
-            return await fromData(data, modelType, modelId, dataRepo, {
-              version,
-              modelName,
-              dataName,
-              vaultService: this.vaultService,
-            });
-          }
-        }
-        return null;
+        if (!this.dataQueryService) return null;
+        const predicate = `modelName == "${escapeCelString(modelName)}" ` +
+          `&& name == "${escapeCelString(dataName)}" && version == ${version}`;
+        const results = await this.dataQueryService.query(predicate, {
+          limit: 1,
+          loadAttributes: true,
+        }) as DataRecord[];
+        return results.length > 0 ? results[0] : null;
       },
       latest: async (
         modelName: string,
         dataName: string,
       ): Promise<DataRecord | null> => {
         if (!this.dataQueryService) return null;
-        const escaped = escapeCelString;
-        const predicate = `modelName == "${escaped(modelName)}" && name == "${
-          escaped(dataName)
-        }"`;
+        const predicate = `modelName == "${escapeCelString(modelName)}" ` +
+          `&& name == "${escapeCelString(dataName)}"`;
         const results = await this.dataQueryService.query(predicate, {
           limit: 1,
           loadAttributes: true,
@@ -578,26 +571,27 @@ export class ModelResolver {
         return results.length > 0 ? results[0] : null;
       },
       listVersions: (modelName: string, dataName: string): number[] => {
-        if (!dataRepo) return [];
-        const allCoords = coordsMap.get(modelName);
-        if (!allCoords) return [];
-        for (const { modelType, modelId } of allCoords) {
-          const versions = dataRepo.listVersionsSync(
-            modelType,
-            modelId,
-            dataName,
-          );
-          if (versions.length > 0) return versions;
-        }
-        return [];
+        if (!this.dataQueryService) return [];
+        // `version >= 0` is the history opt-in: it suppresses the implicit
+        // `isLatest == true` injection so every version of this data item
+        // is returned. The select projection extracts just the version
+        // numbers. querySync is used so this helper can be called from
+        // synchronous CEL contexts.
+        const predicate = `modelName == "${escapeCelString(modelName)}" ` +
+          `&& name == "${escapeCelString(dataName)}" && version >= 0`;
+        const results = this.dataQueryService.querySync(predicate, {
+          select: "version",
+        }) as number[];
+        return results.slice().sort((a, b) => a - b);
       },
       findByTag: async (
         tagKey: string,
         tagValue: string,
       ): Promise<DataRecord[]> => {
         if (!this.dataQueryService) return [];
-        const escaped = escapeCelString;
-        const predicate = `tags.${escaped(tagKey)} == "${escaped(tagValue)}"`;
+        const predicate = `tags.${escapeCelString(tagKey)} == "${
+          escapeCelString(tagValue)
+        }"`;
         const results = await this.dataQueryService.query(predicate, {
           loadAttributes: true,
         }) as DataRecord[];
@@ -608,10 +602,8 @@ export class ModelResolver {
         specName: string,
       ): Promise<DataRecord[]> => {
         if (!this.dataQueryService) return [];
-        const escaped = escapeCelString;
-        const predicate = `modelName == "${
-          escaped(specModelName)
-        }" && specName == "${escaped(specName)}"`;
+        const predicate = `modelName == "${escapeCelString(specModelName)}" ` +
+          `&& specName == "${escapeCelString(specName)}"`;
         const results = await this.dataQueryService.query(predicate, {
           loadAttributes: true,
         }) as DataRecord[];
@@ -784,6 +776,10 @@ export class ModelResolver {
       id: data.id,
       name: data.name,
       version: resolvedVersion,
+      // dataToRecord is the eager-population path: it always loads the
+      // latest version of each data item into context.model.*, so the
+      // record here is by construction the latest.
+      isLatest: true,
       createdAt: data.createdAt.toISOString(),
       attributes,
       tags: { ...data.tags },

--- a/src/domain/expressions/model_resolver_test.ts
+++ b/src/domain/expressions/model_resolver_test.ts
@@ -201,7 +201,7 @@ Deno.test("data.version() reads specific version from disk", async () => {
       contentType: "application/json",
       lifetime: "infinite",
       garbageCollection: 10,
-      tags: { type: "resource" },
+      tags: { type: "resource", modelName: "versioned" },
       ownerDefinition: owner,
     });
 
@@ -214,7 +214,12 @@ Deno.test("data.version() reads specific version from disk", async () => {
       );
     }
 
-    const resolver = new ModelResolver(defRepo, { repoDir, dataRepo });
+    const dqs = new DataQueryService(catalogStore, dataRepo);
+    const resolver = new ModelResolver(defRepo, {
+      repoDir,
+      dataRepo,
+      dataQueryService: dqs,
+    });
     const ctx = await resolver.buildContext();
 
     assertExists(ctx.data);
@@ -252,7 +257,7 @@ Deno.test("data.listVersions() returns sorted version numbers", async () => {
       contentType: "text/plain",
       lifetime: "infinite",
       garbageCollection: 100,
-      tags: { type: "log" },
+      tags: { type: "log", modelName: "list-model" },
       ownerDefinition: owner,
     });
 
@@ -265,7 +270,12 @@ Deno.test("data.listVersions() returns sorted version numbers", async () => {
       );
     }
 
-    const resolver = new ModelResolver(defRepo, { repoDir, dataRepo });
+    const dqs = new DataQueryService(catalogStore, dataRepo);
+    const resolver = new ModelResolver(defRepo, {
+      repoDir,
+      dataRepo,
+      dataQueryService: dqs,
+    });
     const ctx = await resolver.buildContext();
 
     assertExists(ctx.data);

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -73,7 +73,6 @@ import {
 } from "../expressions/model_resolver.ts";
 import { CelEvaluator } from "../../infrastructure/cel/cel_evaluator.ts";
 import { UserError } from "../errors.ts";
-import { InvalidExpressionError } from "../expressions/errors.ts";
 import {
   getRunLogger,
   runFileSink,
@@ -595,6 +594,9 @@ export class DefaultStepExecutor implements StepExecutor {
               id: handle.dataId,
               name: handle.name,
               version: handle.version,
+              // The resource was just saved by the current step, so this
+              // record is authoritative for the data item.
+              isLatest: true,
               createdAt: new Date().toISOString(),
               attributes,
               tags: handle.tags,
@@ -1408,7 +1410,23 @@ export class WorkflowExecutionService {
       // Expand forEach steps if we have expression context
       let expandedStepsMap: Map<string, ExpandedStep[]> | undefined;
       if (expressionContext && !options.lastEvaluated) {
-        expandedStepsMap = this.expandForEachSteps(job, expressionContext);
+        expandedStepsMap = await this.expandForEachSteps(
+          job,
+          expressionContext,
+        );
+        // Rewrite the jobRun's step list to match the expansion. The
+        // template StepRun (the step as written in the workflow) never
+        // executes once forEach expands, so leaving it in place makes it
+        // show up in history as a perpetually-pending phantom. When the
+        // original step is *not* a forEach, the expansion map reports a
+        // single entry whose expandedName equals the template — that's a
+        // no-op for replaceExpandedSteps.
+        for (const step of job.steps) {
+          if (!step.forEach) continue;
+          const expanded = expandedStepsMap.get(step.name);
+          const names = expanded ? expanded.map((e) => e.expandedName) : [];
+          jobRun.replaceExpandedSteps(step.name, names);
+        }
       }
 
       // Build step graph nodes from explicit dependencies
@@ -1526,10 +1544,10 @@ export class WorkflowExecutionService {
    * @param context - Expression context for evaluating forEach.in
    * @returns Map of original step name to expanded steps (or single entry for non-forEach steps)
    */
-  private expandForEachSteps(
+  private async expandForEachSteps(
     job: Job,
     context: ExpressionContext,
-  ): Map<string, ExpandedStep[]> {
+  ): Promise<Map<string, ExpandedStep[]>> {
     const celEvaluator = new CelEvaluator();
     const result = new Map<string, ExpandedStep[]>();
 
@@ -1557,29 +1575,12 @@ export class WorkflowExecutionService {
       }
 
       const celExpr = match[1];
-      let items: unknown;
-      try {
-        items = celEvaluator.evaluate(celExpr, context);
-      } catch (error) {
-        if (
-          error instanceof InvalidExpressionError &&
-          error.message.includes("unresolved Promise")
-        ) {
-          throw new UserError(
-            `forEach.in expression '$\{{ ${celExpr} }}' returned an ` +
-              `unresolved Promise.\n\n` +
-              `forEach.in is evaluated synchronously and cannot await ` +
-              `async CEL functions (data.latest, data.findByTag, ` +
-              `data.findBySpec, data.query).\n\n` +
-              `Fix: move the async call into a parent workflow's ` +
-              `task.inputs (which IS awaited) and have the child ` +
-              `iterate over inputs.<name>. See:\n` +
-              `.claude/skills/swamp-workflow/references/` +
-              `nested-workflows.md#when-to-use-nested-workflows`,
-          );
-        }
-        throw error;
-      }
+      // Async evaluator so data.* helpers that return Promises (latest,
+      // findByTag, findBySpec, query, etc.) resolve here before we iterate.
+      // cel-js natively propagates Promises through operators and method
+      // calls; `await` on the Environment.evaluate result yields the
+      // resolved value.
+      const items = await celEvaluator.evaluateAsync(celExpr, context);
 
       // Handle both arrays and objects
       const expandedSteps: ExpandedStep[] = [];

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -17,12 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import {
-  assertEquals,
-  assertNotEquals,
-  assertRejects,
-  assertStringIncludes,
-} from "@std/assert";
+import { assertEquals, assertNotEquals, assertRejects } from "@std/assert";
 import { join } from "@std/path";
 import {
   coerceToSuffix,
@@ -2689,13 +2684,12 @@ Deno.test("DefaultStepExecutor wires dataQueryService into MethodContext", async
   });
 });
 
-// --- forEach.in async Promise detection (Issue #88) ---
+// --- forEach.in async helper resolution (Issue #88) ---
 
 Deno.test({
-  name:
-    "expandForEachSteps: throws UserError when forEach.in uses async data function",
-  // The error path interrupts normal cleanup of internally-opened files
-  // (e.g. the CatalogStore WAL), so resource sanitization is disabled.
+  name: "expandForEachSteps: awaits async data helpers like data.findBySpec",
+  // CatalogStore opens WAL files internally; these are still held by the
+  // time the test returns so resource sanitization is disabled.
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
@@ -2735,22 +2729,12 @@ Deno.test({
           catalogStore,
         );
 
-        // The ModelResolver wires up async data delegates (findBySpec returns
-        // a Promise). expandForEachSteps uses sync evaluate, which hits the
-        // Promise detection guard and throws InvalidExpressionError. The
-        // forEach catch-and-wrap turns it into a UserError.
-        const error = await assertRejects(
-          () => service.execute(workflow.name),
-        );
-
-        assertStringIncludes(
-          (error as Error).message,
-          "unresolved Promise",
-        );
-        assertStringIncludes(
-          (error as Error).message,
-          "nested-workflows.md",
-        );
+        // data.findBySpec returns a Promise; expandForEachSteps awaits it
+        // via CelEvaluator.evaluateAsync. With no seeded data the result
+        // is an empty array, the forEach expands to zero steps, and the
+        // job completes without producing the old "unresolved Promise"
+        // error that this test previously asserted.
+        await service.execute(workflow.name);
       } finally {
         catalogStore.close();
       }

--- a/src/domain/workflows/workflow_run.ts
+++ b/src/domain/workflows/workflow_run.ts
@@ -318,6 +318,38 @@ export class JobRun implements TriggerEvaluationContext {
   }
 
   /**
+   * Replaces a forEach step's template entry with pending StepRuns for each
+   * expanded step name. Called after forEach.in resolves at job start so
+   * the persisted job run reflects the actual set of steps that will run,
+   * rather than leaving the un-executed template alongside the expansions.
+   *
+   * If the template has already been replaced in a prior call (for example
+   * when an expanded step was lazily added via {@link addExpandedStep}),
+   * this method leaves existing entries in place and only inserts missing
+   * expanded names. When `expandedNames` is empty the template is removed
+   * outright — an empty forEach result means no steps run.
+   */
+  replaceExpandedSteps(
+    templateName: string,
+    expandedNames: readonly string[],
+  ): void {
+    const templateIndex = this._steps.findIndex(
+      (s) => s.stepName === templateName,
+    );
+    if (templateIndex === -1) return;
+    const existing = new Map(
+      this._steps.map((s, i) => [s.stepName, i] as const),
+    );
+    const insertions: StepRun[] = [];
+    for (const name of expandedNames) {
+      if (!existing.has(name)) {
+        insertions.push(StepRun.pending(name));
+      }
+    }
+    this._steps.splice(templateIndex, 1, ...insertions);
+  }
+
+  /**
    * Marks the job as running.
    */
   start(): void {

--- a/src/infrastructure/persistence/catalog_store.ts
+++ b/src/infrastructure/persistence/catalog_store.ts
@@ -22,8 +22,9 @@ import { dirname } from "@std/path";
 import { ensureDirSync } from "@std/fs";
 
 /**
- * A single row in the catalog table, representing the latest version
- * of a data artifact.
+ * A single row in the catalog table, representing one version of a data
+ * artifact. The `is_latest` flag is set on exactly one row per
+ * (type_normalized, model_id, data_name) triple.
  */
 export interface CatalogRow {
   type_normalized: string;
@@ -31,6 +32,7 @@ export interface CatalogRow {
   data_name: string;
   id: string;
   version: number;
+  is_latest: number;
   model_name: string;
   spec_name: string;
   data_type: string;
@@ -52,9 +54,10 @@ export interface CatalogRow {
 /**
  * SQLite-backed metadata catalog for data query.
  *
- * Stores one row per data artifact (latest version only) with all metadata
- * fields needed for CEL predicate evaluation. Content is NOT stored — it
- * remains on disk in the existing versioned file layout.
+ * Stores one row per version of each data artifact with all metadata fields
+ * needed for CEL predicate evaluation. The `is_latest` column marks exactly
+ * one row per (type, model, name) as the current latest. Content is NOT
+ * stored — it remains on disk in the existing versioned file layout.
  *
  * The catalog is local-only and excluded from datastore sync. It self-heals
  * by triggering a backfill when missing or not yet populated.
@@ -66,7 +69,7 @@ export const ITERATE_PAGE_SIZE = 1000;
  * On startup, if the stored version differs, the catalog is dropped and
  * rebuilt via self-healing backfill.
  */
-export const CATALOG_SCHEMA_VERSION = "2";
+export const CATALOG_SCHEMA_VERSION = "3";
 
 export class CatalogStore {
   private readonly db: DatabaseSync;
@@ -129,6 +132,7 @@ export class CatalogStore {
         data_name       TEXT NOT NULL,
         id              TEXT NOT NULL,
         version         INTEGER NOT NULL,
+        is_latest       INTEGER NOT NULL DEFAULT 1,
         model_name      TEXT NOT NULL,
         spec_name       TEXT NOT NULL DEFAULT '',
         data_type       TEXT NOT NULL DEFAULT '',
@@ -145,7 +149,7 @@ export class CatalogStore {
         job_name        TEXT NOT NULL DEFAULT '',
         step_name       TEXT NOT NULL DEFAULT '',
         source          TEXT NOT NULL DEFAULT '',
-        PRIMARY KEY (type_normalized, model_id, data_name)
+        PRIMARY KEY (type_normalized, model_id, data_name, version)
       );
 
       CREATE INDEX IF NOT EXISTS idx_catalog_model_name      ON catalog(model_name);
@@ -154,6 +158,7 @@ export class CatalogStore {
       CREATE INDEX IF NOT EXISTS idx_catalog_created_at      ON catalog(created_at);
       CREATE INDEX IF NOT EXISTS idx_catalog_workflow_run_id ON catalog(workflow_run_id);
       CREATE INDEX IF NOT EXISTS idx_catalog_step_name       ON catalog(step_name);
+      CREATE INDEX IF NOT EXISTS idx_catalog_is_latest       ON catalog(type_normalized, model_id, data_name, is_latest);
 
       CREATE TABLE IF NOT EXISTS catalog_meta (
         key   TEXT PRIMARY KEY,
@@ -186,16 +191,21 @@ export class CatalogStore {
 
   /**
    * Upserts a row into the catalog. Replaces any existing row with the
-   * same primary key (type_normalized, model_id, data_name).
+   * same primary key (type_normalized, model_id, data_name, version).
+   *
+   * Writes `is_latest` exactly as supplied. Backfill uses this because it
+   * knows the correct `is_latest` for every version up front. Runtime writes
+   * from a single write path should use {@link upsertNewVersion} instead,
+   * which atomically maintains the "exactly one latest per name" invariant.
    */
   upsert(row: CatalogRow): void {
     const stmt = this.db.prepare(`
       INSERT OR REPLACE INTO catalog (
-        type_normalized, model_id, data_name, id, version, model_name,
+        type_normalized, model_id, data_name, id, version, is_latest, model_name,
         spec_name, data_type, content_type, lifetime, owner_type,
         streaming, size, created_at, tags,
         owner_ref, workflow_run_id, workflow_name, job_name, step_name, source
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     stmt.run(
       row.type_normalized,
@@ -203,6 +213,7 @@ export class CatalogStore {
       row.data_name,
       row.id,
       row.version,
+      row.is_latest,
       row.model_name,
       row.spec_name,
       row.data_type,
@@ -223,13 +234,110 @@ export class CatalogStore {
   }
 
   /**
-   * Removes a row from the catalog by its primary key.
+   * Inserts a row as the new latest version for (type, model, name), clearing
+   * `is_latest` on any prior rows for that triple. The `is_latest` field on
+   * the supplied row is ignored — this method always writes `1`.
+   *
+   * Runs in an IMMEDIATE transaction so concurrent writers serialize
+   * through SQLite's reserved lock rather than racing on the flag.
+   */
+  upsertNewVersion(row: CatalogRow): void {
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      this.db.prepare(
+        `UPDATE catalog SET is_latest = 0
+         WHERE type_normalized = ? AND model_id = ? AND data_name = ?
+           AND is_latest = 1`,
+      ).run(row.type_normalized, row.model_id, row.data_name);
+      this.upsert({ ...row, is_latest: 1 });
+      this.db.exec("COMMIT");
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  /**
+   * Replaces the entire catalog contents with the supplied rows in a single
+   * transaction. Used by the backfill path to rebuild the catalog from disk
+   * in one shot — avoids 10,000+ implicit-transaction fsyncs that would
+   * otherwise leave the catalog in a half-populated state if the process
+   * died mid-backfill.
+   */
+  bulkReplaceAll(rows: readonly CatalogRow[]): void {
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      this.db.exec("DELETE FROM catalog");
+      const stmt = this.db.prepare(`
+        INSERT INTO catalog (
+          type_normalized, model_id, data_name, id, version, is_latest, model_name,
+          spec_name, data_type, content_type, lifetime, owner_type,
+          streaming, size, created_at, tags,
+          owner_ref, workflow_run_id, workflow_name, job_name, step_name, source
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+      for (const row of rows) {
+        stmt.run(
+          row.type_normalized,
+          row.model_id,
+          row.data_name,
+          row.id,
+          row.version,
+          row.is_latest,
+          row.model_name,
+          row.spec_name,
+          row.data_type,
+          row.content_type,
+          row.lifetime,
+          row.owner_type,
+          row.streaming,
+          row.size,
+          row.created_at,
+          row.tags,
+          row.owner_ref,
+          row.workflow_run_id,
+          row.workflow_name,
+          row.job_name,
+          row.step_name,
+          row.source,
+        );
+      }
+      this.db.exec("COMMIT");
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  /**
+   * Removes all rows for (type, model, name) regardless of version.
+   * Used when an entire data item is deleted or tombstoned.
    */
   remove(typeNormalized: string, modelId: string, dataName: string): void {
     const stmt = this.db.prepare(
       "DELETE FROM catalog WHERE type_normalized = ? AND model_id = ? AND data_name = ?",
     );
     stmt.run(typeNormalized, modelId, dataName);
+  }
+
+  /**
+   * Removes a single version row from the catalog.
+   *
+   * Callers that delete the row which was `is_latest` must subsequently
+   * upsert the new latest via {@link upsertNewVersion}; this method does
+   * not promote a surviving row on its own.
+   */
+  removeVersion(
+    typeNormalized: string,
+    modelId: string,
+    dataName: string,
+    version: number,
+  ): void {
+    const stmt = this.db.prepare(
+      `DELETE FROM catalog
+       WHERE type_normalized = ? AND model_id = ? AND data_name = ? AND version = ?`,
+    );
+    stmt.run(typeNormalized, modelId, dataName, version);
   }
 
   /**

--- a/src/infrastructure/persistence/catalog_store_test.ts
+++ b/src/infrastructure/persistence/catalog_store_test.ts
@@ -38,6 +38,7 @@ function makeRow(overrides: Partial<CatalogRow> = {}): CatalogRow {
     data_name: "my-data",
     id: "data-uuid-001",
     version: 1,
+    is_latest: 1,
     model_name: "test-model-name",
     spec_name: "result",
     data_type: "resource",
@@ -81,17 +82,113 @@ Deno.test("CatalogStore: upsert and iterate round-trip", () => {
   store.close();
 });
 
-Deno.test("CatalogStore: upsert overwrites existing row", () => {
+Deno.test("CatalogStore: upsert keeps separate rows for distinct versions", () => {
+  const dbPath = makeTempDbPath();
+  const store = new CatalogStore(dbPath);
+
+  store.upsert(makeRow({ version: 1, size: 100, is_latest: 0 }));
+  store.upsert(makeRow({ version: 2, size: 200, is_latest: 1 }));
+
+  const rows = [...store.iterate()];
+  assertEquals(rows.length, 2);
+  assertEquals(rows.map((r) => r.version).sort(), [1, 2]);
+  const latest = rows.find((r) => r.is_latest === 1)!;
+  assertEquals(latest.version, 2);
+  assertEquals(latest.size, 200);
+  store.close();
+});
+
+Deno.test("CatalogStore: upsert replaces row at same (type, model, name, version)", () => {
   const dbPath = makeTempDbPath();
   const store = new CatalogStore(dbPath);
 
   store.upsert(makeRow({ version: 1, size: 100 }));
-  store.upsert(makeRow({ version: 2, size: 200 }));
+  store.upsert(makeRow({ version: 1, size: 999 }));
 
   const rows = [...store.iterate()];
   assertEquals(rows.length, 1);
-  assertEquals(rows[0].version, 2);
-  assertEquals(rows[0].size, 200);
+  assertEquals(rows[0].size, 999);
+  store.close();
+});
+
+Deno.test("CatalogStore: upsertNewVersion clears is_latest on prior rows", () => {
+  const dbPath = makeTempDbPath();
+  const store = new CatalogStore(dbPath);
+
+  store.upsertNewVersion(makeRow({ version: 1 }));
+  store.upsertNewVersion(makeRow({ version: 2 }));
+  store.upsertNewVersion(makeRow({ version: 3 }));
+
+  const rows = [...store.iterate()];
+  assertEquals(rows.length, 3);
+  const latestRows = rows.filter((r) => r.is_latest === 1);
+  assertEquals(latestRows.length, 1);
+  assertEquals(latestRows[0].version, 3);
+  store.close();
+});
+
+Deno.test("CatalogStore: upsertNewVersion ignores is_latest on input row", () => {
+  const dbPath = makeTempDbPath();
+  const store = new CatalogStore(dbPath);
+
+  // Caller passes is_latest: 0 but the method always records the incoming
+  // row as latest and clears any prior latest.
+  store.upsertNewVersion(makeRow({ version: 1, is_latest: 0 }));
+
+  const rows = [...store.iterate()];
+  assertEquals(rows.length, 1);
+  assertEquals(rows[0].is_latest, 1);
+  store.close();
+});
+
+Deno.test("CatalogStore: upsertNewVersion does not touch unrelated data names", () => {
+  const dbPath = makeTempDbPath();
+  const store = new CatalogStore(dbPath);
+
+  store.upsertNewVersion(makeRow({ data_name: "alpha", version: 1 }));
+  store.upsertNewVersion(makeRow({ data_name: "beta", version: 1 }));
+  store.upsertNewVersion(makeRow({ data_name: "alpha", version: 2 }));
+
+  const rows = [...store.iterate()];
+  assertEquals(rows.length, 3);
+  const alphaLatest = rows.find(
+    (r) => r.data_name === "alpha" && r.is_latest === 1,
+  );
+  const betaLatest = rows.find(
+    (r) => r.data_name === "beta" && r.is_latest === 1,
+  );
+  assertEquals(alphaLatest?.version, 2);
+  assertEquals(betaLatest?.version, 1);
+  store.close();
+});
+
+Deno.test("CatalogStore: removeVersion deletes a single version row", () => {
+  const dbPath = makeTempDbPath();
+  const store = new CatalogStore(dbPath);
+
+  store.upsertNewVersion(makeRow({ version: 1 }));
+  store.upsertNewVersion(makeRow({ version: 2 }));
+  store.upsertNewVersion(makeRow({ version: 3 }));
+
+  store.removeVersion("test-model", "model-001", "my-data", 2);
+
+  const rows = [...store.iterate()];
+  assertEquals(rows.length, 2);
+  assertEquals(rows.map((r) => r.version).sort(), [1, 3]);
+  store.close();
+});
+
+Deno.test("CatalogStore: remove deletes every version of a data name", () => {
+  const dbPath = makeTempDbPath();
+  const store = new CatalogStore(dbPath);
+
+  store.upsertNewVersion(makeRow({ version: 1 }));
+  store.upsertNewVersion(makeRow({ version: 2 }));
+  store.upsertNewVersion(makeRow({ version: 3 }));
+
+  store.remove("test-model", "model-001", "my-data");
+
+  assertEquals(store.count(), 0);
   store.close();
 });
 

--- a/src/infrastructure/persistence/repository_factory.ts
+++ b/src/infrastructure/persistence/repository_factory.ts
@@ -66,6 +66,7 @@ import { YamlVaultConfigRepository } from "./yaml_vault_config_repository.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
 import { CatalogStore } from "./catalog_store.ts";
+import { DataQueryService } from "../../domain/data/data_query_service.ts";
 import { join } from "@std/path";
 
 // =============================================================================
@@ -239,6 +240,7 @@ export interface RepositoryContext {
   workflowRunRepo: YamlWorkflowRunRepository;
   vaultConfigRepo: YamlVaultConfigRepository;
   catalogStore: CatalogStore;
+  dataQueryService: DataQueryService;
 }
 
 /**
@@ -312,6 +314,11 @@ export function createRepositoryContext(
     dsPath(SWAMP_SUBDIRS.data),
     catalogStore,
   );
+
+  // Construct the query service alongside its dependencies so consumers
+  // never need to reach into the repo to rebuild it. This keeps the
+  // catalog handle as an infrastructure detail of the composition root.
+  const dataQueryService = new DataQueryService(catalogStore, unifiedDataRepo);
   const outputRepo = new YamlOutputRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.outputs),
@@ -338,5 +345,6 @@ export function createRepositoryContext(
     workflowRunRepo,
     vaultConfigRepo,
     catalogStore,
+    dataQueryService,
   };
 }

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -442,13 +442,23 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     this.baseDir = baseDir ?? swampPath(repoDir, SWAMP_SUBDIRS.data);
   }
 
+  /**
+   * Records `data` as the latest version for (type, modelId, data.name) in
+   * the catalog. Clears `is_latest` on any prior row atomically and inserts
+   * the new row with `is_latest=1` inside a single SQLite transaction.
+   *
+   * Every production write path that mutates a data item (save, append,
+   * rename, restore, delete-specific-version) calls this exactly once with
+   * the row that should become authoritative afterwards.
+   */
   private catalogUpsert(type: ModelType, modelId: string, data: Data): void {
-    this.catalogStore.upsert({
+    this.catalogStore.upsertNewVersion({
       type_normalized: type.normalized,
       model_id: modelId,
       data_name: data.name,
       id: data.id,
       version: data.version,
+      is_latest: 1,
       model_name: data.tags["modelName"] ?? "",
       spec_name: data.tags["specName"] ?? "",
       data_type: data.tags["type"] ?? "",
@@ -924,6 +934,16 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
           throw error;
         }
       }
+
+      // Drop the deleted version's catalog row before touching the latest
+      // marker — leaves the catalog in a valid state even if the follow-up
+      // latest update fails.
+      this.catalogStore.removeVersion(
+        type.normalized,
+        modelId,
+        dataName,
+        version,
+      );
 
       // Update latest symlink if needed
       const versions = await this.listVersions(type, modelId, dataName);
@@ -1585,6 +1605,16 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
       // Re-scan actual versions after parallel deletions to avoid stale marker.
       // Skip for dry-run — nothing was actually removed.
       if (!dryRun && versionsToRemove.length > 0) {
+        // Drop catalog rows for the versions that were removed from disk.
+        for (const removedVersion of versionsToRemove) {
+          this.catalogStore.removeVersion(
+            type.normalized,
+            modelId,
+            data.name,
+            removedVersion,
+          );
+        }
+
         const currentVersions = await this.listVersions(
           type,
           modelId,

--- a/src/libswamp/data/query.ts
+++ b/src/libswamp/data/query.ts
@@ -93,7 +93,10 @@ export async function* dataQuery(
     (async function* () {
       yield { kind: "resolving" as const };
 
-      const limit = input.limit ?? 100;
+      // Unlimited by default — callers pass an explicit limit when they
+      // need a cap. `limited` in the completed event reflects whether
+      // the query service actually hit the supplied limit.
+      const limit = input.limit;
 
       try {
         const rawResults = await deps.query(input.predicate, {
@@ -101,7 +104,7 @@ export async function* dataQuery(
           select: input.select,
         });
         const total = rawResults.length;
-        const limited = total >= limit;
+        const limited = limit !== undefined && total >= limit;
 
         if (!input.select) {
           // No projection — results are DataRecord[]

--- a/src/libswamp/workflows/evaluate.ts
+++ b/src/libswamp/workflows/evaluate.ts
@@ -46,8 +46,6 @@ import { DataQueryService } from "../../domain/data/data_query_service.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError } from "../errors.ts";
-import { InvalidExpressionError } from "../../domain/expressions/errors.ts";
-import { UserError } from "../../domain/errors.ts";
 
 /** Evaluation result for a single workflow. */
 export interface WorkflowEvaluateItemData {
@@ -96,6 +94,14 @@ export interface WorkflowEvaluateDeps {
     expression: string,
     context: Record<string, unknown>,
   ) => unknown;
+  /**
+   * Async CEL evaluator used by the forEach.in expansion path so
+   * data.* helpers (which return Promises) resolve before iteration.
+   */
+  evaluateCelAsync: (
+    expression: string,
+    context: Record<string, unknown>,
+  ) => Promise<unknown>;
   saveEvaluatedWorkflow: (workflow: Workflow) => Promise<void>;
   getEvaluatedPath: (id: WorkflowId) => string;
 }
@@ -134,6 +140,8 @@ export function createWorkflowEvaluateDeps(
     buildExpressionContext: () => modelResolver.buildContext(),
     evaluateCel: (expression, context) =>
       celEvaluator.evaluate(expression, context),
+    evaluateCelAsync: (expression, context) =>
+      celEvaluator.evaluateAsync(expression, context),
     saveEvaluatedWorkflow: (workflow) => evaluatedWorkflowRepo.save(workflow),
     getEvaluatedPath: (id) => evaluatedWorkflowRepo.getPath(id),
   };
@@ -241,29 +249,10 @@ async function evaluateWorkflowInternal(
         continue;
       }
 
-      let items: unknown;
-      try {
-        items = deps.evaluateCel(inMatch[1], context);
-      } catch (error) {
-        if (
-          error instanceof InvalidExpressionError &&
-          error.message.includes("unresolved Promise")
-        ) {
-          throw new UserError(
-            `forEach.in expression '$\{{ ${inMatch[1]} }}' returned an ` +
-              `unresolved Promise.\n\n` +
-              `forEach.in is evaluated synchronously and cannot await ` +
-              `async CEL functions (data.latest, data.findByTag, ` +
-              `data.findBySpec, data.query).\n\n` +
-              `Fix: move the async call into a parent workflow's ` +
-              `task.inputs (which IS awaited) and have the child ` +
-              `iterate over inputs.<name>. See:\n` +
-              `.claude/skills/swamp-workflow/references/` +
-              `nested-workflows.md#when-to-use-nested-workflows`,
-          );
-        }
-        throw error;
-      }
+      // Async so data.* helpers that return Promises (latest, findByTag,
+      // findBySpec, query, etc.) resolve before we iterate. cel-js
+      // propagates Promises through its evaluator natively.
+      const items = await deps.evaluateCelAsync(inMatch[1], context);
       const itemName = stepData.forEach.item;
       const nameHasExpression = /\$\{\{.+?\}\}/.test(stepData.name);
 

--- a/src/libswamp/workflows/evaluate_test.ts
+++ b/src/libswamp/workflows/evaluate_test.ts
@@ -68,6 +68,7 @@ function makeDeps(
         > extends Promise<infer T> ? T : never,
       ),
     evaluateCel: (expr: string) => expr,
+    evaluateCelAsync: (expr: string) => Promise.resolve(expr),
     saveEvaluatedWorkflow: () => Promise.resolve(),
     getEvaluatedPath: (id) =>
       `/tmp/.swamp/workflows-evaluated/workflow-${id}.yaml`,

--- a/src/presentation/renderers/data_query.ts
+++ b/src/presentation/renderers/data_query.ts
@@ -27,6 +27,8 @@ import type { OutputMode } from "../output/output.ts";
 import { UserError } from "../../domain/errors.ts";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import { renderMarkdownToTerminal } from "../markdown_renderer.ts";
+import { Table } from "@cliffy/table";
+import { bold } from "@std/fmt/colors";
 
 function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes}B`;
@@ -64,6 +66,12 @@ function markdownTable(
 
 /**
  * Renders the default DataRecord table (no --select).
+ *
+ * Builds the table directly with Cliffy's Table primitive and returns
+ * already-rendered terminal text. The earlier implementation returned
+ * markdown that was then parsed by `marked` + `marked-terminal`, which
+ * scaled at ~3ms per row — fine for the TUI's bounded result set, fatal
+ * for `--limit 100000` on a real catalog.
  */
 function renderDefaultTable(data: DataQueryData): string {
   if (data.results.length === 0) {
@@ -87,13 +95,19 @@ function renderDefaultTable(data: DataQueryData): string {
     formatSize(r.size),
   ]);
 
-  let md = markdownTable(headers, rows);
+  const table = new Table()
+    .header(headers.map((h) => bold(h)))
+    .body(rows)
+    .border(true)
+    .padding(1);
+
+  let out = table.toString();
   if (data.limited) {
-    md += `\n\n*Showing ${data.total} results (limit reached)*`;
+    out += `\n\nShowing ${data.total} results (limit reached)`;
   } else {
-    md += `\n\n${data.total} result${data.total === 1 ? "" : "s"}`;
+    out += `\n\n${data.total} result${data.total === 1 ? "" : "s"}`;
   }
-  return md;
+  return out;
 }
 
 /**
@@ -195,11 +209,30 @@ function renderJson(data: DataQueryData): void {
 }
 
 /**
- * Renders query results as a markdown string, suitable for terminal display.
- * Used by both the non-interactive renderer and the interactive TUI.
+ * Renders query results as a markdown string. Only used for the projected
+ * (`--select`) path; the default table path bypasses markdown entirely and
+ * builds ANSI output directly via {@link renderQueryResultsTerminal}.
  */
 export function renderQueryResultsMarkdown(data: DataQueryData): string {
   return data.projected ? renderProjected(data) : renderDefaultTable(data);
+}
+
+/**
+ * Renders query results as pre-formatted terminal text. The default
+ * (non-projected) path uses Cliffy's Table primitive directly; the
+ * projected path still flows through `marked` since its output shapes
+ * (scalar/map/list) are easier to express as markdown.
+ *
+ * Used by both the non-interactive CLI renderer and the interactive TUI.
+ * The default-table branch scales linearly in row count; the projected
+ * branch is bounded by the markdown parser and should only be used for
+ * small result sets.
+ */
+export function renderQueryResultsTerminal(data: DataQueryData): string {
+  if (data.projected) {
+    return renderMarkdownToTerminal(renderQueryResultsMarkdown(data));
+  }
+  return renderDefaultTable(data);
 }
 
 export function createDataQueryRenderer(
@@ -213,11 +246,9 @@ export function createDataQueryRenderer(
       completed: (event: DataQueryEvent & { kind: "completed" }) => {
         if (outputMode === "json") {
           renderJson(event.data);
-        } else {
-          writeOutput(
-            renderMarkdownToTerminal(renderQueryResultsMarkdown(event.data)),
-          );
+          return;
         }
+        writeOutput(renderQueryResultsTerminal(event.data));
       },
       error: (event: DataQueryEvent & { kind: "error" }) => {
         throw new UserError(event.error.message);

--- a/src/presentation/renderers/data_query_tui.tsx
+++ b/src/presentation/renderers/data_query_tui.tsx
@@ -37,8 +37,7 @@ import {
   type CompletionItem,
 } from "../../domain/data/autocomplete_provider.ts";
 import { determineCursorContext } from "../../domain/data/cel_cursor_context.ts";
-import { renderQueryResultsMarkdown } from "./data_query.ts";
-import { renderMarkdownToTerminal } from "../markdown_renderer.ts";
+import { renderQueryResultsTerminal } from "./data_query.ts";
 
 /**
  * Dependencies for the interactive query TUI.
@@ -68,7 +67,7 @@ function buildCliCommand(
   if (pred.trim()) parts.push(`'${esc(pred.trim())}'`);
   if (sel.trim()) parts.push(`--select '${esc(sel.trim())}'`);
   const parsedLimit = parseInt(limit, 10);
-  if (parsedLimit && parsedLimit !== 100) {
+  if (parsedLimit > 0) {
     parts.push(`--limit ${parsedLimit}`);
   }
   return parts.join(" ");
@@ -95,8 +94,8 @@ function DataQueryTUI(
     cursorPos: 0,
   });
   const [limitInput, setLimitInput] = useState<InputState>({
-    text: "100",
-    cursorPos: 3,
+    text: "",
+    cursorPos: 0,
   });
   const [focusedInput, setFocusedInput] = useState<
     "predicate" | "select" | "limit"
@@ -109,8 +108,14 @@ function DataQueryTUI(
   const [resultsScrollOffset, setResultsScrollOffset] = useState(0);
   const [horizontalScrollOffset, setHorizontalScrollOffset] = useState(0);
 
-  // Parse limit — default to 100 if invalid
-  const parsedLimit = Math.max(1, parseInt(limitInput.text, 10) || 100);
+  // Parse limit — unlimited when the field is empty or invalid, which is
+  // the default. Users cap the result set by typing a positive integer.
+  const parsedLimit = (() => {
+    const trimmed = limitInput.text.trim();
+    if (!trimmed) return undefined;
+    const n = parseInt(trimmed, 10);
+    return Number.isFinite(n) && n > 0 ? n : undefined;
+  })();
 
   // Query execution
   const queryState = useDebouncedQuery(
@@ -183,20 +188,18 @@ function DataQueryTUI(
     }
     : undefined;
 
-  const renderedMarkdown = useMemo(
-    () => queryData ? renderQueryResultsMarkdown(queryData) : undefined,
+  // Directly build Cliffy-rendered terminal text for the default table and
+  // only fall back to the markdown pipeline for projected output. Routing
+  // the default table through `marked` scaled at ~3ms per row and
+  // stalled (or OOM'd) the event loop on 10K+ result sets.
+  const renderedTerminal = useMemo(
+    () => queryData ? renderQueryResultsTerminal(queryData) : undefined,
     [
       queryData?.total,
       queryData?.projected,
       queryData?.results,
       queryData?.limited,
     ],
-  );
-
-  const renderedTerminal = useMemo(
-    () =>
-      renderedMarkdown ? renderMarkdownToTerminal(renderedMarkdown) : undefined,
-    [renderedMarkdown],
   );
 
   // Keep track of last rendered output for scrollback on exit

--- a/src/presentation/renderers/data_query_tui/hooks/use_debounced_query.ts
+++ b/src/presentation/renderers/data_query_tui/hooks/use_debounced_query.ts
@@ -60,7 +60,7 @@ export function useDebouncedQuery(
   select: string | undefined,
   queryDeps: DataQueryDeps,
   debounceMs: number = 150,
-  limit: number = 100,
+  limit?: number,
 ): QueryState {
   const [state, setState] = useState<QueryState>(INITIAL_STATE);
   const controllerRef = useRef<AbortController | null>(null);


### PR DESCRIPTION
## Summary

Establishes `swamp data query` / `data.query()` as the single catalog-backed
primitive for data access. The existing `swamp data get|list|search|versions`
commands and `data.latest|version|listVersions|findByTag|findBySpec` CEL
helpers are recast as readable shortcuts that delegate to the same query
path — prefer a shortcut when it fits (it reads more clearly); reach for
`data.query()` when you need a multi-field predicate, projection, or history
access.

## Catalog and query service

- **Schema v3** — catalog PK extends to `(type, model_id, data_name, version)`
  and gains an `is_latest` column. Every version of every data item is
  indexed, not just the latest. Existing repos auto-migrate via the
  drop-and-rebuild path that's already built into `CatalogStore`.
- **Implicit latest-only** — queries whose predicate references neither
  `version` nor `isLatest` are restricted to current-state rows by
  wrapping with `isLatest == true`. Predicates that mention either field
  (`version == 2`, `version >= 0`, `isLatest == false`) opt into history.
  String literals like `name == "version-report"` don't trip the opt-out
  because the detection walks the parsed CEL AST.
- **Write-path invariant** — `upsertNewVersion` holds "exactly one
  `is_latest` per `(type, model, name)`" in a `BEGIN IMMEDIATE`
  transaction. The prior row is cleared atomically before the new row
  lands.
- **Bulk backfill** — `bulkReplaceAll` commits the entire rebuild in one
  SQLite transaction. Previously the per-row upsert loop could produce
  "database is locked" and leave `populated` unset on real repos with 10K+
  rows (the test case was ~55K rows hanging for 5+ minutes).
- **`fromRow` loads per-version content** — historical-version queries
  now return the right bytes. Previously every row read latest content
  because `getContentSync` was called without the version.
- **Default limit removed** — `data.query()` and `swamp data query` return
  every matching row when no limit is set. Callers that need a cap pass one
  explicitly. The interactive TUI's limit field is empty by default too.

## CEL helpers

- `data.latest`, `data.version`, `data.findByTag`, `data.findBySpec`, and
  `data.query` all delegate to `DataQueryService`. The helpers become pure
  predicate composition.
- `data.listVersions` stays sync (via `querySync`) for ergonomic use in
  sync contexts.

## forEach.in awaits async data helpers

`forEach.in` is now evaluated through `CelEvaluator.evaluateAsync`, so
`data.findBySpec`, `data.findByTag`, `data.latest`, and `data.query` all
work directly in a flat workflow. The old "unresolved Promise" guard and
the "use a child workflow as a workaround" framing are gone.

`expandForEachSteps` also now replaces each forEach template StepRun with
pending StepRuns for the expanded names when a job starts. Previously the
template lingered in history as a permanently-pending phantom alongside
the real expansions.

## DDD cleanup

- `DataQueryService` is constructed once by `createRepositoryContext` and
  exposed on `RepositoryContext.dataQueryService`. `ModelResolver` takes
  the service from its repos config, no longer reaching through the data
  repo to lazily build one.
- `UnifiedDataRepository.getCatalogStore()` is deleted — it was an
  infrastructure leak through a domain repository contract.

## CLI rendering

- `swamp data query` default table output uses Cliffy's `Table` primitive
  directly instead of routing through `marked` + `marked-terminal`. For a
  55K-row query that's ~3s vs 5+ minutes (the markdown parse blocked the
  event loop; in the TUI it crashed Ink).
- The interactive TUI uses the same Cliffy path, so large result sets no
  longer OOM Ink.
- Projected (`--select`) output still flows through markdown (smaller,
  scalar/map/list shapes).

## Docs migration

Every skill and design doc now teaches `data.query()` / `swamp data query`
as the primitive, with the existing helpers framed as shortcuts for common
predicates. Full shortcut mapping tables (CLI + CEL) live in
`.claude/skills/swamp-data/SKILL.md` and
`.claude/skills/swamp-data/references/expressions.md` so the skills stay
self-contained — downstream skills reference those, not `design/`.

`swamp-workflow/references/nested-workflows.md` is rewritten: the obsolete
"async helpers can't be used in forEach.in, use a child workflow as a
workaround" section is replaced with a shape-validated-handoff framing.
Child workflows remain a first-class recommendation for reusable
sub-processes, shape-validated boundaries, and independent cadence — just
not as a forEach workaround.

## Test plan

- [x] `deno check` clean
- [x] `deno lint` clean
- [x] `deno fmt` clean
- [x] `deno run test` — 4323 / 4323 passing
- [x] `deno run compile` clean
- [x] New unit coverage: catalog `is_latest` invariant, implicit injection,
      history opt-in, string-literal AST guard, bulk backfill
- [x] Pre-existing "throws on unresolved Promise in forEach.in" test
      rewritten as a positive test (findBySpec in forEach.in succeeds)
- [x] Reproduced the UAT `foreach_findbyspec_test.ts` scenario locally —
      producer runs 3×, consumer forEach-expands to exactly 1 step, history
      shows 1 step (not 2)
- [x] Benchmarked `swamp data query 'version > 0' --limit 100000` on a
      ~55K-row real repo — 1.78s JSON, 2.89s Cliffy table, both from
      previously timing out