### PR TITLE
ci: smoke-test compiled binary on Linux + Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,21 @@ jobs:
       - name: Compile binary
         run: deno task compile
 
+      - name: Smoke test compiled binary
+        # Compiling proves the binary builds; running --version and --help
+        # proves it actually boots, registers the command tree, and exits
+        # cleanly. Catches runtime regressions (e.g. a top-level import
+        # that throws on load) that the compile step alone doesn't.
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            binary="./swamp.exe"
+          else
+            binary="./swamp"
+          fi
+          "$binary" --version
+          "$binary" --help > /dev/null
+
   deps-audit:
     name: Dependency Audit
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Compiling proves the binary builds; this confirms it actually boots. Adds a step after \`deno task compile\` that runs \`--version\` and \`--help\` against the produced binary on both matrix legs. Catches runtime regressions (e.g. a top-level import that throws on load, a missing command registration) that the compile step alone doesn't surface.

Both commands run without a repository, so the smoke test is hermetic and adds no I/O. \`--help\` is piped to /dev/null since the output is verbose.

Confirmed locally on macOS:

\`\`\`
$ ./swamp --version
swamp 20260206.200442.0-sha.
$ ./swamp --help > /dev/null
--help exited 0
\`\`\`

## Test plan

- [x] Smoke commands exit 0 locally
- [ ] CI run on this PR confirms both commands work on the produced Linux + Windows binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)