### PR TITLE
docs(extensions): document jsr:/https: specifiers as first-class peers of npm: (swamp-club#143)

### DIFF
--- a/.claude/skills/swamp-extension-publish/references/publishing.md
+++ b/.claude/skills/swamp-extension-publish/references/publishing.md
@@ -92,13 +92,20 @@ dependencies:
 
 - `import { z } from "npm:zod@4";` is always required
 - Any Deno-compatible import (`npm:`, `jsr:`, `https://`) can be used — swamp
-  bundles all dependencies automatically
+  resolves and inlines all three kinds identically, with zod as the sole
+  externalization exception
 - Extensions with a `deno.json` or `package.json` can use bare specifiers (e.g.,
   `from "zod"`)
 - All imports must be static top-level imports — dynamic `import()` calls are
   rejected during push
-- Always pin npm versions — either inline (`npm:lodash-es@4.17.21`), via a
-  `deno.json` import map, or in `package.json` dependencies
+- Always pin versions on all non-local imports for reproducibility. An unpinned
+  specifier resolves to the registry's current "latest" at push time, so the
+  published bundle silently changes across pushes. Examples:
+  - `npm:lodash-es@4.17.21` (inline), or via `deno.json` import map, or in
+    `package.json` dependencies
+  - `jsr:@std/assert@1.0.0` (inline) or via `deno.json` import map
+  - `https://deno.land/std@0.224.0/async/delay.ts` (the version lives in the
+    URL)
 - Use `include` in the manifest for helper scripts executed via `Deno.Command`
   that shouldn't be bundled
 

--- a/design/extension.md
+++ b/design/extension.md
@@ -160,12 +160,25 @@ dependencies (e.g., native modules used via `Deno.Command` subprocess).
 ### Bundles
 
 Each model entry point is compiled using `deno bundle` with zod externalized.
-All other npm packages are inlined into the bundle, which ensures they work in
-the compiled binary where only swamp's own embedded dependency graph is
-available. Zod is externalized so extensions share the same zod instance as
-swamp (required for schema `instanceof` checks). Dynamic `import()` calls are
-not supported — all imports must be static top-level imports. Bundles are
-JavaScript files stored alongside their source counterparts under `bundles/`.
+All other non-local specifiers (`npm:`, `jsr:`, `https:`) are resolved and
+inlined into the bundle, which ensures they work in the compiled binary where
+only swamp's own embedded dependency graph is available. Zod is externalized so
+extensions share the same zod instance as swamp (required for schema
+`instanceof` checks). Dynamic `import()` calls are not supported — all imports
+must be static top-level imports. Bundles are JavaScript files stored alongside
+their source counterparts under `bundles/`.
+
+**First-class specifier kinds:** `npm:`, `jsr:`, and `https:` are peers —
+`deno bundle` resolves all three natively with identical treatment (all
+inlined, all cached by Deno's module cache, all subject to the same
+externalization rules for zod). No per-specifier-kind configuration is required.
+
+**Pin versions on all non-local specifiers** (`npm:`, `jsr:`, `https:`) for
+reproducibility. An unpinned specifier resolves to the registry's current
+"latest" at push time, which means the published bundle silently changes
+whenever the upstream package publishes a new version. See
+`.claude/skills/swamp-extension-publish/references/publishing.md` for
+author-facing guidance.
 
 #### Project-aware bundling
 
@@ -198,6 +211,11 @@ it, an unrelated `package.json` anywhere in the directory tree causes Deno to
 switch to `node_modules/` resolution mode, breaking `npm:` prefixed imports with
 errors like "Could not find a matching package for 'npm:@octokit/rest@22.0.1'
 in the node_modules directory."
+
+`jsr:` and `https:` specifiers work identically across all four rows — they
+don't require `deno.json` or `package.json` to resolve, so the project-config
+detection logic is irrelevant to them. They are fetched and cached by Deno's
+module cache on first use and reused offline thereafter.
 
 #### Zod externalization
 
@@ -279,7 +297,8 @@ starting from each entry point (model, vault, driver, datastore, or report).
 The resolver follows relative `import`/`export` statements (e.g.,
 `./helpers.ts`, `../shared.ts`) and includes all transitively imported files.
 Only files within the respective directory boundary are included. Non-local
-imports (npm packages) are skipped as they are resolved at runtime.
+imports (`npm:`, `jsr:`, `https:`) are skipped here — they are resolved and
+inlined at bundle time by `deno bundle`, not by the local-import resolver.
 
 ## Dependencies
 

--- a/src/domain/models/bundle.ts
+++ b/src/domain/models/bundle.ts
@@ -170,26 +170,36 @@ export interface BundleOptions {
 /**
  * Checks whether a TypeScript source file contains bare specifier imports
  * (e.g., `from "zod"`, `from "@aws-sdk/..."`) that require a deno.json
- * import map to resolve. Returns true if any non-relative, non-npm: import
- * is found.
+ * import map to resolve. Returns true if any bare specifier is found.
+ *
+ * The bundler recognizes these import kinds; all but "bare" reach
+ * `deno bundle` unchanged and are resolved by it without an import map:
+ *
+ * - relative (`./foo`, `../bar`) — resolved by path
+ * - npm: (`npm:zod@4`) — non-local, resolved and inlined by deno bundle
+ * - jsr: (`jsr:@std/assert@1`) — non-local, resolved and inlined by deno bundle
+ * - https: (`https://deno.land/std/...`) — non-local, resolved and inlined by deno bundle
+ * - node: (`node:fs`) — built-in, passed through unchanged
+ * - bare (`zod`, `@aws-sdk/...`) — requires a deno.json or package.json to resolve
  *
  * Used by runtime loaders to determine whether a cached bundle should be
- * preferred over re-bundling when no deno.json is available.
+ * preferred over re-bundling when no deno.json is available (pulled
+ * extensions with bare specifiers would always fail to rebundle locally).
  */
 export function sourceHasBareSpecifiers(source: string): boolean {
-  // Match import/export from statements with non-relative, non-npm: specifiers
   const importPattern = /(?:import|export)\s+[\s\S]*?from\s+["']([^"']+)["']/g;
   for (const match of source.matchAll(importPattern)) {
     const specifier = match[1];
-    // Skip relative imports (./foo, ../bar)
+    // Relative imports resolve by path — not bare.
     if (specifier.startsWith(".")) continue;
-    // Skip npm: prefixed imports (these resolve without an import map)
+    // Non-local specifiers resolve without an import map — not bare.
     if (specifier.startsWith("npm:")) continue;
-    // Skip jsr: prefixed imports
     if (specifier.startsWith("jsr:")) continue;
-    // Skip node: built-ins
+    if (specifier.startsWith("https:")) continue;
+    if (specifier.startsWith("http:")) continue;
+    // Node built-ins pass through unchanged — not bare.
     if (specifier.startsWith("node:")) continue;
-    // Anything else is a bare specifier that needs an import map
+    // Anything else is a bare specifier that needs an import map.
     return true;
   }
   return false;

--- a/src/domain/models/bundle_test.ts
+++ b/src/domain/models/bundle_test.ts
@@ -345,6 +345,112 @@ Deno.test("sanitizeDataUrlError leaves short errors untouched", () => {
   assertEquals(sanitizeDataUrlError(error), error);
 });
 
+Deno.test("bundleExtension resolves and inlines jsr: specifiers", async () => {
+  // Network-dependent (matches the existing npm: bar). Guards the "first-class
+  // jsr:" contract: deno bundle must resolve jsr: without requiring an import
+  // map and inline the fetched source into the bundle.
+  const tsCode = `
+import { z } from "npm:zod@4";
+import { parse } from "jsr:@std/semver@1.0.8";
+
+const schema = z.object({ version: z.string() });
+
+export const model = {
+  type: "@test/jsr-inlining",
+  schema,
+  major: (v: string) => parse(v).major,
+};
+`;
+
+  await withTempFile(tsCode, async (path) => {
+    const js = await bundleExtension(path, DENO_PATH);
+
+    // No jsr: specifier should remain in the bundle — proves resolution, not
+    // pass-through.
+    assertEquals(
+      js.includes('from "jsr:'),
+      false,
+      "jsr: specifier should be resolved, not passed through",
+    );
+
+    // The inlined source carries a deno:https://jsr.io header comment. Its
+    // presence is the strongest signal jsr code is actually inlined.
+    assertEquals(
+      js.includes("deno:https://jsr.io/@std/semver"),
+      true,
+      "bundle should contain inlined jsr source with deno:https://jsr.io header",
+    );
+  });
+});
+
+Deno.test("bundleExtension resolves and inlines https: specifiers", async () => {
+  // Network-dependent. Parity proof: https: is treated identically to jsr:
+  // and npm: — resolved and inlined by deno bundle.
+  const tsCode = `
+import { z } from "npm:zod@4";
+import { delay } from "https://deno.land/std@0.224.0/async/delay.ts";
+
+export const model = {
+  type: "@test/https-inlining",
+  schema: z.object({}),
+  wait: async () => { await delay(1); },
+};
+`;
+
+  await withTempFile(tsCode, async (path) => {
+    const js = await bundleExtension(path, DENO_PATH);
+
+    assertEquals(
+      js.includes('from "https:'),
+      false,
+      "https: specifier should be resolved, not passed through",
+    );
+
+    assertEquals(
+      js.includes("deno:https://deno.land/std"),
+      true,
+      "bundle should contain inlined https source with deno:https://deno.land header",
+    );
+  });
+});
+
+Deno.test("rewriteZodImports leaves jsr: inlined content untouched", async () => {
+  // Regression: rewriteZodImports' regex is zod-specific and must not
+  // coincidentally match jsr: identifiers in inlined source. A combined
+  // npm:zod + jsr:@std/semver fixture pins this down.
+  const tsCode = `
+import { z } from "npm:zod@4";
+import { parse } from "jsr:@std/semver@1.0.8";
+
+export const schema = z.object({ version: z.string() });
+export const check = (v: string) => parse(v).major;
+`;
+
+  await withTempFile(tsCode, async (path) => {
+    const js = await bundleExtension(path, DENO_PATH);
+    const rewritten = rewriteZodImports(js);
+
+    // Zod was rewritten to globalThis.__swamp_zod.
+    assertEquals(
+      rewritten.includes("globalThis.__swamp_zod"),
+      true,
+      "rewriteZodImports should rewrite zod import",
+    );
+    assertEquals(
+      rewritten.includes('from "npm:zod'),
+      false,
+      "no npm:zod import should remain after rewrite",
+    );
+
+    // jsr: inlined content is still present and untouched.
+    assertEquals(
+      rewritten.includes("deno:https://jsr.io/@std/semver"),
+      true,
+      "jsr inlined source must survive the zod rewrite",
+    );
+  });
+});
+
 Deno.test("bundleExtension uses deno.json config when denoConfigPath provided", async () => {
   const dir = await Deno.makeTempDir({ prefix: "swamp_bundle_test_" });
   const tsPath = join(dir, "test_ext.ts");
@@ -419,6 +525,24 @@ Deno.test("sourceHasBareSpecifiers returns false for jsr: import", () => {
 Deno.test("sourceHasBareSpecifiers returns false for node: import", () => {
   assertEquals(
     sourceHasBareSpecifiers('import { readFile } from "node:fs";'),
+    false,
+  );
+});
+
+Deno.test("sourceHasBareSpecifiers returns false for https: import", () => {
+  assertEquals(
+    sourceHasBareSpecifiers(
+      'import { delay } from "https://deno.land/std@0.224.0/async/delay.ts";',
+    ),
+    false,
+  );
+});
+
+Deno.test("sourceHasBareSpecifiers returns false for http: import", () => {
+  assertEquals(
+    sourceHasBareSpecifiers(
+      'import { x } from "http://example.com/mod.ts";',
+    ),
     false,
   );
 });


### PR DESCRIPTION
## Summary

- Issue #143 filed a feature request for first-class `jsr:` specifier support based on a comment at `bundle.ts:189` that read `// Skip jsr: prefixed imports`. Empirical probe confirms the premise is incorrect — the comment lives inside `sourceHasBareSpecifiers` (a heuristic for "does this source need an import map?"), not in any code path that filters specifiers reaching `deno bundle`. `jsr:` and `https:` have always been resolved and inlined by `deno bundle` identically to `npm:`.
- Close the gap between documented behavior and observable reality: reword the misleading comments, expand the `sourceHasBareSpecifiers` JSDoc, update `design/extension.md` to document `jsr:`/`https:` as first-class peers of `npm:`, widen the pinning convention in the swamp-extension-publish skill, and add three bundler regression tests (`jsr:` inlining, `https:` inlining, `rewriteZodImports` isolation against `jsr:` content).
- One small behavior change: `sourceHasBareSpecifiers` now also skips `http:`/`https:` specifiers (before, they fell through to the "bare specifier" branch and returned `true`). This brings `https:` into parity with `npm:`/`jsr:`. Affects no real-world extensions today (no pulled `https:` extensions exist).

## Why zero behavioral changes to the bundler itself

Empirically verified before writing code, against the exact flags `bundleExtension` passes today:

```
deno bundle --no-lock --node-modules-dir=none --external npm:zod@4 --external npm:zod --platform deno ...
```

- `jsr:@std/semver@1` — resolved, inlined (11 `deno:https://jsr.io/@std/semver/...` headers in output, 0 `from "jsr:"` remaining)
- `jsr:@std/assert@1` — same outcome
- `https://deno.land/std@0.224.0/async/delay.ts` — resolved, inlined (`deno:https://deno.land/std` header in output, 0 `from "https:"` remaining)
- Verified identically under `--config <deno.json>` mode

## Parity framing

The invariant maintained by this PR: `npm:`, `jsr:`, and `https:` are peers — `deno bundle` resolves all three natively, swamp passes all three through unchanged (except zod externalization), and all three share the same cold-start behavior for pulled extensions without a repo-side `deno.json`. This framing informed three decisions:

1. **No loader/fast-path change.** Pulled `jsr:`-only extensions without `deno.json` still attempt rebundle on cold start (same as `npm:`-only extensions today). Treating `jsr:` specially would diverge from `npm:`, violating parity. Cold-start optimization for all non-local specifiers is separable work (deliberately not filed — real users filing it with concrete context will trigger it).
2. **No validation gate.** The pinning convention is documented, not enforced, for `npm:` today; `jsr:`/`https:` follow the same pattern. A validation gate (for either specifier class) is separable.
3. **No bundler command-line changes.** Current flags work for all three specifier kinds.

## Follow-ups filed (not blocking this PR)

- [swamp-club #144](https://swamp.club/lab/issues/144) — user-facing manual docs in `content/manual/` lag behind (only mention `npm:`).
- [swamp-uat #154](https://github.com/systeminit/swamp-uat/issues/154) — CLI UAT scenario for `jsr:` push/pull/load end-to-end (unit regression added here; E2E gap is separate).
- [swamp-uat #155](https://github.com/systeminit/swamp-uat/issues/155) — adversarial scenarios for `jsr.io` unreachable + yanked version.

## Test plan

- [x] `deno check` clean on both modified TS files
- [x] `deno lint` clean
- [x] `deno fmt` applied
- [x] `deno run test` — 4581 passing, 0 failed, including 5 new cases in `src/domain/models/bundle_test.ts` (`jsr:` inlining, `https:` inlining, `rewriteZodImports` isolation, `sourceHasBareSpecifiers` for `https:`/`http:`)
- [x] `deno run compile` — succeeds, binary produced
- [ ] End-to-end `swamp extension push` against a `jsr:` extension using the compiled binary — deliberately not done here; tracked as swamp-uat #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)