### PR TITLE
chore(agent-constraints): add state-unwind heuristic to Risk dimension

### DIFF
--- a/agent-constraints/adversarial-dimensions.md
+++ b/agent-constraints/adversarial-dimensions.md
@@ -18,6 +18,14 @@ creep? Are there unnecessary changes?
 Are all failure modes identified? What about edge cases, race conditions,
 backwards compatibility? What could go wrong that isn't listed?
 
+Pay particular attention to **state that persists across failure
+boundaries**. If a function mutates module-scope state (a map, registry,
+cache, signal handler) before performing I/O that can throw, check every
+failure path unwinds that state — especially when an outer `catch` block
+re-reads the same state for cleanup. The failure mode is silent: the
+first error propagates, the cleanup hits orphaned state, and the
+cleanup's own failure shadows the original error.
+
 ## Testing
 
 Is the testing strategy sufficient? Are edge cases covered? Are there


### PR DESCRIPTION
## Summary

Adds a concrete failure-mode check under the Risk adversarial dimension for module-scope state that persists across failure boundaries.

## Why

Post-merge review on #1216 surfaced a named class of bug that the pre-merge adversarial review did not catch: if a function mutates module-scope state (in that case, the datastore sync coordinator's `entries` map) before performing I/O that can throw, and an outer `catch` block re-reads the same state for cleanup, an error during the I/O can leave orphaned state. The cleanup then re-encounters it and its own failure shadows the original error — silently, because the original error is gone from the stack by the time the user sees the message.

The existing Risk prompt ("what could go wrong that isn't listed?") is general enough to cover this in principle, but in practice it didn't. Adding the specific sub-check gives reviewers something concrete to look for: **find the `someMap.set(...)` or `register(...)` line, then trace every `throw` path below it and confirm the state is unwound.**

## Design choices

- **Appended to `## Risk`, not a new dimension.** Seven dimensions is already the practical limit for a reviewer to keep in mind. This is a subclass of "what could go wrong" that the Risk section already frames.
- **Under `## Risk`, not `## Correctness`.** Orphaned-state bugs happen *after* the main thing works — they're about recovery paths, not primary semantics.
- **No reference to the originating incident (#1216).** The heuristic should transfer to any registry/cache/handler-map the codebase accumulates over time; an anecdote that only fits one incident isn't a durable review rule.

## Net effect on the file

\`## Risk\` grows from 3 lines to 8 lines. Still shorter than \`## Testing\` or \`## Documentation\`. Agents running the issue-lifecycle skill's adversarial-review phase now have one more concrete prompt that maps to a real class of bug this codebase has seen.

## Test plan

- [x] \`deno fmt --check\` clean
- [ ] Confirm adversarial-review agents actually consult the new text (manual spot-check on the next issue that gets triaged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)