### PR TITLE
ci: add .gitattributes to pin line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Pin line endings to LF for all text files. Without this, Windows
+# checkouts default to core.autocrlf=true, which converts LF -> CRLF
+# and trips deno fmt --check.
+* text=auto eol=lf
+
+# Explicit binary types (don't auto-detect)
+*.png binary
+*.jpg binary
+*.gz binary


### PR DESCRIPTION
## Summary

Adds a top-level `.gitattributes` that pins all text files to LF line endings. Without this, Windows checkouts default to `core.autocrlf=true`, converting LF → CRLF and tripping `deno fmt --check`.

## Motivation

The first manually-triggered run of the [Cross Platform Builds workflow](https://github.com/systeminit/swamp/actions/runs/25049336361) (added in #1233) showed Windows failing at step 4 (`deno fmt --check`) on every text file with `Text differed by line endings`. macOS came back fully green. With `deno fmt` failing, the rest of the pipeline (`deno check`, `deno test`, `deno task compile`) is shadowed and can't be observed.

This PR is the prerequisite for surfacing the actual Windows code-level failures.

## Effect

- **macOS / Linux**: zero change. Existing files already have LF in the index.
- **Windows**: fresh checkouts (including CI) get LF. `deno fmt --check` will pass on text files.
- **Anyone cloning the repo on Windows**: same benefit going forward.

## Test plan

- [ ] Merge PR.
- [ ] Manually re-trigger the Cross Platform Builds workflow against `main`.
- [ ] Confirm `deno fmt --check` now passes on `windows-latest`.
- [ ] Capture the next failure (likely in `deno check`, `deno test`, or `compile`) to inform the next Windows-support PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)