### PR TITLE
test(shell): address review feedback from #1268

### DIFF
--- a/integration/keeb_shell_model_test.ts
+++ b/integration/keeb_shell_model_test.ts
@@ -21,7 +21,7 @@
  * Integration tests for command/shell models with workflow execution.
  */
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { join } from "@std/path";
 import { ensureDir } from "@std/fs";
 import { stringify as stringifyYaml } from "@std/yaml";
@@ -434,6 +434,13 @@ Deno.test({
       const output = JSON.parse(result.stdout);
       assertEquals(output.modelName, "self-ref-shell");
       assertEquals(output.dataArtifacts[0].attributes.exitCode, 0);
+      // Verify `${{ self.name }}` actually resolved — without this
+      // assertion the test would still pass if the templating regressed
+      // and the shell printed the literal `${{ self.name }}` string.
+      assertStringIncludes(
+        output.dataArtifacts[0].attributes.stdout,
+        "self-ref-shell",
+      );
     });
   },
 });
@@ -544,6 +551,13 @@ Deno.test({
       const output = JSON.parse(result.stdout);
       assertEquals(output.modelName, "self-ref-shell");
       assertEquals(output.dataArtifacts[0].attributes.exitCode, 0);
+      // Verify `${{ self.name }}` actually resolved — without this
+      // assertion the test would still pass if the templating regressed
+      // and PowerShell printed the literal `${{ self.name }}` string.
+      assertStringIncludes(
+        output.dataArtifacts[0].attributes.stdout,
+        "self-ref-shell",
+      );
     });
   },
 });

--- a/src/domain/models/command/shell/shell_model_test.ts
+++ b/src/domain/models/command/shell/shell_model_test.ts
@@ -802,21 +802,12 @@ windowsOnlyTest(
   },
 );
 
-windowsOnlyTest(
-  "shellModel.methods.execute (powershell): throws on command failure",
-  async () => {
-    // PowerShell has no `false` builtin; `exit 1` is the closest
-    // equivalent.
-    const args: ShellInputAttributes = { run: "exit 1" };
-
-    const { context } = createTestContext();
-    await assertRejects(
-      () => shellModel.methods.execute.execute(args, context),
-      Error,
-      "Command exited with code 1",
-    );
-  },
-);
+// No PowerShell sibling for "throws on command failure" — the POSIX
+// version distinguished `false` (separate program) from `exit 42` (shell
+// builtin). PowerShell has no `false` analogue, so the obvious
+// translation (`exit 1`) is functionally identical to the
+// "throws on non-zero exit code" case above. The exit-N path is already
+// covered; adding a second `exit N` test wouldn't exercise anything new.
 
 windowsOnlyTest(
   "shellModel.methods.execute (powershell): respects workingDir",


### PR DESCRIPTION
## Summary

Two real test-coverage issues surfaced by the adversarial review on PR #1268.

### 1. Drop duplicative PowerShell test

The POSIX version distinguished \`false\` (separate program) from \`exit 42\` (shell builtin). PowerShell has no \`false\` analogue, so the obvious translation (\`exit 1\`) was functionally identical to the \"throws on non-zero exit code\" case — both go through the same \`exit N\` path.

Replaced the duplicative \`windowsOnlyTest\` with an inline comment explaining why no sibling exists.

### 2. Strengthen self-reference expression test

The keeb \"command/shell model with self-reference expressions\" test (both POSIX and PowerShell siblings) only asserted \`exitCode === 0\`. That would still pass if \`\${{ self.name }}\` templating silently regressed and the shell printed the literal placeholder string instead of resolving to the model name.

Added \`assertStringIncludes(stdout, \"self-ref-shell\")\` to both siblings so the test actually verifies template resolution.

## Out of scope

Other review items skipped per the discussion:
- Theoretical Windows path canonicalization concern in \`respects workingDir\` / \`handles complex commands\` (CI green so far)
- Stylistic suggestion to shorten section-divider comments (kept for navigability of the 1100-line file)

## Test plan

- [x] \`deno check\`, \`deno lint\`, \`deno fmt --check\` clean
- [x] Touched tests pass locally on macOS (52 / 0 / 22 ignored)
- [ ] CI run confirms both matrix legs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)