### PR TITLE
docs(extensions): clarify has-readme/has-license remediation for nested additionalFiles (swamp-club#182)

### DIFF
--- a/.claude/skills/swamp-extension-quality/SKILL.md
+++ b/.claude/skills/swamp-extension-quality/SKILL.md
@@ -39,19 +39,19 @@ signals layered on top of whatever the type-specific skill produced.
 
 ## The factor-to-action map (memorise this)
 
-| Factor                | Pts | Earn it by                                                                                         |
-| --------------------- | --- | -------------------------------------------------------------------------------------------------- |
-| `has-readme`          | 2   | List `README.md` under `additionalFiles:` in `manifest.yaml`                                       |
-| `readme-example`      | 1   | Include ≥1 fenced code block in the README                                                         |
-| `rich-readme`         | 1   | Make the README ≥500 characters AND have ≥2 fenced code blocks                                     |
-| `symbols-docs`        | 1   | JSDoc ≥80% of exported symbols across all entrypoints                                              |
-| `fast-check`          | 1   | Explicit return types on every export; no private-type references in public exports                |
-| `description`         | 1   | Fill `description:` in `manifest.yaml` with a non-empty string (not "TODO")                        |
-| `platforms-one`       | 1   | Set `platforms:` to a non-empty list OR leave empty (empty = "universal")                          |
-| `platforms-two`       | 1   | Set `platforms:` to ≥2 entries OR leave empty                                                      |
-| `has-license`         | 1   | Add a LICENSE file (`LICENSE`, `LICENSE.md`, `LICENSE.txt`, or `COPYING`) under `additionalFiles:` |
-| `repository-verified` | 2   | Set `repository:` to a public HTTPS URL on github.com, gitlab.com, codeberg.org, or bitbucket.org  |
-| `verified-by-swamp`   | 1   | Only earnable by the `@swamp` namespace or admin review — do not try to game it                    |
+| Factor                | Pts | Earn it by                                                                                                            |
+| --------------------- | --- | --------------------------------------------------------------------------------------------------------------------- |
+| `has-readme`          | 2   | List `README.md` under `additionalFiles:` in `manifest.yaml` (use a bare basename)                                    |
+| `readme-example`      | 1   | Include ≥1 fenced code block in the README                                                                            |
+| `rich-readme`         | 1   | Make the README ≥500 characters AND have ≥2 fenced code blocks                                                        |
+| `symbols-docs`        | 1   | JSDoc ≥80% of exported symbols across all entrypoints                                                                 |
+| `fast-check`          | 1   | Explicit return types on every export; no private-type references in public exports                                   |
+| `description`         | 1   | Fill `description:` in `manifest.yaml` with a non-empty string (not "TODO")                                           |
+| `platforms-one`       | 1   | Set `platforms:` to a non-empty list OR leave empty (empty = "universal")                                             |
+| `platforms-two`       | 1   | Set `platforms:` to ≥2 entries OR leave empty                                                                         |
+| `has-license`         | 1   | Add a LICENSE file (`LICENSE`, `LICENSE.md`, `LICENSE.txt`, or `COPYING`) under `additionalFiles:` as a bare basename |
+| `repository-verified` | 2   | Set `repository:` to a public HTTPS URL on github.com, gitlab.com, codeberg.org, or bitbucket.org                     |
+| `verified-by-swamp`   | 1   | Only earnable by the `@swamp` namespace or admin review — do not try to game it                                       |
 
 `verified-by-swamp` is the one third-party authors cannot earn; everything above
 it is fair game.
@@ -59,10 +59,19 @@ it is fair game.
 ## Essential mechanics authors get wrong
 
 **Files listed in `additionalFiles:` end up under `extension/files/` in the
-tarball**, not at the extension root. The analyzer checks both locations for
-README and LICENSE, so either works, but this trips up authors who assume the
-root is the only path. If a README is in the repo root but not in
-`additionalFiles:`, **it is not in the tarball at all** and earns zero.
+tarball**, not at the extension root. The analyzer checks the extension root and
+`extension/files/` for README and LICENSE — but only at that exact level. There
+is no recursion, so the entry must be a bare basename. Writing
+`additionalFiles: [docs/README.md]` lands the file at
+`extension/files/docs/README.md` and earns zero — change it to
+`additionalFiles: [README.md]` instead. If a README is in the repo root but not
+in `additionalFiles:`, it is not in the tarball at all and also earns zero.
+
+For per-extension-subdir layouts where the source files sit alongside the
+manifest, opt into `paths.base: manifest` so the bare-basename entry resolves
+correctly. See
+[references/templates.md](references/templates.md#per-extension-subdir-layout--opt-in-pathsbase-manifest)
+for the canonical example.
 
 **`repository:` must be on one of the allowlisted hosts** — github.com,
 gitlab.com (public SaaS only), codeberg.org, bitbucket.org. Self-hosted GitHub

--- a/.claude/skills/swamp-extension-quality/references/rubric.md
+++ b/.claude/skills/swamp-extension-quality/references/rubric.md
@@ -32,7 +32,11 @@ Earned when the tarball contains a README file. The analyzer looks at:
 2. `<logical root>/files/README.md` (same case variants)
 
 The second location is where files listed in `manifest.yaml`'s
-`additionalFiles:` field land.
+`additionalFiles:` field land. Both lookups are exact at this level — the
+analyzer does NOT recurse, so a nested entry like
+`additionalFiles: [docs/README.md]` lands at `<root>/files/docs/README.md` and
+earns zero. Use a bare basename and, if your source layout requires it, opt into
+`paths.base: manifest`.
 
 ### `readme-example` (1 pt)
 
@@ -121,6 +125,11 @@ Earned when **either**:
 - The extension's `license` field is a non-empty trimmed string (set via PATCH
   on the extension record), OR
 - The tarball contains a license file at `<root>/*` or `<root>/files/*`
+
+Both lookups are exact at this level — the analyzer does NOT recurse, so a
+nested entry like `additionalFiles: [legal/LICENSE]` lands at
+`<root>/files/legal/LICENSE` and earns zero. Use a bare basename and, if your
+source layout requires it, opt into `paths.base: manifest`.
 
 Recognized license filenames (case-sensitive matches):
 

--- a/src/domain/extensions/extension_rubric_scorer.ts
+++ b/src/domain/extensions/extension_rubric_scorer.ts
@@ -312,8 +312,12 @@ export function composeScore(
   const rows: RubricFactor[] = [
     boolRow("has-readme", "Has README or module doc", 2, factors.hasReadme, {
       remediation:
-        "Add README.md under `additionalFiles:` in manifest.yaml, or add a " +
-        "module-level JSDoc comment at the top of every entrypoint file.",
+        "Add `README.md` to `additionalFiles:` as a bare basename — the " +
+        "entry is copied verbatim to `extension/files/<entry>` in the " +
+        "archive, so nested paths like `docs/README.md` won't earn the " +
+        "factor. For per-directory layouts (manifest beside README), opt " +
+        "in with `paths.base: manifest`. Or add a module-level JSDoc at " +
+        "the top of every entrypoint file.",
     }),
     boolRow(
       "readme-example",
@@ -367,7 +371,11 @@ export function composeScore(
       factors.hasLicenseFile,
       {
         remediation:
-          "Add LICENSE / LICENSE.md / LICENSE.txt / COPYING under `additionalFiles:`.",
+          "Add a LICENSE / LICENSE.md / LICENSE.txt / COPYING entry to " +
+          "`additionalFiles:` as a bare basename — entries are copied " +
+          "verbatim to `extension/files/<entry>` in the archive, so " +
+          "nested paths won't earn the factor. For per-directory layouts " +
+          "(manifest beside LICENSE), opt in with `paths.base: manifest`.",
       },
     ),
     boolRow(

--- a/src/domain/extensions/extension_rubric_scorer_test.ts
+++ b/src/domain/extensions/extension_rubric_scorer_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import type { ExtensionManifest } from "./extension_manifest.ts";
 import {
   composeScore,
@@ -439,6 +439,30 @@ Deno.test("composeScore: missing LICENSE file misses has-license", () => {
   );
   const f = score.factors.find((f) => f.id === "has-license")!;
   assertEquals(f.status, "missing");
+});
+
+Deno.test("composeScore: has-readme remediation names the archive path and bare-basename rule", () => {
+  const score = composeScore(
+    { ...factorsAllEarned(), hasReadme: false },
+    makeManifest(),
+  );
+  const f = score.factors.find((f) => f.id === "has-readme")!;
+  assertEquals(f.status, "missing");
+  const remediation = f.remediation ?? "";
+  assertStringIncludes(remediation, "extension/files/");
+  assertStringIncludes(remediation, "bare basename");
+});
+
+Deno.test("composeScore: has-license remediation names the archive path and bare-basename rule", () => {
+  const score = composeScore(
+    { ...factorsAllEarned(), hasLicenseFile: false },
+    makeManifest(),
+  );
+  const f = score.factors.find((f) => f.id === "has-license")!;
+  assertEquals(f.status, "missing");
+  const remediation = f.remediation ?? "";
+  assertStringIncludes(remediation, "extension/files/");
+  assertStringIncludes(remediation, "bare basename");
 });
 
 Deno.test("composeScore: symbols-docs below 80% fails", () => {


### PR DESCRIPTION
## Summary

Closes swamp-club#182.

The remediation strings on the `has-readme` and `has-license` rubric factors said "Add README.md / LICENSE under `additionalFiles:`" without telling authors that the entry must be a bare basename. Anyone who organised their repo around nested `additionalFiles` entries (e.g. `additionalFiles: [docs/README.md]`) followed the remediation literally, watched the file land at `extension/files/docs/README.md` in the archive (preserved verbatim by `push.ts` under both default and `paths.base: manifest` modes), and earned zero.

This rewrites both remediation strings to lead with the bare-basename rule and mentions `paths.base: manifest` (introduced in #1238) as the complementary layout option for per-extension-subdir authors. The `swamp-extension-quality` skill copy is updated in lockstep.

## Why this is docs-only — not a scorer logic change

The CLI scorer's `<field>/<entry>` literal lookup is the parity-protected contract with the swamp-club server scorer that #1238 explicitly relied on:

> "Server-side scorecard mirrors the same `<field>/<entry>` lookup; no changes needed there because archive layout matches manifest entries verbatim under both modes."

Making `findReadme` recursive would break this contract — local would credit authors for nested READMEs and the server would not, so `swamp extension quality` would pass and publish would fail. The right fix is to match the docs to what the scorer actually does, not the other way around.

## What changed

**Code (`src/domain/extensions/extension_rubric_scorer.ts`):**

- `has-readme` remediation now leads with the bare-basename rule and mentions `paths.base: manifest`.
- `has-license` remediation matches.

**Tests (`extension_rubric_scorer_test.ts`):**

Two new tests assert the durable invariants of the remediation copy (`extension/files/` and `bare basename` substrings), using `assertStringIncludes` so future minor wording tweaks don't break the suite.

**Skill (`.claude/skills/swamp-extension-quality/`):**

- `SKILL.md` factor-to-action map rows for `has-readme` and `has-license` updated.
- `SKILL.md` "Essential mechanics" paragraph rewritten to make the bare-basename rule primary and `paths.base` the complementary mention.
- `references/rubric.md` `has-readme` and `has-license` per-factor sections updated with the same nuance.
- `references/templates.md` already covered post-#1238 — no change.

## Verification

- `deno check` — clean
- `deno lint` — 1124 files clean
- `deno fmt` — clean
- `deno run test` — 4959 passed, 0 failed (including 2 new tests)
- `deno run compile` — binary rebuilt
- Re-ran the reproduction at `/tmp/swamp-repro-issue-182` (extension with `additionalFiles: [adversarial_review/README.md, adversarial_review/LICENSE.txt]`) — `has-license` remediation now reads:

  > Add a LICENSE / LICENSE.md / LICENSE.txt / COPYING entry to `additionalFiles:` as a bare basename — entries are copied verbatim to `extension/files/<entry>` in the archive, so nested paths won't earn the factor. For per-directory layouts (manifest beside LICENSE), opt in with `paths.base: manifest`.

## Risk

Zero impact on scoring. The `remediation` field is documented as free-form human-readable text emitted only when a factor is missing; it never feeds back into score computation. `cacheHash` derives from archive bytes (verified by cache-hit on the reproduction), not output text. Archive layout, push behavior, and existing extension scores are byte-identical pre/post.

## Companion PR

The swamp-club public docs (`extension-scorecard-rubric.md` and `improve-extension-score.md`) had the same gap. A companion PR updates them — link to follow once that PR is open.

## Test plan

- [x] `deno check` — clean
- [x] `deno lint` — clean
- [x] `deno fmt` — clean
- [x] `deno run test` — 4959 passed
- [x] `deno run compile` — binary rebuilt
- [x] Reproduction from `/tmp/swamp-repro-issue-182`: new remediation string surfaces in JSON output

🤖 Generated with [Claude Code](https://claude.com/claude-code)