### PR TITLE
feat(doctor): add `swamp doctor extensions` subcommand (swamp-club#180)

### DIFF
--- a/integration/extensions/doctor_extensions_test.ts
+++ b/integration/extensions/doctor_extensions_test.ts
@@ -1,0 +1,392 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+// End-to-end coverage for `swamp doctor extensions` (swamp-club#180).
+// Each test uses a fresh repo because `kind: "extension"` warnings
+// only fire on the catalog-population path
+// (user_model_loader.ts:populateCatalogFromDir), which only runs when
+// the bundle catalog is empty. A warmed catalog from a previous run
+// would skip the populate path and the fold rule would not be
+// exercised end-to-end.
+
+import { assertEquals } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { initializeTestRepo, runCliCommand } from "../test_helpers.ts";
+
+// Valid model with a quoted `type` literal — loads cleanly. Fixture
+// (d) extends THIS model, so it must always appear so that the
+// extension's `processExtension` succeeds at runtime (otherwise the
+// "Cannot extend unregistered model type" failure short-circuits to
+// retryable+log-only and never reaches the captured warnings array).
+const VALID_MODEL = `
+import { z } from "npm:zod@4";
+export const model = {
+  type: "@tutorial/working",
+  version: "2026.04.28.0",
+  globalArguments: z.object({}),
+  resources: {},
+  methods: {
+    run: {
+      description: "no-op",
+      arguments: z.object({}),
+      execute: () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+// Missing `version` — fails Zod validation in loadModels. Recorded
+// under kind=model.
+const BAD_MODEL_VALIDATION = `
+import { z } from "npm:zod@4";
+export const model = {
+  type: "@tutorial/missing-version",
+  globalArguments: z.object({}),
+  resources: {},
+  methods: {
+    run: {
+      description: "no-op",
+      arguments: z.object({}),
+      execute: () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+// `type` field is a const, not a literal — populateCatalogFromDir's
+// regex cannot extract it. Recorded under kind=model.
+const BAD_MODEL_REGEX = `
+import { z } from "npm:zod@4";
+const TYPE = "@tutorial/non-literal-type";
+export const model = {
+  type: TYPE,
+  version: "2026.04.28.0",
+  globalArguments: z.object({}),
+  resources: {},
+  methods: {
+    run: {
+      description: "no-op",
+      arguments: z.object({}),
+      execute: () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+// EXTENSION (not model) with a non-literal `type`. This is the only
+// fixture that triggers `emitTypeExtractionFailure(file, "extension")`
+// — recorded under kind=extension by populateCatalogFromDir. The
+// doctor service must fold this into the model registry's row.
+//
+// The extension targets the type from VALID_MODEL so processExtension
+// succeeds at runtime; the catalog-population regex still fails on
+// the source text because TYPE is a const reference.
+const BAD_EXTENSION_REGEX = `
+import { z } from "npm:zod@4";
+const TYPE = "@tutorial/working";
+export const extension = {
+  type: TYPE,
+  methods: [{
+    extra: {
+      description: "no-op extension method",
+      arguments: z.object({}),
+      execute: () => ({ dataHandles: [] }),
+    },
+  }],
+};
+`;
+
+interface DoctorJson {
+  overallStatus: "pass" | "fail";
+  registries: Record<
+    string,
+    {
+      status: "pass" | "fail";
+      failures: Array<{ file: string; error: string }>;
+    }
+  >;
+}
+
+function findFailureFor(
+  failures: Array<{ file: string; error: string }>,
+  needle: string,
+): { file: string; error: string } | undefined {
+  return failures.find((f) => f.file.includes(needle));
+}
+
+Deno.test(
+  "doctor extensions: failing fixtures land under the model row (model+extension fold), all five registries reported",
+  async () => {
+    const repoDir = await Deno.makeTempDir({
+      prefix: "swamp-issue-180-fail-",
+    });
+    try {
+      await initializeTestRepo(repoDir);
+      const modelsDir = join(repoDir, "extensions", "models");
+      await ensureDir(modelsDir);
+      await Deno.writeTextFile(join(modelsDir, "working.ts"), VALID_MODEL);
+      await Deno.writeTextFile(
+        join(modelsDir, "missing_version.ts"),
+        BAD_MODEL_VALIDATION,
+      );
+      await Deno.writeTextFile(
+        join(modelsDir, "non_literal_type.ts"),
+        BAD_MODEL_REGEX,
+      );
+      await Deno.writeTextFile(
+        join(modelsDir, "non_literal_type_extension.ts"),
+        BAD_EXTENSION_REGEX,
+      );
+
+      // Run the doctor as the FIRST swamp command in this repo so the
+      // bundle catalog is empty when ensureLoaded() runs.
+      const { stdout, code } = await runCliCommand(
+        ["--json", "doctor", "extensions"],
+        repoDir,
+      );
+
+      // The doctor command's JSON mode emits a single pretty-printed
+      // object on stdout. Find the first `{` to skip any cliffy
+      // bootstrap chatter (there shouldn't be any with --json, but
+      // defensive).
+      const firstBrace = stdout.indexOf("{");
+      const slice = stdout.slice(firstBrace);
+      const parsed = JSON.parse(slice) as DoctorJson;
+
+      assertEquals(
+        code,
+        1,
+        `expected exit 1; got code=${code}, stdout=${stdout}`,
+      );
+      assertEquals(parsed.overallStatus, "fail");
+
+      // All five registry keys present.
+      const keys = Object.keys(parsed.registries).sort();
+      assertEquals(
+        keys,
+        ["datastore", "driver", "model", "report", "vault"],
+      );
+
+      // The non-model registries pass with empty failure arrays.
+      assertEquals(parsed.registries.vault.status, "pass");
+      assertEquals(parsed.registries.driver.status, "pass");
+      assertEquals(parsed.registries.datastore.status, "pass");
+      assertEquals(parsed.registries.report.status, "pass");
+      assertEquals(parsed.registries.vault.failures.length, 0);
+      assertEquals(parsed.registries.driver.failures.length, 0);
+      assertEquals(parsed.registries.datastore.failures.length, 0);
+      assertEquals(parsed.registries.report.failures.length, 0);
+
+      // The model registry's row absorbs the kind=model failures (b, c)
+      // AND the kind=extension failure (d) thanks to the fold.
+      const modelRow = parsed.registries.model;
+      assertEquals(modelRow.status, "fail");
+
+      const validationFailure = findFailureFor(
+        modelRow.failures,
+        "missing_version.ts",
+      );
+      const regexFailure = findFailureFor(
+        modelRow.failures,
+        "non_literal_type.ts",
+      );
+      const extensionFailure = findFailureFor(
+        modelRow.failures,
+        "non_literal_type_extension.ts",
+      );
+
+      assertEquals(
+        typeof validationFailure?.file,
+        "string",
+        `expected missing_version.ts under model row; got: ${
+          JSON.stringify(modelRow.failures)
+        }`,
+      );
+      assertEquals(
+        typeof regexFailure?.file,
+        "string",
+        `expected non_literal_type.ts under model row; got: ${
+          JSON.stringify(modelRow.failures)
+        }`,
+      );
+      assertEquals(
+        typeof extensionFailure?.file,
+        "string",
+        `expected non_literal_type_extension.ts under model row (proves model+extension fold); got: ${
+          JSON.stringify(modelRow.failures)
+        }`,
+      );
+    } finally {
+      await Deno.remove(repoDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "doctor extensions: clean repo passes with all five registries empty",
+  async () => {
+    const repoDir = await Deno.makeTempDir({
+      prefix: "swamp-issue-180-pass-",
+    });
+    try {
+      await initializeTestRepo(repoDir);
+      // No fixtures — clean repo.
+
+      const { stdout, code } = await runCliCommand(
+        ["--json", "doctor", "extensions"],
+        repoDir,
+      );
+
+      const firstBrace = stdout.indexOf("{");
+      const slice = stdout.slice(firstBrace);
+      const parsed = JSON.parse(slice) as DoctorJson;
+
+      assertEquals(
+        code,
+        0,
+        `expected exit 0; got code=${code}, stdout=${stdout}`,
+      );
+      assertEquals(parsed.overallStatus, "pass");
+
+      // All five registry keys still present, all empty.
+      const keys = Object.keys(parsed.registries).sort();
+      assertEquals(
+        keys,
+        ["datastore", "driver", "model", "report", "vault"],
+      );
+      for (const key of keys) {
+        assertEquals(parsed.registries[key].status, "pass");
+        assertEquals(parsed.registries[key].failures.length, 0);
+      }
+    } finally {
+      await Deno.remove(repoDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "doctor extensions: log mode exits non-zero on failing fixtures",
+  async () => {
+    const repoDir = await Deno.makeTempDir({
+      prefix: "swamp-issue-180-log-",
+    });
+    try {
+      await initializeTestRepo(repoDir);
+      const modelsDir = join(repoDir, "extensions", "models");
+      await ensureDir(modelsDir);
+      await Deno.writeTextFile(
+        join(modelsDir, "missing_version.ts"),
+        BAD_MODEL_VALIDATION,
+      );
+
+      const { code } = await runCliCommand(
+        ["doctor", "extensions"],
+        repoDir,
+      );
+
+      assertEquals(code, 1, `expected exit 1 in log mode on failure`);
+    } finally {
+      await Deno.remove(repoDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "doctor extensions: repeat invocation in same repo reports the same failures (catalog-rescan regression guard)",
+  async () => {
+    // The bundle catalog short-circuits ensureLoaded() when populated,
+    // which would silently hide failures on a second invocation. The
+    // doctor command invalidates the catalog before each run; this
+    // test guards against regression of that fix.
+    const repoDir = await Deno.makeTempDir({
+      prefix: "swamp-issue-180-repeat-",
+    });
+    try {
+      await initializeTestRepo(repoDir);
+      const modelsDir = join(repoDir, "extensions", "models");
+      await ensureDir(modelsDir);
+      await Deno.writeTextFile(join(modelsDir, "working.ts"), VALID_MODEL);
+      await Deno.writeTextFile(
+        join(modelsDir, "missing_version.ts"),
+        BAD_MODEL_VALIDATION,
+      );
+      await Deno.writeTextFile(
+        join(modelsDir, "non_literal_type_extension.ts"),
+        BAD_EXTENSION_REGEX,
+      );
+
+      // First invocation — catalog starts empty, populates during this run.
+      const first = await runCliCommand(
+        ["--json", "doctor", "extensions"],
+        repoDir,
+      );
+      const firstParsed = JSON.parse(
+        first.stdout.slice(first.stdout.indexOf("{")),
+      ) as DoctorJson;
+
+      // Second invocation — catalog now populated. Without the
+      // doctor's catalog-rescan, this would short-circuit and report pass.
+      const second = await runCliCommand(
+        ["--json", "doctor", "extensions"],
+        repoDir,
+      );
+      const secondParsed = JSON.parse(
+        second.stdout.slice(second.stdout.indexOf("{")),
+      ) as DoctorJson;
+
+      assertEquals(
+        first.code,
+        1,
+        `first run expected exit 1; got ${first.code}, stdout=${first.stdout}`,
+      );
+      assertEquals(
+        second.code,
+        1,
+        `second run expected exit 1 (catalog-rescan regression?); got ${second.code}, stdout=${second.stdout}`,
+      );
+      assertEquals(firstParsed.overallStatus, "fail");
+      assertEquals(secondParsed.overallStatus, "fail");
+
+      // The second run must surface the same failure files as the first.
+      const firstFiles = firstParsed.registries.model.failures
+        .map((f) => f.file.split("/").pop()!)
+        .sort();
+      const secondFiles = secondParsed.registries.model.failures
+        .map((f) => f.file.split("/").pop()!)
+        .sort();
+      assertEquals(
+        firstFiles,
+        secondFiles,
+        "second invocation must report the same failures as the first",
+      );
+      // Both files we expect to fail are present (validation + extension fold).
+      assertEquals(
+        secondFiles.includes("missing_version.ts"),
+        true,
+      );
+      assertEquals(
+        secondFiles.includes("non_literal_type_extension.ts"),
+        true,
+      );
+    } finally {
+      await Deno.remove(repoDir, { recursive: true });
+    }
+  },
+);

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -19,6 +19,7 @@
 
 import { Command } from "@cliffy/command";
 import { doctorAuditCommand } from "./doctor_audit.ts";
+import { doctorExtensionsCommand } from "./doctor_extensions.ts";
 
 /**
  * Parent namespace for diagnostic subcommands.
@@ -40,4 +41,9 @@ export const doctorCommand = new Command()
     "Check the audit integration for a specific tool",
     "swamp doctor audit --tool kiro",
   )
-  .command("audit", doctorAuditCommand);
+  .example(
+    "Check that user-defined extensions in this repo load cleanly",
+    "swamp doctor extensions",
+  )
+  .command("audit", doctorAuditCommand)
+  .command("extensions", doctorExtensionsCommand);

--- a/src/cli/commands/doctor_extensions.ts
+++ b/src/cli/commands/doctor_extensions.ts
@@ -1,0 +1,146 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+// `swamp doctor extensions` — runs ensureLoaded() across all five user
+// extension registries, captures load failures via the issue-177
+// emitter, and emits a per-registry pass/fail report.
+//
+// Relies on `doctor` not being in NON_REPO_COMMANDS — see
+// `cli/mod.ts:NON_REPO_COMMANDS` (the constant lives near line 191).
+// Without that, configureExtensionLoaders never runs and the
+// registries' ensureLoaded would be no-ops.
+//
+// Caller does NOT need to call resetState/resetLoadedFlag — the
+// service handles that ordering as the first steps of its async
+// generator.
+//
+// Note: `resolveDatastoreForRepo()` warms `datastoreTypeRegistry`'s
+// `ensureLoaded()` BEFORE the service runs. The service then calls
+// `resetLoadedFlag()` and `ensureLoaded()` again. The double-run is
+// intentional — the second run is what the user sees in the report
+// — and it is consistent with how registries that the CLI bootstrap
+// already warmed get re-loaded.
+
+import { Command } from "@cliffy/command";
+import {
+  consumeStream,
+  doctorExtensions,
+  type DoctorRegistryDeps,
+} from "../../libswamp/mod.ts";
+import {
+  getExtensionLoadWarnings,
+  resetExtensionLoadWarnings,
+} from "../../infrastructure/logging/extension_load_warnings.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
+import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
+import { driverTypeRegistry } from "../../domain/drivers/driver_type_registry.ts";
+import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
+import { reportRegistry } from "../../domain/reports/report_registry.ts";
+import { forceCatalogRescan } from "../../infrastructure/persistence/extension_catalog_store.ts";
+import { createDoctorExtensionsRenderer } from "../../presentation/renderers/doctor_extensions.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { resolveDatastoreForRepo } from "../repo_context.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+/**
+ * `swamp doctor extensions` — re-runs the extension loaders across
+ * all five user registries and reports any load failures. Exits
+ * non-zero on any failure so the command composes into CI preflight
+ * checks.
+ */
+export const doctorExtensionsCommand = new Command()
+  .description(
+    "Verify that user-defined extensions in this repo load cleanly.",
+  )
+  .example("Check this repo's extensions", "swamp doctor extensions")
+  .example("Machine-readable output for CI", "swamp doctor extensions --json")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(async function (options: AnyOptions) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "doctor",
+      "extensions",
+    ]);
+    cliCtx.logger.debug("Executing doctor extensions command");
+
+    const repoDir = resolveRepoDir(options.repoDir);
+    // Same gate as `doctor audit` — fails loudly outside a swamp repo.
+    await resolveDatastoreForRepo(repoDir);
+
+    // Invalidate the catalog so the loaders run a full re-validation
+    // instead of returning the cached lazy entries. Without this, the
+    // doctor reports stale results when run after another swamp
+    // command in the same repo.
+    forceCatalogRescan(repoDir);
+
+    const registries: ReadonlyArray<DoctorRegistryDeps> = [
+      {
+        registry: "model",
+        ensureLoaded: () => modelRegistry.ensureLoaded(),
+        resetLoadedFlag: () => modelRegistry.resetLoadedFlag(),
+      },
+      {
+        registry: "vault",
+        ensureLoaded: () => vaultTypeRegistry.ensureLoaded(),
+        resetLoadedFlag: () => vaultTypeRegistry.resetLoadedFlag(),
+      },
+      {
+        registry: "driver",
+        ensureLoaded: () => driverTypeRegistry.ensureLoaded(),
+        resetLoadedFlag: () => driverTypeRegistry.resetLoadedFlag(),
+      },
+      {
+        registry: "datastore",
+        ensureLoaded: () => datastoreTypeRegistry.ensureLoaded(),
+        resetLoadedFlag: () => datastoreTypeRegistry.resetLoadedFlag(),
+      },
+      {
+        registry: "report",
+        ensureLoaded: () => reportRegistry.ensureLoaded(),
+        resetLoadedFlag: () => reportRegistry.resetLoadedFlag(),
+      },
+    ];
+
+    const controller = new AbortController();
+    const renderer = createDoctorExtensionsRenderer(cliCtx.outputMode);
+
+    await consumeStream(
+      doctorExtensions({
+        registries,
+        getWarnings: getExtensionLoadWarnings,
+        resetState: resetExtensionLoadWarnings,
+        abortSignal: controller.signal,
+      }),
+      renderer.handlers(),
+    );
+
+    cliCtx.logger.debug("doctor extensions command completed");
+
+    if (renderer.overallStatus === "fail") {
+      Deno.exit(1);
+    }
+  });

--- a/src/cli/commands/doctor_extensions_test.ts
+++ b/src/cli/commands/doctor_extensions_test.ts
@@ -1,0 +1,38 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Import models barrel to trigger self-registration
+import "../../domain/models/models.ts";
+
+await initializeLogging({});
+
+Deno.test("doctorExtensionsCommand module loads", async () => {
+  const mod = await import("./doctor_extensions.ts");
+  assertEquals(typeof mod.doctorExtensionsCommand, "object");
+});
+
+Deno.test("doctorExtensionsCommand is registered as subcommand of doctorCommand", async () => {
+  const { doctorCommand } = await import("./doctor.ts");
+  const commands = doctorCommand.getCommands();
+  const extCmd = commands.find((c) => c.getName() === "extensions");
+  assertEquals(extCmd !== undefined, true);
+});

--- a/src/cli/commands/open.ts
+++ b/src/cli/commands/open.ts
@@ -49,8 +49,7 @@ import { pullExtension } from "./extension_pull.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
-import { swampPath } from "../../infrastructure/persistence/paths.ts";
-import { ExtensionCatalogStore } from "../../infrastructure/persistence/extension_catalog_store.ts";
+import { forceCatalogRescan } from "../../infrastructure/persistence/extension_catalog_store.ts";
 import {
   configureExtensionAutoResolver,
   configureExtensionLoaders,
@@ -64,24 +63,6 @@ import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
 type AnyOptions = any;
 
 const logger = getSwampLogger(["open"]);
-
-function forceExtensionCatalogRescan(repoDir: string): void {
-  try {
-    const dbPath = swampPath(repoDir, "_extension_catalog.db");
-    const catalog = new ExtensionCatalogStore(dbPath);
-    try {
-      catalog.invalidate("model");
-      catalog.invalidate("vault");
-      catalog.invalidate("driver");
-      catalog.invalidate("datastore");
-      catalog.invalidate("report");
-    } finally {
-      catalog.close();
-    }
-  } catch {
-    // Best-effort — the loader will bootstrap a fresh catalog if this fails.
-  }
-}
 
 async function reloadExtensionRegistries(): Promise<void> {
   // Force the registries to re-run their loaders so newly pulled
@@ -123,7 +104,7 @@ async function loadRepoIntoState(
   const deferred: DeferredWarning[] = [];
   await configureExtensionLoaders(result.repoDir, marker, [], deferred);
   configureExtensionAutoResolver(result.repoDir, marker, undefined, outputMode);
-  forceExtensionCatalogRescan(result.repoDir);
+  forceCatalogRescan(result.repoDir);
   await reloadExtensionRegistries();
 }
 

--- a/src/domain/datastore/datastore_type_registry.ts
+++ b/src/domain/datastore/datastore_type_registry.ts
@@ -107,6 +107,16 @@ export class DatastoreTypeRegistry {
   }
 
   /**
+   * Clears the extension-loaded flag so the next call to
+   * {@link ensureLoaded} re-runs the configured loader. Used by commands
+   * that re-scan extensions at runtime (e.g. `swamp doctor extensions`).
+   */
+  resetLoadedFlag(): void {
+    this.extensionsLoaded = false;
+    this.extensionLoadPromise = null;
+  }
+
+  /**
    * Ensures a specific datastore type's bundle has been imported.
    * If the type is lazy, invokes the type loader to import just that bundle.
    * Concurrent callers for the same type share the same promise.

--- a/src/domain/datastore/datastore_type_registry_test.ts
+++ b/src/domain/datastore/datastore_type_registry_test.ts
@@ -270,3 +270,23 @@ Deno.test("DatastoreTypeRegistry.ensureTypeLoaded: retries after transient failu
   assertEquals(callCount, 2);
   assertEquals(registry.get("@myorg/custom")?.name, "@myorg/custom store");
 });
+
+Deno.test("DatastoreTypeRegistry.resetLoadedFlag re-runs the loader on next ensureLoaded", async () => {
+  const registry = new DatastoreTypeRegistry();
+  let loadCount = 0;
+  registry.setLoader(() => {
+    loadCount++;
+    return Promise.resolve();
+  });
+
+  await registry.ensureLoaded();
+  assertEquals(loadCount, 1);
+
+  // Without reset, a second ensureLoaded is a no-op.
+  await registry.ensureLoaded();
+  assertEquals(loadCount, 1);
+
+  registry.resetLoadedFlag();
+  await registry.ensureLoaded();
+  assertEquals(loadCount, 2);
+});

--- a/src/infrastructure/logging/extension_load_warnings.ts
+++ b/src/infrastructure/logging/extension_load_warnings.ts
@@ -53,6 +53,7 @@ export interface EmitterOptions {
 interface EmitterState {
   emitted: Set<string>;
   hintsEmittedFor: Set<ExtensionKind>;
+  warnings: ExtensionLoadWarning[];
 }
 
 const STATE_KEY = "__swampExtensionLoadWarningState";
@@ -65,6 +66,7 @@ function getState(): EmitterState {
     globalAny[STATE_KEY] = {
       emitted: new Set<string>(),
       hintsEmittedFor: new Set<ExtensionKind>(),
+      warnings: [],
     } satisfies EmitterState;
   }
   return globalAny[STATE_KEY];
@@ -117,19 +119,23 @@ function isSilenced(options: EmitterOptions): boolean {
  * common wrong-turn (registering an extension source for a path
  * that's already auto-discovered).
  *
- * Quiet mode short-circuits to a no-op so `swamp --quiet` stays
- * quiet without callers having to filter.
+ * Capture is always-on: every unique warning is also pushed onto the
+ * structured `warnings` array, regardless of quiet mode. `swamp doctor
+ * extensions` reads the array via {@link getExtensionLoadWarnings} so
+ * the diagnostic surface stays available even when stderr is muted.
+ * Quiet mode only suppresses the writer call.
  */
 export function emitExtensionLoadWarning(
   warning: ExtensionLoadWarning,
   options: EmitterOptions = {},
 ): void {
-  if (isSilenced(options)) return;
-
   const state = getState();
   const key = dedupeKey(warning);
   if (state.emitted.has(key)) return;
   state.emitted.add(key);
+  state.warnings.push(warning);
+
+  if (isSilenced(options)) return;
 
   const writer = options.writer ?? defaultWriter;
   writer(`swamp-warning: ${warning.file}: ${warning.error}`);
@@ -138,6 +144,18 @@ export function emitExtensionLoadWarning(
     state.hintsEmittedFor.add(warning.kind);
     writer(`  hint: ${HINT_BY_KIND[warning.kind]}`);
   }
+}
+
+/**
+ * Returns a defensive copy of the structured warnings captured so far.
+ * Read by `swamp doctor extensions` to render its per-registry report.
+ * Each unique (kind, file, error) tuple appears exactly once because
+ * the emitter dedupes before pushing.
+ */
+export function getExtensionLoadWarnings(): ReadonlyArray<
+  ExtensionLoadWarning
+> {
+  return [...getState().warnings];
 }
 
 /**
@@ -185,13 +203,16 @@ export function emitTypeExtractionFailure(
 }
 
 /**
- * Clears the emitter's process-scoped dedupe + hint-tracking state.
- * Long-running processes (swamp serve, swamp open) call this
- * alongside ModelRegistry.resetLoadedFlag() so a subsequent reload
- * re-emits warnings cleanly.
+ * Clears the emitter's process-scoped dedupe + hint-tracking state
+ * AND the structured warnings array. Long-running processes (swamp
+ * serve, swamp open) call this alongside ModelRegistry.resetLoadedFlag()
+ * so a subsequent reload re-emits warnings cleanly. `swamp doctor
+ * extensions` calls this before re-running loaders so its report
+ * reflects only the warnings produced by its own pass.
  */
 export function resetExtensionLoadWarnings(): void {
   const state = getState();
   state.emitted.clear();
   state.hintsEmittedFor.clear();
+  state.warnings.length = 0;
 }

--- a/src/infrastructure/logging/extension_load_warnings_test.ts
+++ b/src/infrastructure/logging/extension_load_warnings_test.ts
@@ -21,9 +21,15 @@ import { assertEquals, assertStringIncludes } from "@std/assert";
 import {
   emitExtensionLoadWarning,
   emitTypeExtractionFailure,
+  getExtensionLoadWarnings,
   recordLoadFailures,
   resetExtensionLoadWarnings,
 } from "./extension_load_warnings.ts";
+
+// Every test in this file MUST call resetExtensionLoadWarnings() at the
+// start so the always-on capture array does not bleed warnings between
+// cases. The dedupe set already cleared per-case before the array was
+// added; the array makes the requirement load-bearing.
 
 function makeCapture() {
   const lines: string[] = [];
@@ -144,6 +150,21 @@ Deno.test("emitExtensionLoadWarning: quiet=true suppresses output entirely", () 
   assertEquals(cap.lines.length, 0);
 });
 
+Deno.test("emitExtensionLoadWarning: quiet=true still captures into the warnings array", () => {
+  // The doctor command relies on this contract — capture is always-on
+  // so the diagnostic stays available even when stderr is muted.
+  resetExtensionLoadWarnings();
+
+  emitExtensionLoadWarning(
+    { kind: "model", file: "/m.ts", error: "boom" },
+    { quiet: true },
+  );
+
+  const warnings = getExtensionLoadWarnings();
+  assertEquals(warnings.length, 1);
+  assertEquals(warnings[0].file, "/m.ts");
+});
+
 Deno.test("emitExtensionLoadWarning: quiet=false overrides any process-level --quiet detection", () => {
   resetExtensionLoadWarnings();
   const cap = makeCapture();
@@ -215,4 +236,55 @@ Deno.test("resetExtensionLoadWarnings: clears dedupe and hint state", () => {
 
   // Two warning lines + two hint lines.
   assertEquals(cap.lines.length, 4);
+});
+
+Deno.test("getExtensionLoadWarnings: returns each unique warning once", () => {
+  resetExtensionLoadWarnings();
+
+  emitExtensionLoadWarning(
+    { kind: "model", file: "/a.ts", error: "e1" },
+    { quiet: true },
+  );
+  emitExtensionLoadWarning(
+    { kind: "extension", file: "/b.ts", error: "e2" },
+    { quiet: true },
+  );
+  // Duplicate of the first — should be deduped.
+  emitExtensionLoadWarning(
+    { kind: "model", file: "/a.ts", error: "e1" },
+    { quiet: true },
+  );
+
+  const warnings = getExtensionLoadWarnings();
+  assertEquals(warnings.length, 2);
+  assertEquals(warnings[0].kind, "model");
+  assertEquals(warnings[1].kind, "extension");
+});
+
+Deno.test("getExtensionLoadWarnings: returns a defensive copy (caller cannot mutate state)", () => {
+  resetExtensionLoadWarnings();
+
+  emitExtensionLoadWarning(
+    { kind: "model", file: "/a.ts", error: "e" },
+    { quiet: true },
+  );
+
+  const snapshot = getExtensionLoadWarnings() as Array<unknown>;
+  snapshot.push({ kind: "vault", file: "/x.ts", error: "tampered" });
+
+  // Internal state must not have grown.
+  assertEquals(getExtensionLoadWarnings().length, 1);
+});
+
+Deno.test("resetExtensionLoadWarnings: clears the captured warnings array", () => {
+  resetExtensionLoadWarnings();
+
+  emitExtensionLoadWarning(
+    { kind: "model", file: "/a.ts", error: "e" },
+    { quiet: true },
+  );
+  assertEquals(getExtensionLoadWarnings().length, 1);
+
+  resetExtensionLoadWarnings();
+  assertEquals(getExtensionLoadWarnings().length, 0);
 });

--- a/src/infrastructure/persistence/extension_catalog_store.ts
+++ b/src/infrastructure/persistence/extension_catalog_store.ts
@@ -20,6 +20,7 @@
 import { DatabaseSync } from "node:sqlite";
 import { dirname } from "@std/path";
 import { ensureDirSync } from "@std/fs";
+import { swampPath } from "./paths.ts";
 
 /**
  * The kind of bundle entry — which registry type it belongs to.
@@ -406,4 +407,42 @@ export function sourceDirsFingerprint(
 ): string {
   const dirs = [primaryDir, ...(additionalDirs ?? [])];
   return dirs.sort().join("\n");
+}
+
+/**
+ * Invalidates every kind in the bundle catalog so the next
+ * `ensureLoaded()` runs the full discovery + validation pass instead
+ * of taking the lazy short-circuit. Used by commands that need a
+ * deterministic re-load regardless of prior catalog state — e.g.
+ * `swamp open` (after a repo switch) and `swamp doctor extensions`
+ * (so the diagnostic always re-validates).
+ *
+ * Invalidates only the five registry kinds that own a `populated:`
+ * flag in `bundle_meta` (model, vault, driver, datastore, report).
+ * The `extension` ExtensionKind is recorded on individual catalog
+ * rows but never gets its own populated flag — it is always
+ * re-discovered through the model populate path. See
+ * {@link ExtensionCatalogStore.markPopulated} for the canonical
+ * list of flag-owning kinds.
+ *
+ * Best-effort: a failure to open the database is swallowed so the
+ * caller's flow continues. The next loader pass will bootstrap a
+ * fresh catalog if the file is missing or corrupt.
+ */
+export function forceCatalogRescan(repoDir: string): void {
+  try {
+    const dbPath = swampPath(repoDir, "_extension_catalog.db");
+    const catalog = new ExtensionCatalogStore(dbPath);
+    try {
+      catalog.invalidate("model");
+      catalog.invalidate("vault");
+      catalog.invalidate("driver");
+      catalog.invalidate("datastore");
+      catalog.invalidate("report");
+    } finally {
+      catalog.close();
+    }
+  } catch {
+    // Best-effort — the loader will bootstrap a fresh catalog if this fails.
+  }
 }

--- a/src/libswamp/extensions/doctor.ts
+++ b/src/libswamp/extensions/doctor.ts
@@ -1,0 +1,210 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ExtensionLoadWarning } from "../../infrastructure/logging/extension_load_warnings.ts";
+import type { SwampError } from "../errors.ts";
+
+/**
+ * Public registry name for the doctor report. The infrastructure-layer
+ * `ExtensionKind` enum has six values (`model`, `extension`, `vault`,
+ * `driver`, `datastore`, `report`) but only five user-facing registries
+ * exist — `extension` is a sub-kind of the model loader (it indicates
+ * a user extension extending an existing model type) and folds into
+ * the `model` row in this report.
+ */
+export type DoctorRegistryName =
+  | "model"
+  | "vault"
+  | "driver"
+  | "datastore"
+  | "report";
+
+/** Fixed run order — also the row order in the rendered report. */
+export const DOCTOR_REGISTRY_ORDER: ReadonlyArray<DoctorRegistryName> = [
+  "model",
+  "vault",
+  "driver",
+  "datastore",
+  "report",
+];
+
+/** A single registry's failure record after the model/extension fold. */
+export interface DoctorRegistryFailure {
+  file: string;
+  error: string;
+}
+
+/** Per-registry result emitted on `kind-completed`. */
+export interface DoctorRegistryResult {
+  registry: DoctorRegistryName;
+  status: "pass" | "fail";
+  failures: DoctorRegistryFailure[];
+}
+
+/** Final overall status — `pass` when every registry passed. */
+export type DoctorOverallStatus = "pass" | "fail";
+
+/** Final report shape — used by the renderer's JSON mode. */
+export interface DoctorExtensionsReport {
+  overallStatus: DoctorOverallStatus;
+  /** Map of registry name → its result. All five keys always present. */
+  registries: Record<DoctorRegistryName, DoctorRegistryResult>;
+}
+
+/**
+ * Streaming events from the doctor extensions pipeline. The `error`
+ * variant is required by libswamp's stream-protocol type system but
+ * is not produced today — every per-registry failure is folded into
+ * the report. Reserved for future failure modes that need to
+ * short-circuit the stream mid-run.
+ */
+export type DoctorExtensionsEvent =
+  | { kind: "kind-started"; registry: DoctorRegistryName }
+  | { kind: "kind-completed"; result: DoctorRegistryResult }
+  | { kind: "completed"; report: DoctorExtensionsReport }
+  | { kind: "error"; error: SwampError };
+
+/**
+ * Per-registry callbacks supplied by the CLI. Each entry pairs the
+ * loader-trigger with its reset-flag callback so the doctor service
+ * can force a re-run regardless of whether the registry was already
+ * warmed earlier in the same process.
+ */
+export interface DoctorRegistryDeps {
+  registry: DoctorRegistryName;
+  ensureLoaded: () => Promise<void>;
+  resetLoadedFlag: () => void;
+}
+
+/** Dependencies for the doctor extensions operation. */
+export interface DoctorExtensionsDeps {
+  /** One entry per registry, in DOCTOR_REGISTRY_ORDER. */
+  registries: ReadonlyArray<DoctorRegistryDeps>;
+  /** Reads the captured warnings array (defensive snapshot). */
+  getWarnings: () => ReadonlyArray<ExtensionLoadWarning>;
+  /** Clears the captured warnings array + dedupe state. */
+  resetState: () => void;
+  abortSignal: AbortSignal;
+}
+
+function overallStatus(
+  results: ReadonlyArray<DoctorRegistryResult>,
+): DoctorOverallStatus {
+  return results.some((r) => r.status === "fail") ? "fail" : "pass";
+}
+
+/**
+ * Filters the captured warnings down to the ones owned by a given
+ * registry. The model registry absorbs both `model` and `extension`
+ * ExtensionKind values — `extension` warnings come exclusively from
+ * the model loader's catalog-population path (see
+ * `user_model_loader.ts:populateCatalogFromDir`) and so logically
+ * belong to the model registry's row.
+ */
+function partitionForRegistry(
+  registry: DoctorRegistryName,
+  warnings: ReadonlyArray<ExtensionLoadWarning>,
+): DoctorRegistryFailure[] {
+  return warnings
+    .filter((w) => {
+      if (registry === "model") {
+        return w.kind === "model" || w.kind === "extension";
+      }
+      return w.kind === registry;
+    })
+    .map((w) => ({ file: w.file, error: w.error }));
+}
+
+/**
+ * Runs `ensureLoaded()` across all five user-facing extension
+ * registries and reports per-registry pass/fail. The first steps of
+ * the generator are a state reset + a `resetLoadedFlag()` on every
+ * registry so the diagnostic forces a full re-load even when the CLI
+ * bootstrap already warmed the registries earlier in the process.
+ *
+ * Order of operations is the load-bearing invariant: callers must
+ * NOT pre-reset state — the service owns that ordering.
+ */
+export async function* doctorExtensions(
+  deps: DoctorExtensionsDeps,
+): AsyncIterable<DoctorExtensionsEvent> {
+  // Step (a): clear the emitter so we only see what THIS pass produces.
+  deps.resetState();
+  // Step (b): force every registry's loader to re-run, even if a prior
+  // CLI codepath already warmed it.
+  for (const reg of deps.registries) {
+    reg.resetLoadedFlag();
+  }
+
+  const results: DoctorRegistryResult[] = [];
+
+  // Step (c): iterate each registry, run its loader, partition the
+  // captured warnings, and emit a per-registry result.
+  for (const reg of deps.registries) {
+    if (deps.abortSignal.aborted) break;
+
+    yield { kind: "kind-started", registry: reg.registry };
+
+    try {
+      await reg.ensureLoaded();
+    } catch (error) {
+      // A throw from ensureLoaded means the loader couldn't even run.
+      // Convert it into a synthetic failure so the report still surfaces
+      // the problem and the remaining registries continue running.
+      const synthetic: ExtensionLoadWarning = {
+        kind: reg.registry === "model" ? "model" : reg.registry,
+        file: `<${reg.registry} loader>`,
+        error: error instanceof Error ? error.message : String(error),
+      };
+      // Fold the synthetic failure into the partitioned list directly —
+      // we cannot rely on the emitter capturing it.
+      const captured = partitionForRegistry(reg.registry, deps.getWarnings());
+      const failures = [...captured, {
+        file: synthetic.file,
+        error: synthetic.error,
+      }];
+      const result: DoctorRegistryResult = {
+        registry: reg.registry,
+        status: "fail",
+        failures,
+      };
+      results.push(result);
+      yield { kind: "kind-completed", result };
+      continue;
+    }
+
+    const failures = partitionForRegistry(reg.registry, deps.getWarnings());
+    const result: DoctorRegistryResult = {
+      registry: reg.registry,
+      status: failures.length > 0 ? "fail" : "pass",
+      failures,
+    };
+    results.push(result);
+    yield { kind: "kind-completed", result };
+  }
+
+  const registries = Object.fromEntries(
+    results.map((r) => [r.registry, r]),
+  ) as Record<DoctorRegistryName, DoctorRegistryResult>;
+
+  yield {
+    kind: "completed",
+    report: { overallStatus: overallStatus(results), registries },
+  };
+}

--- a/src/libswamp/extensions/doctor_test.ts
+++ b/src/libswamp/extensions/doctor_test.ts
@@ -1,0 +1,239 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import type { ExtensionLoadWarning } from "../../infrastructure/logging/extension_load_warnings.ts";
+import { resetExtensionLoadWarnings } from "../../infrastructure/logging/extension_load_warnings.ts";
+import {
+  DOCTOR_REGISTRY_ORDER,
+  doctorExtensions,
+  type DoctorExtensionsDeps,
+  type DoctorExtensionsEvent,
+  type DoctorRegistryName,
+} from "./doctor.ts";
+
+interface SpyEntry {
+  fn: string;
+  registry?: DoctorRegistryName;
+}
+
+/**
+ * Builds a deps object with spy callbacks. The shared `events` array
+ * records every callback invocation so tests can assert ordering.
+ *
+ * The `getWarnings` stub returns a stable closure over the supplied
+ * snapshot — it is called once per kind iteration and must return the
+ * same value every time so partition-by-kind is deterministic.
+ */
+function buildDeps(
+  options: {
+    warnings?: ReadonlyArray<ExtensionLoadWarning>;
+    throwForRegistry?: DoctorRegistryName;
+  } = {},
+): {
+  deps: DoctorExtensionsDeps;
+  events: SpyEntry[];
+} {
+  const events: SpyEntry[] = [];
+  const warnings = options.warnings ?? [];
+
+  const registries = DOCTOR_REGISTRY_ORDER.map((registry) => ({
+    registry,
+    ensureLoaded: () => {
+      events.push({ fn: "ensureLoaded", registry });
+      if (options.throwForRegistry === registry) {
+        throw new Error(`stub-throw-${registry}`);
+      }
+      return Promise.resolve();
+    },
+    resetLoadedFlag: () => {
+      events.push({ fn: "resetLoadedFlag", registry });
+    },
+  }));
+
+  const deps: DoctorExtensionsDeps = {
+    registries,
+    getWarnings: () => warnings,
+    resetState: () => {
+      events.push({ fn: "resetState" });
+    },
+    abortSignal: new AbortController().signal,
+  };
+
+  return { deps, events };
+}
+
+async function collect(
+  stream: AsyncIterable<DoctorExtensionsEvent>,
+): Promise<DoctorExtensionsEvent[]> {
+  const out: DoctorExtensionsEvent[] = [];
+  for await (const event of stream) {
+    out.push(event);
+  }
+  return out;
+}
+
+Deno.test("doctorExtensions: clean state — all five registries pass", async () => {
+  resetExtensionLoadWarnings();
+  const { deps } = buildDeps();
+
+  const events = await collect(doctorExtensions(deps));
+
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind !== "completed") return;
+  assertEquals(completed.report.overallStatus, "pass");
+  for (const registry of DOCTOR_REGISTRY_ORDER) {
+    const result = completed.report.registries[registry];
+    assertEquals(result.status, "pass");
+    assertEquals(result.failures.length, 0);
+  }
+});
+
+Deno.test("doctorExtensions: emits all five kind-completed events in fixed order", async () => {
+  resetExtensionLoadWarnings();
+  const { deps } = buildDeps();
+
+  const events = await collect(doctorExtensions(deps));
+  const completedEvents = events.filter((e) => e.kind === "kind-completed");
+
+  assertEquals(completedEvents.length, 5);
+  for (let i = 0; i < DOCTOR_REGISTRY_ORDER.length; i++) {
+    const event = completedEvents[i];
+    if (event.kind !== "kind-completed") throw new Error("unreachable");
+    assertEquals(event.result.registry, DOCTOR_REGISTRY_ORDER[i]);
+  }
+});
+
+Deno.test("doctorExtensions: order of operations — resetState + all resetLoadedFlag run BEFORE any ensureLoaded", async () => {
+  resetExtensionLoadWarnings();
+  const { deps, events } = buildDeps();
+
+  await collect(doctorExtensions(deps));
+
+  // Find the indices of the first ensureLoaded vs all resets.
+  const firstEnsureLoadedIdx = events.findIndex((e) => e.fn === "ensureLoaded");
+  const lastResetIdx = events.reduce(
+    (acc, e, i) =>
+      e.fn === "resetState" || e.fn === "resetLoadedFlag" ? i : acc,
+    -1,
+  );
+
+  // The last reset must come before the first ensureLoaded — that is
+  // the load-bearing invariant the service owns.
+  assertEquals(lastResetIdx < firstEnsureLoadedIdx, true);
+
+  // resetState runs exactly once, and before any resetLoadedFlag.
+  const resetStateIdx = events.findIndex((e) => e.fn === "resetState");
+  assertEquals(resetStateIdx, 0);
+  assertEquals(
+    events.filter((e) => e.fn === "resetState").length,
+    1,
+  );
+
+  // All five resetLoadedFlag calls fire exactly once.
+  const resetCounts = new Map<DoctorRegistryName, number>();
+  for (const e of events) {
+    if (e.fn !== "resetLoadedFlag" || !e.registry) continue;
+    resetCounts.set(e.registry, (resetCounts.get(e.registry) ?? 0) + 1);
+  }
+  for (const registry of DOCTOR_REGISTRY_ORDER) {
+    assertEquals(resetCounts.get(registry), 1);
+  }
+});
+
+Deno.test("doctorExtensions: model/extension fold — both ExtensionKind values land under the model registry's row", async () => {
+  resetExtensionLoadWarnings();
+  const mixedWarnings: ExtensionLoadWarning[] = [
+    { kind: "model", file: "/m1.ts", error: "missing version" },
+    { kind: "extension", file: "/m2.ts", error: "non-literal type" },
+    { kind: "vault", file: "/v.ts", error: "broken vault" },
+    { kind: "driver", file: "/d.ts", error: "broken driver" },
+  ];
+  const { deps } = buildDeps({ warnings: mixedWarnings });
+
+  const events = await collect(doctorExtensions(deps));
+  const completed = events.find((e) => e.kind === "completed");
+  if (completed?.kind !== "completed") {
+    throw new Error("expected completed event");
+  }
+
+  // The model row absorbs BOTH the kind=model AND the kind=extension warnings.
+  const modelRow = completed.report.registries.model;
+  assertEquals(modelRow.status, "fail");
+  assertEquals(modelRow.failures.length, 2);
+  assertEquals(modelRow.failures[0].file, "/m1.ts");
+  assertEquals(modelRow.failures[1].file, "/m2.ts");
+
+  // The vault row sees only its own warnings.
+  const vaultRow = completed.report.registries.vault;
+  assertEquals(vaultRow.status, "fail");
+  assertEquals(vaultRow.failures.length, 1);
+  assertEquals(vaultRow.failures[0].file, "/v.ts");
+
+  // datastore + report rows are clean.
+  assertEquals(completed.report.registries.datastore.status, "pass");
+  assertEquals(completed.report.registries.report.status, "pass");
+
+  // Overall status is fail because at least one registry failed.
+  assertEquals(completed.report.overallStatus, "fail");
+});
+
+Deno.test("doctorExtensions: per-kind throw isolation — a thrown ensureLoaded becomes a fail without aborting other kinds", async () => {
+  resetExtensionLoadWarnings();
+  const { deps } = buildDeps({ throwForRegistry: "vault" });
+
+  const events = await collect(doctorExtensions(deps));
+  const completed = events.find((e) => e.kind === "completed");
+  if (completed?.kind !== "completed") {
+    throw new Error("expected completed event");
+  }
+
+  // Vault failed, others passed.
+  assertEquals(completed.report.registries.vault.status, "fail");
+  assertEquals(completed.report.registries.vault.failures.length, 1);
+  assertEquals(
+    completed.report.registries.vault.failures[0].error.includes("stub-throw"),
+    true,
+  );
+
+  // The other registries still ran and reported pass.
+  assertEquals(completed.report.registries.model.status, "pass");
+  assertEquals(completed.report.registries.driver.status, "pass");
+  assertEquals(completed.report.registries.datastore.status, "pass");
+  assertEquals(completed.report.registries.report.status, "pass");
+
+  // All five kind-completed events were emitted.
+  const completedEvents = events.filter((e) => e.kind === "kind-completed");
+  assertEquals(completedEvents.length, 5);
+});
+
+Deno.test("doctorExtensions: completed report has all five registry keys even on pass", async () => {
+  resetExtensionLoadWarnings();
+  const { deps } = buildDeps();
+
+  const events = await collect(doctorExtensions(deps));
+  const completed = events.find((e) => e.kind === "completed");
+  if (completed?.kind !== "completed") {
+    throw new Error("expected completed event");
+  }
+
+  const keys = Object.keys(completed.report.registries).sort();
+  assertEquals(keys, ["datastore", "driver", "model", "report", "vault"]);
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -691,6 +691,20 @@ export {
   type ExtensionInstallEvent,
 } from "./extensions/install.ts";
 
+// Extension load diagnostic (`swamp doctor extensions`)
+export {
+  DOCTOR_REGISTRY_ORDER,
+  doctorExtensions,
+  type DoctorExtensionsDeps,
+  type DoctorExtensionsEvent,
+  type DoctorExtensionsReport,
+  type DoctorOverallStatus,
+  type DoctorRegistryDeps,
+  type DoctorRegistryFailure,
+  type DoctorRegistryName,
+  type DoctorRegistryResult,
+} from "./extensions/doctor.ts";
+
 // Model edit operations
 export {
   createModelEditDeps,

--- a/src/presentation/renderers/doctor_extensions.ts
+++ b/src/presentation/renderers/doctor_extensions.ts
@@ -1,0 +1,149 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { bold, dim, green, red, yellow } from "@std/fmt/colors";
+import {
+  DOCTOR_REGISTRY_ORDER,
+  type DoctorExtensionsEvent,
+  type DoctorOverallStatus,
+  type DoctorRegistryName,
+  type DoctorRegistryResult,
+  type EventHandlers,
+} from "../../libswamp/mod.ts";
+import { UserError } from "../../domain/errors.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import type { OutputMode } from "../output/output.ts";
+
+/**
+ * Renderer for `swamp doctor extensions`. Receives exactly five
+ * `kind-completed` events (one per registry) and renders each row
+ * verbatim — the model/extension fold has already happened in the
+ * service. The renderer never imports the infrastructure-layer
+ * `ExtensionKind` enum.
+ *
+ * Exposes `overallStatus` so the CLI can exit non-zero on a failing
+ * report.
+ */
+export interface DoctorExtensionsRenderer {
+  handlers(): EventHandlers<DoctorExtensionsEvent>;
+  readonly overallStatus: DoctorOverallStatus;
+}
+
+function iconFor(status: DoctorRegistryResult["status"]): string {
+  switch (status) {
+    case "pass":
+      return green("✓");
+    case "fail":
+      return red("✗");
+  }
+}
+
+function summaryLine(status: DoctorOverallStatus): string {
+  switch (status) {
+    case "pass":
+      return green(bold("OVERALL: PASS"));
+    case "fail":
+      return red(bold("OVERALL: FAIL"));
+  }
+}
+
+class LogDoctorExtensionsRenderer implements DoctorExtensionsRenderer {
+  overallStatus: DoctorOverallStatus = "pass";
+
+  handlers(): EventHandlers<DoctorExtensionsEvent> {
+    return {
+      "kind-started": () => {
+        // No-op. ensureLoaded() runs fast enough that an in-progress
+        // line is visual noise — users see the ✓/✗ on kind-completed.
+      },
+      "kind-completed": (e) => {
+        const r = e.result;
+        const failureSuffix = r.failures.length > 0
+          ? dim(` (${r.failures.length} failure(s))`)
+          : "";
+        writeOutput(`${iconFor(r.status)} ${bold(r.registry)}${failureSuffix}`);
+        for (const failure of r.failures) {
+          writeOutput(`    ${yellow("•")} ${failure.file}: ${failure.error}`);
+        }
+      },
+      completed: (e) => {
+        this.overallStatus = e.report.overallStatus;
+        const passCount = Object.values(e.report.registries)
+          .filter((r) => r.status === "pass").length;
+        const failCount = Object.values(e.report.registries)
+          .filter((r) => r.status === "fail").length;
+        writeOutput(
+          `\n${passCount} passed, ${failCount} failed — ${
+            summaryLine(e.report.overallStatus)
+          }`,
+        );
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonDoctorExtensionsRenderer implements DoctorExtensionsRenderer {
+  overallStatus: DoctorOverallStatus = "pass";
+
+  handlers(): EventHandlers<DoctorExtensionsEvent> {
+    return {
+      "kind-started": () => {
+        // No-op — JSON consumers get a single final emit.
+      },
+      "kind-completed": () => {
+        // No-op — per-kind progress is swallowed in JSON mode.
+      },
+      completed: (e) => {
+        this.overallStatus = e.report.overallStatus;
+        // Re-build the registries object in DOCTOR_REGISTRY_ORDER so the
+        // JSON output has stable key ordering. All five keys are always
+        // present even on pass — that's a stability promise to consumers.
+        const registries: Record<DoctorRegistryName, DoctorRegistryResult> =
+          {} as Record<DoctorRegistryName, DoctorRegistryResult>;
+        for (const name of DOCTOR_REGISTRY_ORDER) {
+          registries[name] = e.report.registries[name];
+        }
+        console.log(
+          JSON.stringify(
+            { overallStatus: e.report.overallStatus, registries },
+            null,
+            2,
+          ),
+        );
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createDoctorExtensionsRenderer(
+  mode: OutputMode,
+): DoctorExtensionsRenderer {
+  switch (mode) {
+    case "json":
+      return new JsonDoctorExtensionsRenderer();
+    case "log":
+      return new LogDoctorExtensionsRenderer();
+  }
+}

--- a/src/presentation/renderers/doctor_extensions_test.ts
+++ b/src/presentation/renderers/doctor_extensions_test.ts
@@ -1,0 +1,207 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import type {
+  DoctorExtensionsReport,
+  DoctorRegistryName,
+  DoctorRegistryResult,
+} from "../../libswamp/mod.ts";
+import { createDoctorExtensionsRenderer } from "./doctor_extensions.ts";
+
+await initializeLogging({});
+
+function captureStdout(fn: () => void | Promise<void>): Promise<string> {
+  const originalLog = console.log;
+  const lines: string[] = [];
+  console.log = (...args: unknown[]) => {
+    lines.push(
+      args.map((a) => typeof a === "string" ? a : String(a)).join(" "),
+    );
+  };
+  return Promise.resolve(fn())
+    .finally(() => {
+      console.log = originalLog;
+    })
+    .then(() => lines.join("\n"));
+}
+
+function passResult(registry: DoctorRegistryName): DoctorRegistryResult {
+  return { registry, status: "pass", failures: [] };
+}
+
+function failResult(
+  registry: DoctorRegistryName,
+  failures: Array<{ file: string; error: string }>,
+): DoctorRegistryResult {
+  return { registry, status: "fail", failures };
+}
+
+function buildPassReport(): DoctorExtensionsReport {
+  return {
+    overallStatus: "pass",
+    registries: {
+      model: passResult("model"),
+      vault: passResult("vault"),
+      driver: passResult("driver"),
+      datastore: passResult("datastore"),
+      report: passResult("report"),
+    },
+  };
+}
+
+function buildFailReport(): DoctorExtensionsReport {
+  return {
+    overallStatus: "fail",
+    registries: {
+      model: failResult("model", [
+        { file: "/repo/extensions/models/bad.ts", error: "missing version" },
+      ]),
+      vault: passResult("vault"),
+      driver: passResult("driver"),
+      datastore: passResult("datastore"),
+      report: passResult("report"),
+    },
+  };
+}
+
+Deno.test("doctor_extensions json renderer: emits all five registry keys on pass", async () => {
+  const out = await captureStdout(async () => {
+    const r = createDoctorExtensionsRenderer("json");
+    const handlers = r.handlers();
+    await handlers.completed({ kind: "completed", report: buildPassReport() });
+  });
+
+  const parsed = JSON.parse(out);
+  assertEquals(parsed.overallStatus, "pass");
+  const keys = Object.keys(parsed.registries).sort();
+  assertEquals(keys, ["datastore", "driver", "model", "report", "vault"]);
+  for (const key of keys) {
+    assertEquals(parsed.registries[key].status, "pass");
+    assertEquals(parsed.registries[key].failures.length, 0);
+  }
+});
+
+Deno.test("doctor_extensions json renderer: emits all five registry keys on fail", async () => {
+  const out = await captureStdout(async () => {
+    const r = createDoctorExtensionsRenderer("json");
+    const handlers = r.handlers();
+    await handlers.completed({ kind: "completed", report: buildFailReport() });
+  });
+
+  const parsed = JSON.parse(out);
+  assertEquals(parsed.overallStatus, "fail");
+  // All five keys still present even though only one registry failed.
+  const keys = Object.keys(parsed.registries).sort();
+  assertEquals(keys, ["datastore", "driver", "model", "report", "vault"]);
+  assertEquals(parsed.registries.model.status, "fail");
+  assertEquals(parsed.registries.model.failures.length, 1);
+  assertEquals(parsed.registries.vault.status, "pass");
+});
+
+Deno.test("doctor_extensions log renderer: tracks overallStatus across completion", async () => {
+  const r = createDoctorExtensionsRenderer("log");
+  const handlers = r.handlers();
+  assertEquals(r.overallStatus, "pass");
+  await handlers.completed({ kind: "completed", report: buildFailReport() });
+  assertEquals(r.overallStatus, "fail");
+});
+
+Deno.test("doctor_extensions log renderer: emits one failure bullet per file", async () => {
+  // Capture writeOutput by spying on console (writeOutput funnels through
+  // LogTape; we assert the rendered handlers don't throw and overallStatus
+  // tracks correctly. Bullet rendering itself is verified by integration tests).
+  const r = createDoctorExtensionsRenderer("log");
+  const handlers = r.handlers();
+  // No-op for kind-started.
+  await handlers["kind-started"]({ kind: "kind-started", registry: "model" });
+  // kind-completed for a failing model row should not throw.
+  await handlers["kind-completed"]({
+    kind: "kind-completed",
+    result: failResult("model", [
+      { file: "/a.ts", error: "boom" },
+      { file: "/b.ts", error: "boom2" },
+    ]),
+  });
+  // completed sets overallStatus.
+  await handlers.completed({ kind: "completed", report: buildFailReport() });
+  assertEquals(r.overallStatus, "fail");
+});
+
+Deno.test("doctor_extensions json renderer: stable key ordering", async () => {
+  // Even if the input report has registries in a different order, the JSON
+  // output respects DOCTOR_REGISTRY_ORDER.
+  const out = await captureStdout(async () => {
+    const r = createDoctorExtensionsRenderer("json");
+    const handlers = r.handlers();
+    // Build a report with registries inserted in reverse order — output
+    // should still be model, vault, driver, datastore, report.
+    const reversed: DoctorExtensionsReport = {
+      overallStatus: "pass",
+      registries: {
+        report: passResult("report"),
+        datastore: passResult("datastore"),
+        driver: passResult("driver"),
+        vault: passResult("vault"),
+        model: passResult("model"),
+      },
+    };
+    await handlers.completed({ kind: "completed", report: reversed });
+  });
+
+  // Find the order of keys in the printed JSON string.
+  const startOfRegistries = out.indexOf('"registries"');
+  const slice = out.slice(startOfRegistries);
+  const modelIdx = slice.indexOf('"model"');
+  const vaultIdx = slice.indexOf('"vault"');
+  const driverIdx = slice.indexOf('"driver"');
+  const datastoreIdx = slice.indexOf('"datastore"');
+  const reportIdx = slice.indexOf('"report"');
+
+  assertEquals(modelIdx < vaultIdx, true);
+  assertEquals(vaultIdx < driverIdx, true);
+  assertEquals(driverIdx < datastoreIdx, true);
+  assertEquals(datastoreIdx < reportIdx, true);
+});
+
+Deno.test("doctor_extensions log renderer: no implicit fold — renders every row it receives", async () => {
+  // The renderer must not absorb or rename ExtensionKind values. It
+  // expects exactly the five DoctorRegistryName values from the service.
+  // Asserting this contract by checking it does not throw on any single
+  // valid registry row and overallStatus tracks the report it sees.
+  const r = createDoctorExtensionsRenderer("log");
+  const handlers = r.handlers();
+  for (
+    const registry of [
+      "model",
+      "vault",
+      "driver",
+      "datastore",
+      "report",
+    ] as const
+  ) {
+    await handlers["kind-completed"]({
+      kind: "kind-completed",
+      result: passResult(registry),
+    });
+  }
+  // overallStatus only updates on `completed`.
+  assertEquals(r.overallStatus, "pass");
+});


### PR DESCRIPTION
## Summary

Adds `swamp doctor extensions` as a sibling to `swamp doctor audit`. Runs `ensureLoaded()` across all five user extension registries (model, vault, driver, datastore, report), captures any load failures via the issue-177 stderr emitter, and renders a per-registry pass/fail report in both log and JSON modes. Exits non-zero on any failure so it composes into doctor aggregations and CI preflight checks.

Fixes [swamp-club#180](https://swamp-club.com/lab/issues/180).

## Approach

The issue body's "~30 lines of orchestration plus the renderer" estimate assumed three things that turned out to be wrong on inspection. Each had to be addressed for the diagnostic to actually work:

1. **`DatastoreTypeRegistry` was missing `resetLoadedFlag()`** that the other four registries expose. Added to match. Also closes a latent gap in `open.ts:86`'s reload pattern (which currently omits the datastore registry — out of scope to wire there in this PR; the method just needs to exist for the doctor to wire all five).

2. **The issue-177 stderr emitter only stored a dedupe set, not structured warnings.** Extended `extension_load_warnings.ts` with always-on capture + `getExtensionLoadWarnings()` accessor. `resetExtensionLoadWarnings()` clears the array. `--quiet` still suppresses stderr but capture remains, so the doctor's diagnostic stays available regardless of the user's quiet flag.

3. **`ensureLoaded()` short-circuits on a populated bundle catalog**, so repeat invocations would silently report `pass` even with broken extensions on disk. Added `forceCatalogRescan()` to `extension_catalog_store.ts` (extracted the inline helper from `open.ts` so both call sites share one implementation) and call it before each doctor run. Verified via a regression integration test that fails when the rescan is disabled.

The doctor service lives at `src/libswamp/extensions/doctor.ts` and performs its own state reset + `resetLoadedFlag` on all five registries as the first steps of the async generator, so callers cannot get the ordering wrong. The model/extension ExtensionKind fold (kind=extension warnings come exclusively from the model loader's `populateCatalogFromDir` path and belong on the model registry's row) lives only in the service — the renderer renders rows verbatim and never imports the `ExtensionKind` enum.

JSON output always includes all five registry keys, even on pass — a stability promise to consumers, asserted in both unit and integration tests.

## Test Plan

- [x] Unit: `DatastoreTypeRegistry.resetLoadedFlag()` re-runs the loader on next `ensureLoaded()`
- [x] Unit: emitter capture records each unique warning, `getExtensionLoadWarnings()` returns a defensive snapshot, `resetExtensionLoadWarnings()` clears the array, `--quiet` still captures
- [x] Unit: doctor service order-of-operations (resetState + all five resetLoadedFlag run BEFORE any ensureLoaded — verified with spy callbacks)
- [x] Unit: doctor service explicit fold assertion (mixed kind=model + kind=extension warnings both land under the model row)
- [x] Unit: doctor service per-kind throw isolation (a thrown ensureLoaded becomes a fail without aborting other kinds)
- [x] Unit: renderer all-five-keys-always-present in JSON (pass and fail), stable key ordering, no implicit fold
- [x] Unit: CLI command module-load + subcommand-registered (matches `doctor_audit_test.ts` scope)
- [x] Integration: failing fixtures land under model row including extension-fold case (4 broken fixtures, fresh repo)
- [x] Integration: clean repo passes with all five registry keys empty
- [x] Integration: log mode exits non-zero
- [x] Integration: **catalog-rescan regression guard** — repeat invocation in same repo reports the same failures (verified to fail when the rescan is disabled, then pass when re-enabled)
- [x] Full suite: 4966 passed, 0 failed, 1 ignored
- [x] `deno check`, `deno lint`, `deno fmt --check` clean
- [x] `deno run compile` produces a working binary
- [x] Manual smoke: log + JSON modes both exit 1 on broken fixtures, exit 0 on clean repo, consistent across repeat invocations

## Follow-ups

These are tracked as separate post-merge issues, kept distinct so each is independently triageable:

- swamp-uat: `tests/cli/doctor/extensions_test.ts` CLI UAT coverage for this PR's deliverable
- swamp-uat: `tests/cli/doctor/audit_test.ts` for the parallel UAT gap on the existing `swamp doctor audit` command
- swamp-club: `content/manual/reference/doctor.md` covering both doctor subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)