### PR TITLE
fix(datastore): clarify --timeout scope in SyncTimeoutError message

### DIFF
--- a/src/domain/datastore/datastore_sync_service.ts
+++ b/src/domain/datastore/datastore_sync_service.ts
@@ -78,10 +78,13 @@ export class SyncTimeoutError extends UserError {
   ) {
     const msg = `Datastore ${direction} to "${label}" timed out after ` +
       `${timeoutMs}ms. Try one of:\n` +
-      `  • Rerun with --timeout <seconds> (e.g. --timeout 1800 for large ` +
-      `one-off syncs).\n` +
       `  • Set SWAMP_DATASTORE_SYNC_TIMEOUT_MS for the duration of your ` +
-      `shell session.\n` +
+      `shell session — applies to every command that triggers sync, ` +
+      `including the implicit pull/push around write commands.\n` +
+      `  • If the timeout fired on an explicit 'swamp datastore sync', ` +
+      `rerun with --timeout <seconds> (e.g. --timeout 1800 for large ` +
+      `one-off syncs). The flag is not available on other commands; use ` +
+      `the env var above for those.\n` +
       `  • If you are on @swamp/s3-datastore or @swamp/gcs-datastore at ` +
       `scale, update to the latest extension — the fingerprint fast path ` +
       `short-circuits zero-diff syncs.\n` +

--- a/src/domain/datastore/datastore_sync_service_test.ts
+++ b/src/domain/datastore/datastore_sync_service_test.ts
@@ -30,15 +30,31 @@ Deno.test("SyncTimeoutError: message includes direction, label, and timeout", ()
 
 Deno.test("SyncTimeoutError: message lists all four remedies", () => {
   const err = new SyncTimeoutError("@swamp/s3-datastore", "pull", 300_000);
-  // Remedy 1: --timeout flag
-  assertStringIncludes(err.message, "--timeout");
-  // Remedy 2: env var
+  // Remedy 1: env var (universal — applies to implicit and explicit sync alike).
+  // Ordered first because most timeout firings happen on implicit sync after
+  // write commands, where --timeout is not available.
   assertStringIncludes(err.message, "SWAMP_DATASTORE_SYNC_TIMEOUT_MS");
+  // Remedy 2: --timeout flag, scoped to `swamp datastore sync` only.
+  assertStringIncludes(err.message, "--timeout");
   // Remedy 3: extension update (version-free wording — "the latest extension",
-  // not a specific version that would rot across releases)
+  // not a specific version that would rot across releases).
   assertStringIncludes(err.message, "latest extension");
-  // Remedy 4: stuck-lock release
+  // Remedy 4: stuck-lock release.
   assertStringIncludes(err.message, "swamp datastore lock release --force");
+});
+
+Deno.test("SyncTimeoutError: --timeout remedy is scoped to 'swamp datastore sync'", () => {
+  // The timeout fires from `flushDatastoreSync()` after every command, not
+  // just explicit `swamp datastore sync`. A user running e.g. `swamp model
+  // run` who hits the timeout will see `--timeout` in the remedies but the
+  // flag is not available on their command. The message must make the
+  // scope unambiguous so they do not fruitlessly try `swamp model run
+  // --timeout ...` and hit "unknown flag".
+  const err = new SyncTimeoutError("@swamp/s3-datastore", "push", 300_000);
+  assertStringIncludes(err.message, "swamp datastore sync");
+  // The env var hint must also mention that it covers implicit syncs —
+  // that is the real escape hatch for non-sync commands.
+  assertStringIncludes(err.message, "implicit");
 });
 
 Deno.test("SyncTimeoutError: extension-update hint does not hardcode a version", () => {

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -945,6 +945,7 @@ export {
 } from "./datastores/status.ts";
 export {
   createDatastoreSyncDeps,
+  type CreateDatastoreSyncDepsOptions,
   datastoreSync,
   type DatastoreSyncData,
   type DatastoreSyncDeps,


### PR DESCRIPTION
## Summary

Follow-up to #1222 addressing the two actionable findings from review:

### 1. CLI UX Review — `--timeout` remedy was misleading for implicit syncs

The timeout fires from `flushDatastoreSync()` after *every* command, not just `swamp datastore sync`. The previous message led with `• Rerun with --timeout <seconds>`, which would fail for a user whose timeout fired from e.g. `swamp model run` (the flag only exists on `swamp datastore sync`).

**Fix:** reorder remedies so the env var (universal escape hatch) is listed first and the `--timeout` flag is explicitly scoped to `swamp datastore sync`:

\`\`\`
Datastore push to "@swamp/s3-datastore" timed out after 300000ms. Try one of:
  • Set SWAMP_DATASTORE_SYNC_TIMEOUT_MS for the duration of your shell session — applies to every command that triggers sync, including the implicit pull/push around write commands.
  • If the timeout fired on an explicit 'swamp datastore sync', rerun with --timeout <seconds> (e.g. --timeout 1800 for large one-off syncs). The flag is not available on other commands; use the env var above for those.
  • If you are on @swamp/s3-datastore or @swamp/gcs-datastore at scale, update to the latest extension — the fingerprint fast path short-circuits zero-diff syncs.
  • If a prior process crashed without releasing the lock, run 'swamp datastore lock release --force' (add --model <type>/<id> for a specific model lock).
\`\`\`

New scope-clarification test pins the contract: the message MUST name `swamp datastore sync` explicitly and MUST mention the env var covers implicit syncs. That prevents a future well-meaning reword from reintroducing the same trap.

### 2. Code Review + Adversarial Review — `CreateDatastoreSyncDepsOptions` not re-exported from barrel

The new interface lived at the internal path `src/libswamp/datastores/sync.ts`. Any consumer outside the CLI wanting to type an options variable would have had to violate CLAUDE.md's barrel-import convention. One-line fix: add `type CreateDatastoreSyncDepsOptions` to the export from `src/libswamp/mod.ts`.

## What this does NOT change

- The precedence chain (CLI flag → config → env var → default) is unchanged.
- The structured fields of `SyncTimeoutError` (`label`, `direction`, `timeoutMs`, `cause`) are unchanged.
- No behavior change for users who don't hit the timeout.

## Test plan

- [x] `deno check` — clean
- [x] `deno lint` — clean (1094 files)
- [x] `deno fmt` — clean
- [x] `deno run test` — 4843 passed / 0 failed
- [x] `deno run compile` — binary built
- [x] New test `SyncTimeoutError: --timeout remedy is scoped to 'swamp datastore sync'` passes

## Links

- Primary PR: #1222
- Lab issue: https://swamp.club/lab/164