### PR TITLE
fix(tests): use fromFileUrl for paths derived from import.meta.url

### DIFF
--- a/src/domain/models/method_context_arch_test.ts
+++ b/src/domain/models/method_context_arch_test.ts
@@ -25,10 +25,12 @@
 
 import { assertEquals } from "@std/assert";
 import { walk } from "@std/fs";
-import { relative } from "@std/path";
+import { fromFileUrl, join, relative } from "@std/path";
 
-const REPO_ROOT = new URL("../../..", import.meta.url).pathname;
-const SRC_ROOT = `${REPO_ROOT}src`;
+// Use fromFileUrl so Windows produces "D:\\..." instead of URL-pathname
+// "/D:/..." which Deno.readDir cannot resolve on Windows.
+const REPO_ROOT = fromFileUrl(new URL("../../..", import.meta.url));
+const SRC_ROOT = join(REPO_ROOT, "src");
 
 const ALLOWED_FILES: ReadonlySet<string> = new Set([
   // The factory itself.

--- a/src/domain/models/method_context_arch_test.ts
+++ b/src/domain/models/method_context_arch_test.ts
@@ -56,7 +56,10 @@ Deno.test("architecture: no inline MethodContext literals outside factory and te
       followSymlinks: false,
     })
   ) {
-    const rel = relative(REPO_ROOT, entry.path);
+    // Normalize to forward slashes so the ALLOWED_FILES set (which uses
+    // forward slashes) matches on Windows where `relative()` returns
+    // backslash-separated paths.
+    const rel = relative(REPO_ROOT, entry.path).replaceAll("\\", "/");
     if (rel.endsWith("_test.ts")) continue;
     if (ALLOWED_FILES.has(rel)) continue;
 

--- a/src/domain/reports/report_context_arch_test.ts
+++ b/src/domain/reports/report_context_arch_test.ts
@@ -25,10 +25,12 @@
 
 import { assertEquals } from "@std/assert";
 import { walk } from "@std/fs";
-import { relative } from "@std/path";
+import { fromFileUrl, join, relative } from "@std/path";
 
-const REPO_ROOT = new URL("../../..", import.meta.url).pathname;
-const SRC_ROOT = `${REPO_ROOT}src`;
+// Use fromFileUrl so Windows produces "D:\\..." instead of URL-pathname
+// "/D:/..." which Deno.readDir cannot resolve on Windows.
+const REPO_ROOT = fromFileUrl(new URL("../../..", import.meta.url));
+const SRC_ROOT = join(REPO_ROOT, "src");
 
 const ALLOWED_FILES: ReadonlySet<string> = new Set([
   // The factory itself.

--- a/src/domain/reports/report_context_arch_test.ts
+++ b/src/domain/reports/report_context_arch_test.ts
@@ -50,7 +50,10 @@ Deno.test("architecture: no inline MethodReportContext literals outside factory 
       followSymlinks: false,
     })
   ) {
-    const rel = relative(REPO_ROOT, entry.path);
+    // Normalize to forward slashes so the ALLOWED_FILES set (which uses
+    // forward slashes) matches on Windows where `relative()` returns
+    // backslash-separated paths.
+    const rel = relative(REPO_ROOT, entry.path).replaceAll("\\", "/");
     if (rel.endsWith("_test.ts")) continue;
     if (ALLOWED_FILES.has(rel)) continue;
 

--- a/src/infrastructure/persistence/catalog_store_test.ts
+++ b/src/infrastructure/persistence/catalog_store_test.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { dirname, join } from "@std/path";
+import { dirname, fromFileUrl, join } from "@std/path";
 import { DatabaseSync } from "node:sqlite";
 import {
   type CatalogRow,
@@ -443,7 +443,11 @@ Deno.test("CatalogStore: constructor retries under write lock contention", async
 
   // Start a subprocess — it will block in busy_timeout waiting for our lock.
   // Pass --config so the subprocess can resolve @std/fs and other imports.
-  const denoJsonPath = new URL("../../../deno.json", import.meta.url).pathname;
+  // Use fromFileUrl so Windows produces "D:\\..." instead of URL-pathname
+  // "/D:/..." which Deno.Command cannot resolve as --config on Windows.
+  const denoJsonPath = fromFileUrl(
+    new URL("../../../deno.json", import.meta.url),
+  );
   const proc = new Deno.Command(Deno.execPath(), {
     args: [
       "run",


### PR DESCRIPTION
## Summary

Three test files constructed file paths from `import.meta.url` using `.pathname`, which produces a URL-pathname form (`/D:/...`) on Windows instead of a native OS path (`D:\...`). Switch to `fromFileUrl` which correctly handles both platforms.

## The bug

```typescript
const REPO_ROOT = new URL("../../..", import.meta.url).pathname;
```

- POSIX: `.pathname` returns `/Users/.../swamp/` — works fine.
- Windows: `.pathname` returns `/D:/a/swamp/swamp/` — leading slash + forward slashes; not a valid Windows path. `Deno.readDir` and `Deno.Command --config` reject it with `NotFound (os error 3)`.

This is the source of the 2 residual `readdir '/D:/a/swamp/swamp/src'` errors in the most recent Cross Platform Builds run.

## The fix

```typescript
import { fromFileUrl } from "@std/path";
const REPO_ROOT = fromFileUrl(new URL("../../..", import.meta.url));
```

`fromFileUrl` produces `D:\a\swamp\swamp\` on Windows and `/Users/.../swamp/` on POSIX. Identical to `.pathname` on POSIX, correct on Windows.

## Sites fixed

| File | Use |
|---|---|
| `src/domain/models/method_context_arch_test.ts` | architecture walk of `src/` for inline literals |
| `src/domain/reports/report_context_arch_test.ts` | architecture walk of `src/` for inline literals |
| `src/infrastructure/persistence/catalog_store_test.ts` | `--config` argument passed to a subprocess |

## Risk-control summary

- **Diff size**: 3 files, ~16 insertions / 8 deletions. Pure substitution: `.pathname` → `fromFileUrl(...)`.
- **POSIX behaviour**: provably identical. `fromFileUrl` returns the same value as `.pathname` for POSIX `file://` URLs.
- **Empirical validation**: full local test suite passes (4995/0).

## Verification

- [x] `deno fmt`, `deno lint`, `deno task check` all clean
- [x] `deno run test` (full suite): 4995 passed, 0 failed
- [x] The 3 affected test files specifically: 26 passed, 0 failed
- [ ] After merge: trigger Cross Platform Builds, expect `/D:/` errors at 0

## Cumulative Windows progress

| Stage | Total Failed |
|---|---|
| Pre-Windows-work | 500+ |
| After PR 1241 | 318 |
| After PR 1243 | 241 |
| After PR 1244 | 234 |
| After PR 1246 | ~85 |
| After this PR | ~83 |

Continuing to chip away at the residual clusters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)