### PR TITLE
fix(datastores): address CLI UX review on sync error enrichment

### DIFF
--- a/src/infrastructure/persistence/sync_error_diagnostic.ts
+++ b/src/infrastructure/persistence/sync_error_diagnostic.ts
@@ -107,7 +107,10 @@ export function summarizeSyncError(
   if (requestId) fields.requestId = requestId;
   if (code) fields.code = code;
   if (name) fields.name = name;
-  if (rawMessage) fields.message = rawMessage;
+  // Exposed as `errorMessage` (not `message`) so that when `fields` is
+  // spread into LogTape calls the entry doesn't collide with LogTape's
+  // reserved `message` property on the log record.
+  if (rawMessage) fields.errorMessage = rawMessage;
 
   const detailParts: string[] = [];
   if (httpStatusCode !== undefined) detailParts.push(`HTTP ${httpStatusCode}`);
@@ -115,8 +118,13 @@ export function summarizeSyncError(
   if (code) detailParts.push(`code=${code}`);
   const details = detailParts.length > 0 ? ` (${detailParts.join(", ")})` : "";
 
-  const trailer = rawMessage && rawMessage !== name
-    ? `: ${truncate(rawMessage)}`
+  // Collapse any whitespace runs containing newlines so the rendered
+  // summary stays single-line. The full, unmodified message remains
+  // available on `fields.errorMessage` for consumers that want fidelity.
+  const singleLineMessage = rawMessage?.replace(/\s*\n+\s*/g, " ").trim();
+
+  const trailer = singleLineMessage && singleLineMessage !== name
+    ? `: ${truncate(singleLineMessage)}`
     : name
     ? `: ${name}`
     : "";

--- a/src/infrastructure/persistence/sync_error_diagnostic_test.ts
+++ b/src/infrastructure/persistence/sync_error_diagnostic_test.ts
@@ -32,7 +32,7 @@ Deno.test("summarizeSyncError: plain Error with message", () => {
     operation: "pull",
     label: "@swamp/s3-datastore",
     name: "Error",
-    message: "boom",
+    errorMessage: "boom",
   });
 });
 
@@ -61,7 +61,7 @@ Deno.test("summarizeSyncError: AWS-SDK-style opaque error with full $metadata", 
     requestId: "ABC",
     code: "AccessDenied",
     name: "UnknownError",
-    message: "UnknownError",
+    errorMessage: "UnknownError",
   });
 });
 
@@ -91,12 +91,12 @@ Deno.test("summarizeSyncError: string error", () => {
   const { summary, fields } = summarizeSyncError("pull", "@t/x", "oops");
   assertStringIncludes(summary, "@t/x pull failed");
   assertStringIncludes(summary, "oops");
-  assertEquals(fields.message, "oops");
+  assertEquals(fields.errorMessage, "oops");
 });
 
 Deno.test("summarizeSyncError: number error", () => {
   const { fields } = summarizeSyncError("pull", "@t/x", 42);
-  assertEquals(fields.message, "42");
+  assertEquals(fields.errorMessage, "42");
 });
 
 Deno.test("summarizeSyncError: null error — only operation+label present", () => {
@@ -118,7 +118,7 @@ Deno.test("summarizeSyncError: plain object error with no message", () => {
   assertStringIncludes(summary, "code=X");
   assertEquals(fields.httpStatusCode, 500);
   assertEquals(fields.code, "X");
-  assertEquals(fields.message, undefined);
+  assertEquals(fields.errorMessage, undefined);
 });
 
 Deno.test("summarizeSyncError: empty message treated as missing", () => {
@@ -126,16 +126,16 @@ Deno.test("summarizeSyncError: empty message treated as missing", () => {
   const { summary, fields } = summarizeSyncError("pull", "@t/x", err);
   // Falls back to the error name ("Error") as trailer.
   assertStringIncludes(summary, ": Error");
-  assertEquals(fields.message, undefined);
+  assertEquals(fields.errorMessage, undefined);
 });
 
 Deno.test("summarizeSyncError: long message truncated at 200 chars with ellipsis", () => {
   const long = "a".repeat(500);
   const err = new Error(long);
   const { summary, fields } = summarizeSyncError("pull", "@t/x", err);
-  // `fields.message` retains the full message for consumers that want it
+  // `fields.errorMessage` retains the full message for consumers that want it
   // (e.g. .cause-walking renderers); only the summary is truncated.
-  assertEquals(fields.message, long);
+  assertEquals(fields.errorMessage, long);
   // Summary contains exactly 200 'a's followed by ellipsis.
   assertStringIncludes(summary, "a".repeat(200) + "…");
   // Summary does NOT contain the 201st 'a' because it was truncated.
@@ -166,7 +166,7 @@ Deno.test("summarizeSyncError: throwing getters on read fields don't break extra
   assertEquals(fields.requestId, "R1");
   assertEquals(fields.code, "AccessDenied");
   // Throwing fields are treated as missing, not surfaced as errors.
-  assertEquals(fields.message, undefined);
+  assertEquals(fields.errorMessage, undefined);
   assertEquals(fields.name, undefined);
   // Summary still renders without the throwing fields.
   assertStringIncludes(summary, "@t/x pull failed");
@@ -183,7 +183,7 @@ Deno.test("summarizeSyncError: throwing $metadata getter is safe", () => {
     },
   });
   const { fields } = summarizeSyncError("pull", "@t/x", err);
-  assertEquals(fields.message, "real");
+  assertEquals(fields.errorMessage, "real");
   assertEquals(fields.code, "X");
   assertEquals(fields.httpStatusCode, undefined);
   assertEquals(fields.requestId, undefined);
@@ -195,17 +195,21 @@ Deno.test("summarizeSyncError: non-numeric httpStatusCode is ignored", () => {
   assertEquals(fields.httpStatusCode, undefined);
 });
 
-Deno.test("summarizeSyncError: summary is always single-line", () => {
-  const err = new Error("line1\nline2\nline3") as Error & { Code: string };
+Deno.test("summarizeSyncError: summary strips newlines so it stays single-line", () => {
+  const err = new Error("line1\nline2\n\n  line3") as Error & {
+    Code: string;
+  };
   err.Code = "X";
-  const { summary } = summarizeSyncError("pull", "@t/x", err);
-  // We don't strip newlines from the raw message (preserves fidelity in
-  // fields.message), but the rendered summary is used as an Error.message
-  // which most consumers treat as opaque text. Assert the preamble and
-  // structural delimiters are on the first line.
-  const firstLine = summary.split("\n")[0];
-  assertStringIncludes(firstLine, "@t/x pull failed");
-  assertStringIncludes(firstLine, "code=X");
+  const { summary, fields } = summarizeSyncError("pull", "@t/x", err);
+  // Summary collapses newline runs to single spaces so it survives line-
+  // oriented log sinks and JSON-encoded error renderers as one line.
+  assertEquals(summary.includes("\n"), false);
+  assertStringIncludes(summary, "@t/x pull failed");
+  assertStringIncludes(summary, "code=X");
+  assertStringIncludes(summary, "line1 line2 line3");
+  // Full, unmodified message remains on `errorMessage` for consumers
+  // that want fidelity (e.g. a later renderer walking .cause).
+  assertEquals(fields.errorMessage, "line1\nline2\n\n  line3");
 });
 
 Deno.test("summarizeSyncError: missing optional fields are absent from `fields`", () => {


### PR DESCRIPTION
## Summary

Addresses the two non-blocking suggestions from the CLI UX Review bot on #1200 (now merged).

1. **Newline stripping in summary.** If an extension throws an error with embedded newlines, the thrown `Error.message` and the rendered LogTape record previously leaked those newlines into the summary. Now `summarizeSyncError` collapses any `\s*\n+\s*` run to a single space when building the summary. The full, unmodified message is still available on `fields.errorMessage` so consumers that want fidelity (e.g. a later `.cause`-walking renderer) lose nothing.

2. **Rename `message` to `errorMessage` in structured fields.** Spreading `{ ...fields }` into LogTape calls previously injected a `message` key that collides with LogTape's reserved `message` property on the log record. `errorMessage` is also the naming convention used across the rest of the codebase (telemetry entry, report context, audit hook input, workflow execution service). Tests updated to match.

## Test Plan

- [x] Helper unit tests: 17 passing, including the strengthened single-line test that now asserts `summary.includes("\n") === false` and that `line1\nline2` becomes `line1 line2` in the summary while `fields.errorMessage` retains the original.
- [x] Coordinator tests: 7 passing.
- [x] `deno check`, `deno fmt`, `deno lint` clean.
- [x] Recompiled and re-ran the stub-extension scratch repo — all 5 enrichment fields still surface in the pull-path JSON output.