### PR TITLE
feat(extensions): add extension unyank command and clarify yank scope (swamp-club#140)

### DIFF
--- a/src/cli/commands/extension.ts
+++ b/src/cli/commands/extension.ts
@@ -28,6 +28,7 @@ import { extensionSearchCommand } from "./extension_search.ts";
 import { extensionUpdateCommand } from "./extension_update.ts";
 import { extensionVersionCommand } from "./extension_version.ts";
 import { extensionYankCommand } from "./extension_yank.ts";
+import { extensionUnyankCommand } from "./extension_unyank.ts";
 import { extensionTrustCommand } from "./extension_trust.ts";
 import { extensionSourceCommand } from "./extension_source.ts";
 import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
@@ -49,5 +50,6 @@ export const extensionCommand = new Command()
   .command("update", extensionUpdateCommand)
   .command("version", extensionVersionCommand)
   .command("yank", extensionYankCommand)
+  .command("unyank", extensionUnyankCommand)
   .command("trust", extensionTrustCommand)
   .command("source", extensionSourceCommand);

--- a/src/cli/commands/extension_unyank.ts
+++ b/src/cli/commands/extension_unyank.ts
@@ -1,0 +1,89 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  consumeStream,
+  createExtensionUnyankDeps,
+  createLibSwampContext,
+  extensionUnyank,
+  extensionUnyankPreview,
+} from "../../libswamp/mod.ts";
+import { createExtensionUnyankRenderer } from "../../presentation/renderers/extension_unyank.ts";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { UserError } from "../../domain/errors.ts";
+import { parseExtensionRef } from "./extension_pull.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const extensionUnyankCommand = new Command()
+  .name("unyank")
+  .description(
+    "Unyank an extension or specific version, restoring availability",
+  )
+  .example(
+    "Unyank an extension",
+    `swamp extension unyank @stack72/aws-ec2 --reason "accidental yank"`,
+  )
+  .example(
+    "Unyank specific version",
+    `swamp extension unyank @stack72/aws-ec2 2026.3.1`,
+  )
+  .arguments("<extension:string> [version:string]")
+  .option("--reason <reason:string>", "Optional reason (audit log only)")
+  .action(async function (
+    options: AnyOptions,
+    extension: string,
+    version?: string,
+  ) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "extension",
+      "unyank",
+    ]);
+    cliCtx.logger.debug`Starting extension unyank`;
+
+    const ref = parseExtensionRef(extension);
+    const resolvedVersion = version ?? ref.version ?? null;
+
+    const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = createExtensionUnyankDeps();
+    const input = {
+      extensionName: ref.name,
+      version: resolvedVersion,
+      reason: (options.reason as string | undefined) ?? null,
+    };
+
+    try {
+      await extensionUnyankPreview(ctx, deps, input);
+    } catch (error) {
+      if ("code" in (error as Record<string, unknown>)) {
+        throw new UserError((error as { message: string }).message);
+      }
+      throw error;
+    }
+
+    const renderer = createExtensionUnyankRenderer(cliCtx.outputMode);
+    await consumeStream(
+      extensionUnyank(ctx, deps, input),
+      renderer.handlers(),
+    );
+
+    cliCtx.logger.debug("Extension unyank command completed");
+  });

--- a/src/cli/commands/extension_yank.ts
+++ b/src/cli/commands/extension_yank.ts
@@ -52,13 +52,15 @@ async function promptConfirmation(message: string): Promise<boolean> {
 
 export const extensionYankCommand = new Command()
   .name("yank")
-  .description("Yank an extension or specific version from the registry")
+  .description(
+    "Yank an extension or specific version from the registry. Use `swamp extension unyank` to reverse.",
+  )
   .example(
-    "Yank all versions",
+    "Yank every version (blocks all future pushes until unyanked)",
     `swamp extension yank @stack72/aws-ec2 --reason "security issue"`,
   )
   .example(
-    "Yank specific version",
+    "Yank one version (future versions can still be pushed)",
     `swamp extension yank @stack72/aws-ec2 2026.3.1 --reason "broken release"`,
   )
   .arguments("<extension:string> [version:string]")
@@ -100,12 +102,10 @@ export const extensionYankCommand = new Command()
 
     // Phase 2: Confirmation prompt (log mode only, unless --yes)
     if (cliCtx.outputMode === "log" && !options.yes) {
-      const target = preview.version
-        ? `${preview.extensionName}@${preview.version}`
-        : `${preview.extensionName} (all versions)`;
-      const confirmed = await promptConfirmation(
-        `Yank ${target}? This will remove it from the registry.`,
-      );
+      const prompt = preview.version
+        ? `Yank ${preview.extensionName}@${preview.version}? This will mark it yanked.`
+        : `Yank ALL versions of ${preview.extensionName}? Future pushes will be blocked until you run \`swamp extension unyank\`.`;
+      const confirmed = await promptConfirmation(prompt);
       if (!confirmed) {
         renderExtensionYankCancelled(cliCtx.outputMode);
         return;

--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -104,6 +104,11 @@ export interface YankResult {
   message: string;
 }
 
+/** Response from the unyank endpoint. */
+export interface UnyankResult {
+  message: string;
+}
+
 /**
  * HTTP client for the swamp-club extension registry API.
  *
@@ -395,6 +400,38 @@ export class ExtensionApiClient {
       body: JSON.stringify({ reason }),
     });
 
+    await this.checkResponse(res);
+    return await res.json();
+  }
+
+  /**
+   * Unyank an extension or a specific version, restoring availability.
+   * When reason is null, the request is sent with no body — the server
+   * accepts an empty POST and logs the unyank without a reason.
+   */
+  async unyankExtension(
+    name: string,
+    version: string | null,
+    reason: string | null,
+    apiKey: string,
+  ): Promise<UnyankResult> {
+    const encodedName = encodeURIComponent(name);
+    const path = version
+      ? `/api/v1/extensions/${encodedName}@${version}/unyank`
+      : `/api/v1/extensions/${encodedName}/unyank`;
+
+    const init: RequestInit = reason === null
+      ? { method: "POST", headers: this.authHeaders(apiKey) }
+      : {
+        method: "POST",
+        headers: {
+          ...this.authHeaders(apiKey),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ reason }),
+      };
+
+    const res = await this.fetch(path, init);
     await this.checkResponse(res);
     return await res.json();
   }

--- a/src/infrastructure/http/extension_api_client_test.ts
+++ b/src/infrastructure/http/extension_api_client_test.ts
@@ -350,3 +350,136 @@ Deno.test("ExtensionApiClient.yankExtension throws UserError on connection failu
   );
   assertStringIncludes(error.message, "Could not connect");
 });
+
+Deno.test("ExtensionApiClient.unyankExtension sends POST with reason to version unyank endpoint", async () => {
+  let capturedUrl = "";
+  let capturedMethod = "";
+  let capturedBody = "";
+  let capturedAuth = "";
+  let capturedContentType = "";
+  const server = Deno.serve({ port: 0, onListen: () => {} }, async (req) => {
+    capturedUrl = req.url;
+    capturedMethod = req.method;
+    capturedAuth = req.headers.get("x-api-key") ?? "";
+    capturedContentType = req.headers.get("content-type") ?? "";
+    capturedBody = await req.text();
+    return new Response(
+      JSON.stringify({ message: "Unyanked @test/ext@2026.02.26.1" }),
+      { headers: { "content-type": "application/json" } },
+    );
+  });
+  const addr = server.addr;
+  const client = new ExtensionApiClient(`http://localhost:${addr.port}`);
+  const result = await client.unyankExtension(
+    "@test/ext",
+    "2026.02.26.1",
+    "Mistake yank",
+    "swamp_fake-key",
+  );
+  const url = new URL(capturedUrl);
+  assertEquals(capturedMethod, "POST");
+  assertEquals(
+    url.pathname,
+    "/api/v1/extensions/%40test%2Fext@2026.02.26.1/unyank",
+  );
+  assertEquals(capturedAuth, "swamp_fake-key");
+  assertEquals(capturedContentType, "application/json");
+  assertEquals(JSON.parse(capturedBody).reason, "Mistake yank");
+  assertStringIncludes(result.message, "Unyanked");
+  await server.shutdown();
+});
+
+Deno.test("ExtensionApiClient.unyankExtension sends POST to extension unyank endpoint when no version", async () => {
+  let capturedUrl = "";
+  const server = Deno.serve({ port: 0, onListen: () => {} }, (_req) => {
+    capturedUrl = _req.url;
+    return new Response(
+      JSON.stringify({ message: "Unyanked @test/ext" }),
+      { headers: { "content-type": "application/json" } },
+    );
+  });
+  const addr = server.addr;
+  const client = new ExtensionApiClient(`http://localhost:${addr.port}`);
+  await client.unyankExtension(
+    "@test/ext",
+    null,
+    "restoring name",
+    "swamp_fake-key",
+  );
+  const url = new URL(capturedUrl);
+  assertEquals(url.pathname, "/api/v1/extensions/%40test%2Fext/unyank");
+  await server.shutdown();
+});
+
+Deno.test("ExtensionApiClient.unyankExtension sends POST with no body and no Content-Type when reason is null", async () => {
+  let capturedBody = "";
+  let capturedContentType: string | null = "";
+  const server = Deno.serve({ port: 0, onListen: () => {} }, async (req) => {
+    capturedContentType = req.headers.get("content-type");
+    capturedBody = await req.text();
+    return new Response(
+      JSON.stringify({ message: "Unyanked @test/ext" }),
+      { headers: { "content-type": "application/json" } },
+    );
+  });
+  const addr = server.addr;
+  const client = new ExtensionApiClient(`http://localhost:${addr.port}`);
+  await client.unyankExtension(
+    "@test/ext",
+    null,
+    null,
+    "swamp_fake-key",
+  );
+  assertEquals(capturedBody, "");
+  assertEquals(capturedContentType, null);
+  await server.shutdown();
+});
+
+Deno.test("ExtensionApiClient.unyankExtension throws UserError on 409 not yanked", async () => {
+  const server = Deno.serve({ port: 0, onListen: () => {} }, (_req) => {
+    return new Response(
+      JSON.stringify({ error: "'@test/ext' is not yanked" }),
+      { status: 409, headers: { "content-type": "application/json" } },
+    );
+  });
+  const addr = server.addr;
+  const client = new ExtensionApiClient(`http://localhost:${addr.port}`);
+  const error = await assertRejects(
+    () => client.unyankExtension("@test/ext", null, null, "swamp_fake-key"),
+    UserError,
+  );
+  assertStringIncludes(error.message, "not yanked");
+  await server.shutdown();
+});
+
+Deno.test("ExtensionApiClient.unyankExtension throws UserError on 404 not found", async () => {
+  const server = Deno.serve({ port: 0, onListen: () => {} }, (_req) => {
+    return new Response(
+      JSON.stringify({ error: "Extension '@test/ext' not found" }),
+      { status: 404, headers: { "content-type": "application/json" } },
+    );
+  });
+  const addr = server.addr;
+  const client = new ExtensionApiClient(`http://localhost:${addr.port}`);
+  const error = await assertRejects(
+    () => client.unyankExtension("@test/ext", null, null, "swamp_fake-key"),
+    UserError,
+  );
+  assertStringIncludes(error.message, "not found");
+  await server.shutdown();
+});
+
+Deno.test("ExtensionApiClient.unyankExtension throws UserError on connection failure", async () => {
+  const client = new ExtensionApiClient("http://localhost:1");
+  const error = await assertRejects(
+    () =>
+      client.unyankExtension(
+        "@test/ext",
+        "2026.02.26.1",
+        "reason",
+        "fake-key",
+      ),
+    UserError,
+  );
+  assertStringIncludes(error.message, "Could not connect");
+});

--- a/src/libswamp/extensions/unyank.ts
+++ b/src/libswamp/extensions/unyank.ts
@@ -1,0 +1,162 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
+import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { notAuthenticated, validationFailed } from "../errors.ts";
+
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+const SCOPED_NAME_PATTERN = /^@[a-z0-9_-]+\/[a-z0-9_-]+(\/[a-z0-9_-]+)*$/;
+const DEFAULT_SERVER_URL = "https://swamp.club";
+
+/** Data structure for the extension unyank output. */
+export interface ExtensionUnyankData {
+  name: string;
+  version: string | null;
+  reason: string | null;
+}
+
+export type ExtensionUnyankEvent =
+  | { kind: "completed"; data: ExtensionUnyankData }
+  | { kind: "error"; error: SwampError };
+
+/** Input for the extension unyank operation. */
+export interface ExtensionUnyankInput {
+  extensionName: string;
+  version: string | null;
+  reason: string | null;
+}
+
+/** Preview data returned before executing the mutation. */
+export interface ExtensionUnyankPreview {
+  extensionName: string;
+  version: string | null;
+  reason: string | null;
+}
+
+/** Dependencies for the extension unyank operation. */
+export interface ExtensionUnyankDeps {
+  loadCredentials: () => Promise<
+    { serverUrl: string; apiKey: string } | null
+  >;
+  unyankExtension: (
+    serverUrl: string,
+    name: string,
+    version: string | null,
+    reason: string | null,
+    apiKey: string,
+  ) => Promise<void>;
+}
+
+/** Wires real infrastructure into ExtensionUnyankDeps. */
+export function createExtensionUnyankDeps(): ExtensionUnyankDeps {
+  const authRepo = new AuthRepository();
+  return {
+    loadCredentials: async () => {
+      const creds = await authRepo.load();
+      if (!creds) return null;
+      return {
+        serverUrl: creds.serverUrl ?? resolveServerUrl(),
+        apiKey: creds.apiKey,
+      };
+    },
+    unyankExtension: async (
+      serverUrl: string,
+      name: string,
+      version: string | null,
+      reason: string | null,
+      apiKey: string,
+    ) => {
+      const client = new ExtensionApiClient(serverUrl);
+      await client.unyankExtension(name, version, reason, apiKey);
+    },
+  };
+}
+
+function resolveServerUrl(): string {
+  return Deno.env.get("SWAMP_CLUB_URL") ?? DEFAULT_SERVER_URL;
+}
+
+/** Gathers preview info for the extension unyank operation, validating inputs. */
+export async function extensionUnyankPreview(
+  ctx: LibSwampContext,
+  deps: ExtensionUnyankDeps,
+  input: ExtensionUnyankInput,
+): Promise<ExtensionUnyankPreview> {
+  ctx.logger.debug`Validating extension unyank preview`;
+
+  const credentials = await deps.loadCredentials();
+  if (!credentials) {
+    throw notAuthenticated();
+  }
+
+  if (!SCOPED_NAME_PATTERN.test(input.extensionName)) {
+    throw validationFailed(
+      `Invalid extension name: "${input.extensionName}". Must match @collective/name pattern (lowercase, alphanumeric, hyphens, underscores, additional /segments allowed).`,
+    );
+  }
+
+  return {
+    extensionName: input.extensionName,
+    version: input.version,
+    reason: input.reason,
+  };
+}
+
+/** Unyanks an extension or specific version, restoring availability. */
+export async function* extensionUnyank(
+  ctx: LibSwampContext,
+  deps: ExtensionUnyankDeps,
+  input: ExtensionUnyankInput,
+): AsyncIterable<ExtensionUnyankEvent> {
+  yield* withGeneratorSpan(
+    "swamp.extension.unyank",
+    {},
+    (async function* () {
+      ctx.logger.debug`Executing extension unyank`;
+
+      const credentials = await deps.loadCredentials();
+      if (!credentials) {
+        yield { kind: "error", error: notAuthenticated() };
+        return;
+      }
+
+      await deps.unyankExtension(
+        credentials.serverUrl,
+        input.extensionName,
+        input.version,
+        input.reason,
+        credentials.apiKey,
+      );
+
+      ctx.logger.debug`Unyanked extension ${input.extensionName}`;
+
+      yield {
+        kind: "completed",
+        data: {
+          name: input.extensionName,
+          version: input.version,
+          reason: input.reason,
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/extensions/unyank_test.ts
+++ b/src/libswamp/extensions/unyank_test.ts
@@ -1,0 +1,144 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { assertCompletes, assertErrors } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import {
+  extensionUnyank,
+  type ExtensionUnyankDeps,
+  type ExtensionUnyankEvent,
+  type ExtensionUnyankInput,
+  extensionUnyankPreview,
+} from "./unyank.ts";
+
+function fakeDeps(
+  overrides?: Partial<ExtensionUnyankDeps>,
+): ExtensionUnyankDeps {
+  return {
+    loadCredentials: () =>
+      Promise.resolve({
+        serverUrl: "https://test.club",
+        apiKey: "key-123",
+      }),
+    unyankExtension: () => Promise.resolve(),
+    ...overrides,
+  };
+}
+
+Deno.test("extensionUnyank: unyanks specific version", async () => {
+  const ctx = createLibSwampContext();
+  const deps = fakeDeps();
+  const input: ExtensionUnyankInput = {
+    extensionName: "@test/ext",
+    version: "2025.01",
+    reason: "recovered",
+  };
+  await assertCompletes<ExtensionUnyankEvent>(
+    extensionUnyank(ctx, deps, input),
+    {
+      kind: "completed",
+      data: { name: "@test/ext", version: "2025.01", reason: "recovered" },
+    },
+  );
+});
+
+Deno.test("extensionUnyank: unyanks extension when version is null", async () => {
+  const ctx = createLibSwampContext();
+  const deps = fakeDeps();
+  const input: ExtensionUnyankInput = {
+    extensionName: "@test/ext",
+    version: null,
+    reason: "restoring name",
+  };
+  await assertCompletes<ExtensionUnyankEvent>(
+    extensionUnyank(ctx, deps, input),
+    {
+      kind: "completed",
+      data: { name: "@test/ext", version: null, reason: "restoring name" },
+    },
+  );
+});
+
+Deno.test("extensionUnyank: accepts null reason", async () => {
+  const ctx = createLibSwampContext();
+  const deps = fakeDeps();
+  const input: ExtensionUnyankInput = {
+    extensionName: "@test/ext",
+    version: "2025.01",
+    reason: null,
+  };
+  await assertCompletes<ExtensionUnyankEvent>(
+    extensionUnyank(ctx, deps, input),
+    {
+      kind: "completed",
+      data: { name: "@test/ext", version: "2025.01", reason: null },
+    },
+  );
+});
+
+Deno.test("extensionUnyank: errors when not authenticated", async () => {
+  const ctx = createLibSwampContext();
+  const deps = fakeDeps({
+    loadCredentials: () => Promise.resolve(null),
+  });
+  const input: ExtensionUnyankInput = {
+    extensionName: "@test/ext",
+    version: "2025.01",
+    reason: "recovered",
+  };
+  await assertErrors<ExtensionUnyankEvent>(
+    extensionUnyank(ctx, deps, input),
+    "not_authenticated",
+  );
+});
+
+Deno.test("extensionUnyankPreview: rejects invalid extension name", async () => {
+  const ctx = createLibSwampContext();
+  const deps = fakeDeps();
+  const input: ExtensionUnyankInput = {
+    extensionName: "invalid-name",
+    version: "2025.01",
+    reason: "recovered",
+  };
+  try {
+    await extensionUnyankPreview(ctx, deps, input);
+    throw new Error("Expected to throw");
+  } catch (error) {
+    assertEquals((error as { code: string }).code, "validation_failed");
+  }
+});
+
+Deno.test("extensionUnyankPreview: rejects when not authenticated", async () => {
+  const ctx = createLibSwampContext();
+  const deps = fakeDeps({
+    loadCredentials: () => Promise.resolve(null),
+  });
+  const input: ExtensionUnyankInput = {
+    extensionName: "@test/ext",
+    version: "2025.01",
+    reason: "recovered",
+  };
+  try {
+    await extensionUnyankPreview(ctx, deps, input);
+    throw new Error("Expected to throw");
+  } catch (error) {
+    assertEquals((error as { code: string }).code, "not_authenticated");
+  }
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -549,6 +549,16 @@ export {
   extensionYankPreview,
 } from "./extensions/yank.ts";
 export {
+  createExtensionUnyankDeps,
+  extensionUnyank,
+  type ExtensionUnyankData,
+  type ExtensionUnyankDeps,
+  type ExtensionUnyankEvent,
+  type ExtensionUnyankInput,
+  type ExtensionUnyankPreview,
+  extensionUnyankPreview,
+} from "./extensions/unyank.ts";
+export {
   createExtensionUpdateDeps,
   extensionUpdate,
   type ExtensionUpdateDeps,

--- a/src/presentation/renderers/extension_unyank.ts
+++ b/src/presentation/renderers/extension_unyank.ts
@@ -1,0 +1,75 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type {
+  EventHandlers,
+  ExtensionUnyankEvent,
+} from "../../libswamp/mod.ts";
+import type { Renderer } from "../renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import { UserError } from "../../domain/errors.ts";
+
+class LogExtensionUnyankRenderer implements Renderer<ExtensionUnyankEvent> {
+  handlers(): EventHandlers<ExtensionUnyankEvent> {
+    const logger = getSwampLogger(["extension", "unyank"]);
+    return {
+      completed: (e) => {
+        if (e.data.version) {
+          logger.info("Unyanked {name}@{version}", {
+            name: e.data.name,
+            version: e.data.version,
+          });
+        } else {
+          logger.info("Unyanked {name}", { name: e.data.name });
+        }
+        if (e.data.reason !== null) {
+          logger.info("Reason: {reason}", { reason: e.data.reason });
+        }
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonExtensionUnyankRenderer implements Renderer<ExtensionUnyankEvent> {
+  handlers(): EventHandlers<ExtensionUnyankEvent> {
+    return {
+      completed: (e) => {
+        console.log(JSON.stringify({ unyanked: e.data }, null, 2));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createExtensionUnyankRenderer(
+  mode: OutputMode,
+): Renderer<ExtensionUnyankEvent> {
+  switch (mode) {
+    case "json":
+      return new JsonExtensionUnyankRenderer();
+    case "log":
+      return new LogExtensionUnyankRenderer();
+  }
+}


### PR DESCRIPTION
## Summary

CLI half of [swamp-club#140](https://github.com/systeminit/swamp-club/issues/140). The server half shipped in [systeminit/swamp-club#426](https://github.com/systeminit/swamp-club/pull/426) — version-specific yanks no longer cascade to a full-extension yank, and new `POST /api/v1/extensions/<name>[@<version>]/unyank` endpoints are live.

- **New `swamp extension unyank <name> [version]` command.** Recovery op — no confirmation prompt, `--reason` is optional (server logs it, does not persist).
- **`ExtensionApiClient.unyankExtension`** sends a JSON body when `--reason` is provided; sends no body and no `Content-Type` when it isn't (matches the server spec that allows empty POSTs).
- **Yank help text / prompt clarified** so users understand scope before they pull the trigger. The extension-level confirmation prompt now warns that future pushes will be blocked until `unyank` is run.

## Changes

| File | Change |
|---|---|
| `src/libswamp/extensions/unyank.ts` | **new** — app function, wrapped in `withGeneratorSpan` |
| `src/libswamp/extensions/unyank_test.ts` | **new** — 6 unit tests |
| `src/libswamp/mod.ts` | re-export unyank surface adjacent to yank |
| `src/infrastructure/http/extension_api_client.ts` | `UnyankResult` interface + `unyankExtension` method |
| `src/infrastructure/http/extension_api_client_test.ts` | 6 new tests including explicit null-body / no-Content-Type case |
| `src/presentation/renderers/extension_unyank.ts` | **new** — Log + JSON renderers |
| `src/cli/commands/extension_unyank.ts` | **new** — CLI command wiring |
| `src/cli/commands/extension.ts` | register `unyank` subcommand |
| `src/cli/commands/extension_yank.ts` | updated description, examples, and prompt copy |

## Test Plan

### Automated — all green locally

- `deno fmt --check` / `deno lint` / `deno check` clean
- `deno run test` → **4514 passed, 0 failed**
- `deno run compile` produces a working binary; `--help` verified on both `yank` and `unyank`

Unit coverage:
- 6 libswamp tests (version success, extension success, null reason, not-auth, invalid name preview, preview no-auth)
- 6 API client tests (version endpoint with reason, extension endpoint with reason, **null body with no Content-Type**, 409 NotYankedError, 404 not found, connection failure)

### End-to-end smoke test — to be run by reviewer against live registry

Version-yank cascade fix:
```bash
./swamp extension push <ext>                               # v1
./swamp extension yank @stack72/<name> <v1> --reason "…"   # should NOT cascade
./swamp extension push <ext>                               # v2 → must succeed (pre-fix: 410)
./swamp extension unyank @stack72/<name> <v1>              # recovers v1
```

Extension-level recovery:
```bash
./swamp extension yank @stack72/<name> --reason "…" -y     # full yank
./swamp extension push <ext>                               # v3 → expected 410
./swamp extension unyank @stack72/<name>                   # recovery
./swamp extension push <ext>                               # v3 → must succeed
```

## Follow-ups

- [systeminit/swamp-uat#153](https://github.com/systeminit/swamp-uat/issues/153) — UAT coverage for the full yank/unyank lifecycle (including the cascade regression scenario). Not a blocker for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)