### PR TITLE
fix(audit): repair kiro-cli audit integration

### DIFF
--- a/src/domain/audit/hook_input.ts
+++ b/src/domain/audit/hook_input.ts
@@ -140,21 +140,32 @@ function normalizeCursor(
 }
 
 /**
+ * Kiro shell tool aliases. kiro-cli emits "shell" at runtime even though agent
+ * configs accept "executeBash" / "execute_bash" / "execute_cmd" as aliases.
+ */
+const KIRO_SHELL_TOOL_NAMES = new Set([
+  "execute_bash",
+  "shell",
+  "execute_cmd",
+]);
+
+/**
  * Kiro: postToolUse hook (fires for both success and failure).
  *
  * Supports two input formats:
  * - kiro-cli (stdin, snake_case): tool_name, tool_input, tool_response
  * - Kiro IDE (USER_PROMPT env var, camelCase): toolName, toolArgs, toolResult, toolSuccess
  *
- * tool_name/toolName === "execute_bash", command from tool_input/toolArgs,
- * failure when tool_response.success === false or toolSuccess === false.
+ * tool_name/toolName is one of KIRO_SHELL_TOOL_NAMES, command from
+ * tool_input/toolArgs, failure when tool_response.success === false or
+ * toolSuccess === false.
  */
 function normalizeKiro(
   raw: Record<string, unknown>,
 ): NormalizedHookInput | null {
   // Support both kiro-cli (snake_case) and Kiro IDE (camelCase) field names
   const toolName = (raw.tool_name ?? raw.toolName) as string | undefined;
-  if (toolName !== "execute_bash") return null;
+  if (!KIRO_SHELL_TOOL_NAMES.has(toolName ?? "")) return null;
 
   const toolInput = (raw.tool_input ?? raw.toolArgs) as
     | { command?: string }

--- a/src/domain/audit/hook_input_test.ts
+++ b/src/domain/audit/hook_input_test.ts
@@ -200,6 +200,33 @@ Deno.test("normalizeHookInput kiro: skips non-execute_bash tools", () => {
   assertEquals(result, null);
 });
 
+Deno.test("normalizeHookInput kiro: normalizes kiro-cli runtime 'shell' tool name", () => {
+  const result = normalizeHookInput("kiro", {
+    cwd: "/workspace",
+    tool_name: "shell",
+    tool_input: { command: "docker ps" },
+    tool_response: { success: true },
+  });
+
+  assertEquals(result, {
+    command: "docker ps",
+    cwd: "/workspace",
+    isFailure: false,
+  });
+});
+
+Deno.test("normalizeHookInput kiro: normalizes 'execute_cmd' alias", () => {
+  const result = normalizeHookInput("kiro", {
+    cwd: "/workspace",
+    tool_name: "execute_cmd",
+    tool_input: { command: "ls -la" },
+    tool_response: { success: true },
+  });
+
+  assertEquals(result?.command, "ls -la");
+  assertEquals(result?.isFailure, false);
+});
+
 // ---- Kiro IDE (USER_PROMPT camelCase format) normalization ----
 
 Deno.test("normalizeHookInput kiro: normalizes Kiro IDE camelCase successful execute_bash", () => {

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -19,6 +19,7 @@
 
 import { dirname, join, resolve } from "@std/path";
 import { ensureDir } from "@std/fs";
+import { getLogger } from "@logtape/logtape";
 import { atomicWriteTextFile } from "../../infrastructure/persistence/atomic_write.ts";
 import {
   readUpstreamExtensions,
@@ -39,6 +40,8 @@ import {
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { SkillAssets } from "../../infrastructure/assets/skill_assets.ts";
 import { assertNever, UserError } from "../errors.ts";
+
+const logger = getLogger(["swamp", "repo", "service"]);
 
 export type { AiTool } from "../../infrastructure/persistence/repo_marker_repository.ts";
 
@@ -241,7 +244,8 @@ export class RepoService {
           const a = isAlreadyInit
             ? await this.updateKiroAgentConfig(repoPath)
             : await this.createKiroAgentConfigIfNotExists(repoPath);
-          settingsCreated = s || h || a;
+          const c = await this.ensureKiroCliDefaultAgent(repoPath);
+          settingsCreated = s || h || a || c;
           break;
         }
         case "opencode":
@@ -334,7 +338,8 @@ export class RepoService {
           const s = await this.updateKiroSettings(repoPath);
           const h = await this.updateKiroHooks(repoPath);
           const a = await this.updateKiroAgentConfig(repoPath);
-          settingsUpdated = s || h || a;
+          const c = await this.ensureKiroCliDefaultAgent(repoPath);
+          settingsUpdated = s || h || a || c;
           break;
         }
         case "opencode":
@@ -1412,7 +1417,10 @@ ${body}`;
     const config = {
       name: "swamp",
       description: "Swamp automation agent with audit tracking",
-      tools: ["*"],
+      // kiro-cli's agent schema only accepts explicit tool names from its
+      // built-in list. Using "*" silently fails parsing and kiro-cli falls
+      // back to the default agent, skipping the postToolUse audit hook.
+      tools: ["read", "write", "shell", "grep", "glob", "thinking", "todo"],
       resources: [
         "file://.kiro/steering/**/*.md",
         "skill://.kiro/skills/**/SKILL.md",
@@ -1465,6 +1473,64 @@ ${body}`;
       configPath,
       this.generateKiroAgentConfigContent(),
     );
+  }
+
+  /**
+   * Ensures `.kiro/settings/cli.json` selects the swamp agent as the workspace
+   * default. Without this, plain `kiro-cli chat` (no --agent flag) loads the
+   * built-in `kiro_default` agent and the swamp audit hook never fires.
+   *
+   * If the file doesn't exist, creates it with `{ "chat.defaultAgent": "swamp" }`.
+   * If it exists, merges the key — preserving any unrelated settings the user
+   * has set. If `chat.defaultAgent` is already set to a non-"swamp" value, the
+   * user's preference wins and we log a warning.
+   */
+  private async ensureKiroCliDefaultAgent(
+    repoPath: RepoPath,
+  ): Promise<boolean> {
+    const settingsDir = join(repoPath.value, ".kiro", "settings");
+    const settingsPath = join(settingsDir, "cli.json");
+
+    let existingSettings: Record<string, unknown> = {};
+    let settingsExisted = false;
+
+    try {
+      const content = await Deno.readTextFile(settingsPath);
+      existingSettings = JSON.parse(content);
+      settingsExisted = true;
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) throw error;
+    }
+
+    const currentDefault = existingSettings["chat.defaultAgent"];
+    if (
+      settingsExisted &&
+      typeof currentDefault === "string" &&
+      currentDefault !== "swamp"
+    ) {
+      logger.warn(
+        "Leaving existing chat.defaultAgent={current} in {path} — " +
+          "swamp audit hooks will not run under kiro-cli unless you " +
+          'either switch it to "swamp" or invoke `kiro-cli chat --agent swamp`.',
+        { current: currentDefault, path: settingsPath },
+      );
+      return false;
+    }
+
+    if (settingsExisted && currentDefault === "swamp") {
+      return false;
+    }
+
+    const newSettings = {
+      ...existingSettings,
+      "chat.defaultAgent": "swamp",
+    };
+    await ensureDir(settingsDir);
+    await atomicWriteTextFile(
+      settingsPath,
+      JSON.stringify(newSettings, null, 2) + "\n",
+    );
+    return true;
   }
 
   /**

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -1569,7 +1569,10 @@ Deno.test("RepoService.init with kiro creates .kiro/agents/swamp.json", async ()
     const content = await Deno.readTextFile(configPath);
     const config = JSON.parse(content);
     assertEquals(config.name, "swamp");
-    assertEquals(config.tools, ["*"]);
+    assertEquals(
+      config.tools,
+      ["read", "write", "shell", "grep", "glob", "thinking", "todo"],
+    );
     assertStringIncludes(
       JSON.stringify(config.toolsSettings.shell.allowedCommands),
       "swamp .*",
@@ -1602,6 +1605,74 @@ Deno.test("RepoService.upgrade with kiro updates agent config", async () => {
       JSON.stringify(config.hooks.postToolUse),
       "audit record --from-hook --tool kiro",
     );
+  });
+});
+
+// Kiro CLI workspace default agent tests (.kiro/settings/cli.json)
+
+Deno.test("RepoService.init with kiro produces hook, agent, and cli.json together", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath, { tool: "kiro" });
+
+    // Hook file
+    const hookPath = join(tempDir, ".kiro", "hooks", "swamp-audit.kiro.hook");
+    await Deno.stat(hookPath);
+
+    // Agent config with explicit tools list (no "*")
+    const agentPath = join(tempDir, ".kiro", "agents", "swamp.json");
+    const agent = JSON.parse(await Deno.readTextFile(agentPath));
+    assertEquals(Array.isArray(agent.tools), true);
+    assertEquals((agent.tools as string[]).includes("*"), false);
+    assertEquals((agent.tools as string[]).includes("shell"), true);
+
+    // Workspace default-agent wiring
+    const cliPath = join(tempDir, ".kiro", "settings", "cli.json");
+    const cli = JSON.parse(await Deno.readTextFile(cliPath));
+    assertEquals(cli["chat.defaultAgent"], "swamp");
+  });
+});
+
+Deno.test("RepoService.init with kiro merges existing cli.json preserving unrelated keys", async () => {
+  await withTempDir(async (tempDir) => {
+    // Pre-create cli.json with an unrelated key
+    const settingsDir = join(tempDir, ".kiro", "settings");
+    await Deno.mkdir(settingsDir, { recursive: true });
+    const cliPath = join(settingsDir, "cli.json");
+    await Deno.writeTextFile(
+      cliPath,
+      JSON.stringify({ "some.unrelated.setting": 42 }, null, 2) + "\n",
+    );
+
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+    await service.init(repoPath, { tool: "kiro" });
+
+    const cli = JSON.parse(await Deno.readTextFile(cliPath));
+    assertEquals(cli["chat.defaultAgent"], "swamp");
+    assertEquals(cli["some.unrelated.setting"], 42);
+  });
+});
+
+Deno.test("RepoService.init with kiro leaves existing non-swamp defaultAgent alone", async () => {
+  await withTempDir(async (tempDir) => {
+    const settingsDir = join(tempDir, ".kiro", "settings");
+    await Deno.mkdir(settingsDir, { recursive: true });
+    const cliPath = join(settingsDir, "cli.json");
+    await Deno.writeTextFile(
+      cliPath,
+      JSON.stringify({ "chat.defaultAgent": "my-custom-agent" }, null, 2) +
+        "\n",
+    );
+
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+    await service.init(repoPath, { tool: "kiro" });
+
+    const cli = JSON.parse(await Deno.readTextFile(cliPath));
+    assertEquals(cli["chat.defaultAgent"], "my-custom-agent");
   });
 });
 


### PR DESCRIPTION
## Summary

Three independent bugs prevented `swamp init --tool kiro` from ever recording a kiro-cli shell command to the audit log. End-to-end verified against a throwaway repo with `kiro-cli chat` → `swamp audit`.

**Bug 1 — normalizer dropped every real event**
`src/domain/audit/hook_input.ts` hard-coded `tool_name !== "execute_bash"`, but kiro-cli emits `tool_name: "shell"` at runtime (it's Amazon Q Developer CLI under the hood; `execute_bash` / `execute_cmd` / `shell` are all aliases its agent schema accepts, and `shell` is the canonical runtime name). Accept all three.

**Bug 2 — agent config used invalid `tools: ["*"]`**
The `.kiro/agents/swamp.json` template used `"tools": ["*"]`, which fails kiro-cli schema parsing and causes silent fallback to the built-in `kiro_default` agent — so the swamp postToolUse audit hook never fires. Replaced with an explicit list: `["read", "write", "shell", "grep", "glob", "thinking", "todo"]`.

**Bug 3 — no workspace default agent**
`swamp init --tool kiro` created the hook + agent but never wrote `.kiro/settings/cli.json`. Without it, plain `kiro-cli chat` (no `--agent` flag) loads the default agent and skips swamp entirely. Now created with `{ "chat.defaultAgent": "swamp" }`. If the file already exists, merge the key while preserving unrelated settings; if a non-swamp `chat.defaultAgent` is already set, leave it alone and log a warning.

## Test Plan

- [x] Unit tests: added `shell` and `execute_cmd` cases to `hook_input_test.ts`; existing `execute_bash` / Kiro-IDE camelCase cases still pass
- [x] Integration tests: added three `repo_service_test.ts` cases covering all-three-files output, cli.json merge with unrelated keys preserved, and non-swamp defaultAgent preserved
- [x] `deno check` / `deno lint` / `deno fmt --check` clean
- [x] Full `deno run test`: 4709 pass (one unrelated parallel-env-var flake in `src/libswamp/auth/logout_test.ts` that passes in isolation; not touched here)
- [x] `deno run compile` + manual `swamp init --tool kiro ./tmp` — confirmed `.kiro/settings/cli.json` contains `{"chat.defaultAgent":"swamp"}` and `.kiro/agents/swamp.json` has the explicit tools list