### PR TITLE
fix(tests): drop flaky wall-clock parallelism + auth env-race

### DIFF
--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -642,24 +642,15 @@ Deno.test("executes independent jobs in parallel", async () => {
       catalogStore,
     );
 
-    const startTime = Date.now();
     const run = await service.execute(workflow.name);
-    const elapsed = Date.now() - startTime;
 
     assertEquals(run.status, "succeeded");
     assertEquals(executor.executedSteps.length, 3);
 
-    // Verify jobs ran in parallel: max concurrency should be 3
+    // `getMaxConcurrency() === 3` is the actual proof of parallelism —
+    // the executor saw 3 simultaneous in-flight invocations. A sequential
+    // run would never exceed 1.
     assertEquals(executor.getMaxConcurrency(), 3);
-
-    // If running sequentially, it would take ~150ms (3 * 50ms)
-    // Running in parallel should take ~50-100ms
-    // Allow generous margin but should be less than sequential time
-    assertEquals(
-      elapsed < 140,
-      true,
-      `Expected parallel execution to be faster than 140ms, got ${elapsed}ms`,
-    );
   });
 });
 
@@ -815,23 +806,15 @@ Deno.test("executes independent steps within a job in parallel", async () => {
       catalogStore,
     );
 
-    const startTime = Date.now();
     const run = await service.execute(workflow.name);
-    const elapsed = Date.now() - startTime;
 
     assertEquals(run.status, "succeeded");
     assertEquals(executor.executedSteps.length, 3);
 
-    // Verify steps ran in parallel: max concurrency should be 3
+    // `getMaxConcurrency() === 3` is the actual proof of parallelism —
+    // the executor saw 3 simultaneous in-flight invocations. A sequential
+    // run would never exceed 1.
     assertEquals(executor.getMaxConcurrency(), 3);
-
-    // If running sequentially, it would take ~150ms (3 * 50ms)
-    // Running in parallel should take ~50-100ms
-    assertEquals(
-      elapsed < 140,
-      true,
-      `Expected parallel execution to be faster than 140ms, got ${elapsed}ms`,
-    );
   });
 });
 

--- a/src/infrastructure/persistence/auth_repository.ts
+++ b/src/infrastructure/persistence/auth_repository.ts
@@ -29,6 +29,27 @@ import {
 const AUTH_FILE = "auth.json";
 
 /**
+ * Optional overrides for `AuthRepository`. Used by tests to bypass the
+ * shared `Deno.env` global, which races across files when
+ * `deno test --parallel` runs multiple auth-touching test files at
+ * once. Production callers pass nothing and get env-reading defaults.
+ */
+export interface AuthRepositoryOptions {
+  /** Override the config dir; default is `getSwampConfigDir()`. */
+  configDir?: string;
+  /**
+   * Override the SWAMP_API_KEY lookup; default reads
+   * `Deno.env.get("SWAMP_API_KEY")` lazily at call time.
+   */
+  getApiKey?: () => string | undefined;
+  /**
+   * Override the SWAMP_CLUB_URL lookup; default reads
+   * `Deno.env.get("SWAMP_CLUB_URL")` lazily at call time.
+   */
+  getServerUrl?: () => string | undefined;
+}
+
+/**
  * Repository for managing swamp-club authentication credentials.
  * Stores API key and server info at ~/.config/swamp/auth.json
  * (or $XDG_CONFIG_HOME/swamp/auth.json).
@@ -36,8 +57,22 @@ const AUTH_FILE = "auth.json";
  * Precedence: SWAMP_API_KEY env var > auth.json file.
  */
 export class AuthRepository {
+  private readonly getConfigDir: () => string;
+  private readonly getApiKey: () => string | undefined;
+  private readonly getServerUrl: () => string | undefined;
+
+  constructor(options: AuthRepositoryOptions = {}) {
+    this.getConfigDir = options.configDir !== undefined
+      ? () => options.configDir!
+      : getSwampConfigDir;
+    this.getApiKey = options.getApiKey ??
+      (() => Deno.env.get("SWAMP_API_KEY"));
+    this.getServerUrl = options.getServerUrl ??
+      (() => Deno.env.get("SWAMP_CLUB_URL"));
+  }
+
   private getAuthPath(): string {
-    return join(getSwampConfigDir(), AUTH_FILE);
+    return join(this.getConfigDir(), AUTH_FILE);
   }
 
   /**
@@ -51,10 +86,10 @@ export class AuthRepository {
    *   a UserError since login/logout don't apply to env-var auth
    */
   async load(): Promise<AuthCredentials | null> {
-    const envApiKey = Deno.env.get("SWAMP_API_KEY");
+    const envApiKey = this.getApiKey();
     if (envApiKey) {
       return {
-        serverUrl: Deno.env.get("SWAMP_CLUB_URL") ?? DEFAULT_SWAMP_CLUB_URL,
+        serverUrl: this.getServerUrl() ?? DEFAULT_SWAMP_CLUB_URL,
         apiKey: envApiKey,
         apiKeyId: "",
         username: "",
@@ -83,8 +118,7 @@ export class AuthRepository {
 
   /** Write auth credentials to disk. Creates directory if needed. */
   async save(credentials: AuthCredentials): Promise<void> {
-    const configDir = getSwampConfigDir();
-    await Deno.mkdir(configDir, { recursive: true });
+    await Deno.mkdir(this.getConfigDir(), { recursive: true });
     await atomicWriteTextFile(
       this.getAuthPath(),
       JSON.stringify(credentials, null, 2) + "\n",

--- a/src/infrastructure/persistence/auth_repository_test.ts
+++ b/src/infrastructure/persistence/auth_repository_test.ts
@@ -29,32 +29,18 @@ const TEST_CREDENTIALS: AuthCredentials = {
   username: "testuser",
 };
 
-/** Save and restore env vars around a test to prevent pollution. */
-function saveEnv(
-  ...names: string[]
-): { saved: Map<string, string | undefined>; restore: () => void } {
-  const saved = new Map<string, string | undefined>();
-  for (const name of names) {
-    saved.set(name, Deno.env.get(name));
-  }
-  return {
-    saved,
-    restore: () => {
-      for (const [name, value] of saved) {
-        if (value !== undefined) Deno.env.set(name, value);
-        else Deno.env.delete(name);
-      }
-    },
-  };
-}
+// All tests inject `configDir`, `getApiKey`, and `getServerUrl` directly
+// into the AuthRepository constructor instead of mutating Deno.env. The
+// previous `Deno.env.set/delete` pattern raced across files when
+// `deno test --parallel` ran auth-touching files concurrently — see PR #1266.
 
 Deno.test("AuthRepository - save and load round trip", async () => {
   const tmpDir = await Deno.makeTempDir();
-  const env = saveEnv("XDG_CONFIG_HOME", "SWAMP_API_KEY");
   try {
-    Deno.env.set("XDG_CONFIG_HOME", tmpDir);
-    Deno.env.delete("SWAMP_API_KEY");
-    const repo = new AuthRepository();
+    const repo = new AuthRepository({
+      configDir: join(tmpDir, "swamp"),
+      getApiKey: () => undefined,
+    });
 
     await repo.save(TEST_CREDENTIALS);
     const loaded = await repo.load();
@@ -65,34 +51,32 @@ Deno.test("AuthRepository - save and load round trip", async () => {
     assertEquals(loaded.apiKeyId, TEST_CREDENTIALS.apiKeyId);
     assertEquals(loaded.username, TEST_CREDENTIALS.username);
   } finally {
-    env.restore();
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
 
 Deno.test("AuthRepository - load returns null when no file exists", async () => {
   const tmpDir = await Deno.makeTempDir();
-  const env = saveEnv("XDG_CONFIG_HOME", "SWAMP_API_KEY");
   try {
-    Deno.env.set("XDG_CONFIG_HOME", tmpDir);
-    Deno.env.delete("SWAMP_API_KEY");
-    const repo = new AuthRepository();
+    const repo = new AuthRepository({
+      configDir: join(tmpDir, "swamp"),
+      getApiKey: () => undefined,
+    });
 
     const loaded = await repo.load();
     assertEquals(loaded, null);
   } finally {
-    env.restore();
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
 
 Deno.test("AuthRepository - delete removes credentials", async () => {
   const tmpDir = await Deno.makeTempDir();
-  const env = saveEnv("XDG_CONFIG_HOME", "SWAMP_API_KEY");
   try {
-    Deno.env.set("XDG_CONFIG_HOME", tmpDir);
-    Deno.env.delete("SWAMP_API_KEY");
-    const repo = new AuthRepository();
+    const repo = new AuthRepository({
+      configDir: join(tmpDir, "swamp"),
+      getApiKey: () => undefined,
+    });
 
     await repo.save(TEST_CREDENTIALS);
     assertEquals((await repo.load()) !== null, true);
@@ -100,33 +84,31 @@ Deno.test("AuthRepository - delete removes credentials", async () => {
     await repo.delete();
     assertEquals(await repo.load(), null);
   } finally {
-    env.restore();
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
 
 Deno.test("AuthRepository - delete is idempotent (no error when missing)", async () => {
   const tmpDir = await Deno.makeTempDir();
-  const env = saveEnv("XDG_CONFIG_HOME");
   try {
-    Deno.env.set("XDG_CONFIG_HOME", tmpDir);
-    const repo = new AuthRepository();
+    const repo = new AuthRepository({
+      configDir: join(tmpDir, "swamp"),
+    });
 
     // Should not throw
     await repo.delete();
   } finally {
-    env.restore();
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
 
 Deno.test("AuthRepository - save and load round trip with collectives", async () => {
   const tmpDir = await Deno.makeTempDir();
-  const env = saveEnv("XDG_CONFIG_HOME", "SWAMP_API_KEY");
   try {
-    Deno.env.set("XDG_CONFIG_HOME", tmpDir);
-    Deno.env.delete("SWAMP_API_KEY");
-    const repo = new AuthRepository();
+    const repo = new AuthRepository({
+      configDir: join(tmpDir, "swamp"),
+      getApiKey: () => undefined,
+    });
 
     const credsWithCollectives: AuthCredentials = {
       ...TEST_CREDENTIALS,
@@ -138,18 +120,17 @@ Deno.test("AuthRepository - save and load round trip with collectives", async ()
     assertExists(loaded);
     assertEquals(loaded.collectives, ["myorg", "swamp"]);
   } finally {
-    env.restore();
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
 
 Deno.test("AuthRepository - load without collectives returns undefined for field", async () => {
   const tmpDir = await Deno.makeTempDir();
-  const env = saveEnv("XDG_CONFIG_HOME", "SWAMP_API_KEY");
   try {
-    Deno.env.set("XDG_CONFIG_HOME", tmpDir);
-    Deno.env.delete("SWAMP_API_KEY");
-    const repo = new AuthRepository();
+    const repo = new AuthRepository({
+      configDir: join(tmpDir, "swamp"),
+      getApiKey: () => undefined,
+    });
 
     await repo.save(TEST_CREDENTIALS);
     const loaded = await repo.load();
@@ -157,7 +138,6 @@ Deno.test("AuthRepository - load without collectives returns undefined for field
     assertExists(loaded);
     assertEquals(loaded.collectives, undefined);
   } finally {
-    env.restore();
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
@@ -165,95 +145,88 @@ Deno.test("AuthRepository - load without collectives returns undefined for field
 Deno.test("AuthRepository - save sets restrictive file permissions", async () => {
   if (Deno.build.os === "windows") return; // mode not enforced on Windows
   const tmpDir = await Deno.makeTempDir();
-  const env = saveEnv("XDG_CONFIG_HOME");
   try {
-    Deno.env.set("XDG_CONFIG_HOME", tmpDir);
-    const repo = new AuthRepository();
+    const repo = new AuthRepository({
+      configDir: join(tmpDir, "swamp"),
+    });
 
     await repo.save(TEST_CREDENTIALS);
 
-    const stat = await Deno.stat(`${tmpDir}/swamp/auth.json`);
+    const stat = await Deno.stat(join(tmpDir, "swamp", "auth.json"));
     // mode 0o600 = owner read/write only
     assertEquals(stat.mode !== null && (stat.mode & 0o777) === 0o600, true);
   } finally {
-    env.restore();
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
 
-// ── SWAMP_API_KEY env var tests ──────────────────────────────────────
+// ── SWAMP_API_KEY override tests ─────────────────────────────────────
 
 Deno.test("AuthRepository - load returns env var credentials when SWAMP_API_KEY is set", async () => {
-  const env = saveEnv("SWAMP_API_KEY", "SWAMP_CLUB_URL");
-  try {
-    Deno.env.set("SWAMP_API_KEY", "swamp_env_key_123");
-    Deno.env.delete("SWAMP_CLUB_URL");
-    const repo = new AuthRepository();
+  const repo = new AuthRepository({
+    getApiKey: () => "swamp_env_key_123",
+    getServerUrl: () => undefined,
+  });
 
-    const loaded = await repo.load();
+  const loaded = await repo.load();
 
-    assertExists(loaded);
-    assertEquals(loaded.apiKey, "swamp_env_key_123");
-    assertEquals(loaded.serverUrl, "https://swamp-club.com");
-    assertEquals(loaded.apiKeyId, "");
-    assertEquals(loaded.username, "");
-  } finally {
-    env.restore();
-  }
+  assertExists(loaded);
+  assertEquals(loaded.apiKey, "swamp_env_key_123");
+  assertEquals(loaded.serverUrl, "https://swamp-club.com");
+  assertEquals(loaded.apiKeyId, "");
+  assertEquals(loaded.username, "");
 });
 
 Deno.test("AuthRepository - SWAMP_API_KEY takes precedence over auth.json file", async () => {
   const tmpDir = await Deno.makeTempDir();
-  const env = saveEnv("XDG_CONFIG_HOME", "SWAMP_API_KEY", "SWAMP_CLUB_URL");
   try {
-    Deno.env.set("XDG_CONFIG_HOME", tmpDir);
-    Deno.env.delete("SWAMP_CLUB_URL");
-    const repo = new AuthRepository();
+    // First seed file-based credentials with API key off.
+    const fileRepo = new AuthRepository({
+      configDir: join(tmpDir, "swamp"),
+      getApiKey: () => undefined,
+      getServerUrl: () => undefined,
+    });
+    await fileRepo.save(TEST_CREDENTIALS);
 
-    // Save file-based credentials first
-    await repo.save(TEST_CREDENTIALS);
-
-    // Set env var — should take precedence
-    Deno.env.set("SWAMP_API_KEY", "swamp_env_override");
-    const loaded = await repo.load();
+    // Now load with API key set — should take precedence.
+    const envRepo = new AuthRepository({
+      configDir: join(tmpDir, "swamp"),
+      getApiKey: () => "swamp_env_override",
+      getServerUrl: () => undefined,
+    });
+    const loaded = await envRepo.load();
 
     assertExists(loaded);
     assertEquals(loaded.apiKey, "swamp_env_override");
     assertEquals(loaded.username, "");
   } finally {
-    env.restore();
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
 
 Deno.test("AuthRepository - SWAMP_API_KEY uses SWAMP_CLUB_URL for server", async () => {
-  const env = saveEnv("SWAMP_API_KEY", "SWAMP_CLUB_URL");
-  try {
-    Deno.env.set("SWAMP_API_KEY", "swamp_env_key_456");
-    Deno.env.set("SWAMP_CLUB_URL", "https://custom.server");
-    const repo = new AuthRepository();
+  const repo = new AuthRepository({
+    getApiKey: () => "swamp_env_key_456",
+    getServerUrl: () => "https://custom.server",
+  });
 
-    const loaded = await repo.load();
+  const loaded = await repo.load();
 
-    assertExists(loaded);
-    assertEquals(loaded.serverUrl, "https://custom.server");
-  } finally {
-    env.restore();
-  }
+  assertExists(loaded);
+  assertEquals(loaded.serverUrl, "https://custom.server");
 });
 
 Deno.test("AuthRepository - empty SWAMP_API_KEY is treated as unset", async () => {
   const tmpDir = await Deno.makeTempDir();
-  const env = saveEnv("XDG_CONFIG_HOME", "SWAMP_API_KEY");
   try {
-    Deno.env.set("XDG_CONFIG_HOME", tmpDir);
-    Deno.env.set("SWAMP_API_KEY", "");
-    const repo = new AuthRepository();
+    const repo = new AuthRepository({
+      configDir: join(tmpDir, "swamp"),
+      getApiKey: () => "",
+    });
 
     const loaded = await repo.load();
     assertEquals(loaded, null);
   } finally {
-    env.restore();
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
@@ -262,11 +235,11 @@ Deno.test("AuthRepository - empty SWAMP_API_KEY is treated as unset", async () =
 
 Deno.test("AuthRepository - load rewrites legacy https://swamp.club to new domain and persists", async () => {
   const tmpDir = await Deno.makeTempDir();
-  const env = saveEnv("XDG_CONFIG_HOME", "SWAMP_API_KEY");
   try {
-    Deno.env.set("XDG_CONFIG_HOME", tmpDir);
-    Deno.env.delete("SWAMP_API_KEY");
-    const repo = new AuthRepository();
+    const repo = new AuthRepository({
+      configDir: join(tmpDir, "swamp"),
+      getApiKey: () => undefined,
+    });
 
     // Seed an auth.json carrying the legacy domain.
     await repo.save({
@@ -284,18 +257,17 @@ Deno.test("AuthRepository - load rewrites legacy https://swamp.club to new domai
     const onDisk = JSON.parse(raw) as AuthCredentials;
     assertEquals(onDisk.serverUrl, "https://swamp-club.com");
   } finally {
-    env.restore();
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
 
 Deno.test("AuthRepository - load leaves custom server URLs untouched", async () => {
   const tmpDir = await Deno.makeTempDir();
-  const env = saveEnv("XDG_CONFIG_HOME", "SWAMP_API_KEY");
   try {
-    Deno.env.set("XDG_CONFIG_HOME", tmpDir);
-    Deno.env.delete("SWAMP_API_KEY");
-    const repo = new AuthRepository();
+    const repo = new AuthRepository({
+      configDir: join(tmpDir, "swamp"),
+      getApiKey: () => undefined,
+    });
 
     await repo.save({
       ...TEST_CREDENTIALS,
@@ -306,7 +278,6 @@ Deno.test("AuthRepository - load leaves custom server URLs untouched", async () 
     assertExists(loaded);
     assertEquals(loaded.serverUrl, "https://staging.swamp.club");
   } finally {
-    env.restore();
     await Deno.remove(tmpDir, { recursive: true });
   }
 });

--- a/src/libswamp/auth/logout.ts
+++ b/src/libswamp/auth/logout.ts
@@ -17,7 +17,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
+import {
+  AuthRepository,
+  type AuthRepositoryOptions,
+} from "../../infrastructure/persistence/auth_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
@@ -43,9 +46,22 @@ export interface AuthLogoutDeps {
   deleteCredentials: () => Promise<void>;
 }
 
+/**
+ * Options for {@link createAuthLogoutDeps}. The `repo` field accepts
+ * the same overrides as `AuthRepository` itself — used by tests to
+ * bypass the shared `Deno.env` global, which races across files when
+ * `deno test --parallel` runs multiple auth-touching test files at
+ * once.
+ */
+export interface CreateAuthLogoutDepsOptions {
+  repo?: AuthRepositoryOptions;
+}
+
 /** Wires real infrastructure into AuthLogoutDeps. */
-export function createAuthLogoutDeps(): AuthLogoutDeps {
-  const repo = new AuthRepository();
+export function createAuthLogoutDeps(
+  options: CreateAuthLogoutDepsOptions = {},
+): AuthLogoutDeps {
+  const repo = new AuthRepository(options.repo);
   return {
     loadCredentials: async () => {
       const creds = await repo.load();

--- a/src/libswamp/auth/logout_test.ts
+++ b/src/libswamp/auth/logout_test.ts
@@ -84,23 +84,24 @@ Deno.test("authLogout: yields completed with loggedOut false when not authentica
 });
 
 Deno.test("createAuthLogoutDeps: loadCredentials returns env-var creds when SWAMP_API_KEY is set", async () => {
-  const originalKey = Deno.env.get("SWAMP_API_KEY");
-  const originalXdg = Deno.env.get("XDG_CONFIG_HOME");
   const tmpDir = await Deno.makeTempDir();
   try {
-    Deno.env.set("SWAMP_API_KEY", "swamp_test_env_key");
-    Deno.env.set("XDG_CONFIG_HOME", tmpDir);
-    const deps = createAuthLogoutDeps();
+    // Inject overrides instead of mutating Deno.env — `deno test --parallel`
+    // runs logout_test and whoami_test in different files concurrently and
+    // both touch SWAMP_API_KEY / XDG_CONFIG_HOME. Going through the deps
+    // options keeps this test hermetic.
+    const deps = createAuthLogoutDeps({
+      repo: {
+        configDir: `${tmpDir}/swamp`,
+        getApiKey: () => "swamp_test_env_key",
+      },
+    });
     const creds = await deps.loadCredentials();
     // With SWAMP_API_KEY set, loadCredentials returns env-var creds
     // (username is empty since env var doesn't provide it)
     assertEquals(creds !== null, true);
     assertEquals(creds!.username, "");
   } finally {
-    if (originalKey) Deno.env.set("SWAMP_API_KEY", originalKey);
-    else Deno.env.delete("SWAMP_API_KEY");
-    if (originalXdg) Deno.env.set("XDG_CONFIG_HOME", originalXdg);
-    else Deno.env.delete("XDG_CONFIG_HOME");
     await Deno.remove(tmpDir, { recursive: true });
   }
 });

--- a/src/libswamp/auth/whoami.ts
+++ b/src/libswamp/auth/whoami.ts
@@ -23,7 +23,10 @@ import {
   getCollectives,
   SwampClubClient,
 } from "../../infrastructure/http/swamp_club_client.ts";
-import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
+import {
+  AuthRepository,
+  type AuthRepositoryOptions,
+} from "../../infrastructure/persistence/auth_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import {
   cancelled,
@@ -59,26 +62,35 @@ export interface AuthDeps {
   serverUrlOverride?: string;
 }
 
+/**
+ * Options for {@link createAuthDeps}. The `repo` field accepts the
+ * same overrides as `AuthRepository` itself — used by tests to bypass
+ * the shared `Deno.env` global, which races across files when
+ * `deno test --parallel` runs multiple auth-touching test files at once.
+ */
+export interface CreateAuthDepsOptions {
+  serverUrlOverride?: string;
+  repo?: AuthRepositoryOptions;
+}
+
 /** Wires real infrastructure into AuthDeps. */
-export function createAuthDeps(
-  options?: { serverUrlOverride?: string },
-): AuthDeps {
-  const repo = new AuthRepository();
+export function createAuthDeps(options: CreateAuthDepsOptions = {}): AuthDeps {
+  const repo = new AuthRepository(options.repo);
+  // When SWAMP_API_KEY is set, skip writing credentials to disk — env-var
+  // auth is ephemeral and shouldn't create/update auth.json. Checked
+  // lazily through the same getApiKey hook the repo uses, so test
+  // overrides flow through here too.
+  const getApiKey = options.repo?.getApiKey ??
+    (() => Deno.env.get("SWAMP_API_KEY"));
   return {
     loadCredentials: () => repo.load(),
-    // When SWAMP_API_KEY is set, skip writing credentials to disk — env-var
-    // auth is ephemeral and shouldn't create/update auth.json. Checked lazily
-    // to stay consistent with loadCredentials (which also reads env at call time
-    // via repo.load()).
     saveCredentials: (credentials) =>
-      Deno.env.get("SWAMP_API_KEY")
-        ? Promise.resolve()
-        : repo.save(credentials),
+      getApiKey() ? Promise.resolve() : repo.save(credentials),
     fetchWhoami: (serverUrl, apiKey, signal) => {
       const client = new SwampClubClient(serverUrl);
       return client.whoami(apiKey, signal);
     },
-    serverUrlOverride: options?.serverUrlOverride,
+    serverUrlOverride: options.serverUrlOverride,
   };
 }
 

--- a/src/libswamp/auth/whoami_test.ts
+++ b/src/libswamp/auth/whoami_test.ts
@@ -234,13 +234,18 @@ Deno.test("whoami does not persist credentials when saveCredentials is a no-op",
 });
 
 Deno.test("createAuthDeps: saveCredentials is a no-op when SWAMP_API_KEY is set", async () => {
-  const originalKey = Deno.env.get("SWAMP_API_KEY");
-  const originalXdg = Deno.env.get("XDG_CONFIG_HOME");
   const tmpDir = await Deno.makeTempDir();
   try {
-    Deno.env.set("SWAMP_API_KEY", "swamp_test_env_key");
-    Deno.env.set("XDG_CONFIG_HOME", tmpDir);
-    const deps = createAuthDeps();
+    // Inject overrides instead of mutating Deno.env — `deno test --parallel`
+    // runs whoami_test and logout_test in different files concurrently and
+    // both touch SWAMP_API_KEY / XDG_CONFIG_HOME. Going through the deps
+    // options keeps this test hermetic.
+    const deps = createAuthDeps({
+      repo: {
+        configDir: `${tmpDir}/swamp`,
+        getApiKey: () => "swamp_test_env_key",
+      },
+    });
 
     // saveCredentials should be a no-op — no file should be written
     await deps.saveCredentials(testCredentials);
@@ -254,31 +259,24 @@ Deno.test("createAuthDeps: saveCredentials is a no-op when SWAMP_API_KEY is set"
     }
     assertEquals(files.includes("auth.json"), false);
   } finally {
-    if (originalKey) Deno.env.set("SWAMP_API_KEY", originalKey);
-    else Deno.env.delete("SWAMP_API_KEY");
-    if (originalXdg) Deno.env.set("XDG_CONFIG_HOME", originalXdg);
-    else Deno.env.delete("XDG_CONFIG_HOME");
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
 
 Deno.test("createAuthDeps: saveCredentials writes file when SWAMP_API_KEY is not set", async () => {
-  const originalKey = Deno.env.get("SWAMP_API_KEY");
-  const originalXdg = Deno.env.get("XDG_CONFIG_HOME");
   const tmpDir = await Deno.makeTempDir();
   try {
-    Deno.env.delete("SWAMP_API_KEY");
-    Deno.env.set("XDG_CONFIG_HOME", tmpDir);
-    const deps = createAuthDeps();
+    const deps = createAuthDeps({
+      repo: {
+        configDir: `${tmpDir}/swamp`,
+        getApiKey: () => undefined,
+      },
+    });
 
     await deps.saveCredentials(testCredentials);
     const stat = await Deno.stat(`${tmpDir}/swamp/auth.json`);
     assertEquals(stat.isFile, true);
   } finally {
-    if (originalKey) Deno.env.set("SWAMP_API_KEY", originalKey);
-    else Deno.env.delete("SWAMP_API_KEY");
-    if (originalXdg) Deno.env.set("XDG_CONFIG_HOME", originalXdg);
-    else Deno.env.delete("XDG_CONFIG_HOME");
     await Deno.remove(tmpDir, { recursive: true });
   }
 });


### PR DESCRIPTION
## Summary

Two unrelated test flakes bundled into one PR per request:

### 1. Wall-clock parallelism assertions (original scope)

\`execution_service_test\` had two tests that asserted parallel runs complete in <140ms. Both also asserted \`getMaxConcurrency() === 3\` immediately above — that's the actual proof of parallelism, since a sequential run would never exceed concurrency 1. The wall-clock check is redundant *and* brittle: PR #1264 saw one take 957ms on Windows due to GHA scheduling jitter. Dropped both timing assertions; concurrency assertion stays.

### 2. Auth tests racing on Deno.env

Three files (\`whoami_test.ts\`, \`logout_test.ts\`, \`auth_repository_test.ts\`) all mutate \`SWAMP_API_KEY\` and \`XDG_CONFIG_HOME\` in their setup blocks. \`deno test --parallel\` runs separate files concurrently, so they race on global env. Symptom: \`createAuthDeps: saveCredentials writes file when SWAMP_API_KEY is not set\` failed with NotFound on \`/tmp/.../auth.json\` because another test set SWAMP_API_KEY between the test's \`Deno.env.delete\` and \`saveCredentials\`, causing the lazy env check inside the production \`saveCredentials\` to return early without writing the file.

Fix: refactor \`AuthRepository\` to accept \`AuthRepositoryOptions\` (\`configDir\`, \`getApiKey\`, \`getServerUrl\`) at construction. \`createAuthDeps\` and \`createAuthLogoutDeps\` accept the same options bag and thread it through. Tests inject explicit values; production callers pass nothing and get the previous env-reading behavior. No env mutation in any of the three changed test files.

## Production-side surface

- New: \`AuthRepositoryOptions\` interface
- Changed: \`AuthRepository\` constructor signature (was implicit zero-arg, now \`options: AuthRepositoryOptions = {}\` — backwards-compatible)
- Changed: \`createAuthDeps\` and \`createAuthLogoutDeps\` accept an optional \`repo: AuthRepositoryOptions\` field

Every production caller of \`new AuthRepository()\` and \`createAuth*Deps()\` passes no args; all of those still work unchanged.

## Test plan

- [x] \`deno check\`, \`deno lint\`, \`deno fmt --check\` clean
- [x] Full test suite passes locally on macOS (5074 / 0 / 1 ignored)
- [x] All 25 auth tests pass after refactor
- [ ] CI run confirms both matrix legs pass and the env-race flake is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)