### PR TITLE
chore(deps): bump promptfoo to 0.121.7 to clear Dependabot alerts

### DIFF
--- a/.claude/skills/swamp-issue/SKILL.md
+++ b/.claude/skills/swamp-issue/SKILL.md
@@ -56,6 +56,9 @@ swamp issue bug --email --title "Crash report" --body "Details..."
 }
 ```
 
+See [references/output_shapes.md](references/output_shapes.md) for all other
+shapes (email fallback, extension-scoped, refusals, security variants).
+
 ## Extension-Scoped Submission (`--extension @collective/name`)
 
 Routes reports to the extension's publisher. Requires the extension to be pulled
@@ -78,17 +81,9 @@ swamp issue bug --extension @adam/cfgmgmt --title "..." --body "..." --json
 swamp issue security --extension @adam/cfgmgmt --title "..." --body "..." --json
 ```
 
-**Output shapes (`--json`):**
-
-- `@swamp/*` →
-  `{ "method": "extension-lab", "number": 42, "extensionName": "@swamp/aws", ... }`
-- Third-party with `gh` →
-  `{ "status": "handoff", "method": "gh", "variant": "issue", "url": "...", "number": 42 }`
-- Third-party without `gh` →
-  `{ "status": "handoff", "method": "browser", "variant": "issue", "url": "...", "preparedTitle": "...", "preparedBody": "..." }`
-- Refused (not pulled / no repo / PVR disabled for security) →
-  `{ "status": "refused", "reason": "...", "guidance": "..." }`
-
+Output shapes differ by routing path (`extension-lab`, `gh` handoff, browser
+handoff, refusal). See
+[references/output_shapes.md](references/output_shapes.md) for full examples.
 Refusals exit **0**, not as errors — the CLI is honoring the user's intent when
 the target can't accept reports.
 
@@ -109,11 +104,26 @@ checks GitHub's Private Vulnerability Reporting (PVR) status first:
 
 1. Gather details from the user (bug reproduction steps, feature context, or
    vulnerability description).
-2. For extension-scoped reports, confirm the extension is pulled locally.
+2. For extension-scoped reports, confirm the extension is pulled locally with
+   `swamp extension list` — if missing, run `swamp extension pull <name>` first.
 3. Verify syntax with `swamp help issue`.
 4. Run the appropriate command.
 5. Verify with the returned issue number / URL (or relay the refusal guidance to
    the user).
+
+### Error Recovery
+
+Map the failure to the right fix rather than retrying blindly:
+
+| Failure signal                                  | Likely cause                | Fix                                                                                     |
+| ----------------------------------------------- | --------------------------- | --------------------------------------------------------------------------------------- |
+| Lab submission returns 401 / "unauthorized"     | Auth token expired          | Run `swamp auth login` and retry                                                        |
+| Lab submission times out or 5xx                 | swamp.club outage           | Retry with `--email` to fall back to email submission                                   |
+| `gh` handoff errors with auth failure           | `GH_TOKEN` unset or invalid | Run `gh auth login` (or export a valid `GH_TOKEN`); re-run — CLI will retry `gh`        |
+| `gh` not installed                              | Missing binary              | No action needed — CLI falls back to `method: "browser"` automatically                  |
+| `status: "refused"` with "extension not pulled" | Extension not local         | `swamp extension pull <name>`, then retry                                               |
+| `status: "refused"` with "no repository"        | Publisher declared no repo  | Do not retry; relay the guidance field to the user (points at publisher's profile page) |
+| `status: "refused"` on `security` command       | PVR disabled on target repo | Do not retry as a public issue; relay guidance to contact publisher privately           |
 
 ## Requirements
 

--- a/.claude/skills/swamp-issue/references/output_shapes.md
+++ b/.claude/skills/swamp-issue/references/output_shapes.md
@@ -1,0 +1,94 @@
+# Output Shapes
+
+JSON output shapes for `swamp issue *` commands invoked with `--json`. Use these
+to assert on results programmatically.
+
+## Plain Submission (no `--extension`)
+
+**Lab submission** (user logged in):
+
+```json
+{
+  "method": "lab",
+  "number": 42,
+  "type": "bug",
+  "title": "My Bug",
+  "serverUrl": "https://swamp.club"
+}
+```
+
+**Email fallback** (`--email` or not logged in and user chose email):
+
+```json
+{
+  "method": "email",
+  "to": "support@systeminit.com",
+  "subject": "...",
+  "body": "..."
+}
+```
+
+## Extension-Scoped Submission (`--extension @collective/name`)
+
+**`@swamp/*` — Lab with extension tag:**
+
+```json
+{
+  "method": "extension-lab",
+  "number": 42,
+  "extensionName": "@swamp/aws",
+  "type": "bug",
+  "title": "..."
+}
+```
+
+**Third-party with `gh` CLI available:**
+
+```json
+{
+  "status": "handoff",
+  "method": "gh",
+  "variant": "issue",
+  "url": "https://github.com/publisher/repo/issues/42",
+  "number": 42
+}
+```
+
+**Third-party without `gh` (browser handoff):**
+
+```json
+{
+  "status": "handoff",
+  "method": "browser",
+  "variant": "issue",
+  "url": "https://github.com/publisher/repo/issues/new?...",
+  "preparedTitle": "...",
+  "preparedBody": "..."
+}
+```
+
+**Refused** (extension not pulled, publisher declared no repo, or PVR disabled
+for a security report):
+
+```json
+{
+  "status": "refused",
+  "reason": "...",
+  "guidance": "..."
+}
+```
+
+Refusals exit **0**, not as errors — the CLI is honoring the user's intent when
+the target can't accept reports.
+
+## Security-Specific Variants
+
+For `swamp issue security --extension` against a third-party GitHub repo, the
+`variant` field changes based on GitHub's Private Vulnerability Reporting (PVR)
+status:
+
+- PVR enabled → `variant: "advisory"`, URL points at the advisory form.
+- PVR disabled → `status: "refused"` with guidance to contact the publisher
+  privately.
+- Check failed or `gh` unavailable → `variant: "advisory"` with a `fallbackUrl`
+  field pointing at the public issue URL.

--- a/evals/promptfoo/package-lock.json
+++ b/evals/promptfoo/package-lock.json
@@ -8,7 +8,7 @@
       "name": "swamp-evals-promptfoo",
       "version": "0.0.0",
       "dependencies": {
-        "promptfoo": "0.121.5"
+        "promptfoo": "0.121.7"
       }
     },
     "node_modules/@ai-sdk/gateway": {
@@ -90,9 +90,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.112",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.112.tgz",
-      "integrity": "sha512-vMFoiDKlOive8p3tphpV1gQaaytOipwGJ+uw9mvvaLQUODSC2+fCdRDAY25i2Tsv+lOtxzXBKctmaDuWqZY7ig==",
+      "version": "0.2.118",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.118.tgz",
+      "integrity": "sha512-OfxCTzmfqvctpTLd3CP+UrpC0JdhYcJp12rD+SK29k+9+hrbblCrLobvhdWpTuYFejTPJuiLVsbHxq0BkEuELQ==",
       "license": "SEE LICENSE IN README.md",
       "optional": true,
       "dependencies": {
@@ -103,19 +103,122 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "^0.34.2",
-        "@img/sharp-darwin-x64": "^0.34.2",
-        "@img/sharp-linux-arm": "^0.34.2",
-        "@img/sharp-linux-arm64": "^0.34.2",
-        "@img/sharp-linux-x64": "^0.34.2",
-        "@img/sharp-linuxmusl-arm64": "^0.34.2",
-        "@img/sharp-linuxmusl-x64": "^0.34.2",
-        "@img/sharp-win32-arm64": "^0.34.2",
-        "@img/sharp-win32-x64": "^0.34.2"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.118",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.118",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.118",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.118",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.118",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.118",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.118",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.118"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
       }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.2.118",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.118.tgz",
+      "integrity": "sha512-RudnoBekv0c9CPL0EeMc4RqDe4Pb7tdz/2oxa5EYqaajXNRlYtTvru9q7wq7Zvp40JQ24hz38swOTJ7PkW7G/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.2.118",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.118.tgz",
+      "integrity": "sha512-Hf/H46uElpfygALlb4KZR2EuyyJRe7jBuWa+TDA4jmAHVblNfwkVyaCp8s61hZINB3kAmXdLdM81VI+xwruWzA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.2.118",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.118.tgz",
+      "integrity": "sha512-lwMXnweJKpzESezJFM8mngRxJfaq/N0gqyFXBm5bOYaPIZnlGlP3h1JMKsJeqC4neLVGbe5a3Hq4T22Rr7OoAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.2.118",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.118.tgz",
+      "integrity": "sha512-gSuZS8GM8MZuklzAJS8VCCjqK2UJJeerV+JpVYzXNMelotq4sXUg2dp17VbjCJ1jhUC9u1gpzlQDWkmYrXCbOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.2.118",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.118.tgz",
+      "integrity": "sha512-m0KBbwN9s0+hQwAPzeUFvegrEqoT9EOC+Vz3vr4dd9FcZyvKZE0yiv9S7YbFp1ZKWDQmppmvpcB+9eME7WQ0yA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.2.118",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.118.tgz",
+      "integrity": "sha512-36lG1F9IsuNBV7AzJY98z8KwryoWZCeEtMzgZL7614zPBhZGBsziQUZEBm2Eu7FVWbRQmYv6BL52+gffpkM4Gw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.2.118",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.118.tgz",
+      "integrity": "sha512-o30/SL084+a8wJ+5cgKM1BflxiBUEy+xEcEpZPW+zCFtiqY0b1Pr+K35ECsbKBrv+w5/0Byp4/CvCkP15Otsgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.2.118",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.118.tgz",
+      "integrity": "sha512-TSqsVBUaZGgYMkjCZckXhPvmJDTS7C6VAl4IOeMVNB/oPINVFaobtVagjYvY0BFnlDCOzz6sb8puafHwcm7qQA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@anthropic-ai/sdk": {
       "version": "0.81.0",
@@ -139,9 +242,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.88.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.88.0.tgz",
-      "integrity": "sha512-QQOtB5U9ZBJQj6y1ICmDZl14LWa4JCiJRoihI+0yuZ4OjbONrakP0yLwPv4DJFb3VYCtQM31bTOpCBMs2zghPw==",
+      "version": "0.90.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
+      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -1366,9 +1469,9 @@
       }
     },
     "node_modules/@azure/ai-projects": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@azure/ai-projects/-/ai-projects-2.0.2.tgz",
-      "integrity": "sha512-8m4Kh6BjhBI5zFnJyBIr85cBbop7XABjwD0FgtL4JQ6GEmTSnIIRmXOBNAjYI95SorNnw4jGOSoonkHXVqyGrQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/ai-projects/-/ai-projects-2.1.0.tgz",
+      "integrity": "sha512-1NWxmcfAqa9xBS+RcekdT6FRVcTlPdw5VMLXq+tJxZo1jGtJghiuXa7tsriReA42pAjUHJ4N2fYL/JIZAeCizg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1583,22 +1686,22 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.7.0.tgz",
-      "integrity": "sha512-uYbJ0YarxkVGWEq814BysJry/IPvpDNkVKmc2bMZp4G+igUQkJ5nlFirycwPGUeA9ICLQqCxqExCA1Z1E07bPA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.8.0.tgz",
+      "integrity": "sha512-X7IZV77bN56l7sbLjkcbQJX1t3U4tgxqztDr/XFbUcUfKk+z2FavcLgKP+OYUNj0wl/pEEtV9lldW9siY8BuHQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@azure/msal-common": "16.5.0"
+        "@azure/msal-common": "16.5.1"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.5.0.tgz",
-      "integrity": "sha512-i3eS/5pmxDbIU/mLMENs88Qg3k6XxqJytJy6PpB7L1tCBjdXHJDadCD3Hu1TyTooe7iQo7CYqbocgL/l/8u90g==",
+      "version": "16.5.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.5.1.tgz",
+      "integrity": "sha512-WS9w9SfI8SEYO7mTnxGeZ3UwQfhAVYCWglYF2/7GNx3ioHiAs2gPkl9eSwVs8cPrmiGh+zi9ai/OOKoq4cyzDw==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1606,13 +1709,13 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.3.tgz",
-      "integrity": "sha512-LqT8mRZpEils9zGR9eW+Ljqifh2aMA99UF/X0jxIKDYZeHr6onlHwhVP4xHCeLhh55BI63JCbdf1iWJbMh1mPw==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.4.tgz",
+      "integrity": "sha512-G4LXGGggok1QC48uKu64/SV2DPRDlddmV8EieK8pflsNYMj9/Zz+Y9OHoEBhT15h+zpdwXXLYA/7PJCR/yZ8aw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@azure/msal-common": "16.5.0",
+        "@azure/msal-common": "16.5.1",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -3208,9 +3311,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.120.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.120.0.tgz",
-      "integrity": "sha512-e2P1Gya3dwsRe9IPOiswVz5JfR700u+/sWCqDc3jkqv2QViPkNiBmZoGhFnZL5jBpKakSjehC4/Fpspg70nHTw==",
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.121.0.tgz",
+      "integrity": "sha512-kCJ2NeATd4QBQRmqV04ymdN1ZU3MSwnJQDm/KzjpuzGvCuUVEn7no/T2mRyxQ2x77AACqriNOyPPoM/yufyvNg==",
       "license": "Apache-2.0",
       "optional": true,
       "bin": {
@@ -3220,19 +3323,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.120.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.120.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.120.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.120.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.120.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.120.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.121.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.121.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.121.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.121.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.121.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.121.0-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.120.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-darwin-arm64.tgz",
-      "integrity": "sha512-7CU+I5kBaMuoqfG3xisq0mUWzxoEHvfu34cB8a0KpBiIhAgu12fKpmYgZ4/DvRP6Wm9Fu6LJYKVF5apUHFp8nQ==",
+      "version": "0.121.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.121.0-darwin-arm64.tgz",
+      "integrity": "sha512-ZyBqIB6Fb4I0hGb/h65Vu7ePYjHSmGiqqfm+/1djEuxDPkqjfi4wkxYxNYNY+6najyNGN4UijOSTTf19eDCrqw==",
       "cpu": [
         "arm64"
       ],
@@ -3247,9 +3350,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.120.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-darwin-x64.tgz",
-      "integrity": "sha512-d7joNYuwrmd5iIdp/xAE5f8bZT1r82MnmU6Hzgxq3G+xClwEyhxU737ZWnstFSpnZNfxJ5zXCuFUJh4CAkHNtQ==",
+      "version": "0.121.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.121.0-darwin-x64.tgz",
+      "integrity": "sha512-1/OAtdkAZ5yPI3xqaEFlHuPziS1yCqL2gOZdswE7HTmmwpIxi6Z3FCo60JWDPluIp89z4tftdjq73/OCN0YVcw==",
       "cpu": [
         "x64"
       ],
@@ -3264,9 +3367,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.120.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-linux-arm64.tgz",
-      "integrity": "sha512-sVYY25/URlpZPtb0Q0ryLh+lcq9UTEtHAkdZKa0a/R7mAdyPuhpU9V6jWmxwiUh7s53XZOEVFoKmLfH8YIDWCQ==",
+      "version": "0.121.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.121.0-linux-arm64.tgz",
+      "integrity": "sha512-2UgMmdo237o7SCMsfb529cOSEM2HFUgN6OBkv5SBLwfNY1NO2Ex6JnUjlppEXlX6/4cXfZ5qjDghVz5j/+B9zw==",
       "cpu": [
         "arm64"
       ],
@@ -3281,9 +3384,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.120.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-linux-x64.tgz",
-      "integrity": "sha512-VcP9B/c/O+EFEgqoetCzvHrLfAdo8vrt09Gx1lJ8ikewctqAuJ/ozj/6wuvlz7XaaK64ib5cge01pOAeCyt2Sg==",
+      "version": "0.121.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.121.0-linux-x64.tgz",
+      "integrity": "sha512-vlpNJXIqss800J+32Vy7TUZzv31n61b45OLxmsVQGFkTNLJcjFrj9jDUC7I62eC4F16gLioilefNfv4CdJQOEw==",
       "cpu": [
         "x64"
       ],
@@ -3297,13 +3400,13 @@
       }
     },
     "node_modules/@openai/codex-sdk": {
-      "version": "0.120.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.120.0.tgz",
-      "integrity": "sha512-Y6y3EyLpSSJjRGqIFxxb1G9X6Hod+B1CnWzGoO7qrg3URPnjBL/DLLQWdZSENU5yIlRjHEQDSu7y1rKBlx+jUA==",
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.121.0.tgz",
+      "integrity": "sha512-LfDbIBIrRYya6Y+zR8i5ci+wGx8zyTpzTy9iSeRTzZnb4N8Cn30cW+un1Vd2JfjoWhxGXcOTpXy8sSjlSeyvKA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@openai/codex": "0.120.0"
+        "@openai/codex": "0.121.0"
       },
       "engines": {
         "node": ">=18"
@@ -3311,9 +3414,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.120.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-win32-arm64.tgz",
-      "integrity": "sha512-SAaTQU1XHa1qDnmQldmbyROIY5SiaspF+Cw3ziWeeTgyAET3rWusm4ELOElx6QiY1ugYW5ZD+7AFufS2z1xtpQ==",
+      "version": "0.121.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.121.0-win32-arm64.tgz",
+      "integrity": "sha512-m88q4f3XI5npn1t6OG0nWGHWWAjO5FgjRwxh4hdujbLO6t9CiCNfhfPZIOSsoATbrCNwLC+6S77m3cjbNToPNg==",
       "cpu": [
         "arm64"
       ],
@@ -3328,9 +3431,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.120.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-win32-x64.tgz",
-      "integrity": "sha512-zja1GNrbHyOUTvOy5FVMa+rAYIs3m+FOS8rAXftxMEhodMmkMw2O8zcvso657SHhZR0hIEiZ6T70lcyH2YX0mQ==",
+      "version": "0.121.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.121.0-win32-x64.tgz",
+      "integrity": "sha512-Fp0ecVOyM+VcBi/y4HVvRzhifO9YqRiHzhV3rhtAppC7flh22WPguLC4kmvXYAR0p3RPzbo35M2CedWnkOT+cw==",
       "cpu": [
         "x64"
       ],
@@ -3362,9 +3465,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.214.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
-      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.215.0.tgz",
+      "integrity": "sha512-xrFlqhdhUyO8wSRn6DjE0145/HPWSJ5Nm0C7vWua6TdL/FSEAZvEyvdsa9CRXuxo9ebb7j/NEPhEcO62IJ0qUA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -3401,194 +3504,59 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.214.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.214.0.tgz",
-      "integrity": "sha512-kIN8nTBMgV2hXzV/a20BCFilPZdAIMYYJGSgfMMRm/Xa+07y5hRDS2Vm12A/z8Cdu3Sq++ZvJfElokX2rkgGgw==",
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.215.0.tgz",
+      "integrity": "sha512-k4J9ISeGpb0Bm/wCrlcrbroMFTkiWMrdhNxQGrlktxLy127Yzd4/7nrTawn5d/ApktYTknvdixsE6++34Qfi1w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/otlp-exporter-base": "0.214.0",
-        "@opentelemetry/otlp-transformer": "0.214.0",
-        "@opentelemetry/resources": "2.6.1",
-        "@opentelemetry/sdk-trace-base": "2.6.1"
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/otlp-exporter-base": "0.215.0",
+        "@opentelemetry/otlp-transformer": "0.215.0",
+        "@opentelemetry/resources": "2.7.0",
+        "@opentelemetry/sdk-trace-base": "2.7.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/core": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
-      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
-      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
-      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/resources": "2.6.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.214.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.214.0.tgz",
-      "integrity": "sha512-u1Gdv0/E9wP+apqWf7Wv2npXmgJtxsW2XL0TEv9FZloTZRuMBKmu8cYVXwS4Hm3q/f/3FuCnPTgiwYvIqRSpRg==",
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.215.0.tgz",
+      "integrity": "sha512-lHrfbmeLSmesGSkkHiqDwOzfaEMSWXdc7q6UoLfbW8byONCb+bE/zkAr0kapN4US1baT/2nbpNT7Cn9XoB96Vg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/otlp-transformer": "0.214.0"
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/otlp-transformer": "0.215.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
-      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.214.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.214.0.tgz",
-      "integrity": "sha512-DSaYcuBRh6uozfsWN3R8HsN0yDhCuWP7tOFdkUOVaWD1KVJg8m4qiLUsg/tNhTLS9HUYUcwNpwL2eroLtsZZ/w==",
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.215.0.tgz",
+      "integrity": "sha512-cWwBvaV+vkXHkSoTYR8hGw+AW03UlgTr6xtrUKOMeum3T+8vffYXIfXu6KY5MLu8O9QtoBKqaKWw9I5xoOepng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.214.0",
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/resources": "2.6.1",
-        "@opentelemetry/sdk-logs": "0.214.0",
-        "@opentelemetry/sdk-metrics": "2.6.1",
-        "@opentelemetry/sdk-trace-base": "2.6.1",
-        "protobufjs": "^7.0.0"
+        "@opentelemetry/api-logs": "0.215.0",
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/resources": "2.7.0",
+        "@opentelemetry/sdk-logs": "0.215.0",
+        "@opentelemetry/sdk-metrics": "2.7.0",
+        "@opentelemetry/sdk-trace-base": "2.7.0",
+        "protobufjs": "^8.0.1"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
-      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
-      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
-      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/resources": "2.6.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/@opentelemetry/resources": {
@@ -3608,14 +3576,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.214.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.214.0.tgz",
-      "integrity": "sha512-zf6acnScjhsaBUU22zXZ/sLWim1dfhUAbGXdMmHmNG3LfBnQ3DKsOCITb2IZwoUsNNMTogqFKBnlIPPftUgGwA==",
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.215.0.tgz",
+      "integrity": "sha512-y3ucOmphzc4vgBTyIGchs+N/1rkACmoka8QalT2z1LBNM232Z17zMYayHcMl+dgMoOadZ0b72UZv7mDtqy1cFA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.214.0",
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/api-logs": "0.215.0",
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/resources": "2.7.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -3625,82 +3593,20 @@
         "@opentelemetry/api": ">=1.4.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
-      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
-      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.6.1.tgz",
-      "integrity": "sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.0.tgz",
+      "integrity": "sha512-Vd7h95av/LYRsAVN7wbprvvJnHkq7swMXAo7Uad0Uxf9jl6NSReLa0JNivrcc5BVIx/vl2t+cgdVQQbnVhsR9w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/resources": "2.6.1"
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/resources": "2.7.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.9.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
-      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
-      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
@@ -5220,13 +5126,13 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
       "license": "MIT",
       "optional": true,
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.6"
       }
     },
     "node_modules/a-sync-waterfall": {
@@ -7372,9 +7278,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.0.tgz",
-      "integrity": "sha512-MTcrUoRQ1GSQ9iG3QJzBGquYYYeA7piZaJoIWbPFGbRn6Jj6z7xgoAyi4DrZX4y2ZIQQBF59gc/zmvvejjgoFQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "funding": [
         {
           "type": "github",
@@ -8736,9 +8642,9 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10543,16 +10449,16 @@
       "optional": true
     },
     "node_modules/promptfoo": {
-      "version": "0.121.5",
-      "resolved": "https://registry.npmjs.org/promptfoo/-/promptfoo-0.121.5.tgz",
-      "integrity": "sha512-VjslYQGx/ldT+TBQIngNjeonSETorRycCOZoXsw4yhDKJmsaHkgD+mQKznMRfOjLxfDchdSoZmgOm9OF0GsAuQ==",
+      "version": "0.121.7",
+      "resolved": "https://registry.npmjs.org/promptfoo/-/promptfoo-0.121.7.tgz",
+      "integrity": "sha512-dYT2CxlQJdCwLijEquxegie7RAnE1UluROLXc5NQnFgiFZ6xrXrOAnZ3dOoLvAFGKC5C+62cMICerE7rZ59a1g==",
       "license": "MIT",
       "workspaces": [
         "src/app",
         "site"
       ],
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.88.0",
+        "@anthropic-ai/sdk": "^0.90.0",
         "@apidevtools/json-schema-ref-parser": "^15.3.1",
         "@googleapis/sheets": "^13.0.1",
         "@inquirer/checkbox": "^5.1.0",
@@ -10566,7 +10472,7 @@
         "@opencode-ai/sdk": "^1.2.19",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^2.6.0",
-        "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.215.0",
         "@opentelemetry/resources": "^2.6.0",
         "@opentelemetry/sdk-trace-base": "^2.6.0",
         "@opentelemetry/sdk-trace-node": "^2.6.0",
@@ -10646,13 +10552,13 @@
         "node": "^20.20.0 || >=22.22.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.104",
-        "@aws-sdk/client-bedrock-agent-runtime": "^3.1028.0",
-        "@aws-sdk/client-bedrock-runtime": "^3.1028.0",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.114",
+        "@aws-sdk/client-bedrock-agent-runtime": "^3.1031.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.1031.0",
         "@aws-sdk/client-s3": "^3.1003.0",
-        "@aws-sdk/client-sagemaker-runtime": "^3.1028.0",
+        "@aws-sdk/client-sagemaker-runtime": "^3.1031.0",
         "@aws-sdk/credential-provider-sso": "^3.972.16",
-        "@azure/ai-projects": "^2.0.2",
+        "@azure/ai-projects": "^2.1.0",
         "@azure/identity": "^4.13.0",
         "@azure/msal-node": "^5.1.0",
         "@azure/openai-assistants": "^1.0.0-beta.6",
@@ -10660,7 +10566,7 @@
         "@huggingface/transformers": "^4.0.0",
         "@ibm-cloud/watsonx-ai": "^1.7.11",
         "@ibm-generative-ai/node-sdk": "^3.2.4",
-        "@openai/codex-sdk": "^0.120.0",
+        "@openai/codex-sdk": "^0.121.0",
         "@playwright/browser-chromium": "^1.59.1",
         "@rollup/rollup-linux-x64-gnu": "^4.59.0",
         "@slack/web-api": "^7.15.0",
@@ -10680,7 +10586,7 @@
         "pdf-parse": "^2.4.5",
         "playwright": "^1.59.1",
         "playwright-extra": "^4.3.6",
-        "read-excel-file": "^8.0.0",
+        "read-excel-file": "^9.0.0",
         "sharp": "^0.34.5"
       }
     },
@@ -10955,13 +10861,13 @@
       }
     },
     "node_modules/read-excel-file": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/read-excel-file/-/read-excel-file-8.0.3.tgz",
-      "integrity": "sha512-IPxOBdWNAn0FZuWB49IVj+8e4zkLJMGDMRwUErmvuyu42brAnOkvdkm0j/RD+nMabNjNs+LFmbwdm9qUQ12SgA==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/read-excel-file/-/read-excel-file-9.0.6.tgz",
+      "integrity": "sha512-lVFe97e7XLsw9C7KPy5sZZd+axnIXweKK/LV8Gdb+eSx0j0V+aqXbDCQaMvrW66C2SHgTrsSaxrrhGraHxV2VQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@xmldom/xmldom": "^0.8.11",
+        "@xmldom/xmldom": "^0.9.9",
         "fflate": "^0.8.2",
         "unzipper": "^0.12.3"
       },

--- a/evals/promptfoo/package.json
+++ b/evals/promptfoo/package.json
@@ -3,6 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "promptfoo": "0.121.5"
+    "promptfoo": "0.121.7"
   }
 }


### PR DESCRIPTION
## Summary

Bumps `promptfoo` from `0.121.5` → `0.121.7` in `evals/promptfoo/` to clear 5 open Dependabot alerts. The vulnerable packages come in as transitive deps; a simple `promptfoo` bump pulls patched versions through, so no `overrides` block is needed.

Resolved alerts:

| # | Package | Before | After | Severity |
|---|---|---|---|---|
| [#16-19](https://github.com/systeminit/swamp/security/dependabot) | `@xmldom/xmldom` | 0.8.12 | 0.9.10 | high (×4) |
| [#20](https://github.com/systeminit/swamp/security/dependabot) | `fast-xml-parser` | 5.7.0 | 5.7.1 | medium |

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] Verified via `npm install --package-lock-only` that the new lock resolves `@xmldom/xmldom@0.9.10` and `fast-xml-parser@5.7.1` (both above the patched-version thresholds)
- [ ] CI passes