### PR TITLE
feat(issue-lifecycle): add author field to FetchedIssue type

### DIFF
--- a/extensions/models/_lib/swamp_club.ts
+++ b/extensions/models/_lib/swamp_club.ts
@@ -42,6 +42,7 @@ export interface FetchedIssue {
   status: string;
   title: string;
   body: string;
+  author: string;
   comments: { author: string; body: string; createdAt: string }[];
   assignees: { userId: string; username: string }[];
 }
@@ -105,6 +106,7 @@ export class SwampClubClient {
           status?: string;
           title?: string;
           body?: string;
+          authorUsername?: string;
           comments?: {
             authorUsername?: string;
             author?: string;
@@ -125,6 +127,7 @@ export class SwampClubClient {
         status: issue.status ?? "open",
         title: issue.title ?? "",
         body: issue.body ?? "",
+        author: issue.authorUsername ?? "unknown",
         comments: (issue.comments ?? []).map((c) => ({
           author: c.authorUsername ?? c.author ?? "unknown",
           body: c.body ?? "",


### PR DESCRIPTION
## Summary

- The swamp-club API already returns `authorId` and `authorUsername` in the issue response, but `FetchedIssue` didn't extract them
- Adds `author: string` to the `FetchedIssue` interface and maps it from `issue.authorUsername` in `fetchIssue()`
- Enables downstream tooling to determine who filed an issue

Closes systeminit/swamp-club#117

🤖 Generated with [Claude Code](https://claude.com/claude-code)