### PR TITLE
fix(extensions): port bundle_freshness to reports/drivers/datastores/vaults loaders (#128)

### DIFF
--- a/.claude/skills/swamp-extension-datastore/SKILL.md
+++ b/.claude/skills/swamp-extension-datastore/SKILL.md
@@ -175,7 +175,9 @@ swamp datastore status --json
 - Discovery: Recursive, all `.ts` files
 - Excluded: Files ending in `_test.ts`
 - Export: Files without `export const datastore` are silently skipped
-- Caching: Bundles are cached in `.swamp/datastore-bundles/` (mtime-based)
+- Caching: Bundles are cached in `.swamp/datastore-bundles/`
+  (content-fingerprint based — sha-256 over the entry point plus every local
+  `.ts` dep)
 
 ## Key Rules
 

--- a/.claude/skills/swamp-extension-datastore/references/troubleshooting.md
+++ b/.claude/skills/swamp-extension-datastore/references/troubleshooting.md
@@ -34,9 +34,15 @@ files).
 
 **Symptom:** Changes to your datastore code aren't taking effect.
 
-**Cause:** Bundles are cached in `.swamp/datastore-bundles/` with mtime-based
-invalidation. If file timestamps are incorrect (e.g., after `git checkout`), the
-cache may serve stale code.
+**Cause:** Bundles are cached in `.swamp/datastore-bundles/` with
+content-fingerprint (sha-256) invalidation, so edits should be detected
+regardless of mtime. If a bundle still looks stale, the cache file itself may be
+corrupt.
+
+**Note on first upgrade:** The first `swamp` command after upgrading from a
+pre-fingerprint binary rebundles every datastore extension once — legacy catalog
+rows carry an empty fingerprint that forces one rebundle, then subsequent runs
+settle back to the normal cache-hit path.
 
 **Fix:** Delete the cached bundle:
 

--- a/.claude/skills/swamp-extension-driver/SKILL.md
+++ b/.claude/skills/swamp-extension-driver/SKILL.md
@@ -215,7 +215,8 @@ driver file — swamp silently skips files that fail to compile.
 - Discovery: Recursive, all `.ts` files
 - Excluded: Files ending in `_test.ts`
 - Export: Files without `export const driver` are silently skipped
-- Caching: Bundles are cached in `.swamp/driver-bundles/` (mtime-based)
+- Caching: Bundles are cached in `.swamp/driver-bundles/` (content-fingerprint
+  based — sha-256 over the entry point plus every local `.ts` dep)
 
 ## Key Rules
 

--- a/.claude/skills/swamp-extension-driver/references/troubleshooting.md
+++ b/.claude/skills/swamp-extension-driver/references/troubleshooting.md
@@ -47,9 +47,15 @@ fields. The most specific (step-level) takes precedence.
 
 **Symptom:** Changes to your driver code aren't taking effect.
 
-**Cause:** Bundles are cached in `.swamp/driver-bundles/` with mtime-based
-invalidation. If file timestamps are incorrect (e.g., after `git checkout`), the
-cache may serve stale code.
+**Cause:** Bundles are cached in `.swamp/driver-bundles/` with
+content-fingerprint (sha-256) invalidation, so edits should be detected
+regardless of mtime. If a bundle still looks stale, the cache file itself may be
+corrupt.
+
+**Note on first upgrade:** The first `swamp` command after upgrading from a
+pre-fingerprint binary rebundles every driver extension once — legacy catalog
+rows carry an empty fingerprint that forces one rebundle, then subsequent runs
+settle back to the normal cache-hit path.
 
 **Fix:** Delete the cached bundle:
 

--- a/.claude/skills/swamp-extension-vault/SKILL.md
+++ b/.claude/skills/swamp-extension-vault/SKILL.md
@@ -186,7 +186,8 @@ swamp vault status --json
 - Discovery: Recursive, all `.ts` files
 - Excluded: Files ending in `_test.ts`, directories starting with `_`
 - Export: Files without `export const vault` are silently skipped
-- Caching: Bundles are cached in `.swamp/vault-bundles/` (mtime-based)
+- Caching: Bundles are cached in `.swamp/vault-bundles/` (content-fingerprint
+  based — sha-256 over the entry point plus every local `.ts` dep)
 
 ## Key Rules
 

--- a/.claude/skills/swamp-extension-vault/references/troubleshooting.md
+++ b/.claude/skills/swamp-extension-vault/references/troubleshooting.md
@@ -33,9 +33,15 @@
 
 **Symptom:** Changes to your vault code aren't taking effect.
 
-**Cause:** Bundles are cached in `.swamp/vault-bundles/` with mtime-based
-invalidation. If file timestamps are incorrect (e.g., after `git checkout`), the
-cache may serve stale code.
+**Cause:** Bundles are cached in `.swamp/vault-bundles/` with
+content-fingerprint (sha-256) invalidation, so edits should be detected
+regardless of mtime. If a bundle still looks stale, the cache file itself may be
+corrupt.
+
+**Note on first upgrade:** The first `swamp` command after upgrading from a
+pre-fingerprint binary rebundles every vault extension once — legacy catalog
+rows carry an empty fingerprint that forces one rebundle, then subsequent runs
+settle back to the normal cache-hit path.
 
 **Fix:** Delete the cached bundle:
 

--- a/design/datastores.md
+++ b/design/datastores.md
@@ -91,7 +91,10 @@ externalized, and validates the export against `UserDatastoreSchema` — a Zod
 schema requiring `type`, `name`, `description`, an optional `configSchema`, and
 a `createProvider` factory function. Files without a `datastore` export are
 silently skipped. Bundles are cached in `.swamp/datastore-bundles/` with
-mtime-based invalidation to avoid redundant compilation. If the source contains
+content-fingerprint invalidation (sha-256 over the entry point plus every
+local `.ts` dep) to avoid redundant compilation — mtime-based freshness was
+unreliable under atomic-rename saves, mtime-preserving sync tools, and
+sub-millisecond edits (issue #125). If the source contains
 bare specifiers (e.g., `from "zod"` instead of `from "npm:zod@4"`) and a cached
 bundle exists, the cached bundle is used since re-bundling would fail without
 the project's `deno.json` import map.

--- a/design/execution-drivers.md
+++ b/design/execution-drivers.md
@@ -196,7 +196,10 @@ See `src/domain/drivers/execution_driver.ts` for the full interface.
 externalized, and validates the export against `UserDriverSchema` — requiring
 `type`, `name`, `description`, an optional `configSchema`, and a `createDriver`
 factory function. Files without a `driver` export are silently skipped. Bundles
-are cached in `.swamp/driver-bundles/` with mtime-based invalidation.
+are cached in `.swamp/driver-bundles/` with content-fingerprint invalidation
+(sha-256 over the entry point plus every local `.ts` dep) — mtime-based
+freshness was unreliable under atomic-rename saves, mtime-preserving sync
+tools, and sub-millisecond edits (issue #125).
 
 ### Resolution with Custom Drivers
 

--- a/design/extension.md
+++ b/design/extension.md
@@ -633,8 +633,9 @@ how many extensions are installed.
 
 **Extension Catalog**: A SQLite database at `.swamp/_extension_catalog.db`
 indexes all known bundle types. Each entry stores the type name, bundle path,
-source path, source mtime, version, and (for extensions) the base type it
-targets. The catalog lives at the `.swamp` root level because it is shared
+source path, source mtime, source fingerprint (sha-256 content hash), version,
+and (for extensions) the base type it targets. Freshness is decided by the
+content fingerprint; `source_mtime` is retained for observability only. The catalog lives at the `.swamp` root level because it is shared
 across all registry types (models, vaults, drivers, datastores, reports). It
 is completely independent of the data catalog (`_catalog.db`) used for data
 queries.
@@ -648,10 +649,14 @@ the model registry is wired up initially.
 1. On first `ensureLoaded()` call, the model registry's loader runs
    `buildIndex()` which:
    - Checks the catalog's `populated` flag
-   - If populated: scans source directories, compares entry-point mtimes
-     against catalog entries and checks transitive dependency mtimes against
-     cached bundle files, rebundles only changed files, then registers lazy
-     entries for all types from the catalog (no bundle imports)
+   - If populated: scans source directories, computes a sha-256 content
+     fingerprint over each entry point plus its transitive local `.ts`
+     dependencies, compares that against the catalog's stored fingerprint,
+     rebundles only changed files, then registers lazy entries for all types
+     from the catalog (no bundle imports). Fingerprint-based freshness
+     replaced mtime-based freshness in issue #125 — mtime was fragile under
+     atomic-rename saves, mtime-preserving sync tools, and sub-millisecond
+     edits.
    - If not populated (first run or DB deleted): falls back to the existing
      full-import path, then populates the catalog from the loaded registry
 

--- a/design/reports.md
+++ b/design/reports.md
@@ -144,8 +144,10 @@ validates the export against a Zod schema requiring:
 - `execute` — function
 
 Files without a `report` export are silently skipped (they may be utility
-modules). Bundles are cached in `.swamp/report-bundles/` with mtime-based
-invalidation.
+modules). Bundles are cached in `.swamp/report-bundles/` with
+content-fingerprint invalidation (sha-256 over the entry point plus every
+local `.ts` dep) — mtime-based freshness was unreliable under atomic-rename
+saves, mtime-preserving sync tools, and sub-millisecond edits (issue #125).
 
 See `src/domain/reports/user_report_loader.ts`.
 

--- a/integration/architecture_boundary_test.ts
+++ b/integration/architecture_boundary_test.ts
@@ -136,7 +136,16 @@ function importsLayer(
 // cross-cutting extensions-domain service consumed by the models loader.
 // The reverse edge (extensions → models) already existed via
 // extension_auto_resolver and friends.
-const KNOWN_MUTUAL_DEPENDENCIES = 14;
+//
+// extensions <-> datastore was added by #128 — user_datastore_loader
+// now consumes bundle_freshness (extensions-domain) for content-fingerprint
+// cache invalidation. The reverse edge (extensions → datastore) already
+// existed via extension_auto_resolver. reports/drivers/vaults loaders
+// also gained unidirectional dependencies on extensions for the same
+// reason, but extensions does not import from reports/drivers so those
+// remain non-mutual. vaults ↔ extensions was already mutual pre-#128
+// via extension_auto_resolver ↔ user_vault_loader.
+const KNOWN_MUTUAL_DEPENDENCIES = 15;
 
 Deno.test(
   "no new mutual dependencies between bounded contexts (ratchet)",

--- a/src/domain/datastore/user_datastore_loader.ts
+++ b/src/domain/datastore/user_datastore_loader.ts
@@ -29,7 +29,12 @@ import {
   sanitizeDataUrlError,
   uint8ArrayToBase64,
 } from "../models/bundle.ts";
-import { resolveLocalImports } from "../models/local_import_resolver.ts";
+import {
+  computeSourceFingerprint,
+  createFreshnessCache,
+  findStaleFiles as findStaleFilesShared,
+  type FreshnessCache,
+} from "../extensions/bundle_freshness.ts";
 import type { DenoRuntime } from "../runtime/deno_runtime.ts";
 import type { DatastoreProvider } from "./datastore_provider.ts";
 import { datastoreTypeRegistry } from "./datastore_type_registry.ts";
@@ -226,40 +231,27 @@ export class UserDatastoreLoader {
         relativePath.replace(/\.ts$/, ".js"),
       );
 
-      // Check mtime-based cache against all local dependencies.
-      // If the bundle exists but freshness cannot be determined (e.g. a
-      // dependency file is missing because the extension was pushed with an
-      // older swamp that had a single-line import regex), fall back to the
-      // cached bundle rather than attempting a re-bundle that will also fail.
+      // Freshness is decided by the caller via
+      // bundle_freshness.findStaleFiles (content-fingerprint compare).
+      // We only care whether a bundle file exists on disk so we can
+      // fall back to it if rebundling fails with an expected error
+      // (bare specifiers without deno.json). No mtime check here —
+      // mtime-based freshness was unreliable under atomic-rename
+      // saves (#125).
       let bundleExists = false;
       try {
-        const bundleStat = await Deno.stat(bundlePath);
+        await Deno.stat(bundlePath);
         bundleExists = true;
-        if (bundleStat.mtime) {
-          const { resolvedFiles } = await resolveLocalImports(
-            [absolutePath],
-            boundaryDir,
-          );
-          const depStats = await Promise.all(
-            resolvedFiles.map((f) => Deno.stat(f)),
-          );
-          const newestSourceMtime = depStats.reduce<Date | null>(
-            (max, s) => {
-              if (!s.mtime) return max;
-              if (!max) return s.mtime;
-              return s.mtime > max ? s.mtime : max;
-            },
-            null,
-          );
-          if (newestSourceMtime && bundleStat.mtime >= newestSourceMtime) {
-            logger.debug`Using cached datastore bundle for ${relativePath}`;
-            return await Deno.readTextFile(bundlePath);
-          }
-        }
       } catch {
-        // Freshness check failed (e.g. missing dependency file).
-        // Fall through to attempt a rebundle rather than using a
-        // potentially stale cache.
+        // No bundle on disk yet — first-run bootstrap.
+      }
+
+      // Fast-path for pulled extensions with bare specifiers and no
+      // repo-side deno.json. bundleExtension would always fail for them
+      // and we'd wastefully spawn Deno before falling back to the
+      // cached bundle anyway.
+      if (bundleExists && isExpectedBundleFailure(absolutePath, this.repoDir)) {
+        return await Deno.readTextFile(bundlePath);
       }
 
       // Try to rebundle from source. If bundling fails (e.g. bare specifiers
@@ -454,7 +446,7 @@ export class UserDatastoreLoader {
       skipAlreadyRegistered: true,
     });
 
-    this.populateCatalogFromRegistry(
+    await this.populateCatalogFromRegistry(
       catalog,
       datastoresDir,
       options?.additionalDirs,
@@ -541,11 +533,11 @@ export class UserDatastoreLoader {
   /**
    * Populates the catalog from the currently loaded registry.
    */
-  private populateCatalogFromRegistry(
+  private async populateCatalogFromRegistry(
     catalog: ExtensionCatalogStore,
     datastoresDir: string,
     additionalDirs?: string[],
-  ): void {
+  ): Promise<void> {
     if (!this.repoDir) return;
 
     const bundleBaseDir = join(
@@ -553,11 +545,12 @@ export class UserDatastoreLoader {
       SWAMP_DATA_DIR,
       SWAMP_SUBDIRS.datastoreBundles,
     );
+    const cache = createFreshnessCache();
 
     const dirs = [datastoresDir, ...(additionalDirs ?? [])];
     for (const dir of dirs) {
       try {
-        this.populateCatalogFromDir(dir, bundleBaseDir, catalog);
+        await this.populateCatalogFromDir(dir, bundleBaseDir, catalog, cache);
       } catch {
         // Directory doesn't exist — skip
       }
@@ -565,13 +558,16 @@ export class UserDatastoreLoader {
   }
 
   /**
-   * Synchronously populates catalog entries from a single directory.
+   * Populates catalog entries from a single directory, recording a
+   * content-fingerprint for each entry so subsequent findStaleFiles
+   * passes can detect mtime-preserving edits (#125).
    */
-  private populateCatalogFromDir(
+  private async populateCatalogFromDir(
     dir: string,
     bundleBaseDir: string,
     catalog: ExtensionCatalogStore,
-  ): void {
+    cache: FreshnessCache,
+  ): Promise<void> {
     const files = this.discoverFilesSync(dir);
     const ns = this.repoDir ? bundleNamespace(dir, this.repoDir) : "";
     for (const relativePath of files) {
@@ -594,6 +590,12 @@ export class UserDatastoreLoader {
 
         const typeNormalized = typeMatch[1].toLowerCase();
 
+        const sourceFingerprint = await computeSourceFingerprint(
+          absolutePath,
+          dir,
+          cache,
+        );
+
         catalog.upsert({
           type_normalized: typeNormalized,
           kind: "datastore",
@@ -603,6 +605,7 @@ export class UserDatastoreLoader {
           description: "",
           extends_type: "",
           source_mtime: sourceStat.mtime?.toISOString() ?? "",
+          source_fingerprint: sourceFingerprint,
         });
       } catch {
         // Skip files that can't be read or don't have bundles
@@ -633,7 +636,10 @@ export class UserDatastoreLoader {
   }
 
   /**
-   * Finds files that have changed since the catalog was last populated.
+   * Finds files that need rebundling since the catalog was last populated.
+   * Delegates to the shared content-fingerprint freshness check —
+   * mtime-based invalidation was unreliable under atomic-rename saves and
+   * mtime-preserving sync tools (issue #125).
    */
   private async findStaleFiles(
     datastoresDir: string,
@@ -642,96 +648,13 @@ export class UserDatastoreLoader {
   ): Promise<
     Array<{ absolutePath: string; relativePath: string; baseDir: string }>
   > {
-    const stale: Array<{
-      absolutePath: string;
-      relativePath: string;
-      baseDir: string;
-    }> = [];
-
-    const allDirs = [datastoresDir, ...(additionalDirs ?? [])];
-
-    const catalogEntries = catalog.findByKind("datastore");
-    const catalogBySource = new Map<string, ExtensionTypeRow>();
-    for (const entry of catalogEntries) {
-      catalogBySource.set(entry.source_path, entry);
-    }
-
-    const seenSources = new Set<string>();
-
-    for (const dir of allDirs) {
-      try {
-        await Deno.stat(dir);
-      } catch {
-        continue;
-      }
-
-      const files = await this.discoverFiles(dir);
-      for (const relativePath of files) {
-        const absolutePath = resolve(dir, relativePath);
-        seenSources.add(absolutePath);
-
-        const catalogEntry = catalogBySource.get(absolutePath);
-        if (!catalogEntry) {
-          stale.push({ absolutePath, relativePath, baseDir: dir });
-          continue;
-        }
-
-        try {
-          const stat = await Deno.stat(absolutePath);
-          const sourceMtime = stat.mtime?.toISOString() ?? "";
-          if (sourceMtime !== catalogEntry.source_mtime) {
-            stale.push({ absolutePath, relativePath, baseDir: dir });
-            continue;
-          }
-
-          // Entry point is fresh — check transitive dependencies against
-          // the cached bundle file's mtime. This catches edits to imported
-          // .ts files that don't touch the entry point (#1094).
-          const bundlePath = this.getDatastoreBundlePath(relativePath, dir);
-          if (bundlePath) {
-            try {
-              const bundleStat = await Deno.stat(bundlePath);
-              if (bundleStat.mtime) {
-                const { resolvedFiles } = await resolveLocalImports(
-                  [absolutePath],
-                  dir,
-                );
-                const depStats = await Promise.all(
-                  resolvedFiles.map((f) => Deno.stat(f)),
-                );
-                const newestDepMtime = depStats.reduce<Date | null>(
-                  (max, s) => {
-                    if (!s.mtime) return max;
-                    if (!max) return s.mtime;
-                    return s.mtime > max ? s.mtime : max;
-                  },
-                  null,
-                );
-                if (
-                  newestDepMtime && newestDepMtime >= bundleStat.mtime
-                ) {
-                  stale.push({ absolutePath, relativePath, baseDir: dir });
-                }
-              }
-            } catch {
-              // Bundle file missing or dep stat failed — mark as stale
-              // to trigger a rebundle.
-              stale.push({ absolutePath, relativePath, baseDir: dir });
-            }
-          }
-        } catch {
-          stale.push({ absolutePath, relativePath, baseDir: dir });
-        }
-      }
-    }
-
-    for (const [sourcePath] of catalogBySource) {
-      if (!seenSources.has(sourcePath)) {
-        catalog.removeBySourcePath(sourcePath);
-      }
-    }
-
-    return stale;
+    return await findStaleFilesShared({
+      modelsDir: datastoresDir,
+      additionalDirs,
+      catalog,
+      discoverFiles: (dir) => this.discoverFiles(dir),
+      kinds: ["datastore"],
+    });
   }
 
   /**
@@ -766,6 +689,10 @@ export class UserDatastoreLoader {
 
     const stat = await Deno.stat(absolutePath);
     const sourceMtime = stat.mtime?.toISOString() ?? "";
+    const sourceFingerprint = await computeSourceFingerprint(
+      absolutePath,
+      baseDir,
+    );
     const typeNormalized = parsed.data.type.toLowerCase();
     const bundlePath = this.getDatastoreBundlePath(relativePath, baseDir);
 
@@ -778,6 +705,7 @@ export class UserDatastoreLoader {
       description: parsed.data.description,
       extends_type: "",
       source_mtime: sourceMtime,
+      source_fingerprint: sourceFingerprint,
     });
 
     // Also register since we already imported

--- a/src/domain/datastore/user_datastore_loader_test.ts
+++ b/src/domain/datastore/user_datastore_loader_test.ts
@@ -17,10 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertNotEquals } from "@std/assert";
 import { join } from "@std/path";
 import { UserDatastoreLoader } from "./user_datastore_loader.ts";
 import { DatastoreTypeRegistry } from "./datastore_type_registry.ts";
+import { bundleNamespace } from "../../infrastructure/persistence/paths.ts";
+import { ExtensionCatalogStore } from "../../infrastructure/persistence/extension_catalog_store.ts";
 import type { DenoRuntime } from "../runtime/deno_runtime.ts";
 
 /** Stub runtime that returns "deno" as the binary path. */
@@ -297,6 +299,178 @@ export const datastore = {
     // The bundle should have been regenerated with the new dependency content
     const cachedBundle2 = await Deno.readTextFile(bundlePath);
     assertEquals(cachedBundle1 !== cachedBundle2, true);
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+    await Deno.remove(datastoresDir, { recursive: true });
+  }
+});
+
+Deno.test("UserDatastoreLoader buildIndex rebundles when source content changes with preserved mtime (#128)", async () => {
+  const ts = Date.now();
+  const datastoreType = `@user/preserved-mtime-datastore-${ts}`;
+  const v1 = `
+export const datastore = {
+  type: "${datastoreType}",
+  name: "V1_MARKER",
+  description: "V1_MARKER",
+  createProvider: (_config) => ({
+    async read() { return "V1_MARKER"; },
+    async write() {},
+    async delete() {},
+    async list() { return []; },
+    async exists() { return false; },
+  }),
+};
+`;
+  const v2 = `
+export const datastore = {
+  type: "${datastoreType}",
+  name: "V2_MARKER",
+  description: "V2_MARKER",
+  createProvider: (_config) => ({
+    async read() { return "V2_MARKER"; },
+    async write() {},
+    async delete() {},
+    async list() { return []; },
+    async exists() { return false; },
+  }),
+};
+`;
+
+  const repoDir = await Deno.makeTempDir({
+    prefix: "swamp_preserved_mtime_ds_repo_",
+  });
+  const datastoresDir = await Deno.makeTempDir({
+    prefix: "swamp_preserved_mtime_ds_src_",
+  });
+  const dbPath = join(repoDir, ".swamp", "_extension_catalog.db");
+
+  try {
+    const sourcePath = join(datastoresDir, "store.ts");
+    await Deno.writeTextFile(sourcePath, v1);
+
+    const catalog1 = new ExtensionCatalogStore(dbPath);
+    const loader1 = new UserDatastoreLoader(new StubDenoRuntime(), repoDir);
+    await loader1.buildIndex(datastoresDir, catalog1);
+    catalog1.close();
+
+    const ns = bundleNamespace(datastoresDir, repoDir);
+    const bundlePath = join(
+      repoDir,
+      ".swamp",
+      "datastore-bundles",
+      ns,
+      "store.js",
+    );
+    const v1Bundle = await Deno.readTextFile(bundlePath);
+    assertEquals(v1Bundle.includes("V1_MARKER"), true);
+
+    const origMtime = (await Deno.stat(sourcePath)).mtime!;
+
+    await new Promise((r) => setTimeout(r, 1100));
+
+    await Deno.writeTextFile(sourcePath, v2);
+    await Deno.utime(sourcePath, origMtime, origMtime);
+
+    const srcStat = await Deno.stat(sourcePath);
+    const bundleStat = await Deno.stat(bundlePath);
+    assertEquals(
+      srcStat.mtime!.getTime() <= bundleStat.mtime!.getTime(),
+      true,
+      "Precondition — source mtime must be <= bundle mtime to exercise the bug",
+    );
+
+    const catalog2 = new ExtensionCatalogStore(dbPath);
+    const loader2 = new UserDatastoreLoader(new StubDenoRuntime(), repoDir);
+    await loader2.buildIndex(datastoresDir, catalog2);
+    catalog2.close();
+
+    const v2Bundle = await Deno.readTextFile(bundlePath);
+    assertNotEquals(v1Bundle, v2Bundle);
+    assertEquals(
+      v2Bundle.includes("V2_MARKER"),
+      true,
+      "V2 marker must be present in the regenerated bundle",
+    );
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+    await Deno.remove(datastoresDir, { recursive: true });
+  }
+});
+
+Deno.test("UserDatastoreLoader buildIndex rebundles when transitive dep content changes with preserved mtime (#128)", async () => {
+  const ts = Date.now();
+  const datastoreType = `@user/preserved-mtime-datastore-dep-${ts}`;
+  const entry = `
+import { marker } from "./_lib/marker.ts";
+export const datastore = {
+  type: "${datastoreType}",
+  name: "dep-transitive",
+  description: "dep-transitive",
+  createProvider: (_config) => ({
+    async read() { return marker(); },
+    async write() {},
+    async delete() {},
+    async list() { return []; },
+    async exists() { return false; },
+  }),
+};
+`;
+  const libV1 = `export const marker = () => "V1_DEP_MARKER";\n`;
+  const libV2 = `export const marker = () => "V2_DEP_MARKER";\n`;
+
+  const repoDir = await Deno.makeTempDir({
+    prefix: "swamp_preserved_mtime_ds_dep_repo_",
+  });
+  const datastoresDir = await Deno.makeTempDir({
+    prefix: "swamp_preserved_mtime_ds_dep_src_",
+  });
+  const dbPath = join(repoDir, ".swamp", "_extension_catalog.db");
+
+  try {
+    await Deno.mkdir(join(datastoresDir, "_lib"), { recursive: true });
+    const entryPath = join(datastoresDir, "store.ts");
+    const libPath = join(datastoresDir, "_lib", "marker.ts");
+    await Deno.writeTextFile(entryPath, entry);
+    await Deno.writeTextFile(libPath, libV1);
+
+    const catalog1 = new ExtensionCatalogStore(dbPath);
+    const loader1 = new UserDatastoreLoader(new StubDenoRuntime(), repoDir);
+    await loader1.buildIndex(datastoresDir, catalog1);
+    catalog1.close();
+
+    const ns = bundleNamespace(datastoresDir, repoDir);
+    const bundlePath = join(
+      repoDir,
+      ".swamp",
+      "datastore-bundles",
+      ns,
+      "store.js",
+    );
+    const v1Bundle = await Deno.readTextFile(bundlePath);
+    assertEquals(v1Bundle.includes("V1_DEP_MARKER"), true);
+
+    const entryMtime = (await Deno.stat(entryPath)).mtime!;
+    const libMtime = (await Deno.stat(libPath)).mtime!;
+
+    await new Promise((r) => setTimeout(r, 1100));
+
+    await Deno.writeTextFile(libPath, libV2);
+    await Deno.utime(libPath, libMtime, libMtime);
+    await Deno.utime(entryPath, entryMtime, entryMtime);
+
+    const catalog2 = new ExtensionCatalogStore(dbPath);
+    const loader2 = new UserDatastoreLoader(new StubDenoRuntime(), repoDir);
+    await loader2.buildIndex(datastoresDir, catalog2);
+    catalog2.close();
+
+    const v2Bundle = await Deno.readTextFile(bundlePath);
+    assertNotEquals(v1Bundle, v2Bundle);
+    assertEquals(
+      v2Bundle.includes("V2_DEP_MARKER"),
+      true,
+      "V2 dep marker must be present in the regenerated bundle",
+    );
   } finally {
     await Deno.remove(repoDir, { recursive: true });
     await Deno.remove(datastoresDir, { recursive: true });

--- a/src/domain/drivers/user_driver_loader.ts
+++ b/src/domain/drivers/user_driver_loader.ts
@@ -29,7 +29,12 @@ import {
   sanitizeDataUrlError,
   uint8ArrayToBase64,
 } from "../models/bundle.ts";
-import { resolveLocalImports } from "../models/local_import_resolver.ts";
+import {
+  computeSourceFingerprint,
+  createFreshnessCache,
+  findStaleFiles as findStaleFilesShared,
+  type FreshnessCache,
+} from "../extensions/bundle_freshness.ts";
 import type { DenoRuntime } from "../runtime/deno_runtime.ts";
 import type { ExecutionDriver } from "./execution_driver.ts";
 import { driverTypeRegistry } from "./driver_type_registry.ts";
@@ -251,40 +256,27 @@ export class UserDriverLoader {
         relativePath.replace(/\.ts$/, ".js"),
       );
 
-      // Check mtime-based cache against all local dependencies.
-      // If the bundle exists but freshness cannot be determined (e.g. a
-      // dependency file is missing because the extension was pushed with an
-      // older swamp that had a single-line import regex), fall back to the
-      // cached bundle rather than attempting a re-bundle that will also fail.
+      // Freshness is decided by the caller via
+      // bundle_freshness.findStaleFiles (content-fingerprint compare).
+      // We only care whether a bundle file exists on disk so we can
+      // fall back to it if rebundling fails with an expected error
+      // (bare specifiers without deno.json). No mtime check here —
+      // mtime-based freshness was unreliable under atomic-rename
+      // saves (#125).
       let bundleExists = false;
       try {
-        const bundleStat = await Deno.stat(bundlePath);
+        await Deno.stat(bundlePath);
         bundleExists = true;
-        if (bundleStat.mtime) {
-          const { resolvedFiles } = await resolveLocalImports(
-            [absolutePath],
-            boundaryDir,
-          );
-          const depStats = await Promise.all(
-            resolvedFiles.map((f) => Deno.stat(f)),
-          );
-          const newestSourceMtime = depStats.reduce<Date | null>(
-            (max, s) => {
-              if (!s.mtime) return max;
-              if (!max) return s.mtime;
-              return s.mtime > max ? s.mtime : max;
-            },
-            null,
-          );
-          if (newestSourceMtime && bundleStat.mtime >= newestSourceMtime) {
-            logger.debug`Using cached driver bundle for ${relativePath}`;
-            return await Deno.readTextFile(bundlePath);
-          }
-        }
       } catch {
-        // Freshness check failed (e.g. missing dependency file).
-        // Fall through to attempt a rebundle rather than using a
-        // potentially stale cache.
+        // No bundle on disk yet — first-run bootstrap.
+      }
+
+      // Fast-path for pulled extensions with bare specifiers and no
+      // repo-side deno.json. bundleExtension would always fail for them
+      // and we'd wastefully spawn Deno before falling back to the
+      // cached bundle anyway.
+      if (bundleExists && isExpectedBundleFailure(absolutePath, this.repoDir)) {
+        return await Deno.readTextFile(bundlePath);
       }
 
       // Try to rebundle from source. If bundling fails (e.g. bare specifiers
@@ -468,7 +460,7 @@ export class UserDriverLoader {
       skipAlreadyRegistered: true,
     });
 
-    this.populateCatalogFromRegistry(
+    await this.populateCatalogFromRegistry(
       catalog,
       driversDir,
       options?.additionalDirs,
@@ -551,19 +543,21 @@ export class UserDriverLoader {
   /**
    * Populates the catalog from the currently loaded registry.
    */
-  private populateCatalogFromRegistry(
+  private async populateCatalogFromRegistry(
     catalog: ExtensionCatalogStore,
     driversDir: string,
     additionalDirs?: string[],
-  ): void {
+  ): Promise<void> {
     if (!this.repoDir) return;
 
     const bundleBaseDir = this.resolveBundlePath();
+    // One cache per populate pass so shared deps are hashed once.
+    const cache = createFreshnessCache();
 
     const dirs = [driversDir, ...(additionalDirs ?? [])];
     for (const dir of dirs) {
       try {
-        this.populateCatalogFromDir(dir, bundleBaseDir, catalog);
+        await this.populateCatalogFromDir(dir, bundleBaseDir, catalog, cache);
       } catch {
         // Directory doesn't exist — skip
       }
@@ -571,13 +565,16 @@ export class UserDriverLoader {
   }
 
   /**
-   * Synchronously populates catalog entries from a single directory.
+   * Populates catalog entries from a single directory, recording a
+   * content-fingerprint for each entry so subsequent findStaleFiles
+   * passes can detect mtime-preserving edits (#125).
    */
-  private populateCatalogFromDir(
+  private async populateCatalogFromDir(
     dir: string,
     bundleBaseDir: string,
     catalog: ExtensionCatalogStore,
-  ): void {
+    cache: FreshnessCache,
+  ): Promise<void> {
     const files = this.discoverFilesSync(dir);
     const ns = this.repoDir ? bundleNamespace(dir, this.repoDir) : "";
     for (const relativePath of files) {
@@ -600,6 +597,12 @@ export class UserDriverLoader {
 
         const typeNormalized = typeMatch[1].toLowerCase();
 
+        const sourceFingerprint = await computeSourceFingerprint(
+          absolutePath,
+          dir,
+          cache,
+        );
+
         catalog.upsert({
           type_normalized: typeNormalized,
           kind: "driver",
@@ -609,6 +612,7 @@ export class UserDriverLoader {
           description: "",
           extends_type: "",
           source_mtime: sourceStat.mtime?.toISOString() ?? "",
+          source_fingerprint: sourceFingerprint,
         });
       } catch {
         // Skip files that can't be read or don't have bundles
@@ -639,7 +643,10 @@ export class UserDriverLoader {
   }
 
   /**
-   * Finds files that have changed since the catalog was last populated.
+   * Finds files that need rebundling since the catalog was last populated.
+   * Delegates to the shared content-fingerprint freshness check —
+   * mtime-based invalidation was unreliable under atomic-rename saves and
+   * mtime-preserving sync tools (issue #125).
    */
   private async findStaleFiles(
     driversDir: string,
@@ -648,96 +655,13 @@ export class UserDriverLoader {
   ): Promise<
     Array<{ absolutePath: string; relativePath: string; baseDir: string }>
   > {
-    const stale: Array<{
-      absolutePath: string;
-      relativePath: string;
-      baseDir: string;
-    }> = [];
-
-    const allDirs = [driversDir, ...(additionalDirs ?? [])];
-
-    const catalogEntries = catalog.findByKind("driver");
-    const catalogBySource = new Map<string, ExtensionTypeRow>();
-    for (const entry of catalogEntries) {
-      catalogBySource.set(entry.source_path, entry);
-    }
-
-    const seenSources = new Set<string>();
-
-    for (const dir of allDirs) {
-      try {
-        await Deno.stat(dir);
-      } catch {
-        continue;
-      }
-
-      const files = await this.discoverFiles(dir);
-      for (const relativePath of files) {
-        const absolutePath = resolve(dir, relativePath);
-        seenSources.add(absolutePath);
-
-        const catalogEntry = catalogBySource.get(absolutePath);
-        if (!catalogEntry) {
-          stale.push({ absolutePath, relativePath, baseDir: dir });
-          continue;
-        }
-
-        try {
-          const stat = await Deno.stat(absolutePath);
-          const sourceMtime = stat.mtime?.toISOString() ?? "";
-          if (sourceMtime !== catalogEntry.source_mtime) {
-            stale.push({ absolutePath, relativePath, baseDir: dir });
-            continue;
-          }
-
-          // Entry point is fresh — check transitive dependencies against
-          // the cached bundle file's mtime. This catches edits to imported
-          // .ts files that don't touch the entry point (#1094).
-          const bundlePath = this.getDriverBundlePath(relativePath, dir);
-          if (bundlePath) {
-            try {
-              const bundleStat = await Deno.stat(bundlePath);
-              if (bundleStat.mtime) {
-                const { resolvedFiles } = await resolveLocalImports(
-                  [absolutePath],
-                  dir,
-                );
-                const depStats = await Promise.all(
-                  resolvedFiles.map((f) => Deno.stat(f)),
-                );
-                const newestDepMtime = depStats.reduce<Date | null>(
-                  (max, s) => {
-                    if (!s.mtime) return max;
-                    if (!max) return s.mtime;
-                    return s.mtime > max ? s.mtime : max;
-                  },
-                  null,
-                );
-                if (
-                  newestDepMtime && newestDepMtime >= bundleStat.mtime
-                ) {
-                  stale.push({ absolutePath, relativePath, baseDir: dir });
-                }
-              }
-            } catch {
-              // Bundle file missing or dep stat failed — mark as stale
-              // to trigger a rebundle.
-              stale.push({ absolutePath, relativePath, baseDir: dir });
-            }
-          }
-        } catch {
-          stale.push({ absolutePath, relativePath, baseDir: dir });
-        }
-      }
-    }
-
-    for (const [sourcePath] of catalogBySource) {
-      if (!seenSources.has(sourcePath)) {
-        catalog.removeBySourcePath(sourcePath);
-      }
-    }
-
-    return stale;
+    return await findStaleFilesShared({
+      modelsDir: driversDir,
+      additionalDirs,
+      catalog,
+      discoverFiles: (dir) => this.discoverFiles(dir),
+      kinds: ["driver"],
+    });
   }
 
   /**
@@ -772,6 +696,10 @@ export class UserDriverLoader {
 
     const stat = await Deno.stat(absolutePath);
     const sourceMtime = stat.mtime?.toISOString() ?? "";
+    const sourceFingerprint = await computeSourceFingerprint(
+      absolutePath,
+      baseDir,
+    );
     const typeNormalized = parsed.data.type.toLowerCase();
     const bundlePath = this.getDriverBundlePath(relativePath, baseDir);
 
@@ -784,6 +712,7 @@ export class UserDriverLoader {
       description: parsed.data.description,
       extends_type: "",
       source_mtime: sourceMtime,
+      source_fingerprint: sourceFingerprint,
     });
 
     // Also register since we already imported

--- a/src/domain/drivers/user_driver_loader_test.ts
+++ b/src/domain/drivers/user_driver_loader_test.ts
@@ -1,0 +1,195 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertNotEquals } from "@std/assert";
+import { join } from "@std/path";
+import { UserDriverLoader } from "./user_driver_loader.ts";
+import { bundleNamespace } from "../../infrastructure/persistence/paths.ts";
+import { ExtensionCatalogStore } from "../../infrastructure/persistence/extension_catalog_store.ts";
+import type { DenoRuntime } from "../runtime/deno_runtime.ts";
+
+const testDenoRuntime: DenoRuntime = {
+  ensureDeno: () => Promise.resolve(Deno.execPath()),
+};
+
+Deno.test("UserDriverLoader buildIndex rebundles when source content changes with preserved mtime (#128)", async () => {
+  const ts = Date.now();
+  const driverType = `@user/preserved-mtime-driver-${ts}`;
+  const v1 = `
+export const driver = {
+  type: "${driverType}",
+  name: "V1_MARKER",
+  description: "V1_MARKER",
+  createDriver: (_config) => ({
+    async executeMethod() {
+      return { dataHandles: [], ok: "V1_MARKER" };
+    },
+  }),
+};
+`;
+  const v2 = `
+export const driver = {
+  type: "${driverType}",
+  name: "V2_MARKER",
+  description: "V2_MARKER",
+  createDriver: (_config) => ({
+    async executeMethod() {
+      return { dataHandles: [], ok: "V2_MARKER" };
+    },
+  }),
+};
+`;
+
+  const repoDir = await Deno.makeTempDir({
+    prefix: "swamp_preserved_mtime_driver_repo_",
+  });
+  const driversDir = await Deno.makeTempDir({
+    prefix: "swamp_preserved_mtime_drivers_",
+  });
+  const dbPath = join(repoDir, ".swamp", "_extension_catalog.db");
+
+  try {
+    const sourcePath = join(driversDir, "driver.ts");
+    await Deno.writeTextFile(sourcePath, v1);
+
+    const catalog1 = new ExtensionCatalogStore(dbPath);
+    const loader1 = new UserDriverLoader(testDenoRuntime, repoDir);
+    await loader1.buildIndex(driversDir, catalog1);
+    catalog1.close();
+
+    const ns = bundleNamespace(driversDir, repoDir);
+    const bundlePath = join(
+      repoDir,
+      ".swamp",
+      "driver-bundles",
+      ns,
+      "driver.js",
+    );
+    const v1Bundle = await Deno.readTextFile(bundlePath);
+    assertEquals(v1Bundle.includes("V1_MARKER"), true);
+
+    const origMtime = (await Deno.stat(sourcePath)).mtime!;
+
+    await new Promise((r) => setTimeout(r, 1100));
+
+    await Deno.writeTextFile(sourcePath, v2);
+    await Deno.utime(sourcePath, origMtime, origMtime);
+
+    const srcStat = await Deno.stat(sourcePath);
+    const bundleStat = await Deno.stat(bundlePath);
+    assertEquals(
+      srcStat.mtime!.getTime() <= bundleStat.mtime!.getTime(),
+      true,
+      "Precondition — source mtime must be <= bundle mtime to exercise the bug",
+    );
+
+    const catalog2 = new ExtensionCatalogStore(dbPath);
+    const loader2 = new UserDriverLoader(testDenoRuntime, repoDir);
+    await loader2.buildIndex(driversDir, catalog2);
+    catalog2.close();
+
+    const v2Bundle = await Deno.readTextFile(bundlePath);
+    assertNotEquals(v1Bundle, v2Bundle);
+    assertEquals(
+      v2Bundle.includes("V2_MARKER"),
+      true,
+      "V2 marker must be present in the regenerated bundle",
+    );
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+    await Deno.remove(driversDir, { recursive: true });
+  }
+});
+
+Deno.test("UserDriverLoader buildIndex rebundles when transitive dep content changes with preserved mtime (#128)", async () => {
+  const ts = Date.now();
+  const driverType = `@user/preserved-mtime-driver-dep-${ts}`;
+  const entry = `
+import { marker } from "./_lib/marker.ts";
+export const driver = {
+  type: "${driverType}",
+  name: "dep-transitive",
+  description: "dep-transitive",
+  createDriver: (_config) => ({
+    async executeMethod() {
+      return { dataHandles: [], ok: marker() };
+    },
+  }),
+};
+`;
+  const libV1 = `export const marker = () => "V1_DEP_MARKER";\n`;
+  const libV2 = `export const marker = () => "V2_DEP_MARKER";\n`;
+
+  const repoDir = await Deno.makeTempDir({
+    prefix: "swamp_preserved_mtime_driver_dep_repo_",
+  });
+  const driversDir = await Deno.makeTempDir({
+    prefix: "swamp_preserved_mtime_driver_dep_src_",
+  });
+  const dbPath = join(repoDir, ".swamp", "_extension_catalog.db");
+
+  try {
+    await Deno.mkdir(join(driversDir, "_lib"), { recursive: true });
+    const entryPath = join(driversDir, "driver.ts");
+    const libPath = join(driversDir, "_lib", "marker.ts");
+    await Deno.writeTextFile(entryPath, entry);
+    await Deno.writeTextFile(libPath, libV1);
+
+    const catalog1 = new ExtensionCatalogStore(dbPath);
+    const loader1 = new UserDriverLoader(testDenoRuntime, repoDir);
+    await loader1.buildIndex(driversDir, catalog1);
+    catalog1.close();
+
+    const ns = bundleNamespace(driversDir, repoDir);
+    const bundlePath = join(
+      repoDir,
+      ".swamp",
+      "driver-bundles",
+      ns,
+      "driver.js",
+    );
+    const v1Bundle = await Deno.readTextFile(bundlePath);
+    assertEquals(v1Bundle.includes("V1_DEP_MARKER"), true);
+
+    const entryMtime = (await Deno.stat(entryPath)).mtime!;
+    const libMtime = (await Deno.stat(libPath)).mtime!;
+
+    await new Promise((r) => setTimeout(r, 1100));
+
+    await Deno.writeTextFile(libPath, libV2);
+    await Deno.utime(libPath, libMtime, libMtime);
+    await Deno.utime(entryPath, entryMtime, entryMtime);
+
+    const catalog2 = new ExtensionCatalogStore(dbPath);
+    const loader2 = new UserDriverLoader(testDenoRuntime, repoDir);
+    await loader2.buildIndex(driversDir, catalog2);
+    catalog2.close();
+
+    const v2Bundle = await Deno.readTextFile(bundlePath);
+    assertNotEquals(v1Bundle, v2Bundle);
+    assertEquals(
+      v2Bundle.includes("V2_DEP_MARKER"),
+      true,
+      "V2 dep marker must be present in the regenerated bundle",
+    );
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+    await Deno.remove(driversDir, { recursive: true });
+  }
+});

--- a/src/domain/extensions/bundle_freshness.ts
+++ b/src/domain/extensions/bundle_freshness.ts
@@ -21,6 +21,25 @@ import { relative, resolve } from "@std/path";
 import { resolveLocalImports } from "../models/local_import_resolver.ts";
 
 /**
+ * The extension-catalog kinds this helper can query. Declared
+ * domain-local so the freshness check does not import ExtensionKind
+ * from the infrastructure catalog store — matches the inline pattern
+ * of FreshnessCatalogRow below and preserves the
+ * domain→infrastructure boundary rule.
+ *
+ * Must stay in sync with the ExtensionKind union on ExtensionTypeRow;
+ * the infrastructure row type structurally satisfies this helper's
+ * FreshnessCatalog interface.
+ */
+export type FreshnessKind =
+  | "model"
+  | "extension"
+  | "vault"
+  | "driver"
+  | "datastore"
+  | "report";
+
+/**
  * Minimal row shape this module needs from the catalog. The concrete
  * ExtensionTypeRow in the infrastructure layer extends this; keeping
  * the dependency one-way (infrastructure knows the domain shape, not
@@ -153,7 +172,7 @@ function toHex(buffer: ArrayBuffer): string {
  * module to every catalog method.
  */
 export interface FreshnessCatalog {
-  findByKind(kind: "model" | "extension"): FreshnessCatalogRow[];
+  findByKind(kind: FreshnessKind): FreshnessCatalogRow[];
   removeBySourcePath(sourcePath: string): void;
 }
 
@@ -166,6 +185,14 @@ export interface FindStaleFilesParams {
   catalog: FreshnessCatalog;
   /** Discovers `.ts` files under a directory, returning repo-relative paths. */
   discoverFiles: (dir: string) => Promise<string[]>;
+  /**
+   * Catalog kinds to query. Each loader passes its own kind(s) so that
+   * findStaleFiles only considers rows it owns. The models loader
+   * passes ["model", "extension"] — models plus user-defined extensions
+   * that target base models. Sibling loaders pass singletons
+   * (["report"], ["driver"], etc.).
+   */
+  kinds: FreshnessKind[];
 }
 
 /**
@@ -187,16 +214,13 @@ export interface FindStaleFilesParams {
 export async function findStaleFiles(
   params: FindStaleFilesParams,
 ): Promise<StaleFile[]> {
-  const { modelsDir, additionalDirs, catalog, discoverFiles } = params;
+  const { modelsDir, additionalDirs, catalog, discoverFiles, kinds } = params;
   const stale: StaleFile[] = [];
   const cache = createFreshnessCache();
 
   const allDirs = [modelsDir, ...(additionalDirs ?? [])];
 
-  const catalogEntries = [
-    ...catalog.findByKind("model"),
-    ...catalog.findByKind("extension"),
-  ];
+  const catalogEntries = kinds.flatMap((k) => catalog.findByKind(k));
   const catalogBySource = new Map<string, FreshnessCatalogRow>();
   for (const entry of catalogEntries) {
     catalogBySource.set(entry.source_path, entry);

--- a/src/domain/extensions/bundle_freshness_test.ts
+++ b/src/domain/extensions/bundle_freshness_test.ts
@@ -23,6 +23,7 @@ import {
   computeSourceFingerprint,
   findStaleFiles,
   type FreshnessCatalog,
+  type FreshnessKind,
 } from "./bundle_freshness.ts";
 import type { ExtensionTypeRow } from "../../infrastructure/persistence/extension_catalog_store.ts";
 
@@ -35,7 +36,7 @@ class FakeCatalog implements FreshnessCatalog {
     this.rows.push(row);
   }
 
-  findByKind(kind: "model" | "extension"): ExtensionTypeRow[] {
+  findByKind(kind: FreshnessKind): ExtensionTypeRow[] {
     return this.rows.filter((r) => r.kind === kind);
   }
 
@@ -193,6 +194,7 @@ Deno.test("findStaleFiles: empty catalog → every file is stale", async () => {
       modelsDir: dir,
       catalog,
       discoverFiles: discoverTsFiles,
+      kinds: ["model"],
     });
 
     assertEquals(stale.length, 2);
@@ -229,6 +231,7 @@ Deno.test("findStaleFiles: matching fingerprint → not stale", async () => {
       modelsDir: dir,
       catalog,
       discoverFiles: discoverTsFiles,
+      kinds: ["model"],
     });
     assertEquals(stale.length, 0);
   } finally {
@@ -259,6 +262,7 @@ Deno.test("findStaleFiles: mismatching fingerprint → stale", async () => {
       modelsDir: dir,
       catalog,
       discoverFiles: discoverTsFiles,
+      kinds: ["model"],
     });
     assertEquals(stale.length, 1);
     assertEquals(stale[0].relativePath, "a.ts");
@@ -297,6 +301,7 @@ Deno.test("findStaleFiles: catches mtime-preserving content change (#125)", asyn
       modelsDir: dir,
       catalog,
       discoverFiles: discoverTsFiles,
+      kinds: ["model"],
     });
     assertEquals(
       stale.length,
@@ -343,12 +348,113 @@ Deno.test("findStaleFiles: deleted file is removed from catalog", async () => {
       modelsDir: dir,
       catalog,
       discoverFiles: discoverTsFiles,
+      kinds: ["model"],
     });
 
     const remaining = catalog.snapshot().map((r) => r.source_path);
     assertEquals(remaining, [survivor]);
   } finally {
     await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("findStaleFiles: kinds filter scopes both the staleness check and deletion — rows of other kinds in unseen dirs are not touched (#128)", async () => {
+  const driverDir = await Deno.makeTempDir({
+    prefix: "swamp_bf_stale_kinds_driver_",
+  });
+  const vaultDir = await Deno.makeTempDir({
+    prefix: "swamp_bf_stale_kinds_vault_",
+  });
+  try {
+    // Current on-disk: driver dir has one file, vault dir has one file.
+    const driverFile = join(driverDir, "my_driver.ts");
+    const vaultFile = join(vaultDir, "my_vault.ts");
+    await Deno.writeTextFile(driverFile, "export const d = 1;");
+    await Deno.writeTextFile(vaultFile, "export const v = 1;");
+
+    const driverFp = await computeSourceFingerprint(driverFile, driverDir);
+    const vaultFp = await computeSourceFingerprint(vaultFile, vaultDir);
+
+    // Catalog has rows for BOTH kinds, plus a stale driver row whose
+    // source file has been deleted from disk.
+    const catalog = new FakeCatalog();
+    catalog.add({
+      source_path: driverFile,
+      type_normalized: "@user/d",
+      kind: "driver",
+      bundle_path: "/ignored",
+      version: "",
+      description: "",
+      extends_type: "",
+      source_mtime: "",
+      source_fingerprint: driverFp,
+    });
+    catalog.add({
+      source_path: join(driverDir, "gone.ts"),
+      type_normalized: "@user/gone",
+      kind: "driver",
+      bundle_path: "/ignored",
+      version: "",
+      description: "",
+      extends_type: "",
+      source_mtime: "",
+      source_fingerprint: "whatever",
+    });
+    catalog.add({
+      source_path: vaultFile,
+      type_normalized: "@user/v",
+      kind: "vault",
+      bundle_path: "/ignored",
+      version: "",
+      description: "",
+      extends_type: "",
+      source_mtime: "",
+      source_fingerprint: vaultFp,
+    });
+
+    // Scan driver dir with kinds: ["driver"] — only driver rows are
+    // compared, and only driver rows are deleted. The vault row for
+    // a file living outside driverDir must NOT be deleted.
+    const stale = await findStaleFiles({
+      modelsDir: driverDir,
+      catalog,
+      discoverFiles: discoverTsFiles,
+      kinds: ["driver"],
+    });
+
+    assertEquals(
+      stale.length,
+      0,
+      "driver row fingerprint matches — nothing should be stale",
+    );
+
+    const remaining = catalog.snapshot().map((r) => ({
+      path: r.source_path,
+      kind: r.kind,
+    })).sort((a, b) => a.path.localeCompare(b.path));
+
+    // The stale driver row (gone.ts) must be deleted.
+    // The vault row (in a dir outside the scan) must survive — this is
+    // the cross-kind isolation guarantee that lets sibling loaders
+    // share the catalog without stepping on each other.
+    assertEquals(
+      remaining.some((r) => r.kind === "driver" && r.path === driverFile),
+      true,
+      "driver survivor must remain",
+    );
+    assertEquals(
+      remaining.some((r) => r.kind === "driver" && r.path.endsWith("gone.ts")),
+      false,
+      "deleted driver row must be removed",
+    );
+    assertEquals(
+      remaining.some((r) => r.kind === "vault" && r.path === vaultFile),
+      true,
+      "vault row in a dir outside the driver scan must survive — kinds filter must NOT delete rows of other kinds",
+    );
+  } finally {
+    await Deno.remove(driverDir, { recursive: true });
+    await Deno.remove(vaultDir, { recursive: true });
   }
 });
 
@@ -362,6 +468,7 @@ Deno.test("findStaleFiles: missing source dir is silently skipped", async () => 
       modelsDir: dir,
       catalog,
       discoverFiles: discoverTsFiles,
+      kinds: ["model"],
     });
     assertEquals(stale, []);
   } catch (err) {

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -1024,6 +1024,7 @@ export class UserModelLoader {
       additionalDirs,
       catalog,
       discoverFiles: (dir) => this.discoverFiles(dir),
+      kinds: ["model", "extension"],
     });
   }
 

--- a/src/domain/reports/user_report_loader.ts
+++ b/src/domain/reports/user_report_loader.ts
@@ -29,7 +29,12 @@ import {
   sanitizeDataUrlError,
   uint8ArrayToBase64,
 } from "../models/bundle.ts";
-import { resolveLocalImports } from "../models/local_import_resolver.ts";
+import {
+  computeSourceFingerprint,
+  createFreshnessCache,
+  findStaleFiles as findStaleFilesShared,
+  type FreshnessCache,
+} from "../extensions/bundle_freshness.ts";
 import type { DenoRuntime } from "../runtime/deno_runtime.ts";
 import type { ReportContext } from "./report_context.ts";
 import type { ReportResult } from "./report.ts";
@@ -305,7 +310,7 @@ export class UserReportLoader {
       skipAlreadyRegistered: true,
     });
 
-    this.populateCatalogFromRegistry(
+    await this.populateCatalogFromRegistry(
       catalog,
       reportsDir,
       options?.additionalDirs,
@@ -386,19 +391,22 @@ export class UserReportLoader {
   /**
    * Populates the catalog from the currently loaded registry.
    */
-  private populateCatalogFromRegistry(
+  private async populateCatalogFromRegistry(
     catalog: ExtensionCatalogStore,
     reportsDir: string,
     additionalDirs?: string[],
-  ): void {
+  ): Promise<void> {
     if (!this.repoDir) return;
 
     const bundleBaseDir = this.resolveBundlePath();
+    // One cache per populate pass so shared deps (e.g. files in a
+    // pulled extension's _lib/) are hashed once, not once per entry.
+    const cache = createFreshnessCache();
 
     const dirs = [reportsDir, ...(additionalDirs ?? [])];
     for (const dir of dirs) {
       try {
-        this.populateCatalogFromDir(dir, bundleBaseDir, catalog);
+        await this.populateCatalogFromDir(dir, bundleBaseDir, catalog, cache);
       } catch {
         // Directory doesn't exist — skip
       }
@@ -406,13 +414,16 @@ export class UserReportLoader {
   }
 
   /**
-   * Synchronously populates catalog entries from a single directory.
+   * Populates catalog entries from a single directory, recording a
+   * content-fingerprint for each entry so subsequent findStaleFiles
+   * passes can detect mtime-preserving edits (#125).
    */
-  private populateCatalogFromDir(
+  private async populateCatalogFromDir(
     dir: string,
     bundleBaseDir: string,
     catalog: ExtensionCatalogStore,
-  ): void {
+    cache: FreshnessCache,
+  ): Promise<void> {
     const files = this.discoverFilesSync(dir);
     const ns = this.repoDir ? bundleNamespace(dir, this.repoDir) : "";
     for (const relativePath of files) {
@@ -435,6 +446,12 @@ export class UserReportLoader {
 
         const typeNormalized = typeMatch[1].toLowerCase();
 
+        const sourceFingerprint = await computeSourceFingerprint(
+          absolutePath,
+          dir,
+          cache,
+        );
+
         catalog.upsert({
           type_normalized: typeNormalized,
           kind: "report",
@@ -444,6 +461,7 @@ export class UserReportLoader {
           description: "",
           extends_type: "",
           source_mtime: sourceStat.mtime?.toISOString() ?? "",
+          source_fingerprint: sourceFingerprint,
         });
       } catch {
         // Skip files that can't be read or don't have bundles
@@ -474,7 +492,10 @@ export class UserReportLoader {
   }
 
   /**
-   * Finds files that have changed since the catalog was last populated.
+   * Finds files that need rebundling since the catalog was last populated.
+   * Delegates to the shared content-fingerprint freshness check —
+   * mtime-based invalidation was unreliable under atomic-rename saves and
+   * mtime-preserving sync tools (issue #125).
    */
   private async findStaleFiles(
     reportsDir: string,
@@ -483,96 +504,13 @@ export class UserReportLoader {
   ): Promise<
     Array<{ absolutePath: string; relativePath: string; baseDir: string }>
   > {
-    const stale: Array<{
-      absolutePath: string;
-      relativePath: string;
-      baseDir: string;
-    }> = [];
-
-    const allDirs = [reportsDir, ...(additionalDirs ?? [])];
-
-    const catalogEntries = catalog.findByKind("report");
-    const catalogBySource = new Map<string, ExtensionTypeRow>();
-    for (const entry of catalogEntries) {
-      catalogBySource.set(entry.source_path, entry);
-    }
-
-    const seenSources = new Set<string>();
-
-    for (const dir of allDirs) {
-      try {
-        await Deno.stat(dir);
-      } catch {
-        continue;
-      }
-
-      const files = await this.discoverFiles(dir);
-      for (const relativePath of files) {
-        const absolutePath = resolve(dir, relativePath);
-        seenSources.add(absolutePath);
-
-        const catalogEntry = catalogBySource.get(absolutePath);
-        if (!catalogEntry) {
-          stale.push({ absolutePath, relativePath, baseDir: dir });
-          continue;
-        }
-
-        try {
-          const stat = await Deno.stat(absolutePath);
-          const sourceMtime = stat.mtime?.toISOString() ?? "";
-          if (sourceMtime !== catalogEntry.source_mtime) {
-            stale.push({ absolutePath, relativePath, baseDir: dir });
-            continue;
-          }
-
-          // Entry point is fresh — check transitive dependencies against
-          // the cached bundle file's mtime. This catches edits to imported
-          // .ts files that don't touch the entry point (#1094).
-          const bundlePath = this.getReportBundlePath(relativePath, dir);
-          if (bundlePath) {
-            try {
-              const bundleStat = await Deno.stat(bundlePath);
-              if (bundleStat.mtime) {
-                const { resolvedFiles } = await resolveLocalImports(
-                  [absolutePath],
-                  dir,
-                );
-                const depStats = await Promise.all(
-                  resolvedFiles.map((f) => Deno.stat(f)),
-                );
-                const newestDepMtime = depStats.reduce<Date | null>(
-                  (max, s) => {
-                    if (!s.mtime) return max;
-                    if (!max) return s.mtime;
-                    return s.mtime > max ? s.mtime : max;
-                  },
-                  null,
-                );
-                if (
-                  newestDepMtime && newestDepMtime >= bundleStat.mtime
-                ) {
-                  stale.push({ absolutePath, relativePath, baseDir: dir });
-                }
-              }
-            } catch {
-              // Bundle file missing or dep stat failed — mark as stale
-              // to trigger a rebundle.
-              stale.push({ absolutePath, relativePath, baseDir: dir });
-            }
-          }
-        } catch {
-          stale.push({ absolutePath, relativePath, baseDir: dir });
-        }
-      }
-    }
-
-    for (const [sourcePath] of catalogBySource) {
-      if (!seenSources.has(sourcePath)) {
-        catalog.removeBySourcePath(sourcePath);
-      }
-    }
-
-    return stale;
+    return await findStaleFilesShared({
+      modelsDir: reportsDir,
+      additionalDirs,
+      catalog,
+      discoverFiles: (dir) => this.discoverFiles(dir),
+      kinds: ["report"],
+    });
   }
 
   /**
@@ -607,6 +545,10 @@ export class UserReportLoader {
 
     const stat = await Deno.stat(absolutePath);
     const sourceMtime = stat.mtime?.toISOString() ?? "";
+    const sourceFingerprint = await computeSourceFingerprint(
+      absolutePath,
+      baseDir,
+    );
     const typeNormalized = parsed.data.name.toLowerCase();
     const bundlePath = this.getReportBundlePath(relativePath, baseDir);
 
@@ -619,6 +561,7 @@ export class UserReportLoader {
       description: parsed.data.description,
       extends_type: "",
       source_mtime: sourceMtime,
+      source_fingerprint: sourceFingerprint,
     });
 
     // Also register since we already imported
@@ -661,40 +604,27 @@ export class UserReportLoader {
         relativePath.replace(/\.ts$/, ".js"),
       );
 
-      // Check mtime-based cache against all local dependencies.
-      // If the bundle exists but freshness cannot be determined (e.g. a
-      // dependency file is missing because the extension was pushed with an
-      // older swamp that had a single-line import regex), fall back to the
-      // cached bundle rather than attempting a re-bundle that will also fail.
+      // Freshness is decided by the caller via
+      // bundle_freshness.findStaleFiles (content-fingerprint compare).
+      // We only care whether a bundle file exists on disk so we can
+      // fall back to it if rebundling fails with an expected error
+      // (bare specifiers without deno.json). No mtime check here —
+      // mtime-based freshness was unreliable under atomic-rename
+      // saves (#125).
       let bundleExists = false;
       try {
-        const bundleStat = await Deno.stat(bundlePath);
+        await Deno.stat(bundlePath);
         bundleExists = true;
-        if (bundleStat.mtime) {
-          const { resolvedFiles } = await resolveLocalImports(
-            [absolutePath],
-            boundaryDir,
-          );
-          const depStats = await Promise.all(
-            resolvedFiles.map((f) => Deno.stat(f)),
-          );
-          const newestSourceMtime = depStats.reduce<Date | null>(
-            (max, s) => {
-              if (!s.mtime) return max;
-              if (!max) return s.mtime;
-              return s.mtime > max ? s.mtime : max;
-            },
-            null,
-          );
-          if (newestSourceMtime && bundleStat.mtime >= newestSourceMtime) {
-            logger.debug`Using cached report bundle for ${relativePath}`;
-            return await Deno.readTextFile(bundlePath);
-          }
-        }
       } catch {
-        // Freshness check failed (e.g. missing dependency file).
-        // Fall through to attempt a rebundle rather than using a
-        // potentially stale cache.
+        // No bundle on disk yet — first-run bootstrap.
+      }
+
+      // Fast-path for pulled extensions with bare specifiers and no
+      // repo-side deno.json. bundleExtension would always fail for them
+      // and we'd wastefully spawn Deno before falling back to the
+      // cached bundle anyway.
+      if (bundleExists && isExpectedBundleFailure(absolutePath, this.repoDir)) {
+        return await Deno.readTextFile(bundlePath);
       }
 
       // Try to rebundle from source. If bundling fails (e.g. bare specifiers

--- a/src/domain/reports/user_report_loader_test.ts
+++ b/src/domain/reports/user_report_loader_test.ts
@@ -1,0 +1,211 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertNotEquals } from "@std/assert";
+import { join } from "@std/path";
+import { UserReportLoader } from "./user_report_loader.ts";
+import { bundleNamespace } from "../../infrastructure/persistence/paths.ts";
+import { ExtensionCatalogStore } from "../../infrastructure/persistence/extension_catalog_store.ts";
+import type { DenoRuntime } from "../runtime/deno_runtime.ts";
+
+/** Test DenoRuntime that returns the current deno binary path. */
+const testDenoRuntime: DenoRuntime = {
+  ensureDeno: () => Promise.resolve(Deno.execPath()),
+};
+
+Deno.test("UserReportLoader buildIndex rebundles when source content changes with preserved mtime (#128)", async () => {
+  // Mirrors the models-loader regression at user_model_loader_test.ts —
+  // swap source content but restore the original mtime (the atomic-rename
+  // / rsync --times / sub-ms edit signature), then re-run buildIndex and
+  // verify the regenerated bundle carries the new content. With the old
+  // mtime-based freshness check the stale bundle would be served.
+  const ts = Date.now();
+  const name = `@user/preserved-mtime-report-${ts}`;
+  const v1 = `
+export const report = {
+  name: "${name}",
+  description: "V1_MARKER",
+  scope: "method",
+  execute: async (_ctx) => ({ markdown: "V1_MARKER", json: { marker: "V1" } }),
+};
+`;
+  const v2 = `
+export const report = {
+  name: "${name}",
+  description: "V2_MARKER",
+  scope: "method",
+  execute: async (_ctx) => ({ markdown: "V2_MARKER", json: { marker: "V2" } }),
+};
+`;
+
+  const repoDir = await Deno.makeTempDir({
+    prefix: "swamp_preserved_mtime_report_repo_",
+  });
+  const reportsDir = await Deno.makeTempDir({
+    prefix: "swamp_preserved_mtime_reports_",
+  });
+  const dbPath = join(repoDir, ".swamp", "_extension_catalog.db");
+
+  try {
+    const sourcePath = join(reportsDir, "report.ts");
+    await Deno.writeTextFile(sourcePath, v1);
+
+    const catalog1 = new ExtensionCatalogStore(dbPath);
+    const loader1 = new UserReportLoader(testDenoRuntime, repoDir);
+    await loader1.buildIndex(reportsDir, catalog1);
+    catalog1.close();
+
+    const ns = bundleNamespace(reportsDir, repoDir);
+    const bundlePath = join(
+      repoDir,
+      ".swamp",
+      "report-bundles",
+      ns,
+      "report.js",
+    );
+    const v1Bundle = await Deno.readTextFile(bundlePath);
+    assertEquals(
+      v1Bundle.includes("V1_MARKER"),
+      true,
+      "V1 marker should be present in the initial bundle",
+    );
+
+    const origMtime = (await Deno.stat(sourcePath)).mtime!;
+
+    // Advance wall clock so any mtime-based comparison would notice a
+    // rebundle moment, making the test deterministic.
+    await new Promise((r) => setTimeout(r, 1100));
+
+    // Swap content, then restore the original mtime — the #125 trigger.
+    await Deno.writeTextFile(sourcePath, v2);
+    await Deno.utime(sourcePath, origMtime, origMtime);
+
+    const srcStatAfterRestore = await Deno.stat(sourcePath);
+    const bundleStatBeforeRun2 = await Deno.stat(bundlePath);
+    assertEquals(
+      srcStatAfterRestore.mtime!.getTime() <=
+        bundleStatBeforeRun2.mtime!.getTime(),
+      true,
+      "Precondition — source mtime must be <= bundle mtime to exercise the bug",
+    );
+
+    // Drop the registry entry so the second buildIndex fully re-imports.
+    const catalog2 = new ExtensionCatalogStore(dbPath);
+    const loader2 = new UserReportLoader(testDenoRuntime, repoDir);
+    await loader2.buildIndex(reportsDir, catalog2);
+    catalog2.close();
+
+    const v2Bundle = await Deno.readTextFile(bundlePath);
+    assertNotEquals(
+      v1Bundle,
+      v2Bundle,
+      "Bundle must be regenerated when source content changes, even with preserved mtime",
+    );
+    assertEquals(
+      v2Bundle.includes("V2_MARKER"),
+      true,
+      "V2 marker must be present in the regenerated bundle",
+    );
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+    await Deno.remove(reportsDir, { recursive: true });
+  }
+});
+
+Deno.test("UserReportLoader buildIndex rebundles when transitive dep content changes with preserved mtime (#128)", async () => {
+  // Transitive-dep variant — edit a _lib/*.ts helper, preserve the entry
+  // point's mtime, verify the fingerprint helper walks the dep graph and
+  // marks the entry point stale.
+  const ts = Date.now();
+  const name = `@user/preserved-mtime-report-dep-${ts}`;
+  const entry = `
+import { marker } from "./_lib/marker.ts";
+export const report = {
+  name: "${name}",
+  description: "dep-transitive",
+  scope: "method",
+  execute: async (_ctx) => ({ markdown: marker(), json: { marker: marker() } }),
+};
+`;
+  const libV1 = `export const marker = () => "V1_DEP_MARKER";\n`;
+  const libV2 = `export const marker = () => "V2_DEP_MARKER";\n`;
+
+  const repoDir = await Deno.makeTempDir({
+    prefix: "swamp_preserved_mtime_report_dep_repo_",
+  });
+  const reportsDir = await Deno.makeTempDir({
+    prefix: "swamp_preserved_mtime_report_dep_src_",
+  });
+  const dbPath = join(repoDir, ".swamp", "_extension_catalog.db");
+
+  try {
+    await Deno.mkdir(join(reportsDir, "_lib"), { recursive: true });
+    const entryPath = join(reportsDir, "report.ts");
+    const libPath = join(reportsDir, "_lib", "marker.ts");
+    await Deno.writeTextFile(entryPath, entry);
+    await Deno.writeTextFile(libPath, libV1);
+
+    const catalog1 = new ExtensionCatalogStore(dbPath);
+    const loader1 = new UserReportLoader(testDenoRuntime, repoDir);
+    await loader1.buildIndex(reportsDir, catalog1);
+    catalog1.close();
+
+    const ns = bundleNamespace(reportsDir, repoDir);
+    const bundlePath = join(
+      repoDir,
+      ".swamp",
+      "report-bundles",
+      ns,
+      "report.js",
+    );
+    const v1Bundle = await Deno.readTextFile(bundlePath);
+    assertEquals(v1Bundle.includes("V1_DEP_MARKER"), true);
+
+    // Capture both the entry and dep mtimes, edit the dep content, restore
+    // both mtimes so nothing on disk suggests a change except the bytes.
+    const entryMtime = (await Deno.stat(entryPath)).mtime!;
+    const libMtime = (await Deno.stat(libPath)).mtime!;
+
+    await new Promise((r) => setTimeout(r, 1100));
+
+    await Deno.writeTextFile(libPath, libV2);
+    await Deno.utime(libPath, libMtime, libMtime);
+    await Deno.utime(entryPath, entryMtime, entryMtime);
+
+    const catalog2 = new ExtensionCatalogStore(dbPath);
+    const loader2 = new UserReportLoader(testDenoRuntime, repoDir);
+    await loader2.buildIndex(reportsDir, catalog2);
+    catalog2.close();
+
+    const v2Bundle = await Deno.readTextFile(bundlePath);
+    assertNotEquals(
+      v1Bundle,
+      v2Bundle,
+      "Bundle must be regenerated when a transitive dep changes, even with preserved mtimes",
+    );
+    assertEquals(
+      v2Bundle.includes("V2_DEP_MARKER"),
+      true,
+      "V2 dep marker must be present in the regenerated bundle",
+    );
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+    await Deno.remove(reportsDir, { recursive: true });
+  }
+});

--- a/src/domain/vaults/user_vault_loader.ts
+++ b/src/domain/vaults/user_vault_loader.ts
@@ -29,7 +29,12 @@ import {
   sanitizeDataUrlError,
   uint8ArrayToBase64,
 } from "../models/bundle.ts";
-import { resolveLocalImports } from "../models/local_import_resolver.ts";
+import {
+  computeSourceFingerprint,
+  createFreshnessCache,
+  findStaleFiles as findStaleFilesShared,
+  type FreshnessCache,
+} from "../extensions/bundle_freshness.ts";
 import type { DenoRuntime } from "../runtime/deno_runtime.ts";
 import type { VaultProvider } from "./vault_provider.ts";
 import { vaultTypeRegistry } from "./vault_type_registry.ts";
@@ -252,40 +257,27 @@ export class UserVaultLoader {
         relativePath.replace(/\.ts$/, ".js"),
       );
 
-      // Check mtime-based cache against all local dependencies.
-      // If the bundle exists but freshness cannot be determined (e.g. a
-      // dependency file is missing because the extension was pushed with an
-      // older swamp that had a single-line import regex), fall back to the
-      // cached bundle rather than attempting a re-bundle that will also fail.
+      // Freshness is decided by the caller via
+      // bundle_freshness.findStaleFiles (content-fingerprint compare).
+      // We only care whether a bundle file exists on disk so we can
+      // fall back to it if rebundling fails with an expected error
+      // (bare specifiers without deno.json). No mtime check here —
+      // mtime-based freshness was unreliable under atomic-rename
+      // saves (#125).
       let bundleExists = false;
       try {
-        const bundleStat = await Deno.stat(bundlePath);
+        await Deno.stat(bundlePath);
         bundleExists = true;
-        if (bundleStat.mtime) {
-          const { resolvedFiles } = await resolveLocalImports(
-            [absolutePath],
-            boundaryDir,
-          );
-          const depStats = await Promise.all(
-            resolvedFiles.map((f) => Deno.stat(f)),
-          );
-          const newestSourceMtime = depStats.reduce<Date | null>(
-            (max, s) => {
-              if (!s.mtime) return max;
-              if (!max) return s.mtime;
-              return s.mtime > max ? s.mtime : max;
-            },
-            null,
-          );
-          if (newestSourceMtime && bundleStat.mtime >= newestSourceMtime) {
-            logger.debug`Using cached vault bundle for ${relativePath}`;
-            return await Deno.readTextFile(bundlePath);
-          }
-        }
       } catch {
-        // Freshness check failed (e.g. missing dependency file).
-        // Fall through to attempt a rebundle rather than using a
-        // potentially stale cache.
+        // No bundle on disk yet — first-run bootstrap.
+      }
+
+      // Fast-path for pulled extensions with bare specifiers and no
+      // repo-side deno.json. bundleExtension would always fail for them
+      // and we'd wastefully spawn Deno before falling back to the
+      // cached bundle anyway.
+      if (bundleExists && isExpectedBundleFailure(absolutePath, this.repoDir)) {
+        return await Deno.readTextFile(bundlePath);
       }
 
       // Try to rebundle from source. If bundling fails (e.g. bare specifiers
@@ -469,7 +461,7 @@ export class UserVaultLoader {
       skipAlreadyRegistered: true,
     });
 
-    this.populateCatalogFromRegistry(
+    await this.populateCatalogFromRegistry(
       catalog,
       vaultsDir,
       options?.additionalDirs,
@@ -553,19 +545,20 @@ export class UserVaultLoader {
   /**
    * Populates the catalog from the currently loaded registry.
    */
-  private populateCatalogFromRegistry(
+  private async populateCatalogFromRegistry(
     catalog: ExtensionCatalogStore,
     vaultsDir: string,
     additionalDirs?: string[],
-  ): void {
+  ): Promise<void> {
     if (!this.repoDir) return;
 
     const bundleBaseDir = this.resolveBundlePath();
+    const cache = createFreshnessCache();
 
     const dirs = [vaultsDir, ...(additionalDirs ?? [])];
     for (const dir of dirs) {
       try {
-        this.populateCatalogFromDir(dir, bundleBaseDir, catalog);
+        await this.populateCatalogFromDir(dir, bundleBaseDir, catalog, cache);
       } catch {
         // Directory doesn't exist — skip
       }
@@ -573,13 +566,16 @@ export class UserVaultLoader {
   }
 
   /**
-   * Synchronously populates catalog entries from a single directory.
+   * Populates catalog entries from a single directory, recording a
+   * content-fingerprint for each entry so subsequent findStaleFiles
+   * passes can detect mtime-preserving edits (#125).
    */
-  private populateCatalogFromDir(
+  private async populateCatalogFromDir(
     dir: string,
     bundleBaseDir: string,
     catalog: ExtensionCatalogStore,
-  ): void {
+    cache: FreshnessCache,
+  ): Promise<void> {
     const files = this.discoverFilesSync(dir);
     const ns = this.repoDir ? bundleNamespace(dir, this.repoDir) : "";
     for (const relativePath of files) {
@@ -605,6 +601,12 @@ export class UserVaultLoader {
         // Try to get description from the already-loaded registry
         const registryInfo = vaultTypeRegistry.get(typeNormalized);
 
+        const sourceFingerprint = await computeSourceFingerprint(
+          absolutePath,
+          dir,
+          cache,
+        );
+
         catalog.upsert({
           type_normalized: typeNormalized,
           kind: "vault",
@@ -614,6 +616,7 @@ export class UserVaultLoader {
           description: registryInfo?.description ?? "",
           extends_type: "",
           source_mtime: sourceStat.mtime?.toISOString() ?? "",
+          source_fingerprint: sourceFingerprint,
         });
       } catch {
         // Skip files that can't be read or don't have bundles
@@ -644,7 +647,10 @@ export class UserVaultLoader {
   }
 
   /**
-   * Finds files that have changed since the catalog was last populated.
+   * Finds files that need rebundling since the catalog was last populated.
+   * Delegates to the shared content-fingerprint freshness check —
+   * mtime-based invalidation was unreliable under atomic-rename saves and
+   * mtime-preserving sync tools (issue #125).
    */
   private async findStaleFiles(
     vaultsDir: string,
@@ -653,96 +659,13 @@ export class UserVaultLoader {
   ): Promise<
     Array<{ absolutePath: string; relativePath: string; baseDir: string }>
   > {
-    const stale: Array<{
-      absolutePath: string;
-      relativePath: string;
-      baseDir: string;
-    }> = [];
-
-    const allDirs = [vaultsDir, ...(additionalDirs ?? [])];
-
-    const catalogEntries = catalog.findByKind("vault");
-    const catalogBySource = new Map<string, ExtensionTypeRow>();
-    for (const entry of catalogEntries) {
-      catalogBySource.set(entry.source_path, entry);
-    }
-
-    const seenSources = new Set<string>();
-
-    for (const dir of allDirs) {
-      try {
-        await Deno.stat(dir);
-      } catch {
-        continue;
-      }
-
-      const files = await this.discoverFiles(dir);
-      for (const relativePath of files) {
-        const absolutePath = resolve(dir, relativePath);
-        seenSources.add(absolutePath);
-
-        const catalogEntry = catalogBySource.get(absolutePath);
-        if (!catalogEntry) {
-          stale.push({ absolutePath, relativePath, baseDir: dir });
-          continue;
-        }
-
-        try {
-          const stat = await Deno.stat(absolutePath);
-          const sourceMtime = stat.mtime?.toISOString() ?? "";
-          if (sourceMtime !== catalogEntry.source_mtime) {
-            stale.push({ absolutePath, relativePath, baseDir: dir });
-            continue;
-          }
-
-          // Entry point is fresh — check transitive dependencies against
-          // the cached bundle file's mtime. This catches edits to imported
-          // .ts files that don't touch the entry point (#1094).
-          const bundlePath = this.getVaultBundlePath(relativePath, dir);
-          if (bundlePath) {
-            try {
-              const bundleStat = await Deno.stat(bundlePath);
-              if (bundleStat.mtime) {
-                const { resolvedFiles } = await resolveLocalImports(
-                  [absolutePath],
-                  dir,
-                );
-                const depStats = await Promise.all(
-                  resolvedFiles.map((f) => Deno.stat(f)),
-                );
-                const newestDepMtime = depStats.reduce<Date | null>(
-                  (max, s) => {
-                    if (!s.mtime) return max;
-                    if (!max) return s.mtime;
-                    return s.mtime > max ? s.mtime : max;
-                  },
-                  null,
-                );
-                if (
-                  newestDepMtime && newestDepMtime >= bundleStat.mtime
-                ) {
-                  stale.push({ absolutePath, relativePath, baseDir: dir });
-                }
-              }
-            } catch {
-              // Bundle file missing or dep stat failed — mark as stale
-              // to trigger a rebundle.
-              stale.push({ absolutePath, relativePath, baseDir: dir });
-            }
-          }
-        } catch {
-          stale.push({ absolutePath, relativePath, baseDir: dir });
-        }
-      }
-    }
-
-    for (const [sourcePath] of catalogBySource) {
-      if (!seenSources.has(sourcePath)) {
-        catalog.removeBySourcePath(sourcePath);
-      }
-    }
-
-    return stale;
+    return await findStaleFilesShared({
+      modelsDir: vaultsDir,
+      additionalDirs,
+      catalog,
+      discoverFiles: (dir) => this.discoverFiles(dir),
+      kinds: ["vault"],
+    });
   }
 
   /**
@@ -777,6 +700,10 @@ export class UserVaultLoader {
 
     const stat = await Deno.stat(absolutePath);
     const sourceMtime = stat.mtime?.toISOString() ?? "";
+    const sourceFingerprint = await computeSourceFingerprint(
+      absolutePath,
+      baseDir,
+    );
     const typeNormalized = parsed.data.type.toLowerCase();
     const bundlePath = this.getVaultBundlePath(relativePath, baseDir);
 
@@ -789,6 +716,7 @@ export class UserVaultLoader {
       description: parsed.data.description,
       extends_type: "",
       source_mtime: sourceMtime,
+      source_fingerprint: sourceFingerprint,
     });
 
     // Also register since we already imported

--- a/src/domain/vaults/user_vault_loader_test.ts
+++ b/src/domain/vaults/user_vault_loader_test.ts
@@ -17,10 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertNotEquals } from "@std/assert";
 import { join } from "@std/path";
 import { UserVaultLoader } from "./user_vault_loader.ts";
 import { VaultTypeRegistry } from "./vault_type_registry.ts";
+import { bundleNamespace } from "../../infrastructure/persistence/paths.ts";
+import { ExtensionCatalogStore } from "../../infrastructure/persistence/extension_catalog_store.ts";
 import type { DenoRuntime } from "../runtime/deno_runtime.ts";
 
 /** Stub runtime that returns "deno" as the binary path. */
@@ -334,5 +336,177 @@ export const vault = {
     assertEquals(result.failed.length, 0);
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("UserVaultLoader buildIndex rebundles when source content changes with preserved mtime (#128)", async () => {
+  const ts = Date.now();
+  const vaultType = `@user/preserved-mtime-vault-${ts}`;
+  const v1 = `
+export const vault = {
+  type: "${vaultType}",
+  name: "V1_MARKER",
+  description: "V1_MARKER",
+  createProvider: (_name, _config) => ({
+    async get() { return "V1_MARKER"; },
+    async set() {},
+    async has() { return false; },
+    async list() { return []; },
+    async delete() {},
+  }),
+};
+`;
+  const v2 = `
+export const vault = {
+  type: "${vaultType}",
+  name: "V2_MARKER",
+  description: "V2_MARKER",
+  createProvider: (_name, _config) => ({
+    async get() { return "V2_MARKER"; },
+    async set() {},
+    async has() { return false; },
+    async list() { return []; },
+    async delete() {},
+  }),
+};
+`;
+
+  const repoDir = await Deno.makeTempDir({
+    prefix: "swamp_preserved_mtime_vault_repo_",
+  });
+  const vaultsDir = await Deno.makeTempDir({
+    prefix: "swamp_preserved_mtime_vaults_",
+  });
+  const dbPath = join(repoDir, ".swamp", "_extension_catalog.db");
+
+  try {
+    const sourcePath = join(vaultsDir, "vault.ts");
+    await Deno.writeTextFile(sourcePath, v1);
+
+    const catalog1 = new ExtensionCatalogStore(dbPath);
+    const loader1 = new UserVaultLoader(new StubDenoRuntime(), repoDir);
+    await loader1.buildIndex(vaultsDir, catalog1);
+    catalog1.close();
+
+    const ns = bundleNamespace(vaultsDir, repoDir);
+    const bundlePath = join(
+      repoDir,
+      ".swamp",
+      "vault-bundles",
+      ns,
+      "vault.js",
+    );
+    const v1Bundle = await Deno.readTextFile(bundlePath);
+    assertEquals(v1Bundle.includes("V1_MARKER"), true);
+
+    const origMtime = (await Deno.stat(sourcePath)).mtime!;
+
+    await new Promise((r) => setTimeout(r, 1100));
+
+    await Deno.writeTextFile(sourcePath, v2);
+    await Deno.utime(sourcePath, origMtime, origMtime);
+
+    const srcStat = await Deno.stat(sourcePath);
+    const bundleStat = await Deno.stat(bundlePath);
+    assertEquals(
+      srcStat.mtime!.getTime() <= bundleStat.mtime!.getTime(),
+      true,
+      "Precondition — source mtime must be <= bundle mtime to exercise the bug",
+    );
+
+    const catalog2 = new ExtensionCatalogStore(dbPath);
+    const loader2 = new UserVaultLoader(new StubDenoRuntime(), repoDir);
+    await loader2.buildIndex(vaultsDir, catalog2);
+    catalog2.close();
+
+    const v2Bundle = await Deno.readTextFile(bundlePath);
+    assertNotEquals(v1Bundle, v2Bundle);
+    assertEquals(
+      v2Bundle.includes("V2_MARKER"),
+      true,
+      "V2 marker must be present in the regenerated bundle",
+    );
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+    await Deno.remove(vaultsDir, { recursive: true });
+  }
+});
+
+Deno.test("UserVaultLoader buildIndex rebundles when transitive dep content changes with preserved mtime (#128)", async () => {
+  const ts = Date.now();
+  const vaultType = `@user/preserved-mtime-vault-dep-${ts}`;
+  const entry = `
+import { marker } from "./_lib/marker.ts";
+export const vault = {
+  type: "${vaultType}",
+  name: "dep-transitive",
+  description: "dep-transitive",
+  createProvider: (_name, _config) => ({
+    async get() { return marker(); },
+    async set() {},
+    async has() { return false; },
+    async list() { return []; },
+    async delete() {},
+  }),
+};
+`;
+  const libV1 = `export const marker = () => "V1_DEP_MARKER";\n`;
+  const libV2 = `export const marker = () => "V2_DEP_MARKER";\n`;
+
+  const repoDir = await Deno.makeTempDir({
+    prefix: "swamp_preserved_mtime_vault_dep_repo_",
+  });
+  const vaultsDir = await Deno.makeTempDir({
+    prefix: "swamp_preserved_mtime_vault_dep_src_",
+  });
+  const dbPath = join(repoDir, ".swamp", "_extension_catalog.db");
+
+  try {
+    await Deno.mkdir(join(vaultsDir, "_lib"), { recursive: true });
+    const entryPath = join(vaultsDir, "vault.ts");
+    const libPath = join(vaultsDir, "_lib", "marker.ts");
+    await Deno.writeTextFile(entryPath, entry);
+    await Deno.writeTextFile(libPath, libV1);
+
+    const catalog1 = new ExtensionCatalogStore(dbPath);
+    const loader1 = new UserVaultLoader(new StubDenoRuntime(), repoDir);
+    await loader1.buildIndex(vaultsDir, catalog1);
+    catalog1.close();
+
+    const ns = bundleNamespace(vaultsDir, repoDir);
+    const bundlePath = join(
+      repoDir,
+      ".swamp",
+      "vault-bundles",
+      ns,
+      "vault.js",
+    );
+    const v1Bundle = await Deno.readTextFile(bundlePath);
+    assertEquals(v1Bundle.includes("V1_DEP_MARKER"), true);
+
+    const entryMtime = (await Deno.stat(entryPath)).mtime!;
+    const libMtime = (await Deno.stat(libPath)).mtime!;
+
+    await new Promise((r) => setTimeout(r, 1100));
+
+    await Deno.writeTextFile(libPath, libV2);
+    await Deno.utime(libPath, libMtime, libMtime);
+    await Deno.utime(entryPath, entryMtime, entryMtime);
+
+    const catalog2 = new ExtensionCatalogStore(dbPath);
+    const loader2 = new UserVaultLoader(new StubDenoRuntime(), repoDir);
+    await loader2.buildIndex(vaultsDir, catalog2);
+    catalog2.close();
+
+    const v2Bundle = await Deno.readTextFile(bundlePath);
+    assertNotEquals(v1Bundle, v2Bundle);
+    assertEquals(
+      v2Bundle.includes("V2_DEP_MARKER"),
+      true,
+      "V2 dep marker must be present in the regenerated bundle",
+    );
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+    await Deno.remove(vaultsDir, { recursive: true });
   }
 });

--- a/src/infrastructure/persistence/extension_catalog_store_test.ts
+++ b/src/infrastructure/persistence/extension_catalog_store_test.ts
@@ -470,3 +470,68 @@ Deno.test("ExtensionCatalogStore: migrates pre-#125 schema by adding source_fing
   assertEquals(again?.source_fingerprint, "");
   store2.close();
 });
+
+// --- per-kind migration tests (#128) ---
+//
+// The sibling loaders (report/driver/datastore/vault) ported to the
+// shared freshness helper in #128. Legacy catalog rows written by the
+// pre-port binary have `source_fingerprint = ""`; they must survive the
+// migration so the next findStaleFiles pass sees fingerprint mismatch
+// and rebundles exactly once. This matches the PR #1188 precedent for
+// the models loader above — accept+document one-time rebundle on
+// upgrade rather than silently backfill.
+
+for (
+  const kind of ["report", "driver", "datastore", "vault"] as const
+) {
+  Deno.test(
+    `ExtensionCatalogStore: migrates pre-#128 ${kind} row by adding empty source_fingerprint (#128)`,
+    () => {
+      const dbPath = makeTempDbPath();
+      ensureDirSync(dirname(dbPath));
+
+      // Seed a DB with the pre-#125 schema — no source_fingerprint
+      // column — carrying a row of the target kind.
+      const seed = new DatabaseSync(dbPath);
+      seed.exec(`
+        CREATE TABLE bundle_types (
+          source_path     TEXT NOT NULL PRIMARY KEY,
+          type_normalized TEXT NOT NULL,
+          kind            TEXT NOT NULL DEFAULT 'model',
+          bundle_path     TEXT NOT NULL,
+          version         TEXT NOT NULL DEFAULT '',
+          description     TEXT NOT NULL DEFAULT '',
+          extends_type    TEXT NOT NULL DEFAULT '',
+          source_mtime    TEXT NOT NULL DEFAULT ''
+        );
+        CREATE TABLE bundle_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        INSERT INTO bundle_types (
+          source_path, type_normalized, kind, bundle_path, version,
+          description, extends_type, source_mtime
+        ) VALUES (
+          '/old/${kind}.ts', '@legacy/${kind}-row', '${kind}',
+          '/old/${kind}.js', '', '', '', '2026-01-01T00:00:00.000Z'
+        );
+      `);
+      seed.close();
+
+      // Opening through ExtensionCatalogStore must run the migration.
+      const store = new ExtensionCatalogStore(dbPath);
+
+      // Legacy row of the target kind survives with empty
+      // source_fingerprint — forces a rebundle on the next
+      // findStaleFiles pass when this kind's loader delegates to the
+      // shared helper.
+      const legacy = store.findByType(`@legacy/${kind}-row`, kind);
+      assertEquals(legacy?.source_fingerprint, "");
+      assertEquals(legacy?.kind, kind);
+
+      // Re-opening is a no-op — migration is idempotent.
+      store.close();
+      const store2 = new ExtensionCatalogStore(dbPath);
+      const again = store2.findByType(`@legacy/${kind}-row`, kind);
+      assertEquals(again?.source_fingerprint, "");
+      store2.close();
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Port content-fingerprint cache invalidation (PR #1188, issue swamp-club#125) from the models loader to the four sibling user-extension loaders: reports, drivers, datastores, vaults. Closes swamp-club#128.
- Make the shared `bundle_freshness` helper kind-aware so sibling loaders can delegate without cross-loader interference. `FreshnessKind` union declared domain-local (no infrastructure import).
- Matches the established shape: each sibling now uses `findStaleFilesShared` with its own kind, drops the old mtime fast-path in `bundleWithCache`, and persists `source_fingerprint` alongside `source_mtime`.

## Why single-PR shape

Kind-isolation verification (a driver-loader `buildIndex` must not rebundle vault/datastore/report/model extensions, and vice versa) requires all four ports landing together. Splitting would defer the most load-bearing integration check until the final PR. The helper refactor + four loader ports + per-kind regression tests + migration tests together form the smallest verifiable unit.

## Design / skill doc catch-up

Updates four `design/*.md` files and six skill files (datastore / driver / vault SKILL.md + references/troubleshooting.md) to describe fingerprint-based invalidation. These docs were already stale for models after #1188 — adjacent catch-up rather than scope creep, called out here so reviewers don't flag it.

## Upgrade contract (matches PR #1188 precedent)

Legacy catalog rows written by the pre-port binary have `source_fingerprint = ""`. The next `findStaleFiles` pass after upgrade treats them as stale and rebundles exactly once per extension; subsequent runs settle to cache-hit. Four new per-kind migration tests in `extension_catalog_store_test.ts` lock in this contract, mirroring the shipped "migrates pre-#125 schema" test.

## Architecture ratchet

`KNOWN_MUTUAL_DEPENDENCIES` 14 → 15. `datastore ↔ extensions` became mutual (extensions → datastore already existed via `extension_auto_resolver`; datastore → extensions is new via the `bundle_freshness` import). Reports / drivers gained unidirectional edges only — extensions does not import from them. `extensions ↔ vaults` was already mutual pre-#128. Comment at the constant explains why.

## Test plan

- [x] `deno check` clean
- [x] `deno lint` clean
- [x] `deno fmt` clean
- [x] `deno run test` — **4460 passed / 0 failed** (includes new unit tests below)
- [x] `deno run compile` — succeeds
- [x] **New regression tests** per loader — `Deno.utime`-preserved content swap + transitive `_lib/*.ts` dep variant (mirrors the shipped `user_model_loader_test.ts:2454` regression from #1188). Added `user_report_loader_test.ts`, `user_driver_loader_test.ts`; appended to existing `user_datastore_loader_test.ts`, `user_vault_loader_test.ts`.
- [x] **Kind-filter unit test** in `bundle_freshness_test.ts` — multi-kind catalog, helper invoked per-kind, rows of unrelated kinds in unseen dirs are NOT deleted.
- [x] **4 new per-kind catalog migration tests** in `extension_catalog_store_test.ts` — legacy row with empty fingerprint survives, forces one rebundle on next pass.
- [x] **Per-loader binary smoke** against the recompiled binary. For each of report / driver / datastore / vault in `/tmp/swamp-repro-issue-128-<type>`: fingerprint populated in `.swamp/_extension_catalog.db`, mtime-preserved content swap takes effect, transitive `_lib` swap takes effect, no-op re-run leaves bundle mtime stable.
- [x] **Deletion path** per loader — removing a source file propagates via `removeBySourcePath` scoped to the loader's kind.
- [x] **Mixed-repo kind-isolation** (the load-bearing check for the ADV-1 refactor) — one repo with model + all four ported kinds. Edited driver + vault sources only; confirmed driver + vault rebundled, model / report / datastore bundle mtimes and catalog fingerprints stayed byte-identical. No cross-loader churn.
- [x] **Catalog migration idempotency** against compiled binary — sqlite-simulated pre-port catalog. Pass 1 rebundled every kind; pass 2 was clean cache-hit for every kind. Upgrade contract matches PR #1188 precedent.
- [x] **swamp-uat CLI suite** against recompiled binary — **329 passed / 1 failed / 2 ignored**. The single failure (`swamp model create surfaces auto-resolve network error`) reproduces identically against the on-PATH release binary — a local swamp-club running on :8000 defeats the test's "unreachable localhost" assumption. Pre-existing, unrelated to this change.
- [x] **UAT gap filed** — systeminit/swamp-uat#151 covering the mtime-preserving content-swap scenario for each extension type (no existing UAT coverage for any of them, including models).

Closes systeminit/swamp-club#128

🤖 Generated with [Claude Code](https://claude.com/claude-code)