### PR TITLE
feat: add manual documentation assessment to planning conventions

### DIFF
--- a/.claude/skills/issue-lifecycle/SKILL.md
+++ b/.claude/skills/issue-lifecycle/SKILL.md
@@ -55,8 +55,8 @@ issue, and reproducing bugs.
 ### Phase 2: Planning (steps 6–9)
 
 Read [references/planning.md](references/planning.md) after triage is complete.
-Covers: generating the implementation plan, checking documentation impact,
-assessing UAT coverage gaps, and presenting to the human.
+Covers: generating the implementation plan, applying repo-specific planning
+conventions, and presenting to the human.
 
 ### Phase 3: Adversarial Review & Iteration
 

--- a/.claude/skills/issue-lifecycle/references/planning.md
+++ b/.claude/skills/issue-lifecycle/references/planning.md
@@ -49,10 +49,12 @@ swamp model method run issue-<N> plan \
 
 Read `agent-constraints/planning-conventions.md` at the repo root for
 repo-specific planning requirements (documentation checks, test strategy,
-analysis conventions, UAT assessment). If it does not exist, generate the plan
-based on your codebase analysis and CLAUDE.md conventions.
+analysis conventions, and any additional assessments the repo defines). If it
+does not exist, generate the plan based on your codebase analysis and CLAUDE.md
+conventions.
 
 ## 8. Present the Plan
 
-Show the plan to the human, then run adversarial review (see
+Show the plan to the human, including any assessment findings required by the
+repo's planning conventions. Then run adversarial review (see
 [adversarial-review.md](adversarial-review.md)).

--- a/agent-constraints/planning-conventions.md
+++ b/agent-constraints/planning-conventions.md
@@ -50,3 +50,51 @@ Then assess:
   Use the label `cli` for CLI UAT gaps or `adversarial` for adversarial test
   gaps.
 - Include UAT assessment findings when presenting the plan to the human.
+
+## Manual Documentation Assessment
+
+Evaluate whether the change requires updates to the user-facing documentation in
+the `systeminit/swamp-club` repo under `content/manual/`. That directory follows
+the Diátaxis framework:
+
+- **How-to guides** (`content/manual/how-to/`) — task-oriented guides (e.g.
+  creating and publishing extensions).
+- **Reference** (`content/manual/reference/`) — technical descriptions of CLI
+  commands, configuration, schemas, and APIs (e.g. CEL expressions, model
+  definitions, workflows, vaults, datastores).
+- **Explanation** (`content/manual/explanation/`) — conceptual overviews (e.g.
+  how swamp works, AI agent integration).
+- **Tutorials** (`content/manual/tutorials/`) — learning-oriented walkthroughs
+  (e.g. hello-world).
+
+First, check what documentation exists:
+
+```
+gh api repos/systeminit/swamp-club/contents/content/manual/reference --jq '.[].name'
+gh api repos/systeminit/swamp-club/contents/content/manual/how-to --jq '.[].name'
+gh api repos/systeminit/swamp-club/contents/content/manual/explanation --jq '.[].name'
+gh api repos/systeminit/swamp-club/contents/content/manual/tutorials --jq '.[].name'
+```
+
+Then assess:
+
+- If the change **is purely internal** (refactors, internal API changes, test
+  improvements) with no user-visible behavior change → no docs action needed.
+  State this when presenting the plan.
+- If the change **adds a new user-facing feature** (new CLI command, new flag,
+  new extension pattern, new configuration option) and no existing doc covers it
+  → flag this to the human.
+- If the change **modifies existing user-facing behavior** (changed CLI output,
+  renamed flags, altered configuration schema, changed defaults) and an existing
+  doc describes the old behavior → flag the stale doc to the human.
+- If the change **deprecates or removes a feature** documented in the manual →
+  flag the doc that needs updating or removal.
+- If the human agrees a documentation gap exists, file an issue in `swamp-club`:
+  ```
+  gh issue create --repo systeminit/swamp-club \
+    --title "Docs: <describe the documentation gap>" \
+    --body "<what changed, which manual page needs updating, suggested content>"
+  ```
+  Use the label `documentation` for doc gaps.
+- Include documentation assessment findings when presenting the plan to the
+  human.


### PR DESCRIPTION
## Summary

- Adds a **Manual Documentation Assessment** section to `agent-constraints/planning-conventions.md` that checks whether changes require updates to `swamp-club content/manual/` docs (Diátaxis: how-to, reference, explanation, tutorials)
- Makes the shipped skill files (`SKILL.md`, `references/planning.md`) generic — they defer to whatever assessments the repo's planning conventions define, so repos without the docs section aren't affected
- Provides `gh api` commands, assessment criteria, and instructions to file `swamp-club` issues with the `documentation` label when gaps are found

## Test plan

- [ ] Verify the skill works correctly in the swamp repo (has the docs assessment section)
- [ ] Verify the skill works correctly in a repo without the docs assessment section in its planning conventions
- [ ] Verify `deno fmt` passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)