### PR TITLE
feat(repo): bundle swamp-extension-quality skill in repo init/upgrade

### DIFF
--- a/src/infrastructure/assets/skill_assets.ts
+++ b/src/infrastructure/assets/skill_assets.ts
@@ -286,6 +286,18 @@ const BUNDLED_SKILLS: SkillInfo[] = [
     relativePath: "swamp-getting-started/references/tracks.md",
     name: "swamp-getting-started",
   },
+  {
+    relativePath: "swamp-extension-quality/SKILL.md",
+    name: "swamp-extension-quality",
+  },
+  {
+    relativePath: "swamp-extension-quality/references/rubric.md",
+    name: "swamp-extension-quality",
+  },
+  {
+    relativePath: "swamp-extension-quality/references/templates.md",
+    name: "swamp-extension-quality",
+  },
 ];
 
 /**

--- a/src/infrastructure/assets/skill_assets_test.ts
+++ b/src/infrastructure/assets/skill_assets_test.ts
@@ -573,3 +573,40 @@ Deno.test("SkillAssets.copySkillsTo copies swamp-troubleshooting skill", async (
     assertEquals(skillStat.isFile, true);
   });
 });
+
+Deno.test("SkillAssets includes swamp-extension-quality skill", () => {
+  const assets = new SkillAssets();
+  const names = assets.getSkillNames();
+
+  assertEquals(names.includes("swamp-extension-quality"), true);
+});
+
+Deno.test("SkillAssets.copySkillsTo copies swamp-extension-quality reference files", async () => {
+  await withTempDir(async (dir) => {
+    const assets = new SkillAssets();
+    await assets.copySkillsTo(dir);
+
+    const skillPath = join(dir, "swamp-extension-quality", "SKILL.md");
+    const rubricPath = join(
+      dir,
+      "swamp-extension-quality",
+      "references",
+      "rubric.md",
+    );
+    const templatesPath = join(
+      dir,
+      "swamp-extension-quality",
+      "references",
+      "templates.md",
+    );
+
+    const skillStat = await Deno.stat(skillPath);
+    assertEquals(skillStat.isFile, true);
+
+    const rubricStat = await Deno.stat(rubricPath);
+    assertEquals(rubricStat.isFile, true);
+
+    const templatesStat = await Deno.stat(templatesPath);
+    assertEquals(templatesStat.isFile, true);
+  });
+});


### PR DESCRIPTION
## Summary

The `swamp-extension-quality` skill (added in #1211) lived in `.claude/skills/` and was embedded in the compiled binary, but it was missing from the `BUNDLED_SKILLS` list in `src/infrastructure/assets/skill_assets.ts`. As a result, `swamp repo init` and `swamp repo upgrade` did not copy it into user repos.

- Add three entries to `BUNDLED_SKILLS` for `swamp-extension-quality/SKILL.md`, `references/rubric.md`, and `references/templates.md`.
- Add two tests in `skill_assets_test.ts` mirroring the `swamp-getting-started` pattern — one asserts the skill is registered, one asserts the files are copied.

## Test Plan

- [x] `deno fmt --check`
- [x] `deno lint`
- [x] `deno run test` (4703 passed)
- [x] `deno check` on modified files