### PR TITLE
fix(libswamp): emit `tool: "none"` for empty tools list

### DIFF
--- a/src/libswamp/repo/init.ts
+++ b/src/libswamp/repo/init.ts
@@ -168,12 +168,18 @@ function resolveToolsInput(
 
 /**
  * Maps the canonical `tools` array onto the deprecated single-value `tool`
- * field. Returns the primary tool only when exactly one tool is enrolled;
- * `null` for empty or multi-tool repos so SDK consumers cannot silently
- * miss state.
+ * field for SDK backwards compat:
+ *
+ *  - `tools: []` (the `--tool none` case) → `"none"`, matching the legacy
+ *    sentinel value the user passed and preserving the prior contract.
+ *  - `tools: [X]` (single tool enrolled) → `X`, the primary tool.
+ *  - `tools: [X, Y, ...]` (multi-tool) → `null` so SDK consumers cannot
+ *    silently miss the second enrolled tool — they must read `tools`.
  */
 function legacyToolField(tools: AiTool[]): string | null {
-  return tools.length === 1 ? tools[0] : null;
+  if (tools.length === 0) return "none";
+  if (tools.length === 1) return tools[0];
+  return null;
 }
 
 // --- Repo Upgrade ---

--- a/src/libswamp/repo/init_test.ts
+++ b/src/libswamp/repo/init_test.ts
@@ -102,6 +102,41 @@ Deno.test("repoInit: yields completed on successful init", async () => {
   assertEquals(completed.data.tool, "claude");
 });
 
+Deno.test('repoInit: legacy `tool` field returns "none" for empty tools (--tool none)', async () => {
+  const deps = makeInitDeps({
+    init: () =>
+      Promise.resolve({
+        path: "/repo",
+        version: "1.0.0",
+        initializedAt: "2026-01-01T00:00:00Z",
+        skillsCopied: [],
+        instructionsFileCreated: false,
+        settingsCreated: false,
+        gitignoreAction: "created",
+        tools: [],
+        removedTools: [],
+      }),
+  });
+
+  const events = await collect<RepoInitEvent>(
+    repoInit(createLibSwampContext(), deps, {
+      path: "/repo",
+      force: false,
+      tools: [],
+      version: "1.0.0",
+    }),
+  );
+
+  const completed = events[1] as Extract<
+    RepoInitEvent,
+    { kind: "completed" }
+  >;
+  // `--tool none` users see `tool: "none"` matching what they passed,
+  // preserving the legacy contract. Multi-tool returns `null` (next test).
+  assertEquals(completed.data.tools, []);
+  assertEquals(completed.data.tool, "none");
+});
+
 Deno.test("repoInit: legacy `tool` field returns null for multi-tool repos", async () => {
   const deps = makeInitDeps({
     init: () =>


### PR DESCRIPTION
## Summary

Follow-up to PR #1250 (multi-tool repo init/upgrade — swamp-club#172). Fixes a regression where `swamp repo init --tool none --json` returns `tool: null` instead of `tool: "none"`, breaking the swamp-uat acceptance test `tests/cli/repo/init_test.ts:190` (`swamp repo init --tool none --json returns valid JSON with tool field`).

The "always-null-when-not-single-tool" rule introduced in #1250 was too strict for the empty case. The legacy contract was: `tool` echoes the value the user passed, including `"none"` when they explicitly opted out. Multi-tool repos still return `null` so SDK consumers can't silently miss a second enrolled tool.

## Fix

```typescript
function legacyToolField(tools: AiTool[]): string | null {
  if (tools.length === 0) return "none";   // matches user input, legacy contract
  if (tools.length === 1) return tools[0]; // primary tool
  return null;                              // multi-tool — force SDK migration
}
```

Verified end-to-end with the compiled binary:

| Input                            | `tools`             | `tool`     |
| -------------------------------- | ------------------- | ---------- |
| `--tool none`                    | `[]`                | `"none"`   |
| `--tool claude`                  | `["claude"]`        | `"claude"` |
| `--tool claude --tool kiro`      | `["claude","kiro"]` | `null`     |

## Test plan

- [x] New unit test asserting `tool: "none"` for empty tools array
- [x] Existing test still asserts `tool: null` for multi-tool repos
- [x] Existing test still asserts `tool: <name>` for single-tool repos
- [x] `deno check` / `deno lint` / `deno fmt --check` / `deno run test` / `deno run compile`
- [x] Manual repro of the failing UAT against compiled binary — passes

## Failing UAT

- Failing run: https://github.com/systeminit/swamp-uat/actions/runs/25184503239 (swamp release `a1c3cc79`)
- User bisected to commit 6cd54ea5 (PR #1250)
- The previous UAT run on the same swamp-uat SHA tested release `da7d9fe9` (the release immediately before #1250 merged) and passed; first bad release was `a1c3cc79` which contains both #1250 and #1252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)