### PR TITLE
fix(extensions): refuse datastore auto-update on local edits (swamp-club#126)

### DIFF
--- a/src/cli/resolve_datastore.ts
+++ b/src/cli/resolve_datastore.ts
@@ -44,6 +44,7 @@ import { getAutoResolver } from "../domain/extensions/auto_resolver_context.ts";
 import { maybeAutoUpdateDatastoreExtension } from "../libswamp/extensions/datastore_auto_update.ts";
 import { FileExtensionUpdateCheckRepository } from "../infrastructure/persistence/extension_update_check_repository.ts";
 import { readUpstreamExtensions } from "../infrastructure/persistence/upstream_extensions.ts";
+import { readInstalledExtensionDigest } from "../infrastructure/persistence/installed_extension_digest_reader.ts";
 import { ExtensionApiClient } from "../infrastructure/http/extension_api_client.ts";
 import {
   enumeratePulledExtensionDirs,
@@ -109,6 +110,28 @@ async function maybeAutoUpdateSwampDatastore(
           return null;
         }
       },
+      detectLocalEdits: async (name) => {
+        // Compare the stored at-install digest with a fresh digest over
+        // the on-disk per-extension subtree. Infrastructure errors (lockfile
+        // missing, dir unreadable) degrade to "no-anchor" so auto-update
+        // never blocks a user command on a safety-check bug (issue #126).
+        try {
+          const upstream = await readUpstreamExtensions(lockfilePath);
+          const stored = upstream[name]?.filesChecksum;
+          if (!stored) return "no-anchor";
+          const extRoot = join(
+            resolve(repoDir),
+            ".swamp",
+            "pulled-extensions",
+            name,
+          );
+          const onDisk = await readInstalledExtensionDigest(extRoot);
+          if (onDisk === null) return "no-anchor";
+          return onDisk === stored ? "match" : "mismatch";
+        } catch {
+          return "no-anchor";
+        }
+      },
       pullExtension: async (name, version) => {
         const resolvedRepoDir = resolve(repoDir);
 
@@ -162,10 +185,32 @@ async function maybeAutoUpdateSwampDatastore(
         "Updated {name} {from} → {to}",
         { name: type, from: result.previousVersion, to: result.newVersion },
       );
+    } else if (result?.skipped === "local_edits") {
+      // Caller-layer surface for the auto-update refusal. The service
+      // returns a structured result (not an exception) specifically so
+      // this path bypasses the outer catch and reaches the user via
+      // logtape WARN. Mirrors the #121 auto-resolver refusal message.
+      logger.warn(buildLocalEditsWarning(type, result));
     }
   } catch {
     // Never block command execution for auto-update failures
   }
+}
+
+/**
+ * Renders the user-visible warning for an auto-update that was refused
+ * because local edits were detected. Exported so the message shape can be
+ * unit-tested without having to mock the full datastore-resolution stack.
+ */
+export function buildLocalEditsWarning(
+  type: string,
+  result: { previousVersion?: string; newVersion?: string },
+): string {
+  return (
+    `Not auto-updating ${type} ${result.previousVersion} → ${result.newVersion}: ` +
+    `local edits detected under .swamp/pulled-extensions/${type}/. ` +
+    `Run \`swamp extension pull ${type} --force\` to discard your edits and install the latest version.`
+  );
 }
 
 /**

--- a/src/cli/resolve_datastore_test.ts
+++ b/src/cli/resolve_datastore_test.ts
@@ -17,8 +17,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertRejects } from "@std/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import {
+  buildLocalEditsWarning,
   parseDatastoreEnvVar,
   RENAMED_DATASTORE_TYPES,
   resolveDatastoreConfig,
@@ -350,5 +351,20 @@ Deno.test("isCustomDatastoreConfig: returns true for custom type", () => {
       datastorePath: "/tmp",
     }),
     true,
+  );
+});
+
+Deno.test("buildLocalEditsWarning: names the extension and the opt-in command", () => {
+  const msg = buildLocalEditsWarning("@swamp/s3-datastore", {
+    previousVersion: "2026.03.15.1",
+    newVersion: "2026.03.30.1",
+  });
+  assertStringIncludes(msg, "@swamp/s3-datastore");
+  assertStringIncludes(msg, "2026.03.15.1");
+  assertStringIncludes(msg, "2026.03.30.1");
+  assertStringIncludes(msg, ".swamp/pulled-extensions/@swamp/s3-datastore/");
+  assertStringIncludes(
+    msg,
+    "swamp extension pull @swamp/s3-datastore --force",
   );
 });

--- a/src/domain/extensions/installed_extension_digest.ts
+++ b/src/domain/extensions/installed_extension_digest.ts
@@ -1,0 +1,55 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { computeChecksum } from "../models/checksum.ts";
+
+/**
+ * A single file's contribution to the installed-extension digest.
+ *
+ * `relPath` is the file's path relative to the per-extension root, using
+ * forward slashes regardless of OS. `contentSha` is the hex-encoded SHA-256
+ * of the file's raw bytes. Infrastructure code produces these entries; the
+ * domain rolls them up into a single digest.
+ */
+export interface InstalledExtensionDigestEntry {
+  relPath: string;
+  contentSha: string;
+}
+
+/**
+ * Rolls a set of per-file SHA-256 hashes into a single stable digest.
+ *
+ * Determinism: entries are sorted by relPath, then encoded as lines of
+ * `<relPath>\0<contentSha>\n` and hashed. Sorting guarantees stability
+ * regardless of the order callers pass entries in; the NUL separator
+ * prevents path/content ambiguity for paths containing newlines.
+ *
+ * Pure: no filesystem access. Infrastructure reads files and produces
+ * entries; this function combines them.
+ */
+export async function computeInstalledExtensionDigest(
+  entries: InstalledExtensionDigestEntry[],
+): Promise<string> {
+  const sorted = [...entries].sort((a, b) =>
+    a.relPath < b.relPath ? -1 : a.relPath > b.relPath ? 1 : 0
+  );
+  const encoder = new TextEncoder();
+  const lines = sorted.map((e) => `${e.relPath}\0${e.contentSha}\n`);
+  return await computeChecksum(encoder.encode(lines.join("")));
+}

--- a/src/domain/extensions/installed_extension_digest_test.ts
+++ b/src/domain/extensions/installed_extension_digest_test.ts
@@ -1,0 +1,114 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertNotEquals } from "@std/assert";
+import { computeInstalledExtensionDigest } from "./installed_extension_digest.ts";
+
+Deno.test("computeInstalledExtensionDigest: identical entries produce identical digests", async () => {
+  const a = await computeInstalledExtensionDigest([
+    { relPath: "models/foo.ts", contentSha: "a".repeat(64) },
+    { relPath: "datastores/bar.ts", contentSha: "b".repeat(64) },
+  ]);
+  const b = await computeInstalledExtensionDigest([
+    { relPath: "models/foo.ts", contentSha: "a".repeat(64) },
+    { relPath: "datastores/bar.ts", contentSha: "b".repeat(64) },
+  ]);
+  assertEquals(a, b);
+});
+
+Deno.test("computeInstalledExtensionDigest: entry order does not affect digest", async () => {
+  const ascending = await computeInstalledExtensionDigest([
+    { relPath: "a.ts", contentSha: "1".repeat(64) },
+    { relPath: "b.ts", contentSha: "2".repeat(64) },
+    { relPath: "c.ts", contentSha: "3".repeat(64) },
+  ]);
+  const descending = await computeInstalledExtensionDigest([
+    { relPath: "c.ts", contentSha: "3".repeat(64) },
+    { relPath: "b.ts", contentSha: "2".repeat(64) },
+    { relPath: "a.ts", contentSha: "1".repeat(64) },
+  ]);
+  assertEquals(ascending, descending);
+});
+
+Deno.test("computeInstalledExtensionDigest: changing file content produces different digest", async () => {
+  const before = await computeInstalledExtensionDigest([
+    { relPath: "models/foo.ts", contentSha: "a".repeat(64) },
+  ]);
+  const after = await computeInstalledExtensionDigest([
+    { relPath: "models/foo.ts", contentSha: "b".repeat(64) },
+  ]);
+  assertNotEquals(before, after);
+});
+
+Deno.test("computeInstalledExtensionDigest: changing path produces different digest", async () => {
+  const before = await computeInstalledExtensionDigest([
+    { relPath: "models/foo.ts", contentSha: "a".repeat(64) },
+  ]);
+  const after = await computeInstalledExtensionDigest([
+    { relPath: "models/bar.ts", contentSha: "a".repeat(64) },
+  ]);
+  assertNotEquals(before, after);
+});
+
+Deno.test("computeInstalledExtensionDigest: adding a file produces different digest", async () => {
+  const before = await computeInstalledExtensionDigest([
+    { relPath: "models/foo.ts", contentSha: "a".repeat(64) },
+  ]);
+  const after = await computeInstalledExtensionDigest([
+    { relPath: "models/foo.ts", contentSha: "a".repeat(64) },
+    { relPath: "models/bar.ts", contentSha: "b".repeat(64) },
+  ]);
+  assertNotEquals(before, after);
+});
+
+Deno.test("computeInstalledExtensionDigest: removing a file produces different digest", async () => {
+  const before = await computeInstalledExtensionDigest([
+    { relPath: "models/foo.ts", contentSha: "a".repeat(64) },
+    { relPath: "models/bar.ts", contentSha: "b".repeat(64) },
+  ]);
+  const after = await computeInstalledExtensionDigest([
+    { relPath: "models/foo.ts", contentSha: "a".repeat(64) },
+  ]);
+  assertNotEquals(before, after);
+});
+
+Deno.test("computeInstalledExtensionDigest: empty entry set produces stable digest", async () => {
+  const a = await computeInstalledExtensionDigest([]);
+  const b = await computeInstalledExtensionDigest([]);
+  assertEquals(a, b);
+  // SHA-256 of empty input is well-known.
+  assertEquals(
+    a,
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  );
+});
+
+Deno.test("computeInstalledExtensionDigest: paths with newlines are unambiguous", async () => {
+  // NUL separator between relPath and contentSha prevents any parsing of
+  // "<path>\n<sha>" vs "<path>" + "\n" + "<sha>" ambiguity if a path ever
+  // contained a newline. Two entries that would collide under a naive
+  // join must produce different digests.
+  const a = await computeInstalledExtensionDigest([
+    { relPath: "a\nb", contentSha: "c".repeat(64) },
+  ]);
+  const b = await computeInstalledExtensionDigest([
+    { relPath: "a", contentSha: "b\n" + "c".repeat(63) },
+  ]);
+  assertNotEquals(a, b);
+});

--- a/src/infrastructure/persistence/installed_extension_digest_reader.ts
+++ b/src/infrastructure/persistence/installed_extension_digest_reader.ts
@@ -1,0 +1,80 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join, relative } from "@std/path";
+import { computeChecksum } from "../../domain/models/checksum.ts";
+import {
+  computeInstalledExtensionDigest,
+  type InstalledExtensionDigestEntry,
+} from "../../domain/extensions/installed_extension_digest.ts";
+
+/**
+ * Walks a per-extension root (e.g. `.swamp/pulled-extensions/<name>/`) and
+ * produces the rolled-up digest over every file found. Used by the auto-
+ * update service to detect whether the user has modified any files since
+ * install.
+ *
+ * Ignores macOS AppleDouble resource forks (`._*`) — matches the installer's
+ * behavior in `isMacOsResourceFork`, so forks created by a Finder copy of
+ * the extension tree do not change the digest.
+ *
+ * Returns `null` if the extension root does not exist (a caller-visible
+ * signal distinct from "exists but empty" → empty-set digest).
+ */
+export async function readInstalledExtensionDigest(
+  extRoot: string,
+): Promise<string | null> {
+  try {
+    const stat = await Deno.stat(extRoot);
+    if (!stat.isDirectory) return null;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return null;
+    throw error;
+  }
+
+  const entries: InstalledExtensionDigestEntry[] = [];
+  await walk(extRoot, extRoot, entries);
+  return await computeInstalledExtensionDigest(entries);
+}
+
+async function walk(
+  currentDir: string,
+  extRoot: string,
+  entries: InstalledExtensionDigestEntry[],
+): Promise<void> {
+  for await (const entry of Deno.readDir(currentDir)) {
+    if (isMacOsResourceFork(entry.name)) continue;
+
+    const childPath = join(currentDir, entry.name);
+    if (entry.isDirectory) {
+      await walk(childPath, extRoot, entries);
+    } else if (entry.isFile) {
+      const bytes = await Deno.readFile(childPath);
+      const contentSha = await computeChecksum(bytes);
+      // Use forward slashes in the hashed relPath so the digest matches
+      // across platforms (Windows back-slashes would otherwise diverge).
+      const relPath = relative(extRoot, childPath).split("\\").join("/");
+      entries.push({ relPath, contentSha });
+    }
+  }
+}
+
+function isMacOsResourceFork(name: string): boolean {
+  return name.startsWith("._");
+}

--- a/src/infrastructure/persistence/installed_extension_digest_reader_test.ts
+++ b/src/infrastructure/persistence/installed_extension_digest_reader_test.ts
@@ -1,0 +1,125 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertNotEquals } from "@std/assert";
+import { join } from "@std/path";
+import { readInstalledExtensionDigest } from "./installed_extension_digest_reader.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp_digest_test_" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("readInstalledExtensionDigest: returns null when root does not exist", async () => {
+  const result = await readInstalledExtensionDigest(
+    "/tmp/definitely-does-not-exist-" + crypto.randomUUID(),
+  );
+  assertEquals(result, null);
+});
+
+Deno.test("readInstalledExtensionDigest: identical trees produce identical digests", async () => {
+  await withTempDir(async (dir) => {
+    const a = join(dir, "a");
+    const b = join(dir, "b");
+    await Deno.mkdir(join(a, "models"), { recursive: true });
+    await Deno.mkdir(join(b, "models"), { recursive: true });
+    await Deno.writeTextFile(join(a, "models", "foo.ts"), "content");
+    await Deno.writeTextFile(join(b, "models", "foo.ts"), "content");
+    await Deno.writeTextFile(join(a, "manifest.yaml"), "name: x");
+    await Deno.writeTextFile(join(b, "manifest.yaml"), "name: x");
+
+    const digestA = await readInstalledExtensionDigest(a);
+    const digestB = await readInstalledExtensionDigest(b);
+    assertEquals(digestA, digestB);
+  });
+});
+
+Deno.test("readInstalledExtensionDigest: editing a file changes the digest", async () => {
+  await withTempDir(async (dir) => {
+    await Deno.mkdir(join(dir, "models"), { recursive: true });
+    await Deno.writeTextFile(join(dir, "models", "foo.ts"), "original");
+
+    const before = await readInstalledExtensionDigest(dir);
+
+    await Deno.writeTextFile(join(dir, "models", "foo.ts"), "edited");
+
+    const after = await readInstalledExtensionDigest(dir);
+    assertNotEquals(before, after);
+  });
+});
+
+Deno.test("readInstalledExtensionDigest: adding a file changes the digest", async () => {
+  await withTempDir(async (dir) => {
+    await Deno.mkdir(join(dir, "models"), { recursive: true });
+    await Deno.writeTextFile(join(dir, "models", "foo.ts"), "content");
+
+    const before = await readInstalledExtensionDigest(dir);
+
+    await Deno.writeTextFile(join(dir, "models", "bar.ts"), "new");
+
+    const after = await readInstalledExtensionDigest(dir);
+    assertNotEquals(before, after);
+  });
+});
+
+Deno.test("readInstalledExtensionDigest: removing a file changes the digest", async () => {
+  await withTempDir(async (dir) => {
+    await Deno.mkdir(join(dir, "models"), { recursive: true });
+    await Deno.writeTextFile(join(dir, "models", "foo.ts"), "content");
+    await Deno.writeTextFile(join(dir, "models", "bar.ts"), "content");
+
+    const before = await readInstalledExtensionDigest(dir);
+
+    await Deno.remove(join(dir, "models", "bar.ts"));
+
+    const after = await readInstalledExtensionDigest(dir);
+    assertNotEquals(before, after);
+  });
+});
+
+Deno.test("readInstalledExtensionDigest: macOS resource forks are ignored", async () => {
+  await withTempDir(async (dir) => {
+    await Deno.mkdir(join(dir, "models"), { recursive: true });
+    await Deno.writeTextFile(join(dir, "models", "foo.ts"), "content");
+
+    const before = await readInstalledExtensionDigest(dir);
+
+    // Dropping a Finder-copy resource fork should not perturb the digest.
+    await Deno.writeTextFile(join(dir, "models", "._foo.ts"), "fork");
+    await Deno.writeTextFile(join(dir, "._manifest.yaml"), "fork");
+
+    const after = await readInstalledExtensionDigest(dir);
+    assertEquals(before, after);
+  });
+});
+
+Deno.test("readInstalledExtensionDigest: empty directory produces a stable digest", async () => {
+  await withTempDir(async (dir) => {
+    const digest = await readInstalledExtensionDigest(dir);
+    // Empty-set digest: SHA-256 of the empty string.
+    assertEquals(
+      digest,
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    );
+  });
+});

--- a/src/infrastructure/persistence/upstream_extensions.ts
+++ b/src/infrastructure/persistence/upstream_extensions.ts
@@ -25,6 +25,14 @@ export interface UpstreamExtensionEntry {
   include?: string[];
   /** SHA-256 checksum of the extension archive, for verification on re-install. */
   checksum?: string;
+  /**
+   * Rolled-up SHA-256 digest of the on-disk per-extension subtree at install
+   * time. Distinct from `checksum` (which hashes the archive bytes): this
+   * anchors the EXTRACTED files so auto-update can detect local edits
+   * before overwriting. Absent on pre-anchor lockfile entries (grandfather
+   * path) — consumers must tolerate the missing value.
+   */
+  filesChecksum?: string;
   /** Registry server URL used when pulling, for non-default registries. */
   serverUrl?: string;
 }

--- a/src/libswamp/extensions/datastore_auto_update.ts
+++ b/src/libswamp/extensions/datastore_auto_update.ts
@@ -26,9 +26,34 @@ import { checkExtensionVersion } from "../../domain/extensions/extension_update_
 
 const logger = getLogger(["swamp", "extensions", "auto-update"]);
 
+/**
+ * Tri-state outcome from the local-edits check. Produced by the caller-
+ * supplied `detectLocalEdits` dep.
+ *
+ * - `match` — on-disk digest equals the stored anchor; safe to overwrite.
+ * - `mismatch` — on-disk digest diverges from the anchor; user has edited
+ *   something and auto-update must refuse.
+ * - `no-anchor` — no stored anchor for this extension (pre-upgrade lockfile
+ *   entry); grandfather path, proceed as before.
+ */
+export type LocalEditsStatus = "match" | "mismatch" | "no-anchor";
+
+/**
+ * Reason an auto-update attempt was skipped. Distinct from silent errors
+ * (which continue to return null) — `skipped` signals a deliberate refusal
+ * that callers surface visibly to the user. `local_edits` covers the
+ * issue #126 refusal path.
+ */
+export type DatastoreAutoUpdateSkipReason = "local_edits";
+
 /** Result of an auto-update attempt. */
 export interface DatastoreAutoUpdateResult {
   updated: boolean;
+  /**
+   * Set when the update was intentionally refused. Present only on
+   * deliberate refusals so callers can surface them visibly to the user.
+   */
+  skipped?: DatastoreAutoUpdateSkipReason;
   previousVersion?: string;
   newVersion?: string;
 }
@@ -43,6 +68,13 @@ export interface DatastoreAutoUpdateDeps {
   pullExtension: (name: string, version: string) => Promise<void>;
   /** Cache repository for per-extension update check timestamps. */
   cacheRepository: ExtensionUpdateCheckRepository;
+  /**
+   * Detect whether the on-disk per-extension subtree has been edited since
+   * install. Optional: when omitted, the service behaves as before this
+   * dep existed (no local-edits protection). Returns `no-anchor` for
+   * lockfile entries that pre-date the filesChecksum field.
+   */
+  detectLocalEdits?: (name: string) => Promise<LocalEditsStatus>;
 }
 
 const SWAMP_COLLECTIVE = "@swamp/";
@@ -114,6 +146,28 @@ export async function maybeAutoUpdateDatastoreExtension(
 
     if (status.status !== "update_available") {
       return { updated: false };
+    }
+
+    // Local-edits check before the force-pull. Refuse silent overwrite of
+    // user edits to the on-disk extension subtree (issue #126). Runs only
+    // when detectLocalEdits is wired; callers without the dep get the
+    // pre-fix behavior.
+    if (deps.detectLocalEdits) {
+      const editsStatus = await deps.detectLocalEdits(extensionName);
+      if (editsStatus === "mismatch") {
+        logger
+          .debug`Refusing auto-update for ${extensionName}: local edits detected`;
+        return {
+          updated: false,
+          skipped: "local_edits",
+          previousVersion: installedVersion,
+          newVersion: latestVersion,
+        };
+      }
+      if (editsStatus === "no-anchor") {
+        logger
+          .debug`No stored anchor for ${extensionName}; grandfathering auto-update (anchor will be written on next install)`;
+      }
     }
 
     // Pull the new version

--- a/src/libswamp/extensions/datastore_auto_update_test.ts
+++ b/src/libswamp/extensions/datastore_auto_update_test.ts
@@ -51,6 +51,7 @@ function createMockDeps(
         return Promise.resolve();
       },
     },
+    detectLocalEdits: overrides?.detectLocalEdits,
   };
 }
 
@@ -154,5 +155,47 @@ Deno.test("maybeAutoUpdateDatastoreExtension: checks again after 24h", async () 
     deps,
   );
   assertEquals(result?.updated, true);
+  assertEquals(deps.pulled, ["@swamp/s3-datastore@2026.03.30.1"]);
+});
+
+Deno.test("maybeAutoUpdateDatastoreExtension: proceeds when detectLocalEdits returns match", async () => {
+  const deps = createMockDeps({
+    detectLocalEdits: () => Promise.resolve("match"),
+  });
+  const result = await maybeAutoUpdateDatastoreExtension(
+    "@swamp/s3-datastore",
+    deps,
+  );
+  assertEquals(result?.updated, true);
+  assertEquals(result?.skipped, undefined);
+  assertEquals(deps.pulled, ["@swamp/s3-datastore@2026.03.30.1"]);
+});
+
+Deno.test("maybeAutoUpdateDatastoreExtension: refuses when detectLocalEdits returns mismatch", async () => {
+  const deps = createMockDeps({
+    detectLocalEdits: () => Promise.resolve("mismatch"),
+  });
+  const result = await maybeAutoUpdateDatastoreExtension(
+    "@swamp/s3-datastore",
+    deps,
+  );
+  assertEquals(result?.updated, false);
+  assertEquals(result?.skipped, "local_edits");
+  assertEquals(result?.previousVersion, "2026.03.15.1");
+  assertEquals(result?.newVersion, "2026.03.30.1");
+  // Must NOT invoke pullExtension — the whole point of the refusal.
+  assertEquals(deps.pulled.length, 0);
+});
+
+Deno.test("maybeAutoUpdateDatastoreExtension: grandfathers when detectLocalEdits returns no-anchor", async () => {
+  const deps = createMockDeps({
+    detectLocalEdits: () => Promise.resolve("no-anchor"),
+  });
+  const result = await maybeAutoUpdateDatastoreExtension(
+    "@swamp/s3-datastore",
+    deps,
+  );
+  assertEquals(result?.updated, true);
+  assertEquals(result?.skipped, undefined);
   assertEquals(deps.pulled, ["@swamp/s3-datastore@2026.03.30.1"]);
 });

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -29,6 +29,7 @@ import {
   swampPath,
 } from "../../infrastructure/persistence/paths.ts";
 import { computeChecksum } from "../../domain/models/checksum.ts";
+import { readInstalledExtensionDigest } from "../../infrastructure/persistence/installed_extension_digest_reader.ts";
 import { verifyChecksum } from "../../domain/update/integrity.ts";
 import { resolveLocalImports } from "../../domain/models/local_import_resolver.ts";
 import type { Logger } from "@logtape/logtape";
@@ -253,6 +254,7 @@ export async function updateUpstreamExtensions(
   options?: {
     include?: string[];
     checksum?: string;
+    filesChecksum?: string;
     serverUrl?: string;
   },
 ): Promise<void> {
@@ -283,6 +285,9 @@ export async function updateUpstreamExtensions(
         ? { include: options.include }
         : {}),
       ...(options?.checksum ? { checksum: options.checksum } : {}),
+      ...(options?.filesChecksum
+        ? { filesChecksum: options.filesChecksum }
+        : {}),
       ...(options?.serverUrl ? { serverUrl: options.serverUrl } : {}),
     };
 
@@ -1072,6 +1077,14 @@ export async function installExtension(
       )
       : undefined;
 
+    // Per-extension on-disk digest anchor. Computed AFTER every write that
+    // belongs to the install (copyDir + the read-only manifest.yaml copy)
+    // and BEFORE the lockfile write, so the digest captures exactly what
+    // the installer just produced. Auto-update consults this on the next
+    // version bump to refuse overwrites when the user has local edits
+    // (issue #126).
+    const filesChecksum = await readInstalledExtensionDigest(absoluteExtRoot);
+
     await updateUpstreamExtensions(
       ctx.lockfilePath,
       ref.name,
@@ -1080,6 +1093,7 @@ export async function installExtension(
       {
         include: includeFiles,
         checksum: localChecksum,
+        filesChecksum: filesChecksum ?? undefined,
         serverUrl: resolveServerUrl(),
       },
     );


### PR DESCRIPTION
## Summary

Fixes swamp-club#126 — datastore auto-update uses `force: true` in the `pullExtension` callback and silently overwrites any local edits a user has made under `.swamp/pulled-extensions/<name>/`. Same data-loss family as swamp-club#121/#1187 (auto-resolver force-pull), different trigger (version-behind rather than type-not-found), different fix shape (per-file anchor rather than `isInstalled` skip — because auto-update, by definition, wants to replace the prior install).

**Approach:**

- Record a rolled-up SHA-256 digest of the per-extension on-disk subtree in `upstream_extensions.json` at install time (`filesChecksum`), distinct from the existing archive `checksum`.
- Before auto-update fires `installExtension` with `force: true`, the service calls a new `detectLocalEdits` dep that compares the stored anchor with a fresh disk digest. Tri-state outcome: `match` proceeds; `mismatch` returns a structured `{ skipped: "local_edits", previousVersion, newVersion }` result and does NOT call `pullExtension`; `no-anchor` grandfathers pre-existing installs and proceeds.
- The CLI caller (`resolve_datastore.ts`) inspects the skipped result and emits `logger.warn` directing the user to `swamp extension pull <name> --force` as the explicit opt-in. The refusal is a STRUCTURED RESULT rather than a thrown error because the outer try/catch intentionally swallows exceptions to honor "never block command execution for auto-update failures"; a structured result separates \"error — swallow\" from \"refusal — surface\" cleanly.

**DDD split:**

- Pure combiner in `src/domain/extensions/installed_extension_digest.ts` takes pre-hashed entries and produces the rollup digest. No FS access.
- FS-walking reader in `src/infrastructure/persistence/installed_extension_digest_reader.ts` walks the per-extension tree, hashes each file, and calls the pure combiner.
- Mirrors the pattern already in use for `src/domain/models/checksum.ts` (pure compute) vs callers that read bytes from disk.

**Grandfather / migration:**

Pre-anchor lockfile entries (installs from before this change) lack `filesChecksum`. `detectLocalEdits` returns `no-anchor` for them and auto-update proceeds as it does today. On the next install, the anchor is written and all subsequent auto-updates are protected. A one-time silent-overwrite window remains for users with pending edits AND a stale lockfile entry AND an auto-update firing before they next pull — acceptable given the scope of the fix; mentioned here for release notes.

## Follow-ups filed separately

- **swamp-club#129** — `src/cli/commands/open.ts:185` has the same `force: true` pattern in the web UI's non-interactive install callback. Same data-loss family, different trigger; tracked separately.
- **swamp-club#130** — `logger.warn` is silent in `--json` mode because the logger's catch-all is `lowestLevel: \"fatal\"` in JSON output mode. The auto-update refusal is silent in JSON mode (data is still protected — refusal short-circuits before `installExtension` — but the user gets no signal why auto-update isn't happening). Pre-existing issue affecting ~50 `logger.warn` call sites; changing it is too much blast radius for a bug-fix PR.

**Explicitly out of scope / confirmed safe:**

- `src/cli/commands/extension_install.ts:114` uses `force: true` but the caller in `src/libswamp/extensions/install.ts:88-97` short-circuits via `hasAnyMissingFiles` before calling `installExtension` if any tracked file exists. Local edits and force:true cannot co-exist on that path.
- `swamp extension pull` / `extension update` — explicit user opt-in, not a silent path; unaffected.

## Test plan

- [x] `deno check` clean
- [x] `deno lint` clean
- [x] `deno fmt` applied
- [x] `deno run test` — 4447 passed, 0 failed (includes 7 new tests covering: digest determinism, FS-reader invariants, auto-update tri-state decision tree, caller-layer warning message)
- [x] `deno run compile` succeeded
- [ ] Manual JSON-mode verification deliberately skipped — this PR does not change JSON-mode behavior (the WARN is silent in JSON mode by pre-existing design; tracked as swamp-club#130)
- [ ] UAT follow-up: a new `tests/cli/extension/auto_update_preserves_local_edits_test.ts` parallel to `pull_wip_preservation_test.ts` (which locks in the #121 fix) should be filed as a swamp-uat issue after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)