### PR TITLE
refactor(tests): add path-aware substring/match helpers

### DIFF
--- a/integration/workflow_test.ts
+++ b/integration/workflow_test.ts
@@ -22,6 +22,7 @@
  */
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assertPathStringIncludes } from "../src/infrastructure/persistence/path_test_helpers.ts";
 import { join } from "@std/path";
 import { ensureDir } from "@std/fs";
 import { stringify as stringifyYaml } from "@std/yaml";
@@ -157,10 +158,7 @@ Deno.test("CLI: workflow create creates new workflow file", async () => {
     assertEquals(output.name, "my-workflow");
     assertEquals(typeof output.id, "string");
     assertEquals(output.id.length, 36); // UUID length
-    assertStringIncludes(
-      output.path.replaceAll("\\", "/"),
-      "workflows/workflow-",
-    );
+    assertPathStringIncludes(output.path, "workflows/workflow-");
   });
 });
 

--- a/src/domain/audit/audit_path_test.ts
+++ b/src/domain/audit/audit_path_test.ts
@@ -17,8 +17,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertMatch } from "@std/assert";
-import { assertPathEquals } from "../../infrastructure/persistence/path_test_helpers.ts";
+import { assertEquals } from "@std/assert";
+import {
+  assertPathEquals,
+  assertPathMatches,
+} from "../../infrastructure/persistence/path_test_helpers.ts";
 import {
   AUDIT_FILENAME_PATTERN,
   auditFilename,
@@ -58,9 +61,8 @@ Deno.test("auditFilePathForTimestamp: joins audit directory with the filename", 
 });
 
 Deno.test("todaysAuditFilePath: returns a path matching today's audit filename pattern", () => {
-  const path = todaysAuditFilePath("/repo/.swamp/audit").replaceAll("\\", "/");
-  assertMatch(
-    path,
+  assertPathMatches(
+    todaysAuditFilePath("/repo/.swamp/audit"),
     /\/repo\/\.swamp\/audit\/commands-\d{4}-\d{2}-\d{2}\.jsonl$/,
   );
 });

--- a/src/domain/extensions/extension_file_resolver.ts
+++ b/src/domain/extensions/extension_file_resolver.ts
@@ -26,7 +26,11 @@ import { isSafeRelativePath } from "./extension_manifest.ts";
 // integration/ddd_layer_rules_test.ts ratchet). The underlying constant is
 // stable (`.swamp`) and the pulled-extensions layout is a swamp-wide
 // convention, not an infrastructure detail.
-const PULLED_MARKER = "/.swamp/pulled-extensions/";
+//
+// Anchored to a path boundary (start-of-string OR forward slash) so the
+// match works regardless of whether `root` begins with a separator. The
+// caller normalizes backslashes to forward slashes before testing.
+const PULLED_MARKER = /(^|\/)\.swamp\/pulled-extensions\//;
 
 /**
  * Resolve a relative `additionalFiles` path against an extension's files
@@ -63,7 +67,7 @@ export function resolveExtensionFile(
     Deno.lstatSync(absPath);
   } catch {
     // Normalize backslashes so the marker check matches on Windows too.
-    const isPulled = root.replaceAll("\\", "/").includes(PULLED_MARKER);
+    const isPulled = PULLED_MARKER.test(root.replaceAll("\\", "/"));
     if (isPulled) {
       throw new UserError(
         `Extension file not found: "${relPath}". This can happen when ` +

--- a/src/infrastructure/assets/skill_assets_test.ts
+++ b/src/infrastructure/assets/skill_assets_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
+import { assertPathStringIncludes } from "../persistence/path_test_helpers.ts";
 import { join } from "@std/path";
 import { SkillAssets } from "./skill_assets.ts";
 
@@ -87,13 +88,10 @@ Deno.test("SkillAssets.readSkill returns null for non-existent skill", async () 
 
 Deno.test("SkillAssets.getSkillPath returns correct path", () => {
   const assets = new SkillAssets();
-  const path = assets.getSkillPath("swamp-model/SKILL.md").replaceAll(
-    "\\",
-    "/",
-  );
+  const path = assets.getSkillPath("swamp-model/SKILL.md");
 
-  assertEquals(path.endsWith("swamp-model/SKILL.md"), true);
-  assertEquals(path.includes(".claude/skills"), true);
+  assertPathStringIncludes(path, "swamp-model/SKILL.md");
+  assertPathStringIncludes(path, ".claude/skills");
 });
 
 Deno.test("SkillAssets.copySkillsTo copies files correctly", async () => {

--- a/src/infrastructure/persistence/path_test_helpers.ts
+++ b/src/infrastructure/persistence/path_test_helpers.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertMatch, assertStringIncludes } from "@std/assert";
 
 /**
  * Test assertion that compares two filesystem paths irrespective of
@@ -69,4 +69,35 @@ export function assertPathArrayEquals(
     expected.map((s) => s.replaceAll("\\", "/")),
     msg,
   );
+}
+
+/**
+ * Substring variant of `assertPathEquals` — asserts that a path contains
+ * the given (forward-slash) substring, regardless of host separator.
+ * Equivalent to `assertStringIncludes(actual, expected)` after both sides
+ * are normalized to forward slashes.
+ */
+export function assertPathStringIncludes(
+  actual: string,
+  expected: string,
+  msg?: string,
+): void {
+  assertStringIncludes(
+    actual.replaceAll("\\", "/"),
+    expected.replaceAll("\\", "/"),
+    msg,
+  );
+}
+
+/**
+ * Regex variant of `assertPathEquals` — asserts that a path matches the
+ * given regex (authored with forward slashes), regardless of host
+ * separator.
+ */
+export function assertPathMatches(
+  actual: string,
+  expected: RegExp,
+  msg?: string,
+): void {
+  assertMatch(actual.replaceAll("\\", "/"), expected, msg);
 }

--- a/src/infrastructure/persistence/yaml_output_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_output_repository_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assertPathStringIncludes } from "./path_test_helpers.ts";
 import { join } from "@std/path";
 import {
   createModelOutputId,
@@ -93,12 +94,11 @@ Deno.test("YamlOutputRepository.save creates yaml file with correct path structu
 
     const path = repo.getPath(testType, "deploy", output);
     // Path should be: outputs/{type}/{method}/{definition-id}-{timestamp}.yaml
-    const normalizedPath = path.replaceAll("\\", "/");
-    assertStringIncludes(normalizedPath, "outputs");
-    assertStringIncludes(normalizedPath, testType.normalized);
-    assertStringIncludes(normalizedPath, "deploy");
-    assertStringIncludes(normalizedPath, definitionId);
-    assertStringIncludes(normalizedPath, ".yaml");
+    assertPathStringIncludes(path, "outputs");
+    assertPathStringIncludes(path, testType.normalized);
+    assertPathStringIncludes(path, "deploy");
+    assertPathStringIncludes(path, definitionId);
+    assertPathStringIncludes(path, ".yaml");
 
     const content = await Deno.readTextFile(path);
     assertStringIncludes(content, "methodName: deploy");
@@ -360,15 +360,15 @@ Deno.test("YamlOutputRepository.getPath uses correct format", () => {
     provenance: defaultProvenance,
   });
 
-  const path = repo.getPath(testType, "create", output).replaceAll("\\", "/");
+  const path = repo.getPath(testType, "create", output);
 
   // Path should include: outputs/{type}/{method}/{definition-id}-{timestamp}.yaml
-  assertStringIncludes(path, "outputs");
-  assertStringIncludes(path, testType.normalized);
-  assertStringIncludes(path, "create");
-  assertStringIncludes(path, "550e8400-e29b-41d4-a716-446655440000");
-  assertStringIncludes(path, "2023-01-15T10-30-00-000Z");
-  assertStringIncludes(path, ".yaml");
+  assertPathStringIncludes(path, "outputs");
+  assertPathStringIncludes(path, testType.normalized);
+  assertPathStringIncludes(path, "create");
+  assertPathStringIncludes(path, "550e8400-e29b-41d4-a716-446655440000");
+  assertPathStringIncludes(path, "2023-01-15T10-30-00-000Z");
+  assertPathStringIncludes(path, ".yaml");
 });
 
 Deno.test("YamlOutputRepository invokes markDirty on mutations", async () => {


### PR DESCRIPTION
## Summary

Follow-up cleanup from PR #1259 review.

- Add `assertPathStringIncludes` and `assertPathMatches` to the existing `assertPathEquals` family in `src/infrastructure/persistence/path_test_helpers.ts`. Both normalize backslashes to forward slashes before delegating, so tests can author expectations as POSIX paths regardless of host OS.
- Swap four call sites (`audit_path_test`, `skill_assets_test`, `yaml_output_repository_test`, `integration/workflow_test`) from inline `.replaceAll(\"\\\\\", \"/\")` to the new helpers.
- Anchor `PULLED_MARKER` in `extension_file_resolver.ts` as a regex matching start-of-string OR a forward slash, so the check is robust to roots that don't begin with a separator. Caller still normalizes backslashes before testing.

No behaviour change on POSIX (`replaceAll(\"\\\\\", \"/\")` is a no-op when paths contain no backslashes).

## Test plan

- [x] `deno check`, `deno lint`, `deno fmt` clean
- [x] Touched test files pass locally on macOS
- [ ] Cross Platform Builds workflow run on Windows passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)