### PR TITLE
docs(datastore): clarify resolveCachePath runtime equivalence (swamp-club#150)

### DIFF
--- a/.claude/skills/swamp-extension-datastore/SKILL.md
+++ b/.claude/skills/swamp-extension-datastore/SKILL.md
@@ -115,7 +115,10 @@ The `type` must match the pattern `@collective/name` or `collective/name` (e.g.,
 | `createVerifier`       | Yes      | Returns a `DatastoreVerifier` for health checks     |
 | `createSyncService`    | No       | Returns a `DatastoreSyncService` for remote sync    |
 | `resolveDatastorePath` | Yes      | Returns the absolute path for runtime data storage  |
-| `resolveCachePath`     | No       | Returns a local cache path for remote datastores    |
+| `resolveCachePath`     | No†      | Local cache path for remote datastores (see note)   |
+
+† Optional in the type, but define it — return `undefined` for core's default.
+See [references/api.md](references/api.md).
 
 For full interface signatures and type details, see
 [references/api.md](references/api.md).

--- a/.claude/skills/swamp-extension-datastore/references/api.md
+++ b/.claude/skills/swamp-extension-datastore/references/api.md
@@ -20,9 +20,17 @@ interface DatastoreProvider {
   createVerifier(): DatastoreVerifier;
   createSyncService?(repoDir: string, cachePath: string): DatastoreSyncService;
   resolveDatastorePath(repoDir: string): string;
-  resolveCachePath?(repoDir: string): string;
+  resolveCachePath?(repoDir: string): string | undefined;
 }
 ```
+
+Although `resolveCachePath` is marked optional with `?`, the convention across
+all `@swamp/*` datastores is to define it and return `undefined` when no custom
+cache is desired. Omitting the method and returning `undefined` are
+runtime-equivalent — every consumer in swamp core uses
+`provider.resolveCachePath?.(repoDir) ?? <repoId-keyed default>`, so both cases
+fall back to `~/.swamp/repos/<repoId>`. Defining the method makes the intent
+explicit to readers.
 
 ### `createLock(datastorePath, options?)`
 
@@ -54,9 +62,10 @@ should be the local cache path.
 
 ### `resolveCachePath(repoDir)?`
 
-Optional. Returns a local cache path for remote datastores. When present, swamp
-uses this path for local caching and syncs to/from the remote backend via the
-sync service.
+Returns a local cache path for remote datastores, or `undefined` to accept
+core's `~/.swamp/repos/<repoId>` default. Convention details above. When a
+concrete path is returned, swamp uses it for local caching and syncs to/from the
+remote backend via the sync service.
 
 ## DistributedLock
 

--- a/.claude/skills/swamp-extension-model/references/adversarial-review.md
+++ b/.claude/skills/swamp-extension-model/references/adversarial-review.md
@@ -140,7 +140,9 @@ These apply to **all** extension types (models, drivers, vaults, datastores).
 - `withLock` must release the lock on both success and error paths.
 - `createVerifier` must return accurate health information with latency.
 - `resolveDatastorePath` must be deterministic for the same inputs.
-- Remote datastores must implement `resolveCachePath`.
+- Remote datastores should define `resolveCachePath` (return `undefined` for
+  core's repoId-keyed default). Optional in the type, but every `@swamp/*`
+  datastore follows this convention so the intent is explicit.
 
 ## What This Review Does NOT Check
 

--- a/packages/testing/datastore_types.ts
+++ b/packages/testing/datastore_types.ts
@@ -82,5 +82,19 @@ export interface DatastoreProvider {
   createVerifier(): DatastoreVerifier;
   createSyncService?(repoDir: string, cachePath: string): DatastoreSyncService;
   resolveDatastorePath(repoDir: string): string;
+  /**
+   * Resolve a local cache path for remote datastores.
+   *
+   * Optional at the type level, but note the runtime equivalence: every
+   * consumer in swamp core invokes this as
+   * `provider.resolveCachePath?.(repoDir) ?? <repoId-keyed default>`, so
+   * omitting the method and defining it to return `undefined` both fall
+   * back to `~/.swamp/repos/<repoId>`.
+   *
+   * The convention across all `@swamp/*` datastores is to define the
+   * method and return `undefined` when no custom cache is desired, so the
+   * intent ("I want core's default") is explicit to readers rather than
+   * inferred from a missing property.
+   */
   resolveCachePath?(repoDir: string): string | undefined;
 }

--- a/src/cli/resolve_datastore_test.ts
+++ b/src/cli/resolve_datastore_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
 import {
   buildLocalEditsWarning,
   parseDatastoreEnvVar,
@@ -30,6 +31,7 @@ import {
 } from "../domain/datastore/datastore_config.ts";
 import { datastoreTypeRegistry } from "../domain/datastore/datastore_type_registry.ts";
 import type { DatastoreProvider } from "../domain/datastore/datastore_provider.ts";
+import { getSwampDataDir } from "../infrastructure/persistence/paths.ts";
 import type { RepoMarkerData } from "../infrastructure/persistence/repo_marker_repository.ts";
 import { z } from "zod";
 
@@ -310,6 +312,69 @@ Deno.test("resolveDatastoreConfig: YAML custom type with no config defaults to e
   const config = await resolveDatastoreConfig(marker, undefined, "/repo");
   const custom = config as CustomDatastoreConfig;
   assertEquals(custom.config, {});
+});
+
+// ============================================================================
+// resolveCachePath contract — lock single-path cache resolution (swamp-club#150)
+// ============================================================================
+
+// The #150 reporter claimed a missing `resolveCachePath` method and a method
+// returning `undefined` take different code paths in swamp core. They do not.
+// Every consumer uses `provider.resolveCachePath?.(x) ?? <fallback>` — the
+// codebase convention — which JavaScript evaluates identically for both
+// cases. See src/cli/resolve_datastore.ts and src/libswamp/datastores/setup.ts;
+// grep `resolveCachePath` to enumerate the call sites.
+//
+// These tests lock in the single-path runtime behavior: a provider that
+// returns `undefined` routes to core's repoId-keyed default, while a provider
+// that returns a concrete path uses that path. A future refactor that changes
+// the fallback or drops the `?.` must update these assertions deliberately.
+
+Deno.test("resolveCachePath: undefined return routes to repoId-keyed default", async () => {
+  const typeName = "test-cache-undefined";
+  if (!datastoreTypeRegistry.has(typeName)) {
+    datastoreTypeRegistry.register({
+      type: typeName,
+      name: `Test ${typeName}`,
+      description: `Test datastore type: ${typeName}`,
+      isBuiltIn: false,
+      createProvider: () =>
+        createStubProvider({
+          resolveCachePath: (_repoDir: string) => undefined,
+        }),
+    });
+  }
+  const config = await parseDatastoreEnvVar(
+    `${typeName}:{}`,
+    "repo-abc",
+    "/my/repo",
+  );
+  const custom = config as CustomDatastoreConfig;
+  assertEquals(custom.cachePath, join(getSwampDataDir(), "repos", "repo-abc"));
+});
+
+Deno.test("resolveCachePath: concrete return is used as-is", async () => {
+  const typeName = "test-cache-concrete";
+  if (!datastoreTypeRegistry.has(typeName)) {
+    datastoreTypeRegistry.register({
+      type: typeName,
+      name: `Test ${typeName}`,
+      description: `Test datastore type: ${typeName}`,
+      isBuiltIn: false,
+      createProvider: () =>
+        createStubProvider({
+          resolveCachePath: (repoDir: string) =>
+            `${repoDir}/.test-explicit-cache`,
+        }),
+    });
+  }
+  const config = await parseDatastoreEnvVar(
+    `${typeName}:{}`,
+    "repo-xyz",
+    "/my/repo",
+  );
+  const custom = config as CustomDatastoreConfig;
+  assertEquals(custom.cachePath, "/my/repo/.test-explicit-cache");
 });
 
 // ============================================================================

--- a/src/domain/datastore/datastore_provider.ts
+++ b/src/domain/datastore/datastore_provider.ts
@@ -36,6 +36,19 @@ export interface DatastoreProvider {
   createSyncService?(repoDir: string, cachePath: string): DatastoreSyncService;
   /** Resolve the datastore path relative to the repository. */
   resolveDatastorePath(repoDir: string): string;
-  /** Optionally resolve a local cache path for remote datastores. */
+  /**
+   * Resolve a local cache path for remote datastores.
+   *
+   * Optional at the type level, but note the runtime equivalence: every
+   * consumer in swamp core invokes this as
+   * `provider.resolveCachePath?.(repoDir) ?? <repoId-keyed default>`, so
+   * omitting the method and defining it to return `undefined` both fall
+   * back to `~/.swamp/repos/<repoId>`.
+   *
+   * The convention across all `@swamp/*` datastores is to define the
+   * method and return `undefined` when no custom cache is desired, so the
+   * intent ("I want core's default") is explicit to readers rather than
+   * inferred from a missing property.
+   */
   resolveCachePath?(repoDir: string): string | undefined;
 }


### PR DESCRIPTION
## Summary

Narrow response to swamp-club#150: documentation + a regression test that locks in the single-path runtime behavior. No interface change, no call-site change, no runtime change.

- JSDoc tightened on `DatastoreProvider.resolveCachePath` in both the canonical interface and the testing-package mirror (kept aligned by `testing_package_compat_test.ts`)
- `swamp-extension-datastore` skill docs note the convention (define the method, return `undefined` when no custom cache is desired)
- `swamp-extension-model/references/adversarial-review.md:143` reworded to match actual contract semantics
- New regression test in `src/cli/resolve_datastore_test.ts` with an in-code correction-of-record comment

## The reporter's mechanism claim doesn't hold

swamp-club#150 argues that missing-method vs returns-undefined take different runtime paths in swamp core. They don't. Every consumer uses `provider.resolveCachePath?.(repoDir) ?? <repoId-keyed default>` — JavaScript's optional chaining evaluates both cases identically. Call sites:

- `src/cli/resolve_datastore.ts:261, 330, 419, 495`
- `src/libswamp/datastores/setup.ts:301`

## What actually broke the GCS UAT

The regression the reporter experienced was real, but the cause was different. Pre-a30741ea, the GCS provider hard-coded `~/.swamp/repos/unknown/` — a literal path that happened to collide across two fresh repos on the same machine, so writer and reader shared a cache dir by accident. Removing that override unmasked core's per-repoId fallback, which correctly gives each repo its own cache dir — and that exposed the latent cache-sharing problem the hard-coded path was masking. Already fixed in systeminit/swamp-extensions#91 (restoring the method to return `undefined`, matching `@swamp/s3-datastore`).

## Why not make the method required (the reporter's suggested fix)?

It wouldn't prevent the bug class the GCS author experienced. A provider that defines `resolveCachePath(_) { return undefined; }` still routes to the same repoId-keyed fallback that caused the writer/reader cache split. The real fix is always at the extension layer — define something sensible for your backend. Dropping the `?` would add compile-time ceremony without addressing the root cause.

## Test plan

- [x] `deno check` — passes (1080 files)
- [x] `deno lint` — passes (1080 files)
- [x] `deno fmt` — applied
- [x] `deno run test` — 4705 passed / 0 failed / 1 ignored
- [x] `deno run test src/cli/resolve_datastore_test.ts` — 24/24 (includes 2 new regression tests)
- [x] `deno run compile` — clean

Closes swamp-club#150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)