### PR TITLE
fix(repo): translate legacy `tool: none` to empty tools array on migration

### DIFF
--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -76,11 +76,14 @@ export interface RepoMarkerData {
 
 /**
  * Promotes the legacy `tool` field to `tools` and strips the legacy field.
- * `tools` wins when both are present.
+ * `tools` wins when both are present. The legacy `tool: none` sentinel maps
+ * to the canonical `tools: []` (no tools enrolled), not `tools: ["none"]` —
+ * the former matches a fresh `--tool none` init and keeps the round-trip
+ * idempotent.
  */
 function normalizeMarker(data: RepoMarkerData): RepoMarkerData {
   if (data.tools === undefined && data.tool !== undefined) {
-    data.tools = [data.tool];
+    data.tools = data.tool === "none" ? [] : [data.tool];
   }
   delete data.tool;
   return data;

--- a/src/infrastructure/persistence/repo_marker_repository_test.ts
+++ b/src/infrastructure/persistence/repo_marker_repository_test.ts
@@ -292,6 +292,28 @@ tool: claude
   });
 });
 
+Deno.test("RepoMarkerRepository.read translates legacy `tool: none` into an empty tools array", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new RepoMarkerRepository();
+    const repoPath = RepoPath.create(dir);
+
+    const markerPath = join(dir, ".swamp.yaml");
+    const content = `swampVersion: "1.2.3"
+initializedAt: "2024-01-15T10:30:00.000Z"
+tool: none
+`;
+    await Deno.writeTextFile(markerPath, content);
+
+    const result = await repo.read(repoPath);
+
+    // Legacy `tool: none` is the "no tools enrolled" sentinel and should
+    // promote to `tools: []` (matching a fresh `--tool none` init), not
+    // `tools: ["none"]` (which leaks the sentinel into the array).
+    assertEquals(result!.tools, []);
+    assertEquals(result!.tool, undefined);
+  });
+});
+
 Deno.test("RepoMarkerRepository.read prefers `tools` when both fields are present", async () => {
   await withTempDir(async (dir) => {
     const repo = new RepoMarkerRepository();


### PR DESCRIPTION
## Summary

Two follow-ups to PR #1250 (multi-tool repo init/upgrade — swamp-club#172). Both about `--tool none` semantics that drifted in the multi-tool refactor.

### 1. Legacy `tool: none` migration (review feedback)

The lazy migration from `tool: <name>` to `tools: AiTool[]` was promoting `tool: none` into `tools: ["none"]` instead of `tools: []`. A fresh `swamp repo init --tool none` produces `tools: []`. Legacy and fresh tool-none repos diverged. Round-trip wasn't idempotent.

```typescript
// normalizeMarker — translate legacy `tool: none` to []
data.tools = data.tool === "none" ? [] : [data.tool];
```

### 2. UAT regression — `tool: null` instead of `tool: "none"` (commit 7fc3bc4e)

The user's bisection: this PR's libswamp facade was returning `tool: null` for empty tools (`--tool none`), breaking `tests/cli/repo/init_test.ts:190` in [systeminit/swamp-uat](https://github.com/systeminit/swamp-uat) which asserts `data.tool === "none"`. The "always-null-when-not-single-tool" rule was over-strict: the legacy contract was `tool` echoes the user's input, including `"none"`. Multi-tool repos still return `null`.

```typescript
function legacyToolField(tools: AiTool[]): string | null {
  if (tools.length === 0) return "none";       // matches user input
  if (tools.length === 1) return tools[0];     // primary tool
  return null;                                 // multi-tool — force SDK migration
}
```

Verified end-to-end with the compiled binary:

```
swamp repo init --tool none      → "tool": "none", "tools": []
swamp repo init --tool claude    → "tool": "claude", "tools": ["claude"]
swamp repo init --tool A --tool B → "tool": null, "tools": ["A","B"]
```

## Test plan

- [x] New unit test: legacy `tool: none` reads as `tools: []`, not `tools: ["none"]`
- [x] New unit test: libswamp `tool` field is `"none"` for empty tools array
- [x] Existing test: multi-tool case still returns `null`
- [x] Existing test: single-tool case returns the primary tool name
- [x] All 5047 existing tests pass
- [x] `deno check` / `deno lint` / `deno fmt` / `deno run compile`
- [x] Manual repro of failing UAT against compiled binary — passes

## Failing UAT references

- Failing run: https://github.com/systeminit/swamp-uat/actions/runs/25184503239
- The previous UAT run on the same swamp-uat SHA (https://github.com/systeminit/swamp-uat/actions/runs/25184373393) tested release `da7d9fe9` (the release immediately before #1250 merged) and passed. The first bad release was `a1c3cc79`, which contains both #1250 and #1252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)