### PR TITLE
fix(extensions): refuse web UI install on local edits (swamp-club#129)

### DIFF
--- a/src/cli/commands/open.ts
+++ b/src/cli/commands/open.ts
@@ -36,6 +36,8 @@ import {
 import {
   createLibSwampContext,
   createModelCreateDeps,
+  detectLocalEditsForExtension,
+  LocalEditsError,
   modelCreate,
 } from "../../libswamp/mod.ts";
 import { pullExtension } from "./extension_pull.ts";
@@ -169,6 +171,22 @@ export const openCommand = new Command()
           absoluteModelsDir,
           "upstream_extensions.json",
         );
+        // Refuse to silently overwrite local edits. The web UI install path
+        // runs with force:true (no stdin for the "overwrite?" prompt), so
+        // the force-pull is the only thing protecting user edits from
+        // silent loss (swamp-club#129, sibling of #121/#126). The check
+        // covers only the top-level extension the user clicked; dependency
+        // re-install is already short-circuited in installExtension when a
+        // dep is present in upstream_extensions.json, so dependency edits
+        // are not at risk through this surface.
+        const editsStatus = await detectLocalEditsForExtension(
+          repoDir,
+          name,
+          lockfilePath,
+        );
+        if (editsStatus === "mismatch") {
+          throw new LocalEditsError(name);
+        }
         await pullExtension(
           { name, version: null },
           {
@@ -181,7 +199,7 @@ export const openCommand = new Command()
             repoDir,
             // Force overwrite — the web UI has no stdin to answer the
             // "overwrite existing files?" prompt, so we always install
-            // non-interactively and let the latest version win.
+            // non-interactively. Local-edits protection runs above.
             force: true,
             outputMode: ctx.outputMode,
             alreadyPulled: new Set(),

--- a/src/cli/resolve_datastore.ts
+++ b/src/cli/resolve_datastore.ts
@@ -44,9 +44,9 @@ import { getAutoResolver } from "../domain/extensions/auto_resolver_context.ts";
 import { maybeAutoUpdateDatastoreExtension } from "../libswamp/extensions/datastore_auto_update.ts";
 import { FileExtensionUpdateCheckRepository } from "../infrastructure/persistence/extension_update_check_repository.ts";
 import { readUpstreamExtensions } from "../infrastructure/persistence/upstream_extensions.ts";
-import { readInstalledExtensionDigest } from "../infrastructure/persistence/installed_extension_digest_reader.ts";
 import { ExtensionApiClient } from "../infrastructure/http/extension_api_client.ts";
 import {
+  detectLocalEditsForExtension,
   enumeratePulledExtensionDirs,
   installExtension,
 } from "../libswamp/mod.ts";
@@ -110,28 +110,8 @@ async function maybeAutoUpdateSwampDatastore(
           return null;
         }
       },
-      detectLocalEdits: async (name) => {
-        // Compare the stored at-install digest with a fresh digest over
-        // the on-disk per-extension subtree. Infrastructure errors (lockfile
-        // missing, dir unreadable) degrade to "no-anchor" so auto-update
-        // never blocks a user command on a safety-check bug (issue #126).
-        try {
-          const upstream = await readUpstreamExtensions(lockfilePath);
-          const stored = upstream[name]?.filesChecksum;
-          if (!stored) return "no-anchor";
-          const extRoot = join(
-            resolve(repoDir),
-            ".swamp",
-            "pulled-extensions",
-            name,
-          );
-          const onDisk = await readInstalledExtensionDigest(extRoot);
-          if (onDisk === null) return "no-anchor";
-          return onDisk === stored ? "match" : "mismatch";
-        } catch {
-          return "no-anchor";
-        }
-      },
+      detectLocalEdits: (name) =>
+        detectLocalEditsForExtension(repoDir, name, lockfilePath),
       pullExtension: async (name, version) => {
         const resolvedRepoDir = resolve(repoDir);
 

--- a/src/libswamp/extensions/datastore_auto_update.ts
+++ b/src/libswamp/extensions/datastore_auto_update.ts
@@ -23,20 +23,9 @@ import {
   isExtensionCheckStale,
 } from "../../domain/extensions/extension_update_check_cache.ts";
 import { checkExtensionVersion } from "../../domain/extensions/extension_update_service.ts";
+import type { LocalEditsStatus } from "./local_edits.ts";
 
 const logger = getLogger(["swamp", "extensions", "auto-update"]);
-
-/**
- * Tri-state outcome from the local-edits check. Produced by the caller-
- * supplied `detectLocalEdits` dep.
- *
- * - `match` — on-disk digest equals the stored anchor; safe to overwrite.
- * - `mismatch` — on-disk digest diverges from the anchor; user has edited
- *   something and auto-update must refuse.
- * - `no-anchor` — no stored anchor for this extension (pre-upgrade lockfile
- *   entry); grandfather path, proceed as before.
- */
-export type LocalEditsStatus = "match" | "mismatch" | "no-anchor";
 
 /**
  * Reason an auto-update attempt was skipped. Distinct from silent errors

--- a/src/libswamp/extensions/local_edits.ts
+++ b/src/libswamp/extensions/local_edits.ts
@@ -1,0 +1,86 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join, resolve } from "@std/path";
+import { UserError } from "../../domain/errors.ts";
+import { readInstalledExtensionDigest } from "../../infrastructure/persistence/installed_extension_digest_reader.ts";
+import { readUpstreamExtensions } from "../../infrastructure/persistence/upstream_extensions.ts";
+
+/**
+ * Tri-state outcome of the local-edits check.
+ *
+ * - `match` — on-disk digest equals the stored filesChecksum anchor;
+ *   safe to overwrite.
+ * - `mismatch` — on-disk digest diverges from the anchor; user has edited
+ *   something since install and the caller must refuse silent overwrite.
+ * - `no-anchor` — no stored anchor (pre-filesChecksum lockfile entry, or
+ *   extension not installed at all). Grandfather path — caller proceeds
+ *   as before the check existed.
+ */
+export type LocalEditsStatus = "match" | "mismatch" | "no-anchor";
+
+/**
+ * Compares the lockfile-stored filesChecksum for `name` against a fresh
+ * digest of the on-disk per-extension subtree. Any infrastructure error
+ * (lockfile unreadable, per-extension dir unwalkable) degrades to
+ * `no-anchor` so callers never wedge a user command on a safety-check bug.
+ */
+export async function detectLocalEditsForExtension(
+  repoDir: string,
+  name: string,
+  lockfilePath: string,
+): Promise<LocalEditsStatus> {
+  try {
+    const upstream = await readUpstreamExtensions(lockfilePath);
+    const stored = upstream[name]?.filesChecksum;
+    if (!stored) return "no-anchor";
+    const extRoot = join(
+      resolve(repoDir),
+      ".swamp",
+      "pulled-extensions",
+      name,
+    );
+    const onDisk = await readInstalledExtensionDigest(extRoot);
+    if (onDisk === null) return "no-anchor";
+    return onDisk === stored ? "match" : "mismatch";
+  } catch {
+    return "no-anchor";
+  }
+}
+
+/**
+ * Thrown synchronously by callers that refuse a force-overwrite when
+ * local edits are detected. Message names the extension and points the
+ * user at the explicit opt-in command. Extends UserError so CLI layers
+ * render it without a stack trace; distinct class so HTTP layers can map
+ * it to a dedicated status code (409 Conflict).
+ */
+export class LocalEditsError extends UserError {
+  readonly extensionName: string;
+  constructor(extensionName: string) {
+    super(
+      `Refusing to overwrite ${extensionName}: local edits detected under ` +
+        `.swamp/pulled-extensions/${extensionName}/. Run ` +
+        `'swamp extension pull ${extensionName} --force' from the terminal ` +
+        `to overwrite, or revert your edits first.`,
+    );
+    this.name = "LocalEditsError";
+    this.extensionName = extensionName;
+  }
+}

--- a/src/libswamp/extensions/local_edits_test.ts
+++ b/src/libswamp/extensions/local_edits_test.ts
@@ -1,0 +1,160 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import {
+  detectLocalEditsForExtension,
+  LocalEditsError,
+} from "./local_edits.ts";
+import { readInstalledExtensionDigest } from "../../infrastructure/persistence/installed_extension_digest_reader.ts";
+import { UserError } from "../../domain/errors.ts";
+
+const EXT_NAME = "@test/ext";
+
+async function withRepo(
+  fn: (repoDir: string, lockfilePath: string, extRoot: string) => Promise<void>,
+): Promise<void> {
+  const repoDir = await Deno.makeTempDir({ prefix: "swamp_local_edits_" });
+  try {
+    const modelsDir = join(repoDir, "extensions", "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+    const lockfilePath = join(modelsDir, "upstream_extensions.json");
+    const extRoot = join(repoDir, ".swamp", "pulled-extensions", EXT_NAME);
+    await Deno.mkdir(extRoot, { recursive: true });
+    await fn(repoDir, lockfilePath, extRoot);
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+  }
+}
+
+async function writeLockfile(
+  lockfilePath: string,
+  entry: Record<string, unknown>,
+): Promise<void> {
+  await Deno.writeTextFile(
+    lockfilePath,
+    JSON.stringify({ [EXT_NAME]: entry }, null, 2) + "\n",
+  );
+}
+
+Deno.test("detectLocalEditsForExtension: match when on-disk digest equals anchor", async () => {
+  await withRepo(async (repoDir, lockfilePath, extRoot) => {
+    await Deno.mkdir(join(extRoot, "models"), { recursive: true });
+    await Deno.writeTextFile(join(extRoot, "models", "foo.ts"), "content");
+    const anchor = await readInstalledExtensionDigest(extRoot);
+    assert(anchor !== null);
+    await writeLockfile(lockfilePath, {
+      version: "1.0.0",
+      pulledAt: new Date().toISOString(),
+      filesChecksum: anchor,
+    });
+
+    const result = await detectLocalEditsForExtension(
+      repoDir,
+      EXT_NAME,
+      lockfilePath,
+    );
+    assertEquals(result, "match");
+  });
+});
+
+Deno.test("detectLocalEditsForExtension: mismatch when a file is edited after install", async () => {
+  await withRepo(async (repoDir, lockfilePath, extRoot) => {
+    await Deno.mkdir(join(extRoot, "models"), { recursive: true });
+    await Deno.writeTextFile(join(extRoot, "models", "foo.ts"), "original");
+    const anchor = await readInstalledExtensionDigest(extRoot);
+    assert(anchor !== null);
+    await writeLockfile(lockfilePath, {
+      version: "1.0.0",
+      pulledAt: new Date().toISOString(),
+      filesChecksum: anchor,
+    });
+
+    await Deno.writeTextFile(join(extRoot, "models", "foo.ts"), "edited");
+
+    const result = await detectLocalEditsForExtension(
+      repoDir,
+      EXT_NAME,
+      lockfilePath,
+    );
+    assertEquals(result, "mismatch");
+  });
+});
+
+Deno.test("detectLocalEditsForExtension: no-anchor when lockfile entry lacks filesChecksum", async () => {
+  await withRepo(async (repoDir, lockfilePath, extRoot) => {
+    await Deno.mkdir(join(extRoot, "models"), { recursive: true });
+    await Deno.writeTextFile(join(extRoot, "models", "foo.ts"), "content");
+    await writeLockfile(lockfilePath, {
+      version: "1.0.0",
+      pulledAt: new Date().toISOString(),
+      // Pre-anchor lockfile entry: no filesChecksum field.
+    });
+
+    const result = await detectLocalEditsForExtension(
+      repoDir,
+      EXT_NAME,
+      lockfilePath,
+    );
+    assertEquals(result, "no-anchor");
+  });
+});
+
+Deno.test("detectLocalEditsForExtension: no-anchor when lockfile does not exist", async () => {
+  await withRepo(async (repoDir, _lockfilePath, _extRoot) => {
+    const missingLockfile = join(repoDir, "missing-lockfile.json");
+    const result = await detectLocalEditsForExtension(
+      repoDir,
+      EXT_NAME,
+      missingLockfile,
+    );
+    assertEquals(result, "no-anchor");
+  });
+});
+
+Deno.test("detectLocalEditsForExtension: no-anchor when per-extension dir is missing", async () => {
+  await withRepo(async (repoDir, lockfilePath, extRoot) => {
+    await writeLockfile(lockfilePath, {
+      version: "1.0.0",
+      pulledAt: new Date().toISOString(),
+      filesChecksum: "deadbeef".repeat(8),
+    });
+    await Deno.remove(extRoot, { recursive: true });
+
+    const result = await detectLocalEditsForExtension(
+      repoDir,
+      EXT_NAME,
+      lockfilePath,
+    );
+    assertEquals(result, "no-anchor");
+  });
+});
+
+Deno.test("LocalEditsError: message names the extension and the remediation", () => {
+  const err = new LocalEditsError("@swamp/aws-ec2");
+  assertStringIncludes(err.message, "@swamp/aws-ec2");
+  assertStringIncludes(
+    err.message,
+    "swamp extension pull @swamp/aws-ec2 --force",
+  );
+  assertEquals(err.extensionName, "@swamp/aws-ec2");
+  assertEquals(err.name, "LocalEditsError");
+  assert(err instanceof UserError);
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -570,6 +570,11 @@ export {
   maybeAutoUpdateDatastoreExtension,
 } from "./extensions/datastore_auto_update.ts";
 export {
+  detectLocalEditsForExtension,
+  LocalEditsError,
+  type LocalEditsStatus,
+} from "./extensions/local_edits.ts";
+export {
   type ExtensionUpdateCheckMap,
   type ExtensionUpdateCheckRepository,
   isExtensionCheckStale,

--- a/src/serve/open/http.ts
+++ b/src/serve/open/http.ts
@@ -31,6 +31,7 @@ import {
   extensionList,
   extensionSearch,
   type ExtensionSearchDeps,
+  LocalEditsError,
   modelDelete,
   modelMethodDescribe,
   modelMethodRun,
@@ -1085,6 +1086,15 @@ async function handleExtensionInstall(
   try {
     await state.installExtension(body.name);
   } catch (e) {
+    // LocalEditsError → 409 Conflict so the UI can distinguish a refusal
+    // (user must act: edit elsewhere or opt in via --force from the
+    // terminal) from an unexpected server error. swamp-club#129.
+    if (e instanceof LocalEditsError) {
+      return Response.json(
+        { error: { message: e.message } },
+        { status: 409 },
+      );
+    }
     return Response.json(
       { error: { message: e instanceof Error ? e.message : String(e) } },
       { status: 500 },

--- a/src/serve/open/http_test.ts
+++ b/src/serve/open/http_test.ts
@@ -17,9 +17,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { handleOpenRequest, type OpenServerState } from "./http.ts";
 import type { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
+import { LocalEditsError } from "../../libswamp/mod.ts";
 
 function stubState(): OpenServerState {
   const extClient = {
@@ -161,4 +162,55 @@ Deno.test("handleOpenRequest: /api/repo/meta requires absolute path", async () =
   assertEquals(res.status, 400);
   const body = await res.json();
   assertEquals(body.error.message, "Absolute path required");
+});
+
+function stubLoadedState(
+  installExtension: (name: string) => Promise<void>,
+): OpenServerState {
+  const state = stubState();
+  // The /api/extensions/install route is gated by requireRepo, which only
+  // checks that these three fields are truthy. The install handler itself
+  // never reads repoContext or datastoreConfig — it calls
+  // state.installExtension — so stubbing with empty objects is sufficient.
+  state.repoDir = "/tmp/stub-repo";
+  state.repoContext = {} as OpenServerState["repoContext"];
+  state.datastoreConfig = {} as OpenServerState["datastoreConfig"];
+  state.installExtension = installExtension;
+  return state;
+}
+
+Deno.test("handleOpenRequest: POST /api/extensions/install maps LocalEditsError to 409", async () => {
+  const state = stubLoadedState(() =>
+    Promise.reject(new LocalEditsError("@test/ext"))
+  );
+  const res = await handleOpenRequest(
+    new Request("http://127.0.0.1:9191/api/extensions/install", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "@test/ext" }),
+    }),
+    state,
+  );
+  assertEquals(res.status, 409);
+  const body = await res.json();
+  assertStringIncludes(body.error.message, "@test/ext");
+  assertStringIncludes(
+    body.error.message,
+    "swamp extension pull @test/ext --force",
+  );
+});
+
+Deno.test("handleOpenRequest: POST /api/extensions/install maps unexpected errors to 500", async () => {
+  const state = stubLoadedState(() => Promise.reject(new Error("boom")));
+  const res = await handleOpenRequest(
+    new Request("http://127.0.0.1:9191/api/extensions/install", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "@test/ext" }),
+    }),
+    state,
+  );
+  assertEquals(res.status, 500);
+  const body = await res.json();
+  assertEquals(body.error.message, "boom");
 });


### PR DESCRIPTION
## Summary

Third in the data-loss family (sibling of #121/#1187 and #126/#1190). `swamp open`'s web UI install callback calls `pullExtension` with `force: true` and, pre-fix, had no local-edits check — so hitting `POST /api/extensions/install` for an already-installed extension would silently overwrite anything the user had edited under `.swamp/pulled-extensions/<name>/`.

Port #126's `filesChecksum` anchor + detectLocalEdits pattern into a shared libswamp helper and consult it from the web UI before the force-pull. On mismatch, throw a typed `LocalEditsError`; the HTTP handler maps it to **409 Conflict** with a body that names the extension and the opt-in remediation (`swamp extension pull <name> --force`).

The ui.ts Install button only renders for **uninstalled** extensions today, so there's no UI click path that reaches this bug — the fix is defense-in-depth for the HTTP endpoint itself, which is reachable by curl, scripts, or any future UI change (e.g. an "Update / Reinstall" button). Scope and fix-shape intentionally mirror #126.

### What changes
- New `src/libswamp/extensions/local_edits.ts` — shared helper (`detectLocalEditsForExtension`, `LocalEditsStatus`, `LocalEditsError`), re-exported through `libswamp/mod.ts`
- `src/cli/resolve_datastore.ts` — #126's inline `detectLocalEdits` closure collapses to a one-line call into the new helper (pure DRY)
- `src/cli/commands/open.ts` — `installExtension` callback runs the local-edits check before force-pull; throws `LocalEditsError` on mismatch
- `src/serve/open/http.ts` — `handleExtensionInstall` maps `LocalEditsError` → 409, unchanged 500 fallthrough for other errors
- Unit tests at the new helper and at the HTTP handler layer

### What's out of scope
- `extension_update.ts:118` and `extension_install.ts:114` still use `force:true`; the former is an explicit user command, the latter is lockfile-restore. Refusing them would break their contracts.
- The dependency-with-corrupt-lockfile edge case (parent reinstall recurses into a dep missing from `upstream_extensions.json` but present on disk with edits) — matches #126's scope. Fixing it would require pushing the check into `installExtension` itself, which would wrongly refuse the opt-in paths above.
- End-to-end UAT for the web UI refuse flow: filed as [systeminit/swamp-uat#150](https://github.com/systeminit/swamp-uat/issues/150).

## Test Plan

- [x] `deno check`, `deno lint`, `deno fmt`, full `deno run test` (4455 passed), `deno run compile`
- [x] New unit coverage: 6 tests in `src/libswamp/extensions/local_edits_test.ts` (match, mismatch, no-anchor × 3 conditions, LocalEditsError message shape)
- [x] New handler coverage: 2 tests in `src/serve/open/http_test.ts` (409 on `LocalEditsError`, 500 on plain `Error` as a regression fence)
- [x] Manual E2E with locally compiled binary: scratch repo → `swamp extension pull @stack72/system-extensions` → edit a file → `curl POST /api/extensions/install` → got 409 with the expected remediation body. `swamp extension pull --force` → curl again → 200.
- [x] #126's `datastore_auto_update_test.ts` and `resolve_datastore_test.ts` both still green after the helper refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)