### PR TITLE
feat(skills): add swamp-extension-quality scorecard guide

### DIFF
--- a/.claude/skills/swamp-extension-datastore/SKILL.md
+++ b/.claude/skills/swamp-extension-datastore/SKILL.md
@@ -211,14 +211,15 @@ verification) before allowing a push.
 
 ## When to Use Other Skills
 
-| Need                                | Use Skill                |
-| ----------------------------------- | ------------------------ |
-| Use existing datastores             | `swamp-repo`             |
-| Create custom models                | `swamp-extension-model`  |
-| Create custom execution drivers     | `swamp-extension-driver` |
-| Repository setup and configuration  | `swamp-repo`             |
-| Manage secrets for datastore config | `swamp-vault`            |
-| Understand swamp internals          | `swamp-troubleshooting`  |
+| Need                                | Use Skill                 |
+| ----------------------------------- | ------------------------- |
+| Use existing datastores             | `swamp-repo`              |
+| Create custom models                | `swamp-extension-model`   |
+| Create custom execution drivers     | `swamp-extension-driver`  |
+| Repository setup and configuration  | `swamp-repo`              |
+| Manage secrets for datastore config | `swamp-vault`             |
+| Quality scorecard & best practices  | `swamp-extension-quality` |
+| Understand swamp internals          | `swamp-troubleshooting`   |
 
 ## References
 

--- a/.claude/skills/swamp-extension-driver/SKILL.md
+++ b/.claude/skills/swamp-extension-driver/SKILL.md
@@ -263,9 +263,10 @@ verification) before allowing a push.
 
 ## When to Use Other Skills
 
-| Need                       | Use Skill               |
-| -------------------------- | ----------------------- |
-| Use existing models        | `swamp-model`           |
-| Create custom models       | `swamp-extension-model` |
-| Repository structure       | `swamp-repo`            |
-| Understand swamp internals | `swamp-troubleshooting` |
+| Need                               | Use Skill                 |
+| ---------------------------------- | ------------------------- |
+| Use existing models                | `swamp-model`             |
+| Create custom models               | `swamp-extension-model`   |
+| Repository structure               | `swamp-repo`              |
+| Quality scorecard & best practices | `swamp-extension-quality` |
+| Understand swamp internals         | `swamp-troubleshooting`   |

--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -511,15 +511,16 @@ publishing workflow.
 
 ## When to Use Other Skills
 
-| Need                       | Use Skill               |
-| -------------------------- | ----------------------- |
-| Use existing models        | `swamp-model`           |
-| Create/run workflows       | `swamp-workflow`        |
-| Manage secrets for models  | `swamp-vault`           |
-| Repository structure       | `swamp-repo`            |
-| Manage model data          | `swamp-data`            |
-| Create reports for models  | `swamp-report`          |
-| Understand swamp internals | `swamp-troubleshooting` |
+| Need                               | Use Skill                 |
+| ---------------------------------- | ------------------------- |
+| Use existing models                | `swamp-model`             |
+| Create/run workflows               | `swamp-workflow`          |
+| Manage secrets for models          | `swamp-vault`             |
+| Repository structure               | `swamp-repo`              |
+| Manage model data                  | `swamp-data`              |
+| Create reports for models          | `swamp-report`            |
+| Quality scorecard & best practices | `swamp-extension-quality` |
+| Understand swamp internals         | `swamp-troubleshooting`   |
 
 ## References
 

--- a/.claude/skills/swamp-extension-publish/SKILL.md
+++ b/.claude/skills/swamp-extension-publish/SKILL.md
@@ -263,11 +263,12 @@ swamp extension push manifest.yaml --yes --json
 
 ## When to Use Other Skills
 
-| Need                            | Use Skill                   |
-| ------------------------------- | --------------------------- |
-| Create custom models            | `swamp-extension-model`     |
-| Create custom vaults            | `swamp-extension-vault`     |
-| Create custom datastores        | `swamp-extension-datastore` |
-| Create custom execution drivers | `swamp-extension-driver`    |
-| Repository setup and management | `swamp-repo`                |
-| Create reports                  | `swamp-report`              |
+| Need                               | Use Skill                   |
+| ---------------------------------- | --------------------------- |
+| Create custom models               | `swamp-extension-model`     |
+| Create custom vaults               | `swamp-extension-vault`     |
+| Create custom datastores           | `swamp-extension-datastore` |
+| Create custom execution drivers    | `swamp-extension-driver`    |
+| Repository setup and management    | `swamp-repo`                |
+| Create reports                     | `swamp-report`              |
+| Quality scorecard & best practices | `swamp-extension-quality`   |

--- a/.claude/skills/swamp-extension-quality/SKILL.md
+++ b/.claude/skills/swamp-extension-quality/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: swamp-extension-quality
+description: >
+  Guide extension authors to hit the Swamp Club quality scorecard — raise
+  an extension's score (percentage + letter grade) by following the 11-factor
+  rubric covering README, LICENSE, JSDoc coverage, type safety, manifest
+  completeness, and repository verification. Use when authoring or reviewing
+  a swamp extension for quality, preparing for a good score, troubleshooting
+  a low score, or understanding what each factor measures. Do NOT use for
+  implementing a specific extension type (that is swamp-extension-model,
+  -driver, -vault, or -datastore), for publishing mechanics (that is
+  swamp-extension-publish), or for runtime debugging (that is
+  swamp-troubleshooting). Triggers on "quality score", "scorecard",
+  "improve my extension", "extension quality", "factor breakdown", "why
+  is my score low", "Grade A extension", "quality checklist", "what makes
+  a good extension", "scorecard factors", "rubric", "extension best
+  practices", "swamp club score".
+---
+
+# Swamp Extension Quality
+
+Swamp Club scores every published extension against a rubric that rewards
+documentation, type safety, and supply-chain signals. Use this skill to shape an
+extension so it earns the maximum score a third-party extension can reach:
+**12/13 = 92% (Grade A)**. The remaining 8% is reserved for first-party
+(`@swamp`) or admin-curated extensions and is not earnable through authoring.
+
+## Scope boundaries — when this skill fires vs. when another one does
+
+| Task                                   | Skill                                                                                                      |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Authoring for a high scorecard         | `swamp-extension-quality` (this one)                                                                       |
+| Implementing a specific extension type | `swamp-extension-model` / `swamp-extension-driver` / `swamp-extension-vault` / `swamp-extension-datastore` |
+| Mechanics of pushing to the registry   | `swamp-extension-publish`                                                                                  |
+| Debugging an error or failure          | `swamp-troubleshooting`                                                                                    |
+
+This skill does **not** duplicate content from those. It only adds the quality
+signals layered on top of whatever the type-specific skill produced.
+
+## The factor-to-action map (memorise this)
+
+| Factor                | Pts | Earn it by                                                                                         |
+| --------------------- | --- | -------------------------------------------------------------------------------------------------- |
+| `has-readme`          | 2   | List `README.md` under `additionalFiles:` in `manifest.yaml`                                       |
+| `readme-example`      | 1   | Include ≥1 fenced code block in the README                                                         |
+| `rich-readme`         | 1   | Make the README ≥500 characters AND have ≥2 fenced code blocks                                     |
+| `symbols-docs`        | 1   | JSDoc ≥80% of exported symbols across all entrypoints                                              |
+| `fast-check`          | 1   | Explicit return types on every export; no private-type references in public exports                |
+| `description`         | 1   | Fill `description:` in `manifest.yaml` with a non-empty string (not "TODO")                        |
+| `platforms-one`       | 1   | Set `platforms:` to a non-empty list OR leave empty (empty = "universal")                          |
+| `platforms-two`       | 1   | Set `platforms:` to ≥2 entries OR leave empty                                                      |
+| `has-license`         | 1   | Add a LICENSE file (`LICENSE`, `LICENSE.md`, `LICENSE.txt`, or `COPYING`) under `additionalFiles:` |
+| `repository-verified` | 2   | Set `repository:` to a public HTTPS URL on github.com, gitlab.com, codeberg.org, or bitbucket.org  |
+| `verified-by-swamp`   | 1   | Only earnable by the `@swamp` namespace or admin review — do not try to game it                    |
+
+`verified-by-swamp` is the one third-party authors cannot earn; everything above
+it is fair game.
+
+## Essential mechanics authors get wrong
+
+**Files listed in `additionalFiles:` end up under `extension/files/` in the
+tarball**, not at the extension root. The analyzer checks both locations for
+README and LICENSE, so either works, but this trips up authors who assume the
+root is the only path. If a README is in the repo root but not in
+`additionalFiles:`, **it is not in the tarball at all** and earns zero.
+
+**`repository:` must be on one of the allowlisted hosts** — github.com,
+gitlab.com (public SaaS only), codeberg.org, bitbucket.org. Self-hosted GitHub
+Enterprise, self-hosted GitLab, private Gitea, Azure DevOps, Bitbucket Server —
+none earn the 2-point verification factor. URL must be HTTPS.
+
+**`fast-check` is subtle.** A single missing return type on an exported function
+or a public export that leaks a private type costs the whole point. Run
+`deno doc --lint <entrypoints>` locally to catch this before publish.
+
+**`symbols-docs` means exported symbols, not internal helpers.** Only exports
+count toward the 80% threshold. Private functions do not lower the score but
+also do not raise it.
+
+## Pre-publish quality checklist
+
+Walk this before invoking `swamp-extension-publish`. Each row maps to a factor
+and a concrete check.
+
+1. `manifest.yaml` has a non-empty `description:`
+2. `manifest.yaml` sets `repository:` to an HTTPS URL on github.com, gitlab.com,
+   codeberg.org, or bitbucket.org
+3. `manifest.yaml` lists every entrypoint file
+   (models/drivers/vaults/datastores/reports as applicable)
+4. `manifest.yaml` lists `README.md` and a LICENSE file under `additionalFiles:`
+5. `manifest.yaml` either lists `platforms:` with ≥2 entries OR leaves the field
+   empty
+6. `README.md` is ≥500 characters with ≥2 fenced code blocks, one of which is a
+   working usage example
+7. LICENSE file present in the repo (any standard OSS license)
+8. Every exported function has an explicit return type annotation
+9. No public export references a private type
+10. ≥80% of exported symbols carry a JSDoc comment
+11. Every entrypoint file has a module-level JSDoc at the top
+12. `deno doc --lint <entrypoints>` produces zero slow-type diagnostics
+13. `deno doc --json <entrypoints>` runs without errors
+
+If any row fails, fix it before handing off to `swamp-extension-publish`.
+
+## Details when needed
+
+For the full per-factor mechanics, the grade thresholds, and a worked example of
+a manifest that earns every third-party point:
+
+- **[references/rubric.md](references/rubric.md)** — complete factor reference
+  with exact criteria, tarball layout, grade thresholds, score math.
+- **[references/templates.md](references/templates.md)** — ready-to-use
+  `manifest.yaml`, `README.md`, and JSDoc-annotated entrypoint skeletons.
+
+Load the relevant reference file when an author needs more than the summary
+above can give.
+
+## When an author's score is already showing and they want to improve it
+
+Work backwards from the factor breakdown rendered on the extension's Swamp Club
+page. Each missing-row label maps 1:1 to an entry in the factor-to-action map
+above. Do not speculate — look at the actual breakdown.
+
+Common patterns:
+
+- **"Has README" shows 0/2 but the repo has a README** → not listed in
+  `additionalFiles:`, so it is not in the tarball. Publish a new version with
+  the manifest fixed.
+- **"License declared" shows 0/1 but LICENSE file exists** → same cause. Add it
+  to `additionalFiles:`.
+- **"No slow types" shows 0/1** → run `deno doc --lint <entrypoints>` locally;
+  fix each diagnostic.
+- **"Verified public repository" shows 0/2** → URL host is not allowlisted, URL
+  is HTTP not HTTPS, or the repo is private/404.
+- **"Most symbols documented" shows 0/1** → export JSDoc coverage is below 80%.
+
+Every missing factor is a fixable factor.

--- a/.claude/skills/swamp-extension-quality/evals/trigger_evals.json
+++ b/.claude/skills/swamp-extension-quality/evals/trigger_evals.json
@@ -1,0 +1,122 @@
+[
+  {
+    "query": "How do I improve my extension's quality score?",
+    "should_trigger": true
+  },
+  {
+    "query": "What do I need to do to get a Grade A extension?",
+    "should_trigger": true
+  },
+  {
+    "query": "My extension scored 53% — why is it so low?",
+    "should_trigger": true
+  },
+  {
+    "query": "What makes a good swamp extension?",
+    "should_trigger": true
+  },
+  {
+    "query": "Walk me through the scorecard rubric for extensions.",
+    "should_trigger": true
+  },
+  {
+    "query": "Give me a pre-publish quality checklist for my extension.",
+    "should_trigger": true
+  },
+  {
+    "query": "How are Swamp Club extension scores calculated?",
+    "should_trigger": true
+  },
+  {
+    "query": "What do each of the scorecard factors measure?",
+    "should_trigger": true
+  },
+  {
+    "query": "Review my extension for scorecard-relevant issues.",
+    "should_trigger": true
+  },
+  {
+    "query": "My scorecard says 'Has README 0/2' but I have a README — why?",
+    "should_trigger": true
+  },
+  {
+    "query": "Why is fast-check failing on my extension?",
+    "should_trigger": true
+  },
+  {
+    "query": "How do I earn the repository-verified factor?",
+    "should_trigger": true
+  },
+  {
+    "query": "What counts as a substantive README for the scorecard?",
+    "should_trigger": true
+  },
+  {
+    "query": "Can a third-party extension get to 100% on the scorecard?",
+    "should_trigger": true
+  },
+  {
+    "query": "What's the difference between grade B and grade C?",
+    "should_trigger": true
+  },
+  {
+    "query": "Help me raise my extension from a C to an A grade.",
+    "should_trigger": true
+  },
+  {
+    "query": "Best practices for publishing a high-quality swamp extension",
+    "should_trigger": true
+  },
+  {
+    "query": "What is the Swamp Club scorecard and how does it work?",
+    "should_trigger": true
+  },
+  {
+    "query": "Scorecard factor breakdown — what does each one mean?",
+    "should_trigger": true
+  },
+  {
+    "query": "How do I make sure my extension earns every earnable point?",
+    "should_trigger": true
+  },
+  {
+    "query": "Create a new model that validates JSON against a Zod schema.",
+    "should_trigger": false
+  },
+  {
+    "query": "Implement an ExecutionDriver for running methods in Docker.",
+    "should_trigger": false
+  },
+  {
+    "query": "Build a custom vault that reads secrets from AWS Secrets Manager.",
+    "should_trigger": false
+  },
+  {
+    "query": "How do I publish my extension to the registry?",
+    "should_trigger": false
+  },
+  {
+    "query": "My extension is crashing with 'module not found' — help debug.",
+    "should_trigger": false
+  },
+  {
+    "query": "Run a swamp model method with these input args.",
+    "should_trigger": false
+  },
+  {
+    "query": "Create a workflow that chains two models together.",
+    "should_trigger": false
+  },
+  {
+    "query": "Set up a datastore provider for an S3 backend.",
+    "should_trigger": false
+  },
+  {
+    "query": "How do I use Zod describe() in a schema?",
+    "should_trigger": false
+  },
+  {
+    "query": "Delete expired data versions with swamp data gc.",
+    "should_trigger": false
+  }
+]

--- a/.claude/skills/swamp-extension-quality/references/rubric.md
+++ b/.claude/skills/swamp-extension-quality/references/rubric.md
@@ -1,0 +1,235 @@
+# Swamp Club scorecard rubric — complete reference
+
+The rubric evaluates an extension against 11 factors, totaling 13 points. The
+displayed percentage is `floor(earned * 100 / 13)`. The letter grade is derived
+from the percentage.
+
+## Grade thresholds
+
+| Grade | Range |
+| ----- | ----- |
+| A     | ≥ 90% |
+| B     | ≥ 75% |
+| C     | ≥ 60% |
+| D     | ≥ 40% |
+| F     | < 40% |
+
+## Score ceilings
+
+| Extension type                  | Ceiling      | Why                                                    |
+| ------------------------------- | ------------ | ------------------------------------------------------ |
+| Third-party, all factors earned | 12/13 = 92%  | `verified-by-swamp` is unearnable without admin review |
+| First-party (`@swamp/*`)        | 13/13 = 100% | First-party namespace auto-earns `verified-by-swamp`   |
+| Admin-curated third-party       | 13/13 = 100% | Admin review endpoint earns the factor                 |
+
+## Per-factor reference
+
+### `has-readme` (2 pts)
+
+Earned when the tarball contains a README file. The analyzer looks at:
+
+1. `<logical root>/README.md` (and `.MD`, and `readme.md`)
+2. `<logical root>/files/README.md` (same case variants)
+
+The second location is where files listed in `manifest.yaml`'s
+`additionalFiles:` field land.
+
+### `readme-example` (1 pt)
+
+Earned when the README contains at least one fenced code block. Detection is
+regex-based:
+
+````
+^```[word characters or -]*\s*\n[any content]\n```
+````
+
+Any language tag (or no language tag) counts.
+
+### `rich-readme` (1 pt)
+
+Earned when **both** conditions hold:
+
+- README length ≥ 500 characters (raw byte count of the decoded file)
+- README contains ≥ 2 fenced code blocks (same regex as above)
+
+A README that is 499 characters or has exactly one code block earns 0 for this
+factor. It is deliberately cheap to clear; any substantive README satisfies it.
+
+### `symbols-docs` (1 pt)
+
+Earned when at least 80% of exported symbols across the declared entrypoints
+have a JSDoc comment. Computed via `deno doc --json`:
+`documentedExports / totalExports ≥ 0.80`.
+
+Counting rules:
+
+- Only exported symbols count.
+- Each symbol is counted once per declaration (function overloads count as
+  separate declarations).
+- A symbol is "documented" if its `jsDoc.doc` field is a non-empty string.
+- Types, interfaces, classes, functions, and constants all count.
+
+### `fast-check` (1 pt)
+
+Earned when `deno doc --lint <entrypoints>` produces zero slow-type diagnostics.
+Slow-type diagnostic codes include:
+
+- `missing-return-type`
+- `missing-explicit-type`
+- `private-type-ref`
+- `unsupported-ambient-module`
+- `unsupported-complex-reference`
+- `unsupported-default-export-expr`
+- `unsupported-destructuring`
+- `unsupported-global-module`
+- `unsupported-require`
+- `unsupported-ts-export-assignment`
+- `unsupported-ts-instantiation-expression`
+- `unsupported-ts-namespace-export`
+- `unsupported-using-stmt`
+
+A single diagnostic of any of these codes costs the whole point.
+
+### `description` (1 pt)
+
+Earned when the `description` field on the extension record is a non-empty
+string. The CLI populates this from `manifest.yaml`'s `description:` field
+during push. Owners can also edit it post-publish via the Swamp Club owner
+panel.
+
+### `platforms-one` (1 pt)
+
+Earned when **either**:
+
+- `platforms:` has at least one entry, OR
+- `platforms:` is empty (an empty array is treated as "supports all platforms",
+  which is strictly more permissive than any explicit list)
+
+### `platforms-two` (1 pt)
+
+Same rule, but the array must have ≥ 2 entries (or be empty).
+
+An array of exactly one platform fails this factor because it is a more
+restrictive declaration than "universal". This is intentional — an author who
+has tested on multiple platforms is more trusted than one who has tested on
+exactly one.
+
+### `has-license` (1 pt)
+
+Earned when **either**:
+
+- The extension's `license` field is a non-empty trimmed string (set via PATCH
+  on the extension record), OR
+- The tarball contains a license file at `<root>/*` or `<root>/files/*`
+
+Recognized license filenames (case-sensitive matches):
+
+```
+LICENSE, LICENSE.md, LICENSE.txt, LICENSE.MD, LICENSE.TXT,
+License, License.md, License.txt,
+license, license.md, license.txt,
+COPYING, COPYING.md, COPYING.txt
+```
+
+### `repository-verified` (2 pts)
+
+Earned when the `repository:` URL points to a public repository on an
+allowlisted host, confirmed via that host's public API.
+
+Allowlisted hosts and the API endpoints used:
+
+| Host            | API endpoint                                                      |
+| --------------- | ----------------------------------------------------------------- |
+| `github.com`    | `GET https://api.github.com/repos/:owner/:repo`                   |
+| `gitlab.com`    | `GET https://gitlab.com/api/v4/projects/:encoded-path`            |
+| `codeberg.org`  | `GET https://codeberg.org/api/v1/repos/:owner/:repo`              |
+| `bitbucket.org` | `GET https://api.bitbucket.org/2.0/repositories/:workspace/:repo` |
+
+The URL is parsed to extract owner/repo (nested group paths supported for
+GitLab). A 200 response with the repo reporting itself public earns the factor.
+404, private, rate-limited, or any network error means not verified.
+
+Self-hosted Git (GitHub Enterprise, self-hosted GitLab, private Gitea, Azure
+DevOps, Bitbucket Server) cannot earn this factor — verification requires the
+public API, which only the SaaS instances of those four hosts expose.
+
+Verification is cached for 7 days on the extension record. URL changes clear the
+cache and trigger re-verification.
+
+### `verified-by-swamp` (1 pt)
+
+Earned in one of two ways:
+
+1. The extension is published under the `@swamp` namespace (the first-party
+   collective), OR
+2. A Swamp Club admin has explicitly marked the extension verified via a
+   curation endpoint (not yet built)
+
+Third-party authors should not try to earn this factor. It is the deliberate gap
+between 92% and 100%.
+
+## Factors in the codebase but not currently rendered
+
+### `provenance` (1 pt, gated)
+
+Earned when the extension was published from GitHub Actions with a
+Sigstore-signed bundle verified by the server. Currently gated behind a feature
+flag (`PROVENANCE_IN_RUBRIC = false`) because CLI-side signing support has not
+shipped. When the CLI lands provenance support and the flag flips, the rubric
+divisor becomes 14 and extensions published from CI earn an additional point.
+
+## Worked example: a third-party extension that earns 92%
+
+Manifest:
+
+```yaml
+manifestVersion: 1
+name: "@mycollective/my-extension"
+version: "2026.04.22.1"
+description: "One-sentence explanation of what this extension does."
+
+repository: https://github.com/mycollective/my-extension
+
+additionalFiles:
+  - README.md
+  - LICENSE
+
+models:
+  - my-model.ts
+
+platforms:
+  - linux-x86_64
+  - darwin-aarch64
+```
+
+Factor results:
+
+| Factor              | Earned | Reason                                       |
+| ------------------- | ------ | -------------------------------------------- |
+| has-readme          | 2/2    | README.md listed in additionalFiles          |
+| readme-example      | 1/1    | README contains a usage code block           |
+| rich-readme         | 1/1    | README is 1.2k chars with 3 code blocks      |
+| symbols-docs        | 1/1    | All 8 exports documented (100%)              |
+| fast-check          | 1/1    | Explicit return types, no private-type leaks |
+| description         | 1/1    | Non-empty                                    |
+| platforms-one       | 1/1    | 2 platforms listed                           |
+| platforms-two       | 1/1    | 2 platforms listed                           |
+| has-license         | 1/1    | LICENSE file in additionalFiles              |
+| repository-verified | 2/2    | Public github.com URL                        |
+| verified-by-swamp   | 0/1    | Third-party, not admin-curated               |
+
+**Total: 12/13 = 92% Grade A.**
+
+## Ceiling with future provenance
+
+Once `PROVENANCE_IN_RUBRIC` is enabled:
+
+| State                          | Divisor | Third-party ceiling |
+| ------------------------------ | ------- | ------------------- |
+| Flags off (current)            | 13      | 12/13 = 92%         |
+| Provenance on, publish from CI | 14      | 13/14 = 92%         |
+| Provenance on, no CI publish   | 14      | 12/14 = 85%         |
+
+When the flag flips, extensions not publishing from CI will see an 8%
+regression. Authors who want to stay at 92% will need to switch to publishing
+via GitHub Actions at that point.

--- a/.claude/skills/swamp-extension-quality/references/templates.md
+++ b/.claude/skills/swamp-extension-quality/references/templates.md
@@ -1,0 +1,175 @@
+# Templates for a Grade A extension
+
+Ready-to-adapt skeletons that hit every earnable factor for a third-party
+extension. Adjust names, content, and extension type to taste; the structure is
+what earns the score.
+
+## `manifest.yaml` — full example
+
+```yaml
+manifestVersion: 1
+name: "@mycollective/my-extension"
+version: "2026.04.22.1"
+description: "One clear sentence about what this extension does and who would use it."
+
+repository: https://github.com/mycollective/my-extension
+
+additionalFiles:
+  - README.md
+  - LICENSE
+
+# Choose whichever field applies to your extension type.
+# Pick one — or multiple — and remove the rest.
+models:
+  - my-model.ts
+# drivers:
+#   - my-driver.ts
+# vaults:
+#   - my-vault.ts
+# datastores:
+#   - my-datastore.ts
+# reports:
+#   - my-report.ts
+
+# Empty platforms is "universal" — earns both platform factors.
+# Populate with ≥2 entries if the extension is actually platform-specific.
+platforms:
+  - linux-x86_64
+  - darwin-aarch64
+```
+
+Fields to double-check before publishing:
+
+- `description` is not `"TODO"`, `"tbd"`, or an empty string
+- `repository` is HTTPS and on github.com, gitlab.com, codeberg.org, or
+  bitbucket.org
+- Both `README.md` and a LICENSE file are listed in `additionalFiles:`
+- `platforms:` is either empty or has ≥2 entries (a single explicit platform
+  fails `platforms-two`)
+
+## `README.md` — minimal substantive template
+
+Needs ≥500 characters total and ≥2 fenced code blocks. This template clears both
+bars.
+
+````markdown
+# @mycollective/my-extension
+
+One paragraph explaining what this extension does. Keep it concrete — what
+problem it solves, what inputs it accepts, what side effects it has. The goal is
+that a reader can decide in 30 seconds whether this extension is relevant to
+them.
+
+## Installation
+
+```sh
+swamp extension install @mycollective/my-extension
+```
+
+## Usage
+
+```ts
+import { validate } from "./my-model.ts";
+
+const input = validate({
+  name: "example-input",
+  limit: 10,
+});
+```
+
+## How it works
+
+A short paragraph on the mechanics. Mention any prerequisites: environment
+variables, external services, required permissions, network access, or
+credentials in the vault. If the extension depends on other swamp extensions,
+list them here.
+
+## License
+
+MIT — see LICENSE for details.
+````
+
+## Entrypoint skeleton — JSDoc-annotated TypeScript
+
+Earns `symbols-docs` (≥80% JSDoc coverage), `fast-check` (explicit return types,
+no private-type leaks), and the module-level doc signal for `has-readme`.
+
+```ts
+/**
+ * Module-level doc. Two or three sentences explaining what this
+ * entrypoint is for and when someone would import or invoke it. Keep
+ * implementation details out — they belong in per-symbol docs below.
+ *
+ * @module
+ */
+
+import { z } from "zod";
+
+/** Accepted input shape for this model's operations. */
+export const argsSchema = z.object({
+  name: z.string().describe("The name of the thing to process."),
+  limit: z.number().int().positive().describe("Maximum items to return."),
+});
+
+/** Resolved input type, derived from `argsSchema`. */
+export type Args = z.infer<typeof argsSchema>;
+
+/** Shape returned from a successful operation. */
+export interface Result {
+  processed: number;
+  skipped: number;
+}
+
+/** Validate caller-supplied arguments and return a typed object. */
+export function validate(input: unknown): Args {
+  return argsSchema.parse(input);
+}
+
+/** Process the validated arguments and return a Result. */
+export async function run(args: Args): Promise<Result> {
+  // implementation
+  return { processed: args.limit, skipped: 0 };
+}
+```
+
+Rules this example demonstrates:
+
+- **Every export has a JSDoc comment** — hits the 80% threshold easily.
+- **Explicit return types on every exported function** (`: Args`,
+  `: Promise<Result>`).
+- **All public types are themselves exported** (`Args`, `Result`, `argsSchema`)
+  — so nothing exposed through the API refers to a private type.
+- **Module-level `@module` block at the top** — satisfies module-doc detection.
+
+## Pre-publish command sequence
+
+Run from the extension's directory before invoking `swamp extension push`:
+
+```sh
+# Verify types and catch slow-type issues.
+deno doc --lint models/my-model.ts
+# Exit status 0 + no output means clean.
+
+# See extracted doc structure — confirms exports are well-shaped.
+deno doc --json models/my-model.ts | jq '.nodes | keys'
+
+# Verify formatting and standard lint.
+deno fmt --check
+deno lint
+```
+
+Any diagnostic from `deno doc --lint` costs the `fast-check` point. Fix each one
+before pushing.
+
+## Common mistakes and their fixes
+
+| Mistake                                                          | Consequence                                                        | Fix                                                         |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------- |
+| README in repo root but not in `additionalFiles:`                | `has-readme` 0/2, `readme-example` 0/1, `rich-readme` 0/1 = -4 pts | Add `README.md` to `additionalFiles:` in the manifest       |
+| LICENSE file in repo but not in `additionalFiles:`               | `has-license` 0/1 = -1 pt                                          | Add the LICENSE file to `additionalFiles:`                  |
+| Missing return type on one exported function                     | `fast-check` 0/1 = -1 pt                                           | Add explicit `: ReturnType` annotation                      |
+| Description set to `"TODO"`                                      | technically passes, wastes the signal                              | Write a real one-sentence description                       |
+| `repository:` URL is HTTP not HTTPS                              | `repository-verified` 0/2 = -2 pts                                 | Switch to `https://`                                        |
+| `repository:` on self-hosted GitLab or Gitea                     | `repository-verified` 0/2 = -2 pts                                 | Use a public mirror on github.com or gitlab.com if possible |
+| `platforms:` has exactly one entry                               | `platforms-two` 0/1 = -1 pt                                        | Either leave empty (universal) or list ≥2                   |
+| One exported helper without a JSDoc comment, out of five exports | `symbols-docs` 0/1 = -1 pt                                         | Add JSDoc to hit ≥80% coverage                              |

--- a/.claude/skills/swamp-extension-vault/SKILL.md
+++ b/.claude/skills/swamp-extension-vault/SKILL.md
@@ -229,6 +229,7 @@ verification) before allowing a push.
 | Create custom datastores           | `swamp-extension-datastore` |
 | Create custom execution drivers    | `swamp-extension-driver`    |
 | Repository setup and configuration | `swamp-repo`                |
+| Quality scorecard & best practices | `swamp-extension-quality`   |
 | Understand swamp internals         | `swamp-troubleshooting`     |
 
 ## References

--- a/integration/extension_rm_test.ts
+++ b/integration/extension_rm_test.ts
@@ -184,10 +184,16 @@ Deno.test("extension pull then rm removes files and JSON entry", async () => {
       "files should be an array before rm",
     );
 
-    // Verify files exist on disk before removal
+    // Verify entries exist on disk before removal. Entries can be either
+    // files or directories — skills are tracked as a single directory root
+    // so `extension rm` can delete them in one shot (see pull.ts:992-1016).
     for (const file of files!) {
       const stat = await Deno.stat(`${tmpDir}/${file}`);
-      assertEquals(stat.isFile, true, `File should exist before rm: ${file}`);
+      assertEquals(
+        stat.isFile || stat.isDirectory,
+        true,
+        `Entry should exist before rm: ${file}`,
+      );
     }
 
     // Remove the extension


### PR DESCRIPTION
## Summary

- New `swamp-extension-quality` skill that guides extension authors to hit the Swamp Club quality scorecard (11-factor rubric, third-party ceiling 12/13 = 92% Grade A).
- Scope-bounded so it doesn't overlap with `swamp-extension-{model,driver,vault,datastore,publish}` or `swamp-troubleshooting` — the SKILL.md opens with a "when this skill fires vs. when another one does" table.
- Cross-reference row added to each sibling extension skill's "When to Use Other Skills" table (`Quality scorecard & best practices → swamp-extension-quality`).

## What's inside

- `SKILL.md` — scope boundaries, factor-to-action map (11 rows), pre-publish 13-step checklist, troubleshooting for each "row shows 0/n" pattern.
- `references/rubric.md` — per-factor mechanics (exact criteria, tarball layout, host allowlist), grade thresholds, ceiling math, worked 92% example.
- `references/templates.md` — ready-to-adapt `manifest.yaml`, `README.md` (≥500 chars, ≥2 fenced blocks), JSDoc-annotated entrypoint skeleton, pre-publish command sequence, common-mistakes fix table.
- `evals/trigger_evals.json` — 20 positive triggers + 10 negative triggers (covering the overlapping-skill boundaries).

## Validation

- `tessl skill review` passed at **100%** (Description 100%, Content 100%).
- `deno fmt` clean on all modified skill markdown.

## Test plan

- [ ] Spot-check each sibling skill's "When to Use Other Skills" table renders correctly.
- [ ] Trigger the skill with one positive-eval query and confirm it fires.
- [ ] Trigger with one negative-eval query (e.g. "How do I publish my extension to the registry?") and confirm it does NOT fire (publish skill does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)