### PR TITLE
fix(tracing): default to SimpleSpanProcessor so spans flush in short-lived CLIs

### DIFF
--- a/src/infrastructure/tracing/fetch_otlp_exporter.ts
+++ b/src/infrastructure/tracing/fetch_otlp_exporter.ts
@@ -99,6 +99,8 @@ export class FetchOtlpExporter implements SpanExporter {
       if (!response.ok) {
         // Drain the body to avoid resource leaks, but don't throw.
         await response.arrayBuffer();
+      } else {
+        await response.body?.cancel();
       }
     } finally {
       clearTimeout(timer);

--- a/src/infrastructure/tracing/otel_init.ts
+++ b/src/infrastructure/tracing/otel_init.ts
@@ -38,7 +38,12 @@ export async function initTracing(): Promise<void> {
 
   // Dynamic imports — only loaded when tracing is actually enabled.
   const [
-    { BasicTracerProvider, BatchSpanProcessor, ConsoleSpanExporter },
+    {
+      BasicTracerProvider,
+      BatchSpanProcessor,
+      SimpleSpanProcessor,
+      ConsoleSpanExporter,
+    },
     { AsyncLocalStorageContextManager },
     { Resource },
     { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION },
@@ -50,6 +55,12 @@ export async function initTracing(): Promise<void> {
     import("@opentelemetry/semantic-conventions"),
     import("@opentelemetry/api"),
   ]);
+
+  // Short-lived CLI invocations may exit before BatchSpanProcessor's batching
+  // window completes (Deno.exit short-circuits finally blocks). Default to
+  // SimpleSpanProcessor for predictable per-span flush; allow opting back into
+  // BatchSpanProcessor via OTEL_BSP_USE=1 for long-running modes (`swamp serve`).
+  const useBatch = Deno.env.get("OTEL_BSP_USE") === "1";
 
   // Register AsyncLocalStorage-based context manager
   const contextManager = new AsyncLocalStorageContextManager();
@@ -64,10 +75,12 @@ export async function initTracing(): Promise<void> {
 
   const provider = new BasicTracerProvider({ resource });
 
+  const wrapProcessor = (
+    e: ConstructorParameters<typeof SimpleSpanProcessor>[0],
+  ) => useBatch ? new BatchSpanProcessor(e) : new SimpleSpanProcessor(e);
+
   if (exporterKind === "console") {
-    provider.addSpanProcessor(
-      new BatchSpanProcessor(new ConsoleSpanExporter()),
-    );
+    provider.addSpanProcessor(wrapProcessor(new ConsoleSpanExporter()));
   } else {
     // Fetch-based OTLP/HTTP exporter — uses Deno's native fetch instead of
     // Node.js http/https modules, which fail TLS in compiled binaries.
@@ -88,7 +101,7 @@ export async function initTracing(): Promise<void> {
       url: `${endpoint!.replace(/\/+$/, "")}/v1/traces`,
       headers,
     });
-    provider.addSpanProcessor(new BatchSpanProcessor(exporter));
+    provider.addSpanProcessor(wrapProcessor(exporter));
   }
 
   // Register as global tracer provider


### PR DESCRIPTION
## Summary

- Tracing is wired through `main.ts` (`initTracing` + `shutdownTracing` in a `finally`), but in practice spans never reach the OTLP endpoint for short-lived CLI commands. `BatchSpanProcessor` relies on its batching window (or `provider.shutdown`) to flush, and several swamp commands take exit paths that short-circuit the post-run flush.
- Default to `SimpleSpanProcessor` so each span exports per-emit. Opt back into `BatchSpanProcessor` via `OTEL_BSP_USE=1` for long-running modes (`swamp serve`) where batching is preferable.
- Drain the response body on the success path of `FetchOtlpExporter` for parity with the error path (resource hygiene).

## Verification

End-to-end against a local OTLP/JSON sink:

```sh
OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4699 OTEL_SERVICE_NAME=swamp \
  swamp workflow history search --json
```

Before this patch: 0 spans received.
After this patch: `swamp.cli` parent + `swamp.workflow.history.search` child arrive in real time, with the `service.name` resource attribute and full `swamp.command` / `swamp.subcommand` / `swamp.version` attribute set.

## Test plan

- [x] `deno fmt` clean
- [x] `deno lint src/infrastructure/tracing/` clean
- [x] `deno task check` (type check) passes
- [x] `deno test src/infrastructure/tracing/` — all 14 existing tests pass unchanged
- [x] Manual smoke: `swamp model search`, `swamp workflow history search` against a local sink — spans delivered
- [ ] Optional: add a regression test that points an exporter at a stub server and asserts spans arrive without an explicit shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)