### PR TITLE
fix(extensions): address CLI UX and pre-scan review on source resolution

### DIFF
--- a/src/cli/commands/extension_source_add.ts
+++ b/src/cli/commands/extension_source_add.ts
@@ -40,20 +40,19 @@ type AnyOptions = any;
 export const extensionSourceAddCommand = new Command()
   .name("add")
   .description(
-    "Add a local extension source. Path may be a repo root with " +
-      "extensions/<kind>/ subdirs or a dir containing extension files directly.",
+    "Add a local extension source (standard or direct-content layout).",
   )
   .example(
-    "Repo root with extensions/<kind>/ subdirs",
-    "swamp extension source add ~/code/swamp-extensions/model/aws/ec2",
+    "Standard layout (path contains extensions/<kind>/ subdirs)",
+    "swamp extension source add ~/code/my-swamp-extensions",
   )
   .example(
     "Glob across sibling extension roots",
-    'swamp extension source add "~/code/swamp-extensions/model/aws/*"',
+    'swamp extension source add "~/code/my-swamp-extensions/*"',
   )
   .example(
-    "Directory containing extension files directly (any layout)",
-    "swamp extension source add ~/code/my-extensions/vault",
+    "Direct-content layout (path holds extension files directly)",
+    "swamp extension source add ~/code/my-vault-prototype",
   )
   .example(
     "Restrict to a single extension kind",

--- a/src/infrastructure/persistence/swamp_sources_repository.ts
+++ b/src/infrastructure/persistence/swamp_sources_repository.ts
@@ -253,13 +253,16 @@ async function contentPreScan(
       // Secondary skip for well-known dirs that the regex-based skip above
       // can't express cleanly. walk doesn't drop the dir itself; it emits
       // files underneath. Cheaper to filter on the path.
-      if (
-        [...PRE_SCAN_SKIP_DIRS].some((d) =>
+      let inSkipDir = false;
+      for (const d of PRE_SCAN_SKIP_DIRS) {
+        if (
           entry.path.includes(`/${d}/`) || entry.path.endsWith(`/${d}`)
-        )
-      ) {
-        continue;
+        ) {
+          inSkipDir = true;
+          break;
+        }
       }
+      if (inSkipDir) continue;
 
       if (entry.isFile && entry.name.endsWith(".ts")) {
         if (entry.name.endsWith("_test.ts")) continue;
@@ -289,6 +292,13 @@ async function contentPreScan(
       ) {
         if (found.has("workflows")) continue;
         try {
+          // Size cap mirrors the .ts branch above. Legitimate workflow
+          // YAML files are small; this guards against a source dir that
+          // happens to contain large YAML data fixtures (e.g. generated
+          // dumps) that would otherwise be read fully into memory before
+          // `parseYaml` could reject them.
+          const yamlStat = await Deno.stat(entry.path);
+          if (yamlStat.size > PRE_SCAN_MAX_BYTES) continue;
           const content = await Deno.readTextFile(entry.path);
           const raw = parseYaml(content);
           if (

--- a/src/infrastructure/persistence/swamp_sources_repository_test.ts
+++ b/src/infrastructure/persistence/swamp_sources_repository_test.ts
@@ -428,6 +428,31 @@ Deno.test("resolveSourceExtensionDirs snapshot: non-standard layout via content 
   }
 });
 
+Deno.test("resolveSourceExtensionDirs: large YAML file is skipped during pre-scan (no OOM)", async () => {
+  // Guards the content pre-scan from OOM on source dirs that happen to
+  // hold large YAML data fixtures. Legitimate workflow YAML is small;
+  // anything over the 64 KiB cap is skipped without being read into
+  // memory or parsed.
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_yaml_cap_" });
+  try {
+    const src = join(tmp, "pipeline");
+    await Deno.mkdir(src, { recursive: true });
+    // Build a 128 KiB YAML that WOULD parse as a workflow (has top-level
+    // jobs:) but should be skipped by the size guard.
+    const padding = "x: ".repeat(30_000);
+    await Deno.writeTextFile(
+      join(src, "big-fixture.yaml"),
+      `${padding}\njobs:\n  one:\n    steps: []\n`,
+    );
+    const result = await resolveSourceExtensionDirs([{ path: src }]);
+    // Because the large YAML was skipped, the source contributes no
+    // kinds — no workflow detected.
+    assertEquals(result[0].workflowsDir, undefined);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
 // -----------------------------------------------------------------
 // Parity test: resolveExtensionKindsForSource must agree with
 // resolveSourceExtensionDirs about which kinds a source contributes.

--- a/src/libswamp/sources/add.ts
+++ b/src/libswamp/sources/add.ts
@@ -21,6 +21,7 @@ import type { LibSwampContext } from "../context.ts";
 import { alreadyExists, validationFailed } from "../errors.ts";
 import type { SourceModifyEvent } from "./source_events.ts";
 import {
+  EXTENSION_KINDS,
   type ExtensionKind,
   isGlobPattern,
   type SwampSource,
@@ -110,14 +111,7 @@ export async function* sourceAdd(
       }
       // Unexpanded glob → allow (pre-population workflow).
     } else {
-      const probed = only ?? [
-        "models",
-        "vaults",
-        "drivers",
-        "datastores",
-        "reports",
-        "workflows",
-      ];
+      const probed = only ?? EXTENSION_KINDS;
       yield {
         kind: "error",
         error: validationFailed(

--- a/src/presentation/renderers/extension_source_list.ts
+++ b/src/presentation/renderers/extension_source_list.ts
@@ -57,8 +57,18 @@ class LogSourceListRenderer implements Renderer<SourceListEvent> {
 
           if (source.status === "path_not_found") {
             writeOutput(red("    path not found"));
+            writeOutput(
+              dim(
+                `    Run 'swamp extension source rm ${source.path}' or fix the path.`,
+              ),
+            );
           } else if (source.status === "no_extensions") {
             writeOutput(yellow("    no extensions found"));
+            writeOutput(
+              dim(
+                `    Add extension files to the path, or run 'swamp extension source rm ${source.path}'.`,
+              ),
+            );
           } else {
             if (source.resolvedKinds && source.resolvedKinds.length > 0) {
               writeOutput(

--- a/src/presentation/renderers/extension_source_list_test.ts
+++ b/src/presentation/renderers/extension_source_list_test.ts
@@ -88,7 +88,7 @@ Deno.test("extension_source_list renderer: omits kinds line when resolvedKinds i
   assertEquals(joined.includes("kinds:"), false);
 });
 
-Deno.test("extension_source_list renderer: shows 'no extensions found' for no_extensions status", async () => {
+Deno.test("extension_source_list renderer: no_extensions status shows message + remediation hint", async () => {
   const renderer = createSourceListRenderer("log");
   const handlers = renderer.handlers();
   const lines = await captureLog(() => {
@@ -107,9 +107,11 @@ Deno.test("extension_source_list renderer: shows 'no extensions found' for no_ex
   });
   const joined = lines.join("\n");
   assertStringIncludes(joined, "no extensions found");
+  // Remediation hint so users know how to recover without consulting docs.
+  assertStringIncludes(joined, "swamp extension source rm /c");
 });
 
-Deno.test("extension_source_list renderer: shows 'path not found' for path_not_found status", async () => {
+Deno.test("extension_source_list renderer: path_not_found status shows message + remediation hint", async () => {
   const renderer = createSourceListRenderer("log");
   const handlers = renderer.handlers();
   const lines = await captureLog(() => {
@@ -128,6 +130,7 @@ Deno.test("extension_source_list renderer: shows 'path not found' for path_not_f
   });
   const joined = lines.join("\n");
   assertStringIncludes(joined, "path not found");
+  assertStringIncludes(joined, "swamp extension source rm /d");
 });
 
 Deno.test("extension_source_list renderer: JSON mode passes resolvedKinds through", async () => {


### PR DESCRIPTION
Follow-up to #1202 addressing review feedback on the extension-source resolver fix.

## Summary

- Clearer `--help` labels and a shorter description on `swamp extension source add`.
- Remediation hints on `swamp extension source list` for `path_not_found` and `no_extensions` statuses (the latter newly surfaces for pre-existing misconfigured sources after #1202).
- Use `EXTENSION_KINDS` from the domain module instead of a hardcoded list in the `sourceAdd` error path.
- Avoid spreading `PRE_SCAN_SKIP_DIRS` Set into a fresh array per walk entry in `contentPreScan`.
- Cap YAML reads in `contentPreScan` by `Deno.stat` size check, mirroring the `.ts` handling, so a source dir containing a large YAML data fixture can't OOM the pre-scan.

## What changed

- **`src/cli/commands/extension_source_add.ts`**
  - `.description()` reduced to one scannable line: "Add a local extension source (standard or direct-content layout)."
  - `.example()` labels conveys the layout; paths swapped to ones that don't contradict the label (first example now points at a repo dir, not a leaf like `.../aws/ec2`).
- **`src/presentation/renderers/extension_source_list.ts`** (+test)
  - `path_not_found` and `no_extensions` entries now emit a one-line `dim()` hint pointing at `swamp extension source rm <path>` so users can recover without docs.
- **`src/libswamp/sources/add.ts`**
  - Imports `EXTENSION_KINDS` and uses it in the "no extensions" error message instead of a duplicated array literal.
- **`src/infrastructure/persistence/swamp_sources_repository.ts`** (+test)
  - `contentPreScan` iterates `PRE_SCAN_SKIP_DIRS` with a `for...of` loop, avoiding per-entry array allocation.
  - YAML branch `Deno.stat`s the file and skips it when size exceeds `PRE_SCAN_MAX_BYTES`, mirroring the `.ts` branch.

## Testing

- `deno check` / `deno lint` / `deno fmt --check` — clean.
- `deno run test` — 4561 passed / 0 failed (+1 YAML cap test).
- `deno run compile` — binary rebuilt.
- Verification harness (`/tmp/v139-verify.sh` from #1202) — 19/19 still green. Confirms no regression to the behaviour that #1202 introduced.
- Manually confirmed `--help` renders as a single-line description with the updated examples.

## Test plan

- [ ] CI green.
- [ ] Spot-check `swamp extension source list` output on a repo with at least one intentionally-broken source path — should see the new remediation hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)