### PR TITLE
fix(extensions): address review follow-ups from #1204

### DIFF
--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -104,7 +104,13 @@ export interface YankResult {
   message: string;
 }
 
-/** Response from the unyank endpoint. */
+/**
+ * Response from the unyank endpoint.
+ *
+ * Note: unyank accepts an optional reason (unlike yank, where reason is
+ * required). Callers passing `null` for reason send an empty POST body; the
+ * server logs the unyank without a reason and still returns a message.
+ */
 export interface UnyankResult {
   message: string;
 }
@@ -388,8 +394,11 @@ export class ExtensionApiClient {
     apiKey: string,
   ): Promise<YankResult> {
     const encodedName = encodeURIComponent(name);
-    const path = version
-      ? `/api/v1/extensions/${encodedName}@${version}/yank`
+    const encodedVersion = version === null
+      ? null
+      : encodeURIComponent(version);
+    const path = encodedVersion
+      ? `/api/v1/extensions/${encodedName}@${encodedVersion}/yank`
       : `/api/v1/extensions/${encodedName}/yank`;
     const res = await this.fetch(path, {
       method: "POST",
@@ -416,8 +425,11 @@ export class ExtensionApiClient {
     apiKey: string,
   ): Promise<UnyankResult> {
     const encodedName = encodeURIComponent(name);
-    const path = version
-      ? `/api/v1/extensions/${encodedName}@${version}/unyank`
+    const encodedVersion = version === null
+      ? null
+      : encodeURIComponent(version);
+    const path = encodedVersion
+      ? `/api/v1/extensions/${encodedName}@${encodedVersion}/unyank`
       : `/api/v1/extensions/${encodedName}/unyank`;
 
     const init: RequestInit = reason === null

--- a/src/infrastructure/http/extension_api_client_test.ts
+++ b/src/infrastructure/http/extension_api_client_test.ts
@@ -483,3 +483,44 @@ Deno.test("ExtensionApiClient.unyankExtension throws UserError on connection fai
   );
   assertStringIncludes(error.message, "Could not connect");
 });
+
+Deno.test("ExtensionApiClient yank/unyank URL-encode version path segments", async () => {
+  let capturedYankUrl = "";
+  let capturedUnyankUrl = "";
+  const server = Deno.serve({ port: 0, onListen: () => {} }, (req) => {
+    const url = new URL(req.url);
+    if (url.pathname.endsWith("/yank")) capturedYankUrl = req.url;
+    if (url.pathname.endsWith("/unyank")) capturedUnyankUrl = req.url;
+    return new Response(
+      JSON.stringify({ message: "ok" }),
+      { headers: { "content-type": "application/json" } },
+    );
+  });
+  const addr = server.addr;
+  const client = new ExtensionApiClient(`http://localhost:${addr.port}`);
+
+  // A version containing characters that would corrupt the URL if spliced raw:
+  // `?` would start a query string, `#` would truncate the path, `/` would
+  // create an extra path segment. Real CalVer inputs never contain these, but
+  // the adapter must encode defensively.
+  const hostileVersion = "2026.02.26.1?foo#bar/baz";
+  const encoded = encodeURIComponent(hostileVersion);
+
+  await client.yankExtension("@test/ext", hostileVersion, "reason", "key");
+  const yankUrl = new URL(capturedYankUrl);
+  assertEquals(
+    yankUrl.pathname,
+    `/api/v1/extensions/%40test%2Fext@${encoded}/yank`,
+  );
+  assertEquals(yankUrl.search, "");
+
+  await client.unyankExtension("@test/ext", hostileVersion, null, "key");
+  const unyankUrl = new URL(capturedUnyankUrl);
+  assertEquals(
+    unyankUrl.pathname,
+    `/api/v1/extensions/%40test%2Fext@${encoded}/unyank`,
+  );
+  assertEquals(unyankUrl.search, "");
+
+  await server.shutdown();
+});

--- a/src/libswamp/extensions/unyank.ts
+++ b/src/libswamp/extensions/unyank.ts
@@ -27,7 +27,13 @@ import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 const SCOPED_NAME_PATTERN = /^@[a-z0-9_-]+\/[a-z0-9_-]+(\/[a-z0-9_-]+)*$/;
 const DEFAULT_SERVER_URL = "https://swamp.club";
 
-/** Data structure for the extension unyank output. */
+/**
+ * Data structure for the extension unyank output.
+ *
+ * Note: `reason` is nullable (unlike the yank equivalent where reason is
+ * required). The unyank endpoint accepts an empty body, so callers may omit
+ * a reason. JSON consumers should handle `reason: null` explicitly.
+ */
 export interface ExtensionUnyankData {
   name: string;
   version: string | null;

--- a/src/presentation/renderers/extension_unyank.ts
+++ b/src/presentation/renderers/extension_unyank.ts
@@ -37,7 +37,9 @@ class LogExtensionUnyankRenderer implements Renderer<ExtensionUnyankEvent> {
             version: e.data.version,
           });
         } else {
-          logger.info("Unyanked {name}", { name: e.data.name });
+          logger.info("Unyanked {name} (all versions)", {
+            name: e.data.name,
+          });
         }
         if (e.data.reason !== null) {
           logger.info("Reason: {reason}", { reason: e.data.reason });


### PR DESCRIPTION
## Summary

Follow-up to [#1204](https://github.com/systeminit/swamp/pull/1204) addressing the actionable suggestions from the bot reviews. No new behavior — small UX and defense-in-depth fixes.

### Addressed

1. **CLI UX suggestion** — extension-level unyank now logs `"Unyanked {name} (all versions)"` so users can tell whether one version or the full extension was restored. Mirrors the yank renderer's scope qualifier.
2. **Adversarial review (medium)** — `yankExtension` and `unyankExtension` URL paths now `encodeURIComponent` the `version` segment. Real CalVer inputs are already URL-safe, so this is defensive: blocks hostile input containing `?`, `#`, or `/` from corrupting the path. Applies to both methods because the pattern was pre-existing in yank.
3. **Docs** — `ExtensionUnyankData` and `UnyankResult` now document the nullable-`reason` asymmetry with yank, for API consumers.

### Deliberately skipped

- **Shared `SCOPED_NAME_PATTERN`** — reviewer called it premature abstraction; CLAUDE.md explicitly endorses "three similar lines is better than a premature abstraction."
- **`parseExtensionRef` import alternative** — reviewer noted it as informational only, no action.

## Test Plan

- `deno fmt` / `deno lint` / `deno check` clean
- `deno run test` — **4574 passed, 0 failed**
- New test `ExtensionApiClient yank/unyank URL-encode version path segments` exercises both endpoints with a hostile version string `"2026.02.26.1?foo#bar/baz"` and asserts the encoded path + empty query string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)