### PR TITLE
fix(persistence,extensions): use platform-aware separator in path-boundary checks

### DIFF
--- a/src/domain/extensions/extension_rubric_scorer.ts
+++ b/src/domain/extensions/extension_rubric_scorer.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { join, resolve } from "@std/path";
+import { join, resolve, SEPARATOR } from "@std/path";
 import type { ExtensionManifest } from "./extension_manifest.ts";
 
 /**
@@ -644,7 +644,7 @@ function collectEntrypoints(
         ? normalized
         : `${field}/${normalized}`;
       const entryAbs = resolve(root, prefixed);
-      if (entryAbs !== rootAbs && !entryAbs.startsWith(rootAbs + "/")) {
+      if (entryAbs !== rootAbs && !entryAbs.startsWith(rootAbs + SEPARATOR)) {
         throw new Error(`Entrypoint escapes extraction root: ${p}`);
       }
       eps.push(entryAbs);

--- a/src/infrastructure/persistence/safe_path.ts
+++ b/src/infrastructure/persistence/safe_path.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { dirname, join, resolve } from "@std/path";
+import { dirname, join, resolve, SEPARATOR } from "@std/path";
 
 /**
  * Error thrown when a path resolves outside its expected boundary,
@@ -109,7 +109,7 @@ export async function assertSafePath(
 
   if (
     resolvedPath !== resolvedBoundary &&
-    !resolvedPath.startsWith(resolvedBoundary + "/")
+    !resolvedPath.startsWith(resolvedBoundary + SEPARATOR)
   ) {
     throw new PathTraversalError(path, boundary, resolvedPath);
   }

--- a/src/infrastructure/persistence/safe_path_test.ts
+++ b/src/infrastructure/persistence/safe_path_test.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertRejects } from "@std/assert";
-import { join } from "@std/path";
+import { dirname, join } from "@std/path";
 import { assertSafePath, PathTraversalError } from "./safe_path.ts";
 
 Deno.test("assertSafePath", async (t) => {
@@ -180,6 +180,54 @@ Deno.test("assertSafePath", async (t) => {
         await Deno.remove(symlinkPath);
       }
     });
+
+    await t.step(
+      "deeply nested child path is accepted (platform separator)",
+      async () => {
+        // Mirrors the bundle-cache path shape that fails on Windows when the
+        // separator check is hardcoded to "/". Uses `join` so the path is
+        // built with the platform's native separator.
+        const nested = join(boundary, "bundles", "abc12345", "model.js");
+        await Deno.mkdir(dirname(nested), { recursive: true });
+        await Deno.writeTextFile(nested, "// test");
+
+        try {
+          await assertSafePath(nested, boundary);
+        } finally {
+          await Deno.remove(nested);
+        }
+      },
+    );
+
+    await t.step(
+      "path lexically outside boundary throws (no symlinks)",
+      async () => {
+        const outsideFile = join(outsideDir, "secret.txt");
+        await assertRejects(
+          () => assertSafePath(outsideFile, boundary),
+          PathTraversalError,
+          "outside boundary",
+        );
+      },
+    );
+
+    await t.step(
+      "file whose name starts with '..' is accepted as a child",
+      async () => {
+        // Guards against a string-prefix-vs-segment bug class: a future
+        // refactor that checks `rel.startsWith("..")` would incorrectly
+        // reject these legitimate child filenames.
+        for (const name of ["..foo", "...config", "..hidden.txt"]) {
+          const filePath = join(boundary, name);
+          await Deno.writeTextFile(filePath, "");
+          try {
+            await assertSafePath(filePath, boundary);
+          } finally {
+            await Deno.remove(filePath);
+          }
+        }
+      },
+    );
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { join, resolve } from "@std/path";
+import { join, resolve, SEPARATOR } from "@std/path";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import { atomicWriteFile, atomicWriteTextFile } from "./atomic_write.ts";
 import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
@@ -1752,7 +1752,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     const resolvedParent = resolve(expectedParent);
     if (
       resolvedPath !== resolvedParent &&
-      !resolvedPath.startsWith(resolvedParent + "/")
+      !resolvedPath.startsWith(resolvedParent + SEPARATOR)
     ) {
       throw new Error(
         `Path traversal detected: ${context} resolves outside expected directory`,

--- a/src/infrastructure/persistence/yaml_vault_config_repository.ts
+++ b/src/infrastructure/persistence/yaml_vault_config_repository.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { ensureDir, walk } from "@std/fs";
-import { join, resolve } from "@std/path";
+import { join, resolve, SEPARATOR } from "@std/path";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import { atomicWriteTextFile } from "./atomic_write.ts";
 import { assertSafePath } from "./safe_path.ts";
@@ -252,7 +252,7 @@ export class YamlVaultConfigRepository {
     const resolvedParent = resolve(expectedParent);
     if (
       resolvedPath !== resolvedParent &&
-      !resolvedPath.startsWith(resolvedParent + "/")
+      !resolvedPath.startsWith(resolvedParent + SEPARATOR)
     ) {
       throw new Error(
         `Path traversal detected: ${context} resolves outside expected directory`,

--- a/src/infrastructure/source/http_source_downloader.ts
+++ b/src/infrastructure/source/http_source_downloader.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { ensureDir } from "@std/fs";
-import { dirname, join, resolve } from "@std/path";
+import { dirname, join, resolve, SEPARATOR } from "@std/path";
 import type { SourceDownloader } from "../../domain/source/mod.ts";
 import { UserError } from "../../domain/errors.ts";
 
@@ -174,7 +174,7 @@ export class HttpSourceDownloader implements SourceDownloader {
         const resolvedTarget = resolve(dirname(targetPath), linkTarget);
         if (
           resolvedTarget === effectiveRoot ||
-          resolvedTarget.startsWith(effectiveRoot + "/")
+          resolvedTarget.startsWith(effectiveRoot + SEPARATOR)
         ) {
           await Deno.symlink(linkTarget, targetPath);
         }

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -17,7 +17,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { basename, dirname, join, relative, resolve } from "@std/path";
+import {
+  basename,
+  dirname,
+  join,
+  relative,
+  resolve,
+  SEPARATOR,
+} from "@std/path";
 import { UserError } from "../../domain/errors.ts";
 import { parseExtensionManifest } from "../../domain/extensions/extension_manifest.ts";
 import { analyzeExtensionSafety } from "../../domain/extensions/extension_safety_analyzer.ts";
@@ -421,7 +428,7 @@ async function validateNoSymlinkEscape(
   if (stat.isSymlink) {
     const linkTarget = await Deno.readLink(path);
     const resolvedTarget = resolve(join(path, "..", linkTarget));
-    if (!resolvedTarget.startsWith(resolvedTmpDir + "/")) {
+    if (!resolvedTarget.startsWith(resolvedTmpDir + SEPARATOR)) {
       throw new UserError(
         `Archive contains a symlink that escapes the temp directory: ${path}`,
       );


### PR DESCRIPTION
## Summary

Two-commit surgical fix for the dominant root cause of Windows test failures in [Cross Platform Builds](https://github.com/systeminit/swamp/actions/runs/25057505097): five copy-pasted instances of a hardcoded `"/"` path separator in path-boundary security checks. On Windows, where `Deno.realPath` returns paths with `\`, these checks reject every legitimate child path as a traversal.

## Sites fixed

| File | Line | Check | Symptom on Windows |
|---|---|---|---|
| `src/infrastructure/persistence/safe_path.ts` | 112 | `assertSafePath` | Bundle cache writes blocked → `NotFound` cascade across hundreds of integration tests |
| `src/infrastructure/persistence/unified_data_repository.ts` | 1755 | `assertPathContained` (duplicate of `assertSafePath`) | `Path traversal detected: modelId "..." resolves outside expected directory` |
| `src/infrastructure/persistence/yaml_vault_config_repository.ts` | 255 | `assertPathContained` (duplicate again) | `Path traversal detected: vaultType "..." resolves outside expected directory` |
| `src/domain/extensions/extension_rubric_scorer.ts` | 647 | Entrypoint containment | `Entrypoint escapes extraction root: model.ts` |
| `src/libswamp/extensions/pull.ts` | 424 | Symlink-escape during extension pull | Symlink validation fails inside legitimate temp dir |
| `src/infrastructure/source/http_source_downloader.ts` | 177 | Symlink-escape during HTTP source download | Same |

All five sites use the identical `+ "/"` hardcode pattern. The fix is the same `+ SEPARATOR` swap, applied to each.

## The change

```diff
- import { join, resolve } from "@std/path";
+ import { join, resolve, SEPARATOR } from "@std/path";

- !resolvedPath.startsWith(resolvedParent + "/")
+ !resolvedPath.startsWith(resolvedParent + SEPARATOR)
```

(Repeated across the six sites, including `safe_path.ts` from the first commit.)

**On POSIX, the change is byte-for-byte identical** — `SEPARATOR === "/"`. On Windows, it correctly becomes `\`.

## Empirical validation

After the first commit (covering only `safe_path.ts`), a manually triggered Cross Platform Builds run against this branch ([run 25135978485](https://github.com/systeminit/swamp/actions/runs/25135978485)) confirmed:

- ✅ **Bundle `NotFound` cascade: 0 occurrences** (was hundreds). The `safe_path` fix flowed through to bundle-cache writes as predicted.
- ⚠️ 21 `Path traversal detected` errors **remained** — but with a **different error message format** than the ones we fixed.

A comprehensive grep then revealed four more sites with the same bug class, each producing the residual errors. This second commit applies the same fix to those four sites.

## Risk-control summary

- **Diff size**: 6 source-line changes (5 imports + 6 operands) + 50 test lines (3 new tests added in commit 1).
- **POSIX behaviour**: provably unchanged on every site. `SEPARATOR` resolves to `"/"` on POSIX, identical to the old hardcoded literal. Confirmed by full local test runs after **both** commits: 4943 passed, 0 failed (1m1s on macOS).
- **No structural refactor.** Function shape, control flow, and helpers are untouched. Only the comparison operand changes.
- **No new logic.** Earlier drafts considered a `relative()`-based rewrite, which had a subtle string-prefix-vs-segment hole. Rejected in favour of this minimal swap.

## Verified containment cases

| Case | Behaviour |
|---|---|
| Legitimate POSIX child `/repo/sub/file` | accepted ✓ |
| Legitimate Windows child `C:\repo\sub\file` | accepted ✓ (was: rejected) |
| Symlink escape to `/etc/passwd` | rejected ✓ |
| Prefix collision (`/foo` vs `/foobar/file`) | rejected ✓ |
| Different drive on Windows (`C:\repo` vs `D:\foo`) | rejected ✓ |
| File whose name starts with `..` (`/repo/..foo`) | accepted ✓ |
| Lexical traversal (path resolves outside boundary) | rejected ✓ |

## Tests added (commit 1)

Three new sub-steps in `safe_path_test.ts`:

1. **Deeply nested child path is accepted (platform separator)** — mirrors the bundle-cache path shape; would catch a re-introduction of the hardcoded `/` on Windows CI.
2. **Path lexically outside boundary throws (no symlinks)** — direct security regression detector.
3. **File whose name starts with `..` is accepted as a child** — guards against a string-prefix-vs-segment bug class.

The four additional sites in commit 2 are covered by the existing test suites for those modules — verified by 4943-passed full-suite run.

## Expected post-merge state

After merge, manually trigger Cross Platform Builds and expect:

- ✅ **All `Path traversal detected` errors gone** (was ~30, then 21 after commit 1, expected 0 after commit 2).
- ✅ Bundle `NotFound` cascade gone (already gone after commit 1).
- ✅ `Entrypoint escapes extraction root: model.ts` gone.
- ⚠️ Remaining unrelated Windows issues, addressed in separate PRs:
  - `Deno.symlink` calls missing the Windows-required `options` arg in some tests.
  - Path mangling: `readdir '/D:/a/swamp/swamp/src'` — POSIX-only `/`-prepending in some code path.

**This PR is not the finish line for Windows support, but it should clear the largest cluster — the path-boundary check family.**

## Out-of-scope follow-ups

Three more `+ "/"` instances exist elsewhere in the codebase (`serve/open/http.ts:978`, `env_path.ts:86`, `extension_auto_resolver.ts:322`). They are not security-critical — they handle autocomplete prefix matching, env-var collapse for display, and collective name prefix matching. They will not surface as test failures. Separate cleanup PR.

A future PR should also **centralize** the three near-identical `assertSafePath`/`assertPathContained` implementations into a single shared helper in `safe_path.ts` to prevent re-introduction of this bug class in a fourth or fifth site. Out of scope here — this PR keeps the structural shape unchanged.

## Review asks

- Verify `SEPARATOR` resolves to `/` on POSIX (proves byte-for-byte identical behaviour for existing users).
- Note that all five sites use the same fix pattern — review one, verify the others match.
- Let `claude-adversarial-review` actually run.
- If you want extra confidence: run `deno task test` locally; expect 4943 passed / 0 failed.

## Test plan

- [x] `deno fmt` clean
- [x] `deno lint` clean
- [x] `deno task check` clean
- [x] `deno run test src/infrastructure/persistence/safe_path_test.ts` — all 12 sub-steps pass
- [x] `deno task test` (full suite) after each commit — 4943 passed, 0 failed locally on macOS
- [x] Cross Platform Builds workflow run against the branch after commit 1 — confirmed bundle cascade cleared, surfaced the remaining four sites
- [ ] After merge: manually trigger Cross Platform Builds, confirm Path-traversal cluster is now 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)