### PR TITLE
feat(cli): add SWAMP_REPO_DIR env var support

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,22 @@ export SWAMP_DATASTORE=s3:my-bucket/my-prefix
 export SWAMP_DATASTORE=filesystem:/tmp/swamp-data
 ```
 
+## Repository Directory
+
+Every command runs against a swamp repository. By default this is the current
+working directory. Pass `--repo-dir` to point at a different repo per
+invocation, or set `SWAMP_REPO_DIR` to persist the override across a shell
+session or CI job:
+
+```bash
+swamp model search --repo-dir /path/to/repo
+export SWAMP_REPO_DIR=/path/to/repo
+swamp model search
+```
+
+Priority order (highest to lowest): `--repo-dir` flag → `SWAMP_REPO_DIR` env var
+→ current working directory.
+
 ## Log Level
 
 By default, swamp outputs at the `info` level. You can change this once rather

--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import { AuditService } from "../../domain/audit/audit_service.ts";
 import { createBashCommandEntry } from "../../domain/audit/audit_command_entry.ts";
@@ -85,7 +89,10 @@ export const auditRecordCommand = new Command()
   .option("--tool <tool:string>", "AI tool providing hook input", {
     default: "claude",
   })
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(async function (options) {
     try {
       const tool = options.tool as HookTool;
@@ -116,11 +123,11 @@ export const auditRecordCommand = new Command()
       const entry = createBashCommandEntry(
         normalized.sessionId,
         normalized.command,
-        normalized.cwd || options.repoDir || ".",
+        normalized.cwd || resolveRepoDir(options.repoDir as string | undefined),
         failure,
       );
 
-      const repoDir = options.repoDir || ".";
+      const repoDir = resolveRepoDir(options.repoDir as string | undefined);
       const repository = new JsonlAuditRepository(repoDir);
       await repository.append(entry);
 
@@ -145,7 +152,10 @@ export const auditCommand = new Command()
   .example("View audit timeline", "swamp audit")
   .example("Last 4 hours", "swamp audit --hours 4")
   .example("Include all commands", "swamp audit --all")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("--hours <hours:number>", "Number of hours to analyze", {
     default: 24,
   })
@@ -156,7 +166,7 @@ export const auditCommand = new Command()
     ctx.logger.debug`Fetching audit timeline`;
 
     const { repoDir } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: ctx.outputMode,
     });
 

--- a/src/cli/commands/data_gc.ts
+++ b/src/cli/commands/data_gc.ts
@@ -30,7 +30,11 @@ import {
   renderDataGcCancelled,
   renderDataGcPreview,
 } from "../../presentation/renderers/data_gc.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 
 async function promptConfirmation(message: string): Promise<boolean> {
@@ -55,14 +59,17 @@ export const dataGcCommand = new Command()
   .description("Run garbage collection on data (lifecycle and versions)")
   .example("Preview what would be collected", "swamp data gc --dry-run")
   .example("Run garbage collection", "swamp data gc --force")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("--dry-run", "Show what would be deleted without deleting")
   .option("-f, --force", "Skip confirmation prompt")
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, ["data", "gc"]);
 
     const { repoDir, datastoreResolver } = await requireInitializedRepo({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
 

--- a/src/cli/commands/data_get.ts
+++ b/src/cli/commands/data_get.ts
@@ -25,7 +25,11 @@ import {
   dataGet,
 } from "../../libswamp/mod.ts";
 import { createDataGetRenderer } from "../../presentation/renderers/data_get.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -45,7 +49,10 @@ export const dataGetCommand = new Command()
     "swamp data get my-server system-info --no-content",
   )
   .arguments("[model_id_or_name:model_name] [data_name:string]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("--version <version:number>", "Specific version (defaults to latest)")
   .option(
     "--workflow <name:string>",
@@ -70,7 +77,7 @@ export const dataGetCommand = new Command()
 
       const { repoDir, datastoreResolver } =
         await requireInitializedRepoReadOnly({
-          repoDir: options.repoDir ?? ".",
+          repoDir: resolveRepoDir(options.repoDir),
           outputMode: cliCtx.outputMode,
         });
 

--- a/src/cli/commands/data_list.ts
+++ b/src/cli/commands/data_list.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import {
   consumeStream,
@@ -38,7 +42,10 @@ export const dataListCommand = new Command()
   .example("Filter by type", "swamp data list my-server --type output")
   .example("List workflow run data", "swamp data list --workflow deploy")
   .arguments("[model_id_or_name:model_name]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option(
     "--type <type:string>",
     "Filter by data type (log, file, resource, data)",
@@ -57,7 +64,7 @@ export const dataListCommand = new Command()
 
     const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
       {
-        repoDir: options.repoDir ?? ".",
+        repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
       },
     );

--- a/src/cli/commands/data_query.ts
+++ b/src/cli/commands/data_query.ts
@@ -26,7 +26,11 @@ import {
 } from "../../libswamp/mod.ts";
 import { createDataQueryRenderer } from "../../presentation/renderers/data_query.ts";
 import { renderInteractiveQuery } from "../../presentation/renderers/data_query_tui.tsx";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 
@@ -39,7 +43,10 @@ export const dataQueryCommand = new Command()
     "Query data artifacts using CEL predicates (interactive TUI when no predicate given)",
   )
   .arguments("[predicate:string]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option(
     "--limit <n:number>",
     "Maximum results (unlimited when omitted)",
@@ -65,7 +72,7 @@ export const dataQueryCommand = new Command()
     const ctx = createContext(options as GlobalOptions, ["data", "query"]);
 
     const { repoContext } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: ctx.outputMode,
     });
 

--- a/src/cli/commands/data_rename.ts
+++ b/src/cli/commands/data_rename.ts
@@ -25,7 +25,11 @@ import {
   dataRename,
 } from "../../libswamp/mod.ts";
 import { createDataRenameRenderer } from "../../presentation/renderers/data_rename.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 
 export const dataRenameCommand = new Command()
@@ -36,10 +40,13 @@ export const dataRenameCommand = new Command()
     "swamp data rename my-server old-name new-name",
   )
   .arguments("<model_id_or_name:string> <old_name:string> <new_name:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(
     async function (
-      options: { repoDir: string; json?: boolean },
+      options: { repoDir?: string; json?: boolean },
       modelIdOrName: string,
       oldName: string,
       newName: string,
@@ -50,7 +57,7 @@ export const dataRenameCommand = new Command()
       ]);
 
       const { repoDir, datastoreResolver } = await requireInitializedRepo({
-        repoDir: options.repoDir ?? ".",
+        repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
       });
 

--- a/src/cli/commands/data_search.ts
+++ b/src/cli/commands/data_search.ts
@@ -36,6 +36,7 @@ import {
   createContext,
   type GlobalOptions,
   interactiveOutputMode,
+  resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
@@ -168,7 +169,10 @@ export const dataSearchCommand = new Command()
   .example("Search with query", "swamp data search cpu-metrics")
   .example("Search within a model", "swamp data search --model my-server")
   .arguments("[query:string]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option(
     "--type <type:string>",
     "Filter by data type tag (log, file, resource, data, output)",
@@ -216,7 +220,7 @@ export const dataSearchCommand = new Command()
     ctx.logger.debug`Searching data with query: ${query ?? "(none)"}`;
 
     const { repoContext } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: effectiveMode,
     });
     const definitionRepo = repoContext.definitionRepo;
@@ -238,7 +242,7 @@ export const dataSearchCommand = new Command()
         findDefinitionByIdOrName(definitionRepo, idOrName),
     };
 
-    const repoDir = options.repoDir ?? ".";
+    const repoDir = resolveRepoDir(options.repoDir);
     const fetchPreview = effectiveMode === "log"
       ? createDataFetchPreview(dataRepo, repoDir)
       : undefined;

--- a/src/cli/commands/data_versions.ts
+++ b/src/cli/commands/data_versions.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import {
   consumeStream,
@@ -36,7 +40,10 @@ export const dataVersionsCommand = new Command()
   .description("List all versions of specific data")
   .example("List all versions", "swamp data versions my-server system-info")
   .arguments("<model_id_or_name:model_name> <data_name:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(
     // @ts-expect-error - Cliffy custom type returns unknown instead of string
     async function (
@@ -53,7 +60,7 @@ export const dataVersionsCommand = new Command()
 
       const { repoDir, datastoreResolver } =
         await requireInitializedRepoReadOnly({
-          repoDir: options.repoDir ?? ".",
+          repoDir: resolveRepoDir(options.repoDir),
           outputMode: cliCtx.outputMode,
         });
 

--- a/src/cli/commands/datastore_lock.ts
+++ b/src/cli/commands/datastore_lock.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import {
   createDatastoreLock,
   createModelLock,
@@ -48,7 +52,10 @@ type AnyOptions = any;
 const datastoreLockStatusCommand = new Command()
   .description("Show who holds the datastore lock")
   .example("Check lock status", "swamp datastore lock status")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, [
       "datastore",
@@ -57,7 +64,7 @@ const datastoreLockStatusCommand = new Command()
     ]);
 
     const { datastoreConfig: config } = await resolveDatastoreForRepo(
-      options.repoDir ?? ".",
+      resolveRepoDir(options.repoDir),
     );
 
     const lock = await createDatastoreLock(config);
@@ -91,7 +98,10 @@ const datastoreLockReleaseCommand = new Command()
     "Release a model lock",
     "swamp datastore lock release --force --model aws-ec2/my-server",
   )
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("--force", "Required to confirm force release", { required: true })
   .option(
     "--model <model:string>",
@@ -112,7 +122,7 @@ const datastoreLockReleaseCommand = new Command()
     }
 
     const { datastoreConfig: config } = await resolveDatastoreForRepo(
-      options.repoDir ?? ".",
+      resolveRepoDir(options.repoDir),
     );
 
     const modelSpec = options.model as string | undefined;

--- a/src/cli/commands/datastore_setup.ts
+++ b/src/cli/commands/datastore_setup.ts
@@ -19,7 +19,11 @@
 
 import { Command } from "@cliffy/command";
 import { isAbsolute, resolve } from "@std/path";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import {
   requireInitializedRepo,
   resolveDatastoreForRepo,
@@ -53,7 +57,10 @@ const datastoreSetupFilesystemCommand = new Command()
     "Custom subdirectories",
     "swamp datastore setup filesystem --path /data --directories models,outputs",
   )
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("--path <path:string>", "Path for the datastore directory", {
     required: true,
   })
@@ -70,7 +77,7 @@ const datastoreSetupFilesystemCommand = new Command()
     ]);
 
     const { repoDir } = await requireInitializedRepo({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
 
@@ -105,7 +112,10 @@ const datastoreSetupExtensionCommand = new Command()
     `swamp datastore setup extension @swamp/s3-datastore --config '{"bucket":"my-bucket","region":"us-east-1"}'`,
   )
   .arguments("<type:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option(
     "--config <config:string>",
     'JSON config object for the extension (e.g., \'{"bucket":"name","region":"us-east-1"}\')',
@@ -154,7 +164,7 @@ const datastoreSetupExtensionCommand = new Command()
     }
 
     const { repoDir, marker } = await resolveDatastoreForRepo(
-      options.repoDir ?? ".",
+      resolveRepoDir(options.repoDir),
     );
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });

--- a/src/cli/commands/datastore_status.ts
+++ b/src/cli/commands/datastore_status.ts
@@ -25,7 +25,11 @@ import {
   datastoreStatus,
 } from "../../libswamp/mod.ts";
 import { createDatastoreStatusRenderer } from "../../presentation/renderers/datastore_status.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -37,7 +41,10 @@ type AnyOptions = any;
 export const datastoreStatusCommand = new Command()
   .description("Show datastore configuration and health")
   .example("Show datastore health", "swamp datastore status")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, [
       "datastore",
@@ -46,7 +53,7 @@ export const datastoreStatusCommand = new Command()
     cliCtx.logger.debug("Executing datastore status command");
 
     const { datastoreResolver } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
 

--- a/src/cli/commands/datastore_sync.ts
+++ b/src/cli/commands/datastore_sync.ts
@@ -25,7 +25,11 @@ import {
   datastoreSync,
 } from "../../libswamp/mod.ts";
 import { createDatastoreSyncRenderer } from "../../presentation/renderers/datastore_sync.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import {
   requireInitializedRepo,
   requireInitializedRepoReadOnly,
@@ -42,7 +46,10 @@ export const datastoreSyncCommand = new Command()
   .example("Full sync", "swamp datastore sync")
   .example("Pull only", "swamp datastore sync --pull")
   .example("Push only", "swamp datastore sync --push")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("--pull", "Pull-only mode (fetch all remote data to local cache)")
   .option("--push", "Push-only mode (upload all local cache data to S3)")
   .action(async function (options: AnyOptions) {
@@ -62,11 +69,11 @@ export const datastoreSyncCommand = new Command()
     // lock and triggering a coordinator push on flush.
     const { repoDir, datastoreResolver } = mode === "pull"
       ? await requireInitializedRepoReadOnly({
-        repoDir: options.repoDir ?? ".",
+        repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
       })
       : await requireInitializedRepo({
-        repoDir: options.repoDir ?? ".",
+        repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
       });
 

--- a/src/cli/commands/extension_fmt.ts
+++ b/src/cli/commands/extension_fmt.ts
@@ -25,13 +25,17 @@ import {
   extensionFmt,
 } from "../../libswamp/mod.ts";
 import { createExtensionFmtRenderer } from "../../presentation/renderers/extension_fmt.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { resolveExtensionFiles } from "../resolve_extension_files.ts";
 import { UserError } from "../../domain/errors.ts";
 
 interface ExtensionFmtOptions extends GlobalOptions {
-  repoDir: string;
+  repoDir?: string;
   check?: boolean;
 }
 
@@ -47,14 +51,17 @@ export const extensionFmtCommand = new Command()
     "swamp extension fmt extensions/models/my-model/manifest.json --check",
   )
   .arguments("<manifest-path:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("--check", "Check only, do not auto-fix")
   .action(async function (options: ExtensionFmtOptions, manifestPath: string) {
     const cliCtx = createContext(options, ["extension", "fmt"]);
     cliCtx.logger.debug`Starting extension fmt`;
 
     // 1. Validate repo
-    const repoDir = options.repoDir ?? ".";
+    const repoDir = resolveRepoDir(options.repoDir);
     const { repoContext } = await requireInitializedRepo({
       repoDir,
       outputMode: cliCtx.outputMode,

--- a/src/cli/commands/extension_install.ts
+++ b/src/cli/commands/extension_install.ts
@@ -19,7 +19,11 @@
 
 import { Command } from "@cliffy/command";
 import { join, resolve } from "@std/path";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
 import {
@@ -48,7 +52,10 @@ export const extensionInstallCommand = new Command()
   )
   .example("Restore extensions from lockfile", "swamp extension install")
   .arguments("[unexpected:string]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(async function (options: AnyOptions, unexpected?: string) {
     if (unexpected) {
       throw new UserError(
@@ -64,7 +71,7 @@ export const extensionInstallCommand = new Command()
     cliCtx.logger.debug`Starting extension install`;
 
     // 1. Validate repo
-    const repoDir = options.repoDir ?? ".";
+    const repoDir = resolveRepoDir(options.repoDir);
     await requireInitializedRepo({
       repoDir,
       outputMode: cliCtx.outputMode,

--- a/src/cli/commands/extension_list.ts
+++ b/src/cli/commands/extension_list.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import { join, resolve } from "@std/path";
 import {
@@ -43,7 +47,10 @@ export const extensionListCommand = new Command()
   .alias("ls")
   .description("List upstream installed extensions")
   .example("List installed extensions", "swamp extension list")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, [
       "extension",
@@ -51,7 +58,7 @@ export const extensionListCommand = new Command()
     ]);
     cliCtx.logger.debug`Starting extension list`;
 
-    const repoDir = options.repoDir ?? ".";
+    const repoDir = resolveRepoDir(options.repoDir);
     await requireInitializedRepoReadOnly({
       repoDir,
       outputMode: cliCtx.outputMode,

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -20,7 +20,11 @@
 import { Command } from "@cliffy/command";
 import type { Logger } from "@logtape/logtape";
 import { join, resolve } from "@std/path";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
 import {
@@ -156,14 +160,17 @@ export const extensionPullCommand = new Command()
   .example("Pull an extension", "swamp extension pull @stack72/aws-ec2")
   .example("Force re-pull", "swamp extension pull @stack72/aws-ec2 --force")
   .arguments("<extension:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("--force", "Overwrite existing files without prompting")
   .action(async function (options: AnyOptions, extension: string) {
     const ctx = createContext(options as GlobalOptions, ["extension", "pull"]);
     ctx.logger.debug`Starting extension pull`;
 
     // 1. Validate repo
-    const repoDir = options.repoDir ?? ".";
+    const repoDir = resolveRepoDir(options.repoDir);
     await requireInitializedRepo({
       repoDir,
       outputMode: ctx.outputMode,

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -19,7 +19,11 @@
 
 import { Command } from "@cliffy/command";
 import { dirname, join, resolve } from "@std/path";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { resolveExtensionFiles } from "../resolve_extension_files.ts";
 import { UserError } from "../../domain/errors.ts";
@@ -45,7 +49,7 @@ import type {
 import type { CompilationError, SwampError } from "../../libswamp/mod.ts";
 
 interface ExtensionPushOptions extends GlobalOptions {
-  repoDir: string;
+  repoDir?: string;
   yes?: boolean;
   dryRun?: boolean;
   releaseNotes?: string;
@@ -168,7 +172,10 @@ export const extensionPushCommand = new Command()
     `swamp extension push extensions/models/my-model/manifest.json --release-notes "Added validate method"`,
   )
   .arguments("<manifest-path:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("-y, --yes", "Skip confirmation prompts")
   .option("--dry-run", "Build archive locally without pushing to registry")
   .option(
@@ -180,7 +187,7 @@ export const extensionPushCommand = new Command()
     cliCtx.logger.debug`Starting extension push`;
 
     // 1. Validate repo
-    const repoDir = options.repoDir ?? ".";
+    const repoDir = resolveRepoDir(options.repoDir);
     const { repoContext } = await requireInitializedRepo({
       repoDir,
       outputMode: cliCtx.outputMode,

--- a/src/cli/commands/extension_rm.ts
+++ b/src/cli/commands/extension_rm.ts
@@ -19,7 +19,11 @@
 
 import { Command } from "@cliffy/command";
 import { join, resolve } from "@std/path";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
 import {
@@ -65,13 +69,16 @@ export const extensionRemoveCommand = new Command()
   .example("Remove extension", "swamp extension rm @stack72/aws-ec2")
   .example("Force remove", "swamp extension rm @stack72/aws-ec2 --force")
   .arguments("<extension:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("-f, --force", "Skip confirmation prompt")
   .action(async function (options: AnyOptions, extension: string) {
     const ctx = createContext(options as GlobalOptions, ["extension", "rm"]);
     ctx.logger.debug`Starting extension remove`;
 
-    const repoDir = options.repoDir ?? ".";
+    const repoDir = resolveRepoDir(options.repoDir);
     await requireInitializedRepo({
       repoDir,
       outputMode: ctx.outputMode,

--- a/src/cli/commands/extension_source_add.ts
+++ b/src/cli/commands/extension_source_add.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import {
   consumeStream,
   createLibSwampContext,
@@ -49,7 +53,10 @@ export const extensionSourceAddCommand = new Command()
     "swamp extension source add ~/code/my-vaults --only vaults",
   )
   .arguments("<path:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option(
     "--only <types:string>",
     "Only load these extension types (comma-separated: models,vaults,drivers,datastores,reports,workflows)",
@@ -63,7 +70,7 @@ export const extensionSourceAddCommand = new Command()
     cliCtx.logger.debug`Adding extension source: ${path}`;
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createSourceAddDeps(options.repoDir ?? ".");
+    const deps = createSourceAddDeps(resolveRepoDir(options.repoDir));
 
     let only: ExtensionKind[] | undefined;
     if (options.only) {

--- a/src/cli/commands/extension_source_list.ts
+++ b/src/cli/commands/extension_source_list.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import {
   consumeStream,
   createLibSwampContext,
@@ -34,7 +38,10 @@ export const extensionSourceListCommand = new Command()
   .name("list")
   .description("List configured extension sources")
   .example("List all sources", "swamp extension source list")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, [
       "extension",
@@ -43,7 +50,7 @@ export const extensionSourceListCommand = new Command()
     ]);
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createSourceListDeps(options.repoDir ?? ".");
+    const deps = createSourceListDeps(resolveRepoDir(options.repoDir));
 
     const renderer = createSourceListRenderer(cliCtx.outputMode);
     await consumeStream(sourceList(ctx, deps), renderer.handlers());

--- a/src/cli/commands/extension_source_rm.ts
+++ b/src/cli/commands/extension_source_rm.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import {
   consumeStream,
   createLibSwampContext,
@@ -38,7 +42,10 @@ export const extensionSourceRmCommand = new Command()
     'swamp extension source rm "~/code/swamp-extensions/model/aws/*"',
   )
   .arguments("<path:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(async function (options: AnyOptions, path: string) {
     const cliCtx = createContext(options as GlobalOptions, [
       "extension",
@@ -48,7 +55,7 @@ export const extensionSourceRmCommand = new Command()
     cliCtx.logger.debug`Removing extension source: ${path}`;
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createSourceRemoveDeps(options.repoDir ?? ".");
+    const deps = createSourceRemoveDeps(resolveRepoDir(options.repoDir));
 
     const renderer = createSourceModifyRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/cli/commands/extension_trust_add.ts
+++ b/src/cli/commands/extension_trust_add.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import {
   consumeStream,
   createLibSwampContext,
@@ -35,7 +39,10 @@ export const extensionTrustAddCommand = new Command()
   .description("Add a collective to the trusted list")
   .example("Trust a collective", "swamp extension trust add stack72")
   .arguments("<collective:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(async function (options: AnyOptions, collective: string) {
     const cliCtx = createContext(options as GlobalOptions, [
       "extension",
@@ -45,7 +52,7 @@ export const extensionTrustAddCommand = new Command()
     cliCtx.logger.debug`Adding trusted collective: ${collective}`;
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createTrustAddDeps(options.repoDir ?? ".");
+    const deps = createTrustAddDeps(resolveRepoDir(options.repoDir));
 
     const renderer = createTrustModifyRenderer(cliCtx.outputMode);
     await consumeStream(trustAdd(ctx, deps, collective), renderer.handlers());

--- a/src/cli/commands/extension_trust_auto_trust.ts
+++ b/src/cli/commands/extension_trust_auto_trust.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import {
   consumeStream,
   createLibSwampContext,
@@ -39,7 +43,10 @@ export const extensionTrustAutoTrustCommand = new Command()
   .example("Enable auto-trust", "swamp extension trust auto-trust enable")
   .example("Disable auto-trust", "swamp extension trust auto-trust disable")
   .arguments("<enabled:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(async function (options: AnyOptions, enabled: string) {
     const cliCtx = createContext(options as GlobalOptions, [
       "extension",
@@ -63,7 +70,7 @@ export const extensionTrustAutoTrustCommand = new Command()
     cliCtx.logger.debug`Setting auto-trust: ${boolValue}`;
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createTrustAutoTrustDeps(options.repoDir ?? ".");
+    const deps = createTrustAutoTrustDeps(resolveRepoDir(options.repoDir));
 
     const renderer = createTrustAutoTrustRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/cli/commands/extension_trust_list.ts
+++ b/src/cli/commands/extension_trust_list.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import {
   consumeStream,
   createLibSwampContext,
@@ -34,7 +38,10 @@ export const extensionTrustListCommand = new Command()
   .name("list")
   .description("List trusted collectives for extension auto-resolution")
   .example("List trusted collectives", "swamp extension trust list")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, [
       "extension",
@@ -44,7 +51,7 @@ export const extensionTrustListCommand = new Command()
     cliCtx.logger.debug("Executing extension trust list command");
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createTrustListDeps(options.repoDir ?? ".");
+    const deps = createTrustListDeps(resolveRepoDir(options.repoDir));
 
     const renderer = createTrustListRenderer(cliCtx.outputMode);
     await consumeStream(trustList(ctx, deps), renderer.handlers());

--- a/src/cli/commands/extension_trust_rm.ts
+++ b/src/cli/commands/extension_trust_rm.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import {
   consumeStream,
   createLibSwampContext,
@@ -35,7 +39,10 @@ export const extensionTrustRmCommand = new Command()
   .description("Remove a collective from the trusted list")
   .example("Remove trusted collective", "swamp extension trust rm stack72")
   .arguments("<collective:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(async function (options: AnyOptions, collective: string) {
     const cliCtx = createContext(options as GlobalOptions, [
       "extension",
@@ -45,7 +52,7 @@ export const extensionTrustRmCommand = new Command()
     cliCtx.logger.debug`Removing trusted collective: ${collective}`;
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createTrustRmDeps(options.repoDir ?? ".");
+    const deps = createTrustRmDeps(resolveRepoDir(options.repoDir));
 
     const renderer = createTrustModifyRenderer(cliCtx.outputMode);
     await consumeStream(trustRm(ctx, deps, collective), renderer.handlers());

--- a/src/cli/commands/extension_update.ts
+++ b/src/cli/commands/extension_update.ts
@@ -19,7 +19,11 @@
 
 import { Command } from "@cliffy/command";
 import { join, resolve } from "@std/path";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
 import {
@@ -57,7 +61,10 @@ export const extensionUpdateCommand = new Command()
   .example("Update one extension", "swamp extension update @stack72/aws-ec2")
   .example("Check for updates", "swamp extension update --check")
   .arguments("[extension:string]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("--check", "Show what's outdated without pulling")
   .action(async function (options: AnyOptions, extensionArg?: string) {
     const cliCtx = createContext(options as GlobalOptions, [
@@ -67,7 +74,7 @@ export const extensionUpdateCommand = new Command()
     cliCtx.logger.debug`Starting extension update`;
 
     // 1. Validate repo
-    const repoDir = options.repoDir ?? ".";
+    const repoDir = resolveRepoDir(options.repoDir);
     await requireInitializedRepo({
       repoDir,
       outputMode: cliCtx.outputMode,

--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -25,7 +25,11 @@ import {
   modelCreate,
 } from "../../libswamp/mod.ts";
 import { createModelCreateRenderer } from "../../presentation/renderers/model_create.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { parseKeyValueInputs } from "../input_parser.ts";
 import { modelValidateCommand } from "./model_validate.ts";
@@ -50,7 +54,10 @@ export const modelCreateCommand = new Command()
     "swamp model create aws-ec2 my-server --global-arg region=us-east-1",
   )
   .arguments("<type:model_type> <name:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option(
     "--global-arg <arg:string>",
     "Set global argument (key=value, repeatable)",
@@ -63,7 +70,7 @@ export const modelCreateCommand = new Command()
       .debug`Creating model definition: type=${typeArg}, name=${name}`;
 
     const { repoDir } = await requireInitializedRepo({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
 
@@ -107,8 +114,9 @@ export const modelCommand = new Command()
       .description("Alias for model search")
       .hidden()
       .arguments("[query:string]")
-      .option("--repo-dir <dir:string>", "Repository directory", {
-        default: ".",
-      })
+      .option(
+        "--repo-dir <dir:string>",
+        "Repository directory (env: SWAMP_REPO_DIR)",
+      )
       .action(modelSearchAction),
   );

--- a/src/cli/commands/model_delete.ts
+++ b/src/cli/commands/model_delete.ts
@@ -29,7 +29,11 @@ import {
   createModelDeleteRenderer,
   renderModelDeleteCancelled,
 } from "../../presentation/renderers/model_delete.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 
@@ -56,7 +60,10 @@ export const modelDeleteCommand = new Command()
   .example("Delete a model", "swamp model delete my-server")
   .example("Force delete", "swamp model delete my-server --force")
   .arguments("<model_id_or_name:model_name>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option(
     "-f, --force",
     "Skip confirmation and allow deletion when data artifacts exist",
@@ -67,7 +74,7 @@ export const modelDeleteCommand = new Command()
     cliCtx.logger.debug`Deleting model: ${modelIdOrName}`;
 
     const { repoDir, datastoreResolver } = await requireInitializedRepo({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
 

--- a/src/cli/commands/model_edit.ts
+++ b/src/cli/commands/model_edit.ts
@@ -28,7 +28,11 @@ import {
 } from "../../libswamp/mod.ts";
 import { createModelSearchRenderer } from "../../presentation/renderers/model_search.tsx";
 import { createModelEditRenderer } from "../../presentation/renderers/model_edit.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { readStdin } from "../../infrastructure/io/stdin_reader.ts";
@@ -42,14 +46,17 @@ export const modelEditCommand = new Command()
   .example("Edit a model", "swamp model edit my-server")
   .example("Interactive search", "swamp model edit")
   .arguments("[model_id_or_name:model_name]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(async function (options: AnyOptions, modelIdOrName?: string) {
     const cliCtx = createContext(options as GlobalOptions, ["model", "edit"]);
     cliCtx.logger.debug`Editing model: ${modelIdOrName ?? "(interactive)"}`;
 
     const { repoContext, repoDir } = await requireInitializedRepo({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
 

--- a/src/cli/commands/model_evaluate.ts
+++ b/src/cli/commands/model_evaluate.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import {
   acquireModelLocks,
   requireInitializedRepo,
@@ -43,7 +47,10 @@ export const modelEvaluateCommand = new Command()
   .example("Evaluate a model", "swamp model evaluate my-server")
   .example("Evaluate all models", "swamp model evaluate --all")
   .arguments("[model_id_or_name:string]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("--all", "Evaluate all model definitions")
   .action(
     async function (options: AnyOptions, modelIdOrName?: string) {
@@ -55,7 +62,7 @@ export const modelEvaluateCommand = new Command()
       // If --all flag or no argument, evaluate all definitions (global lock)
       if (options.all || !modelIdOrName) {
         const { repoDir, datastoreResolver } = await requireInitializedRepo({
-          repoDir: options.repoDir ?? ".",
+          repoDir: resolveRepoDir(options.repoDir),
           outputMode: cliCtx.outputMode,
         });
 
@@ -73,7 +80,7 @@ export const modelEvaluateCommand = new Command()
       // Single model evaluation — use per-model lock
       const { repoDir, repoContext, datastoreConfig, datastoreResolver } =
         await requireInitializedRepoUnlocked({
-          repoDir: options.repoDir ?? ".",
+          repoDir: resolveRepoDir(options.repoDir),
           outputMode: cliCtx.outputMode,
         });
 

--- a/src/cli/commands/model_get.ts
+++ b/src/cli/commands/model_get.ts
@@ -25,7 +25,11 @@ import {
   modelGet,
 } from "../../libswamp/mod.ts";
 import { createModelGetRenderer } from "../../presentation/renderers/model_get.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -37,14 +41,17 @@ export const modelGetCommand = new Command()
   .example("Show model details", "swamp model get my-server")
   .example("JSON output", "swamp model get my-server --json")
   .arguments("<model_id_or_name:model_name>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(async function (options: AnyOptions, modelIdOrName: string) {
     const cliCtx = createContext(options as GlobalOptions, ["model", "get"]);
     cliCtx.logger.debug`Getting model: ${modelIdOrName}`;
 
     const { repoDir } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
 

--- a/src/cli/commands/model_method_describe.ts
+++ b/src/cli/commands/model_method_describe.ts
@@ -25,7 +25,11 @@ import {
   modelMethodDescribe,
 } from "../../libswamp/mod.ts";
 import { createModelMethodDescribeRenderer } from "../../presentation/renderers/model_method_describe.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 
@@ -40,7 +44,10 @@ export const modelMethodDescribeCommand = new Command()
     "swamp model method describe my-server getSystemInfo",
   )
   .arguments("<model_id_or_name:model_name> <method_name:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(
     // @ts-expect-error - Cliffy custom type returns unknown instead of string
     async function (
@@ -55,7 +62,7 @@ export const modelMethodDescribeCommand = new Command()
       ]);
 
       const { repoDir } = await requireInitializedRepoReadOnly({
-        repoDir: options.repoDir ?? ".",
+        repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
       });
 

--- a/src/cli/commands/model_method_history_get.ts
+++ b/src/cli/commands/model_method_history_get.ts
@@ -25,7 +25,11 @@ import {
   modelOutputGet,
 } from "../../libswamp/mod.ts";
 import { createModelOutputGetRenderer } from "../../presentation/renderers/model_output_get.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -40,7 +44,10 @@ export const modelMethodHistoryGetCommand = new Command()
     "swamp model method history get my-server",
   )
   .arguments("<output_id_or_model_name:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(async function (options: AnyOptions, outputIdOrModelName: string) {
     const cliCtx = createContext(options as GlobalOptions, [
       "model",
@@ -52,7 +59,7 @@ export const modelMethodHistoryGetCommand = new Command()
 
     const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
       {
-        repoDir: options.repoDir ?? ".",
+        repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
       },
     );

--- a/src/cli/commands/model_method_history_logs.ts
+++ b/src/cli/commands/model_method_history_logs.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import {
   consumeStream,
@@ -40,7 +44,10 @@ export const modelMethodHistoryLogsCommand = new Command()
     "swamp model method history logs abc123 --tail 50",
   )
   .arguments("<output_id_or_model_name:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("--tail <lines:number>", "Show only the last N lines")
   .action(async function (options: AnyOptions, outputIdOrModelName: string) {
     const cliCtx = createContext(options as GlobalOptions, [
@@ -53,7 +60,7 @@ export const modelMethodHistoryLogsCommand = new Command()
 
     const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
       {
-        repoDir: options.repoDir ?? ".",
+        repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
       },
     );

--- a/src/cli/commands/model_method_history_search.ts
+++ b/src/cli/commands/model_method_history_search.ts
@@ -32,6 +32,7 @@ import {
   createContext,
   type GlobalOptions,
   interactiveOutputMode,
+  resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
@@ -46,7 +47,10 @@ export const modelMethodHistorySearchCommand = new Command()
   .example("Browse all history", "swamp model method history search")
   .example("Search by keyword", "swamp model method history search deploy")
   .arguments("[query:string]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(async function (options: AnyOptions, query?: string) {
     const ctx = createContext(options as GlobalOptions, [
       "model",
@@ -59,7 +63,7 @@ export const modelMethodHistorySearchCommand = new Command()
     ctx.logger.debug`Searching method history with query: ${query ?? "(none)"}`;
 
     const { repoContext } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: effectiveMode,
     });
 
@@ -82,7 +86,9 @@ export const modelMethodHistorySearchCommand = new Command()
     if (selected) {
       ctx.logger.debug`Selected output: ${selected.id}`;
       const getRenderer = createModelOutputGetRenderer(effectiveMode);
-      const getDeps = await createModelOutputGetDeps(options.repoDir ?? ".");
+      const getDeps = await createModelOutputGetDeps(
+        resolveRepoDir(options.repoDir),
+      );
       await consumeStream(
         modelOutputGet(libCtx, getDeps, selected.id),
         getRenderer.handlers(),

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import {
   acquireModelLocks,
   requireInitializedRepoUnlocked,
@@ -71,7 +75,10 @@ export const modelMethodRunCommand = new Command()
     "swamp model method run my-server deploy --input env=prod",
   )
   .arguments("<model_id_or_name:model_name> <method_name:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option(
     "--last-evaluated",
     "Skip CEL evaluation, use previously evaluated definition",
@@ -136,7 +143,7 @@ export const modelMethodRunCommand = new Command()
       ]);
       const { repoDir, repoContext, datastoreConfig } =
         await requireInitializedRepoUnlocked({
-          repoDir: options.repoDir ?? ".",
+          repoDir: resolveRepoDir(options.repoDir),
           outputMode: ctx.outputMode,
         });
 

--- a/src/cli/commands/model_output_data.ts
+++ b/src/cli/commands/model_output_data.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import {
   consumeStream,
@@ -44,7 +48,10 @@ export const modelOutputDataCommand = new Command()
     "swamp model output data abc123 --version 2",
   )
   .arguments("<output_id:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("--field <name:string>", "Show only a specific field from the data")
   .option(
     "--version <version:number>",
@@ -64,7 +71,7 @@ export const modelOutputDataCommand = new Command()
 
     const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
       {
-        repoDir: options.repoDir ?? ".",
+        repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
       },
     );

--- a/src/cli/commands/model_output_get.ts
+++ b/src/cli/commands/model_output_get.ts
@@ -25,7 +25,11 @@ import {
   modelOutputGet,
 } from "../../libswamp/mod.ts";
 import { createModelOutputGetRenderer } from "../../presentation/renderers/model_output_get.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -37,7 +41,10 @@ export const modelOutputGetCommand = new Command()
   .example("Show output details by ID", "swamp model output get abc123")
   .example("Show latest output for a model", "swamp model output get my-server")
   .arguments("<output_id_or_model_name:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(async function (options: AnyOptions, outputIdOrModelName: string) {
     const cliCtx = createContext(options as GlobalOptions, [
       "model",
@@ -48,7 +55,7 @@ export const modelOutputGetCommand = new Command()
 
     const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
       {
-        repoDir: options.repoDir ?? ".",
+        repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
       },
     );

--- a/src/cli/commands/model_output_logs.ts
+++ b/src/cli/commands/model_output_logs.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import {
   consumeStream,
@@ -37,7 +41,10 @@ export const modelOutputLogsCommand = new Command()
   .example("Show output logs", "swamp model output logs abc123")
   .example("Tail last 100 lines", "swamp model output logs abc123 --tail 100")
   .arguments("<output_id:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("--tail <n:number>", "Show only last N lines")
   .action(async function (options: AnyOptions, outputIdArg: string) {
     const cliCtx = createContext(options as GlobalOptions, [
@@ -49,7 +56,7 @@ export const modelOutputLogsCommand = new Command()
 
     const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
       {
-        repoDir: options.repoDir ?? ".",
+        repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
       },
     );

--- a/src/cli/commands/model_output_search.ts
+++ b/src/cli/commands/model_output_search.ts
@@ -34,6 +34,7 @@ import {
   createContext,
   type GlobalOptions,
   interactiveOutputMode,
+  resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
@@ -75,7 +76,10 @@ export const modelOutputSearchCommand = new Command()
   .example("Browse all outputs", "swamp model output search")
   .example("Search by keyword", "swamp model output search deploy")
   .arguments("[query:string]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(async function (options: AnyOptions, query?: string) {
     const ctx = createContext(options as GlobalOptions, [
       "model",
@@ -87,7 +91,7 @@ export const modelOutputSearchCommand = new Command()
     ctx.logger.debug`Searching outputs with query: ${query ?? "(none)"}`;
 
     const { repoContext } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: effectiveMode,
     });
 
@@ -100,7 +104,7 @@ export const modelOutputSearchCommand = new Command()
         ),
     };
 
-    const repoDir = options.repoDir ?? ".";
+    const repoDir = resolveRepoDir(options.repoDir);
     const fetchPreview = effectiveMode === "log"
       ? await createOutputFetchPreview(repoDir)
       : undefined;

--- a/src/cli/commands/model_search.ts
+++ b/src/cli/commands/model_search.ts
@@ -34,6 +34,7 @@ import {
   createContext,
   type GlobalOptions,
   interactiveOutputMode,
+  resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 
@@ -77,7 +78,7 @@ export async function modelSearchAction(
   ctx.logger.debug`Searching models with query: ${query ?? "(none)"}`;
 
   const { repoContext } = await requireInitializedRepoReadOnly({
-    repoDir: options.repoDir ?? ".",
+    repoDir: resolveRepoDir(options.repoDir),
     outputMode: effectiveMode,
   });
 
@@ -85,7 +86,7 @@ export async function modelSearchAction(
     findAllGlobal: () => repoContext.definitionRepo.findAllGlobal(),
   };
 
-  const repoDir = options.repoDir ?? ".";
+  const repoDir = resolveRepoDir(options.repoDir);
   const fetchPreview = effectiveMode === "log"
     ? await createModelFetchPreview(repoDir)
     : undefined;
@@ -123,5 +124,8 @@ export const modelSearchCommand = new Command()
   .example("Browse all models", "swamp model search")
   .example("Search by keyword", "swamp model search aws")
   .arguments("[query:string]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(modelSearchAction);

--- a/src/cli/commands/model_validate.ts
+++ b/src/cli/commands/model_validate.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import {
   requireInitializedRepo,
   requireInitializedRepoReadOnly,
@@ -45,7 +49,10 @@ export const modelValidateCommand = new Command()
     "swamp model validate --label production",
   )
   .arguments("[model_id_or_name:string]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option(
     "--label <label:string>",
     "Only run checks with this label",
@@ -68,11 +75,11 @@ export const modelValidateCommand = new Command()
 
       const { repoDir, datastoreResolver } = hasCheckOptions
         ? await requireInitializedRepo({
-          repoDir: options.repoDir ?? ".",
+          repoDir: resolveRepoDir(options.repoDir),
           outputMode: cliCtx.outputMode,
         })
         : await requireInitializedRepoReadOnly({
-          repoDir: options.repoDir ?? ".",
+          repoDir: resolveRepoDir(options.repoDir),
           outputMode: cliCtx.outputMode,
         });
 

--- a/src/cli/commands/open.ts
+++ b/src/cli/commands/open.ts
@@ -19,7 +19,11 @@
 
 import { Command } from "@cliffy/command";
 import { join, resolve } from "@std/path";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
@@ -130,12 +134,15 @@ export const openCommand = new Command()
   )
   .example("Point at a specific repo", "swamp open --repo-dir /path/to/repo")
   .example("Custom port", "swamp open --port 9192")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("--port <port:number>", "Port to listen on", { default: 9191 })
   .option("--no-open", "Do not auto-open the browser")
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, ["open"]);
-    const repoDir = options.repoDir as string ?? ".";
+    const repoDir = resolveRepoDir(options.repoDir as string | undefined);
     const port = options.port as number;
     const isJson = ctx.outputMode === "json";
 

--- a/src/cli/commands/report_get.ts
+++ b/src/cli/commands/report_get.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { createDefinitionId } from "../../domain/definitions/definition.ts";
@@ -46,7 +50,10 @@ export const reportGetCommand = new Command()
     "swamp report get cost-summary --workflow deploy-pipeline",
   )
   .arguments("<report_name:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("--model <name:string>", "Scope to a specific model")
   .option("--workflow <name:string>", "Scope to a specific workflow")
   .option(
@@ -58,7 +65,7 @@ export const reportGetCommand = new Command()
     const ctx = createContext(options as GlobalOptions, ["report", "get"]);
 
     const { repoContext } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: ctx.outputMode,
     });
 

--- a/src/cli/commands/report_search.ts
+++ b/src/cli/commands/report_search.ts
@@ -22,6 +22,7 @@ import {
   createContext,
   type GlobalOptions,
   interactiveOutputMode,
+  resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
@@ -164,7 +165,10 @@ export const reportSearchCommand = new Command()
   .example("Browse all reports", "swamp report search")
   .example("Search by keyword", "swamp report search cost")
   .arguments("[query:string]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("--model <name:string>", "Filter to a specific model")
   .option("--workflow <name:string>", "Filter to a specific workflow")
   .option(
@@ -184,7 +188,7 @@ export const reportSearchCommand = new Command()
     const effectiveMode = interactiveOutputMode(ctx);
 
     const { repoContext } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: effectiveMode,
     });
 

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { handleConnection } from "../../serve/connection.ts";
 import { executeWorkflowWithLocks } from "../../serve/deps.ts";
@@ -40,7 +44,10 @@ export const serveCommand = new Command()
     "Bind to all interfaces",
     "swamp serve --host 0.0.0.0 --port 3000",
   )
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("--port <port:number>", "Port to listen on", { default: 9090 })
   .option("--host <host:string>", "Host to bind to", { default: "127.0.0.1" })
   .option("--no-schedule", "Disable scheduled workflow execution")
@@ -55,7 +62,7 @@ export const serveCommand = new Command()
   )
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, ["serve"]);
-    const repoDir = options.repoDir as string ?? ".";
+    const repoDir = resolveRepoDir(options.repoDir as string | undefined);
     const port = options.port as number;
     const host = options.host as string;
     const isJson = ctx.outputMode === "json";

--- a/src/cli/commands/summarise.ts
+++ b/src/cli/commands/summarise.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import { parseDuration } from "../../libswamp/mod.ts";
 import {
@@ -43,7 +47,10 @@ export const summariseCommand = new Command()
   .example("Show recent activity", "swamp summarise")
   .example("Activity from the last day", "swamp summarise --since 1d")
   .example("Activity from the last hour", "swamp summarise --since 1h")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("--since <duration:string>", "Time window (e.g. 1h, 1d, 7d, 1w)", {
     default: "7d",
   })
@@ -52,7 +59,7 @@ export const summariseCommand = new Command()
     ctx.logger.debug`Generating activity summary`;
 
     const { repoContext } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: ctx.outputMode,
     });
 

--- a/src/cli/commands/telemetry_stats.ts
+++ b/src/cli/commands/telemetry_stats.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import {
   consumeStream,
@@ -34,7 +38,10 @@ export const telemetryStatsCommand = new Command()
   .description("View telemetry usage statistics")
   .example("View usage statistics", "swamp telemetry stats")
   .example("Last 7 days", "swamp telemetry stats --days 7")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("--days <days:number>", "Number of days to analyze", { default: 2 })
   .action(async function (options) {
     const cliCtx = createContext(options as GlobalOptions, [
@@ -44,7 +51,7 @@ export const telemetryStatsCommand = new Command()
     cliCtx.logger.debug`Fetching telemetry stats`;
 
     const { repoDir } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
 

--- a/src/cli/commands/vault.ts
+++ b/src/cli/commands/vault.ts
@@ -76,8 +76,9 @@ export const vaultCommand = new Command()
       .description("Alias for vault search")
       .hidden()
       .arguments("[query:string]")
-      .option("--repo-dir <dir:string>", "Repository directory", {
-        default: ".",
-      })
+      .option(
+        "--repo-dir <dir:string>",
+        "Repository directory (env: SWAMP_REPO_DIR)",
+      )
       .action(vaultSearchAction),
   );

--- a/src/cli/commands/vault_create.ts
+++ b/src/cli/commands/vault_create.ts
@@ -25,7 +25,11 @@ import {
   vaultCreate,
 } from "../../libswamp/mod.ts";
 import { createVaultCreateRenderer } from "../../presentation/renderers/vault_create.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 
@@ -59,7 +63,10 @@ export const vaultCreateCommand = new Command()
     `swamp vault create aws-secrets-manager my-vault --config '{"region":"us-east-1"}'`,
   )
   .arguments("<type:string> [name:string]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option(
     "--config <json:string>",
     "Provider configuration as JSON",
@@ -75,7 +82,7 @@ export const vaultCreateCommand = new Command()
         "create",
       ]);
       const { repoDir } = await requireInitializedRepo({
-        repoDir: options.repoDir ?? ".",
+        repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
       });
 

--- a/src/cli/commands/vault_describe.ts
+++ b/src/cli/commands/vault_describe.ts
@@ -25,7 +25,11 @@ import {
   vaultDescribe,
 } from "../../libswamp/mod.ts";
 import { createVaultDescribeRenderer } from "../../presentation/renderers/vault_describe.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -36,7 +40,10 @@ export const vaultDescribeCommand = new Command()
   .description("Describe a vault configuration")
   .example("Describe a vault", "swamp vault describe my-vault")
   .arguments("<vault_name_or_id:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("-t, --type <type:string>", "Vault type (optional, narrows search)")
   .action(async function (options: AnyOptions, vaultNameOrId: string) {
     const cliCtx = createContext(options as GlobalOptions, [
@@ -46,7 +53,7 @@ export const vaultDescribeCommand = new Command()
     cliCtx.logger.debug`Describing vault: ${vaultNameOrId}`;
 
     const { repoDir } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
     const vaultType = options.type as string | undefined;

--- a/src/cli/commands/vault_edit.ts
+++ b/src/cli/commands/vault_edit.ts
@@ -28,7 +28,11 @@ import {
 } from "../../libswamp/mod.ts";
 import { createVaultSearchRenderer } from "../../presentation/renderers/vault_search.tsx";
 import { createVaultEditRenderer } from "../../presentation/renderers/vault_edit.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 
@@ -41,14 +45,17 @@ export const vaultEditCommand = new Command()
   .example("Edit a vault", "swamp vault edit my-vault")
   .example("Interactive search", "swamp vault edit")
   .arguments("[vault_name_or_id:string]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("-t, --type <type:string>", "Vault type (optional, narrows search)")
   .action(async function (options: AnyOptions, vaultNameOrId?: string) {
     const cliCtx = createContext(options as GlobalOptions, ["vault", "edit"]);
     cliCtx.logger.debug`Editing vault: ${vaultNameOrId ?? "(interactive)"}`;
 
     const { repoContext, repoDir } = await requireInitializedRepo({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
     const vaultType = options.type as string | undefined;

--- a/src/cli/commands/vault_get.ts
+++ b/src/cli/commands/vault_get.ts
@@ -25,7 +25,11 @@ import {
   vaultGet,
 } from "../../libswamp/mod.ts";
 import { createVaultGetRenderer } from "../../presentation/renderers/vault_get.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 
@@ -37,7 +41,10 @@ export const vaultGetCommand = new Command()
   .description("Show details of a vault configuration")
   .example("Show vault details", "swamp vault get my-vault")
   .arguments("<vault_name_or_id:string> [extra:string]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("-t, --type <type:string>", "Vault type (optional, narrows search)")
   .action(
     async function (
@@ -57,7 +64,7 @@ export const vaultGetCommand = new Command()
       cliCtx.logger.debug`Getting vault: ${vaultNameOrId}`;
 
       const { repoDir } = await requireInitializedRepoReadOnly({
-        repoDir: options.repoDir ?? ".",
+        repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
       });
       const vaultType = options.type as string | undefined;

--- a/src/cli/commands/vault_list_keys.ts
+++ b/src/cli/commands/vault_list_keys.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import {
   consumeStream,
@@ -37,7 +41,10 @@ export const vaultListKeysCommand = new Command()
   .example("List keys in a vault", "swamp vault list-keys my-vault")
   .example("List all vault keys", "swamp vault list-keys")
   .arguments("[vault_name:string]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(async function (options: AnyOptions, vaultName?: string) {
     const cliCtx = createContext(options as GlobalOptions, [
       "vault",
@@ -46,7 +53,7 @@ export const vaultListKeysCommand = new Command()
     cliCtx.logger.debug`Listing secret keys in vault: ${vaultName}`;
 
     const { repoDir } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
 

--- a/src/cli/commands/vault_migrate.ts
+++ b/src/cli/commands/vault_migrate.ts
@@ -29,7 +29,11 @@ import {
   createVaultMigrateRenderer,
   renderVaultMigrateCancelled,
 } from "../../presentation/renderers/vault_migrate.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
@@ -70,7 +74,10 @@ Both the source and target vaults must be different types.`,
   )
   .option("-f, --force", "Skip confirmation prompt")
   .option("--dry-run", "Preview migration without making changes")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .example(
     "Migrate to AWS Secrets Manager",
     'swamp vault migrate my-vault --to-type @swamp/aws-sm --config \'{"region":"us-east-1"}\'',
@@ -87,7 +94,7 @@ Both the source and target vaults must be different types.`,
     cliCtx.logger.debug`Migrating vault: ${vaultName}`;
 
     const { repoDir } = await requireInitializedRepo({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
 

--- a/src/cli/commands/vault_put.ts
+++ b/src/cli/commands/vault_put.ts
@@ -29,7 +29,12 @@ import {
   createVaultPutRenderer,
   renderVaultPutCancelled,
 } from "../../presentation/renderers/vault_put.ts";
-import { createContext, type GlobalOptions, isStdinTty } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  isStdinTty,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import {
@@ -137,7 +142,10 @@ Piping via stdin is recommended for scripts and CI to avoid exposing secrets in 
     "Overwrite existing secret",
     "swamp vault put my-vault API_KEY=new-value --force",
   )
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("-f, --force", "Skip confirmation prompt when overwriting")
   .action(async function (
     options: AnyOptions,
@@ -149,7 +157,7 @@ Piping via stdin is recommended for scripts and CI to avoid exposing secrets in 
     cliCtx.logger.debug`Storing secret in vault: ${vaultName}`;
 
     const { repoDir, repoContext } = await requireInitializedRepo({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
 

--- a/src/cli/commands/vault_search.ts
+++ b/src/cli/commands/vault_search.ts
@@ -34,6 +34,7 @@ import {
   createContext,
   type GlobalOptions,
   interactiveOutputMode,
+  resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 
@@ -77,7 +78,7 @@ export async function vaultSearchAction(
   ctx.logger.debug`Searching vaults with query: ${query ?? "(none)"}`;
 
   const { repoContext } = await requireInitializedRepoReadOnly({
-    repoDir: options.repoDir ?? ".",
+    repoDir: resolveRepoDir(options.repoDir),
     outputMode: effectiveMode,
   });
 
@@ -85,7 +86,7 @@ export async function vaultSearchAction(
     findAllVaults: () => repoContext.vaultConfigRepo.findAll(),
   };
 
-  const repoDir = options.repoDir ?? ".";
+  const repoDir = resolveRepoDir(options.repoDir);
   const fetchPreview = effectiveMode === "log"
     ? createVaultFetchPreview(repoDir)
     : undefined;
@@ -123,5 +124,8 @@ export const vaultSearchCommand = new Command()
   .example("Browse all vaults", "swamp vault search")
   .example("Search by keyword", "swamp vault search aws")
   .arguments("[query:string]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(vaultSearchAction);

--- a/src/cli/commands/workflow_create.ts
+++ b/src/cli/commands/workflow_create.ts
@@ -25,7 +25,11 @@ import {
   workflowCreate,
 } from "../../libswamp/mod.ts";
 import { createWorkflowCreateRenderer } from "../../presentation/renderers/workflow_create.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -35,7 +39,10 @@ export const workflowCreateCommand = new Command()
   .description("Create a new workflow")
   .example("Create a workflow", "swamp workflow create deploy-pipeline")
   .arguments("<name:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(async function (options: AnyOptions, name: string) {
     const cliCtx = createContext(options as GlobalOptions, [
       "workflow",
@@ -44,7 +51,7 @@ export const workflowCreateCommand = new Command()
     cliCtx.logger.debug`Creating workflow: name=${name}`;
 
     const { repoDir } = await requireInitializedRepo({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
 

--- a/src/cli/commands/workflow_delete.ts
+++ b/src/cli/commands/workflow_delete.ts
@@ -29,7 +29,11 @@ import {
   createWorkflowDeleteRenderer,
   renderWorkflowDeleteCancelled,
 } from "../../presentation/renderers/workflow_delete.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 
@@ -56,7 +60,10 @@ export const workflowDeleteCommand = new Command()
   .example("Delete a workflow", "swamp workflow delete deploy-pipeline")
   .example("Force delete", "swamp workflow delete deploy-pipeline --force")
   .arguments("<workflow_id_or_name:workflow_name>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("-f, --force", "Skip confirmation prompt")
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(async function (options: AnyOptions, workflowIdOrName: string) {
@@ -67,7 +74,7 @@ export const workflowDeleteCommand = new Command()
     cliCtx.logger.debug`Deleting workflow: ${workflowIdOrName}`;
 
     const { repoDir, datastoreResolver } = await requireInitializedRepo({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
 

--- a/src/cli/commands/workflow_edit.ts
+++ b/src/cli/commands/workflow_edit.ts
@@ -28,7 +28,11 @@ import {
 } from "../../libswamp/mod.ts";
 import { createWorkflowSearchRenderer } from "../../presentation/renderers/workflow_search.tsx";
 import { createWorkflowEditRenderer } from "../../presentation/renderers/workflow_edit.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { readStdin } from "../../infrastructure/io/stdin_reader.ts";
@@ -42,7 +46,10 @@ export const workflowEditCommand = new Command()
   .example("Edit a workflow", "swamp workflow edit deploy-pipeline")
   .example("Interactive search", "swamp workflow edit")
   .arguments("[workflow_id_or_name:workflow_name]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(async function (options: AnyOptions, workflowIdOrName?: string) {
     const cliCtx = createContext(options as GlobalOptions, [
@@ -53,7 +60,7 @@ export const workflowEditCommand = new Command()
       .debug`Editing workflow: ${workflowIdOrName ?? "(interactive)"}`;
 
     const { repoContext, repoDir } = await requireInitializedRepo({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
 

--- a/src/cli/commands/workflow_evaluate.ts
+++ b/src/cli/commands/workflow_evaluate.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import {
   acquireModelLocks,
   requireInitializedRepo,
@@ -52,7 +56,10 @@ export const workflowEvaluateCommand = new Command()
     "swamp workflow evaluate deploy-pipeline --input env=prod",
   )
   .arguments("[workflow_id_or_name:string]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("--all", "Evaluate all workflow definitions")
   .option("--input <value:string>", "Input values (key=value or JSON)", {
     collect: true,
@@ -75,7 +82,7 @@ export const workflowEvaluateCommand = new Command()
       if (options.all || !workflowIdOrName) {
         const { repoDir, repoContext, datastoreResolver } =
           await requireInitializedRepo({
-            repoDir: options.repoDir ?? ".",
+            repoDir: resolveRepoDir(options.repoDir),
             outputMode: cliCtx.outputMode,
           });
 
@@ -96,7 +103,7 @@ export const workflowEvaluateCommand = new Command()
 
       // Single workflow evaluation — use per-model lock
       const unlocked = await requireInitializedRepoUnlocked({
-        repoDir: options.repoDir ?? ".",
+        repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
       });
       const workflowRepo = unlocked.repoContext.workflowRepo;
@@ -178,7 +185,7 @@ export const workflowEvaluateCommand = new Command()
         logger
           .info`Workflow contains dynamic model references — using global lock`;
         const globalResult = await requireInitializedRepo({
-          repoDir: options.repoDir ?? ".",
+          repoDir: resolveRepoDir(options.repoDir),
           outputMode: cliCtx.outputMode,
         });
         repoDir = globalResult.repoDir;

--- a/src/cli/commands/workflow_get.ts
+++ b/src/cli/commands/workflow_get.ts
@@ -25,7 +25,11 @@ import {
   workflowGet,
 } from "../../libswamp/mod.ts";
 import { createWorkflowGetRenderer } from "../../presentation/renderers/workflow_get.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -36,14 +40,17 @@ export const workflowGetCommand = new Command()
   .description("Show details of a workflow")
   .example("Show workflow details", "swamp workflow get deploy-pipeline")
   .arguments("<workflow_id_or_name:workflow_name>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(async function (options: AnyOptions, workflowIdOrName: string) {
     const cliCtx = createContext(options as GlobalOptions, ["workflow", "get"]);
     cliCtx.logger.debug`Getting workflow: ${workflowIdOrName}`;
 
     const { repoContext } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
 

--- a/src/cli/commands/workflow_history.ts
+++ b/src/cli/commands/workflow_history.ts
@@ -40,8 +40,9 @@ export const workflowHistoryCommand = new Command()
       .description("Alias for workflow history search")
       .hidden()
       .arguments("[query:string]")
-      .option("--repo-dir <dir:string>", "Repository directory", {
-        default: ".",
-      })
+      .option(
+        "--repo-dir <dir:string>",
+        "Repository directory (env: SWAMP_REPO_DIR)",
+      )
       .action(workflowHistorySearchAction),
   );

--- a/src/cli/commands/workflow_history_get.ts
+++ b/src/cli/commands/workflow_history_get.ts
@@ -25,7 +25,11 @@ import {
   workflowHistoryGet,
 } from "../../libswamp/mod.ts";
 import { createWorkflowHistoryGetRenderer } from "../../presentation/renderers/workflow_history_get.ts";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -36,7 +40,10 @@ export const workflowHistoryGetCommand = new Command()
   .description("Show the latest run for a workflow")
   .example("Show latest run", "swamp workflow history get deploy-pipeline")
   .arguments("<workflow_id_or_name:workflow_name>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(async function (options: AnyOptions, workflowIdOrName: string) {
     const cliCtx = createContext(options as GlobalOptions, [
@@ -48,7 +55,7 @@ export const workflowHistoryGetCommand = new Command()
 
     const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
       {
-        repoDir: options.repoDir ?? ".",
+        repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
       },
     );

--- a/src/cli/commands/workflow_history_logs.ts
+++ b/src/cli/commands/workflow_history_logs.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import {
   consumeStream,
@@ -37,7 +41,10 @@ export const workflowHistoryLogsCommand = new Command()
   .example("Show run logs", "swamp workflow history logs deploy-pipeline")
   .example("Tail last 50 lines", "swamp workflow history logs abc123 --tail 50")
   .arguments("<run_id_or_workflow:string>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option("--tail <lines:number>", "Show only the last N lines")
   .action(async function (
     options: AnyOptions,
@@ -51,7 +58,7 @@ export const workflowHistoryLogsCommand = new Command()
 
     const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
       {
-        repoDir: options.repoDir ?? ".",
+        repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
       },
     );

--- a/src/cli/commands/workflow_history_search.ts
+++ b/src/cli/commands/workflow_history_search.ts
@@ -35,6 +35,7 @@ import {
   createContext,
   type GlobalOptions,
   interactiveOutputMode,
+  resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
@@ -127,7 +128,7 @@ export async function workflowHistorySearchAction(
   ctx.logger.debug`Searching workflow history with query: ${query ?? "(none)"}`;
 
   const { repoContext } = await requireInitializedRepoReadOnly({
-    repoDir: options.repoDir ?? ".",
+    repoDir: resolveRepoDir(options.repoDir),
     outputMode: effectiveMode,
   });
   const workflowRepo = repoContext.workflowRepo;
@@ -185,5 +186,8 @@ export const workflowHistorySearchCommand = new Command()
   .example("Browse run history", "swamp workflow history search")
   .example("Search runs", "swamp workflow history search deploy")
   .arguments("[query:string]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(workflowHistorySearchAction);

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import {
   acquireModelLocks,
   requireInitializedRepo,
@@ -64,7 +68,10 @@ export const workflowRunCommand = new Command()
   )
   .example("Skip reports", "swamp workflow run deploy-pipeline --skip-reports")
   .arguments("<workflow_id_or_name:workflow_name>")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option(
     "--last-evaluated",
     "Skip CEL evaluation, use previously evaluated workflow and definitions",
@@ -122,7 +129,7 @@ export const workflowRunCommand = new Command()
 
     // First try unlocked to resolve workflow and model references
     const unlocked = await requireInitializedRepoUnlocked({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: ctx.outputMode,
     });
     const workflowRepo = unlocked.repoContext.workflowRepo;
@@ -195,7 +202,7 @@ export const workflowRunCommand = new Command()
           logger
             .info`Workflow contains dynamic model references — using global lock`;
           const globalResult = await requireInitializedRepo({
-            repoDir: options.repoDir ?? ".",
+            repoDir: resolveRepoDir(options.repoDir),
             outputMode: ctx.outputMode,
           });
           repoDir = globalResult.repoDir;

--- a/src/cli/commands/workflow_run_search.ts
+++ b/src/cli/commands/workflow_run_search.ts
@@ -36,6 +36,7 @@ import {
   createContext,
   type GlobalOptions,
   interactiveOutputMode,
+  resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
@@ -126,7 +127,7 @@ export async function workflowRunSearchAction(
   ctx.logger.debug`Searching workflow runs with query: ${query ?? "(none)"}`;
 
   const { repoContext } = await requireInitializedRepoReadOnly({
-    repoDir: options.repoDir ?? ".",
+    repoDir: resolveRepoDir(options.repoDir),
     outputMode: effectiveMode,
   });
   const workflowRepo = repoContext.workflowRepo;
@@ -196,7 +197,10 @@ export const workflowRunSearchCommand = new Command()
   .example("Browse all runs", "swamp workflow run search")
   .example("Search runs", "swamp workflow run search deploy")
   .arguments("[query:string]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .option(
     "--since <duration:string>",
     "Only runs started within duration (1h, 1d, 7d, 1w, 1mo)",

--- a/src/cli/commands/workflow_search.ts
+++ b/src/cli/commands/workflow_search.ts
@@ -35,6 +35,7 @@ import {
   createContext,
   type GlobalOptions,
   interactiveOutputMode,
+  resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
@@ -101,7 +102,10 @@ export const workflowSearchCommand = new Command()
   .example("Browse all workflows", "swamp workflow search")
   .example("Search by keyword", "swamp workflow search deploy")
   .arguments("[query:string]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(async function (options: AnyOptions, query?: string) {
     const ctx = createContext(options as GlobalOptions, ["workflow", "search"]);
     const effectiveMode = interactiveOutputMode(ctx);
@@ -111,7 +115,7 @@ export const workflowSearchCommand = new Command()
     // Search is always read-only. Execution (if "r" is pressed) happens via
     // subprocess, so we don't need a write lock.
     const { repoContext } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: effectiveMode,
     });
     const repo = repoContext.workflowRepo;
@@ -141,7 +145,7 @@ export const workflowSearchCommand = new Command()
         // so the user gets the full interactive experience (input file selection,
         // progress tree, etc.)
         ctx.logger.debug`Running workflow: ${selected.name}`;
-        const repoDir = options.repoDir ?? ".";
+        const repoDir = resolveRepoDir(options.repoDir);
         const cmd = new Deno.Command(Deno.execPath(), {
           args: ["workflow", "run", selected.name, "--repo-dir", repoDir],
           stdin: "inherit",

--- a/src/cli/commands/workflow_validate.ts
+++ b/src/cli/commands/workflow_validate.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import {
   consumeStream,
@@ -37,14 +41,17 @@ export const workflowValidateCommand = new Command()
   .example("Validate a workflow", "swamp workflow validate deploy-pipeline")
   .example("Validate all workflows", "swamp workflow validate")
   .arguments("[workflow_id_or_name:string]")
-  .option("--repo-dir <dir:string>", "Repository directory", { default: "." })
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
   .action(async function (options: AnyOptions, workflowIdOrName?: string) {
     const cliCtx = createContext(options as GlobalOptions, [
       "workflow",
       "validate",
     ]);
     const { repoContext } = await requireInitializedRepoReadOnly({
-      repoDir: options.repoDir ?? ".",
+      repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
 

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -102,7 +102,9 @@ export function getOutputModeFromArgs(args: string[]): OutputMode {
  * Pre-parses --repo-dir from raw CLI arguments before Cliffy option parsing.
  *
  * Supports both `--repo-dir <value>` and `--repo-dir=<value>` forms.
- * Returns the resolved absolute path, defaulting to cwd when not specified.
+ * Returns the resolved absolute path.
+ *
+ * Priority: --repo-dir flag > SWAMP_REPO_DIR env var > cwd.
  */
 export function getRepoDirFromArgs(args: string[]): string {
   for (let i = 0; i < args.length; i++) {
@@ -114,5 +116,29 @@ export function getRepoDirFromArgs(args: string[]): string {
       return resolve(arg.slice("--repo-dir=".length));
     }
   }
+  const envDir = Deno.env.get("SWAMP_REPO_DIR");
+  if (envDir && envDir.length > 0) {
+    return resolve(envDir);
+  }
   return Deno.cwd();
+}
+
+/**
+ * Resolves the repository directory for a command action, given the Cliffy
+ * parsed `--repo-dir` option value.
+ *
+ * Priority: --repo-dir flag > SWAMP_REPO_DIR env var > "." (cwd).
+ *
+ * Command option definitions must NOT set a Cliffy `default` for `--repo-dir`
+ * — otherwise Cliffy always populates the value and the env var is ignored.
+ */
+export function resolveRepoDir(cliValue: string | undefined): string {
+  if (cliValue !== undefined) {
+    return cliValue;
+  }
+  const envDir = Deno.env.get("SWAMP_REPO_DIR");
+  if (envDir && envDir.length > 0) {
+    return envDir;
+  }
+  return ".";
 }

--- a/src/cli/context_test.ts
+++ b/src/cli/context_test.ts
@@ -23,6 +23,7 @@ import {
   getOutputModeFromArgs,
   getRepoDirFromArgs,
   type GlobalOptions,
+  resolveRepoDir,
 } from "./context.ts";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
 
@@ -141,6 +142,103 @@ Deno.test("getRepoDirFromArgs finds flag among other args", () => {
     "my-method",
   ]);
   assertEquals(result, "/tmp/my-repo");
+});
+
+Deno.test("getRepoDirFromArgs uses SWAMP_REPO_DIR when flag absent", () => {
+  const original = Deno.env.get("SWAMP_REPO_DIR");
+  try {
+    Deno.env.set("SWAMP_REPO_DIR", "/tmp/env-repo");
+    assertEquals(getRepoDirFromArgs([]), "/tmp/env-repo");
+    assertEquals(getRepoDirFromArgs(["model", "create"]), "/tmp/env-repo");
+  } finally {
+    if (original !== undefined) Deno.env.set("SWAMP_REPO_DIR", original);
+    else Deno.env.delete("SWAMP_REPO_DIR");
+  }
+});
+
+Deno.test("getRepoDirFromArgs prefers --repo-dir flag over SWAMP_REPO_DIR", () => {
+  const original = Deno.env.get("SWAMP_REPO_DIR");
+  try {
+    Deno.env.set("SWAMP_REPO_DIR", "/tmp/env-repo");
+    const result = getRepoDirFromArgs(["--repo-dir", "/tmp/flag-repo"]);
+    assertEquals(result, "/tmp/flag-repo");
+  } finally {
+    if (original !== undefined) Deno.env.set("SWAMP_REPO_DIR", original);
+    else Deno.env.delete("SWAMP_REPO_DIR");
+  }
+});
+
+Deno.test("getRepoDirFromArgs ignores empty SWAMP_REPO_DIR and falls back to cwd", () => {
+  const original = Deno.env.get("SWAMP_REPO_DIR");
+  try {
+    Deno.env.set("SWAMP_REPO_DIR", "");
+    assertEquals(getRepoDirFromArgs([]), Deno.cwd());
+  } finally {
+    if (original !== undefined) Deno.env.set("SWAMP_REPO_DIR", original);
+    else Deno.env.delete("SWAMP_REPO_DIR");
+  }
+});
+
+Deno.test("getRepoDirFromArgs resolves SWAMP_REPO_DIR to absolute path", () => {
+  const original = Deno.env.get("SWAMP_REPO_DIR");
+  try {
+    Deno.env.set("SWAMP_REPO_DIR", "./relative/env/path");
+    const result = getRepoDirFromArgs([]);
+    assertEquals(result.startsWith("/"), true);
+    assertEquals(result.endsWith("relative/env/path"), true);
+  } finally {
+    if (original !== undefined) Deno.env.set("SWAMP_REPO_DIR", original);
+    else Deno.env.delete("SWAMP_REPO_DIR");
+  }
+});
+
+// ============================================================================
+// resolveRepoDir Tests
+// ============================================================================
+
+Deno.test("resolveRepoDir returns cli value when provided", () => {
+  const original = Deno.env.get("SWAMP_REPO_DIR");
+  try {
+    Deno.env.set("SWAMP_REPO_DIR", "/tmp/env-repo");
+    assertEquals(resolveRepoDir("/tmp/flag-repo"), "/tmp/flag-repo");
+    // explicit "." from flag should win over env var
+    assertEquals(resolveRepoDir("."), ".");
+  } finally {
+    if (original !== undefined) Deno.env.set("SWAMP_REPO_DIR", original);
+    else Deno.env.delete("SWAMP_REPO_DIR");
+  }
+});
+
+Deno.test("resolveRepoDir returns SWAMP_REPO_DIR when cli value undefined", () => {
+  const original = Deno.env.get("SWAMP_REPO_DIR");
+  try {
+    Deno.env.set("SWAMP_REPO_DIR", "/tmp/env-repo");
+    assertEquals(resolveRepoDir(undefined), "/tmp/env-repo");
+  } finally {
+    if (original !== undefined) Deno.env.set("SWAMP_REPO_DIR", original);
+    else Deno.env.delete("SWAMP_REPO_DIR");
+  }
+});
+
+Deno.test('resolveRepoDir returns "." when neither cli value nor env var set', () => {
+  const original = Deno.env.get("SWAMP_REPO_DIR");
+  try {
+    Deno.env.delete("SWAMP_REPO_DIR");
+    assertEquals(resolveRepoDir(undefined), ".");
+  } finally {
+    if (original !== undefined) Deno.env.set("SWAMP_REPO_DIR", original);
+  }
+});
+
+Deno.test("resolveRepoDir treats empty SWAMP_REPO_DIR as unset", () => {
+  const original = Deno.env.get("SWAMP_REPO_DIR");
+  try {
+    Deno.env.set("SWAMP_REPO_DIR", "");
+    assertEquals(resolveRepoDir(undefined), ".");
+  } finally {
+    if (original !== undefined) Deno.env.set("SWAMP_REPO_DIR", original);
+    else Deno.env.delete("SWAMP_REPO_DIR");
+  }
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Adds `SWAMP_REPO_DIR` as a fallback for `--repo-dir`, matching the precedence convention used by every other `SWAMP_*` variable.

**Precedence:** `--repo-dir` flag → `SWAMP_REPO_DIR` env → current working directory.

## Changes

- `src/cli/context.ts` — `getRepoDirFromArgs()` consults the env var after the flag but before falling back to cwd. New `resolveRepoDir(cliValue)` helper returns cli > env > `"."` for per-command consumption.
- `src/cli/commands/*.ts` — 70 command files swept: removed Cliffy `{ default: "." }` from `--repo-dir` option definitions (otherwise Cliffy always populates the value and the env var is silently ignored), swapped `options.repoDir ?? "."` for `resolveRepoDir(options.repoDir)`, updated help text to mention the env var.
- 3 option interfaces (`ExtensionFmtOptions`, `ExtensionPushOptions`, inline options in `data_rename`) relaxed from `repoDir: string` to `repoDir?: string` to match Cliffy's no-default shape.
- 9 new precedence tests in `src/cli/context_test.ts` using the save-restore env pattern from `mod_test.ts`.
- `README.md` gains a "Repository Directory" section with the precedence ordering sentence.

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] `deno run test` — 4477 passed, 0 failed (27 passing context tests including 9 new ones)
- [x] `deno run compile` produces a working binary
- [x] Manual smoke test across five precedence scenarios with the compiled binary:
  - cwd with no repo, no flag, no env → errors cleanly
  - `SWAMP_REPO_DIR=/path/to/repo` (no flag) → uses that repo
  - Flag + env both set → flag wins
  - cwd inside a repo, no flag, no env → uses cwd
  - `SWAMP_REPO_DIR=` (empty) → falls back to cwd