### PR TITLE
feat(extensions): namespace pulled extensions by scoped name (per-extension layout)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"14da7912-a7ac-4a6b-877d-7d814549a356","pid":27130,"acquiredAt":1776451088696}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"14da7912-a7ac-4a6b-877d-7d814549a356","pid":27130,"acquiredAt":1776451088696}

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ plans/
 test-repo/
 .vault-*/
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
+.claude/scheduled_tasks.json
 CLAUDE.local.md
 .envrc
 resources/deno/

--- a/design/extension.md
+++ b/design/extension.md
@@ -441,7 +441,8 @@ Push uses a three-phase protocol:
 
 When an extension is pulled, its metadata and the list of extracted files are
 recorded in `upstream_extensions.json` in the models directory. This file
-enables clean removal and conflict detection.
+enables clean removal, conflict detection, and **integrity-anchored restore**
+(see `checksum` field below).
 
 ### Structure
 
@@ -450,14 +451,33 @@ enables clean removal and conflict detection.
   "@keeb/ssh": {
     "version": "2026.02.26.1",
     "pulledAt": "2026-02-27T10:30:00.000Z",
+    "checksum": "sha256-…",
     "files": [
-      "extensions/models/ssh/connection.ts",
-      "extensions/models/ssh/helpers.ts",
-      "extensions/workflows/ssh-check.yaml"
+      ".swamp/pulled-extensions/@keeb/ssh/models/ssh/connection.ts",
+      ".swamp/pulled-extensions/@keeb/ssh/models/ssh/helpers.ts",
+      ".swamp/pulled-extensions/@keeb/ssh/workflows/ssh-check.yaml",
+      ".swamp/pulled-extensions/@keeb/ssh/manifest.yaml",
+      ".swamp/bundles/<hash>/ssh/connection.js"
     ]
   }
 }
 ```
+
+### Integrity Anchor
+
+Every lockfile entry records the SHA-256 of the extension archive at install
+time (`checksum`). On any lockfile-restore flow (`swamp extension install`,
+phase-two migration re-pull), the freshly-downloaded archive is verified
+byte-for-byte against this stored value. On mismatch, the restore fails
+loudly with a message offering the user a choice: accept current registry
+content (`swamp extension pull <name>`) or pin an older version. This turns
+the lockfile into an integrity manifest rather than just a version record —
+restores cannot silently accept drifted registry bytes. Entries predating
+checksum tracking (pre-commit `f4dfc083`) skip verification gracefully.
+
+Explicit `swamp extension pull <name>` is the user's opt-in path to accept
+whatever bytes the registry currently serves; integrity verification is
+scoped strictly to lockfile-restore flows.
 
 ### Concurrency Safety
 
@@ -465,30 +485,105 @@ All mutations to `upstream_extensions.json` use an advisory lockfile
 (`upstream_extensions.json.lock`) with retry logic (10 attempts, 100ms backoff)
 and atomic file writes to prevent corruption from concurrent operations.
 
-## File Extraction
+## File Extraction (Per-Extension Layout)
 
-When pulled, extension files are extracted to their destinations:
+Each installed extension owns a dedicated on-disk subtree at
+`.swamp/pulled-extensions/<ext-name>/`, where `<ext-name>` is the extension's
+scoped name (e.g. `@swamp/aws/ec2`). Inside that subtree, per-type directories
+mirror the archive structure:
 
-| Archive directory    | Destination                                                            |
-| -------------------- | ---------------------------------------------------------------------- |
-| `models/`            | `{modelsDir}` (from `.swamp.yaml`, default `extensions/models/`)       |
-| `bundles/`           | `.swamp/bundles/`                                                      |
-| `workflows/`         | `{workflowsDir}` (from `.swamp.yaml`, default `extensions/workflows/`) |
-| `vaults/`            | `{vaultsDir}` (from `.swamp.yaml`, default `extensions/vaults/`)       |
-| `vault-bundles/`     | `.swamp/vault-bundles/`                                                |
-| `drivers/`           | `{driversDir}` (from `.swamp.yaml`, default `extensions/drivers/`)     |
-| `driver-bundles/`    | `.swamp/driver-bundles/`                                               |
-| `datastores/`        | `{datastoresDir}` (from `.swamp.yaml`, default `extensions/datastores/`) |
-| `datastore-bundles/` | `.swamp/datastore-bundles/`                                            |
-| `reports/`           | `{reportsDir}` (from `.swamp.yaml`, default `extensions/reports/`)     |
-| `report-bundles/`    | `.swamp/report-bundles/`                                               |
-| `files/`             | `{modelsDir}`                                                          |
+| Archive directory    | Destination                                                  |
+| -------------------- | ------------------------------------------------------------ |
+| `manifest.yaml`      | `.swamp/pulled-extensions/<ext-name>/manifest.yaml` (ro)     |
+| `models/`            | `.swamp/pulled-extensions/<ext-name>/models/`                |
+| `workflows/`         | `.swamp/pulled-extensions/<ext-name>/workflows/`             |
+| `vaults/`            | `.swamp/pulled-extensions/<ext-name>/vaults/`                |
+| `drivers/`           | `.swamp/pulled-extensions/<ext-name>/drivers/`               |
+| `datastores/`        | `.swamp/pulled-extensions/<ext-name>/datastores/`            |
+| `reports/`           | `.swamp/pulled-extensions/<ext-name>/reports/`               |
+| `files/`             | `.swamp/pulled-extensions/<ext-name>/files/`                 |
+| `bundles/`           | `.swamp/bundles/<bundleNamespace(per-extension models dir)>/`  |
+| `vault-bundles/`     | `.swamp/vault-bundles/<bundleNamespace(…vaults dir)>/`       |
+| `driver-bundles/`    | `.swamp/driver-bundles/<bundleNamespace(…drivers dir)>/`     |
+| `datastore-bundles/` | `.swamp/datastore-bundles/<bundleNamespace(…datastores dir)>/` |
+| `report-bundles/`    | `.swamp/report-bundles/<bundleNamespace(…reports dir)>/`     |
+| `skills/`            | Tool-specific skills dir (e.g. `.claude/skills/<skill-name>/`) |
+
+### Why extension-first?
+
+Two sibling extensions from the same collective (e.g. `@swamp/aws/ec2` and
+`@swamp/aws/eks`) frequently ship files with identical basenames — shared
+helpers under `_lib/`, boilerplate like `README.md` and `LICENSE.txt`, and
+occasional type-coincidences like `cluster.ts`. In a type-first (flat) layout,
+these collide at extraction time: the second pull either errors with
+`ConflictError` or silently overwrites the first with `--force`. The silent
+overwrite is the dangerous case — `_lib/*` helpers are imported transitively
+by model bundles, so a swap of `_lib/aws.ts` between ec2 and eks produces
+incorrect runtime behavior with no type or load error.
+
+Extension-first layout eliminates this entirely: each extension's files live
+in a disjoint subtree keyed on its scoped name. The scoped name is already
+a value object the registry uses for identity, so promoting it to the
+filesystem aggregate root costs nothing beyond joining a path segment.
+
+### manifest.yaml colocation
+
+Each extension's archive manifest is extracted to
+`.swamp/pulled-extensions/<ext-name>/manifest.yaml` with file mode `0o444`
+(read-only) and prefixed with a `# Read-only; regenerate via 'swamp
+extension pull'` header. Colocation makes every installed extension
+self-describing on disk: `extension rm`'s dependent-resolution reads the
+tracked manifest directly rather than re-fetching or re-parsing the
+archive. The read-only mode is advisory on some filesystems (notably
+Windows); it is documented via the header, not enforced as a security
+boundary.
+
+### Bundle cache isolation
+
+`bundleNamespace(baseDir, repoDir)` hashes its input relative path. With
+per-extension models dirs, each extension's hash is unique, so every
+extension ends up in its own namespace under `.swamp/bundles/…` — bundle
+keys are disjoint per extension without any additional logic. For
+datastore-backed repos where `bundles/` is tiered to S3 (see
+`DEFAULT_DATASTORE_SUBDIRS`), this means team members' bundle caches are
+cleanly separated per extension.
 
 If files already exist at the destination and `--force` is not set, the user is
-prompted to confirm overwriting.
+prompted to confirm overwriting. Because every extension has its own subtree,
+the only path that triggers ConflictError today is re-installing the same
+extension on top of itself — cross-extension collisions cannot happen.
 
 macOS resource fork files (`._*`) are skipped during both push (via
 `COPYFILE_DISABLE=1`) and pull.
+
+## Layout Migration
+
+Existing repos that installed extensions under older layouts migrate via
+`swamp repo upgrade`. Three generations are recognised:
+
+- **gen-1 (pre-`.swamp/`):** files under `extensions/<type>/...`. `repo
+  upgrade` renames them to `.swamp/pulled-extensions/<type>/...` and rewrites
+  lockfile paths in place. Safe because the same bytes just move.
+- **gen-2 (flat under `.swamp/`):** files under
+  `.swamp/pulled-extensions/<type>/<file>`. Because filenames collide
+  across extensions in this layout, prior installs may have silently
+  overwritten each other, so rename cannot recover authentic content.
+  `repo upgrade` instead selectively deletes each gen-2 entry's tracked
+  files (leaving the lockfile unchanged); the next
+  `swamp extension install` re-pulls each affected extension into its new
+  per-extension subtree, with integrity verified against the lockfile's
+  stored checksum.
+- **current (per-extension):** files under
+  `.swamp/pulled-extensions/<ext-name>/<type>/...`. No migration needed.
+
+The lockfile tolerates mixed-generation state: each entry stands alone, and
+the warn-not-block guard at the CLI layer proceeds with a one-line
+reminder rather than hard-failing so that already-migrated extensions stay
+usable during a partial upgrade. The migration is **resumable**:
+`Deno.errors.NotFound` during selective delete is treated as success
+(expected on a retry after an interrupted prior pass); any other IO error
+aborts the upgrade before any further mutations, leaving the lockfile
+intact so retry starts from a consistent state.
 
 ## Removal
 

--- a/src/cli/auto_resolver_adapters.ts
+++ b/src/cli/auto_resolver_adapters.ts
@@ -18,7 +18,6 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { getLogger } from "@logtape/logtape";
-import { isAbsolute, resolve } from "@std/path";
 import {
   SWAMP_SUBDIRS,
   swampPath,
@@ -29,6 +28,7 @@ import type {
   ExtensionInstallerPort,
 } from "../domain/extensions/extension_auto_resolver.ts";
 import {
+  enumeratePulledExtensionDirs,
   type ExtensionRegistryInfo,
   installExtension,
 } from "../libswamp/mod.ts";
@@ -53,12 +53,6 @@ interface InstallerAdapterConfig {
   getChecksum: (name: string, version: string) => Promise<string | null>;
   /** Full path to the upstream_extensions.json lockfile. */
   lockfilePath: string;
-  modelsDir: string;
-  workflowsDir: string;
-  vaultsDir: string;
-  driversDir: string;
-  datastoresDir: string;
-  reportsDir: string;
   repoDir: string;
   denoRuntime: DenoRuntime;
   datastoreResolver?: DatastorePathResolver;
@@ -76,12 +70,6 @@ export function createAutoResolveInstallerAdapter(
     downloadArchive,
     getChecksum,
     lockfilePath,
-    modelsDir,
-    workflowsDir,
-    vaultsDir,
-    driversDir,
-    datastoresDir,
-    reportsDir,
     repoDir,
     denoRuntime,
     datastoreResolver,
@@ -97,12 +85,6 @@ export function createAutoResolveInstallerAdapter(
           getChecksum,
           logger,
           lockfilePath,
-          modelsDir,
-          workflowsDir,
-          vaultsDir,
-          driversDir,
-          datastoresDir,
-          reportsDir,
           skillsDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledSkills),
           repoDir,
           force: true,
@@ -114,44 +96,65 @@ export function createAutoResolveInstallerAdapter(
       return { version: result.version };
     },
 
+    // Hot-load walks every pulled extension's per-type subtree (via
+    // enumeratePulledExtensionDirs). Under issue 120's per-extension
+    // layout, each extension owns .swamp/pulled-extensions/<ext-name>/,
+    // so there is no single shared directory to pass to the loader.
+    // skipAlreadyRegistered lets the newly-installed extension's types
+    // register while already-loaded types stay put.
     async hotLoadModels() {
-      const absoluteModelsDir = isAbsolute(modelsDir)
-        ? modelsDir
-        : resolve(repoDir, modelsDir);
+      const pulledDirs = await enumeratePulledExtensionDirs(
+        lockfilePath,
+        repoDir,
+        "models",
+      );
+      if (pulledDirs.length === 0) return 0;
       const loader = new UserModelLoader(
         denoRuntime,
         repoDir,
         datastoreResolver,
       );
-      const result = await loader.loadModels(absoluteModelsDir, {
+      const [primary, ...rest] = pulledDirs;
+      const result = await loader.loadModels(primary, {
         skipAlreadyRegistered: true,
+        additionalDirs: rest,
       });
       return result.loaded.length;
     },
 
     async hotLoadVaults() {
-      const absoluteVaultsDir = isAbsolute(vaultsDir)
-        ? vaultsDir
-        : resolve(repoDir, vaultsDir);
+      const pulledDirs = await enumeratePulledExtensionDirs(
+        lockfilePath,
+        repoDir,
+        "vaults",
+      );
+      if (pulledDirs.length === 0) return;
       const loader = new UserVaultLoader(
         denoRuntime,
         repoDir,
         datastoreResolver,
       );
-      await loader.loadVaults(absoluteVaultsDir, {
+      const [primary, ...rest] = pulledDirs;
+      await loader.loadVaults(primary, {
         skipAlreadyRegistered: true,
+        additionalDirs: rest,
       });
     },
 
     async hotLoadDatastores() {
-      const absoluteDatastoresDir = isAbsolute(datastoresDir)
-        ? datastoresDir
-        : resolve(repoDir, datastoresDir);
+      const pulledDirs = await enumeratePulledExtensionDirs(
+        lockfilePath,
+        repoDir,
+        "datastores",
+      );
+      if (pulledDirs.length === 0) return;
       // Bootstrap: datastore loader must NOT receive the resolver —
       // it loads datastore extensions that configure the resolver.
       const loader = new UserDatastoreLoader(denoRuntime, repoDir);
-      await loader.loadDatastores(absoluteDatastoresDir, {
+      const [primary, ...rest] = pulledDirs;
+      await loader.loadDatastores(primary, {
         skipAlreadyRegistered: true,
+        additionalDirs: rest,
       });
     },
   };

--- a/src/cli/auto_resolver_adapters_test.ts
+++ b/src/cli/auto_resolver_adapters_test.ts
@@ -1,0 +1,215 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { createAutoResolveInstallerAdapter } from "./auto_resolver_adapters.ts";
+import type { DenoRuntime } from "../domain/runtime/deno_runtime.ts";
+
+// Stub DenoRuntime — the adapter constructs a real UserModelLoader
+// internally, which requires a DenoRuntime. We return a bogus path so
+// any bundling attempt fails cleanly (the loader records the failure in
+// `result.failed` rather than throwing). The tests care about the
+// enumerate → primary/rest plumbing, not about actual bundling.
+const stubDenoRuntime: DenoRuntime = {
+  ensureDeno: () => Promise.resolve("/usr/bin/false"),
+};
+
+const stubCallbacks = {
+  getExtension: () => Promise.resolve(null),
+  downloadArchive: () =>
+    Promise.reject(new Error("not used in hot-load tests")),
+  getChecksum: () => Promise.resolve(null),
+};
+
+async function seedLockfile(
+  repoDir: string,
+  entries: Record<string, string[]>,
+): Promise<string> {
+  const lockfilePath = join(
+    repoDir,
+    "extensions",
+    "models",
+    "upstream_extensions.json",
+  );
+  await ensureDir(join(repoDir, "extensions", "models"));
+  const map: Record<string, unknown> = {};
+  for (const [name, files] of Object.entries(entries)) {
+    map[name] = {
+      version: "2026.01.01.1",
+      pulledAt: "2026-01-01T00:00:00Z",
+      files,
+    };
+  }
+  await Deno.writeTextFile(lockfilePath, JSON.stringify(map, null, 2));
+  return lockfilePath;
+}
+
+// Regression test locking in the auto-resolver hot-load plumbing added
+// alongside issue 120's per-extension layout. Pre-120, hot-load walked
+// `.swamp/pulled-extensions/<type>/` — a single flat dir. After 120,
+// that dir doesn't exist; each extension owns
+// `.swamp/pulled-extensions/<ext-name>/<type>/`. The adapter must use
+// `enumeratePulledExtensionDirs` to discover per-extension dirs and
+// pass them to the loader as (primary, additionalDirs).
+//
+// If the adapter regresses to the old flat-dir pattern, these tests
+// will catch it: enumerate won't return paths, the pre-loader early
+// returns fire, and the recorded behavior changes.
+
+Deno.test("auto_resolver_adapters: hotLoadModels returns 0 when lockfile missing", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = join(
+      tmpDir,
+      "extensions",
+      "models",
+      "upstream_extensions.json",
+    );
+    const adapter = createAutoResolveInstallerAdapter({
+      ...stubCallbacks,
+      lockfilePath,
+      repoDir: tmpDir,
+      denoRuntime: stubDenoRuntime,
+    });
+
+    assertEquals(await adapter.hotLoadModels(), 0);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("auto_resolver_adapters: hotLoadModels returns 0 when lockfile has entries but no on-disk dirs", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    // Lockfile references an extension whose per-extension models dir
+    // does not exist on disk. enumeratePulledExtensionDirs filters
+    // those out, so the adapter must not attempt to load.
+    const lockfilePath = await seedLockfile(tmpDir, {
+      "@fake/never-installed": [
+        ".swamp/pulled-extensions/@fake/never-installed/models/foo.ts",
+      ],
+    });
+
+    const adapter = createAutoResolveInstallerAdapter({
+      ...stubCallbacks,
+      lockfilePath,
+      repoDir: tmpDir,
+      denoRuntime: stubDenoRuntime,
+    });
+
+    assertEquals(await adapter.hotLoadModels(), 0);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("auto_resolver_adapters: hotLoadModels reaches the loader for each installed per-extension dir", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    // Seed two extensions whose per-extension models subtrees exist on
+    // disk. We don't care that the .ts files are real models — the
+    // stub DenoRuntime makes bundling fail, which is fine. What we're
+    // proving is that the adapter reaches the loader rather than
+    // early-returning.
+    const lockfilePath = await seedLockfile(tmpDir, {
+      "@fake/a": [".swamp/pulled-extensions/@fake/a/models/foo.ts"],
+      "@fake/b": [".swamp/pulled-extensions/@fake/b/models/bar.ts"],
+    });
+
+    for (const name of ["@fake/a", "@fake/b"]) {
+      const dir = join(tmpDir, ".swamp/pulled-extensions", name, "models");
+      await ensureDir(dir);
+      // Minimal source — export const model is the loader's pre-check.
+      // Bundling will fail against /usr/bin/false, but that's recorded
+      // in result.failed, not thrown. The adapter's returned count is
+      // 0 (nothing successfully loaded) which is exactly what we want
+      // to assert: the adapter reached the loader without error.
+      await Deno.writeTextFile(
+        join(dir, name === "@fake/a" ? "foo.ts" : "bar.ts"),
+        "export const model = {};",
+      );
+    }
+
+    const adapter = createAutoResolveInstallerAdapter({
+      ...stubCallbacks,
+      lockfilePath,
+      repoDir: tmpDir,
+      denoRuntime: stubDenoRuntime,
+    });
+
+    // Returns a number (not a throw). With a stub deno that can't
+    // bundle, result.loaded is 0. The value itself is less important
+    // than the fact that the call completed — that's what proves the
+    // enumerate → primary/rest plumbing doesn't crash.
+    const loaded = await adapter.hotLoadModels();
+    assertEquals(typeof loaded, "number");
+    assertEquals(loaded, 0);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("auto_resolver_adapters: hotLoadVaults is a no-op when no pulled vault dirs exist", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = await seedLockfile(tmpDir, {
+      "@fake/ext": [".swamp/pulled-extensions/@fake/ext/models/foo.ts"],
+    });
+    // Seed models dir but NOT a vaults dir — enumerate should skip.
+    await ensureDir(
+      join(tmpDir, ".swamp/pulled-extensions/@fake/ext/models"),
+    );
+
+    const adapter = createAutoResolveInstallerAdapter({
+      ...stubCallbacks,
+      lockfilePath,
+      repoDir: tmpDir,
+      denoRuntime: stubDenoRuntime,
+    });
+
+    // Should not throw — return value is void.
+    await adapter.hotLoadVaults();
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("auto_resolver_adapters: hotLoadDatastores is a no-op when no pulled datastore dirs exist", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = await seedLockfile(tmpDir, {
+      "@fake/ext": [".swamp/pulled-extensions/@fake/ext/models/foo.ts"],
+    });
+
+    const adapter = createAutoResolveInstallerAdapter({
+      ...stubCallbacks,
+      lockfilePath,
+      repoDir: tmpDir,
+      denoRuntime: stubDenoRuntime,
+    });
+
+    // Empty lockfile for datastores perspective (no datastore dir
+    // exists for @fake/ext). Should not throw.
+    await adapter.hotLoadDatastores();
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});

--- a/src/cli/commands/extension_install.ts
+++ b/src/cli/commands/extension_install.ts
@@ -27,15 +27,11 @@ import {
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
 import {
-  SWAMP_SUBDIRS,
-  swampPath,
-} from "../../infrastructure/persistence/paths.ts";
-import {
   consumeStream,
   createLibSwampContext,
   extensionInstall,
-  requireCurrentExtensionLayout,
   resolveServerUrl,
+  warnLegacyExtensionLayout,
 } from "../../libswamp/mod.ts";
 import { UserError } from "../../domain/errors.ts";
 import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
@@ -82,26 +78,21 @@ export const extensionInstallCommand = new Command()
     const absoluteModelsDir = resolve(repoDir, modelsDir);
     const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
 
-    // 3. Check for legacy extension layout
-    await requireCurrentExtensionLayout(lockfilePath);
+    // 3. Warn (don't block) on legacy layout. extension install is the
+    // migration mechanism for missing-files state: it re-installs into
+    // the new per-extension layout automatically.
+    await warnLegacyExtensionLayout(
+      lockfilePath,
+      (msg) => cliCtx.logger.warn(msg),
+    );
 
-    // 4. Resolve pulled-extension dirs
-    const pulledModelsDir = swampPath(repoDir, SWAMP_SUBDIRS.pulledModels);
-    const pulledWorkflowsDir = swampPath(
-      repoDir,
-      SWAMP_SUBDIRS.pulledWorkflows,
-    );
-    const pulledVaultsDir = swampPath(repoDir, SWAMP_SUBDIRS.pulledVaults);
-    const pulledDriversDir = swampPath(repoDir, SWAMP_SUBDIRS.pulledDrivers);
-    const pulledDatastoresDir = swampPath(
-      repoDir,
-      SWAMP_SUBDIRS.pulledDatastores,
-    );
-    const pulledReportsDir = swampPath(repoDir, SWAMP_SUBDIRS.pulledReports);
+    // 4. Resolve skills destination (tool-aware). Per-extension
+    // models/workflows/vaults/drivers/datastores/reports destinations
+    // are derived inside installExtension from each extension's name.
     const tool = marker?.tool ?? "claude";
     const skillsDir = resolveSkillsDir(repoDir, tool);
 
-    // 4. Wire deps and execute
+    // 5. Wire deps and execute
     const serverUrl = resolveServerUrl();
     const client = new ExtensionApiClient(serverUrl);
 
@@ -118,12 +109,6 @@ export const extensionInstallCommand = new Command()
           getChecksum: (n, v) => client.getChecksum(n, v),
           logger: cliCtx.logger,
           lockfilePath,
-          modelsDir: pulledModelsDir,
-          workflowsDir: pulledWorkflowsDir,
-          vaultsDir: pulledVaultsDir,
-          driversDir: pulledDriversDir,
-          datastoresDir: pulledDatastoresDir,
-          reportsDir: pulledReportsDir,
           skillsDir,
           repoDir,
           force: true,

--- a/src/cli/commands/extension_list.ts
+++ b/src/cli/commands/extension_list.ts
@@ -26,7 +26,7 @@ import {
   createExtensionListDeps,
   createLibSwampContext,
   extensionList,
-  requireCurrentExtensionLayout,
+  warnLegacyExtensionLayout,
 } from "../../libswamp/mod.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
 import {
@@ -57,14 +57,18 @@ export const extensionListCommand = new Command()
       outputMode: cliCtx.outputMode,
     });
 
-    // Check for legacy extension layout
+    // Warn (don't block) if any extensions are still in a legacy layout.
+    // list reads the lockfile, which tolerates mixed-generation state.
     const repoPath = RepoPath.create(repoDir);
     const markerRepo = new RepoMarkerRepository();
     const marker = await markerRepo.read(repoPath);
     const modelsDir = resolveModelsDir(marker);
     const absoluteModelsDir = resolve(repoDir, modelsDir);
     const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
-    await requireCurrentExtensionLayout(lockfilePath);
+    await warnLegacyExtensionLayout(
+      lockfilePath,
+      (msg) => cliCtx.logger.warn(msg),
+    );
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
     const deps = await createExtensionListDeps(repoDir);

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -28,10 +28,6 @@ import {
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { UserError } from "../../domain/errors.ts";
-import {
-  SWAMP_SUBDIRS,
-  swampPath,
-} from "../../infrastructure/persistence/paths.ts";
 import { resolveSkillsDir } from "../../domain/repo/skill_dirs.ts";
 import {
   ConflictError,
@@ -42,9 +38,9 @@ import {
   type ExtensionPullDeps,
   type ExtensionRegistryInfo,
   parseExtensionRef,
-  requireCurrentExtensionLayout,
   resolveServerUrl,
   validateExtensionName,
+  warnLegacyExtensionLayout,
 } from "../../libswamp/mod.ts";
 import {
   createExtensionPullRenderer,
@@ -92,12 +88,7 @@ export interface PullContext {
   logger: Logger;
   /** Full path to the upstream_extensions.json lockfile. */
   lockfilePath: string;
-  modelsDir: string;
-  workflowsDir: string;
-  vaultsDir: string;
-  driversDir: string;
-  datastoresDir: string;
-  reportsDir: string;
+  /** Tool-aware skills destination (e.g. `.claude/skills/`). */
   skillsDir: string;
   repoDir: string;
   force: boolean;
@@ -120,12 +111,6 @@ export async function pullExtension(
     downloadArchive: ctx.downloadArchive,
     getChecksum: ctx.getChecksum,
     lockfilePath: ctx.lockfilePath,
-    modelsDir: ctx.modelsDir,
-    workflowsDir: ctx.workflowsDir,
-    vaultsDir: ctx.vaultsDir,
-    driversDir: ctx.driversDir,
-    datastoresDir: ctx.datastoresDir,
-    reportsDir: ctx.reportsDir,
     skillsDir: ctx.skillsDir,
     repoDir: ctx.repoDir,
     alreadyPulled: ctx.alreadyPulled,
@@ -198,24 +183,18 @@ export const extensionPullCommand = new Command()
     const absoluteModelsDir = resolve(repoDir, modelsDir);
     const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
 
-    // 5. Check for legacy extension layout
-    await requireCurrentExtensionLayout(lockfilePath);
-
-    // 6. Resolve pulled-extension dirs (.swamp/pulled-extensions/{type}/)
-    const pulledModelsDir = swampPath(repoDir, SWAMP_SUBDIRS.pulledModels);
-    const pulledWorkflowsDir = swampPath(
-      repoDir,
-      SWAMP_SUBDIRS.pulledWorkflows,
+    // 5. Warn if any extensions are still in a legacy layout. We don't
+    // block — the lockfile tolerates mixed generations and the new pull
+    // writes to the per-extension subtree regardless.
+    await warnLegacyExtensionLayout(
+      lockfilePath,
+      (msg) => ctx.logger.warn(msg),
     );
-    const pulledVaultsDir = swampPath(repoDir, SWAMP_SUBDIRS.pulledVaults);
-    const pulledDriversDir = swampPath(repoDir, SWAMP_SUBDIRS.pulledDrivers);
-    const pulledDatastoresDir = swampPath(
-      repoDir,
-      SWAMP_SUBDIRS.pulledDatastores,
-    );
-    const pulledReportsDir = swampPath(repoDir, SWAMP_SUBDIRS.pulledReports);
 
-    // 6b. Resolve skills destination (tool-aware)
+    // 6. Resolve skills destination (tool-aware). Per-extension
+    // models/workflows/vaults/drivers/datastores/reports destinations
+    // are derived inside installExtension from `ref.name` — the CLI
+    // doesn't need to compute them.
     const tool = marker?.tool ?? "claude";
     const skillsDir = resolveSkillsDir(repoDir, tool);
 
@@ -224,12 +203,6 @@ export const extensionPullCommand = new Command()
     const deps = createExtensionPullDeps(
       serverUrl,
       lockfilePath,
-      pulledModelsDir,
-      pulledWorkflowsDir,
-      pulledVaultsDir,
-      pulledDriversDir,
-      pulledDatastoresDir,
-      pulledReportsDir,
       skillsDir,
       repoDir,
     );
@@ -240,12 +213,6 @@ export const extensionPullCommand = new Command()
       getChecksum: deps.getChecksum,
       logger: ctx.logger,
       lockfilePath,
-      modelsDir: pulledModelsDir,
-      workflowsDir: pulledWorkflowsDir,
-      vaultsDir: pulledVaultsDir,
-      driversDir: pulledDriversDir,
-      datastoresDir: pulledDatastoresDir,
-      reportsDir: pulledReportsDir,
       skillsDir,
       repoDir,
       force: options.force ?? false,

--- a/src/cli/commands/extension_rm.ts
+++ b/src/cli/commands/extension_rm.ts
@@ -33,8 +33,8 @@ import {
   extensionRm,
   extensionRmPreview,
   parseExtensionRef,
-  requireCurrentExtensionLayout,
   validateExtensionName,
+  warnLegacyExtensionLayout,
 } from "../../libswamp/mod.ts";
 import {
   createExtensionRmRenderer,
@@ -89,8 +89,12 @@ export const extensionRemoveCommand = new Command()
     const absoluteModelsDir = resolve(repoDir, modelsDir);
     const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
 
-    // Check for legacy extension layout
-    await requireCurrentExtensionLayout(lockfilePath);
+    // Warn if any extensions are still in a legacy layout. rm follows
+    // the lockfile's tracked paths so it works against either generation.
+    await warnLegacyExtensionLayout(
+      lockfilePath,
+      (msg) => ctx.logger.warn(msg),
+    );
 
     // Create libswamp context, deps, renderer
     const libCtx = createLibSwampContext({ logger: ctx.logger });

--- a/src/cli/commands/extension_search.ts
+++ b/src/cli/commands/extension_search.ts
@@ -27,10 +27,6 @@ import {
 import { requireInitializedRepo } from "../repo_context.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
 import {
-  SWAMP_SUBDIRS,
-  swampPath,
-} from "../../infrastructure/persistence/paths.ts";
-import {
   RepoMarkerRepository,
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
@@ -44,7 +40,7 @@ import {
   createLibSwampContext,
   extensionSearch,
   type ExtensionSearchDeps,
-  requireCurrentExtensionLayout,
+  warnLegacyExtensionLayout,
 } from "../../libswamp/mod.ts";
 import { createExtensionSearchRenderer } from "../../presentation/renderers/extension_search.tsx";
 import { resolveSkillsDir } from "../../domain/repo/skill_dirs.ts";
@@ -202,8 +198,12 @@ export const extensionSearchCommand = new Command()
         "upstream_extensions.json",
       );
 
-      // Check for legacy extension layout before pulling
-      await requireCurrentExtensionLayout(lockfilePath);
+      // Warn (don't block) on legacy layout. The pull that follows writes
+      // to the per-extension subtree regardless of existing layout state.
+      await warnLegacyExtensionLayout(
+        lockfilePath,
+        (msg) => ctx.logger.warn(msg),
+      );
 
       const pullCtx: PullContext = {
         getExtension: (name) => client.getExtension(name),
@@ -212,12 +212,6 @@ export const extensionSearchCommand = new Command()
         getChecksum: (name, version) => client.getChecksum(name, version),
         logger: ctx.logger,
         lockfilePath,
-        modelsDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledModels),
-        workflowsDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledWorkflows),
-        vaultsDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledVaults),
-        driversDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledDrivers),
-        datastoresDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledDatastores),
-        reportsDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledReports),
         skillsDir: resolveSkillsDir(repoDir, marker?.tool ?? "claude"),
         repoDir,
         force: false,

--- a/src/cli/commands/extension_update.ts
+++ b/src/cli/commands/extension_update.ts
@@ -23,10 +23,6 @@ import { createContext, type GlobalOptions } from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
 import {
-  SWAMP_SUBDIRS,
-  swampPath,
-} from "../../infrastructure/persistence/paths.ts";
-import {
   RepoMarkerRepository,
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
@@ -40,7 +36,7 @@ import {
   createExtensionUpdateDeps,
   createLibSwampContext,
   extensionUpdate,
-  requireCurrentExtensionLayout,
+  warnLegacyExtensionLayout,
 } from "../../libswamp/mod.ts";
 import { createExtensionUpdateRenderer } from "../../presentation/renderers/extension_update.ts";
 import { resolveSkillsDir } from "../../domain/repo/skill_dirs.ts";
@@ -85,24 +81,19 @@ export const extensionUpdateCommand = new Command()
     const absoluteModelsDir = resolve(repoDir, modelsDir);
     const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
 
-    // Pulled-extension dirs for install
-    const pulledModelsDir = swampPath(repoDir, SWAMP_SUBDIRS.pulledModels);
-    const pulledWorkflowsDir = swampPath(
-      repoDir,
-      SWAMP_SUBDIRS.pulledWorkflows,
-    );
-    const pulledVaultsDir = swampPath(repoDir, SWAMP_SUBDIRS.pulledVaults);
-    const pulledDriversDir = swampPath(repoDir, SWAMP_SUBDIRS.pulledDrivers);
-    const pulledDatastoresDir = swampPath(
-      repoDir,
-      SWAMP_SUBDIRS.pulledDatastores,
-    );
-    const pulledReportsDir = swampPath(repoDir, SWAMP_SUBDIRS.pulledReports);
+    // Per-extension models/workflows/vaults/drivers/datastores/reports
+    // destinations are derived inside installExtension from the
+    // extension's scoped name. Only skillsDir is tool-dependent.
     const tool = marker?.tool ?? "claude";
     const skillsDir = resolveSkillsDir(repoDir, tool);
 
-    // 3. Check for legacy extension layout
-    await requireCurrentExtensionLayout(lockfilePath);
+    // 3. Warn (don't block) on legacy layout. update pulls new versions
+    // which write to the per-extension subtree, migrating each extension
+    // as it goes.
+    await warnLegacyExtensionLayout(
+      lockfilePath,
+      (msg) => cliCtx.logger.warn(msg),
+    );
 
     // 4. Parse extension name if given
     let extensionName: string | undefined;
@@ -122,12 +113,6 @@ export const extensionUpdateCommand = new Command()
         const installCtx = createInstallContext(serverUrl, {
           logger: cliCtx.logger,
           lockfilePath,
-          modelsDir: pulledModelsDir,
-          workflowsDir: pulledWorkflowsDir,
-          vaultsDir: pulledVaultsDir,
-          driversDir: pulledDriversDir,
-          datastoresDir: pulledDatastoresDir,
-          reportsDir: pulledReportsDir,
           skillsDir,
           repoDir,
           force: true,

--- a/src/cli/commands/open.ts
+++ b/src/cli/commands/open.ts
@@ -42,10 +42,7 @@ import { pullExtension } from "./extension_pull.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
-import {
-  SWAMP_SUBDIRS,
-  swampPath,
-} from "../../infrastructure/persistence/paths.ts";
+import { swampPath } from "../../infrastructure/persistence/paths.ts";
 import { ExtensionCatalogStore } from "../../infrastructure/persistence/extension_catalog_store.ts";
 import {
   configureExtensionAutoResolver,
@@ -180,12 +177,6 @@ export const openCommand = new Command()
             getChecksum: (n, v) => extClient.getChecksum(n, v),
             logger: ctx.logger,
             lockfilePath,
-            modelsDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledModels),
-            workflowsDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledWorkflows),
-            vaultsDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledVaults),
-            driversDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledDrivers),
-            datastoresDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledDatastores),
-            reportsDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledReports),
             skillsDir: resolveSkillsDir(repoDir, marker?.tool ?? "claude"),
             repoDir,
             // Force overwrite — the web UI has no stdin to answer the

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -22,7 +22,7 @@ import { setColorEnabled } from "@std/fmt/colors";
 import { isAbsolute, join, resolve } from "@std/path";
 import { swampPath } from "../infrastructure/persistence/paths.ts";
 import { readUpstreamExtensions } from "../infrastructure/persistence/upstream_extensions.ts";
-import { enumeratePulledExtensionDirs } from "../libswamp/extensions/enumerate_pulled.ts";
+import { enumeratePulledExtensionDirs } from "../libswamp/mod.ts";
 import { getLogger, parseLogLevel } from "@logtape/logtape";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
 import { VERSION, versionCommand } from "./commands/version.ts";

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -20,11 +20,9 @@
 import { Command } from "@cliffy/command";
 import { setColorEnabled } from "@std/fmt/colors";
 import { isAbsolute, join, resolve } from "@std/path";
-import {
-  SWAMP_SUBDIRS,
-  swampPath,
-} from "../infrastructure/persistence/paths.ts";
+import { swampPath } from "../infrastructure/persistence/paths.ts";
 import { readUpstreamExtensions } from "../infrastructure/persistence/upstream_extensions.ts";
+import { enumeratePulledExtensionDirs } from "../libswamp/extensions/enumerate_pulled.ts";
 import { getLogger, parseLogLevel } from "@logtape/logtape";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
 import { VERSION, versionCommand } from "./commands/version.ts";
@@ -339,12 +337,6 @@ export function configureExtensionAutoResolver(
           resolve(repoDir, modelsDir),
           "upstream_extensions.json",
         ),
-        modelsDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledModels),
-        workflowsDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledWorkflows),
-        vaultsDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledVaults),
-        driversDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledDrivers),
-        datastoresDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledDatastores),
-        reportsDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledReports),
         repoDir,
         denoRuntime,
       }),
@@ -386,7 +378,12 @@ async function loadUserModels(
 
     const resolver = resolverFactory ? await resolverFactory() : undefined;
     const loader = new UserModelLoader(denoRuntime, repoDir, resolver);
-    const pulledDir = swampPath(repoDir, SWAMP_SUBDIRS.pulledModels);
+    const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+    const pulledDirs = await enumeratePulledExtensionDirs(
+      lockfilePath,
+      repoDir,
+      "models",
+    );
 
     // Use bundle catalog for lazy per-bundle loading.
     // The catalog stays open for the process lifetime so the type loader
@@ -403,12 +400,15 @@ async function loadUserModels(
     // If catalog is populated, only rebundles changed files.
     // If not populated (first run), does a full import to bootstrap.
     // Always scans for staleness so users never see stale data.
-    // Load order: local > sources > pulled (sources override pulled)
+    // Load order: local > sources > pulled (sources override pulled).
+    // pulledDirs is one entry per installed extension — the loader walks
+    // each extension's subtree independently so file-name collisions across
+    // sibling extensions can't bleed into each other.
     const result = await loader.buildIndex(
       absoluteModelsDir,
       effectiveCatalog,
       {
-        additionalDirs: [...sourceDirs, pulledDir],
+        additionalDirs: [...sourceDirs, ...pulledDirs],
       },
     );
 
@@ -440,7 +440,16 @@ async function loadUserVaults(
 
     const resolver = resolverFactory ? await resolverFactory() : undefined;
     const loader = new UserVaultLoader(denoRuntime, repoDir, resolver);
-    const pulledDir = swampPath(repoDir, SWAMP_SUBDIRS.pulledVaults);
+    const modelsDir = resolveModelsDir(marker);
+    const lockfilePath = join(
+      isAbsolute(modelsDir) ? modelsDir : resolve(repoDir, modelsDir),
+      "upstream_extensions.json",
+    );
+    const pulledDirs = await enumeratePulledExtensionDirs(
+      lockfilePath,
+      repoDir,
+      "vaults",
+    );
 
     if (catalog) {
       vaultTypeRegistry.setTypeLoader(async (type) => {
@@ -448,7 +457,7 @@ async function loadUserVaults(
       });
 
       const result = await loader.buildIndex(absoluteVaultsDir, catalog, {
-        additionalDirs: [...sourceDirs, pulledDir],
+        additionalDirs: [...sourceDirs, ...pulledDirs],
       });
 
       for (const failure of result.failed) {
@@ -457,7 +466,7 @@ async function loadUserVaults(
       }
     } else {
       const result = await loader.loadVaults(absoluteVaultsDir, {
-        additionalDirs: [...sourceDirs, pulledDir],
+        additionalDirs: [...sourceDirs, ...pulledDirs],
         skipAlreadyRegistered: true,
       });
 
@@ -487,7 +496,16 @@ async function loadUserDrivers(
 
     const resolver = resolverFactory ? await resolverFactory() : undefined;
     const loader = new UserDriverLoader(denoRuntime, repoDir, resolver);
-    const pulledDir = swampPath(repoDir, SWAMP_SUBDIRS.pulledDrivers);
+    const modelsDir = resolveModelsDir(marker);
+    const lockfilePath = join(
+      isAbsolute(modelsDir) ? modelsDir : resolve(repoDir, modelsDir),
+      "upstream_extensions.json",
+    );
+    const pulledDirs = await enumeratePulledExtensionDirs(
+      lockfilePath,
+      repoDir,
+      "drivers",
+    );
 
     if (catalog) {
       driverTypeRegistry.setTypeLoader(async (type) => {
@@ -495,7 +513,7 @@ async function loadUserDrivers(
       });
 
       const result = await loader.buildIndex(absoluteDriversDir, catalog, {
-        additionalDirs: [...sourceDirs, pulledDir],
+        additionalDirs: [...sourceDirs, ...pulledDirs],
       });
 
       for (const failure of result.failed) {
@@ -504,7 +522,7 @@ async function loadUserDrivers(
       }
     } else {
       const result = await loader.loadDrivers(absoluteDriversDir, {
-        additionalDirs: [...sourceDirs, pulledDir],
+        additionalDirs: [...sourceDirs, ...pulledDirs],
         skipAlreadyRegistered: true,
       });
 
@@ -532,7 +550,16 @@ async function loadUserDatastores(
       : resolve(repoDir, datastoresDir);
 
     const loader = new UserDatastoreLoader(denoRuntime, repoDir);
-    const pulledDir = swampPath(repoDir, SWAMP_SUBDIRS.pulledDatastores);
+    const modelsDir = resolveModelsDir(marker);
+    const lockfilePath = join(
+      isAbsolute(modelsDir) ? modelsDir : resolve(repoDir, modelsDir),
+      "upstream_extensions.json",
+    );
+    const pulledDirs = await enumeratePulledExtensionDirs(
+      lockfilePath,
+      repoDir,
+      "datastores",
+    );
 
     if (catalog) {
       datastoreTypeRegistry.setTypeLoader(async (type) => {
@@ -543,7 +570,7 @@ async function loadUserDatastores(
         absoluteDatastoresDir,
         catalog,
         {
-          additionalDirs: [...sourceDirs, pulledDir],
+          additionalDirs: [...sourceDirs, ...pulledDirs],
         },
       );
 
@@ -553,7 +580,7 @@ async function loadUserDatastores(
       }
     } else {
       const result = await loader.loadDatastores(absoluteDatastoresDir, {
-        additionalDirs: [...sourceDirs, pulledDir],
+        additionalDirs: [...sourceDirs, ...pulledDirs],
         skipAlreadyRegistered: true,
       });
 
@@ -583,7 +610,16 @@ async function loadUserReports(
 
     const resolver = resolverFactory ? await resolverFactory() : undefined;
     const loader = new UserReportLoader(denoRuntime, repoDir, resolver);
-    const pulledDir = swampPath(repoDir, SWAMP_SUBDIRS.pulledReports);
+    const modelsDir = resolveModelsDir(marker);
+    const lockfilePath = join(
+      isAbsolute(modelsDir) ? modelsDir : resolve(repoDir, modelsDir),
+      "upstream_extensions.json",
+    );
+    const pulledDirs = await enumeratePulledExtensionDirs(
+      lockfilePath,
+      repoDir,
+      "reports",
+    );
 
     if (catalog) {
       reportRegistry.setTypeLoader(async (type) => {
@@ -591,7 +627,7 @@ async function loadUserReports(
       });
 
       const result = await loader.buildIndex(absoluteReportsDir, catalog, {
-        additionalDirs: [...sourceDirs, pulledDir],
+        additionalDirs: [...sourceDirs, ...pulledDirs],
       });
 
       for (const failure of result.failed) {
@@ -600,7 +636,7 @@ async function loadUserReports(
       }
     } else {
       const result = await loader.loadReports(absoluteReportsDir, {
-        additionalDirs: [...sourceDirs, pulledDir],
+        additionalDirs: [...sourceDirs, ...pulledDirs],
         skipAlreadyRegistered: true,
       });
 

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -42,7 +42,7 @@ import { UserError } from "../domain/errors.ts";
 import { VERSION } from "./commands/version.ts";
 import { resolveWorkflowsDir } from "./resolve_workflows_dir.ts";
 import { resolveModelsDir } from "./resolve_models_dir.ts";
-import { enumeratePulledExtensionDirs } from "../libswamp/extensions/enumerate_pulled.ts";
+import { enumeratePulledExtensionDirs } from "../libswamp/mod.ts";
 import { resolveDatastoreConfig } from "./resolve_datastore.ts";
 import { DefaultDatastorePathResolver } from "../infrastructure/persistence/default_datastore_path_resolver.ts";
 import type { DatastorePathResolver } from "../domain/datastore/datastore_path_resolver.ts";

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -41,10 +41,8 @@ import {
 import { UserError } from "../domain/errors.ts";
 import { VERSION } from "./commands/version.ts";
 import { resolveWorkflowsDir } from "./resolve_workflows_dir.ts";
-import {
-  SWAMP_SUBDIRS,
-  swampPath,
-} from "../infrastructure/persistence/paths.ts";
+import { resolveModelsDir } from "./resolve_models_dir.ts";
+import { enumeratePulledExtensionDirs } from "../libswamp/extensions/enumerate_pulled.ts";
 import { resolveDatastoreConfig } from "./resolve_datastore.ts";
 import { DefaultDatastorePathResolver } from "../infrastructure/persistence/default_datastore_path_resolver.ts";
 import type { DatastorePathResolver } from "../domain/datastore/datastore_path_resolver.ts";
@@ -251,7 +249,16 @@ export async function requireInitializedRepoReadOnly(
     workflowsDir,
     additionalWorkflowsDirs: [
       ...sourceWorkflowDirs,
-      swampPath(repoPath.value, SWAMP_SUBDIRS.pulledWorkflows),
+      ...(await enumeratePulledExtensionDirs(
+        join(
+          isAbsolute(resolveModelsDir(marker))
+            ? resolveModelsDir(marker)
+            : resolve(repoPath.value, resolveModelsDir(marker)),
+          "upstream_extensions.json",
+        ),
+        repoPath.value,
+        "workflows",
+      )),
     ],
     definitionsDir,
     yamlWorkflowsDir,
@@ -376,7 +383,16 @@ export function requireInitializedRepo(
       workflowsDir,
       additionalWorkflowsDirs: [
         ...sourceWorkflowDirs,
-        swampPath(repoPath.value, SWAMP_SUBDIRS.pulledWorkflows),
+        ...(await enumeratePulledExtensionDirs(
+          join(
+            isAbsolute(resolveModelsDir(marker))
+              ? resolveModelsDir(marker)
+              : resolve(repoPath.value, resolveModelsDir(marker)),
+            "upstream_extensions.json",
+          ),
+          repoPath.value,
+          "workflows",
+        )),
       ],
       definitionsDir,
       yamlWorkflowsDir,
@@ -475,7 +491,16 @@ export async function requireInitializedRepoUnlocked(
     workflowsDir,
     additionalWorkflowsDirs: [
       ...sourceWorkflowDirs,
-      swampPath(repoPath.value, SWAMP_SUBDIRS.pulledWorkflows),
+      ...(await enumeratePulledExtensionDirs(
+        join(
+          isAbsolute(resolveModelsDir(marker))
+            ? resolveModelsDir(marker)
+            : resolve(repoPath.value, resolveModelsDir(marker)),
+          "upstream_extensions.json",
+        ),
+        repoPath.value,
+        "workflows",
+      )),
     ],
     definitionsDir,
     yamlWorkflowsDir,

--- a/src/cli/resolve_datastore.ts
+++ b/src/cli/resolve_datastore.ts
@@ -45,7 +45,10 @@ import { maybeAutoUpdateDatastoreExtension } from "../libswamp/extensions/datast
 import { FileExtensionUpdateCheckRepository } from "../infrastructure/persistence/extension_update_check_repository.ts";
 import { readUpstreamExtensions } from "../infrastructure/persistence/upstream_extensions.ts";
 import { ExtensionApiClient } from "../infrastructure/http/extension_api_client.ts";
-import { installExtension } from "../libswamp/mod.ts";
+import {
+  enumeratePulledExtensionDirs,
+  installExtension,
+} from "../libswamp/mod.ts";
 import { UserDatastoreLoader } from "../domain/datastore/user_datastore_loader.ts";
 import { EmbeddedDenoRuntime } from "../infrastructure/runtime/embedded_deno_runtime.ts";
 import { swampPath } from "../infrastructure/persistence/paths.ts";
@@ -108,12 +111,11 @@ async function maybeAutoUpdateSwampDatastore(
       },
       pullExtension: async (name, version) => {
         const resolvedRepoDir = resolve(repoDir);
-        const datastoresDir = swampPath(
-          resolvedRepoDir,
-          SWAMP_SUBDIRS.pulledDatastores,
-        );
 
-        // Pull the extension with the specific version
+        // Pull the extension with the specific version. installExtension
+        // derives per-extension destinations (models/workflows/vaults/
+        // drivers/datastores/reports) from `name`; only skillsDir is
+        // caller-owned because skills land in a tool-specific dir.
         await installExtension(
           { name, version },
           {
@@ -122,21 +124,6 @@ async function maybeAutoUpdateSwampDatastore(
             getChecksum: (n, v) => extensionClient.getChecksum(n, v),
             logger,
             lockfilePath,
-            modelsDir: swampPath(resolvedRepoDir, SWAMP_SUBDIRS.pulledModels),
-            workflowsDir: swampPath(
-              resolvedRepoDir,
-              SWAMP_SUBDIRS.pulledWorkflows,
-            ),
-            vaultsDir: swampPath(resolvedRepoDir, SWAMP_SUBDIRS.pulledVaults),
-            driversDir: swampPath(
-              resolvedRepoDir,
-              SWAMP_SUBDIRS.pulledDrivers,
-            ),
-            datastoresDir,
-            reportsDir: swampPath(
-              resolvedRepoDir,
-              SWAMP_SUBDIRS.pulledReports,
-            ),
             skillsDir: swampPath(
               resolvedRepoDir,
               SWAMP_SUBDIRS.pulledSkills,
@@ -148,12 +135,24 @@ async function maybeAutoUpdateSwampDatastore(
           },
         );
 
-        // Hot-reload the datastore type from the updated extension
-        const denoRuntime = new EmbeddedDenoRuntime();
-        const loader = new UserDatastoreLoader(denoRuntime, resolvedRepoDir);
-        await loader.loadDatastores(datastoresDir, {
-          skipAlreadyRegistered: false,
-        });
+        // Hot-reload the datastore type from the updated extension.
+        // Under the per-extension layout the loader walks each installed
+        // extension's datastores subdir via enumeratePulledExtensionDirs
+        // rather than a single shared dir.
+        const pulledDirs = await enumeratePulledExtensionDirs(
+          lockfilePath,
+          resolvedRepoDir,
+          "datastores",
+        );
+        if (pulledDirs.length > 0) {
+          const denoRuntime = new EmbeddedDenoRuntime();
+          const loader = new UserDatastoreLoader(denoRuntime, resolvedRepoDir);
+          const [primary, ...rest] = pulledDirs;
+          await loader.loadDatastores(primary, {
+            skipAlreadyRegistered: false,
+            additionalDirs: rest,
+          });
+        }
       },
       cacheRepository,
     });

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -65,9 +65,13 @@ const logger = getLogger(["swamp", "models", "loader"]);
 /**
  * Bundle layout version. Stored in the catalog's bundle_meta table.
  * When this doesn't match, the catalog is invalidated to force a full
- * rescan — migrating from flat to namespaced bundle paths.
+ * rescan. Bump when bundle cache keys or source layout conventions
+ * change so stale entries don't leak across the migration boundary.
+ * History: "namespaced-v1" (per-source-dir hash) →
+ * "per-extension-v2" (each pulled extension owns its own bundle
+ * namespace via its per-extension models dir).
  */
-const BUNDLE_LAYOUT_VERSION = "namespaced-v1";
+const BUNDLE_LAYOUT_VERSION = "per-extension-v2";
 
 /**
  * Plain object result returned by user methods before conversion.

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -22,9 +22,11 @@ import { ensureDir } from "@std/fs";
 import { atomicWriteTextFile } from "../../infrastructure/persistence/atomic_write.ts";
 import {
   readUpstreamExtensions,
+  type UpstreamExtensionsMap,
 } from "../../infrastructure/persistence/upstream_extensions.ts";
 import type { RepoPath } from "./repo_path.ts";
 import {
+  SWAMP_DATA_DIR,
   SWAMP_SUBDIRS,
   swampPath,
 } from "../../infrastructure/persistence/paths.ts";
@@ -93,6 +95,22 @@ export interface RepoInitResult {
 }
 
 /**
+ * Summary of extension layout migration that ran during `repo upgrade`.
+ *
+ * - `phase1MovedCount`: gen-1 (`extensions/<type>/...`) files renamed to
+ *   gen-2 (`.swamp/pulled-extensions/<type>/...`).
+ * - `phase2DeletedPerExtension`: for each gen-2 entry detected, how many
+ *   tracked files were removed from disk. The lockfile entries remain,
+ *   so the next `swamp extension install` re-pulls each affected
+ *   extension into the per-extension subtree with integrity verification
+ *   against the lockfile's stored checksum.
+ */
+export interface ExtensionLayoutMigrationSummary {
+  phase1MovedCount: number;
+  phase2DeletedPerExtension: Array<{ name: string; fileCount: number }>;
+}
+
+/**
  * Result of a repository upgrade operation.
  */
 export interface RepoUpgradeResult {
@@ -105,6 +123,13 @@ export interface RepoUpgradeResult {
   settingsUpdated: boolean;
   gitignoreAction: GitignoreAction;
   tool: AiTool;
+  /**
+   * Extension layout migration summary, present only when the upgrade
+   * actually moved or deleted files. Callers render this to tell users
+   * what happened to their pulled-extensions state so they know to run
+   * `swamp extension install` to restore phase-2-deleted content.
+   */
+  extensionMigration?: ExtensionLayoutMigrationSummary;
 }
 
 /**
@@ -341,8 +366,8 @@ export class RepoService {
     // Migrate from symlink-based layout to datastore layout
     await this.migrateFromSymlinks(repoPath);
 
-    // Migrate pulled extensions from extensions/ to .swamp/pulled-extensions/
-    await this.migrateExtensionLayout(repoPath);
+    // Migrate pulled extensions across on-disk layout generations.
+    const extensionMigration = await this.migrateExtensionLayout(repoPath);
 
     await this.markerRepo.write(repoPath, updatedMarker);
 
@@ -363,6 +388,7 @@ export class RepoService {
       settingsUpdated,
       gitignoreAction,
       tool,
+      ...(extensionMigration ? { extensionMigration } : {}),
     };
   }
 
@@ -1582,11 +1608,37 @@ export const SwampAudit: Plugin = async ({ directory }) => {
   }
 
   /**
-   * Migrates pulled extension files from extensions/{type}/ to
-   * .swamp/pulled-extensions/{type}/. Reads upstream_extensions.json
-   * to find tracked files, moves them, and updates the lockfile paths.
+   * Migrates pulled extensions across on-disk layout generations.
+   *
+   * Runs in two phases:
+   *
+   * **Phase 1 — gen-1 → gen-2 (rename):** moves files from
+   * `extensions/<type>/...` to `.swamp/pulled-extensions/<type>/...`
+   * and rewrites the lockfile's `files[]` in place. Safe because the
+   * same bytes move to a new path.
+   *
+   * **Phase 2 — gen-2 → current (selective delete; re-install on next
+   * `swamp extension install`):** when lockfile entries point at the
+   * flat layout (`.swamp/pulled-extensions/<type>/<file>`), those files
+   * may have been silently overwritten by sibling extensions because
+   * filenames collide across extensions in that layout. Rename cannot
+   * restore authentic content, so phase 2 deletes each gen-2 entry's
+   * tracked files and leaves the lockfile paths unchanged — the next
+   * `swamp extension install` invocation detects missing files and
+   * re-pulls from the registry, writing to the per-extension subtree
+   * under `.swamp/pulled-extensions/<ext-name>/<type>/...`. The
+   * lockfile's stored checksum (step 7 integrity anchor) guarantees
+   * re-installed bytes match what the user originally installed.
+   *
+   * Selective delete treats `Deno.errors.NotFound` as success
+   * (already-deleted files are expected on a retry after an
+   * interrupted prior pass). Any other IO error aborts the whole
+   * migration before any further changes so the repo is never left in
+   * a worse state than it started.
    */
-  private async migrateExtensionLayout(repoPath: RepoPath): Promise<void> {
+  private async migrateExtensionLayout(
+    repoPath: RepoPath,
+  ): Promise<ExtensionLayoutMigrationSummary | undefined> {
     // Find the lockfile — use marker's modelsDir or default
     const marker = await this.markerRepo.read(repoPath);
     const modelsDir = marker?.modelsDir ?? "extensions/models";
@@ -1595,10 +1647,38 @@ export const SwampAudit: Plugin = async ({ directory }) => {
 
     const upstream = await readUpstreamExtensions(lockfilePath);
     if (Object.keys(upstream).length === 0) {
-      return; // No extensions to migrate
+      return undefined;
     }
 
-    // Check if any files use the old layout (not in .swamp/)
+    const phase1MovedCount = await this.migrateExtensionLayoutPhase1(
+      repoPath,
+      lockfilePath,
+      upstream,
+    );
+
+    // Re-read after phase 1 may have rewritten the lockfile.
+    const upstreamAfterPhase1 = await readUpstreamExtensions(lockfilePath);
+    const phase2DeletedPerExtension = await this.migrateExtensionLayoutPhase2(
+      repoPath,
+      upstreamAfterPhase1,
+    );
+
+    if (phase1MovedCount === 0 && phase2DeletedPerExtension.length === 0) {
+      return undefined;
+    }
+    return { phase1MovedCount, phase2DeletedPerExtension };
+  }
+
+  /**
+   * Phase 1: rename gen-1 paths (`extensions/<type>/...`) to gen-2
+   * paths (`.swamp/pulled-extensions/<type>/...`) and rewrite the
+   * lockfile's `files[]`.
+   */
+  private async migrateExtensionLayoutPhase1(
+    repoPath: RepoPath,
+    lockfilePath: string,
+    upstream: UpstreamExtensionsMap,
+  ): Promise<number> {
     const swampPrefix = ".swamp/";
     let hasLegacyFiles = false;
     for (const entry of Object.values(upstream)) {
@@ -1609,10 +1689,11 @@ export const SwampAudit: Plugin = async ({ directory }) => {
     }
 
     if (!hasLegacyFiles) {
-      return; // Already on new layout
+      return 0;
     }
 
-    // Mapping from old extension dir prefixes to new pulled-extension subdirs
+    let movedCount = 0;
+
     const dirMapping: Record<string, string> = {
       "extensions/models/": SWAMP_SUBDIRS.pulledModels + "/",
       "extensions/vaults/": SWAMP_SUBDIRS.pulledVaults + "/",
@@ -1622,21 +1703,16 @@ export const SwampAudit: Plugin = async ({ directory }) => {
       "extensions/reports/": SWAMP_SUBDIRS.pulledReports + "/",
     };
 
-    const gitTrackedFiles: string[] = [];
-
-    // Move files and update paths
     for (const [name, entry] of Object.entries(upstream)) {
       if (!entry.files) continue;
 
       const updatedFiles: string[] = [];
       for (const file of entry.files) {
         if (file.startsWith(swampPrefix)) {
-          // Already in .swamp/ — keep as-is (bundles, etc.)
           updatedFiles.push(file);
           continue;
         }
 
-        // Find matching dir prefix and compute new path
         let newPath: string | null = null;
         for (const [oldPrefix, newPrefix] of Object.entries(dirMapping)) {
           if (file.startsWith(oldPrefix)) {
@@ -1647,19 +1723,17 @@ export const SwampAudit: Plugin = async ({ directory }) => {
         }
 
         if (!newPath) {
-          // Unknown prefix — keep as-is but note it
           updatedFiles.push(file);
           continue;
         }
 
-        // Move the file
         const srcAbsolute = join(repoPath.value, file);
         const destAbsolute = join(repoPath.value, newPath);
 
         try {
           await ensureDir(dirname(destAbsolute));
           await Deno.rename(srcAbsolute, destAbsolute);
-          gitTrackedFiles.push(file);
+          movedCount++;
         } catch (error) {
           if (error instanceof Deno.errors.NotFound) {
             // Source file missing — already removed or never committed
@@ -1674,13 +1748,11 @@ export const SwampAudit: Plugin = async ({ directory }) => {
       upstream[name] = { ...entry, files: updatedFiles };
     }
 
-    // Write updated lockfile
     await atomicWriteTextFile(
       lockfilePath,
       JSON.stringify(upstream, null, 2) + "\n",
     );
 
-    // Prune empty directories left behind
     for (const oldPrefix of Object.keys(dirMapping)) {
       const dirPath = join(repoPath.value, oldPrefix);
       try {
@@ -1689,6 +1761,117 @@ export const SwampAudit: Plugin = async ({ directory }) => {
         // Non-fatal
       }
     }
+    return movedCount;
+  }
+
+  /**
+   * Phase 2: delete any lockfile-tracked files that live in the flat
+   * `.swamp/pulled-extensions/<type>/<file>` (gen-2) layout. Leaves
+   * the lockfile entries untouched so the next
+   * `swamp extension install` re-pulls each affected extension into
+   * the per-extension subtree.
+   *
+   * NotFound is tolerated (expected on retry after an interrupted
+   * prior pass). Any other IO error aborts with a fatal error that
+   * leaves the lockfile — our coordination primitive — intact.
+   */
+  private async migrateExtensionLayoutPhase2(
+    repoPath: RepoPath,
+    upstream: UpstreamExtensionsMap,
+  ): Promise<Array<{ name: string; fileCount: number }>> {
+    const pulledPrefix = `${SWAMP_DATA_DIR}/pulled-extensions/`;
+    const pulledTypeDirs = new Set([
+      "models",
+      "workflows",
+      "vaults",
+      "drivers",
+      "datastores",
+      "reports",
+      "skills",
+      "files",
+    ]);
+
+    // Identify gen-2 files per extension: under pulled-extensions/ with
+    // a type dir as the first path segment (vs. @scope/name for the
+    // current layout).
+    const gen2ByExtension = new Map<string, string[]>();
+    for (const [name, entry] of Object.entries(upstream)) {
+      if (!entry.files) continue;
+      for (const file of entry.files) {
+        if (!file.startsWith(pulledPrefix)) continue;
+        const firstSegment = file.slice(pulledPrefix.length).split("/")[0];
+        if (pulledTypeDirs.has(firstSegment)) {
+          const list = gen2ByExtension.get(name) ?? [];
+          list.push(file);
+          gen2ByExtension.set(name, list);
+        }
+      }
+    }
+
+    if (gen2ByExtension.size === 0) {
+      return [];
+    }
+
+    const parentDirs = new Set<string>();
+    const deletedPerExtension: Array<{ name: string; fileCount: number }> = [];
+    for (const [name, files] of gen2ByExtension) {
+      let deleted = 0;
+      for (const relPath of files) {
+        const absPath = join(repoPath.value, relPath);
+        try {
+          await Deno.remove(absPath);
+          parentDirs.add(dirname(absPath));
+          deleted++;
+        } catch (error) {
+          if (error instanceof Deno.errors.NotFound) {
+            // Already deleted by a prior interrupted migration pass — skip.
+            continue;
+          }
+          throw new UserError(
+            `Could not remove ${relPath} during extension layout migration: ${
+              error instanceof Error ? error.message : String(error)
+            }. Inspect the path, remove it manually, and re-run ` +
+              `'swamp repo upgrade'. The lockfile has not been modified.`,
+          );
+        }
+      }
+      deletedPerExtension.push({ name, fileCount: deleted });
+    }
+
+    for (const dir of parentDirs) {
+      try {
+        await this.pruneEmptyDirsUp(dir, repoPath.value);
+      } catch {
+        // Non-fatal — leave empty dirs behind rather than failing the upgrade.
+      }
+    }
+
+    // Also sweep the gen-2 type-level dirs themselves. The flat-layout
+    // pull created empty `.swamp/pulled-extensions/<type>/` shells even
+    // for types where no files were installed, which pruneEmptyDirsUp
+    // doesn't reach because nothing under them was tracked. Remove any
+    // that are now empty so post-migration users don't see stale shells.
+    for (const type of pulledTypeDirs) {
+      const typeDir = join(
+        repoPath.value,
+        SWAMP_DATA_DIR,
+        "pulled-extensions",
+        type,
+      );
+      try {
+        const entries: Deno.DirEntry[] = [];
+        for await (const entry of Deno.readDir(typeDir)) {
+          entries.push(entry);
+        }
+        if (entries.length === 0) {
+          await Deno.remove(typeDir);
+        }
+      } catch {
+        // Dir missing or non-empty — both fine, skip.
+      }
+    }
+
+    return deletedPerExtension;
   }
 
   /**

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -24,6 +24,7 @@ import {
   readUpstreamExtensions,
   type UpstreamExtensionsMap,
 } from "../../infrastructure/persistence/upstream_extensions.ts";
+import { PULLED_TYPE_DIRS } from "../../libswamp/extensions/layout.ts";
 import type { RepoPath } from "./repo_path.ts";
 import {
   SWAMP_DATA_DIR,
@@ -97,17 +98,17 @@ export interface RepoInitResult {
 /**
  * Summary of extension layout migration that ran during `repo upgrade`.
  *
- * - `phase1MovedCount`: gen-1 (`extensions/<type>/...`) files renamed to
- *   gen-2 (`.swamp/pulled-extensions/<type>/...`).
- * - `phase2DeletedPerExtension`: for each gen-2 entry detected, how many
- *   tracked files were removed from disk. The lockfile entries remain,
- *   so the next `swamp extension install` re-pulls each affected
- *   extension into the per-extension subtree with integrity verification
- *   against the lockfile's stored checksum.
+ * - `renamedFileCount`: files renamed from the pre-`.swamp/` layout
+ *   (`extensions/<type>/…`) to `.swamp/pulled-extensions/<type>/…`.
+ * - `deletedPerExtension`: per extension, how many outdated files were
+ *   removed from disk. The lockfile entries remain, so the next
+ *   `swamp extension install` re-pulls each affected extension into
+ *   the per-extension subtree with integrity verification against the
+ *   lockfile's stored checksum.
  */
 export interface ExtensionLayoutMigrationSummary {
-  phase1MovedCount: number;
-  phase2DeletedPerExtension: Array<{ name: string; fileCount: number }>;
+  renamedFileCount: number;
+  deletedPerExtension: Array<{ name: string; fileCount: number }>;
 }
 
 /**
@@ -1650,7 +1651,7 @@ export const SwampAudit: Plugin = async ({ directory }) => {
       return undefined;
     }
 
-    const phase1MovedCount = await this.migrateExtensionLayoutPhase1(
+    const renamedFileCount = await this.migrateExtensionLayoutPhase1(
       repoPath,
       lockfilePath,
       upstream,
@@ -1658,15 +1659,15 @@ export const SwampAudit: Plugin = async ({ directory }) => {
 
     // Re-read after phase 1 may have rewritten the lockfile.
     const upstreamAfterPhase1 = await readUpstreamExtensions(lockfilePath);
-    const phase2DeletedPerExtension = await this.migrateExtensionLayoutPhase2(
+    const deletedPerExtension = await this.migrateExtensionLayoutPhase2(
       repoPath,
       upstreamAfterPhase1,
     );
 
-    if (phase1MovedCount === 0 && phase2DeletedPerExtension.length === 0) {
+    if (renamedFileCount === 0 && deletedPerExtension.length === 0) {
       return undefined;
     }
-    return { phase1MovedCount, phase2DeletedPerExtension };
+    return { renamedFileCount, deletedPerExtension };
   }
 
   /**
@@ -1780,27 +1781,19 @@ export const SwampAudit: Plugin = async ({ directory }) => {
     upstream: UpstreamExtensionsMap,
   ): Promise<Array<{ name: string; fileCount: number }>> {
     const pulledPrefix = `${SWAMP_DATA_DIR}/pulled-extensions/`;
-    const pulledTypeDirs = new Set([
-      "models",
-      "workflows",
-      "vaults",
-      "drivers",
-      "datastores",
-      "reports",
-      "skills",
-      "files",
-    ]);
 
     // Identify gen-2 files per extension: under pulled-extensions/ with
     // a type dir as the first path segment (vs. @scope/name for the
-    // current layout).
+    // current layout). PULLED_TYPE_DIRS is shared with
+    // `classifyExtensionFile` in layout.ts — the two must agree on what
+    // counts as a gen-2 path.
     const gen2ByExtension = new Map<string, string[]>();
     for (const [name, entry] of Object.entries(upstream)) {
       if (!entry.files) continue;
       for (const file of entry.files) {
         if (!file.startsWith(pulledPrefix)) continue;
         const firstSegment = file.slice(pulledPrefix.length).split("/")[0];
-        if (pulledTypeDirs.has(firstSegment)) {
+        if (PULLED_TYPE_DIRS.has(firstSegment)) {
           const list = gen2ByExtension.get(name) ?? [];
           list.push(file);
           gen2ByExtension.set(name, list);
@@ -1851,7 +1844,7 @@ export const SwampAudit: Plugin = async ({ directory }) => {
     // for types where no files were installed, which pruneEmptyDirsUp
     // doesn't reach because nothing under them was tracked. Remove any
     // that are now empty so post-migration users don't see stale shells.
-    for (const type of pulledTypeDirs) {
+    for (const type of PULLED_TYPE_DIRS) {
       const typeDir = join(
         repoPath.value,
         SWAMP_DATA_DIR,

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -2171,3 +2171,293 @@ Deno.test("RepoService.upgrade with tool none skips skills and instructions", as
     assertEquals(result.settingsUpdated, false);
   });
 });
+
+// --- Extension layout phase-two migration (issue 120) ---
+//
+// These tests cover the gen-2 → per-extension migration path added in
+// issue 120: repo upgrade deletes gen-2 (flat-under-.swamp) tracked files
+// so the next `swamp extension install` can re-pull each extension into
+// a per-extension subtree. See migrateExtensionLayoutPhase2 for
+// invariants — selective delete, NotFound tolerance, abort-on-other-IO.
+
+async function seedLegacyPulledLayout(
+  tempDir: string,
+  opts: {
+    files: string[];
+    extensionName: string;
+    version: string;
+    lockfilePath: string;
+    includeSkipChecksum?: boolean;
+  },
+): Promise<void> {
+  // Seed files on disk under flat .swamp/pulled-extensions/<type>/<file>.
+  for (const rel of opts.files) {
+    const abs = join(tempDir, rel);
+    const parent = abs.slice(0, abs.lastIndexOf("/"));
+    await Deno.mkdir(parent, { recursive: true });
+    await Deno.writeTextFile(abs, `// seed for ${rel}`);
+  }
+
+  // Seed the lockfile with gen-2 file paths.
+  const parent = opts.lockfilePath.slice(0, opts.lockfilePath.lastIndexOf("/"));
+  await Deno.mkdir(parent, { recursive: true });
+  await Deno.writeTextFile(
+    opts.lockfilePath,
+    JSON.stringify(
+      {
+        [opts.extensionName]: {
+          version: opts.version,
+          pulledAt: "2026-01-01T00:00:00Z",
+          files: opts.files,
+          ...(opts.includeSkipChecksum ? {} : { checksum: "abc123" }),
+        },
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+async function initRepoForUpgrade(tempDir: string): Promise<void> {
+  // Pre-init with the current version so the upgrade path has a marker
+  // to read. Use tool:"none" to keep the setup minimal.
+  const initService = new RepoService("0.1.0");
+  await initService.init(RepoPath.create(tempDir), { tool: "none" });
+}
+
+Deno.test("RepoService.upgrade phase 2: deletes gen-2 tracked files and lockfile is preserved", async () => {
+  await withTempDir(async (tempDir) => {
+    await initRepoForUpgrade(tempDir);
+    const lockfilePath = join(
+      tempDir,
+      "extensions",
+      "models",
+      "upstream_extensions.json",
+    );
+    const files = [
+      ".swamp/pulled-extensions/models/cluster.ts",
+      ".swamp/pulled-extensions/models/_lib/aws.ts",
+      ".swamp/pulled-extensions/files/README.md",
+    ];
+    await seedLegacyPulledLayout(tempDir, {
+      files,
+      extensionName: "@fake/ext",
+      version: "2026.01.01.1",
+      lockfilePath,
+    });
+
+    const lockfileBefore = await Deno.readTextFile(lockfilePath);
+
+    const service = new RepoService("0.2.0");
+    await service.upgrade(RepoPath.create(tempDir), { tool: "none" });
+
+    // Files removed on disk
+    for (const rel of files) {
+      const abs = join(tempDir, rel);
+      let exists = true;
+      try {
+        await Deno.stat(abs);
+      } catch (err) {
+        if (err instanceof Deno.errors.NotFound) exists = false;
+        else throw err;
+      }
+      assertEquals(exists, false, `${rel} should have been deleted`);
+    }
+
+    // Lockfile unchanged — re-install path uses these paths to detect
+    // missing files and trigger re-pull.
+    const lockfileAfter = await Deno.readTextFile(lockfilePath);
+    assertEquals(lockfileAfter, lockfileBefore);
+  });
+});
+
+Deno.test("RepoService.upgrade phase 2: NotFound tolerated on retry after partial delete", async () => {
+  await withTempDir(async (tempDir) => {
+    await initRepoForUpgrade(tempDir);
+    const lockfilePath = join(
+      tempDir,
+      "extensions",
+      "models",
+      "upstream_extensions.json",
+    );
+    const files = [
+      ".swamp/pulled-extensions/models/a.ts",
+      ".swamp/pulled-extensions/models/b.ts",
+      ".swamp/pulled-extensions/models/c.ts",
+    ];
+    await seedLegacyPulledLayout(tempDir, {
+      files,
+      extensionName: "@fake/ext",
+      version: "2026.01.01.1",
+      lockfilePath,
+    });
+
+    // Simulate an interrupted prior migration pass: pre-delete the first
+    // file so phase 2 encounters NotFound for it. The migration must
+    // continue and delete the remaining files without error.
+    await Deno.remove(join(tempDir, files[0]));
+
+    const service = new RepoService("0.2.0");
+    await service.upgrade(RepoPath.create(tempDir), { tool: "none" });
+
+    for (const rel of files) {
+      let exists = true;
+      try {
+        await Deno.stat(join(tempDir, rel));
+      } catch (err) {
+        if (err instanceof Deno.errors.NotFound) exists = false;
+        else throw err;
+      }
+      assertEquals(exists, false, `${rel} should be absent post-migration`);
+    }
+  });
+});
+
+Deno.test("RepoService.upgrade phase 2: second invocation is a no-op", async () => {
+  await withTempDir(async (tempDir) => {
+    await initRepoForUpgrade(tempDir);
+    const lockfilePath = join(
+      tempDir,
+      "extensions",
+      "models",
+      "upstream_extensions.json",
+    );
+    await seedLegacyPulledLayout(tempDir, {
+      files: [".swamp/pulled-extensions/models/foo.ts"],
+      extensionName: "@fake/ext",
+      version: "2026.01.01.1",
+      lockfilePath,
+    });
+
+    const service = new RepoService("0.2.0");
+    await service.upgrade(RepoPath.create(tempDir), { tool: "none" });
+    // All tracked gen-2 files are now gone. Second upgrade sees no gen-2
+    // disk state and no lockfile churn.
+    const lockfileAfterFirst = await Deno.readTextFile(lockfilePath);
+    await service.upgrade(RepoPath.create(tempDir), { tool: "none" });
+    const lockfileAfterSecond = await Deno.readTextFile(lockfilePath);
+    assertEquals(lockfileAfterSecond, lockfileAfterFirst);
+  });
+});
+
+Deno.test("RepoService.upgrade phase 2: fatal abort on non-NotFound IO error leaves lockfile intact", async () => {
+  await withTempDir(async (tempDir) => {
+    await initRepoForUpgrade(tempDir);
+    const lockfilePath = join(
+      tempDir,
+      "extensions",
+      "models",
+      "upstream_extensions.json",
+    );
+
+    // Seed a lockfile entry that points at a "file" path that is
+    // actually a non-empty directory on disk. Deno.remove on a
+    // non-empty directory without {recursive:true} fails with an IO
+    // error that is NOT Deno.errors.NotFound — the exact case phase 2
+    // must treat as fatal.
+    const pseudoFile = ".swamp/pulled-extensions/models/stubborn.ts";
+    const pseudoFileAbs = join(tempDir, pseudoFile);
+    await Deno.mkdir(pseudoFileAbs, { recursive: true });
+    // Populate it so Deno.remove can't quietly succeed.
+    await Deno.writeTextFile(
+      join(pseudoFileAbs, "child.txt"),
+      "makes the dir non-empty",
+    );
+
+    await Deno.mkdir(join(tempDir, "extensions/models"), { recursive: true });
+    await Deno.writeTextFile(
+      lockfilePath,
+      JSON.stringify(
+        {
+          "@stubborn/ext": {
+            version: "1.0.0",
+            pulledAt: "2026-01-01T00:00:00Z",
+            files: [pseudoFile],
+            checksum: "abc",
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    const lockfileBefore = await Deno.readTextFile(lockfilePath);
+
+    const service = new RepoService("0.2.0");
+    await assertRejects(
+      () => service.upgrade(RepoPath.create(tempDir), { tool: "none" }),
+      Error,
+      "Could not remove",
+    );
+
+    // Coordination primitive — the lockfile — must be untouched so the
+    // retry after the user clears the blocker starts from a consistent
+    // state.
+    const lockfileAfter = await Deno.readTextFile(lockfilePath);
+    assertEquals(lockfileAfter, lockfileBefore);
+
+    // The pseudo-file "directory" must still be on disk (nothing was
+    // partially mutated beyond the one failed remove attempt).
+    const stat = await Deno.stat(pseudoFileAbs);
+    assertEquals(stat.isDirectory, true);
+  });
+});
+
+Deno.test("RepoService.upgrade phase 2: leaves per-extension (current) entries untouched", async () => {
+  await withTempDir(async (tempDir) => {
+    await initRepoForUpgrade(tempDir);
+    const lockfilePath = join(
+      tempDir,
+      "extensions",
+      "models",
+      "upstream_extensions.json",
+    );
+
+    // Mixed state: one extension already in current layout, one still
+    // in gen-2. Only the gen-2 one should get its files deleted.
+    const gen2File = ".swamp/pulled-extensions/models/flat.ts";
+    const currentFile =
+      ".swamp/pulled-extensions/@scope/ext/models/already-migrated.ts";
+
+    for (const rel of [gen2File, currentFile]) {
+      const abs = join(tempDir, rel);
+      const parent = abs.slice(0, abs.lastIndexOf("/"));
+      await Deno.mkdir(parent, { recursive: true });
+      await Deno.writeTextFile(abs, "// seed");
+    }
+
+    await Deno.mkdir(join(tempDir, "extensions/models"), { recursive: true });
+    await Deno.writeTextFile(
+      lockfilePath,
+      JSON.stringify(
+        {
+          "@flat/gen2": {
+            version: "1.0.0",
+            pulledAt: "2026-01-01T00:00:00Z",
+            files: [gen2File],
+            checksum: "abc",
+          },
+          "@scope/ext": {
+            version: "1.0.0",
+            pulledAt: "2026-01-01T00:00:00Z",
+            files: [currentFile],
+            checksum: "def",
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const service = new RepoService("0.2.0");
+    await service.upgrade(RepoPath.create(tempDir), { tool: "none" });
+
+    // gen2 file gone
+    await assertRejects(
+      () => Deno.stat(join(tempDir, gen2File)),
+      Deno.errors.NotFound,
+    );
+    // current-layout file retained
+    const stat = await Deno.stat(join(tempDir, currentFile));
+    assertEquals(stat.isFile, true);
+  });
+});

--- a/src/libswamp/extensions/enumerate_pulled.ts
+++ b/src/libswamp/extensions/enumerate_pulled.ts
@@ -1,0 +1,75 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join } from "@std/path";
+import { readUpstreamExtensions } from "../../infrastructure/persistence/upstream_extensions.ts";
+import { swampPath } from "../../infrastructure/persistence/paths.ts";
+
+/** Types that can appear under a per-extension subtree. */
+export type PulledExtensionType =
+  | "models"
+  | "workflows"
+  | "vaults"
+  | "drivers"
+  | "datastores"
+  | "reports"
+  | "files";
+
+/**
+ * Enumerates the per-extension type dirs for every installed pulled
+ * extension that has a per-extension on-disk subtree present.
+ *
+ * Reads upstream_extensions.json, filters to entries whose per-extension
+ * dir exists on disk (skipping extensions still in a legacy flat layout
+ * or missing altogether), and returns absolute paths sorted for
+ * deterministic output — required for sourceDirsFingerprint stability
+ * across repeat loads.
+ *
+ * Callers pass each returned path as a separate element of
+ * `additionalDirs` when invoking `UserModelLoader.loadModels` /
+ * `buildIndex`, so the loader walks each extension's subtree in
+ * isolation.
+ */
+export async function enumeratePulledExtensionDirs(
+  lockfilePath: string,
+  repoDir: string,
+  type: PulledExtensionType,
+): Promise<string[]> {
+  const upstream = await readUpstreamExtensions(lockfilePath);
+  const pulledRoot = swampPath(repoDir, "pulled-extensions");
+  const dirs: string[] = [];
+
+  for (const name of Object.keys(upstream)) {
+    const candidate = join(pulledRoot, name, type);
+    try {
+      const stat = await Deno.stat(candidate);
+      if (stat.isDirectory) {
+        dirs.push(candidate);
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  dirs.sort();
+  return dirs;
+}

--- a/src/libswamp/extensions/enumerate_pulled_test.ts
+++ b/src/libswamp/extensions/enumerate_pulled_test.ts
@@ -1,0 +1,207 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { enumeratePulledExtensionDirs } from "./enumerate_pulled.ts";
+
+async function seedLockfile(
+  repoDir: string,
+  entries: Record<string, { version: string; files?: string[] }>,
+): Promise<string> {
+  const lockfilePath = join(repoDir, "upstream_extensions.json");
+  const map: Record<string, unknown> = {};
+  for (const [name, { version, files }] of Object.entries(entries)) {
+    map[name] = {
+      version,
+      pulledAt: "2026-01-01T00:00:00Z",
+      ...(files ? { files } : {}),
+    };
+  }
+  await Deno.writeTextFile(lockfilePath, JSON.stringify(map, null, 2));
+  return lockfilePath;
+}
+
+Deno.test("enumeratePulledExtensionDirs: returns empty when lockfile missing", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = join(tmpDir, "upstream_extensions.json");
+    const dirs = await enumeratePulledExtensionDirs(
+      lockfilePath,
+      tmpDir,
+      "models",
+    );
+    assertEquals(dirs, []);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("enumeratePulledExtensionDirs: returns only dirs that exist on disk", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = await seedLockfile(tmpDir, {
+      "@fake/a": { version: "1.0.0" },
+      "@fake/b": { version: "1.0.0" },
+    });
+    // Create only @fake/a's models dir
+    await ensureDir(
+      join(tmpDir, ".swamp/pulled-extensions/@fake/a/models"),
+    );
+
+    const dirs = await enumeratePulledExtensionDirs(
+      lockfilePath,
+      tmpDir,
+      "models",
+    );
+    assertEquals(dirs, [
+      join(tmpDir, ".swamp/pulled-extensions/@fake/a/models"),
+    ]);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("enumeratePulledExtensionDirs: sorts output deterministically", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = await seedLockfile(tmpDir, {
+      "@fake/z": { version: "1.0.0" },
+      "@fake/a": { version: "1.0.0" },
+      "@fake/m": { version: "1.0.0" },
+    });
+    for (const name of ["@fake/z", "@fake/a", "@fake/m"]) {
+      await ensureDir(
+        join(tmpDir, ".swamp/pulled-extensions", name, "workflows"),
+      );
+    }
+
+    const dirs = await enumeratePulledExtensionDirs(
+      lockfilePath,
+      tmpDir,
+      "workflows",
+    );
+    assertEquals(dirs, [
+      join(tmpDir, ".swamp/pulled-extensions/@fake/a/workflows"),
+      join(tmpDir, ".swamp/pulled-extensions/@fake/m/workflows"),
+      join(tmpDir, ".swamp/pulled-extensions/@fake/z/workflows"),
+    ]);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("enumeratePulledExtensionDirs: same lockfile → same result (stable)", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = await seedLockfile(tmpDir, {
+      "@fake/a": { version: "1.0.0" },
+      "@fake/b": { version: "2.0.0" },
+    });
+    for (const name of ["@fake/a", "@fake/b"]) {
+      await ensureDir(
+        join(tmpDir, ".swamp/pulled-extensions", name, "models"),
+      );
+    }
+
+    const first = await enumeratePulledExtensionDirs(
+      lockfilePath,
+      tmpDir,
+      "models",
+    );
+    const second = await enumeratePulledExtensionDirs(
+      lockfilePath,
+      tmpDir,
+      "models",
+    );
+    assertEquals(first, second);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("enumeratePulledExtensionDirs: version bump → paths unchanged (name-keyed, not version-keyed)", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = await seedLockfile(tmpDir, {
+      "@fake/a": { version: "1.0.0" },
+    });
+    await ensureDir(
+      join(tmpDir, ".swamp/pulled-extensions/@fake/a/models"),
+    );
+
+    const before = await enumeratePulledExtensionDirs(
+      lockfilePath,
+      tmpDir,
+      "models",
+    );
+
+    // Bump version in lockfile
+    await seedLockfile(tmpDir, {
+      "@fake/a": { version: "2.0.0" },
+    });
+
+    const after = await enumeratePulledExtensionDirs(
+      lockfilePath,
+      tmpDir,
+      "models",
+    );
+
+    assertEquals(before, after);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("enumeratePulledExtensionDirs: adding extension changes result", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = await seedLockfile(tmpDir, {
+      "@fake/a": { version: "1.0.0" },
+    });
+    await ensureDir(
+      join(tmpDir, ".swamp/pulled-extensions/@fake/a/models"),
+    );
+
+    const before = await enumeratePulledExtensionDirs(
+      lockfilePath,
+      tmpDir,
+      "models",
+    );
+    assertEquals(before.length, 1);
+
+    await seedLockfile(tmpDir, {
+      "@fake/a": { version: "1.0.0" },
+      "@fake/b": { version: "1.0.0" },
+    });
+    await ensureDir(
+      join(tmpDir, ".swamp/pulled-extensions/@fake/b/models"),
+    );
+
+    const after = await enumeratePulledExtensionDirs(
+      lockfilePath,
+      tmpDir,
+      "models",
+    );
+    assertEquals(after.length, 2);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});

--- a/src/libswamp/extensions/install.ts
+++ b/src/libswamp/extensions/install.ts
@@ -100,6 +100,14 @@ export async function* extensionInstall(
 
         try {
           const installCtx = deps.createInstallContext(name, version);
+          // Thread the lockfile's stored checksum through as an integrity
+          // anchor. installExtension verifies the freshly-downloaded archive
+          // matches byte-for-byte and fails loudly on registry drift.
+          // Pre-checksum-tracking entries (pre-f4dfc083) have no stored
+          // value and skip verification (handled in installExtension).
+          if (entry.checksum) {
+            installCtx.expectedChecksum = entry.checksum;
+          }
           const ref = parseExtensionRef(`${name}@${version}`);
           await installExtension(ref, installCtx);
           entries.push({ name, version, status: "installed" });

--- a/src/libswamp/extensions/install_test.ts
+++ b/src/libswamp/extensions/install_test.ts
@@ -138,15 +138,6 @@ Deno.test("extensionInstall: detects missing files and calls install", async () 
             downloadArchive: () => Promise.reject(new Error("test stub")),
             getChecksum: () => Promise.resolve(null),
             lockfilePath,
-            modelsDir: join(tmpDir, ".swamp/pulled-extensions/models"),
-            workflowsDir: join(tmpDir, ".swamp/pulled-extensions/workflows"),
-            vaultsDir: join(tmpDir, ".swamp/pulled-extensions/vaults"),
-            driversDir: join(tmpDir, ".swamp/pulled-extensions/drivers"),
-            datastoresDir: join(
-              tmpDir,
-              ".swamp/pulled-extensions/datastores",
-            ),
-            reportsDir: join(tmpDir, ".swamp/pulled-extensions/reports"),
             skillsDir: join(tmpDir, ".swamp/pulled-extensions/skills"),
             repoDir: tmpDir,
             force: true,
@@ -199,6 +190,74 @@ Deno.test("extensionInstall: missing lockfile yields empty result", async () => 
     assertEquals(completed?.kind, "completed");
     if (completed?.kind === "completed") {
       assertEquals(completed.data.entries.length, 0);
+    }
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extensionInstall: lockfile-anchored checksum mismatch fails with drift message", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    // Seed a lockfile pointing at files that don't exist on disk (so
+    // hasAnyMissingFiles triggers the install path) with a stored
+    // checksum that will not match the "fresh download" bytes.
+    const lockfilePath = join(tmpDir, "upstream_extensions.json");
+    await Deno.writeTextFile(
+      lockfilePath,
+      JSON.stringify({
+        "@fake/ext": {
+          version: "1.0.0",
+          pulledAt: "2026-01-01T00:00:00Z",
+          // SHA-256 this value will never match our stub's bytes.
+          checksum: "0".repeat(64),
+          files: [".swamp/pulled-extensions/@fake/ext/models/missing.ts"],
+        },
+      }),
+    );
+
+    // Stub downloadArchive returns bytes that — when SHA-256'd — won't
+    // match the stored checksum. installExtension must throw BEFORE
+    // attempting tar extraction, so the nonsense bytes never matter.
+    const ctx = createLibSwampContext({});
+    const events = await collectEvents(
+      extensionInstall(ctx, {
+        lockfilePath,
+        repoDir: tmpDir,
+        createInstallContext: () => ({
+          getExtension: () =>
+            Promise.resolve({
+              name: "@fake/ext",
+              description: "test",
+              latestVersion: "1.0.0",
+            }),
+          downloadArchive: () =>
+            Promise.resolve(new TextEncoder().encode("drifted content")),
+          getChecksum: () => Promise.resolve(null),
+          lockfilePath,
+          skillsDir: "unused",
+          repoDir: tmpDir,
+          force: true,
+          alreadyPulled: new Set<string>(),
+          depth: 0,
+        }),
+      }),
+    );
+
+    const completed = events.find((e) => e.kind === "completed");
+    assertEquals(completed?.kind, "completed");
+    if (completed?.kind === "completed") {
+      assertEquals(completed.data.failed, 1);
+      assertEquals(completed.data.entries[0].status, "failed");
+      // Error should name checksum, stored, fetched, and offer the
+      // user-recovery hint (pull to accept).
+      const err = completed.data.entries[0].error ?? "";
+      if (!err.includes("Checksum mismatch")) {
+        throw new Error(`expected drift message, got: ${err}`);
+      }
+      if (!err.includes("'swamp extension pull @fake/ext'")) {
+        throw new Error(`expected recovery hint, got: ${err}`);
+      }
     }
   } finally {
     await Deno.remove(tmpDir, { recursive: true });

--- a/src/libswamp/extensions/layout.ts
+++ b/src/libswamp/extensions/layout.ts
@@ -39,8 +39,13 @@ export interface LegacyFileEntry {
   generation: "gen-1" | "gen-2";
 }
 
-/** Known pulled-type dir names under `.swamp/pulled-extensions/`. */
-const PULLED_TYPE_DIRS = new Set([
+/**
+ * Known pulled-type dir names under `.swamp/pulled-extensions/`. Used
+ * both by `classifyExtensionFile` (to detect gen-2 flat paths) and by
+ * the phase-two migration in `RepoService` (to decide which tracked
+ * files to delete). Keep this list in one place so the two never drift.
+ */
+export const PULLED_TYPE_DIRS: ReadonlySet<string> = new Set([
   "models",
   "workflows",
   "vaults",

--- a/src/libswamp/extensions/layout.ts
+++ b/src/libswamp/extensions/layout.ts
@@ -19,53 +19,180 @@
 
 import { SWAMP_DATA_DIR } from "../../infrastructure/persistence/paths.ts";
 import { readUpstreamExtensions } from "../../infrastructure/persistence/upstream_extensions.ts";
-import { UserError } from "../../domain/errors.ts";
 
 /**
- * Detects whether a repository has pulled extensions in the legacy layout
- * (files in extensions/{type}/ instead of .swamp/pulled-extensions/{type}/).
+ * Generation of an on-disk extension layout.
  *
- * Checks the upstream_extensions.json lockfile for file paths that don't
- * start with the .swamp/ prefix, indicating the old layout.
+ * - `gen-1`: files in `extensions/<type>/…` (pre-`.swamp/`).
+ * - `gen-2`: files in `.swamp/pulled-extensions/<type>/…` — the "flat"
+ *   layout where types sit at the top and filenames collide across
+ *   extensions.
+ * - `current`: files in `.swamp/pulled-extensions/<@scope>/<name>/<type>/…`
+ *   — per-extension subtree, no cross-extension collisions.
+ */
+export type ExtensionLayoutGeneration = "gen-1" | "gen-2" | "current";
+
+/** A single lockfile file entry classified by generation. */
+export interface LegacyFileEntry {
+  extensionName: string;
+  file: string;
+  generation: "gen-1" | "gen-2";
+}
+
+/** Known pulled-type dir names under `.swamp/pulled-extensions/`. */
+const PULLED_TYPE_DIRS = new Set([
+  "models",
+  "workflows",
+  "vaults",
+  "drivers",
+  "datastores",
+  "reports",
+  "skills",
+  "files",
+]);
+
+const PULLED_PREFIX = `${SWAMP_DATA_DIR}/pulled-extensions/`;
+
+/**
+ * Classifies a single lockfile file path.
+ *
+ * - Returns `"gen-1"` when the path lives outside `.swamp/` (pre-`.swamp/`
+ *   layout, e.g. `extensions/models/foo.ts`).
+ * - Returns `"gen-2"` when the path lives under
+ *   `.swamp/pulled-extensions/<type>/...` where `<type>` is a known
+ *   pulled-type dir — the "flat" layout where filenames collide across
+ *   extensions.
+ * - Returns `"current"` for the per-extension subtree
+ *   (`.swamp/pulled-extensions/@<scope>/...`) and for paths outside
+ *   `pulled-extensions/` entirely (bundles, etc.).
+ */
+export function classifyExtensionFile(file: string): ExtensionLayoutGeneration {
+  if (!file.startsWith(`${SWAMP_DATA_DIR}/`)) {
+    return "gen-1";
+  }
+  if (!file.startsWith(PULLED_PREFIX)) {
+    return "current";
+  }
+  const firstSegment = file.slice(PULLED_PREFIX.length).split("/")[0];
+  if (PULLED_TYPE_DIRS.has(firstSegment)) {
+    return "gen-2";
+  }
+  return "current";
+}
+
+/**
+ * Detects whether a repository has pulled extensions in any legacy layout.
+ *
+ * Reads `upstream_extensions.json` and classifies each tracked file.
+ * Returns a flat list of legacy entries (both gen-1 and gen-2) with their
+ * generation tag so the upgrade migrator can branch.
  *
  * @param lockfilePath Full path to upstream_extensions.json
- * @returns List of legacy file paths, or empty array if layout is current
  */
 export async function detectLegacyExtensionLayout(
   lockfilePath: string,
-): Promise<string[]> {
+): Promise<LegacyFileEntry[]> {
   const upstream = await readUpstreamExtensions(lockfilePath);
-  const legacyFiles: string[] = [];
+  const legacy: LegacyFileEntry[] = [];
 
-  for (const [_name, entry] of Object.entries(upstream)) {
+  for (const [name, entry] of Object.entries(upstream)) {
     if (!entry.files) continue;
     for (const file of entry.files) {
-      // Files in the new layout start with .swamp/
-      // Bundle files already live in .swamp/ and are fine
-      if (!file.startsWith(`${SWAMP_DATA_DIR}/`)) {
-        legacyFiles.push(file);
+      const generation = classifyExtensionFile(file);
+      if (generation === "gen-1" || generation === "gen-2") {
+        legacy.push({ extensionName: name, file, generation });
       }
     }
   }
 
-  return legacyFiles;
+  return legacy;
 }
 
 /**
- * Checks for legacy extension layout and throws a UserError if detected.
- * Call this at the start of extension commands to prevent operations on
- * repos that haven't been migrated.
+ * Emits a structured summary of legacy state suitable for renderer
+ * consumption: per-extension set of flagged files and the generations
+ * represented.
+ */
+export interface LegacyLayoutSummary {
+  /** Names of extensions whose lockfile entries reference legacy paths. */
+  extensionNames: string[];
+  /** Total count of flagged file entries across all extensions. */
+  fileCount: number;
+  /** Which legacy generations are present. */
+  generations: Set<"gen-1" | "gen-2">;
+}
+
+/**
+ * Summarises detectLegacyExtensionLayout output into the shape that CLI
+ * commands and the renderer prefer.
+ */
+export function summariseLegacyLayout(
+  legacy: LegacyFileEntry[],
+): LegacyLayoutSummary {
+  const names = new Set<string>();
+  const generations = new Set<"gen-1" | "gen-2">();
+  for (const entry of legacy) {
+    names.add(entry.extensionName);
+    generations.add(entry.generation);
+  }
+  return {
+    extensionNames: [...names].sort(),
+    fileCount: legacy.length,
+    generations,
+  };
+}
+
+/**
+ * Logs a warning when any pulled-extension entries are in a legacy layout.
+ *
+ * Prior versions threw here to hard-block extension commands until the
+ * user ran `swamp repo upgrade`. That was the right call when migration
+ * was rename-based and had to move everything atomically. The current
+ * migration path is per-extension (re-install from the lockfile), so the
+ * lockfile tolerates mixed-generation state and individual extensions can
+ * be upgraded in any order. Commands proceed normally — they operate on
+ * whatever paths the lockfile records — so extensions already in the new
+ * layout stay usable even when others are pending migration.
  *
  * @param lockfilePath Full path to upstream_extensions.json
+ * @param warn Invoked with a short human-readable message when legacy
+ *   entries exist. Callers typically wire this to their logger's warn
+ *   channel.
+ * @returns The legacy summary, or `undefined` if everything is current.
+ */
+export async function warnLegacyExtensionLayout(
+  lockfilePath: string,
+  warn: (message: string) => void,
+): Promise<LegacyLayoutSummary | undefined> {
+  const legacy = await detectLegacyExtensionLayout(lockfilePath);
+  if (legacy.length === 0) return undefined;
+  const summary = summariseLegacyLayout(legacy);
+  warn(
+    `${summary.extensionNames.length} extension(s) pending migration. ` +
+      `Run 'swamp repo upgrade' to complete.`,
+  );
+  return summary;
+}
+
+/**
+ * Backwards-compatible alias that retains the old throw-on-legacy shape
+ * for any caller that still depends on a hard-gate. New code should use
+ * `warnLegacyExtensionLayout`. Kept to keep the migration window's diff
+ * small — remove in a follow-up once all call sites have moved over.
+ *
+ * @deprecated Prefer `warnLegacyExtensionLayout` — the lockfile tolerates
+ *   mixed-generation state.
  */
 export async function requireCurrentExtensionLayout(
   lockfilePath: string,
 ): Promise<void> {
-  const legacyFiles = await detectLegacyExtensionLayout(lockfilePath);
-  if (legacyFiles.length > 0) {
-    throw new UserError(
-      `This repo has pulled extensions in the old layout (extensions/).\n` +
-        `Run 'swamp repo upgrade' to migrate them to .swamp/pulled-extensions/.`,
-    );
-  }
+  const legacy = await detectLegacyExtensionLayout(lockfilePath);
+  if (legacy.length === 0) return;
+  const summary = summariseLegacyLayout(legacy);
+  const msg =
+    `${summary.extensionNames.length} extension(s) pending migration. ` +
+    `Run 'swamp repo upgrade' to complete.`;
+  // Lazy import to avoid circular deps with UserError consumers.
+  const { UserError } = await import("../../domain/errors.ts");
+  throw new UserError(msg);
 }

--- a/src/libswamp/extensions/layout_test.ts
+++ b/src/libswamp/extensions/layout_test.ts
@@ -20,80 +20,285 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import { join } from "@std/path";
 import {
+  classifyExtensionFile,
   detectLegacyExtensionLayout,
   requireCurrentExtensionLayout,
+  summariseLegacyLayout,
+  warnLegacyExtensionLayout,
 } from "./layout.ts";
 import { UserError } from "../../domain/errors.ts";
 
-Deno.test("detectLegacyExtensionLayout: returns empty for new layout", async () => {
+Deno.test("classifyExtensionFile: pre-.swamp path is gen-1", () => {
+  assertEquals(classifyExtensionFile("extensions/models/foo.ts"), "gen-1");
+  assertEquals(classifyExtensionFile("extensions/vaults/bar.ts"), "gen-1");
+});
+
+Deno.test("classifyExtensionFile: flat under .swamp is gen-2", () => {
+  assertEquals(
+    classifyExtensionFile(".swamp/pulled-extensions/models/foo.ts"),
+    "gen-2",
+  );
+  assertEquals(
+    classifyExtensionFile(".swamp/pulled-extensions/workflows/foo.yaml"),
+    "gen-2",
+  );
+  assertEquals(
+    classifyExtensionFile(".swamp/pulled-extensions/vaults/sub/bar.ts"),
+    "gen-2",
+  );
+});
+
+Deno.test("classifyExtensionFile: per-extension subtree is current", () => {
+  assertEquals(
+    classifyExtensionFile(
+      ".swamp/pulled-extensions/@stack72/ubiquity/models/unifi_traffic.ts",
+    ),
+    "current",
+  );
+  assertEquals(
+    classifyExtensionFile(
+      ".swamp/pulled-extensions/@swamp/aws/ec2/models/_lib/aws.ts",
+    ),
+    "current",
+  );
+  assertEquals(
+    classifyExtensionFile(
+      ".swamp/pulled-extensions/@swamp/aws/ec2/manifest.yaml",
+    ),
+    "current",
+  );
+});
+
+Deno.test("classifyExtensionFile: .swamp paths outside pulled-extensions are current", () => {
+  assertEquals(
+    classifyExtensionFile(".swamp/bundles/abc123/foo.js"),
+    "current",
+  );
+  assertEquals(
+    classifyExtensionFile(".swamp/bundles/abc123/@scope/name/foo.js"),
+    "current",
+  );
+});
+
+Deno.test("detectLegacyExtensionLayout: returns empty for current layout", async () => {
   const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
   try {
     const lockfilePath = join(tmpDir, "upstream_extensions.json");
     await Deno.writeTextFile(
       lockfilePath,
       JSON.stringify({
-        "@test/ext": {
+        "@scope/ext": {
           version: "1.0.0",
           pulledAt: "2026-01-01T00:00:00Z",
           files: [
-            ".swamp/pulled-extensions/models/ext.ts",
-            ".swamp/bundles/ext.js",
+            ".swamp/pulled-extensions/@scope/ext/models/foo.ts",
+            ".swamp/pulled-extensions/@scope/ext/manifest.yaml",
+            ".swamp/bundles/abc123/foo.js",
           ],
         },
       }),
     );
 
-    const legacyFiles = await detectLegacyExtensionLayout(lockfilePath);
-    assertEquals(legacyFiles, []);
+    const legacy = await detectLegacyExtensionLayout(lockfilePath);
+    assertEquals(legacy, []);
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
 
-Deno.test("detectLegacyExtensionLayout: detects old layout files", async () => {
+Deno.test("detectLegacyExtensionLayout: detects gen-1 paths", async () => {
   const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
   try {
     const lockfilePath = join(tmpDir, "upstream_extensions.json");
     await Deno.writeTextFile(
       lockfilePath,
       JSON.stringify({
-        "@test/ext": {
+        "@scope/ext": {
           version: "1.0.0",
           pulledAt: "2026-01-01T00:00:00Z",
           files: [
             "extensions/models/ext.ts",
-            ".swamp/bundles/ext.js",
+            ".swamp/bundles/abc123/ext.js",
           ],
         },
       }),
     );
 
-    const legacyFiles = await detectLegacyExtensionLayout(lockfilePath);
-    assertEquals(legacyFiles, ["extensions/models/ext.ts"]);
+    const legacy = await detectLegacyExtensionLayout(lockfilePath);
+    assertEquals(legacy.length, 1);
+    assertEquals(legacy[0].extensionName, "@scope/ext");
+    assertEquals(legacy[0].file, "extensions/models/ext.ts");
+    assertEquals(legacy[0].generation, "gen-1");
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
 
-Deno.test("detectLegacyExtensionLayout: returns empty when no lockfile", async () => {
-  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
-  try {
-    const lockfilePath = join(tmpDir, "upstream_extensions.json");
-    const legacyFiles = await detectLegacyExtensionLayout(lockfilePath);
-    assertEquals(legacyFiles, []);
-  } finally {
-    await Deno.remove(tmpDir, { recursive: true });
-  }
-});
-
-Deno.test("requireCurrentExtensionLayout: throws on legacy layout", async () => {
+Deno.test("detectLegacyExtensionLayout: detects gen-2 flat-under-.swamp paths", async () => {
   const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
   try {
     const lockfilePath = join(tmpDir, "upstream_extensions.json");
     await Deno.writeTextFile(
       lockfilePath,
       JSON.stringify({
-        "@test/ext": {
+        "@swamp/aws/ec2": {
+          version: "2026.04.03.2",
+          pulledAt: "2026-04-03T00:00:00Z",
+          files: [
+            ".swamp/pulled-extensions/models/_lib/aws.ts",
+            ".swamp/pulled-extensions/models/README.md",
+          ],
+        },
+      }),
+    );
+
+    const legacy = await detectLegacyExtensionLayout(lockfilePath);
+    assertEquals(legacy.length, 2);
+    for (const entry of legacy) {
+      assertEquals(entry.extensionName, "@swamp/aws/ec2");
+      assertEquals(entry.generation, "gen-2");
+    }
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("detectLegacyExtensionLayout: mixed generations in one lockfile", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = join(tmpDir, "upstream_extensions.json");
+    await Deno.writeTextFile(
+      lockfilePath,
+      JSON.stringify({
+        "@old/gen1": {
+          version: "1.0.0",
+          pulledAt: "2026-01-01T00:00:00Z",
+          files: ["extensions/models/old.ts"],
+        },
+        "@flat/gen2": {
+          version: "1.0.0",
+          pulledAt: "2026-01-01T00:00:00Z",
+          files: [".swamp/pulled-extensions/models/flat.ts"],
+        },
+        "@per/current": {
+          version: "1.0.0",
+          pulledAt: "2026-01-01T00:00:00Z",
+          files: [".swamp/pulled-extensions/@per/current/models/ok.ts"],
+        },
+      }),
+    );
+
+    const legacy = await detectLegacyExtensionLayout(lockfilePath);
+    assertEquals(legacy.length, 2);
+    const byGen = new Map(legacy.map((e) => [e.generation, e]));
+    assertEquals(byGen.get("gen-1")?.extensionName, "@old/gen1");
+    assertEquals(byGen.get("gen-2")?.extensionName, "@flat/gen2");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("detectLegacyExtensionLayout: returns empty when lockfile missing", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = join(tmpDir, "upstream_extensions.json");
+    const legacy = await detectLegacyExtensionLayout(lockfilePath);
+    assertEquals(legacy, []);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("summariseLegacyLayout: deduplicates extension names and collects generations", () => {
+  const summary = summariseLegacyLayout([
+    {
+      extensionName: "@a/b",
+      file: "extensions/models/foo.ts",
+      generation: "gen-1",
+    },
+    {
+      extensionName: "@a/b",
+      file: "extensions/models/bar.ts",
+      generation: "gen-1",
+    },
+    {
+      extensionName: "@c/d",
+      file: ".swamp/pulled-extensions/models/foo.ts",
+      generation: "gen-2",
+    },
+  ]);
+  assertEquals(summary.extensionNames, ["@a/b", "@c/d"]);
+  assertEquals(summary.fileCount, 3);
+  assertEquals(summary.generations.has("gen-1"), true);
+  assertEquals(summary.generations.has("gen-2"), true);
+});
+
+Deno.test("warnLegacyExtensionLayout: warns on legacy, returns summary", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = join(tmpDir, "upstream_extensions.json");
+    await Deno.writeTextFile(
+      lockfilePath,
+      JSON.stringify({
+        "@scope/ext": {
+          version: "1.0.0",
+          pulledAt: "2026-01-01T00:00:00Z",
+          files: [".swamp/pulled-extensions/models/foo.ts"],
+        },
+      }),
+    );
+
+    const messages: string[] = [];
+    const summary = await warnLegacyExtensionLayout(
+      lockfilePath,
+      (msg) => messages.push(msg),
+    );
+    assertEquals(summary?.extensionNames, ["@scope/ext"]);
+    assertEquals(messages.length, 1);
+    assertEquals(
+      messages[0],
+      "1 extension(s) pending migration. Run 'swamp repo upgrade' to complete.",
+    );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("warnLegacyExtensionLayout: silent when layout is current", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = join(tmpDir, "upstream_extensions.json");
+    await Deno.writeTextFile(
+      lockfilePath,
+      JSON.stringify({
+        "@scope/ext": {
+          version: "1.0.0",
+          pulledAt: "2026-01-01T00:00:00Z",
+          files: [".swamp/pulled-extensions/@scope/ext/models/foo.ts"],
+        },
+      }),
+    );
+
+    const messages: string[] = [];
+    const summary = await warnLegacyExtensionLayout(
+      lockfilePath,
+      (msg) => messages.push(msg),
+    );
+    assertEquals(summary, undefined);
+    assertEquals(messages, []);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("requireCurrentExtensionLayout: throws on legacy (backwards compat)", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = join(tmpDir, "upstream_extensions.json");
+    await Deno.writeTextFile(
+      lockfilePath,
+      JSON.stringify({
+        "@scope/ext": {
           version: "1.0.0",
           pulledAt: "2026-01-01T00:00:00Z",
           files: ["extensions/models/ext.ts"],
@@ -104,7 +309,7 @@ Deno.test("requireCurrentExtensionLayout: throws on legacy layout", async () => 
     await assertRejects(
       () => requireCurrentExtensionLayout(lockfilePath),
       UserError,
-      "old layout",
+      "pending migration",
     );
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
@@ -118,15 +323,13 @@ Deno.test("requireCurrentExtensionLayout: passes on current layout", async () =>
     await Deno.writeTextFile(
       lockfilePath,
       JSON.stringify({
-        "@test/ext": {
+        "@scope/ext": {
           version: "1.0.0",
           pulledAt: "2026-01-01T00:00:00Z",
-          files: [".swamp/pulled-extensions/models/ext.ts"],
+          files: [".swamp/pulled-extensions/@scope/ext/models/foo.ts"],
         },
       }),
     );
-
-    // Should not throw
     await requireCurrentExtensionLayout(lockfilePath);
   } finally {
     await Deno.remove(tmpDir, { recursive: true });

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -79,7 +79,18 @@ export interface InstallResult {
   dependencyResults: InstallResult[];
 }
 
-/** Context for the headless install function (internal, used by extension_update). */
+/**
+ * Context for the headless install function (internal, used by
+ * extension_update, extensionInstall, and extensionPull).
+ *
+ * Per-type destination dirs (models/workflows/vaults/drivers/
+ * datastores/reports) are deliberately NOT fields on this context —
+ * `installExtension` derives them itself as
+ * `.swamp/pulled-extensions/<ref.name>/<type>/` so filesystem state is
+ * strictly per-extension (issue 120). Only `skillsDir` remains because
+ * skills land in a tool-specific dir (`.claude/skills/`, etc.) that
+ * the caller owns.
+ */
 export interface InstallContext {
   getExtension: (name: string) => Promise<ExtensionRegistryInfo | null>;
   downloadArchive: (name: string, version: string) => Promise<Uint8Array>;
@@ -90,17 +101,21 @@ export interface InstallContext {
   logger?: Logger;
   /** Full path to the upstream_extensions.json lockfile. */
   lockfilePath: string;
-  modelsDir: string;
-  workflowsDir: string;
-  vaultsDir: string;
-  driversDir: string;
-  datastoresDir: string;
-  reportsDir: string;
+  /** Tool-aware skills destination (e.g. `.claude/skills/`). */
   skillsDir: string;
   repoDir: string;
   force: boolean;
   alreadyPulled: Set<string>;
   depth: number;
+  /**
+   * Optional lockfile-anchored integrity check. When set, installExtension
+   * verifies the downloaded archive's SHA-256 matches this value BEFORE
+   * extraction and throws a UserError on mismatch. Scoped strictly to the
+   * lockfile-restore path (extensionInstall, migration re-pull) — explicit
+   * `swamp extension pull` leaves this unset so the user opts into
+   * whatever bytes the registry currently serves.
+   */
+  expectedChecksum?: string;
 }
 
 /** Thrown when file conflicts are detected and force is false. */
@@ -134,12 +149,7 @@ export interface ExtensionPullDeps {
   getChecksum: (name: string, version: string) => Promise<string | null>;
   /** Full path to the upstream_extensions.json lockfile. */
   lockfilePath: string;
-  modelsDir: string;
-  workflowsDir: string;
-  vaultsDir: string;
-  driversDir: string;
-  datastoresDir: string;
-  reportsDir: string;
+  /** Tool-aware skills destination (e.g. `.claude/skills/`). */
   skillsDir: string;
   repoDir: string;
   alreadyPulled: Set<string>;
@@ -420,6 +430,11 @@ async function validateNoSymlinkEscape(
 
 /**
  * Detects files that already exist at target paths.
+ *
+ * Under the extension-first layout, every dir passed in is per-extension,
+ * so a non-empty return means this extension is being re-installed on top
+ * of itself (resolved by --force) — it never means a collision with a
+ * different extension.
  */
 export async function detectConflicts(
   extractDir: string,
@@ -435,6 +450,7 @@ export async function detectConflicts(
   datastoreBundlesDir?: string,
   reportsDir?: string,
   reportBundlesDir?: string,
+  filesDir?: string,
 ): Promise<string[]> {
   const conflicts: string[] = [];
 
@@ -552,12 +568,14 @@ export async function detectConflicts(
     }
   }
 
-  const filesSrc = join(extractDir, "files");
-  for (const file of await listFiles(filesSrc)) {
-    const relPath = relative(filesSrc, file);
-    const destPath = join(modelsDir, relPath);
-    if (await fileExists(destPath)) {
-      conflicts.push(relative(repoDir, destPath));
+  if (filesDir) {
+    const filesSrc = join(extractDir, "files");
+    for (const file of await listFiles(filesSrc)) {
+      const relPath = relative(filesSrc, file);
+      const destPath = join(filesDir, relPath);
+      if (await fileExists(destPath)) {
+        conflicts.push(relative(repoDir, destPath));
+      }
     }
   }
 
@@ -630,7 +648,7 @@ export async function installExtension(
   ref: ExtensionRef,
   ctx: InstallContext,
 ): Promise<InstallResult | undefined> {
-  const { logger, modelsDir, repoDir } = ctx;
+  const { logger, repoDir } = ctx;
 
   if (ctx.alreadyPulled.has(ref.name)) {
     return undefined;
@@ -671,6 +689,35 @@ export async function installExtension(
     integrityStatus = "verified";
   } else {
     integrityStatus = "unverified";
+  }
+
+  // Lockfile-anchored integrity check. When expectedChecksum is provided
+  // (lockfile-restore flows: extensionInstall, migration re-pull), verify
+  // the freshly-downloaded bytes match what was recorded when the user
+  // originally installed this version. This catches registry content drift
+  // between the user's original install and their upgrade/reinstall and
+  // lets us restore authentic per-extension content during migration.
+  if (ctx.expectedChecksum !== undefined) {
+    if (ctx.expectedChecksum !== localChecksum) {
+      throw new UserError(
+        `Checksum mismatch for ${ref.name}@${version} ` +
+          `(stored ${ctx.expectedChecksum}, fetched ${localChecksum}). ` +
+          `The registry content has changed since your original install. ` +
+          `Run 'swamp extension pull ${ref.name}' to accept the current ` +
+          `version, or 'swamp extension pull ${ref.name}@<pinned-version>' ` +
+          `to hold a specific release.`,
+      );
+    }
+    integrityStatus = "verified";
+    if (logger) {
+      logger.debug`Lockfile integrity verified for ${ref.name}@${version}`;
+    }
+  } else if (logger) {
+    // Pre-checksum-tracking lockfile entries (pre-f4dfc083) have no stored
+    // checksum; verification is skipped. Subsequent installs write a fresh
+    // checksum so future restores gain full integrity coverage.
+    logger
+      .debug`No stored checksum for ${ref.name}@${version}; skipping lockfile-anchored verification`;
   }
 
   const tmpDir = await Deno.makeTempDir({ prefix: "swamp_pull_" });
@@ -778,14 +825,25 @@ export async function installExtension(
       safetyWarnings.push(...safetyResult.warnings);
     }
 
-    const absoluteModelsDir = resolve(repoDir, modelsDir);
-    const absoluteWorkflowsDir = resolve(repoDir, ctx.workflowsDir);
-    const absoluteVaultsDir = resolve(repoDir, ctx.vaultsDir);
-    const absoluteDriversDir = resolve(repoDir, ctx.driversDir);
-    const absoluteDatastoresDir = resolve(repoDir, ctx.datastoresDir);
-    const absoluteReportsDir = resolve(repoDir, ctx.reportsDir);
-    // Namespace bundles by source directory hash to prevent cache collisions
-    // between local, pulled, and source extensions with the same filenames.
+    // Extension-first on-disk layout: each installed extension owns a
+    // dedicated subtree under .swamp/pulled-extensions/<ext-name>/. Prevents
+    // cross-extension filename collisions (e.g. _lib/aws.ts shared between
+    // @swamp/aws/ec2 and @swamp/aws/eks, or README.md across unrelated
+    // extensions). Skills remain at ctx.skillsDir — already per-skill.
+    const absoluteExtRoot = join(
+      swampPath(repoDir, "pulled-extensions"),
+      ref.name,
+    );
+    const absoluteModelsDir = join(absoluteExtRoot, "models");
+    const absoluteWorkflowsDir = join(absoluteExtRoot, "workflows");
+    const absoluteVaultsDir = join(absoluteExtRoot, "vaults");
+    const absoluteDriversDir = join(absoluteExtRoot, "drivers");
+    const absoluteDatastoresDir = join(absoluteExtRoot, "datastores");
+    const absoluteReportsDir = join(absoluteExtRoot, "reports");
+    const absoluteFilesDir = join(absoluteExtRoot, "files");
+    // Bundle cache is namespaced by source dir path. Because each extension
+    // now has a unique per-extension models dir, each extension gets its own
+    // bundle namespace automatically — no cross-extension bundle collisions.
     const bundlesDir = join(
       swampPath(repoDir, "bundles"),
       bundleNamespace(absoluteModelsDir, repoDir),
@@ -821,6 +879,7 @@ export async function installExtension(
       datastoreBundlesDir,
       absoluteReportsDir,
       reportBundlesDir,
+      absoluteFilesDir,
     );
 
     if (conflicts.length > 0 && !ctx.force) {
@@ -917,9 +976,10 @@ export async function installExtension(
     );
     extractedFiles.push(...reportBundlesExtracted);
 
+    await Deno.mkdir(absoluteFilesDir, { recursive: true });
     const filesExtracted = await copyDir(
       join(extractDir, "files"),
-      absoluteModelsDir,
+      absoluteFilesDir,
       repoDir,
     );
     extractedFiles.push(...filesExtracted);
@@ -976,6 +1036,34 @@ export async function installExtension(
       absoluteDatastoresDir,
       absoluteReportsDir,
     );
+
+    // Extract manifest.yaml into the per-extension root as a read-only
+    // copy. Makes each installed extension self-describing on disk so
+    // downstream consumers (e.g. findDependents in extension rm) can
+    // resolve the manifest without re-parsing the archive. Scoped to
+    // per-extension so the file cannot collide across extensions.
+    const manifestDestPath = join(absoluteExtRoot, "manifest.yaml");
+    const manifestWithHeader =
+      "# Read-only; regenerate via 'swamp extension pull'\n" + manifestContent;
+    await Deno.mkdir(absoluteExtRoot, { recursive: true });
+    // chmod 0o444 makes subsequent overwrites fail; remove the prior copy
+    // first so re-installs (--force) succeed. NotFound is expected on a
+    // first install.
+    try {
+      await Deno.remove(manifestDestPath);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+    await Deno.writeTextFile(manifestDestPath, manifestWithHeader);
+    try {
+      await Deno.chmod(manifestDestPath, 0o444);
+    } catch {
+      // chmod is advisory on some filesystems/platforms (notably Windows);
+      // intent is documented via the file header, enforcement is best-effort.
+    }
+    extractedFiles.push(relative(repoDir, manifestDestPath));
 
     // Record include files from manifest for loader skip logic
     const includeFiles = manifest.include.length > 0
@@ -1072,12 +1160,6 @@ export async function* extensionPull(
         getChecksum: deps.getChecksum,
         logger: ctx.logger,
         lockfilePath: deps.lockfilePath,
-        modelsDir: deps.modelsDir,
-        workflowsDir: deps.workflowsDir,
-        vaultsDir: deps.vaultsDir,
-        driversDir: deps.driversDir,
-        datastoresDir: deps.datastoresDir,
-        reportsDir: deps.reportsDir,
         skillsDir: deps.skillsDir,
         repoDir: deps.repoDir,
         force: input.force,
@@ -1098,12 +1180,6 @@ export async function* extensionPull(
 export function createExtensionPullDeps(
   serverUrl: string,
   lockfilePath: string,
-  modelsDir: string,
-  workflowsDir: string,
-  vaultsDir: string,
-  driversDir: string,
-  datastoresDir: string,
-  reportsDir: string,
   skillsDir: string,
   repoDir: string,
 ): ExtensionPullDeps {
@@ -1113,12 +1189,6 @@ export function createExtensionPullDeps(
     downloadArchive: (name, version) => client.downloadArchive(name, version),
     getChecksum: (name, version) => client.getChecksum(name, version),
     lockfilePath,
-    modelsDir,
-    workflowsDir,
-    vaultsDir,
-    driversDir,
-    datastoresDir,
-    reportsDir,
     skillsDir,
     repoDir,
     alreadyPulled: new Set(),
@@ -1131,12 +1201,6 @@ export function createInstallContext(
   serverUrl: string,
   opts: {
     lockfilePath: string;
-    modelsDir: string;
-    workflowsDir: string;
-    vaultsDir: string;
-    driversDir: string;
-    datastoresDir: string;
-    reportsDir: string;
     skillsDir: string;
     repoDir: string;
     force: boolean;
@@ -1150,12 +1214,6 @@ export function createInstallContext(
     getChecksum: (name, version) => client.getChecksum(name, version),
     logger: opts.logger,
     lockfilePath: opts.lockfilePath,
-    modelsDir: opts.modelsDir,
-    workflowsDir: opts.workflowsDir,
-    vaultsDir: opts.vaultsDir,
-    driversDir: opts.driversDir,
-    datastoresDir: opts.datastoresDir,
-    reportsDir: opts.reportsDir,
     skillsDir: opts.skillsDir,
     repoDir: opts.repoDir,
     force: opts.force,

--- a/src/libswamp/extensions/rm_test.ts
+++ b/src/libswamp/extensions/rm_test.ts
@@ -207,3 +207,179 @@ Deno.test("extensionRm: events include deleting then completed", async () => {
   assertEquals(events[0].kind, "deleting");
   assertEquals(events[1].kind, "completed");
 });
+
+// --- issue 120 regression coverage ---
+
+async function seedLockfileOnDisk(
+  lockfilePath: string,
+  entries: Record<string, string[]>,
+): Promise<void> {
+  const parent = lockfilePath.slice(0, lockfilePath.lastIndexOf("/"));
+  await Deno.mkdir(parent, { recursive: true });
+  const map: Record<string, unknown> = {};
+  for (const [name, files] of Object.entries(entries)) {
+    map[name] = {
+      version: "1.0.0",
+      pulledAt: "2026-01-01T00:00:00Z",
+      files,
+    };
+  }
+  await Deno.writeTextFile(lockfilePath, JSON.stringify(map, null, 2));
+}
+
+async function seedFile(repoDir: string, relPath: string): Promise<void> {
+  const { join } = await import("@std/path");
+  const abs = join(repoDir, relPath);
+  const parent = abs.slice(0, abs.lastIndexOf("/"));
+  await Deno.mkdir(parent, { recursive: true });
+  await Deno.writeTextFile(abs, `// seed for ${relPath}`);
+}
+
+// Regression test for plan step 15. Two sibling extensions under a
+// shared scope root (@swamp/aws/ec2 + @swamp/aws/eks) must cleanly
+// support removing one without destroying the other's parent. Guards
+// against pruneEmptyDirs over-walking upward past a still-populated
+// intermediate directory.
+Deno.test("extensionRm: removing one sibling leaves the other intact under a shared scope root", async () => {
+  const { createExtensionRmDeps } = await import("./rm.ts");
+  const { join } = await import("@std/path");
+
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = join(
+      tmpDir,
+      "extensions",
+      "models",
+      "upstream_extensions.json",
+    );
+
+    const ec2Files = [
+      ".swamp/pulled-extensions/@swamp/aws/ec2/models/instance.ts",
+      ".swamp/pulled-extensions/@swamp/aws/ec2/manifest.yaml",
+    ];
+    const eksFiles = [
+      ".swamp/pulled-extensions/@swamp/aws/eks/models/cluster.ts",
+      ".swamp/pulled-extensions/@swamp/aws/eks/manifest.yaml",
+    ];
+
+    for (const f of [...ec2Files, ...eksFiles]) {
+      await seedFile(tmpDir, f);
+    }
+    await seedLockfileOnDisk(lockfilePath, {
+      "@swamp/aws/ec2": ec2Files,
+      "@swamp/aws/eks": eksFiles,
+    });
+
+    const ctx = createLibSwampContext({});
+    const deps = createExtensionRmDeps(tmpDir, lockfilePath);
+    const events = await collect(
+      extensionRm(ctx, deps, { extensionName: "@swamp/aws/ec2" }),
+    );
+
+    const completed = events.find((e) => e.kind === "completed");
+    assertEquals(completed?.kind, "completed");
+
+    // ec2 subtree is gone
+    const ec2Root = join(tmpDir, ".swamp/pulled-extensions/@swamp/aws/ec2");
+    let ec2Exists = true;
+    try {
+      await Deno.stat(ec2Root);
+    } catch (err) {
+      if (err instanceof Deno.errors.NotFound) ec2Exists = false;
+      else throw err;
+    }
+    assertEquals(ec2Exists, false, "@swamp/aws/ec2 subtree should be removed");
+
+    // eks subtree is intact
+    const eksModel = join(
+      tmpDir,
+      ".swamp/pulled-extensions/@swamp/aws/eks/models/cluster.ts",
+    );
+    const stat = await Deno.stat(eksModel);
+    assertEquals(stat.isFile, true, "@swamp/aws/eks file must remain");
+
+    // Crucially, the shared @swamp/aws/ scope parent must survive —
+    // pruneEmptyDirs walks upward but must stop when it hits a
+    // non-empty directory (eks still lives there).
+    const awsScope = join(tmpDir, ".swamp/pulled-extensions/@swamp/aws");
+    const awsStat = await Deno.stat(awsScope);
+    assertEquals(awsStat.isDirectory, true, "@swamp/aws/ must still exist");
+
+    // Sibling eks must still appear in the lockfile; only ec2 was removed.
+    const lockfileAfter = JSON.parse(
+      await Deno.readTextFile(lockfilePath),
+    );
+    assertEquals(lockfileAfter["@swamp/aws/ec2"], undefined);
+    assertEquals(
+      lockfileAfter["@swamp/aws/eks"].files,
+      eksFiles,
+      "eks lockfile entry must be untouched",
+    );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+// findDependents regression — issue 120's manifest.yaml colocation
+// fixes the latent bug where pull.ts never extracted manifest.yaml to
+// disk, so rm.ts's findDependents (which searches entry.files for a
+// manifest.yaml path) could never resolve a dependency graph. After
+// issue 120, each installed extension tracks its manifest in the
+// lockfile's files[], and findDependents works as documented.
+Deno.test("extensionRmPreview: resolves dependents via the tracked per-extension manifest.yaml", async () => {
+  const { createExtensionRmDeps } = await import("./rm.ts");
+  const { join } = await import("@std/path");
+
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = join(
+      tmpDir,
+      "extensions",
+      "models",
+      "upstream_extensions.json",
+    );
+
+    const baseFiles = [
+      ".swamp/pulled-extensions/@fake/base/models/thing.ts",
+      ".swamp/pulled-extensions/@fake/base/manifest.yaml",
+    ];
+    const consumerFiles = [
+      ".swamp/pulled-extensions/@fake/consumer/models/consumer.ts",
+      ".swamp/pulled-extensions/@fake/consumer/manifest.yaml",
+    ];
+
+    for (const f of [...baseFiles, ...consumerFiles]) {
+      await seedFile(tmpDir, f);
+    }
+
+    // Consumer's manifest declares a dependency on @fake/base. Use a
+    // valid CalVer version so parseExtensionManifest accepts it.
+    await Deno.writeTextFile(
+      join(tmpDir, consumerFiles[1]),
+      [
+        "manifestVersion: 1",
+        'name: "@fake/consumer"',
+        'version: "2026.01.01.1"',
+        "models:",
+        "  - consumer.ts",
+        "dependencies:",
+        '  - "@fake/base"',
+      ].join("\n") + "\n",
+    );
+
+    await seedLockfileOnDisk(lockfilePath, {
+      "@fake/base": baseFiles,
+      "@fake/consumer": consumerFiles,
+    });
+
+    const ctx = createLibSwampContext({});
+    const deps = createExtensionRmDeps(tmpDir, lockfilePath);
+    const preview = await extensionRmPreview(ctx, deps, {
+      extensionName: "@fake/base",
+    });
+
+    assertEquals(preview.dependents, ["@fake/consumer"]);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -631,9 +631,21 @@ export {
 
 // Extension layout detection
 export {
+  classifyExtensionFile,
   detectLegacyExtensionLayout,
+  type ExtensionLayoutGeneration,
+  type LegacyFileEntry,
+  type LegacyLayoutSummary,
   requireCurrentExtensionLayout,
+  summariseLegacyLayout,
+  warnLegacyExtensionLayout,
 } from "./extensions/layout.ts";
+
+// Pulled-extension enumeration helper
+export {
+  enumeratePulledExtensionDirs,
+  type PulledExtensionType,
+} from "./extensions/enumerate_pulled.ts";
 
 // Extension install (restore from lockfile)
 export {
@@ -792,6 +804,7 @@ export {
 export {
   createRepoInitDeps,
   createRepoUpgradeDeps,
+  type ExtensionLayoutMigrationSummary,
   repoInit,
   type RepoInitData,
   type RepoInitDeps,

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -636,6 +636,7 @@ export {
   type ExtensionLayoutGeneration,
   type LegacyFileEntry,
   type LegacyLayoutSummary,
+  PULLED_TYPE_DIRS,
   requireCurrentExtensionLayout,
   summariseLegacyLayout,
   warnLegacyExtensionLayout,

--- a/src/libswamp/repo/init.ts
+++ b/src/libswamp/repo/init.ts
@@ -20,10 +20,13 @@
 import { RepoPath } from "../../domain/repo/repo_path.ts";
 import {
   type AiTool,
+  type ExtensionLayoutMigrationSummary,
   type RepoInitResult,
   RepoService,
   type RepoUpgradeResult,
 } from "../../domain/repo/repo_service.ts";
+
+export type { ExtensionLayoutMigrationSummary };
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { validationFailed } from "../errors.ts";
@@ -137,6 +140,9 @@ export interface RepoUpgradeData {
   settingsUpdated: boolean;
   gitignoreAction: string;
   tool: string;
+  /** Structured migration summary, only present when extensions were
+   * actually moved or deleted during the upgrade. */
+  extensionMigration?: ExtensionLayoutMigrationSummary;
 }
 
 export type RepoUpgradeEvent =
@@ -212,6 +218,9 @@ export async function* repoUpgrade(
         settingsUpdated: result.settingsUpdated,
         gitignoreAction: result.gitignoreAction,
         tool: result.tool,
+        ...(result.extensionMigration
+          ? { extensionMigration: result.extensionMigration }
+          : {}),
       };
 
       yield { kind: "completed", data };

--- a/src/presentation/renderers/repo_init.ts
+++ b/src/presentation/renderers/repo_init.ts
@@ -117,26 +117,26 @@ class LogRepoUpgradeRenderer implements Renderer<RepoUpgradeEvent> {
         if (data.extensionMigration) {
           const m = data.extensionMigration;
           logger.info("  Extension layout migration:");
-          if (m.phase1MovedCount > 0) {
+          if (m.renamedFileCount > 0) {
             logger.info(
-              `    Moved ${m.phase1MovedCount} legacy file(s) from ` +
+              `    Moved ${m.renamedFileCount} legacy file(s) from ` +
                 `extensions/<type>/ to .swamp/pulled-extensions/<type>/`,
             );
           }
-          if (m.phase2DeletedPerExtension.length > 0) {
-            const total = m.phase2DeletedPerExtension.reduce(
+          if (m.deletedPerExtension.length > 0) {
+            const total = m.deletedPerExtension.reduce(
               (n, e) => n + e.fileCount,
               0,
             );
             logger.info(
-              `    Removed ${total} flat-layout file(s) across ` +
-                `${m.phase2DeletedPerExtension.length} extension(s):`,
+              `    Removed ${total} outdated file(s) across ` +
+                `${m.deletedPerExtension.length} extension(s):`,
             );
-            for (const { name, fileCount } of m.phase2DeletedPerExtension) {
+            for (const { name, fileCount } of m.deletedPerExtension) {
               logger.info(`      - ${name} (${fileCount} file(s))`);
             }
             logger
-              .info`    Run 'swamp extension install' to restore these extensions into the per-extension layout. The lockfile's stored checksum is verified on each re-pull.`;
+              .info`    Run 'swamp extension install' to restore these extensions into the per-extension layout.`;
           }
         }
       },

--- a/src/presentation/renderers/repo_init.ts
+++ b/src/presentation/renderers/repo_init.ts
@@ -109,6 +109,36 @@ class LogRepoUpgradeRenderer implements Renderer<RepoUpgradeEvent> {
           "  Settings: " + (data.settingsUpdated ? "updated" : "unchanged"),
         );
         logger.info("  .gitignore: " + data.gitignoreAction);
+
+        // Surface the extension layout migration so users understand
+        // what happened to their pulled-extensions state. Without this,
+        // phase-two deletions are silent and users only discover the
+        // change via a warning on the next extension command.
+        if (data.extensionMigration) {
+          const m = data.extensionMigration;
+          logger.info("  Extension layout migration:");
+          if (m.phase1MovedCount > 0) {
+            logger.info(
+              `    Moved ${m.phase1MovedCount} legacy file(s) from ` +
+                `extensions/<type>/ to .swamp/pulled-extensions/<type>/`,
+            );
+          }
+          if (m.phase2DeletedPerExtension.length > 0) {
+            const total = m.phase2DeletedPerExtension.reduce(
+              (n, e) => n + e.fileCount,
+              0,
+            );
+            logger.info(
+              `    Removed ${total} flat-layout file(s) across ` +
+                `${m.phase2DeletedPerExtension.length} extension(s):`,
+            );
+            for (const { name, fileCount } of m.phase2DeletedPerExtension) {
+              logger.info(`      - ${name} (${fileCount} file(s))`);
+            }
+            logger
+              .info`    Run 'swamp extension install' to restore these extensions into the per-extension layout. The lockfile's stored checksum is verified on each re-pull.`;
+          }
+        }
       },
       error: (e) => {
         throw new UserError(e.error.message);


### PR DESCRIPTION
Fixes [swamp-club#120](https://swamp.club/lab/issues/120).

## Summary

Pulled extensions now land in per-extension on-disk subtrees
(`.swamp/pulled-extensions/<ext-name>/{models,workflows,…}/`) instead
of a shared flat layout. Fixes the silent overwrite of shared
filenames (`_lib/aws.ts`, `README.md`, `LICENSE.txt`) across sibling
extensions from the same collective — a bug observed in the wild with
`@swamp/aws/ec2` + `@swamp/aws/eks`, where prior pulls corrupted each
other's helpers.

Additional changes riding along:

- **Integrity anchor**: `upstream_extensions.json` stores a SHA-256 per
  install and `extension install` / migration re-pull now verify
  freshly-downloaded archives against it. Explicit `extension pull`
  stays opt-in to new registry content.
- **Migration**: `swamp repo upgrade` detects legacy layouts (gen-1
  `extensions/<type>/`, gen-2 flat `.swamp/pulled-extensions/<type>/`)
  and migrates. Gen-2 uses selective delete + re-install via the
  integrity anchor because rename cannot restore content that was
  silently overwritten pre-fix. Partial migrations are resumable
  (NotFound on retry is tolerated; any other IO error aborts with the
  lockfile intact).
- **Renderer output**: `repo upgrade` surfaces per-extension deletion
  counts and a next-step hint so users understand what happened.
- **Warn-not-block guard**: replaces throw-on-legacy with warn so
  already-migrated extensions stay usable during partial state.
- **Manifest colocation**: each installed extension now has a
  read-only `manifest.yaml` at its root. Fixes a latent
  `findDependents` bug (never worked pre-120 because the manifest was
  never persisted).
- **Auto-resolve fix**: repaired a regression in `auto_resolver_adapters.ts`
  and `resolve_datastore.ts` hot-load paths that were still walking
  the flat layout.
- **API cleanup**: `InstallContext` / `ExtensionPullDeps` lose six
  dead path fields; `createExtensionPullDeps` shrinks from 10 to 4
  params.

## Test Plan

- [x] `deno check` clean
- [x] `deno lint` clean
- [x] `deno fmt` clean
- [x] `deno run test` — 4392 pass / 0 fail (up from 4379 baseline):
      5 new migration tests, 6 enumerate-helper tests, 4 layout-tests,
      1 checksum-mismatch test, 2 rm regression tests, 5 auto-resolve
      adapter tests
- [x] Compiled binary end-to-end against triage reproduction snapshot:
      `repo upgrade` → migration summary → `extension install`
      (integrity-verified) → `extension list` → `extension rm
      @stack72/ubiquity` → siblings `@swamp/aws/ec2` + `@swamp/aws/eks`
      intact
- [x] Offline scenario: `SWAMP_CLUB_URL=http://localhost:8080` during
      `extension install` → all entries recorded as failed, lockfile
      preserved, online retry recovers cleanly
- [x] `design/extension.md` updated with new layout, integrity anchor,
      and migration generations

## Follow-up UAT

- [systeminit/swamp-uat#142](https://github.com/systeminit/swamp-uat/issues/142)
  — auto-resolution end-to-end coverage
- [systeminit/swamp-uat#143](https://github.com/systeminit/swamp-uat/issues/143)
  — co-install sibling extensions user story

🤖 Generated with [Claude Code](https://claude.com/claude-code)