### PR TITLE
ci: add manually-triggered Cross Platform Builds workflow

### DIFF
--- a/.github/workflows/cross-platform-builds.yml
+++ b/.github/workflows/cross-platform-builds.yml
@@ -1,0 +1,39 @@
+name: Cross Platform Builds
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Cross Platform Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Run deno lint
+        run: deno lint
+
+      - name: Run deno fmt --check
+        run: deno fmt --check
+
+      - name: Run deno check
+        run: deno task check
+
+      - name: Run deno test
+        run: deno task test
+
+      - name: Compile binary
+        run: deno task compile


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/cross-platform-builds.yml`, a manually-triggered workflow that runs the full pipeline (lint, check, test, compile) on `windows-latest` and `macos-latest`.
- Triggered via `workflow_dispatch` only — does **not** run on PRs, pushes, or a schedule, so there's no CI noise on regular work.
- First step in incremental Windows-support effort. The first run produces the failure inventory we'll work through; subsequent runs verify progress.

## How to invoke

Via GitHub UI: Actions → Cross Platform Builds → Run workflow

Or CLI:
```bash
gh workflow run cross-platform-builds.yml
```

## Why workflow_dispatch only?

Until Windows support exists, every triggered run will fail loudly. Wiring it to PRs or a schedule would mean red checks / red emails on every workday — alert fatigue, and the signal stops being useful. On-demand runs let us capture the failure list when we want it (now, and after each Windows-support PR) without polluting unrelated work.

Once Windows support is complete, a follow-up PR can flip the triggers to `pull_request` and remove this manual step.

## Test plan

- [ ] Open and merge PR.
- [ ] From the Actions tab, manually trigger "Cross Platform Builds" against `main`.
- [ ] Confirm both `Cross Platform Build (windows-latest)` and `Cross Platform Build (macos-latest)` jobs run independently (`fail-fast: false` keeps macOS running when Windows fails).
- [ ] Capture the Windows failure list to inform PR 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)