### PR TITLE
feat(file-lock): add Windows process-liveness check via tasklist

### DIFF
--- a/src/infrastructure/persistence/file_lock.ts
+++ b/src/infrastructure/persistence/file_lock.ts
@@ -38,11 +38,25 @@ import { getSwampLogger } from "../logging/logger.ts";
 
 /**
  * Check if a process with the given PID is no longer running.
- * Uses signal 0 (no-op) to test process existence.
- * Returns false (not dead) on any error other than NotFound,
- * so TTL-based detection remains the fallback.
+ *
+ * POSIX hosts use `Deno.kill(pid, "SIGCONT")` — SIGCONT is a no-op
+ * for an already-running process and produces a `NotFound` error
+ * when the PID is gone.
+ *
+ * Windows hosts shell out to `tasklist /FI "PID eq <pid>" /FO CSV
+ * /NH`, which prints a CSV row when the PID is alive and the literal
+ * `INFO: No tasks are running which match the specified criteria.`
+ * (to stdout) when it isn't. `tasklist.exe` ships with every
+ * Windows install since XP, so no extra dependency.
+ *
+ * Returns `false` (not dead) on any unexpected error — TTL-based
+ * detection remains the fallback so a busted probe never causes us
+ * to clobber a valid lock.
  */
 function isProcessDead(pid: number): boolean {
+  if (Deno.build.os === "windows") {
+    return isProcessDeadWindows(pid);
+  }
   try {
     Deno.kill(pid, "SIGCONT");
     return false; // Process exists
@@ -51,6 +65,31 @@ function isProcessDead(pid: number): boolean {
       return true; // Process does not exist
     }
     // PermissionDenied or other error — can't determine, fall back to TTL
+    return false;
+  }
+}
+
+function isProcessDeadWindows(pid: number): boolean {
+  try {
+    const result = new Deno.Command("tasklist", {
+      args: ["/FI", `PID eq ${pid}`, "/FO", "CSV", "/NH"],
+      stdout: "piped",
+      stderr: "null",
+    }).outputSync();
+    if (!result.success) {
+      // Non-zero exit from tasklist itself — fall back to TTL.
+      return false;
+    }
+    const stdout = new TextDecoder().decode(result.stdout).trim();
+    // `INFO:` to stdout means "no match" — process is gone.
+    // Empty stdout shouldn't happen under `/NH`, but treat it as gone too.
+    if (stdout.length === 0 || stdout.startsWith("INFO:")) {
+      return true;
+    }
+    // CSV row produced — process is alive.
+    return false;
+  } catch {
+    // tasklist not on PATH, or spawn failed — fall back to TTL.
     return false;
   }
 }

--- a/src/infrastructure/persistence/file_lock_test.ts
+++ b/src/infrastructure/persistence/file_lock_test.ts
@@ -198,41 +198,33 @@ Deno.test("FileLock - forceRelease returns false when no lock exists", async () 
   });
 });
 
-Deno.test({
-  name: "FileLock - stale lock from dead process is immediately acquired",
-  // PID liveness uses Deno.kill(pid, "SIGCONT"), which is POSIX-only;
-  // Windows has no equivalent signal probe, so dead-process detection
-  // falls back to TTL there. Tracked separately if we ever add a Windows
-  // implementation.
-  ignore: Deno.build.os === "windows",
-  fn: async () => {
-    await withTempDir(async (dir) => {
-      // Simulate a lock held by a non-existent process with a fresh timestamp
-      // (i.e., TTL has NOT expired, but the process is dead)
-      const staleLockInfo: LockInfo = {
-        holder: "dead@host",
-        hostname: "host",
-        pid: 2147483647, // Very high PID — extremely unlikely to exist
-        acquiredAt: new Date().toISOString(), // Fresh timestamp — TTL not expired
-        ttlMs: 60_000, // Long TTL
-      };
-      const lockPath = `${dir}/.datastore.lock`;
-      await Deno.writeTextFile(
-        lockPath,
-        JSON.stringify(staleLockInfo, null, 2),
-      );
+Deno.test("FileLock - stale lock from dead process is immediately acquired", async () => {
+  await withTempDir(async (dir) => {
+    // Simulate a lock held by a non-existent process with a fresh timestamp
+    // (i.e., TTL has NOT expired, but the process is dead)
+    const staleLockInfo: LockInfo = {
+      holder: "dead@host",
+      hostname: "host",
+      pid: 2147483647, // Very high PID — extremely unlikely to exist
+      acquiredAt: new Date().toISOString(), // Fresh timestamp — TTL not expired
+      ttlMs: 60_000, // Long TTL
+    };
+    const lockPath = `${dir}/.datastore.lock`;
+    await Deno.writeTextFile(
+      lockPath,
+      JSON.stringify(staleLockInfo, null, 2),
+    );
 
-      // New lock should detect the dead PID and acquire immediately
-      const lock = new FileLock(dir, { ttlMs: 5000, maxWaitMs: 2000 });
-      await lock.acquire();
+    // New lock should detect the dead PID and acquire immediately
+    const lock = new FileLock(dir, { ttlMs: 5000, maxWaitMs: 2000 });
+    await lock.acquire();
 
-      const info = await lock.inspect();
-      assertEquals(info !== null, true);
-      assertEquals(info!.pid, Deno.pid);
+    const info = await lock.inspect();
+    assertEquals(info !== null, true);
+    assertEquals(info!.pid, Deno.pid);
 
-      await lock.release();
-    });
-  },
+    await lock.release();
+  });
 });
 
 Deno.test("FileLock - lock held by live process is not stolen via PID check", async () => {


### PR DESCRIPTION
## Summary

\`isProcessDead()\` previously used \`Deno.kill(pid, \"SIGCONT\")\` to probe liveness — POSIX-only. On Windows the function fell through the catch and returned \`false\` for every PID, which meant locks held by crashed Windows processes always waited the full TTL (default 30s) before being reclaimed. Subsequent swamp invocations sat blocked.

This adds a Windows branch that shells out to \`tasklist /FI \"PID eq <pid>\" /FO CSV /NH\`. \`tasklist.exe\` ships with every Windows install since XP, so no new dependency.

### Output shapes detected

- **Process alive**: a CSV row like \`\"swamp.exe\",\"1234\",\"Console\",...\`
- **Process gone**: the literal \`INFO: No tasks are running which match the specified criteria.\` printed to stdout

Returning \`false\` (not dead) is preserved as the conservative fallback when the probe itself fails — TTL-based detection still catches everything.

### Re-enabled test

The \`FileLock - stale lock from dead process is immediately acquired\` test was previously \`Deno.test({ ignore: Deno.build.os === \"windows\" })\`. Now runs on Windows.

Closes one of the items tracked in issue #1260.

## Test plan

- [x] \`deno check\`, \`deno lint\`, \`deno fmt --check\` clean
- [x] All 13 file_lock tests pass locally on macOS
- [x] Full suite: 5085 / 0 / 23 ignored (one fewer ignored than before)
- [ ] CI confirms the re-enabled test passes on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)