### PR TITLE
feat(extensions): add quality command and opportunistic package cache (swamp-club#163)

### DIFF
--- a/.claude/skills/swamp-extension-publish/SKILL.md
+++ b/.claude/skills/swamp-extension-publish/SKILL.md
@@ -36,6 +36,11 @@ Present the full checklist to the user so they know what to expect:
 > 7. **Dry run** — validate push without uploading
 > 8. **Push** — publish to registry (requires your explicit approval)
 >
+> Optional between steps 6 and 7: run `swamp extension quality manifest.yaml` to
+> see how the extension scores against the Swamp Club rubric. The packaged
+> tarball is cached and reused by the dry-run and push steps if you run it
+> there.
+>
 > Starting now. I'll report progress at each step.
 
 Then begin with State 1.
@@ -188,6 +193,27 @@ re-run `swamp extension fmt manifest.yaml`.
 
 See [references/publishing.md](references/publishing.md#extension-formatting)
 for details on what fmt checks.
+
+### Optional — quality self-check
+
+After State 6 (formatted) and before State 7 (dry_run_passed), the author can
+run a rubric score locally:
+
+```bash
+swamp extension quality manifest.yaml --json
+```
+
+This packages the extension, scores it against the 10 client-earnable Swamp Club
+quality factors (README, LICENSE, JSDoc coverage, repository URL, manifest
+completeness, slow-type diagnostics, …), and prints per- factor results with
+remediation hints. The packaged tarball is written to
+`.swamp/cache/packages/<hash>/` and is transparently reused by the dry run and
+push steps below when the source tree hasn't changed — so no work is duplicated.
+
+This step is purely optional. Skipping it does not block the push; users who
+want rubric feedback should run it before State 7. See the
+[`swamp-extension-quality`](../swamp-extension-quality/SKILL.md) skill for the
+full rubric breakdown and per-factor remediation guidance.
 
 ## State 7: dry_run_passed
 

--- a/.claude/skills/swamp-extension-publish/references/publishing.md
+++ b/.claude/skills/swamp-extension-publish/references/publishing.md
@@ -224,8 +224,22 @@ reports:
    `swamp extension version --manifest manifest.yaml --json`
 2. **Bump version** in `manifest.yaml` — use `nextVersion` from the output above
 3. **Format & lint**: `swamp extension fmt manifest.yaml`
-4. **Dry-run push**: `swamp extension push manifest.yaml --dry-run --json`
-5. **Push**: `swamp extension push manifest.yaml --yes --json`
+4. **(Optional) Quality score**: `swamp extension quality manifest.yaml --json`
+   — see the `swamp-extension-quality` skill for the rubric. Packages and caches
+   the tarball at `.swamp/cache/packages/<hash>/`; the cache is reused by the
+   dry-run and push below if source hasn't changed.
+5. **Dry-run push**: `swamp extension push manifest.yaml --dry-run --json`
+6. **Push**: `swamp extension push manifest.yaml --yes --json`
+
+### Opportunistic package cache
+
+`swamp extension quality`, `swamp extension push --dry-run`, and
+`swamp extension push` all consult a content-hash-keyed cache at
+`.swamp/cache/packages/<hash>/`. The hash is derived from the manifest, every
+referenced source file, and the deno/package-json configuration — so any source
+change invalidates the entry by construction. The cache is a pure optimization:
+a cache miss falls back to fresh packaging. The cache is never load-bearing for
+correctness and can be deleted safely at any time.
 
 ## Push Workflow
 

--- a/.claude/skills/swamp-extension-quality/SKILL.md
+++ b/.claude/skills/swamp-extension-quality/SKILL.md
@@ -102,6 +102,26 @@ and a concrete check.
 
 If any row fails, fix it before handing off to `swamp-extension-publish`.
 
+## Self-check your score locally
+
+The CLI exposes the 10 client-earnable factors as a standalone command:
+
+```
+swamp extension quality manifest.yaml
+swamp extension quality manifest.yaml --json
+```
+
+This packages the extension (reusing the push flow's packaging code), scores the
+tarball contents against the rubric, and prints per-factor pass/fail with
+remediation hints. The tarball is cached under `.swamp/cache/packages/<hash>/` —
+if you run `swamp extension push` against the same source afterwards, it
+transparently reuses the cached bytes so no work is duplicated.
+
+Running `quality` is optional. `push` does not depend on it; running it just
+surfaces rubric failures earlier and prepopulates the package cache.
+`verified-by-swamp` is the one factor the CLI cannot score — it is reserved for
+`@swamp` namespace or admin review and is granted server-side at publish time.
+
 ## Details when needed
 
 For the full per-factor mechanics, the grade thresholds, and a worked example of

--- a/integration/extension_quality_test.ts
+++ b/integration/extension_quality_test.ts
@@ -1,0 +1,468 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { stringify as stringifyYaml } from "@std/yaml";
+import { CLI_ARGS } from "./test_helpers.ts";
+
+const PROJECT_ROOT = Deno.cwd();
+
+async function runCli(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [...CLI_ARGS, ...args],
+    stdout: "piped",
+    stderr: "piped",
+    cwd: PROJECT_ROOT,
+    env: { ...Deno.env.toObject(), SWAMP_NO_TELEMETRY: "1" },
+  });
+  const { code, stdout, stderr } = await command.output();
+  return {
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+    code,
+  };
+}
+
+/**
+ * Parse the first top-level JSON object from a string. When the CLI
+ * exits non-zero in JSON mode, it prints the score object followed by
+ * an error object — tests care about the score and want to ignore the
+ * trailing error.
+ */
+// deno-lint-ignore no-explicit-any
+function parseFirstJson(stdout: string): any {
+  let depth = 0;
+  let start = -1;
+  for (let i = 0; i < stdout.length; i++) {
+    const ch = stdout[i];
+    if (ch === "{") {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (ch === "}") {
+      depth--;
+      if (depth === 0 && start >= 0) {
+        return JSON.parse(stdout.slice(start, i + 1));
+      }
+    }
+  }
+  throw new Error(`No complete JSON object in output: ${stdout}`);
+}
+
+async function initTempRepo(): Promise<string> {
+  const tmpDir = await Deno.makeTempDir();
+  await runCli(["init", tmpDir]);
+  return tmpDir;
+}
+
+/**
+ * Build a minimal, well-documented model suitable for earning every
+ * rubric factor. Writes one model file with an exported function that
+ * has a JSDoc comment AND an explicit return type, plus a README long
+ * enough for `rich-readme` and a LICENSE file.
+ */
+async function writeDocumentedExtension(
+  tmpDir: string,
+  overrides: {
+    description?: string;
+    repository?: string;
+    platforms?: string[];
+    writeReadme?: boolean;
+    writeLicense?: boolean;
+  } = {},
+): Promise<string> {
+  const modelsDir = join(tmpDir, "extensions", "models");
+  await Deno.mkdir(modelsDir, { recursive: true });
+
+  // Well-documented model: module doc + JSDoc on every export +
+  // explicit return types. Passes `deno doc --lint` and contributes
+  // documented symbols.
+  await Deno.writeTextFile(
+    join(modelsDir, "model.ts"),
+    `/**
+ * A sample model for rubric integration testing.
+ *
+ * @module
+ */
+
+/**
+ * Adds two numbers.
+ */
+export function add(a: number, b: number): number {
+  return a + b;
+}
+
+/**
+ * Subtracts two numbers.
+ */
+export function sub(a: number, b: number): number {
+  return a - b;
+}
+`,
+  );
+
+  if (overrides.writeReadme !== false) {
+    // README ≥500 chars with ≥2 fenced code blocks earns has-readme
+    // (2) + readme-example (1) + rich-readme (1).
+    await Deno.writeTextFile(
+      join(tmpDir, "README.md"),
+      `# Sample Extension
+
+This extension demonstrates the rubric integration test fixture. It
+ships a trivial model that earns every client-detectable factor so we
+can assert a perfect score against the opportunistic package cache and
+the deno-doc pipeline.
+
+## Usage
+
+\`\`\`ts
+import { add } from "./model.ts";
+console.log(add(1, 2));
+\`\`\`
+
+## Notes
+
+\`\`\`yaml
+name: "@test/sample"
+version: "2026.02.26.1"
+\`\`\`
+
+Plenty of prose here so the README clears the 500-character floor that
+the rich-readme factor enforces. Writing lorem-ipsum-ish prose to push
+past the floor without blowing the fixture up.
+`,
+    );
+  }
+
+  if (overrides.writeLicense !== false) {
+    await Deno.writeTextFile(join(tmpDir, "LICENSE.txt"), "MIT\n");
+  }
+
+  const manifest: Record<string, unknown> = {
+    manifestVersion: 1,
+    name: "@test/sample",
+    version: "2026.02.26.1",
+    description: overrides.description ?? "A sample extension for testing",
+    models: ["model.ts"],
+    platforms: overrides.platforms ?? ["linux", "darwin"],
+    additionalFiles: [
+      ...(overrides.writeReadme !== false ? ["README.md"] : []),
+      ...(overrides.writeLicense !== false ? ["LICENSE.txt"] : []),
+    ],
+  };
+  if (overrides.repository !== undefined) {
+    manifest.repository = overrides.repository;
+  } else {
+    manifest.repository = "https://github.com/test/sample";
+  }
+
+  const manifestPath = join(tmpDir, "manifest.yaml");
+  await Deno.writeTextFile(manifestPath, stringifyYaml(manifest));
+  return manifestPath;
+}
+
+Deno.test(
+  "extension quality: fully-documented extension scores 12/12 (100%)",
+  async () => {
+    const tmpDir = await initTempRepo();
+    try {
+      const manifestPath = await writeDocumentedExtension(tmpDir);
+
+      const { code, stdout, stderr } = await runCli([
+        "extension",
+        "quality",
+        manifestPath,
+        "--repo-dir",
+        tmpDir,
+        "--json",
+        "--no-color",
+      ]);
+
+      if (code !== 0) {
+        throw new Error(
+          `quality command failed (code ${code})\nstdout: ${stdout}\nstderr: ${stderr}`,
+        );
+      }
+      const parsed = parseFirstJson(stdout);
+      assertEquals(parsed.status, "passed");
+      assertEquals(parsed.rubricVersion, 2);
+      assertEquals(parsed.earnedPoints, 12);
+      assertEquals(parsed.maxEarnablePoints, 12);
+      assertEquals(parsed.percentage, 100);
+      assertEquals(parsed.allPassed, true);
+
+      // Every factor must be "earned" — catches any regression where a
+      // specific factor's pass logic drifts from the server.
+      for (const f of parsed.factors) {
+        assertEquals(f.status, "earned", `factor ${f.id} not earned`);
+      }
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "extension quality: bad manifest fails targeted factors",
+  async () => {
+    const tmpDir = await initTempRepo();
+    try {
+      // Empty description, self-hosted repo, single platform — each of
+      // these should miss a specific factor; the rest should still
+      // earn.
+      const manifestPath = await writeDocumentedExtension(tmpDir, {
+        description: "",
+        repository: "https://git.company.com/x/y",
+        platforms: ["linux"],
+      });
+
+      const { code, stdout } = await runCli([
+        "extension",
+        "quality",
+        manifestPath,
+        "--repo-dir",
+        tmpDir,
+        "--json",
+        "--no-color",
+      ]);
+
+      // Exit non-zero since factors missed.
+      assertEquals(code !== 0, true);
+      const parsed = parseFirstJson(stdout);
+      assertEquals(parsed.allPassed, false);
+
+      const statusById = new Map<string, string>(
+        parsed.factors.map((f: { id: string; status: string }) => [
+          f.id,
+          f.status,
+        ]),
+      );
+      assertEquals(statusById.get("description"), "missing");
+      assertEquals(statusById.get("repository-verified"), "missing");
+      assertEquals(statusById.get("platforms-two"), "missing");
+      // Still-earned controls:
+      assertEquals(statusById.get("has-readme"), "earned");
+      assertEquals(statusById.get("has-license"), "earned");
+      assertEquals(statusById.get("platforms-one"), "earned");
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "extension quality: missing README fails has-readme and readme-example",
+  async () => {
+    const tmpDir = await initTempRepo();
+    try {
+      const manifestPath = await writeDocumentedExtension(tmpDir, {
+        writeReadme: false,
+      });
+
+      const { code, stdout } = await runCli([
+        "extension",
+        "quality",
+        manifestPath,
+        "--repo-dir",
+        tmpDir,
+        "--json",
+        "--no-color",
+      ]);
+
+      assertEquals(code !== 0, true);
+      const parsed = parseFirstJson(stdout);
+      const byId = new Map<string, { status: string }>(
+        parsed.factors.map((f: { id: string; status: string }) => [f.id, f]),
+      );
+      // has-readme is true when README OR every entrypoint has
+      // module-level doc. Our fixture has module docs, so has-readme
+      // still earns. But readme-example and rich-readme both fail.
+      assertEquals(
+        byId.get("has-readme")?.status,
+        "earned",
+        "has-readme should be earned via module-level doc",
+      );
+      assertEquals(
+        byId.get("readme-example")?.status,
+        "missing",
+        "readme-example should be missing when no README",
+      );
+      assertEquals(
+        byId.get("rich-readme")?.status,
+        "missing",
+        "rich-readme should be missing when no README",
+      );
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "extension quality: cache populated by quality is reused on second run",
+  async () => {
+    const tmpDir = await initTempRepo();
+    try {
+      const manifestPath = await writeDocumentedExtension(tmpDir);
+
+      const first = await runCli([
+        "extension",
+        "quality",
+        manifestPath,
+        "--repo-dir",
+        tmpDir,
+        "--json",
+        "--no-color",
+      ]);
+      if (first.code !== 0) {
+        throw new Error(
+          `first quality run failed: ${first.stderr}\n${first.stdout}`,
+        );
+      }
+      const firstParsed = JSON.parse(first.stdout);
+      assertEquals(firstParsed.cacheHit, false);
+
+      const cacheDir = join(
+        tmpDir,
+        ".swamp",
+        "cache",
+        "packages",
+        firstParsed.cacheHash,
+      );
+      const archivePath = join(cacheDir, "extension.tar.gz");
+      const archiveStat = await Deno.stat(archivePath);
+      assert(archiveStat.isFile, "cache entry should hold a tarball");
+
+      const second = await runCli([
+        "extension",
+        "quality",
+        manifestPath,
+        "--repo-dir",
+        tmpDir,
+        "--json",
+        "--no-color",
+      ]);
+      if (second.code !== 0) {
+        throw new Error(
+          `second quality run failed: ${second.stderr}\n${second.stdout}`,
+        );
+      }
+      const secondParsed = JSON.parse(second.stdout);
+      assertEquals(secondParsed.cacheHit, true);
+      assertEquals(secondParsed.cacheHash, firstParsed.cacheHash);
+      assertEquals(secondParsed.earnedPoints, firstParsed.earnedPoints);
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "extension quality: changing a source file invalidates the cache",
+  async () => {
+    const tmpDir = await initTempRepo();
+    try {
+      const manifestPath = await writeDocumentedExtension(tmpDir);
+
+      const first = await runCli([
+        "extension",
+        "quality",
+        manifestPath,
+        "--repo-dir",
+        tmpDir,
+        "--json",
+        "--no-color",
+      ]);
+      const firstHash = JSON.parse(first.stdout).cacheHash as string;
+
+      // Mutate a source file; a re-run must compute a different hash
+      // and fully re-package.
+      await Deno.writeTextFile(
+        join(tmpDir, "extensions", "models", "model.ts"),
+        `/**
+ * Different file now.
+ *
+ * @module
+ */
+
+/** A different exported function. */
+export function mul(a: number, b: number): number {
+  return a * b;
+}
+`,
+      );
+
+      const second = await runCli([
+        "extension",
+        "quality",
+        manifestPath,
+        "--repo-dir",
+        tmpDir,
+        "--json",
+        "--no-color",
+      ]);
+      const secondParsed = JSON.parse(second.stdout);
+      const secondHash = secondParsed.cacheHash as string;
+
+      assertEquals(
+        secondParsed.cacheHit,
+        false,
+        "changed source should miss the cache",
+      );
+      assert(
+        firstHash !== secondHash,
+        "cache hash should change when source changes",
+      );
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test("extension quality: log mode renders per-factor lines", async () => {
+  const tmpDir = await initTempRepo();
+  try {
+    const manifestPath = await writeDocumentedExtension(tmpDir);
+
+    const { code, stdout, stderr } = await runCli([
+      "extension",
+      "quality",
+      manifestPath,
+      "--repo-dir",
+      tmpDir,
+      "--log",
+      "--no-color",
+    ]);
+
+    if (code !== 0) {
+      throw new Error(`log-mode quality failed: ${stderr}\n${stdout}`);
+    }
+    // The renderer logs to stderr via logtape; check both streams.
+    const combined = stdout + stderr;
+    assertStringIncludes(combined, "Rubric v2");
+    assertStringIncludes(combined, "has-readme");
+    assertStringIncludes(combined, "fast-check");
+    assertStringIncludes(combined, "symbols-docs");
+    assertStringIncludes(combined, "repository-verified");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});

--- a/src/cli/commands/extension.ts
+++ b/src/cli/commands/extension.ts
@@ -22,6 +22,7 @@ import { extensionPushCommand } from "./extension_push.ts";
 import { extensionPullCommand } from "./extension_pull.ts";
 import { extensionInstallCommand } from "./extension_install.ts";
 import { extensionFmtCommand } from "./extension_fmt.ts";
+import { extensionQualityCommand } from "./extension_quality.ts";
 import { extensionRemoveCommand } from "./extension_rm.ts";
 import { extensionListCommand } from "./extension_list.ts";
 import { extensionSearchCommand } from "./extension_search.ts";
@@ -42,6 +43,7 @@ export const extensionCommand = new Command()
   })
   .command("push", extensionPushCommand)
   .command("fmt", extensionFmtCommand)
+  .command("quality", extensionQualityCommand)
   .command("pull", extensionPullCommand)
   .command("install", extensionInstallCommand)
   .command("rm", extensionRemoveCommand)

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -30,12 +30,16 @@ import { UserError } from "../../domain/errors.ts";
 import { sourceHasBareSpecifiers } from "../../domain/models/bundle.ts";
 import { CalVer } from "../../domain/models/calver.ts";
 import {
+  computePackageCacheHash,
   consumeStream,
   createExtensionPushExecuteDeps,
   createExtensionPushPrepareDeps,
   createLibSwampContext,
+  defaultPackageCacheRoot,
+  ExtensionPackageCache,
   extensionPush,
   extensionPushPrepare,
+  RUBRIC_VERSION,
 } from "../../libswamp/mod.ts";
 import {
   createExtensionPushRenderer,
@@ -266,6 +270,33 @@ export const extensionPushCommand = new Command()
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
     const prepareDeps = createExtensionPushPrepareDeps();
     const renderer = createExtensionPushRenderer(cliCtx.outputMode);
+    const cache = new ExtensionPackageCache(defaultPackageCacheRoot(repoDir));
+
+    // 3b. Opportunistic package cache lookup — if a prior `swamp
+    // extension quality` run packaged the same source, reuse those
+    // bytes. Cache miss falls back to packaging from scratch.
+    const cacheHashInput = {
+      manifest,
+      modelFilePaths: allModelFiles,
+      vaultFilePaths: allVaultFiles,
+      driverFilePaths: allDriverFiles,
+      datastoreFilePaths: allDatastoreFiles,
+      reportFilePaths: allReportFiles,
+      workflowFilePaths: workflowFiles.map((w) => w.sourcePath),
+      additionalFilePaths,
+      skillFilePaths: resolved.allSkillFiles,
+      includeFilePaths,
+      denoConfigPath,
+      packageJsonPath: undefined,
+    };
+    const cacheHash = await computePackageCacheHash(cacheHashInput);
+    const cached = await cache.get(cacheHash);
+    if (cached) {
+      cliCtx.logger
+        .debug`Reusing cached package ${
+        cacheHash.slice(0, 12)
+      } (${cached.archiveBytes.length} bytes)`;
+    }
 
     // 4. Run prepare phase
     let prepared;
@@ -297,6 +328,7 @@ export const extensionPushCommand = new Command()
         releaseNotes: options.releaseNotes,
         denoConfigPath,
         packageJsonDir,
+        cachedArchive: cached?.archiveBytes,
       });
     } catch (error) {
       // Handle structured errors from the prepare phase with rich rendering
@@ -381,6 +413,22 @@ export const extensionPushCommand = new Command()
         }
       } else {
         throw error;
+      }
+    }
+
+    // 4b. Populate the package cache on a miss. Writing here lets a
+    // subsequent `swamp extension quality` run against the same source
+    // reuse these bytes without repackaging.
+    if (!cached) {
+      try {
+        await cache.put(cacheHash, prepared.archiveBytes, {
+          extensionName: prepared.manifest.name,
+          extensionVersion: prepared.manifest.version,
+          rubricVersion: RUBRIC_VERSION,
+        });
+      } catch (cacheError) {
+        cliCtx.logger
+          .debug`Failed to write package cache (continuing): ${cacheError}`;
       }
     }
 

--- a/src/cli/commands/extension_quality.ts
+++ b/src/cli/commands/extension_quality.ts
@@ -1,0 +1,174 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { dirname, resolve } from "@std/path";
+import {
+  consumeStream,
+  createExtensionPushPrepareDeps,
+  createExtensionQualityDeps,
+  createLibSwampContext,
+  defaultPackageCacheRoot,
+  ExtensionPackageCache,
+  extensionQuality,
+} from "../../libswamp/mod.ts";
+import { createExtensionQualityRenderer } from "../../presentation/renderers/extension_quality.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
+import { resolveExtensionFiles } from "../resolve_extension_files.ts";
+import { UserError } from "../../domain/errors.ts";
+
+interface ExtensionQualityOptions extends GlobalOptions {
+  repoDir?: string;
+}
+
+/**
+ * Walks up from `startDir` looking for a `deno.json` file, stopping at
+ * `boundaryDir` (inclusive). Kept consistent with the equivalent helper
+ * in `extension_push.ts`.
+ */
+async function findDenoConfig(
+  startDir: string,
+  boundaryDir: string,
+): Promise<string | undefined> {
+  let current = resolve(startDir);
+  const boundary = resolve(boundaryDir);
+
+  while (true) {
+    const candidate = `${current}/deno.json`;
+    try {
+      await Deno.stat(candidate);
+      return candidate;
+    } catch {
+      // not here
+    }
+    if (current === boundary) break;
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return undefined;
+}
+
+export const extensionQualityCommand = new Command()
+  .name("quality")
+  .description(
+    "Score an extension against the Swamp Club quality rubric (10 client-earnable factors) and cache the packaged tarball for reuse by push",
+  )
+  .example(
+    "Score extension",
+    "swamp extension quality extensions/models/my-model/manifest.yaml",
+  )
+  .example(
+    "Machine-readable output",
+    "swamp extension quality extensions/models/my-model/manifest.yaml --json",
+  )
+  .arguments("<manifest-path:string>")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(
+    async function (options: ExtensionQualityOptions, manifestPath: string) {
+      const cliCtx = createContext(options, ["extension", "quality"]);
+      cliCtx.logger.debug`Starting extension quality`;
+
+      const repoDir = resolveRepoDir(options.repoDir);
+      const { repoContext } = await requireInitializedRepo({
+        repoDir,
+        outputMode: cliCtx.outputMode,
+      });
+
+      const resolved = await resolveExtensionFiles({
+        repoDir,
+        manifestPath,
+        repoContext,
+        logger: cliCtx.logger,
+      });
+
+      const absoluteManifestPath = resolve(repoDir, manifestPath);
+      const manifestDir = dirname(absoluteManifestPath);
+      const denoConfigPath = await findDenoConfig(
+        manifestDir,
+        resolve(repoDir),
+      );
+
+      const ctx = createLibSwampContext({ logger: cliCtx.logger });
+      const prepareDeps = createExtensionPushPrepareDeps();
+      const cache = new ExtensionPackageCache(defaultPackageCacheRoot(repoDir));
+      const deps = createExtensionQualityDeps(prepareDeps, cache);
+      const renderer = createExtensionQualityRenderer(cliCtx.outputMode);
+
+      await consumeStream(
+        extensionQuality(ctx, deps, {
+          prepareInput: {
+            manifest: resolved.manifest,
+            repoDir,
+            modelsDir: resolved.modelsDir,
+            allModelFiles: resolved.allModelFiles,
+            modelEntryPoints: resolved.modelEntryPoints,
+            vaultsDir: resolved.vaultsDir,
+            allVaultFiles: resolved.allVaultFiles,
+            vaultEntryPoints: resolved.vaultEntryPoints,
+            driversDir: resolved.driversDir,
+            allDriverFiles: resolved.allDriverFiles,
+            driverEntryPoints: resolved.driverEntryPoints,
+            datastoresDir: resolved.datastoresDir,
+            allDatastoreFiles: resolved.allDatastoreFiles,
+            datastoreEntryPoints: resolved.datastoreEntryPoints,
+            reportsDir: resolved.reportsDir,
+            allReportFiles: resolved.allReportFiles,
+            reportEntryPoints: resolved.reportEntryPoints,
+            workflowFiles: resolved.workflowFiles,
+            skillDirs: resolved.skillDirs,
+            allSkillFiles: resolved.allSkillFiles,
+            includeFilePaths: resolved.includeFilePaths,
+            additionalFilePaths: resolved.additionalFilePaths,
+            dryRun: true,
+            denoConfigPath,
+          },
+          hashInput: {
+            manifest: resolved.manifest,
+            modelFilePaths: resolved.allModelFiles,
+            vaultFilePaths: resolved.allVaultFiles,
+            driverFilePaths: resolved.allDriverFiles,
+            datastoreFilePaths: resolved.allDatastoreFiles,
+            reportFilePaths: resolved.allReportFiles,
+            workflowFilePaths: resolved.workflowFiles.map((w) => w.sourcePath),
+            additionalFilePaths: resolved.additionalFilePaths,
+            skillFilePaths: resolved.allSkillFiles,
+            includeFilePaths: resolved.includeFilePaths,
+            denoConfigPath,
+            packageJsonPath: undefined,
+          },
+        }),
+        renderer.handlers(),
+      );
+
+      if (!renderer.passed()) {
+        throw new UserError(renderer.failureMessage());
+      }
+
+      cliCtx.logger.debug`Extension quality command completed`;
+    },
+  );

--- a/src/domain/extensions/extension_package_cache.ts
+++ b/src/domain/extensions/extension_package_cache.ts
@@ -1,0 +1,244 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join } from "@std/path";
+import type { ExtensionManifest } from "./extension_manifest.ts";
+
+function encodeHex(bytes: Uint8Array): string {
+  const chars: string[] = [];
+  for (const b of bytes) {
+    chars.push(b.toString(16).padStart(2, "0"));
+  }
+  return chars.join("");
+}
+
+/**
+ * Content-hash-keyed cache for packaged extension tarballs.
+ *
+ * The cache is opportunistic: `swamp extension quality` packages once,
+ * writes the tarball here, and `swamp extension push` can later reuse the
+ * same bytes if the source inputs have not changed. The cache is a pure
+ * optimization — cache misses fall back to fresh packaging.
+ *
+ * Cache entries live at:
+ *   <cacheRoot>/<hash>/extension.tar.gz
+ *   <cacheRoot>/<hash>/metadata.json
+ *
+ * The hash is a SHA-256 over the normalized manifest YAML plus the
+ * contents of every file that ends up in the tarball — so any source
+ * change invalidates the entry by construction.
+ */
+
+/** Inputs used to compute the cache hash. All source-tree state that
+ * affects the tarball must be represented here. */
+export interface PackageCacheHashInput {
+  manifest: ExtensionManifest;
+  modelFilePaths: string[];
+  vaultFilePaths: string[];
+  driverFilePaths: string[];
+  datastoreFilePaths: string[];
+  reportFilePaths: string[];
+  workflowFilePaths: string[];
+  additionalFilePaths: string[];
+  skillFilePaths: string[];
+  includeFilePaths: string[];
+  denoConfigPath: string | undefined;
+  packageJsonPath: string | undefined;
+}
+
+/** Cached per-entry metadata written alongside the tarball. */
+export interface CachedPackageMetadata {
+  hash: string;
+  extensionName: string;
+  extensionVersion: string;
+  archiveSize: number;
+  cachedAt: string;
+  rubricVersion: number;
+}
+
+/** A cached package retrieved from disk. */
+export interface CachedPackage {
+  archiveBytes: Uint8Array;
+  metadata: CachedPackageMetadata;
+}
+
+/**
+ * Computes a deterministic SHA-256 hash over all inputs that would
+ * affect the packaged tarball's contents. Uses the file paths as
+ * deterministic labels and the file contents as the material to hash.
+ */
+export async function computePackageCacheHash(
+  input: PackageCacheHashInput,
+): Promise<string> {
+  const parts: string[] = [];
+
+  parts.push("manifest-v1");
+  parts.push(serializeManifestForHash(input.manifest));
+
+  await appendFileGroup("models", input.modelFilePaths, parts);
+  await appendFileGroup("vaults", input.vaultFilePaths, parts);
+  await appendFileGroup("drivers", input.driverFilePaths, parts);
+  await appendFileGroup("datastores", input.datastoreFilePaths, parts);
+  await appendFileGroup("reports", input.reportFilePaths, parts);
+  await appendFileGroup("workflows", input.workflowFilePaths, parts);
+  await appendFileGroup("additional", input.additionalFilePaths, parts);
+  await appendFileGroup("skills", input.skillFilePaths, parts);
+  await appendFileGroup("include", input.includeFilePaths, parts);
+
+  if (input.denoConfigPath) {
+    parts.push("deno-config");
+    parts.push(await readFileIfExists(input.denoConfigPath));
+  }
+  if (input.packageJsonPath) {
+    parts.push("package-json");
+    parts.push(await readFileIfExists(input.packageJsonPath));
+  }
+
+  const payload = new TextEncoder().encode(parts.join("\n"));
+  const digest = await crypto.subtle.digest("SHA-256", payload);
+  return encodeHex(new Uint8Array(digest));
+}
+
+/**
+ * Serialises the manifest fields relevant to the tarball into a stable
+ * deterministic string. Field order is fixed; optional fields appear
+ * only when set so equivalent-shaped manifests produce identical output.
+ */
+function serializeManifestForHash(manifest: ExtensionManifest): string {
+  const lines: string[] = [];
+  lines.push(`name=${manifest.name}`);
+  lines.push(`version=${manifest.version}`);
+  lines.push(`manifestVersion=${manifest.manifestVersion}`);
+  lines.push(`description=${manifest.description ?? ""}`);
+  lines.push(`repository=${manifest.repository ?? ""}`);
+  lines.push(`models=${JSON.stringify(manifest.models)}`);
+  lines.push(`workflows=${JSON.stringify(manifest.workflows)}`);
+  lines.push(`vaults=${JSON.stringify(manifest.vaults)}`);
+  lines.push(`drivers=${JSON.stringify(manifest.drivers)}`);
+  lines.push(`datastores=${JSON.stringify(manifest.datastores)}`);
+  lines.push(`reports=${JSON.stringify(manifest.reports)}`);
+  lines.push(`skills=${JSON.stringify(manifest.skills)}`);
+  lines.push(`include=${JSON.stringify(manifest.include)}`);
+  lines.push(`additionalFiles=${JSON.stringify(manifest.additionalFiles)}`);
+  lines.push(`platforms=${JSON.stringify(manifest.platforms)}`);
+  lines.push(`labels=${JSON.stringify(manifest.labels)}`);
+  lines.push(`dependencies=${JSON.stringify(manifest.dependencies)}`);
+  return lines.join("\n");
+}
+
+async function appendFileGroup(
+  label: string,
+  paths: string[],
+  out: string[],
+): Promise<void> {
+  const sorted = [...paths].sort();
+  out.push(`group=${label}`);
+  for (const p of sorted) {
+    out.push(`file=${p}`);
+    out.push(await readFileIfExists(p));
+  }
+}
+
+async function readFileIfExists(path: string): Promise<string> {
+  try {
+    const bytes = await Deno.readFile(path);
+    const digest = await crypto.subtle.digest("SHA-256", bytes);
+    return `sha256:${encodeHex(new Uint8Array(digest))}`;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return "missing";
+    }
+    throw error;
+  }
+}
+
+/**
+ * On-disk repository for cached extension tarballs. Construct with the
+ * cache root directory (typically `<repoDir>/.swamp/cache/packages/`).
+ */
+export class ExtensionPackageCache {
+  constructor(private readonly cacheRoot: string) {}
+
+  /** Returns the per-entry directory for a given hash. */
+  entryDir(hash: string): string {
+    return join(this.cacheRoot, hash);
+  }
+
+  /** Retrieves a cached package, or returns null if not present. */
+  async get(hash: string): Promise<CachedPackage | null> {
+    const dir = this.entryDir(hash);
+    const archivePath = join(dir, "extension.tar.gz");
+    const metadataPath = join(dir, "metadata.json");
+
+    let archiveBytes: Uint8Array;
+    let metadataJson: string;
+    try {
+      archiveBytes = await Deno.readFile(archivePath);
+      metadataJson = await Deno.readTextFile(metadataPath);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) return null;
+      throw error;
+    }
+
+    let metadata: CachedPackageMetadata;
+    try {
+      metadata = JSON.parse(metadataJson) as CachedPackageMetadata;
+    } catch {
+      return null;
+    }
+
+    return { archiveBytes, metadata };
+  }
+
+  /** Stores a package under the given hash. */
+  async put(
+    hash: string,
+    archiveBytes: Uint8Array,
+    extras: {
+      extensionName: string;
+      extensionVersion: string;
+      rubricVersion: number;
+    },
+  ): Promise<CachedPackageMetadata> {
+    const dir = this.entryDir(hash);
+    await Deno.mkdir(dir, { recursive: true });
+
+    const archivePath = join(dir, "extension.tar.gz");
+    const metadataPath = join(dir, "metadata.json");
+
+    await Deno.writeFile(archivePath, archiveBytes);
+
+    const metadata: CachedPackageMetadata = {
+      hash,
+      extensionName: extras.extensionName,
+      extensionVersion: extras.extensionVersion,
+      archiveSize: archiveBytes.length,
+      cachedAt: new Date().toISOString(),
+      rubricVersion: extras.rubricVersion,
+    };
+    await Deno.writeTextFile(metadataPath, JSON.stringify(metadata, null, 2));
+
+    return metadata;
+  }
+}
+
+/** Resolves the standard cache root inside a swamp repo. */
+export function defaultPackageCacheRoot(repoDir: string): string {
+  return join(repoDir, ".swamp", "cache", "packages");
+}

--- a/src/domain/extensions/extension_package_cache_test.ts
+++ b/src/domain/extensions/extension_package_cache_test.ts
@@ -1,0 +1,226 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertEquals, assertNotEquals } from "@std/assert";
+import { join } from "@std/path";
+import type { ExtensionManifest } from "./extension_manifest.ts";
+import {
+  computePackageCacheHash,
+  defaultPackageCacheRoot,
+  ExtensionPackageCache,
+  type PackageCacheHashInput,
+} from "./extension_package_cache.ts";
+
+function makeManifest(
+  overrides: Partial<ExtensionManifest> = {},
+): ExtensionManifest {
+  return {
+    manifestVersion: 1,
+    name: "@example/test",
+    version: "2026.01.01.0",
+    description: "A test extension",
+    repository: "https://github.com/example/test",
+    workflows: [],
+    models: ["my-model.ts"],
+    vaults: [],
+    drivers: [],
+    datastores: [],
+    reports: [],
+    skills: [],
+    include: [],
+    additionalFiles: ["README.md"],
+    platforms: ["linux", "darwin"],
+    labels: [],
+    releaseNotes: undefined,
+    dependencies: [],
+    ...overrides,
+  };
+}
+
+async function makeHashInput(
+  tmp: string,
+  overrides: Partial<PackageCacheHashInput> = {},
+): Promise<PackageCacheHashInput> {
+  const model = join(tmp, "model.ts");
+  await Deno.writeTextFile(model, "export function hi() {}\n");
+  return {
+    manifest: makeManifest(),
+    modelFilePaths: [model],
+    vaultFilePaths: [],
+    driverFilePaths: [],
+    datastoreFilePaths: [],
+    reportFilePaths: [],
+    workflowFilePaths: [],
+    additionalFilePaths: [],
+    skillFilePaths: [],
+    includeFilePaths: [],
+    denoConfigPath: undefined,
+    packageJsonPath: undefined,
+    ...overrides,
+  };
+}
+
+Deno.test("computePackageCacheHash: identical inputs produce identical hashes", async () => {
+  const tmp = await Deno.makeTempDir();
+  try {
+    const input = await makeHashInput(tmp);
+    const h1 = await computePackageCacheHash(input);
+    const h2 = await computePackageCacheHash(input);
+    assertEquals(h1, h2);
+    assertEquals(h1.length, 64); // SHA-256 hex
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("computePackageCacheHash: manifest name change invalidates hash", async () => {
+  const tmp = await Deno.makeTempDir();
+  try {
+    const base = await makeHashInput(tmp);
+    const changed = {
+      ...base,
+      manifest: makeManifest({ name: "@example/other" }),
+    };
+    const h1 = await computePackageCacheHash(base);
+    const h2 = await computePackageCacheHash(changed);
+    assertNotEquals(h1, h2);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("computePackageCacheHash: file content change invalidates hash", async () => {
+  const tmp = await Deno.makeTempDir();
+  try {
+    const input = await makeHashInput(tmp);
+    const h1 = await computePackageCacheHash(input);
+    await Deno.writeTextFile(
+      input.modelFilePaths[0],
+      "export function hi() { return 1; }\n",
+    );
+    const h2 = await computePackageCacheHash(input);
+    assertNotEquals(h1, h2);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("computePackageCacheHash: deno config change invalidates hash", async () => {
+  const tmp = await Deno.makeTempDir();
+  try {
+    const denoConfigPath = join(tmp, "deno.json");
+    await Deno.writeTextFile(denoConfigPath, `{"compilerOptions":{}}`);
+    const base = await makeHashInput(tmp, { denoConfigPath });
+    const h1 = await computePackageCacheHash(base);
+    await Deno.writeTextFile(
+      denoConfigPath,
+      `{"compilerOptions":{"strict":true}}`,
+    );
+    const h2 = await computePackageCacheHash(base);
+    assertNotEquals(h1, h2);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("computePackageCacheHash: missing file still hashes deterministically", async () => {
+  const tmp = await Deno.makeTempDir();
+  try {
+    const input = await makeHashInput(tmp, {
+      modelFilePaths: [join(tmp, "does-not-exist.ts")],
+    });
+    const h1 = await computePackageCacheHash(input);
+    const h2 = await computePackageCacheHash(input);
+    assertEquals(h1, h2);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("computePackageCacheHash: file order does not affect hash", async () => {
+  const tmp = await Deno.makeTempDir();
+  try {
+    const a = join(tmp, "a.ts");
+    const b = join(tmp, "b.ts");
+    await Deno.writeTextFile(a, "a");
+    await Deno.writeTextFile(b, "b");
+    const input1 = await makeHashInput(tmp, { modelFilePaths: [a, b] });
+    const input2 = { ...input1, modelFilePaths: [b, a] };
+    const h1 = await computePackageCacheHash(input1);
+    const h2 = await computePackageCacheHash(input2);
+    assertEquals(h1, h2);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("ExtensionPackageCache: get returns null when entry absent", async () => {
+  const tmp = await Deno.makeTempDir();
+  try {
+    const cache = new ExtensionPackageCache(join(tmp, "packages"));
+    const got = await cache.get("deadbeef");
+    assertEquals(got, null);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("ExtensionPackageCache: put writes and get retrieves", async () => {
+  const tmp = await Deno.makeTempDir();
+  try {
+    const cache = new ExtensionPackageCache(join(tmp, "packages"));
+    const bytes = new Uint8Array([0x1f, 0x8b, 0x01, 0x02, 0x03]);
+    await cache.put("abcd1234", bytes, {
+      extensionName: "@example/test",
+      extensionVersion: "2026.01.01.0",
+      rubricVersion: 1,
+    });
+
+    const got = await cache.get("abcd1234");
+    assert(got !== null);
+    assertEquals(got.archiveBytes, bytes);
+    assertEquals(got.metadata.extensionName, "@example/test");
+    assertEquals(got.metadata.extensionVersion, "2026.01.01.0");
+    assertEquals(got.metadata.rubricVersion, 1);
+    assertEquals(got.metadata.archiveSize, bytes.length);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("ExtensionPackageCache: get returns null for corrupt metadata", async () => {
+  const tmp = await Deno.makeTempDir();
+  try {
+    const cache = new ExtensionPackageCache(join(tmp, "packages"));
+    const entry = cache.entryDir("abc");
+    await Deno.mkdir(entry, { recursive: true });
+    await Deno.writeFile(join(entry, "extension.tar.gz"), new Uint8Array([1]));
+    await Deno.writeTextFile(join(entry, "metadata.json"), "not json");
+
+    const got = await cache.get("abc");
+    assertEquals(got, null);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("defaultPackageCacheRoot: returns canonical path under .swamp", () => {
+  const root = defaultPackageCacheRoot("/tmp/repo");
+  assertEquals(root, "/tmp/repo/.swamp/cache/packages");
+});

--- a/src/domain/extensions/extension_rubric_scorer.ts
+++ b/src/domain/extensions/extension_rubric_scorer.ts
@@ -1,0 +1,723 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join, resolve } from "@std/path";
+import type { ExtensionManifest } from "./extension_manifest.ts";
+
+/**
+ * Client-side scorer for the Swamp Club extension quality rubric.
+ *
+ * Mirrors swamp-club's server-side scorecard pipeline byte-for-byte
+ * (`lib/domain/scorecard/analysis-factors.ts` and
+ * `lib/domain/scorecard/score.ts` in the swamp-club repo) so local
+ * `swamp extension quality` results match the score the registry will
+ * compute after publish.
+ *
+ * Distinct from `extension_quality_checker.ts` in this directory —
+ * that module runs `deno fmt` / `deno lint` / dynamic-import checks as
+ * part of packaging (bundle safety). This module computes the
+ * authoring-quality rubric (README, LICENSE, JSDoc coverage, manifest
+ * completeness, repository URL).
+ *
+ * Pipeline:
+ *   1. Extract the pre-built tarball to a temp directory.
+ *   2. Strip attacker-controlled config files (matches server's
+ *      hermeticity stripping) and write a controlled deno.json so
+ *      `deno doc` resolves npm/jsr specifiers consistently.
+ *   3. Collect entrypoints from the manifest, prefixing with the
+ *      field name the way the server does.
+ *   4. Run `deno doc --json` and `deno doc --lint` with CWD at the
+ *      extraction root. `--lint` exits 0 regardless of diagnostics;
+ *      we parse stdout/stderr for `error[<code>]` patterns.
+ *   5. Compute the 5 per-version factors and the 4 per-package
+ *      factors + `repository-verified`, then compose a rubric v2
+ *      score.
+ */
+
+/** Schema version. Matches swamp-club's RUBRIC_VERSION. */
+export const RUBRIC_VERSION = 2;
+
+/**
+ * Slow-type diagnostic codes emitted by `deno doc --lint`. When any of
+ * these appear the package fails the `fast-check` factor. Mirrors
+ * swamp-club's SLOW_TYPE_CODES set exactly.
+ */
+export const SLOW_TYPE_CODES: ReadonlySet<string> = new Set([
+  "missing-return-type",
+  "missing-explicit-type",
+  "private-type-ref",
+  "unsupported-ambient-module",
+  "unsupported-complex-reference",
+  "unsupported-default-export-expr",
+  "unsupported-destructuring",
+  "unsupported-global-module",
+  "unsupported-require",
+  "unsupported-ts-export-assignment",
+  "unsupported-ts-instantiation-expression",
+  "unsupported-ts-namespace-export",
+  "unsupported-using-stmt",
+]);
+
+/** Hosts recognised as publicly-verifiable for `repository-verified`. */
+const VERIFIED_REPO_HOSTS: ReadonlySet<string> = new Set([
+  "github.com",
+  "gitlab.com",
+  "codeberg.org",
+  "bitbucket.org",
+]);
+
+/** Entrypoint-bearing manifest fields the analyzer runs `deno doc` against. */
+const ENTRYPOINT_FIELDS = [
+  "models",
+  "drivers",
+  "vaults",
+  "datastores",
+  "reports",
+] as const;
+
+const RICH_README_MIN_LENGTH = 500;
+const RICH_README_MIN_CODE_BLOCKS = 2;
+const SYMBOLS_DOCS_FULL_THRESHOLD = 0.8;
+
+// ── Pure helpers (mirror analysis-factors.ts) ──────────────────────────
+
+// deno-lint-ignore no-control-regex
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
+export function stripAnsi(input: string): string {
+  return input.replace(ANSI_RE, "");
+}
+
+/** True if the markdown text contains a fenced code block. */
+export function hasFencedCodeBlock(md: string): boolean {
+  return /^```[\w-]*\s*\n[\s\S]*?\n```/m.test(md);
+}
+
+/** Count fenced code blocks; non-overlapping, same regex as the boolean check. */
+export function countFencedCodeBlocks(md: string): number {
+  const matches = md.match(/^```[\w-]*\s*\n[\s\S]*?\n```/gm);
+  return matches ? matches.length : 0;
+}
+
+/**
+ * Parse the combined stdout+stderr from `deno doc --lint`, strip ANSI,
+ * and count how many diagnostics belong to {@link SLOW_TYPE_CODES}.
+ * `deno doc --lint` exits 0 even with errors printed, so the caller
+ * does NOT rely on exit status — this is the source of truth.
+ */
+export function countSlowTypeDiagnostics(rawLintOutput: string): number {
+  const plain = stripAnsi(rawLintOutput);
+  const codes = [...plain.matchAll(/error\[([a-z-]+)\]/g)].map((m) => m[1]);
+  let count = 0;
+  for (const code of codes) {
+    if (SLOW_TYPE_CODES.has(code)) count++;
+  }
+  return count;
+}
+
+/** A single node in `deno doc --json` output. */
+export interface DocNode {
+  module_doc?: { doc?: string };
+  symbols?: Array<{
+    name: string;
+    declarations?: Array<{
+      declarationKind: string;
+      jsDoc?: { doc?: string };
+      kind: string;
+    }>;
+  }>;
+}
+
+/** Full `deno doc --json` shape. */
+export interface DocOutput {
+  version: number;
+  nodes: Record<string, DocNode>;
+}
+
+/**
+ * Module-level doc check for a single entrypoint. The entrypointUrl is
+ * a `file://` URL — that's how `deno doc` keys its output nodes.
+ */
+export function hasModuleDoc(doc: DocOutput, entrypointUrl: string): boolean {
+  const node = doc.nodes[entrypointUrl];
+  return !!(node?.module_doc?.doc && node.module_doc.doc.trim());
+}
+
+/**
+ * Count `(totalExports, documentedExports)` for one entrypoint.
+ * An exported declaration is any symbol with `declarationKind === "export"`.
+ * Overloaded symbols declare multiple declarations — each counts separately.
+ */
+export function countExports(
+  doc: DocOutput,
+  entrypointUrl: string,
+): { total: number; documented: number } {
+  const node = doc.nodes[entrypointUrl];
+  let total = 0;
+  let documented = 0;
+  for (const sym of node?.symbols ?? []) {
+    for (const d of sym.declarations ?? []) {
+      if (d.declarationKind !== "export") continue;
+      total++;
+      if (d.jsDoc?.doc?.trim()) documented++;
+    }
+  }
+  return { total, documented };
+}
+
+/** Per-version analysis factors, mirrors server's AnalysisFactors. */
+export interface AnalysisFactors {
+  hasReadme: boolean;
+  hasReadmeExamples: boolean;
+  allEntrypointsDocs: boolean;
+  percentageDocumentedSymbols: number;
+  allFastCheck: boolean;
+  readmeLength: number | null;
+  readmeCodeBlockCount: number | null;
+  hasLicenseFile: boolean;
+}
+
+/**
+ * Compose all per-version factors from subprocess output plus README
+ * text. Pure — no I/O, no subprocess calls. Mirrors
+ * analysis-factors.ts#computeAnalysisFactors verbatim.
+ */
+export function computeAnalysisFactors(input: {
+  entrypointUrls: string[];
+  readme: string | null;
+  hasLicenseFile: boolean;
+  doc: DocOutput;
+  rawLintOutput: string;
+}): AnalysisFactors {
+  const { entrypointUrls, readme, hasLicenseFile, doc, rawLintOutput } = input;
+
+  const moduleDocs = entrypointUrls.map((ep) => ({
+    ep,
+    hasDoc: hasModuleDoc(doc, ep),
+  }));
+
+  let totalSymbols = 0;
+  let documentedSymbols = 0;
+  for (const ep of entrypointUrls) {
+    const { total, documented } = countExports(doc, ep);
+    totalSymbols += total;
+    documentedSymbols += documented;
+  }
+
+  const hasReadmeFile = readme !== null;
+  const hasReadme = hasReadmeFile || moduleDocs.some((m) => m.hasDoc);
+  const hasReadmeExamples = readme ? hasFencedCodeBlock(readme) : false;
+  const allEntrypointsDocs = moduleDocs.length > 0 &&
+    moduleDocs.every((m) => m.hasDoc);
+  const ratio = totalSymbols === 0 ? 1 : documentedSymbols / totalSymbols;
+  const percentageDocumentedSymbols = Number(ratio.toFixed(4));
+  const allFastCheck = countSlowTypeDiagnostics(rawLintOutput) === 0;
+
+  const readmeLength = readme === null ? null : readme.length;
+  const readmeCodeBlockCount = readme === null
+    ? null
+    : countFencedCodeBlocks(readme);
+
+  return {
+    hasReadme,
+    hasReadmeExamples,
+    allEntrypointsDocs,
+    percentageDocumentedSymbols,
+    allFastCheck,
+    readmeLength,
+    readmeCodeBlockCount,
+    hasLicenseFile,
+  };
+}
+
+// ── Score composition (mirror score.ts) ────────────────────────────────
+
+/** Status of one scorecard row. */
+export type FactorStatus = "earned" | "partial" | "missing";
+
+/** One row of the scorecard. */
+export interface RubricFactor {
+  id: string;
+  label: string;
+  earnedPoints: number;
+  maxPoints: number;
+  status: FactorStatus;
+  remediation?: string;
+}
+
+/** Complete rubric score. */
+export interface RubricScore {
+  rubricVersion: number;
+  factors: RubricFactor[];
+  earnedPoints: number;
+  maxEarnablePoints: number;
+  percentage: number;
+  allPassed: boolean;
+}
+
+/**
+ * Structural check for repository verification. The server does an
+ * additional HTTP HEAD to confirm the URL is live and public — the CLI
+ * reports the structural result optimistically, noting that the final
+ * verdict comes from the server after publish. Returns:
+ *   true  → URL is HTTPS and on an allowlisted host (will earn the
+ *           factor if the repo is public at publish time)
+ *   false → URL is missing, malformed, non-HTTPS, or on a host the
+ *           server does not accept for verification
+ */
+export function repositoryLikelyVerifiable(
+  repository: string | undefined,
+): boolean {
+  if (!repository) return false;
+  let url: URL;
+  try {
+    url = new URL(repository);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "https:") return false;
+  return VERIFIED_REPO_HOSTS.has(url.hostname.toLowerCase());
+}
+
+/**
+ * Compose a RubricScore from the per-version analysis factors and the
+ * manifest. Mirrors score.ts#composeScore but restricted to the
+ * signals the CLI can observe (no access to server-side `license`
+ * SPDX string or the server's HTTP-HEAD repository verification).
+ *
+ * `verified-by-swamp` is not in the rubric — it's an editorial badge
+ * that does not move the percentage. Provenance is currently gated
+ * off on the server and is omitted here for parity.
+ */
+export function composeScore(
+  factors: AnalysisFactors,
+  manifest: ExtensionManifest,
+): RubricScore {
+  const rows: RubricFactor[] = [
+    boolRow("has-readme", "Has README or module doc", 2, factors.hasReadme, {
+      remediation:
+        "Add README.md under `additionalFiles:` in manifest.yaml, or add a " +
+        "module-level JSDoc comment at the top of every entrypoint file.",
+    }),
+    boolRow(
+      "readme-example",
+      "README has a code example",
+      1,
+      factors.hasReadmeExamples,
+      {
+        remediation:
+          "Add at least one fenced code block (``` … ```) to README showing usage.",
+      },
+    ),
+    richReadmeRow(factors.readmeLength, factors.readmeCodeBlockCount),
+    symbolsRow(factors.percentageDocumentedSymbols),
+    boolRow("fast-check", "No slow types", 1, factors.allFastCheck, {
+      remediation:
+        "Run `deno doc --lint <entrypoint>` — add explicit return types and " +
+        "avoid leaking private types in public exports.",
+    }),
+    boolRow(
+      "description",
+      "Has description",
+      1,
+      typeof manifest.description === "string" &&
+        manifest.description.trim().length > 0,
+      { remediation: "Fill `description:` in manifest.yaml." },
+    ),
+    boolRow(
+      "platforms-one",
+      "At least one platform tag (or universal)",
+      1,
+      manifest.platforms.length === 0 || manifest.platforms.length >= 1,
+      {
+        remediation:
+          "Leave `platforms:` empty (= universal) or add at least one entry.",
+      },
+    ),
+    boolRow(
+      "platforms-two",
+      "Two or more platform tags (or universal)",
+      1,
+      manifest.platforms.length === 0 || manifest.platforms.length >= 2,
+      {
+        remediation:
+          "Leave `platforms:` empty (= universal) or add ≥2 entries.",
+      },
+    ),
+    boolRow(
+      "has-license",
+      "License declared",
+      1,
+      factors.hasLicenseFile,
+      {
+        remediation:
+          "Add LICENSE / LICENSE.md / LICENSE.txt / COPYING under `additionalFiles:`.",
+      },
+    ),
+    boolRow(
+      "repository-verified",
+      "Verified public repository (server confirms on publish)",
+      2,
+      repositoryLikelyVerifiable(manifest.repository),
+      {
+        remediation:
+          "Set `repository:` to a public HTTPS URL on github.com, gitlab.com, " +
+          "codeberg.org, or bitbucket.org. Server will verify it resolves publicly.",
+      },
+    ),
+  ];
+
+  const earned = rows.reduce((s, r) => s + r.earnedPoints, 0);
+  const max = rows.reduce((s, r) => s + r.maxPoints, 0);
+  const percentage = max === 0 ? 0 : Math.floor((earned * 100) / max);
+
+  return {
+    rubricVersion: RUBRIC_VERSION,
+    factors: rows,
+    earnedPoints: earned,
+    maxEarnablePoints: max,
+    percentage,
+    allPassed: rows.every((r) => r.status === "earned"),
+  };
+}
+
+function boolRow(
+  id: string,
+  label: string,
+  maxPoints: number,
+  earned: boolean,
+  extra: { remediation?: string } = {},
+): RubricFactor {
+  return {
+    id,
+    label,
+    earnedPoints: earned ? maxPoints : 0,
+    maxPoints,
+    status: earned ? "earned" : "missing",
+    remediation: earned ? undefined : extra.remediation,
+  };
+}
+
+function richReadmeRow(
+  readmeLength: number | null,
+  readmeCodeBlockCount: number | null,
+): RubricFactor {
+  if (readmeLength === null || readmeCodeBlockCount === null) {
+    return {
+      id: "rich-readme",
+      label: "README is substantive",
+      earnedPoints: 0,
+      maxPoints: 1,
+      status: "missing",
+      remediation:
+        `Add a README ≥${RICH_README_MIN_LENGTH} characters with ≥${RICH_README_MIN_CODE_BLOCKS} fenced code blocks.`,
+    };
+  }
+  const earned = readmeLength >= RICH_README_MIN_LENGTH &&
+    readmeCodeBlockCount >= RICH_README_MIN_CODE_BLOCKS;
+  return {
+    id: "rich-readme",
+    label: "README is substantive",
+    earnedPoints: earned ? 1 : 0,
+    maxPoints: 1,
+    status: earned ? "earned" : "missing",
+    remediation: earned
+      ? undefined
+      : `Expand README to ≥${RICH_README_MIN_LENGTH} chars with ≥${RICH_README_MIN_CODE_BLOCKS} fenced blocks.`,
+  };
+}
+
+function symbolsRow(pct: number): RubricFactor {
+  const earned = pct >= SYMBOLS_DOCS_FULL_THRESHOLD;
+  return {
+    id: "symbols-docs",
+    label: "Most symbols documented",
+    earnedPoints: earned ? 1 : 0,
+    maxPoints: 1,
+    status: earned ? "earned" : "missing",
+    remediation: earned
+      ? undefined
+      : `Add JSDoc to ≥${
+        Math.round(SYMBOLS_DOCS_FULL_THRESHOLD * 100)
+      }% of exported symbols in entrypoints (current: ${
+        Math.round(pct * 100)
+      }%).`,
+  };
+}
+
+// ── Tarball extraction + deno doc orchestrator ─────────────────────────
+
+/** Injected subprocess deps — makes tests hermetic. */
+export interface RubricScoreDeps {
+  runDeno: (
+    args: string[],
+    cwd: string,
+  ) => Promise<{ success: boolean; stdout: string; stderr: string }>;
+}
+
+/** Default deps: real `deno` subprocess. */
+export function createRubricScoreDeps(denoPath: string): RubricScoreDeps {
+  return {
+    runDeno: async (args, cwd) => {
+      const cmd = new Deno.Command(denoPath, {
+        args,
+        cwd,
+        stdout: "piped",
+        stderr: "piped",
+        env: { ...Deno.env.toObject(), NO_COLOR: "1" },
+      });
+      const out = await cmd.output();
+      return {
+        success: out.success,
+        stdout: new TextDecoder().decode(out.stdout),
+        stderr: new TextDecoder().decode(out.stderr),
+      };
+    },
+  };
+}
+
+const CONTROLLED_DENO_JSON = JSON.stringify(
+  { nodeModulesDir: "auto" },
+  null,
+  2,
+) + "\n";
+
+const STRIPPED_CONFIG_FILES = [
+  "deno.json",
+  "deno.jsonc",
+  "deno.lock",
+  "package.json",
+  "package-lock.json",
+  ".npmrc",
+] as const;
+
+const README_FILENAMES = ["README.md", "README.MD", "readme.md", "Readme.md"];
+
+const LICENSE_FILENAMES = [
+  "LICENSE",
+  "LICENSE.md",
+  "LICENSE.txt",
+  "LICENSE.MD",
+  "LICENSE.TXT",
+  "License",
+  "License.md",
+  "License.txt",
+  "license",
+  "license.md",
+  "license.txt",
+  "COPYING",
+  "COPYING.md",
+  "COPYING.txt",
+];
+
+/**
+ * Score a pre-built extension tarball against the rubric. Extracts
+ * the tarball to a temp dir, strips hermetic configs, writes a
+ * controlled deno.json, runs `deno doc`, and composes the score —
+ * mirroring swamp-club's DenoDocExtensionTarballAnalyzer +
+ * composeScore pipeline.
+ */
+export async function scoreExtensionTarball(
+  tarballBytes: Uint8Array,
+  manifest: ExtensionManifest,
+  deps: RubricScoreDeps,
+): Promise<RubricScore> {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_quality_" });
+  try {
+    const tarballPath = join(tmpDir, "archive.tar.gz");
+    const extractDir = join(tmpDir, "extract");
+    await Deno.writeFile(tarballPath, tarballBytes);
+    await Deno.mkdir(extractDir);
+
+    // Extract with the system `tar`. The CLI built this tarball itself,
+    // so we skip the server-side Zip-Slip / type checks — we trust our
+    // own output.
+    const tarCmd = new Deno.Command("tar", {
+      args: ["-xzf", tarballPath, "-C", extractDir],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const tarOut = await tarCmd.output();
+    if (!tarOut.success) {
+      const err = new TextDecoder().decode(tarOut.stderr);
+      throw new Error(`Failed to extract tarball for scoring: ${err}`);
+    }
+
+    // Locate the directory that holds manifest.yaml. Swamp CLI's
+    // archives put everything under `extension/`, so the common case
+    // is extractDir/extension/manifest.yaml.
+    const logicalRoot = await findManifestRoot(extractDir);
+
+    // Strip any config files the packager might have included, then
+    // write our controlled deno.json so `deno doc` resolves npm/jsr
+    // specifiers consistently. Mirrors server hermeticity.
+    for (const name of STRIPPED_CONFIG_FILES) {
+      await Deno.remove(join(logicalRoot, name)).catch(() => {});
+    }
+    await Deno.remove(join(logicalRoot, "node_modules"), { recursive: true })
+      .catch(() => {});
+    await Deno.writeTextFile(
+      join(logicalRoot, "deno.json"),
+      CONTROLLED_DENO_JSON,
+    );
+
+    const rootAbs = resolve(logicalRoot);
+    const entrypointPaths = collectEntrypoints(logicalRoot, rootAbs, manifest);
+
+    const readme = await findReadme(logicalRoot);
+    const hasLicenseFile = await findLicenseFile(logicalRoot);
+
+    let doc: DocOutput = { version: 1, nodes: {} };
+    let lintOutput = "";
+    if (entrypointPaths.length > 0) {
+      doc = await runDenoDocJson(entrypointPaths, logicalRoot, deps);
+      lintOutput = await runDenoDocLint(entrypointPaths, logicalRoot, deps);
+    }
+
+    const entrypointUrls = entrypointPaths.map(toFileUrl);
+    const analysisFactors = computeAnalysisFactors({
+      entrypointUrls,
+      readme,
+      hasLicenseFile,
+      doc,
+      rawLintOutput: lintOutput,
+    });
+
+    return composeScore(analysisFactors, manifest);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+}
+
+async function findManifestRoot(extractDir: string): Promise<string> {
+  try {
+    await Deno.stat(join(extractDir, "manifest.yaml"));
+    return extractDir;
+  } catch {
+    // Not at top level — check one level down (CLI packages under `extension/`).
+  }
+  for await (const entry of Deno.readDir(extractDir)) {
+    if (!entry.isDirectory) continue;
+    const candidate = join(extractDir, entry.name);
+    try {
+      await Deno.stat(join(candidate, "manifest.yaml"));
+      return candidate;
+    } catch {
+      // keep looking
+    }
+  }
+  throw new Error(
+    `No manifest.yaml found in extracted tarball at ${extractDir}`,
+  );
+}
+
+/** Walk manifest fields for entrypoints; prefix each with its field directory. */
+function collectEntrypoints(
+  root: string,
+  rootAbs: string,
+  manifest: ExtensionManifest,
+): string[] {
+  const eps: string[] = [];
+  for (const field of ENTRYPOINT_FIELDS) {
+    const list = manifest[field];
+    if (!Array.isArray(list)) continue;
+    for (const p of list) {
+      if (typeof p !== "string") continue;
+      const normalized = p.replace(/^\.\//, "");
+      const prefixed = normalized.startsWith(`${field}/`)
+        ? normalized
+        : `${field}/${normalized}`;
+      const entryAbs = resolve(root, prefixed);
+      if (entryAbs !== rootAbs && !entryAbs.startsWith(rootAbs + "/")) {
+        throw new Error(`Entrypoint escapes extraction root: ${p}`);
+      }
+      eps.push(entryAbs);
+    }
+  }
+  return eps;
+}
+
+/** README lookup at logical root AND files/ subdirectory. */
+async function findReadme(root: string): Promise<string | null> {
+  const dirs = [root, join(root, "files")];
+  for (const dir of dirs) {
+    for (const name of README_FILENAMES) {
+      try {
+        return await Deno.readTextFile(join(dir, name));
+      } catch {
+        // keep looking
+      }
+    }
+  }
+  return null;
+}
+
+/** LICENSE file lookup at logical root AND files/ subdirectory. */
+async function findLicenseFile(root: string): Promise<boolean> {
+  const dirs = [root, join(root, "files")];
+  for (const dir of dirs) {
+    for (const name of LICENSE_FILENAMES) {
+      try {
+        await Deno.stat(join(dir, name));
+        return true;
+      } catch {
+        // keep looking
+      }
+    }
+  }
+  return false;
+}
+
+function toFileUrl(abs: string): string {
+  return new URL("file://" + abs).href;
+}
+
+async function runDenoDocJson(
+  entrypoints: string[],
+  cwd: string,
+  deps: RubricScoreDeps,
+): Promise<DocOutput> {
+  const result = await deps.runDeno(
+    ["doc", "--json", ...entrypoints],
+    cwd,
+  );
+  if (!result.success) {
+    throw new Error(
+      `deno doc --json failed: ${(result.stderr || result.stdout).trim()}`,
+    );
+  }
+  try {
+    return JSON.parse(result.stdout) as DocOutput;
+  } catch (err) {
+    throw new Error(`deno doc --json returned invalid JSON: ${String(err)}`);
+  }
+}
+
+async function runDenoDocLint(
+  entrypoints: string[],
+  cwd: string,
+  deps: RubricScoreDeps,
+): Promise<string> {
+  // `deno doc --lint` exits 0 even with diagnostics; we parse the text.
+  const result = await deps.runDeno(
+    ["doc", "--lint", ...entrypoints],
+    cwd,
+  );
+  return result.stdout + result.stderr;
+}

--- a/src/domain/extensions/extension_rubric_scorer_test.ts
+++ b/src/domain/extensions/extension_rubric_scorer_test.ts
@@ -1,0 +1,874 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertEquals } from "@std/assert";
+import type { ExtensionManifest } from "./extension_manifest.ts";
+import {
+  composeScore,
+  computeAnalysisFactors,
+  countExports,
+  countFencedCodeBlocks,
+  countSlowTypeDiagnostics,
+  type DocOutput,
+  hasFencedCodeBlock,
+  hasModuleDoc,
+  repositoryLikelyVerifiable,
+  RUBRIC_VERSION,
+  SLOW_TYPE_CODES,
+  stripAnsi,
+} from "./extension_rubric_scorer.ts";
+
+function makeManifest(
+  overrides: Partial<ExtensionManifest> = {},
+): ExtensionManifest {
+  return {
+    manifestVersion: 1,
+    name: "@example/test",
+    version: "2026.01.01.0",
+    description: "A test extension",
+    repository: "https://github.com/example/test",
+    workflows: [],
+    models: [],
+    vaults: [],
+    drivers: [],
+    datastores: [],
+    reports: [],
+    skills: [],
+    include: [],
+    additionalFiles: [],
+    platforms: ["linux", "darwin"],
+    labels: [],
+    releaseNotes: undefined,
+    dependencies: [],
+    ...overrides,
+  };
+}
+
+// ── Pure helper tests (mirror server analysis-factors_test.ts) ─────────
+
+Deno.test("RUBRIC_VERSION is 2 (matches swamp-club)", () => {
+  assertEquals(RUBRIC_VERSION, 2);
+});
+
+Deno.test("SLOW_TYPE_CODES contains expected codes", () => {
+  assert(SLOW_TYPE_CODES.has("missing-return-type"));
+  assert(SLOW_TYPE_CODES.has("private-type-ref"));
+  assert(SLOW_TYPE_CODES.has("unsupported-default-export-expr"));
+  assertEquals(SLOW_TYPE_CODES.size, 13);
+});
+
+Deno.test("stripAnsi removes colour codes", () => {
+  const input = "\x1b[31merror\x1b[0m";
+  assertEquals(stripAnsi(input), "error");
+});
+
+Deno.test("hasFencedCodeBlock: true when markdown has a fence", () => {
+  assertEquals(hasFencedCodeBlock("# hi\n```ts\nconsole.log(1)\n```\n"), true);
+});
+
+Deno.test("hasFencedCodeBlock: false when no fence", () => {
+  assertEquals(hasFencedCodeBlock("# hi\njust text\n"), false);
+});
+
+Deno.test("countFencedCodeBlocks: counts complete fences", () => {
+  const md = "# hi\n```\nA\n```\n\n```ts\nB\n```\n";
+  assertEquals(countFencedCodeBlocks(md), 2);
+});
+
+Deno.test("countFencedCodeBlocks: 0 when empty", () => {
+  assertEquals(countFencedCodeBlocks(""), 0);
+});
+
+Deno.test("countSlowTypeDiagnostics: counts listed slow-type codes", () => {
+  const lintOutput =
+    "error[missing-return-type]: bad\nerror[private-type-ref]: bad\nerror[something-else]: ok\n";
+  assertEquals(countSlowTypeDiagnostics(lintOutput), 2);
+});
+
+Deno.test("countSlowTypeDiagnostics: returns 0 when no diagnostics", () => {
+  assertEquals(countSlowTypeDiagnostics(""), 0);
+});
+
+Deno.test("countSlowTypeDiagnostics: strips ANSI before matching", () => {
+  const withAnsi = "\x1b[31merror[missing-return-type]\x1b[0m: bad";
+  assertEquals(countSlowTypeDiagnostics(withAnsi), 1);
+});
+
+Deno.test("hasModuleDoc: true when node has trimmed module_doc", () => {
+  const doc: DocOutput = {
+    version: 1,
+    nodes: {
+      "file:///a.ts": { module_doc: { doc: "  docs  " } },
+    },
+  };
+  assertEquals(hasModuleDoc(doc, "file:///a.ts"), true);
+});
+
+Deno.test("hasModuleDoc: false when module_doc is empty string", () => {
+  const doc: DocOutput = {
+    version: 1,
+    nodes: { "file:///a.ts": { module_doc: { doc: "   " } } },
+  };
+  assertEquals(hasModuleDoc(doc, "file:///a.ts"), false);
+});
+
+Deno.test("hasModuleDoc: false when node missing", () => {
+  const doc: DocOutput = { version: 1, nodes: {} };
+  assertEquals(hasModuleDoc(doc, "file:///a.ts"), false);
+});
+
+Deno.test("countExports: counts exported declarations with jsDoc", () => {
+  const doc: DocOutput = {
+    version: 1,
+    nodes: {
+      "file:///a.ts": {
+        symbols: [
+          {
+            name: "a",
+            declarations: [
+              {
+                declarationKind: "export",
+                kind: "function",
+                jsDoc: { doc: "x" },
+              },
+            ],
+          },
+          {
+            name: "b",
+            declarations: [{ declarationKind: "export", kind: "function" }],
+          },
+          {
+            name: "internal",
+            declarations: [
+              { declarationKind: "declare", kind: "function" },
+            ],
+          },
+        ],
+      },
+    },
+  };
+  const r = countExports(doc, "file:///a.ts");
+  assertEquals(r.total, 2);
+  assertEquals(r.documented, 1);
+});
+
+Deno.test("countExports: overloaded declarations each count separately", () => {
+  const doc: DocOutput = {
+    version: 1,
+    nodes: {
+      "file:///a.ts": {
+        symbols: [
+          {
+            name: "overloaded",
+            declarations: [
+              {
+                declarationKind: "export",
+                kind: "function",
+                jsDoc: { doc: "x" },
+              },
+              { declarationKind: "export", kind: "function" },
+            ],
+          },
+        ],
+      },
+    },
+  };
+  const r = countExports(doc, "file:///a.ts");
+  assertEquals(r.total, 2);
+  assertEquals(r.documented, 1);
+});
+
+// ── computeAnalysisFactors ─────────────────────────────────────────────
+
+Deno.test("computeAnalysisFactors: all clean", () => {
+  const doc: DocOutput = {
+    version: 1,
+    nodes: {
+      "file:///a.ts": {
+        module_doc: { doc: "top-level" },
+        symbols: [
+          {
+            name: "a",
+            declarations: [
+              {
+                declarationKind: "export",
+                kind: "function",
+                jsDoc: { doc: "x" },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  };
+  const f = computeAnalysisFactors({
+    entrypointUrls: ["file:///a.ts"],
+    readme: "# title\n\n" + "abc ".repeat(200) +
+      "\n\n```ts\nusage\n```\n\n```ts\nmore\n```\n",
+    hasLicenseFile: true,
+    doc,
+    rawLintOutput: "",
+  });
+  assertEquals(f.hasReadme, true);
+  assertEquals(f.hasReadmeExamples, true);
+  assertEquals(f.allEntrypointsDocs, true);
+  assertEquals(f.percentageDocumentedSymbols, 1);
+  assertEquals(f.allFastCheck, true);
+  assertEquals(f.hasLicenseFile, true);
+  assert(f.readmeLength !== null && f.readmeLength > 500);
+  assertEquals(f.readmeCodeBlockCount, 2);
+});
+
+Deno.test("computeAnalysisFactors: hasReadme is true when only module doc present", () => {
+  const doc: DocOutput = {
+    version: 1,
+    nodes: {
+      "file:///a.ts": { module_doc: { doc: "module-level" } },
+    },
+  };
+  const f = computeAnalysisFactors({
+    entrypointUrls: ["file:///a.ts"],
+    readme: null,
+    hasLicenseFile: false,
+    doc,
+    rawLintOutput: "",
+  });
+  assertEquals(f.hasReadme, true);
+  assertEquals(f.hasReadmeExamples, false);
+  assertEquals(f.readmeLength, null);
+});
+
+Deno.test("computeAnalysisFactors: zero entrypoints = percentage 1 (vacuous)", () => {
+  const f = computeAnalysisFactors({
+    entrypointUrls: [],
+    readme: "# hi",
+    hasLicenseFile: false,
+    doc: { version: 1, nodes: {} },
+    rawLintOutput: "",
+  });
+  assertEquals(f.percentageDocumentedSymbols, 1);
+  assertEquals(f.allEntrypointsDocs, false); // empty entrypoints → false by server convention
+});
+
+Deno.test("computeAnalysisFactors: slow-type diagnostic fails fast-check", () => {
+  const f = computeAnalysisFactors({
+    entrypointUrls: [],
+    readme: null,
+    hasLicenseFile: false,
+    doc: { version: 1, nodes: {} },
+    rawLintOutput: "error[missing-return-type]: bad",
+  });
+  assertEquals(f.allFastCheck, false);
+});
+
+Deno.test("computeAnalysisFactors: percentage rounds to 4 decimal places", () => {
+  const doc: DocOutput = {
+    version: 1,
+    nodes: {
+      "file:///a.ts": {
+        symbols: [
+          {
+            name: "a",
+            declarations: [
+              {
+                declarationKind: "export",
+                kind: "function",
+                jsDoc: { doc: "x" },
+              },
+            ],
+          },
+          {
+            name: "b",
+            declarations: [{ declarationKind: "export", kind: "function" }],
+          },
+          {
+            name: "c",
+            declarations: [{ declarationKind: "export", kind: "function" }],
+          },
+        ],
+      },
+    },
+  };
+  const f = computeAnalysisFactors({
+    entrypointUrls: ["file:///a.ts"],
+    readme: null,
+    hasLicenseFile: false,
+    doc,
+    rawLintOutput: "",
+  });
+  assertEquals(f.percentageDocumentedSymbols, 0.3333);
+});
+
+// ── repositoryLikelyVerifiable ─────────────────────────────────────────
+
+Deno.test("repositoryLikelyVerifiable: true for https github.com", () => {
+  assertEquals(
+    repositoryLikelyVerifiable("https://github.com/x/y"),
+    true,
+  );
+});
+
+Deno.test("repositoryLikelyVerifiable: true for https gitlab.com", () => {
+  assertEquals(
+    repositoryLikelyVerifiable("https://gitlab.com/x/y"),
+    true,
+  );
+});
+
+Deno.test("repositoryLikelyVerifiable: true for https codeberg.org", () => {
+  assertEquals(
+    repositoryLikelyVerifiable("https://codeberg.org/x/y"),
+    true,
+  );
+});
+
+Deno.test("repositoryLikelyVerifiable: true for https bitbucket.org", () => {
+  assertEquals(
+    repositoryLikelyVerifiable("https://bitbucket.org/x/y"),
+    true,
+  );
+});
+
+Deno.test("repositoryLikelyVerifiable: false for http (not https)", () => {
+  assertEquals(
+    repositoryLikelyVerifiable("http://github.com/x/y"),
+    false,
+  );
+});
+
+Deno.test("repositoryLikelyVerifiable: false for self-hosted host", () => {
+  assertEquals(
+    repositoryLikelyVerifiable("https://git.company.com/x/y"),
+    false,
+  );
+});
+
+Deno.test("repositoryLikelyVerifiable: false for missing URL", () => {
+  assertEquals(repositoryLikelyVerifiable(undefined), false);
+});
+
+Deno.test("repositoryLikelyVerifiable: false for malformed URL", () => {
+  assertEquals(repositoryLikelyVerifiable("not a url"), false);
+});
+
+// ── composeScore (mirror server score.ts v2) ───────────────────────────
+
+function factorsAllEarned(): Parameters<typeof composeScore>[0] {
+  return {
+    hasReadme: true,
+    hasReadmeExamples: true,
+    allEntrypointsDocs: true,
+    percentageDocumentedSymbols: 1,
+    allFastCheck: true,
+    readmeLength: 800,
+    readmeCodeBlockCount: 3,
+    hasLicenseFile: true,
+  };
+}
+
+Deno.test("composeScore: perfect extension earns 12/12 (100%)", () => {
+  const score = composeScore(factorsAllEarned(), makeManifest());
+  assertEquals(score.earnedPoints, 12);
+  assertEquals(score.maxEarnablePoints, 12);
+  assertEquals(score.percentage, 100);
+  assertEquals(score.allPassed, true);
+});
+
+Deno.test("composeScore: has-readme is worth 2 points", () => {
+  const score = composeScore(factorsAllEarned(), makeManifest());
+  const factor = score.factors.find((f) => f.id === "has-readme")!;
+  assertEquals(factor.maxPoints, 2);
+});
+
+Deno.test("composeScore: repository-verified is worth 2 points", () => {
+  const score = composeScore(factorsAllEarned(), makeManifest());
+  const factor = score.factors.find((f) => f.id === "repository-verified")!;
+  assertEquals(factor.maxPoints, 2);
+});
+
+Deno.test("composeScore: bad manifest fails several factors", () => {
+  const score = composeScore(
+    factorsAllEarned(),
+    makeManifest({
+      description: "",
+      repository: "http://bad/x",
+      platforms: ["linux"],
+    }),
+  );
+  assertEquals(score.allPassed, false);
+  const failed = score.factors
+    .filter((f) => f.status !== "earned")
+    .map((f) => f.id);
+  assert(failed.includes("description"));
+  assert(failed.includes("repository-verified"));
+  assert(failed.includes("platforms-two"));
+});
+
+Deno.test("composeScore: empty platforms is universal (both platform factors earned)", () => {
+  const score = composeScore(
+    factorsAllEarned(),
+    makeManifest({ platforms: [] }),
+  );
+  const one = score.factors.find((f) => f.id === "platforms-one")!;
+  const two = score.factors.find((f) => f.id === "platforms-two")!;
+  assertEquals(one.status, "earned");
+  assertEquals(two.status, "earned");
+});
+
+Deno.test("composeScore: missing LICENSE file misses has-license", () => {
+  const score = composeScore(
+    { ...factorsAllEarned(), hasLicenseFile: false },
+    makeManifest(),
+  );
+  const f = score.factors.find((f) => f.id === "has-license")!;
+  assertEquals(f.status, "missing");
+});
+
+Deno.test("composeScore: symbols-docs below 80% fails", () => {
+  const score = composeScore(
+    { ...factorsAllEarned(), percentageDocumentedSymbols: 0.79 },
+    makeManifest(),
+  );
+  const f = score.factors.find((f) => f.id === "symbols-docs")!;
+  assertEquals(f.status, "missing");
+});
+
+Deno.test("composeScore: symbols-docs at exactly 80% earns", () => {
+  const score = composeScore(
+    { ...factorsAllEarned(), percentageDocumentedSymbols: 0.8 },
+    makeManifest(),
+  );
+  const f = score.factors.find((f) => f.id === "symbols-docs")!;
+  assertEquals(f.status, "earned");
+});
+
+Deno.test("composeScore: rich-readme requires both length AND fences", () => {
+  // Long enough but only 1 fence
+  const s1 = composeScore(
+    {
+      ...factorsAllEarned(),
+      readmeLength: 1000,
+      readmeCodeBlockCount: 1,
+    },
+    makeManifest(),
+  );
+  assertEquals(
+    s1.factors.find((f) => f.id === "rich-readme")!.status,
+    "missing",
+  );
+
+  // Enough fences but too short
+  const s2 = composeScore(
+    {
+      ...factorsAllEarned(),
+      readmeLength: 300,
+      readmeCodeBlockCount: 5,
+    },
+    makeManifest(),
+  );
+  assertEquals(
+    s2.factors.find((f) => f.id === "rich-readme")!.status,
+    "missing",
+  );
+});
+
+Deno.test("composeScore: factor IDs and order match server", () => {
+  const score = composeScore(factorsAllEarned(), makeManifest());
+  const ids = score.factors.map((f) => f.id);
+  assertEquals(ids, [
+    "has-readme",
+    "readme-example",
+    "rich-readme",
+    "symbols-docs",
+    "fast-check",
+    "description",
+    "platforms-one",
+    "platforms-two",
+    "has-license",
+    "repository-verified",
+  ]);
+});
+
+Deno.test("composeScore: percentage floors (not rounds)", () => {
+  // 11/12 = 91.67 → floor = 91
+  const score = composeScore(
+    { ...factorsAllEarned(), hasLicenseFile: false },
+    makeManifest(),
+  );
+  assertEquals(score.earnedPoints, 11);
+  assertEquals(score.percentage, 91);
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Parity tests with swamp-club server scorer.
+//
+// These are ports of the authoritative test suite at
+// swamp-club/tests/domain/analysis-factors_test.ts and the core cases
+// from swamp-club/tests/domain/scorecard_test.ts. They exist so that if
+// our mirrored logic ever drifts from the server's — even by a byte —
+// the drift is caught here before it ships. Do NOT remove cases when
+// pruning; if something looks redundant, check the server file first.
+// ═══════════════════════════════════════════════════════════════════════
+
+// --- analysis-factors_test.ts ports ------------------------------------
+
+Deno.test("[parity] hasFencedCodeBlock - triple-backtick block matches", () => {
+  const md = "# Title\n\n```ts\nconst x = 1;\n```\n";
+  assertEquals(hasFencedCodeBlock(md), true);
+});
+
+Deno.test("[parity] hasFencedCodeBlock - fenced block with language tag", () => {
+  const md = "preamble\n\n```yaml\nkey: value\n```\n";
+  assertEquals(hasFencedCodeBlock(md), true);
+});
+
+Deno.test("[parity] hasFencedCodeBlock - no fence returns false", () => {
+  const md = "# Title\n\nSome prose.\n\nMore prose.";
+  assertEquals(hasFencedCodeBlock(md), false);
+});
+
+Deno.test("[parity] hasFencedCodeBlock - inline backticks are not a block", () => {
+  const md = "Use `foo()` to do it.";
+  assertEquals(hasFencedCodeBlock(md), false);
+});
+
+Deno.test("[parity] countFencedCodeBlocks - counts multiple blocks", () => {
+  const md = "# Title\n\n```ts\nconst x = 1;\n```\n\nSome prose.\n\n" +
+    "```yaml\nfoo: bar\n```\n";
+  assertEquals(countFencedCodeBlocks(md), 2);
+});
+
+Deno.test("[parity] countFencedCodeBlocks - returns 0 when there are no fences", () => {
+  assertEquals(countFencedCodeBlocks("# Plain markdown"), 0);
+});
+
+Deno.test("[parity] countFencedCodeBlocks - single block counts as 1", () => {
+  const md = "```ts\nconst x = 1;\n```\n";
+  assertEquals(countFencedCodeBlocks(md), 1);
+});
+
+Deno.test("[parity] countSlowTypeDiagnostics - matches documented codes", () => {
+  const out = "error[missing-return-type] at foo.ts:1:1\n" +
+    "error[missing-explicit-type] at bar.ts:2:2";
+  assertEquals(countSlowTypeDiagnostics(out), 2);
+});
+
+Deno.test("[parity] countSlowTypeDiagnostics - strips ANSI before matching", () => {
+  const out = "\x1b[31merror[missing-return-type]\x1b[0m at foo.ts:1:1";
+  assertEquals(countSlowTypeDiagnostics(out), 1);
+});
+
+Deno.test("[parity] countSlowTypeDiagnostics - ignores non-slow-type codes", () => {
+  const out = "error[missing-jsdoc] at foo.ts:1:1";
+  assertEquals(countSlowTypeDiagnostics(out), 0);
+});
+
+Deno.test("[parity] countSlowTypeDiagnostics - empty output returns 0", () => {
+  assertEquals(countSlowTypeDiagnostics(""), 0);
+});
+
+function parityMakeDoc(
+  fn: () => {
+    module_doc?: { doc?: string };
+    symbols?: DocOutput["nodes"][string]["symbols"];
+  },
+): DocOutput {
+  return {
+    version: 1,
+    nodes: { "file:///tmp/a.ts": fn() },
+  };
+}
+
+Deno.test("[parity] hasModuleDoc - true when module_doc.doc is non-empty", () => {
+  const doc = parityMakeDoc(() => ({ module_doc: { doc: "Hello" } }));
+  assertEquals(hasModuleDoc(doc, "file:///tmp/a.ts"), true);
+});
+
+Deno.test("[parity] hasModuleDoc - false when doc is whitespace", () => {
+  const doc = parityMakeDoc(() => ({ module_doc: { doc: "   " } }));
+  assertEquals(hasModuleDoc(doc, "file:///tmp/a.ts"), false);
+});
+
+Deno.test("[parity] hasModuleDoc - false when entrypoint missing from map", () => {
+  const doc = parityMakeDoc(() => ({}));
+  assertEquals(hasModuleDoc(doc, "file:///tmp/other.ts"), false);
+});
+
+Deno.test("[parity] countExports - counts declared exports, optionally documented", () => {
+  const doc = parityMakeDoc(() => ({
+    symbols: [
+      {
+        name: "A",
+        declarations: [
+          {
+            declarationKind: "export",
+            kind: "function",
+            jsDoc: { doc: "Documented" },
+          },
+          { declarationKind: "export", kind: "function" },
+        ],
+      },
+      {
+        name: "B",
+        declarations: [{ declarationKind: "private", kind: "function" }],
+      },
+    ],
+  }));
+  const result = countExports(doc, "file:///tmp/a.ts");
+  assertEquals(result.total, 2);
+  assertEquals(result.documented, 1);
+});
+
+Deno.test(
+  "[parity] computeAnalysisFactors - README present with fence + all docs",
+  () => {
+    const doc: DocOutput = {
+      version: 1,
+      nodes: {
+        "file:///tmp/a.ts": {
+          module_doc: { doc: "module doc" },
+          symbols: [
+            {
+              name: "x",
+              declarations: [
+                {
+                  declarationKind: "export",
+                  kind: "function",
+                  jsDoc: { doc: "docs" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+    const readme = "# Title\n\n```ts\nfoo();\n```\n";
+    const factors = computeAnalysisFactors({
+      entrypointUrls: ["file:///tmp/a.ts"],
+      readme,
+      doc,
+      hasLicenseFile: false,
+      rawLintOutput: "",
+    });
+    assertEquals(factors, {
+      hasReadme: true,
+      hasReadmeExamples: true,
+      allEntrypointsDocs: true,
+      percentageDocumentedSymbols: 1,
+      allFastCheck: true,
+      readmeLength: readme.length,
+      readmeCodeBlockCount: 1,
+      hasLicenseFile: false,
+    });
+  },
+);
+
+Deno.test(
+  "[parity] computeAnalysisFactors - no README but module doc on every entrypoint",
+  () => {
+    const doc: DocOutput = {
+      version: 1,
+      nodes: {
+        "file:///tmp/a.ts": {
+          module_doc: { doc: "fallback doc" },
+          symbols: [],
+        },
+      },
+    };
+    const factors = computeAnalysisFactors({
+      entrypointUrls: ["file:///tmp/a.ts"],
+      readme: null,
+      doc,
+      hasLicenseFile: false,
+      rawLintOutput: "",
+    });
+    assertEquals(factors.hasReadme, true);
+    assertEquals(factors.hasReadmeExamples, false);
+    assertEquals(factors.allEntrypointsDocs, true);
+    assertEquals(factors.readmeLength, null);
+    assertEquals(factors.readmeCodeBlockCount, null);
+  },
+);
+
+Deno.test(
+  "[parity] computeAnalysisFactors - empty entrypoints give vacuous 1.0 ratio",
+  () => {
+    const factors = computeAnalysisFactors({
+      entrypointUrls: [],
+      readme: "hello",
+      doc: { version: 1, nodes: {} },
+      hasLicenseFile: false,
+      rawLintOutput: "",
+    });
+    assertEquals(factors.allEntrypointsDocs, false);
+    assertEquals(factors.percentageDocumentedSymbols, 1);
+    assertEquals(factors.allFastCheck, true);
+  },
+);
+
+Deno.test(
+  "[parity] computeAnalysisFactors - partial docs produce fractional ratio (0.3333)",
+  () => {
+    const doc: DocOutput = {
+      version: 1,
+      nodes: {
+        "file:///tmp/a.ts": {
+          module_doc: { doc: "hi" },
+          symbols: [
+            {
+              name: "x",
+              declarations: [
+                {
+                  declarationKind: "export",
+                  kind: "function",
+                  jsDoc: { doc: "docs" },
+                },
+              ],
+            },
+            {
+              name: "y",
+              declarations: [{ declarationKind: "export", kind: "function" }],
+            },
+            {
+              name: "z",
+              declarations: [{ declarationKind: "export", kind: "function" }],
+            },
+          ],
+        },
+      },
+    };
+    const factors = computeAnalysisFactors({
+      entrypointUrls: ["file:///tmp/a.ts"],
+      readme: "plain",
+      doc,
+      hasLicenseFile: false,
+      rawLintOutput: "",
+    });
+    assertEquals(factors.percentageDocumentedSymbols, 0.3333);
+  },
+);
+
+Deno.test(
+  "[parity] computeAnalysisFactors - slow-type diagnostic fails allFastCheck",
+  () => {
+    const factors = computeAnalysisFactors({
+      entrypointUrls: [],
+      readme: "hi",
+      doc: { version: 1, nodes: {} },
+      hasLicenseFile: false,
+      rawLintOutput: "error[missing-return-type] at foo.ts:1:1",
+    });
+    assertEquals(factors.allFastCheck, false);
+  },
+);
+
+Deno.test(
+  "[parity] computeAnalysisFactors - missing-jsdoc is NOT a slow type",
+  () => {
+    const factors = computeAnalysisFactors({
+      entrypointUrls: [],
+      readme: "hi",
+      doc: { version: 1, nodes: {} },
+      hasLicenseFile: false,
+      rawLintOutput: "error[missing-jsdoc] at foo.ts:1:1",
+    });
+    assertEquals(factors.allFastCheck, true);
+  },
+);
+
+// --- scorecard_test.ts ports (core scenarios) --------------------------
+
+Deno.test("[parity] composeScore: empty everything earns universal-platform only", () => {
+  const score = composeScore(
+    {
+      hasReadme: false,
+      hasReadmeExamples: false,
+      allEntrypointsDocs: false,
+      percentageDocumentedSymbols: 0,
+      allFastCheck: false,
+      readmeLength: null,
+      readmeCodeBlockCount: null,
+      hasLicenseFile: false,
+    },
+    makeManifest({
+      description: "",
+      repository: undefined,
+      platforms: [],
+    }),
+  );
+  // Universal platforms earns 2 points (platforms-one + platforms-two).
+  assertEquals(score.earnedPoints, 2);
+  assertEquals(score.percentage, Math.floor((2 * 100) / 12));
+  assertEquals(score.rubricVersion, 2);
+  assertEquals(score.factors.length, 10);
+  const byId = new Map(score.factors.map((f) => [f.id, f]));
+  assertEquals(byId.get("platforms-one")?.status, "earned");
+  assertEquals(byId.get("platforms-two")?.status, "earned");
+  assertEquals(byId.get("repository-verified")?.status, "missing");
+  // verified-by-swamp is not a factor in the rubric (badge only)
+  assertEquals(byId.get("verified-by-swamp"), undefined);
+  // entrypoints-docs was dropped at v2
+  assertEquals(byId.get("entrypoints-docs"), undefined);
+});
+
+Deno.test("[parity] composeScore: perfect score hits 100% without any verification badge", () => {
+  const score = composeScore(factorsAllEarned(), makeManifest());
+  // 12/12
+  assertEquals(score.earnedPoints, 12);
+  assertEquals(score.percentage, 100);
+  assertEquals(score.allPassed, true);
+});
+
+Deno.test("[parity] composeScore: percentage floors (11/12 → 91)", () => {
+  const score = composeScore(
+    { ...factorsAllEarned(), hasLicenseFile: false },
+    makeManifest(),
+  );
+  assertEquals(score.earnedPoints, 11);
+  assertEquals(score.percentage, 91);
+});
+
+Deno.test("[parity] composeScore: platforms thresholds", () => {
+  // 1 platform: platforms-one earned, platforms-two missing
+  const s1 = composeScore(
+    factorsAllEarned(),
+    makeManifest({ platforms: ["linux"] }),
+  );
+  const m1 = new Map(s1.factors.map((f) => [f.id, f]));
+  assertEquals(m1.get("platforms-one")?.status, "earned");
+  assertEquals(m1.get("platforms-two")?.status, "missing");
+
+  // 2+ platforms: both earned
+  const s2 = composeScore(
+    factorsAllEarned(),
+    makeManifest({ platforms: ["linux", "darwin"] }),
+  );
+  const m2 = new Map(s2.factors.map((f) => [f.id, f]));
+  assertEquals(m2.get("platforms-one")?.status, "earned");
+  assertEquals(m2.get("platforms-two")?.status, "earned");
+
+  // Empty (= universal): both earned
+  const s3 = composeScore(
+    factorsAllEarned(),
+    makeManifest({ platforms: [] }),
+  );
+  const m3 = new Map(s3.factors.map((f) => [f.id, f]));
+  assertEquals(m3.get("platforms-one")?.status, "earned");
+  assertEquals(m3.get("platforms-two")?.status, "earned");
+});

--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -154,6 +154,15 @@ export interface ExtensionPushPrepareInput {
   releaseNotes?: string;
   denoConfigPath?: string;
   packageJsonDir?: string;
+  /**
+   * If provided, reuse these archive bytes instead of bundling and
+   * tarring from source. Callers supply this when a prior
+   * `swamp extension quality` run left a cached tarball whose source
+   * hash matches the current tree — letting push skip the expensive
+   * bundling step. The caller is responsible for validating that the
+   * cache key corresponds to the current source state.
+   */
+  cachedArchive?: Uint8Array;
 }
 
 /** Result of the prepare phase, containing everything needed for push. */
@@ -523,101 +532,41 @@ export async function extensionPushPrepare(
     }
   }
 
-  // 7. Resolve deno binary
-  const denoPath = await deps.ensureDenoPath();
-
-  // 8. Quality checks
-  const qualityResult = await deps.checkExtensionQuality(
-    qualityFiles,
-    denoPath,
-    input.denoConfigPath,
-  );
-  if (!qualityResult.passed) {
-    throw validationFailed(
-      "Extension has formatting or lint issues. Run 'swamp extension fmt <manifest-path>' to fix.",
-      { qualityErrors: qualityResult.issues },
-    );
+  // 7. Resolve deno binary (only needed when building a fresh archive)
+  const usingCachedArchive = input.cachedArchive !== undefined;
+  let denoPath = "";
+  if (!usingCachedArchive) {
+    denoPath = await deps.ensureDenoPath();
   }
 
-  // 9. Bundle each entry point type
-  const bundleOptions = input.denoConfigPath
-    ? { denoConfigPath: input.denoConfigPath }
-    : input.packageJsonDir
-    ? { packageJsonDir: input.packageJsonDir }
-    : undefined;
-
-  const bundles = new Map<string, string>();
-  const compilationErrors: CompilationError[] = [];
-
-  await bundleEntryPoints(
-    input.modelEntryPoints,
-    input.modelsDir,
-    bundles,
-    compilationErrors,
-    deps,
-    denoPath,
-    bundleOptions,
-    ctx,
-    "model",
-  );
-
-  const vaultBundles = new Map<string, string>();
-  await bundleEntryPoints(
-    input.vaultEntryPoints,
-    input.vaultsDir,
-    vaultBundles,
-    compilationErrors,
-    deps,
-    denoPath,
-    bundleOptions,
-    ctx,
-    "vault",
-  );
-
-  const driverBundles = new Map<string, string>();
-  await bundleEntryPoints(
-    input.driverEntryPoints,
-    input.driversDir,
-    driverBundles,
-    compilationErrors,
-    deps,
-    denoPath,
-    bundleOptions,
-    ctx,
-    "driver",
-  );
-
-  const datastoreBundles = new Map<string, string>();
-  await bundleEntryPoints(
-    input.datastoreEntryPoints,
-    input.datastoresDir,
-    datastoreBundles,
-    compilationErrors,
-    deps,
-    denoPath,
-    bundleOptions,
-    ctx,
-    "datastore",
-  );
-
-  const reportBundles = new Map<string, string>();
-  await bundleEntryPoints(
-    input.reportEntryPoints,
-    input.reportsDir,
-    reportBundles,
-    compilationErrors,
-    deps,
-    denoPath,
-    bundleOptions,
-    ctx,
-    "report",
-  );
-
-  if (compilationErrors.length > 0) {
-    throw validationFailed(
-      "Bundle compilation failed. Fix the errors above and try again.",
-      { compilationErrors },
+  // 8. Quality checks — skip on cache hit (the cached archive was
+  // written only after quality checks passed)
+  if (!usingCachedArchive) {
+    const qualityResult = await deps.checkExtensionQuality(
+      qualityFiles,
+      denoPath,
+      input.denoConfigPath,
     );
+    if (!qualityResult.passed) {
+      throw validationFailed(
+        "Extension has formatting or lint issues. Run 'swamp extension fmt <manifest-path>' to fix.",
+        { qualityErrors: qualityResult.issues },
+      );
+    }
+  }
+
+  // 9. Bundle entry points + build archive — skip on cache hit
+  let totalBundles: number;
+  let archiveBytes: Uint8Array;
+  if (usingCachedArchive) {
+    totalBundles = input.modelEntryPoints.length +
+      input.vaultEntryPoints.length + input.driverEntryPoints.length +
+      input.datastoreEntryPoints.length + input.reportEntryPoints.length;
+    archiveBytes = input.cachedArchive!;
+  } else {
+    const built = await bundleAndArchive(input, deps, denoPath, ctx);
+    totalBundles = built.totalBundles;
+    archiveBytes = built.archiveBytes;
   }
 
   // 10. Check version (skip in dry-run)
@@ -634,20 +583,6 @@ export async function extensionPushPrepare(
       );
     }
   }
-
-  // 11. Create archive
-  const archiveBytes = await createArchive(
-    input,
-    bundles,
-    vaultBundles,
-    driverBundles,
-    datastoreBundles,
-    reportBundles,
-    ctx,
-  );
-
-  const totalBundles = bundles.size + vaultBundles.size +
-    driverBundles.size + datastoreBundles.size + reportBundles.size;
 
   return {
     resolvedData,
@@ -910,6 +845,108 @@ function buildResolvedData(
     labels: input.manifest.labels,
     dependencies: input.manifest.dependencies,
   };
+}
+
+async function bundleAndArchive(
+  input: ExtensionPushPrepareInput,
+  deps: ExtensionPushPrepareDeps,
+  denoPath: string,
+  ctx: LibSwampContext,
+): Promise<{ archiveBytes: Uint8Array; totalBundles: number }> {
+  const bundleOptions = input.denoConfigPath
+    ? { denoConfigPath: input.denoConfigPath }
+    : input.packageJsonDir
+    ? { packageJsonDir: input.packageJsonDir }
+    : undefined;
+
+  const bundles = new Map<string, string>();
+  const compilationErrors: CompilationError[] = [];
+
+  await bundleEntryPoints(
+    input.modelEntryPoints,
+    input.modelsDir,
+    bundles,
+    compilationErrors,
+    deps,
+    denoPath,
+    bundleOptions,
+    ctx,
+    "model",
+  );
+
+  const vaultBundles = new Map<string, string>();
+  await bundleEntryPoints(
+    input.vaultEntryPoints,
+    input.vaultsDir,
+    vaultBundles,
+    compilationErrors,
+    deps,
+    denoPath,
+    bundleOptions,
+    ctx,
+    "vault",
+  );
+
+  const driverBundles = new Map<string, string>();
+  await bundleEntryPoints(
+    input.driverEntryPoints,
+    input.driversDir,
+    driverBundles,
+    compilationErrors,
+    deps,
+    denoPath,
+    bundleOptions,
+    ctx,
+    "driver",
+  );
+
+  const datastoreBundles = new Map<string, string>();
+  await bundleEntryPoints(
+    input.datastoreEntryPoints,
+    input.datastoresDir,
+    datastoreBundles,
+    compilationErrors,
+    deps,
+    denoPath,
+    bundleOptions,
+    ctx,
+    "datastore",
+  );
+
+  const reportBundles = new Map<string, string>();
+  await bundleEntryPoints(
+    input.reportEntryPoints,
+    input.reportsDir,
+    reportBundles,
+    compilationErrors,
+    deps,
+    denoPath,
+    bundleOptions,
+    ctx,
+    "report",
+  );
+
+  if (compilationErrors.length > 0) {
+    throw validationFailed(
+      "Bundle compilation failed. Fix the errors above and try again.",
+      { compilationErrors },
+    );
+  }
+
+  const totalBundles = bundles.size + vaultBundles.size +
+    driverBundles.size + datastoreBundles.size + reportBundles.size;
+
+  const archiveBytes = await createArchive(
+    input,
+    bundles,
+    vaultBundles,
+    driverBundles,
+    datastoreBundles,
+    reportBundles,
+    ctx,
+  );
+
+  return { archiveBytes, totalBundles };
 }
 
 async function bundleEntryPoints(

--- a/src/libswamp/extensions/quality.ts
+++ b/src/libswamp/extensions/quality.ts
@@ -1,0 +1,160 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import {
+  computePackageCacheHash,
+  type ExtensionPackageCache,
+  type PackageCacheHashInput,
+} from "../../domain/extensions/extension_package_cache.ts";
+import {
+  createRubricScoreDeps,
+  RUBRIC_VERSION,
+  type RubricScore,
+  type RubricScoreDeps,
+  scoreExtensionTarball,
+} from "../../domain/extensions/extension_rubric_scorer.ts";
+import { EmbeddedDenoRuntime } from "../../infrastructure/runtime/embedded_deno_runtime.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import {
+  extensionPushPrepare,
+  type ExtensionPushPrepared,
+  type ExtensionPushPrepareDeps,
+  type ExtensionPushPrepareInput,
+} from "./push.ts";
+
+/** Emitted by the extension quality generator. */
+export type ExtensionQualityEvent =
+  | { kind: "packaging" }
+  | { kind: "cache_hit"; hash: string }
+  | { kind: "scoring" }
+  | { kind: "completed"; data: ExtensionQualityData }
+  | { kind: "error"; error: SwampError };
+
+/** Result of a quality scoring run. */
+export interface ExtensionQualityData {
+  score: RubricScore;
+  cacheHash: string;
+  archiveSize: number;
+  cacheHit: boolean;
+}
+
+/** Input to run a quality score. */
+export interface ExtensionQualityInput {
+  prepareInput: ExtensionPushPrepareInput;
+  hashInput: PackageCacheHashInput;
+}
+
+/** Dependencies injected into the quality generator. */
+export interface ExtensionQualityDeps {
+  pushPrepareDeps: ExtensionPushPrepareDeps;
+  cache: ExtensionPackageCache;
+  ensureDenoPath: () => Promise<string>;
+  makeScoreDeps: (denoPath: string) => RubricScoreDeps;
+}
+
+/** Wires real infrastructure into ExtensionQualityDeps. */
+export function createExtensionQualityDeps(
+  pushPrepareDeps: ExtensionPushPrepareDeps,
+  cache: ExtensionPackageCache,
+): ExtensionQualityDeps {
+  const denoRuntime = new EmbeddedDenoRuntime();
+  return {
+    pushPrepareDeps,
+    cache,
+    ensureDenoPath: () => denoRuntime.ensureDeno(),
+    makeScoreDeps: (denoPath) => createRubricScoreDeps(denoPath),
+  };
+}
+
+/**
+ * Runs the quality scorer against an extension, reusing or populating
+ * the opportunistic package cache along the way. The bytes scored are
+ * the bytes a subsequent `swamp extension push` would upload if run
+ * against the same source — same input hash, same tarball, same score
+ * as the registry will compute server-side.
+ */
+export async function* extensionQuality(
+  ctx: LibSwampContext,
+  deps: ExtensionQualityDeps,
+  input: ExtensionQualityInput,
+): AsyncIterable<ExtensionQualityEvent> {
+  yield* withGeneratorSpan(
+    "swamp.extension.quality",
+    { "extension.name": input.prepareInput.manifest.name },
+    (async function* () {
+      ctx.logger.debug`Executing extension quality`;
+
+      const hash = await computePackageCacheHash(input.hashInput);
+      ctx.logger.debug`Package cache hash: ${hash}`;
+
+      let archiveBytes: Uint8Array;
+      let cacheHit = false;
+
+      const cached = await deps.cache.get(hash);
+      if (cached) {
+        cacheHit = true;
+        archiveBytes = cached.archiveBytes;
+        ctx.logger
+          .debug`Cache hit: reusing ${cached.archiveBytes.length} bytes`;
+        yield { kind: "cache_hit", hash };
+      } else {
+        yield { kind: "packaging" };
+        let prepared: ExtensionPushPrepared;
+        try {
+          prepared = await extensionPushPrepare(
+            ctx,
+            deps.pushPrepareDeps,
+            { ...input.prepareInput, dryRun: true },
+          );
+        } catch (error) {
+          yield { kind: "error", error: error as SwampError };
+          return;
+        }
+        archiveBytes = prepared.archiveBytes;
+        await deps.cache.put(hash, archiveBytes, {
+          extensionName: input.prepareInput.manifest.name,
+          extensionVersion: input.prepareInput.manifest.version,
+          rubricVersion: RUBRIC_VERSION,
+        });
+        ctx.logger.debug`Cache put: ${archiveBytes.length} bytes at ${hash}`;
+      }
+
+      yield { kind: "scoring" };
+      const denoPath = await deps.ensureDenoPath();
+      const scoreDeps = deps.makeScoreDeps(denoPath);
+      const score = await scoreExtensionTarball(
+        archiveBytes,
+        input.prepareInput.manifest,
+        scoreDeps,
+      );
+
+      yield {
+        kind: "completed",
+        data: {
+          score,
+          cacheHash: hash,
+          archiveSize: archiveBytes.length,
+          cacheHit,
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -559,6 +559,25 @@ export {
   extensionUnyankPreview,
 } from "./extensions/unyank.ts";
 export {
+  createExtensionQualityDeps,
+  extensionQuality,
+  type ExtensionQualityData,
+  type ExtensionQualityDeps,
+  type ExtensionQualityEvent,
+  type ExtensionQualityInput,
+} from "./extensions/quality.ts";
+export {
+  computePackageCacheHash,
+  defaultPackageCacheRoot,
+  ExtensionPackageCache,
+  type PackageCacheHashInput,
+} from "../domain/extensions/extension_package_cache.ts";
+export {
+  RUBRIC_VERSION,
+  type RubricFactor,
+  type RubricScore,
+} from "../domain/extensions/extension_rubric_scorer.ts";
+export {
   createExtensionUpdateDeps,
   extensionUpdate,
   type ExtensionUpdateDeps,

--- a/src/presentation/renderers/extension_quality.ts
+++ b/src/presentation/renderers/extension_quality.ts
@@ -1,0 +1,160 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type {
+  EventHandlers,
+  ExtensionQualityEvent,
+} from "../../libswamp/mod.ts";
+import type { Renderer } from "../renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { UserError } from "../../domain/errors.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+
+/** Renderer interface that also reports pass/fail to the CLI. */
+export interface ExtensionQualityRenderer
+  extends Renderer<ExtensionQualityEvent> {
+  passed(): boolean;
+  failureMessage(): string;
+}
+
+class LogExtensionQualityRenderer implements ExtensionQualityRenderer {
+  private _passed = true;
+  private _failureMessage = "";
+
+  passed(): boolean {
+    return this._passed;
+  }
+
+  failureMessage(): string {
+    return this._failureMessage;
+  }
+
+  handlers(): EventHandlers<ExtensionQualityEvent> {
+    const logger = getSwampLogger(["extension", "quality"]);
+    return {
+      packaging: () => {
+        logger.info("Packaging extension for quality scoring...");
+      },
+      cache_hit: (e) => {
+        logger.info`Cache hit — reusing previously packaged tarball (${
+          e.hash.slice(0, 12)
+        })`;
+      },
+      scoring: () => {
+        logger.info("Scoring extension against Swamp Club quality rubric...");
+      },
+      completed: (e) => {
+        const { score, archiveSize } = e.data;
+        logger
+          .info`Rubric v${score.rubricVersion} — ${score.earnedPoints}/${score.maxEarnablePoints} points (${score.percentage}%, ${
+          score.allPassed ? "all factors earned" : "some factors missing"
+        })`;
+        for (const factor of score.factors) {
+          const mark = factor.status === "earned" ? "✓" : "✗";
+          const pts = `${factor.earnedPoints}/${factor.maxPoints}`;
+          logger.info`  ${mark} ${factor.id} [${pts}] — ${factor.label}`;
+          if (factor.status !== "earned" && factor.remediation) {
+            logger.info`      → ${factor.remediation}`;
+          }
+        }
+        // `repository-verified` is a structural check on our side — the
+        // server does the final HTTP HEAD to confirm the repo is public.
+        // Surface that caveat so users know why their local "earned"
+        // could still come back "missing" from the registry.
+        logger
+          .info`Note: \`repository-verified\` earns here when the URL is well-formed on an allowlisted host; the registry does the final public-reachable check on publish.`;
+        logger.info`Packaged archive: ${archiveSize} bytes`;
+        if (!score.allPassed) {
+          this._passed = false;
+          const missing = score.factors
+            .filter((f) => f.status !== "earned")
+            .map((f) => f.id)
+            .join(", ");
+          this._failureMessage =
+            `Quality rubric factors missing: ${missing}. See messages above for remediation.`;
+        }
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonExtensionQualityRenderer implements ExtensionQualityRenderer {
+  private _passed = true;
+  private _failureMessage = "";
+
+  passed(): boolean {
+    return this._passed;
+  }
+
+  failureMessage(): string {
+    return this._failureMessage;
+  }
+
+  handlers(): EventHandlers<ExtensionQualityEvent> {
+    return {
+      packaging: () => {},
+      cache_hit: () => {},
+      scoring: () => {},
+      completed: (e) => {
+        const { score, cacheHash, archiveSize, cacheHit } = e.data;
+        console.log(JSON.stringify(
+          {
+            status: score.allPassed ? "passed" : "failed",
+            rubricVersion: score.rubricVersion,
+            earnedPoints: score.earnedPoints,
+            maxEarnablePoints: score.maxEarnablePoints,
+            percentage: score.percentage,
+            allPassed: score.allPassed,
+            factors: score.factors,
+            cacheHash,
+            archiveSize,
+            cacheHit,
+          },
+          null,
+          2,
+        ));
+        if (!score.allPassed) {
+          this._passed = false;
+          const missing = score.factors
+            .filter((f) => f.status !== "earned")
+            .map((f) => f.id)
+            .join(", ");
+          this._failureMessage = `Quality rubric factors missing: ${missing}.`;
+        }
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createExtensionQualityRenderer(
+  mode: OutputMode,
+): ExtensionQualityRenderer {
+  switch (mode) {
+    case "json":
+      return new JsonExtensionQualityRenderer();
+    case "log":
+      return new LogExtensionQualityRenderer();
+  }
+}


### PR DESCRIPTION
## Summary

Implements swamp-club#163 — a new `swamp extension quality <manifest>` CLI that scores an extension against the Swamp Club rubric locally, mirroring the server's scorecard pipeline so local results match the score the registry will compute after publish.

- **New CLI command:** `swamp extension quality manifest.yaml [--json]`. Exits non-zero if any factor misses; suitable for CI self-checks.
- **Server-mirrored scorer:** `extension_rubric_scorer.ts` mirrors [`analysis-factors.ts`](https://github.com/systeminit/swamp-club/blob/main/lib/domain/scorecard/analysis-factors.ts) and the rubric-v2 composition from [`score.ts`](https://github.com/systeminit/swamp-club/blob/main/lib/domain/scorecard/score.ts) — same slow-type code set, same JSDoc coverage shape, same README/LICENSE lookup in the extracted tarball, same 12-point weighting.
- **Parity tests:** 24 tests marked `[parity]` port the upstream swamp-club test suite so logic drift is caught before release.
- **Opportunistic package cache** at `.swamp/cache/packages/<hash>/`: keyed on source inputs (manifest + resolved file contents + deno config). `extension quality` writes the packaged tarball; `extension push` checks the cache before packaging and reuses the bytes on a hit. Any source change invalidates the entry by construction — authors who run quality before push don't pay twice, and the bytes scored equal the bytes uploaded.

### Opt-in by design
`quality` is uniformly opt-in: push's behaviour is unchanged, no new flags, no mandatory gate. The `swamp-extension-publish` and `swamp-extension-quality` skills gain brief pointers at the new CLI between states 6 and 7 of the publish flow.

### Known caveat
`repository-verified` is a structural check on the CLI side (HTTPS + allowlisted host). The server additionally performs an HTTP HEAD to confirm the repo is public — so a local "earned" can come back "missing" from the registry if the repo URL is malformed or private. The log renderer surfaces this caveat. Follow-up issue: narrow the gap (HTTP HEAD from the CLI, or a shared scoring package between this repo and swamp-club).

### Smoke test
Ran against `systeminit/swamp-extensions/datastore/s3` — reports **12/12 points, 100%, all factors earned**, matching the registry.

## Test Plan

- [x] 10 unit tests for `extension_package_cache.ts` (hit/miss, determinism, cache invalidation)
- [x] 39 unit tests for `extension_rubric_scorer.ts` covering every factor and edge case
- [x] 24 `[parity]` tests ported from swamp-club's `analysis-factors_test.ts` and `scorecard_test.ts`
- [x] 6 integration tests in `integration/extension_quality_test.ts` covering the full CLI pipeline (package → cache → extract → deno doc → compose), including cache hit/miss, source mutation invalidating cache, log and JSON modes
- [x] Smoke test against real `@si/s3-datastore` extension — 12/12 (100%), matches registry
- [x] `deno check` clean
- [x] `deno lint` clean
- [x] `deno fmt --check` clean
- [x] `deno run test` (4,802 passed, 1 pre-existing flaky unrelated to this change, 1 ignored)
- [x] `deno run compile` succeeds

## Follow-ups (not in this PR)

- File issue in `systeminit/swamp-uat` for CLI UAT coverage (`tests/cli/extension/quality/`)
- File issue in `systeminit/swamp-club` to document the new command in `content/manual/how-to`
- Consider a shared scoring package between `systeminit/swamp` and `systeminit/swamp-club` to eliminate the current ~100 lines of mirrored logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)