### PR TITLE
fix(extensions): exclude regenerable bundles from auto-resolve truncation check

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -395,6 +395,15 @@ entry for an extension that cannot be stat'd on disk. The check stops
 at presence — it does not verify file contents, only that the paths the
 lockfile says should exist actually do.
 
+Paths under `.swamp/bundles/`, `.swamp/vault-bundles/`,
+`.swamp/driver-bundles/`, `.swamp/datastore-bundles/`, and
+`.swamp/report-bundles/` are excluded from this check. Those are
+regenerable build artifacts: clearing the bundle cache is a normal
+hygiene operation and must not flip an extension with intact source
+into the truncated branch (which would steal the user-WIP path from
+issue #121). Only source-tree files — the per-extension subtree under
+`.swamp/pulled-extensions/<name>/` — drive truncation.
+
 ### Hot-Loading
 
 After installation, swamp re-runs model and vault discovery with

--- a/src/cli/auto_resolver_adapters.ts
+++ b/src/cli/auto_resolver_adapters.ts
@@ -55,6 +55,23 @@ import {
 
 const logger = getLogger(["swamp", "extensions", "auto-resolver"]);
 
+// Lockfile-relative prefixes for regenerable bundle output. Sourced from
+// SWAMP_SUBDIRS so a future bundle-dir addition only needs the key list
+// extended below to stay in sync. Forward slashes match how
+// installExtension writes lockfile paths (POSIX-normalized via
+// `relative()` in src/libswamp/extensions/pull.ts).
+const BUNDLE_ARTIFACT_PREFIXES: readonly string[] = [
+  SWAMP_SUBDIRS.bundles,
+  SWAMP_SUBDIRS.vaultBundles,
+  SWAMP_SUBDIRS.driverBundles,
+  SWAMP_SUBDIRS.datastoreBundles,
+  SWAMP_SUBDIRS.reportBundles,
+].map((subdir) => `.swamp/${subdir}/`);
+
+function isBundleArtifactPath(relPath: string): boolean {
+  return BUNDLE_ARTIFACT_PREFIXES.some((prefix) => relPath.startsWith(prefix));
+}
+
 interface InstallerAdapterConfig {
   getExtension: (name: string) => Promise<ExtensionRegistryInfo | null>;
   downloadArchive: (name: string, version: string) => Promise<Uint8Array>;
@@ -104,11 +121,19 @@ export function createAutoResolveInstallerAdapter(
       // - missing: no lockfile entry, or the per-extension directory is
       //   absent. A clean install should proceed.
       // - truncated: lockfile + directory both present, but one or more
-      //   listed files are absent on disk (swamp-club#133). The tree is
-      //   broken; surface a distinct error with `--force` recovery.
+      //   listed source files are absent on disk (swamp-club#133). The
+      //   tree is broken; surface a distinct error with `--force`
+      //   recovery.
       // - intact: everything lined up. If the type still failed to
       //   register, the cause is local (user edits) — issue #121's
       //   "never overwrite" guard applies.
+      //
+      // Bundle artifacts under .swamp/{bundles,vault-bundles,
+      // driver-bundles,datastore-bundles,report-bundles}/ are excluded
+      // from the truncation check because they are regenerable build
+      // output, not source. Clearing the bundle cache (a normal hygiene
+      // operation) must not flip the inspection to truncated and steal
+      // the user-WIP path from issue #121.
       const upstream = await readUpstreamExtensions(lockfilePath);
       const entry = upstream[extensionName];
       if (!entry) return { state: "missing" };
@@ -126,6 +151,7 @@ export function createAutoResolveInstallerAdapter(
       const files = entry.files ?? [];
       const missing: string[] = [];
       for (const relPath of files) {
+        if (isBundleArtifactPath(relPath)) continue;
         try {
           await Deno.stat(join(repoDir, relPath));
         } catch {

--- a/src/cli/auto_resolver_adapters_test.ts
+++ b/src/cli/auto_resolver_adapters_test.ts
@@ -413,6 +413,82 @@ Deno.test("auto_resolver_adapters: inspectInstallation returns intact when lockf
   }
 });
 
+// Regression for the bundle-cache false-positive: clearing
+// .swamp/bundles/ (or any sibling *-bundles cache) must not flip the
+// inspection to truncated. The lockfile lists bundles alongside source,
+// but bundles are regenerable build artifacts — their absence does not
+// indicate a broken install. See the follow-up to swamp-club#133.
+Deno.test("auto_resolver_adapters: inspectInstallation ignores absent bundle artifacts and stays intact", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const sourceRel = ".swamp/pulled-extensions/@fake/with-bundles/models/x.ts";
+    const bundleRels = [
+      ".swamp/bundles/abc123/x.js",
+      ".swamp/vault-bundles/abc123/v.js",
+      ".swamp/driver-bundles/abc123/d.js",
+      ".swamp/datastore-bundles/abc123/ds.js",
+      ".swamp/report-bundles/abc123/r.js",
+    ];
+    const lockfilePath = await seedLockfile(tmpDir, {
+      "@fake/with-bundles": [sourceRel, ...bundleRels],
+    });
+    // Source on disk; every bundle deliberately absent.
+    await seedPulledTree(tmpDir, "@fake/with-bundles", [sourceRel]);
+
+    const adapter = createAutoResolveInstallerAdapter({
+      ...stubCallbacks,
+      lockfilePath,
+      repoDir: tmpDir,
+      denoRuntime: stubDenoRuntime,
+    });
+
+    const result = await adapter.inspectInstallation("@fake/with-bundles");
+    assertEquals(result, {
+      state: "intact",
+      path: join(
+        tmpDir,
+        ".swamp",
+        "pulled-extensions",
+        "@fake/with-bundles",
+      ),
+    });
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("auto_resolver_adapters: inspectInstallation reports truncated only for missing source, not missing bundles", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const keptManifest = ".swamp/pulled-extensions/@fake/mixed/manifest.yaml";
+    const goneSource = ".swamp/pulled-extensions/@fake/mixed/models/x.ts";
+    const goneBundle = ".swamp/bundles/abc123/x.js";
+    const lockfilePath = await seedLockfile(tmpDir, {
+      "@fake/mixed": [keptManifest, goneSource, goneBundle],
+    });
+    // Manifest stays; source removed; bundle never written. Only the
+    // missing source file should appear in `missing` — the bundle is
+    // filtered out before the stat check.
+    await seedPulledTree(tmpDir, "@fake/mixed", [keptManifest]);
+
+    const adapter = createAutoResolveInstallerAdapter({
+      ...stubCallbacks,
+      lockfilePath,
+      repoDir: tmpDir,
+      denoRuntime: stubDenoRuntime,
+    });
+
+    const result = await adapter.inspectInstallation("@fake/mixed");
+    assertEquals(result, {
+      state: "truncated",
+      path: join(tmpDir, ".swamp", "pulled-extensions", "@fake/mixed"),
+      missing: [goneSource],
+    });
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
 Deno.test("auto_resolver_adapters: hotLoadDatastores is a no-op when no pulled datastore dirs exist", async () => {
   const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
   try {


### PR DESCRIPTION
## Summary

The tri-state `inspectInstallation` introduced in #1197 stats every path in the lockfile's file list to detect a truncated install. That list includes compiled bundles under `.swamp/bundles/**`, `.swamp/vault-bundles/**`, `.swamp/driver-bundles/**`, `.swamp/datastore-bundles/**`, and `.swamp/report-bundles/**` — regenerable build artifacts, not source.

When a user clears any of those caches (normal hygiene, stale rebuild, fresh worktree), auto-resolve flipped from `intact` → `truncated` and emitted:

```
incomplete — missing 1 file(s): ".swamp/bundles/91139983/system_usage.js"
```

…instead of the `alreadyInstalledButFailed` ("already installed at … run `--force` to recover") path that protects user WIP per #121. The motivating swamp-club#133 symptoms are all source-tree artifacts (manifest, kind subdirs, declared source), so the fix is to scope the truncation predicate to source files only.

This filters bundle prefixes out of the stat loop in `inspectInstallation`. Prefixes are derived from `SWAMP_SUBDIRS.{bundles, vaultBundles, driverBundles, datastoreBundles, reportBundles}` so a future bundle-dir addition stays in sync. No filesystem mutation, no API/event/wire-format changes.

## Test Plan

- [x] `deno fmt --check`, `deno lint`, `deno check` clean
- [x] `src/cli/auto_resolver_adapters_test.ts` — 18/18 pass, including 2 new regression cases:
  - `inspectInstallation ignores absent bundle artifacts and stays intact` (covers all 5 bundle subdirs)
  - `inspectInstallation reports truncated only for missing source, not missing bundles`
- [x] `integration/auto_resolver_truncated_test.ts` — passes (#1197/#133 source-truncation behaviour preserved)
- [x] `integration/auto_resolver_no_clobber_test.ts` — passes (#121 no-clobber invariant preserved)
- [x] `deno run compile` succeeded
- [x] **End-to-end repro against the rebuilt binary:** `swamp extension pull @stack72/system-extensions@2026.03.03.1` → edit pulled `.ts` with WIP marker + syntax error → `rm -rf .swamp/bundles` → `swamp model create @stack72/system-usage instance1` now produces:
  ```
  Extension "@stack72/system-extensions" is already installed at … but failed to load.
  Local edits may be preventing it from registering — inspect the source and fix errors.
  To reset to the registry version and discard local changes, run: swamp extension pull "@stack72/system-extensions" --force
  ```
  …instead of the buggy `incomplete — missing 1 file(s): ".swamp/bundles/91139983/system_usage.js"`.
- [ ] UAT `tests/cli/extension/pull_wip_preservation_test.ts:156` in swamp-uat (CI gate — local run blocked by membership auto-trust collision unrelated to this fix)

## Cross-references

- Introducing PR: #1197
- Fixes regression to swamp-club#121 / #1187 user-WIP preservation
- swamp-uat coverage: swamp-uat#149