### PR TITLE
fix(datastore): signal cache writes to sync service fast path

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -283,6 +283,35 @@ must never skip real work.
 The sidecar is client-local state. It is never uploaded, is excluded from the
 sync walker, and can always be deleted to force a full re-verification.
 
+#### `markDirty()` contract
+
+Swamp core writes into the cache directly — the persistence repositories
+(`FileSystemUnifiedDataRepository`, `YamlOutputRepository`,
+`YamlWorkflowRunRepository`, `YamlEvaluatedDefinitionRepository`) call
+`atomicWriteFile` / `atomicWriteTextFile` / `Deno.remove` against paths that
+the sync service walks. These writes bypass the extension's own write path, so
+the fast path's local-dirty flag would stay `false` and the next `pushChanged`
+would short-circuit past real work.
+
+The `markDirty()` method on `DatastoreSyncService` is the contract that closes
+this gap:
+
+- **Extension obligation.** Any sync service that caches a clean/dirty
+  watermark MUST flip it to dirty in `markDirty()` — same primitive as the
+  internal `pushFile`-equivalent. Sync services without a fast path MAY
+  no-op. `markDirty()` must be idempotent and cheap (not deduplicated by
+  core).
+- **Core obligation.** Repositories writing into the cache call `markDirty()`
+  at the start of every public mutation method (`save`, `append`, `delete`,
+  `rename`, `allocateVersion`, `finalizeVersion`, `removeLatestMarker`,
+  non-dry-run `collectGarbage`, and the equivalents on the three yaml
+  repositories). The call happens **before** any write begins so a crash
+  mid-write leaves the watermark dirty — `markDirty()` then slow-walk is
+  always recoverable; a lost dirty-flip is not.
+
+Filesystem datastores have no fast path and wire no sync service, so the
+markDirty plumbing is a no-op for them.
+
 **Sync is not a content-integrity tool.** The fingerprint detects index-level
 changes, not per-file corruption — a silently damaged cache file (bit rot,
 truncated write after a crash) can slip through the fast path if the index

--- a/packages/testing/datastore_test_context.ts
+++ b/packages/testing/datastore_test_context.ts
@@ -36,7 +36,7 @@ export interface LockOperation {
 
 /** A recorded sync operation for inspection. */
 export interface SyncOperation {
-  method: "pullChanged" | "pushChanged";
+  method: "pullChanged" | "pushChanged" | "markDirty";
   timestamp: number;
 }
 
@@ -203,6 +203,10 @@ export function createDatastoreTestContext(
       },
       pushChanged(): Promise<void> {
         syncOperations.push({ method: "pushChanged", timestamp: Date.now() });
+        return Promise.resolve();
+      },
+      markDirty(): Promise<void> {
+        syncOperations.push({ method: "markDirty", timestamp: Date.now() });
         return Promise.resolve();
       },
     }

--- a/packages/testing/datastore_types.ts
+++ b/packages/testing/datastore_types.ts
@@ -75,6 +75,7 @@ export interface DatastoreSyncOptions {
 export interface DatastoreSyncService {
   pullChanged(options?: DatastoreSyncOptions): Promise<number | void>;
   pushChanged(options?: DatastoreSyncOptions): Promise<number | void>;
+  markDirty(options?: DatastoreSyncOptions): Promise<void>;
 }
 
 /**

--- a/src/cli/commands/model_evaluate.ts
+++ b/src/cli/commands/model_evaluate.ts
@@ -78,11 +78,16 @@ export const modelEvaluateCommand = new Command()
       }
 
       // Single model evaluation — use per-model lock
-      const { repoDir, repoContext, datastoreConfig, datastoreResolver } =
-        await requireInitializedRepoUnlocked({
-          repoDir: resolveRepoDir(options.repoDir),
-          outputMode: cliCtx.outputMode,
-        });
+      const {
+        repoDir,
+        repoContext,
+        datastoreConfig,
+        datastoreResolver,
+        syncService,
+      } = await requireInitializedRepoUnlocked({
+        repoDir: resolveRepoDir(options.repoDir),
+        outputMode: cliCtx.outputMode,
+      });
 
       // Pre-lookup for lock target
       const lookupResult = await findDefinitionByIdOrName(
@@ -96,9 +101,14 @@ export const modelEvaluateCommand = new Command()
       const { definition, type } = lookupResult;
 
       // Acquire per-model lock (for S3, also pulls model-scoped files)
-      const lockResult = await acquireModelLocks(datastoreConfig, [
-        { modelType: type.normalized, modelId: definition.id },
-      ], repoDir);
+      const lockResult = await acquireModelLocks(
+        datastoreConfig,
+        [
+          { modelType: type.normalized, modelId: definition.id },
+        ],
+        repoDir,
+        syncService,
+      );
       if (lockResult.synced) repoContext.catalogStore.invalidate();
       const flushModelLocks = lockResult.flush;
 

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -143,7 +143,7 @@ export const modelMethodRunCommand = new Command()
         "method",
         "run",
       ]);
-      const { repoDir, repoContext, datastoreConfig } =
+      const { repoDir, repoContext, datastoreConfig, syncService } =
         await requireInitializedRepoUnlocked({
           repoDir: resolveRepoDir(options.repoDir),
           outputMode: ctx.outputMode,
@@ -246,12 +246,17 @@ export const modelMethodRunCommand = new Command()
       );
       let flushModelLocks: (() => Promise<void>) | null = null;
       if (preResult) {
-        const lockResult = await acquireModelLocks(datastoreConfig, [
-          {
-            modelType: preResult.type.normalized,
-            modelId: preResult.definition.id,
-          },
-        ], repoDir);
+        const lockResult = await acquireModelLocks(
+          datastoreConfig,
+          [
+            {
+              modelType: preResult.type.normalized,
+              modelId: preResult.definition.id,
+            },
+          ],
+          repoDir,
+          syncService,
+        );
         if (lockResult.synced) repoContext.catalogStore.invalidate();
         flushModelLocks = lockResult.flush;
       }

--- a/src/cli/commands/open.ts
+++ b/src/cli/commands/open.ts
@@ -109,6 +109,7 @@ async function loadRepoIntoState(
   state.repoDir = result.repoDir;
   state.repoContext = result.repoContext;
   state.datastoreConfig = result.datastoreConfig;
+  state.syncService = result.syncService ?? null;
 
   // Reconfigure the extension loaders/auto-resolver for this repo — the CLI
   // bootstrap wired them to whatever directory the binary was launched from,
@@ -161,6 +162,7 @@ export const openCommand = new Command()
       repoDir: null,
       repoContext: null,
       datastoreConfig: null,
+      syncService: null,
       extClient,
       version: VERSION,
       initializeRepo: async (path: string) => {

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -69,11 +69,15 @@ export const serveCommand = new Command()
 
     ctx.logger.info`Initializing repository at ${repoDir}`;
 
-    const { repoDir: resolvedRepoDir, repoContext, datastoreConfig } =
-      await requireInitializedRepoUnlocked({
-        repoDir,
-        outputMode: ctx.outputMode,
-      });
+    const {
+      repoDir: resolvedRepoDir,
+      repoContext,
+      datastoreConfig,
+      syncService,
+    } = await requireInitializedRepoUnlocked({
+      repoDir,
+      outputMode: ctx.outputMode,
+    });
 
     if (host !== "127.0.0.1" && host !== "localhost") {
       logger.warn(
@@ -85,6 +89,7 @@ export const serveCommand = new Command()
       repoDir: resolvedRepoDir,
       repoContext,
       datastoreConfig,
+      syncService,
     };
 
     const ac = new AbortController();
@@ -105,6 +110,7 @@ export const serveCommand = new Command()
             input,
             signal,
             onEvent,
+            syncService,
           ),
       });
 
@@ -163,6 +169,7 @@ export const serveCommand = new Command()
         repoContext,
         datastoreConfig,
         endpoints,
+        syncService,
       });
 
       webhookService.setEventHandler((event) => {

--- a/src/cli/commands/workflow_evaluate.ts
+++ b/src/cli/commands/workflow_evaluate.ts
@@ -171,6 +171,7 @@ export const workflowEvaluateCommand = new Command()
             unlocked.datastoreConfig,
             resolvedModels,
             unlocked.repoDir,
+            unlocked.syncService,
           );
           if (lockResult.synced) {
             unlocked.repoContext.catalogStore.invalidate();

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -187,6 +187,7 @@ export const workflowRunCommand = new Command()
               unlocked.datastoreConfig,
               resolvedModels,
               unlocked.repoDir,
+              unlocked.syncService,
             );
             if (lockResult.synced) {
               unlocked.repoContext.catalogStore.invalidate();

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -65,6 +65,7 @@ import {
   resolveSyncTimeoutMs,
 } from "../domain/datastore/datastore_config.ts";
 import type { DatastoreProvider } from "../domain/datastore/datastore_provider.ts";
+import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
 import { datastoreTypeRegistry } from "../domain/datastore/datastore_type_registry.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 import { withSpan } from "../infrastructure/tracing/mod.ts";
@@ -314,13 +315,22 @@ export function requireInitializedRepo(
     // Track whether a remote sync happened so we can invalidate the catalog
     let needsCatalogInvalidation = false;
 
+    // Sync service is shared between the coordinator (pull/push) and the
+    // repositories (markDirty on cache writes). Hoisted so both wirings
+    // reference the same instance.
+    let syncService:
+      | ReturnType<
+        NonNullable<DatastoreProvider["createSyncService"]>
+      >
+      | undefined;
+
     // Verify datastore is accessible
     if (isCustomDatastoreConfig(datastoreConfig)) {
       const provider = await resolveCustomProvider(datastoreConfig);
       const lock = provider.createLock(datastoreConfig.datastorePath);
 
       // If the custom provider supports sync, register sync service too
-      const syncService = datastoreConfig.cachePath
+      syncService = datastoreConfig.cachePath
         ? provider.createSyncService?.(
           repoPath.value,
           datastoreConfig.cachePath,
@@ -401,6 +411,7 @@ export function requireInitializedRepo(
       yamlWorkflowsDir,
       vaultsDir,
       datastoreResolver,
+      markDirty: syncService ? () => syncService!.markDirty() : undefined,
       ...factoryConfig,
     });
 
@@ -435,7 +446,20 @@ export function requireInitializedRepo(
 export async function requireInitializedRepoUnlocked(
   options: RequireRepoOptions,
   factoryConfig?: Partial<Omit<RepositoryFactoryConfig, "repoDir">>,
-): Promise<RepoValidationContext & { datastoreConfig: DatastoreConfig }> {
+): Promise<
+  RepoValidationContext & {
+    datastoreConfig: DatastoreConfig;
+    /**
+     * Single sync service instance shared by this repo context's markDirty
+     * hook and any subsequent `acquireModelLocks` pull/push call. Undefined
+     * for filesystem datastores or custom datastores without a cache. Passed
+     * into `acquireModelLocks` so cache writes and the fast-path watermark
+     * read go through the same instance — implementations that cache the
+     * sidecar flag in memory stay coherent. See `design/datastores.md`.
+     */
+    syncService?: DatastoreSyncService;
+  }
+> {
   const { repoDir, datastoreConfig, marker } = await resolveDatastoreForRepo(
     options.repoDir,
   );
@@ -452,10 +476,17 @@ export async function requireInitializedRepoUnlocked(
     datastoreConfig,
   );
 
+  let syncService: DatastoreSyncService | undefined;
+
   // Verify datastore is accessible (same checks as requireInitializedRepo)
   if (isCustomDatastoreConfig(datastoreConfig)) {
     if (datastoreConfig.cachePath) {
       await ensureDir(datastoreConfig.cachePath);
+      const provider = await resolveCustomProvider(datastoreConfig);
+      syncService = provider.createSyncService?.(
+        repoPath.value,
+        datastoreConfig.cachePath,
+      );
     }
   } else if (datastoreConfig.type === "filesystem") {
     try {
@@ -509,6 +540,7 @@ export async function requireInitializedRepoUnlocked(
     yamlWorkflowsDir,
     vaultsDir,
     datastoreResolver,
+    markDirty: syncService ? () => syncService!.markDirty() : undefined,
     ...factoryConfig,
   });
 
@@ -517,6 +549,7 @@ export async function requireInitializedRepoUnlocked(
     repoContext,
     datastoreResolver,
     datastoreConfig,
+    syncService,
   };
 }
 
@@ -627,18 +660,26 @@ export async function acquireModelLocks(
   config: DatastoreConfig,
   models: Array<{ modelType: string; modelId: string }>,
   repoDir?: string,
+  /**
+   * Sync service to use for pull/push. Normally supplied by the caller
+   * (e.g. via `requireInitializedRepoUnlocked` or the serve context) so the
+   * same instance handles both the markDirty hook on cache writes and the
+   * fast-path watermark read here — implementations that cache the sidecar
+   * flag in memory stay coherent across the two call sites. Omit to let
+   * this function create one; doing so is only safe when no separate
+   * repo-context markDirty hook will race this instance.
+   */
+  syncService?: DatastoreSyncService,
 ): Promise<ModelLockResult> {
   const logger = getSwampLogger(["datastore", "lock"]);
   let synced = false;
 
   // For custom datastores, resolve the provider once and reuse it everywhere
   let customProvider: DatastoreProvider | undefined;
-  let customSyncService:
-    | ReturnType<NonNullable<DatastoreProvider["createSyncService"]>>
-    | undefined;
+  let customSyncService = syncService;
   if (isCustomDatastoreConfig(config)) {
     customProvider = await resolveCustomProvider(config);
-    if (config.cachePath) {
+    if (!customSyncService && config.cachePath) {
       customSyncService = customProvider.createSyncService?.(
         repoDir ?? ".",
         config.cachePath,
@@ -756,8 +797,10 @@ export async function acquireModelLocks(
         }
       }
 
-      // Restart the entire per-model lock acquisition from scratch
-      return acquireModelLocks(config, models, repoDir);
+      // Restart the entire per-model lock acquisition from scratch —
+      // propagate the shared sync service so the retry keeps single-instance
+      // semantics.
+      return acquireModelLocks(config, models, repoDir, customSyncService);
     }
 
     // For custom sync-capable datastores: pull after acquiring per-model lock

--- a/src/domain/datastore/datastore_sync_service.ts
+++ b/src/domain/datastore/datastore_sync_service.ts
@@ -43,10 +43,37 @@ export interface DatastoreSyncService {
   pullChanged(options?: DatastoreSyncOptions): Promise<number | void>;
   /** Push changed files from the local cache to the remote datastore. */
   pushChanged(options?: DatastoreSyncOptions): Promise<number | void>;
+  /**
+   * Signal that the local cache has uncommitted work.
+   *
+   * Must be called before (or immediately after) any write into the cache
+   * directory that does not go through a sync-service method, so the next
+   * `pushChanged` fast path cannot short-circuit past the write. Implementations
+   * that cache a clean/dirty watermark (e.g. the s3/gcs zero-diff fast path
+   * described in `design/datastores.md`) MUST invalidate the watermark here.
+   * Implementations without a fast path MAY no-op.
+   *
+   * Implementations must be idempotent and cheap — swamp core calls this at
+   * the start of every repository-layer mutation that writes into the cache,
+   * and calls are not deduplicated. Called before the write begins so a crash
+   * mid-write still leaves the watermark dirty.
+   */
+  markDirty(options?: DatastoreSyncOptions): Promise<void>;
 }
 
 /** Direction of a sync operation. */
 export type SyncDirection = "push" | "pull";
+
+/**
+ * Callback invoked by repositories before they write into the datastore cache.
+ *
+ * Thin indirection over {@link DatastoreSyncService.markDirty} so repositories
+ * do not need a handle on the full sync service (or to know whether one is
+ * registered at all). Undefined when the repository is wired against a
+ * datastore with no sync service (e.g. filesystem) — callers treat it as a
+ * no-op.
+ */
+export type MarkDirtyHook = () => Promise<void>;
 
 /**
  * Thrown when a datastore sync operation exceeds the configured timeout.

--- a/src/domain/datastore/mod.ts
+++ b/src/domain/datastore/mod.ts
@@ -49,6 +49,7 @@ export { type DatastorePathResolver } from "./datastore_path_resolver.ts";
 export {
   type DatastoreSyncOptions,
   type DatastoreSyncService,
+  type MarkDirtyHook,
   type SyncDirection,
   SyncTimeoutError,
 } from "./datastore_sync_service.ts";

--- a/src/domain/datastore/testing_package_compat_test.ts
+++ b/src/domain/datastore/testing_package_compat_test.ts
@@ -68,7 +68,9 @@ function _checkDatastoreSyncServiceFields(sync: TestingDatastoreSyncService) {
     .pullChanged();
   const _push: ReturnType<CanonicalDatastoreSyncService["pushChanged"]> = sync
     .pushChanged();
-  void [_pull, _push];
+  const _markDirty: ReturnType<CanonicalDatastoreSyncService["markDirty"]> =
+    sync.markDirty();
+  void [_pull, _push, _markDirty];
 }
 
 // DatastoreProvider: verify methods exist and return compatible types.

--- a/src/infrastructure/persistence/datastore_sync_coordinator_test.ts
+++ b/src/infrastructure/persistence/datastore_sync_coordinator_test.ts
@@ -161,6 +161,7 @@ Deno.test("registerDatastoreSync enriches pullChanged failure with SDK metadata"
       throw opaqueError;
     },
     pushChanged: () => Promise.resolve(0),
+    markDirty: () => Promise.resolve(),
   };
 
   const thrown = await assertRejects(
@@ -193,6 +194,7 @@ Deno.test("flushDatastoreSync swallows pushChanged failures (warn-only)", async 
         $metadata: { httpStatusCode: 500 },
       });
     },
+    markDirty: () => Promise.resolve(),
   };
 
   await registerDatastoreSync({
@@ -218,6 +220,7 @@ Deno.test("flushDatastoreSync: hanging pushChanged surfaces SyncTimeoutError wit
   const hangingService = {
     pullChanged: () => Promise.resolve(0),
     pushChanged: () => new Promise<number>(() => {}), // never resolves
+    markDirty: () => Promise.resolve(),
   };
 
   await registerDatastoreSync({
@@ -257,6 +260,7 @@ Deno.test("flushDatastoreSync: signal-compliant extension aborts cooperatively",
           );
         }, { once: true });
       }),
+    markDirty: () => Promise.resolve(),
   };
 
   await registerDatastoreSync({
@@ -280,6 +284,7 @@ Deno.test("flushDatastoreSync: releases lock even when push times out", async ()
   const hangingService = {
     pullChanged: () => Promise.resolve(0),
     pushChanged: () => new Promise<number>(() => {}),
+    markDirty: () => Promise.resolve(),
   };
   const lock = new FakeLock();
 
@@ -302,6 +307,7 @@ Deno.test("registerDatastoreSync: hanging pullChanged surfaces SyncTimeoutError"
   const hangingService = {
     pullChanged: () => new Promise<number>(() => {}),
     pushChanged: () => Promise.resolve(0),
+    markDirty: () => Promise.resolve(),
   };
 
   // Pull-path timeouts throw SyncTimeoutError directly (not wrapped) so
@@ -330,6 +336,7 @@ Deno.test("registerDatastoreSyncNamed: pull timeout cleans up entry and releases
   const hanging = {
     pullChanged: () => new Promise<number>(() => {}),
     pushChanged: () => Promise.resolve(0),
+    markDirty: () => Promise.resolve(),
   };
   const lock = new FakeLock();
 
@@ -362,6 +369,7 @@ Deno.test("registerDatastoreSyncNamed: lock acquire failure removes entry", asyn
   const service = {
     pullChanged: () => Promise.resolve(0),
     pushChanged: () => Promise.resolve(0),
+    markDirty: () => Promise.resolve(),
   };
   const failingLock = {
     async acquire() {
@@ -403,6 +411,7 @@ Deno.test("flushDatastoreSync: normal settlement within timeout does not throw",
   const fastService = {
     pullChanged: () => Promise.resolve(0),
     pushChanged: () => Promise.resolve(3),
+    markDirty: () => Promise.resolve(),
   };
 
   await registerDatastoreSync({
@@ -465,10 +474,12 @@ Deno.test("flushDatastoreSync: one entry's timeout still flushes other entries",
   const hanging = {
     pullChanged: () => Promise.resolve(0),
     pushChanged: () => new Promise<number>(() => {}),
+    markDirty: () => Promise.resolve(),
   };
   const fast = {
     pullChanged: () => Promise.resolve(0),
     pushChanged: () => Promise.resolve(0),
+    markDirty: () => Promise.resolve(),
   };
   const lockA = new FakeLock();
   const lockB = new FakeLock();
@@ -507,6 +518,7 @@ Deno.test("flushDatastoreSync: config timeout is honored end-to-end", async () =
   const hangingService = {
     pullChanged: () => Promise.resolve(0),
     pushChanged: () => new Promise<number>(() => {}),
+    markDirty: () => Promise.resolve(),
   };
   const cfg = {
     type: "@test/integration",

--- a/src/infrastructure/persistence/repository_factory.ts
+++ b/src/infrastructure/persistence/repository_factory.ts
@@ -64,6 +64,7 @@ import type { RepoIndexService } from "../../domain/repo/repo_index_service.ts";
 import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 import { YamlVaultConfigRepository } from "./yaml_vault_config_repository.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
+import type { MarkDirtyHook } from "../../domain/datastore/datastore_sync_service.ts";
 import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
 import { CatalogStore } from "./catalog_store.ts";
 import { DataQueryService } from "../../domain/data/data_query_service.ts";
@@ -126,8 +127,10 @@ export function createDefinitionRepository(
  */
 export function createEvaluatedDefinitionRepository(
   repoDir: string,
+  baseDir?: string,
+  markDirty?: MarkDirtyHook,
 ): YamlEvaluatedDefinitionRepository {
-  return new YamlEvaluatedDefinitionRepository(repoDir);
+  return new YamlEvaluatedDefinitionRepository(repoDir, baseDir, markDirty);
 }
 
 /**
@@ -146,8 +149,14 @@ export function createUnifiedDataRepository(
   repoDir: string,
   catalogStore: CatalogStore,
   baseDir?: string,
+  markDirty?: MarkDirtyHook,
 ): FileSystemUnifiedDataRepository {
-  return new FileSystemUnifiedDataRepository(repoDir, baseDir, catalogStore);
+  return new FileSystemUnifiedDataRepository(
+    repoDir,
+    baseDir,
+    catalogStore,
+    markDirty,
+  );
 }
 
 /**
@@ -158,8 +167,12 @@ export function createUnifiedDataRepository(
  * @param repoDir - The repository directory path
  * @returns A new YamlOutputRepository instance
  */
-export function createOutputRepository(repoDir: string): YamlOutputRepository {
-  return new YamlOutputRepository(repoDir);
+export function createOutputRepository(
+  repoDir: string,
+  baseDir?: string,
+  markDirty?: MarkDirtyHook,
+): YamlOutputRepository {
+  return new YamlOutputRepository(repoDir, baseDir, markDirty);
 }
 
 /**
@@ -187,8 +200,10 @@ export function createWorkflowRepository(
 export function createWorkflowRunRepository(
   repoDir: string,
   eventBus?: EventBus,
+  baseDir?: string,
+  markDirty?: MarkDirtyHook,
 ): YamlWorkflowRunRepository {
-  return new YamlWorkflowRunRepository(repoDir, eventBus);
+  return new YamlWorkflowRunRepository(repoDir, eventBus, baseDir, markDirty);
 }
 
 /**
@@ -223,6 +238,14 @@ export interface RepositoryFactoryConfig {
   yamlWorkflowsDir?: string;
   vaultsDir?: string;
   datastoreResolver?: DatastorePathResolver;
+  /**
+   * Hook wired through to every datastore-tier repository so cache writes
+   * invalidate the sync service's fast-path watermark. Supplied by the CLI
+   * when a remote datastore with a sync service is active; absent for
+   * filesystem datastores. When absent, writes do not notify — which is
+   * correct for datastores without a fast-path. See `design/datastores.md`.
+   */
+  markDirty?: MarkDirtyHook;
 }
 
 /**
@@ -261,6 +284,7 @@ export function createRepositoryContext(
     yamlWorkflowsDir,
     vaultsDir,
     datastoreResolver,
+    markDirty,
   } = config;
 
   // Helper to resolve datastore-tier base directories
@@ -292,17 +316,21 @@ export function createRepositoryContext(
     extensionWorkflowRepo,
   );
 
-  // Datastore-tier repositories get resolved base directories
+  // Datastore-tier repositories get resolved base directories. markDirty
+  // is only wired when the caller supplies one — bare factory consumers
+  // (tests, filesystem datastores) pass undefined and writes do not notify.
   const workflowRunRepo = new YamlWorkflowRunRepository(
     repoDir,
     enableIndexing ? eventBus : undefined,
     dsPath(SWAMP_SUBDIRS.workflowRuns),
+    markDirty,
   );
 
   // Evaluated definition repository (derived data, no events)
   const evaluatedDefinitionRepo = new YamlEvaluatedDefinitionRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.definitionsEvaluated),
+    markDirty,
   );
 
   // Create catalog store for data query
@@ -313,6 +341,7 @@ export function createRepositoryContext(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     catalogStore,
+    markDirty,
   );
 
   // Construct the query service alongside its dependencies so consumers
@@ -322,6 +351,7 @@ export function createRepositoryContext(
   const outputRepo = new YamlOutputRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.outputs),
+    markDirty,
   );
 
   // Vault config repository with event bus

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -33,6 +33,7 @@ import {
   parseDataDuration,
 } from "../../domain/data/mod.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
+import type { MarkDirtyHook } from "../../domain/datastore/datastore_sync_service.ts";
 import type { CatalogStore } from "./catalog_store.ts";
 
 const logger = getSwampLogger(["data", "repository"]);
@@ -438,8 +439,21 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     private readonly repoDir: string,
     baseDir: string | undefined,
     private readonly catalogStore: CatalogStore,
+    private readonly markDirty?: MarkDirtyHook,
   ) {
     this.baseDir = baseDir ?? swampPath(repoDir, SWAMP_SUBDIRS.data);
+  }
+
+  /**
+   * Signals the configured sync service that the cache has uncommitted work.
+   *
+   * Called at the start of every mutation that writes into (or removes from)
+   * the cache directory. The hook is no-op when no sync service is wired —
+   * e.g. filesystem datastores, or when constructing the repository outside
+   * a CLI sync lifecycle. See `design/datastores.md` for the contract.
+   */
+  private async notifyDirty(): Promise<void> {
+    if (this.markDirty) await this.markDirty();
   }
 
   /**
@@ -741,6 +755,8 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
       );
     }
 
+    await this.notifyDirty();
+
     // Check if data with this name already exists
     const existing = await this.findByName(type, modelId, data.name);
     if (existing) {
@@ -807,6 +823,8 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     dataName: string,
     content: Uint8Array,
   ): Promise<void> {
+    await this.notifyDirty();
+
     const latestVersion = await this.getLatestVersion(type, modelId, dataName);
     if (latestVersion === null) {
       throw new Error(`No existing data found for "${dataName}"`);
@@ -924,6 +942,8 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     dataName: string,
     version?: number,
   ): Promise<void> {
+    await this.notifyDirty();
+
     if (version !== undefined) {
       // Delete specific version
       const versionDir = this.getPath(type, modelId, dataName, version);
@@ -989,6 +1009,8 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     modelId: string,
     dataName: string,
   ): Promise<void> {
+    await this.notifyDirty();
+
     const dataNameDir = this.getDataNameDir(type, modelId, dataName);
     const latestSymlink = join(dataNameDir, "latest");
 
@@ -1017,6 +1039,8 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
       newVersion: number;
     }
   > {
+    await this.notifyDirty();
+
     // Read the latest version of old data
     const oldData = await this.findByName(type, modelId, oldName);
     if (!oldData) {
@@ -1173,6 +1197,8 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
       );
     }
 
+    await this.notifyDirty();
+
     // Validate ownership if data with this name already exists
     const existing = await this.findByName(type, modelId, data.name);
     if (existing) {
@@ -1208,6 +1234,8 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     data: Data,
     version: number,
   ): Promise<{ size: number; checksum: string }> {
+    await this.notifyDirty();
+
     const contentPath = this.getContentPath(
       type,
       modelId,
@@ -1524,6 +1552,10 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     const dryRun = options?.dryRun ?? false;
     let versionsRemoved = 0;
     let bytesReclaimed = 0;
+
+    // Dry-run does not touch the cache; live runs remove version directories
+    // and rewrite the latest marker, both of which are cache writes.
+    if (!dryRun) await this.notifyDirty();
 
     const allData = await this.findAllForModel(type, modelId);
 

--- a/src/infrastructure/persistence/unified_data_repository_test.ts
+++ b/src/infrastructure/persistence/unified_data_repository_test.ts
@@ -493,3 +493,117 @@ Deno.test("findAllForModelSync returns empty for missing model", () => {
   const results = repo.findAllForModelSync(testType, "missing-model");
   assertEquals(results, []);
 });
+
+// Pins the markDirty contract from design/datastores.md: every public mutation
+// that writes into the cache must call the sync service's markDirty hook before
+// the write begins, so the fast-path sidecar cannot short-circuit past it.
+// Regression coverage for the datastore fast-path contract violation that
+// silently lost writes when the sidecar stayed clean.
+Deno.test("mutations call markDirty before writing", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const catalogStore = new CatalogStore(join(tmpDir, "_catalog.db"));
+    const calls: string[] = [];
+    const markDirty = () => {
+      calls.push("markDirty");
+      return Promise.resolve();
+    };
+    const repo = new FileSystemUnifiedDataRepository(
+      tmpDir,
+      undefined,
+      catalogStore,
+      markDirty,
+    );
+
+    // save
+    const data = makeData("mark-dirty-save");
+    await repo.save(
+      testType,
+      "model-1",
+      data,
+      new TextEncoder().encode("hello"),
+    );
+    assertEquals(calls.length, 1);
+
+    // allocateVersion + finalizeVersion
+    const data2 = makeData("mark-dirty-alloc");
+    const { version, contentPath } = await repo.allocateVersion(
+      testType,
+      "model-1",
+      data2,
+    );
+    assertEquals(calls.length, 2);
+    await Deno.writeFile(contentPath, new TextEncoder().encode("direct"));
+    await repo.finalizeVersion(testType, "model-1", data2, version);
+    assertEquals(calls.length, 3);
+
+    // rename
+    await repo.rename(testType, "model-1", "mark-dirty-save", "mark-dirty-ren");
+    // rename calls markDirty once at entry + once per internal save()
+    // (the new-name save). Both are cache writes, so both signals are
+    // legitimate. Pin ≥ 4 to assert at-least-once-per-mutation without
+    // overspecifying internal call count.
+    if (calls.length < 4) {
+      throw new Error(`rename did not call markDirty: ${calls.length}`);
+    }
+    const afterRename = calls.length;
+
+    // delete (specific version then all)
+    await repo.delete(testType, "model-1", "mark-dirty-ren", 1);
+    assertEquals(calls.length, afterRename + 1);
+    await repo.delete(testType, "model-1", "mark-dirty-ren");
+    assertEquals(calls.length, afterRename + 2);
+
+    // collectGarbage (live)
+    await repo.collectGarbage(testType, "model-1");
+    assertEquals(calls.length, afterRename + 3);
+
+    // collectGarbage (dry-run) must not notify — it does not touch the cache
+    const before = calls.length;
+    await repo.collectGarbage(testType, "model-1", { dryRun: true });
+    assertEquals(calls.length, before);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("markDirty is not called on read paths", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const catalogStore = new CatalogStore(join(tmpDir, "_catalog.db"));
+    const calls: string[] = [];
+    const markDirty = () => {
+      calls.push("markDirty");
+      return Promise.resolve();
+    };
+    const repo = new FileSystemUnifiedDataRepository(
+      tmpDir,
+      undefined,
+      catalogStore,
+      markDirty,
+    );
+
+    // Seed data with a write (counts as 1 call).
+    const data = makeData("read-probe");
+    await repo.save(
+      testType,
+      "model-1",
+      data,
+      new TextEncoder().encode("x"),
+    );
+    assertEquals(calls.length, 1);
+
+    // All reads below must not increment the count.
+    await repo.findAllGlobal();
+    await repo.findByName(testType, "model-1", "read-probe");
+    await repo.findAllForModel(testType, "model-1");
+    await repo.listVersions(testType, "model-1", "read-probe");
+    await repo.getContent(testType, "model-1", "read-probe");
+    repo.findAllForModelSync(testType, "model-1");
+    repo.findByNameSync(testType, "model-1", "read-probe");
+    repo.getContentSync(testType, "model-1", "read-probe");
+    assertEquals(calls.length, 1);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});

--- a/src/infrastructure/persistence/yaml_evaluated_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_definition_repository.ts
@@ -31,6 +31,7 @@ import {
   type DefinitionData,
   type DefinitionId,
 } from "../../domain/definitions/definition.ts";
+import type { MarkDirtyHook } from "../../domain/datastore/datastore_sync_service.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 
 /**
@@ -48,9 +49,14 @@ export class YamlEvaluatedDefinitionRepository {
   constructor(
     private readonly repoDir: string,
     baseDir?: string,
+    private readonly markDirty?: MarkDirtyHook,
   ) {
     this.baseDir = baseDir ??
       swampPath(repoDir, SWAMP_SUBDIRS.definitionsEvaluated);
+  }
+
+  private async notifyDirty(): Promise<void> {
+    if (this.markDirty) await this.markDirty();
   }
 
   /**
@@ -234,6 +240,8 @@ export class YamlEvaluatedDefinitionRepository {
    * @param definition - The evaluated definition to save
    */
   async save(type: ModelType, definition: Definition): Promise<void> {
+    await this.notifyDirty();
+
     const dir = this.getTypeDir(type);
     await assertSafePath(dir, this.baseDir);
     await ensureDir(dir);
@@ -259,6 +267,8 @@ export class YamlEvaluatedDefinitionRepository {
    * @param id - The definition ID
    */
   async delete(type: ModelType, id: DefinitionId): Promise<void> {
+    await this.notifyDirty();
+
     const path = this.getPath(type, id);
 
     try {
@@ -304,6 +314,8 @@ export class YamlEvaluatedDefinitionRepository {
    * Used when needing to regenerate all evaluations.
    */
   async clearAll(): Promise<void> {
+    await this.notifyDirty();
+
     const definitionsDir = this.baseDir;
     try {
       await Deno.remove(definitionsDir, { recursive: true });

--- a/src/infrastructure/persistence/yaml_output_repository.ts
+++ b/src/infrastructure/persistence/yaml_output_repository.ts
@@ -31,6 +31,7 @@ import {
 import { assertSafePath } from "./safe_path.ts";
 import type { OutputRepository } from "../../domain/models/repositories.ts";
 import type { DefinitionId } from "../../domain/definitions/definition.ts";
+import type { MarkDirtyHook } from "../../domain/datastore/datastore_sync_service.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
 import {
   createModelOutputId,
@@ -49,8 +50,16 @@ import { modelRegistry } from "../../domain/models/model.ts";
 export class YamlOutputRepository implements OutputRepository {
   private readonly baseDir: string;
 
-  constructor(private readonly repoDir: string, baseDir?: string) {
+  constructor(
+    private readonly repoDir: string,
+    baseDir?: string,
+    private readonly markDirty?: MarkDirtyHook,
+  ) {
     this.baseDir = baseDir ?? swampPath(repoDir, SWAMP_SUBDIRS.outputs);
+  }
+
+  private async notifyDirty(): Promise<void> {
+    if (this.markDirty) await this.markDirty();
   }
 
   async findById(
@@ -166,6 +175,8 @@ export class YamlOutputRepository implements OutputRepository {
     method: string,
     output: ModelOutput,
   ): Promise<void> {
+    await this.notifyDirty();
+
     const dir = this.getMethodDir(type, method);
     await assertSafePath(dir, this.baseDir);
     await ensureDir(dir);
@@ -187,6 +198,8 @@ export class YamlOutputRepository implements OutputRepository {
     method: string,
     id: ModelOutputId,
   ): Promise<void> {
+    await this.notifyDirty();
+
     // We need to find the file first since filename includes timestamp
     const dir = this.getMethodDir(type, method);
     try {

--- a/src/infrastructure/persistence/yaml_output_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_output_repository_test.ts
@@ -363,3 +363,31 @@ Deno.test("YamlOutputRepository.getPath uses correct format", () => {
   assertStringIncludes(path, "2023-01-15T10-30-00-000Z");
   assertStringIncludes(path, ".yaml");
 });
+
+Deno.test("YamlOutputRepository invokes markDirty on mutations", async () => {
+  await withTempDir(async (dir) => {
+    const calls: string[] = [];
+    const markDirty = () => {
+      calls.push("markDirty");
+      return Promise.resolve();
+    };
+    const repo = new YamlOutputRepository(dir, undefined, markDirty);
+
+    const output = ModelOutput.create({
+      definitionId: createDefinitionId(crypto.randomUUID()),
+      methodName: "create",
+      provenance: defaultProvenance,
+    });
+
+    await repo.save(testType, "create", output);
+    assertEquals(calls.length, 1);
+
+    await repo.delete(testType, "create", output.id);
+    assertEquals(calls.length, 2);
+
+    // Reads do not notify.
+    await repo.findAll(testType);
+    await repo.findById(testType, "create", output.id);
+    assertEquals(calls.length, 2);
+  });
+});

--- a/src/infrastructure/persistence/yaml_workflow_run_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository.ts
@@ -22,6 +22,7 @@ import { join } from "@std/path";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import { atomicWriteTextFile } from "./atomic_write.ts";
 import type { WorkflowRunRepository } from "../../domain/workflows/repositories.ts";
+import type { MarkDirtyHook } from "../../domain/datastore/datastore_sync_service.ts";
 import {
   SWAMP_SUBDIRS,
   swampPath,
@@ -58,8 +59,13 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
     private readonly repoDir: string,
     private readonly eventBus?: EventBus,
     baseDir?: string,
+    private readonly markDirty?: MarkDirtyHook,
   ) {
     this.baseDir = baseDir ?? swampPath(repoDir, SWAMP_SUBDIRS.workflowRuns);
+  }
+
+  private async notifyDirty(): Promise<void> {
+    if (this.markDirty) await this.markDirty();
   }
 
   async findById(
@@ -175,6 +181,8 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
   }
 
   async save(workflowId: WorkflowId, run: WorkflowRun): Promise<void> {
+    await this.notifyDirty();
+
     const dir = this.getRunsDir(workflowId);
     await assertSafePath(dir, this.baseDir);
     await ensureDir(dir);
@@ -259,6 +267,8 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
     if (count === 0) {
       return 0;
     }
+
+    await this.notifyDirty();
 
     try {
       await Deno.remove(dir, { recursive: true });

--- a/src/infrastructure/persistence/yaml_workflow_run_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository_test.ts
@@ -389,3 +389,38 @@ Deno.test("YamlWorkflowRunRepository.deleteAllByWorkflowId does not affect other
     assertEquals(runs2After.length, 1);
   });
 });
+
+Deno.test("YamlWorkflowRunRepository invokes markDirty on mutations", async () => {
+  await withTempDir(async (dir) => {
+    const calls: string[] = [];
+    const markDirty = () => {
+      calls.push("markDirty");
+      return Promise.resolve();
+    };
+    const repo = new YamlWorkflowRunRepository(
+      dir,
+      undefined,
+      undefined,
+      markDirty,
+    );
+
+    const workflow = createTestWorkflow();
+    const run = WorkflowRun.create(workflow);
+    run.start();
+
+    await repo.save(workflow.id, run);
+    assertEquals(calls.length, 1);
+
+    await repo.findById(workflow.id, run.id);
+    await repo.findAllByWorkflowId(workflow.id);
+    assertEquals(calls.length, 1);
+
+    await repo.deleteAllByWorkflowId(workflow.id);
+    assertEquals(calls.length, 2);
+
+    // deleteAllByWorkflowId on an empty workflow is a no-op and must not
+    // notify — nothing was written or removed.
+    await repo.deleteAllByWorkflowId(workflow.id);
+    assertEquals(calls.length, 2);
+  });
+});

--- a/src/libswamp/datastores/setup_test.ts
+++ b/src/libswamp/datastores/setup_test.ts
@@ -185,6 +185,7 @@ function createStubProvider(
         createSyncService: () => ({
           pullChanged: () => Promise.resolve(),
           pushChanged: () => Promise.resolve(),
+          markDirty: () => Promise.resolve(),
         }),
       }
       : {}),

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -25,6 +25,7 @@
 import { z } from "zod";
 import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
 import type { DatastoreConfig } from "../domain/datastore/datastore_config.ts";
+import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
 import { createLibSwampContext, modelMethodRun } from "../libswamp/mod.ts";
 import { createModelMethodRunDeps, executeWorkflowWithLocks } from "./deps.ts";
 import { serializeEvent } from "./serializer.ts";
@@ -100,6 +101,12 @@ export interface ConnectionContext {
   repoDir: string;
   repoContext: RepositoryContext;
   datastoreConfig: DatastoreConfig;
+  /**
+   * Shared sync service instance. Same one the repo context's markDirty hook
+   * references — see `design/datastores.md`. Undefined for filesystem
+   * datastores or custom datastores without a cache.
+   */
+  syncService?: DatastoreSyncService;
 }
 
 export function handleConnection(
@@ -220,6 +227,7 @@ async function handleWorkflowRun(
         );
         send(socket, { type: "event", id: requestId, event: serialized });
       },
+      ctx.syncService,
     );
   } catch (error) {
     if (error instanceof DOMException && error.name === "AbortError") {
@@ -254,6 +262,7 @@ async function handleModelMethodRun(
           modelId: preResult.definition.id,
         }],
         ctx.repoDir,
+        ctx.syncService,
       );
       if (lockResult.synced) ctx.repoContext.catalogStore.invalidate();
       flushLocks = lockResult.flush;

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -55,6 +55,7 @@ import { vaultTypeRegistry } from "../domain/vaults/vault_type_registry.ts";
 import { driverTypeRegistry } from "../domain/drivers/driver_type_registry.ts";
 import { reportRegistry } from "../domain/reports/report_registry.ts";
 import type { DatastoreConfig } from "../domain/datastore/datastore_config.ts";
+import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
 import { acquireModelLocks } from "../cli/repo_context.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 
@@ -179,6 +180,13 @@ export async function executeWorkflowWithLocks(
   input: WorkflowRunInput,
   signal: AbortSignal,
   onEvent: (event: WorkflowRunEvent) => void,
+  /**
+   * Sync service shared with the repo context's markDirty hook so the
+   * fast-path watermark read here sees the writes the hook flipped. See
+   * `design/datastores.md` for the contract; omit only for filesystem
+   * datastores where no service exists.
+   */
+  syncService?: DatastoreSyncService,
 ): Promise<void> {
   let flushLocks: (() => Promise<void>) | null = null;
 
@@ -216,6 +224,7 @@ export async function executeWorkflowWithLocks(
             datastoreConfig,
             resolvedModels,
             repoDir,
+            syncService,
           );
           if (lockResult.synced) repoContext.catalogStore.invalidate();
           flushLocks = lockResult.flush;

--- a/src/serve/open/http.ts
+++ b/src/serve/open/http.ts
@@ -83,6 +83,7 @@ import {
 import { acquireModelLocks } from "../../cli/repo_context.ts";
 import type { RepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
 import type { DatastoreConfig } from "../../domain/datastore/datastore_config.ts";
+import type { DatastoreSyncService } from "../../domain/datastore/datastore_sync_service.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 import { OPEN_UI_HTML } from "./ui.ts";
 import { FAVICON_SVG } from "./favicon.ts";
@@ -99,6 +100,8 @@ export interface OpenServerState {
   repoDir: string | null;
   repoContext: RepositoryContext | null;
   datastoreConfig: DatastoreConfig | null;
+  /** Shared sync service — see `design/datastores.md` markDirty contract. */
+  syncService: DatastoreSyncService | null;
   extClient: ExtensionApiClient;
   version: string;
   initializeRepo: (repoDir: string) => Promise<void>;
@@ -115,6 +118,7 @@ interface InitializedDeps {
   repoDir: string;
   repoContext: RepositoryContext;
   datastoreConfig: DatastoreConfig;
+  syncService: DatastoreSyncService | null;
   extClient: ExtensionApiClient;
 }
 
@@ -126,6 +130,7 @@ function requireRepo(state: OpenServerState): InitializedDeps | null {
     repoDir: state.repoDir,
     repoContext: state.repoContext,
     datastoreConfig: state.datastoreConfig,
+    syncService: state.syncService,
     extClient: state.extClient,
   };
 }
@@ -1756,12 +1761,17 @@ async function handleRun(
     }, { status: 404 });
   }
 
-  const lockResult = await acquireModelLocks(deps.datastoreConfig, [
-    {
-      modelType: preResult.type.normalized,
-      modelId: preResult.definition.id,
-    },
-  ], deps.repoDir);
+  const lockResult = await acquireModelLocks(
+    deps.datastoreConfig,
+    [
+      {
+        modelType: preResult.type.normalized,
+        modelId: preResult.definition.id,
+      },
+    ],
+    deps.repoDir,
+    deps.syncService ?? undefined,
+  );
   if (lockResult.synced) deps.repoContext.catalogStore.invalidate();
   const flushLocks = lockResult.flush;
 

--- a/src/serve/open/http_test.ts
+++ b/src/serve/open/http_test.ts
@@ -32,6 +32,7 @@ function stubState(): OpenServerState {
     repoDir: null,
     repoContext: null,
     datastoreConfig: null,
+    syncService: null,
     extClient,
     version: "test-version",
     initializeRepo: () => Promise.resolve(),

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -25,6 +25,7 @@
 
 import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
 import type { DatastoreConfig } from "../domain/datastore/datastore_config.ts";
+import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
 import { UserError } from "../domain/errors.ts";
 import { executeWorkflowWithLocks } from "./deps.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
@@ -216,6 +217,8 @@ export interface WebhookServiceDeps {
   repoContext: RepositoryContext;
   datastoreConfig: DatastoreConfig;
   endpoints: WebhookEndpoint[];
+  /** Shared sync service; see `design/datastores.md` markDirty contract. */
+  syncService?: DatastoreSyncService;
 }
 
 /**
@@ -409,6 +412,7 @@ export class WebhookService {
             runId = event.runId;
           }
         },
+        this.deps.syncService,
       );
 
       this.emit({


### PR DESCRIPTION
## Summary

The s3/gcs zero-diff fast path in `DatastoreSyncService` maintains a
local-dirty watermark that it flips during its own `pushFile`-equivalent.
Swamp core writes into the cache directly from the persistence
repositories (`UnifiedDataRepository`, `YamlOutputRepository`,
`YamlWorkflowRunRepository`, `YamlEvaluatedDefinitionRepository`), which
bypasses that hook — the next `pushChanged` short-circuits past the
write and the data lives only in the local cache until eviction. Single
writer setups against a low-traffic bucket are most exposed; high
traffic masks the bug because unrelated remote mutations invalidate the
sidecar.

### Fix

- Add a required `markDirty()` method to `DatastoreSyncService` (mirrored
  in `packages/testing/datastore_types.ts`).
- Every public mutation on the four datastore-tier repositories calls
  `notifyDirty()` before any cache write begins, so a crash mid-write
  still leaves the watermark dirty — per-method (not per-atomicWrite)
  keeps the repositories clean and the hook is idempotent anyway.
- Single sync service instance threads through
  `requireInitializedRepoUnlocked` → `acquireModelLocks` and through the
  serve context (`OpenServerState`, `ConnectionContext`,
  `WebhookServiceDeps`), so an implementation that caches the sidecar
  flag in memory stays coherent across the `markDirty` hook and the
  pull/push fast-path read. The \`acquireModelLocks\` param is optional
  for backward compatibility; every caller in the repo now passes one.
- Document the contract under the Zero-Diff Fast Path section in
  \`design/datastores.md\`.
- Filesystem datastores wire no service; \`notifyDirty\` is a no-op for
  them.

### Extension follow-up

The required interface change surfaces as a compile-time signal to
extension authors (\`@swamp/s3-datastore\`, \`@swamp/gcs-datastore\`,
swamp-club/166) that they need to implement \`markDirty()\` — trivial:
it's the same primitive as their internal \`pushFile\` hook's dirty-flip.

## Test Plan

- [x] New repository contract tests pin \`markDirty\` invocation on every
      public mutation, including the negative cases (reads, dry-run GC,
      no-op delete) where it must not fire.
- [x] Existing \`datastore_sync_service_test.ts\` still passes; 12 stub
      sync services across tests updated to include the new field.
- [x] \`testing_package_compat_test.ts\` structurally verifies the
      \`@systeminit/swamp-testing\` mirror still matches core.
- [x] \`deno check\`, \`deno lint\`, \`deno fmt --check\`,
      \`deno run test\` (4854 passed, 0 failed, 1 ignored),
      \`deno run compile\` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)