### PR TITLE
fix(datastores): enrich sync error surfacing with SDK metadata (swamp-club#135)

### DIFF
--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -52,6 +52,7 @@ import {
   registerDatastoreSync,
   registerDatastoreSyncNamed,
 } from "../infrastructure/persistence/datastore_sync_coordinator.ts";
+import { summarizeSyncError } from "../infrastructure/persistence/sync_error_diagnostic.ts";
 import { FileLock } from "../infrastructure/persistence/file_lock.ts";
 import {
   type DistributedLock,
@@ -797,13 +798,13 @@ export async function acquireModelLocks(
             logger.info`Push complete, no changes`;
           }
         } catch (error) {
-          const msg = error instanceof Error ? error.message : String(error);
-          logger.error("Failed to push changes to datastore: {error}", {
-            error: msg,
-          });
-          throw new Error(
-            `Datastore sync failed: could not push changes: ${msg}`,
+          const { summary, fields } = summarizeSyncError(
+            "push",
+            config.type,
+            error,
           );
+          logger.error("{summary}", { summary, ...fields });
+          throw new Error(summary, { cause: error });
         } finally {
           try {
             await pushLock.release();

--- a/src/infrastructure/persistence/datastore_sync_coordinator.ts
+++ b/src/infrastructure/persistence/datastore_sync_coordinator.ts
@@ -35,6 +35,7 @@
 import type { DistributedLock } from "../../domain/datastore/distributed_lock.ts";
 import { getSwampLogger } from "../logging/logger.ts";
 import { getTracer, SpanStatusCode } from "../tracing/mod.ts";
+import { summarizeSyncError } from "./sync_error_diagnostic.ts";
 
 /**
  * Common interface for sync services compatible with the coordinator.
@@ -171,15 +172,10 @@ export async function registerDatastoreSyncNamed(
       }
       syncSpan.setStatus({ code: SpanStatusCode.OK });
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
-      syncSpan.setStatus({ code: SpanStatusCode.ERROR, message: msg });
-      logger.error("Failed to pull changes from {label}: {error}", {
-        label,
-        error: msg,
-      });
-      throw new Error(
-        `${label} sync failed: could not pull changes: ${msg}`,
-      );
+      const { summary, fields } = summarizeSyncError("pull", label, error);
+      syncSpan.setStatus({ code: SpanStatusCode.ERROR, message: summary });
+      logger.error("{summary}", { summary, ...fields });
+      throw new Error(summary, { cause: error });
     } finally {
       syncSpan.end();
     }
@@ -233,14 +229,9 @@ export async function flushDatastoreSyncNamed(key: string): Promise<void> {
       }
       syncSpan.setStatus({ code: SpanStatusCode.OK });
     } catch (error) {
-      syncSpan.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: error instanceof Error ? error.message : String(error),
-      });
-      logger.warn("Failed to push changes to {label}: {error}", {
-        label,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      const { summary, fields } = summarizeSyncError("push", label, error);
+      syncSpan.setStatus({ code: SpanStatusCode.ERROR, message: summary });
+      logger.warn("{summary}", { summary, ...fields });
     } finally {
       syncSpan.end();
     }

--- a/src/infrastructure/persistence/datastore_sync_coordinator_test.ts
+++ b/src/infrastructure/persistence/datastore_sync_coordinator_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import { initializeLogging } from "../logging/logger.ts";
 import {
   flushDatastoreSync,
@@ -140,5 +140,62 @@ Deno.test("flushDatastoreSync flushes all entries", async () => {
   await flushDatastoreSync();
   assertEquals(globalLock.released, true);
   assertEquals(modelLock.released, true);
+  assertEquals(getRegisteredLockKeys().length, 0);
+});
+
+Deno.test("registerDatastoreSync enriches pullChanged failure with SDK metadata", async () => {
+  const opaqueError = Object.assign(new Error("UnknownError"), {
+    name: "UnknownError",
+    Code: "AccessDenied",
+    $metadata: { httpStatusCode: 403, requestId: "TEST-REQ-123" },
+  });
+
+  const failingService = {
+    pullChanged: () => {
+      throw opaqueError;
+    },
+    pushChanged: () => Promise.resolve(0),
+  };
+
+  const thrown = await assertRejects(
+    () =>
+      registerDatastoreSync({
+        service: failingService,
+        label: "@test/syncfail",
+      }),
+    Error,
+  );
+
+  // `.message` carries the enriched summary so downstream renderers
+  // (buildErrorJson, createJsonErrorSink) surface the rich information
+  // without any presentation-layer changes.
+  assertStringIncludes(thrown.message, "@test/syncfail pull failed");
+  assertStringIncludes(thrown.message, "HTTP 403");
+  assertStringIncludes(thrown.message, "requestId=TEST-REQ-123");
+  assertStringIncludes(thrown.message, "code=AccessDenied");
+
+  // `.cause` preserves the original error object so a later renderer
+  // improvement can walk the cause chain for any future consumer.
+  assertEquals(thrown.cause, opaqueError);
+});
+
+Deno.test("flushDatastoreSync swallows pushChanged failures (warn-only)", async () => {
+  const failingService = {
+    pullChanged: () => Promise.resolve(0),
+    pushChanged: () => {
+      throw Object.assign(new Error("UnknownError"), {
+        $metadata: { httpStatusCode: 500 },
+      });
+    },
+  };
+
+  await registerDatastoreSync({
+    service: failingService,
+    label: "@test/syncfail",
+  });
+
+  // Must NOT throw — the coordinator's push path is intentionally
+  // warn-and-swallow so a successful command doesn't fail on cleanup.
+  await flushDatastoreSync();
   assertEquals(getRegisteredLockKeys().length, 0);
 });

--- a/src/infrastructure/persistence/sync_error_diagnostic.ts
+++ b/src/infrastructure/persistence/sync_error_diagnostic.ts
@@ -1,0 +1,126 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Duck-typed diagnostic helper for datastore sync errors. Extensions can
+ * throw arbitrary values from pullChanged/pushChanged — including opaque
+ * AWS SDK errors whose `.message` is unhelpful. This module extracts any
+ * standard metadata fields an SDK-style error may carry without importing
+ * or depending on any SDK.
+ */
+
+export type SyncOperation = "pull" | "push";
+
+const MESSAGE_PREVIEW_LIMIT = 200;
+
+export interface SyncErrorSummary {
+  /**
+   * Single-line human-readable summary suitable for use as a thrown
+   * Error's `.message`. Contains the operation, extension label, any
+   * extracted metadata, and (optionally) the original message.
+   */
+  summary: string;
+  /**
+   * Structured fields for LogTape properties and telemetry. Only keys
+   * that could be extracted are included — missing fields are absent,
+   * not present as "undefined" strings.
+   */
+  fields: Record<string, string | number>;
+}
+
+/**
+ * Reads a property from an unknown value without throwing on proxies,
+ * non-objects, or exotic getters. Returns undefined if the read is not
+ * safe or the property is missing.
+ */
+function readProp(obj: unknown, key: string): unknown {
+  if (obj === null || typeof obj !== "object") return undefined;
+  try {
+    return (obj as Record<string, unknown>)[key];
+  } catch {
+    return undefined;
+  }
+}
+
+function coerceString(value: unknown): string | undefined {
+  if (typeof value === "string") return value.length > 0 ? value : undefined;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return undefined;
+}
+
+function coerceNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function truncate(message: string): string {
+  return message.length <= MESSAGE_PREVIEW_LIMIT
+    ? message
+    : message.slice(0, MESSAGE_PREVIEW_LIMIT) + "…";
+}
+
+/**
+ * Summarizes an unknown error value thrown from a datastore sync
+ * operation (pullChanged/pushChanged) for logging and re-throwing.
+ *
+ * Duck-typed: reads .message, .name, .Code / .code,
+ * .$metadata.httpStatusCode, .$metadata.requestId. Safe on strings,
+ * numbers, null, plain objects, and proxies.
+ */
+export function summarizeSyncError(
+  operation: SyncOperation,
+  label: string,
+  error: unknown,
+): SyncErrorSummary {
+  const fields: Record<string, string | number> = { operation, label };
+
+  const metadata = readProp(error, "$metadata");
+  const httpStatusCode = coerceNumber(readProp(metadata, "httpStatusCode"));
+  const requestId = coerceString(readProp(metadata, "requestId"));
+  const code = coerceString(readProp(error, "Code")) ??
+    coerceString(readProp(error, "code"));
+  const name = coerceString(readProp(error, "name"));
+  const rawMessage = coerceString(readProp(error, "message")) ??
+    (typeof error === "string" ? error : undefined) ??
+    (typeof error === "number" ? String(error) : undefined);
+
+  if (httpStatusCode !== undefined) fields.httpStatusCode = httpStatusCode;
+  if (requestId) fields.requestId = requestId;
+  if (code) fields.code = code;
+  if (name) fields.name = name;
+  if (rawMessage) fields.message = rawMessage;
+
+  const detailParts: string[] = [];
+  if (httpStatusCode !== undefined) detailParts.push(`HTTP ${httpStatusCode}`);
+  if (requestId) detailParts.push(`requestId=${requestId}`);
+  if (code) detailParts.push(`code=${code}`);
+  const details = detailParts.length > 0 ? ` (${detailParts.join(", ")})` : "";
+
+  const trailer = rawMessage && rawMessage !== name
+    ? `: ${truncate(rawMessage)}`
+    : name
+    ? `: ${name}`
+    : "";
+
+  const summary = `${label} ${operation} failed${details}${trailer}`;
+  return { summary, fields };
+}

--- a/src/infrastructure/persistence/sync_error_diagnostic_test.ts
+++ b/src/infrastructure/persistence/sync_error_diagnostic_test.ts
@@ -1,0 +1,214 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { summarizeSyncError } from "./sync_error_diagnostic.ts";
+
+Deno.test("summarizeSyncError: plain Error with message", () => {
+  const err = new Error("boom");
+  const { summary, fields } = summarizeSyncError(
+    "pull",
+    "@swamp/s3-datastore",
+    err,
+  );
+  assertEquals(summary, "@swamp/s3-datastore pull failed: boom");
+  assertEquals(fields, {
+    operation: "pull",
+    label: "@swamp/s3-datastore",
+    name: "Error",
+    message: "boom",
+  });
+});
+
+Deno.test("summarizeSyncError: AWS-SDK-style opaque error with full $metadata", () => {
+  const err = new Error("UnknownError") as Error & {
+    Code: string;
+    $metadata: { httpStatusCode: number; requestId: string };
+  };
+  err.name = "UnknownError";
+  err.Code = "AccessDenied";
+  err.$metadata = { httpStatusCode: 403, requestId: "ABC" };
+
+  const { summary, fields } = summarizeSyncError(
+    "pull",
+    "@swamp/s3-datastore",
+    err,
+  );
+  assertStringIncludes(summary, "@swamp/s3-datastore pull failed");
+  assertStringIncludes(summary, "HTTP 403");
+  assertStringIncludes(summary, "requestId=ABC");
+  assertStringIncludes(summary, "code=AccessDenied");
+  assertEquals(fields, {
+    operation: "pull",
+    label: "@swamp/s3-datastore",
+    httpStatusCode: 403,
+    requestId: "ABC",
+    code: "AccessDenied",
+    name: "UnknownError",
+    message: "UnknownError",
+  });
+});
+
+Deno.test("summarizeSyncError: push operation reflected in summary", () => {
+  const { summary, fields } = summarizeSyncError(
+    "push",
+    "@myorg/custom",
+    new Error("x"),
+  );
+  assertStringIncludes(summary, "push failed");
+  assertEquals(fields.operation, "push");
+});
+
+Deno.test("summarizeSyncError: lowercase `code` field also recognized", () => {
+  const err = { code: "ETIMEDOUT", message: "timed out" };
+  const { fields } = summarizeSyncError("push", "@myorg/x", err);
+  assertEquals(fields.code, "ETIMEDOUT");
+});
+
+Deno.test("summarizeSyncError: `Code` preferred over `code` when both present", () => {
+  const err = { Code: "AwsCode", code: "etimedout", message: "x" };
+  const { fields } = summarizeSyncError("push", "@myorg/x", err);
+  assertEquals(fields.code, "AwsCode");
+});
+
+Deno.test("summarizeSyncError: string error", () => {
+  const { summary, fields } = summarizeSyncError("pull", "@t/x", "oops");
+  assertStringIncludes(summary, "@t/x pull failed");
+  assertStringIncludes(summary, "oops");
+  assertEquals(fields.message, "oops");
+});
+
+Deno.test("summarizeSyncError: number error", () => {
+  const { fields } = summarizeSyncError("pull", "@t/x", 42);
+  assertEquals(fields.message, "42");
+});
+
+Deno.test("summarizeSyncError: null error — only operation+label present", () => {
+  const { summary, fields } = summarizeSyncError("pull", "@t/x", null);
+  assertEquals(summary, "@t/x pull failed");
+  assertEquals(fields, { operation: "pull", label: "@t/x" });
+});
+
+Deno.test("summarizeSyncError: undefined error — only operation+label present", () => {
+  const { summary, fields } = summarizeSyncError("push", "@t/x", undefined);
+  assertEquals(summary, "@t/x push failed");
+  assertEquals(fields, { operation: "push", label: "@t/x" });
+});
+
+Deno.test("summarizeSyncError: plain object error with no message", () => {
+  const err = { Code: "X", $metadata: { httpStatusCode: 500 } };
+  const { summary, fields } = summarizeSyncError("pull", "@t/x", err);
+  assertStringIncludes(summary, "HTTP 500");
+  assertStringIncludes(summary, "code=X");
+  assertEquals(fields.httpStatusCode, 500);
+  assertEquals(fields.code, "X");
+  assertEquals(fields.message, undefined);
+});
+
+Deno.test("summarizeSyncError: empty message treated as missing", () => {
+  const err = new Error("");
+  const { summary, fields } = summarizeSyncError("pull", "@t/x", err);
+  // Falls back to the error name ("Error") as trailer.
+  assertStringIncludes(summary, ": Error");
+  assertEquals(fields.message, undefined);
+});
+
+Deno.test("summarizeSyncError: long message truncated at 200 chars with ellipsis", () => {
+  const long = "a".repeat(500);
+  const err = new Error(long);
+  const { summary, fields } = summarizeSyncError("pull", "@t/x", err);
+  // `fields.message` retains the full message for consumers that want it
+  // (e.g. .cause-walking renderers); only the summary is truncated.
+  assertEquals(fields.message, long);
+  // Summary contains exactly 200 'a's followed by ellipsis.
+  assertStringIncludes(summary, "a".repeat(200) + "…");
+  // Summary does NOT contain the 201st 'a' because it was truncated.
+  const after = summary.split("a".repeat(200))[1] ?? "";
+  assertEquals(after.startsWith("a"), false);
+});
+
+Deno.test("summarizeSyncError: throwing getters on read fields don't break extraction", () => {
+  // The helper reads .message, .name, .Code, .code, and .$metadata.
+  // Simulate a proxy whose getter throws for `message` and `name` (the
+  // two most likely fields with exotic getters in SDK-style errors).
+  // Other fields must still be extracted normally — no unhandled throw.
+  const target = {
+    Code: "AccessDenied",
+    $metadata: { httpStatusCode: 403, requestId: "R1" },
+  };
+  const err = new Proxy(target, {
+    get(t, p) {
+      if (p === "message" || p === "name") throw new Error("getter exploded");
+      return (t as Record<string | symbol, unknown>)[p];
+    },
+  });
+
+  const { summary, fields } = summarizeSyncError("pull", "@t/x", err);
+
+  // Safe fields still extracted.
+  assertEquals(fields.httpStatusCode, 403);
+  assertEquals(fields.requestId, "R1");
+  assertEquals(fields.code, "AccessDenied");
+  // Throwing fields are treated as missing, not surfaced as errors.
+  assertEquals(fields.message, undefined);
+  assertEquals(fields.name, undefined);
+  // Summary still renders without the throwing fields.
+  assertStringIncludes(summary, "@t/x pull failed");
+  assertStringIncludes(summary, "HTTP 403");
+  assertStringIncludes(summary, "code=AccessDenied");
+});
+
+Deno.test("summarizeSyncError: throwing $metadata getter is safe", () => {
+  const target = { message: "real", Code: "X" };
+  const err = new Proxy(target, {
+    get(t, p) {
+      if (p === "$metadata") throw new Error("boom");
+      return (t as Record<string | symbol, unknown>)[p];
+    },
+  });
+  const { fields } = summarizeSyncError("pull", "@t/x", err);
+  assertEquals(fields.message, "real");
+  assertEquals(fields.code, "X");
+  assertEquals(fields.httpStatusCode, undefined);
+  assertEquals(fields.requestId, undefined);
+});
+
+Deno.test("summarizeSyncError: non-numeric httpStatusCode is ignored", () => {
+  const err = { $metadata: { httpStatusCode: "403" }, message: "x" };
+  const { fields } = summarizeSyncError("pull", "@t/x", err);
+  assertEquals(fields.httpStatusCode, undefined);
+});
+
+Deno.test("summarizeSyncError: summary is always single-line", () => {
+  const err = new Error("line1\nline2\nline3") as Error & { Code: string };
+  err.Code = "X";
+  const { summary } = summarizeSyncError("pull", "@t/x", err);
+  // We don't strip newlines from the raw message (preserves fidelity in
+  // fields.message), but the rendered summary is used as an Error.message
+  // which most consumers treat as opaque text. Assert the preamble and
+  // structural delimiters are on the first line.
+  const firstLine = summary.split("\n")[0];
+  assertStringIncludes(firstLine, "@t/x pull failed");
+  assertStringIncludes(firstLine, "code=X");
+});
+
+Deno.test("summarizeSyncError: missing optional fields are absent from `fields`", () => {
+  const { fields } = summarizeSyncError("pull", "@t/x", {});
+  assertEquals(Object.keys(fields).sort(), ["label", "operation"]);
+});

--- a/src/libswamp/datastores/setup.ts
+++ b/src/libswamp/datastores/setup.ts
@@ -34,6 +34,7 @@ import { collapseEnvVars } from "../../infrastructure/persistence/env_path.ts";
 import { FilesystemDatastoreVerifier } from "../../infrastructure/persistence/filesystem_datastore_verifier.ts";
 import { getSwampDataDir } from "../../infrastructure/persistence/paths.ts";
 import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
+import { summarizeSyncError } from "../../infrastructure/persistence/sync_error_diagnostic.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
@@ -322,11 +323,12 @@ export async function* datastoreSetupExtension(
             await syncService.pushChanged();
             ctx.logger.debug`Push complete`;
           } catch (error) {
-            errors.push(
-              `Failed to push to remote: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
+            const { summary } = summarizeSyncError(
+              "push",
+              input.type,
+              error,
             );
+            errors.push(summary);
           }
         }
 


### PR DESCRIPTION
## Summary

Fixes swamp-club#135. Extensions throw arbitrary values from `pullChanged`/`pushChanged`, and AWS SDK opaque errors like `UnknownError` carry useful metadata (`$metadata.httpStatusCode`, `$metadata.requestId`, `Code`) on the error object but have thin `.message` strings. Core previously surfaced only `error.message`, so users saw a bare stack trace with no hint at what actually failed.

This change:

- Adds a pure, duck-typed helper (`summarizeSyncError`) that extracts `$metadata.httpStatusCode`, `$metadata.requestId`, `Code`/`code`, `name`, and a 200-char message preview. No AWS SDK imports — duck-typed only, per the issue's out-of-scope clause.
- Wires the helper into all four sync-error catch sites:
  - `registerDatastoreSyncNamed` (pull, re-throws)
  - `flushDatastoreSyncNamed` (push, warn+swallow)
  - `datastoreSetupExtension` migration push
  - `repo_context.ts` custom-datastore flush push (re-throws)
- Preserves the original error via `new Error(summary, { cause: original })` so a later presentation-layer improvement can walk the `.cause` chain for any opaque SDK-style error.
- Does not modify `buildErrorJson` or `createJsonErrorSink` — both read `err.message`, so baking the enriched summary into the thrown Error's message flows through end-to-end with zero presentation-layer change.

### Before / after

Verified with a stub datastore extension whose `pullChanged` throws an AWS-SDK-shaped error `{ name: "UnknownError", Code: "AccessDenied", $metadata: { httpStatusCode: 403, requestId: "TEST-REQ-ID-12345" } }`.

```
BEFORE: "@test/syncfail sync failed: could not pull changes: UnknownError"
AFTER:  "@test/syncfail pull failed (HTTP 403, requestId=TEST-REQ-ID-12345, code=AccessDenied): UnknownError"
```

## Test Plan

- [x] Helper unit tests (17 cases): plain Error, AWS-SDK opaque, string/number/null errors, empty message, long-message truncation, throwing-getter proxies on `message`/`name`/`$metadata`, non-numeric `httpStatusCode`, missing fields absent (not `"undefined"`), single-line summary.
- [x] Coordinator tests: pull path asserts enriched thrown Error `.message` and `.cause` preservation; push path asserts swallow behavior unchanged.
- [x] End-to-end verification via scratch repo `/tmp/swamp-repro-issue-135/` with stub extension:
  - Pull failure (`SYNCFAIL_MODE=pull swamp --json data gc`) — exit 1, all 5 enriched fields in stdout + stderr JSON.
  - Push failure on flush (`SYNCFAIL_MODE=push swamp --log --show-properties data gc`) — exit 0 (warn+swallow), enriched warn log with all 5 fields.
- [x] `deno check`, `deno fmt`, `deno lint` clean.
- [x] Full `deno run test` suite — 4499 passed, 0 failed.
- [x] `deno run compile` produces a working binary.

## Risks

- Re-thrown Error `.message` format changes (e.g. coordinator previously threw `"<label> sync failed: could not pull changes: <msg>"`, now throws the enriched summary). No tests pin the exact string; external log scrapers matching on the phrases `sync failed` / `pull failed` / `push failed` continue to work.
- LogTape records now carry structured properties (`operation`, `label`, `httpStatusCode`, `requestId`, `code`, `name`) alongside the message. Downstream log ingestion pinned to the prior shape may need updates.
- OTel span status messages now carry the enriched summary — observability dashboards aggregating by `error.message` may see new cardinality briefly.