### PR TITLE
fix(extensions): refuse to silently overwrite on-disk extensions in auto-resolver

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -355,6 +355,24 @@ swamp extension trust auto-trust <on|off> # Enable/disable membership auto-trust
 3. **Search fallback** — if direct lookup fails, search the registry for
    matching extensions.
 
+### Safety: never overwrite on-disk extensions
+
+Auto-resolution will never overwrite an extension that is already installed
+on disk. If the type failed to register despite the extension being present,
+something is wrong locally (commonly a user's in-progress edit introducing
+a syntax error) and a silent force-pull would destroy that work. The
+resolver detects this case by combining two checks: the extension must be
+listed in `upstream_extensions.json` **and** its per-extension directory
+must exist under `.swamp/pulled-extensions/<name>/`. Both must hold for
+the resolver to refuse; if either is missing (e.g. the user removed the
+directory), a clean install proceeds.
+
+When the resolver refuses, the user sees the on-disk path and the exact
+command to reset to the registry version:
+`swamp extension pull <name> --force`. That command is the only way
+auto-installation state can overwrite a pulled extension — no other
+auto-resolve, validate, or run command will ever clobber local edits.
+
 ### Hot-Loading
 
 After installation, swamp re-runs model and vault discovery with

--- a/integration/auto_resolver_no_clobber_test.ts
+++ b/integration/auto_resolver_no_clobber_test.ts
@@ -1,0 +1,155 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import {
+  createAutoResolveInstallerAdapter,
+  createAutoResolveOutputAdapter,
+} from "../src/cli/auto_resolver_adapters.ts";
+import { ExtensionAutoResolver } from "../src/domain/extensions/extension_auto_resolver.ts";
+import type { DenoRuntime } from "../src/domain/runtime/deno_runtime.ts";
+
+// Regression guard for swamp-club issue 121: an auto-resolver attempt on
+// a type whose extension is already installed on disk must NEVER overwrite
+// the local copy. Pre-fix, the adapter passed force:true to installExtension
+// and silently clobbered user edits. This test assembles the real adapter
+// and real domain service and confirms the file-survival invariant: the
+// on-disk file's mtime and contents are unchanged after a failed
+// auto-resolution.
+
+const stubDenoRuntime: DenoRuntime = {
+  ensureDeno: () => Promise.resolve("/usr/bin/false"),
+};
+
+Deno.test("integration: auto-resolver refuses to overwrite an existing pulled extension", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_issue_121_" });
+  try {
+    const extensionName = "@test/fixture";
+    const extRoot = join(
+      tmpDir,
+      ".swamp",
+      "pulled-extensions",
+      extensionName,
+    );
+    const modelsDir = join(extRoot, "models");
+    await ensureDir(modelsDir);
+
+    // "User's local edits" — a marker comment that must survive the
+    // failed auto-resolve attempt.
+    const localFile = join(modelsDir, "local_wip.ts");
+    const localContents = [
+      "// MY LOCAL WIP — do not lose this",
+      "export const model = { broken: true };",
+    ].join("\n");
+    await Deno.writeTextFile(localFile, localContents);
+    const originalMtime = (await Deno.stat(localFile)).mtime?.getTime();
+
+    // Lockfile records the fixture extension — isInstalled must return
+    // true on this combination (lockfile entry AND dir present).
+    const lockfilePath = join(
+      tmpDir,
+      "extensions",
+      "models",
+      "upstream_extensions.json",
+    );
+    await ensureDir(join(tmpDir, "extensions", "models"));
+    await Deno.writeTextFile(
+      lockfilePath,
+      JSON.stringify(
+        {
+          [extensionName]: {
+            version: "2026.01.01.1",
+            pulledAt: "2026-01-01T00:00:00Z",
+            files: [join(".swamp/pulled-extensions", extensionName, "models")],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    // The getExtension callback advertises the fixture — but install()
+    // must never be called, because isInstalled will short-circuit it.
+    // downloadArchive throws if reached; that's the regression signal.
+    let downloadArchiveCalled = false;
+    const adapter = createAutoResolveInstallerAdapter({
+      getExtension: (name: string) =>
+        name === extensionName
+          ? Promise.resolve({
+            name,
+            description: "Test fixture",
+            latestVersion: "2026.01.01.1",
+          })
+          : Promise.resolve(null),
+      downloadArchive: () => {
+        downloadArchiveCalled = true;
+        return Promise.reject(
+          new Error(
+            "REGRESSION: install was attempted on an on-disk extension",
+          ),
+        );
+      },
+      getChecksum: () => Promise.resolve(null),
+      lockfilePath,
+      repoDir: tmpDir,
+      denoRuntime: stubDenoRuntime,
+    });
+
+    // Assemble the real service with a silent output adapter so the
+    // test stays quiet. We check behavior via adapter calls and file
+    // state, not via log lines.
+    const output = createAutoResolveOutputAdapter("json");
+    const resolver = new ExtensionAutoResolver({
+      allowedCollectives: ["test"],
+      extensionLookup: {
+        getExtension: (name: string) =>
+          adapter.isInstalled(name).then((installed) =>
+            installed
+              ? Promise.resolve({
+                name,
+                description: "Test fixture",
+                latestVersion: "2026.01.01.1",
+              })
+              : Promise.resolve(null)
+          ),
+        searchExtensions: () => Promise.resolve({ extensions: [] }),
+      },
+      extensionInstaller: adapter,
+      output,
+    });
+
+    const result = await resolver.resolve(`${extensionName}/some-type`);
+
+    // The resolver must report failure — the type couldn't be
+    // registered and we refused to install.
+    assertEquals(result, false);
+    // install() must not have reached the downloadArchive callback.
+    assertEquals(downloadArchiveCalled, false);
+    // The local file must still exist with the original contents and
+    // mtime. These two assertions are the core user-visible invariant.
+    const currentContents = await Deno.readTextFile(localFile);
+    assertEquals(currentContents, localContents);
+    const currentMtime = (await Deno.stat(localFile)).mtime?.getTime();
+    assertEquals(currentMtime, originalMtime);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});

--- a/src/cli/auto_resolver_adapters.ts
+++ b/src/cli/auto_resolver_adapters.ts
@@ -22,12 +22,14 @@ import {
   SWAMP_SUBDIRS,
   swampPath,
 } from "../infrastructure/persistence/paths.ts";
+import { readUpstreamExtensions } from "../infrastructure/persistence/upstream_extensions.ts";
 import type { DenoRuntime } from "../domain/runtime/deno_runtime.ts";
 import type {
   AutoResolveOutputPort,
   ExtensionInstallerPort,
 } from "../domain/extensions/extension_auto_resolver.ts";
 import {
+  ConflictError,
   enumeratePulledExtensionDirs,
   type ExtensionRegistryInfo,
   installExtension,
@@ -38,6 +40,7 @@ import { UserDatastoreLoader } from "../domain/datastore/user_datastore_loader.t
 import type { DatastorePathResolver } from "../domain/datastore/datastore_path_resolver.ts";
 import type { OutputMode } from "../presentation/output/output.ts";
 import {
+  renderAutoResolveAlreadyInstalled,
   renderAutoResolveInstalled,
   renderAutoResolveInstalling,
   renderAutoResolveNetworkError,
@@ -76,24 +79,63 @@ export function createAutoResolveInstallerAdapter(
   } = config;
 
   return {
+    async isInstalled(extensionName: string) {
+      // Dual check: lockfile entry AND per-extension directory present on
+      // disk. Lockfile-only would miss the drift case where the user
+      // `rm -rf`'d the pulled dir; fs-only would miss the fact that a
+      // pre-existing directory could belong to a different extension.
+      // Both must hold for the service's "never overwrite" policy to
+      // apply — otherwise a clean install should proceed.
+      const upstream = await readUpstreamExtensions(lockfilePath);
+      if (!upstream[extensionName]) return false;
+      try {
+        const stat = await Deno.stat(
+          swampPath(repoDir, "pulled-extensions", extensionName),
+        );
+        return stat.isDirectory;
+      } catch {
+        return false;
+      }
+    },
+
+    installedPath(extensionName: string) {
+      return swampPath(repoDir, "pulled-extensions", extensionName);
+    },
+
     async install(extensionName: string) {
-      const result = await installExtension(
-        { name: extensionName, version: null },
-        {
-          getExtension,
-          downloadArchive,
-          getChecksum,
-          logger,
-          lockfilePath,
-          skillsDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledSkills),
-          repoDir,
-          force: true,
-          alreadyPulled: new Set(),
-          depth: 0,
-        },
-      );
-      if (!result) return null;
-      return { version: result.version };
+      // force: false so installExtension raises ConflictError rather than
+      // silently overwriting any existing files. The service's
+      // isInstalled check normally prevents reaching this point when the
+      // extension is already on disk; the ConflictError catch below is
+      // defence-in-depth for races between isInstalled and install that
+      // the per-type re-entrancy guard in the resolver cannot cover
+      // (e.g. two types resolving the same extension concurrently).
+      try {
+        const result = await installExtension(
+          { name: extensionName, version: null },
+          {
+            getExtension,
+            downloadArchive,
+            getChecksum,
+            logger,
+            lockfilePath,
+            skillsDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledSkills),
+            repoDir,
+            force: false,
+            alreadyPulled: new Set(),
+            depth: 0,
+          },
+        );
+        if (!result) return null;
+        return { version: result.version };
+      } catch (error) {
+        if (error instanceof ConflictError) {
+          logger
+            .debug`Auto-install of ${extensionName} hit conflicts: ${error.conflicts}`;
+          return null;
+        }
+        throw error;
+      }
     },
 
     // Hot-load walks every pulled extension's per-type subtree (via
@@ -186,6 +228,9 @@ export function createAutoResolveOutputAdapter(
     },
     networkError(type: string, error: string) {
       renderAutoResolveNetworkError(type, error, mode);
+    },
+    alreadyInstalledButFailed(extension: string, path: string) {
+      renderAutoResolveAlreadyInstalled(extension, path, mode);
     },
   };
 }

--- a/src/cli/auto_resolver_adapters_test.ts
+++ b/src/cli/auto_resolver_adapters_test.ts
@@ -192,6 +192,128 @@ Deno.test("auto_resolver_adapters: hotLoadVaults is a no-op when no pulled vault
   }
 });
 
+// Issue #121 regression tests: the auto-resolver adapter must refuse to
+// silently overwrite on-disk extensions. These tests lock in the behavior
+// that prevents the force-pull data-loss bug from returning.
+
+Deno.test("auto_resolver_adapters: isInstalled returns false when lockfile is missing", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = join(
+      tmpDir,
+      "extensions",
+      "models",
+      "upstream_extensions.json",
+    );
+    const adapter = createAutoResolveInstallerAdapter({
+      ...stubCallbacks,
+      lockfilePath,
+      repoDir: tmpDir,
+      denoRuntime: stubDenoRuntime,
+    });
+
+    assertEquals(await adapter.isInstalled("@fake/anything"), false);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("auto_resolver_adapters: isInstalled returns false on lockfile/filesystem drift", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    // Lockfile lists the extension, but the on-disk directory was
+    // manually removed. Returning true here would make the resolver
+    // surface a confusing "already installed but failed" error when
+    // the files are actually gone — a clean reinstall is correct.
+    const lockfilePath = await seedLockfile(tmpDir, {
+      "@fake/deleted-on-disk": [
+        ".swamp/pulled-extensions/@fake/deleted-on-disk/models/x.ts",
+      ],
+    });
+
+    const adapter = createAutoResolveInstallerAdapter({
+      ...stubCallbacks,
+      lockfilePath,
+      repoDir: tmpDir,
+      denoRuntime: stubDenoRuntime,
+    });
+
+    assertEquals(await adapter.isInstalled("@fake/deleted-on-disk"), false);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("auto_resolver_adapters: isInstalled returns true when lockfile AND dir both present", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = await seedLockfile(tmpDir, {
+      "@fake/on-disk": [
+        ".swamp/pulled-extensions/@fake/on-disk/models/x.ts",
+      ],
+    });
+    await ensureDir(
+      join(tmpDir, ".swamp/pulled-extensions/@fake/on-disk"),
+    );
+
+    const adapter = createAutoResolveInstallerAdapter({
+      ...stubCallbacks,
+      lockfilePath,
+      repoDir: tmpDir,
+      denoRuntime: stubDenoRuntime,
+    });
+
+    assertEquals(await adapter.isInstalled("@fake/on-disk"), true);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("auto_resolver_adapters: isInstalled returns false for extension not in lockfile", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = await seedLockfile(tmpDir, {
+      "@fake/other": [".swamp/pulled-extensions/@fake/other/models/x.ts"],
+    });
+
+    const adapter = createAutoResolveInstallerAdapter({
+      ...stubCallbacks,
+      lockfilePath,
+      repoDir: tmpDir,
+      denoRuntime: stubDenoRuntime,
+    });
+
+    assertEquals(await adapter.isInstalled("@fake/not-listed"), false);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("auto_resolver_adapters: installedPath returns the per-extension root", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = join(
+      tmpDir,
+      "extensions",
+      "models",
+      "upstream_extensions.json",
+    );
+    const adapter = createAutoResolveInstallerAdapter({
+      ...stubCallbacks,
+      lockfilePath,
+      repoDir: tmpDir,
+      denoRuntime: stubDenoRuntime,
+    });
+
+    assertEquals(
+      adapter.installedPath("@fake/ext"),
+      join(tmpDir, ".swamp", "pulled-extensions", "@fake/ext"),
+    );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
 Deno.test("auto_resolver_adapters: hotLoadDatastores is a no-op when no pulled datastore dirs exist", async () => {
   const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
   try {

--- a/src/domain/extensions/extension_auto_resolver.ts
+++ b/src/domain/extensions/extension_auto_resolver.ts
@@ -66,6 +66,19 @@ export interface ExtensionInstallResultInfo {
  * Decouples the domain service from the CLI install infrastructure.
  */
 export interface ExtensionInstallerPort {
+  /**
+   * Returns true when the extension is already present on disk. The domain
+   * service uses this to refuse silent re-installs that would overwrite
+   * local edits (issue #121).
+   */
+  isInstalled(extensionName: string): Promise<boolean>;
+  /**
+   * Returns the absolute path where the extension is (or would be)
+   * installed on disk. Paired with `isInstalled` so the domain service
+   * can surface the path in error messages without reaching into
+   * infrastructure.
+   */
+  installedPath(extensionName: string): string;
   install(extensionName: string): Promise<ExtensionInstallResultInfo | null>;
   hotLoadModels(): Promise<number>;
   hotLoadVaults(): Promise<void>;
@@ -86,6 +99,13 @@ export interface AutoResolveOutputPort {
   installed(extension: string, version: string, modelsRegistered: number): void;
   notFound(type: string): void;
   networkError(type: string, error: string): void;
+  /**
+   * Emitted when auto-resolution finds an extension on disk but refuses
+   * to re-install it because local edits may be preventing the type
+   * from registering. Gives the user the file path and the explicit
+   * opt-in command to reset to the registry version.
+   */
+  alreadyInstalledButFailed(extension: string, path: string): void;
 }
 
 /**
@@ -299,6 +319,19 @@ export class ExtensionAutoResolver {
 
     const version = extInfo.latestVersion;
     if (!version) return false;
+
+    // Issue #121: refuse to re-install an extension that already exists
+    // on disk. The type failing to register here means something is
+    // broken locally (e.g. user edits introduced a syntax error); a
+    // silent force-pull would overwrite those edits and destroy WIP.
+    // Surface an actionable error and let the user decide.
+    if (await extensionInstaller.isInstalled(extensionName)) {
+      output.alreadyInstalledButFailed(
+        extensionName,
+        extensionInstaller.installedPath(extensionName),
+      );
+      return false;
+    }
 
     output.installing(extensionName, version, extInfo.description);
 

--- a/src/domain/extensions/extension_auto_resolver_test.ts
+++ b/src/domain/extensions/extension_auto_resolver_test.ts
@@ -53,6 +53,9 @@ function createMockOutput(): AutoResolveOutputPort & { calls: string[] } {
     networkError(type: string, _err: string) {
       calls.push(`networkError:${type}`);
     },
+    alreadyInstalledButFailed(ext: string, path: string) {
+      calls.push(`alreadyInstalledButFailed:${ext}:${path}`);
+    },
   };
 }
 
@@ -86,10 +89,23 @@ function createMockLookup(
 function createMockInstaller(
   shouldSucceed = true,
   version = "2026.03.16.1",
-): ExtensionInstallerPort & { installCalls: string[] } {
+  alreadyInstalled = false,
+): ExtensionInstallerPort & {
+  installCalls: string[];
+  isInstalledCalls: string[];
+} {
   const installCalls: string[] = [];
+  const isInstalledCalls: string[] = [];
   return {
     installCalls,
+    isInstalledCalls,
+    isInstalled(extensionName: string) {
+      isInstalledCalls.push(extensionName);
+      return Promise.resolve(alreadyInstalled);
+    },
+    installedPath(extensionName: string) {
+      return `/fake/pulled-extensions/${extensionName}`;
+    },
     install(extensionName: string) {
       installCalls.push(extensionName);
       if (!shouldSucceed) return Promise.resolve(null);
@@ -298,6 +314,56 @@ Deno.test("ExtensionAutoResolver - handles non-@ prefixed types", async () => {
   const result = await resolver.resolve("swamp/echo/v2");
   assertEquals(result, true);
   assertEquals(installer.installCalls, ["@swamp/echo"]);
+});
+
+Deno.test("ExtensionAutoResolver - refuses to install when extension is already on disk", async () => {
+  const output = createMockOutput();
+  const installer = createMockInstaller(true, "2026.03.16.1", true);
+  const resolver = new ExtensionAutoResolver({
+    allowedCollectives: ["swamp"],
+    extensionLookup: createMockLookup({
+      "@swamp/aws": {
+        description: "AWS models",
+        latestVersion: "2026.03.16.1",
+      },
+    }),
+    extensionInstaller: installer,
+    output,
+  });
+
+  const result = await resolver.resolve("@swamp/aws/ec2/instance");
+  assertEquals(result, false);
+  // install must not have been called — silent overwrite would destroy edits
+  assertEquals(installer.installCalls, []);
+  // isInstalled was asked
+  assertEquals(installer.isInstalledCalls, ["@swamp/aws"]);
+  // user-visible output surfaced the "already installed but failed" event,
+  // not an install-started event
+  const kinds = output.calls.map((c) => c.split(":")[0]);
+  assertEquals(kinds.includes("installing"), false);
+  assertEquals(kinds.includes("alreadyInstalledButFailed"), true);
+});
+
+Deno.test("ExtensionAutoResolver - isInstalled is checked before install on the happy path", async () => {
+  const output = createMockOutput();
+  const installer = createMockInstaller();
+  const resolver = new ExtensionAutoResolver({
+    allowedCollectives: ["swamp"],
+    extensionLookup: createMockLookup({
+      "@swamp/aws": {
+        description: "AWS models",
+        latestVersion: "2026.03.16.1",
+      },
+    }),
+    extensionInstaller: installer,
+    output,
+  });
+
+  await resolver.resolve("@swamp/aws/ec2/instance");
+  // isInstalled must be consulted before the install proceeds — this is
+  // the regression guard for issue #121.
+  assertEquals(installer.isInstalledCalls, ["@swamp/aws"]);
+  assertEquals(installer.installCalls, ["@swamp/aws"]);
 });
 
 Deno.test("ExtensionAutoResolver - skips types without a collective", async () => {

--- a/src/presentation/renderers/extension_auto_resolve.ts
+++ b/src/presentation/renderers/extension_auto_resolve.ts
@@ -114,6 +114,38 @@ export function renderAutoResolveNotFound(
 }
 
 /**
+ * Renders an error message when auto-resolution finds the extension
+ * on disk but refuses to re-install it (issue #121). The user likely
+ * has local edits preventing the type from registering; they must
+ * either fix the source or opt in to discarding edits via an explicit
+ * `extension pull --force`.
+ */
+export function renderAutoResolveAlreadyInstalled(
+  extension: string,
+  path: string,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(
+      JSON.stringify({
+        event: "auto_resolve",
+        status: "failed",
+        extension,
+        path,
+        reason: "already_installed",
+      }),
+    );
+  } else {
+    logger
+      .error`Extension ${extension} is already installed at ${path} but failed to load.`;
+    logger
+      .error`Local edits may be preventing it from registering — inspect the source and fix errors.`;
+    logger
+      .error`To reset to the registry version and discard local changes, run: swamp extension pull ${extension} --force`;
+  }
+}
+
+/**
  * Renders an error message when auto-resolution fails due to a network error.
  */
 export function renderAutoResolveNetworkError(


### PR DESCRIPTION
Fixes [swamp-club#121](https://swamp.club/lab/issues/121).

## Summary

`workflow validate` and other commands that trigger auto-resolution could silently overwrite local edits to pulled extensions. The auto-resolver adapter hardcoded `force: true` when installing a type it failed to find locally, and `installExtension`'s conflict check was gated on `!force` — so any user edits in the pulled directory were `copyDir`'d over with no prompt, no warning, and no diff.

The fix adds an `isInstalled` capability to `ExtensionInstallerPort` and has the domain service consult it before calling `install`. If the extension is already on disk (lockfile entry **and** per-extension directory both present), the resolver surfaces a new `alreadyInstalledButFailed` event naming the path and the explicit opt-in command (`swamp extension pull <name> --force`) and returns failure rather than clobbering. Belt-and-braces: the adapter now passes `force: false` and catches `ConflictError`, so a race past the per-type re-entrancy guard (concurrent auto-resolves for sibling types) still fails safely.

The datastore auto-update path in `resolve_datastore.ts:132` has a related but distinct `force: true` bug with a different trigger and fix shape; tracked separately as [swamp-club#126](https://swamp.club/lab/issues/126).

## What changed

- `src/domain/extensions/extension_auto_resolver.ts` — port gains `isInstalled` and `installedPath`; service gains `alreadyInstalledButFailed` output event and the pre-install check in `installAndLoad`.
- `src/cli/auto_resolver_adapters.ts` — installer adapter implements `isInstalled` (dual lockfile + filesystem check against the per-extension layout from #1186), `installedPath` returns the per-extension root, `install()` flips to `force: false` and catches `ConflictError` with a defence-in-depth comment.
- `src/presentation/renderers/extension_auto_resolve.ts` — new `renderAutoResolveAlreadyInstalled` for both `log` and `json` modes.
- `design/extension.md` — new \"Safety: never overwrite on-disk extensions\" subsection under Automatic Resolution.

## Test plan

- [x] `deno fmt` clean
- [x] `deno check` clean
- [x] `deno lint` clean
- [x] `deno run test` — 4400 pass / 0 fail (2 new service tests, 5 new adapter tests, 1 new integration regression test)
- [x] Manual reproduction against `/tmp/swamp-repro-issue-121`:
  - **Pre-fix:** md5 of `system_usage.ts` changed from user-edited to pristine registry version; WIP marker comment lost
  - **Post-fix:** md5 identical before/after trigger; marker preserved; user sees three ERR lines naming the path and the `--force` recovery command

## Follow-up

- [swamp-club#126](https://swamp.club/lab/issues/126) — datastore auto-update `force: true` in `resolve_datastore.ts:132` (related data-loss vector, different fix shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)