### PR TITLE
fix(tests): add assertPathEquals helper for cross-platform path comparisons

### DIFF
--- a/src/cli/context_test.ts
+++ b/src/cli/context_test.ts
@@ -26,6 +26,7 @@ import {
   resolveRepoDir,
 } from "./context.ts";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
+import { assertPathEquals } from "../infrastructure/persistence/path_test_helpers.ts";
 
 // Initialize logging once before tests run
 await initializeLogging({});
@@ -108,7 +109,7 @@ Deno.test("getRepoDirFromArgs parses --repo-dir with space separator", () => {
     "--repo-dir",
     "/tmp/my-repo",
   ]);
-  assertEquals(result, "/tmp/my-repo");
+  assertPathEquals(result, "/tmp/my-repo");
 });
 
 Deno.test("getRepoDirFromArgs parses --repo-dir with equals separator", () => {
@@ -117,7 +118,7 @@ Deno.test("getRepoDirFromArgs parses --repo-dir with equals separator", () => {
     "run",
     "--repo-dir=/tmp/my-repo",
   ]);
-  assertEquals(result, "/tmp/my-repo");
+  assertPathEquals(result, "/tmp/my-repo");
 });
 
 Deno.test("getRepoDirFromArgs resolves relative paths to absolute", () => {
@@ -141,15 +142,15 @@ Deno.test("getRepoDirFromArgs finds flag among other args", () => {
     "my-model",
     "my-method",
   ]);
-  assertEquals(result, "/tmp/my-repo");
+  assertPathEquals(result, "/tmp/my-repo");
 });
 
 Deno.test("getRepoDirFromArgs uses SWAMP_REPO_DIR when flag absent", () => {
   const original = Deno.env.get("SWAMP_REPO_DIR");
   try {
     Deno.env.set("SWAMP_REPO_DIR", "/tmp/env-repo");
-    assertEquals(getRepoDirFromArgs([]), "/tmp/env-repo");
-    assertEquals(getRepoDirFromArgs(["model", "create"]), "/tmp/env-repo");
+    assertPathEquals(getRepoDirFromArgs([]), "/tmp/env-repo");
+    assertPathEquals(getRepoDirFromArgs(["model", "create"]), "/tmp/env-repo");
   } finally {
     if (original !== undefined) Deno.env.set("SWAMP_REPO_DIR", original);
     else Deno.env.delete("SWAMP_REPO_DIR");
@@ -161,7 +162,7 @@ Deno.test("getRepoDirFromArgs prefers --repo-dir flag over SWAMP_REPO_DIR", () =
   try {
     Deno.env.set("SWAMP_REPO_DIR", "/tmp/env-repo");
     const result = getRepoDirFromArgs(["--repo-dir", "/tmp/flag-repo"]);
-    assertEquals(result, "/tmp/flag-repo");
+    assertPathEquals(result, "/tmp/flag-repo");
   } finally {
     if (original !== undefined) Deno.env.set("SWAMP_REPO_DIR", original);
     else Deno.env.delete("SWAMP_REPO_DIR");
@@ -200,7 +201,7 @@ Deno.test("resolveRepoDir returns cli value when provided", () => {
   const original = Deno.env.get("SWAMP_REPO_DIR");
   try {
     Deno.env.set("SWAMP_REPO_DIR", "/tmp/env-repo");
-    assertEquals(resolveRepoDir("/tmp/flag-repo"), "/tmp/flag-repo");
+    assertPathEquals(resolveRepoDir("/tmp/flag-repo"), "/tmp/flag-repo");
     // explicit "." from flag should win over env var
     assertEquals(resolveRepoDir("."), ".");
   } finally {
@@ -213,7 +214,7 @@ Deno.test("resolveRepoDir returns SWAMP_REPO_DIR when cli value undefined", () =
   const original = Deno.env.get("SWAMP_REPO_DIR");
   try {
     Deno.env.set("SWAMP_REPO_DIR", "/tmp/env-repo");
-    assertEquals(resolveRepoDir(undefined), "/tmp/env-repo");
+    assertPathEquals(resolveRepoDir(undefined), "/tmp/env-repo");
   } finally {
     if (original !== undefined) Deno.env.set("SWAMP_REPO_DIR", original);
     else Deno.env.delete("SWAMP_REPO_DIR");

--- a/src/cli/resolve_datastore_test.ts
+++ b/src/cli/resolve_datastore_test.ts
@@ -34,6 +34,7 @@ import type { DatastoreProvider } from "../domain/datastore/datastore_provider.t
 import { getSwampDataDir } from "../infrastructure/persistence/paths.ts";
 import type { RepoMarkerData } from "../infrastructure/persistence/repo_marker_repository.ts";
 import { z } from "zod";
+import { assertPathEquals } from "../infrastructure/persistence/path_test_helpers.ts";
 
 /**
  * Creates a stub DatastoreProvider for testing custom datastore resolution.
@@ -85,7 +86,7 @@ Deno.test("parseDatastoreEnvVar: parses filesystem path", async () => {
   const config = await parseDatastoreEnvVar("filesystem:/data/my-project");
   assertEquals(config.type, "filesystem");
   if (!isCustomDatastoreConfig(config) && config.type === "filesystem") {
-    assertEquals(config.path, "/data/my-project");
+    assertPathEquals(config.path, "/data/my-project");
   }
 });
 
@@ -118,7 +119,7 @@ Deno.test("resolveDatastoreConfig: default is filesystem at .swamp/", async () =
   const config = await resolveDatastoreConfig(null, undefined, "/repo");
   assertEquals(config.type, "filesystem");
   if (!isCustomDatastoreConfig(config) && config.type === "filesystem") {
-    assertEquals(config.path, "/repo/.swamp");
+    assertPathEquals(config.path, "/repo/.swamp");
   }
 });
 
@@ -129,7 +130,7 @@ Deno.test("resolveDatastoreConfig: env var takes priority", async () => {
     const config = await resolveDatastoreConfig(null, undefined, "/repo");
     assertEquals(config.type, "filesystem");
     if (!isCustomDatastoreConfig(config) && config.type === "filesystem") {
-      assertEquals(config.path, "/custom/path");
+      assertPathEquals(config.path, "/custom/path");
     }
   } finally {
     if (originalEnv) {
@@ -154,7 +155,7 @@ Deno.test("resolveDatastoreConfig: CLI arg overrides marker", async () => {
   );
   assertEquals(config.type, "filesystem");
   if (!isCustomDatastoreConfig(config) && config.type === "filesystem") {
-    assertEquals(config.path, "/cli-path");
+    assertPathEquals(config.path, "/cli-path");
   }
 });
 
@@ -172,7 +173,7 @@ Deno.test("resolveDatastoreConfig: marker config used when no env/cli", async ()
   const config = await resolveDatastoreConfig(marker, undefined, "/repo");
   assertEquals(config.type, "filesystem");
   if (!isCustomDatastoreConfig(config) && config.type === "filesystem") {
-    assertEquals(config.path, "/marker-path");
+    assertPathEquals(config.path, "/marker-path");
     assertEquals(config.directories, ["data", "outputs"]);
   }
 });
@@ -217,8 +218,8 @@ Deno.test("parseDatastoreEnvVar: parses custom type with JSON config", async () 
   assertEquals(isCustomDatastoreConfig(config), true);
   const custom = config as CustomDatastoreConfig;
   assertEquals(custom.config, { region: "us-east-1" });
-  assertEquals(custom.datastorePath, "/my/repo/.custom-store");
-  assertEquals(custom.cachePath, "/my/repo/.custom-cache");
+  assertPathEquals(custom.datastorePath, "/my/repo/.custom-store");
+  assertPathEquals(custom.cachePath, "/my/repo/.custom-cache");
 });
 
 Deno.test("parseDatastoreEnvVar: parses custom type with empty config", async () => {
@@ -243,7 +244,7 @@ Deno.test("parseDatastoreEnvVar: custom type uses repoDir not repoId for path re
   );
   const custom = config as CustomDatastoreConfig;
   // Should use repoDir, not repoId
-  assertEquals(custom.datastorePath, "/actual/repo/dir/.custom-store");
+  assertPathEquals(custom.datastorePath, "/actual/repo/dir/.custom-store");
 });
 
 Deno.test("parseDatastoreEnvVar: custom type throws on invalid JSON", async () => {
@@ -282,8 +283,8 @@ Deno.test("resolveDatastoreConfig: YAML custom type produces CustomDatastoreConf
   assertEquals(isCustomDatastoreConfig(config), true);
   const custom = config as CustomDatastoreConfig;
   assertEquals(custom.config, { key: "value" });
-  assertEquals(custom.datastorePath, "/repo/.custom-store");
-  assertEquals(custom.cachePath, "/repo/.custom-cache");
+  assertPathEquals(custom.datastorePath, "/repo/.custom-store");
+  assertPathEquals(custom.cachePath, "/repo/.custom-cache");
   assertEquals(custom.directories, ["data"]);
 });
 
@@ -374,7 +375,7 @@ Deno.test("resolveCachePath: concrete return is used as-is", async () => {
     "/my/repo",
   );
   const custom = config as CustomDatastoreConfig;
-  assertEquals(custom.cachePath, "/my/repo/.test-explicit-cache");
+  assertPathEquals(custom.cachePath, "/my/repo/.test-explicit-cache");
 });
 
 // ============================================================================

--- a/src/domain/audit/audit_path_test.ts
+++ b/src/domain/audit/audit_path_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertMatch } from "@std/assert";
+import { assertPathEquals } from "../../infrastructure/persistence/path_test_helpers.ts";
 import {
   AUDIT_FILENAME_PATTERN,
   auditFilename,
@@ -50,7 +51,7 @@ Deno.test("auditFilenameForTimestamp: composes filename from ISO timestamp", () 
 });
 
 Deno.test("auditFilePathForTimestamp: joins audit directory with the filename", () => {
-  assertEquals(
+  assertPathEquals(
     auditFilePathForTimestamp("/repo/.swamp/audit", "2026-04-24T10:00:00Z"),
     "/repo/.swamp/audit/commands-2026-04-24.jsonl",
   );

--- a/src/domain/extensions/extension_package_cache_test.ts
+++ b/src/domain/extensions/extension_package_cache_test.ts
@@ -20,6 +20,7 @@
 import { assert, assertEquals, assertNotEquals } from "@std/assert";
 import { join } from "@std/path";
 import type { ExtensionManifest } from "./extension_manifest.ts";
+import { assertPathEquals } from "../../infrastructure/persistence/path_test_helpers.ts";
 import {
   computePackageCacheHash,
   defaultPackageCacheRoot,
@@ -223,5 +224,5 @@ Deno.test("ExtensionPackageCache: get returns null for corrupt metadata", async 
 
 Deno.test("defaultPackageCacheRoot: returns canonical path under .swamp", () => {
   const root = defaultPackageCacheRoot("/tmp/repo");
-  assertEquals(root, "/tmp/repo/.swamp/cache/packages");
+  assertPathEquals(root, "/tmp/repo/.swamp/cache/packages");
 });

--- a/src/domain/repo/repo_path_test.ts
+++ b/src/domain/repo/repo_path_test.ts
@@ -19,11 +19,12 @@
 
 import { assertEquals, assertThrows } from "@std/assert";
 import { RepoPath } from "./repo_path.ts";
+import { assertPathEquals } from "../../infrastructure/persistence/path_test_helpers.ts";
 
 Deno.test("RepoPath.create accepts absolute path", () => {
   const path = RepoPath.create("/home/user/repo");
-  assertEquals(path.value, "/home/user/repo");
-  assertEquals(path.toString(), "/home/user/repo");
+  assertPathEquals(path.value, "/home/user/repo");
+  assertPathEquals(path.toString(), "/home/user/repo");
 });
 
 Deno.test("RepoPath.create converts relative path to absolute", () => {
@@ -42,7 +43,7 @@ Deno.test("RepoPath.create converts bare relative path to absolute", () => {
 
 Deno.test("RepoPath.create trims whitespace", () => {
   const path = RepoPath.create("  /home/user/repo  ");
-  assertEquals(path.value, "/home/user/repo");
+  assertPathEquals(path.value, "/home/user/repo");
 });
 
 Deno.test("RepoPath.create throws on empty string", () => {

--- a/src/infrastructure/persistence/default_datastore_path_resolver_test.ts
+++ b/src/infrastructure/persistence/default_datastore_path_resolver_test.ts
@@ -20,6 +20,7 @@
 import { assertEquals } from "@std/assert";
 import { DefaultDatastorePathResolver } from "./default_datastore_path_resolver.ts";
 import type { DatastoreConfig } from "../../domain/datastore/datastore_config.ts";
+import { assertPathEquals } from "./path_test_helpers.ts";
 
 Deno.test("DefaultDatastorePathResolver - localPath always uses .swamp", () => {
   const config: DatastoreConfig = {
@@ -27,7 +28,7 @@ Deno.test("DefaultDatastorePathResolver - localPath always uses .swamp", () => {
     path: "/data/store",
   };
   const resolver = new DefaultDatastorePathResolver("/repo", config);
-  assertEquals(
+  assertPathEquals(
     resolver.localPath("definitions", "foo.yaml"),
     "/repo/.swamp/definitions/foo.yaml",
   );
@@ -39,7 +40,10 @@ Deno.test("DefaultDatastorePathResolver - datastorePath uses configured path", (
     path: "/data/store",
   };
   const resolver = new DefaultDatastorePathResolver("/repo", config);
-  assertEquals(resolver.datastorePath("data", "foo"), "/data/store/data/foo");
+  assertPathEquals(
+    resolver.datastorePath("data", "foo"),
+    "/data/store/data/foo",
+  );
 });
 
 Deno.test("DefaultDatastorePathResolver - custom datastorePath uses datastorePath", () => {
@@ -50,7 +54,7 @@ Deno.test("DefaultDatastorePathResolver - custom datastorePath uses datastorePat
     cachePath: "/home/user/.swamp/repos/abc",
   };
   const resolver = new DefaultDatastorePathResolver("/repo", config);
-  assertEquals(
+  assertPathEquals(
     resolver.datastorePath("data"),
     "/home/user/.swamp/repos/abc/data",
   );
@@ -105,10 +109,10 @@ Deno.test("DefaultDatastorePathResolver - resolvePath routes datastore subdirs",
   const resolver = new DefaultDatastorePathResolver("/repo", config);
 
   // Datastore subdir goes to datastore
-  assertEquals(resolver.resolvePath("data", "foo"), "/data/store/data/foo");
+  assertPathEquals(resolver.resolvePath("data", "foo"), "/data/store/data/foo");
   // Non-datastore subdir stays local (definitions is no longer always-local
   // but it's also not in DEFAULT_DATASTORE_SUBDIRS, so it stays local)
-  assertEquals(
+  assertPathEquals(
     resolver.resolvePath("definitions", "foo"),
     "/repo/.swamp/definitions/foo",
   );
@@ -123,12 +127,12 @@ Deno.test("DefaultDatastorePathResolver - resolvePath with exclude patterns", ()
   const resolver = new DefaultDatastorePathResolver("/repo", config);
 
   // telemetry is a datastore subdir, but excluded by pattern
-  assertEquals(
+  assertPathEquals(
     resolver.resolvePath("telemetry", "foo.json"),
     "/repo/.swamp/telemetry/foo.json",
   );
   // data is not excluded
-  assertEquals(resolver.resolvePath("data", "foo"), "/data/store/data/foo");
+  assertPathEquals(resolver.resolvePath("data", "foo"), "/data/store/data/foo");
 });
 
 Deno.test("DefaultDatastorePathResolver - default config (no external datastore) keeps paths in .swamp", () => {
@@ -139,9 +143,12 @@ Deno.test("DefaultDatastorePathResolver - default config (no external datastore)
   const resolver = new DefaultDatastorePathResolver("/repo", config);
 
   // Both local and datastore paths resolve to .swamp
-  assertEquals(resolver.resolvePath("data", "foo"), "/repo/.swamp/data/foo");
+  assertPathEquals(
+    resolver.resolvePath("data", "foo"),
+    "/repo/.swamp/data/foo",
+  );
   // definitions is not a datastore subdir, so it stays in .swamp even with default config
-  assertEquals(
+  assertPathEquals(
     resolver.resolvePath("definitions", "foo"),
     "/repo/.swamp/definitions/foo",
   );
@@ -156,11 +163,11 @@ Deno.test("DefaultDatastorePathResolver - custom datastore prefers cachePath ove
   };
   const resolver = new DefaultDatastorePathResolver("/repo", config);
   // Data should go to cachePath so the sync service can find it
-  assertEquals(
+  assertPathEquals(
     resolver.datastorePath("data"),
     "/home/user/.swamp/repos/abc/data",
   );
-  assertEquals(
+  assertPathEquals(
     resolver.resolvePath("data", "foo"),
     "/home/user/.swamp/repos/abc/data/foo",
   );
@@ -173,7 +180,7 @@ Deno.test("DefaultDatastorePathResolver - custom datastore falls back to datasto
     datastorePath: "/shared/datastore",
   };
   const resolver = new DefaultDatastorePathResolver("/repo", config);
-  assertEquals(
+  assertPathEquals(
     resolver.datastorePath("data"),
     "/shared/datastore/data",
   );
@@ -215,20 +222,20 @@ Deno.test("DefaultDatastorePathResolver - resolvePath routes bundles to S3 cache
     resolver.resolvePath("bundles", "2e4ea9ae", "aws/logs.js"),
     "/home/user/.swamp/repos/abc/bundles/2e4ea9ae/aws/logs.js",
   );
-  assertEquals(
+  assertPathEquals(
     resolver.resolvePath("vault-bundles", "ff00aa11", "sm.js"),
     "/home/user/.swamp/repos/abc/vault-bundles/ff00aa11/sm.js",
   );
-  assertEquals(
+  assertPathEquals(
     resolver.resolvePath("driver-bundles", "bb22cc33", "driver.js"),
     "/home/user/.swamp/repos/abc/driver-bundles/bb22cc33/driver.js",
   );
   // datastore-bundles stays local (bootstrap ordering — excluded from datastore tier)
-  assertEquals(
+  assertPathEquals(
     resolver.resolvePath("datastore-bundles", "dd44ee55", "ds.js"),
     "/repo/.swamp/datastore-bundles/dd44ee55/ds.js",
   );
-  assertEquals(
+  assertPathEquals(
     resolver.resolvePath("report-bundles", "66778899", "report.js"),
     "/home/user/.swamp/repos/abc/report-bundles/66778899/report.js",
   );
@@ -242,7 +249,7 @@ Deno.test("DefaultDatastorePathResolver - filesystem datastore resolves bundles 
   const resolver = new DefaultDatastorePathResolver("/repo", config);
 
   // With default filesystem datastore, bundles stay in .swamp/ (same path)
-  assertEquals(
+  assertPathEquals(
     resolver.resolvePath("bundles", "2e4ea9ae", "aws/logs.js"),
     "/repo/.swamp/bundles/2e4ea9ae/aws/logs.js",
   );

--- a/src/infrastructure/persistence/default_datastore_path_resolver_test.ts
+++ b/src/infrastructure/persistence/default_datastore_path_resolver_test.ts
@@ -218,7 +218,7 @@ Deno.test("DefaultDatastorePathResolver - resolvePath routes bundles to S3 cache
   };
   const resolver = new DefaultDatastorePathResolver("/repo", config);
 
-  assertEquals(
+  assertPathEquals(
     resolver.resolvePath("bundles", "2e4ea9ae", "aws/logs.js"),
     "/home/user/.swamp/repos/abc/bundles/2e4ea9ae/aws/logs.js",
   );

--- a/src/infrastructure/persistence/path_test_helpers.ts
+++ b/src/infrastructure/persistence/path_test_helpers.ts
@@ -1,0 +1,55 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+
+/**
+ * Test assertion that compares two filesystem paths irrespective of
+ * platform separator. Both `actual` and `expected` are normalized to
+ * forward slashes before comparison so tests can use forward-slash
+ * literals in their expected values regardless of host OS.
+ *
+ * On POSIX, the `replaceAll("\\", "/")` normalization is a no-op since
+ * POSIX paths do not contain backslashes — behaviour is identical to
+ * `assertEquals` for any path string. On Windows, where `Deno.realPath`,
+ * `@std/path/join`, etc. produce backslash-separated paths, the
+ * normalization on both sides makes string-equality assertions work
+ * cross-platform without per-test platform branching.
+ *
+ * Use this for any test that asserts string equality on a filesystem
+ * path. Do not use it for assertions on URL pathnames, S3 keys, or
+ * anything else where backslashes are semantically distinct.
+ */
+export function assertPathEquals(
+  actual: string | undefined,
+  expected: string | undefined,
+  msg?: string,
+): void {
+  if (typeof actual === "string" && typeof expected === "string") {
+    assertEquals(
+      actual.replaceAll("\\", "/"),
+      expected.replaceAll("\\", "/"),
+      msg,
+    );
+  } else {
+    // One or both is undefined — fall back to plain equality so the
+    // failure surfaces with a useful diff (undefined vs "<expected>").
+    assertEquals(actual, expected, msg);
+  }
+}

--- a/src/infrastructure/persistence/path_test_helpers_test.ts
+++ b/src/infrastructure/persistence/path_test_helpers_test.ts
@@ -1,0 +1,56 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { AssertionError, assertThrows } from "@std/assert";
+import { assertPathEquals } from "./path_test_helpers.ts";
+
+Deno.test("assertPathEquals: forward-slash paths compare equal", () => {
+  assertPathEquals("/repo/foo/bar", "/repo/foo/bar");
+});
+
+Deno.test("assertPathEquals: backslash actual matches forward-slash expected", () => {
+  assertPathEquals("\\repo\\foo\\bar", "/repo/foo/bar");
+});
+
+Deno.test("assertPathEquals: forward-slash actual matches backslash expected", () => {
+  assertPathEquals("/repo/foo/bar", "\\repo\\foo\\bar");
+});
+
+Deno.test("assertPathEquals: mixed separators normalize to equal", () => {
+  assertPathEquals("/repo\\foo/bar", "\\repo/foo\\bar");
+});
+
+Deno.test("assertPathEquals: genuinely different paths still throw", () => {
+  assertThrows(
+    () => assertPathEquals("/repo/foo", "/repo/bar"),
+    AssertionError,
+  );
+});
+
+Deno.test("assertPathEquals: optional message is forwarded", () => {
+  const err = assertThrows(
+    () => assertPathEquals("a", "b", "custom-msg"),
+    AssertionError,
+  );
+  if (!err.message.includes("custom-msg")) {
+    throw new Error(
+      `expected message to include 'custom-msg', got: ${err.message}`,
+    );
+  }
+});

--- a/src/infrastructure/persistence/paths_test.ts
+++ b/src/infrastructure/persistence/paths_test.ts
@@ -30,6 +30,7 @@ import {
   toAbsolutePath,
   toRelativePath,
 } from "./paths.ts";
+import { assertPathEquals } from "./path_test_helpers.ts";
 
 Deno.test("SWAMP_DATA_DIR is .swamp", () => {
   assertEquals(SWAMP_DATA_DIR, ".swamp");
@@ -40,22 +41,22 @@ Deno.test("SWAMP_MARKER_FILE is .swamp.yaml", () => {
 });
 
 Deno.test("swampPath joins segments correctly", () => {
-  assertEquals(
+  assertPathEquals(
     swampPath("/repo", "definitions", "aws/ec2", "my-vpc.yaml"),
     "/repo/.swamp/definitions/aws/ec2/my-vpc.yaml",
   );
 });
 
 Deno.test("swampPath with no segments returns data dir", () => {
-  assertEquals(swampPath("/repo"), "/repo/.swamp");
+  assertPathEquals(swampPath("/repo"), "/repo/.swamp");
 });
 
 Deno.test("swampPath with single segment", () => {
-  assertEquals(swampPath("/repo", "workflows"), "/repo/.swamp/workflows");
+  assertPathEquals(swampPath("/repo", "workflows"), "/repo/.swamp/workflows");
 });
 
 Deno.test("swampMarkerPath returns marker file path", () => {
-  assertEquals(swampMarkerPath("/repo"), "/repo/.swamp.yaml");
+  assertPathEquals(swampMarkerPath("/repo"), "/repo/.swamp.yaml");
 });
 
 Deno.test("SWAMP_SUBDIRS has all expected directories", () => {
@@ -77,11 +78,11 @@ Deno.test("SWAMP_SUBDIRS has all expected directories", () => {
 });
 
 Deno.test("swampPath with SWAMP_SUBDIRS constants", () => {
-  assertEquals(
+  assertPathEquals(
     swampPath("/repo", SWAMP_SUBDIRS.definitions),
     "/repo/.swamp/definitions",
   );
-  assertEquals(
+  assertPathEquals(
     swampPath("/repo", SWAMP_SUBDIRS.workflowRuns, "workflow-123"),
     "/repo/.swamp/workflow-runs/workflow-123",
   );
@@ -93,7 +94,7 @@ Deno.test("toRelativePath - converts absolute path inside repo to relative", () 
 
   const result = toRelativePath(repoDir, absolutePath);
 
-  assertEquals(result, ".swamp/outputs/aws/cli/run.log");
+  assertPathEquals(result, ".swamp/outputs/aws/cli/run.log");
 });
 
 Deno.test("toRelativePath - returns already relative path unchanged", () => {
@@ -120,7 +121,7 @@ Deno.test("toAbsolutePath - converts relative path to absolute", () => {
 
   const result = toAbsolutePath(repoDir, relativePath);
 
-  assertEquals(result, "/Users/john/repo/.swamp/outputs/aws/cli/run.log");
+  assertPathEquals(result, "/Users/john/repo/.swamp/outputs/aws/cli/run.log");
 });
 
 Deno.test("toAbsolutePath - returns already absolute path unchanged (backwards compat)", () => {
@@ -138,7 +139,7 @@ Deno.test("toAbsolutePath - handles different repo directory", () => {
 
   const result = toAbsolutePath(repoDir, relativePath);
 
-  assertEquals(
+  assertPathEquals(
     result,
     "/home/alice/projects/infra/.swamp/workflow-runs/my-workflow/run.yaml",
   );
@@ -151,14 +152,14 @@ Deno.test("toRelativePath and toAbsolutePath - round trip", () => {
   const relative = toRelativePath(repoDir, originalAbsolute);
   const backToAbsolute = toAbsolutePath(repoDir, relative);
 
-  assertEquals(backToAbsolute, originalAbsolute);
+  assertPathEquals(backToAbsolute, originalAbsolute);
 });
 
 Deno.test("getSwampConfigDir uses XDG_CONFIG_HOME when set", () => {
   const originalXdg = Deno.env.get("XDG_CONFIG_HOME");
   try {
     Deno.env.set("XDG_CONFIG_HOME", "/custom/config");
-    assertEquals(getSwampConfigDir(), "/custom/config/swamp");
+    assertPathEquals(getSwampConfigDir(), "/custom/config/swamp");
   } finally {
     if (originalXdg) Deno.env.set("XDG_CONFIG_HOME", originalXdg);
     else Deno.env.delete("XDG_CONFIG_HOME");
@@ -171,7 +172,7 @@ Deno.test("getSwampConfigDir falls back to HOME/.config/swamp", () => {
   try {
     Deno.env.delete("XDG_CONFIG_HOME");
     Deno.env.set("HOME", "/home/testuser");
-    assertEquals(getSwampConfigDir(), "/home/testuser/.config/swamp");
+    assertPathEquals(getSwampConfigDir(), "/home/testuser/.config/swamp");
   } finally {
     if (originalXdg) Deno.env.set("XDG_CONFIG_HOME", originalXdg);
     else Deno.env.delete("XDG_CONFIG_HOME");
@@ -203,7 +204,7 @@ Deno.test("getSwampDataDir uses HOME", () => {
   const originalHome = Deno.env.get("HOME");
   try {
     Deno.env.set("HOME", "/home/testuser");
-    assertEquals(getSwampDataDir(), "/home/testuser/.swamp");
+    assertPathEquals(getSwampDataDir(), "/home/testuser/.swamp");
   } finally {
     if (originalHome) Deno.env.set("HOME", originalHome);
     else Deno.env.delete("HOME");
@@ -216,7 +217,7 @@ Deno.test("getSwampDataDir falls back to USERPROFILE", () => {
   try {
     Deno.env.delete("HOME");
     Deno.env.set("USERPROFILE", "C:\\Users\\testuser");
-    assertEquals(getSwampDataDir(), "C:\\Users\\testuser/.swamp");
+    assertPathEquals(getSwampDataDir(), "C:\\Users\\testuser/.swamp");
   } finally {
     if (originalHome) Deno.env.set("HOME", originalHome);
     else Deno.env.delete("HOME");

--- a/src/infrastructure/persistence/repo_marker_repository_test.ts
+++ b/src/infrastructure/persistence/repo_marker_repository_test.ts
@@ -22,6 +22,7 @@ import { join } from "@std/path";
 import { RepoMarkerRepository } from "./repo_marker_repository.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { SwampVersion } from "../../domain/repo/swamp_version.ts";
+import { assertPathEquals } from "./path_test_helpers.ts";
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   const dir = await Deno.makeTempDir({ prefix: "swamp-marker-test-" });
@@ -44,7 +45,7 @@ Deno.test("RepoMarkerRepository.getMarkerPath returns correct path", () => {
 
   const markerPath = repo.getMarkerPath(repoPath);
 
-  assertEquals(markerPath, "/some/repo/.swamp.yaml");
+  assertPathEquals(markerPath, "/some/repo/.swamp.yaml");
 });
 
 Deno.test("RepoMarkerRepository.exists returns false when marker does not exist", async () => {

--- a/src/infrastructure/persistence/swamp_sources_repository_test.ts
+++ b/src/infrastructure/persistence/swamp_sources_repository_test.ts
@@ -29,6 +29,7 @@ import {
   writeSwampSources,
 } from "./swamp_sources_repository.ts";
 import type { ExtensionKind } from "../../domain/repo/swamp_sources.ts";
+import { assertPathEquals } from "./path_test_helpers.ts";
 
 Deno.test("readSwampSources: returns null when file does not exist", async () => {
   const tmpDir = await Deno.makeTempDir({ prefix: "swamp_sources_test_" });
@@ -49,7 +50,7 @@ Deno.test("readSwampSources: parses valid sources file", async () => {
     );
     const result = await readSwampSources(tmpDir);
     assertEquals(result?.sources.length, 2);
-    assertEquals(result?.sources[0].path, "/tmp/ext-a");
+    assertPathEquals(result?.sources[0].path, "/tmp/ext-a");
     assertEquals(result?.sources[1].only, ["models"]);
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
@@ -64,7 +65,7 @@ Deno.test("writeSwampSources: creates file and readSwampSources reads it back", 
     });
     const result = await readSwampSources(tmpDir);
     assertEquals(result?.sources.length, 1);
-    assertEquals(result?.sources[0].path, "/tmp/my-ext");
+    assertPathEquals(result?.sources[0].path, "/tmp/my-ext");
     assertEquals(result?.sources[0].only, ["vaults"]);
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
@@ -103,7 +104,7 @@ Deno.test("expandSourcePaths: expands non-glob path as-is", async () => {
       tmpDir,
     );
     assertEquals(result.length, 1);
-    assertEquals(result[0].path, "/tmp/my-ext");
+    assertPathEquals(result[0].path, "/tmp/my-ext");
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }
@@ -199,7 +200,7 @@ Deno.test("resolveSourceExtensionDirs: handles missing source path gracefully", 
     { path: "/nonexistent/path" },
   ]);
   assertEquals(result.length, 1);
-  assertEquals(result[0].sourcePath, "/nonexistent/path");
+  assertPathEquals(result[0].sourcePath, "/nonexistent/path");
   assertEquals(result[0].modelsDir, undefined);
 });
 
@@ -372,7 +373,7 @@ Deno.test("resolveSourceExtensionDirs snapshot: non-existent path yields empty",
     { path: "/definitely/does/not/exist/v139" },
   ]);
   assertEquals(result.length, 1);
-  assertEquals(result[0].sourcePath, "/definitely/does/not/exist/v139");
+  assertPathEquals(result[0].sourcePath, "/definitely/does/not/exist/v139");
   assertEquals(result[0].modelsDir, undefined);
   assertEquals(result[0].vaultsDir, undefined);
   assertEquals(result[0].driversDir, undefined);

--- a/src/libswamp/workflows/watcher_test.ts
+++ b/src/libswamp/workflows/watcher_test.ts
@@ -17,9 +17,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
 import { workflowsDir } from "./watcher.ts";
+import { assertPathEquals } from "../../infrastructure/persistence/path_test_helpers.ts";
 
 Deno.test("workflowsDir: returns correct path", () => {
-  assertEquals(workflowsDir("/repo"), "/repo/workflows");
+  assertPathEquals(workflowsDir("/repo"), "/repo/workflows");
 });


### PR DESCRIPTION
## Summary

Adds `assertPathEquals` — a path-aware variant of `assertEquals` that normalizes both sides to forward slashes before comparing — and applies it across the path-handling test files. Targets the dominant residual Windows cluster: ~64 generic `AssertionError: Values are not equal` failures where tests assert against forward-slash literals but production functions return platform-native separators.

## The bug

```typescript
assertEquals(swampPath("/repo", "definitions"), "/repo/.swamp/definitions");
```

- POSIX: `swampPath` returns `/repo/.swamp/definitions` → matches.
- Windows: `swampPath` returns `\repo\.swamp\definitions` (because `@std/path/join` produces platform-native separators) → fails string equality.

The TESTS are wrong, not production code. Production functions correctly produce platform-native paths; the tests just hardcode POSIX-style expected strings.

## The fix

New `src/infrastructure/persistence/path_test_helpers.ts`:

```typescript
export function assertPathEquals(
  actual: string | undefined,
  expected: string | undefined,
  msg?: string,
): void {
  if (typeof actual === "string" && typeof expected === "string") {
    assertEquals(
      actual.replaceAll("\\", "/"),
      expected.replaceAll("\\", "/"),
      msg,
    );
  } else {
    assertEquals(actual, expected, msg);
  }
}
```

Applied across 10 test files and ~46 assertion sites.

## POSIX safety

`replaceAll("\\", "/")` is a no-op on POSIX paths (POSIX paths don't contain backslashes). Behaviour identical to `assertEquals` for any path string on Linux/macOS. The undefined-fallback branch preserves the original error semantics for type mismatches.

## Sites converted

| File | Sites |
|---|---|
| `default_datastore_path_resolver_test.ts` | 16 |
| `paths_test.ts` | 13 |
| `resolve_datastore_test.ts` | 11 |
| `context_test.ts` | 8 |
| `swamp_sources_repository_test.ts` | 5 |
| `repo_path_test.ts` | 3 |
| `audit_path_test.ts` | 1 |
| `repo_marker_repository_test.ts` | 1 |
| `extension_package_cache_test.ts` | 1 |
| `watcher_test.ts` | 1 |

## Risk-control summary

- **Diff size**: 12 files, ~189 insertions / 63 deletions. Pure substitution: `assertEquals` → `assertPathEquals` for path-string assertions only.
- **POSIX behaviour**: provably identical. The normalization is a no-op on POSIX. Helper has 6 unit tests covering forward/backslash mixtures.
- **No production code touched.** Tests only.
- **Empirical validation**: full local test suite passes (5001/0).

## Verification

- [x] `deno fmt`, `deno lint`, `deno task check` all clean
- [x] `deno run test` (full suite): 5001 passed, 0 failed (count went up from 4995 because the helper file adds 6 tests)
- [x] Targeted files all green locally
- [ ] After merge: trigger Cross Platform Builds, expect generic AssertionError cluster to drop substantially

## Cumulative Windows progress

| Stage | Total Failed |
|---|---|
| Pre-Windows-work | 500+ |
| After PR 1241 | 318 |
| After PR 1243 | 241 |
| After PR 1244 | 234 |
| After PR 1246 | 95 |
| After PR 1248 | 79 |
| After this PR | ~30-40 (estimate) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)