### PR TITLE
feat(issue): route extension-scoped reports to publishers (swamp-club#4)

### DIFF
--- a/.claude/skills/swamp-extension-publish/references/publishing.md
+++ b/.claude/skills/swamp-extension-publish/references/publishing.md
@@ -28,6 +28,7 @@ manifestVersion: 1
 name: "@myorg/my-extension"
 version: "2026.02.26.1"
 description: "Optional description of the extension"
+repository: "https://github.com/myorg/my-extension"
 models:
   - my_model.ts
   - utils/helper_model.ts
@@ -47,23 +48,24 @@ dependencies:
 
 ### Field Reference
 
-| Field             | Required | Description                                                                                      |
-| ----------------- | -------- | ------------------------------------------------------------------------------------------------ |
-| `manifestVersion` | Yes      | Must be `1`                                                                                      |
-| `name`            | Yes      | Scoped name: `@collective/name` or `@collective/name/sub/path` (lowercase, hyphens, underscores) |
-| `version`         | Yes      | CalVer format: `YYYY.MM.DD.MICRO`                                                                |
-| `description`     | No       | Human-readable description                                                                       |
-| `models`          | No*      | Model file paths relative to `extensions/models/`                                                |
-| `workflows`       | No*      | Workflow file paths relative to `workflows/`                                                     |
-| `vaults`          | No*      | Vault file paths relative to `extensions/vaults/`                                                |
-| `drivers`         | No*      | Driver file paths relative to `extensions/drivers/`                                              |
-| `datastores`      | No*      | Datastore file paths relative to `extensions/datastores/`                                        |
-| `reports`         | No*      | Report file paths relative to `extensions/reports/`                                              |
-| `skills`          | No*      | Skill directory names resolved from the tool's skill directory (e.g., `.claude/skills/`)         |
-| `additionalFiles` | No       | Extra files relative to the manifest location                                                    |
-| `platforms`       | No       | OS/architecture hints (e.g. `darwin-aarch64`, `linux-x86_64`)                                    |
-| `labels`          | No       | Categorization labels (e.g. `aws`, `kubernetes`, `security`)                                     |
-| `dependencies`    | No       | Other extensions this one depends on                                                             |
+| Field             | Required | Description                                                                                                                                       |
+| ----------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `manifestVersion` | Yes      | Must be `1`                                                                                                                                       |
+| `name`            | Yes      | Scoped name: `@collective/name` or `@collective/name/sub/path` (lowercase, hyphens, underscores)                                                  |
+| `version`         | Yes      | CalVer format: `YYYY.MM.DD.MICRO`                                                                                                                 |
+| `description`     | No       | Human-readable description                                                                                                                        |
+| `repository`      | No       | HTTPS URL of the upstream repository. Required for users to file issues via `swamp issue --extension` — `swamp extension push` warns when absent. |
+| `models`          | No*      | Model file paths relative to `extensions/models/`                                                                                                 |
+| `workflows`       | No*      | Workflow file paths relative to `workflows/`                                                                                                      |
+| `vaults`          | No*      | Vault file paths relative to `extensions/vaults/`                                                                                                 |
+| `drivers`         | No*      | Driver file paths relative to `extensions/drivers/`                                                                                               |
+| `datastores`      | No*      | Datastore file paths relative to `extensions/datastores/`                                                                                         |
+| `reports`         | No*      | Report file paths relative to `extensions/reports/`                                                                                               |
+| `skills`          | No*      | Skill directory names resolved from the tool's skill directory (e.g., `.claude/skills/`)                                                          |
+| `additionalFiles` | No       | Extra files relative to the manifest location                                                                                                     |
+| `platforms`       | No       | OS/architecture hints (e.g. `darwin-aarch64`, `linux-x86_64`)                                                                                     |
+| `labels`          | No       | Categorization labels (e.g. `aws`, `kubernetes`, `security`)                                                                                      |
+| `dependencies`    | No       | Other extensions this one depends on                                                                                                              |
 
 *At least one of `models`, `workflows`, `vaults`, `drivers`, `datastores`,
 `reports`, or `skills` must be present with entries.

--- a/.claude/skills/swamp-issue/SKILL.md
+++ b/.claude/skills/swamp-issue/SKILL.md
@@ -1,42 +1,48 @@
 ---
 name: swamp-issue
-description: Submit issues to the swamp Lab — file bug reports with reproduction steps or submit feature requests with implementation context. Use when the user wants to report a bug, request a feature, or provide feedback about swamp. Triggers on "bug report", "feature request", "report bug", "request feature", "file bug", "submit bug", "swamp bug", "swamp feature", "feedback", "report issue", "file issue".
+description: Submit issues to the swamp Lab or route them to the publisher's repository — file bug reports, feature requests, and security vulnerability reports against swamp itself or against a specific extension. Use when the user wants to report a bug, request a feature, disclose a vulnerability, or provide feedback about swamp. Triggers on "bug report", "feature request", "security report", "vulnerability", "report bug", "request feature", "file bug", "submit bug", "swamp bug", "swamp feature", "feedback", "report issue", "file issue", "report against extension", "extension bug".
 ---
 
 # Swamp Issue Submission Skill
 
-Submit bug reports and feature requests through the swamp CLI. When logged in
-(`swamp auth login`), issues are submitted directly to the swamp.club Lab. When
-not logged in, the user is prompted to log in or send via email. The `--email`
-flag skips straight to a pre-filled email.
+Submit bug reports, feature requests, and security vulnerability disclosures
+through the swamp CLI. When logged in (`swamp auth login`), issues are submitted
+directly to the swamp.club Lab. When not logged in, the user is prompted to log
+in or send via email. The `--email` flag skips straight to a pre-filled email.
+
+With `--extension <name>`, reports are routed to the extension's publisher
+instead — either as a tagged swamp.club Lab issue (for `@swamp/*` extensions) or
+to the publisher's declared repository (for third-party extensions).
 
 **Verify CLI syntax:** If unsure about exact flags or subcommands, run
 `swamp help issue` for the complete, up-to-date CLI schema.
 
-## Submission Flow
+## Commands
+
+All three commands support interactive mode (opens `$EDITOR` with a template)
+and non-interactive mode with `--title` and `--body` flags.
+
+| Command                | Template sections                                             |
+| ---------------------- | ------------------------------------------------------------- |
+| `swamp issue bug`      | Title, description, steps to reproduce, environment           |
+| `swamp issue feature`  | Title, problem statement, proposed solution, alternatives     |
+| `swamp issue security` | Title, description, reproduction, affected components, impact |
+
+**Basic non-interactive examples:**
+
+```bash
+swamp issue bug --title "CLI crashes on empty input" --body "When running..." --json
+swamp issue feature --title "Add dark mode" --body "I'd like..." --json
+swamp issue security --title "..." --body "..." --json
+swamp issue bug --email --title "Crash report" --body "Details..."
+```
+
+## Plain Submission Flow (no `--extension`)
 
 1. **Logged in** → submits to Lab API → returns issue number and URL
 2. **Not logged in** → prompts: log in now, or send via email
 3. **`--email` flag** → opens email client with pre-filled subject/body to
    `support@systeminit.com`
-
-## Commands
-
-Both commands support interactive mode (opens `$EDITOR` with a template) and
-non-interactive mode with `--title` and `--body` flags.
-
-| Command               | Labels                    | Template sections                                         |
-| --------------------- | ------------------------- | --------------------------------------------------------- |
-| `swamp issue bug`     | `bug`, `needs-triage`     | Title, description, steps to reproduce, environment       |
-| `swamp issue feature` | `feature`, `needs-triage` | Title, problem statement, proposed solution, alternatives |
-
-**Non-interactive examples:**
-
-```bash
-swamp issue bug --title "CLI crashes on empty input" --body "When running..." --json
-swamp issue feature --title "Add dark mode" --body "I'd like..." --json
-swamp issue bug --email --title "Crash report" --body "Details..."
-```
 
 **Output shape** (Lab submission with `--json`):
 
@@ -50,20 +56,72 @@ swamp issue bug --email --title "Crash report" --body "Details..."
 }
 ```
 
-**Verify submission:** Check the returned URL at
-`https://swamp.club/lab/<number>`.
+## Extension-Scoped Submission (`--extension @collective/name`)
+
+Routes reports to the extension's publisher. Requires the extension to be pulled
+locally (`swamp extension pull <name>`) and the command to run from inside a
+swamp repo (or pass `--repo-dir <path>`).
+
+Three outcomes depending on the extension:
+
+| Collective                  | Destination                                         |
+| --------------------------- | --------------------------------------------------- |
+| `@swamp/*`                  | swamp.club Lab, tagged with extension metadata      |
+| Third-party with repository | Publisher's repo (via `gh` CLI or browser handoff)  |
+| Third-party without repo    | Refused cleanly; points at publisher's profile page |
+
+**Non-interactive examples:**
+
+```bash
+swamp issue bug --extension @swamp/aws --title "..." --body "..." --json
+swamp issue bug --extension @adam/cfgmgmt --title "..." --body "..." --json
+swamp issue security --extension @adam/cfgmgmt --title "..." --body "..." --json
+```
+
+**Output shapes (`--json`):**
+
+- `@swamp/*` →
+  `{ "method": "extension-lab", "number": 42, "extensionName": "@swamp/aws", ... }`
+- Third-party with `gh` →
+  `{ "status": "handoff", "method": "gh", "variant": "issue", "url": "...", "number": 42 }`
+- Third-party without `gh` →
+  `{ "status": "handoff", "method": "browser", "variant": "issue", "url": "...", "preparedTitle": "...", "preparedBody": "..." }`
+- Refused (not pulled / no repo / PVR disabled for security) →
+  `{ "status": "refused", "reason": "...", "guidance": "..." }`
+
+Refusals exit **0**, not as errors — the CLI is honoring the user's intent when
+the target can't accept reports.
+
+## Security Routing
+
+`swamp issue security --extension` against a third-party GitHub repository
+checks GitHub's Private Vulnerability Reporting (PVR) status first:
+
+- **PVR enabled** → opens the advisory form in the browser.
+- **PVR disabled** → **refuses**. The CLI never falls back to creating a public
+  issue for a security report, because that would silently publish the
+  vulnerability. The guidance tells the reporter to contact the publisher
+  privately and tells the publisher how to enable PVR.
+- **Check failed or `gh` unavailable** → opens the advisory URL with a fallback
+  issue URL surfaced in the output.
 
 ## Workflow
 
-1. Gather details from the user (bug reproduction steps or feature context)
-2. Verify syntax with `swamp help issue`
-3. Run the appropriate command (`swamp issue bug` or `swamp issue feature`)
-4. Verify with the returned issue number or URL
+1. Gather details from the user (bug reproduction steps, feature context, or
+   vulnerability description).
+2. For extension-scoped reports, confirm the extension is pulled locally.
+3. Verify syntax with `swamp help issue`.
+4. Run the appropriate command.
+5. Verify with the returned issue number / URL (or relay the refusal guidance to
+   the user).
 
 ## Requirements
 
-Requires `swamp auth login` for Lab submission. Use `--email` as alternative
-when not logged in.
+- Lab submission (`@swamp/*` + plain commands) requires `swamp auth login`.
+- Third-party repository routing uses `gh` CLI when available (`GH_TOKEN` env
+  var or `gh auth login`) and falls back to browser handoff.
+- Extension-scoped commands require the extension to be pulled locally via
+  `swamp extension pull`.
 
 ## Formatting Issue Content
 
@@ -72,7 +130,9 @@ feature request formatting guidelines with examples.
 
 ## Related Skills
 
-| Need                   | Use Skill             |
-| ---------------------- | --------------------- |
-| Debug swamp issues     | swamp-troubleshooting |
-| View swamp source code | swamp-troubleshooting |
+| Need                                  | Use Skill               |
+| ------------------------------------- | ----------------------- |
+| Debug swamp issues                    | swamp-troubleshooting   |
+| View swamp source code                | swamp-troubleshooting   |
+| Pull an extension before reporting    | swamp-repo              |
+| Publish an extension with a repo link | swamp-extension-publish |

--- a/.claude/skills/swamp-issue/references/formatting.md
+++ b/.claude/skills/swamp-issue/references/formatting.md
@@ -37,33 +37,39 @@ Provide a summary of the implementation plan:
 
 ## Extension Issues
 
-When filing an issue for an official extension, prefix the title with the
-extension name:
+Prefer `--extension @collective/name` when filing against a specific extension.
+The CLI attaches the extension name, installed version, and a `## Environment`
+section to the body automatically — do **not** also prefix the title with the
+extension name, because it would be redundant.
+
+**Example bug (using `--extension`):**
+
+```bash
+swamp issue bug --extension @swamp/aws-ec2 \
+  --title "describe method returns empty attributes for stopped instances" \
+  --body "$(cat <<'EOF'
+The describe method returns an empty attributes map when an EC2 instance is
+in a stopped state, instead of the instance metadata.
+
+The fix would involve updating the attribute mapping in the describe method
+to handle stopped-state API responses, which return a subset of fields.
+EOF
+)"
+```
+
+**When `--extension` isn't an option** (e.g. the extension isn't pulled and
+won't be, or filing via `--email`), fall back to prefixing the title with the
+extension name so readers can still identify scope:
 
 **Format:** `@collective/extension-name: brief description`
 
-**Example bug:**
+**Example:**
 
 > **Title:**
 > `@swamp/aws-ec2: describe method returns empty attributes for stopped instances`
 >
-> This bug affects the `@swamp/aws-ec2` extension's `describe` method. When an
-> EC2 instance is in a stopped state, the method returns an empty attributes map
-> instead of the instance metadata.
+> The describe method returns an empty attributes map when an EC2 instance is in
+> a stopped state, instead of the instance metadata.
 >
 > The fix would involve updating the attribute mapping in the describe method to
 > handle stopped-state API responses, which return a subset of fields.
-
-**Example feature:**
-
-> **Title:** `@swamp/aws-s3: add support for bucket lifecycle rules`
->
-> This feature would add a `lifecycle` method to the `@swamp/aws-s3` extension
-> model. Changes would be needed in:
->
-> - New `lifecycle` method definition in the extension model
-> - S3 lifecycle rule API integration
-> - Output type definitions for lifecycle configuration
->
-> The approach would follow the existing pattern used by the `policy` method for
-> bucket policy management.

--- a/design/extension.md
+++ b/design/extension.md
@@ -733,3 +733,60 @@ mechanism.
 Per-bundle lazy loading for vault, driver, datastore, and report registries
 will follow the same pattern using the shared `kind` column in the bundle
 catalog schema.
+
+## Reporting Issues Against Extensions
+
+Users can file reports against a specific extension with `--extension <name>`
+on the `swamp issue bug|feature|security` commands. The CLI routes the report
+according to the extension's collective and its declared `repository`:
+
+1. **`@swamp/*` extensions** — routed to the existing swamp-club Lab (the same
+   endpoint `swamp issue bug` already uses). Extension name, installed version,
+   and the reporter's environment are appended to the body under a
+   `## Environment` section. The title is not modified.
+
+2. **Third-party extensions with `repository` set** — routed to the declared
+   upstream repository. When the `gh` CLI is installed and authenticated
+   (`GH_TOKEN` or `gh auth login`), the report is created via `gh issue
+   create`. Otherwise the CLI opens the provider's new-issue URL in the
+   browser with title and body pre-filled (GitHub and GitLab supported;
+   other hosts open the repo root and the prepared body is printed to the
+   terminal for manual pasting).
+
+3. **Third-party extensions without `repository`** — refused cleanly with
+   guidance that points reporters at the extension's swamp-club page (where
+   publisher contact info lives) and tells publishers to add a `repository:`
+   field to their manifest. Exit code stays 0; the refusal is informational.
+
+### Security Routing
+
+For `swamp issue security --extension <name>` against a third-party GitHub
+repository, the CLI first checks whether the repository has enabled GitHub's
+Private Vulnerability Reporting (PVR) feature via `gh api
+repos/<owner>/<repo>/private-vulnerability-reporting`:
+
+- **PVR enabled** — open the GitHub advisory form
+  (`<repo>/security/advisories/new`). The form is structured and doesn't
+  accept URL prefill; the user fills it in manually.
+- **PVR disabled** — **refuse**. This is a load-bearing security guardrail:
+  the CLI never falls back to creating a public issue for a security report,
+  because that would silently publish the vulnerability. The refusal guidance
+  tells the reporter to contact the publisher privately and tells the
+  publisher to enable PVR at `<repo>/settings/security_analysis`.
+- **PVR check failed or gh unavailable** — open the advisory URL with a
+  fallback issue URL surfaced in the output. The user decides after seeing
+  what GitHub responds with.
+
+The asymmetry between GitHub (hard refusal when PVR is off) and GitLab
+(routes to the normal issue form with a "toggle confidential" warning) is
+intentional: GitLab's confidential-issues feature is universal and
+reliable, so the user always has a safe in-form path. GitHub's PVR is
+opt-in per repo, so the CLI refuses rather than trust the reporter to
+remember not to file publicly.
+
+### Publish-Time Nudge
+
+When `swamp extension push` runs against a manifest without a `repository`
+field, the CLI emits a non-blocking warning reminding the publisher that
+users will not be able to file issues via `--extension`. The warning never
+blocks the push — some publishers may deliberately omit `repository`.

--- a/integration/issue_extension_test.ts
+++ b/integration/issue_extension_test.ts
@@ -1,0 +1,298 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Integration tests for `swamp issue bug|feature|security --extension`.
+ *
+ * Two tiers of coverage live here:
+ *
+ *   1. Hermetic tier (always runs) — exercises the refusal paths, which
+ *      never need a network or gh install. These tests run in CI to
+ *      catch regressions in the local dispatch logic.
+ *
+ *   2. Live gh tier (gated on environment) — invokes the real `gh`
+ *      binary against a throwaway GitHub repo.
+ *
+ *      Required env vars:
+ *        GH_TOKEN         — a PAT or fine-grained token with `issues:
+ *                           write` on GH_TEST_REPO.
+ *        GH_TEST_REPO     — `owner/repo` of a repository the test can
+ *                           write to. Issues created here must be
+ *                           cleaned up manually (we don't delete on
+ *                           purpose so you can inspect them).
+ *
+ *      The live tier is skipped via Deno.test's `ignore` option when
+ *      either env var is absent, so CI without gh still passes.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+import { initializeTestRepo, runCliCommand } from "./test_helpers.ts";
+
+/** Writes a pulled-extension manifest at the canonical on-disk location. */
+async function writePulledExtension(
+  repoDir: string,
+  extensionName: string,
+  manifest: Record<string, unknown>,
+): Promise<void> {
+  const extDir = join(
+    repoDir,
+    ".swamp",
+    "pulled-extensions",
+    extensionName,
+  );
+  await ensureDir(extDir);
+  await Deno.writeTextFile(
+    join(extDir, "manifest.yaml"),
+    Object.entries(manifest)
+      .map(([k, v]) => typeof v === "string" ? `${k}: "${v}"` : `${k}: ${v}`)
+      .join("\n") + "\n",
+  );
+
+  // Lockfile — extensions/models/upstream_extensions.json.
+  const modelsDir = join(repoDir, "extensions", "models");
+  await ensureDir(modelsDir);
+  const lockfile = join(modelsDir, "upstream_extensions.json");
+  const existing = await tryReadJson(lockfile) ?? {};
+  existing[extensionName] = {
+    version: manifest.version ?? "2026.04.22.1",
+    pulledAt: new Date().toISOString(),
+  };
+  await Deno.writeTextFile(lockfile, JSON.stringify(existing));
+}
+
+async function tryReadJson(
+  path: string,
+): Promise<Record<string, unknown> | null> {
+  try {
+    return JSON.parse(await Deno.readTextFile(path));
+  } catch {
+    return null;
+  }
+}
+
+async function makeTempRepo(): Promise<string> {
+  const repo = await Deno.makeTempDir({ prefix: "swamp_issue_ext_" });
+  await initializeTestRepo(repo);
+  return repo;
+}
+
+// ---- Hermetic tier: refusal paths ----
+
+Deno.test("issue bug --extension: refuses not-pulled extension with exact pull command", async () => {
+  const repo = await makeTempRepo();
+  try {
+    const { stdout, code } = await runCliCommand(
+      [
+        "--json",
+        "issue",
+        "bug",
+        "--extension",
+        "@adam/cfgmgmt",
+        "--title",
+        "t",
+        "--body",
+        "b",
+      ],
+      repo,
+    );
+
+    assertEquals(code, 0, "refusals must exit 0, not as errors");
+    const parsed = JSON.parse(stdout);
+    assertEquals(parsed.status, "refused");
+    assertEquals(parsed.reason, "not-pulled");
+    assertStringIncludes(
+      parsed.guidance,
+      "swamp extension pull @adam/cfgmgmt",
+    );
+  } finally {
+    await Deno.remove(repo, { recursive: true });
+  }
+});
+
+Deno.test("issue bug --extension: refuses no-repository extension pointing at swamp-club extension page", async () => {
+  const repo = await makeTempRepo();
+  try {
+    await writePulledExtension(repo, "@adam/cfgmgmt", {
+      manifestVersion: 1,
+      name: "@adam/cfgmgmt",
+      version: "2026.04.22.1",
+      models: "",
+    });
+    // The stringify above produces "models: " which is invalid — rewrite properly.
+    await Deno.writeTextFile(
+      join(
+        repo,
+        ".swamp",
+        "pulled-extensions",
+        "@adam/cfgmgmt",
+        "manifest.yaml",
+      ),
+      `manifestVersion: 1
+name: "@adam/cfgmgmt"
+version: "2026.04.22.1"
+models:
+  - foo.yaml
+`,
+    );
+
+    const { stdout, code } = await runCliCommand(
+      [
+        "--json",
+        "issue",
+        "bug",
+        "--extension",
+        "@adam/cfgmgmt",
+        "--title",
+        "t",
+        "--body",
+        "b",
+      ],
+      repo,
+    );
+
+    assertEquals(code, 0);
+    const parsed = JSON.parse(stdout);
+    assertEquals(parsed.status, "refused");
+    assertEquals(parsed.reason, "no-repository");
+    assertStringIncludes(
+      parsed.guidance,
+      "swamp.club/extensions/%40adam%2Fcfgmgmt",
+    );
+  } finally {
+    await Deno.remove(repo, { recursive: true });
+  }
+});
+
+Deno.test("issue bug --extension: rejects malformed extension name", async () => {
+  const repo = await makeTempRepo();
+  try {
+    const { code, stderr } = await runCliCommand(
+      [
+        "issue",
+        "bug",
+        "--extension",
+        "not-a-scoped-name",
+        "--title",
+        "t",
+        "--body",
+        "b",
+      ],
+      repo,
+    );
+    assertEquals(code !== 0, true);
+    // Error text may live in stderr or stdout depending on logger config.
+    assertStringIncludes(stderr, "Invalid extension name");
+  } finally {
+    await Deno.remove(repo, { recursive: true });
+  }
+});
+
+Deno.test("issue bug --extension conflicts with --email", async () => {
+  const repo = await makeTempRepo();
+  try {
+    const { code, stderr } = await runCliCommand(
+      [
+        "issue",
+        "bug",
+        "--extension",
+        "@adam/cfgmgmt",
+        "--email",
+        "--title",
+        "t",
+        "--body",
+        "b",
+      ],
+      repo,
+    );
+    assertEquals(code !== 0, true);
+    assertStringIncludes(stderr, "cannot be used together");
+  } finally {
+    await Deno.remove(repo, { recursive: true });
+  }
+});
+
+// ---- Live gh tier ----
+
+const LIVE_GH_TOKEN = Deno.env.get("GH_TOKEN") ?? Deno.env.get("GITHUB_TOKEN");
+const LIVE_TEST_REPO = Deno.env.get("GH_TEST_REPO");
+const LIVE_TIER_ENABLED = Boolean(LIVE_GH_TOKEN) && Boolean(LIVE_TEST_REPO);
+
+Deno.test({
+  name:
+    "issue bug --extension (live gh): files a real issue against GH_TEST_REPO",
+  ignore: !LIVE_TIER_ENABLED,
+  async fn() {
+    const repo = await makeTempRepo();
+    try {
+      await writePulledExtension(repo, "@testuser/fixture", {
+        manifestVersion: 1,
+        name: "@testuser/fixture",
+        version: "2026.04.22.1",
+        repository: `https://github.com/${LIVE_TEST_REPO}`,
+        models: [],
+      });
+      // Rewrite with proper list format.
+      await Deno.writeTextFile(
+        join(
+          repo,
+          ".swamp",
+          "pulled-extensions",
+          "@testuser/fixture",
+          "manifest.yaml",
+        ),
+        `manifestVersion: 1
+name: "@testuser/fixture"
+version: "2026.04.22.1"
+repository: "https://github.com/${LIVE_TEST_REPO}"
+models:
+  - foo.yaml
+`,
+      );
+
+      const title = `[swamp-integration-test] ${crypto.randomUUID()}`;
+      const { stdout, code } = await runCliCommand(
+        [
+          "--json",
+          "issue",
+          "bug",
+          "--extension",
+          "@testuser/fixture",
+          "--title",
+          title,
+          "--body",
+          "Integration test body — close when seen.",
+        ],
+        repo,
+      );
+
+      assertEquals(code, 0);
+      const parsed = JSON.parse(stdout);
+      assertEquals(parsed.status, "handoff");
+      assertEquals(parsed.method, "gh");
+      assertEquals(parsed.variant, "issue");
+      assertStringIncludes(parsed.url, `github.com/${LIVE_TEST_REPO}/issues/`);
+      // Leave the issue open — the user reviewing the test repo closes
+      // them manually so they can inspect what was filed.
+    } finally {
+      await Deno.remove(repo, { recursive: true });
+    }
+  },
+});

--- a/src/cli/commands/extension_report_dispatcher.ts
+++ b/src/cli/commands/extension_report_dispatcher.ts
@@ -1,0 +1,531 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join, resolve } from "@std/path";
+import type { Logger } from "@logtape/logtape";
+import { UserError } from "../../domain/errors.ts";
+import {
+  isSwampCollective,
+  loadInstalledExtensionManifest,
+  readInstalledExtensionVersion,
+  validateExtensionName,
+} from "../../domain/extensions/installed_extension_lookup.ts";
+import {
+  buildGithubAdvisoryUrl,
+  buildGithubNewIssueUrl,
+  buildGithubSecuritySettingsUrl,
+  buildGitlabNewIssueUrl,
+  type ParsedRepositoryUrl,
+  parseRepositoryUrl,
+  swampClubExtensionUrl,
+} from "../../domain/extensions/repository_url.ts";
+import {
+  assembleExtensionReportBody,
+  type ReporterContext,
+} from "../../domain/extensions/reporter_context.ts";
+import { swampPath } from "../../infrastructure/persistence/paths.ts";
+import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
+import { RepoPath } from "../../domain/repo/repo_path.ts";
+import { resolveModelsDir } from "../resolve_models_dir.ts";
+import { readSwampSources } from "../../infrastructure/persistence/swamp_sources_repository.ts";
+import {
+  checkGithubPvrEnabled,
+  createGithubIssueViaGh,
+  type GhCliRunner,
+  isGhCliAvailable,
+} from "../../infrastructure/process/gh_cli.ts";
+import { openBrowser } from "../../infrastructure/process/browser.ts";
+
+/** Issue type (re-exported for the dispatcher API). */
+export type ReportType = "bug" | "feature" | "security";
+
+/** Output mode, mirrors CommandContext.outputMode. */
+export type OutputMode = "log" | "json";
+
+/** Refusal reasons the dispatcher can emit. */
+export type RefusalReason =
+  | "not-pulled"
+  | "no-repository"
+  | "pvr-disabled";
+
+/** Result of {@link resolveExtensionTarget}. */
+export type ExtensionTarget =
+  | {
+    kind: "swamp-lab";
+    extensionName: string;
+    extensionVersion: string;
+    repositoryUrl?: string;
+  }
+  | {
+    kind: "repository";
+    extensionName: string;
+    extensionVersion: string;
+    repositoryUrl: string;
+    parsed: ParsedRepositoryUrl;
+  }
+  | {
+    kind: "refused";
+    extensionName: string;
+    reason: RefusalReason;
+    guidance: string;
+  };
+
+/** Result of {@link dispatchRepositoryReport}. */
+export type RepositoryDispatchResult =
+  | {
+    kind: "handoff";
+    method: "gh" | "browser";
+    variant: "issue" | "advisory";
+    url: string;
+    number?: number;
+    preparedTitle: string;
+    preparedBody: string;
+    fallbackIssueUrl?: string;
+    /** True when a PVR check was attempted and failed (timeout / auth). */
+    pvrCheckFailed?: boolean;
+    /** True when no PVR check was attempted (gh unavailable). */
+    pvrCheckSkipped?: boolean;
+    /** True for security with PVR confirmed disabled (rare path — never). */
+    nonGithubWarning?: string;
+  }
+  | {
+    kind: "refused";
+    reason: RefusalReason;
+    guidance: string;
+  };
+
+/** Injectable dependencies for the dispatcher — tests pass fakes. */
+export interface DispatcherDeps {
+  ghRunner?: GhCliRunner;
+  env?: { get(key: string): string | undefined };
+  /** openBrowser replacement. No-op returning success is a valid test stub. */
+  openBrowser?: (url: string) => Promise<void>;
+  /** Optional logger used for the default writeLog when tests don't inject one. */
+  logger?: Logger;
+  /**
+   * Log-mode stdout sink for the prepared title/body. Default writes to
+   * the logger at info level. Tests pass a collector.
+   */
+  writeLog?: (text: string) => void;
+}
+
+/**
+ * Resolves the CLI-side target for a report against `extensionName`.
+ *
+ * Does not talk to the network — repository-side checks (e.g. PVR) are
+ * the dispatcher's job and happen later. Refusals produced here are the
+ * "local" variety (not installed, no repo declared).
+ */
+export async function resolveExtensionTarget(
+  repoDir: string,
+  extensionName: string,
+): Promise<ExtensionTarget> {
+  validateExtensionName(extensionName);
+
+  // Verify this is actually a swamp repo before touching the pulled-extensions
+  // subtree — otherwise a missing manifest is indistinguishable from a user
+  // running from the wrong directory, and we'd send them chasing the wrong fix.
+  const markerRepo = new RepoMarkerRepository();
+  const repoPath = RepoPath.create(repoDir);
+  const marker = await markerRepo.read(repoPath);
+  if (marker === null) {
+    throw new UserError(
+      `No swamp repository found at \`${repoDir}\`. ` +
+        `Run \`swamp issue ...\` from inside a swamp repo, or pass ` +
+        `\`--repo-dir <path>\` / set SWAMP_REPO_DIR.`,
+    );
+  }
+
+  const pulledExtRoot = swampPath(repoDir, "pulled-extensions");
+  const manifest = await loadInstalledExtensionManifest(
+    pulledExtRoot,
+    extensionName,
+  );
+
+  if (manifest === null) {
+    const guidance = await buildNotPulledGuidance(repoDir, extensionName);
+    return {
+      kind: "refused",
+      extensionName,
+      reason: "not-pulled",
+      guidance,
+    };
+  }
+
+  const modelsDir = resolveModelsDir(marker);
+  const lockfilePath = join(
+    resolve(repoDir, modelsDir),
+    "upstream_extensions.json",
+  );
+  const extensionVersion =
+    (await readInstalledExtensionVersion(lockfilePath, extensionName)) ??
+      manifest.version;
+
+  if (isSwampCollective(extensionName)) {
+    return {
+      kind: "swamp-lab",
+      extensionName,
+      extensionVersion,
+      repositoryUrl: manifest.repository,
+    };
+  }
+
+  if (!manifest.repository) {
+    return {
+      kind: "refused",
+      extensionName,
+      reason: "no-repository",
+      guidance: [
+        `The extension \`${extensionName}\` does not declare a repository ` +
+        `URL, so swamp can't route reports anywhere.`,
+        ``,
+        `For reporters:`,
+        `  Contact the publisher via ${swampClubExtensionUrl(extensionName)}.`,
+        ``,
+        `For publishers:`,
+        `  Add a \`repository:\` field to your extension's manifest.yaml ` +
+        `so users can file issues against it.`,
+      ].join("\n"),
+    };
+  }
+
+  const parsed = parseRepositoryUrl(manifest.repository);
+  return {
+    kind: "repository",
+    extensionName,
+    extensionVersion,
+    repositoryUrl: manifest.repository,
+    parsed,
+  };
+}
+
+export interface DispatchRepositoryReportInput {
+  type: ReportType;
+  title: string;
+  body: string;
+  reporterContext: ReporterContext;
+  outputMode: OutputMode;
+  labels?: string[];
+}
+
+/**
+ * Dispatches a report against a third-party (non-@swamp) extension to
+ * the publisher's declared repository. Owns the gh/browser selection,
+ * the security-specific PVR routing, and the PVR-disabled refusal.
+ *
+ * Key invariant: when `type === "security"` and PVR is confirmed
+ * DISABLED, this function returns a refusal — it MUST NOT create a
+ * public issue. That would silently publish a vulnerability.
+ */
+export async function dispatchRepositoryReport(
+  target: Extract<ExtensionTarget, { kind: "repository" }>,
+  input: DispatchRepositoryReportInput,
+  deps: DispatcherDeps = {},
+): Promise<RepositoryDispatchResult> {
+  const openBrowserFn = deps.openBrowser ?? openBrowser;
+  const writeLog = deps.writeLog ?? ((text) => {
+    if (deps.logger) deps.logger.info(text);
+    else console.log(text); // fallback, tests should always pass writeLog
+  });
+
+  const preparedBody = assembleExtensionReportBody(
+    input.body,
+    target.repositoryUrl,
+    input.reporterContext,
+  );
+  const preparedTitle = input.title;
+
+  if (input.type === "security") {
+    return await dispatchSecurity(
+      target,
+      preparedTitle,
+      preparedBody,
+      input,
+      deps,
+      openBrowserFn,
+      writeLog,
+    );
+  }
+
+  return await dispatchBugOrFeature(
+    target,
+    preparedTitle,
+    preparedBody,
+    input,
+    deps,
+    openBrowserFn,
+    writeLog,
+  );
+}
+
+async function dispatchBugOrFeature(
+  target: Extract<ExtensionTarget, { kind: "repository" }>,
+  preparedTitle: string,
+  preparedBody: string,
+  input: DispatchRepositoryReportInput,
+  deps: DispatcherDeps,
+  openBrowserFn: (url: string) => Promise<void>,
+  writeLog: (text: string) => void,
+): Promise<RepositoryDispatchResult> {
+  const { parsed } = target;
+
+  if (parsed.provider === "github") {
+    const ghAvailable = await isGhCliAvailable(deps.ghRunner, deps.env);
+    if (ghAvailable) {
+      const created = await createGithubIssueViaGh(
+        {
+          ownerRepo: parsed.ownerRepo!,
+          title: preparedTitle,
+          body: preparedBody,
+          labels: input.labels,
+        },
+        deps.ghRunner,
+      );
+      return {
+        kind: "handoff",
+        method: "gh",
+        variant: "issue",
+        url: created.url,
+        number: created.number,
+        preparedTitle,
+        preparedBody,
+      };
+    }
+    const url = buildGithubNewIssueUrl(
+      parsed.ownerRepo!,
+      preparedTitle,
+      preparedBody,
+      input.labels,
+    );
+    printHandoffStdout(
+      writeLog,
+      input.outputMode,
+      preparedTitle,
+      preparedBody,
+    );
+    await openBrowserFn(url);
+    return {
+      kind: "handoff",
+      method: "browser",
+      variant: "issue",
+      url,
+      preparedTitle,
+      preparedBody,
+    };
+  }
+
+  if (parsed.provider === "gitlab" && parsed.ownerRepo) {
+    const url = buildGitlabNewIssueUrl(
+      parsed.url,
+      preparedTitle,
+      preparedBody,
+    );
+    printHandoffStdout(
+      writeLog,
+      input.outputMode,
+      preparedTitle,
+      preparedBody,
+    );
+    await openBrowserFn(url);
+    return {
+      kind: "handoff",
+      method: "browser",
+      variant: "issue",
+      url,
+      preparedTitle,
+      preparedBody,
+    };
+  }
+
+  // "other" provider (self-hosted, Bitbucket, Gitea, etc.) — open the repo
+  // root and rely on the printed body for manual paste.
+  printHandoffStdout(writeLog, input.outputMode, preparedTitle, preparedBody);
+  await openBrowserFn(parsed.url);
+  return {
+    kind: "handoff",
+    method: "browser",
+    variant: "issue",
+    url: parsed.url,
+    preparedTitle,
+    preparedBody,
+  };
+}
+
+async function dispatchSecurity(
+  target: Extract<ExtensionTarget, { kind: "repository" }>,
+  preparedTitle: string,
+  preparedBody: string,
+  input: DispatchRepositoryReportInput,
+  deps: DispatcherDeps,
+  openBrowserFn: (url: string) => Promise<void>,
+  writeLog: (text: string) => void,
+): Promise<RepositoryDispatchResult> {
+  const { parsed } = target;
+
+  // GitHub: PVR-aware routing. Never silently publishes a vuln.
+  if (parsed.provider === "github" && parsed.ownerRepo) {
+    const ghAvailable = await isGhCliAvailable(deps.ghRunner, deps.env);
+    const advisoryUrl = buildGithubAdvisoryUrl(parsed.ownerRepo);
+    const fallbackIssueUrl = buildGithubNewIssueUrl(
+      parsed.ownerRepo,
+      preparedTitle,
+      preparedBody,
+      input.labels,
+    );
+
+    if (!ghAvailable) {
+      printHandoffStdout(
+        writeLog,
+        input.outputMode,
+        preparedTitle,
+        preparedBody,
+      );
+      await openBrowserFn(advisoryUrl);
+      return {
+        kind: "handoff",
+        method: "browser",
+        variant: "advisory",
+        url: advisoryUrl,
+        preparedTitle,
+        preparedBody,
+        fallbackIssueUrl,
+        pvrCheckSkipped: true,
+      };
+    }
+
+    const pvr = await checkGithubPvrEnabled(
+      parsed.ownerRepo,
+      deps.ghRunner,
+    );
+
+    if (pvr === false) {
+      // SECURITY GUARDRAIL: never fall back to a public issue when PVR
+      // is confirmed disabled. Users may forward this message to the
+      // publisher — include both the reporter action (contact publisher)
+      // and the publisher action (enable PVR).
+      return {
+        kind: "refused",
+        reason: "pvr-disabled",
+        guidance: [
+          `The repository \`${parsed.ownerRepo}\` does not have GitHub's ` +
+          `private vulnerability reporting enabled, so swamp can't file a ` +
+          `private report. To avoid publishing the vulnerability, the CLI ` +
+          `will NOT file a public issue on your behalf.`,
+          ``,
+          `For reporters:`,
+          `  Contact the publisher privately via ` +
+          `${swampClubExtensionUrl(target.extensionName)}.`,
+          ``,
+          `For publishers:`,
+          `  Enable private vulnerability reporting at ` +
+          `${buildGithubSecuritySettingsUrl(parsed.ownerRepo)}.`,
+        ].join("\n"),
+      };
+    }
+
+    // PVR enabled or check failed: route to the advisory form. When the
+    // check failed, the fallbackIssueUrl lets the user decide after
+    // GitHub responds; don't auto-file a public issue under any path.
+    printHandoffStdout(
+      writeLog,
+      input.outputMode,
+      preparedTitle,
+      preparedBody,
+    );
+    await openBrowserFn(advisoryUrl);
+    return {
+      kind: "handoff",
+      method: "browser",
+      variant: "advisory",
+      url: advisoryUrl,
+      preparedTitle,
+      preparedBody,
+      fallbackIssueUrl,
+      pvrCheckFailed: pvr === null,
+    };
+  }
+
+  // Non-GitHub provider: route to the normal issue form and warn the
+  // user to toggle the provider's private/confidential option.
+  const nonGithubWarning =
+    `Security reports against \`${parsed.host}\` must be filed with the ` +
+    `provider's private/confidential option if the platform supports one. ` +
+    `Confirm the report is marked private before submitting.`;
+
+  const url = parsed.provider === "gitlab" && parsed.ownerRepo
+    ? buildGitlabNewIssueUrl(parsed.url, preparedTitle, preparedBody)
+    : parsed.url;
+  printHandoffStdout(writeLog, input.outputMode, preparedTitle, preparedBody);
+  await openBrowserFn(url);
+  return {
+    kind: "handoff",
+    method: "browser",
+    variant: "issue",
+    url,
+    preparedTitle,
+    preparedBody,
+    nonGithubWarning,
+  };
+}
+
+function printHandoffStdout(
+  writeLog: (text: string) => void,
+  outputMode: OutputMode,
+  title: string,
+  body: string,
+): void {
+  // JSON mode: the renderer embeds title/body in the payload. Printing
+  // freeform markdown to stdout would corrupt the structured output.
+  if (outputMode === "json") return;
+  writeLog(
+    [
+      "Preparing report — you can copy this if the handoff fails:",
+      "---",
+      `Title: ${title}`,
+      "",
+      body,
+      "---",
+    ].join("\n"),
+  );
+}
+
+async function buildNotPulledGuidance(
+  repoDir: string,
+  extensionName: string,
+): Promise<string> {
+  const lines: string[] = [
+    `Extension \`${extensionName}\` is not installed. Pull it first with:`,
+    `  swamp extension pull ${extensionName}`,
+  ];
+  try {
+    const sources = await readSwampSources(repoDir);
+    if (sources && sources.sources.length > 0) {
+      lines.push(
+        ``,
+        `If you're running \`${extensionName}\` via \`.swamp-sources.yaml\` ` +
+          `(locally sourced), reports against locally-sourced extensions are ` +
+          `not supported in this release — pull from the registry or contact ` +
+          `the publisher directly.`,
+      );
+    }
+  } catch {
+    // Best-effort: if swamp-sources can't be read, just omit the hint.
+  }
+  return lines.join("\n");
+}

--- a/src/cli/commands/extension_report_dispatcher_test.ts
+++ b/src/cli/commands/extension_report_dispatcher_test.ts
@@ -1,0 +1,598 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
+import { join } from "@std/path";
+import { UserError } from "../../domain/errors.ts";
+import type { ReporterContext } from "../../domain/extensions/reporter_context.ts";
+import {
+  dispatchRepositoryReport,
+  type ExtensionTarget,
+  resolveExtensionTarget,
+} from "./extension_report_dispatcher.ts";
+import type {
+  GhCliRunner,
+  GhRunResult,
+} from "../../infrastructure/process/gh_cli.ts";
+import { parseRepositoryUrl } from "../../domain/extensions/repository_url.ts";
+
+const MANIFEST_NO_REPO = `manifestVersion: 1
+name: "@adam/cfgmgmt"
+version: "2026.04.22.1"
+models:
+  - foo.yaml
+`;
+
+const MANIFEST_GH = `manifestVersion: 1
+name: "@adam/cfgmgmt"
+version: "2026.04.22.1"
+repository: "https://github.com/adam/cfgmgmt"
+models:
+  - foo.yaml
+`;
+
+const MANIFEST_SWAMP = `manifestVersion: 1
+name: "@swamp/aws"
+version: "2026.04.22.1"
+models:
+  - foo.yaml
+`;
+
+const SAMPLE_CONTEXT: ReporterContext = {
+  extensionName: "@adam/cfgmgmt",
+  extensionVersion: "2026.04.22.1",
+  swampVersion: "20260422.000000.0-sha.abc",
+  os: "darwin",
+  arch: "aarch64",
+  shell: "/bin/zsh",
+  denoVersion: "1.45.0",
+};
+
+async function makeRepo(
+  extensionName: string,
+  manifestContent: string | null,
+  opts: { includeSources?: boolean; lockedVersion?: string } = {},
+): Promise<string> {
+  const repo = await Deno.makeTempDir({ prefix: "swamp_dispatch_" });
+  // Minimal repo marker (empty file is fine).
+  await Deno.writeTextFile(join(repo, ".swamp.yaml"), "repo: {}\n");
+  await Deno.mkdir(join(repo, ".swamp"), { recursive: true });
+
+  if (manifestContent !== null) {
+    const extDir = join(repo, ".swamp", "pulled-extensions", extensionName);
+    await Deno.mkdir(extDir, { recursive: true });
+    await Deno.writeTextFile(
+      join(extDir, "manifest.yaml"),
+      manifestContent,
+    );
+    // Write a minimal lockfile so version lookups succeed.
+    const modelsDir = join(repo, "extensions", "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+    const lockfile = join(modelsDir, "upstream_extensions.json");
+    const entry = {
+      [extensionName]: {
+        version: opts.lockedVersion ?? "2026.04.22.1",
+        pulledAt: new Date().toISOString(),
+      },
+    };
+    await Deno.writeTextFile(lockfile, JSON.stringify(entry));
+  }
+
+  if (opts.includeSources) {
+    await Deno.writeTextFile(
+      join(repo, ".swamp-sources.yaml"),
+      "sources:\n  - path: ./local-sources\n    kinds: [models]\n",
+    );
+  }
+
+  return repo;
+}
+
+function fakeRunner(
+  handler: (args: string[], stdin?: string) => GhRunResult,
+): GhCliRunner {
+  return {
+    run(args, opts) {
+      return Promise.resolve(handler(args, opts?.stdin));
+    },
+  };
+}
+
+// ---- resolveExtensionTarget ----
+
+Deno.test("resolveExtensionTarget: not-pulled refusal when manifest is missing", async () => {
+  const repo = await makeRepo("@adam/cfgmgmt", null);
+  try {
+    const t = await resolveExtensionTarget(repo, "@adam/cfgmgmt");
+    assertEquals(t.kind, "refused");
+    if (t.kind === "refused") {
+      assertEquals(t.reason, "not-pulled");
+      assertStringIncludes(t.guidance, "swamp extension pull @adam/cfgmgmt");
+    }
+  } finally {
+    await Deno.remove(repo, { recursive: true });
+  }
+});
+
+Deno.test("resolveExtensionTarget: not-pulled mentions sources when .swamp-sources.yaml present", async () => {
+  const repo = await makeRepo("@adam/cfgmgmt", null, { includeSources: true });
+  try {
+    const t = await resolveExtensionTarget(repo, "@adam/cfgmgmt");
+    if (t.kind !== "refused") throw new Error("expected refusal");
+    assertStringIncludes(t.guidance, "locally sourced");
+  } finally {
+    await Deno.remove(repo, { recursive: true });
+  }
+});
+
+Deno.test("resolveExtensionTarget: no-repository refusal when manifest has no repository", async () => {
+  const repo = await makeRepo("@adam/cfgmgmt", MANIFEST_NO_REPO);
+  try {
+    const t = await resolveExtensionTarget(repo, "@adam/cfgmgmt");
+    if (t.kind !== "refused") throw new Error("expected refusal");
+    assertEquals(t.reason, "no-repository");
+    assertStringIncludes(t.guidance, "does not declare a repository");
+    assertStringIncludes(
+      t.guidance,
+      "swamp.club/extensions/%40adam%2Fcfgmgmt",
+    );
+  } finally {
+    await Deno.remove(repo, { recursive: true });
+  }
+});
+
+Deno.test("resolveExtensionTarget: swamp-lab target for @swamp collective", async () => {
+  const repo = await makeRepo("@swamp/aws", MANIFEST_SWAMP);
+  try {
+    const t = await resolveExtensionTarget(repo, "@swamp/aws");
+    assertEquals(t.kind, "swamp-lab");
+    if (t.kind === "swamp-lab") {
+      assertEquals(t.extensionName, "@swamp/aws");
+      assertEquals(t.extensionVersion, "2026.04.22.1");
+    }
+  } finally {
+    await Deno.remove(repo, { recursive: true });
+  }
+});
+
+Deno.test("resolveExtensionTarget: repository target for third-party with manifest.repository", async () => {
+  const repo = await makeRepo("@adam/cfgmgmt", MANIFEST_GH);
+  try {
+    const t = await resolveExtensionTarget(repo, "@adam/cfgmgmt");
+    assertEquals(t.kind, "repository");
+    if (t.kind === "repository") {
+      assertEquals(t.repositoryUrl, "https://github.com/adam/cfgmgmt");
+      assertEquals(t.parsed.provider, "github");
+      assertEquals(t.parsed.ownerRepo, "adam/cfgmgmt");
+    }
+  } finally {
+    await Deno.remove(repo, { recursive: true });
+  }
+});
+
+Deno.test("resolveExtensionTarget: rejects malformed extension names early", async () => {
+  const repo = await Deno.makeTempDir({ prefix: "swamp_dispatch_" });
+  try {
+    await assertRejects(
+      () => resolveExtensionTarget(repo, "not-a-scoped-name"),
+      UserError,
+      "Invalid extension name",
+    );
+  } finally {
+    await Deno.remove(repo, { recursive: true });
+  }
+});
+
+// ---- dispatchRepositoryReport: bug/feature branches ----
+
+function makeRepoTarget(
+  repositoryUrl = "https://github.com/adam/cfgmgmt",
+): Extract<ExtensionTarget, { kind: "repository" }> {
+  return {
+    kind: "repository",
+    extensionName: "@adam/cfgmgmt",
+    extensionVersion: "2026.04.22.1",
+    repositoryUrl,
+    parsed: parseRepositoryUrl(repositoryUrl),
+  };
+}
+
+Deno.test("dispatchRepositoryReport: bug + gh available → gh issue create", async () => {
+  const calls: string[][] = [];
+  const runner = fakeRunner((args) => {
+    calls.push(args);
+    if (args[0] === "issue" && args[1] === "create") {
+      return {
+        exitCode: 0,
+        stdout: "https://github.com/adam/cfgmgmt/issues/42\n",
+        stderr: "",
+      };
+    }
+    return { exitCode: 0, stdout: "{}", stderr: "" };
+  });
+
+  const result = await dispatchRepositoryReport(
+    makeRepoTarget(),
+    {
+      type: "bug",
+      title: "Boom",
+      body: "body",
+      reporterContext: SAMPLE_CONTEXT,
+      outputMode: "log",
+    },
+    {
+      ghRunner: runner,
+      env: { get: () => "gh_x" },
+      openBrowser: () => Promise.resolve(),
+      writeLog: () => {},
+    },
+  );
+
+  assertEquals(result.kind, "handoff");
+  if (result.kind === "handoff") {
+    assertEquals(result.method, "gh");
+    assertEquals(result.variant, "issue");
+    assertEquals(result.number, 42);
+    assertStringIncludes(result.preparedBody, "Upstream repository:");
+    assertStringIncludes(result.preparedBody, "## Environment");
+  }
+});
+
+Deno.test("dispatchRepositoryReport: bug + gh unavailable → browser handoff", async () => {
+  const openBrowserCalls: string[] = [];
+  const runner = fakeRunner(() => ({
+    exitCode: 1,
+    stdout: "",
+    stderr: "not logged in",
+  }));
+
+  const result = await dispatchRepositoryReport(
+    makeRepoTarget(),
+    {
+      type: "bug",
+      title: "Boom",
+      body: "body",
+      reporterContext: SAMPLE_CONTEXT,
+      outputMode: "log",
+    },
+    {
+      ghRunner: runner,
+      env: { get: () => undefined },
+      openBrowser: (url) => {
+        openBrowserCalls.push(url);
+        return Promise.resolve();
+      },
+      writeLog: () => {},
+    },
+  );
+
+  assertEquals(result.kind, "handoff");
+  if (result.kind === "handoff") {
+    assertEquals(result.method, "browser");
+    assertEquals(result.variant, "issue");
+  }
+  assertEquals(openBrowserCalls.length, 1);
+  assertStringIncludes(
+    openBrowserCalls[0],
+    "github.com/adam/cfgmgmt/issues/new",
+  );
+});
+
+Deno.test("dispatchRepositoryReport: gitlab provider routes to gitlab new-issue URL", async () => {
+  const openBrowserCalls: string[] = [];
+  const result = await dispatchRepositoryReport(
+    makeRepoTarget("https://gitlab.com/group/proj"),
+    {
+      type: "bug",
+      title: "t",
+      body: "b",
+      reporterContext: SAMPLE_CONTEXT,
+      outputMode: "log",
+    },
+    {
+      openBrowser: (url) => {
+        openBrowserCalls.push(url);
+        return Promise.resolve();
+      },
+      writeLog: () => {},
+    },
+  );
+  assertEquals(result.kind, "handoff");
+  assertStringIncludes(
+    openBrowserCalls[0],
+    "gitlab.com/group/proj/-/issues/new",
+  );
+});
+
+Deno.test("dispatchRepositoryReport: other provider opens repo root", async () => {
+  const openBrowserCalls: string[] = [];
+  const result = await dispatchRepositoryReport(
+    makeRepoTarget("https://bitbucket.org/group/proj"),
+    {
+      type: "bug",
+      title: "t",
+      body: "b",
+      reporterContext: SAMPLE_CONTEXT,
+      outputMode: "log",
+    },
+    {
+      openBrowser: (url) => {
+        openBrowserCalls.push(url);
+        return Promise.resolve();
+      },
+      writeLog: () => {},
+    },
+  );
+  assertEquals(result.kind, "handoff");
+  assertEquals(openBrowserCalls[0], "https://bitbucket.org/group/proj");
+});
+
+Deno.test("dispatchRepositoryReport: log mode prints prepared title/body to writeLog", async () => {
+  const logs: string[] = [];
+  await dispatchRepositoryReport(
+    makeRepoTarget(),
+    {
+      type: "bug",
+      title: "T",
+      body: "B",
+      reporterContext: SAMPLE_CONTEXT,
+      outputMode: "log",
+    },
+    {
+      env: { get: () => undefined },
+      ghRunner: fakeRunner(() => ({
+        exitCode: 1,
+        stdout: "",
+        stderr: "not logged in",
+      })),
+      openBrowser: () => Promise.resolve(),
+      writeLog: (text) => logs.push(text),
+    },
+  );
+  assertEquals(logs.length, 1);
+  assertStringIncludes(logs[0], "Title: T");
+  assertStringIncludes(logs[0], "## Environment");
+});
+
+Deno.test("dispatchRepositoryReport: json mode does NOT print to writeLog", async () => {
+  const logs: string[] = [];
+  await dispatchRepositoryReport(
+    makeRepoTarget(),
+    {
+      type: "bug",
+      title: "T",
+      body: "B",
+      reporterContext: SAMPLE_CONTEXT,
+      outputMode: "json",
+    },
+    {
+      env: { get: () => undefined },
+      ghRunner: fakeRunner(() => ({
+        exitCode: 1,
+        stdout: "",
+        stderr: "not logged in",
+      })),
+      openBrowser: () => Promise.resolve(),
+      writeLog: (text) => logs.push(text),
+    },
+  );
+  assertEquals(logs.length, 0);
+});
+
+// ---- dispatchRepositoryReport: security branch (table-driven) ----
+
+type SecurityCase = {
+  name: string;
+  ghAvailable: boolean;
+  pvr: boolean | null | "gh-unavailable";
+  expectedKind: "handoff" | "refused";
+  expectedVariant?: "advisory" | "issue";
+  expectedRefusalReason?: "pvr-disabled";
+  assertFallback?: boolean;
+  assertPvrCheckFailed?: boolean;
+  assertPvrCheckSkipped?: boolean;
+};
+
+const SECURITY_CASES: SecurityCase[] = [
+  {
+    name: "PVR enabled + gh available → advisory handoff",
+    ghAvailable: true,
+    pvr: true,
+    expectedKind: "handoff",
+    expectedVariant: "advisory",
+    assertFallback: true,
+  },
+  {
+    name: "PVR disabled + gh available → REFUSAL (never public issue)",
+    ghAvailable: true,
+    pvr: false,
+    expectedKind: "refused",
+    expectedRefusalReason: "pvr-disabled",
+  },
+  {
+    name:
+      "PVR check failed + gh available → advisory handoff with checkFailed flag",
+    ghAvailable: true,
+    pvr: null,
+    expectedKind: "handoff",
+    expectedVariant: "advisory",
+    assertFallback: true,
+    assertPvrCheckFailed: true,
+  },
+  {
+    name: "gh unavailable → advisory handoff with checkSkipped flag",
+    ghAvailable: false,
+    pvr: "gh-unavailable",
+    expectedKind: "handoff",
+    expectedVariant: "advisory",
+    assertFallback: true,
+    assertPvrCheckSkipped: true,
+  },
+];
+
+for (const tc of SECURITY_CASES) {
+  Deno.test(`dispatchRepositoryReport: security (github) — ${tc.name}`, async () => {
+    const createIssueCalls: string[][] = [];
+    const runner = fakeRunner((args) => {
+      if (!tc.ghAvailable) {
+        return { exitCode: -1, stdout: "", stderr: "", spawnFailed: true };
+      }
+      if (args[0] === "auth" && args[1] === "status") {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      if (args[0] === "api") {
+        if (tc.pvr === null) {
+          return { exitCode: 1, stdout: "", stderr: "HTTP 500" };
+        }
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({ enabled: tc.pvr === true }),
+          stderr: "",
+        };
+      }
+      if (args[0] === "issue" && args[1] === "create") {
+        createIssueCalls.push(args);
+        return {
+          exitCode: 0,
+          stdout: "https://github.com/a/b/issues/1\n",
+          stderr: "",
+        };
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    });
+
+    const result = await dispatchRepositoryReport(
+      makeRepoTarget(),
+      {
+        type: "security",
+        title: "vuln",
+        body: "b",
+        reporterContext: SAMPLE_CONTEXT,
+        outputMode: "log",
+      },
+      {
+        ghRunner: runner,
+        env: { get: () => undefined },
+        openBrowser: () => Promise.resolve(),
+        writeLog: () => {},
+      },
+    );
+
+    assertEquals(result.kind, tc.expectedKind);
+    // SECURITY INVARIANT: no public issue should ever be created on the
+    // security path. createIssueCalls MUST be empty across every case.
+    assertEquals(
+      createIssueCalls.length,
+      0,
+      "PVR-aware security path must never call gh issue create",
+    );
+
+    if (result.kind === "handoff") {
+      assertEquals(result.variant, tc.expectedVariant);
+      if (tc.assertFallback) {
+        assert(
+          typeof result.fallbackIssueUrl === "string",
+          "expected fallbackIssueUrl to be populated",
+        );
+      }
+      if (tc.assertPvrCheckFailed) {
+        assertEquals(result.pvrCheckFailed, true);
+      }
+      if (tc.assertPvrCheckSkipped) {
+        assertEquals(result.pvrCheckSkipped, true);
+      }
+    }
+    if (result.kind === "refused") {
+      assertEquals(result.reason, tc.expectedRefusalReason);
+      assertStringIncludes(result.guidance, "For reporters:");
+      assertStringIncludes(result.guidance, "For publishers:");
+      assertStringIncludes(
+        result.guidance,
+        "settings/security_analysis",
+      );
+    }
+  });
+}
+
+Deno.test("dispatchRepositoryReport: PVR disabled never files a public issue (invariant)", async () => {
+  // Belt-and-suspenders test — asserts the security guardrail explicitly.
+  const createIssueCalls: string[][] = [];
+  const runner = fakeRunner((args) => {
+    if (args[0] === "auth") {
+      return { exitCode: 0, stdout: "", stderr: "" };
+    }
+    if (args[0] === "api") {
+      return { exitCode: 0, stdout: '{"enabled":false}', stderr: "" };
+    }
+    if (args[0] === "issue" && args[1] === "create") {
+      createIssueCalls.push(args);
+    }
+    return { exitCode: 0, stdout: "", stderr: "" };
+  });
+
+  const result = await dispatchRepositoryReport(
+    makeRepoTarget(),
+    {
+      type: "security",
+      title: "vuln",
+      body: "b",
+      reporterContext: SAMPLE_CONTEXT,
+      outputMode: "log",
+    },
+    {
+      ghRunner: runner,
+      env: { get: () => undefined },
+      openBrowser: () => Promise.resolve(),
+      writeLog: () => {},
+    },
+  );
+
+  assertEquals(result.kind, "refused");
+  assertEquals(createIssueCalls.length, 0);
+});
+
+Deno.test("dispatchRepositoryReport: security on gitlab provider surfaces confidential warning", async () => {
+  const openBrowserCalls: string[] = [];
+  const result = await dispatchRepositoryReport(
+    makeRepoTarget("https://gitlab.com/group/proj"),
+    {
+      type: "security",
+      title: "vuln",
+      body: "b",
+      reporterContext: SAMPLE_CONTEXT,
+      outputMode: "log",
+    },
+    {
+      openBrowser: (url) => {
+        openBrowserCalls.push(url);
+        return Promise.resolve();
+      },
+      writeLog: () => {},
+    },
+  );
+  assertEquals(result.kind, "handoff");
+  if (result.kind === "handoff") {
+    assertStringIncludes(result.nonGithubWarning ?? "", "confidential");
+  }
+});

--- a/src/cli/commands/issue_bug.ts
+++ b/src/cli/commands/issue_bug.ts
@@ -28,7 +28,13 @@ import {
 } from "../../presentation/renderers/issue_create.ts";
 import { EditorService } from "../../infrastructure/editor/editor_service.ts";
 import { UserError } from "../../domain/errors.ts";
-import { resolveDestination, submitIssue } from "./issue_submit.ts";
+import {
+  dispatchExtensionRepositoryReport,
+  resolveDestination,
+  resolveExtensionOrRefuse,
+  submitIssue,
+  type UsableExtensionTarget,
+} from "./issue_submit.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -136,9 +142,26 @@ export const issueBugCommand = new Command()
       throw new UserError("--email and --extension cannot be used together.");
     }
 
-    // Resolve destination BEFORE collecting content so we don't waste the user's time
-    const destination = await resolveDestination(ctx, options.email);
-    if (destination.method === "abort") {
+    // Extension-aware pre-flight: resolve the target BEFORE auth so refusals
+    // and third-party repository handoffs don't spuriously fail on Lab auth
+    // (they never touch swamp-club).
+    let extensionTarget: UsableExtensionTarget | undefined;
+    if (options.extension) {
+      const resolved = await resolveExtensionOrRefuse(
+        ctx,
+        options.extension,
+        resolveRepoDir(options.repoDir),
+      );
+      if (resolved === null) return; // refusal rendered
+      extensionTarget = resolved;
+    }
+
+    // Lab auth is only needed for the plain path and the `@swamp/*` path.
+    // Third-party repository handoffs skip this step entirely.
+    const destination = !extensionTarget || extensionTarget.kind === "swamp-lab"
+      ? await resolveDestination(ctx, options.email)
+      : undefined;
+    if (destination?.method === "abort") {
       await submitIssue(ctx, destination, {
         type: "bug",
         title: "",
@@ -197,12 +220,22 @@ export const issueBugCommand = new Command()
 
     ctx.logger.debug`Submitting bug report with title: ${title}`;
 
-    await submitIssue(ctx, destination, {
+    if (extensionTarget?.kind === "repository") {
+      await dispatchExtensionRepositoryReport(ctx, extensionTarget, {
+        type: "bug",
+        title,
+        body,
+      });
+      return;
+    }
+
+    await submitIssue(ctx, destination!, {
       type: "bug",
       title,
       body,
-      extensionName: options.extension,
-      repoDir: options.extension ? resolveRepoDir(options.repoDir) : undefined,
+      swampLabTarget: extensionTarget?.kind === "swamp-lab"
+        ? extensionTarget
+        : undefined,
     });
 
     ctx.logger.debug("Bug report submitted successfully");

--- a/src/cli/commands/issue_bug.ts
+++ b/src/cli/commands/issue_bug.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import {
   renderIssueCancelled,
 } from "../../presentation/renderers/issue_create.ts";
@@ -106,15 +110,31 @@ export const issueBugCommand = new Command()
   .name("bug")
   .description("Submit a bug report")
   .example("Submit a bug report", "swamp issue bug")
+  .example(
+    "Report a bug against a specific extension",
+    "swamp issue bug --extension @adam/cfgmgmt",
+  )
   .option("-t, --title <title:string>", "Bug title (skips editor for title)")
   .option(
     "-b, --body <body:string>",
     "Bug description (requires --title, skips editor entirely)",
   )
   .option("-e, --email", "Open email client with pre-filled bug report")
+  .option(
+    "-x, --extension <name:string>",
+    "Route the bug against a specific extension (e.g. @adam/cfgmgmt)",
+  )
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR) — only used with --extension",
+  )
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, ["issue", "bug"]);
     ctx.logger.debug`Submitting bug report`;
+
+    if (options.email && options.extension) {
+      throw new UserError("--email and --extension cannot be used together.");
+    }
 
     // Resolve destination BEFORE collecting content so we don't waste the user's time
     const destination = await resolveDestination(ctx, options.email);
@@ -181,6 +201,8 @@ export const issueBugCommand = new Command()
       type: "bug",
       title,
       body,
+      extensionName: options.extension,
+      repoDir: options.extension ? resolveRepoDir(options.repoDir) : undefined,
     });
 
     ctx.logger.debug("Bug report submitted successfully");

--- a/src/cli/commands/issue_feature.ts
+++ b/src/cli/commands/issue_feature.ts
@@ -28,7 +28,13 @@ import {
 } from "../../presentation/renderers/issue_create.ts";
 import { EditorService } from "../../infrastructure/editor/editor_service.ts";
 import { UserError } from "../../domain/errors.ts";
-import { resolveDestination, submitIssue } from "./issue_submit.ts";
+import {
+  dispatchExtensionRepositoryReport,
+  resolveDestination,
+  resolveExtensionOrRefuse,
+  submitIssue,
+  type UsableExtensionTarget,
+} from "./issue_submit.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -135,9 +141,21 @@ export const issueFeatureCommand = new Command()
       throw new UserError("--email and --extension cannot be used together.");
     }
 
-    // Resolve destination BEFORE collecting content so we don't waste the user's time
-    const destination = await resolveDestination(ctx, options.email);
-    if (destination.method === "abort") {
+    let extensionTarget: UsableExtensionTarget | undefined;
+    if (options.extension) {
+      const resolved = await resolveExtensionOrRefuse(
+        ctx,
+        options.extension,
+        resolveRepoDir(options.repoDir),
+      );
+      if (resolved === null) return;
+      extensionTarget = resolved;
+    }
+
+    const destination = !extensionTarget || extensionTarget.kind === "swamp-lab"
+      ? await resolveDestination(ctx, options.email)
+      : undefined;
+    if (destination?.method === "abort") {
       await submitIssue(ctx, destination, {
         type: "feature",
         title: "",
@@ -196,12 +214,22 @@ export const issueFeatureCommand = new Command()
 
     ctx.logger.debug`Submitting feature request with title: ${title}`;
 
-    await submitIssue(ctx, destination, {
+    if (extensionTarget?.kind === "repository") {
+      await dispatchExtensionRepositoryReport(ctx, extensionTarget, {
+        type: "feature",
+        title,
+        body,
+      });
+      return;
+    }
+
+    await submitIssue(ctx, destination!, {
       type: "feature",
       title,
       body,
-      extensionName: options.extension,
-      repoDir: options.extension ? resolveRepoDir(options.repoDir) : undefined,
+      swampLabTarget: extensionTarget?.kind === "swamp-lab"
+        ? extensionTarget
+        : undefined,
     });
 
     ctx.logger.debug("Feature request submitted successfully");

--- a/src/cli/commands/issue_feature.ts
+++ b/src/cli/commands/issue_feature.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import {
   renderIssueCancelled,
 } from "../../presentation/renderers/issue_create.ts";
@@ -102,6 +106,10 @@ export const issueFeatureCommand = new Command()
   .name("feature")
   .description("Submit a feature request")
   .example("Submit a feature request", "swamp issue feature")
+  .example(
+    "Request a feature on a specific extension",
+    "swamp issue feature --extension @adam/cfgmgmt",
+  )
   .option(
     "-t, --title <title:string>",
     "Feature title (skips editor for title)",
@@ -111,9 +119,21 @@ export const issueFeatureCommand = new Command()
     "Feature description (requires --title, skips editor entirely)",
   )
   .option("-e, --email", "Open email client with pre-filled feature request")
+  .option(
+    "-x, --extension <name:string>",
+    "Route the feature against a specific extension (e.g. @adam/cfgmgmt)",
+  )
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR) — only used with --extension",
+  )
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, ["issue", "feature"]);
     ctx.logger.debug`Submitting feature request`;
+
+    if (options.email && options.extension) {
+      throw new UserError("--email and --extension cannot be used together.");
+    }
 
     // Resolve destination BEFORE collecting content so we don't waste the user's time
     const destination = await resolveDestination(ctx, options.email);
@@ -180,6 +200,8 @@ export const issueFeatureCommand = new Command()
       type: "feature",
       title,
       body,
+      extensionName: options.extension,
+      repoDir: options.extension ? resolveRepoDir(options.repoDir) : undefined,
     });
 
     ctx.logger.debug("Feature request submitted successfully");

--- a/src/cli/commands/issue_security.ts
+++ b/src/cli/commands/issue_security.ts
@@ -28,7 +28,13 @@ import {
 } from "../../presentation/renderers/issue_create.ts";
 import { EditorService } from "../../infrastructure/editor/editor_service.ts";
 import { UserError } from "../../domain/errors.ts";
-import { resolveDestination, submitIssue } from "./issue_submit.ts";
+import {
+  dispatchExtensionRepositoryReport,
+  resolveDestination,
+  resolveExtensionOrRefuse,
+  submitIssue,
+  type UsableExtensionTarget,
+} from "./issue_submit.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -141,8 +147,21 @@ export const issueSecurityCommand = new Command()
       throw new UserError("--email and --extension cannot be used together.");
     }
 
-    const destination = await resolveDestination(ctx, options.email);
-    if (destination.method === "abort") {
+    let extensionTarget: UsableExtensionTarget | undefined;
+    if (options.extension) {
+      const resolved = await resolveExtensionOrRefuse(
+        ctx,
+        options.extension,
+        resolveRepoDir(options.repoDir),
+      );
+      if (resolved === null) return;
+      extensionTarget = resolved;
+    }
+
+    const destination = !extensionTarget || extensionTarget.kind === "swamp-lab"
+      ? await resolveDestination(ctx, options.email)
+      : undefined;
+    if (destination?.method === "abort") {
       await submitIssue(ctx, destination, {
         type: "security",
         title: "",
@@ -201,12 +220,22 @@ export const issueSecurityCommand = new Command()
 
     ctx.logger.debug`Submitting security report with title: ${title}`;
 
-    await submitIssue(ctx, destination, {
+    if (extensionTarget?.kind === "repository") {
+      await dispatchExtensionRepositoryReport(ctx, extensionTarget, {
+        type: "security",
+        title,
+        body,
+      });
+      return;
+    }
+
+    await submitIssue(ctx, destination!, {
       type: "security",
       title,
       body,
-      extensionName: options.extension,
-      repoDir: options.extension ? resolveRepoDir(options.repoDir) : undefined,
+      swampLabTarget: extensionTarget?.kind === "swamp-lab"
+        ? extensionTarget
+        : undefined,
     });
 
     ctx.logger.debug("Security report submitted successfully");

--- a/src/cli/commands/issue_security.ts
+++ b/src/cli/commands/issue_security.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
 import {
   renderIssueCancelled,
 } from "../../presentation/renderers/issue_create.ts";
@@ -105,6 +109,10 @@ export const issueSecurityCommand = new Command()
     "Submit a security vulnerability report (visible only to you and admins)",
   )
   .example("Submit a security report", "swamp issue security")
+  .example(
+    "Report a security vulnerability against an extension",
+    "swamp issue security --extension @adam/cfgmgmt",
+  )
   .option(
     "-t, --title <title:string>",
     "Vulnerability title (skips editor for title)",
@@ -117,9 +125,21 @@ export const issueSecurityCommand = new Command()
     "-e, --email",
     "Open email client with pre-filled security report",
   )
+  .option(
+    "-x, --extension <name:string>",
+    "Route the security report against a specific extension (e.g. @adam/cfgmgmt)",
+  )
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR) — only used with --extension",
+  )
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, ["issue", "security"]);
     ctx.logger.debug`Submitting security report`;
+
+    if (options.email && options.extension) {
+      throw new UserError("--email and --extension cannot be used together.");
+    }
 
     const destination = await resolveDestination(ctx, options.email);
     if (destination.method === "abort") {
@@ -185,6 +205,8 @@ export const issueSecurityCommand = new Command()
       type: "security",
       title,
       body,
+      extensionName: options.extension,
+      repoDir: options.extension ? resolveRepoDir(options.repoDir) : undefined,
     });
 
     ctx.logger.debug("Security report submitted successfully");

--- a/src/cli/commands/issue_submit.ts
+++ b/src/cli/commands/issue_submit.ts
@@ -23,6 +23,10 @@
  * Split into two phases so the auth check happens BEFORE the editor opens:
  * 1. resolveDestination() — check auth, prompt if needed, return where to send
  * 2. submitIssue() — send the issue to the resolved destination
+ *
+ * When `--extension` is supplied, submitIssue additionally resolves the
+ * extension target (pulled/sourced/no-repo refusal vs @swamp-lab vs
+ * third-party repository) and dispatches accordingly.
  */
 
 import type { CommandContext } from "../context.ts";
@@ -34,12 +38,21 @@ import {
 } from "../../libswamp/mod.ts";
 import {
   createIssueCreateRenderer,
+  renderExtensionRefusal,
+  renderExtensionRepositoryHandoff,
 } from "../../presentation/renderers/issue_create.ts";
 import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
 import { SwampClubClient } from "../../infrastructure/http/swamp_club_client.ts";
 import { openBrowser } from "../../infrastructure/process/browser.ts";
 import { UserError } from "../../domain/errors.ts";
 import type { AuthCredentials } from "../../domain/auth/auth_credentials.ts";
+import {
+  dispatchRepositoryReport,
+  type ExtensionTarget,
+  resolveExtensionTarget,
+} from "./extension_report_dispatcher.ts";
+import { collectReporterContext } from "../../infrastructure/process/reporter_context_collector.ts";
+import { VERSION } from "./version.ts";
 
 const SUPPORT_EMAIL = "support@systeminit.com";
 
@@ -80,6 +93,10 @@ export interface SubmitIssueInput {
   type: "bug" | "feature" | "security";
   title: string;
   body: string;
+  /** Extension name from `--extension`, triggers extension-scoped routing. */
+  extensionName?: string;
+  /** Repository directory used to resolve the pulled extension. */
+  repoDir?: string;
 }
 
 /** Build a mailto: URL with pre-filled subject and body using RFC 6068 percent-encoding. */
@@ -123,6 +140,10 @@ async function promptLoginOrEmail(): Promise<"login" | "email"> {
 /**
  * Submit an issue to the already-resolved destination.
  * Called after title/body are collected.
+ *
+ * When `input.extensionName` is set, the extension target is resolved
+ * first. Refusals and third-party repository handoffs never hit swamp-
+ * club — they short-circuit the Lab submission path entirely.
  */
 export async function submitIssue(
   ctx: CommandContext,
@@ -132,9 +153,62 @@ export async function submitIssue(
   const libCtx = createLibSwampContext({ logger: ctx.logger });
   const renderer = createIssueCreateRenderer(ctx.outputMode);
 
+  // Extension-scoped routing: resolve the target first.
+  // Refusals are INFORMATIONAL (exit 0), not errors.
+  let extensionTarget: ExtensionTarget | undefined;
+  if (input.extensionName) {
+    if (!input.repoDir) {
+      throw new UserError(
+        "--extension requires a repository directory. Run swamp from inside a swamp repo.",
+      );
+    }
+    extensionTarget = await resolveExtensionTarget(
+      input.repoDir,
+      input.extensionName,
+    );
+    if (extensionTarget.kind === "refused") {
+      renderExtensionRefusal(
+        {
+          extensionName: extensionTarget.extensionName,
+          reason: extensionTarget.reason,
+          guidance: extensionTarget.guidance,
+        },
+        ctx.outputMode,
+      );
+      return;
+    }
+  }
+
   if (destination.method === "abort") {
     libCtx.logger
       .info`Run "swamp auth login" first, then retry this command.`;
+    return;
+  }
+
+  // Third-party repository handoff — never touches swamp-club Lab.
+  if (extensionTarget?.kind === "repository") {
+    const reporterContext = collectReporterContext({
+      extensionName: extensionTarget.extensionName,
+      extensionVersion: extensionTarget.extensionVersion,
+      swampVersion: VERSION,
+    });
+    const result = await dispatchRepositoryReport(
+      extensionTarget,
+      {
+        type: input.type,
+        title: input.title,
+        body: input.body,
+        reporterContext,
+        outputMode: ctx.outputMode,
+      },
+      {
+        logger: ctx.logger,
+      },
+    );
+    renderExtensionRepositoryHandoff(
+      { result, extensionName: extensionTarget.extensionName },
+      ctx.outputMode,
+    );
     return;
   }
 
@@ -162,7 +236,7 @@ export async function submitIssue(
     return;
   }
 
-  // Lab submission
+  // Lab submission (both plain and @swamp-extension paths).
   const client = new SwampClubClient(destination.credentials.serverUrl);
   const deps: IssueCreateDeps = {
     submitToLab: async (params) => {
@@ -177,8 +251,30 @@ export async function submitIssue(
     },
   };
 
+  // @swamp path: populate the extension metadata so libswamp assembles
+  // the body with Extension: / Upstream repository: / Environment lines.
+  const labInput = extensionTarget?.kind === "swamp-lab"
+    ? {
+      type: input.type,
+      title: input.title,
+      body: input.body,
+      extensionName: extensionTarget.extensionName,
+      extensionVersion: extensionTarget.extensionVersion,
+      repositoryUrl: extensionTarget.repositoryUrl,
+      reporterContext: collectReporterContext({
+        extensionName: extensionTarget.extensionName,
+        extensionVersion: extensionTarget.extensionVersion,
+        swampVersion: VERSION,
+      }),
+    }
+    : {
+      type: input.type,
+      title: input.title,
+      body: input.body,
+    };
+
   await consumeStream(
-    issueCreate(libCtx, deps, input),
+    issueCreate(libCtx, deps, labInput),
     renderer.handlers(),
   );
 }

--- a/src/cli/commands/issue_submit.ts
+++ b/src/cli/commands/issue_submit.ts
@@ -54,6 +54,12 @@ import {
 import { collectReporterContext } from "../../infrastructure/process/reporter_context_collector.ts";
 import { VERSION } from "./version.ts";
 
+/** Extension target after refusals have been rendered out — never "refused". */
+export type UsableExtensionTarget = Exclude<
+  ExtensionTarget,
+  { kind: "refused" }
+>;
+
 const SUPPORT_EMAIL = "support@systeminit.com";
 
 /** The resolved submission destination. */
@@ -93,10 +99,13 @@ export interface SubmitIssueInput {
   type: "bug" | "feature" | "security";
   title: string;
   body: string;
-  /** Extension name from `--extension`, triggers extension-scoped routing. */
-  extensionName?: string;
-  /** Repository directory used to resolve the pulled extension. */
-  repoDir?: string;
+  /**
+   * Pre-resolved `@swamp/*` target (from {@link resolveExtensionOrRefuse}).
+   * Only passed on the `@swamp/*` extension path — third-party targets
+   * use {@link dispatchExtensionRepositoryReport} directly and never
+   * reach submitIssue.
+   */
+  swampLabTarget?: Extract<UsableExtensionTarget, { kind: "swamp-lab" }>;
 }
 
 /** Build a mailto: URL with pre-filled subject and body using RFC 6068 percent-encoding. */
@@ -138,12 +147,74 @@ async function promptLoginOrEmail(): Promise<"login" | "email"> {
 }
 
 /**
- * Submit an issue to the already-resolved destination.
- * Called after title/body are collected.
+ * Extension pre-flight: resolves the target, renders any refusal, and
+ * returns a usable target for the caller to act on. Returns null when
+ * the refusal was rendered and the subcommand should exit.
  *
- * When `input.extensionName` is set, the extension target is resolved
- * first. Refusals and third-party repository handoffs never hit swamp-
- * club — they short-circuit the Lab submission path entirely.
+ * Call this BEFORE {@link resolveDestination} — refusals and repository
+ * handoffs don't need Lab auth, so auth-checking the user up-front would
+ * spuriously fail commands that were never going to touch the Lab.
+ */
+export async function resolveExtensionOrRefuse(
+  ctx: CommandContext,
+  extensionName: string,
+  repoDir: string,
+): Promise<UsableExtensionTarget | null> {
+  const target = await resolveExtensionTarget(repoDir, extensionName);
+  if (target.kind === "refused") {
+    renderExtensionRefusal(
+      {
+        extensionName: target.extensionName,
+        reason: target.reason,
+        guidance: target.guidance,
+      },
+      ctx.outputMode,
+    );
+    return null;
+  }
+  return target;
+}
+
+/**
+ * Dispatches a report to the publisher's declared repository via gh or
+ * browser handoff, then renders the completion event. Used by all three
+ * subcommands once the body has been collected.
+ */
+export async function dispatchExtensionRepositoryReport(
+  ctx: CommandContext,
+  target: Extract<UsableExtensionTarget, { kind: "repository" }>,
+  input: { type: "bug" | "feature" | "security"; title: string; body: string },
+): Promise<void> {
+  const reporterContext = collectReporterContext({
+    extensionName: target.extensionName,
+    extensionVersion: target.extensionVersion,
+    swampVersion: VERSION,
+  });
+  const result = await dispatchRepositoryReport(
+    target,
+    {
+      type: input.type,
+      title: input.title,
+      body: input.body,
+      reporterContext,
+      outputMode: ctx.outputMode,
+    },
+    { logger: ctx.logger },
+  );
+  renderExtensionRepositoryHandoff(
+    { result, extensionName: target.extensionName },
+    ctx.outputMode,
+  );
+}
+
+/**
+ * Submit an issue to the already-resolved destination. Called after
+ * title/body are collected for the plain (non-extension) path and for
+ * the `@swamp/*` extension path (both of which need Lab auth).
+ *
+ * For the plain path, `input.extensionName` is unset.
+ * For the `@swamp/*` path, `input.extensionName` is set and libswamp
+ * appends extension metadata to the body.
  */
 export async function submitIssue(
   ctx: CommandContext,
@@ -153,62 +224,9 @@ export async function submitIssue(
   const libCtx = createLibSwampContext({ logger: ctx.logger });
   const renderer = createIssueCreateRenderer(ctx.outputMode);
 
-  // Extension-scoped routing: resolve the target first.
-  // Refusals are INFORMATIONAL (exit 0), not errors.
-  let extensionTarget: ExtensionTarget | undefined;
-  if (input.extensionName) {
-    if (!input.repoDir) {
-      throw new UserError(
-        "--extension requires a repository directory. Run swamp from inside a swamp repo.",
-      );
-    }
-    extensionTarget = await resolveExtensionTarget(
-      input.repoDir,
-      input.extensionName,
-    );
-    if (extensionTarget.kind === "refused") {
-      renderExtensionRefusal(
-        {
-          extensionName: extensionTarget.extensionName,
-          reason: extensionTarget.reason,
-          guidance: extensionTarget.guidance,
-        },
-        ctx.outputMode,
-      );
-      return;
-    }
-  }
-
   if (destination.method === "abort") {
     libCtx.logger
       .info`Run "swamp auth login" first, then retry this command.`;
-    return;
-  }
-
-  // Third-party repository handoff — never touches swamp-club Lab.
-  if (extensionTarget?.kind === "repository") {
-    const reporterContext = collectReporterContext({
-      extensionName: extensionTarget.extensionName,
-      extensionVersion: extensionTarget.extensionVersion,
-      swampVersion: VERSION,
-    });
-    const result = await dispatchRepositoryReport(
-      extensionTarget,
-      {
-        type: input.type,
-        title: input.title,
-        body: input.body,
-        reporterContext,
-        outputMode: ctx.outputMode,
-      },
-      {
-        logger: ctx.logger,
-      },
-    );
-    renderExtensionRepositoryHandoff(
-      { result, extensionName: extensionTarget.extensionName },
-      ctx.outputMode,
-    );
     return;
   }
 
@@ -253,17 +271,17 @@ export async function submitIssue(
 
   // @swamp path: populate the extension metadata so libswamp assembles
   // the body with Extension: / Upstream repository: / Environment lines.
-  const labInput = extensionTarget?.kind === "swamp-lab"
+  const labInput = input.swampLabTarget
     ? {
       type: input.type,
       title: input.title,
       body: input.body,
-      extensionName: extensionTarget.extensionName,
-      extensionVersion: extensionTarget.extensionVersion,
-      repositoryUrl: extensionTarget.repositoryUrl,
+      extensionName: input.swampLabTarget.extensionName,
+      extensionVersion: input.swampLabTarget.extensionVersion,
+      repositoryUrl: input.swampLabTarget.repositoryUrl,
       reporterContext: collectReporterContext({
-        extensionName: extensionTarget.extensionName,
-        extensionVersion: extensionTarget.extensionVersion,
+        extensionName: input.swampLabTarget.extensionName,
+        extensionVersion: input.swampLabTarget.extensionVersion,
         swampVersion: VERSION,
       }),
     }

--- a/src/domain/extensions/installed_extension_lookup.ts
+++ b/src/domain/extensions/installed_extension_lookup.ts
@@ -1,0 +1,114 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join } from "@std/path";
+import { UserError } from "../errors.ts";
+import {
+  type ExtensionManifest,
+  parseExtensionManifest,
+} from "./extension_manifest.ts";
+
+/** Shape of a per-entry record in upstream_extensions.json. */
+interface UpstreamExtensionEntry {
+  version: string;
+}
+
+const SCOPED_NAME_PATTERN = /^@[a-z0-9_-]+\/[a-z0-9_-]+(\/[a-z0-9_-]+)*$/;
+
+/**
+ * Reads the read-only manifest copy written by `swamp extension pull` at
+ * `<pulledExtRoot>/<name>/manifest.yaml`. Returns null when the extension
+ * has never been pulled (file not present).
+ *
+ * The caller resolves `pulledExtRoot` (typically `swampPath(repoDir,
+ * "pulled-extensions")`) — this module does not touch infrastructure
+ * paths so tests stay hermetic.
+ */
+export async function loadInstalledExtensionManifest(
+  pulledExtRoot: string,
+  name: string,
+): Promise<ExtensionManifest | null> {
+  validateExtensionName(name);
+  const manifestPath = join(pulledExtRoot, name, "manifest.yaml");
+  let content: string;
+  try {
+    content = await Deno.readTextFile(manifestPath);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return null;
+    throw error;
+  }
+  return parseExtensionManifest(content);
+}
+
+/**
+ * Looks up the installed version of `name` in the upstream_extensions.json
+ * lockfile. Returns null when the extension has no entry.
+ *
+ * The caller resolves `lockfilePath` — typically
+ * `<models-dir>/upstream_extensions.json`, mirroring how
+ * `extension_pull.ts` assembles the path.
+ */
+export async function readInstalledExtensionVersion(
+  lockfilePath: string,
+  name: string,
+): Promise<string | null> {
+  let content: string;
+  try {
+    content = await Deno.readTextFile(lockfilePath);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return null;
+    throw error;
+  }
+  const map = JSON.parse(content) as Record<
+    string,
+    UpstreamExtensionEntry | undefined
+  >;
+  return map[name]?.version ?? null;
+}
+
+/**
+ * Extracts the collective slug from a scoped extension name.
+ * `@adam/cfgmgmt` → `adam`; `@foo/bar/baz` → `foo`.
+ *
+ * Throws UserError for malformed names via {@link validateExtensionName}.
+ */
+export function extractCollective(name: string): string {
+  validateExtensionName(name);
+  const slashIdx = name.indexOf("/");
+  // validateExtensionName guarantees the shape @collective/name[/...].
+  return name.slice(1, slashIdx);
+}
+
+/** True when the extension's collective is the `@swamp` organization. */
+export function isSwampCollective(name: string): boolean {
+  return extractCollective(name) === "swamp";
+}
+
+/**
+ * Validates a scoped extension name. Mirrors the check used by
+ * `swamp extension pull` so error messages stay consistent across
+ * commands.
+ */
+export function validateExtensionName(name: string): void {
+  if (!SCOPED_NAME_PATTERN.test(name)) {
+    throw new UserError(
+      `Invalid extension name: "${name}". Must match @collective/name pattern (lowercase, alphanumeric, hyphens, underscores, additional /segments allowed).`,
+    );
+  }
+}

--- a/src/domain/extensions/installed_extension_lookup_test.ts
+++ b/src/domain/extensions/installed_extension_lookup_test.ts
@@ -1,0 +1,177 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import { join } from "@std/path";
+import { UserError } from "../errors.ts";
+import {
+  extractCollective,
+  isSwampCollective,
+  loadInstalledExtensionManifest,
+  readInstalledExtensionVersion,
+  validateExtensionName,
+} from "./installed_extension_lookup.ts";
+
+const VALID_MANIFEST = `manifestVersion: 1
+name: "@adam/cfgmgmt"
+version: "2026.04.22.1"
+description: "Config management"
+repository: "https://github.com/adam/cfgmgmt"
+models:
+  - foo.yaml
+`;
+
+Deno.test("loadInstalledExtensionManifest: returns null when extension is not pulled", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_iel_" });
+  try {
+    const result = await loadInstalledExtensionManifest(tmp, "@adam/cfgmgmt");
+    assertEquals(result, null);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("loadInstalledExtensionManifest: reads manifest from <root>/<name>/manifest.yaml", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_iel_" });
+  try {
+    const extDir = join(tmp, "@adam", "cfgmgmt");
+    await Deno.mkdir(extDir, { recursive: true });
+    await Deno.writeTextFile(join(extDir, "manifest.yaml"), VALID_MANIFEST);
+
+    const manifest = await loadInstalledExtensionManifest(
+      tmp,
+      "@adam/cfgmgmt",
+    );
+    assertEquals(manifest?.name, "@adam/cfgmgmt");
+    assertEquals(manifest?.version, "2026.04.22.1");
+    assertEquals(manifest?.repository, "https://github.com/adam/cfgmgmt");
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("loadInstalledExtensionManifest: throws UserError for malformed name", async () => {
+  await assertRejects(
+    () => loadInstalledExtensionManifest("/tmp", "not-a-scoped-name"),
+    UserError,
+    "Invalid extension name",
+  );
+});
+
+Deno.test("readInstalledExtensionVersion: returns version when entry exists", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_iel_" });
+  try {
+    const lockfilePath = join(tmp, "upstream_extensions.json");
+    const data = {
+      "@adam/cfgmgmt": {
+        version: "2026.04.22.1",
+        pulledAt: new Date().toISOString(),
+      },
+    };
+    await Deno.writeTextFile(lockfilePath, JSON.stringify(data));
+
+    const version = await readInstalledExtensionVersion(
+      lockfilePath,
+      "@adam/cfgmgmt",
+    );
+    assertEquals(version, "2026.04.22.1");
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("readInstalledExtensionVersion: returns null when entry is absent", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_iel_" });
+  try {
+    const lockfilePath = join(tmp, "upstream_extensions.json");
+    await Deno.writeTextFile(lockfilePath, "{}");
+
+    const version = await readInstalledExtensionVersion(
+      lockfilePath,
+      "@adam/cfgmgmt",
+    );
+    assertEquals(version, null);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("readInstalledExtensionVersion: returns null when lockfile is missing", async () => {
+  const version = await readInstalledExtensionVersion(
+    "/nonexistent/upstream_extensions.json",
+    "@adam/cfgmgmt",
+  );
+  assertEquals(version, null);
+});
+
+Deno.test("extractCollective: single-segment name", () => {
+  assertEquals(extractCollective("@adam/cfgmgmt"), "adam");
+});
+
+Deno.test("extractCollective: multi-segment name takes the collective only", () => {
+  assertEquals(extractCollective("@foo/bar/baz"), "foo");
+});
+
+Deno.test("extractCollective: throws UserError for malformed name", () => {
+  assertThrows(
+    () => extractCollective("not-a-scoped-name"),
+    UserError,
+    "Invalid extension name",
+  );
+});
+
+Deno.test("isSwampCollective: true for @swamp/*", () => {
+  assertEquals(isSwampCollective("@swamp/aws"), true);
+  assertEquals(isSwampCollective("@swamp/aws/ec2"), true);
+});
+
+Deno.test("isSwampCollective: false for non-swamp collectives", () => {
+  assertEquals(isSwampCollective("@adam/cfgmgmt"), false);
+  assertEquals(isSwampCollective("@swampy/aws"), false);
+});
+
+Deno.test("validateExtensionName: accepts valid scoped names", () => {
+  validateExtensionName("@adam/cfgmgmt");
+  validateExtensionName("@foo/bar/baz");
+  validateExtensionName("@swamp_team/my-ext");
+});
+
+Deno.test("validateExtensionName: rejects names without leading @", () => {
+  assertThrows(
+    () => validateExtensionName("adam/cfgmgmt"),
+    UserError,
+    "Invalid extension name",
+  );
+});
+
+Deno.test("validateExtensionName: rejects names without slash", () => {
+  assertThrows(
+    () => validateExtensionName("@adam"),
+    UserError,
+    "Invalid extension name",
+  );
+});
+
+Deno.test("validateExtensionName: rejects uppercase characters", () => {
+  assertThrows(
+    () => validateExtensionName("@Adam/cfgmgmt"),
+    UserError,
+    "Invalid extension name",
+  );
+});

--- a/src/domain/extensions/reporter_context.ts
+++ b/src/domain/extensions/reporter_context.ts
@@ -1,0 +1,86 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Reproducibility context attached to every extension-scoped issue
+ * report so the publisher sees which version / runtime the reporter hit
+ * the bug on.
+ *
+ * The field list is intentionally narrow — extending it widens a trust
+ * boundary (this data is shipped to third-party repos) and must be an
+ * explicit decision, not an incidental one.
+ */
+export interface ReporterContext {
+  extensionName: string;
+  extensionVersion: string;
+  swampVersion: string;
+  os: string;
+  arch: string;
+  shell: string;
+  denoVersion: string;
+}
+
+/**
+ * Renders the reporter context as a Markdown section suitable for
+ * appending to the body of an issue. The "## Environment" header shape
+ * mirrors the existing bug/security templates so users who know those
+ * see something familiar.
+ */
+export function formatReporterContextMarkdown(ctx: ReporterContext): string {
+  return [
+    "## Environment",
+    `- Extension: \`${ctx.extensionName}@${ctx.extensionVersion}\``,
+    `- swamp: \`${ctx.swampVersion}\``,
+    `- OS: \`${ctx.os}\` (${ctx.arch})`,
+    `- Deno: \`${ctx.denoVersion}\``,
+    `- Shell: \`${ctx.shell}\``,
+  ].join("\n");
+}
+
+/**
+ * Assembles the final issue body for an extension-scoped report.
+ *
+ * Shared by the @swamp Lab path (libswamp) and the third-party
+ * repository path (CLI dispatcher) so the two destinations produce
+ * identical formatting — readers comparing an @swamp report to a
+ * third-party one shouldn't find cosmetic drift.
+ *
+ * Layout:
+ *   <user body>
+ *
+ *   Upstream repository: <url>        ← only when repositoryUrl is set
+ *
+ *   ## Environment
+ *   - Extension: `@name@version`
+ *   - swamp: ...
+ *   - ...
+ */
+export function assembleExtensionReportBody(
+  userBody: string,
+  repositoryUrl: string | undefined,
+  reporterContext: ReporterContext,
+): string {
+  const parts: string[] = [userBody.trimEnd(), ""];
+  if (repositoryUrl) {
+    parts.push(`Upstream repository: ${repositoryUrl}`);
+    parts.push("");
+  }
+  parts.push(formatReporterContextMarkdown(reporterContext));
+  return parts.join("\n");
+}

--- a/src/domain/extensions/reporter_context_test.ts
+++ b/src/domain/extensions/reporter_context_test.ts
@@ -1,0 +1,68 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  formatReporterContextMarkdown,
+  type ReporterContext,
+} from "./reporter_context.ts";
+
+const SAMPLE: ReporterContext = {
+  extensionName: "@adam/cfgmgmt",
+  extensionVersion: "2026.04.22.1",
+  swampVersion: "20260422.123456.0-sha.abc123",
+  os: "darwin",
+  arch: "aarch64",
+  shell: "/bin/zsh",
+  denoVersion: "1.45.0",
+};
+
+Deno.test("formatReporterContextMarkdown: renders a stable shape", () => {
+  const expected = [
+    "## Environment",
+    "- Extension: `@adam/cfgmgmt@2026.04.22.1`",
+    "- swamp: `20260422.123456.0-sha.abc123`",
+    "- OS: `darwin` (aarch64)",
+    "- Deno: `1.45.0`",
+    "- Shell: `/bin/zsh`",
+  ].join("\n");
+  assertEquals(formatReporterContextMarkdown(SAMPLE), expected);
+});
+
+Deno.test("formatReporterContextMarkdown: starts with the Environment header", () => {
+  const out = formatReporterContextMarkdown(SAMPLE);
+  assertStringIncludes(out, "## Environment");
+});
+
+Deno.test("formatReporterContextMarkdown: includes every field exactly once", () => {
+  const out = formatReporterContextMarkdown(SAMPLE);
+  assertStringIncludes(out, SAMPLE.extensionName);
+  assertStringIncludes(out, SAMPLE.extensionVersion);
+  assertStringIncludes(out, SAMPLE.swampVersion);
+  assertStringIncludes(out, SAMPLE.os);
+  assertStringIncludes(out, SAMPLE.arch);
+  assertStringIncludes(out, SAMPLE.denoVersion);
+  assertStringIncludes(out, SAMPLE.shell);
+});
+
+Deno.test("formatReporterContextMarkdown: shell value with spaces is wrapped in backticks", () => {
+  const ctx: ReporterContext = { ...SAMPLE, shell: "/my path/zsh" };
+  const out = formatReporterContextMarkdown(ctx);
+  assertStringIncludes(out, "- Shell: `/my path/zsh`");
+});

--- a/src/domain/extensions/repository_url.ts
+++ b/src/domain/extensions/repository_url.ts
@@ -1,0 +1,167 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { UserError } from "../errors.ts";
+
+/** Supported third-party repository providers. */
+export type RepositoryProvider = "github" | "gitlab" | "other";
+
+/** Parsed view of a manifest `repository` URL. */
+export interface ParsedRepositoryUrl {
+  provider: RepositoryProvider;
+  host: string;
+  /** "owner/repo" for GitHub/GitLab; undefined for "other". */
+  ownerRepo?: string;
+  /** The original URL, canonicalised (trailing slash and `.git` stripped). */
+  url: string;
+}
+
+/**
+ * GitHub URLs pre-fill title/body in the issue-new page up to ~8KB — truncate
+ * conservatively well under that so percent-encoding doesn't push us over.
+ */
+const URL_BODY_MAX_LEN = 7000;
+const URL_BODY_TRUNCATION_SUFFIX = "\n\n…(body truncated; see terminal output)";
+
+/**
+ * Parses a repository URL from an extension manifest.
+ *
+ * Only HTTPS URLs are accepted — `git@github.com:...` style URLs cannot be
+ * opened in a browser and are rejected with a clear error so the caller
+ * surfaces the right guidance.
+ */
+export function parseRepositoryUrl(url: string): ParsedRepositoryUrl {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new UserError(
+      `Invalid repository URL: "${url}". Must be an HTTPS URL.`,
+    );
+  }
+  if (parsed.protocol !== "https:") {
+    throw new UserError(
+      `Repository URL must use HTTPS: "${url}". ` +
+        `Opening non-HTTPS URLs in a browser isn't supported.`,
+    );
+  }
+
+  const canonical = canonicaliseUrl(parsed);
+  const host = parsed.hostname.toLowerCase();
+
+  if (host === "github.com") {
+    const ownerRepo = extractOwnerRepo(parsed);
+    if (ownerRepo) {
+      return { provider: "github", host, ownerRepo, url: canonical };
+    }
+  }
+
+  if (host === "gitlab.com") {
+    const ownerRepo = extractOwnerRepo(parsed);
+    if (ownerRepo) {
+      return { provider: "gitlab", host, ownerRepo, url: canonical };
+    }
+  }
+
+  return { provider: "other", host, url: canonical };
+}
+
+/**
+ * Builds the pre-filled GitHub new-issue URL. Body is truncated with a
+ * visible suffix if it would otherwise blow past GitHub's URL-length cap.
+ */
+export function buildGithubNewIssueUrl(
+  ownerRepo: string,
+  title: string,
+  body: string,
+  labels: string[] = [],
+): string {
+  const safeBody = truncateForUrl(body);
+  const params = new URLSearchParams();
+  params.set("title", title);
+  params.set("body", safeBody);
+  if (labels.length > 0) params.set("labels", labels.join(","));
+  return `https://github.com/${ownerRepo}/issues/new?${params.toString()}`;
+}
+
+/**
+ * Builds the GitHub private vulnerability reporting URL. GitHub's advisory
+ * form is structured and does not accept URL query parameters — the CLI
+ * hands off to this URL and the user fills in the form.
+ */
+export function buildGithubAdvisoryUrl(ownerRepo: string): string {
+  return `https://github.com/${ownerRepo}/security/advisories/new`;
+}
+
+/** Builds the pre-filled GitLab new-issue URL (gitlab.com only). */
+export function buildGitlabNewIssueUrl(
+  repoUrl: string,
+  title: string,
+  body: string,
+): string {
+  const safeBody = truncateForUrl(body);
+  const base = repoUrl.replace(/\/$/, "");
+  const params = new URLSearchParams();
+  params.set("issue[title]", title);
+  params.set("issue[description]", safeBody);
+  return `${base}/-/issues/new?${params.toString()}`;
+}
+
+/**
+ * Centralises the swamp-club extension-page URL so future swamp-club
+ * route changes land in one place. The URL template matches
+ * swamp-club/routes/extensions/[...name].tsx.
+ */
+export function swampClubExtensionUrl(extensionName: string): string {
+  return `https://swamp.club/extensions/${encodeURIComponent(extensionName)}`;
+}
+
+/**
+ * Builds the GitHub "enable private vulnerability reporting" repo-settings
+ * URL. Only useful to the repo's admin, but included in the refusal
+ * guidance so publishers have a one-click action when a reporter forwards
+ * the message to them.
+ */
+export function buildGithubSecuritySettingsUrl(ownerRepo: string): string {
+  return `https://github.com/${ownerRepo}/settings/security_analysis`;
+}
+
+function truncateForUrl(body: string): string {
+  if (body.length <= URL_BODY_MAX_LEN) return body;
+  const head = body.slice(
+    0,
+    URL_BODY_MAX_LEN - URL_BODY_TRUNCATION_SUFFIX.length,
+  );
+  return head + URL_BODY_TRUNCATION_SUFFIX;
+}
+
+function canonicaliseUrl(parsed: URL): string {
+  let pathname = parsed.pathname.replace(/\/+$/, "");
+  if (pathname.endsWith(".git")) pathname = pathname.slice(0, -4);
+  return `${parsed.protocol}//${parsed.host}${pathname}`;
+}
+
+function extractOwnerRepo(parsed: URL): string | undefined {
+  // Strip leading "/", drop trailing ".git", then take the first two segments.
+  const cleaned = parsed.pathname.replace(/^\/+/, "").replace(/\.git$/, "");
+  if (!cleaned) return undefined;
+  const segments = cleaned.split("/").filter((s) => s.length > 0);
+  if (segments.length < 2) return undefined;
+  return `${segments[0]}/${segments[1]}`;
+}

--- a/src/domain/extensions/repository_url_test.ts
+++ b/src/domain/extensions/repository_url_test.ts
@@ -1,0 +1,180 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
+import { UserError } from "../errors.ts";
+import {
+  buildGithubAdvisoryUrl,
+  buildGithubNewIssueUrl,
+  buildGithubSecuritySettingsUrl,
+  buildGitlabNewIssueUrl,
+  parseRepositoryUrl,
+  swampClubExtensionUrl,
+} from "./repository_url.ts";
+
+Deno.test("parseRepositoryUrl: github.com recognised", () => {
+  const parsed = parseRepositoryUrl("https://github.com/adam/cfgmgmt");
+  assertEquals(parsed.provider, "github");
+  assertEquals(parsed.host, "github.com");
+  assertEquals(parsed.ownerRepo, "adam/cfgmgmt");
+});
+
+Deno.test("parseRepositoryUrl: github.com with .git suffix stripped", () => {
+  const parsed = parseRepositoryUrl("https://github.com/adam/cfgmgmt.git");
+  assertEquals(parsed.ownerRepo, "adam/cfgmgmt");
+  assertEquals(parsed.url, "https://github.com/adam/cfgmgmt");
+});
+
+Deno.test("parseRepositoryUrl: github.com with trailing slash stripped", () => {
+  const parsed = parseRepositoryUrl("https://github.com/adam/cfgmgmt/");
+  assertEquals(parsed.ownerRepo, "adam/cfgmgmt");
+  assertEquals(parsed.url, "https://github.com/adam/cfgmgmt");
+});
+
+Deno.test("parseRepositoryUrl: github.com with deep path still extracts owner/repo", () => {
+  const parsed = parseRepositoryUrl(
+    "https://github.com/adam/cfgmgmt/tree/main/docs",
+  );
+  assertEquals(parsed.provider, "github");
+  assertEquals(parsed.ownerRepo, "adam/cfgmgmt");
+});
+
+Deno.test("parseRepositoryUrl: gitlab.com recognised", () => {
+  const parsed = parseRepositoryUrl("https://gitlab.com/group/proj");
+  assertEquals(parsed.provider, "gitlab");
+  assertEquals(parsed.ownerRepo, "group/proj");
+});
+
+Deno.test("parseRepositoryUrl: self-hosted GitLab becomes 'other'", () => {
+  const parsed = parseRepositoryUrl("https://gitlab.company.com/group/proj");
+  assertEquals(parsed.provider, "other");
+  assertEquals(parsed.host, "gitlab.company.com");
+  assertEquals(parsed.ownerRepo, undefined);
+});
+
+Deno.test("parseRepositoryUrl: bitbucket.org becomes 'other'", () => {
+  const parsed = parseRepositoryUrl(
+    "https://bitbucket.org/owner/repo",
+  );
+  assertEquals(parsed.provider, "other");
+});
+
+Deno.test("parseRepositoryUrl: rejects non-HTTPS URLs", () => {
+  assertThrows(
+    () => parseRepositoryUrl("http://github.com/adam/cfgmgmt"),
+    UserError,
+    "must use HTTPS",
+  );
+  assertThrows(
+    () => parseRepositoryUrl("git@github.com:adam/cfgmgmt.git"),
+    UserError,
+  );
+});
+
+Deno.test("parseRepositoryUrl: rejects malformed URLs", () => {
+  assertThrows(
+    () => parseRepositoryUrl("not a url"),
+    UserError,
+    "Invalid repository URL",
+  );
+});
+
+Deno.test("parseRepositoryUrl: host is lowercased", () => {
+  const parsed = parseRepositoryUrl("https://GITHUB.com/adam/cfgmgmt");
+  assertEquals(parsed.provider, "github");
+  assertEquals(parsed.host, "github.com");
+});
+
+Deno.test("buildGithubNewIssueUrl: percent-encodes title and body", () => {
+  const url = buildGithubNewIssueUrl(
+    "adam/cfgmgmt",
+    "Fails on `foo`",
+    "Hello\n```js\ncode\n```",
+  );
+  // URLSearchParams uses '+' for spaces; also encodes backticks/newlines.
+  assertStringIncludes(url, "title=Fails+on+%60foo%60");
+  assertStringIncludes(url, "body=");
+  assertEquals(
+    url.startsWith("https://github.com/adam/cfgmgmt/issues/new?"),
+    true,
+  );
+});
+
+Deno.test("buildGithubNewIssueUrl: appends labels when provided", () => {
+  const url = buildGithubNewIssueUrl(
+    "adam/cfgmgmt",
+    "t",
+    "b",
+    ["swamp-extension", "bug"],
+  );
+  assertStringIncludes(url, "labels=swamp-extension%2Cbug");
+});
+
+Deno.test("buildGithubNewIssueUrl: truncates oversize body with visible suffix", () => {
+  const huge = "x".repeat(10_000);
+  const url = buildGithubNewIssueUrl("adam/cfgmgmt", "t", huge);
+  const params = new URL(url).searchParams;
+  const body = params.get("body") ?? "";
+  assertEquals(body.length < huge.length, true);
+  assertStringIncludes(body, "body truncated");
+});
+
+Deno.test("buildGithubAdvisoryUrl: shape", () => {
+  assertEquals(
+    buildGithubAdvisoryUrl("adam/cfgmgmt"),
+    "https://github.com/adam/cfgmgmt/security/advisories/new",
+  );
+});
+
+Deno.test("buildGitlabNewIssueUrl: uses issue[title] and issue[description]", () => {
+  const url = buildGitlabNewIssueUrl(
+    "https://gitlab.com/group/proj",
+    "Hello",
+    "body",
+  );
+  assertStringIncludes(url, "/-/issues/new?");
+  assertStringIncludes(url, "issue%5Btitle%5D=Hello");
+  assertStringIncludes(url, "issue%5Bdescription%5D=body");
+});
+
+Deno.test("buildGitlabNewIssueUrl: strips trailing slash from repo URL", () => {
+  const url = buildGitlabNewIssueUrl(
+    "https://gitlab.com/group/proj/",
+    "t",
+    "b",
+  );
+  assertEquals(
+    url.startsWith("https://gitlab.com/group/proj/-/issues/new?"),
+    true,
+  );
+});
+
+Deno.test("swampClubExtensionUrl: percent-encodes the scoped name", () => {
+  assertEquals(
+    swampClubExtensionUrl("@adam/cfgmgmt"),
+    "https://swamp.club/extensions/%40adam%2Fcfgmgmt",
+  );
+});
+
+Deno.test("buildGithubSecuritySettingsUrl: shape", () => {
+  assertEquals(
+    buildGithubSecuritySettingsUrl("adam/cfgmgmt"),
+    "https://github.com/adam/cfgmgmt/settings/security_analysis",
+  );
+});

--- a/src/infrastructure/process/gh_cli.ts
+++ b/src/infrastructure/process/gh_cli.ts
@@ -1,0 +1,242 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { UserError } from "../../domain/errors.ts";
+
+/** 3s cap on gh subprocesses so a slow/broken gh install doesn't stall the CLI. */
+const GH_TIMEOUT_MS = 3000;
+
+/** Commander shape so tests can inject a fake without touching real processes. */
+export interface GhCliRunner {
+  /**
+   * Runs `gh <args>`. Writes `stdin` to the subprocess's stdin when provided.
+   * Returns whatever the subprocess emitted, with no throwing — callers
+   * interpret the exit code.
+   */
+  run(
+    args: string[],
+    opts?: { stdin?: string; timeoutMs?: number },
+  ): Promise<GhRunResult>;
+}
+
+export interface GhRunResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  /** True if the subprocess could not be spawned at all (e.g. `gh` not on PATH). */
+  spawnFailed?: boolean;
+  /** True if the subprocess was killed by the AbortSignal. */
+  timedOut?: boolean;
+}
+
+/** Default runner that shells out to the real `gh` binary via Deno.Command. */
+export const defaultGhRunner: GhCliRunner = {
+  async run(args, opts) {
+    const timeoutMs = opts?.timeoutMs ?? GH_TIMEOUT_MS;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const cmd = new Deno.Command("gh", {
+        args,
+        stdin: opts?.stdin !== undefined ? "piped" : "null",
+        stdout: "piped",
+        stderr: "piped",
+        signal: controller.signal,
+      });
+      const child = cmd.spawn();
+      if (opts?.stdin !== undefined) {
+        const writer = child.stdin.getWriter();
+        await writer.write(new TextEncoder().encode(opts.stdin));
+        await writer.close();
+      }
+      const output = await child.output();
+      return {
+        exitCode: output.code,
+        stdout: new TextDecoder().decode(output.stdout),
+        stderr: new TextDecoder().decode(output.stderr),
+        timedOut: controller.signal.aborted,
+      };
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return { exitCode: -1, stdout: "", stderr: "", spawnFailed: true };
+      }
+      if (error instanceof DOMException && error.name === "AbortError") {
+        return { exitCode: -1, stdout: "", stderr: "", timedOut: true };
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+  },
+};
+
+/**
+ * Returns true when the CLI can shell out to `gh` to post an issue.
+ *
+ * Fast path: if `GH_TOKEN` (or `GITHUB_TOKEN`) is set, `gh` will use that
+ * token without a separate auth check — no subprocess needed.
+ *
+ * Slow path: run `gh auth status`. Non-zero exit, missing binary, or
+ * timeout all resolve to false.
+ */
+export async function isGhCliAvailable(
+  runner: GhCliRunner = defaultGhRunner,
+  env: { get(key: string): string | undefined } = {
+    get: (key) => Deno.env.get(key),
+  },
+): Promise<boolean> {
+  if (env.get("GH_TOKEN") || env.get("GITHUB_TOKEN")) return true;
+  const result = await runner.run(["auth", "status"]);
+  return result.exitCode === 0;
+}
+
+/**
+ * Checks whether a repository has GitHub's Private Vulnerability Reporting
+ * (PVR) feature enabled.
+ *
+ * Returns:
+ * - `true` when PVR is enabled (security reports should route to the
+ *   advisory form);
+ * - `false` when PVR is disabled (security reports must NOT be filed as
+ *   public issues — caller should refuse cleanly);
+ * - `null` when the check itself failed (network, auth scope, rate-limit,
+ *   timeout). Callers treat `null` as "fall back to the safer default" —
+ *   i.e. still route to the advisory URL and let GitHub tell the user.
+ */
+export async function checkGithubPvrEnabled(
+  ownerRepo: string,
+  runner: GhCliRunner = defaultGhRunner,
+): Promise<boolean | null> {
+  const result = await runner.run([
+    "api",
+    `repos/${ownerRepo}/private-vulnerability-reporting`,
+  ]);
+  if (result.spawnFailed || result.timedOut || result.exitCode !== 0) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(result.stdout);
+    if (typeof parsed?.enabled === "boolean") return parsed.enabled;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export interface CreateIssueInput {
+  ownerRepo: string;
+  title: string;
+  body: string;
+  labels?: string[];
+}
+
+export interface CreateIssueResult {
+  url: string;
+  number: number;
+}
+
+/**
+ * Creates a GitHub issue via `gh issue create`. The body is piped over
+ * stdin so it can be arbitrarily long and doesn't appear in `ps` output.
+ *
+ * Throws:
+ * - `UserError` with "authenticated but not authorised" wording when gh
+ *   reports a 401/403. This is distinct from generic subprocess failures
+ *   so users get a clear recovery path.
+ * - `UserError` with gh's stderr included on any other non-zero exit.
+ */
+export async function createGithubIssueViaGh(
+  input: CreateIssueInput,
+  runner: GhCliRunner = defaultGhRunner,
+): Promise<CreateIssueResult> {
+  const args: string[] = [
+    "issue",
+    "create",
+    "--repo",
+    input.ownerRepo,
+    "--title",
+    input.title,
+    "--body-file",
+    "-",
+  ];
+  if (input.labels && input.labels.length > 0) {
+    args.push("--label", input.labels.join(","));
+  }
+
+  // Larger timeout for create; network round-trip matters here.
+  const result = await runner.run(args, {
+    stdin: input.body,
+    timeoutMs: 15_000,
+  });
+
+  if (result.spawnFailed) {
+    throw new UserError("gh CLI not found on PATH.");
+  }
+  if (result.timedOut) {
+    throw new UserError("gh issue create timed out.");
+  }
+  if (result.exitCode !== 0) {
+    if (isAuthUnauthorisedError(result.stderr)) {
+      throw new UserError(
+        `gh is authenticated but not authorised to create issues on ${input.ownerRepo}. ` +
+          `Check that your token has the required scope (public_repo or repo) and that you have ` +
+          `write access to the repository.\n\n${result.stderr.trim()}`,
+      );
+    }
+    throw new UserError(
+      `gh issue create failed (exit ${result.exitCode}): ${result.stderr.trim()}`,
+    );
+  }
+
+  const url = extractIssueUrl(result.stdout);
+  if (!url) {
+    throw new UserError(
+      `gh issue create succeeded but returned no URL:\n${result.stdout}`,
+    );
+  }
+  const number = extractIssueNumber(url);
+  if (number === null) {
+    throw new UserError(
+      `gh issue create returned a URL without a parseable issue number: ${url}`,
+    );
+  }
+  return { url, number };
+}
+
+function isAuthUnauthorisedError(stderr: string): boolean {
+  const s = stderr.toLowerCase();
+  return (
+    s.includes("http 401") ||
+    s.includes("http 403") ||
+    s.includes("resource not accessible") ||
+    s.includes("not authorized")
+  );
+}
+
+function extractIssueUrl(stdout: string): string | undefined {
+  const match = stdout.match(/https:\/\/github\.com\/[^\s]+\/issues\/\d+/);
+  return match?.[0];
+}
+
+function extractIssueNumber(url: string): number | null {
+  const match = url.match(/\/issues\/(\d+)$/);
+  if (!match) return null;
+  const n = Number(match[1]);
+  return Number.isFinite(n) ? n : null;
+}

--- a/src/infrastructure/process/gh_cli_test.ts
+++ b/src/infrastructure/process/gh_cli_test.ts
@@ -1,0 +1,364 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { UserError } from "../../domain/errors.ts";
+import {
+  checkGithubPvrEnabled,
+  createGithubIssueViaGh,
+  type GhCliRunner,
+  type GhRunResult,
+  isGhCliAvailable,
+} from "./gh_cli.ts";
+
+/** Test runner that records calls and returns pre-programmed responses. */
+function fakeRunner(
+  responses: Array<(args: string[], stdin?: string) => GhRunResult>,
+): GhCliRunner & { calls: Array<{ args: string[]; stdin?: string }> } {
+  const calls: Array<{ args: string[]; stdin?: string }> = [];
+  let idx = 0;
+  const runner: GhCliRunner = {
+    run(args, opts) {
+      calls.push({ args, stdin: opts?.stdin });
+      const handler = responses[Math.min(idx, responses.length - 1)];
+      idx++;
+      return Promise.resolve(handler(args, opts?.stdin));
+    },
+  };
+  return Object.assign(runner, { calls });
+}
+
+function fakeEnv(
+  values: Record<string, string | undefined> = {},
+): { get(key: string): string | undefined } {
+  return { get: (key) => values[key] };
+}
+
+// ---- isGhCliAvailable ----
+
+Deno.test("isGhCliAvailable: GH_TOKEN fast path returns true without subprocess", async () => {
+  const runner = fakeRunner([
+    () => ({ exitCode: 0, stdout: "", stderr: "" }),
+  ]);
+  const env = fakeEnv({ GH_TOKEN: "ghp_x" });
+  const result = await isGhCliAvailable(runner, env);
+  assertEquals(result, true);
+  assertEquals(runner.calls.length, 0);
+});
+
+Deno.test("isGhCliAvailable: GITHUB_TOKEN fast path also returns true", async () => {
+  const runner = fakeRunner([
+    () => ({ exitCode: 0, stdout: "", stderr: "" }),
+  ]);
+  const env = fakeEnv({ GITHUB_TOKEN: "ghp_x" });
+  const result = await isGhCliAvailable(runner, env);
+  assertEquals(result, true);
+  assertEquals(runner.calls.length, 0);
+});
+
+Deno.test("isGhCliAvailable: shells out to gh auth status when no env token", async () => {
+  const runner = fakeRunner([
+    (args) => {
+      assertEquals(args, ["auth", "status"]);
+      return { exitCode: 0, stdout: "", stderr: "" };
+    },
+  ]);
+  const result = await isGhCliAvailable(runner, fakeEnv());
+  assertEquals(result, true);
+});
+
+Deno.test("isGhCliAvailable: returns false when gh auth status exits non-zero", async () => {
+  const runner = fakeRunner([
+    () => ({ exitCode: 1, stdout: "", stderr: "not logged in" }),
+  ]);
+  const result = await isGhCliAvailable(runner, fakeEnv());
+  assertEquals(result, false);
+});
+
+Deno.test("isGhCliAvailable: returns false when gh is not installed", async () => {
+  const runner = fakeRunner([
+    () => ({ exitCode: -1, stdout: "", stderr: "", spawnFailed: true }),
+  ]);
+  const result = await isGhCliAvailable(runner, fakeEnv());
+  assertEquals(result, false);
+});
+
+Deno.test("isGhCliAvailable: returns false when gh auth status times out", async () => {
+  const runner = fakeRunner([
+    () => ({ exitCode: -1, stdout: "", stderr: "", timedOut: true }),
+  ]);
+  const result = await isGhCliAvailable(runner, fakeEnv());
+  assertEquals(result, false);
+});
+
+// ---- checkGithubPvrEnabled ----
+
+Deno.test("checkGithubPvrEnabled: returns true when API reports enabled", async () => {
+  const runner = fakeRunner([
+    (args) => {
+      assertEquals(args, [
+        "api",
+        "repos/adam/cfgmgmt/private-vulnerability-reporting",
+      ]);
+      return { exitCode: 0, stdout: '{"enabled":true}', stderr: "" };
+    },
+  ]);
+  const result = await checkGithubPvrEnabled("adam/cfgmgmt", runner);
+  assertEquals(result, true);
+});
+
+Deno.test("checkGithubPvrEnabled: returns false when API reports disabled", async () => {
+  const runner = fakeRunner([
+    () => ({ exitCode: 0, stdout: '{"enabled":false}', stderr: "" }),
+  ]);
+  const result = await checkGithubPvrEnabled("adam/cfgmgmt", runner);
+  assertEquals(result, false);
+});
+
+Deno.test("checkGithubPvrEnabled: returns null on subprocess failure", async () => {
+  const runner = fakeRunner([
+    () => ({ exitCode: 1, stdout: "", stderr: "HTTP 403" }),
+  ]);
+  const result = await checkGithubPvrEnabled("adam/cfgmgmt", runner);
+  assertEquals(result, null);
+});
+
+Deno.test("checkGithubPvrEnabled: returns null on spawn failure", async () => {
+  const runner = fakeRunner([
+    () => ({ exitCode: -1, stdout: "", stderr: "", spawnFailed: true }),
+  ]);
+  const result = await checkGithubPvrEnabled("adam/cfgmgmt", runner);
+  assertEquals(result, null);
+});
+
+Deno.test("checkGithubPvrEnabled: returns null on timeout", async () => {
+  const runner = fakeRunner([
+    () => ({ exitCode: -1, stdout: "", stderr: "", timedOut: true }),
+  ]);
+  const result = await checkGithubPvrEnabled("adam/cfgmgmt", runner);
+  assertEquals(result, null);
+});
+
+Deno.test("checkGithubPvrEnabled: returns null when response is not parseable JSON", async () => {
+  const runner = fakeRunner([
+    () => ({ exitCode: 0, stdout: "not json", stderr: "" }),
+  ]);
+  const result = await checkGithubPvrEnabled("adam/cfgmgmt", runner);
+  assertEquals(result, null);
+});
+
+Deno.test("checkGithubPvrEnabled: returns null when response lacks 'enabled' key", async () => {
+  const runner = fakeRunner([
+    () => ({ exitCode: 0, stdout: '{"something":"else"}', stderr: "" }),
+  ]);
+  const result = await checkGithubPvrEnabled("adam/cfgmgmt", runner);
+  assertEquals(result, null);
+});
+
+// ---- createGithubIssueViaGh ----
+
+Deno.test("createGithubIssueViaGh: passes body via stdin, returns parsed result", async () => {
+  const runner = fakeRunner([
+    (args, stdin) => {
+      assertEquals(args, [
+        "issue",
+        "create",
+        "--repo",
+        "adam/cfgmgmt",
+        "--title",
+        "Boom",
+        "--body-file",
+        "-",
+      ]);
+      assertEquals(stdin, "body text");
+      return {
+        exitCode: 0,
+        stdout: "https://github.com/adam/cfgmgmt/issues/42\n",
+        stderr: "",
+      };
+    },
+  ]);
+  const result = await createGithubIssueViaGh({
+    ownerRepo: "adam/cfgmgmt",
+    title: "Boom",
+    body: "body text",
+  }, runner);
+  assertEquals(result.number, 42);
+  assertEquals(result.url, "https://github.com/adam/cfgmgmt/issues/42");
+});
+
+Deno.test("createGithubIssueViaGh: appends --label when labels provided", async () => {
+  const runner = fakeRunner([
+    (args) => {
+      assertStringIncludes(args.join(" "), "--label swamp-extension,bug");
+      return {
+        exitCode: 0,
+        stdout: "https://github.com/a/b/issues/1\n",
+        stderr: "",
+      };
+    },
+  ]);
+  await createGithubIssueViaGh({
+    ownerRepo: "a/b",
+    title: "t",
+    body: "b",
+    labels: ["swamp-extension", "bug"],
+  }, runner);
+});
+
+Deno.test("createGithubIssueViaGh: surfaces 401 as auth-unauthorised error", async () => {
+  const runner = fakeRunner([
+    () => ({
+      exitCode: 1,
+      stdout: "",
+      stderr: "HTTP 401: Bad credentials",
+    }),
+  ]);
+  await assertRejects(
+    () =>
+      createGithubIssueViaGh({
+        ownerRepo: "a/b",
+        title: "t",
+        body: "b",
+      }, runner),
+    UserError,
+    "authenticated but not authorised",
+  );
+});
+
+Deno.test("createGithubIssueViaGh: surfaces 403 as auth-unauthorised error", async () => {
+  const runner = fakeRunner([
+    () => ({
+      exitCode: 1,
+      stdout: "",
+      stderr: "HTTP 403: Resource not accessible by integration",
+    }),
+  ]);
+  await assertRejects(
+    () =>
+      createGithubIssueViaGh({
+        ownerRepo: "a/b",
+        title: "t",
+        body: "b",
+      }, runner),
+    UserError,
+    "authenticated but not authorised",
+  );
+});
+
+Deno.test("createGithubIssueViaGh: generic failure includes stderr", async () => {
+  const runner = fakeRunner([
+    () => ({
+      exitCode: 1,
+      stdout: "",
+      stderr: "something broke",
+    }),
+  ]);
+  await assertRejects(
+    () =>
+      createGithubIssueViaGh({
+        ownerRepo: "a/b",
+        title: "t",
+        body: "b",
+      }, runner),
+    UserError,
+    "something broke",
+  );
+});
+
+Deno.test("createGithubIssueViaGh: spawn failure produces a clear error", async () => {
+  const runner = fakeRunner([
+    () => ({
+      exitCode: -1,
+      stdout: "",
+      stderr: "",
+      spawnFailed: true,
+    }),
+  ]);
+  await assertRejects(
+    () =>
+      createGithubIssueViaGh({
+        ownerRepo: "a/b",
+        title: "t",
+        body: "b",
+      }, runner),
+    UserError,
+    "gh CLI not found",
+  );
+});
+
+Deno.test("createGithubIssueViaGh: timeout produces a clear error", async () => {
+  const runner = fakeRunner([
+    () => ({
+      exitCode: -1,
+      stdout: "",
+      stderr: "",
+      timedOut: true,
+    }),
+  ]);
+  await assertRejects(
+    () =>
+      createGithubIssueViaGh({
+        ownerRepo: "a/b",
+        title: "t",
+        body: "b",
+      }, runner),
+    UserError,
+    "timed out",
+  );
+});
+
+Deno.test("createGithubIssueViaGh: failure when stdout has no URL", async () => {
+  const runner = fakeRunner([
+    () => ({
+      exitCode: 0,
+      stdout: "no url here",
+      stderr: "",
+    }),
+  ]);
+  await assertRejects(
+    () =>
+      createGithubIssueViaGh({
+        ownerRepo: "a/b",
+        title: "t",
+        body: "b",
+      }, runner),
+    UserError,
+    "returned no URL",
+  );
+});
+
+Deno.test("createGithubIssueViaGh: large body is passed verbatim via stdin", async () => {
+  const huge = "x".repeat(200_000);
+  const runner = fakeRunner([
+    (_args, stdin) => {
+      assertEquals(stdin, huge);
+      return {
+        exitCode: 0,
+        stdout: "https://github.com/a/b/issues/1\n",
+        stderr: "",
+      };
+    },
+  ]);
+  await createGithubIssueViaGh({
+    ownerRepo: "a/b",
+    title: "t",
+    body: huge,
+  }, runner);
+});

--- a/src/infrastructure/process/reporter_context_collector.ts
+++ b/src/infrastructure/process/reporter_context_collector.ts
@@ -1,0 +1,50 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ReporterContext } from "../../domain/extensions/reporter_context.ts";
+
+/** Caller-supplied fields that the runtime cannot infer on its own. */
+export interface ReporterContextInputs {
+  extensionName: string;
+  extensionVersion: string;
+  swampVersion: string;
+}
+
+/**
+ * Populates the runtime half of a {@link ReporterContext} (os, arch,
+ * shell, denoVersion) and stitches it to the caller-supplied extension
+ * and swamp-version fields.
+ *
+ * The field list is hardcoded — this is the ONLY module allowed to
+ * read runtime values into a ReporterContext, which keeps the trust
+ * boundary auditable.
+ */
+export function collectReporterContext(
+  inputs: ReporterContextInputs,
+): ReporterContext {
+  return {
+    extensionName: inputs.extensionName,
+    extensionVersion: inputs.extensionVersion,
+    swampVersion: inputs.swampVersion,
+    os: Deno.build.os,
+    arch: Deno.build.arch,
+    shell: Deno.env.get("SHELL") ?? "unknown",
+    denoVersion: Deno.version.deno,
+  };
+}

--- a/src/infrastructure/process/reporter_context_collector_test.ts
+++ b/src/infrastructure/process/reporter_context_collector_test.ts
@@ -1,0 +1,79 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { collectReporterContext } from "./reporter_context_collector.ts";
+
+const INPUTS = {
+  extensionName: "@adam/cfgmgmt",
+  extensionVersion: "2026.04.22.1",
+  swampVersion: "20260422.123456.0-sha.abc123",
+};
+
+Deno.test("collectReporterContext: populates runtime fields from Deno", () => {
+  const ctx = collectReporterContext(INPUTS);
+  assertEquals(ctx.extensionName, INPUTS.extensionName);
+  assertEquals(ctx.extensionVersion, INPUTS.extensionVersion);
+  assertEquals(ctx.swampVersion, INPUTS.swampVersion);
+  assertEquals(ctx.os, Deno.build.os);
+  assertEquals(ctx.arch, Deno.build.arch);
+  assertEquals(ctx.denoVersion, Deno.version.deno);
+});
+
+Deno.test("collectReporterContext: SHELL env var flows through when set", () => {
+  const originalShell = Deno.env.get("SHELL");
+  Deno.env.set("SHELL", "/bin/zsh-test");
+  try {
+    const ctx = collectReporterContext(INPUTS);
+    assertEquals(ctx.shell, "/bin/zsh-test");
+  } finally {
+    if (originalShell === undefined) {
+      Deno.env.delete("SHELL");
+    } else {
+      Deno.env.set("SHELL", originalShell);
+    }
+  }
+});
+
+Deno.test("collectReporterContext: SHELL falls back to 'unknown' when unset", () => {
+  const originalShell = Deno.env.get("SHELL");
+  Deno.env.delete("SHELL");
+  try {
+    const ctx = collectReporterContext(INPUTS);
+    assertEquals(ctx.shell, "unknown");
+  } finally {
+    if (originalShell !== undefined) {
+      Deno.env.set("SHELL", originalShell);
+    }
+  }
+});
+
+Deno.test("collectReporterContext: only populates the seven declared fields", () => {
+  const ctx = collectReporterContext(INPUTS);
+  const keys = Object.keys(ctx).sort();
+  assertEquals(keys, [
+    "arch",
+    "denoVersion",
+    "extensionName",
+    "extensionVersion",
+    "os",
+    "shell",
+    "swampVersion",
+  ]);
+});

--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -690,6 +690,15 @@ export async function* extensionPush(
         return;
       }
 
+      if (!input.manifest.repository) {
+        ctx.logger.warn(
+          "Your extension manifest doesn't declare a `repository` URL. " +
+            `Users running \`swamp issue bug --extension ${input.manifest.name}\` ` +
+            "won't be able to file issues against it. " +
+            "Consider adding a `repository:` field to manifest.yaml.",
+        );
+      }
+
       const releaseNotes = input.releaseNotes ?? input.manifest.releaseNotes;
       const pushMetadata = {
         name: input.manifest.name,

--- a/src/libswamp/extensions/push_test.ts
+++ b/src/libswamp/extensions/push_test.ts
@@ -17,9 +17,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertRejects } from "@std/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
+import type { Logger } from "@logtape/logtape";
 import {
   extensionPush,
   type ExtensionPushExecuteDeps,
@@ -275,6 +276,56 @@ Deno.test("extensionPush: successful push yields completed", async () => {
     assertEquals(last.data.name, "@testuser/test-ext");
     assertEquals(last.data.extensionId, "ext-123");
   }
+});
+
+Deno.test("extensionPush: warns when manifest has no repository (non-blocking)", async () => {
+  const warnings: string[] = [];
+  const mockLogger = {
+    debug: () => {},
+    info: () => {},
+    warn: (line: string) => warnings.push(line),
+    error: () => {},
+    trace: () => {},
+    fatal: () => {},
+  } as unknown as Logger;
+  const testCtx = createLibSwampContext({ logger: mockLogger });
+  const deps = makeExecuteDeps();
+  const input = makeExecuteInput({
+    manifest: makeManifest({ repository: undefined }),
+  });
+
+  const events = await collect(extensionPush(testCtx, deps, input));
+  const last = events[events.length - 1];
+  assertEquals(last.kind, "completed"); // Warning does not block push.
+  assertEquals(warnings.length, 1);
+  assertStringIncludes(
+    warnings[0],
+    "doesn't declare a `repository` URL",
+  );
+  assertStringIncludes(warnings[0], "@testuser/test-ext");
+});
+
+Deno.test("extensionPush: no warning when manifest declares a repository", async () => {
+  const warnings: string[] = [];
+  const mockLogger = {
+    debug: () => {},
+    info: () => {},
+    warn: (line: string) => warnings.push(line),
+    error: () => {},
+    trace: () => {},
+    fatal: () => {},
+  } as unknown as Logger;
+  const testCtx = createLibSwampContext({ logger: mockLogger });
+  const deps = makeExecuteDeps();
+  const input = makeExecuteInput({
+    manifest: makeManifest({
+      repository: "https://github.com/testuser/test-ext",
+    }),
+  });
+
+  const events = await collect(extensionPush(testCtx, deps, input));
+  assertEquals(events[events.length - 1].kind, "completed");
+  assertEquals(warnings.length, 0);
 });
 
 Deno.test("extensionPush: not authenticated yields error", async () => {

--- a/src/libswamp/issues/create.ts
+++ b/src/libswamp/issues/create.ts
@@ -19,6 +19,10 @@
 
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
+import {
+  assembleExtensionReportBody,
+  type ReporterContext,
+} from "../../domain/extensions/reporter_context.ts";
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
@@ -37,6 +41,20 @@ export type IssueCreateData =
     mailtoUrl: string;
     type: "bug" | "feature" | "security";
     title: string;
+  }
+  | {
+    /**
+     * Lab submission tagged with an extension name — used when the caller
+     * ran `swamp issue <type> --extension @swamp/<name>`. Same wire
+     * contract as "lab"; the distinct method name lets the renderer say
+     * "Filed against @swamp/<name>".
+     */
+    method: "extension-lab";
+    number: number;
+    type: "bug" | "feature" | "security";
+    title: string;
+    serverUrl: string;
+    extensionName: string;
   };
 
 export type IssueCreateEvent =
@@ -48,6 +66,14 @@ export interface IssueCreateInput {
   title: string;
   body: string;
   type: "bug" | "feature" | "security";
+  /** Set for extension-scoped submissions; @swamp collectives route to Lab. */
+  extensionName?: string;
+  /** Installed version of `extensionName`, surfaced in the body. */
+  extensionVersion?: string;
+  /** Upstream repository URL from the manifest, surfaced in the body when set. */
+  repositoryUrl?: string;
+  /** Runtime context for reproducibility, appended to the body. */
+  reporterContext?: ReporterContext;
 }
 
 /** Dependencies for the issue create operation. */
@@ -59,7 +85,7 @@ export interface IssueCreateDeps {
   }) => Promise<{ number: number; serverUrl: string }>;
 }
 
-/** Submits a bug or feature issue to the Lab API. */
+/** Submits a bug, feature, or security issue to the Lab API. */
 export async function* issueCreate(
   ctx: LibSwampContext,
   deps: IssueCreateDeps,
@@ -71,11 +97,31 @@ export async function* issueCreate(
     (async function* () {
       ctx.logger.debug`Creating ${input.type} issue: ${input.title}`;
 
+      const body = input.extensionName
+        ? assembleExtensionLabBody(input)
+        : input.body;
+
       const labResult = await deps.submitToLab({
         type: input.type,
         title: input.title,
-        body: input.body,
+        body,
       });
+
+      if (input.extensionName) {
+        yield {
+          kind: "completed",
+          data: {
+            method: "extension-lab",
+            number: labResult.number,
+            type: input.type,
+            title: input.title,
+            serverUrl: labResult.serverUrl,
+            extensionName: input.extensionName,
+          },
+        };
+        return;
+      }
+
       yield {
         kind: "completed",
         data: {
@@ -87,5 +133,28 @@ export async function* issueCreate(
         },
       };
     })(),
+  );
+}
+
+/**
+ * Appends extension metadata and reporter context to the user-provided body.
+ * Title is deliberately left alone — a `[@swamp/foo]` prefix would collide
+ * with existing Lab UI title filters.
+ *
+ * Shares its formatting with the third-party repository path via
+ * {@link assembleExtensionReportBody} so both destinations see identical
+ * report bodies.
+ */
+function assembleExtensionLabBody(input: IssueCreateInput): string {
+  if (!input.reporterContext) {
+    // Extension metadata without reporter context — rare, only surfaces
+    // when tests exercise the extension path without wiring a context.
+    // Keep behavior forgiving: return the user body unchanged.
+    return input.body;
+  }
+  return assembleExtensionReportBody(
+    input.body,
+    input.repositoryUrl,
+    input.reporterContext,
   );
 }

--- a/src/libswamp/issues/create_test.ts
+++ b/src/libswamp/issues/create_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
@@ -25,6 +25,7 @@ import {
   type IssueCreateDeps,
   type IssueCreateEvent,
 } from "./create.ts";
+import type { ReporterContext } from "../../domain/extensions/reporter_context.ts";
 
 function makeDeps(overrides: Partial<IssueCreateDeps> = {}): IssueCreateDeps {
   return {
@@ -33,6 +34,16 @@ function makeDeps(overrides: Partial<IssueCreateDeps> = {}): IssueCreateDeps {
     ...overrides,
   };
 }
+
+const SAMPLE_CONTEXT: ReporterContext = {
+  extensionName: "@swamp/aws",
+  extensionVersion: "2026.04.22.1",
+  swampVersion: "20260422.000000.0-sha.abc",
+  os: "darwin",
+  arch: "aarch64",
+  shell: "/bin/zsh",
+  denoVersion: "1.45.0",
+};
 
 Deno.test("issueCreate: submits bug to Lab and yields completed", async () => {
   const deps = makeDeps();
@@ -124,4 +135,168 @@ Deno.test("issueCreate: includes serverUrl in result", async () => {
   if (data.method === "lab") {
     assertEquals(data.serverUrl, "https://custom.server.com");
   }
+});
+
+// ---- Regression: plain-lab request body is byte-identical ----
+
+Deno.test("issueCreate: plain lab request body is byte-identical to caller body (regression)", async () => {
+  let captured: { body: string } | undefined;
+  const deps = makeDeps({
+    submitToLab: (input) => {
+      captured = { body: input.body };
+      return Promise.resolve({ number: 1, serverUrl: "https://swamp.club" });
+    },
+  });
+
+  const userBody = "Hello\n\nA multi-line body\nwith trailing lines\n";
+  await collect(issueCreate(createLibSwampContext(), deps, {
+    title: "t",
+    body: userBody,
+    type: "bug",
+  }));
+
+  // Exact match — no trimming, no appending.
+  assertEquals(captured?.body, userBody);
+});
+
+// ---- Extension-lab path ----
+
+Deno.test("issueCreate: extension-lab variant set when extensionName present", async () => {
+  const deps = makeDeps({
+    submitToLab: () =>
+      Promise.resolve({ number: 9, serverUrl: "https://swamp.club" }),
+  });
+
+  const events = await collect<IssueCreateEvent>(
+    issueCreate(createLibSwampContext(), deps, {
+      title: "t",
+      body: "b",
+      type: "bug",
+      extensionName: "@swamp/aws",
+      extensionVersion: "2026.04.22.1",
+      reporterContext: SAMPLE_CONTEXT,
+    }),
+  );
+
+  const data = (events[0] as Extract<IssueCreateEvent, { kind: "completed" }>)
+    .data;
+  assertEquals(data.method, "extension-lab");
+  if (data.method === "extension-lab") {
+    assertEquals(data.extensionName, "@swamp/aws");
+    assertEquals(data.number, 9);
+  }
+});
+
+Deno.test("issueCreate: extension body contains Extension: line", async () => {
+  let captured: { body: string } | undefined;
+  const deps = makeDeps({
+    submitToLab: (input) => {
+      captured = { body: input.body };
+      return Promise.resolve({ number: 1, serverUrl: "https://swamp.club" });
+    },
+  });
+
+  await collect(issueCreate(createLibSwampContext(), deps, {
+    title: "t",
+    body: "b",
+    type: "bug",
+    extensionName: "@swamp/aws",
+    extensionVersion: "2026.04.22.1",
+    reporterContext: SAMPLE_CONTEXT,
+  }));
+
+  assertStringIncludes(
+    captured?.body ?? "",
+    "Extension: `@swamp/aws@2026.04.22.1`",
+  );
+});
+
+Deno.test("issueCreate: extension body contains Upstream repository line when set", async () => {
+  let captured: { body: string } | undefined;
+  const deps = makeDeps({
+    submitToLab: (input) => {
+      captured = { body: input.body };
+      return Promise.resolve({ number: 1, serverUrl: "https://swamp.club" });
+    },
+  });
+
+  await collect(issueCreate(createLibSwampContext(), deps, {
+    title: "t",
+    body: "b",
+    type: "bug",
+    extensionName: "@swamp/aws",
+    extensionVersion: "2026.04.22.1",
+    repositoryUrl: "https://github.com/systeminit/swamp-aws",
+    reporterContext: SAMPLE_CONTEXT,
+  }));
+
+  assertStringIncludes(
+    captured?.body ?? "",
+    "Upstream repository: https://github.com/systeminit/swamp-aws",
+  );
+});
+
+Deno.test("issueCreate: extension body omits Upstream repository when unset", async () => {
+  let captured: { body: string } | undefined;
+  const deps = makeDeps({
+    submitToLab: (input) => {
+      captured = { body: input.body };
+      return Promise.resolve({ number: 1, serverUrl: "https://swamp.club" });
+    },
+  });
+
+  await collect(issueCreate(createLibSwampContext(), deps, {
+    title: "t",
+    body: "b",
+    type: "bug",
+    extensionName: "@swamp/aws",
+    extensionVersion: "2026.04.22.1",
+    reporterContext: SAMPLE_CONTEXT,
+  }));
+
+  const body = captured?.body ?? "";
+  assertEquals(body.includes("Upstream repository:"), false);
+});
+
+Deno.test("issueCreate: extension body contains reporter-context Environment section", async () => {
+  let captured: { body: string } | undefined;
+  const deps = makeDeps({
+    submitToLab: (input) => {
+      captured = { body: input.body };
+      return Promise.resolve({ number: 1, serverUrl: "https://swamp.club" });
+    },
+  });
+
+  await collect(issueCreate(createLibSwampContext(), deps, {
+    title: "t",
+    body: "b",
+    type: "bug",
+    extensionName: "@swamp/aws",
+    extensionVersion: "2026.04.22.1",
+    reporterContext: SAMPLE_CONTEXT,
+  }));
+
+  assertStringIncludes(captured?.body ?? "", "## Environment");
+  assertStringIncludes(captured?.body ?? "", "darwin");
+});
+
+Deno.test("issueCreate: extension path does not modify title", async () => {
+  let captured: { title: string } | undefined;
+  const deps = makeDeps({
+    submitToLab: (input) => {
+      captured = { title: input.title };
+      return Promise.resolve({ number: 1, serverUrl: "https://swamp.club" });
+    },
+  });
+
+  await collect(issueCreate(createLibSwampContext(), deps, {
+    title: "Plain title",
+    body: "b",
+    type: "bug",
+    extensionName: "@swamp/aws",
+    extensionVersion: "2026.04.22.1",
+    reporterContext: SAMPLE_CONTEXT,
+  }));
+
+  assertEquals(captured?.title, "Plain title");
 });

--- a/src/presentation/renderers/issue_create.ts
+++ b/src/presentation/renderers/issue_create.ts
@@ -22,6 +22,10 @@ import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 import { UserError } from "../../domain/errors.ts";
+import type {
+  RefusalReason,
+  RepositoryDispatchResult,
+} from "../../cli/commands/extension_report_dispatcher.ts";
 
 class LogIssueCreateRenderer implements Renderer<IssueCreateEvent> {
   handlers(): EventHandlers<IssueCreateEvent> {
@@ -33,6 +37,23 @@ class LogIssueCreateRenderer implements Renderer<IssueCreateEvent> {
           logger.info(
             "Submitted {type} report #{number}: {title}",
             { type: data.type, number: data.number, title: data.title },
+          );
+          logger.info("View at: {url}", {
+            url: `${data.serverUrl}/lab/${data.number}`,
+          });
+          if (data.type === "security") {
+            logger.info(
+              "This security report is visible only to you and the admin team at swamp.club.",
+            );
+          }
+        } else if (data.method === "extension-lab") {
+          logger.info(
+            "Filed #{number} against {extension} on swamp-club Lab: {title}",
+            {
+              number: data.number,
+              extension: data.extensionName,
+              title: data.title,
+            },
           );
           logger.info("View at: {url}", {
             url: `${data.serverUrl}/lab/${data.number}`,
@@ -103,5 +124,142 @@ export function renderIssueCancelled(
     } else {
       logger.info("Issue creation cancelled");
     }
+  }
+}
+
+// ---- Extension-scoped rendering ----
+
+export interface ExtensionRefusalData {
+  extensionName: string;
+  reason: RefusalReason;
+  guidance: string;
+}
+
+/**
+ * Renders a refusal as informational output — never error-styled.
+ * Exit code stays 0; the guidance itself communicates the "can't do
+ * that here" outcome.
+ */
+export function renderExtensionRefusal(
+  data: ExtensionRefusalData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(
+      JSON.stringify(
+        {
+          status: "refused",
+          extensionName: data.extensionName,
+          reason: data.reason,
+          guidance: data.guidance,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+  // Split the guidance into lines so the renderer prints each as its own
+  // log line — readable on terminals that wrap long single-line logs.
+  const logger = getSwampLogger(["issue", "create"]);
+  for (const line of data.guidance.split("\n")) {
+    logger.info(line);
+  }
+}
+
+export interface ExtensionRepositoryHandoffData {
+  result: RepositoryDispatchResult;
+  extensionName: string;
+}
+
+/** Renders the completed `dispatchRepositoryReport` result. */
+export function renderExtensionRepositoryHandoff(
+  data: ExtensionRepositoryHandoffData,
+  mode: OutputMode,
+): void {
+  const result = data.result;
+
+  if (result.kind === "refused") {
+    renderExtensionRefusal(
+      {
+        extensionName: data.extensionName,
+        reason: result.reason,
+        guidance: result.guidance,
+      },
+      mode,
+    );
+    return;
+  }
+
+  if (mode === "json") {
+    console.log(
+      JSON.stringify(
+        {
+          status: "handoff",
+          extensionName: data.extensionName,
+          method: result.method,
+          variant: result.variant,
+          url: result.url,
+          number: result.number,
+          fallbackIssueUrl: result.fallbackIssueUrl,
+          pvrCheckFailed: result.pvrCheckFailed,
+          pvrCheckSkipped: result.pvrCheckSkipped,
+          nonGithubWarning: result.nonGithubWarning,
+          preparedTitle: result.preparedTitle,
+          preparedBody: result.preparedBody,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  const logger = getSwampLogger(["issue", "create"]);
+
+  if (result.variant === "advisory") {
+    // Advisory URL is load-bearing — print it on its own line so
+    // headless-environment users can see it even if openBrowser is a
+    // no-op.
+    logger.info(
+      "Opened the GitHub private vulnerability report form:",
+    );
+    logger.info("  {url}", { url: result.url });
+    if (result.pvrCheckFailed) {
+      logger.info(
+        "(PVR status could not be verified — the form will tell you if " +
+          "private reporting isn't available on this repo.)",
+      );
+    }
+    if (result.pvrCheckSkipped) {
+      logger.info(
+        "(gh CLI not available; could not verify PVR status.)",
+      );
+    }
+    if (result.fallbackIssueUrl) {
+      logger.info(
+        "If the form indicates private reporting isn't enabled, file " +
+          "publicly at: {fallback}",
+        { fallback: result.fallbackIssueUrl },
+      );
+    }
+    return;
+  }
+
+  // Variant "issue"
+  if (result.method === "gh") {
+    logger.info(
+      "Filed issue #{number} at {url} via the gh CLI.",
+      { number: result.number, url: result.url },
+    );
+  } else {
+    logger.info(
+      "Opened {url} in your browser. The prepared title/body were printed " +
+        "above so you can paste if the handoff failed.",
+      { url: result.url },
+    );
+  }
+  if (result.nonGithubWarning) {
+    logger.info(result.nonGithubWarning);
   }
 }

--- a/src/presentation/renderers/issue_create_test.ts
+++ b/src/presentation/renderers/issue_create_test.ts
@@ -1,0 +1,238 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { consumeStream, type IssueCreateEvent } from "../../libswamp/mod.ts";
+import {
+  createIssueCreateRenderer,
+  renderExtensionRefusal,
+  renderExtensionRepositoryHandoff,
+} from "./issue_create.ts";
+import type { RepositoryDispatchResult } from "../../cli/commands/extension_report_dispatcher.ts";
+
+/** Captures console.log calls during `fn` and returns the concatenated output. */
+async function captureConsoleLog(
+  fn: () => Promise<void> | void,
+): Promise<string> {
+  const original = console.log;
+  const lines: string[] = [];
+  console.log = (...args: unknown[]) => {
+    lines.push(args.map((a) => String(a)).join(" "));
+  };
+  try {
+    await fn();
+  } finally {
+    console.log = original;
+  }
+  return lines.join("\n");
+}
+
+async function* toStream(
+  events: IssueCreateEvent[],
+): AsyncGenerator<IssueCreateEvent> {
+  for (const event of events) yield event;
+}
+
+Deno.test("issue_create renderer (log): extension-lab variant runs without error", async () => {
+  const renderer = createIssueCreateRenderer("log");
+  await consumeStream(
+    toStream([
+      {
+        kind: "completed",
+        data: {
+          method: "extension-lab",
+          number: 42,
+          type: "bug",
+          title: "t",
+          serverUrl: "https://swamp.club",
+          extensionName: "@swamp/aws",
+        },
+      },
+    ]),
+    renderer.handlers(),
+  );
+});
+
+Deno.test("issue_create renderer (json): extension-lab variant serialises method + extensionName", async () => {
+  const renderer = createIssueCreateRenderer("json");
+  const out = await captureConsoleLog(async () => {
+    await consumeStream(
+      toStream([
+        {
+          kind: "completed",
+          data: {
+            method: "extension-lab",
+            number: 42,
+            type: "bug",
+            title: "t",
+            serverUrl: "https://swamp.club",
+            extensionName: "@swamp/aws",
+          },
+        },
+      ]),
+      renderer.handlers(),
+    );
+  });
+  const parsed = JSON.parse(out);
+  assertEquals(parsed.method, "extension-lab");
+  assertEquals(parsed.extensionName, "@swamp/aws");
+  assertEquals(parsed.number, 42);
+});
+
+// ---- renderExtensionRefusal ----
+
+Deno.test("renderExtensionRefusal (log): emits guidance lines, runs without error", () => {
+  renderExtensionRefusal(
+    {
+      extensionName: "@adam/cfgmgmt",
+      reason: "no-repository",
+      guidance: "Line 1\nLine 2",
+    },
+    "log",
+  );
+});
+
+Deno.test("renderExtensionRefusal (json): emits structured refusal payload", async () => {
+  const out = await captureConsoleLog(() => {
+    renderExtensionRefusal(
+      {
+        extensionName: "@adam/cfgmgmt",
+        reason: "pvr-disabled",
+        guidance: "Contact publisher",
+      },
+      "json",
+    );
+  });
+  const parsed = JSON.parse(out);
+  assertEquals(parsed.status, "refused");
+  assertEquals(parsed.reason, "pvr-disabled");
+  assertEquals(parsed.extensionName, "@adam/cfgmgmt");
+  assertStringIncludes(parsed.guidance, "Contact publisher");
+});
+
+// ---- renderExtensionRepositoryHandoff ----
+
+function handoffIssueGh(): RepositoryDispatchResult {
+  return {
+    kind: "handoff",
+    method: "gh",
+    variant: "issue",
+    url: "https://github.com/adam/cfgmgmt/issues/42",
+    number: 42,
+    preparedTitle: "t",
+    preparedBody: "b",
+  };
+}
+
+function handoffAdvisoryBrowser(
+  opts: Partial<Extract<RepositoryDispatchResult, { kind: "handoff" }>> = {},
+): RepositoryDispatchResult {
+  return {
+    kind: "handoff",
+    method: "browser",
+    variant: "advisory",
+    url: "https://github.com/adam/cfgmgmt/security/advisories/new",
+    fallbackIssueUrl: "https://github.com/adam/cfgmgmt/issues/new?...",
+    preparedTitle: "vuln",
+    preparedBody: "body",
+    ...opts,
+  };
+}
+
+Deno.test("renderExtensionRepositoryHandoff (json): handoff issue via gh carries number + url", async () => {
+  const out = await captureConsoleLog(() => {
+    renderExtensionRepositoryHandoff(
+      { result: handoffIssueGh(), extensionName: "@adam/cfgmgmt" },
+      "json",
+    );
+  });
+  const parsed = JSON.parse(out);
+  assertEquals(parsed.status, "handoff");
+  assertEquals(parsed.method, "gh");
+  assertEquals(parsed.variant, "issue");
+  assertEquals(parsed.number, 42);
+  assertStringIncludes(parsed.url, "issues/42");
+});
+
+Deno.test("renderExtensionRepositoryHandoff (json): advisory variant includes fallbackIssueUrl", async () => {
+  const out = await captureConsoleLog(() => {
+    renderExtensionRepositoryHandoff(
+      { result: handoffAdvisoryBrowser(), extensionName: "@adam/cfgmgmt" },
+      "json",
+    );
+  });
+  const parsed = JSON.parse(out);
+  assertEquals(parsed.variant, "advisory");
+  assertStringIncludes(parsed.fallbackIssueUrl, "issues/new");
+});
+
+Deno.test("renderExtensionRepositoryHandoff (json): embeds preparedTitle and preparedBody", async () => {
+  const out = await captureConsoleLog(() => {
+    renderExtensionRepositoryHandoff(
+      { result: handoffIssueGh(), extensionName: "@adam/cfgmgmt" },
+      "json",
+    );
+  });
+  const parsed = JSON.parse(out);
+  assertEquals(parsed.preparedTitle, "t");
+  assertEquals(parsed.preparedBody, "b");
+});
+
+Deno.test("renderExtensionRepositoryHandoff (json): pvrCheckFailed flag surfaces", async () => {
+  const out = await captureConsoleLog(() => {
+    renderExtensionRepositoryHandoff(
+      {
+        result: handoffAdvisoryBrowser({ pvrCheckFailed: true }),
+        extensionName: "@adam/cfgmgmt",
+      },
+      "json",
+    );
+  });
+  const parsed = JSON.parse(out);
+  assertEquals(parsed.pvrCheckFailed, true);
+});
+
+Deno.test("renderExtensionRepositoryHandoff (log): advisory runs without error", () => {
+  renderExtensionRepositoryHandoff(
+    {
+      result: handoffAdvisoryBrowser(),
+      extensionName: "@adam/cfgmgmt",
+    },
+    "log",
+  );
+});
+
+Deno.test("renderExtensionRepositoryHandoff (json): refused result delegates to refusal renderer", async () => {
+  const out = await captureConsoleLog(() => {
+    renderExtensionRepositoryHandoff(
+      {
+        result: {
+          kind: "refused",
+          reason: "pvr-disabled",
+          guidance: "no go",
+        },
+        extensionName: "@adam/cfgmgmt",
+      },
+      "json",
+    );
+  });
+  const parsed = JSON.parse(out);
+  assertEquals(parsed.status, "refused");
+  assertEquals(parsed.reason, "pvr-disabled");
+});


### PR DESCRIPTION
## Summary

Adds `--extension <name>` to `swamp issue bug|feature|security`. Reports route based on the extension's collective and declared repository — **zero swamp-club server changes required**.

Closes swamp-club#4.

## Routing

| Case | Destination |
| ---- | ----------- |
| `@swamp/*` | Existing swamp-club Lab, with extension metadata appended to body |
| Third-party + `manifest.repository` set | `gh issue create` (if `gh` authed); otherwise prefilled browser handoff |
| Third-party + no `manifest.repository` | Clean refusal, exits 0, points at extension's swamp-club page |

### Security path (GitHub repos)

Checks Private Vulnerability Reporting (PVR) via `gh api repos/<owner>/<repo>/private-vulnerability-reporting`:

- **PVR enabled** → opens `<repo>/security/advisories/new`
- **PVR disabled** → **refuses**. Never falls back to creating a public issue — load-bearing guardrail against silently publishing vulnerabilities. Pinned by a named invariant test at both the dispatcher and subcommand layers.
- **Check failed / gh unavailable** → advisory URL with a fallback issue URL surfaced in output

### Publish-time nudge

`swamp extension push` emits a non-blocking warning when a manifest lacks `repository`, so publishers know users can't file against their extension.

## Architecture

- New domain helpers: `installed_extension_lookup`, `reporter_context`, `repository_url` — all pure, DDD-compliant (the layer ratchet passes).
- New infrastructure: `gh_cli` (PVR check, issue create with 401/403 distinction), `reporter_context_collector` (Deno runtime values).
- New CLI layer: `extension_report_dispatcher` owns the routing decision, PVR check, and refusal emissions — libswamp stays out of third-party repo traffic.
- libswamp gains **one** new `IssueCreateData` variant (`extension-lab`) for the @swamp path. Plain-lab path remains byte-identical (pinned by regression test).

## Test plan

- [x] `deno check` clean
- [x] `deno lint` clean
- [x] `deno fmt` clean
- [x] `deno run test` — 4686 passed, 0 failed, 1 ignored (live-gh tier, gated on `GH_TOKEN` + `GH_TEST_REPO`)
- [x] `deno run compile` — binary built and smoke-tested:
  - `swamp issue bug --help` renders `--extension` and `--repo-dir` options with examples
  - Outside a swamp repo → clear "No swamp repository found" error
  - `@fake/doesnotexist` → `not-pulled` refusal with exact `swamp extension pull` recovery, both log and JSON modes
  - Malformed name → validation error
  - `--email` + `--extension` → mutual-exclusion error
- [ ] Full UAT coverage tracked in systeminit/swamp-uat#156 (companion issue filed)

## Documentation

- `design/extension.md` gained a "Reporting Issues Against Extensions" section covering all three routing paths, the security asymmetry (GitHub hard-refuses on PVR disabled; GitLab relies on the reporter toggling confidential), and the publish-time nudge.
- `.claude/skills/swamp-issue` updated to cover `security`, `--extension`, and the extension-scoped output shapes. Reviewed against skill-creator best practices (frontmatter triggers, <500-line body, no SKILL.md/references duplication).
- `.claude/skills/swamp-extension-publish/references/publishing.md` documents the optional `repository:` field and its connection to `swamp issue --extension`.

## Dependency note

swamp-club has GitHub issues disabled, so the reference-page follow-up couldn't be filed there. The design doc in this PR stands in as the authoritative contract description until swamp-club's `content/manual/` grows an `issue` reference page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)