### PR TITLE
feat(skills): restructure swamp-troubleshooting around diagnostic loop, bundle missing skill files

### DIFF
--- a/.claude/skills/swamp-extension-datastore/SKILL.md
+++ b/.claude/skills/swamp-extension-datastore/SKILL.md
@@ -39,6 +39,7 @@ Custom datastores let you:
 | Search community    | `swamp extension search datastore --json`      |
 | Create datastore    | Create `extensions/datastores/my-store/mod.ts` |
 | Verify registration | `swamp datastore status --json`                |
+| Verify it loads     | `swamp doctor extensions --json`               |
 | Check config        | View `.swamp.yaml` datastore section           |
 | Push extension      | `swamp extension push manifest.yaml --json`    |
 | Dry-run push        | `swamp extension push manifest.yaml --dry-run` |

--- a/.claude/skills/swamp-extension-driver/SKILL.md
+++ b/.claude/skills/swamp-extension-driver/SKILL.md
@@ -24,6 +24,7 @@ startup.
 | Search community    | `swamp extension search driver --json`         |
 | Create driver file  | Create `extensions/drivers/my-driver/mod.ts`   |
 | Verify registration | `swamp model type search --json`               |
+| Verify it loads     | `swamp doctor extensions --json`               |
 | Push extension      | `swamp extension push manifest.yaml --json`    |
 | Dry-run push        | `swamp extension push manifest.yaml --dry-run` |
 

--- a/.claude/skills/swamp-extension-model/SKILL.md
+++ b/.claude/skills/swamp-extension-model/SKILL.md
@@ -62,6 +62,7 @@ and integrations.
 | Search community    | `swamp extension search <query> --json`                              |
 | Create model file   | Create `extensions/models/my_model.ts`                               |
 | Verify registration | `swamp model type search --json`                                     |
+| Verify it loads     | `swamp doctor extensions --json`                                     |
 | Check schema        | `swamp model type describe @myorg/my-model --json`                   |
 | Create instance     | `swamp model create @myorg/my-model my-instance --json`              |
 | Create with args    | `swamp model create @myorg/my-model inst --global-arg message=hi -j` |

--- a/.claude/skills/swamp-extension-vault/SKILL.md
+++ b/.claude/skills/swamp-extension-vault/SKILL.md
@@ -38,6 +38,7 @@ Custom vaults let you:
 | Search community    | `swamp extension search vault --json`          |
 | Create vault        | Create `extensions/vaults/my-vault/mod.ts`     |
 | Verify registration | `swamp vault status --json`                    |
+| Verify it loads     | `swamp doctor extensions --json`               |
 | Check config        | View `.swamp.yaml` vault section               |
 | Push extension      | `swamp extension push manifest.yaml --json`    |
 | Dry-run push        | `swamp extension push manifest.yaml --dry-run` |

--- a/.claude/skills/swamp-repo/SKILL.md
+++ b/.claude/skills/swamp-repo/SKILL.md
@@ -86,14 +86,10 @@ swamp repo init ./my-automation --json
 ### Verify the audit integration
 
 Run `swamp doctor audit` after `init --tool <name>` and after upgrading the
-external AI tool. Catches upstream hook-payload drift before the audit log
-silently goes empty. Exits 1 on any check fail — safe to gate in CI.
-
-```bash
-swamp doctor audit
-swamp doctor audit --tool kiro
-swamp doctor audit --json
-```
+external AI tool. Exits 1 on any check fail — safe to gate in CI. For the full
+diagnostic flow (preflight checks, output shapes, common failures, escalation to
+other tiers), see the `swamp-troubleshooting` skill's
+`references/health-checks.md`.
 
 ## Upgrade a Repository
 

--- a/.claude/skills/swamp-troubleshooting/SKILL.md
+++ b/.claude/skills/swamp-troubleshooting/SKILL.md
@@ -1,284 +1,133 @@
 ---
 name: swamp-troubleshooting
 description: >
-  Navigate swamp source code to trace error origins, identify execution
-  flows, inspect internal data structures, and understand CLI behavior when
-  --help is insufficient. Use this skill whenever something is broken
-  ("error", "failing", "not working", "crash", "timeout", "bug", "fix",
-  "debug", "troubleshoot", "root cause", "stack trace", "isn't being found",
-  "giving me an error", "slow", "performance", "latency") OR when you need
-  to understand how swamp works
-  internally ("how does", "what happens when", "where is", "internals",
-  "under the hood"). Applies even when the query mentions a specific domain
-  (e.g., "vault expressions aren't resolving" or "how does extension push
-  work") — fetch swamp source to find the answer.
+  Diagnose swamp problems and verify swamp's health through a layered
+  diagnostic loop — health checks (`swamp doctor ...`), error
+  inspection, tracing, and source reading. Prefer this skill when the
+  user's primary intent is diagnosis or health verification, not when
+  they're performing the underlying operation. Use when something is
+  broken ("swamp error", "failing", "not working", "crash", "timeout",
+  "bug", "debug", "troubleshoot", "root cause", "slow", "performance",
+  "latency"); when verifying setup health ("is swamp working", "is my
+  repo healthy", "verify swamp setup", "sanity check", "smoke test",
+  "is everything wired up", "are hooks firing", "health check",
+  "diagnose swamp"), often after `swamp init` or `swamp repo upgrade`;
+  when a swamp component looks broken ("audit log empty", "audit not
+  recording", "AI tool not recording", "hooks not firing", "extension
+  not loading", "swamp-warning", "preflight"); or for swamp internals
+  ("how does swamp", "what happens when", "where is", "internals",
+  "under the hood").
 ---
 
-# Swamp Troubleshooting Skill
+# Swamp Troubleshooting
 
-Diagnose and troubleshoot swamp issues, or understand swamp internals, by
-fetching and reading the swamp source code. All commands support `--json` for
-machine-readable output.
+Diagnose swamp problems by working through four diagnostic tiers, cheapest
+first. Each tier answers a different kind of question; escalate only when the
+current tier doesn't resolve the issue.
 
 **Verify CLI syntax:** If unsure about exact flags or subcommands, run
-`swamp help source` for the complete, up-to-date CLI schema.
+`swamp help <command>` for the up-to-date schema. Every swamp command supports
+both `log` (default, human-readable) and `--json` (structured) output, and
+returns non-zero on user-facing failure.
 
-## Quick Reference
+## Diagnostic mindset
 
-| Task                | Command                                      |
-| ------------------- | -------------------------------------------- |
-| Check source status | `swamp source path --json`                   |
-| Fetch source        | `swamp source fetch --json`                  |
-| Fetch specific ver  | `swamp source fetch --version v1.0.0 --json` |
-| Fetch main branch   | `swamp source fetch --version main --json`   |
-| Clean source        | `swamp source clean --json`                  |
+- **Start cheap, escalate.** Don't fetch source when a doctor command would name
+  the problem in seconds.
+- **Read what's already on screen.** Stderr, exit codes, and `--json` output
+  carry most of the answer.
+- **Don't skip tiers.** Tracing without first reading the error is guessing;
+  fetching source without trying `--json` is overkill.
+- **One symptom, one tier.** If a symptom matches the table below, jump directly
+  to that tier — don't run the loop top to bottom.
 
-## When CLI Help Isn't Enough
+## The diagnostic loop
 
-If `swamp <command> --help` doesn't fully answer a question about how something
-works, fetch the source and read the implementation. Common areas where source
-context is needed:
+### Tier 1 — Health checks
 
-- **Auth**: How credentials are stored (`~/.config/swamp/auth.json`), API key
-  format (`swamp_` prefix), headless/CI setup — check `src/infrastructure/auth/`
-- **Extension push**: What the push flow does internally, how bundles are
-  packaged, registry interaction — check `src/cli/commands/extension*.ts` and
-  `src/domain/extensions/`
-- **Init**: What files and directories `swamp repo init` creates and why — check
-  `src/cli/commands/repo*.ts` and `src/domain/repo/`
-- **Data persistence**: How data is stored, versioned, and garbage collected —
-  check `src/infrastructure/persistence/`
+For symptoms tied to a known integration (audit pipeline, extension loading).
+The doctor commands name the failing piece directly and exit non-zero on
+failure. Cheapest tier, fastest signal.
 
-**General rule:** When a skill's CLI commands and documentation don't provide
-enough detail, use `swamp source fetch` to get the source and read the relevant
-files directly.
+→ See [references/health-checks.md](references/health-checks.md).
 
-## Troubleshooting Workflow
+### Tier 2 — Error inspection
 
-When a user reports a swamp issue:
+For specific command failures and unexpected output. Read stderr, switch to
+`--json`, check exit codes, grep for `swamp-warning:` lines. Most failures are
+loud — the error surface itself usually answers the question.
 
-### 1. Check Current Source Status
+→ See [references/error-inspection.md](references/error-inspection.md).
 
-```bash
-swamp source path --json
-```
+### Tier 3 — Tracing
 
-**Output shape (found):**
+For timing and flow questions: slow workflows, mysterious waits, "where is this
+spending its time?" Enable OpenTelemetry tracing and read the span hierarchy.
+Not for diagnosing errors — for understanding execution shape.
 
-```json
-{
-  "status": "found",
-  "version": "20260206.200442.0-sha.abc123",
-  "path": "/Users/user/.swamp/source",
-  "fileCount": 245,
-  "fetchedAt": "2026-02-06T20:04:42.000Z"
-}
-```
+→ See [references/tracing.md](references/tracing.md).
 
-**Output shape (not found):**
+### Tier 4 — Source reading
 
-```json
-{
-  "status": "not_found"
-}
-```
+For questions Tiers 1–3 can't answer, and for "how does X work internally?"
+questions where `swamp <command> --help` is insufficient. Fetch swamp's source
+with `swamp source fetch` and read the implementation. Most expensive tier —
+reach for it last.
 
-### 2. Fetch Source If Needed
+→ See [references/source-reading.md](references/source-reading.md).
 
-If source is missing or the version doesn't match the user's swamp version:
+## Symptom → tier index
 
-```bash
-swamp source fetch --json
-```
+| Symptom                                                  | Start at                                                  |
+| -------------------------------------------------------- | --------------------------------------------------------- |
+| Audit log empty / hooks not firing                       | Tier 1 → `swamp doctor audit`                             |
+| Extension model/vault/driver/datastore/report not loaded | Tier 1 → `swamp doctor extensions`                        |
+| `swamp-warning:` line on stderr                          | Tier 1 → `swamp doctor extensions`                        |
+| CI preflight needs to gate on integration health         | Tier 1 → either doctor with `--json`                      |
+| Command errored — message is clear                       | Tier 2 → read it, fix the named issue                     |
+| Command errored — message is vague or unhelpful          | Tier 2 → re-run with `--json`, then escalate              |
+| Item "not found" / "not in search results"               | Tier 2 → check stderr for `swamp-warning:`                |
+| Method failed `Pre-flight check failed: …`               | Tier 2 → see [references/checks.md](references/checks.md) |
+| Workflow / method / sync is slow                         | Tier 3 → enable tracing                                   |
+| "Where is this spending its time?"                       | Tier 3 → enable tracing                                   |
+| Need to understand internal behavior of a command        | Tier 4 → fetch source                                     |
+| Tier-1-clean integration that still misbehaves           | Tier 4 → fetch source                                     |
 
-This fetches source for the current CLI version. To fetch a specific version:
+## Diagnostic playbook
 
-```bash
-swamp source fetch --version 20260206.200442.0-sha.abc123 --json
-```
+For a typical investigation:
 
-**Output shape:**
+1. Match the symptom against the index above. If a tier is named, jump there.
+2. If no tier matches, run Tier 2 (error inspection) — read stderr and switch to
+   `--json` first.
+3. Capture what each tier ruled out before escalating, so the next tier has
+   context.
+4. Once the root cause is identified, state it clearly, suggest a fix or
+   workaround, and (if it's a bug) summarize for an issue report.
 
-```json
-{
-  "status": "fetched",
-  "version": "20260206.200442.0-sha.abc123",
-  "path": "/Users/user/.swamp/source",
-  "fileCount": 245,
-  "fetchedAt": "2026-02-06T20:04:42.000Z",
-  "previousVersion": "20260205.100000.0-sha.xyz789"
-}
-```
+## When to use other skills
 
-### 3. Read Source Files
+| Need                                  | Use Skill                                                         |
+| ------------------------------------- | ----------------------------------------------------------------- |
+| Run/create models                     | `swamp-model`                                                     |
+| Run/create workflows                  | `swamp-workflow`                                                  |
+| Manage secrets                        | `swamp-vault`                                                     |
+| Manage repository / install / upgrade | `swamp-repo`                                                      |
+| Author custom TypeScript models       | `swamp-extension-model`                                           |
+| Debug method preflight checks         | this skill, Tier 2 + [references/checks.md](references/checks.md) |
 
-Once source is fetched, read files from `~/.swamp/source/`:
+## References
 
-**Key directories:**
-
-- `src/cli/` - CLI commands and entry point
-- `src/domain/` - Domain logic (models, workflows, vaults, etc.)
-- `src/infrastructure/` - Infrastructure adapters (persistence, HTTP, etc.)
-- `src/presentation/` - Output rendering
-
-**Example: Read the CLI entry point**
-
-```
-Read ~/.swamp/source/src/cli/mod.ts
-```
-
-**Example: Read model service**
-
-```
-Read ~/.swamp/source/src/domain/models/model_service.ts
-```
-
-### 4. Enable Tracing (Performance Issues)
-
-If the issue is about slowness, timeouts, or understanding execution flow,
-enable OpenTelemetry tracing:
-
-```bash
-# Quick: print spans to stderr
-OTEL_TRACES_EXPORTER=console swamp workflow run my-workflow
-
-# Visual: send to local Jaeger (docker run -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one)
-OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 swamp workflow run my-workflow
-```
-
-Traces show the full execution hierarchy with timing for every operation — CLI
-command → workflow → job → step → method → driver. See
-[references/tracing.md](references/tracing.md) for setup, span names, and
-diagnosing common issues.
-
-### 5. Diagnose the Issue
-
-Based on the error message or symptoms:
-
-1. **Command not working**: Check `src/cli/commands/{command}.ts`
-2. **Model issues**: Check `src/domain/models/`
-3. **Workflow issues**: Check `src/domain/workflows/`
-4. **Vault/secret issues**: Check `src/domain/vaults/`
-5. **Data persistence issues**: Check `src/infrastructure/persistence/`
-6. **Output formatting issues**: Check `src/presentation/output/`
-7. **Pre-flight check failures**: See
-   [references/checks.md](references/checks.md) for skip flags, check selection
-   errors, extension conflicts, and required check behavior
-8. **Slow operations**: Enable tracing — see
-   [references/tracing.md](references/tracing.md)
-
-### 6. Explain and Suggest Fixes
-
-After diagnosing:
-
-1. Explain what the code is doing
-2. Identify the root cause
-3. Suggest a workaround if available
-4. If it's a bug, summarize the issue and potential fix
-
-## Source Directory Structure
-
-```
-~/.swamp/source/
-├── src/
-│   ├── cli/
-│   │   ├── commands/        # CLI command implementations
-│   │   ├── context.ts       # Command context and options
-│   │   └── mod.ts           # CLI entry point
-│   ├── domain/
-│   │   ├── errors.ts        # User-facing errors
-│   │   ├── models/          # Model types and services
-│   │   ├── workflows/       # Workflow execution
-│   │   ├── vaults/          # Secret management
-│   │   ├── data/            # Data lifecycle
-│   │   └── events/          # Domain events
-│   ├── infrastructure/
-│   │   ├── persistence/     # File-based storage
-│   │   ├── logging/         # LogTape configuration
-│   │   ├── tracing/         # OpenTelemetry tracing
-│   │   └── update/          # Self-update mechanism
-│   └── presentation/
-│       └── output/          # Terminal output rendering
-├── integration/             # Integration tests
-├── design/                  # Design documents
-└── deno.json                # Deno configuration
-```
-
-## Clean Up Source
-
-When done troubleshooting:
-
-```bash
-swamp source clean --json
-```
-
-**Output shape:**
-
-```json
-{
-  "status": "cleaned",
-  "path": "/Users/user/.swamp/source"
-}
-```
-
-## Version Matching
-
-- By default, `swamp source fetch` downloads source matching the current CLI
-  version
-- Use `--version main` to get the latest unreleased code
-- Use `--version <tag>` to get a specific release
-
-## Local Extension Model Not Appearing in Type Search
-
-If a model file at `extensions/models/<name>.ts` doesn't show up in
-`swamp model type search`:
-
-1. **Check stderr.** Swamp emits one `swamp-warning:` line per failed extension
-   load, naming the file and the error. The line goes to stderr (not stdout) so
-   it stays out of `--json` output but is still visible. Common causes:
-   - Missing or invalid `version` field — must be CalVer (`YYYY.MM.DD.MICRO`).
-   - `type` is a variable instead of a string literal — the catalog extracts the
-     type via regex and only matches literal strings.
-   - Bundle failure (syntax error, unresolvable import).
-2. **Do NOT run `swamp extension source add extensions/models`.** That path is
-   auto-discovered by default; registering it as a source is a no-op that adds
-   confusion. The source-add flow is for directories _outside_ the repo.
-3. **Confirm `deno check` passes** on the file. Type errors that pass
-   `deno check` may still be rejected by swamp's stricter validation (e.g.
-   missing `version`).
-
-The discovery code lives in `src/cli/mod.ts` (`loadUserModels`) and
-`src/domain/models/user_model_loader.ts` (`UserModelLoader.buildIndex`). The
-stderr emitter is at `src/infrastructure/logging/extension_load_warnings.ts`.
-
-## Source Extension Not Loading
-
-If a source extension isn't appearing in `swamp model type search`:
-
-1. **Check the source is registered**: `swamp extension source list` — look for
-   green checkmark. Red cross means the path doesn't exist.
-2. **Check the directory structure**: The source path must contain
-   `extensions/models/` (or the appropriate type directory).
-3. **Check for a `deno.json`**: Source extensions need a `deno.json` with
-   dependency mappings (e.g., `"zod": "npm:zod@4"`). Without it, bundling fails
-   with `"Import "zod" not a dependency"`.
-4. **Check the warning output**: Look for `"Using discovered deno config"`
-   warnings — this confirms the bundler found the source's config file.
-5. **Check the `only` filter**: If the source was added with `--only vaults`,
-   model types won't load from it.
-
-The source loading code lives in:
-
-- `src/infrastructure/persistence/swamp_sources_repository.ts` — file reading
-  and path resolution
-- `src/cli/mod.ts` — wiring sources into the loader pipeline
-
-## When to Use Other Skills
-
-| Need                    | Use Skill               |
-| ----------------------- | ----------------------- |
-| Run/create models       | `swamp-model`           |
-| Run/create workflows    | `swamp-workflow`        |
-| Manage secrets          | `swamp-vault`           |
-| Manage repository       | `swamp-repo`            |
-| Create extension models | `swamp-extension-model` |
+- [references/health-checks.md](references/health-checks.md) — Tier 1: doctor
+  commands (`swamp doctor audit`, `swamp doctor extensions`), exit codes, CI
+  usage.
+- [references/error-inspection.md](references/error-inspection.md) — Tier 2:
+  stderr habits, `--json` switching, `swamp-warning:` lines, recipes for
+  "extension not appearing" and "source extension not loading."
+- [references/tracing.md](references/tracing.md) — Tier 3: OpenTelemetry setup,
+  span hierarchy, diagnosing slow workflows / GC / sync.
+- [references/source-reading.md](references/source-reading.md) — Tier 4:
+  `swamp source fetch/path/clean`, source layout, where to look by symptom.
+- [references/checks.md](references/checks.md) — Per-method preflight check
+  troubleshooting (skip flags, check selection errors, conflicts) — separate
+  concept from Tier 1 doctor commands.

--- a/.claude/skills/swamp-troubleshooting/references/error-inspection.md
+++ b/.claude/skills/swamp-troubleshooting/references/error-inspection.md
@@ -1,0 +1,151 @@
+# Error Inspection (Tier 2)
+
+When a command fails or behaves unexpectedly and Tier 1 doesn't apply (or has
+already passed), inspect the error surface itself before reaching for tracing or
+source. Most swamp failures announce themselves loudly on stderr or in
+structured form via `--json` — read those before guessing.
+
+## Contents
+
+- [The error surface](#the-error-surface)
+- [Read stderr first](#read-stderr-first)
+- [Switch to `--json`](#switch-to---json)
+- [Exit codes](#exit-codes)
+- [`swamp-warning:` lines](#swamp-warning-lines)
+- [Recipe: extension not in `model type search`](#recipe-extension-not-in-model-type-search)
+- [Recipe: source extension not loading](#recipe-source-extension-not-loading)
+- [Recipe: method preflight check failed](#recipe-method-preflight-check-failed)
+- [Escalating to other tiers](#escalating-to-other-tiers)
+
+## The error surface
+
+Every swamp command exposes the same surfaces. Cover them in order:
+
+1. **Stderr** — human-readable errors, warnings (`swamp-warning:` prefix), and
+   debug logs.
+2. **Stdout** — command output. In `--json` mode, errors and structured payloads
+   land here too.
+3. **Exit code** — `0` on success, `1` on user-facing failure. Doctor commands
+   exit `1` on any check fail; CI should gate on this.
+4. **Audit log** — `.swamp/audit/<date>.jsonl` records every CLI action with
+   inputs, outputs, and exit codes. Useful when the failure is not from the
+   command being investigated but from something earlier.
+
+## Read stderr first
+
+Many "silent" failures are not silent — they print a `swamp-warning:` line to
+stderr and continue. `--json` only shapes stdout, so warnings stay visible
+regardless of mode.
+
+```bash
+swamp model type search --json 2>warnings.txt
+cat warnings.txt          # check for swamp-warning: lines
+```
+
+If the user reports "X isn't appearing" or "X isn't being found," check stderr
+before anything else.
+
+## Switch to `--json`
+
+Every command supports `--json`. When the human-readable output is ambiguous,
+re-run with `--json` to see the structured shape — error messages, validation
+details, and per-item status are all surfaced explicitly.
+
+```bash
+swamp model method run my-model my-method --json
+```
+
+JSON output is also stable — fields rarely change between releases, so it's the
+right surface for scripting and CI gating.
+
+## Exit codes
+
+| Code | Meaning                                                       |
+| ---- | ------------------------------------------------------------- |
+| `0`  | Success                                                       |
+| `1`  | User-facing failure (validation, missing config, doctor fail) |
+| `2+` | Reserved — currently unused, but capture for future-proofing  |
+
+CI should treat any non-zero exit as actionable. Combine with `--json` for the
+structured failure context.
+
+## `swamp-warning:` lines
+
+When swamp detects a non-fatal issue during extension load (bad version, broken
+import, etc.), it emits a single line to stderr:
+
+```
+swamp-warning: model: extensions/models/my-model.ts: Missing version field — must be CalVer (YYYY.MM.DD.MICRO)
+```
+
+Format: `swamp-warning: <kind>: <file>: <error>`. Kinds match the doctor
+extension registries
+(`model | extension | vault | driver | datastore | report`).
+
+The emitter is at `src/infrastructure/logging/extension_load_warnings.ts`.
+`swamp doctor extensions` consumes the same emitter and folds warnings into a
+structured report — prefer the doctor command when triaging multiple warnings.
+
+## Recipe: extension not in `model type search`
+
+Symptom: a model file at `extensions/models/<name>.ts` doesn't appear in
+`swamp model type search`.
+
+1. **Run `swamp doctor extensions --json`** — Tier 1 names the failing file and
+   error directly. Stop here if the failure is identified.
+2. **If doctor passes**, the model is loading but isn't visible. Re-run
+   `swamp model type search --json` and check stderr for late warnings (some
+   issues only surface when the catalog is queried, not when registries load).
+3. **Verify `deno check` passes** on the file — type errors that pass
+   `deno
+   check` may still be rejected by swamp's stricter validation (e.g.
+   missing `version`).
+4. **Do NOT run `swamp extension source add extensions/models`** — that path is
+   auto-discovered by default. Registering it as a source is a no-op that adds
+   confusion. Source-add is for directories _outside_ the repo.
+
+Discovery code lives in `src/cli/mod.ts` (`loadUserModels`) and
+`src/domain/models/user_model_loader.ts` (`UserModelLoader.buildIndex`). Read
+those via Tier 4 if doctor and stderr both come up clean.
+
+## Recipe: source extension not loading
+
+Symptom: an extension registered in `.swamp-sources.yaml` isn't appearing.
+
+1. **Run `swamp doctor extensions --json`** — failures from a source path show
+   up with the source-relative file path in the failure list.
+2. **Check the source is registered**: `swamp extension source list` — green
+   checkmark means the path resolves; red cross means it doesn't exist on disk.
+3. **Check the directory structure**: the source path must contain
+   `extensions/<kind>/` (or be a direct-content directory of one kind).
+4. **Check for a `deno.json`**: source extensions need a `deno.json` with
+   dependency mappings (e.g. `"zod": "npm:zod@4"`). Without it, bundling fails
+   with `Import "zod" not a dependency`.
+5. **Check the `only` filter**: if the source was added with `--only vaults`,
+   model types won't load from it.
+
+Source loading code:
+
+- `src/infrastructure/persistence/swamp_sources_repository.ts` — file reading
+  and path resolution.
+- `src/cli/mod.ts` — wiring sources into the loader pipeline.
+
+## Recipe: method preflight check failed
+
+Symptom: `swamp model method run` fails with `Pre-flight check failed: …`.
+
+This is a different concept from `swamp doctor` — it's a per-method validation
+check (e.g. "AWS credentials are valid", "API is reachable"), not an integration
+health check. See [checks.md](checks.md) for skip flags, check selection errors,
+extension conflicts, and required-check behavior.
+
+## Escalating to other tiers
+
+If Tier 2 doesn't resolve the issue:
+
+- **Slow / timing-related** → Tier 3: [tracing.md](tracing.md).
+- **Unclear what the command is doing internally**, or a Tier-1-clean
+  integration that still misbehaves → Tier 4:
+  [source-reading.md](source-reading.md).
+- **Doctor flagged a known integration as unhealthy** → Tier 1:
+  [health-checks.md](health-checks.md).

--- a/.claude/skills/swamp-troubleshooting/references/health-checks.md
+++ b/.claude/skills/swamp-troubleshooting/references/health-checks.md
@@ -1,0 +1,229 @@
+# Health Checks (Tier 1)
+
+Run `swamp doctor <subcommand>` first when a known integration is suspected of
+being unhealthy. Doctor commands are the cheapest, most specific diagnostic —
+they exit non-zero on failure, support `--json` for CI, and name the failing
+piece in the output.
+
+## Contents
+
+- [When to use Tier 1](#when-to-use-tier-1)
+- [`swamp doctor audit`](#swamp-doctor-audit)
+- [`swamp doctor extensions`](#swamp-doctor-extensions)
+- [Using doctor in CI](#using-doctor-in-ci)
+- [Escalating to other tiers](#escalating-to-other-tiers)
+
+## When to use Tier 1
+
+Reach for a doctor command when the symptom maps to a known integration:
+
+| Symptom                                                        | Run                       |
+| -------------------------------------------------------------- | ------------------------- |
+| Audit log empty after init/upgrade or after AI-tool change     | `swamp doctor audit`      |
+| Hooks aren't firing for the configured AI tool                 | `swamp doctor audit`      |
+| Extension model/vault/driver/datastore/report missing from CLI | `swamp doctor extensions` |
+| `swamp-warning:` line on stderr mentioning a load failure      | `swamp doctor extensions` |
+| CI preflight needs to gate on integration health               | either, with `--json`     |
+
+If the symptom is generic ("command errored", "method failed"), skip Tier 1 and
+go to Tier 2 (error inspection).
+
+## `swamp doctor audit`
+
+Verifies that the AI-tool audit integration is wired correctly. Reads the tool
+from `.swamp.yaml` unless `--tool` overrides it. Exits 1 on any check fail.
+
+```bash
+swamp doctor audit                  # uses tool from .swamp.yaml
+swamp doctor audit --tool kiro      # override
+swamp doctor audit --json           # machine-readable
+```
+
+Supported tools: `claude | cursor | kiro | opencode | codex | copilot | none`.
+
+### Preflight checks
+
+Runs in fixed order. A failure in one check does not abort later checks.
+
+| Check                   | Verifies                                                         |
+| ----------------------- | ---------------------------------------------------------------- |
+| `binary-on-path`        | The AI tool's binary is reachable on `$PATH`                     |
+| `swamp-binary-on-path`  | The `swamp` binary is on `$PATH` (so hooks can call it)          |
+| `agent-config-loadable` | The AI tool's config file (e.g. `.claude/...`) parses            |
+| `default-agent-set`     | A default agent is configured                                    |
+| `recording-smoke-test`  | A synthetic hook payload roundtrips through `swamp audit record` |
+
+Each check returns `pass | fail | skip` with a short message and (on fail) an
+actionable hint. `skip` means the check does not apply to the configured tool
+(e.g. `tool: none`).
+
+### Output — log mode
+
+```
+✓ binary-on-path           Found at /usr/local/bin/claude
+✓ swamp-binary-on-path     Found at /opt/homebrew/bin/swamp
+✓ agent-config-loadable    .claude/settings.json parsed
+✓ default-agent-set        Default agent: swamp-getting-started
+✓ recording-smoke-test     audit record accepted the synthetic payload
+
+5 passed, 0 failed, 0 skipped — OVERALL: PASS
+```
+
+Fail rows print a `hint:` line beneath them with the remediation step.
+
+### Output — JSON mode
+
+```json
+{
+  "tool": "claude",
+  "overallStatus": "pass",
+  "checks": [
+    {
+      "name": "binary-on-path",
+      "status": "pass",
+      "message": "Found at /usr/local/bin/claude"
+    }
+  ]
+}
+```
+
+Fields per check: `name`, `status` (`pass | fail | skip`), `message`, optional
+`hint` (on fail), optional `details` (structured payload for consumers).
+
+`overallStatus` is `pass` if no fails, `warn` if every check skipped, `fail`
+otherwise. Exit code mirrors `fail` only.
+
+### Common failures
+
+| Hint contains           | Fix                                                                  |
+| ----------------------- | -------------------------------------------------------------------- |
+| "Not found on PATH"     | Install the AI tool, or add its bin dir to `$PATH`                   |
+| "swamp not on PATH"     | Install the `swamp` binary into a directory on `$PATH`               |
+| "Could not parse"       | Run the AI tool to regenerate its config; check for hand edits       |
+| "No default agent"      | Set the default agent through the AI tool's UI/config                |
+| "audit record rejected" | Check `swamp` and AI tool versions match; rerun `swamp repo upgrade` |
+
+### `NoToolConfiguredError`
+
+If neither `--tool` nor `.swamp.yaml` declares a tool, the command exits with:
+
+```
+No AI tool configured in .swamp.yaml and no --tool flag provided.
+Pass --tool <name> (claude | cursor | kiro | opencode | codex | copilot | none)
+or run `swamp init --tool <name>`.
+```
+
+This is expected first-run UX, not a bug. Either pass `--tool` or set the tool
+in `.swamp.yaml` via `swamp init --tool <name>`.
+
+## `swamp doctor extensions`
+
+Verifies that every user-defined extension in this repo loads cleanly. Forces a
+catalog rescan and re-runs each registry's loader from scratch — cached lazy
+entries cannot mask failures. Exits 1 on any registry fail.
+
+```bash
+swamp doctor extensions
+swamp doctor extensions --json
+```
+
+### Registries checked
+
+Five user-facing registries, in fixed order:
+
+| Registry    | Covers                                               |
+| ----------- | ---------------------------------------------------- |
+| `model`     | `extensions/models/` and registered model extensions |
+| `vault`     | `extensions/vaults/`                                 |
+| `driver`    | `extensions/drivers/`                                |
+| `datastore` | `extensions/datastores/`                             |
+| `report`    | `extensions/reports/`                                |
+
+The `model` row absorbs both `model` and `extension` load warnings — extensions
+that augment an existing model type fold into the model registry's row.
+
+### Output — log mode
+
+```
+✓ model
+✓ vault
+✗ driver (1 failure(s))
+    • extensions/drivers/my-driver.ts: Missing version field — must be CalVer (YYYY.MM.DD.MICRO)
+✓ datastore
+✓ report
+
+4 passed, 1 failed — OVERALL: FAIL
+```
+
+### Output — JSON mode
+
+All five registry keys are always present, in fixed order, even on a clean run:
+
+```json
+{
+  "overallStatus": "fail",
+  "registries": {
+    "model": { "registry": "model", "status": "pass", "failures": [] },
+    "vault": { "registry": "vault", "status": "pass", "failures": [] },
+    "driver": {
+      "registry": "driver",
+      "status": "fail",
+      "failures": [
+        {
+          "file": "extensions/drivers/my-driver.ts",
+          "error": "Missing version field …"
+        }
+      ]
+    },
+    "datastore": { "registry": "datastore", "status": "pass", "failures": [] },
+    "report": { "registry": "report", "status": "pass", "failures": [] }
+  }
+}
+```
+
+### Common failures
+
+The error string identifies the cause. Most failures fall into these buckets:
+
+| Error fragment                         | Fix                                                                                                                       |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `Missing version field` / `not CalVer` | Add `version: "YYYY.MM.DD.MICRO"` to the extension export                                                                 |
+| `type` field not a string literal      | Replace the variable with a literal — the catalog regex requires it                                                       |
+| `Import "<dep>" not a dependency`      | Add the dep to the source's `deno.json` `imports` map                                                                     |
+| Syntax / unresolvable import           | Fix the file so `deno check` passes                                                                                       |
+| `<registry> loader>: …`                | The loader itself threw — read the message; usually a config issue in the source's `deno.json` or a missing native binary |
+
+For the deeper "extension not in type search" walkthrough (stderr inspection,
+source registration, `deno.json` discovery), see
+[error-inspection.md](error-inspection.md).
+
+## Using doctor in CI
+
+Both commands exit 1 on failure, so they compose directly into CI. Use `--json`
+to capture structured output for review.
+
+```bash
+# Gate on audit health
+swamp doctor audit --json > audit-health.json
+
+# Gate on extension health
+swamp doctor extensions --json > extension-health.json
+```
+
+Run `doctor extensions` after every PR that touches `extensions/` or
+`.swamp-sources.yaml`. Run `doctor audit` after every `init` or `upgrade` step
+in CI bootstrap.
+
+## Escalating to other tiers
+
+Tier 1 cannot diagnose:
+
+- A method that fails its own preflight checks at run time → see
+  [checks.md](checks.md) (different concept: per-method validation, not
+  integration health).
+- A specific command that errors with a non-doctor failure → go to Tier 2:
+  [error-inspection.md](error-inspection.md).
+- A workflow that's slow or whose execution flow is unclear → go to Tier 3:
+  [tracing.md](tracing.md).
+- A "how does X work internally" question, or a Tier-1-clean integration that
+  still misbehaves → go to Tier 4: [source-reading.md](source-reading.md).

--- a/.claude/skills/swamp-troubleshooting/references/source-reading.md
+++ b/.claude/skills/swamp-troubleshooting/references/source-reading.md
@@ -1,0 +1,159 @@
+# Source Reading (Tier 4)
+
+When Tiers 1–3 don't answer the question — or the question is itself "how does
+swamp do X internally?" — fetch swamp's source and read the implementation
+directly. Source reading is the most expensive tier; reach for it last.
+
+## Contents
+
+- [When to use Tier 4](#when-to-use-tier-4)
+- [Quick reference](#quick-reference)
+- [Workflow](#workflow)
+- [Source directory layout](#source-directory-layout)
+- [Where to look by symptom](#where-to-look-by-symptom)
+- [Version matching](#version-matching)
+- [Cleaning up](#cleaning-up)
+
+## When to use Tier 4
+
+Reach for source reading when:
+
+- Tiers 1–3 ran clean but the symptom persists.
+- The question is conceptual ("how does extension push work?", "what does init
+  create and why?") and `swamp <command> --help` doesn't go deep enough.
+- A behavior contradicts the docs and the truth needs to come from the code.
+
+Skip Tier 4 if a doctor command, error message, or trace already names the
+problem — fetching source is wasted work in that case.
+
+## Quick reference
+
+| Task                | Command                                      |
+| ------------------- | -------------------------------------------- |
+| Check source status | `swamp source path --json`                   |
+| Fetch source        | `swamp source fetch --json`                  |
+| Fetch specific ver  | `swamp source fetch --version v1.0.0 --json` |
+| Fetch main branch   | `swamp source fetch --version main --json`   |
+| Clean source        | `swamp source clean --json`                  |
+
+## Workflow
+
+### 1. Check current source status
+
+```bash
+swamp source path --json
+```
+
+Output (found):
+
+```json
+{
+  "status": "found",
+  "version": "20260206.200442.0-sha.abc123",
+  "path": "/Users/user/.swamp/source",
+  "fileCount": 245,
+  "fetchedAt": "2026-02-06T20:04:42.000Z"
+}
+```
+
+Output (not found):
+
+```json
+{ "status": "not_found" }
+```
+
+### 2. Fetch source if needed
+
+If source is missing or the version doesn't match the running CLI:
+
+```bash
+swamp source fetch --json
+```
+
+Fetches source for the current CLI version. Use `--version <ver>` to fetch a
+specific release; `--version main` for the latest unreleased code.
+
+```json
+{
+  "status": "fetched",
+  "version": "20260206.200442.0-sha.abc123",
+  "path": "/Users/user/.swamp/source",
+  "fileCount": 245,
+  "fetchedAt": "2026-02-06T20:04:42.000Z",
+  "previousVersion": "20260205.100000.0-sha.xyz789"
+}
+```
+
+### 3. Read the relevant files
+
+Source is unpacked at `~/.swamp/source/`. Use Read on absolute paths under that
+directory.
+
+### 4. Diagnose and explain
+
+After reading, state what the code does, identify the root cause, and suggest a
+workaround or fix. If it's a bug, summarize for an issue report.
+
+## Source directory layout
+
+```
+~/.swamp/source/
+├── src/
+│   ├── cli/
+│   │   ├── commands/        # CLI command implementations
+│   │   ├── context.ts       # Command context and options
+│   │   └── mod.ts           # CLI entry point
+│   ├── domain/
+│   │   ├── errors.ts        # User-facing errors
+│   │   ├── models/          # Model types and services
+│   │   ├── workflows/       # Workflow execution
+│   │   ├── vaults/          # Secret management
+│   │   ├── data/            # Data lifecycle
+│   │   └── events/          # Domain events
+│   ├── infrastructure/
+│   │   ├── persistence/     # File-based storage
+│   │   ├── logging/         # LogTape configuration + warning emitters
+│   │   ├── tracing/         # OpenTelemetry tracing
+│   │   └── update/          # Self-update mechanism
+│   └── presentation/
+│       └── output/          # Terminal output rendering
+├── integration/             # Integration tests
+├── design/                  # Design documents
+└── deno.json                # Deno configuration
+```
+
+## Where to look by symptom
+
+| Question                                            | Read first                                              |
+| --------------------------------------------------- | ------------------------------------------------------- |
+| "What does `<command>` do?"                         | `src/cli/commands/<command>.ts`                         |
+| Model loading / catalog issues                      | `src/domain/models/`, `src/cli/mod.ts`                  |
+| Workflow execution / DAG                            | `src/domain/workflows/`                                 |
+| Vault expressions / secrets                         | `src/domain/vaults/`                                    |
+| Data persistence, atomic writes, garbage collection | `src/infrastructure/persistence/`                       |
+| Auth, credentials, API keys                         | `src/infrastructure/auth/`                              |
+| Output formatting (log vs JSON)                     | `src/presentation/output/`                              |
+| Tracing span names, instrumentation                 | `src/infrastructure/tracing/`                           |
+| Extension load warnings                             | `src/infrastructure/logging/extension_load_warnings.ts` |
+
+## Version matching
+
+- By default, `swamp source fetch` downloads source matching the running CLI
+  version. This is almost always what you want — it guarantees the code on disk
+  matches the binary's behavior.
+- Use `--version main` to read unreleased code (e.g. when investigating a fix
+  that has merged but not shipped).
+- Use `--version <tag>` to read a specific release (e.g. when reproducing a bug
+  on an older version).
+
+## Cleaning up
+
+When done, remove the fetched source:
+
+```bash
+swamp source clean --json
+```
+
+```json
+{ "status": "cleaned", "path": "/Users/user/.swamp/source" }
+```

--- a/.claude/skills/swamp-troubleshooting/references/tracing.md
+++ b/.claude/skills/swamp-troubleshooting/references/tracing.md
@@ -1,8 +1,10 @@
-# OpenTelemetry Tracing
+# Tracing (Tier 3)
 
-Swamp has native OpenTelemetry tracing for diagnosing slow or failing
-operations. Tracing is opt-in via environment variables and has zero overhead
-when disabled.
+Reach for tracing when the question is about timing, flow, or where a slow
+operation is spending its time. Tier 1 (health checks) and Tier 2 (error
+inspection) handle most failures; tracing is for everything where the answer is
+"how long" or "what ran when." Tracing is opt-in via environment variables and
+has zero overhead when disabled.
 
 ## Quick Setup
 
@@ -135,3 +137,14 @@ trace, creating a unified trace across process boundaries.
 
 See https://swamp.club/manual/reference/opentelemetry for the full span
 hierarchy, instrumentation points, and attribute reference.
+
+## Escalating to other tiers
+
+If tracing shows the timing but not the cause:
+
+- **Span attributes hint at a known integration failure** → Tier 1:
+  [health-checks.md](health-checks.md).
+- **Span error messages need decoding, or `--json` output would say more** →
+  Tier 2: [error-inspection.md](error-inspection.md).
+- **The span is fast but the behavior is still wrong** → Tier 4:
+  [source-reading.md](source-reading.md) — read the implementation directly.

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -642,6 +642,12 @@ ${skillsIntro}
 
 ${
       skillListEntry(
+        "swamp-getting-started",
+        "Interactive onboarding for new swamp users",
+      )
+    }
+${
+      skillListEntry(
         "swamp-model",
         "Work with swamp models (creating, editing, validating)",
       )
@@ -654,6 +660,12 @@ ${
     }
 ${skillListEntry("swamp-vault", "Manage secrets and credentials")}
 ${skillListEntry("swamp-data", "Manage model data lifecycle")}
+${
+      skillListEntry(
+        "swamp-data-query",
+        "Query model data artifacts with CEL predicates",
+      )
+    }
 ${
       skillListEntry(
         "swamp-report",
@@ -670,8 +682,25 @@ ${
       )
     }
 ${skillListEntry("swamp-extension-vault", "Create custom vault providers")}
+${
+      skillListEntry(
+        "swamp-extension-publish",
+        "Publish extensions to the registry",
+      )
+    }
+${
+      skillListEntry(
+        "swamp-extension-quality",
+        "Improve extension quality scorecards",
+      )
+    }
 ${skillListEntry("swamp-issue", "Submit bug reports and feature requests")}
-${skillListEntry("swamp-troubleshooting", "Debug and diagnose swamp issues")}
+${
+      skillListEntry(
+        "swamp-troubleshooting",
+        "Diagnose swamp problems and verify swamp's health",
+      )
+    }
 
 ## Getting Started
 

--- a/src/infrastructure/assets/skill_assets.ts
+++ b/src/infrastructure/assets/skill_assets.ts
@@ -35,6 +35,10 @@ export interface SkillInfo {
 const BUNDLED_SKILLS: SkillInfo[] = [
   { relativePath: "swamp-data/SKILL.md", name: "swamp-data" },
   {
+    relativePath: "swamp-data/references/concepts.md",
+    name: "swamp-data",
+  },
+  {
     relativePath: "swamp-data/references/data-ownership.md",
     name: "swamp-data",
   },
@@ -44,6 +48,10 @@ const BUNDLED_SKILLS: SkillInfo[] = [
   },
   {
     relativePath: "swamp-data/references/expressions.md",
+    name: "swamp-data",
+  },
+  {
+    relativePath: "swamp-data/references/output-shapes.md",
     name: "swamp-data",
   },
   {
@@ -175,6 +183,18 @@ const BUNDLED_SKILLS: SkillInfo[] = [
     name: "swamp-extension-model",
   },
   {
+    relativePath: "swamp-extension-model/references/skills.md",
+    name: "swamp-extension-model",
+  },
+  {
+    relativePath: "swamp-extension-model/references/typing.md",
+    name: "swamp-extension-model",
+  },
+  {
+    relativePath: "swamp-extension-model/references/upgrades.md",
+    name: "swamp-extension-model",
+  },
+  {
     relativePath: "swamp-model/references/execution-drivers.md",
     name: "swamp-model",
   },
@@ -267,11 +287,31 @@ const BUNDLED_SKILLS: SkillInfo[] = [
     name: "swamp-issue",
   },
   {
+    relativePath: "swamp-issue/references/formatting.md",
+    name: "swamp-issue",
+  },
+  {
+    relativePath: "swamp-issue/references/output_shapes.md",
+    name: "swamp-issue",
+  },
+  {
     relativePath: "swamp-troubleshooting/SKILL.md",
     name: "swamp-troubleshooting",
   },
   {
     relativePath: "swamp-troubleshooting/references/checks.md",
+    name: "swamp-troubleshooting",
+  },
+  {
+    relativePath: "swamp-troubleshooting/references/error-inspection.md",
+    name: "swamp-troubleshooting",
+  },
+  {
+    relativePath: "swamp-troubleshooting/references/health-checks.md",
+    name: "swamp-troubleshooting",
+  },
+  {
+    relativePath: "swamp-troubleshooting/references/source-reading.md",
     name: "swamp-troubleshooting",
   },
   {


### PR DESCRIPTION
## Summary

- Restructures `swamp-troubleshooting` into a layered diagnostic loop (health checks → error inspection → tracing → source reading), with each tier in its own reference. Doctor commands were previously undocumented in the skill; users now find them via natural-language phrasings ("is swamp working", "sanity check", "audit not recording", "hooks not firing"). Tessl review: 94% (Description 100%).
- Fixes a pre-existing bundling gap: 4 of 16 swamp-* skills (`swamp-getting-started`, `swamp-data-query`, `swamp-extension-publish`, `swamp-extension-quality`) were missing from the CLAUDE.md/AGENTS.md skill listing in `repo_service`.
- Fixes a deeper pre-existing gap: 10 reference files exist on disk but were never in `BUNDLED_SKILLS`, so `swamp init` / `swamp repo upgrade` shipped SKILL.md files with broken links to references that never landed in the user's repo. Files added across `swamp-data`, `swamp-extension-model`, `swamp-issue`, and `swamp-troubleshooting`.

### Skill changes

- `swamp-troubleshooting/SKILL.md` is now pure navigation (mindset, tier overview, symptom→tier index, references list). All depth moved to references.
- New references: `health-checks.md` (full `doctor audit` + `doctor extensions` coverage, output shapes, common failures, CI usage), `error-inspection.md` (stderr/`--json`/exit codes/`swamp-warning:` lines, the two extension-not-loading recipes), `source-reading.md` (the source-fetch workflow that previously lived in SKILL.md).
- `tracing.md` reframed lightly as Tier 3.
- `swamp-repo`: deep `swamp doctor audit` section trimmed to a one-liner pointing at the troubleshooting reference.
- `swamp-extension-{model,driver,vault,datastore}`: Quick Reference tables gain a "Verify it loads → `swamp doctor extensions --json`" row.

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno run test` — all 4995 tests pass
- [x] `deno run compile` succeeds; binary boots (`./swamp --version`)
- [x] `npx tessl skill review .claude/skills/swamp-troubleshooting` → 94%, all 11 validation checks pass
- [x] Diff between on-disk skill files and `BUNDLED_SKILLS` is now empty for actual file paths