### PR TITLE
refactor(shell): extract ShellStrategy abstraction, stub PowerShell

### DIFF
--- a/src/domain/models/command/shell/posix_shell_strategy.ts
+++ b/src/domain/models/command/shell/posix_shell_strategy.ts
@@ -1,0 +1,42 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { VaultSecretBag } from "../../../vaults/vault_secret_bag.ts";
+import type { ShellStrategy } from "./shell_strategy.ts";
+
+/**
+ * POSIX `sh -c` shell strategy.
+ *
+ * Used on Linux, macOS, and WSL — the host OS is `linux` or `darwin`
+ * inside any of those. Secret resolution delegates to the existing
+ * `VaultSecretBag.resolveForShell()`, which emits POSIX `${VAR}`
+ * references with quoting-context-aware double quoting.
+ */
+export class PosixShellStrategy implements ShellStrategy {
+  buildInvocation(command: string): { command: string; args: string[] } {
+    return { command: "sh", args: ["-c", command] };
+  }
+
+  resolveSecrets(
+    command: string,
+    secretBag: VaultSecretBag,
+  ): { command: string; env: Record<string, string> } {
+    return secretBag.resolveForShell(command);
+  }
+}

--- a/src/domain/models/command/shell/posix_shell_strategy_test.ts
+++ b/src/domain/models/command/shell/posix_shell_strategy_test.ts
@@ -1,0 +1,62 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { PosixShellStrategy } from "./posix_shell_strategy.ts";
+import { VaultSecretBag } from "../../../vaults/vault_secret_bag.ts";
+
+Deno.test("PosixShellStrategy.buildInvocation: wraps command in sh -c", () => {
+  const strategy = new PosixShellStrategy();
+  assertEquals(
+    strategy.buildInvocation("echo hello"),
+    { command: "sh", args: ["-c", "echo hello"] },
+  );
+});
+
+Deno.test("PosixShellStrategy.buildInvocation: passes command through verbatim (no escaping)", () => {
+  // The shell handles parsing — strategy doesn't pre-escape. This
+  // matches `Deno.Command` semantics where args are passed as-is.
+  const strategy = new PosixShellStrategy();
+  const cmd = `echo "hello $WORLD" && exit 0`;
+  assertEquals(
+    strategy.buildInvocation(cmd),
+    { command: "sh", args: ["-c", cmd] },
+  );
+});
+
+Deno.test("PosixShellStrategy.resolveSecrets: delegates to VaultSecretBag.resolveForShell", () => {
+  const strategy = new PosixShellStrategy();
+  const bag = new VaultSecretBag();
+  const sentinel = bag.addSecret("secret-value");
+
+  const resolved = strategy.resolveSecrets(`echo ${sentinel}`, bag);
+
+  // POSIX strategy emits ${__SWAMP_VAULT_N} references and quotes them
+  // when not already inside double quotes.
+  assertEquals(resolved.command, 'echo "${__SWAMP_VAULT_0}"');
+  assertEquals(resolved.env, { __SWAMP_VAULT_0: "secret-value" });
+});
+
+Deno.test("PosixShellStrategy.resolveSecrets: empty bag returns command unchanged", () => {
+  const strategy = new PosixShellStrategy();
+  const bag = new VaultSecretBag();
+  const resolved = strategy.resolveSecrets("echo hello", bag);
+  assertEquals(resolved.command, "echo hello");
+  assertEquals(resolved.env, {});
+});

--- a/src/domain/models/command/shell/shell_model.ts
+++ b/src/domain/models/command/shell/shell_model.ts
@@ -26,6 +26,9 @@ import {
   type ModelDefinition,
 } from "../../model.ts";
 import { executeProcess } from "../../../../infrastructure/process/process_executor.ts";
+import { selectShellStrategy } from "./shell_strategy.ts";
+
+const shellStrategy = selectShellStrategy();
 
 /**
  * Schema for shell model input attributes.
@@ -97,24 +100,26 @@ async function executeCommand(
   try {
     // Resolve vault secrets via environment variables to prevent shell injection.
     // The unresolved run field contains sentinel tokens for vault secrets.
-    // We replace sentinels with "${__SWAMP_VAULT_N}" env var references and
-    // pass the raw secret values through the process environment, so the shell
-    // never parses secret content as syntax.
+    // The strategy replaces sentinels with shell-appropriate env var references
+    // (`${VAR}` on POSIX, `$env:VAR` on PowerShell) and returns the raw secret
+    // values to inject via the process environment, so the shell never parses
+    // secret content as syntax.
     let shellCommand = args.run;
     let shellEnv = args.env ?? {};
     const secretBag = context.vaultSecrets;
     if (secretBag && !secretBag.isEmpty && context.unresolvedMethodArgs) {
       const unresolvedRun = context.unresolvedMethodArgs.run;
       if (typeof unresolvedRun === "string") {
-        const resolved = secretBag.resolveForShell(unresolvedRun);
+        const resolved = shellStrategy.resolveSecrets(unresolvedRun, secretBag);
         shellCommand = resolved.command;
         shellEnv = { ...shellEnv, ...resolved.env };
       }
     }
 
+    const invocation = shellStrategy.buildInvocation(shellCommand);
     const result = await executeProcess({
-      command: "sh",
-      args: ["-c", shellCommand],
+      command: invocation.command,
+      args: invocation.args,
       cwd: args.workingDir,
       env: Object.keys(shellEnv).length > 0 ? shellEnv : undefined,
       timeoutMs: args.timeout,

--- a/src/domain/models/command/shell/shell_strategy.ts
+++ b/src/domain/models/command/shell/shell_strategy.ts
@@ -1,0 +1,71 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { VaultSecretBag } from "../../../vaults/vault_secret_bag.ts";
+import { PosixShellStrategy } from "./posix_shell_strategy.ts";
+
+/**
+ * Per-host abstraction over the shell that runs `command/shell` model
+ * invocations.
+ *
+ * Today every platform selects `PosixShellStrategy` (`sh -c <cmd>`) —
+ * including native Windows, where the GitHub Actions runner image
+ * bundles Git Bash and most dev machines have it as well. This PR
+ * introduces only the seam; the next PR adds a `PowerShellStrategy`
+ * and switches selection on native Windows hosts so the .exe doesn't
+ * depend on Git Bash being installed.
+ *
+ * Each strategy owns the executable + args used to wrap a user-authored
+ * command string, and the secret-bag resolution that fits the shell's
+ * variable expansion and quoting rules.
+ */
+export interface ShellStrategy {
+  /**
+   * Build the executable + args that wrap a user-authored command
+   * string in the host shell. The returned shape is what
+   * `Deno.Command` consumes via `executeProcess`.
+   */
+  buildInvocation(command: string): {
+    command: string;
+    args: string[];
+  };
+
+  /**
+   * Replace vault sentinels in `command` with shell-appropriate
+   * environment variable references, returning the rewritten command
+   * and the env map of secret values to inject.
+   *
+   * The env map's keys are the variable names referenced from the
+   * rewritten command; the values are the raw secret strings.
+   */
+  resolveSecrets(
+    command: string,
+    secretBag: VaultSecretBag,
+  ): { command: string; env: Record<string, string> };
+}
+
+/**
+ * Pick the shell strategy for the current host OS.
+ *
+ * Always returns `PosixShellStrategy` today. The next PR will route
+ * `Deno.build.os === "windows"` to a real PowerShell strategy.
+ */
+export function selectShellStrategy(): ShellStrategy {
+  return new PosixShellStrategy();
+}

--- a/src/domain/models/command/shell/shell_strategy_test.ts
+++ b/src/domain/models/command/shell/shell_strategy_test.ts
@@ -1,0 +1,31 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { selectShellStrategy } from "./shell_strategy.ts";
+import { PosixShellStrategy } from "./posix_shell_strategy.ts";
+
+Deno.test("selectShellStrategy: returns PosixShellStrategy on every platform", () => {
+  // PR 1 ships only the seam — selection is uniform across hosts.
+  // The next PR will route `Deno.build.os === "windows"` to a real
+  // PowerShellStrategy and update this test to assert the host-driven
+  // dispatch.
+  const strategy = selectShellStrategy();
+  assertEquals(strategy instanceof PosixShellStrategy, true);
+});


### PR DESCRIPTION
## Summary

First of three PRs for issue #1260 item 3 (re-enable shell tests on Windows). **This PR is plumbing only — no behavior change on any platform.**

The shell model previously hardcoded \`sh -c <cmd>\` and called \`VaultSecretBag.resolveForShell\` directly. That's POSIX-specific in two ways: the executable choice and the variable-expansion syntax. To support \`command/shell\` on native Windows .exe builds we'll need a parallel PowerShell implementation; this PR introduces the strategy seam to drop it into.

### Introduces

- \`ShellStrategy\` interface — abstraction over the shell invocation and secret-bag resolution
- \`PosixShellStrategy\` — current behavior, used on every platform today
- \`selectShellStrategy()\` — returns \`PosixShellStrategy\` uniformly; the next PR adds a \`PowerShellStrategy\` and routes \`Deno.build.os === \"windows\"\` to it

### Behavior

Identical on every platform. \`PosixShellStrategy\` delegates back to \`{ command: \"sh\", args: [\"-c\", cmd] }\` and \`secretBag.resolveForShell()\`. The GitHub Actions Windows runner bundles Git Bash, which provides \`sh.exe\` on PATH, so the existing shell tests still pass on the Windows matrix leg via \`sh\`.

### Out of scope (next PRs)

- **PR 2**: \`PowerShellStrategy\` implementation + sibling \`resolveForPowerShell\` on \`vault_secret_bag\`. Selection switches to PowerShell on native Windows so the .exe doesn't depend on Git Bash being installed.
- **PR 3**: re-enable the 5 Windows-skipped shell tests.

## Test plan

- [x] \`deno check\`, \`deno lint\`, \`deno fmt --check\` clean
- [x] All 40 shell-model + strategy tests pass locally on macOS
- [ ] CI run confirms both matrix legs pass — including the previously-passing Windows shell tests, since selection is uniform

🤖 Generated with [Claude Code](https://claude.com/claude-code)