### PR TITLE
fix(extensions): detect source content across both standard and non-standard layouts (swamp-club#139)

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -392,7 +392,9 @@ Files are classified by export name: `export const model` defines new types,
 To test an extension without copying files into the consumer repo:
 
 ```bash
-# In the consumer repo, add the extension as a source
+# In the consumer repo, add the extension as a source.
+# The path can be a repo root with extensions/<kind>/ subdirs, OR a
+# directory whose files declare extension exports directly.
 swamp extension source add ~/code/my-extensions/model/aws/ec2
 
 # Verify it loads
@@ -401,6 +403,11 @@ swamp model type search ec2
 # When done, remove the source
 swamp extension source rm ~/code/my-extensions/model/aws/ec2
 ```
+
+`swamp extension source add` validates the path up-front — if it contributes no
+extensions, the add fails with a clear error naming the kinds it looked for. Use
+`swamp extension source list` to see the resolved kinds for each configured
+source.
 
 The source extension must have a `deno.json` with its dependencies (e.g.,
 `"zod": "npm:zod@4"`) for bundling to succeed.

--- a/.claude/skills/swamp-repo/SKILL.md
+++ b/.claude/skills/swamp-repo/SKILL.md
@@ -274,8 +274,8 @@ multiple locations.
 ### `.swamp-sources.yaml`
 
 A gitignored file at the repo root. Each entry is a **source** — a path (or
-glob) pointing at one or more extension roots. Always added to `.gitignore` by
-`swamp repo init` and `swamp repo upgrade`.
+glob) pointing at a directory that contains extensions. Always added to
+`.gitignore` by `swamp repo init` and `swamp repo upgrade`.
 
 ```yaml
 sources:
@@ -287,8 +287,16 @@ sources:
 
 **Fields:**
 
-- `path` — filesystem path to an extension root. Supports `~`, `$VAR`, and glob
-  patterns (`*`, `**`). Each glob match is treated as a separate extension root.
+- `path` — filesystem path that contains extensions. Supports `~`, `$VAR`, and
+  glob patterns (`*`, `**`). Two layouts are accepted:
+  1. **Repo root**: a directory with `extensions/<kind>/` subdirectories. Most
+     common — matches how published extensions are structured.
+  2. **Direct content**: a directory whose files declare extension exports
+     (`export const model = …`, `export const vault = …`, etc.) or workflow
+     YAML. Useful when you want to point at a single-kind development tree or at
+     an `extensions/<kind>/` directory directly. When both layouts exist in the
+     same directory, the repo-root layout wins — the direct-content files at the
+     root are ignored to prevent double-loading.
 - `only` — optional filter limiting which extension types to load from this
   source: `models`, `vaults`, `drivers`, `datastores`, `reports`, `workflows`.
 
@@ -301,6 +309,9 @@ swamp extension source add ~/code/swamp-extensions/model/aws/ec2
 # Add with glob (all AWS extensions)
 swamp extension source add "~/code/swamp-extensions/model/aws/*"
 
+# Add a directory that contains extension files directly (no extensions/ tree)
+swamp extension source add ~/code/my-extensions/vault
+
 # Add with type filter
 swamp extension source add ~/code/my-vaults --only vaults
 
@@ -311,15 +322,19 @@ swamp extension source list
 swamp extension source rm "~/code/swamp-extensions/model/aws/*"
 ```
 
+`swamp extension source add` fails with a clear error if the path contributes no
+extensions, so misconfigured paths are caught at add time rather than silently
+ignored.
+
 ### Load Order
 
 1. **Local extensions** (`extensions/models/`, etc.)
 2. **Source extensions** (from `.swamp-sources.yaml`, in order listed)
 3. **Pulled extensions** (`.swamp/pulled-extensions/`)
 
-Sources override pulled extensions of the same type. This means you can pull
-`@swamp/aws/ec2` from the registry, then add a source pointing at your local
-development copy — your local version loads instead.
+Load order is unchanged. Sources override pulled extensions of the same type.
+This means you can pull `@swamp/aws/ec2` from the registry, then add a source
+pointing at your local development copy — your local version loads instead.
 
 ## When to Use Other Skills
 

--- a/src/cli/commands/extension_source_add.ts
+++ b/src/cli/commands/extension_source_add.ts
@@ -39,17 +39,24 @@ type AnyOptions = any;
 
 export const extensionSourceAddCommand = new Command()
   .name("add")
-  .description("Add a local extension source")
+  .description(
+    "Add a local extension source. Path may be a repo root with " +
+      "extensions/<kind>/ subdirs or a dir containing extension files directly.",
+  )
   .example(
-    "Add a single extension",
+    "Repo root with extensions/<kind>/ subdirs",
     "swamp extension source add ~/code/swamp-extensions/model/aws/ec2",
   )
   .example(
-    "Add all AWS extensions",
+    "Glob across sibling extension roots",
     'swamp extension source add "~/code/swamp-extensions/model/aws/*"',
   )
   .example(
-    "Add with type filter",
+    "Directory containing extension files directly (any layout)",
+    "swamp extension source add ~/code/my-extensions/vault",
+  )
+  .example(
+    "Restrict to a single extension kind",
     "swamp extension source add ~/code/my-vaults --only vaults",
   )
   .arguments("<path:string>")

--- a/src/domain/datastore/user_datastore_loader.ts
+++ b/src/domain/datastore/user_datastore_loader.ts
@@ -19,6 +19,7 @@
 
 import { z } from "zod";
 import { dirname, join, resolve, toFileUrl } from "@std/path";
+import { isZodSchemaLike } from "../zod_compat.ts";
 import { getLogger } from "@logtape/logtape";
 import {
   bundleExtension,
@@ -68,8 +69,7 @@ const UserDatastoreSchema = z.object({
   ),
   name: z.string(),
   description: z.string(),
-  configSchema: z.custom<z.ZodTypeAny>((val) => val instanceof z.ZodType)
-    .optional(),
+  configSchema: z.custom<z.ZodTypeAny>(isZodSchemaLike).optional(),
   createProvider: z.custom<
     (config: Record<string, unknown>) => DatastoreProvider
   >((val) => typeof val === "function"),

--- a/src/domain/drivers/user_driver_loader.ts
+++ b/src/domain/drivers/user_driver_loader.ts
@@ -19,6 +19,7 @@
 
 import { z } from "zod";
 import { dirname, join, resolve, toFileUrl } from "@std/path";
+import { isZodSchemaLike } from "../zod_compat.ts";
 import { getLogger } from "@logtape/logtape";
 import {
   bundleExtension,
@@ -69,8 +70,7 @@ const UserDriverSchema = z.object({
   ),
   name: z.string(),
   description: z.string(),
-  configSchema: z.custom<z.ZodTypeAny>((val) => val instanceof z.ZodType)
-    .optional(),
+  configSchema: z.custom<z.ZodTypeAny>(isZodSchemaLike).optional(),
   createDriver: z.custom<
     (config: Record<string, unknown>) => ExecutionDriver
   >((val) => typeof val === "function"),

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { z } from "zod";
+import { isZodSchemaLike } from "../zod_compat.ts";
 import type { CloudControlClient } from "@aws-sdk/client-cloudcontrol";
 import type { Logger } from "@logtape/logtape";
 import { ModelType } from "./model_type.ts";
@@ -98,7 +99,8 @@ export interface FileOutputSpec {
  */
 export const ResourceOutputSpecSchema = z.object({
   description: z.string().optional(),
-  schema: z.custom<z.ZodTypeAny>((val) => val instanceof z.ZodType),
+  // Duck-typed so schemas from user-bundled zod instances validate.
+  schema: z.custom<z.ZodTypeAny>(isZodSchemaLike),
   lifetime: LifetimeSchema,
   garbageCollection: GarbageCollectionSchema,
   tags: z.record(z.string(), z.string()).optional(),

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -19,6 +19,7 @@
 
 import { z } from "zod";
 import { dirname, join, resolve, toFileUrl } from "@std/path";
+import { isZodSchemaLike } from "../zod_compat.ts";
 import { getLogger } from "@logtape/logtape";
 import {
   bundleExtension,
@@ -114,7 +115,9 @@ const MethodKindSchema = z.enum([
 const UserMethodSchema = z.object({
   description: z.string(),
   kind: MethodKindSchema.optional(),
-  arguments: z.custom<z.ZodTypeAny>((val) => val instanceof z.ZodType),
+  // Duck-typed schema check so user extensions can bring their own zod
+  // instance without failing the `instanceof` equality against swamp's zod.
+  arguments: z.custom<z.ZodTypeAny>(isZodSchemaLike),
   execute: z.custom<UserExecuteFn>((val) => typeof val === "function"),
 }).passthrough();
 
@@ -148,8 +151,7 @@ const UserModelSchema = z.object({
   version: z.string().refine(CalVer.isValid, {
     message: "version must be valid CalVer (YYYY.MM.DD.MICRO)",
   }),
-  globalArguments: z.custom<z.ZodTypeAny>((val) => val instanceof z.ZodType)
-    .optional(),
+  globalArguments: z.custom<z.ZodTypeAny>(isZodSchemaLike).optional(),
   resources: z.record(z.string(), ResourceOutputSpecSchema).optional(),
   files: z.record(z.string(), FileOutputSpecSchema).optional(),
   methods: z.record(z.string(), UserMethodSchema),

--- a/src/domain/repo/swamp_sources.ts
+++ b/src/domain/repo/swamp_sources.ts
@@ -129,3 +129,50 @@ export function parseSwampSources(yamlContent: string): SwampSourcesConfig {
 export function isGlobPattern(path: string): boolean {
   return /[*?{]/.test(path);
 }
+
+/**
+ * Mapping from extension kind to the `export const <name>` identifiers a
+ * loader will accept. Must stay in sync with each loader's pre-bundle regex
+ * (e.g. `UserModelLoader` checks for `model|extension`, `UserVaultLoader`
+ * checks for `vault`). The content pre-scan in
+ * `resolveExtensionKindsForSource` uses this map so pre-scan detection
+ * equals loader acceptance — avoid silent divergence.
+ *
+ * Workflows are YAML files, not TS modules, so this map has no entry for
+ * them — workflow detection is filename-based (`.yaml`/`.yml` with a
+ * top-level `jobs:` key).
+ */
+export const EXTENSION_EXPORT_NAMES: Record<
+  Exclude<ExtensionKind, "workflows">,
+  readonly string[]
+> = {
+  models: ["model", "extension"],
+  vaults: ["vault"],
+  drivers: ["driver"],
+  datastores: ["datastore"],
+  reports: ["report"],
+} as const;
+
+/**
+ * Examines a `.ts` file's source text and returns the extension kind it
+ * declares, or undefined if no known extension export is present. Uses the
+ * same `export\s+const\s+<name>\s*[=:]` shape the loaders use for their
+ * pre-bundle skip check so detection matches load-time acceptance.
+ *
+ * Returns the first matching kind encountered — files that declare more
+ * than one extension kind in a single module are malformed and outside the
+ * pre-scan's responsibility; the loader catches that downstream.
+ */
+export function detectKindFromSource(
+  sourceText: string,
+): Exclude<ExtensionKind, "workflows"> | undefined {
+  for (const [kind, names] of Object.entries(EXTENSION_EXPORT_NAMES)) {
+    for (const name of names) {
+      const pattern = new RegExp(`export\\s+const\\s+${name}\\s*[=:]`);
+      if (pattern.test(sourceText)) {
+        return kind as Exclude<ExtensionKind, "workflows">;
+      }
+    }
+  }
+  return undefined;
+}

--- a/src/domain/repo/swamp_sources_test.ts
+++ b/src/domain/repo/swamp_sources_test.ts
@@ -18,7 +18,12 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertThrows } from "@std/assert";
-import { isGlobPattern, parseSwampSources } from "./swamp_sources.ts";
+import {
+  detectKindFromSource,
+  EXTENSION_EXPORT_NAMES,
+  isGlobPattern,
+  parseSwampSources,
+} from "./swamp_sources.ts";
 import { UserError } from "../errors.ts";
 
 Deno.test("parseSwampSources: parses valid sources with paths", () => {
@@ -108,4 +113,74 @@ Deno.test("isGlobPattern: detects glob characters", () => {
   assertEquals(isGlobPattern("~/code/ext?"), true);
   assertEquals(isGlobPattern("~/code/ext"), false);
   assertEquals(isGlobPattern("/absolute/path"), false);
+});
+
+Deno.test("EXTENSION_EXPORT_NAMES: covers every non-workflow kind", () => {
+  const expected = ["models", "vaults", "drivers", "datastores", "reports"];
+  assertEquals(Object.keys(EXTENSION_EXPORT_NAMES).sort(), expected.sort());
+});
+
+Deno.test("detectKindFromSource: detects model export", () => {
+  assertEquals(
+    detectKindFromSource(`export const model = { type: "a/b" };`),
+    "models",
+  );
+});
+
+Deno.test("detectKindFromSource: detects extension (models kind)", () => {
+  assertEquals(
+    detectKindFromSource(`export const extension = { type: "a/b" };`),
+    "models",
+  );
+});
+
+Deno.test("detectKindFromSource: detects vault export", () => {
+  assertEquals(
+    detectKindFromSource(`export const vault = { type: "a/b" };`),
+    "vaults",
+  );
+});
+
+Deno.test("detectKindFromSource: detects driver export", () => {
+  assertEquals(
+    detectKindFromSource(`export const driver = { type: "a/b" };`),
+    "drivers",
+  );
+});
+
+Deno.test("detectKindFromSource: detects datastore export", () => {
+  assertEquals(
+    detectKindFromSource(`export const datastore = { type: "a/b" };`),
+    "datastores",
+  );
+});
+
+Deno.test("detectKindFromSource: detects report export", () => {
+  assertEquals(
+    detectKindFromSource(`export const report = { name: "r" };`),
+    "reports",
+  );
+});
+
+Deno.test("detectKindFromSource: returns undefined for unrelated exports", () => {
+  assertEquals(detectKindFromSource(`export const thing = {};`), undefined);
+  assertEquals(detectKindFromSource(`// just a comment`), undefined);
+  assertEquals(detectKindFromSource(``), undefined);
+});
+
+Deno.test("detectKindFromSource: handles type annotation", () => {
+  assertEquals(
+    detectKindFromSource(`export const model: Model = { type: "a/b" };`),
+    "models",
+  );
+});
+
+Deno.test("detectKindFromSource: skips re-exports (parity with loaders)", () => {
+  // Loaders' pre-bundle regex matches `export const model =` or
+  // `export const model:` — re-exports are not in that shape and are
+  // intentionally ignored so pre-scan detection == loader acceptance.
+  assertEquals(
+    detectKindFromSource(`export { model } from "./other.ts";`),
+    undefined,
+  );
 });

--- a/src/domain/vaults/user_vault_loader.ts
+++ b/src/domain/vaults/user_vault_loader.ts
@@ -19,6 +19,7 @@
 
 import { z } from "zod";
 import { dirname, join, resolve, toFileUrl } from "@std/path";
+import { isZodSchemaLike } from "../zod_compat.ts";
 import { getLogger } from "@logtape/logtape";
 import {
   bundleExtension,
@@ -69,8 +70,7 @@ const UserVaultSchema = z.object({
   ),
   name: z.string(),
   description: z.string(),
-  configSchema: z.custom<z.ZodTypeAny>((val) => val instanceof z.ZodType)
-    .optional(),
+  configSchema: z.custom<z.ZodTypeAny>(isZodSchemaLike).optional(),
   createProvider: z.custom<
     (name: string, config: Record<string, unknown>) => VaultProvider
   >((val) => typeof val === "function"),

--- a/src/domain/zod_compat.ts
+++ b/src/domain/zod_compat.ts
@@ -1,0 +1,53 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Duck-typed check for zod-like schemas.
+ *
+ * User extensions can bundle their own copy of zod (via their `deno.json`
+ * import map). When swamp validates a user's model/vault/driver/datastore
+ * definition, the schema object comes from the user's zod instance — and
+ * `val instanceof z.ZodType` against swamp's zod returns false because the
+ * two constructors are different identities.
+ *
+ * Rather than forcing users to pin the exact swamp-bundled zod version,
+ * we duck-type the check. A value is zod-schema-like when it has:
+ *   - a `_def` property (zod's internal-definition convention, present
+ *     across every zod version from v3 onward),
+ *   - a callable `parse` method (zod's public validation API),
+ *   - a callable `safeParse` method (zod's public non-throwing API).
+ *
+ * This contract is stable across zod major versions and implementation
+ * variants. A non-zod object that happens to expose the same shape would
+ * pass this check; in that case runtime `.parse()` calls still safely
+ * surface errors downstream, so false positives degrade gracefully.
+ */
+export function isZodSchemaLike(val: unknown): boolean {
+  if (val === null || typeof val !== "object") return false;
+  const candidate = val as {
+    _def?: unknown;
+    parse?: unknown;
+    safeParse?: unknown;
+  };
+  return (
+    "_def" in candidate &&
+    typeof candidate.parse === "function" &&
+    typeof candidate.safeParse === "function"
+  );
+}

--- a/src/domain/zod_compat_test.ts
+++ b/src/domain/zod_compat_test.ts
@@ -1,0 +1,80 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { z } from "zod";
+import { isZodSchemaLike } from "./zod_compat.ts";
+
+Deno.test("isZodSchemaLike: accepts schemas from swamp's zod", () => {
+  assertEquals(isZodSchemaLike(z.string()), true);
+  assertEquals(isZodSchemaLike(z.object({ name: z.string() })), true);
+  assertEquals(isZodSchemaLike(z.array(z.number())), true);
+  assertEquals(isZodSchemaLike(z.union([z.string(), z.number()])), true);
+  assertEquals(isZodSchemaLike(z.unknown()), true);
+});
+
+Deno.test("isZodSchemaLike: accepts foreign schemas that match the shape", () => {
+  // Simulates a schema coming from a user's bundled zod instance. The
+  // `_def` marker, `parse`, and `safeParse` exist but the prototype is
+  // different from swamp's zod.
+  const foreignSchema = {
+    _def: { typeName: "ZodObject" },
+    parse: (v: unknown) => v,
+    safeParse: (v: unknown) => ({ success: true, data: v }),
+  };
+  assertEquals(isZodSchemaLike(foreignSchema), true);
+});
+
+Deno.test("isZodSchemaLike: rejects null, undefined, primitives", () => {
+  assertEquals(isZodSchemaLike(null), false);
+  assertEquals(isZodSchemaLike(undefined), false);
+  assertEquals(isZodSchemaLike(42), false);
+  assertEquals(isZodSchemaLike("string"), false);
+  assertEquals(isZodSchemaLike(true), false);
+});
+
+Deno.test("isZodSchemaLike: rejects plain objects without zod shape", () => {
+  assertEquals(isZodSchemaLike({}), false);
+  assertEquals(isZodSchemaLike({ type: "string" }), false);
+  assertEquals(isZodSchemaLike({ parse: () => {} }), false); // missing _def
+  assertEquals(isZodSchemaLike({ _def: {} }), false); // missing parse/safeParse
+});
+
+Deno.test("isZodSchemaLike: rejects when parse/safeParse are not functions", () => {
+  assertEquals(
+    isZodSchemaLike({ _def: {}, parse: "not a function", safeParse: () => {} }),
+    false,
+  );
+  assertEquals(
+    isZodSchemaLike({ _def: {}, parse: () => {}, safeParse: 42 }),
+    false,
+  );
+});
+
+Deno.test("isZodSchemaLike: rejects arrays", () => {
+  assertEquals(isZodSchemaLike([]), false);
+  assertEquals(isZodSchemaLike([1, 2, 3]), false);
+});
+
+Deno.test("isZodSchemaLike: rejects zod errors", () => {
+  // ZodError has _def-ish internals but no parse/safeParse — it's the
+  // error class, not a schema. The duck-type check correctly rejects it.
+  const err = new z.ZodError([]);
+  assertEquals(isZodSchemaLike(err), false);
+});

--- a/src/infrastructure/persistence/swamp_sources_repository.ts
+++ b/src/infrastructure/persistence/swamp_sources_repository.ts
@@ -18,13 +18,14 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { isAbsolute, resolve } from "@std/path";
-import { expandGlob } from "@std/fs";
+import { expandGlob, walk } from "@std/fs";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import { getLogger } from "@logtape/logtape";
 import { expandEnvVars } from "./env_path.ts";
 import { swampSourcesPath } from "./paths.ts";
 import { atomicWriteTextFile } from "./atomic_write.ts";
 import {
+  detectKindFromSource,
   EXTENSION_KINDS,
   type ExtensionKind,
   isGlobPattern,
@@ -119,6 +120,196 @@ export async function expandSourcePaths(
 }
 
 /**
+ * Reads the source's own `.swamp.yaml` marker for directory overrides.
+ *
+ * The YAML is from an external repo, so we only extract fields we need
+ * and validate they are strings before using them. Returns null when the
+ * marker file is missing or unreadable — callers fall back to
+ * `extensions/<kind>/` defaults in that case.
+ *
+ * Shared by `resolveSourceExtensionDirs` and
+ * `resolveExtensionKindsForSource` so both agree on marker semantics.
+ * A single pre-fix snapshot in swamp_sources_repository_test.ts pins the
+ * behaviour of this extraction.
+ */
+async function readSourceMarker(
+  sourceDir: string,
+): Promise<RepoMarkerData | null> {
+  try {
+    const markerPath = resolve(sourceDir, ".swamp.yaml");
+    const content = await Deno.readTextFile(markerPath);
+    const raw = parseYaml(content);
+    if (!raw || typeof raw !== "object") return null;
+    const obj = raw as Record<string, unknown>;
+    return {
+      swampVersion: typeof obj.swampVersion === "string"
+        ? obj.swampVersion
+        : "",
+      initializedAt: typeof obj.initializedAt === "string"
+        ? obj.initializedAt
+        : "",
+      modelsDir: typeof obj.modelsDir === "string" ? obj.modelsDir : undefined,
+      workflowsDir: typeof obj.workflowsDir === "string"
+        ? obj.workflowsDir
+        : undefined,
+      vaultsDir: typeof obj.vaultsDir === "string" ? obj.vaultsDir : undefined,
+      driversDir: typeof obj.driversDir === "string"
+        ? obj.driversDir
+        : undefined,
+      datastoresDir: typeof obj.datastoresDir === "string"
+        ? obj.datastoresDir
+        : undefined,
+      reportsDir: typeof obj.reportsDir === "string"
+        ? obj.reportsDir
+        : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Probes the standard `<sourceDir>/extensions/<kind>/` layout for a single
+ * source. Returns the kinds whose dir exists. Respects the marker's
+ * `<kind>Dir` override and the caller's `only` filter. Does NOT perform
+ * any content scanning — purely a directory-existence check.
+ *
+ * Returned in the `kindDirs` map using the ExtensionKind as key so callers
+ * can read both "which kinds resolved" and "what absolute dir each maps
+ * to" in one pass.
+ */
+async function probeStandardLayout(
+  sourceDir: string,
+  marker: RepoMarkerData | null,
+  only: ReadonlyArray<ExtensionKind>,
+): Promise<Map<ExtensionKind, string>> {
+  const out = new Map<ExtensionKind, string>();
+  for (const kind of only) {
+    const relDir = resolveKindDir(kind, marker);
+    const absDir = isAbsolute(relDir) ? relDir : resolve(sourceDir, relDir);
+    try {
+      const stat = await Deno.stat(absDir);
+      if (stat.isDirectory) {
+        out.set(kind, absDir);
+      }
+    } catch {
+      // Kind dir missing — skip.
+    }
+  }
+  return out;
+}
+
+/** Directories skipped during the content pre-scan: test helpers and
+ * unrelated package detritus that would never hold an extension file. */
+const PRE_SCAN_SKIP_DIRS = new Set([
+  "node_modules",
+  ".git",
+  ".swamp",
+  "dist",
+  "build",
+  "target",
+]);
+
+/** Maximum recursion depth for the content pre-scan. Keeps cold add/list
+ * bounded on large repos where the source path is something broad. */
+const PRE_SCAN_MAX_DEPTH = 4;
+
+/** Cap per-file read during the content pre-scan. Normal extension files
+ * sit far below this; a 64 KiB bound prevents blowups on pathological
+ * files with no `export` declaration. */
+const PRE_SCAN_MAX_BYTES = 64 * 1024;
+
+/**
+ * Walks `sourceDir` looking for files that signal extension content.
+ * Returns the set of kinds detected.
+ *
+ * For .ts files: reads up to PRE_SCAN_MAX_BYTES of the file and runs
+ * `detectKindFromSource`, which uses the same export-name regex the
+ * loaders use for their pre-bundle skip check — so pre-scan detection
+ * equals loader acceptance.
+ *
+ * For workflow files (.yaml / .yml): parses the YAML and checks for a
+ * top-level `jobs:` key. Regex shortcuts are unreliable because workflow
+ * YAML often puts `jobs:` after `name:` / `description:` headers.
+ *
+ * Skips `_*` prefixed dirs (helper modules — matches loader convention),
+ * node_modules / .git / .swamp / dist / build / target (unrelated
+ * detritus), and `_test.ts` files. Bounded by PRE_SCAN_MAX_DEPTH.
+ */
+async function contentPreScan(
+  sourceDir: string,
+): Promise<Set<ExtensionKind>> {
+  const found = new Set<ExtensionKind>();
+  try {
+    for await (
+      const entry of walk(sourceDir, {
+        maxDepth: PRE_SCAN_MAX_DEPTH,
+        includeDirs: false,
+        skip: [
+          /(^|\/)_[^/]+($|\/)/, // _-prefixed paths (helper modules, _test.ts)
+        ],
+      })
+    ) {
+      // Secondary skip for well-known dirs that the regex-based skip above
+      // can't express cleanly. walk doesn't drop the dir itself; it emits
+      // files underneath. Cheaper to filter on the path.
+      if (
+        [...PRE_SCAN_SKIP_DIRS].some((d) =>
+          entry.path.includes(`/${d}/`) || entry.path.endsWith(`/${d}`)
+        )
+      ) {
+        continue;
+      }
+
+      if (entry.isFile && entry.name.endsWith(".ts")) {
+        if (entry.name.endsWith("_test.ts")) continue;
+        try {
+          const stat = await Deno.stat(entry.path);
+          const len = Math.min(stat.size, PRE_SCAN_MAX_BYTES);
+          const file = await Deno.open(entry.path, { read: true });
+          try {
+            const buf = new Uint8Array(len);
+            await file.read(buf);
+            const text = new TextDecoder().decode(buf);
+            const kind = detectKindFromSource(text);
+            if (kind) {
+              found.add(kind);
+              // Short-circuit once every known kind has been seen.
+              if (found.size === EXTENSION_KINDS.length - 1) return found;
+            }
+          } finally {
+            file.close();
+          }
+        } catch {
+          // Unreadable file — skip.
+        }
+      } else if (
+        entry.isFile &&
+        (entry.name.endsWith(".yaml") || entry.name.endsWith(".yml"))
+      ) {
+        if (found.has("workflows")) continue;
+        try {
+          const content = await Deno.readTextFile(entry.path);
+          const raw = parseYaml(content);
+          if (
+            raw && typeof raw === "object" && !Array.isArray(raw) &&
+            "jobs" in (raw as Record<string, unknown>)
+          ) {
+            found.add("workflows");
+          }
+        } catch {
+          // Unparseable YAML — not a workflow.
+        }
+      }
+    }
+  } catch {
+    // walk throws if sourceDir is not a directory; callers already stat'd
+    // the path before calling us, so this branch is defensive.
+  }
+  return found;
+}
+
+/**
  * Resolves extension directories for each expanded source.
  *
  * For each source path:
@@ -126,6 +317,12 @@ export async function expandSourcePaths(
  * 2. Falls back to `extensions/<type>` defaults if no marker exists
  * 3. Filters by the `only` field if specified
  * 4. Validates that directories exist (warns but does not fail on missing)
+ *
+ * Since issue #139: when the standard `<path>/extensions/<kind>/` layout
+ * yields zero known kinds for a source, a content pre-scan walks the path
+ * and sets each detected kind's dir to the source path itself. Standard
+ * layout always wins over pre-scan when both are present (prevents
+ * double-loading in transitional repos).
  */
 export async function resolveSourceExtensionDirs(
   expandedSources: SwampSource[],
@@ -135,47 +332,7 @@ export async function resolveSourceExtensionDirs(
   for (const source of expandedSources) {
     const sourceDir = source.path;
     const resolved: ResolvedSourceDirs = { sourcePath: sourceDir };
-
-    // Try to read the source's own .swamp.yaml for directory overrides.
-    // The YAML is from an external repo, so we only extract fields we need
-    // and validate they are strings before using them.
-    let sourceMarker: RepoMarkerData | null = null;
-    try {
-      const markerPath = resolve(sourceDir, ".swamp.yaml");
-      const content = await Deno.readTextFile(markerPath);
-      const raw = parseYaml(content);
-      if (raw && typeof raw === "object") {
-        const obj = raw as Record<string, unknown>;
-        sourceMarker = {
-          swampVersion: typeof obj.swampVersion === "string"
-            ? obj.swampVersion
-            : "",
-          initializedAt: typeof obj.initializedAt === "string"
-            ? obj.initializedAt
-            : "",
-          modelsDir: typeof obj.modelsDir === "string"
-            ? obj.modelsDir
-            : undefined,
-          workflowsDir: typeof obj.workflowsDir === "string"
-            ? obj.workflowsDir
-            : undefined,
-          vaultsDir: typeof obj.vaultsDir === "string"
-            ? obj.vaultsDir
-            : undefined,
-          driversDir: typeof obj.driversDir === "string"
-            ? obj.driversDir
-            : undefined,
-          datastoresDir: typeof obj.datastoresDir === "string"
-            ? obj.datastoresDir
-            : undefined,
-          reportsDir: typeof obj.reportsDir === "string"
-            ? obj.reportsDir
-            : undefined,
-        };
-      }
-    } catch {
-      // No marker file — use defaults
-    }
+    const marker = await readSourceMarker(sourceDir);
 
     // Check if source dir itself exists
     try {
@@ -191,20 +348,23 @@ export async function resolveSourceExtensionDirs(
       continue;
     }
 
-    const kinds = source.only ?? EXTENSION_KINDS;
+    const only = source.only ?? EXTENSION_KINDS;
+    const standard = await probeStandardLayout(sourceDir, marker, only);
 
-    for (const kind of kinds) {
-      const relDir = resolveKindDir(kind, sourceMarker);
-      const absDir = isAbsolute(relDir) ? relDir : resolve(sourceDir, relDir);
-
-      // Only include if the directory actually exists
-      try {
-        const stat = await Deno.stat(absDir);
-        if (stat.isDirectory) {
-          setKindDir(resolved, kind, absDir);
+    if (standard.size > 0) {
+      for (const [kind, dir] of standard) {
+        setKindDir(resolved, kind, dir);
+      }
+    } else {
+      // Standard layout yielded zero known kinds — fall back to content
+      // pre-scan. Each detected kind's dir becomes the source path itself
+      // so the loader walks the full path and filters by export at the
+      // pre-bundle step.
+      const detected = await contentPreScan(sourceDir);
+      for (const kind of detected) {
+        if (only.includes(kind)) {
+          setKindDir(resolved, kind, sourceDir);
         }
-      } catch {
-        // Directory doesn't exist for this kind — skip silently
       }
     }
 
@@ -212,6 +372,58 @@ export async function resolveSourceExtensionDirs(
   }
 
   return results;
+}
+
+/**
+ * Returns the extension kinds a single source actually contributes,
+ * respecting globs, marker overrides, the `only` filter, and both
+ * supported layouts (standard `extensions/<kind>/` and non-standard
+ * content-detected). Sorted by EXTENSION_KINDS declaration order.
+ *
+ * Used by `sourceAdd` to fail fast when a concrete path contributes
+ * nothing, and by `sourceList` to populate `resolvedKinds` per entry.
+ *
+ * Semantics:
+ *   - A glob with zero expansions returns `[]` — add is allowed because
+ *     the user may populate the path later.
+ *   - A glob with ≥1 expansions unions kinds across expansions.
+ *   - A concrete path with zero kinds from both layouts returns `[]` —
+ *     callers reject it at add time.
+ */
+export async function resolveExtensionKindsForSource(
+  source: SwampSource,
+  repoDir: string,
+): Promise<ExtensionKind[]> {
+  const only = source.only ?? EXTENSION_KINDS;
+  const onlySet = new Set<ExtensionKind>(only);
+  const union = new Set<ExtensionKind>();
+
+  const expanded = await expandSourcePaths({ sources: [source] }, repoDir);
+
+  for (const ex of expanded) {
+    const marker = await readSourceMarker(ex.path);
+
+    let stat: Deno.FileInfo;
+    try {
+      stat = await Deno.stat(ex.path);
+    } catch {
+      continue;
+    }
+    if (!stat.isDirectory) continue;
+
+    const standard = await probeStandardLayout(ex.path, marker, only);
+    if (standard.size > 0) {
+      for (const kind of standard.keys()) union.add(kind);
+      continue;
+    }
+
+    const detected = await contentPreScan(ex.path);
+    for (const kind of detected) {
+      if (onlySet.has(kind)) union.add(kind);
+    }
+  }
+
+  return EXTENSION_KINDS.filter((k) => union.has(k));
 }
 
 /**

--- a/src/infrastructure/persistence/swamp_sources_repository_test.ts
+++ b/src/infrastructure/persistence/swamp_sources_repository_test.ts
@@ -24,9 +24,11 @@ import {
   expandSourcePaths,
   readSwampSources,
   removeSwampSources,
+  resolveExtensionKindsForSource,
   resolveSourceExtensionDirs,
   writeSwampSources,
 } from "./swamp_sources_repository.ts";
+import type { ExtensionKind } from "../../domain/repo/swamp_sources.ts";
 
 Deno.test("readSwampSources: returns null when file does not exist", async () => {
   const tmpDir = await Deno.makeTempDir({ prefix: "swamp_sources_test_" });
@@ -243,4 +245,387 @@ Deno.test("collectDirsForKind: extracts dirs for specific kind", () => {
 
   const drivers = collectDirsForKind(sources, "drivers");
   assertEquals(drivers, []);
+});
+
+// -----------------------------------------------------------------
+// Snapshot tests for resolveSourceExtensionDirs.
+//
+// These pin load-time behaviour across the `readSourceMarker` extraction
+// added in the issue-139 fix. Each fixture covers a case that exercises
+// a distinct branch of the resolver: layout default, layout override via
+// marker, missing path, glob expansion, single `only` filter, multi-kind
+// roots, and per-kind dir existence checks.
+//
+// If any snapshot needs updating, verify the change is intentional and
+// propagate it to the parity test below.
+// -----------------------------------------------------------------
+
+/** Serialise a ResolvedSourceDirs array relative to a base tmp dir so
+ * snapshots are stable across different test environments. */
+function snapshotResolved(
+  results: ReadonlyArray<unknown>,
+  base: string,
+): Array<Record<string, string | undefined>> {
+  const rel = (v: unknown): string | undefined => {
+    if (typeof v !== "string") return undefined;
+    return v.startsWith(base) ? v.slice(base.length) : v;
+  };
+  return results.map((r) => {
+    const out: Record<string, string | undefined> = {};
+    for (const [k, v] of Object.entries(r as Record<string, unknown>)) {
+      out[k] = rel(v);
+    }
+    return out;
+  });
+}
+
+Deno.test("resolveSourceExtensionDirs snapshot: all six kinds present", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_snap_" });
+  try {
+    const src = join(tmp, "all");
+    for (
+      const kind of [
+        "models",
+        "vaults",
+        "drivers",
+        "datastores",
+        "reports",
+        "workflows",
+      ]
+    ) {
+      await Deno.mkdir(join(src, "extensions", kind), { recursive: true });
+    }
+    const result = await resolveSourceExtensionDirs([{ path: src }]);
+    assertEquals(snapshotResolved(result, tmp), [
+      {
+        sourcePath: "/all",
+        modelsDir: "/all/extensions/models",
+        vaultsDir: "/all/extensions/vaults",
+        driversDir: "/all/extensions/drivers",
+        datastoresDir: "/all/extensions/datastores",
+        reportsDir: "/all/extensions/reports",
+        workflowsDir: "/all/extensions/workflows",
+      },
+    ]);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("resolveSourceExtensionDirs snapshot: models-only root", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_snap_" });
+  try {
+    const src = join(tmp, "models-only");
+    await Deno.mkdir(join(src, "extensions", "models"), { recursive: true });
+    const result = await resolveSourceExtensionDirs([{ path: src }]);
+    assertEquals(snapshotResolved(result, tmp), [
+      {
+        sourcePath: "/models-only",
+        modelsDir: "/models-only/extensions/models",
+      },
+    ]);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("resolveSourceExtensionDirs snapshot: workflows-only root", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_snap_" });
+  try {
+    const src = join(tmp, "wf");
+    await Deno.mkdir(join(src, "extensions", "workflows"), { recursive: true });
+    const result = await resolveSourceExtensionDirs([{ path: src }]);
+    assertEquals(snapshotResolved(result, tmp), [
+      {
+        sourcePath: "/wf",
+        workflowsDir: "/wf/extensions/workflows",
+      },
+    ]);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("resolveSourceExtensionDirs snapshot: marker overrides modelsDir", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_snap_" });
+  try {
+    const src = join(tmp, "overridden");
+    await Deno.mkdir(join(src, "custom", "models"), { recursive: true });
+    await Deno.writeTextFile(
+      join(src, ".swamp.yaml"),
+      'swampVersion: "1.0.0"\ninitializedAt: "2026-01-01"\nmodelsDir: custom/models\n',
+    );
+    const result = await resolveSourceExtensionDirs([{ path: src }]);
+    assertEquals(snapshotResolved(result, tmp), [
+      {
+        sourcePath: "/overridden",
+        modelsDir: "/overridden/custom/models",
+      },
+    ]);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("resolveSourceExtensionDirs snapshot: non-existent path yields empty", async () => {
+  const result = await resolveSourceExtensionDirs([
+    { path: "/definitely/does/not/exist/v139" },
+  ]);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].sourcePath, "/definitely/does/not/exist/v139");
+  assertEquals(result[0].modelsDir, undefined);
+  assertEquals(result[0].vaultsDir, undefined);
+  assertEquals(result[0].driversDir, undefined);
+  assertEquals(result[0].datastoresDir, undefined);
+  assertEquals(result[0].reportsDir, undefined);
+  assertEquals(result[0].workflowsDir, undefined);
+});
+
+Deno.test("resolveSourceExtensionDirs snapshot: only filter narrows kinds", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_snap_" });
+  try {
+    const src = join(tmp, "filtered");
+    await Deno.mkdir(join(src, "extensions", "models"), { recursive: true });
+    await Deno.mkdir(join(src, "extensions", "vaults"), { recursive: true });
+    const result = await resolveSourceExtensionDirs([
+      { path: src, only: ["vaults"] },
+    ]);
+    assertEquals(snapshotResolved(result, tmp), [
+      {
+        sourcePath: "/filtered",
+        vaultsDir: "/filtered/extensions/vaults",
+      },
+    ]);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("resolveSourceExtensionDirs snapshot: non-standard layout via content pre-scan", async () => {
+  // The reporter's scenario (issue #139): user passes an
+  // `extensions/models/` dir itself as the source path. Pre-fix this
+  // silently resolved to zero kinds; post-fix the content pre-scan sees
+  // the `export const model` declaration in the .ts file and treats the
+  // source path itself as the models dir.
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_snap_" });
+  try {
+    const src = join(tmp, "sister", "extensions", "models");
+    await Deno.mkdir(src, { recursive: true });
+    await Deno.writeTextFile(
+      join(src, "m.ts"),
+      'export const model = { type: "@r/m" };',
+    );
+    const result = await resolveSourceExtensionDirs([{ path: src }]);
+    assertEquals(result.length, 1);
+    assertEquals(result[0].sourcePath, src);
+    // Post-fix: pre-scan detects the model export and sets modelsDir to
+    // the source path itself (the loader will walk it and filter).
+    assertEquals(result[0].modelsDir, src);
+    assertEquals(result[0].vaultsDir, undefined);
+    assertEquals(result[0].workflowsDir, undefined);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+// -----------------------------------------------------------------
+// Parity test: resolveExtensionKindsForSource must agree with
+// resolveSourceExtensionDirs about which kinds a source contributes.
+// Drift between the two would split add-time validation from load-time
+// resolution — users would see add succeed then loads find nothing, or
+// vice versa. The pair below runs both functions against the same set
+// of fixtures and asserts equivalence.
+// -----------------------------------------------------------------
+
+const KIND_FIELDS: Array<
+  [
+    ExtensionKind,
+    keyof import("../../domain/repo/swamp_sources.ts").ResolvedSourceDirs,
+  ]
+> = [
+  ["models", "modelsDir"],
+  ["vaults", "vaultsDir"],
+  ["drivers", "driversDir"],
+  ["datastores", "datastoresDir"],
+  ["reports", "reportsDir"],
+  ["workflows", "workflowsDir"],
+];
+
+function kindsFromResolved(
+  r: import("../../domain/repo/swamp_sources.ts").ResolvedSourceDirs,
+): ExtensionKind[] {
+  const out: ExtensionKind[] = [];
+  for (const [kind, field] of KIND_FIELDS) {
+    if (r[field] !== undefined) out.push(kind);
+  }
+  return out;
+}
+
+Deno.test("parity: resolveExtensionKindsForSource matches resolveSourceExtensionDirs for standard layout", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_parity_" });
+  try {
+    const src = join(tmp, "all");
+    for (
+      const kind of [
+        "models",
+        "vaults",
+        "drivers",
+        "datastores",
+        "reports",
+        "workflows",
+      ]
+    ) {
+      await Deno.mkdir(join(src, "extensions", kind), { recursive: true });
+    }
+    const fromDirs = kindsFromResolved(
+      (await resolveSourceExtensionDirs([{ path: src }]))[0],
+    );
+    const fromHelper = await resolveExtensionKindsForSource(
+      { path: src },
+      tmp,
+    );
+    assertEquals(fromHelper.sort(), fromDirs.sort());
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("parity: non-standard (content pre-scan) layout", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_parity_" });
+  try {
+    const src = join(tmp, "loose");
+    await Deno.mkdir(src, { recursive: true });
+    await Deno.writeTextFile(
+      join(src, "m.ts"),
+      'export const model = { type: "@r/m" };',
+    );
+    await Deno.writeTextFile(
+      join(src, "v.ts"),
+      'export const vault = { type: "@r/v" };',
+    );
+    const fromDirs = kindsFromResolved(
+      (await resolveSourceExtensionDirs([{ path: src }]))[0],
+    );
+    const fromHelper = await resolveExtensionKindsForSource(
+      { path: src },
+      tmp,
+    );
+    assertEquals(fromHelper.sort(), fromDirs.sort());
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("parity: marker-override layout", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_parity_" });
+  try {
+    const src = join(tmp, "mk");
+    await Deno.mkdir(join(src, "custom", "models"), { recursive: true });
+    await Deno.writeTextFile(
+      join(src, ".swamp.yaml"),
+      'swampVersion: "1.0.0"\ninitializedAt: "2026-01-01"\nmodelsDir: custom/models\n',
+    );
+    const fromDirs = kindsFromResolved(
+      (await resolveSourceExtensionDirs([{ path: src }]))[0],
+    );
+    const fromHelper = await resolveExtensionKindsForSource(
+      { path: src },
+      tmp,
+    );
+    assertEquals(fromHelper.sort(), fromDirs.sort());
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("parity: --only filter respected identically", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_parity_" });
+  try {
+    const src = join(tmp, "filt");
+    await Deno.mkdir(join(src, "extensions", "models"), { recursive: true });
+    await Deno.mkdir(join(src, "extensions", "vaults"), { recursive: true });
+    const fromDirs = kindsFromResolved(
+      (await resolveSourceExtensionDirs([{ path: src, only: ["vaults"] }]))[0],
+    );
+    const fromHelper = await resolveExtensionKindsForSource(
+      { path: src, only: ["vaults"] },
+      tmp,
+    );
+    assertEquals(fromHelper.sort(), fromDirs.sort());
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("parity: non-existent path returns empty from both", async () => {
+  const fromDirs = kindsFromResolved(
+    (await resolveSourceExtensionDirs([
+      { path: "/definitely/not/there/v139/parity" },
+    ]))[0],
+  );
+  const fromHelper = await resolveExtensionKindsForSource(
+    { path: "/definitely/not/there/v139/parity" },
+    "/tmp",
+  );
+  assertEquals(fromHelper, []);
+  assertEquals(fromDirs, []);
+});
+
+Deno.test("parity: resolveExtensionKindsForSource returns kinds in EXTENSION_KINDS order", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_parity_" });
+  try {
+    const src = join(tmp, "order");
+    // Create in reverse declaration order to ensure the returned list
+    // is sorted by EXTENSION_KINDS, not by discovery order.
+    for (
+      const kind of [
+        "workflows",
+        "reports",
+        "datastores",
+        "drivers",
+        "vaults",
+        "models",
+      ]
+    ) {
+      await Deno.mkdir(join(src, "extensions", kind), { recursive: true });
+    }
+    const kinds = await resolveExtensionKindsForSource({ path: src }, tmp);
+    assertEquals(kinds, [
+      "models",
+      "vaults",
+      "drivers",
+      "datastores",
+      "reports",
+      "workflows",
+    ]);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("resolveSourceExtensionDirs: standard layout wins over loose root files", async () => {
+  // Mixed layout precedence: when a source has BOTH
+  // extensions/<kind>/ subdirs AND loose extension files at the root,
+  // standard layout takes precedence and the loose files are ignored
+  // (prevents double-loading in transitional repos).
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_mixed_" });
+  try {
+    const src = join(tmp, "mixed");
+    await Deno.mkdir(join(src, "extensions", "models"), { recursive: true });
+    await Deno.writeTextFile(
+      join(src, "extensions", "models", "m.ts"),
+      'export const model = { type: "@r/m" };',
+    );
+    await Deno.writeTextFile(
+      join(src, "loose.ts"),
+      'export const model = { type: "@r/loose" };',
+    );
+    const result = await resolveSourceExtensionDirs([{ path: src }]);
+    assertEquals(result.length, 1);
+    assertEquals(result[0].modelsDir, join(src, "extensions", "models"));
+    // Loose root file NOT surfaced — standard layout precedence.
+    assertEquals(result[0].sourcePath, src);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
 });

--- a/src/libswamp/sources/add.ts
+++ b/src/libswamp/sources/add.ts
@@ -20,10 +20,16 @@
 import type { LibSwampContext } from "../context.ts";
 import { alreadyExists, validationFailed } from "../errors.ts";
 import type { SourceModifyEvent } from "./source_events.ts";
-import type { ExtensionKind } from "../../domain/repo/swamp_sources.ts";
-import type { SwampSourcesConfig } from "../../domain/repo/swamp_sources.ts";
 import {
+  type ExtensionKind,
+  isGlobPattern,
+  type SwampSource,
+  type SwampSourcesConfig,
+} from "../../domain/repo/swamp_sources.ts";
+import {
+  expandSourcePaths,
   readSwampSources,
+  resolveExtensionKindsForSource,
   writeSwampSources,
 } from "../../infrastructure/persistence/swamp_sources_repository.ts";
 
@@ -31,6 +37,12 @@ import {
 export interface SourceAddDeps {
   readSources: () => Promise<SwampSourcesConfig | null>;
   writeSources: (config: SwampSourcesConfig) => Promise<void>;
+  /** Returns the kinds a given source contributes. Injected so tests can
+   * fake the resolver without touching the real filesystem. */
+  resolveKinds: (source: SwampSource) => Promise<ExtensionKind[]>;
+  /** Expands globs to concrete paths. Injected alongside resolveKinds so
+   * the glob-vs-concrete validation split is fully testable. */
+  expandSource: (source: SwampSource) => Promise<SwampSource[]>;
 }
 
 /** Wires real infrastructure into SourceAddDeps. */
@@ -38,6 +50,8 @@ export function createSourceAddDeps(repoDir: string): SourceAddDeps {
   return {
     readSources: () => readSwampSources(repoDir),
     writeSources: (config) => writeSwampSources(repoDir, config),
+    resolveKinds: (source) => resolveExtensionKindsForSource(source, repoDir),
+    expandSource: (source) => expandSourcePaths({ sources: [source] }, repoDir),
   };
 }
 
@@ -68,6 +82,54 @@ export async function* sourceAdd(
       error: alreadyExists("Extension source", path),
     };
     return;
+  }
+
+  // Validate that the source actually contributes extensions. Concrete
+  // paths must resolve to ≥1 kind; unexpanded globs are allowed so users
+  // can configure sources before the target dirs exist (pre-population).
+  const tentative: SwampSource = only ? { path, only } : { path };
+  const resolvedKinds = await deps.resolveKinds(tentative);
+  if (resolvedKinds.length === 0) {
+    const isGlob = isGlobPattern(path);
+    if (isGlob) {
+      const expansions = await deps.expandSource(tentative);
+      if (expansions.length > 0) {
+        // Glob expanded to concrete dirs but none contributed kinds.
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `No extensions found under glob '${path}'. ` +
+              `All ${expansions.length} matched path(s) lack either ` +
+              `'extensions/<kind>/' subdirectories or files declaring ` +
+              `extension exports (model, vault, driver, datastore, ` +
+              `report, or workflow). Check the target paths or remove ` +
+              `the source.`,
+          ),
+        };
+        return;
+      }
+      // Unexpanded glob → allow (pre-population workflow).
+    } else {
+      const probed = only ?? [
+        "models",
+        "vaults",
+        "drivers",
+        "datastores",
+        "reports",
+        "workflows",
+      ];
+      yield {
+        kind: "error",
+        error: validationFailed(
+          `No extensions found at '${path}'. ` +
+            `Expected either 'extensions/<kind>/' subdirectories (where ` +
+            `<kind> is one of ${probed.join(", ")}) OR files declaring ` +
+            `extension exports (model, vault, driver, datastore, report) ` +
+            `or workflow YAML directly in the path.`,
+        ),
+      };
+      return;
+    }
   }
 
   const newEntry = only ? { path, only } : { path };

--- a/src/libswamp/sources/add_test.ts
+++ b/src/libswamp/sources/add_test.ts
@@ -17,22 +17,42 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
 import { sourceAdd, type SourceAddDeps } from "./add.ts";
 import { createLibSwampContext } from "../context.ts";
-import type { SwampSourcesConfig } from "../../domain/repo/swamp_sources.ts";
+import type {
+  ExtensionKind,
+  SwampSource,
+  SwampSourcesConfig,
+} from "../../domain/repo/swamp_sources.ts";
 import type { SourceModifyEvent } from "./source_events.ts";
 
+interface TestDeps extends SourceAddDeps {
+  written: SwampSourcesConfig | null;
+}
+
 function createTestDeps(
-  existing: SwampSourcesConfig | null = null,
-): SourceAddDeps & { written: SwampSourcesConfig | null } {
+  options: {
+    existing?: SwampSourcesConfig | null;
+    /** Override the resolver return for the next call. Accepts a function
+     * so tests can key on the path being validated. */
+    resolveKinds?: (source: SwampSource) => ExtensionKind[];
+    /** Override the glob expansion for the next call. */
+    expandSource?: (source: SwampSource) => SwampSource[];
+  } = {},
+): TestDeps {
   const state = { written: null as SwampSourcesConfig | null };
   return {
-    readSources: () => Promise.resolve(existing),
+    readSources: () => Promise.resolve(options.existing ?? null),
     writeSources: (config) => {
       state.written = config;
       return Promise.resolve();
     },
+    resolveKinds: (source) =>
+      Promise.resolve(options.resolveKinds?.(source) ?? ["models"]),
+    expandSource: (source) =>
+      Promise.resolve(options.expandSource?.(source) ?? [source]),
     get written() {
       return state.written;
     },
@@ -49,19 +69,31 @@ async function collectEvents(
   return events;
 }
 
+function findCompleted(events: SourceModifyEvent[]) {
+  return events.find((e) => e.kind === "completed");
+}
+
+function findError(events: SourceModifyEvent[]) {
+  return events.find((e) => e.kind === "error");
+}
+
 const ctx = createLibSwampContext({});
 
-Deno.test("sourceAdd: adds a new source to empty config", async () => {
-  const deps = createTestDeps(null);
+// ----------------------------------------------------------------
+// Basic add behaviours (independent of resolver validation).
+// ----------------------------------------------------------------
+
+Deno.test("sourceAdd: adds a new source when resolver reports kinds", async () => {
+  const deps = createTestDeps({ resolveKinds: () => ["models"] });
   const events = await collectEvents(
-    sourceAdd(ctx, deps, "~/code/my-extensions"),
+    sourceAdd(ctx, deps, "/some/valid/path"),
   );
 
-  const completed = events.find((e) => e.kind === "completed");
+  const completed = findCompleted(events);
   assertEquals(completed?.kind, "completed");
   if (completed?.kind === "completed") {
     assertEquals(completed.data.action, "added");
-    assertEquals(completed.data.path, "~/code/my-extensions");
+    assertEquals(completed.data.path, "/some/valid/path");
     assertEquals(completed.data.totalSources, 1);
   }
   assertEquals(deps.written?.sources.length, 1);
@@ -69,13 +101,14 @@ Deno.test("sourceAdd: adds a new source to empty config", async () => {
 
 Deno.test("sourceAdd: adds to existing sources", async () => {
   const deps = createTestDeps({
-    sources: [{ path: "~/code/existing" }],
+    existing: { sources: [{ path: "/existing" }] },
+    resolveKinds: () => ["models"],
   });
   const events = await collectEvents(
-    sourceAdd(ctx, deps, "~/code/new-source"),
+    sourceAdd(ctx, deps, "/new-source"),
   );
 
-  const completed = events.find((e) => e.kind === "completed");
+  const completed = findCompleted(events);
   if (completed?.kind === "completed") {
     assertEquals(completed.data.totalSources, 2);
   }
@@ -83,12 +116,12 @@ Deno.test("sourceAdd: adds to existing sources", async () => {
 });
 
 Deno.test("sourceAdd: adds with only filter", async () => {
-  const deps = createTestDeps(null);
+  const deps = createTestDeps({ resolveKinds: () => ["vaults"] });
   const events = await collectEvents(
-    sourceAdd(ctx, deps, "~/code/vaults", ["vaults"]),
+    sourceAdd(ctx, deps, "/vaults-src", ["vaults"]),
   );
 
-  const completed = events.find((e) => e.kind === "completed");
+  const completed = findCompleted(events);
   if (completed?.kind === "completed") {
     assertEquals(completed.data.only, ["vaults"]);
   }
@@ -97,20 +130,247 @@ Deno.test("sourceAdd: adds with only filter", async () => {
 
 Deno.test("sourceAdd: rejects duplicate path", async () => {
   const deps = createTestDeps({
-    sources: [{ path: "~/code/my-extensions" }],
+    existing: { sources: [{ path: "/dup" }] },
+    resolveKinds: () => ["models"],
   });
-  const events = await collectEvents(
-    sourceAdd(ctx, deps, "~/code/my-extensions"),
-  );
+  const events = await collectEvents(sourceAdd(ctx, deps, "/dup"));
 
-  const error = events.find((e) => e.kind === "error");
+  const error = findError(events);
   assertEquals(error?.kind, "error");
+  assertEquals(deps.written, null);
 });
 
 Deno.test("sourceAdd: rejects empty path", async () => {
-  const deps = createTestDeps(null);
+  const deps = createTestDeps();
   const events = await collectEvents(sourceAdd(ctx, deps, ""));
 
-  const error = events.find((e) => e.kind === "error");
+  const error = findError(events);
   assertEquals(error?.kind, "error");
+  assertEquals(deps.written, null);
+});
+
+// ----------------------------------------------------------------
+// Issue-139 validation: fail fast when the source contributes nothing.
+// ----------------------------------------------------------------
+
+Deno.test("sourceAdd: rejects concrete path that resolves to zero kinds", async () => {
+  const deps = createTestDeps({ resolveKinds: () => [] });
+  const events = await collectEvents(sourceAdd(ctx, deps, "/empty"));
+
+  const error = findError(events);
+  assertEquals(error?.kind, "error");
+  if (error?.kind === "error") {
+    assertStringIncludes(error.error.message, "No extensions found");
+    assertStringIncludes(error.error.message, "/empty");
+  }
+  assertEquals(deps.written, null);
+});
+
+Deno.test("sourceAdd: rejection names probed kinds so --only mismatches are self-diagnosable", async () => {
+  const deps = createTestDeps({ resolveKinds: () => [] });
+  const events = await collectEvents(
+    sourceAdd(ctx, deps, "/models-only-repo", ["vaults"]),
+  );
+
+  const error = findError(events);
+  assertEquals(error?.kind, "error");
+  if (error?.kind === "error") {
+    assertStringIncludes(error.error.message, "vaults");
+  }
+  assertEquals(deps.written, null);
+});
+
+Deno.test("sourceAdd: rejection does NOT leak all kinds when --only is set", async () => {
+  const deps = createTestDeps({ resolveKinds: () => [] });
+  const events = await collectEvents(
+    sourceAdd(ctx, deps, "/src", ["vaults"]),
+  );
+
+  const error = findError(events);
+  if (error?.kind === "error") {
+    // Only the requested kind should appear in the "expected" list.
+    // Avoids a confusing message that suggests all kinds are expected
+    // when the user explicitly narrowed via --only.
+    const msg = error.error.message;
+    // vaults is in the list
+    assertStringIncludes(msg, "vaults");
+    // The message should NOT enumerate the unrequested kinds.
+    assertEquals(msg.includes("models"), false);
+    assertEquals(msg.includes("drivers"), false);
+  }
+});
+
+// ----------------------------------------------------------------
+// Glob semantics: unexpanded allowed, expanded-but-empty rejected,
+// expanded-with-content accepted.
+// ----------------------------------------------------------------
+
+Deno.test("sourceAdd: allows unexpanded glob (pre-population workflow)", async () => {
+  const deps = createTestDeps({
+    resolveKinds: () => [], // no kinds (glob hasn't matched anything yet)
+    expandSource: () => [], // zero expansions
+  });
+  const events = await collectEvents(
+    sourceAdd(ctx, deps, "/prefix/*"),
+  );
+
+  const completed = findCompleted(events);
+  assertEquals(
+    completed?.kind,
+    "completed",
+    "unexpanded glob should be allowed",
+  );
+  assertEquals(deps.written?.sources[0].path, "/prefix/*");
+});
+
+Deno.test("sourceAdd: rejects glob with expansions but zero kinds", async () => {
+  const deps = createTestDeps({
+    resolveKinds: () => [],
+    expandSource: () => [
+      { path: "/matched/a" },
+      { path: "/matched/b" },
+    ],
+  });
+  const events = await collectEvents(
+    sourceAdd(ctx, deps, "/matched/*"),
+  );
+
+  const error = findError(events);
+  assertEquals(error?.kind, "error");
+  if (error?.kind === "error") {
+    assertStringIncludes(error.error.message, "glob");
+    assertStringIncludes(error.error.message, "2");
+  }
+  assertEquals(deps.written, null);
+});
+
+Deno.test("sourceAdd: accepts glob when at least one expansion contributes kinds", async () => {
+  const deps = createTestDeps({
+    resolveKinds: () => ["models"],
+    expandSource: () => [
+      { path: "/matched/a" },
+      { path: "/matched/b" },
+      { path: "/matched/c" },
+    ],
+  });
+  const events = await collectEvents(
+    sourceAdd(ctx, deps, "/matched/*"),
+  );
+
+  const completed = findCompleted(events);
+  assertEquals(completed?.kind, "completed");
+});
+
+// ----------------------------------------------------------------
+// End-to-end integration with the real resolver (temp-dir fixtures).
+// These exercise the full path from sourceAdd → resolveExtensionKinds
+// ForSource → both layouts, ensuring the unit-level fakes above agree
+// with real filesystem behaviour.
+// ----------------------------------------------------------------
+
+import { createSourceAddDeps } from "./add.ts";
+
+async function withTempRepo(
+  fn: (repoDir: string) => Promise<void>,
+): Promise<void> {
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_sa_" });
+  try {
+    await fn(tmp);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+}
+
+Deno.test("sourceAdd e2e: standard-layout repo with extensions/models/", async () => {
+  await withTempRepo(async (repo) => {
+    const src = join(repo, "src-root");
+    await Deno.mkdir(join(src, "extensions", "models"), { recursive: true });
+    await Deno.writeTextFile(
+      join(src, "extensions", "models", "m.ts"),
+      'export const model = { type: "@r/m" };',
+    );
+    const deps = createSourceAddDeps(repo);
+    const events = await collectEvents(sourceAdd(ctx, deps, src));
+    assertEquals(findCompleted(events)?.kind, "completed");
+  });
+});
+
+Deno.test("sourceAdd e2e: non-standard layout — loose model.ts at root", async () => {
+  await withTempRepo(async (repo) => {
+    const src = join(repo, "loose");
+    await Deno.mkdir(src, { recursive: true });
+    await Deno.writeTextFile(
+      join(src, "m.ts"),
+      'export const model = { type: "@r/m" };',
+    );
+    const deps = createSourceAddDeps(repo);
+    const events = await collectEvents(sourceAdd(ctx, deps, src));
+    assertEquals(findCompleted(events)?.kind, "completed");
+  });
+});
+
+Deno.test("sourceAdd e2e: reporter's case — extensions/models/ as source path", async () => {
+  await withTempRepo(async (repo) => {
+    // Exactly the issue-139 reporter's misconfiguration: user points at
+    // the models dir itself instead of the parent repo root.
+    const src = join(repo, "sister", "extensions", "models");
+    await Deno.mkdir(src, { recursive: true });
+    await Deno.writeTextFile(
+      join(src, "m.ts"),
+      'export const model = { type: "@r/m" };',
+    );
+    const deps = createSourceAddDeps(repo);
+    const events = await collectEvents(sourceAdd(ctx, deps, src));
+    assertEquals(
+      findCompleted(events)?.kind,
+      "completed",
+      "reporter's case should now succeed",
+    );
+  });
+});
+
+Deno.test("sourceAdd e2e: empty directory is rejected", async () => {
+  await withTempRepo(async (repo) => {
+    const src = join(repo, "empty");
+    await Deno.mkdir(src, { recursive: true });
+    const deps = createSourceAddDeps(repo);
+    const events = await collectEvents(sourceAdd(ctx, deps, src));
+    const error = findError(events);
+    assertEquals(error?.kind, "error");
+  });
+});
+
+Deno.test("sourceAdd e2e: --only mismatch against models-only source is rejected", async () => {
+  await withTempRepo(async (repo) => {
+    const src = join(repo, "m-only");
+    await Deno.mkdir(join(src, "extensions", "models"), { recursive: true });
+    const deps = createSourceAddDeps(repo);
+    const events = await collectEvents(
+      sourceAdd(ctx, deps, src, ["vaults"]),
+    );
+    const error = findError(events);
+    assertEquals(error?.kind, "error");
+    if (error?.kind === "error") {
+      assertStringIncludes(error.error.message, "vaults");
+    }
+  });
+});
+
+Deno.test("sourceAdd e2e: mixed layout — standard wins, loose files ignored", async () => {
+  await withTempRepo(async (repo) => {
+    const src = join(repo, "mixed");
+    await Deno.mkdir(join(src, "extensions", "models"), { recursive: true });
+    await Deno.writeTextFile(
+      join(src, "extensions", "models", "m.ts"),
+      'export const model = { type: "@r/m" };',
+    );
+    await Deno.writeTextFile(
+      join(src, "loose.ts"),
+      'export const model = { type: "@r/loose" };',
+    );
+    const deps = createSourceAddDeps(repo);
+    const events = await collectEvents(sourceAdd(ctx, deps, src));
+    // Should succeed — standard layout has content; loose file ignored.
+    assertEquals(findCompleted(events)?.kind, "completed");
+  });
 });

--- a/src/libswamp/sources/list.ts
+++ b/src/libswamp/sources/list.ts
@@ -20,10 +20,15 @@
 import type { LibSwampContext } from "../context.ts";
 import type { SourceListEntry, SourceListEvent } from "./source_events.ts";
 import { isGlobPattern } from "../../domain/repo/swamp_sources.ts";
-import type { SwampSourcesConfig } from "../../domain/repo/swamp_sources.ts";
+import type {
+  ExtensionKind,
+  SwampSource,
+  SwampSourcesConfig,
+} from "../../domain/repo/swamp_sources.ts";
 import {
   expandSourcePaths,
   readSwampSources,
+  resolveExtensionKindsForSource,
 } from "../../infrastructure/persistence/swamp_sources_repository.ts";
 import { expandEnvVars } from "../../infrastructure/persistence/env_path.ts";
 import { isAbsolute, resolve } from "@std/path";
@@ -32,6 +37,8 @@ import { isAbsolute, resolve } from "@std/path";
 export interface SourceListDeps {
   readSources: () => Promise<SwampSourcesConfig | null>;
   repoDir: string;
+  /** Returns the kinds a source contributes. Injectable for unit tests. */
+  resolveKinds: (source: SwampSource) => Promise<ExtensionKind[]>;
 }
 
 /** Wires real infrastructure into SourceListDeps. */
@@ -39,6 +46,7 @@ export function createSourceListDeps(repoDir: string): SourceListDeps {
   return {
     readSources: () => readSwampSources(repoDir),
     repoDir,
+    resolveKinds: (source) => resolveExtensionKindsForSource(source, repoDir),
   };
 }
 
@@ -70,35 +78,52 @@ export async function* sourceList(
 
     try {
       if (isGlobPattern(source.path)) {
-        // Expand glob to get actual directories
         const expanded = await expandSourcePaths(
           { sources: [source] },
           deps.repoDir,
         );
         entry.expandedPaths = expanded.map((s) => s.path);
         if (expanded.length === 0) {
-          entry.status = "no_extensions";
+          // Unexpanded glob — path(s) not yet present on disk.
+          entry.status = "path_not_found";
+        } else {
+          const kinds = await deps.resolveKinds(source);
+          if (kinds.length === 0) {
+            entry.status = "no_extensions";
+          } else {
+            entry.resolvedKinds = kinds;
+          }
         }
       } else {
-        // Single path — check if it exists
         const expandedPath = expandEnvVars(source.path);
         const absolutePath = isAbsolute(expandedPath)
           ? expandedPath
           : resolve(deps.repoDir, expandedPath);
         entry.expandedPaths = [absolutePath];
 
+        let exists = false;
         try {
           const stat = await Deno.stat(absolutePath);
-          if (!stat.isDirectory) {
-            entry.status = "path_not_found";
-          }
+          exists = stat.isDirectory;
         } catch {
+          exists = false;
+        }
+
+        if (!exists) {
           entry.status = "path_not_found";
+        } else {
+          const kinds = await deps.resolveKinds(source);
+          if (kinds.length === 0) {
+            entry.status = "no_extensions";
+          } else {
+            entry.resolvedKinds = kinds;
+          }
         }
       }
     } catch {
-      // Expansion failed (e.g., unset env var in path) — mark as not found
-      // and continue listing remaining sources rather than aborting.
+      // Expansion or resolver threw (e.g., unset env var, unreadable
+      // marker) — surface the source but mark it missing so the user
+      // sees something went wrong without aborting the rest of the list.
       entry.status = "path_not_found";
     }
 

--- a/src/libswamp/sources/list_test.ts
+++ b/src/libswamp/sources/list_test.ts
@@ -1,0 +1,196 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { createSourceListDeps, sourceList } from "./list.ts";
+import { createLibSwampContext } from "../context.ts";
+import type { SourceListEvent } from "./source_events.ts";
+
+const ctx = createLibSwampContext({});
+
+async function collect(
+  gen: AsyncIterable<SourceListEvent>,
+): Promise<SourceListEvent[]> {
+  const events: SourceListEvent[] = [];
+  for await (const event of gen) events.push(event);
+  return events;
+}
+
+function completedData(events: SourceListEvent[]) {
+  const completed = events.find((e) => e.kind === "completed");
+  if (completed?.kind !== "completed") throw new Error("no completed event");
+  return completed.data;
+}
+
+async function withRepo(fn: (repo: string) => Promise<void>): Promise<void> {
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_list_" });
+  try {
+    await fn(tmp);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+}
+
+async function writeSourcesYaml(repo: string, body: string) {
+  await Deno.writeTextFile(join(repo, ".swamp-sources.yaml"), body);
+}
+
+Deno.test("sourceList: returns empty when no config", async () => {
+  await withRepo(async (repo) => {
+    const deps = createSourceListDeps(repo);
+    const data = completedData(await collect(sourceList(ctx, deps)));
+    assertEquals(data.sources, []);
+  });
+});
+
+Deno.test("sourceList: concrete valid source shows valid + resolvedKinds", async () => {
+  await withRepo(async (repo) => {
+    const src = join(repo, "s");
+    await Deno.mkdir(join(src, "extensions", "models"), { recursive: true });
+    await writeSourcesYaml(repo, `sources:\n  - path: ${src}\n`);
+    const deps = createSourceListDeps(repo);
+    const data = completedData(await collect(sourceList(ctx, deps)));
+    assertEquals(data.sources.length, 1);
+    assertEquals(data.sources[0].status, "valid");
+    assertEquals(data.sources[0].resolvedKinds, ["models"]);
+  });
+});
+
+Deno.test("sourceList: concrete path that exists but resolves to zero kinds → no_extensions", async () => {
+  await withRepo(async (repo) => {
+    const src = join(repo, "empty");
+    await Deno.mkdir(src, { recursive: true });
+    await writeSourcesYaml(repo, `sources:\n  - path: ${src}\n`);
+    const deps = createSourceListDeps(repo);
+    const data = completedData(await collect(sourceList(ctx, deps)));
+    assertEquals(data.sources[0].status, "no_extensions");
+    assertEquals(data.sources[0].resolvedKinds, undefined);
+  });
+});
+
+Deno.test("sourceList: missing path → path_not_found", async () => {
+  await withRepo(async (repo) => {
+    await writeSourcesYaml(
+      repo,
+      `sources:\n  - path: ${repo}/does-not-exist\n`,
+    );
+    const deps = createSourceListDeps(repo);
+    const data = completedData(await collect(sourceList(ctx, deps)));
+    assertEquals(data.sources[0].status, "path_not_found");
+  });
+});
+
+Deno.test("sourceList: glob that matches nothing → path_not_found", async () => {
+  await withRepo(async (repo) => {
+    await writeSourcesYaml(
+      repo,
+      `sources:\n  - path: ${repo}/no-match/*\n`,
+    );
+    const deps = createSourceListDeps(repo);
+    const data = completedData(await collect(sourceList(ctx, deps)));
+    assertEquals(data.sources[0].status, "path_not_found");
+  });
+});
+
+Deno.test("sourceList: glob expanding to dirs with no kinds → no_extensions", async () => {
+  await withRepo(async (repo) => {
+    await Deno.mkdir(join(repo, "parent", "a"), { recursive: true });
+    await Deno.mkdir(join(repo, "parent", "b"), { recursive: true });
+    await writeSourcesYaml(
+      repo,
+      `sources:\n  - path: ${repo}/parent/*\n`,
+    );
+    const deps = createSourceListDeps(repo);
+    const data = completedData(await collect(sourceList(ctx, deps)));
+    assertEquals(data.sources[0].status, "no_extensions");
+  });
+});
+
+Deno.test("sourceList: glob with mixed expansions (1 valid of 3) → valid + resolvedKinds union", async () => {
+  await withRepo(async (repo) => {
+    const parent = join(repo, "mixed");
+    await Deno.mkdir(join(parent, "empty1"), { recursive: true });
+    await Deno.mkdir(join(parent, "empty2"), { recursive: true });
+    await Deno.mkdir(join(parent, "good", "extensions", "vaults"), {
+      recursive: true,
+    });
+    await writeSourcesYaml(
+      repo,
+      `sources:\n  - path: ${parent}/*\n`,
+    );
+    const deps = createSourceListDeps(repo);
+    const data = completedData(await collect(sourceList(ctx, deps)));
+    assertEquals(data.sources[0].status, "valid");
+    assertEquals(data.sources[0].resolvedKinds, ["vaults"]);
+  });
+});
+
+Deno.test("sourceList: non-standard layout (content pre-scan) shows resolvedKinds", async () => {
+  await withRepo(async (repo) => {
+    const src = join(repo, "loose");
+    await Deno.mkdir(src, { recursive: true });
+    await Deno.writeTextFile(
+      join(src, "m.ts"),
+      'export const model = { type: "@r/m" };',
+    );
+    await writeSourcesYaml(repo, `sources:\n  - path: ${src}\n`);
+    const deps = createSourceListDeps(repo);
+    const data = completedData(await collect(sourceList(ctx, deps)));
+    assertEquals(data.sources[0].status, "valid");
+    assertEquals(data.sources[0].resolvedKinds, ["models"]);
+  });
+});
+
+Deno.test("sourceList: resolvedKinds is sorted by EXTENSION_KINDS declaration order", async () => {
+  await withRepo(async (repo) => {
+    const src = join(repo, "multi");
+    // Create in reverse declaration order to force sorting.
+    for (const k of ["workflows", "reports", "vaults", "models"]) {
+      await Deno.mkdir(join(src, "extensions", k), { recursive: true });
+    }
+    await writeSourcesYaml(repo, `sources:\n  - path: ${src}\n`);
+    const deps = createSourceListDeps(repo);
+    const data = completedData(await collect(sourceList(ctx, deps)));
+    assertEquals(data.sources[0].resolvedKinds, [
+      "models",
+      "vaults",
+      "reports",
+      "workflows",
+    ]);
+  });
+});
+
+Deno.test("sourceList: preserves existing fields (path, only, expandedPaths, status)", async () => {
+  await withRepo(async (repo) => {
+    const src = join(repo, "good");
+    await Deno.mkdir(join(src, "extensions", "models"), { recursive: true });
+    await writeSourcesYaml(
+      repo,
+      `sources:\n  - path: ${src}\n    only: [models]\n`,
+    );
+    const deps = createSourceListDeps(repo);
+    const data = completedData(await collect(sourceList(ctx, deps)));
+    const entry = data.sources[0];
+    assertEquals(entry.path, src);
+    assertEquals(entry.only, ["models"]);
+    assertEquals(entry.expandedPaths.length, 1);
+    assertEquals(entry.status, "valid");
+  });
+});

--- a/src/libswamp/sources/source_events.ts
+++ b/src/libswamp/sources/source_events.ts
@@ -40,6 +40,14 @@ export interface SourceListEntry {
   only?: ExtensionKind[];
   expandedPaths: string[];
   status: "valid" | "path_not_found" | "no_extensions";
+  /**
+   * Extension kinds this source contributes, determined by the same
+   * resolver used at load time. Populated when status is `valid`. Sorted
+   * by EXTENSION_KINDS declaration-order index so JSON output and test
+   * assertions are stable. Optional for backwards compatibility — JSON
+   * consumers that predate this field keep working.
+   */
+  resolvedKinds?: ExtensionKind[];
 }
 
 /** Data returned by the source list operation. */

--- a/src/presentation/renderers/extension_source_list.ts
+++ b/src/presentation/renderers/extension_source_list.ts
@@ -59,10 +59,17 @@ class LogSourceListRenderer implements Renderer<SourceListEvent> {
             writeOutput(red("    path not found"));
           } else if (source.status === "no_extensions") {
             writeOutput(yellow("    no extensions found"));
-          } else if (source.expandedPaths.length > 1) {
-            writeOutput(
-              dim(`    ${source.expandedPaths.length} extension roots`),
-            );
+          } else {
+            if (source.resolvedKinds && source.resolvedKinds.length > 0) {
+              writeOutput(
+                dim(`    kinds: ${source.resolvedKinds.join(", ")}`),
+              );
+            }
+            if (source.expandedPaths.length > 1) {
+              writeOutput(
+                dim(`    ${source.expandedPaths.length} extension roots`),
+              );
+            }
           }
         }
       },

--- a/src/presentation/renderers/extension_source_list_test.ts
+++ b/src/presentation/renderers/extension_source_list_test.ts
@@ -1,0 +1,154 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { createSourceListRenderer } from "./extension_source_list.ts";
+
+/**
+ * Captures `console.log` output across a callback. Strips ANSI colour
+ * codes so assertions stay stable regardless of terminal. `writeOutput`
+ * from the logger module wraps `console.log` directly — swapping the
+ * global is the lightest-weight spy for these renderer tests.
+ */
+async function captureLog(fn: () => Promise<void> | void): Promise<string[]> {
+  const lines: string[] = [];
+  const originalLog = console.log;
+  console.log = (...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  };
+  try {
+    await fn();
+  } finally {
+    console.log = originalLog;
+  }
+  // Strip ANSI sequences.
+  // deno-lint-ignore no-control-regex
+  const ansi = /\x1b\[[0-9;]*m/g;
+  return lines.map((l) => l.replace(ansi, ""));
+}
+
+Deno.test("extension_source_list renderer: shows kinds line for valid source", async () => {
+  const renderer = createSourceListRenderer("log");
+  const handlers = renderer.handlers();
+  const lines = await captureLog(() => {
+    handlers.completed({
+      kind: "completed",
+      data: {
+        sources: [
+          {
+            path: "/a",
+            expandedPaths: ["/a"],
+            status: "valid",
+            resolvedKinds: ["models", "workflows"],
+          },
+        ],
+      },
+    });
+  });
+  const joined = lines.join("\n");
+  assertStringIncludes(joined, "/a");
+  assertStringIncludes(joined, "kinds: models, workflows");
+});
+
+Deno.test("extension_source_list renderer: omits kinds line when resolvedKinds is empty/absent", async () => {
+  const renderer = createSourceListRenderer("log");
+  const handlers = renderer.handlers();
+  const lines = await captureLog(() => {
+    handlers.completed({
+      kind: "completed",
+      data: {
+        sources: [
+          {
+            path: "/b",
+            expandedPaths: ["/b"],
+            status: "valid",
+          },
+        ],
+      },
+    });
+  });
+  const joined = lines.join("\n");
+  assertStringIncludes(joined, "/b");
+  assertEquals(joined.includes("kinds:"), false);
+});
+
+Deno.test("extension_source_list renderer: shows 'no extensions found' for no_extensions status", async () => {
+  const renderer = createSourceListRenderer("log");
+  const handlers = renderer.handlers();
+  const lines = await captureLog(() => {
+    handlers.completed({
+      kind: "completed",
+      data: {
+        sources: [
+          {
+            path: "/c",
+            expandedPaths: ["/c"],
+            status: "no_extensions",
+          },
+        ],
+      },
+    });
+  });
+  const joined = lines.join("\n");
+  assertStringIncludes(joined, "no extensions found");
+});
+
+Deno.test("extension_source_list renderer: shows 'path not found' for path_not_found status", async () => {
+  const renderer = createSourceListRenderer("log");
+  const handlers = renderer.handlers();
+  const lines = await captureLog(() => {
+    handlers.completed({
+      kind: "completed",
+      data: {
+        sources: [
+          {
+            path: "/d",
+            expandedPaths: ["/d"],
+            status: "path_not_found",
+          },
+        ],
+      },
+    });
+  });
+  const joined = lines.join("\n");
+  assertStringIncludes(joined, "path not found");
+});
+
+Deno.test("extension_source_list renderer: JSON mode passes resolvedKinds through", async () => {
+  const renderer = createSourceListRenderer("json");
+  const handlers = renderer.handlers();
+  const lines = await captureLog(() => {
+    handlers.completed({
+      kind: "completed",
+      data: {
+        sources: [
+          {
+            path: "/e",
+            expandedPaths: ["/e"],
+            status: "valid",
+            resolvedKinds: ["models"],
+          },
+        ],
+      },
+    });
+  });
+  const joined = lines.join("\n");
+  const parsed = JSON.parse(joined);
+  assertEquals(parsed.sources[0].resolvedKinds, ["models"]);
+});


### PR DESCRIPTION
## Summary

- `swamp extension source add` silently accepted any directory path and treated paths lacking the `extensions/<kind>/` layout as no-ops. Fixes the silent failure by adding a content pre-scan fallback and fail-fast add-time validation.
- User extensions bringing their own zod instance (via their own `deno.json`) no longer trip `instanceof z.ZodType` equality checks — swapped six sites for a shared duck-typed helper.
- Addresses swamp-club#139.

## What changed

**Resolution (`resolveSourceExtensionDirs`, new `resolveExtensionKindsForSource`):**
- Standard layout (`<path>/extensions/<kind>/`) probed first. If it yields any known kind, behaviour is byte-for-byte identical to before (pinned by a snapshot test).
- When standard yields zero kinds, a content pre-scan walks the source path (depth 4, skip `node_modules`/`.git`/`_*`), reads each `.ts` file's header (≤64 KiB), and routes kinds by export name via a shared `detectKindFromSource` helper. YAML files with top-level `jobs:` count as workflows.
- Standard-layout precedence rule: when both layouts coexist, the subdir layout wins so transitional repos don't double-load.

**Validation (`sourceAdd`):**
- Fails fast on concrete paths contributing zero kinds, naming the kinds probed (so `--only` mismatches are self-diagnosable).
- Unexpanded globs still succeed so pre-population workflows continue to work.
- `SourceAddDeps` / `SourceListDeps` gained `repoDir` + injected resolver fields (symmetric with each other).

**Zod duck-type (`isZodSchemaLike`):**
- Six `val instanceof z.ZodType` call sites now use a duck-typed check (`_def` + `parse` + `safeParse`). Strictly looser than `instanceof` — anything that validated before still validates.

**List + renderer:**
- `SourceListEntry` gains an optional `resolvedKinds` field.
- Status logic: `valid` | `no_extensions` | `path_not_found`.
- Log renderer shows `kinds: ...` line for valid sources; JSON renderer passes the new field through unchanged.

**Docs:**
- `.claude/skills/swamp-repo/SKILL.md` and `.claude/skills/swamp-extension-model/SKILL.md` describe both layouts and the new add-time validation.
- CLI `--help` examples + description updated to match.

## Breaking changes to flag

These are all deliberate — the previous behaviour was the bug — but name them explicitly so a reviewer doesn't discover them by surprise:

1. **`swamp extension source add` now rejects empty or content-less paths.** Automation that called `add` expecting unconditional success will fail.
2. **Sources with loose extension files at the root now load those files.** If anyone has a legacy source path with unintended `.ts` files that export `model`/`vault`/etc., those files will register where they previously did not.
3. **`swamp extension source list` may show `status: no_extensions` for pre-existing misconfigured sources** that used to show `valid`.
4. **`SourceAddDeps` / `SourceListDeps` gained required fields.** Affects only external libswamp consumers that construct these interfaces manually.

## Testing

- `deno check` / `deno lint` / `deno fmt --check` — clean.
- `deno run test` — 4560 passed / 0 failed (+7 new `zod_compat_test.ts`, +27 new tests across sources/list/renderer).
- `deno run compile` — binary rebuilt.
- Snapshot test (7 fixtures) pins load-time behaviour across the `readSourceMarker` extraction.
- Parity test (6 fixtures) ensures `resolveExtensionKindsForSource` and `resolveSourceExtensionDirs` agree on which kinds a source contributes.
- Scripted verification harness: 19 rows (7 regression + 12 new-behaviour) against the compiled binary — all green.
- Reporter's original `/tmp/swamp-repro-issue-139` scenario (zod 3 in sister repo, pointing at bare `extensions/models/` dir) end-to-end: source accepted, model discoverable via `type search`, describable via `type describe`.

## Test plan

- [ ] CI green on Claude review + build.
- [ ] Verify `swamp extension source list --json` on an existing-configured repo still includes `path`, `status`, `expandedPaths` (new `resolvedKinds` field is additive).
- [ ] Manually confirm a standard-layout source still loads identically post-merge.

## Post-merge follow-ups

- File a swamp-uat issue covering the new error/list assertions and the non-standard-layout contract (tracked).
- Optional polish: better error message when `deno bundle` fails for a source with bare `zod` imports and no `deno.json` — currently surfaces as `bundling failed`, which is honest but could be friendlier. Lower priority now that the zod-mismatch class is fixed by the duck-type check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)