### PR TITLE
feat(drivers): finish repo-level defaultDriver — direct path + definition tier (swamp-club#165)

### DIFF
--- a/design/execution-drivers.md
+++ b/design/execution-drivers.md
@@ -54,6 +54,13 @@ defaultDriverConfig:
   image: "alpine:latest"
 ```
 
+The same priority chain applies uniformly to workflow runs
+(`swamp workflow run`) and direct model method runs
+(`swamp model method run`). A malformed `.swamp.yaml` aborts both paths
+at the start of the run with a YAML parse error — this is intentional,
+so configuration mistakes surface immediately rather than silently
+falling back to `raw`.
+
 ### CLI Override
 
 ```bash

--- a/integration/driver_resolution_test.ts
+++ b/integration/driver_resolution_test.ts
@@ -1,0 +1,223 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * End-to-end driver-resolution coverage for the direct `swamp model
+ * method run` path against a real `.swamp.yaml` marker file. Raw-driver
+ * only — no Docker required.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+import { stringify as stringifyYaml } from "@std/yaml";
+import { CLI_ARGS } from "./test_helpers.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-driver-res-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+async function writeMarker(
+  repoDir: string,
+  extra: Record<string, unknown>,
+): Promise<void> {
+  const marker = {
+    swampVersion: "0.0.0",
+    initializedAt: new Date().toISOString(),
+    ...extra,
+  };
+  await Deno.writeTextFile(
+    join(repoDir, ".swamp.yaml"),
+    stringifyYaml(marker as Record<string, unknown>),
+  );
+}
+
+async function initializeTestRepo(
+  repoDir: string,
+  markerExtra: Record<string, unknown> = {},
+): Promise<void> {
+  const subdirs = [
+    "models",
+    "workflows",
+    ".swamp/outputs",
+    ".swamp/data",
+    ".swamp/logs",
+    ".swamp/workflow-runs",
+    ".swamp/workflows-evaluated",
+    ".swamp/definitions-evaluated",
+  ];
+  for (const subdir of subdirs) {
+    await ensureDir(join(repoDir, subdir));
+  }
+  await writeMarker(repoDir, markerExtra);
+}
+
+async function createShellModel(
+  repoDir: string,
+  name: string,
+): Promise<void> {
+  const modelData = {
+    type: "command/shell",
+    typeVersion: 1,
+    id: crypto.randomUUID(),
+    name,
+    version: 1,
+    tags: {},
+    globalArguments: {},
+    methods: {
+      execute: {
+        arguments: {
+          run: "echo driver-res-ok",
+        },
+      },
+    },
+  };
+  const modelDir = join(repoDir, "models/command/shell");
+  await ensureDir(modelDir);
+  await Deno.writeTextFile(
+    join(modelDir, `${modelData.id}.yaml`),
+    stringifyYaml(modelData as Record<string, unknown>),
+  );
+}
+
+async function runCli(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [...CLI_ARGS, ...args],
+    stdout: "piped",
+    stderr: "piped",
+    cwd: Deno.cwd(),
+  });
+  const { code, stdout, stderr } = await command.output();
+  return {
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+    code,
+  };
+}
+
+Deno.test(
+  "CLI model method run honors defaultDriver: raw from .swamp.yaml",
+  async () => {
+    await withTempDir(async (repoDir) => {
+      await initializeTestRepo(repoDir, { defaultDriver: "raw" });
+      await createShellModel(repoDir, "driver-res-model");
+
+      const result = await runCli([
+        "model",
+        "method",
+        "run",
+        "driver-res-model",
+        "execute",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ]);
+
+      assertEquals(
+        result.code,
+        0,
+        `Should succeed with raw default. stderr: ${result.stderr}`,
+      );
+      const output = JSON.parse(result.stdout);
+      assertEquals(output.modelName, "driver-res-model");
+    });
+  },
+);
+
+Deno.test(
+  "CLI --driver raw override wins over .swamp.yaml defaultDriver",
+  async () => {
+    await withTempDir(async (repoDir) => {
+      // Configure a docker default — the --driver raw override should win
+      // and keep the method runnable without docker.
+      await initializeTestRepo(repoDir, { defaultDriver: "docker" });
+      await createShellModel(repoDir, "driver-override-model");
+
+      const result = await runCli([
+        "model",
+        "method",
+        "run",
+        "driver-override-model",
+        "execute",
+        "--repo-dir",
+        repoDir,
+        "--driver",
+        "raw",
+        "--json",
+      ]);
+
+      assertEquals(
+        result.code,
+        0,
+        `CLI override should win. stderr: ${result.stderr}`,
+      );
+    });
+  },
+);
+
+Deno.test(
+  "CLI model method run fails loudly on malformed .swamp.yaml",
+  async () => {
+    await withTempDir(async (repoDir) => {
+      const subdirs = [
+        "models",
+        ".swamp/outputs",
+        ".swamp/data",
+        ".swamp/logs",
+      ];
+      for (const subdir of subdirs) {
+        await ensureDir(join(repoDir, subdir));
+      }
+      // Valid YAML frontmatter, but structurally broken — picked up now
+      // that the direct path parses the marker on every invocation.
+      await Deno.writeTextFile(
+        join(repoDir, ".swamp.yaml"),
+        "swampVersion: [unclosed\n",
+      );
+      await createShellModel(repoDir, "malformed-marker-model");
+
+      const result = await runCli([
+        "model",
+        "method",
+        "run",
+        "malformed-marker-model",
+        "execute",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ]);
+
+      assertEquals(
+        result.code !== 0,
+        true,
+        "Malformed .swamp.yaml should abort",
+      );
+      // Error surface is non-specific YAML parse failure; the point is the
+      // run fails rather than silently proceeding with no marker.
+      assertStringIncludes(result.stderr.toLowerCase(), "yaml");
+    });
+  },
+);

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -49,6 +49,8 @@ import {
 } from "../../infrastructure/persistence/paths.ts";
 import { SecretRedactor } from "../../domain/secrets/mod.ts";
 import { DataQueryService } from "../../domain/data/data_query_service.ts";
+import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
+import { createRepoMarkerLoader } from "../../infrastructure/persistence/repo_marker_loader.ts";
 import { modelMethodHistoryCommand } from "./model_method_history.ts";
 import { modelMethodDescribeCommand } from "./model_method_describe.ts";
 import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
@@ -169,6 +171,11 @@ export const modelMethodRunCommand = new Command()
         reportRegistry.ensureLoaded(),
       ]);
 
+      const loadRepoMarker = createRepoMarkerLoader(
+        new RepoMarkerRepository(),
+        repoDir,
+      );
+
       const deps: ModelMethodRunDeps = {
         repoDir,
         lookupDefinition: (idOrName) =>
@@ -201,6 +208,7 @@ export const modelMethodRunCommand = new Command()
           repoContext.catalogStore,
           repoContext.unifiedDataRepo,
         ),
+        loadRepoMarker,
         createRunLog: async (modelType, method, definitionId) => {
           const redactor = new SecretRedactor();
           const timestamp = new Date().toISOString().replace(/[:.]/g, "-");

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -2707,3 +2707,47 @@ Deno.test(
     assertEquals(saved.typeVersion, "2026.04.12.2");
   },
 );
+
+Deno.test(
+  "pre-flight check receives resolved driver/driverConfig from MethodContext",
+  async () => {
+    const service = new DefaultMethodExecutionService();
+    let capturedDriver: string | undefined;
+    let capturedDriverConfig: Record<string, unknown> | undefined;
+    // Check returns pass: false so execution halts after capture — avoids
+    // needing a registered driver downstream; this test is scoped to the
+    // pre-flight propagation contract.
+    const model = createCheckModel({
+      "capture-driver": {
+        description: "Records driver seen by the check",
+        execute: (context) => {
+          capturedDriver = context.driver;
+          capturedDriverConfig = context.driverConfig;
+          return Promise.resolve({
+            pass: false,
+            errors: ["halt after capture"],
+          });
+        },
+      },
+    });
+
+    const definition = Definition.create({
+      name: "test-definition",
+      globalArguments: {},
+    });
+    const { context } = createTestContext({
+      modelType: model.type,
+      driver: "docker",
+      driverConfig: { image: "alpine:latest" },
+    });
+
+    await assertRejects(
+      () => service.executeWorkflow(definition, model, "create", context),
+      UserError,
+    );
+
+    // Check must see the resolved driver, not a raw default.
+    assertEquals(capturedDriver, "docker");
+    assertEquals(capturedDriverConfig, { image: "alpine:latest" });
+  },
+);

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -95,12 +95,29 @@ import { reportRegistry } from "../reports/report_registry.ts";
 import { buildMethodReportContext } from "../reports/report_context.ts";
 import { modelRegistry } from "../models/model.ts";
 import { getTracer, SpanStatusCode } from "../../infrastructure/tracing/mod.ts";
-import { resolveDriverConfig } from "../drivers/driver_resolution.ts";
+import {
+  type DriverSource,
+  resolveDriverConfig,
+} from "../drivers/driver_resolution.ts";
 import {
   type RepoMarkerData,
   RepoMarkerRepository,
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
-import { RepoPath } from "../repo/repo_path.ts";
+import { createRepoMarkerLoader } from "../../infrastructure/persistence/repo_marker_loader.ts";
+
+/**
+ * Driver-resolution tiers available at step-construction time. The
+ * `definition` tier is omitted here because it requires the evaluated
+ * definition, which is only available inside the step executor.
+ */
+export interface DriverTiers {
+  cli?: DriverSource;
+  step?: DriverSource;
+  job?: DriverSource;
+  workflow?: DriverSource;
+  repo?: DriverSource;
+}
+
 /**
  * Context for step execution.
  */
@@ -131,10 +148,13 @@ export interface StepExecutionContext {
   runtimeTags?: Record<string, string>;
   /** Secret redactor for stripping vault secrets from persisted data and logs */
   secretRedactor?: SecretRedactor;
-  /** Execution driver override from workflow/CLI level */
-  driver?: string;
-  /** Execution driver config override from workflow/CLI level */
-  driverConfig?: Record<string, unknown>;
+  /**
+   * Unresolved driver tiers to merge with the `definition` tier inside
+   * the step executor. The `definition` tier can only be populated where
+   * the evaluated definition is in scope, so final resolution happens in
+   * `DefaultStepExecutor.executeModelMethod` rather than here.
+   */
+  driverTiers?: DriverTiers;
   /** Report filter options for per-step report execution */
   reportFilterOptions?: ReportFilterOptions;
   /** The git commit sha of the swamp repo at execution time */
@@ -487,6 +507,23 @@ export class DefaultStepExecutor implements StepExecutor {
         })
         : undefined;
 
+      // Resolve the final driver/driverConfig with all six tiers now that
+      // the evaluated definition is in scope. The pre-definition tiers
+      // (cli/step/job/workflow/repo) were captured at step-construction
+      // time; the definition tier slots in between workflow and repo.
+      const tiers = ctx.driverTiers;
+      const resolved = resolveDriverConfig(
+        tiers?.cli,
+        tiers?.step,
+        tiers?.job,
+        tiers?.workflow,
+        {
+          driver: evaluatedDefinition.driver,
+          driverConfig: evaluatedDefinition.driverConfig,
+        },
+        tiers?.repo,
+      );
+
       // Execute the method with EVALUATED definition
       // Logger handles both console and file persistence via RunFileSink
       // Data is persisted by DataWriter during execution — no double-save
@@ -520,8 +557,8 @@ export class DefaultStepExecutor implements StepExecutor {
             runtimeTags: ctx.runtimeTags,
             dataOutputOverrides: stepDataOutputOverrides,
             vaultSecrets: secretBag,
-            driver: ctx.driver ?? evaluatedDefinition.driver,
-            driverConfig: ctx.driverConfig ?? evaluatedDefinition.driverConfig,
+            driver: resolved.driver,
+            driverConfig: resolved.driverConfig,
             skipCheckNames: ctx.skipCheckNames,
             skipCheckLabels: ctx.skipCheckLabels,
             skipAllChecks: ctx.skipAllChecks,
@@ -1130,11 +1167,11 @@ export class WorkflowExecutionService {
   private readonly catalogStore: CatalogStore;
   private readonly markerRepo = new RepoMarkerRepository();
   /**
-   * Memoized repo marker for this service instance. `undefined` = not yet
-   * loaded; `null` = loaded but file absent. Loaded once on first run() and
-   * reused across nested workflow invocations sharing the same service.
+   * Promise-memoized loader for `.swamp.yaml`. Instance-scoped so a
+   * long-running serve process creates a fresh loader per request and
+   * picks up marker edits between requests.
    */
-  private repoMarker: RepoMarkerData | null | undefined;
+  private readonly loadRepoMarker: () => Promise<RepoMarkerData | null>;
 
   constructor(
     private readonly workflowRepo: WorkflowRepository,
@@ -1159,20 +1196,7 @@ export class WorkflowExecutionService {
       dataRepo: this.dataRepo,
       dataQueryService,
     });
-  }
-
-  /**
-   * Lazily loads and memoizes the `.swamp.yaml` repo marker. Called by
-   * `run()` so the file is read at most once per service instance, even
-   * across nested workflow invocations.
-   */
-  private async loadRepoMarker(): Promise<RepoMarkerData | null> {
-    if (this.repoMarker === undefined) {
-      this.repoMarker = await this.markerRepo.read(
-        RepoPath.create(this.repoDir),
-      );
-    }
-    return this.repoMarker;
+    this.loadRepoMarker = createRepoMarkerLoader(this.markerRepo, repoDir);
   }
 
   /**
@@ -1820,6 +1844,7 @@ export class WorkflowExecutionService {
       // Model method tasks delegate to the step executor.
       // withEventBridge lets the executor push events via callback
       // while we yield them into the parent stream.
+      const repoMarker = await this.loadRepoMarker();
       const output = yield* withEventBridge<
         WorkflowExecutionEvent,
         unknown
@@ -1840,17 +1865,19 @@ export class WorkflowExecutionService {
           workflowTags: options.workflowTags,
           runtimeTags: options.runtimeTags,
           secretRedactor: options.secretRedactor,
-          ...resolveDriverConfig(
-            { driver: options.driver },
-            { driver: step.driver, driverConfig: step.driverConfig },
-            { driver: job.driver, driverConfig: job.driverConfig },
-            { driver: workflow.driver, driverConfig: workflow.driverConfig },
-            undefined,
-            {
-              driver: this.repoMarker?.defaultDriver,
-              driverConfig: this.repoMarker?.defaultDriverConfig,
+          driverTiers: {
+            cli: { driver: options.driver },
+            step: { driver: step.driver, driverConfig: step.driverConfig },
+            job: { driver: job.driver, driverConfig: job.driverConfig },
+            workflow: {
+              driver: workflow.driver,
+              driverConfig: workflow.driverConfig,
             },
-          ),
+            repo: {
+              driver: repoMarker?.defaultDriver,
+              driverConfig: repoMarker?.defaultDriverConfig,
+            },
+          },
           emitEvent: push,
           reportFilterOptions: options.reportFilterOptions,
           swampSha: options.swampSha,

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -2785,8 +2785,17 @@ defaultDriverConfig:
     }
 
     assertEquals(capturedContexts.length, 1);
-    assertEquals(capturedContexts[0].driver, "docker");
-    assertEquals(capturedContexts[0].driverConfig, { image: "alpine:latest" });
+    assertEquals(
+      capturedContexts[0].driverTiers?.repo?.driver,
+      "docker",
+    );
+    assertEquals(
+      capturedContexts[0].driverTiers?.repo?.driverConfig,
+      { image: "alpine:latest" },
+    );
+    // Higher tiers not populated — step executor will resolve to repo tier.
+    assertEquals(capturedContexts[0].driverTiers?.cli?.driver, undefined);
+    assertEquals(capturedContexts[0].driverTiers?.workflow?.driver, undefined);
   });
 });
 
@@ -2835,7 +2844,9 @@ defaultDriver: "docker"
     }
 
     assertEquals(capturedContexts.length, 1);
-    assertEquals(capturedContexts[0].driver, "raw");
+    // CLI tier takes precedence; repo tier still carries its marker value.
+    assertEquals(capturedContexts[0].driverTiers?.cli?.driver, "raw");
+    assertEquals(capturedContexts[0].driverTiers?.repo?.driver, "docker");
   });
 });
 
@@ -2879,7 +2890,13 @@ initializedAt: "2024-01-15T10:30:00.000Z"
     }
 
     assertEquals(capturedContexts.length, 1);
-    assertEquals(capturedContexts[0].driver, "raw");
-    assertEquals(capturedContexts[0].driverConfig, undefined);
+    // No marker defaultDriver and no CLI override — all tiers empty;
+    // step executor will fall back to "raw".
+    assertEquals(capturedContexts[0].driverTiers?.cli?.driver, undefined);
+    assertEquals(capturedContexts[0].driverTiers?.repo?.driver, undefined);
+    assertEquals(
+      capturedContexts[0].driverTiers?.repo?.driverConfig,
+      undefined,
+    );
   });
 });

--- a/src/infrastructure/persistence/repo_marker_loader.ts
+++ b/src/infrastructure/persistence/repo_marker_loader.ts
@@ -1,0 +1,46 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { RepoPath } from "../../domain/repo/repo_path.ts";
+import type {
+  RepoMarkerData,
+  RepoMarkerRepository,
+} from "./repo_marker_repository.ts";
+
+/**
+ * Returns a promise-memoized loader for `.swamp.yaml`. Concurrent callers
+ * share a single in-flight read; the file is read at most once per loader
+ * lifetime. Scope the loader per-request (one per CLI invocation, one per
+ * serve request, one per `WorkflowExecutionService` instance) so that
+ * edits to `.swamp.yaml` between requests are picked up.
+ *
+ * Rejected reads stay cached — marker parse failures are typically
+ * permanent (malformed YAML), so re-reading would not recover.
+ */
+export function createRepoMarkerLoader(
+  markerRepo: RepoMarkerRepository,
+  repoDir: string,
+): () => Promise<RepoMarkerData | null> {
+  const markerPath = RepoPath.create(repoDir);
+  let markerPromise: Promise<RepoMarkerData | null> | undefined;
+  return () => {
+    markerPromise ??= markerRepo.read(markerPath);
+    return markerPromise;
+  };
+}

--- a/src/infrastructure/persistence/repo_marker_loader_test.ts
+++ b/src/infrastructure/persistence/repo_marker_loader_test.ts
@@ -1,0 +1,88 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStrictEquals } from "@std/assert";
+import { createRepoMarkerLoader } from "./repo_marker_loader.ts";
+import type {
+  RepoMarkerData,
+  RepoMarkerRepository,
+} from "./repo_marker_repository.ts";
+
+const sampleMarker: RepoMarkerData = {
+  swampVersion: "1.0.0",
+  initializedAt: "2024-01-15T10:30:00.000Z",
+  defaultDriver: "docker",
+};
+
+function createLatchedRepo(): {
+  repo: RepoMarkerRepository;
+  readCount: () => number;
+  release: (value: RepoMarkerData | null) => void;
+} {
+  const deferred = Promise.withResolvers<RepoMarkerData | null>();
+  let count = 0;
+  const repo = {
+    read: () => {
+      count++;
+      return deferred.promise;
+    },
+  } as unknown as RepoMarkerRepository;
+  return {
+    repo,
+    readCount: () => count,
+    release: (value) => deferred.resolve(value),
+  };
+}
+
+Deno.test("createRepoMarkerLoader: concurrent calls share one in-flight read", async () => {
+  const { repo, readCount, release } = createLatchedRepo();
+  const load = createRepoMarkerLoader(repo, "/fake/repo");
+
+  const first = load();
+  const second = load();
+  release(sampleMarker);
+
+  const [a, b] = await Promise.all([first, second]);
+  assertEquals(readCount(), 1);
+  assertStrictEquals(a, b);
+  assertEquals(a, sampleMarker);
+});
+
+Deno.test("createRepoMarkerLoader: resolved value is cached for later callers", async () => {
+  const { repo, readCount, release } = createLatchedRepo();
+  const load = createRepoMarkerLoader(repo, "/fake/repo");
+
+  release(sampleMarker);
+  const first = await load();
+  const second = await load();
+
+  assertEquals(readCount(), 1);
+  assertEquals(first, sampleMarker);
+  assertEquals(second, sampleMarker);
+});
+
+Deno.test("createRepoMarkerLoader: null result is cached (file absent)", async () => {
+  const { repo, readCount, release } = createLatchedRepo();
+  const load = createRepoMarkerLoader(repo, "/fake/repo");
+
+  release(null);
+  assertEquals(await load(), null);
+  assertEquals(await load(), null);
+  assertEquals(readCount(), 1);
+});

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -45,6 +45,8 @@ import type { VaultService } from "../../domain/vaults/vault_service.ts";
 import type { ExpressionEvaluationService } from "../../domain/expressions/expression_evaluation_service.ts";
 import type { SecretRedactor } from "../../domain/secrets/mod.ts";
 import type { DataQueryService } from "../../domain/data/data_query_service.ts";
+import type { RepoMarkerData } from "../../infrastructure/persistence/repo_marker_repository.ts";
+import { resolveDriverConfig } from "../../domain/drivers/driver_resolution.ts";
 import { buildMethodContext } from "../../domain/models/method_context.ts";
 import type {
   DataArtifactView,
@@ -159,6 +161,13 @@ export interface ModelMethodRunDeps {
   outputRepo: OutputRepository;
   /** Data query service — the driver derives context.queryData from this. */
   dataQueryService: DataQueryService;
+  /**
+   * Lazily loads the `.swamp.yaml` repo marker. Callers must memoize the
+   * promise so the file is read at most once per invocation; edits to
+   * `.swamp.yaml` between invocations are picked up because the dep is
+   * constructed per-request.
+   */
+  loadRepoMarker: () => Promise<RepoMarkerData | null>;
   createRunLog: (
     modelType: ModelType,
     methodName: string,
@@ -397,6 +406,25 @@ export async function* modelMethodRun(
         const vaultService = await deps.createVaultService();
         const executionService = deps.createExecutionService();
 
+        // Resolve the final driver/driverConfig using the full tier chain
+        // (cli > definition > repo > "raw"). No workflow/job/step tiers
+        // apply outside a workflow run.
+        const repoMarker = await deps.loadRepoMarker();
+        const resolvedDriver = resolveDriverConfig(
+          { driver: input.driver },
+          undefined,
+          undefined,
+          undefined,
+          {
+            driver: evaluatedDefinition.driver,
+            driverConfig: evaluatedDefinition.driverConfig,
+          },
+          {
+            driver: repoMarker?.defaultDriver,
+            driverConfig: repoMarker?.defaultDriverConfig,
+          },
+        );
+
         let execResult: MethodResult;
         try {
           execResult = yield* withEventBridge<
@@ -435,7 +463,8 @@ export async function* modelMethodRun(
                     skipCheckNames: input.skipCheckNames,
                     skipCheckLabels: input.skipCheckLabels,
                     skipAllChecks: input.skipAllChecks,
-                    driver: input.driver,
+                    driver: resolvedDriver.driver,
+                    driverConfig: resolvedDriver.driverConfig,
                     extensionFilesRoot: modelDef.extensionFilesRoot,
                     onEvent: (event: MethodExecutionEvent) => {
                       if (event.type === "output") {

--- a/src/libswamp/models/run_test.ts
+++ b/src/libswamp/models/run_test.ts
@@ -169,6 +169,7 @@ function createTestDeps(
     dataQueryService: {
       query: () => Promise.resolve([]),
     } as unknown as DataQueryService,
+    loadRepoMarker: () => Promise.resolve(null),
     createRunLog: () =>
       Promise.resolve({
         logFilePath: "/tmp/test.log",
@@ -389,4 +390,142 @@ Deno.test("methodExecutionFailed wraps error", () => {
   assertEquals(error.code, "method_execution_failed");
   assertEquals(error.message, "boom");
   assertEquals(error.cause?.message, "boom");
+});
+
+// --- Driver resolution tests ---
+
+type CapturedContext = {
+  driver?: string;
+  driverConfig?: Record<string, unknown>;
+};
+
+function createCapturingDeps(
+  name: string,
+  methodName: string,
+  modelDef: ModelDefinition,
+  options: {
+    markerDriver?: string;
+    markerDriverConfig?: Record<string, unknown>;
+    definitionDriver?: string;
+    definitionDriverConfig?: Record<string, unknown>;
+  } = {},
+): { deps: ModelMethodRunDeps; captured: CapturedContext } {
+  const captured: CapturedContext = {};
+  const definition = Definition.create({
+    name,
+    methods: {
+      [methodName]: {
+        arguments: { key: "value" },
+      },
+    },
+    driver: options.definitionDriver,
+    driverConfig: options.definitionDriverConfig,
+  });
+  const deps = createTestDeps(definition, modelDef);
+  // deno-lint-ignore no-explicit-any
+  (deps as any).createExecutionService = () => ({
+    executeWorkflow: (
+      _def: Definition,
+      _modelDef: ModelDefinition,
+      _method: string,
+      ctx: {
+        driver?: string;
+        driverConfig?: Record<string, unknown>;
+      },
+    ) => {
+      captured.driver = ctx.driver;
+      captured.driverConfig = ctx.driverConfig;
+      return Promise.resolve({ dataHandles: [] });
+    },
+  });
+  if (
+    options.markerDriver !== undefined ||
+    options.markerDriverConfig !== undefined
+  ) {
+    deps.loadRepoMarker = () =>
+      Promise.resolve({
+        swampVersion: "1.0.0",
+        initializedAt: "2024-01-15T10:30:00.000Z",
+        defaultDriver: options.markerDriver,
+        defaultDriverConfig: options.markerDriverConfig,
+      });
+  }
+  return { deps, captured };
+}
+
+Deno.test("modelMethodRun: resolves driver from .swamp.yaml defaultDriver when no higher tier sets it", async () => {
+  const modelDef = createTestModelDef("run");
+  const { deps, captured } = createCapturingDeps(
+    "test-model",
+    "run",
+    modelDef,
+    {
+      markerDriver: "docker",
+      markerDriverConfig: { image: "alpine:latest" },
+    },
+  );
+
+  const ctx = createLibSwampContext();
+  await collect(
+    modelMethodRun(ctx, deps, createTestInput("test-model", "run")),
+  );
+
+  assertEquals(captured.driver, "docker");
+  assertEquals(captured.driverConfig, { image: "alpine:latest" });
+});
+
+Deno.test("modelMethodRun: CLI driver overrides .swamp.yaml defaultDriver", async () => {
+  const modelDef = createTestModelDef("run");
+  const { deps, captured } = createCapturingDeps(
+    "test-model",
+    "run",
+    modelDef,
+    {
+      markerDriver: "docker",
+    },
+  );
+
+  const ctx = createLibSwampContext();
+  await collect(
+    modelMethodRun(ctx, deps, {
+      ...createTestInput("test-model", "run"),
+      driver: "raw",
+    }),
+  );
+
+  assertEquals(captured.driver, "raw");
+});
+
+Deno.test("modelMethodRun: falls back to 'raw' when no marker and no CLI override", async () => {
+  const modelDef = createTestModelDef("run");
+  const { deps, captured } = createCapturingDeps("test-model", "run", modelDef);
+
+  const ctx = createLibSwampContext();
+  await collect(
+    modelMethodRun(ctx, deps, createTestInput("test-model", "run")),
+  );
+
+  assertEquals(captured.driver, "raw");
+  assertEquals(captured.driverConfig, undefined);
+});
+
+Deno.test("modelMethodRun: definition.driver applies when no CLI or repo tier sets a driver", async () => {
+  const modelDef = createTestModelDef("run");
+  const { deps, captured } = createCapturingDeps(
+    "test-model",
+    "run",
+    modelDef,
+    {
+      definitionDriver: "docker",
+      definitionDriverConfig: { image: "ubuntu" },
+    },
+  );
+
+  const ctx = createLibSwampContext();
+  await collect(
+    modelMethodRun(ctx, deps, createTestInput("test-model", "run")),
+  );
+
+  assertEquals(captured.driver, "docker");
+  assertEquals(captured.driverConfig, { image: "ubuntu" });
 });

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -43,6 +43,8 @@ import { VaultService } from "../domain/vaults/vault_service.ts";
 import { ExpressionEvaluationService } from "../domain/expressions/expression_evaluation_service.ts";
 import { DataQueryService } from "../domain/data/data_query_service.ts";
 import { runFileSink } from "../infrastructure/logging/logger.ts";
+import { RepoMarkerRepository } from "../infrastructure/persistence/repo_marker_repository.ts";
+import { createRepoMarkerLoader } from "../infrastructure/persistence/repo_marker_loader.ts";
 import {
   SWAMP_SUBDIRS,
   swampPath,
@@ -99,6 +101,10 @@ export async function createModelMethodRunDeps(
     driverTypeRegistry.ensureLoaded(),
     reportRegistry.ensureLoaded(),
   ]);
+  const loadRepoMarker = createRepoMarkerLoader(
+    new RepoMarkerRepository(),
+    repoDir,
+  );
   return {
     repoDir,
     lookupDefinition: (idOrName) =>
@@ -131,6 +137,7 @@ export async function createModelMethodRunDeps(
       repoContext.catalogStore,
       repoContext.unifiedDataRepo,
     ),
+    loadRepoMarker,
     createRunLog: async (modelType, method, definitionId) => {
       const redactor = new SecretRedactor();
       const timestamp = new Date().toISOString().replace(/[:.]/g, "-");

--- a/src/serve/open/http.ts
+++ b/src/serve/open/http.ts
@@ -73,6 +73,7 @@ import type { ExtensionApiClient } from "../../infrastructure/http/extension_api
 import { ModelType } from "../../domain/models/model_type.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
+import { createRepoMarkerLoader } from "../../infrastructure/persistence/repo_marker_loader.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { runFileSink } from "../../infrastructure/logging/logger.ts";
 import {
@@ -1817,6 +1818,10 @@ async function handleRun(
 
 function buildRunDeps(deps: InitializedDeps): ModelMethodRunDeps {
   const { repoDir, repoContext } = deps;
+  const loadRepoMarker = createRepoMarkerLoader(
+    new RepoMarkerRepository(),
+    repoDir,
+  );
   return {
     repoDir,
     lookupDefinition: (idOrName) =>
@@ -1849,6 +1854,7 @@ function buildRunDeps(deps: InitializedDeps): ModelMethodRunDeps {
       repoContext.catalogStore,
       repoContext.unifiedDataRepo,
     ),
+    loadRepoMarker,
     createRunLog: async (modelType, method, definitionId) => {
       const redactor = new SecretRedactor();
       const timestamp = new Date().toISOString().replace(/[:.]/g, "-");


### PR DESCRIPTION
## Summary

Closes swamp-club#165. Completes the cleanup gaps left by #1219 so the repo-level `defaultDriver` priority chain now applies uniformly to both workflow and direct `swamp model method run` paths. Also fixes a concurrent-read race on the marker load and un-breaks the silently-dropped `definition.driver` tier.

Three deliverables, one commit:

- **Direct `swamp model method run` now honors `defaultDriver`.** `src/libswamp/models/run.ts` routes through `resolveDriverConfig` with cli/definition/repo tiers. Serve/WS (`src/serve/connection.ts`) and HTTP SSE (`src/serve/open/http.ts`) paths inherit for free. A new `loadRepoMarker` dep on `ModelMethodRunDeps` is built via the extracted `createRepoMarkerLoader` helper.
- **Promise-memoize the marker read.** Previously `WorkflowExecutionService.loadRepoMarker` cached the resolved value — two concurrent callers both saw `undefined` and both hit the file. Now `this.markerPromise ??= markerRepo.read(...)`; `.swamp.yaml` is read at most once per service instance. The primitive is extracted to `src/infrastructure/persistence/repo_marker_loader.ts` and reused by all four factories (workflow service, CLI, serve/WS, HTTP SSE).
- **Make the `definition` tier live.** `src/domain/workflows/execution_service.ts:523` used to read `ctx.driver ?? evaluatedDefinition.driver` — dead code, because `ctx.driver` was always populated by the old upstream `resolveDriverConfig` call (with `"raw"` as its fallback), so the RHS never fired and `definition.driver` was silently dropped. `StepExecutionContext` now carries unresolved `driverTiers: { cli, step, job, workflow, repo }` and final resolution happens inside `DefaultStepExecutor.executeModelMethod` where `evaluatedDefinition` is in scope.

## Behavior changes

- `swamp model method run <m> <meth>` in a repo with `defaultDriver: docker` in `.swamp.yaml` now runs via docker without `--driver`. `--driver raw` override still wins.
- Model definitions with `driver:` set at the definition level are now honored during workflow execution. **Internal blast radius: zero** — grep of `extensions/**/manifest.yaml` and `extensions/**/*.yaml` returned no hits. Third-party extensions that set `driver:` at the definition level will now apply it (this was the documented design from day one but was never wired).
- Malformed `.swamp.yaml` now aborts every direct method run with a YAML parse error (previously direct runs didn't read the marker at all). Consistent with workflow behavior and documented in `design/execution-drivers.md`.

## Tests added

- `src/infrastructure/persistence/repo_marker_loader_test.ts` — concurrency primitive: two simultaneous calls through a `Promise.withResolvers` latch, assert exactly one underlying `.read()` call. Covers null-result caching too.
- `src/domain/models/method_execution_service_test.ts` — pre-flight check receives the resolved `driver`/`driverConfig` from MethodContext (propagation audit).
- `src/libswamp/models/run_test.ts` — four direct-path resolution tests: defaultDriver from marker wins; CLI override wins; raw fallback; definition tier applies when no higher tier set.
- `src/domain/workflows/execution_service_test.ts` — existing three workflow-path resolution tests updated to assert on the new `driverTiers` shape.
- `integration/driver_resolution_test.ts` — end-to-end CLI smoke (no docker required): defaultDriver honored, CLI override wins, malformed YAML aborts loudly.

## Docs

- `design/execution-drivers.md` — added a short note under "Resolution Priority" stating that the priority chain applies uniformly to workflow and direct paths and that malformed `.swamp.yaml` aborts at start-of-run.
- **Follow-up docs gap (not in this PR):** the swamp-club manual reference at `content/manual/reference/repository-configuration.md` still does not document `defaultDriver` / `defaultDriverConfig` — pre-existing gap from #1219. `systeminit/swamp-club` has GitHub issues disabled; flagging here so the gap can be routed to the swamp-club lab.

## Out of scope (per issue body, separate follow-ups)

- Named-fields refactor of `resolveDriverConfig` (positional `DriverSource | undefined` params).
- `WorkflowExecutionService.execute()` option forwarding (currently drops `driver`).
- Runtime schema validation of `RepoMarkerData` (the `parseYaml(...) as RepoMarkerData` cast).
- UAT coverage for `--driver` / `defaultDriver` in `systeminit/swamp-uat`.

## Test plan

- [x] `deno check` — passes
- [x] `deno lint` — passes
- [x] `deno fmt --check` — passes
- [x] `deno run test` — 4823/4823 pass
- [x] `deno run compile` — binary produced
- [x] Local smoke: scratch repo with `defaultDriver: raw` → honored; `--driver raw` beats `defaultDriver: docker`; malformed YAML aborts with exit code 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)