### PR TITLE
feat(cli): add `swamp issue ripple <N>` to post comments on Lab issues (swamp-club#184)

### DIFF
--- a/.claude/skills/swamp-issue/SKILL.md
+++ b/.claude/skills/swamp-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swamp-issue
-description: Submit issues to the swamp Lab or route them to the publisher's repository — file bug reports, feature requests, and security vulnerability reports against swamp itself or against a specific extension. Use when the user wants to report a bug, request a feature, disclose a vulnerability, or provide feedback about swamp. Triggers on "bug report", "feature request", "security report", "vulnerability", "report bug", "request feature", "file bug", "submit bug", "swamp bug", "swamp feature", "feedback", "report issue", "file issue", "report against extension", "extension bug".
+description: Submit issues to the swamp Lab or route them to the publisher's repository — file bug reports, feature requests, and security vulnerability reports against swamp itself or against a specific extension, and post follow-up ripples (comments) on existing Lab issues. Use when the user wants to report a bug, request a feature, disclose a vulnerability, comment on an existing issue, or provide feedback about swamp. Triggers on "bug report", "feature request", "security report", "vulnerability", "report bug", "request feature", "file bug", "submit bug", "swamp bug", "swamp feature", "feedback", "report issue", "file issue", "report against extension", "extension bug", "ripple", "comment on issue", "reply to issue", "follow up on issue", "add comment to issue".
 ---
 
 # Swamp Issue Submission Skill
@@ -14,19 +14,26 @@ With `--extension <name>`, reports are routed to the extension's publisher
 instead — either as a tagged swamp.club Lab issue (for `@swamp/*` extensions) or
 to the publisher's declared repository (for third-party extensions).
 
+To follow up on an existing Lab issue (e.g. add a related finding, link a
+sibling issue, or update reproduction steps discovered later), use
+`swamp issue ripple <number>` — this posts a comment ("ripple") on the issue.
+
 **Verify CLI syntax:** If unsure about exact flags or subcommands, run
 `swamp help issue` for the complete, up-to-date CLI schema.
 
 ## Commands
 
-All three commands support interactive mode (opens `$EDITOR` with a template)
-and non-interactive mode with `--title` and `--body` flags.
+`bug`, `feature`, and `security` support interactive mode (opens `$EDITOR` with
+a template) and non-interactive mode with `--title` and `--body` flags. `ripple`
+takes a positional issue number and either opens the editor or accepts `--body`
+directly.
 
-| Command                | Template sections                                             |
-| ---------------------- | ------------------------------------------------------------- |
-| `swamp issue bug`      | Title, description, steps to reproduce, environment           |
-| `swamp issue feature`  | Title, problem statement, proposed solution, alternatives     |
-| `swamp issue security` | Title, description, reproduction, affected components, impact |
+| Command                       | Template sections                                             |
+| ----------------------------- | ------------------------------------------------------------- |
+| `swamp issue bug`             | Title, description, steps to reproduce, environment           |
+| `swamp issue feature`         | Title, problem statement, proposed solution, alternatives     |
+| `swamp issue security`        | Title, description, reproduction, affected components, impact |
+| `swamp issue ripple <number>` | Free-form markdown body (no title)                            |
 
 **Basic non-interactive examples:**
 
@@ -35,6 +42,29 @@ swamp issue bug --title "CLI crashes on empty input" --body "When running..." --
 swamp issue feature --title "Add dark mode" --body "I'd like..." --json
 swamp issue security --title "..." --body "..." --json
 swamp issue bug --email --title "Crash report" --body "Details..."
+swamp issue ripple 184 --body "See also #183 for the related finding." --json
+```
+
+## Posting a Ripple
+
+`swamp issue ripple <number>` posts a comment (a "ripple" in swamp.club product
+terms) on an existing Lab issue. Useful when an agent or human discovers a
+related finding, workaround, or updated reproduction during follow-on work and
+wants to record it on the original issue.
+
+- Requires `swamp auth login` — there is no email fallback.
+- `--body` skips the editor; `--json` requires `--body`.
+- The body is plain markdown; the server enforces a 65,536-character limit and
+  rejects profanity.
+
+**Output shape** (with `--json`):
+
+```json
+{
+  "issueNumber": 184,
+  "commentId": "ripple_abc123",
+  "serverUrl": "https://swamp.club"
+}
 ```
 
 ## Plain Submission Flow (no `--extension`)

--- a/src/cli/commands/issue.ts
+++ b/src/cli/commands/issue.ts
@@ -20,14 +20,18 @@
 import { Command } from "@cliffy/command";
 import { issueBugCommand } from "./issue_bug.ts";
 import { issueFeatureCommand } from "./issue_feature.ts";
+import { issueRippleCommand } from "./issue_ripple.ts";
 import { issueSecurityCommand } from "./issue_security.ts";
 
 export const issueCommand = new Command()
   .name("issue")
-  .description("Submit bug reports, feature requests, and security reports")
+  .description(
+    "Submit bug reports, feature requests, security reports, and ripples",
+  )
   .action(function () {
     this.showHelp();
   })
   .command("bug", issueBugCommand)
   .command("feature", issueFeatureCommand)
-  .command("security", issueSecurityCommand);
+  .command("security", issueSecurityCommand)
+  .command("ripple", issueRippleCommand);

--- a/src/cli/commands/issue_ripple.ts
+++ b/src/cli/commands/issue_ripple.ts
@@ -1,0 +1,149 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  consumeStream,
+  createLibSwampContext,
+  issueComment,
+  type IssueCommentDeps,
+} from "../../libswamp/mod.ts";
+import {
+  createIssueCommentRenderer,
+  renderIssueCancelled,
+} from "../../presentation/renderers/issue_create.ts";
+import { EditorService } from "../../infrastructure/editor/editor_service.ts";
+import { UserError } from "../../domain/errors.ts";
+import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
+import { SwampClubClient } from "../../infrastructure/http/swamp_club_client.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+/**
+ * Editor template for ripples. Comment lines (HTML markers) are stripped
+ * by {@link parseRippleContent}, so the hint disappears once the user
+ * writes their actual content. Kept on a single line so the per-line
+ * filter strips it without needing to handle multi-line comments.
+ */
+export const RIPPLE_TEMPLATE =
+  `<!-- Write your ripple in markdown. Lines starting with '<!--' are stripped. Save and close to post; leave blank to cancel. -->
+`;
+
+/**
+ * Parse ripple content from the editor. Strips HTML comment lines and
+ * trims whitespace. Returns null when the result is empty (treated as a
+ * cancellation).
+ */
+export function parseRippleContent(content: string): string | null {
+  const cleaned = content
+    .split("\n")
+    .filter((line) => !line.match(/^\s*<!--.*-->\s*$/))
+    .join("\n")
+    .trim();
+  return cleaned.length > 0 ? cleaned : null;
+}
+
+export const issueRippleCommand = new Command()
+  .name("ripple")
+  .description("Post a ripple (comment) on an existing swamp-club Lab issue")
+  .example("Open the editor to write a ripple", "swamp issue ripple 184")
+  .example(
+    "Post a ripple directly",
+    'swamp issue ripple 184 --body "See also #183."',
+  )
+  .arguments("<number:integer>")
+  .option("-b, --body <body:string>", "Ripple body (skips editor)")
+  .action(async function (options: AnyOptions, issueNumber: number) {
+    const ctx = createContext(options as GlobalOptions, ["issue", "ripple"]);
+
+    if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+      throw new UserError("Issue number must be a positive integer.");
+    }
+
+    const credentials = await new AuthRepository().load();
+    if (!credentials) {
+      throw new UserError(
+        'Not logged in. Run "swamp auth login" first to post ripples.',
+      );
+    }
+
+    let body: string;
+
+    if (typeof options.body === "string" && options.body.length > 0) {
+      body = options.body;
+    } else {
+      if (ctx.outputMode === "json") {
+        throw new UserError(
+          "Interactive mode is not available with --json. Use --body to provide the ripple content.",
+        );
+      }
+
+      const tempFile = await Deno.makeTempFile({
+        prefix: "swamp-ripple-",
+        suffix: ".md",
+      });
+
+      try {
+        await Deno.writeTextFile(tempFile, RIPPLE_TEMPLATE);
+        ctx.logger.debug`Opening editor for ripple on issue #${issueNumber}`;
+        await new EditorService().openFile(tempFile, { wait: true });
+
+        const content = await Deno.readTextFile(tempFile);
+        const parsed = parseRippleContent(content);
+        if (parsed === null) {
+          renderIssueCancelled(
+            { type: "ripple", reason: "empty" },
+            ctx.outputMode,
+          );
+          return;
+        }
+        body = parsed;
+      } finally {
+        try {
+          await Deno.remove(tempFile);
+        } catch {
+          // Ignore cleanup errors
+        }
+      }
+    }
+
+    const libCtx = createLibSwampContext({ logger: ctx.logger });
+    const renderer = createIssueCommentRenderer(ctx.outputMode);
+    const client = new SwampClubClient(credentials.serverUrl);
+    const deps: IssueCommentDeps = {
+      submitToLab: async (input) => {
+        const result = await client.submitComment(
+          credentials.apiKey,
+          input.issueNumber,
+          input.body,
+        );
+        return {
+          commentId: result.id,
+          serverUrl: credentials.serverUrl,
+        };
+      },
+    };
+
+    await consumeStream(
+      issueComment(libCtx, deps, { issueNumber, body }),
+      renderer.handlers(),
+    );
+  });

--- a/src/cli/commands/issue_ripple_test.ts
+++ b/src/cli/commands/issue_ripple_test.ts
@@ -1,0 +1,80 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { parseRippleContent, RIPPLE_TEMPLATE } from "./issue_ripple.ts";
+
+Deno.test("parseRippleContent: returns null for empty content", () => {
+  assertEquals(parseRippleContent(""), null);
+  assertEquals(parseRippleContent("   \n  \t\n"), null);
+});
+
+Deno.test("parseRippleContent: returns null when only the template remains", () => {
+  assertEquals(parseRippleContent(RIPPLE_TEMPLATE), null);
+});
+
+Deno.test("parseRippleContent: returns null when only HTML comments remain", () => {
+  const content = `<!-- one comment -->
+<!-- another -->
+   <!-- and another -->
+`;
+  assertEquals(parseRippleContent(content), null);
+});
+
+Deno.test("parseRippleContent: strips HTML comment lines and returns trimmed content", () => {
+  const content = `<!-- hint -->
+This is the actual ripple body.
+<!-- another comment -->
+
+It can have multiple lines.
+`;
+  assertEquals(
+    parseRippleContent(content),
+    "This is the actual ripple body.\n\nIt can have multiple lines.",
+  );
+});
+
+Deno.test("parseRippleContent: preserves inline HTML comments within content lines", () => {
+  // The filter only matches lines that are entirely an HTML comment;
+  // inline `<!-- ... -->` within prose stays untouched.
+  const content = `Here is some <!-- inline --> content.
+`;
+  assertEquals(
+    parseRippleContent(content),
+    "Here is some <!-- inline --> content.",
+  );
+});
+
+Deno.test("parseRippleContent: preserves markdown formatting", () => {
+  const content = `<!-- hint -->
+# Heading
+
+- bullet 1
+- bullet 2
+
+\`\`\`ts
+const x = 1;
+\`\`\`
+`;
+  const parsed = parseRippleContent(content);
+  assertEquals(
+    parsed,
+    "# Heading\n\n- bullet 1\n- bullet 2\n\n```ts\nconst x = 1;\n```",
+  );
+});

--- a/src/infrastructure/http/swamp_club_client.ts
+++ b/src/infrastructure/http/swamp_club_client.ts
@@ -196,6 +196,62 @@ export class SwampClubClient {
     return { number: data.issue.number, id: data.issue.id };
   }
 
+  /**
+   * Post a comment ("ripple") on an existing Lab issue.
+   * Authenticates using the x-api-key header.
+   *
+   * Surfaces server-side error shapes the Lab returns:
+   *   - 401 → not logged in
+   *   - 403 → comments locked or no access
+   *   - 404 → issue not found / not visible
+   *   - 422 → profanity check failed (response includes `flagged` array)
+   */
+  async submitComment(
+    apiKey: string,
+    issueNumber: number,
+    body: string,
+  ): Promise<{ id: string }> {
+    const res = await this.fetch(
+      `/api/v1/lab/issues/${issueNumber}/comments`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": apiKey,
+        },
+        body: JSON.stringify({ body }),
+      },
+    );
+
+    if (!res.ok) {
+      const text = await res.text();
+      // Try to surface profanity-flagged words from the 422 body so the
+      // user knows what to change without paging through raw JSON.
+      if (res.status === 422) {
+        try {
+          const parsed = JSON.parse(text);
+          if (
+            parsed?.error && Array.isArray(parsed.flagged) &&
+            parsed.flagged.length > 0
+          ) {
+            throw new UserError(
+              `${parsed.error}: ${parsed.flagged.join(", ")}`,
+            );
+          }
+        } catch (err) {
+          if (err instanceof UserError) throw err;
+          // fall through to the generic message below
+        }
+      }
+      throw new UserError(
+        `Failed to post ripple on issue #${issueNumber} (HTTP ${res.status}): ${text}`,
+      );
+    }
+
+    const data = await res.json();
+    return { id: data.id };
+  }
+
   private async fetch(
     path: string,
     init: RequestInit,

--- a/src/libswamp/issues/comment.ts
+++ b/src/libswamp/issues/comment.ts
@@ -1,0 +1,98 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { UserError } from "../../domain/errors.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+/**
+ * Server-side maximum comment length (matches MAX_COMMENT_LENGTH in
+ * swamp-club's comments handler). Validated client-side so callers see a
+ * clear error before round-tripping a too-long body.
+ */
+export const MAX_RIPPLE_LENGTH = 65_536;
+
+/** Output of a successful ripple post. */
+export interface IssueCommentData {
+  issueNumber: number;
+  commentId: string;
+  serverUrl: string;
+}
+
+export type IssueCommentEvent =
+  | { kind: "completed"; data: IssueCommentData }
+  | { kind: "error"; error: SwampError };
+
+export interface IssueCommentInput {
+  issueNumber: number;
+  body: string;
+}
+
+export interface IssueCommentDeps {
+  submitToLab: (input: {
+    issueNumber: number;
+    body: string;
+  }) => Promise<{ commentId: string; serverUrl: string }>;
+}
+
+/**
+ * Post a "ripple" (comment) on an existing swamp-club Lab issue.
+ *
+ * Validates the body client-side to avoid round-tripping obviously bad
+ * input. Server-side checks (profanity, comment-locked, visibility) are
+ * surfaced through the infrastructure adapter as UserErrors.
+ */
+export async function* issueComment(
+  ctx: LibSwampContext,
+  deps: IssueCommentDeps,
+  input: IssueCommentInput,
+): AsyncIterable<IssueCommentEvent> {
+  yield* withGeneratorSpan(
+    "swamp.issue.comment",
+    {},
+    (async function* () {
+      ctx.logger.debug`Posting ripple on issue #${input.issueNumber}`;
+
+      const trimmed = input.body.trim();
+      if (trimmed.length === 0) {
+        throw new UserError("Ripple body must not be empty.");
+      }
+      if (input.body.length > MAX_RIPPLE_LENGTH) {
+        throw new UserError(
+          `Ripple body must not exceed ${MAX_RIPPLE_LENGTH} characters.`,
+        );
+      }
+
+      const result = await deps.submitToLab({
+        issueNumber: input.issueNumber,
+        body: input.body,
+      });
+
+      yield {
+        kind: "completed",
+        data: {
+          issueNumber: input.issueNumber,
+          commentId: result.commentId,
+          serverUrl: result.serverUrl,
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/issues/comment_test.ts
+++ b/src/libswamp/issues/comment_test.ts
@@ -1,0 +1,137 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import { UserError } from "../../domain/errors.ts";
+import {
+  issueComment,
+  type IssueCommentDeps,
+  type IssueCommentEvent,
+  MAX_RIPPLE_LENGTH,
+} from "./comment.ts";
+
+function makeDeps(overrides: Partial<IssueCommentDeps> = {}): IssueCommentDeps {
+  return {
+    submitToLab: () =>
+      Promise.resolve({
+        commentId: "ripple-123",
+        serverUrl: "https://swamp-club.com",
+      }),
+    ...overrides,
+  };
+}
+
+Deno.test("issueComment: yields completed with issue number and comment id", async () => {
+  const events = await collect<IssueCommentEvent>(
+    issueComment(createLibSwampContext(), makeDeps(), {
+      issueNumber: 42,
+      body: "Helpful follow-up.",
+    }),
+  );
+
+  assertEquals(events.length, 1);
+  const completed = events[0] as Extract<
+    IssueCommentEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.issueNumber, 42);
+  assertEquals(completed.data.commentId, "ripple-123");
+  assertEquals(completed.data.serverUrl, "https://swamp-club.com");
+});
+
+Deno.test("issueComment: passes body and issueNumber to submitToLab", async () => {
+  let captured: { issueNumber: number; body: string } | undefined;
+  const deps = makeDeps({
+    submitToLab: (input) => {
+      captured = input;
+      return Promise.resolve({
+        commentId: "ripple-7",
+        serverUrl: "https://swamp-club.com",
+      });
+    },
+  });
+
+  await collect(
+    issueComment(createLibSwampContext(), deps, {
+      issueNumber: 99,
+      body: "Multi\nline\nbody.",
+    }),
+  );
+
+  assertEquals(captured?.issueNumber, 99);
+  assertEquals(captured?.body, "Multi\nline\nbody.");
+});
+
+Deno.test("issueComment: rejects empty body", async () => {
+  await assertRejects(
+    () =>
+      collect(
+        issueComment(createLibSwampContext(), makeDeps(), {
+          issueNumber: 1,
+          body: "",
+        }),
+      ),
+    UserError,
+    "must not be empty",
+  );
+});
+
+Deno.test("issueComment: rejects whitespace-only body", async () => {
+  await assertRejects(
+    () =>
+      collect(
+        issueComment(createLibSwampContext(), makeDeps(), {
+          issueNumber: 1,
+          body: "   \n\t\n  ",
+        }),
+      ),
+    UserError,
+    "must not be empty",
+  );
+});
+
+Deno.test("issueComment: rejects body exceeding max length", async () => {
+  const tooLong = "x".repeat(MAX_RIPPLE_LENGTH + 1);
+  const error = await assertRejects(
+    () =>
+      collect(
+        issueComment(createLibSwampContext(), makeDeps(), {
+          issueNumber: 1,
+          body: tooLong,
+        }),
+      ),
+    UserError,
+  );
+  assertStringIncludes(error.message, String(MAX_RIPPLE_LENGTH));
+});
+
+Deno.test("issueComment: accepts body at exactly the max length", async () => {
+  const exactlyMax = "x".repeat(MAX_RIPPLE_LENGTH);
+  const events = await collect<IssueCommentEvent>(
+    issueComment(createLibSwampContext(), makeDeps(), {
+      issueNumber: 1,
+      body: exactlyMax,
+    }),
+  );
+  assertEquals(events.length, 1);
+  assertEquals(events[0].kind, "completed");
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -903,6 +903,14 @@ export {
   type IssueCreateEvent,
   type IssueCreateInput,
 } from "./issues/create.ts";
+export {
+  issueComment,
+  type IssueCommentData,
+  type IssueCommentDeps,
+  type IssueCommentEvent,
+  type IssueCommentInput,
+  MAX_RIPPLE_LENGTH,
+} from "./issues/comment.ts";
 
 // Audit operations
 export {

--- a/src/presentation/renderers/issue_create.ts
+++ b/src/presentation/renderers/issue_create.ts
@@ -17,7 +17,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import type { EventHandlers, IssueCreateEvent } from "../../libswamp/mod.ts";
+import type {
+  EventHandlers,
+  IssueCommentEvent,
+  IssueCreateEvent,
+} from "../../libswamp/mod.ts";
 import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
@@ -107,7 +111,7 @@ export function createIssueCreateRenderer(
 
 /** Data structure for issue editor cancelled output. */
 export interface IssueCancelledData {
-  type: "bug" | "feature" | "security";
+  type: "bug" | "feature" | "security" | "ripple";
   reason: "empty" | "cancelled";
 }
 
@@ -119,11 +123,59 @@ export function renderIssueCancelled(
     console.log(JSON.stringify({ status: "cancelled", ...data }, null, 2));
   } else {
     const logger = getSwampLogger(["issue", "create"]);
+    const action = data.type === "ripple" ? "Ripple" : "Issue creation";
     if (data.reason === "empty") {
-      logger.info("Issue creation cancelled: no content provided");
+      logger.info(`${action} cancelled: no content provided`);
     } else {
-      logger.info("Issue creation cancelled");
+      logger.info(`${action} cancelled`);
     }
+  }
+}
+
+// ---- Ripple (comment) rendering ----
+
+class LogIssueCommentRenderer implements Renderer<IssueCommentEvent> {
+  handlers(): EventHandlers<IssueCommentEvent> {
+    const logger = getSwampLogger(["issue", "ripple"]);
+    return {
+      completed: (e) => {
+        const data = e.data;
+        logger.info(
+          "Posted ripple on issue #{number}",
+          { number: data.issueNumber },
+        );
+        logger.info("View at: {url}", {
+          url: `${data.serverUrl}/lab/${data.issueNumber}`,
+        });
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonIssueCommentRenderer implements Renderer<IssueCommentEvent> {
+  handlers(): EventHandlers<IssueCommentEvent> {
+    return {
+      completed: (e) => {
+        console.log(JSON.stringify(e.data, null, 2));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createIssueCommentRenderer(
+  mode: OutputMode,
+): Renderer<IssueCommentEvent> {
+  switch (mode) {
+    case "json":
+      return new JsonIssueCommentRenderer();
+    case "log":
+      return new LogIssueCommentRenderer();
   }
 }
 


### PR DESCRIPTION
## Summary

Closes swamp-club#184.

- Adds `swamp issue ripple <number> [--body '...'] [--json]` so agents
  and humans can post comments ("ripples") on existing swamp-club Lab
  issues.
- Lab auth required (no email fallback). `--body` skips the editor;
  `--json` requires `--body`. The editor flow opens with a one-line
  `<!--` hint and treats an empty result as a clean cancellation.
- 422 responses from the profanity check surface the server's `flagged`
  word list rather than dumping raw JSON.

Architecture mirrors the existing `bug`/`feature`/`security` siblings:
infrastructure adapter on `SwampClubClient.submitComment`, application
service in `src/libswamp/issues/comment.ts`, renderer alongside
`issue_create`, and a Cliffy command in `src/cli/commands/issue_ripple.ts`.
The CLI surfaces the product term "ripple" while internal types use the
wire/data term "comment" — same pattern that has `issue` as the user
surface for `/lab/issues`.

Server side already exposes `POST /api/v1/lab/issues/<N>/comments`; no
swamp-club changes.

## Test plan

- [x] `deno check`
- [x] `deno lint`
- [x] `deno fmt`
- [x] `deno run test` (4969 passed, 0 failed)
- [x] `deno run compile`
- [x] Live smoke test against swamp-club: posted ripple
      `68f5316f-a13d-4ca3-bfaa-8cdf96aaae48` to issue #184 itself
- [x] `swamp issue --help` lists `ripple` alongside the existing subcommands
- [x] `swamp issue ripple --help` shows positional `<number>`, `--body`,
      and examples

## Follow-ups (out of scope)

The lifecycle adversarial review surfaced two pre-existing gaps that
are not specific to this PR; tracking them as separate issues:

- No CLI UAT coverage exists for `swamp issue` at all (no
  `tests/cli/issue/` in `swamp-uat`).
- No manual reference page for `swamp issue` in
  `swamp-club/content/manual/reference/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)