### PR TITLE
docs(skills): document markDirty in swamp-extension-datastore

### DIFF
--- a/.claude/skills/swamp-extension-datastore/references/api.md
+++ b/.claude/skills/swamp-extension-datastore/references/api.md
@@ -165,6 +165,7 @@ Optional interface for remote datastore synchronization.
 interface DatastoreSyncService {
   pullChanged(): Promise<void>;
   pushChanged(): Promise<void>;
+  markDirty(): Promise<void>;
 }
 ```
 
@@ -177,3 +178,19 @@ read/write operations on remote datastores.
 
 Push changed files from the local cache to the remote datastore. Called after
 write operations complete.
+
+### `markDirty()`
+
+Signal that the local cache has uncommitted work. Swamp core calls this at the
+start of every repository-layer mutation that writes into the cache (e.g.
+`save`, `delete`, `rename`), **before** the write begins — a crash mid-write
+still leaves the watermark dirty.
+
+The method only matters for implementations that maintain a clean/dirty
+watermark to short-circuit zero-diff syncs (the recommended fast-path pattern —
+see `design/datastores.md`). Those implementations MUST flip the watermark to
+dirty here so the next `pushChanged` cannot skip past core's writes.
+Implementations that unconditionally walk the cache on every `pushChanged` have
+nothing to invalidate and can return `Promise.resolve()`.
+
+`markDirty()` must be idempotent and cheap — core does not deduplicate calls.

--- a/.claude/skills/swamp-extension-datastore/references/examples.md
+++ b/.claude/skills/swamp-extension-datastore/references/examples.md
@@ -245,6 +245,13 @@ export const datastore = {
           // Upload changed files from cachePath to remote
           console.log(`Pushing from ${cachePath} to ${parsed.endpoint}`);
         },
+        markDirty: () => {
+          // Swamp core calls this before every cache write. If your
+          // pushChanged walks the cache unconditionally, there's nothing
+          // to invalidate — no-op. If you add a clean/dirty sidecar
+          // (fast-path pattern in design/datastores.md), flip it here.
+          return Promise.resolve();
+        },
       }),
 
       resolveDatastorePath: (repoDir: string) => {


### PR DESCRIPTION
## Summary

Pick up the \`markDirty()\` addition from #1225 in the skill that guides
authors building custom datastore providers.

- \`references/api.md\` — interface block includes \`markDirty(): Promise<void>\`,
  plus a section describing when it's load-bearing (fast-path implementations
  that cache a clean/dirty watermark) versus when a no-op is correct (sync
  services that unconditionally walk the cache).
- \`references/examples.md\` — the working sync service example returns a
  no-op \`markDirty\` with a comment pointing at the fast-path pattern in
  \`design/datastores.md\`.

No code changes, docs only — keeps guidance for extension authors in
lock-step with the core interface change that already shipped.

## Test Plan

- [x] \`deno fmt\` clean per the skill-files rule in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)