### PR TITLE
feat(datastore): add --timeout flag and enrich SyncTimeoutError (swamp-club#164)

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -172,9 +172,17 @@ datastore:
 
 Each direction of a remote sync (push / pull) is bounded by a hard deadline
 enforced in the coordinator, so a stuck or slow extension cannot hang the CLI
-indefinitely. The default is `DEFAULT_SYNC_TIMEOUT_MS` (5 minutes), overridable
-per-datastore on `CustomDatastoreConfig.syncTimeoutMs` or globally via the
-`SWAMP_DATASTORE_SYNC_TIMEOUT_MS` environment variable.
+indefinitely. The effective timeout is resolved from the first source that
+yields a positive value:
+
+1. `swamp datastore sync --timeout <seconds>` — per-invocation override, capped
+   at 21,600 seconds (6 hours). Preferred escape hatch for one-off large syncs.
+2. `CustomDatastoreConfig.syncTimeoutMs` — per-datastore config in
+   `.swamp.yaml`. Applies to both explicit `swamp datastore sync` calls and
+   the implicit syncs triggered by write commands.
+3. `SWAMP_DATASTORE_SYNC_TIMEOUT_MS` — environment variable, uncapped. Useful
+   for shell-session-scoped overrides during long-haul migrations.
+4. `DEFAULT_SYNC_TIMEOUT_MS` — 5 minutes.
 
 The deadline fires a `SyncTimeoutError` regardless of whether the extension
 honored the `AbortSignal` passed to `pushChanged(options)` / `pullChanged(options)`.
@@ -182,8 +190,16 @@ Timeouts propagate as a non-zero CLI exit so the user sees that data did not
 make it to the remote; other push errors still warn-downgrade (preserves
 historical behavior where a transient S3 blip does not kill a run).
 
+The `SyncTimeoutError` message lists every available remedy inline
+(`--timeout`, the env var, updating the datastore extension, releasing a stuck
+lock) so users get actionable next steps without chasing docs. The wording is
+version-free — it points at "the latest extension" rather than a specific
+version that would rot across releases.
+
 See `src/domain/datastore/datastore_config.ts` (`DEFAULT_SYNC_TIMEOUT_MS`,
-`SYNC_TIMEOUT_ENV_VAR`, `resolveSyncTimeoutMs`) and
+`SYNC_TIMEOUT_ENV_VAR`, `resolveSyncTimeoutMs`),
+`src/domain/datastore/datastore_sync_service.ts` (`SyncTimeoutError`),
+`src/cli/commands/datastore_sync.ts` (`--timeout` flag), and
 `src/infrastructure/persistence/datastore_sync_coordinator.ts`
 (`runBoundedSync`).
 
@@ -236,6 +252,43 @@ concurrently with write operations. On filesystem datastores, reads see writes
 immediately (same directory). On S3 datastores, reads see whatever was last
 synced to the local cache by a write command; users can run
 `swamp datastore sync --pull` to refresh manually.
+
+### Zero-Diff Fast Path (Extension Guidance)
+
+At production scale, most sync invocations are "nothing to do" — the local
+cache already matches the remote index. Sync implementations that walk every
+index entry unconditionally become O(n) in wall time on invocations that
+should be O(1). Extension authors implementing `DatastoreSyncService` SHOULD
+provide a zero-diff fast path that returns `0` without per-entry work when it
+can prove the cache and remote are in sync.
+
+The recommended pattern is a **fingerprint + local-dirty watermark** stored
+in a small sidecar file under the cache directory:
+
+- **Remote fingerprint** — a cheap, backend-native change token for the remote
+  index. S3 uses the object ETag; GCS uses the `generation` number; any
+  monotonic identifier exposed by a metadata-only request (HEAD-equivalent,
+  not the full index body) works. Cache the last-observed fingerprint on disk.
+- **Local-dirty flag** — flipped `true` by every code path that writes to the
+  cache (e.g. the extension's `pushFile`-equivalent); cleared only after a
+  successful writeback or a verified zero-diff pull. Default must be `true`
+  on missing/corrupt sidecar so the slow path runs.
+
+On `pullChanged` and `pushChanged`, the fast path issues one metadata request
+against the remote index. If the returned fingerprint matches the sidecar and
+the local-dirty flag is `false`, return `0` immediately. On any mismatch,
+corruption, or uncertainty, fall through to the full walk — the fast path
+must never skip real work.
+
+The sidecar is client-local state. It is never uploaded, is excluded from the
+sync walker, and can always be deleted to force a full re-verification.
+
+**Sync is not a content-integrity tool.** The fingerprint detects index-level
+changes, not per-file corruption — a silently damaged cache file (bit rot,
+truncated write after a crash) can slip through the fast path if the index
+itself has not changed. Cache integrity is the verifier's job; use
+`DatastoreVerifier.verify()` when integrity needs to be re-established, or
+`rm -rf` the cache and re-pull.
 
 ### Index
 

--- a/src/cli/commands/datastore_sync.ts
+++ b/src/cli/commands/datastore_sync.ts
@@ -34,9 +34,54 @@ import {
   requireInitializedRepo,
   requireInitializedRepoReadOnly,
 } from "../repo_context.ts";
+import { UserError } from "../../domain/errors.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
+
+/**
+ * Upper bound on the `--timeout` flag in seconds. Six hours is generous
+ * enough for realistic one-off scenarios (initial seeding from a slow link,
+ * bulk recovery after an outage, 100k-file repo moves) while still rejecting
+ * effectively-unbounded misconfigs (`--timeout 99999999`).
+ *
+ * The env var (`SWAMP_DATASTORE_SYNC_TIMEOUT_MS`) is intentionally
+ * uncapped because it is shell-session-scoped knob for operators who know
+ * what they want; the CLI flag is a one-off user-facing override and is
+ * worth guarding against fat-fingered values.
+ */
+const SYNC_TIMEOUT_CLI_MAX_SECONDS = 21_600;
+
+/**
+ * Validate and normalize the `--timeout` CLI flag. Cliffy parses
+ * `--timeout <seconds:integer>` as a number; we reject non-positive and
+ * out-of-range values here so the user sees a clean `UserError` at the
+ * CLI boundary rather than a confusing coordinator timeout surprise.
+ *
+ * Exported for unit tests; not part of the public CLI surface.
+ */
+export function parseTimeoutFlag(raw: unknown): number {
+  if (
+    typeof raw !== "number" || !Number.isFinite(raw) || !Number.isInteger(raw)
+  ) {
+    throw new UserError(
+      `--timeout must be a positive integer (seconds); got ${String(raw)}`,
+    );
+  }
+  if (raw <= 0) {
+    throw new UserError(
+      `--timeout must be greater than 0; got ${raw}`,
+    );
+  }
+  if (raw > SYNC_TIMEOUT_CLI_MAX_SECONDS) {
+    throw new UserError(
+      `--timeout must be at most ${SYNC_TIMEOUT_CLI_MAX_SECONDS} seconds ` +
+        `(6 hours); got ${raw}. For higher values, set the ` +
+        `SWAMP_DATASTORE_SYNC_TIMEOUT_MS env var instead.`,
+    );
+  }
+  return raw * 1000;
+}
 
 /**
  * Manual sync command for S3 datastores.
@@ -46,18 +91,29 @@ export const datastoreSyncCommand = new Command()
   .example("Full sync", "swamp datastore sync")
   .example("Pull only", "swamp datastore sync --pull")
   .example("Push only", "swamp datastore sync --push")
+  .example("Large one-off sync", "swamp datastore sync --timeout 1800")
   .option(
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
   .option("--pull", "Pull-only mode (fetch all remote data to local cache)")
   .option("--push", "Push-only mode (upload all local cache data to S3)")
+  .option(
+    "--timeout <seconds:integer>",
+    "Override the per-direction sync timeout for this invocation (seconds, " +
+      "max 21600). Wins over SWAMP_DATASTORE_SYNC_TIMEOUT_MS and per-datastore " +
+      "config. Preferred escape hatch for one-off large syncs.",
+  )
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, [
       "datastore",
       "sync",
     ]);
     cliCtx.logger.debug("Executing datastore sync command");
+
+    const syncTimeoutMsOverride = options.timeout != null
+      ? parseTimeoutFlag(options.timeout)
+      : undefined;
 
     const mode = options.push
       ? "push" as const
@@ -78,7 +134,9 @@ export const datastoreSyncCommand = new Command()
       });
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = await createDatastoreSyncDeps(repoDir, datastoreResolver);
+    const deps = await createDatastoreSyncDeps(repoDir, datastoreResolver, {
+      syncTimeoutMsOverride,
+    });
     const renderer = createDatastoreSyncRenderer(cliCtx.outputMode);
     await consumeStream(
       datastoreSync(ctx, deps, { mode }),

--- a/src/cli/commands/datastore_sync_test.ts
+++ b/src/cli/commands/datastore_sync_test.ts
@@ -1,0 +1,107 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import { UserError } from "../../domain/errors.ts";
+import { parseTimeoutFlag } from "./datastore_sync.ts";
+
+Deno.test("parseTimeoutFlag: converts positive integer seconds to milliseconds", () => {
+  assertEquals(parseTimeoutFlag(1), 1_000);
+  assertEquals(parseTimeoutFlag(60), 60_000);
+  assertEquals(parseTimeoutFlag(1800), 1_800_000);
+});
+
+Deno.test("parseTimeoutFlag: accepts the upper-bound value (21600s = 6h)", () => {
+  assertEquals(parseTimeoutFlag(21_600), 21_600_000);
+});
+
+Deno.test("parseTimeoutFlag: rejects zero with a UserError", () => {
+  assertThrows(
+    () => parseTimeoutFlag(0),
+    UserError,
+    "--timeout must be greater than 0",
+  );
+});
+
+Deno.test("parseTimeoutFlag: rejects negative values with a UserError", () => {
+  assertThrows(
+    () => parseTimeoutFlag(-1),
+    UserError,
+    "--timeout must be greater than 0",
+  );
+  assertThrows(
+    () => parseTimeoutFlag(-3600),
+    UserError,
+    "--timeout must be greater than 0",
+  );
+});
+
+Deno.test("parseTimeoutFlag: rejects values above the 21600s cap", () => {
+  assertThrows(
+    () => parseTimeoutFlag(21_601),
+    UserError,
+    "--timeout must be at most 21600 seconds",
+  );
+  // The error message points users at the env var for higher values —
+  // explicit escape hatch for legitimate long-haul migration scenarios.
+  assertThrows(
+    () => parseTimeoutFlag(99_999),
+    UserError,
+    "SWAMP_DATASTORE_SYNC_TIMEOUT_MS",
+  );
+});
+
+Deno.test("parseTimeoutFlag: rejects non-integer numbers", () => {
+  assertThrows(
+    () => parseTimeoutFlag(1.5),
+    UserError,
+    "--timeout must be a positive integer",
+  );
+  assertThrows(
+    () => parseTimeoutFlag(Number.NaN),
+    UserError,
+    "--timeout must be a positive integer",
+  );
+  assertThrows(
+    () => parseTimeoutFlag(Number.POSITIVE_INFINITY),
+    UserError,
+    "--timeout must be a positive integer",
+  );
+});
+
+Deno.test("parseTimeoutFlag: rejects non-number inputs defensively", () => {
+  // Cliffy's `:integer` parser should deliver a number, but defense in
+  // depth — a future refactor that loosens the parser should still surface
+  // a clean UserError, not a runtime type error.
+  assertThrows(
+    () => parseTimeoutFlag("60"),
+    UserError,
+    "--timeout must be a positive integer",
+  );
+  assertThrows(
+    () => parseTimeoutFlag(null),
+    UserError,
+    "--timeout must be a positive integer",
+  );
+  assertThrows(
+    () => parseTimeoutFlag(undefined),
+    UserError,
+    "--timeout must be a positive integer",
+  );
+});

--- a/src/domain/datastore/datastore_config.ts
+++ b/src/domain/datastore/datastore_config.ts
@@ -168,14 +168,24 @@ export function isAlwaysLocal(subdir: string): boolean {
  * Resolve the effective sync timeout for a datastore config.
  *
  * Resolution order:
- *   1. `config.syncTimeoutMs` (explicit per-datastore override)
- *   2. `SWAMP_DATASTORE_SYNC_TIMEOUT_MS` env var (must parse as positive int)
- *   3. `DEFAULT_SYNC_TIMEOUT_MS` (5 minutes)
+ *   1. `overrideMs` (per-invocation override, e.g. from a CLI flag)
+ *   2. `config.syncTimeoutMs` (explicit per-datastore config)
+ *   3. `SWAMP_DATASTORE_SYNC_TIMEOUT_MS` env var (must parse as positive int)
+ *   4. `DEFAULT_SYNC_TIMEOUT_MS` (5 minutes)
+ *
+ * `overrideMs` is intended for the `swamp datastore sync --timeout` flag,
+ * which is validated at the CLI boundary (positive integer, capped). Any
+ * value reaching here must already be `> 0` — an out-of-band `<= 0`
+ * override is ignored and resolution falls through to the next source.
  *
  * Invalid env values (non-numeric, zero, negative) are ignored with a silent
  * fallback to the default — the coordinator does not crash on a bad env.
  */
-export function resolveSyncTimeoutMs(config: DatastoreConfig): number {
+export function resolveSyncTimeoutMs(
+  config: DatastoreConfig,
+  overrideMs?: number,
+): number {
+  if (overrideMs != null && overrideMs > 0) return overrideMs;
   if (isCustomDatastoreConfig(config) && config.syncTimeoutMs != null) {
     if (config.syncTimeoutMs > 0) return config.syncTimeoutMs;
   }

--- a/src/domain/datastore/datastore_config_test.ts
+++ b/src/domain/datastore/datastore_config_test.ts
@@ -1,0 +1,105 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  type CustomDatastoreConfig,
+  DEFAULT_SYNC_TIMEOUT_MS,
+  type FilesystemDatastoreConfig,
+  resolveSyncTimeoutMs,
+  SYNC_TIMEOUT_ENV_VAR,
+} from "./datastore_config.ts";
+
+const filesystemConfig: FilesystemDatastoreConfig = {
+  type: "filesystem",
+  path: "/tmp/ds",
+};
+
+const customConfig: CustomDatastoreConfig = {
+  type: "s3",
+  config: {},
+  datastorePath: "/tmp/ds",
+  cachePath: "/tmp/cache",
+};
+
+function withEnv<T>(key: string, value: string | undefined, fn: () => T): T {
+  const prior = Deno.env.get(key);
+  if (value === undefined) Deno.env.delete(key);
+  else Deno.env.set(key, value);
+  try {
+    return fn();
+  } finally {
+    if (prior === undefined) Deno.env.delete(key);
+    else Deno.env.set(key, prior);
+  }
+}
+
+Deno.test("resolveSyncTimeoutMs: override wins over config, env, and default", () => {
+  const configured: CustomDatastoreConfig = {
+    ...customConfig,
+    syncTimeoutMs: 60_000,
+  };
+  withEnv(SYNC_TIMEOUT_ENV_VAR, "120000", () => {
+    assertEquals(resolveSyncTimeoutMs(configured, 30_000), 30_000);
+  });
+});
+
+Deno.test("resolveSyncTimeoutMs: override works on filesystem config too", () => {
+  withEnv(SYNC_TIMEOUT_ENV_VAR, undefined, () => {
+    assertEquals(resolveSyncTimeoutMs(filesystemConfig, 45_000), 45_000);
+  });
+});
+
+Deno.test("resolveSyncTimeoutMs: non-positive override falls through", () => {
+  // The CLI boundary rejects <= 0 with a UserError (see parseTimeoutFlag),
+  // but if an out-of-band caller passes 0 or negative, we must not treat it
+  // as a valid override — fall through to the next source.
+  withEnv(SYNC_TIMEOUT_ENV_VAR, undefined, () => {
+    assertEquals(
+      resolveSyncTimeoutMs(customConfig, 0),
+      DEFAULT_SYNC_TIMEOUT_MS,
+    );
+    assertEquals(
+      resolveSyncTimeoutMs(customConfig, -1),
+      DEFAULT_SYNC_TIMEOUT_MS,
+    );
+  });
+});
+
+Deno.test("resolveSyncTimeoutMs: undefined override preserves existing precedence (config)", () => {
+  const configured: CustomDatastoreConfig = {
+    ...customConfig,
+    syncTimeoutMs: 42_000,
+  };
+  withEnv(SYNC_TIMEOUT_ENV_VAR, undefined, () => {
+    assertEquals(resolveSyncTimeoutMs(configured, undefined), 42_000);
+  });
+});
+
+Deno.test("resolveSyncTimeoutMs: undefined override preserves existing precedence (env)", () => {
+  withEnv(SYNC_TIMEOUT_ENV_VAR, "180000", () => {
+    assertEquals(resolveSyncTimeoutMs(customConfig, undefined), 180_000);
+  });
+});
+
+Deno.test("resolveSyncTimeoutMs: no override, no config, no env returns default", () => {
+  withEnv(SYNC_TIMEOUT_ENV_VAR, undefined, () => {
+    assertEquals(resolveSyncTimeoutMs(customConfig), DEFAULT_SYNC_TIMEOUT_MS);
+  });
+});

--- a/src/domain/datastore/datastore_sync_service.ts
+++ b/src/domain/datastore/datastore_sync_service.ts
@@ -53,12 +53,16 @@ export type SyncDirection = "push" | "pull";
  *
  * Raised by the coordinator's hard `Promise.race` deadline, so it fires
  * regardless of whether the underlying extension honored the `AbortSignal`.
- * The message includes the actionable escape hatch for the most common
- * root cause — a stuck datastore lock left behind by a prior crashed run.
+ * The message lists every available remedy inline — tune the timeout via
+ * `--timeout` or the `SWAMP_DATASTORE_SYNC_TIMEOUT_MS` env var, update the
+ * datastore extension (the s3/gcs fingerprint fast path short-circuits
+ * zero-diff syncs), or release a stuck lock — so users get actionable
+ * next steps without needing to chase docs. Version-free wording keeps
+ * the message stable across extension releases.
  *
  * Extends `UserError` so the message renders clean (no stack trace) at
  * the CLI error boundary — the message is already hand-crafted to be
- * actionable, and a stack would bury the escape hatch.
+ * actionable, and a stack would bury the remedies.
  */
 export class SyncTimeoutError extends UserError {
   readonly label: string;
@@ -73,9 +77,17 @@ export class SyncTimeoutError extends UserError {
     options?: { cause?: unknown },
   ) {
     const msg = `Datastore ${direction} to "${label}" timed out after ` +
-      `${timeoutMs}ms. If a prior process crashed without releasing the ` +
-      `lock, run 'swamp datastore lock release --force' (add ` +
-      `--model <type>/<id> for a specific model lock).`;
+      `${timeoutMs}ms. Try one of:\n` +
+      `  • Rerun with --timeout <seconds> (e.g. --timeout 1800 for large ` +
+      `one-off syncs).\n` +
+      `  • Set SWAMP_DATASTORE_SYNC_TIMEOUT_MS for the duration of your ` +
+      `shell session.\n` +
+      `  • If you are on @swamp/s3-datastore or @swamp/gcs-datastore at ` +
+      `scale, update to the latest extension — the fingerprint fast path ` +
+      `short-circuits zero-diff syncs.\n` +
+      `  • If a prior process crashed without releasing the lock, run ` +
+      `'swamp datastore lock release --force' (add --model <type>/<id> ` +
+      `for a specific model lock).`;
     super(msg);
     this.name = "SyncTimeoutError";
     this.label = label;

--- a/src/domain/datastore/datastore_sync_service_test.ts
+++ b/src/domain/datastore/datastore_sync_service_test.ts
@@ -1,0 +1,92 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { UserError } from "../errors.ts";
+import { SyncTimeoutError } from "./datastore_sync_service.ts";
+
+Deno.test("SyncTimeoutError: message includes direction, label, and timeout", () => {
+  const err = new SyncTimeoutError("@swamp/s3-datastore", "push", 300_000);
+  assertStringIncludes(err.message, "push");
+  assertStringIncludes(err.message, "@swamp/s3-datastore");
+  assertStringIncludes(err.message, "300000ms");
+});
+
+Deno.test("SyncTimeoutError: message lists all four remedies", () => {
+  const err = new SyncTimeoutError("@swamp/s3-datastore", "pull", 300_000);
+  // Remedy 1: --timeout flag
+  assertStringIncludes(err.message, "--timeout");
+  // Remedy 2: env var
+  assertStringIncludes(err.message, "SWAMP_DATASTORE_SYNC_TIMEOUT_MS");
+  // Remedy 3: extension update (version-free wording — "the latest extension",
+  // not a specific version that would rot across releases)
+  assertStringIncludes(err.message, "latest extension");
+  // Remedy 4: stuck-lock release
+  assertStringIncludes(err.message, "swamp datastore lock release --force");
+});
+
+Deno.test("SyncTimeoutError: extension-update hint does not hardcode a version", () => {
+  const err = new SyncTimeoutError("@swamp/s3-datastore", "push", 60_000);
+  // Pin the version-free contract: no `YYYY.MM.DD` or `N.N.N` in the message.
+  // Any version string would rot every time the extension ships.
+  const calendarVersion = /\b20\d{2}\.\d{2}\.\d{2}\b/;
+  const semver = /\bv?\d+\.\d+\.\d+\b/;
+  assertEquals(
+    calendarVersion.test(err.message),
+    false,
+    "message must not hardcode a calendar-version; use version-free wording",
+  );
+  assertEquals(
+    semver.test(err.message),
+    false,
+    "message must not hardcode a semver; use version-free wording",
+  );
+});
+
+Deno.test("SyncTimeoutError: is a UserError", () => {
+  const err = new SyncTimeoutError("@swamp/s3-datastore", "push", 1000);
+  assertEquals(err instanceof UserError, true);
+  assertEquals(err.name, "SyncTimeoutError");
+});
+
+Deno.test("SyncTimeoutError: preserves structured fields", () => {
+  const cause = new Error("underlying network failure");
+  const err = new SyncTimeoutError(
+    "@swamp/gcs-datastore",
+    "pull",
+    120_000,
+    { cause },
+  );
+  assertEquals(err.label, "@swamp/gcs-datastore");
+  assertEquals(err.direction, "pull");
+  assertEquals(err.timeoutMs, 120_000);
+  assertEquals(err.cause, cause);
+});
+
+Deno.test("SyncTimeoutError: multi-line message round-trips through JSON", () => {
+  // Pins the contract that the --json output path preserves the enriched
+  // message verbatim. A future renderer that tries to collapse whitespace
+  // or strip newlines would break this assertion.
+  const err = new SyncTimeoutError("@swamp/s3-datastore", "push", 300_000);
+  const serialized = JSON.stringify({ error: err.message });
+  const roundTripped = JSON.parse(serialized) as { error: string };
+  assertEquals(roundTripped.error, err.message);
+  // Newlines survive the round-trip as `\n` — not stripped, not collapsed.
+  assertEquals(roundTripped.error.includes("\n"), true);
+});

--- a/src/libswamp/datastores/sync.ts
+++ b/src/libswamp/datastores/sync.ts
@@ -63,10 +63,22 @@ export interface DatastoreSyncDeps {
   }>;
 }
 
+/** Options for wiring real infrastructure into DatastoreSyncDeps. */
+export interface CreateDatastoreSyncDepsOptions {
+  /**
+   * Per-invocation override for the sync timeout, in milliseconds. Wins
+   * over `CustomDatastoreConfig.syncTimeoutMs`, the env var, and the
+   * default — the CLI `--timeout` flag on `swamp datastore sync` threads
+   * its value through here. Validated at the CLI boundary; must be `> 0`.
+   */
+  readonly syncTimeoutMsOverride?: number;
+}
+
 /** Wires real infrastructure into DatastoreSyncDeps. */
 export async function createDatastoreSyncDeps(
   repoDir: string,
   datastoreResolver: DatastorePathResolver,
+  options: CreateDatastoreSyncDepsOptions = {},
 ): Promise<DatastoreSyncDeps> {
   await datastoreTypeRegistry.ensureLoaded();
   const config = datastoreResolver.config();
@@ -95,7 +107,10 @@ export async function createDatastoreSyncDeps(
       );
     }
     const syncService = provider.createSyncService(repoDir, config.cachePath);
-    const timeoutMs = resolveSyncTimeoutMs(config);
+    const timeoutMs = resolveSyncTimeoutMs(
+      config,
+      options.syncTimeoutMsOverride,
+    );
     const label = config.type;
     return {
       validateSyncSupport: () =>


### PR DESCRIPTION
## Summary

Companion PR to the `@swamp/s3-datastore` fingerprint fast-path fix for [lab/164](https://swamp.club/lab/164) (minutes-slow `swamp datastore sync` at 4k-file scale, even on zero-diff). This PR adds the swamp-core ergonomics: a `--timeout` CLI flag for one-off sync overrides, and a richer `SyncTimeoutError` message so users get actionable next steps when the timeout does fire.

Either PR may land first — the enriched error uses version-free wording, so there is no ordering dependency.

## What changed

### `--timeout <seconds>` flag on `swamp datastore sync`

- Per-invocation override; wins over `CustomDatastoreConfig.syncTimeoutMs` and `SWAMP_DATASTORE_SYNC_TIMEOUT_MS`.
- Validated at the CLI boundary: positive integer, rejected ≤0, capped at **21600s (6h)** — generous enough for initial seeding from a slow link, bulk recovery after an outage, or 100k-file migrations, while rejecting fat-finger misconfigs. The env var stays uncapped as the shell-session escape hatch.
- Scoped to `swamp datastore sync` only. Write commands that trigger implicit sync keep their existing escape hatch (env var). Adding `--timeout` everywhere would inflate the CLI surface without commensurate benefit.
- `--help` clearly describes precedence so users reach for the right knob.

### Enriched `SyncTimeoutError` message

Before:
\`\`\`
Datastore push to "@swamp/s3-datastore" timed out after 300000ms. If a prior process crashed without releasing the lock, run 'swamp datastore lock release --force' (add --model <type>/<id> for a specific model lock).
\`\`\`

After:
\`\`\`
Datastore push to "@swamp/s3-datastore" timed out after 300000ms. Try one of:
  • Rerun with --timeout <seconds> (e.g. --timeout 1800 for large one-off syncs).
  • Set SWAMP_DATASTORE_SYNC_TIMEOUT_MS for the duration of your shell session.
  • If you are on @swamp/s3-datastore or @swamp/gcs-datastore at scale, update to the latest extension — the fingerprint fast path short-circuits zero-diff syncs.
  • If a prior process crashed without releasing the lock, run 'swamp datastore lock release --force' (add --model <type>/<id> for a specific model lock).
\`\`\`

Version-free wording keeps the message stable across extension releases. No changes to the error's structured fields (`label`, `direction`, `timeoutMs`, `cause`).

### Internal plumbing

- `resolveSyncTimeoutMs(config, overrideMs?)` — new optional parameter at highest precedence. Non-positive overrides silently fall through to the next source.
- `createDatastoreSyncDeps(repoDir, resolver, options?)` — new `CreateDatastoreSyncDepsOptions` interface with `syncTimeoutMsOverride`.

### Docs

`design/datastores.md` — expanded "Sync Timeout" section with the 4-tier precedence chain and reference to the enriched error. New "Zero-Diff Fast Path (Extension Guidance)" subsection with backend-agnostic wording (fingerprint + dirty-flag sidecar pattern), so future extension authors have a breadcrumb. Notes that sync is not a content-integrity tool — use `DatastoreVerifier` for that.

## What this does NOT do

- Does not fix the 5-minute zero-diff sync itself — that's the `@swamp/s3-datastore` fingerprint fast-path PR. This PR is the ergonomics layer.
- Does not change default behavior for anyone who doesn't pass `--timeout` or hit the timeout.
- Does not close the AbortSignal plumbing gap in the s3 extension.

## Test plan

- [x] `deno check` — clean
- [x] `deno lint` — clean (1091 files)
- [x] `deno fmt` — clean
- [x] `deno run test` — 4822 passed / 0 failed (19 new tests)
- [x] `deno run compile` — binary built
- [x] `./swamp datastore sync --help` — `--timeout` flag documented correctly
- [ ] Reporter runs `swamp datastore sync --timeout 60` against their 4k-file repo and confirms: (a) validation rejects 0/negative/>21600, (b) enriched error message renders all four remedies, (c) flag override wins over env var when both are set. Tracked on lab/164 as the verification gate.

### New tests

| File | What it covers |
|---|---|
| `src/domain/datastore/datastore_sync_service_test.ts` | Enriched message contents; version-free extension hint (regex guards against calendar-version and semver); structured field preservation; multi-line JSON round-trip. |
| `src/domain/datastore/datastore_config_test.ts` | `resolveSyncTimeoutMs` precedence: override wins over config/env/default; non-positive override falls through; undefined preserves existing precedence. |
| `src/cli/commands/datastore_sync_test.ts` | `parseTimeoutFlag` validation: seconds→ms conversion, upper-bound acceptance, zero/negative/over-cap/non-integer/non-number rejection. |

## Links

- Lab issue: https://swamp.club/lab/164
- Companion PR: `@swamp/s3-datastore` fingerprint fast-path (in `systeminit/swamp-extensions`, being opened in parallel)
- Follow-up issue: https://swamp.club/lab/166 (gcs mirror)