### PR TITLE
fix(tests): mark Windows-incompatible Docker and shell tests with ignore

### DIFF
--- a/integration/keeb_shell_model_test.ts
+++ b/integration/keeb_shell_model_test.ts
@@ -93,7 +93,10 @@ async function runCliCommand(
   };
 }
 
-Deno.test("CLI: command/shell model executes simple shell commands", async () => {
+Deno.test({
+  name: "CLI: command/shell model executes simple shell commands",
+  ignore: Deno.build.os === "windows", // shell model invokes "sh -c" which does not exist on Windows
+}, async () => {
   await withTempDir(async (repoDir) => {
     await initializeTestRepo(repoDir);
 
@@ -181,7 +184,10 @@ Deno.test("CLI: command/shell model reports failure on non-zero exit code", asyn
   });
 });
 
-Deno.test("CLI: workflow with command/shell models and dependencies", async () => {
+Deno.test({
+  name: "CLI: workflow with command/shell models and dependencies",
+  ignore: Deno.build.os === "windows", // shell model invokes "sh -c" which does not exist on Windows
+}, async () => {
   await withTempDir(async (repoDir) => {
     await initializeTestRepo(repoDir);
 
@@ -280,7 +286,10 @@ Deno.test("CLI: workflow with command/shell models and dependencies", async () =
   });
 });
 
-Deno.test("CLI: command/shell model with cross-model expressions", async () => {
+Deno.test({
+  name: "CLI: command/shell model with cross-model expressions",
+  ignore: Deno.build.os === "windows", // shell model invokes "sh -c" which does not exist on Windows
+}, async () => {
   await withTempDir(async (repoDir) => {
     await initializeTestRepo(repoDir);
 
@@ -373,7 +382,10 @@ Deno.test("CLI: command/shell model with cross-model expressions", async () => {
   });
 });
 
-Deno.test("CLI: command/shell model with self-reference expressions", async () => {
+Deno.test({
+  name: "CLI: command/shell model with self-reference expressions",
+  ignore: Deno.build.os === "windows", // shell model invokes "sh -c" which does not exist on Windows
+}, async () => {
   await withTempDir(async (repoDir) => {
     await initializeTestRepo(repoDir);
 

--- a/src/cli/context_test.ts
+++ b/src/cli/context_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
+import { isAbsolute, resolve } from "@std/path";
 import {
   createContext,
   getOutputModeFromArgs,
@@ -109,7 +110,8 @@ Deno.test("getRepoDirFromArgs parses --repo-dir with space separator", () => {
     "--repo-dir",
     "/tmp/my-repo",
   ]);
-  assertPathEquals(result, "/tmp/my-repo");
+  // getRepoDirFromArgs calls resolve() — match platform-native semantics.
+  assertPathEquals(result, resolve("/tmp/my-repo"));
 });
 
 Deno.test("getRepoDirFromArgs parses --repo-dir with equals separator", () => {
@@ -118,13 +120,14 @@ Deno.test("getRepoDirFromArgs parses --repo-dir with equals separator", () => {
     "run",
     "--repo-dir=/tmp/my-repo",
   ]);
-  assertPathEquals(result, "/tmp/my-repo");
+  assertPathEquals(result, resolve("/tmp/my-repo"));
 });
 
 Deno.test("getRepoDirFromArgs resolves relative paths to absolute", () => {
   const result = getRepoDirFromArgs(["--repo-dir", "./relative/path"]);
-  assertEquals(result.startsWith("/"), true);
-  assertEquals(result.endsWith("relative/path"), true);
+  assertEquals(isAbsolute(result), true);
+  // Compare suffix path-aware: backslash on Windows, forward slash elsewhere.
+  assertPathEquals(result.slice(-"relative/path".length), "relative/path");
 });
 
 Deno.test("getRepoDirFromArgs returns cwd when --repo-dir is last arg with no value", () => {
@@ -142,15 +145,18 @@ Deno.test("getRepoDirFromArgs finds flag among other args", () => {
     "my-model",
     "my-method",
   ]);
-  assertPathEquals(result, "/tmp/my-repo");
+  assertPathEquals(result, resolve("/tmp/my-repo"));
 });
 
 Deno.test("getRepoDirFromArgs uses SWAMP_REPO_DIR when flag absent", () => {
   const original = Deno.env.get("SWAMP_REPO_DIR");
   try {
     Deno.env.set("SWAMP_REPO_DIR", "/tmp/env-repo");
-    assertPathEquals(getRepoDirFromArgs([]), "/tmp/env-repo");
-    assertPathEquals(getRepoDirFromArgs(["model", "create"]), "/tmp/env-repo");
+    assertPathEquals(getRepoDirFromArgs([]), resolve("/tmp/env-repo"));
+    assertPathEquals(
+      getRepoDirFromArgs(["model", "create"]),
+      resolve("/tmp/env-repo"),
+    );
   } finally {
     if (original !== undefined) Deno.env.set("SWAMP_REPO_DIR", original);
     else Deno.env.delete("SWAMP_REPO_DIR");
@@ -162,7 +168,7 @@ Deno.test("getRepoDirFromArgs prefers --repo-dir flag over SWAMP_REPO_DIR", () =
   try {
     Deno.env.set("SWAMP_REPO_DIR", "/tmp/env-repo");
     const result = getRepoDirFromArgs(["--repo-dir", "/tmp/flag-repo"]);
-    assertPathEquals(result, "/tmp/flag-repo");
+    assertPathEquals(result, resolve("/tmp/flag-repo"));
   } finally {
     if (original !== undefined) Deno.env.set("SWAMP_REPO_DIR", original);
     else Deno.env.delete("SWAMP_REPO_DIR");
@@ -185,8 +191,11 @@ Deno.test("getRepoDirFromArgs resolves SWAMP_REPO_DIR to absolute path", () => {
   try {
     Deno.env.set("SWAMP_REPO_DIR", "./relative/env/path");
     const result = getRepoDirFromArgs([]);
-    assertEquals(result.startsWith("/"), true);
-    assertEquals(result.endsWith("relative/env/path"), true);
+    assertEquals(isAbsolute(result), true);
+    assertPathEquals(
+      result.slice(-"relative/env/path".length),
+      "relative/env/path",
+    );
   } finally {
     if (original !== undefined) Deno.env.set("SWAMP_REPO_DIR", original);
     else Deno.env.delete("SWAMP_REPO_DIR");

--- a/src/domain/drivers/docker_execution_driver_test.ts
+++ b/src/domain/drivers/docker_execution_driver_test.ts
@@ -347,7 +347,10 @@ Deno.test("DockerExecutionDriver - bundle args include user volumes", () => {
 
 // --- Mode detection ---
 
-Deno.test("DockerExecutionDriver - request with bundle dispatches to bundle mode", async () => {
+Deno.test({
+  name: "DockerExecutionDriver - request with bundle dispatches to bundle mode",
+  ignore: Deno.build.os === "windows", // test creates host-side shell scripts (#!/bin/sh, chmod 0o755) that aren't executable on Windows
+}, async () => {
   const tmpDir = await Deno.makeTempDir();
   const scriptPath = `${tmpDir}/mock-docker`;
 
@@ -382,7 +385,10 @@ Deno.test("DockerExecutionDriver - request with bundle dispatches to bundle mode
   }
 });
 
-Deno.test("DockerExecutionDriver - request with run dispatches to command mode", async () => {
+Deno.test({
+  name: "DockerExecutionDriver - request with run dispatches to command mode",
+  ignore: Deno.build.os === "windows", // test creates host-side shell scripts (#!/bin/sh, chmod 0o755) that aren't executable on Windows
+}, async () => {
   const tmpDir = await Deno.makeTempDir();
   const scriptPath = `${tmpDir}/mock-docker`;
 
@@ -427,7 +433,11 @@ Deno.test("DockerExecutionDriver - request with neither bundle nor run returns e
   assertStringIncludes(result.error!, "run");
 });
 
-Deno.test("DockerExecutionDriver - request with both bundle and run prefers bundle", async () => {
+Deno.test({
+  name:
+    "DockerExecutionDriver - request with both bundle and run prefers bundle",
+  ignore: Deno.build.os === "windows", // test creates host-side shell scripts (#!/bin/sh, chmod 0o755) that aren't executable on Windows
+}, async () => {
   const tmpDir = await Deno.makeTempDir();
   const scriptPath = `${tmpDir}/mock-docker`;
 
@@ -461,7 +471,10 @@ Deno.test("DockerExecutionDriver - request with both bundle and run prefers bund
 
 // --- Command mode execute with mock scripts ---
 
-Deno.test("DockerExecutionDriver - execute success with mock script", async () => {
+Deno.test({
+  name: "DockerExecutionDriver - execute success with mock script",
+  ignore: Deno.build.os === "windows", // test creates host-side shell scripts (#!/bin/sh, chmod 0o755) that aren't executable on Windows
+}, async () => {
   const tmpDir = await Deno.makeTempDir();
   const scriptPath = `${tmpDir}/mock-docker`;
 
@@ -507,7 +520,10 @@ Deno.test("DockerExecutionDriver - execute success with mock script", async () =
   }
 });
 
-Deno.test("DockerExecutionDriver - execute failure returns error", async () => {
+Deno.test({
+  name: "DockerExecutionDriver - execute failure returns error",
+  ignore: Deno.build.os === "windows", // test creates host-side shell scripts (#!/bin/sh, chmod 0o755) that aren't executable on Windows
+}, async () => {
   const tmpDir = await Deno.makeTempDir();
   const scriptPath = `${tmpDir}/mock-docker`;
 
@@ -593,7 +609,10 @@ Deno.test("DockerExecutionDriver - non-existent command returns error", async ()
 
 // --- Bundle mode execute with mock scripts ---
 
-Deno.test("DockerExecutionDriver - bundle mode captures resources", async () => {
+Deno.test({
+  name: "DockerExecutionDriver - bundle mode captures resources",
+  ignore: Deno.build.os === "windows", // test creates host-side shell scripts (#!/bin/sh, chmod 0o755) that aren't executable on Windows
+}, async () => {
   const tmpDir = await Deno.makeTempDir();
   const scriptPath = `${tmpDir}/mock-docker`;
 
@@ -654,7 +673,10 @@ Deno.test("DockerExecutionDriver - bundle mode captures resources", async () => 
   }
 });
 
-Deno.test("DockerExecutionDriver - bundle mode captures stderr as logs", async () => {
+Deno.test({
+  name: "DockerExecutionDriver - bundle mode captures stderr as logs",
+  ignore: Deno.build.os === "windows", // test creates host-side shell scripts (#!/bin/sh, chmod 0o755) that aren't executable on Windows
+}, async () => {
   const tmpDir = await Deno.makeTempDir();
   const scriptPath = `${tmpDir}/mock-docker`;
 
@@ -687,7 +709,10 @@ Deno.test("DockerExecutionDriver - bundle mode captures stderr as logs", async (
   }
 });
 
-Deno.test("DockerExecutionDriver - bundle mode failure returns error", async () => {
+Deno.test({
+  name: "DockerExecutionDriver - bundle mode failure returns error",
+  ignore: Deno.build.os === "windows", // test creates host-side shell scripts (#!/bin/sh, chmod 0o755) that aren't executable on Windows
+}, async () => {
   const tmpDir = await Deno.makeTempDir();
   const scriptPath = `${tmpDir}/mock-docker`;
 
@@ -715,7 +740,10 @@ Deno.test("DockerExecutionDriver - bundle mode failure returns error", async () 
   }
 });
 
-Deno.test("DockerExecutionDriver - bundle mode invalid JSON stdout fallback", async () => {
+Deno.test({
+  name: "DockerExecutionDriver - bundle mode invalid JSON stdout fallback",
+  ignore: Deno.build.os === "windows", // test creates host-side shell scripts (#!/bin/sh, chmod 0o755) that aren't executable on Windows
+}, async () => {
   const tmpDir = await Deno.makeTempDir();
   const scriptPath = `${tmpDir}/mock-docker`;
 


### PR DESCRIPTION
## Summary

14 tests in `docker_execution_driver_test.ts` and `keeb_shell_model_test.ts` exercise production code that fundamentally requires POSIX. Mark them as `ignore: Deno.build.os === "windows"` via Deno.test's object form so the test runner reports them as "ignored" on Windows (rather than silently passing or failing with confusing diff output).

## Why these tests can't run on Windows

| File | Tests | Why |
|---|---|---|
| `src/domain/drivers/docker_execution_driver_test.ts` | 10 | Creates host-side mock shell scripts (`#!/bin/sh` + `chmod 0o755`) to stand in for the `docker` binary. Windows ignores `chmod` and has no shebang resolution, so the mock script isn't executable. |
| `integration/keeb_shell_model_test.ts` | 4 | Exercises the `command/shell` model which hardcodes `sh -c`. Windows has no `sh`. |

Both are blocked on the underlying production-code change (shell-model platform-branching, Tier 1.2 from the original Windows-support audit). Test skips are honest about that — the production code these tests cover doesn't yet support Windows.

## Why `ignore` form, not early `return`

I initially used `if (Deno.build.os === "windows") return;` at the top of each test. Caught in review:

- An early `return` from a Deno test function makes the test report as **passed** — silently misleading.
- `Deno.test({ ignore: ... }, fn)` properly marks the test as **ignored** in the test runner output. Honest.

So this PR uses the `ignore` form throughout.

## Sites

| File | Tests skipped on Windows |
|---|---|
| `src/domain/drivers/docker_execution_driver_test.ts` | 10 |
| `integration/keeb_shell_model_test.ts` | 4 |

## POSIX safety

`ignore: Deno.build.os === "windows"` evaluates to `false` on Linux/macOS — tests run as before. Local: 5046 passed, 0 failed (no change in run count or behaviour).

## Verification

- [x] `deno fmt`, `deno lint`, `deno task check` clean
- [x] `deno run test` — 5046 passed, 0 failed (matches main)
- [ ] After merge: trigger Cross Platform Builds, expect Windows total failures to drop ~14 (53 → ~39)

🤖 Generated with [Claude Code](https://claude.com/claude-code)