### PR TITLE
fix(logging,workflows,persistence): use dirname/basename instead of split('/')

### DIFF
--- a/src/infrastructure/logging/run_file_sink.ts
+++ b/src/infrastructure/logging/run_file_sink.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { getTextFormatter, type LogRecord, type Sink } from "@logtape/logtape";
+import { dirname } from "@std/path";
 import type { SecretRedactor } from "../../domain/secrets/mod.ts";
 import { assertSafePath } from "../persistence/safe_path.ts";
 
@@ -85,8 +86,8 @@ export class RunFileSink {
     }
 
     // Ensure parent directory exists
-    const dir = filePath.substring(0, filePath.lastIndexOf("/"));
-    if (dir) {
+    const dir = dirname(filePath);
+    if (dir && dir !== ".") {
       await Deno.mkdir(dir, { recursive: true });
     }
 

--- a/src/infrastructure/persistence/yaml_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_repository.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { ensureDir } from "@std/fs";
-import { join } from "@std/path";
+import { basename, join } from "@std/path";
 import { getLogger } from "@logtape/logtape";
 import { atomicWriteTextFile } from "./atomic_write.ts";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
@@ -210,7 +210,7 @@ export class YamlWorkflowRepository implements WorkflowRepository {
       // Ignore - fall through to filename
     }
     // Extract filename without extension as fallback
-    const filename = path.split("/").pop() ?? path;
+    const filename = basename(path);
     return filename.replace(/\.yaml$/, "");
   }
 }

--- a/src/libswamp/workflows/watcher.ts
+++ b/src/libswamp/workflows/watcher.ts
@@ -23,7 +23,7 @@
  * Uses Deno.watchFs with debouncing to coalesce rapid filesystem events.
  */
 
-import { join } from "@std/path";
+import { basename, join } from "@std/path";
 import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 import type { WorkflowId } from "../../domain/workflows/workflow_id.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
@@ -132,7 +132,7 @@ export class WorkflowWatcher {
     path: string,
     kind: Deno.FsEvent["kind"],
   ): Promise<void> {
-    const filename = path.split("/").pop() ?? "";
+    const filename = basename(path);
 
     if (kind === "remove") {
       // Extract workflow ID from filename pattern: workflow-{uuid}.yaml


### PR DESCRIPTION
## Summary

Three-site surgical fix for hand-rolled path manipulation that hardcodes the `/` separator. Sibling to #1241 (which fixed a different bug pattern in path-boundary checks). After #1241 cleared the path-traversal / bundle-NotFound clusters, the next dominant Windows failure was ~318 integration tests failing because log-file parent directories couldn't be created.

## Sites fixed

| File | Line | Pattern | Fix |
|---|---|---|---|
| `src/infrastructure/logging/run_file_sink.ts` | 88 | `filePath.substring(0, filePath.lastIndexOf("/"))` | `dirname(filePath)` |
| `src/libswamp/workflows/watcher.ts` | 135 | `path.split("/").pop() ?? ""` | `basename(path)` |
| `src/infrastructure/persistence/yaml_workflow_repository.ts` | 213 | `path.split("/").pop() ?? path` | `basename(path)` |

## Impact

The `run_file_sink.ts:88` site is the load-bearing one. It's called whenever swamp opens a per-run log file (workflow runs, method executions). On Windows:

1. `filePath` arrives as e.g. `C:\Users\...\.swamp\workflow-runs\<uuid>\workflow-run-<uuid>.log`.
2. `lastIndexOf("/")` returns `-1` (Windows uses `\`).
3. `substring(0, -1)` returns `""`.
4. The `if (dir)` guard skips `Deno.mkdir`.
5. `Deno.open` fails with `NotFound (os error 3)` because the parent directory was never created.

This pattern surfaced as `Method execution failed: The system cannot find the path specified` and `Workflow execution failed: The system cannot find the path specified` across ~318 integration tests on Windows after the previous PR cleared the higher-priority cluster.

## What was NOT changed

`src/domain/extensions/extension_auto_resolver.ts:296` also uses `lastIndexOf("/")`, but it operates on a ModelType identifier (e.g., `@swamp/aws/ec2/instance`) where `/` is a domain-logic separator that is independent of the OS path separator. It is correctly hardcoded and intentionally not touched here.

## Risk-control summary

- **Diff size**: 6 source-line changes across 3 files. No new logic, no refactoring.
- **POSIX behaviour**: materially identical. `dirname` and `basename` from `@std/path` produce the same results as the hand-rolled equivalents for any path containing `/`. Edge cases (no separator, root path) map to no-op territory (`mkdir(".", recursive)` or `mkdir("/", recursive)` — both safe).
- **Confirmed by full local test suite**: 4971 passed, 0 failed (1m on macOS). No tests had to be modified.

## Verified semantic equivalence on POSIX

| Input filePath | Old: `substring(0, lastIndexOf("/"))` | New: `dirname()` | Behaviour |
|---|---|---|---|
| `/foo/bar.log` | `/foo` | `/foo` | identical → `mkdir("/foo")` |
| `bar.log` | `""` (skipped) | `"."` (skipped via `dir !== "."`) | equivalent → no mkdir |
| `/bar.log` | `""` (skipped) | `"/"` | new code mkdir's "/", which is a no-op (always exists) |
| `./foo/bar.log` | `./foo` | `./foo` | identical |

| Input path | Old: `split("/").pop() ?? "..."` | New: `basename()` | Behaviour |
|---|---|---|---|
| `/foo/bar.yaml` | `bar.yaml` | `bar.yaml` | identical |
| `bar.yaml` | `bar.yaml` | `bar.yaml` | identical |

## Expected post-merge state

After merge, manually trigger Cross Platform Builds and expect:

- ✅ The ~318 `Method execution failed: ... cannot find the path specified` and `Workflow execution failed: ... cannot find the path specified` failures cleared.
- ⚠️ Remaining unrelated Windows issues, addressed in separate follow-up PRs:
  - `Deno.symlink` calls missing the Windows-required `options` arg in some tests (handful).
  - `UserError: Unsupported operating system: windows. Supported: darwin, linux` — `Platform.from()` allow-list (Tier 1.1 in the original Windows-support audit).

## Review asks

- Verify each `dirname`/`basename` swap matches the hand-rolled equivalent on POSIX.
- Note the deliberately-skipped `extension_auto_resolver.ts:296` (domain-logic separator, not a filesystem path).
- Let `claude-adversarial-review` run.

## Test plan

- [x] `deno fmt` clean
- [x] `deno lint` clean
- [x] `deno task check` clean
- [x] `deno run test` (full suite) — 4971 passed, 0 failed locally on macOS
- [ ] After merge: manually trigger Cross Platform Builds, confirm the `cannot find the path specified` cluster is 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)