### PR TITLE
fix(extensions): detect truncated pulled-extension trees in auto-resolve (swamp-club#133)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -360,18 +360,40 @@ swamp extension trust auto-trust <on|off> # Enable/disable membership auto-trust
 Auto-resolution will never overwrite an extension that is already installed
 on disk. If the type failed to register despite the extension being present,
 something is wrong locally (commonly a user's in-progress edit introducing
-a syntax error) and a silent force-pull would destroy that work. The
-resolver detects this case by combining two checks: the extension must be
-listed in `upstream_extensions.json` **and** its per-extension directory
-must exist under `.swamp/pulled-extensions/<name>/`. Both must hold for
-the resolver to refuse; if either is missing (e.g. the user removed the
-directory), a clean install proceeds.
+a syntax error) and a silent force-pull would destroy that work.
 
-When the resolver refuses, the user sees the on-disk path and the exact
-command to reset to the registry version:
-`swamp extension pull <name> --force`. That command is the only way
-auto-installation state can overwrite a pulled extension — no other
-auto-resolve, validate, or run command will ever clobber local edits.
+The resolver inspects the pulled tree and classifies it into one of three
+states, driving the auto-resolve decision:
+
+- **Missing** — no entry in `upstream_extensions.json`, or the
+  per-extension directory under `.swamp/pulled-extensions/<name>/` is
+  absent. A clean install proceeds.
+- **Intact** — the lockfile entry exists, the directory exists, and
+  every file the lockfile lists for this extension is present on disk.
+  If the type still failed to register, the cause is local. The resolver
+  surfaces `alreadyInstalledButFailed` with the install path and the
+  `--force` recovery command.
+- **Truncated** — the lockfile entry and directory both exist, but one
+  or more files the lockfile lists are missing from disk
+  (swamp-club#133). This is the "present but incomplete" state that
+  used to produce misleading `Unknown <kind> type` errors downstream.
+  The resolver now surfaces `alreadyInstalledTruncated` naming the
+  missing files, exits with an error, and does **not** attempt to
+  repair. In JSON mode the event shape is:
+  ```json
+  {"event":"auto_resolve","status":"failed","extension":"...","path":"...","reason":"truncated","missing":["..."]}
+  ```
+
+Both "intact-but-fails" and "truncated" surface the same
+`swamp extension pull <name> --force` recovery — that command is the
+only way auto-installation state can overwrite a pulled extension. No
+other auto-resolve, validate, or run command will ever clobber local
+edits or silently re-fetch a broken tree.
+
+The truncation predicate is file-level: any file listed in the lockfile
+entry for an extension that cannot be stat'd on disk. The check stops
+at presence — it does not verify file contents, only that the paths the
+lockfile says should exist actually do.
 
 ### Hot-Loading
 

--- a/integration/auto_resolver_no_clobber_test.ts
+++ b/integration/auto_resolver_no_clobber_test.ts
@@ -121,8 +121,8 @@ Deno.test("integration: auto-resolver refuses to overwrite an existing pulled ex
       allowedCollectives: ["test"],
       extensionLookup: {
         getExtension: (name: string) =>
-          adapter.isInstalled(name).then((installed) =>
-            installed
+          adapter.inspectInstallation(name).then((inspection) =>
+            inspection.state !== "missing"
               ? Promise.resolve({
                 name,
                 description: "Test fixture",

--- a/integration/auto_resolver_truncated_test.ts
+++ b/integration/auto_resolver_truncated_test.ts
@@ -1,0 +1,209 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { ensureDir, walk } from "@std/fs";
+import { join, relative } from "@std/path";
+import {
+  createAutoResolveInstallerAdapter,
+  createAutoResolveOutputAdapter,
+} from "../src/cli/auto_resolver_adapters.ts";
+import { ExtensionAutoResolver } from "../src/domain/extensions/extension_auto_resolver.ts";
+import type { DenoRuntime } from "../src/domain/runtime/deno_runtime.ts";
+
+// Regression guard for swamp-club issue 133: when a pulled extension's
+// on-disk tree is present but incomplete (one or more lockfile-declared
+// files are missing), auto-resolve must emit the new
+// `alreadyInstalledTruncated` event naming the missing files — NOT the
+// misleading "Unknown <kind> type" fallback the old code produced, and
+// NOT a silent reinstall. The fix is read-only: the pulled tree on disk
+// must be byte-identical before and after the resolve attempt.
+//
+// This is a collaborator-style integration test: it wires the real
+// adapter into the real domain service against a hand-written scratch
+// repo, rather than shelling through the CLI. The end-to-end CLI path
+// is covered by the CLI UAT suite; here we exercise the full domain →
+// port → adapter → filesystem path with a hermetic fixture so there is
+// no registry dependency.
+
+const stubDenoRuntime: DenoRuntime = {
+  ensureDeno: () => Promise.resolve("/usr/bin/false"),
+};
+
+async function snapshotTree(root: string): Promise<Map<string, string>> {
+  const snapshot = new Map<string, string>();
+  for await (const entry of walk(root, { includeDirs: false })) {
+    const bytes = await Deno.readFile(entry.path);
+    // A zero-mutation assertion needs byte-level equality. Base64 is
+    // stable for Map<string, string> comparison via assertEquals and
+    // doesn't require extra deps like @std/encoding/hex.
+    snapshot.set(
+      relative(root, entry.path),
+      btoa(String.fromCharCode(...bytes)),
+    );
+  }
+  return snapshot;
+}
+
+Deno.test("integration: auto-resolver surfaces truncated error and leaves the tree untouched", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_issue_133_" });
+  try {
+    const extensionName = "@test/truncated";
+    const extRoot = join(
+      tmpDir,
+      ".swamp",
+      "pulled-extensions",
+      extensionName,
+    );
+    await ensureDir(join(extRoot, "models"));
+
+    // Two declared files. One survives; one is deleted below to produce
+    // the truncated state. The lockfile lists both, so the inspection
+    // sees "one missing" and returns { state: "truncated", missing: [..]}.
+    const keptRel = join(
+      ".swamp/pulled-extensions",
+      extensionName,
+      "manifest.yaml",
+    );
+    const goneRel = join(
+      ".swamp/pulled-extensions",
+      extensionName,
+      "models",
+      "deleted.ts",
+    );
+    const keptPath = join(tmpDir, keptRel);
+    const gonePath = join(tmpDir, goneRel);
+
+    await Deno.writeTextFile(
+      keptPath,
+      "manifestVersion: 1\nname: '@test/truncated'\nversion: 2026.01.01.1\n",
+    );
+    await Deno.writeTextFile(gonePath, "// will be deleted\n");
+
+    const lockfilePath = join(
+      tmpDir,
+      "extensions",
+      "models",
+      "upstream_extensions.json",
+    );
+    await ensureDir(join(tmpDir, "extensions", "models"));
+    await Deno.writeTextFile(
+      lockfilePath,
+      JSON.stringify(
+        {
+          [extensionName]: {
+            version: "2026.01.01.1",
+            pulledAt: "2026-01-01T00:00:00Z",
+            files: [keptRel, goneRel],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    // Produce the truncation: remove one of the declared files. The
+    // directory stays — this is the exact state the issue describes.
+    await Deno.remove(gonePath);
+
+    // Snapshot the pulled tree so we can assert zero-mutation after the
+    // resolve attempt. The fix is read-only; a regression that
+    // reintroduced filesystem mutation (e.g. auto-repair) would show up
+    // as a snapshot diff.
+    const before = await snapshotTree(extRoot);
+
+    // Capture json output so we can assert the new `truncated` event
+    // fires with the expected shape.
+    const emitted: string[] = [];
+    const originalLog = console.log;
+    console.log = (line: unknown) => {
+      if (typeof line === "string") emitted.push(line);
+    };
+
+    const adapter = createAutoResolveInstallerAdapter({
+      getExtension: (name: string) =>
+        name === extensionName
+          ? Promise.resolve({
+            name,
+            description: "Truncated fixture",
+            latestVersion: "2026.01.01.1",
+          })
+          : Promise.resolve(null),
+      downloadArchive: () =>
+        Promise.reject(
+          new Error(
+            "REGRESSION: install was attempted on a truncated extension",
+          ),
+        ),
+      getChecksum: () => Promise.resolve(null),
+      lockfilePath,
+      repoDir: tmpDir,
+      denoRuntime: stubDenoRuntime,
+    });
+
+    let result: boolean;
+    try {
+      const output = createAutoResolveOutputAdapter("json");
+      const resolver = new ExtensionAutoResolver({
+        allowedCollectives: ["test"],
+        extensionLookup: {
+          getExtension: (name: string) =>
+            Promise.resolve({
+              name,
+              description: "Truncated fixture",
+              latestVersion: "2026.01.01.1",
+            }),
+          searchExtensions: () => Promise.resolve({ extensions: [] }),
+        },
+        extensionInstaller: adapter,
+        output,
+      });
+
+      result = await resolver.resolve(`${extensionName}/some-type`);
+    } finally {
+      console.log = originalLog;
+    }
+
+    // Resolve reports failure — the type couldn't be registered.
+    assertEquals(result, false);
+
+    // JSON event for the truncated state fires, names the extension and
+    // path, and includes the missing file. Shape must stay compatible
+    // with scripting consumers that key off `reason: "truncated"`.
+    const truncatedLine = emitted.find((line) =>
+      line.includes('"reason":"truncated"')
+    );
+    if (!truncatedLine) {
+      throw new Error(
+        `expected a truncated auto_resolve event, got: ${emitted.join("\n")}`,
+      );
+    }
+    assertStringIncludes(truncatedLine, '"event":"auto_resolve"');
+    assertStringIncludes(truncatedLine, '"status":"failed"');
+    assertStringIncludes(truncatedLine, `"extension":"${extensionName}"`);
+    assertStringIncludes(truncatedLine, goneRel);
+
+    // The pulled tree on disk must be byte-identical to before — no
+    // auto-repair, no overwrite, no side effects.
+    const after = await snapshotTree(extRoot);
+    assertEquals(after, before);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});

--- a/src/cli/auto_resolver_adapters.ts
+++ b/src/cli/auto_resolver_adapters.ts
@@ -24,9 +24,11 @@ import {
 } from "../infrastructure/persistence/paths.ts";
 import { readUpstreamExtensions } from "../infrastructure/persistence/upstream_extensions.ts";
 import type { DenoRuntime } from "../domain/runtime/deno_runtime.ts";
+import { join } from "@std/path";
 import type {
   AutoResolveOutputPort,
   ExtensionInstallerPort,
+  InstallationInspection,
 } from "../domain/extensions/extension_auto_resolver.ts";
 import {
   ConflictError,
@@ -48,6 +50,7 @@ import {
   renderAutoResolveNetworkError,
   renderAutoResolveNotFound,
   renderAutoResolveSearching,
+  renderAutoResolveTruncated,
 } from "../presentation/renderers/extension_auto_resolve.ts";
 
 const logger = getLogger(["swamp", "extensions", "auto-resolver"]);
@@ -88,37 +91,62 @@ export function createAutoResolveInstallerAdapter(
   } = config;
 
   return {
-    async isInstalled(extensionName: string) {
-      // Dual check: lockfile entry AND per-extension directory present on
-      // disk. Lockfile-only would miss the drift case where the user
-      // `rm -rf`'d the pulled dir; fs-only would miss the fact that a
-      // pre-existing directory could belong to a different extension.
-      // Both must hold for the service's "never overwrite" policy to
-      // apply — otherwise a clean install should proceed.
+    async inspectInstallation(
+      extensionName: string,
+    ): Promise<InstallationInspection> {
+      // Tri-state inspection: missing / intact / truncated.
+      //
+      // The lockfile is the source of truth for "which files should be
+      // present". `installExtension` writes the lockfile entry in lockstep
+      // with the file copy at the end of install, so the two stay
+      // paired — if they drift, that's a bug in install, not here.
+      //
+      // - missing: no lockfile entry, or the per-extension directory is
+      //   absent. A clean install should proceed.
+      // - truncated: lockfile + directory both present, but one or more
+      //   listed files are absent on disk (swamp-club#133). The tree is
+      //   broken; surface a distinct error with `--force` recovery.
+      // - intact: everything lined up. If the type still failed to
+      //   register, the cause is local (user edits) — issue #121's
+      //   "never overwrite" guard applies.
       const upstream = await readUpstreamExtensions(lockfilePath);
-      if (!upstream[extensionName]) return false;
+      const entry = upstream[extensionName];
+      if (!entry) return { state: "missing" };
+      const path = swampPath(repoDir, "pulled-extensions", extensionName);
       try {
-        const stat = await Deno.stat(
-          swampPath(repoDir, "pulled-extensions", extensionName),
-        );
-        return stat.isDirectory;
+        const stat = await Deno.stat(path);
+        if (!stat.isDirectory) return { state: "missing" };
       } catch {
-        return false;
+        return { state: "missing" };
       }
-    },
-
-    installedPath(extensionName: string) {
-      return swampPath(repoDir, "pulled-extensions", extensionName);
+      // Pre-anchor lockfile entries (grandfather path in
+      // UpstreamExtensionEntry) may omit `files`. Treat an absent or
+      // empty list as vacuously intact — there's nothing the lockfile
+      // claims should be on disk, so we can't detect truncation.
+      const files = entry.files ?? [];
+      const missing: string[] = [];
+      for (const relPath of files) {
+        try {
+          await Deno.stat(join(repoDir, relPath));
+        } catch {
+          missing.push(relPath);
+        }
+      }
+      if (missing.length > 0) {
+        return { state: "truncated", path, missing };
+      }
+      return { state: "intact", path };
     },
 
     async install(extensionName: string) {
       // force: false so installExtension raises ConflictError rather than
       // silently overwriting any existing files. The service's
-      // isInstalled check normally prevents reaching this point when the
-      // extension is already on disk; the ConflictError catch below is
-      // defence-in-depth for races between isInstalled and install that
-      // the per-type re-entrancy guard in the resolver cannot cover
-      // (e.g. two types resolving the same extension concurrently).
+      // inspectInstallation check normally prevents reaching this point
+      // when the extension is already on disk (intact or truncated); the
+      // ConflictError catch below is defence-in-depth for races between
+      // inspect and install that the per-type re-entrancy guard in the
+      // resolver cannot cover (e.g. two types resolving the same
+      // extension concurrently).
       try {
         const result = await installExtension(
           { name: extensionName, version: null },
@@ -258,6 +286,13 @@ export function createAutoResolveOutputAdapter(
     },
     alreadyInstalledButFailed(extension: string, path: string) {
       renderAutoResolveAlreadyInstalled(extension, path, mode);
+    },
+    alreadyInstalledTruncated(
+      extension: string,
+      path: string,
+      missing: string[],
+    ) {
+      renderAutoResolveTruncated(extension, path, missing, mode);
     },
   };
 }

--- a/src/cli/auto_resolver_adapters_test.ts
+++ b/src/cli/auto_resolver_adapters_test.ts
@@ -201,11 +201,27 @@ Deno.test("auto_resolver_adapters: hotLoadVaults is a no-op when no pulled vault
   }
 });
 
-// Issue #121 regression tests: the auto-resolver adapter must refuse to
-// silently overwrite on-disk extensions. These tests lock in the behavior
-// that prevents the force-pull data-loss bug from returning.
+// inspectInstallation regression tests. Locks in the tri-state return
+// added for swamp-club#133 (truncated-tree detection) and preserves the
+// #121 coverage that the auto-resolver adapter must refuse to silently
+// overwrite on-disk extensions — intact trees still report back as
+// 'intact' so the resolver emits the "local edits" error instead of
+// reinstalling.
 
-Deno.test("auto_resolver_adapters: isInstalled returns false when lockfile is missing", async () => {
+async function seedPulledTree(
+  repoDir: string,
+  extensionName: string,
+  files: string[],
+): Promise<void> {
+  for (const rel of files) {
+    const absPath = join(repoDir, rel);
+    await ensureDir(join(absPath, ".."));
+    await Deno.writeTextFile(absPath, "// fixture\n");
+  }
+  await ensureDir(join(repoDir, ".swamp/pulled-extensions", extensionName));
+}
+
+Deno.test("auto_resolver_adapters: inspectInstallation returns missing when lockfile is missing", async () => {
   const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
   try {
     const lockfilePath = join(
@@ -221,70 +237,19 @@ Deno.test("auto_resolver_adapters: isInstalled returns false when lockfile is mi
       denoRuntime: stubDenoRuntime,
     });
 
-    assertEquals(await adapter.isInstalled("@fake/anything"), false);
+    const result = await adapter.inspectInstallation("@fake/anything");
+    assertEquals(result, { state: "missing" });
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
 
-Deno.test("auto_resolver_adapters: isInstalled returns false on lockfile/filesystem drift", async () => {
-  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
-  try {
-    // Lockfile lists the extension, but the on-disk directory was
-    // manually removed. Returning true here would make the resolver
-    // surface a confusing "already installed but failed" error when
-    // the files are actually gone — a clean reinstall is correct.
-    const lockfilePath = await seedLockfile(tmpDir, {
-      "@fake/deleted-on-disk": [
-        ".swamp/pulled-extensions/@fake/deleted-on-disk/models/x.ts",
-      ],
-    });
-
-    const adapter = createAutoResolveInstallerAdapter({
-      ...stubCallbacks,
-      lockfilePath,
-      repoDir: tmpDir,
-      denoRuntime: stubDenoRuntime,
-    });
-
-    assertEquals(await adapter.isInstalled("@fake/deleted-on-disk"), false);
-  } finally {
-    await Deno.remove(tmpDir, { recursive: true });
-  }
-});
-
-Deno.test("auto_resolver_adapters: isInstalled returns true when lockfile AND dir both present", async () => {
-  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
-  try {
-    const lockfilePath = await seedLockfile(tmpDir, {
-      "@fake/on-disk": [
-        ".swamp/pulled-extensions/@fake/on-disk/models/x.ts",
-      ],
-    });
-    await ensureDir(
-      join(tmpDir, ".swamp/pulled-extensions/@fake/on-disk"),
-    );
-
-    const adapter = createAutoResolveInstallerAdapter({
-      ...stubCallbacks,
-      lockfilePath,
-      repoDir: tmpDir,
-      denoRuntime: stubDenoRuntime,
-    });
-
-    assertEquals(await adapter.isInstalled("@fake/on-disk"), true);
-  } finally {
-    await Deno.remove(tmpDir, { recursive: true });
-  }
-});
-
-Deno.test("auto_resolver_adapters: isInstalled returns false for extension not in lockfile", async () => {
+Deno.test("auto_resolver_adapters: inspectInstallation returns missing when extension not in lockfile", async () => {
   const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
   try {
     const lockfilePath = await seedLockfile(tmpDir, {
       "@fake/other": [".swamp/pulled-extensions/@fake/other/models/x.ts"],
     });
-
     const adapter = createAutoResolveInstallerAdapter({
       ...stubCallbacks,
       lockfilePath,
@@ -292,21 +257,25 @@ Deno.test("auto_resolver_adapters: isInstalled returns false for extension not i
       denoRuntime: stubDenoRuntime,
     });
 
-    assertEquals(await adapter.isInstalled("@fake/not-listed"), false);
+    const result = await adapter.inspectInstallation("@fake/not-listed");
+    assertEquals(result, { state: "missing" });
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
 
-Deno.test("auto_resolver_adapters: installedPath returns the per-extension root", async () => {
+Deno.test("auto_resolver_adapters: inspectInstallation returns missing when directory is absent", async () => {
   const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
   try {
-    const lockfilePath = join(
-      tmpDir,
-      "extensions",
-      "models",
-      "upstream_extensions.json",
-    );
+    // Lockfile lists the extension, but the on-disk directory was
+    // removed. Returning "intact" here would make the resolver surface
+    // a confusing "already installed but failed" error when the files
+    // are actually gone — a clean reinstall is correct.
+    const lockfilePath = await seedLockfile(tmpDir, {
+      "@fake/deleted-on-disk": [
+        ".swamp/pulled-extensions/@fake/deleted-on-disk/models/x.ts",
+      ],
+    });
     const adapter = createAutoResolveInstallerAdapter({
       ...stubCallbacks,
       lockfilePath,
@@ -314,10 +283,131 @@ Deno.test("auto_resolver_adapters: installedPath returns the per-extension root"
       denoRuntime: stubDenoRuntime,
     });
 
-    assertEquals(
-      adapter.installedPath("@fake/ext"),
-      join(tmpDir, ".swamp", "pulled-extensions", "@fake/ext"),
-    );
+    const result = await adapter.inspectInstallation("@fake/deleted-on-disk");
+    assertEquals(result, { state: "missing" });
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("auto_resolver_adapters: inspectInstallation returns intact when every declared file exists", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const files = [
+      ".swamp/pulled-extensions/@fake/on-disk/models/x.ts",
+      ".swamp/pulled-extensions/@fake/on-disk/models/y.ts",
+      ".swamp/pulled-extensions/@fake/on-disk/manifest.yaml",
+    ];
+    const lockfilePath = await seedLockfile(tmpDir, {
+      "@fake/on-disk": files,
+    });
+    await seedPulledTree(tmpDir, "@fake/on-disk", files);
+
+    const adapter = createAutoResolveInstallerAdapter({
+      ...stubCallbacks,
+      lockfilePath,
+      repoDir: tmpDir,
+      denoRuntime: stubDenoRuntime,
+    });
+
+    const result = await adapter.inspectInstallation("@fake/on-disk");
+    assertEquals(result, {
+      state: "intact",
+      path: join(tmpDir, ".swamp", "pulled-extensions", "@fake/on-disk"),
+    });
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("auto_resolver_adapters: inspectInstallation returns truncated when one declared file is missing", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const kept = [
+      ".swamp/pulled-extensions/@fake/partial/manifest.yaml",
+      ".swamp/pulled-extensions/@fake/partial/models/x.ts",
+    ];
+    const gone = ".swamp/pulled-extensions/@fake/partial/datastores/s3.ts";
+    const lockfilePath = await seedLockfile(tmpDir, {
+      "@fake/partial": [...kept, gone],
+    });
+    await seedPulledTree(tmpDir, "@fake/partial", kept);
+
+    const adapter = createAutoResolveInstallerAdapter({
+      ...stubCallbacks,
+      lockfilePath,
+      repoDir: tmpDir,
+      denoRuntime: stubDenoRuntime,
+    });
+
+    const result = await adapter.inspectInstallation("@fake/partial");
+    assertEquals(result, {
+      state: "truncated",
+      path: join(tmpDir, ".swamp", "pulled-extensions", "@fake/partial"),
+      missing: [gone],
+    });
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("auto_resolver_adapters: inspectInstallation collects every missing file", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    // Directory exists (so we get past the stat check) but every
+    // declared file is missing. The returned `missing` array must list
+    // all of them, not truncate to the first miss.
+    const declared = [
+      ".swamp/pulled-extensions/@fake/empty/manifest.yaml",
+      ".swamp/pulled-extensions/@fake/empty/models/a.ts",
+      ".swamp/pulled-extensions/@fake/empty/models/b.ts",
+      ".swamp/pulled-extensions/@fake/empty/datastores/s3.ts",
+    ];
+    const lockfilePath = await seedLockfile(tmpDir, {
+      "@fake/empty": declared,
+    });
+    await ensureDir(join(tmpDir, ".swamp/pulled-extensions/@fake/empty"));
+
+    const adapter = createAutoResolveInstallerAdapter({
+      ...stubCallbacks,
+      lockfilePath,
+      repoDir: tmpDir,
+      denoRuntime: stubDenoRuntime,
+    });
+
+    const result = await adapter.inspectInstallation("@fake/empty");
+    assertEquals(result, {
+      state: "truncated",
+      path: join(tmpDir, ".swamp", "pulled-extensions", "@fake/empty"),
+      missing: declared,
+    });
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("auto_resolver_adapters: inspectInstallation returns intact when lockfile entry has no files", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    // Edge case: an extension recorded with an empty file list. Nothing
+    // to verify, so the tree is vacuously intact.
+    const lockfilePath = await seedLockfile(tmpDir, {
+      "@fake/no-files": [],
+    });
+    await ensureDir(join(tmpDir, ".swamp/pulled-extensions/@fake/no-files"));
+
+    const adapter = createAutoResolveInstallerAdapter({
+      ...stubCallbacks,
+      lockfilePath,
+      repoDir: tmpDir,
+      denoRuntime: stubDenoRuntime,
+    });
+
+    const result = await adapter.inspectInstallation("@fake/no-files");
+    assertEquals(result, {
+      state: "intact",
+      path: join(tmpDir, ".swamp", "pulled-extensions", "@fake/no-files"),
+    });
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }

--- a/src/domain/extensions/extension_auto_resolver.ts
+++ b/src/domain/extensions/extension_auto_resolver.ts
@@ -62,23 +62,42 @@ export interface ExtensionInstallResultInfo {
 }
 
 /**
+ * Tri-state result describing the on-disk state of a pulled extension.
+ *
+ * - `missing`: no lockfile entry, or the per-extension directory does
+ *   not exist. The auto-resolver should proceed to install.
+ * - `intact`: lockfile entry exists, the directory exists, and every
+ *   file listed in the lockfile is present on disk. If the type still
+ *   failed to register, the cause is local (e.g. user edits with a
+ *   syntax error) — see `AutoResolveOutputPort.alreadyInstalledButFailed`.
+ * - `truncated`: lockfile entry + directory both exist, but one or more
+ *   files the lockfile lists are absent from disk. This is the
+ *   "present but incomplete" state that looks installed to a directory
+ *   stat but produces `Unknown <kind> type` errors downstream. See
+ *   swamp-club#133.
+ */
+export type InstallationInspection =
+  | { state: "missing" }
+  | { state: "intact"; path: string }
+  | { state: "truncated"; path: string; missing: string[] };
+
+/**
  * Port: interface for installing extensions and hot-loading them.
  * Decouples the domain service from the CLI install infrastructure.
  */
 export interface ExtensionInstallerPort {
   /**
-   * Returns true when the extension is already present on disk. The domain
-   * service uses this to refuse silent re-installs that would overwrite
-   * local edits (issue #121).
-   */
-  isInstalled(extensionName: string): Promise<boolean>;
-  /**
-   * Returns the absolute path where the extension is (or would be)
-   * installed on disk. Paired with `isInstalled` so the domain service
-   * can surface the path in error messages without reaching into
+   * Inspects the on-disk state of a pulled extension. The domain
+   * service uses the tri-state return to pick the right branch:
+   * install (missing), surface the "local edits" error (intact), or
+   * surface the "truncated tree" error (truncated). Carries the
+   * install path on the non-missing variants so the domain service
+   * can include it in error output without reaching into
    * infrastructure.
    */
-  installedPath(extensionName: string): string;
+  inspectInstallation(
+    extensionName: string,
+  ): Promise<InstallationInspection>;
   install(extensionName: string): Promise<ExtensionInstallResultInfo | null>;
   hotLoadModels(): Promise<number>;
   hotLoadVaults(): Promise<void>;
@@ -106,6 +125,19 @@ export interface AutoResolveOutputPort {
    * opt-in command to reset to the registry version.
    */
   alreadyInstalledButFailed(extension: string, path: string): void;
+  /**
+   * Emitted when auto-resolution finds a pulled extension directory
+   * that is incomplete — the lockfile says certain files should be
+   * present but they are missing on disk. Distinct from
+   * `alreadyInstalledButFailed` (which covers intact-but-fails-to-load):
+   * here the tree itself is broken, so the user needs to re-pull with
+   * `--force` to repair. See swamp-club#133.
+   */
+  alreadyInstalledTruncated(
+    extension: string,
+    path: string,
+    missing: string[],
+  ): void;
 }
 
 /**
@@ -320,18 +352,28 @@ export class ExtensionAutoResolver {
     const version = extInfo.latestVersion;
     if (!version) return false;
 
-    // Issue #121: refuse to re-install an extension that already exists
-    // on disk. The type failing to register here means something is
-    // broken locally (e.g. user edits introduced a syntax error); a
-    // silent force-pull would overwrite those edits and destroy WIP.
-    // Surface an actionable error and let the user decide.
-    if (await extensionInstaller.isInstalled(extensionName)) {
-      output.alreadyInstalledButFailed(
+    // Inspect the on-disk state before deciding to install. Issue #121
+    // introduced the "never overwrite on-disk extensions without --force"
+    // rule to protect user WIP; swamp-club#133 extended that rule to
+    // cover the truncated case (present but incomplete) with a distinct
+    // error because the misleading "Unknown <kind> type" fallback was
+    // hiding the real cause.
+    const inspection = await extensionInstaller.inspectInstallation(
+      extensionName,
+    );
+    if (inspection.state === "intact") {
+      output.alreadyInstalledButFailed(extensionName, inspection.path);
+      return false;
+    }
+    if (inspection.state === "truncated") {
+      output.alreadyInstalledTruncated(
         extensionName,
-        extensionInstaller.installedPath(extensionName),
+        inspection.path,
+        inspection.missing,
       );
       return false;
     }
+    // inspection.state === "missing" — proceed to install.
 
     output.installing(extensionName, version, extInfo.description);
 

--- a/src/domain/extensions/extension_auto_resolver_test.ts
+++ b/src/domain/extensions/extension_auto_resolver_test.ts
@@ -23,6 +23,7 @@ import {
   ExtensionAutoResolver,
   type ExtensionInstallerPort,
   type ExtensionLookupPort,
+  type InstallationInspection,
   resolveDatastoreType,
   resolveModelType,
   resolveVaultType,
@@ -55,6 +56,11 @@ function createMockOutput(): AutoResolveOutputPort & { calls: string[] } {
     },
     alreadyInstalledButFailed(ext: string, path: string) {
       calls.push(`alreadyInstalledButFailed:${ext}:${path}`);
+    },
+    alreadyInstalledTruncated(ext: string, path: string, missing: string[]) {
+      calls.push(
+        `alreadyInstalledTruncated:${ext}:${path}:${missing.join(",")}`,
+      );
     },
   };
 }
@@ -89,22 +95,19 @@ function createMockLookup(
 function createMockInstaller(
   shouldSucceed = true,
   version = "2026.03.16.1",
-  alreadyInstalled = false,
+  inspection: InstallationInspection = { state: "missing" },
 ): ExtensionInstallerPort & {
   installCalls: string[];
-  isInstalledCalls: string[];
+  inspectCalls: string[];
 } {
   const installCalls: string[] = [];
-  const isInstalledCalls: string[] = [];
+  const inspectCalls: string[] = [];
   return {
     installCalls,
-    isInstalledCalls,
-    isInstalled(extensionName: string) {
-      isInstalledCalls.push(extensionName);
-      return Promise.resolve(alreadyInstalled);
-    },
-    installedPath(extensionName: string) {
-      return `/fake/pulled-extensions/${extensionName}`;
+    inspectCalls,
+    inspectInstallation(extensionName: string) {
+      inspectCalls.push(extensionName);
+      return Promise.resolve(inspection);
     },
     install(extensionName: string) {
       installCalls.push(extensionName);
@@ -316,9 +319,15 @@ Deno.test("ExtensionAutoResolver - handles non-@ prefixed types", async () => {
   assertEquals(installer.installCalls, ["@swamp/echo"]);
 });
 
-Deno.test("ExtensionAutoResolver - refuses to install when extension is already on disk", async () => {
+Deno.test("ExtensionAutoResolver - refuses to install when extension is intact on disk", async () => {
+  // Issue #121 regression guard: intact tree + type failed to register
+  // means local edits are the cause; a silent reinstall would destroy
+  // WIP. Must surface `alreadyInstalledButFailed` and skip install.
   const output = createMockOutput();
-  const installer = createMockInstaller(true, "2026.03.16.1", true);
+  const installer = createMockInstaller(true, "2026.03.16.1", {
+    state: "intact",
+    path: "/fake/pulled-extensions/@swamp/aws",
+  });
   const resolver = new ExtensionAutoResolver({
     allowedCollectives: ["swamp"],
     extensionLookup: createMockLookup({
@@ -333,18 +342,64 @@ Deno.test("ExtensionAutoResolver - refuses to install when extension is already 
 
   const result = await resolver.resolve("@swamp/aws/ec2/instance");
   assertEquals(result, false);
-  // install must not have been called — silent overwrite would destroy edits
   assertEquals(installer.installCalls, []);
-  // isInstalled was asked
-  assertEquals(installer.isInstalledCalls, ["@swamp/aws"]);
-  // user-visible output surfaced the "already installed but failed" event,
-  // not an install-started event
+  assertEquals(installer.inspectCalls, ["@swamp/aws"]);
   const kinds = output.calls.map((c) => c.split(":")[0]);
   assertEquals(kinds.includes("installing"), false);
   assertEquals(kinds.includes("alreadyInstalledButFailed"), true);
+  assertEquals(kinds.includes("alreadyInstalledTruncated"), false);
 });
 
-Deno.test("ExtensionAutoResolver - isInstalled is checked before install on the happy path", async () => {
+Deno.test("ExtensionAutoResolver - surfaces truncated error when tree is incomplete", async () => {
+  // swamp-club#133 regression guard: truncated tree + type failed to
+  // register means files listed in the lockfile are missing from disk.
+  // Must surface `alreadyInstalledTruncated` naming the missing files,
+  // not the generic "local edits" message, and must not reinstall.
+  const output = createMockOutput();
+  const installer = createMockInstaller(true, "2026.03.16.1", {
+    state: "truncated",
+    path: "/fake/pulled-extensions/@swamp/aws",
+    missing: [
+      ".swamp/pulled-extensions/@swamp/aws/manifest.yaml",
+      ".swamp/pulled-extensions/@swamp/aws/datastores/s3.ts",
+    ],
+  });
+  const resolver = new ExtensionAutoResolver({
+    allowedCollectives: ["swamp"],
+    extensionLookup: createMockLookup({
+      "@swamp/aws": {
+        description: "AWS models",
+        latestVersion: "2026.03.16.1",
+      },
+    }),
+    extensionInstaller: installer,
+    output,
+  });
+
+  const result = await resolver.resolve("@swamp/aws/ec2/instance");
+  assertEquals(result, false);
+  assertEquals(installer.installCalls, []);
+  assertEquals(installer.inspectCalls, ["@swamp/aws"]);
+  const truncatedCalls = output.calls.filter((c) =>
+    c.startsWith("alreadyInstalledTruncated:")
+  );
+  assertEquals(truncatedCalls.length, 1);
+  // The event must carry the full missing list, not a truncated prefix.
+  assertEquals(
+    truncatedCalls[0],
+    "alreadyInstalledTruncated:@swamp/aws:/fake/pulled-extensions/@swamp/aws:" +
+      ".swamp/pulled-extensions/@swamp/aws/manifest.yaml," +
+      ".swamp/pulled-extensions/@swamp/aws/datastores/s3.ts",
+  );
+  const kinds = output.calls.map((c) => c.split(":")[0]);
+  assertEquals(kinds.includes("installing"), false);
+  assertEquals(kinds.includes("alreadyInstalledButFailed"), false);
+});
+
+Deno.test("ExtensionAutoResolver - inspectInstallation is consulted before install on the happy path", async () => {
+  // Regression guard for #121: the resolver must consult the inspection
+  // port before proceeding to install. When the tree is missing,
+  // install proceeds normally.
   const output = createMockOutput();
   const installer = createMockInstaller();
   const resolver = new ExtensionAutoResolver({
@@ -360,9 +415,7 @@ Deno.test("ExtensionAutoResolver - isInstalled is checked before install on the 
   });
 
   await resolver.resolve("@swamp/aws/ec2/instance");
-  // isInstalled must be consulted before the install proceeds — this is
-  // the regression guard for issue #121.
-  assertEquals(installer.isInstalledCalls, ["@swamp/aws"]);
+  assertEquals(installer.inspectCalls, ["@swamp/aws"]);
   assertEquals(installer.installCalls, ["@swamp/aws"]);
 });
 

--- a/src/presentation/renderers/extension_auto_resolve.ts
+++ b/src/presentation/renderers/extension_auto_resolve.ts
@@ -146,6 +146,47 @@ export function renderAutoResolveAlreadyInstalled(
 }
 
 /**
+ * Renders an error when a pulled extension directory is present but
+ * incomplete — one or more files listed in the lockfile are missing on
+ * disk. Distinct from `renderAutoResolveAlreadyInstalled` (intact tree,
+ * user edits): here the tree itself is broken, so re-pulling with
+ * `--force` is the recovery. See swamp-club#133.
+ */
+export function renderAutoResolveTruncated(
+  extension: string,
+  path: string,
+  missing: string[],
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(
+      JSON.stringify({
+        event: "auto_resolve",
+        status: "failed",
+        extension,
+        path,
+        reason: "truncated",
+        missing,
+      }),
+    );
+  } else {
+    const missingCount = missing.length;
+    // Build the full list string before interpolating so logtape quotes
+    // it once rather than quoting preview and suffix separately (which
+    // produces an odd `"a, b", ...` rendering).
+    const list = missing.length > 5
+      ? `${missing.slice(0, 5).join(", ")}, ... and ${missing.length - 5} more`
+      : missing.join(", ");
+    logger
+      .error`Extension ${extension} at ${path} is incomplete — missing ${missingCount} file(s): ${list}.`;
+    logger
+      .error`The pulled tree was partially removed or never fully extracted; it cannot be loaded in this state.`;
+    logger
+      .error`To re-fetch and repair, run: swamp extension pull ${extension} --force`;
+  }
+}
+
+/**
  * Renders an error message when auto-resolution fails due to a network error.
  */
 export function renderAutoResolveNetworkError(


### PR DESCRIPTION
Fixes [swamp-club#133](https://swamp.club/lab/issues/133).

## Summary

Auto-resolve treated any `pulled-extensions/<name>/` directory that existed on disk as "installed" — regardless of whether its contents were complete. A tree with `manifest.yaml` missing or a declared kind subdirectory missing still passed the `isInstalled` check, so the resolver emitted `reason: already_installed` and the downstream loader produced a confusing `Unknown datastore type "@swamp/s3-datastore"` / `Unknown model type: @swamp/issue-lifecycle` error with no pointer at what was actually wrong.

This is a regression from [PR #1187](https://github.com/systeminit/swamp/pull/1187) (swamp-club#121). Before that change, the adapter called `installExtension` with `force: true` on any load failure — a truncated tree self-healed on the next command. After #1187 the strict "never overwrite" guard caught the truncated case alongside the user-edit case it was meant for, and the truncation recovery path was lost.

## Approach

The fix extends the "never overwrite" guarantee to truncation while giving users an actionable error. It is **read-only** — no filesystem mutation in the auto-resolve path. `--force` remains the only way auto-install state can overwrite a pulled extension.

- Introduces a tri-state `InstallationInspection` result (`missing` | `intact` | `truncated`) on `ExtensionInstallerPort`, replacing `isInstalled` + `installedPath`. Both the path and the missing-files list ride back on the result.
- The adapter drives the check from the lockfile's file list (authoritative file-level granularity, so partial truncation inside a kind subdir is caught too — not just whole-subdir removal).
- The domain service branches on the three states: `missing` → install, `intact` → `alreadyInstalledButFailed` (unchanged #121 path for user WIP), `truncated` → new `alreadyInstalledTruncated` event naming every missing file plus the `swamp extension pull <name> --force` recovery command.

Auto-repair was considered and rejected. The user-journey analysis surfaced that mutating the filesystem in response to a read-shaped command has too many quiet side effects for shared-repo / multi-worktree setups: silent version bumps (install is always `version: null` → latest), concurrent-worktree-rm reversal, masking of deliberate user state changes, and latency surprise. A loud, actionable error with an explicit recovery command is safer and keeps the #121 invariant intact.

## What changed

- `src/domain/extensions/extension_auto_resolver.ts` — new `InstallationInspection` type, port method `inspectInstallation` (replaces `isInstalled` + `installedPath`), new `alreadyInstalledTruncated` event on `AutoResolveOutputPort`, three-way branch in `installAndLoad`.
- `src/cli/auto_resolver_adapters.ts` — implements `inspectInstallation` against the lockfile + per-extension directory + per-file stats; wires the new renderer through `createAutoResolveOutputAdapter`.
- `src/presentation/renderers/extension_auto_resolve.ts` — new `renderAutoResolveTruncated` for both `log` (three-line actionable error) and `json` (`{"event":"auto_resolve","status":"failed","reason":"truncated","missing":[...]}`).
- `src/cli/auto_resolver_adapters_test.ts` — 7 new `inspectInstallation` tests replacing the 5 prior `isInstalled`/`installedPath` cases; covers missing / intact / truncated / partial-truncation / all-files-missing / empty-files edge cases.
- `src/domain/extensions/extension_auto_resolver_test.ts` — updated mock port; new regression guards for the three-way branch (`intact → alreadyInstalledButFailed` preserved from #121, `truncated → alreadyInstalledTruncated` is new).
- `integration/auto_resolver_truncated_test.ts` — new hermetic integration test: hand-written scratch fixture, deletes one declared file, asserts the truncated event fires with the missing file AND the on-disk tree is byte-identical after the resolve attempt.
- `integration/auto_resolver_no_clobber_test.ts` — ported to the new port method (no behavior change; same #121 invariant).
- `design/extension.md` — "Safety: never overwrite on-disk extensions" section extended with the tri-state taxonomy, truncation predicate, and JSON event shape for scripting consumers.

## Coverage

Works across all kinds that go through auto-resolve (models, vaults, datastores) — any file missing anywhere in the extension tree is detected when auto-resolve fires for a type from that extension, because `inspectInstallation` walks the whole lockfile file list. Driver-only or report-only extensions (no auto-resolve trigger) are not covered by this PR; extending to those would require new `resolveDriverType` / `resolveReportType` plumbing and is scope creep for #133. Worth a follow-up if belt-and-braces coverage is desired.

## Test plan

- [x] `deno fmt` clean
- [x] `deno check` clean
- [x] `deno lint` clean
- [x] `deno run test` — 4445 pass / 0 fail (6 new adapter tests, 2 new domain-service tests, 1 new integration test; rewrote 5 #121 regression cases against the new port shape)
- [x] `deno run compile` — binary built
- [x] Manual reproduction against `/tmp/swamp-repro-issue-133` with the compiled binary:
  - **Before truncation:** `swamp extension pull @swamp/digitalocean` then `swamp model create @swamp/digitalocean/droplet test-droplet` succeeds.
  - **Truncate:** `rm -rf .swamp/pulled-extensions/@swamp/digitalocean/models`.
  - **Re-run `model create`:** json mode emits `{"event":"auto_resolve","status":"failed","reason":"truncated","missing":[68 files]}`; log mode emits three ERR lines naming the missing files and the `swamp extension pull @swamp/digitalocean --force` recovery.
  - **Follow the recovery command:** `swamp extension pull @swamp/digitalocean --force` restores the tree.
  - **Re-run `model create`:** succeeds.
- [x] Tree on disk is byte-identical before and after the resolve attempt — no auto-repair, no silent overwrite.

## Follow-up

- Driver-only / report-only extensions remain uncovered by auto-resolve (see "Coverage" above). Worth a separate issue if exhaustive cross-kind coverage is desired.
- Root cause of truncation itself is still unknown (partial extract, interrupted install, concurrent worktree op). This PR makes the symptom actionable so the cause is easier to investigate when it next occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)