### PR TITLE
feat(repo): point agent instructions at `swamp help` for CLI schema

### DIFF
--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -679,7 +679,10 @@ ${gettingStarted}
 
 ## Commands
 
-Use \`swamp --help\` to see available commands.
+Use \`swamp --help\` to see available commands. For a machine-readable JSON
+schema of the CLI (commands, options, arguments) intended for agent
+consumption, run \`swamp help [<command>...]\` — e.g. \`swamp help\` returns
+the full tree, and \`swamp help model method run\` scopes to a subtree.
 `;
   }
 


### PR DESCRIPTION
## Summary

The managed section of the generated `CLAUDE.md` / `AGENTS.md` (written by `swamp repo init` and refreshed by `swamp repo upgrade`) previously only mentioned `swamp --help` — the human-facing summary. There was no signpost in the agent context for `swamp help [<command>...]`, the hidden, JSON-only command intended for AI agent consumption (defined in `src/cli/commands/help.ts`).

This adds one sentence to the `## Commands` section of the template body in `generateInstructionsBody` pointing agents at `swamp help`, with concrete examples (`swamp help`, `swamp help model method run`).

`swamp help` itself remains hidden from the human-facing CLI listing — only the agent context is updated.

## Test Plan

- [x] `deno fmt --check`
- [x] `deno lint`
- [x] `deno run test` — all 4995 tests pass, including the 85 `repo_service_test.ts` cases that anchor on the existing `Use \`swamp --help\`` line (kept intact)
- [ ] After merge: existing repos pick up the new line on next `swamp repo upgrade`