### PR TITLE
fix(extensions): surface silent local extension load failures (swamp-club#177)

### DIFF
--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -129,6 +129,11 @@ one's checkpoint catches a class of regression the next step can't.
    [When to Create a Custom Model](#when-to-create-a-custom-model).
 2. **Author the model file** — copy [Quick Start](#quick-start); `deno check`.
 3. **Verify registration** — `swamp model type search --json` shows the type.
+   Files in `extensions/models/` are auto-discovered on first use; you do
+   **not** need `swamp extension source add` for this directory. If the type
+   does not appear, check stderr for `swamp-warning:` lines naming the model
+   file — they identify validation or type-extraction failures that would
+   otherwise be silent.
 4. **Smoke test** against live APIs —
    [references/smoke_testing.md](references/smoke_testing.md).
 5. **Unit tests** — colocate `*_test.ts`; `deno test` passes.
@@ -422,8 +427,20 @@ Sources override pulled extensions of the same type — if you're developing a
 local copy of a pulled extension, add it as a source and your version loads
 instead.
 
+`extensions/models/` is the **default** local-discovery directory and never
+needs to be registered with `swamp extension source add`. The source-add flow
+exists for OTHER directories outside the repo (a sibling clone of an extension
+you're developing, a shared toolbox dir on the filesystem, etc.). Pointing
+`extension source add` at `extensions/models/` is a no-op at best and a
+confusing duplicate at worst.
+
 Files are classified by export name: `export const model` defines new types,
 `export const extension` adds methods to existing types.
+
+When a model file fails to load — bad `version`, missing required fields,
+non-literal `type` expression, syntax error — swamp emits a stderr line prefixed
+`swamp-warning:` naming the file and the error. Watch stderr if a type isn't
+appearing as expected.
 
 ### Testing Extensions from a Separate Repo
 

--- a/.claude/skills/swamp-troubleshooting/SKILL.md
+++ b/.claude/skills/swamp-troubleshooting/SKILL.md
@@ -228,6 +228,29 @@ swamp source clean --json
 - Use `--version main` to get the latest unreleased code
 - Use `--version <tag>` to get a specific release
 
+## Local Extension Model Not Appearing in Type Search
+
+If a model file at `extensions/models/<name>.ts` doesn't show up in
+`swamp model type search`:
+
+1. **Check stderr.** Swamp emits one `swamp-warning:` line per failed extension
+   load, naming the file and the error. The line goes to stderr (not stdout) so
+   it stays out of `--json` output but is still visible. Common causes:
+   - Missing or invalid `version` field — must be CalVer (`YYYY.MM.DD.MICRO`).
+   - `type` is a variable instead of a string literal — the catalog extracts the
+     type via regex and only matches literal strings.
+   - Bundle failure (syntax error, unresolvable import).
+2. **Do NOT run `swamp extension source add extensions/models`.** That path is
+   auto-discovered by default; registering it as a source is a no-op that adds
+   confusion. The source-add flow is for directories _outside_ the repo.
+3. **Confirm `deno check` passes** on the file. Type errors that pass
+   `deno check` may still be rejected by swamp's stricter validation (e.g.
+   missing `version`).
+
+The discovery code lives in `src/cli/mod.ts` (`loadUserModels`) and
+`src/domain/models/user_model_loader.ts` (`UserModelLoader.buildIndex`). The
+stderr emitter is at `src/infrastructure/logging/extension_load_warnings.ts`.
+
 ## Source Extension Not Loading
 
 If a source extension isn't appearing in `swamp model type search`:

--- a/integration/extensions/silent_load_failure_test.ts
+++ b/integration/extensions/silent_load_failure_test.ts
@@ -1,0 +1,182 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Regression guard for swamp-club#177 — local extension models that fail
+ * to load must produce visible feedback. Two distinct failure modes
+ * (validation rejection through result.failed; regex mismatch through
+ * populateCatalogFromDir) both surface via stderr `swamp-warning:`
+ * lines. Working models in the same repo are unaffected.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { initializeTestRepo, runCliCommand } from "../test_helpers.ts";
+
+const VALID_MODEL = `
+import { z } from "npm:zod@4";
+export const model = {
+  type: "@tutorial/working",
+  version: "2026.04.28.0",
+  globalArguments: z.object({}),
+  resources: {},
+  methods: {
+    run: {
+      description: "no-op",
+      arguments: z.object({}),
+      execute: () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+// Missing version field — fails validation in loadModels (result.failed).
+const BAD_MODEL_VALIDATION = `
+import { z } from "npm:zod@4";
+export const model = {
+  type: "@tutorial/missing-version",
+  globalArguments: z.object({}),
+  resources: {},
+  methods: {
+    run: {
+      description: "no-op",
+      arguments: z.object({}),
+      execute: () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+// Type comes from a constant, not a string literal — the catalog's
+// regex-based type extractor cannot match, so populateCatalogFromDir
+// silently skips this file unless the new emit is wired in.
+const BAD_MODEL_REGEX = `
+import { z } from "npm:zod@4";
+const TYPE = "@tutorial/non-literal-type";
+export const model = {
+  type: TYPE,
+  version: "2026.04.28.0",
+  globalArguments: z.object({}),
+  resources: {},
+  methods: {
+    run: {
+      description: "no-op",
+      arguments: z.object({}),
+      execute: () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+Deno.test(
+  "silent load failure: stderr surfaces both failure modes; working model loads",
+  async () => {
+    const repoDir = await Deno.makeTempDir({
+      prefix: "swamp-issue-177-test-",
+    });
+    try {
+      await initializeTestRepo(repoDir);
+      const modelsDir = join(repoDir, "extensions", "models");
+      await ensureDir(modelsDir);
+      await Deno.writeTextFile(
+        join(modelsDir, "working.ts"),
+        VALID_MODEL,
+      );
+      await Deno.writeTextFile(
+        join(modelsDir, "missing_version.ts"),
+        BAD_MODEL_VALIDATION,
+      );
+      await Deno.writeTextFile(
+        join(modelsDir, "non_literal_type.ts"),
+        BAD_MODEL_REGEX,
+      );
+
+      const { stdout, stderr } = await runCliCommand(
+        ["--json", "model", "type", "search"],
+        repoDir,
+      );
+
+      // Working model is in stdout regardless of broken siblings.
+      const search = JSON.parse(stdout);
+      const types = (search.results as Array<{ normalized: string }>).map((
+        r,
+      ) => r.normalized);
+      assertEquals(
+        types.includes("@tutorial/working"),
+        true,
+        "valid model must appear in type search despite broken siblings",
+      );
+
+      const warningLines = stderr.split("\n").filter((l) =>
+        l.startsWith("swamp-warning:")
+      );
+      const hintLines = stderr.split("\n").filter((l) =>
+        l.trimStart().startsWith("hint:")
+      );
+
+      // Each broken file produces exactly one warning line. The validation
+      // path may emit twice (once during loadModels, once during the
+      // populate pass) — assert AT LEAST one per broken file rather than
+      // pin an exact count.
+      const validationWarning = warningLines.find((l) =>
+        l.includes("missing_version.ts")
+      );
+      const regexWarning = warningLines.find((l) =>
+        l.includes("non_literal_type.ts")
+      );
+      assertEquals(
+        typeof validationWarning,
+        "string",
+        `expected stderr to name missing_version.ts; got: ${stderr}`,
+      );
+      assertEquals(
+        typeof regexWarning,
+        "string",
+        `expected stderr to name non_literal_type.ts; got: ${stderr}`,
+      );
+      assertStringIncludes(validationWarning!, "version");
+      assertStringIncludes(regexWarning!, "string literal");
+
+      // Hint is emitted at most once per kind. Two model failures share
+      // one hint line.
+      assertEquals(
+        hintLines.length,
+        1,
+        `expected exactly one hint line; got ${hintLines.length}: ${
+          hintLines.join(" | ")
+        }`,
+      );
+      assertStringIncludes(hintLines[0], "extensions/models/");
+      assertStringIncludes(hintLines[0], "auto-discovered");
+
+      // Working model is not named in any warning line.
+      const workingMentioned = warningLines.some((l) =>
+        l.includes("working.ts")
+      );
+      assertEquals(
+        workingMentioned,
+        false,
+        "working model must not appear in warning lines",
+      );
+    } finally {
+      await Deno.remove(repoDir, { recursive: true });
+    }
+  },
+);

--- a/integration/extensions/silent_load_failure_test.ts
+++ b/integration/extensions/silent_load_failure_test.ts
@@ -17,13 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-/**
- * Regression guard for swamp-club#177 — local extension models that fail
- * to load must produce visible feedback. Two distinct failure modes
- * (validation rejection through result.failed; regex mismatch through
- * populateCatalogFromDir) both surface via stderr `swamp-warning:`
- * lines. Working models in the same repo are unaffected.
- */
+// Regression guard for swamp-club#177.
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { ensureDir } from "@std/fs";

--- a/src/cli/commands/open.ts
+++ b/src/cli/commands/open.ts
@@ -26,6 +26,7 @@ import {
 } from "../context.ts";
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import { resetExtensionLoadWarnings } from "../../infrastructure/logging/extension_load_warnings.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
 import { driverTypeRegistry } from "../../domain/drivers/driver_type_registry.ts";
@@ -89,6 +90,9 @@ async function reloadExtensionRegistries(): Promise<void> {
   vaultTypeRegistry.resetLoadedFlag();
   driverTypeRegistry.resetLoadedFlag();
   reportRegistry.resetLoadedFlag();
+  // Clear emitter dedupe state so a re-run surfaces any failures fresh
+  // instead of suppressing them as "already seen this process."
+  resetExtensionLoadWarnings();
   await Promise.all([
     modelRegistry.ensureLoaded(),
     vaultTypeRegistry.ensureLoaded(),

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -99,6 +99,15 @@ export function getOutputModeFromArgs(args: string[]): OutputMode {
 }
 
 /**
+ * Pre-parses --quiet / -q from raw CLI arguments. Used by code paths that
+ * fire before Cliffy's globalAction has parsed options (e.g. extension
+ * load warnings emitted from lazy loaders inside ensureLoaded()).
+ */
+export function isQuietFromArgs(args: string[]): boolean {
+  return args.includes("--quiet") || args.includes("-q");
+}
+
+/**
  * Pre-parses --repo-dir from raw CLI arguments before Cliffy option parsing.
  *
  * Supports both `--repo-dir <value>` and `--repo-dir=<value>` forms.

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -106,7 +106,8 @@ import { UpdateCheckCacheFileRepository } from "../infrastructure/update/update_
 import { HttpUpdateChecker } from "../infrastructure/update/http_update_checker.ts";
 import { Platform } from "../domain/update/platform.ts";
 import { renderUpdateNotification } from "../presentation/renderers/update_notification.ts";
-import { getOutputModeFromArgs } from "./context.ts";
+import { getOutputModeFromArgs, isQuietFromArgs } from "./context.ts";
+import { recordLoadFailures } from "../infrastructure/logging/extension_load_warnings.ts";
 import { flushDatastoreSync } from "../infrastructure/persistence/datastore_sync_coordinator.ts";
 import { withSpan } from "../infrastructure/tracing/mod.ts";
 import {
@@ -225,6 +226,7 @@ export async function configureExtensionLoaders(
   marker: RepoMarkerData | null,
   resolvedSources: ResolvedSourceDirs[],
   deferredWarnings: DeferredWarning[],
+  quiet = false,
 ): Promise<void> {
   const denoRuntime = new EmbeddedDenoRuntime();
   const sourceModelsDirs = collectDirsForKind(resolvedSources, "models");
@@ -260,6 +262,7 @@ export async function configureExtensionLoaders(
       sourceModelsDirs,
       lazyResolver,
       catalog,
+      quiet,
     )
   );
   vaultTypeRegistry.setLoader(() =>
@@ -270,6 +273,7 @@ export async function configureExtensionLoaders(
       sourceVaultsDirs,
       lazyResolver,
       catalog,
+      quiet,
     )
   );
   driverTypeRegistry.setLoader(() =>
@@ -280,6 +284,7 @@ export async function configureExtensionLoaders(
       sourceDriversDirs,
       lazyResolver,
       catalog,
+      quiet,
     )
   );
   datastoreTypeRegistry.setLoader(() =>
@@ -289,6 +294,7 @@ export async function configureExtensionLoaders(
       denoRuntime,
       sourceDatastoresDirs,
       catalog,
+      quiet,
     )
   );
   reportRegistry.setLoader(() =>
@@ -299,6 +305,7 @@ export async function configureExtensionLoaders(
       sourceReportsDirs,
       lazyResolver,
       catalog,
+      quiet,
     )
   );
 
@@ -372,6 +379,7 @@ async function loadUserModels(
   sourceDirs: string[] = [],
   resolverFactory?: () => Promise<DatastorePathResolver | undefined>,
   catalog?: ExtensionCatalogStore,
+  quiet = false,
 ): Promise<void> {
   try {
     const modelsDir = resolveModelsDir(marker);
@@ -416,15 +424,23 @@ async function loadUserModels(
       },
     );
 
+    const realFailures = {
+      failed: [] as Array<{ file: string; error: string }>,
+    };
     for (const failure of result.failed) {
       if (failure.error.startsWith("Cannot extend unregistered model type")) {
+        // Retryable: the base type is loaded lazily and this extension
+        // will re-attach via attachPendingExtensionsForType. Not a
+        // user-facing failure — keep it at log-only.
         logger
           .warn`User extension ${failure.file} targets unregistered base type — will retry once the base is loaded: ${failure.error}`;
       } else {
         logger
           .warn`Failed to load user model ${failure.file}: ${failure.error}`;
+        realFailures.failed.push(failure);
       }
     }
+    recordLoadFailures("model", realFailures, { quiet });
   } catch {
     // Not in a swamp repo or models dir doesn't exist — not an error
   }
@@ -441,6 +457,7 @@ async function loadUserVaults(
   sourceDirs: string[] = [],
   resolverFactory?: () => Promise<DatastorePathResolver | undefined>,
   catalog?: ExtensionCatalogStore,
+  quiet = false,
 ): Promise<void> {
   try {
     const vaultsDir = resolveVaultsDir(marker);
@@ -474,6 +491,7 @@ async function loadUserVaults(
         logger
           .warn`Failed to load user vault ${failure.file}: ${failure.error}`;
       }
+      recordLoadFailures("vault", result, { quiet });
     } else {
       const result = await loader.loadVaults(absoluteVaultsDir, {
         additionalDirs: [...sourceDirs, ...pulledDirs],
@@ -484,6 +502,7 @@ async function loadUserVaults(
         logger
           .warn`Failed to load user vault ${failure.file}: ${failure.error}`;
       }
+      recordLoadFailures("vault", result, { quiet });
     }
   } catch {
     // Not in a swamp repo or vaults dir doesn't exist — not an error
@@ -497,6 +516,7 @@ async function loadUserDrivers(
   sourceDirs: string[] = [],
   resolverFactory?: () => Promise<DatastorePathResolver | undefined>,
   catalog?: ExtensionCatalogStore,
+  quiet = false,
 ): Promise<void> {
   try {
     const driversDir = resolveDriversDir(marker);
@@ -530,6 +550,7 @@ async function loadUserDrivers(
         logger
           .warn`Failed to load user driver ${failure.file}: ${failure.error}`;
       }
+      recordLoadFailures("driver", result, { quiet });
     } else {
       const result = await loader.loadDrivers(absoluteDriversDir, {
         additionalDirs: [...sourceDirs, ...pulledDirs],
@@ -540,6 +561,7 @@ async function loadUserDrivers(
         logger
           .warn`Failed to load user driver ${failure.file}: ${failure.error}`;
       }
+      recordLoadFailures("driver", result, { quiet });
     }
   } catch {
     // Not in a swamp repo or drivers dir doesn't exist — not an error
@@ -552,6 +574,7 @@ async function loadUserDatastores(
   denoRuntime: EmbeddedDenoRuntime,
   sourceDirs: string[] = [],
   catalog?: ExtensionCatalogStore,
+  quiet = false,
 ): Promise<void> {
   try {
     const datastoresDir = resolveDatastoresDir(marker);
@@ -588,6 +611,7 @@ async function loadUserDatastores(
         logger
           .warn`Failed to load user datastore ${failure.file}: ${failure.error}`;
       }
+      recordLoadFailures("datastore", result, { quiet });
     } else {
       const result = await loader.loadDatastores(absoluteDatastoresDir, {
         additionalDirs: [...sourceDirs, ...pulledDirs],
@@ -598,6 +622,7 @@ async function loadUserDatastores(
         logger
           .warn`Failed to load user datastore ${failure.file}: ${failure.error}`;
       }
+      recordLoadFailures("datastore", result, { quiet });
     }
   } catch {
     // Not in a swamp repo or datastores dir doesn't exist — not an error
@@ -611,6 +636,7 @@ async function loadUserReports(
   sourceDirs: string[] = [],
   resolverFactory?: () => Promise<DatastorePathResolver | undefined>,
   catalog?: ExtensionCatalogStore,
+  quiet = false,
 ): Promise<void> {
   try {
     const reportsDir = resolveReportsDir(marker);
@@ -644,6 +670,7 @@ async function loadUserReports(
         logger
           .warn`Failed to load user report ${failure.file}: ${failure.error}`;
       }
+      recordLoadFailures("report", result, { quiet });
     } else {
       const result = await loader.loadReports(absoluteReportsDir, {
         additionalDirs: [...sourceDirs, ...pulledDirs],
@@ -654,6 +681,7 @@ async function loadUserReports(
         logger
           .warn`Failed to load user report ${failure.file}: ${failure.error}`;
       }
+      recordLoadFailures("report", result, { quiet });
     }
   } catch {
     // Not in a swamp repo or reports dir doesn't exist — not an error
@@ -889,6 +917,7 @@ export async function runCli(args: string[]): Promise<void> {
       marker,
       resolvedSources,
       deferredWarnings,
+      isQuietFromArgs(args),
     );
   }
 

--- a/src/domain/datastore/user_datastore_loader.ts
+++ b/src/domain/datastore/user_datastore_loader.ts
@@ -45,6 +45,7 @@ import {
   SWAMP_SUBDIRS,
 } from "../../infrastructure/persistence/paths.ts";
 import { assertSafePath } from "../../infrastructure/persistence/safe_path.ts";
+import { emitTypeExtractionFailure } from "../../infrastructure/logging/extension_load_warnings.ts";
 import {
   type ExtensionCatalogStore,
   type ExtensionTypeRow,
@@ -586,7 +587,10 @@ export class UserDatastoreLoader {
         if (!/export\s+const\s+datastore\s*[=:]/.test(source)) continue;
 
         const typeMatch = source.match(/type\s*:\s*["']([^"']+)["']/);
-        if (!typeMatch) continue;
+        if (!typeMatch) {
+          emitTypeExtractionFailure(absolutePath, "datastore");
+          continue;
+        }
 
         const typeNormalized = typeMatch[1].toLowerCase();
 

--- a/src/domain/drivers/user_driver_loader.ts
+++ b/src/domain/drivers/user_driver_loader.ts
@@ -45,6 +45,7 @@ import {
   SWAMP_SUBDIRS,
 } from "../../infrastructure/persistence/paths.ts";
 import { assertSafePath } from "../../infrastructure/persistence/safe_path.ts";
+import { emitTypeExtractionFailure } from "../../infrastructure/logging/extension_load_warnings.ts";
 import type { DatastorePathResolver } from "../datastore/datastore_path_resolver.ts";
 import {
   type ExtensionCatalogStore,
@@ -593,7 +594,10 @@ export class UserDriverLoader {
         if (!/export\s+const\s+driver\s*[=:]/.test(source)) continue;
 
         const typeMatch = source.match(/type\s*:\s*["']([^"']+)["']/);
-        if (!typeMatch) continue;
+        if (!typeMatch) {
+          emitTypeExtractionFailure(absolutePath, "driver");
+          continue;
+        }
 
         const typeNormalized = typeMatch[1].toLowerCase();
 

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -64,6 +64,7 @@ import {
   SWAMP_SUBDIRS,
 } from "../../infrastructure/persistence/paths.ts";
 import { assertSafePath } from "../../infrastructure/persistence/safe_path.ts";
+import { emitTypeExtractionFailure } from "../../infrastructure/logging/extension_load_warnings.ts";
 import type { DatastorePathResolver } from "../datastore/datastore_path_resolver.ts";
 
 const logger = getLogger(["swamp", "models", "loader"]);
@@ -969,7 +970,16 @@ export class UserModelLoader {
         const typeMatch = source.match(
           /export\s+const\s+(?:model|extension)\s*=\s*\{[\s\S]*?type\s*:\s*["']([^"']+)["']/,
         );
-        if (!typeMatch) continue;
+        if (!typeMatch) {
+          // The file has `export const model =` (or extension) but type
+          // is not a string literal we can extract — emit a warning
+          // instead of silently skipping.
+          emitTypeExtractionFailure(
+            absolutePath,
+            extensionMatch ? "extension" : "model",
+          );
+          continue;
+        }
 
         const typeNormalized = ModelType.create(typeMatch[1]).normalized;
 

--- a/src/domain/reports/user_report_loader.ts
+++ b/src/domain/reports/user_report_loader.ts
@@ -45,6 +45,7 @@ import {
   SWAMP_SUBDIRS,
 } from "../../infrastructure/persistence/paths.ts";
 import { assertSafePath } from "../../infrastructure/persistence/safe_path.ts";
+import { emitTypeExtractionFailure } from "../../infrastructure/logging/extension_load_warnings.ts";
 import type { DatastorePathResolver } from "../datastore/datastore_path_resolver.ts";
 import {
   type ExtensionCatalogStore,
@@ -442,7 +443,10 @@ export class UserReportLoader {
         if (!/export\s+const\s+report\s*[=:]/.test(source)) continue;
 
         const typeMatch = source.match(/name\s*:\s*["']([^"']+)["']/);
-        if (!typeMatch) continue;
+        if (!typeMatch) {
+          emitTypeExtractionFailure(absolutePath, "report");
+          continue;
+        }
 
         const typeNormalized = typeMatch[1].toLowerCase();
 

--- a/src/domain/vaults/user_vault_loader.ts
+++ b/src/domain/vaults/user_vault_loader.ts
@@ -45,6 +45,7 @@ import {
   SWAMP_SUBDIRS,
 } from "../../infrastructure/persistence/paths.ts";
 import { assertSafePath } from "../../infrastructure/persistence/safe_path.ts";
+import { emitTypeExtractionFailure } from "../../infrastructure/logging/extension_load_warnings.ts";
 import type { DatastorePathResolver } from "../datastore/datastore_path_resolver.ts";
 import {
   type ExtensionCatalogStore,
@@ -594,7 +595,10 @@ export class UserVaultLoader {
         if (!/export\s+const\s+vault\s*[=:]/.test(source)) continue;
 
         const typeMatch = source.match(/type\s*:\s*["']([^"']+)["']/);
-        if (!typeMatch) continue;
+        if (!typeMatch) {
+          emitTypeExtractionFailure(absolutePath, "vault");
+          continue;
+        }
 
         const typeNormalized = typeMatch[1].toLowerCase();
 

--- a/src/infrastructure/logging/extension_load_warnings.ts
+++ b/src/infrastructure/logging/extension_load_warnings.ts
@@ -72,17 +72,17 @@ function getState(): EmitterState {
 
 const HINT_BY_KIND: Record<ExtensionKind, string> = {
   model:
-    "extensions/models/ is auto-discovered — you do NOT need `swamp extension source add` for files in this directory.",
+    "extensions/models/ is auto-discovered — running `swamp extension source add` here is a no-op.",
   extension:
-    "extensions/models/ is auto-discovered — you do NOT need `swamp extension source add` for files in this directory.",
+    "extensions/models/ is auto-discovered — running `swamp extension source add` here is a no-op.",
   vault:
-    "extensions/vaults/ is auto-discovered — you do NOT need `swamp extension source add` for files in this directory.",
+    "extensions/vaults/ is auto-discovered — running `swamp extension source add` here is a no-op.",
   driver:
-    "extensions/drivers/ is auto-discovered — you do NOT need `swamp extension source add` for files in this directory.",
+    "extensions/drivers/ is auto-discovered — running `swamp extension source add` here is a no-op.",
   datastore:
-    "extensions/datastores/ is auto-discovered — you do NOT need `swamp extension source add` for files in this directory.",
+    "extensions/datastores/ is auto-discovered — running `swamp extension source add` here is a no-op.",
   report:
-    "extensions/reports/ is auto-discovered — you do NOT need `swamp extension source add` for files in this directory.",
+    "extensions/reports/ is auto-discovered — running `swamp extension source add` here is a no-op.",
 };
 
 function defaultWriter(line: string): void {
@@ -92,6 +92,22 @@ function defaultWriter(line: string): void {
 
 function dedupeKey(warning: ExtensionLoadWarning): string {
   return `${warning.kind}\0${warning.file}\0${warning.error}`;
+}
+
+/**
+ * Falls back to scanning Deno.args when the caller did not pass an
+ * explicit `quiet` option. Lets domain-layer callers (which never
+ * see Cliffy-parsed options) honour `swamp --quiet` without threading
+ * a parameter through every call chain.
+ *
+ * Reading Deno.args couples this module to the CLI flag shape but
+ * the alternative — a circular import from src/cli/ into
+ * src/infrastructure/ — is worse. `--quiet` and `-q` are stable.
+ */
+function isSilenced(options: EmitterOptions): boolean {
+  if (options.quiet === true) return true;
+  if (options.quiet === false) return false;
+  return Deno.args.includes("--quiet") || Deno.args.includes("-q");
 }
 
 /**
@@ -108,7 +124,7 @@ export function emitExtensionLoadWarning(
   warning: ExtensionLoadWarning,
   options: EmitterOptions = {},
 ): void {
-  if (options.quiet) return;
+  if (isSilenced(options)) return;
 
   const state = getState();
   const key = dedupeKey(warning);

--- a/src/infrastructure/logging/extension_load_warnings.ts
+++ b/src/infrastructure/logging/extension_load_warnings.ts
@@ -1,0 +1,181 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Stderr emitter for extension load failures.
+ *
+ * LogTape's JSON-mode configuration pins `lowestLevel` to "fatal"
+ * (logger.ts:131-144), which silences the `logger.warn` lines
+ * loaders use to surface failed extension loads. This module bypasses
+ * LogTape entirely with a direct console.error write so warnings
+ * remain visible regardless of output mode.
+ *
+ * State is keyed on globalThis so the dedupe + once-per-kind hint
+ * tracking survives bundler-induced module duplication in the
+ * compiled binary.
+ */
+
+export type ExtensionKind =
+  | "model"
+  | "extension"
+  | "vault"
+  | "driver"
+  | "datastore"
+  | "report";
+
+export interface ExtensionLoadWarning {
+  kind: ExtensionKind;
+  file: string;
+  error: string;
+}
+
+export interface EmitterOptions {
+  writer?: (line: string) => void;
+  quiet?: boolean;
+}
+
+interface EmitterState {
+  emitted: Set<string>;
+  hintsEmittedFor: Set<ExtensionKind>;
+}
+
+const STATE_KEY = "__swampExtensionLoadWarningState";
+
+// deno-lint-ignore no-explicit-any
+const globalAny = globalThis as any;
+
+function getState(): EmitterState {
+  if (!globalAny[STATE_KEY]) {
+    globalAny[STATE_KEY] = {
+      emitted: new Set<string>(),
+      hintsEmittedFor: new Set<ExtensionKind>(),
+    } satisfies EmitterState;
+  }
+  return globalAny[STATE_KEY];
+}
+
+const HINT_BY_KIND: Record<ExtensionKind, string> = {
+  model:
+    "extensions/models/ is auto-discovered — you do NOT need `swamp extension source add` for files in this directory.",
+  extension:
+    "extensions/models/ is auto-discovered — you do NOT need `swamp extension source add` for files in this directory.",
+  vault:
+    "extensions/vaults/ is auto-discovered — you do NOT need `swamp extension source add` for files in this directory.",
+  driver:
+    "extensions/drivers/ is auto-discovered — you do NOT need `swamp extension source add` for files in this directory.",
+  datastore:
+    "extensions/datastores/ is auto-discovered — you do NOT need `swamp extension source add` for files in this directory.",
+  report:
+    "extensions/reports/ is auto-discovered — you do NOT need `swamp extension source add` for files in this directory.",
+};
+
+function defaultWriter(line: string): void {
+  // Direct console.error bypasses LogTape — see file header.
+  console.error(line);
+}
+
+function dedupeKey(warning: ExtensionLoadWarning): string {
+  return `${warning.kind}\0${warning.file}\0${warning.error}`;
+}
+
+/**
+ * Writes a single `swamp-warning:` line to stderr (or the injected
+ * writer). De-dupes on (kind, file, error). The first warning seen
+ * for a given kind also emits a one-line `hint:` redirecting the
+ * common wrong-turn (registering an extension source for a path
+ * that's already auto-discovered).
+ *
+ * Quiet mode short-circuits to a no-op so `swamp --quiet` stays
+ * quiet without callers having to filter.
+ */
+export function emitExtensionLoadWarning(
+  warning: ExtensionLoadWarning,
+  options: EmitterOptions = {},
+): void {
+  if (options.quiet) return;
+
+  const state = getState();
+  const key = dedupeKey(warning);
+  if (state.emitted.has(key)) return;
+  state.emitted.add(key);
+
+  const writer = options.writer ?? defaultWriter;
+  writer(`swamp-warning: ${warning.file}: ${warning.error}`);
+
+  if (!state.hintsEmittedFor.has(warning.kind)) {
+    state.hintsEmittedFor.add(warning.kind);
+    writer(`  hint: ${HINT_BY_KIND[warning.kind]}`);
+  }
+}
+
+/**
+ * Convenience wrapper for buildIndex-style results that expose a
+ * `failed` array of `{file, error}` records. Emits one warning per
+ * failure under the given kind.
+ */
+export function recordLoadFailures(
+  kind: ExtensionKind,
+  result: { failed: ReadonlyArray<{ file: string; error: string }> },
+  options: EmitterOptions = {},
+): void {
+  for (const failure of result.failed) {
+    emitExtensionLoadWarning(
+      { kind, file: failure.file, error: failure.error },
+      options,
+    );
+  }
+}
+
+/**
+ * Emit-only helper for the silent regex-mismatch path in each
+ * loader's populateCatalogFromDir. Loaders perform their
+ * kind-specific export check; if the file declares an export but
+ * type extraction fails, they call this to surface the skip.
+ *
+ * Centralizing the message (not the regex — those stay per-loader
+ * since each kind has its own pattern) keeps the user-facing
+ * wording consistent across kinds.
+ */
+export function emitTypeExtractionFailure(
+  file: string,
+  kind: ExtensionKind,
+  options: EmitterOptions = {},
+): void {
+  emitExtensionLoadWarning(
+    {
+      kind,
+      file,
+      error:
+        'type field could not be extracted from the export block — must be a string literal, e.g. type: "@collective/name"',
+    },
+    options,
+  );
+}
+
+/**
+ * Clears the emitter's process-scoped dedupe + hint-tracking state.
+ * Long-running processes (swamp serve, swamp open) call this
+ * alongside ModelRegistry.resetLoadedFlag() so a subsequent reload
+ * re-emits warnings cleanly.
+ */
+export function resetExtensionLoadWarnings(): void {
+  const state = getState();
+  state.emitted.clear();
+  state.hintsEmittedFor.clear();
+}

--- a/src/infrastructure/logging/extension_load_warnings_test.ts
+++ b/src/infrastructure/logging/extension_load_warnings_test.ts
@@ -1,0 +1,204 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  emitExtensionLoadWarning,
+  emitTypeExtractionFailure,
+  recordLoadFailures,
+  resetExtensionLoadWarnings,
+} from "./extension_load_warnings.ts";
+
+function makeCapture() {
+  const lines: string[] = [];
+  const writer = (line: string) => lines.push(line);
+  return { lines, writer };
+}
+
+Deno.test("emitExtensionLoadWarning: writes a swamp-warning line and a hint for the kind", () => {
+  resetExtensionLoadWarnings();
+  const cap = makeCapture();
+
+  emitExtensionLoadWarning(
+    { kind: "model", file: "/repo/extensions/models/bad.ts", error: "boom" },
+    { writer: cap.writer },
+  );
+
+  assertEquals(cap.lines.length, 2);
+  assertEquals(
+    cap.lines[0],
+    "swamp-warning: /repo/extensions/models/bad.ts: boom",
+  );
+  assertStringIncludes(cap.lines[1], "hint:");
+  assertStringIncludes(cap.lines[1], "extensions/models/");
+  assertStringIncludes(cap.lines[1], "auto-discovered");
+});
+
+Deno.test("emitExtensionLoadWarning: hint is emitted at most once per kind", () => {
+  resetExtensionLoadWarnings();
+  const cap = makeCapture();
+
+  emitExtensionLoadWarning(
+    { kind: "model", file: "/a.ts", error: "e1" },
+    { writer: cap.writer },
+  );
+  emitExtensionLoadWarning(
+    { kind: "model", file: "/b.ts", error: "e2" },
+    { writer: cap.writer },
+  );
+
+  // Two warnings + one hint = three lines total, not four.
+  assertEquals(cap.lines.length, 3);
+  assertEquals(
+    cap.lines.filter((l) => l.includes("hint:")).length,
+    1,
+  );
+});
+
+Deno.test("emitExtensionLoadWarning: hint is kind-specific", () => {
+  resetExtensionLoadWarnings();
+  const cap = makeCapture();
+
+  emitExtensionLoadWarning(
+    { kind: "vault", file: "/v.ts", error: "boom" },
+    { writer: cap.writer },
+  );
+
+  assertStringIncludes(cap.lines[1], "extensions/vaults/");
+});
+
+Deno.test("emitExtensionLoadWarning: each kind gets its own hint once", () => {
+  resetExtensionLoadWarnings();
+  const cap = makeCapture();
+
+  emitExtensionLoadWarning(
+    { kind: "model", file: "/m.ts", error: "e" },
+    { writer: cap.writer },
+  );
+  emitExtensionLoadWarning(
+    { kind: "vault", file: "/v.ts", error: "e" },
+    { writer: cap.writer },
+  );
+
+  const hints = cap.lines.filter((l) => l.includes("hint:"));
+  assertEquals(hints.length, 2);
+  assertStringIncludes(hints[0], "extensions/models/");
+  assertStringIncludes(hints[1], "extensions/vaults/");
+});
+
+Deno.test("emitExtensionLoadWarning: de-duplicates on (kind, file, error)", () => {
+  resetExtensionLoadWarnings();
+  const cap = makeCapture();
+
+  const w = { kind: "model" as const, file: "/m.ts", error: "boom" };
+  emitExtensionLoadWarning(w, { writer: cap.writer });
+  emitExtensionLoadWarning(w, { writer: cap.writer });
+  emitExtensionLoadWarning(w, { writer: cap.writer });
+
+  // One warning + one hint = two lines, not six.
+  assertEquals(cap.lines.length, 2);
+});
+
+Deno.test("emitExtensionLoadWarning: distinct errors for the same file are NOT deduped", () => {
+  resetExtensionLoadWarnings();
+  const cap = makeCapture();
+
+  emitExtensionLoadWarning(
+    { kind: "model", file: "/m.ts", error: "e1" },
+    { writer: cap.writer },
+  );
+  emitExtensionLoadWarning(
+    { kind: "model", file: "/m.ts", error: "e2" },
+    { writer: cap.writer },
+  );
+
+  // Two distinct warnings + one hint = three lines.
+  assertEquals(cap.lines.length, 3);
+});
+
+Deno.test("emitExtensionLoadWarning: quiet flag suppresses output entirely", () => {
+  resetExtensionLoadWarnings();
+  const cap = makeCapture();
+
+  emitExtensionLoadWarning(
+    { kind: "model", file: "/m.ts", error: "boom" },
+    { writer: cap.writer, quiet: true },
+  );
+
+  assertEquals(cap.lines.length, 0);
+});
+
+Deno.test("recordLoadFailures: emits one warning per failed entry", () => {
+  resetExtensionLoadWarnings();
+  const cap = makeCapture();
+
+  recordLoadFailures(
+    "report",
+    {
+      failed: [
+        { file: "/a.ts", error: "e1" },
+        { file: "/b.ts", error: "e2" },
+      ],
+    },
+    { writer: cap.writer },
+  );
+
+  // Two warnings + one hint = three lines. Hint emits after the
+  // first warning (because that's when the kind becomes "seen"),
+  // so the order is: warn, hint, warn.
+  assertEquals(cap.lines.length, 3);
+  assertStringIncludes(cap.lines[0], "/a.ts");
+  assertStringIncludes(cap.lines[1], "extensions/reports/");
+  assertStringIncludes(cap.lines[2], "/b.ts");
+});
+
+Deno.test("recordLoadFailures: empty failed array is a no-op", () => {
+  resetExtensionLoadWarnings();
+  const cap = makeCapture();
+
+  recordLoadFailures("model", { failed: [] }, { writer: cap.writer });
+
+  assertEquals(cap.lines.length, 0);
+});
+
+Deno.test("emitTypeExtractionFailure: surfaces the regex-mismatch case with a clear message", () => {
+  resetExtensionLoadWarnings();
+  const cap = makeCapture();
+
+  emitTypeExtractionFailure("/repo/extensions/vaults/odd.ts", "vault", {
+    writer: cap.writer,
+  });
+
+  assertStringIncludes(cap.lines[0], "/repo/extensions/vaults/odd.ts");
+  assertStringIncludes(cap.lines[0], "string literal");
+});
+
+Deno.test("resetExtensionLoadWarnings: clears dedupe and hint state", () => {
+  resetExtensionLoadWarnings();
+  const cap = makeCapture();
+
+  const w = { kind: "model" as const, file: "/m.ts", error: "boom" };
+  emitExtensionLoadWarning(w, { writer: cap.writer });
+  // Re-emit after reset: should produce a fresh warning + hint.
+  resetExtensionLoadWarnings();
+  emitExtensionLoadWarning(w, { writer: cap.writer });
+
+  // Two warning lines + two hint lines.
+  assertEquals(cap.lines.length, 4);
+});

--- a/src/infrastructure/logging/extension_load_warnings_test.ts
+++ b/src/infrastructure/logging/extension_load_warnings_test.ts
@@ -132,7 +132,7 @@ Deno.test("emitExtensionLoadWarning: distinct errors for the same file are NOT d
   assertEquals(cap.lines.length, 3);
 });
 
-Deno.test("emitExtensionLoadWarning: quiet flag suppresses output entirely", () => {
+Deno.test("emitExtensionLoadWarning: quiet=true suppresses output entirely", () => {
   resetExtensionLoadWarnings();
   const cap = makeCapture();
 
@@ -142,6 +142,20 @@ Deno.test("emitExtensionLoadWarning: quiet flag suppresses output entirely", () 
   );
 
   assertEquals(cap.lines.length, 0);
+});
+
+Deno.test("emitExtensionLoadWarning: quiet=false overrides any process-level --quiet detection", () => {
+  resetExtensionLoadWarnings();
+  const cap = makeCapture();
+
+  // Explicit `false` is the test-seam contract: even if the test runner
+  // somehow received `--quiet`, callers asking for output get output.
+  emitExtensionLoadWarning(
+    { kind: "model", file: "/m.ts", error: "boom" },
+    { writer: cap.writer, quiet: false },
+  );
+
+  assertEquals(cap.lines.length, 2);
 });
 
 Deno.test("recordLoadFailures: emits one warning per failed entry", () => {


### PR DESCRIPTION
## Summary

Fixes [swamp-club#177](https://swamp-club.com/lab/issues/177).

Local extension models in `extensions/models/` are already auto-discovered, but when a model file fails validation (missing `version`, etc.) or its `type` cannot be extracted by the catalog's regex (non-literal expression), the failure is silenced in `--json` mode because `logger.ts:131-144` pins LogTape's `lowestLevel` to `"fatal"` for JSON output. The user sees an empty `swamp model type search` result with no feedback, assumes discovery is broken, and chases unnecessary workarounds like `swamp extension source add extensions/models`.

## Approach

Add a stderr emitter (`src/infrastructure/logging/extension_load_warnings.ts`) that writes via direct `console.error`, bypassing LogTape entirely.

- `recordLoadFailures(kind, result, opts)` — wired into all five `loadUser*` loaders in `src/cli/mod.ts`. Replaces (or supplements, for the `Cannot extend unregistered model type` retry case) the existing `logger.warn` loop.
- `emitTypeExtractionFailure(file, kind, opts)` — wired into all five `populateCatalogFromDir` copies, replacing silent `if (!typeMatch) continue;` skips.
- One `swamp-warning:` line per failure plus a single kind-specific `hint:` line per process — the hint explicitly tells the user `extensions/models/` is auto-discovered and `swamp extension source add` is not needed for this directory.
- State is globalThis-keyed (matching `modelRegistry`'s pattern) so dedupe survives module duplication in the compiled binary. `resetExtensionLoadWarnings()` is wired into `src/cli/commands/open.ts:88-91` alongside the existing `resetLoadedFlag()` block so `swamp open` / `swamp serve` re-emit cleanly on reload.
- `--quiet` flag flows through `isQuietFromArgs()` in `src/cli/context.ts` and the `quiet` parameter on `configureExtensionLoaders` so users who explicitly silence output stay silent.

Skill updates close the documentation loop the issue author fell through:
- `swamp-extension-model` — verify step now points at stderr `swamp-warning:` lines and clarifies auto-discovery.
- `swamp-troubleshooting` — new "Local Extension Model Not Appearing in Type Search" recipe.

## Test plan

- [x] Unit tests for the emitter (`extension_load_warnings_test.ts`) — 11 cases covering format, dedupe, kind-specific hint, hint-once-per-kind, quiet flag, reset.
- [x] Integration test (`integration/extensions/silent_load_failure_test.ts`) — three fixtures (missing `version`, non-literal `type`, working) in one repo + a single `swamp model type search --json` invocation. Asserts working model appears in stdout, both broken files appear in stderr `swamp-warning:` lines, exactly one `hint:` line is emitted (verifies batching), working model is unaffected.
- [x] Full test suite (`deno run test`) — 4938 passed, 0 failed.
- [x] `deno check`, `deno lint`, `deno fmt --check` clean.
- [x] Recompiled binary (`deno run compile`) and re-ran the issue 177 reproduction — user now sees `swamp-warning: random_status.ts: Missing or invalid 'version' field` plus the auto-discovery hint.
- [x] Verified regex-mismatch path: `swamp-warning: ...non_literal.ts: type field could not be extracted from the export block — must be a string literal`.

## Follow-ups

- [swamp-club#180](https://swamp-club.com/lab/issues/180) — `swamp doctor extensions` subcommand to surface these warnings on demand. Blocks on this PR's emitter.
- After merge: file separate swamp-uat issue for adversarial test coverage of extension load failure messaging.
- After merge: file separate swamp-club docs issue (manual reference + tutorial check).
- After merge: file separate small bug — `--log-level=warn` is rejected (only `warning` long-form works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)