### PR TITLE
refactor(workflows): address review comments from PR #1252

### DIFF
--- a/src/domain/expressions/cel_runtime.ts
+++ b/src/domain/expressions/cel_runtime.ts
@@ -1,0 +1,39 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Minimal CEL evaluator surface needed by domain-side evaluators
+ * (expression evaluators, forEach expansion). Defined in the domain
+ * so consumers don't need to reach into infrastructure for the type;
+ * the infrastructure CelEvaluator implements this structurally.
+ *
+ * Includes both sync `evaluate` (used for step-name templates and
+ * predicates) and async `evaluateAsync` (used for `forEach.in` and
+ * any expression that may reach data.* helpers returning Promises).
+ * Consumers that only need one of the two are still served by passing
+ * the broader implementation — extra methods are harmless under
+ * TypeScript's structural typing.
+ */
+export interface CelExpressionEvaluator {
+  evaluate(expression: string, context: Record<string, unknown>): unknown;
+  evaluateAsync(
+    expression: string,
+    context: Record<string, unknown>,
+  ): Promise<unknown>;
+}

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -647,11 +647,15 @@ export class DefaultStepExecutor implements StepExecutor {
       : undefined;
 
     // Finalize driver resolution. When no plan was passed (legacy
-    // callers), fall back to "raw".
-    const resolved = ctx.driverPlan?.withDefinition({
+    // callers, e.g. tests constructing a StepExecutionContext directly),
+    // route through an empty plan so the definition tier is still
+    // honoured — matches the pre-DriverPlan behaviour where the
+    // definition was passed to resolveDriverConfig regardless of whether
+    // upper tiers were set.
+    const resolved = (ctx.driverPlan ?? new DriverPlan({})).withDefinition({
       driver: evaluatedDefinition.driver,
       driverConfig: evaluatedDefinition.driverConfig,
-    }) ?? { driver: "raw" };
+    });
 
     // Execute the method with the EVALUATED definition. The logger
     // handles both console and file persistence via RunFileSink. Data

--- a/src/domain/workflows/expression_evaluators.ts
+++ b/src/domain/workflows/expression_evaluators.ts
@@ -31,18 +31,16 @@ import {
   hasStepOutputDependency,
 } from "../expressions/dependency_extractor.ts";
 import type { ExpressionContext } from "../expressions/model_resolver.ts";
+import type { CelExpressionEvaluator } from "../expressions/cel_runtime.ts";
 
 /**
- * Minimal CEL evaluator surface needed by the workflow + definition
- * evaluators. The infrastructure-side CelEvaluator implements this
- * structurally; the indirection keeps these domain evaluators free of
- * a direct infrastructure import.
+ * Result of evaluating a workflow's CEL expressions.
+ * `expressionsEvaluated` is exposed for callers that record it as a
+ * tracing-span attribute.
  */
-export interface CelExpressionEvaluator {
-  evaluateAsync(
-    expression: string,
-    context: Record<string, unknown>,
-  ): Promise<unknown>;
+export interface WorkflowEvaluationResult {
+  workflow: Workflow;
+  expressionsEvaluated: number;
 }
 
 /**
@@ -57,16 +55,6 @@ export interface CelExpressionEvaluator {
  * behaviour — workflows declare their evaluation order explicitly, so
  * a thrown CEL error is a real bug.
  */
-/**
- * Result of evaluating a workflow's CEL expressions.
- * `expressionsEvaluated` is exposed for callers that record it as a
- * tracing-span attribute.
- */
-export interface WorkflowEvaluationResult {
-  workflow: Workflow;
-  expressionsEvaluated: number;
-}
-
 export class WorkflowExpressionEvaluator {
   constructor(private readonly celEvaluator: CelExpressionEvaluator) {}
 

--- a/src/domain/workflows/for_each_expansion_service.ts
+++ b/src/domain/workflows/for_each_expansion_service.ts
@@ -21,23 +21,8 @@ import { getLogger } from "@logtape/logtape";
 import type { Job } from "./job.ts";
 import type { Step } from "./step.ts";
 import type { ExpressionContext } from "../expressions/model_resolver.ts";
+import type { CelExpressionEvaluator } from "../expressions/cel_runtime.ts";
 import { UserError } from "../errors.ts";
-
-/**
- * Minimal CEL evaluator surface needed by forEach expansion. Includes
- * both sync (for step-name templates) and async (for `forEach.in`,
- * which may call data.* helpers that return Promises).
- *
- * Defined locally to keep this module free of direct infrastructure
- * imports; the infrastructure CelEvaluator implements it structurally.
- */
-export interface CelEvaluatorRuntime {
-  evaluate(expression: string, context: Record<string, unknown>): unknown;
-  evaluateAsync(
-    expression: string,
-    context: Record<string, unknown>,
-  ): Promise<unknown>;
-}
 
 /**
  * One concrete step produced by forEach expansion.
@@ -73,7 +58,7 @@ export function resolveForEachStepName(
   template: string,
   hasExpression: boolean,
   stepContext: Record<string, unknown>,
-  celEvaluator: CelEvaluatorRuntime,
+  celEvaluator: CelExpressionEvaluator,
   fallbackSuffix: string,
 ): ResolvedStepName {
   if (hasExpression) {
@@ -108,7 +93,7 @@ export function resolveForEachStepName(
  * emission, no orchestration concerns.
  */
 export class ForEachExpansionService {
-  constructor(private readonly celEvaluator: CelEvaluatorRuntime) {}
+  constructor(private readonly celEvaluator: CelExpressionEvaluator) {}
 
   async expand(
     job: Job,


### PR DESCRIPTION
## Summary

Follow-up to #1252 picking up three review comments. All small, all behaviour-preserving.

### Changes

1. **Driver fallback preserves the definition tier (real fix).** Adversarial review caught a subtle regression in #1252: `ctx.driverPlan?.withDefinition(...) ?? { driver: "raw" }` silently dropped the definition's driver when no plan was passed. The original `resolveDriverConfig(..., { driver, driverConfig }, ...)` always honoured the definition tier regardless. Production isn't affected (`runStep` always builds a `DriverPlan`) but anyone constructing `StepExecutionContext` directly — like the existing `DefaultStepExecutor` unit tests — would lose the definition tier. Fix: route through an empty `DriverPlan` when none is provided:

   ```ts
   const resolved = (ctx.driverPlan ?? new DriverPlan({})).withDefinition({
     driver: evaluatedDefinition.driver,
     driverConfig: evaluatedDefinition.driverConfig,
   });
   ```

2. **Single shared CEL evaluator interface.** `CelExpressionEvaluator` (in `expression_evaluators.ts`, async-only) and `CelEvaluatorRuntime` (in `for_each_expansion_service.ts`, sync+async) were the same abstraction with two surfaces in two files. Consolidate to a single `CelExpressionEvaluator` in `src/domain/expressions/cel_runtime.ts` with both methods. Structural typing handles narrower uses unchanged.

3. **JSDoc reordering** in `expression_evaluators.ts` — the `WorkflowExpressionEvaluator` class doc had been detached from the class by the `WorkflowEvaluationResult` interface I'd added between the doc and the class. Reorder so the doc sits directly above the class.

### What's deliberately not in this PR

- **Companion `_test.ts` files for the 5 new modules** — separate follow-up. Meaningful work; deserves its own PR with focused unit tests for each extracted class.
- **`method_report_runner.ts` UnifiedDataRepository import from infrastructure** — pre-existing debt; the domain `UnifiedDataRepository` interface in `src/domain/data/repositories.ts` has diverged from the infrastructure one, so it's not a swap.
- **`StepExecutorDeps.evaluatedDefRepo` concrete type** — no domain interface exists for evaluated-definition persistence yet.

## Test Plan

- [x] `deno check` — clean
- [x] `deno lint` — clean
- [x] `deno fmt --check` — clean
- [x] `deno task test` — 5045 passed, 0 failed
- [x] `verify.sh check` against pre-#1252 baseline — OK across all 10 phases (single-step, multi-step pipeline, forEach + vary, cross-model CEL, sub-workflow + `data.findBySpec`, missing-model error, `--last-evaluated` parity, vault canary redaction, repo-state snapshots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)