### PR TITLE
fix(extensions): prune orphan source files dropped between versions

### DIFF
--- a/src/cli/commands/doctor_extensions.ts
+++ b/src/cli/commands/doctor_extensions.ts
@@ -38,6 +38,7 @@
 // already warmed get re-loaded.
 
 import { Command } from "@cliffy/command";
+import { isAbsolute, join, relative, resolve } from "@std/path";
 import {
   consumeStream,
   doctorExtensions,
@@ -47,6 +48,7 @@ import {
   getExtensionLoadWarnings,
   resetExtensionLoadWarnings,
 } from "../../infrastructure/logging/extension_load_warnings.ts";
+import { readUpstreamExtensions } from "../../infrastructure/persistence/upstream_extensions.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
 import { driverTypeRegistry } from "../../domain/drivers/driver_type_registry.ts";
@@ -60,6 +62,11 @@ import {
   resolveRepoDir,
 } from "../context.ts";
 import { resolveDatastoreForRepo } from "../repo_context.ts";
+import { resolveModelsDir } from "../resolve_models_dir.ts";
+import { resolveSkillsDir } from "../../domain/repo/skill_dirs.ts";
+import { RepoPath } from "../../domain/repo/repo_path.ts";
+import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
+import { resolvePrimaryTool } from "../../domain/repo/primary_tool.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -125,6 +132,22 @@ export const doctorExtensionsCommand = new Command()
       },
     ];
 
+    // Resolve lockfile and skills paths so the orphan-detection phase
+    // can walk the per-extension roots referenced by the lockfile.
+    const repoPath = RepoPath.create(repoDir);
+    const markerRepo = new RepoMarkerRepository();
+    const marker = await markerRepo.read(repoPath);
+    const modelsDir = resolveModelsDir(marker);
+    const absoluteModelsDir = isAbsolute(modelsDir)
+      ? modelsDir
+      : resolve(repoDir, modelsDir);
+    const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+    const tool = resolvePrimaryTool(marker);
+    const absoluteSkillsDir = resolveSkillsDir(repoDir, tool);
+    // detectOrphanFiles wants a repo-relative skills dir so it can
+    // compare against entry.files[] paths (which are repo-relative).
+    const repoRelativeSkillsDir = relative(repoDir, absoluteSkillsDir);
+
     const controller = new AbortController();
     const renderer = createDoctorExtensionsRenderer(cliCtx.outputMode);
 
@@ -133,6 +156,9 @@ export const doctorExtensionsCommand = new Command()
         registries,
         getWarnings: getExtensionLoadWarnings,
         resetState: resetExtensionLoadWarnings,
+        readUpstreamExtensions: () => readUpstreamExtensions(lockfilePath),
+        repoDir,
+        skillsDir: repoRelativeSkillsDir,
         abortSignal: controller.signal,
       }),
       renderer.handlers(),

--- a/src/cli/commands/extension_update.ts
+++ b/src/cli/commands/extension_update.ts
@@ -124,7 +124,7 @@ export const extensionUpdateCommand = new Command()
           repoDir,
           force: true,
         });
-        await installExtension({ name, version }, installCtx);
+        return await installExtension({ name, version }, installCtx);
       },
     });
 

--- a/src/infrastructure/persistence/directory_cleanup.ts
+++ b/src/infrastructure/persistence/directory_cleanup.ts
@@ -17,7 +17,47 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { dirname } from "@std/path";
+import { dirname, join } from "@std/path";
+
+/**
+ * Removes a list of repo-relative paths and reports which were actually
+ * removed. Used by `installExtension` to prune source files, bundle
+ * files, and skill directories declared in a prior version's lockfile
+ * entry but absent in the current version's `extractedFiles`.
+ *
+ * Behavior:
+ * - Each path is resolved against `repoDir` and removed with
+ *   `{ recursive: true }` so non-empty entries (skill directory roots
+ *   tracked as a single path) are handled correctly.
+ * - `Deno.errors.NotFound` is tolerated — the path is already gone, so
+ *   it is NOT included in the returned list (the caller should report
+ *   ground truth, not intent).
+ * - Empty parent directories up to `repoDir` are pruned after each
+ *   removal via `cleanupEmptyParentDirs`.
+ * - Any other error propagates immediately.
+ *
+ * @returns the repo-relative paths that were actually removed
+ */
+export async function pruneOrphanFiles(
+  orphanPaths: string[],
+  repoDir: string,
+): Promise<string[]> {
+  const removed: string[] = [];
+  for (const file of orphanPaths) {
+    const absolutePath = join(repoDir, file);
+    try {
+      await Deno.remove(absolutePath, { recursive: true });
+      removed.push(file);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        continue;
+      }
+      throw error;
+    }
+    await cleanupEmptyParentDirs(absolutePath, repoDir);
+  }
+  return removed;
+}
 
 /**
  * Removes empty parent directories up to but not including the stopAt directory.

--- a/src/libswamp/extensions/doctor.ts
+++ b/src/libswamp/extensions/doctor.ts
@@ -17,8 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { walk } from "@std/fs";
+import { join, relative } from "@std/path";
 import type { ExtensionLoadWarning } from "../../infrastructure/logging/extension_load_warnings.ts";
+import type { UpstreamExtensionsMap } from "../../infrastructure/persistence/upstream_extensions.ts";
 import type { SwampError } from "../errors.ts";
+import { extractTopLevelRoot } from "./layout.ts";
 
 /**
  * Public registry name for the doctor report. The infrastructure-layer
@@ -60,11 +64,32 @@ export interface DoctorRegistryResult {
 /** Final overall status — `pass` when every registry passed. */
 export type DoctorOverallStatus = "pass" | "fail";
 
+/**
+ * A single orphan finding: a file or directory present under an
+ * extension's tracked roots but NOT in the current lockfile entry's
+ * files[]. Surfaces in the report's `orphanFiles` warnings list.
+ */
+export interface DoctorOrphanFile {
+  extensionName: string;
+  /** Repo-relative path. */
+  path: string;
+}
+
 /** Final report shape — used by the renderer's JSON mode. */
 export interface DoctorExtensionsReport {
   overallStatus: DoctorOverallStatus;
   /** Map of registry name → its result. All five keys always present. */
   registries: Record<DoctorRegistryName, DoctorRegistryResult>;
+  /**
+   * Filesystem-orphan findings — paths present under tracked roots but
+   * absent from the current lockfile's files[] list. Reported as
+   * WARNINGS, not failures: `overallStatus` is unchanged by orphan
+   * presence so existing CI gates that key on `overallStatus === "fail"`
+   * keep working through the transition. A future release may promote
+   * orphans to failure once routine install/pull/update calls have
+   * drained pre-existing dirt from the ecosystem.
+   */
+  orphanFiles: DoctorOrphanFile[];
 }
 
 /**
@@ -100,6 +125,20 @@ export interface DoctorExtensionsDeps {
   getWarnings: () => ReadonlyArray<ExtensionLoadWarning>;
   /** Clears the captured warnings array + dedupe state. */
   resetState: () => void;
+  /**
+   * Reads upstream_extensions.json so the orphan-detection phase can
+   * walk every per-extension root. Missing lockfile yields {} (the
+   * orphan walk becomes a no-op).
+   */
+  readUpstreamExtensions: () => Promise<UpstreamExtensionsMap>;
+  /** Repo root used to resolve repo-relative paths for filesystem walks. */
+  repoDir: string;
+  /**
+   * Tool-aware skills directory (e.g. `.claude/skills`). Repo-relative.
+   * Skill paths are tracked as directory paths only, so the orphan walk
+   * skips them — extractTopLevelRoot needs this to recognise skill paths.
+   */
+  skillsDir: string;
   abortSignal: AbortSignal;
 }
 
@@ -107,6 +146,63 @@ function overallStatus(
   results: ReadonlyArray<DoctorRegistryResult>,
 ): DoctorOverallStatus {
   return results.some((r) => r.status === "fail") ? "fail" : "pass";
+}
+
+/**
+ * Walks every per-extension root referenced by a lockfile entry and
+ * returns paths on disk that are NOT in the entry's `tracked` set.
+ *
+ * For each entry, derive the unique top-level roots from its
+ * `files[]` list via `extractTopLevelRoot` (skips skills, legacy
+ * paths, and unknown locations) and walk each root recursively. Any
+ * file path under a walked root that isn't in `tracked` is an orphan.
+ *
+ * Empty lockfile / missing entries / no recognisable roots → no walk,
+ * no orphans. Walk errors (e.g. missing root dir) are tolerated and
+ * yield no orphans for that root.
+ */
+async function detectOrphanFiles(
+  upstreamMap: UpstreamExtensionsMap,
+  repoDir: string,
+  skillsDir: string,
+): Promise<DoctorOrphanFile[]> {
+  const orphans: DoctorOrphanFile[] = [];
+
+  for (const [extensionName, entry] of Object.entries(upstreamMap)) {
+    const trackedFiles = entry.files ?? [];
+    if (trackedFiles.length === 0) continue;
+
+    const tracked = new Set(trackedFiles);
+    const roots = new Set<string>();
+    for (const file of trackedFiles) {
+      const root = extractTopLevelRoot(file, skillsDir);
+      if (root !== null) {
+        roots.add(root);
+      }
+    }
+
+    for (const root of roots) {
+      const absoluteRoot = join(repoDir, root);
+      try {
+        for await (
+          const walkEntry of walk(absoluteRoot, {
+            includeDirs: false,
+            includeSymlinks: false,
+          })
+        ) {
+          const relPath = relative(repoDir, walkEntry.path);
+          if (!tracked.has(relPath)) {
+            orphans.push({ extensionName, path: relPath });
+          }
+        }
+      } catch (error) {
+        if (error instanceof Deno.errors.NotFound) continue;
+        throw error;
+      }
+    }
+  }
+
+  return orphans;
 }
 
 /**
@@ -133,10 +229,22 @@ function partitionForRegistry(
 
 /**
  * Runs `ensureLoaded()` across all five user-facing extension
- * registries and reports per-registry pass/fail. The first steps of
- * the generator are a state reset + a `resetLoadedFlag()` on every
- * registry so the diagnostic forces a full re-load even when the CLI
- * bootstrap already warmed the registries earlier in the process.
+ * registries AND walks every per-extension root for orphan files.
+ *
+ * Two distinct concerns share this entry point:
+ * 1. Loader validation — does each registry's loader run cleanly
+ *    against the on-disk extensions? Failures fold into per-registry
+ *    `failures` and DO flip `overallStatus` to `"fail"`.
+ * 2. Filesystem orphan detection — are there files under each
+ *    extension's tracked roots that aren't declared by the lockfile?
+ *    Findings surface in `report.orphanFiles` as WARNINGS and do NOT
+ *    flip `overallStatus`. CI gates on `overallStatus === "fail"`
+ *    keep working through the transition.
+ *
+ * The first steps of the generator are a state reset + a
+ * `resetLoadedFlag()` on every registry so the diagnostic forces a
+ * full re-load even when the CLI bootstrap already warmed the
+ * registries earlier in the process.
  *
  * Order of operations is the load-bearing invariant: callers must
  * NOT pre-reset state — the service owns that ordering.
@@ -203,8 +311,25 @@ export async function* doctorExtensions(
     results.map((r) => [r.registry, r]),
   ) as Record<DoctorRegistryName, DoctorRegistryResult>;
 
+  // Filesystem orphan detection — independent of loader validation.
+  // Always runs (unless aborted) so users get a warning even when
+  // every loader passes. Errors are not folded into `overallStatus`.
+  let orphanFiles: DoctorOrphanFile[] = [];
+  if (!deps.abortSignal.aborted) {
+    const upstreamMap = await deps.readUpstreamExtensions();
+    orphanFiles = await detectOrphanFiles(
+      upstreamMap,
+      deps.repoDir,
+      deps.skillsDir,
+    );
+  }
+
   yield {
     kind: "completed",
-    report: { overallStatus: overallStatus(results), registries },
+    report: {
+      overallStatus: overallStatus(results),
+      registries,
+      orphanFiles,
+    },
   };
 }

--- a/src/libswamp/extensions/doctor.ts
+++ b/src/libswamp/extensions/doctor.ts
@@ -149,6 +149,18 @@ function overallStatus(
 }
 
 /**
+ * Normalises a path to use forward-slash separators regardless of the
+ * platform `relative()` and `walk()` produced. The tracked-set entries
+ * in the lockfile and the helpers in `layout.ts` (PULLED_PREFIX,
+ * extractTopLevelRoot) all assume forward slashes; orphan detection
+ * needs the same normalisation on its walked paths so set membership
+ * works on Windows where native paths use backslashes.
+ */
+function toForwardSlashes(p: string): string {
+  return p.replaceAll("\\", "/");
+}
+
+/**
  * Walks every per-extension root referenced by a lockfile entry and
  * returns paths on disk that are NOT in the entry's `tracked` set.
  *
@@ -156,6 +168,9 @@ function overallStatus(
  * `files[]` list via `extractTopLevelRoot` (skips skills, legacy
  * paths, and unknown locations) and walk each root recursively. Any
  * file path under a walked root that isn't in `tracked` is an orphan.
+ *
+ * All path-set membership comparisons are done in forward-slash form
+ * so the same lockfile entries match on both POSIX and Windows.
  *
  * Empty lockfile / missing entries / no recognisable roots → no walk,
  * no orphans. Walk errors (e.g. missing root dir) are tolerated and
@@ -167,21 +182,25 @@ async function detectOrphanFiles(
   skillsDir: string,
 ): Promise<DoctorOrphanFile[]> {
   const orphans: DoctorOrphanFile[] = [];
+  const normalizedSkillsDir = toForwardSlashes(skillsDir);
 
   for (const [extensionName, entry] of Object.entries(upstreamMap)) {
-    const trackedFiles = entry.files ?? [];
+    const trackedFiles = (entry.files ?? []).map(toForwardSlashes);
     if (trackedFiles.length === 0) continue;
 
     const tracked = new Set(trackedFiles);
     const roots = new Set<string>();
     for (const file of trackedFiles) {
-      const root = extractTopLevelRoot(file, skillsDir);
+      const root = extractTopLevelRoot(file, normalizedSkillsDir);
       if (root !== null) {
         roots.add(root);
       }
     }
 
     for (const root of roots) {
+      // join() uses the platform separator; walk() returns platform-
+      // native paths. We normalise to forward-slash AFTER computing
+      // `relative()` so the tracked-set comparison is platform-stable.
       const absoluteRoot = join(repoDir, root);
       try {
         for await (
@@ -190,7 +209,9 @@ async function detectOrphanFiles(
             includeSymlinks: false,
           })
         ) {
-          const relPath = relative(repoDir, walkEntry.path);
+          const relPath = toForwardSlashes(
+            relative(repoDir, walkEntry.path),
+          );
           if (!tracked.has(relPath)) {
             orphans.push({ extensionName, path: relPath });
           }

--- a/src/libswamp/extensions/doctor_test.ts
+++ b/src/libswamp/extensions/doctor_test.ts
@@ -45,6 +45,8 @@ function buildDeps(
   options: {
     warnings?: ReadonlyArray<ExtensionLoadWarning>;
     throwForRegistry?: DoctorRegistryName;
+    repoDir?: string;
+    skillsDir?: string;
   } = {},
 ): {
   deps: DoctorExtensionsDeps;
@@ -73,6 +75,9 @@ function buildDeps(
     resetState: () => {
       events.push({ fn: "resetState" });
     },
+    readUpstreamExtensions: () => Promise.resolve({}),
+    repoDir: options.repoDir ?? "/tmp/swamp-test-repo",
+    skillsDir: options.skillsDir ?? ".claude/skills",
     abortSignal: new AbortController().signal,
   };
 
@@ -237,3 +242,222 @@ Deno.test("doctorExtensions: completed report has all five registry keys even on
   const keys = Object.keys(completed.report.registries).sort();
   assertEquals(keys, ["datastore", "driver", "model", "report", "vault"]);
 });
+
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import type { UpstreamExtensionsMap } from "../../infrastructure/persistence/upstream_extensions.ts";
+
+Deno.test(
+  "doctorExtensions: detects an orphan file under a per-extension subtree",
+  async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_doctor_orphan_" });
+    try {
+      // Seed a tracked file plus an UNtracked sibling — the sibling
+      // is the orphan we expect doctor to flag.
+      const extDir = join(
+        tmpDir,
+        ".swamp/pulled-extensions/@x/y/models",
+      );
+      await ensureDir(extDir);
+      await Deno.writeTextFile(join(extDir, "tracked.ts"), "// tracked");
+      await Deno.writeTextFile(join(extDir, "orphan.ts"), "// orphan");
+
+      const { deps } = buildDeps({
+        repoDir: tmpDir,
+        skillsDir: ".claude/skills",
+      });
+      const upstream: UpstreamExtensionsMap = {
+        "@x/y": {
+          version: "1.0.0",
+          pulledAt: "2026-01-01T00:00:00Z",
+          files: [".swamp/pulled-extensions/@x/y/models/tracked.ts"],
+        },
+      };
+      deps.readUpstreamExtensions = () => Promise.resolve(upstream);
+
+      const events = await collect(doctorExtensions(deps));
+      const completed = events.find((e) => e.kind === "completed");
+      if (completed?.kind !== "completed") {
+        throw new Error("expected completed event");
+      }
+
+      assertEquals(completed.report.orphanFiles.length, 1);
+      assertEquals(completed.report.orphanFiles[0].extensionName, "@x/y");
+      assertEquals(
+        completed.report.orphanFiles[0].path,
+        ".swamp/pulled-extensions/@x/y/models/orphan.ts",
+      );
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "doctorExtensions: orphans do NOT change overallStatus from pass to fail",
+  async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_doctor_orphan_" });
+    try {
+      const extDir = join(
+        tmpDir,
+        ".swamp/pulled-extensions/@x/y/models",
+      );
+      await ensureDir(extDir);
+      await Deno.writeTextFile(join(extDir, "tracked.ts"), "// tracked");
+      await Deno.writeTextFile(join(extDir, "stray.ts"), "// stray");
+
+      const { deps } = buildDeps({
+        repoDir: tmpDir,
+        skillsDir: ".claude/skills",
+      });
+      const upstream: UpstreamExtensionsMap = {
+        "@x/y": {
+          version: "1.0.0",
+          pulledAt: "2026-01-01T00:00:00Z",
+          files: [".swamp/pulled-extensions/@x/y/models/tracked.ts"],
+        },
+      };
+      deps.readUpstreamExtensions = () => Promise.resolve(upstream);
+
+      const events = await collect(doctorExtensions(deps));
+      const completed = events.find((e) => e.kind === "completed");
+      if (completed?.kind !== "completed") {
+        throw new Error("expected completed event");
+      }
+
+      // Even though there's an orphan, overallStatus stays "pass" —
+      // orphans are warnings, not failures.
+      assertEquals(completed.report.orphanFiles.length, 1);
+      assertEquals(completed.report.overallStatus, "pass");
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "doctorExtensions: missing lockfile yields no orphans (no-op walk)",
+  async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_doctor_orphan_" });
+    try {
+      const { deps } = buildDeps({
+        repoDir: tmpDir,
+        skillsDir: ".claude/skills",
+      });
+      // Default readUpstreamExtensions returns {} — the no-lockfile case.
+      const events = await collect(doctorExtensions(deps));
+      const completed = events.find((e) => e.kind === "completed");
+      if (completed?.kind !== "completed") {
+        throw new Error("expected completed event");
+      }
+      assertEquals(completed.report.orphanFiles, []);
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "doctorExtensions: skill-dir entries do NOT produce orphan walks",
+  async () => {
+    // Skills are tracked as directory paths only; we cannot
+    // meaningfully orphan-detect within a skill dir. extractTopLevelRoot
+    // returns null for skill paths, so the walk skips them.
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_doctor_orphan_" });
+    try {
+      const skillDir = join(tmpDir, ".claude/skills/foo");
+      await ensureDir(skillDir);
+      await Deno.writeTextFile(join(skillDir, "SKILL.md"), "# foo");
+      await Deno.writeTextFile(
+        join(skillDir, "untracked-script.sh"),
+        "#!/bin/sh\n",
+      );
+
+      const { deps } = buildDeps({
+        repoDir: tmpDir,
+        skillsDir: ".claude/skills",
+      });
+      const upstream: UpstreamExtensionsMap = {
+        "@x/y": {
+          version: "1.0.0",
+          pulledAt: "2026-01-01T00:00:00Z",
+          files: [".claude/skills/foo"],
+        },
+      };
+      deps.readUpstreamExtensions = () => Promise.resolve(upstream);
+
+      const events = await collect(doctorExtensions(deps));
+      const completed = events.find((e) => e.kind === "completed");
+      if (completed?.kind !== "completed") {
+        throw new Error("expected completed event");
+      }
+      // Inner files of a skill dir are NOT walked — no orphan reported.
+      assertEquals(completed.report.orphanFiles, []);
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "doctorExtensions: detects an orphan inside a bundle namespace",
+  async () => {
+    // The orphan path that closes the #201 catalog loop: a stray bundle
+    // file under .swamp/bundles/<hash>/ that was dropped between
+    // versions but never removed from disk. The doctor scan must walk
+    // the bundle namespace as a separate root from the per-extension
+    // subtree, since bundles live in a different tree.
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_doctor_orphan_" });
+    try {
+      // Tracked: a model file under pulled-extensions AND its bundle
+      // under bundles/abc/. Untracked: a stray bundle file in the same
+      // namespace from a prior version.
+      const extDir = join(tmpDir, ".swamp/pulled-extensions/@x/y/models");
+      const bundleDir = join(tmpDir, ".swamp/bundles/abc");
+      await ensureDir(extDir);
+      await ensureDir(bundleDir);
+      await Deno.writeTextFile(join(extDir, "current.ts"), "// current");
+      await Deno.writeTextFile(
+        join(bundleDir, "current.js"),
+        "// current bundle",
+      );
+      await Deno.writeTextFile(
+        join(bundleDir, "stray_old_bundle.js"),
+        "// orphan",
+      );
+
+      const { deps } = buildDeps({
+        repoDir: tmpDir,
+        skillsDir: ".claude/skills",
+      });
+      const upstream: UpstreamExtensionsMap = {
+        "@x/y": {
+          version: "2.0.0",
+          pulledAt: "2026-01-01T00:00:00Z",
+          files: [
+            ".swamp/pulled-extensions/@x/y/models/current.ts",
+            ".swamp/bundles/abc/current.js",
+          ],
+        },
+      };
+      deps.readUpstreamExtensions = () => Promise.resolve(upstream);
+
+      const events = await collect(doctorExtensions(deps));
+      const completed = events.find((e) => e.kind === "completed");
+      if (completed?.kind !== "completed") {
+        throw new Error("expected completed event");
+      }
+
+      // Exactly one orphan: the stray bundle file. The pulled-extensions
+      // subtree is clean (only current.ts).
+      assertEquals(completed.report.orphanFiles.length, 1);
+      assertEquals(completed.report.orphanFiles[0].extensionName, "@x/y");
+      assertEquals(
+        completed.report.orphanFiles[0].path,
+        ".swamp/bundles/abc/stray_old_bundle.js",
+      );
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);

--- a/src/libswamp/extensions/install.ts
+++ b/src/libswamp/extensions/install.ts
@@ -27,6 +27,7 @@ import {
   type ExtensionRef,
   type InstallContext,
   installExtension,
+  type InstallResult,
   parseExtensionRef,
 } from "./pull.ts";
 import { classifyExtensionFile } from "./layout.ts";
@@ -36,11 +37,17 @@ import { classifyExtensionFile } from "./layout.ts";
  * `installExtension` from pull.ts; tests inject a stub that simulates
  * the side effects (writing to the per-extension subtree and updating
  * the lockfile) without needing a real tar archive and registry.
+ *
+ * Returns the same shape as `installExtension`: an `InstallResult` on
+ * a fresh install, or `undefined` when the extension was already pulled
+ * earlier in the same call chain (the alreadyPulled short-circuit).
+ * The result's `pruned` field carries the paths actually removed during
+ * orphan cleanup so callers can surface that to the user.
  */
 export type InstallExtensionFn = (
   ref: ExtensionRef,
   ctx: InstallContext,
-) => Promise<unknown>;
+) => Promise<InstallResult | undefined>;
 
 /** Result of installing a single extension during bulk install. */
 export interface ExtensionInstallEntry {
@@ -63,6 +70,12 @@ export type ExtensionInstallEvent =
   | { kind: "resolving" }
   | { kind: "installing"; name: string; version: string }
   | { kind: "migrating"; name: string; version: string }
+  | {
+    kind: "orphans-pruned";
+    name: string;
+    version: string;
+    paths: string[];
+  }
   | { kind: "completed"; data: ExtensionInstallData }
   | { kind: "error"; error: SwampError };
 
@@ -149,7 +162,7 @@ export async function* extensionInstall(
           }
           const ref = parseExtensionRef(`${name}@${version}`);
           const install = deps.installExtensionFn ?? installExtension;
-          await install(ref, installCtx);
+          const result = await install(ref, installCtx);
 
           // For migrations, sweep the original legacy paths now that the
           // current-layout files are on disk. installExtension has already
@@ -163,6 +176,21 @@ export async function* extensionInstall(
           } else {
             entries.push({ name, version, status: "installed" });
             installed++;
+          }
+
+          // Surface orphan removals to the user. Source-of-truth list
+          // is `result.pruned` (paths actually removed by
+          // pruneOrphanFiles inside installExtension), not the diff
+          // we'd compute here. When the test seam returns undefined or
+          // the install was a no-op (alreadyPulled), there's nothing
+          // to emit.
+          if (result && result.pruned.length > 0) {
+            yield {
+              kind: "orphans-pruned",
+              name,
+              version,
+              paths: result.pruned,
+            };
           }
         } catch (error) {
           entries.push({
@@ -226,6 +254,10 @@ export async function needsInstallOrMigration(
  * from an interrupted prior pass). Empty parent directories under the
  * repo root are pruned.
  *
+ * Uses recursive removal so directory entries (e.g. legacy skill dirs
+ * tracked by their root, with nested files inside) are handled — a plain
+ * Deno.remove fails on non-empty directories.
+ *
  * Exported for direct unit testing; production callers invoke it
  * indirectly through `extensionInstall`.
  */
@@ -239,7 +271,7 @@ export async function sweepLegacyPaths(
     }
     const absolutePath = join(repoDir, file);
     try {
-      await Deno.remove(absolutePath);
+      await Deno.remove(absolutePath, { recursive: true });
     } catch (error) {
       if (!(error instanceof Deno.errors.NotFound)) {
         throw error;

--- a/src/libswamp/extensions/install_test.ts
+++ b/src/libswamp/extensions/install_test.ts
@@ -27,6 +27,7 @@ import {
   needsInstallOrMigration,
   sweepLegacyPaths,
 } from "./install.ts";
+import { pruneOrphanFiles } from "../../infrastructure/persistence/directory_cleanup.ts";
 import { createLibSwampContext } from "../context.ts";
 import type { InstallContext } from "./pull.ts";
 import { readUpstreamExtensions } from "../../infrastructure/persistence/upstream_extensions.ts";
@@ -336,11 +337,68 @@ function makeSuccessfulInstall(
       lockfilePath,
       JSON.stringify(upstream, null, 2),
     );
+    return undefined;
   };
 }
 
 function makeFailingInstall(): InstallExtensionFn {
   return () => Promise.reject(new Error("simulated download failure"));
+}
+
+/**
+ * Stub that simulates a successful install AND surfaces a `pruned`
+ * list on its InstallResult — the shape real `installExtension`
+ * returns when prior-version files were dropped between versions.
+ * Lets us verify that `extensionInstall` propagates the prune list
+ * to the orphans-pruned event without needing a real archive.
+ */
+function makeInstallWithPruned(
+  tmpDir: string,
+  lockfilePath: string,
+  prunedPaths: string[],
+): InstallExtensionFn {
+  return async (ref) => {
+    const extRoot = join(
+      tmpDir,
+      ".swamp",
+      "pulled-extensions",
+      ref.name,
+      "models",
+    );
+    await ensureDir(extRoot);
+    await Deno.writeTextFile(join(extRoot, "main.ts"), "// reinstalled");
+
+    const upstream = await readUpstreamExtensions(lockfilePath);
+    upstream[ref.name] = {
+      ...upstream[ref.name],
+      files: [`.swamp/pulled-extensions/${ref.name}/models/main.ts`],
+      filesChecksum: "fake-anchor",
+    };
+    await Deno.writeTextFile(
+      lockfilePath,
+      JSON.stringify(upstream, null, 2),
+    );
+
+    return {
+      name: ref.name,
+      version: "2.0.0",
+      description: undefined,
+      extractedFiles: [
+        `.swamp/pulled-extensions/${ref.name}/models/main.ts`,
+      ],
+      integrityStatus: "verified",
+      repository: undefined,
+      platforms: [],
+      safetyWarnings: [],
+      conflicts: [],
+      missingSourceFiles: [],
+      hasSkills: false,
+      hasSkillScripts: false,
+      skillFiles: [],
+      dependencyResults: [],
+      pruned: prunedPaths,
+    };
+  };
 }
 
 Deno.test("needsInstallOrMigration: current layout returns up_to_date", async () => {
@@ -711,6 +769,297 @@ Deno.test(
         ["extensions/models/ghost.ts"],
         tmpDir,
       );
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "sweepLegacyPaths: removes a non-empty directory entry recursively",
+  async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+    try {
+      // gen-2 path — `.swamp/pulled-extensions/<known-type>/...` —
+      // pointing at a non-empty directory. Plain Deno.remove fails on
+      // non-empty directories; sweep must use { recursive: true } to
+      // handle skill-style directory entries that survive into legacy
+      // lockfile state.
+      const dirPath = join(
+        tmpDir,
+        ".swamp/pulled-extensions/skills/foo",
+      );
+      await ensureDir(dirPath);
+      await Deno.writeTextFile(join(dirPath, "nested.ts"), "// nested");
+
+      await sweepLegacyPaths(
+        [".swamp/pulled-extensions/skills/foo"],
+        tmpDir,
+      );
+
+      let exists = true;
+      try {
+        await Deno.stat(dirPath);
+      } catch (e) {
+        if (e instanceof Deno.errors.NotFound) exists = false;
+      }
+      assertEquals(exists, false, "skills/foo should be removed recursively");
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "pruneOrphanFiles: returns the paths actually removed (file case)",
+  async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+    try {
+      const a = join(tmpDir, ".swamp/pulled-extensions/@x/y/models/a.ts");
+      const b = join(tmpDir, ".swamp/pulled-extensions/@x/y/models/b.ts");
+      await ensureDir(join(tmpDir, ".swamp/pulled-extensions/@x/y/models"));
+      await Deno.writeTextFile(a, "// a");
+      await Deno.writeTextFile(b, "// b");
+
+      const removed = await pruneOrphanFiles(
+        [
+          ".swamp/pulled-extensions/@x/y/models/a.ts",
+          ".swamp/pulled-extensions/@x/y/models/b.ts",
+        ],
+        tmpDir,
+      );
+
+      assertEquals(removed.length, 2);
+      assertEquals(
+        removed.includes(".swamp/pulled-extensions/@x/y/models/a.ts"),
+        true,
+      );
+      assertEquals(
+        removed.includes(".swamp/pulled-extensions/@x/y/models/b.ts"),
+        true,
+      );
+
+      for (const p of [a, b]) {
+        let exists = true;
+        try {
+          await Deno.stat(p);
+        } catch (e) {
+          if (e instanceof Deno.errors.NotFound) exists = false;
+        }
+        assertEquals(exists, false, `${p} should be removed`);
+      }
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "pruneOrphanFiles: removes a non-empty directory recursively (skill case)",
+  async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+    try {
+      // Skills are tracked as directory paths in entry.files[]; the
+      // diff against extractedFiles can hand us a directory entry that
+      // is non-empty. recursive:true is mandatory here.
+      const skillDir = join(tmpDir, ".claude/skills/foo");
+      await ensureDir(skillDir);
+      await Deno.writeTextFile(join(skillDir, "SKILL.md"), "# foo");
+      await ensureDir(join(skillDir, "scripts"));
+      await Deno.writeTextFile(
+        join(skillDir, "scripts", "do.sh"),
+        "#!/bin/sh\n",
+      );
+
+      const removed = await pruneOrphanFiles(
+        [".claude/skills/foo"],
+        tmpDir,
+      );
+
+      assertEquals(removed, [".claude/skills/foo"]);
+
+      let exists = true;
+      try {
+        await Deno.stat(skillDir);
+      } catch (e) {
+        if (e instanceof Deno.errors.NotFound) exists = false;
+      }
+      assertEquals(exists, false, "skill dir should be removed recursively");
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "pruneOrphanFiles: NotFound paths are tolerated and NOT in the return list",
+  async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+    try {
+      // Mix: one path exists, one does not. Ground-truth contract: the
+      // NotFound path must be excluded from the returned list.
+      const real = join(
+        tmpDir,
+        ".swamp/pulled-extensions/@x/y/models/real.ts",
+      );
+      await ensureDir(join(tmpDir, ".swamp/pulled-extensions/@x/y/models"));
+      await Deno.writeTextFile(real, "// real");
+
+      const removed = await pruneOrphanFiles(
+        [
+          ".swamp/pulled-extensions/@x/y/models/real.ts",
+          ".swamp/pulled-extensions/@x/y/models/ghost.ts",
+        ],
+        tmpDir,
+      );
+
+      assertEquals(removed, [
+        ".swamp/pulled-extensions/@x/y/models/real.ts",
+      ]);
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "pruneOrphanFiles: prunes empty parent directories under repoDir",
+  async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+    try {
+      // Solo file in a nested dir — after removal, the parent should
+      // also be pruned via cleanupEmptyParentDirs.
+      const nestedDir = join(
+        tmpDir,
+        ".swamp/pulled-extensions/@x/y/models/nested",
+      );
+      await ensureDir(nestedDir);
+      await Deno.writeTextFile(join(nestedDir, "solo.ts"), "// solo");
+
+      await pruneOrphanFiles(
+        [".swamp/pulled-extensions/@x/y/models/nested/solo.ts"],
+        tmpDir,
+      );
+
+      let exists = true;
+      try {
+        await Deno.stat(nestedDir);
+      } catch (e) {
+        if (e instanceof Deno.errors.NotFound) exists = false;
+      }
+      assertEquals(exists, false, "empty nested/ dir should be pruned");
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "pruneOrphanFiles: empty input list returns empty result",
+  async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+    try {
+      const removed = await pruneOrphanFiles([], tmpDir);
+      assertEquals(removed, []);
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "extensionInstall: orphans-pruned event fires when result.pruned is non-empty",
+  async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+    try {
+      const lockfilePath = join(tmpDir, "upstream_extensions.json");
+      // Seed the lockfile so the entry isn't up-to-date — install is
+      // triggered, the stub runs, and the orphans-pruned event has data.
+      await Deno.writeTextFile(
+        lockfilePath,
+        JSON.stringify({
+          "@me/ext": {
+            version: "1.0.0",
+            pulledAt: "2026-01-01T00:00:00Z",
+            files: [
+              ".swamp/pulled-extensions/@me/ext/models/missing.ts",
+            ],
+          },
+        }),
+      );
+
+      const ctx = createLibSwampContext({});
+      const events = await collectEvents(
+        extensionInstall(ctx, {
+          lockfilePath,
+          repoDir: tmpDir,
+          createInstallContext: () =>
+            makeStubInstallContext(tmpDir, lockfilePath),
+          installExtensionFn: makeInstallWithPruned(
+            tmpDir,
+            lockfilePath,
+            [
+              ".swamp/pulled-extensions/@me/ext/models/orphan.ts",
+              ".swamp/bundles/abc/orphan.js",
+            ],
+          ),
+        }),
+      );
+
+      const orphansPruned = events.find((e) => e.kind === "orphans-pruned");
+      if (orphansPruned?.kind !== "orphans-pruned") {
+        throw new Error(
+          `expected orphans-pruned event, got: ${
+            events.map((e) => e.kind).join(", ")
+          }`,
+        );
+      }
+      assertEquals(orphansPruned.name, "@me/ext");
+      assertEquals(orphansPruned.version, "1.0.0");
+      assertEquals(orphansPruned.paths.length, 2);
+      assertEquals(
+        orphansPruned.paths.includes(
+          ".swamp/pulled-extensions/@me/ext/models/orphan.ts",
+        ),
+        true,
+      );
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "extensionInstall: NO orphans-pruned event when result.pruned is empty",
+  async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+    try {
+      const lockfilePath = join(tmpDir, "upstream_extensions.json");
+      await Deno.writeTextFile(
+        lockfilePath,
+        JSON.stringify({
+          "@me/ext": {
+            version: "1.0.0",
+            pulledAt: "2026-01-01T00:00:00Z",
+            files: [".swamp/pulled-extensions/@me/ext/models/missing.ts"],
+          },
+        }),
+      );
+
+      const ctx = createLibSwampContext({});
+      const events = await collectEvents(
+        extensionInstall(ctx, {
+          lockfilePath,
+          repoDir: tmpDir,
+          createInstallContext: () =>
+            makeStubInstallContext(tmpDir, lockfilePath),
+          // Empty pruned list — no event should fire.
+          installExtensionFn: makeInstallWithPruned(tmpDir, lockfilePath, []),
+        }),
+      );
+
+      const orphansPruned = events.find((e) => e.kind === "orphans-pruned");
+      assertEquals(orphansPruned, undefined);
     } finally {
       await Deno.remove(tmpDir, { recursive: true });
     }

--- a/src/libswamp/extensions/layout.ts
+++ b/src/libswamp/extensions/layout.ts
@@ -86,6 +86,95 @@ export function classifyExtensionFile(file: string): ExtensionLayoutGeneration {
 }
 
 /**
+ * Returns the per-extension root subtree that owns a tracked file path,
+ * or `null` when the path does not anchor to a root that
+ * `doctor extensions` should walk for orphan detection.
+ *
+ * Returns null for:
+ * - skill paths (`<skillsDir>/<skill>/`) — skills are tracked as
+ *   directory paths only, so files inside aren't individually tracked
+ *   and we cannot meaningfully orphan-detect within a skill dir.
+ * - legacy paths (gen-1, gen-2) — the extensionInstall migration path
+ *   handles these; doctor's orphan walk is for current-layout only.
+ *
+ * Otherwise returns the longest path-segment prefix that identifies a
+ * single per-extension subtree:
+ * - `.swamp/pulled-extensions/<@scope>/<name>/...` →
+ *   `.swamp/pulled-extensions/<@scope>/<name>`
+ * - `.swamp/pulled-extensions/<flat-name>/...` →
+ *   `.swamp/pulled-extensions/<flat-name>`
+ * - bundle namespaces (`bundles/<hash>/...`,
+ *   `vault-bundles/<hash>/...`, `driver-bundles/<hash>/...`,
+ *   `datastore-bundles/<hash>/...`, `report-bundles/<hash>/...`) →
+ *   `<kind>/<hash>`
+ *
+ * The skillsDir is repo-and-tool-specific (`.claude/skills/`,
+ * `.cursor/skills/`, etc.); the caller must pass it in.
+ *
+ * @param filePath Repo-relative path from `entry.files[]`
+ * @param skillsDir Repo-relative tool-specific skills directory
+ */
+export function extractTopLevelRoot(
+  filePath: string,
+  skillsDir: string,
+): string | null {
+  // Legacy paths are out of scope for orphan detection; the migrate
+  // flow in extensionInstall handles those.
+  if (classifyExtensionFile(filePath) !== "current") {
+    return null;
+  }
+
+  // Skills are tracked as directory paths (the dir root, not its
+  // contents). We can't detect orphan files within a skill dir
+  // because the inner files aren't in entry.files[].
+  const normalizedSkillsDir = skillsDir.endsWith("/")
+    ? skillsDir
+    : `${skillsDir}/`;
+  if (
+    filePath === skillsDir.replace(/\/$/, "") ||
+    filePath.startsWith(normalizedSkillsDir)
+  ) {
+    return null;
+  }
+
+  // Per-extension subtree: pulled-extensions/<scope>/<name>/...
+  // (current-layout always begins with .swamp/pulled-extensions/).
+  if (filePath.startsWith(PULLED_PREFIX)) {
+    const rest = filePath.slice(PULLED_PREFIX.length);
+    const segments = rest.split("/");
+    if (segments.length === 0 || segments[0].length === 0) return null;
+    // Two segments for scoped names (@scope/name); one for flat.
+    if (segments[0].startsWith("@")) {
+      if (segments.length < 2) return null;
+      return `${PULLED_PREFIX}${segments[0]}/${segments[1]}`;
+    }
+    return `${PULLED_PREFIX}${segments[0]}`;
+  }
+
+  // Bundle namespaces: <kind>/<hash>/...
+  const BUNDLE_KINDS = [
+    "bundles",
+    "vault-bundles",
+    "driver-bundles",
+    "datastore-bundles",
+    "report-bundles",
+  ];
+  for (const kind of BUNDLE_KINDS) {
+    const prefix = `${SWAMP_DATA_DIR}/${kind}/`;
+    if (filePath.startsWith(prefix)) {
+      const rest = filePath.slice(prefix.length);
+      const segments = rest.split("/");
+      if (segments.length === 0 || segments[0].length === 0) return null;
+      return `${prefix}${segments[0]}`;
+    }
+  }
+
+  // Anything else current-layout but not under a known root — no
+  // orphan walk possible.
+  return null;
+}
+
+/**
  * Detects whether a repository has pulled extensions in any legacy layout.
  *
  * Reads `upstream_extensions.json` and classifies each tracked file.

--- a/src/libswamp/extensions/layout_test.ts
+++ b/src/libswamp/extensions/layout_test.ts
@@ -22,6 +22,7 @@ import { join } from "@std/path";
 import {
   classifyExtensionFile,
   detectLegacyExtensionLayout,
+  extractTopLevelRoot,
   requireCurrentExtensionLayout,
   summariseLegacyLayout,
   warnLegacyExtensionLayout,
@@ -334,4 +335,98 @@ Deno.test("requireCurrentExtensionLayout: passes on current layout", async () =>
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }
+});
+
+const SKILLS_DIR = ".claude/skills";
+
+Deno.test("extractTopLevelRoot: per-extension scoped subtree", () => {
+  assertEquals(
+    extractTopLevelRoot(
+      ".swamp/pulled-extensions/@hivemq/harvester/models/foo.ts",
+      SKILLS_DIR,
+    ),
+    ".swamp/pulled-extensions/@hivemq/harvester",
+  );
+});
+
+Deno.test("extractTopLevelRoot: per-extension flat (unscoped) subtree", () => {
+  assertEquals(
+    extractTopLevelRoot(
+      ".swamp/pulled-extensions/myext/models/foo.ts",
+      SKILLS_DIR,
+    ),
+    ".swamp/pulled-extensions/myext",
+  );
+});
+
+Deno.test("extractTopLevelRoot: bundle namespace", () => {
+  assertEquals(
+    extractTopLevelRoot(
+      ".swamp/bundles/abc123/foo.js",
+      SKILLS_DIR,
+    ),
+    ".swamp/bundles/abc123",
+  );
+});
+
+Deno.test("extractTopLevelRoot: each bundle kind", () => {
+  for (
+    const kind of [
+      "bundles",
+      "vault-bundles",
+      "driver-bundles",
+      "datastore-bundles",
+      "report-bundles",
+    ]
+  ) {
+    assertEquals(
+      extractTopLevelRoot(
+        `.swamp/${kind}/hash123/foo.js`,
+        SKILLS_DIR,
+      ),
+      `.swamp/${kind}/hash123`,
+    );
+  }
+});
+
+Deno.test("extractTopLevelRoot: skill dir returns null", () => {
+  assertEquals(
+    extractTopLevelRoot(".claude/skills/foo", SKILLS_DIR),
+    null,
+  );
+  assertEquals(
+    extractTopLevelRoot(".claude/skills/foo/SKILL.md", SKILLS_DIR),
+    null,
+  );
+});
+
+Deno.test("extractTopLevelRoot: gen-1 path returns null", () => {
+  assertEquals(
+    extractTopLevelRoot("extensions/models/legacy.ts", SKILLS_DIR),
+    null,
+  );
+});
+
+Deno.test("extractTopLevelRoot: gen-2 path returns null", () => {
+  assertEquals(
+    extractTopLevelRoot(
+      ".swamp/pulled-extensions/models/flat.ts",
+      SKILLS_DIR,
+    ),
+    null,
+  );
+});
+
+Deno.test("extractTopLevelRoot: unknown current-layout path returns null", () => {
+  assertEquals(
+    extractTopLevelRoot(".swamp/some-other-place/foo.ts", SKILLS_DIR),
+    null,
+  );
+});
+
+Deno.test("extractTopLevelRoot: handles trailing-slash skillsDir", () => {
+  assertEquals(
+    extractTopLevelRoot(".claude/skills/foo/SKILL.md", ".claude/skills/"),
+    null,
+  );
 });

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -30,7 +30,11 @@ import { parseExtensionManifest } from "../../domain/extensions/extension_manife
 import { analyzeExtensionSafety } from "../../domain/extensions/extension_safety_analyzer.ts";
 import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
 import { atomicWriteTextFile } from "../../infrastructure/persistence/atomic_write.ts";
-import type { UpstreamExtensionsMap } from "../../infrastructure/persistence/upstream_extensions.ts";
+import { pruneOrphanFiles } from "../../infrastructure/persistence/directory_cleanup.ts";
+import {
+  readUpstreamExtensions,
+  type UpstreamExtensionsMap,
+} from "../../infrastructure/persistence/upstream_extensions.ts";
 import {
   bundleNamespace,
   swampPath,
@@ -85,6 +89,16 @@ export interface InstallResult {
   hasSkillScripts: boolean;
   skillFiles: string[];
   dependencyResults: InstallResult[];
+  /**
+   * Repo-relative paths that were declared in the prior version's
+   * lockfile entry but absent from the current version's
+   * `extractedFiles`, and which were actually removed from disk by
+   * `pruneOrphanFiles` during this install. Empty for first-installs
+   * (no prior entry) and re-installs of the same version (no diff).
+   * Reflects ground truth — paths skipped due to NotFound are NOT
+   * included.
+   */
+  pruned: string[];
 }
 
 /**
@@ -141,6 +155,12 @@ export class ConflictError extends UserError {
 
 export type ExtensionPullEvent =
   | { kind: "installing" }
+  | {
+    kind: "orphans-pruned";
+    name: string;
+    version: string;
+    paths: string[];
+  }
   | { kind: "completed"; data: InstallResult }
   | { kind: "error"; error: SwampError };
 
@@ -651,6 +671,27 @@ async function collectTsFiles(dir: string): Promise<string[]> {
 }
 
 /**
+ * Computes which paths from a prior version's lockfile entry are
+ * orphans relative to a new version's extracted file set — i.e. paths
+ * declared by the old version but absent from the new one. Pure
+ * function; the caller hands the result to `pruneOrphanFiles` to
+ * remove them from disk.
+ *
+ * Both lists are repo-relative paths. Uses a Set for O(N) lookup
+ * instead of O(N²) `.includes()`.
+ *
+ * Exported for direct unit testing — production callers go through
+ * `installExtension`.
+ */
+export function computeOrphanDiff(
+  oldFiles: ReadonlyArray<string>,
+  extractedFiles: ReadonlyArray<string>,
+): string[] {
+  const newFilesSet = new Set(extractedFiles);
+  return oldFiles.filter((f) => !newFilesSet.has(f));
+}
+
+/**
  * Core install logic: download, verify, extract, copy, track.
  * No rendering — returns structured data for callers to present.
  * Throws ConflictError when !force and conflicts exist.
@@ -673,6 +714,13 @@ export async function installExtension(
   }
 
   ctx.alreadyPulled.add(ref.name);
+
+  // Snapshot the prior lockfile entry's `files[]` BEFORE extraction.
+  // Used after extraction to compute the orphan diff (paths declared
+  // by the prior version but absent from the new version) and prune
+  // them. Empty when this is a first-install (no prior entry).
+  const upstreamMapBefore = await readUpstreamExtensions(ctx.lockfilePath);
+  const oldFiles = upstreamMapBefore[ref.name]?.files ?? [];
 
   const extInfo = await ctx.getExtension(ref.name);
   if (!extInfo) {
@@ -1092,6 +1140,18 @@ export async function installExtension(
     // (issue #126).
     const filesChecksum = await readInstalledExtensionDigest(absoluteExtRoot);
 
+    // Prune orphans: paths declared by the prior version's lockfile
+    // entry that are NOT in the new version's extractedFiles[]. Done
+    // BEFORE updateUpstreamExtensions writes the new entry so a kill
+    // mid-prune leaves the lockfile pointing at the OLD version — the
+    // next install retries the diff. The inverse ordering (write then
+    // prune) would orphan paths the lockfile can't see if the prune
+    // never runs.
+    const orphanDiff = computeOrphanDiff(oldFiles, extractedFiles);
+    const pruned = orphanDiff.length > 0
+      ? await pruneOrphanFiles(orphanDiff, repoDir)
+      : [];
+
     await updateUpstreamExtensions(
       ctx.lockfilePath,
       ref.name,
@@ -1153,6 +1213,7 @@ export async function installExtension(
       hasSkillScripts,
       skillFiles,
       dependencyResults,
+      pruned,
     };
   } finally {
     try {
@@ -1191,6 +1252,14 @@ export async function* extensionPull(
       // Let ConflictError propagate — CLI catches it for the two-phase prompt flow
       const result = await installExtension(input.ref, installCtx);
       if (result) {
+        if (result.pruned.length > 0) {
+          yield {
+            kind: "orphans-pruned" as const,
+            name: result.name,
+            version: result.version,
+            paths: result.pruned,
+          };
+        }
         yield { kind: "completed" as const, data: result };
       }
     })(),

--- a/src/libswamp/extensions/pull_test.ts
+++ b/src/libswamp/extensions/pull_test.ts
@@ -21,6 +21,7 @@ import { assertEquals, assertThrows } from "@std/assert";
 import { assertStringIncludes } from "@std/assert/string-includes";
 import { join } from "@std/path";
 import {
+  computeOrphanDiff,
   parseExtensionRef,
   updateUpstreamExtensions,
   validateExtensionName,
@@ -97,3 +98,71 @@ Deno.test("updateUpstreamExtensions: writes and updates entries", async () => {
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
+
+Deno.test("computeOrphanDiff: empty inputs yield empty diff", () => {
+  assertEquals(computeOrphanDiff([], []), []);
+  assertEquals(computeOrphanDiff(["a.ts"], []), ["a.ts"]);
+  assertEquals(computeOrphanDiff([], ["a.ts"]), []);
+});
+
+Deno.test("computeOrphanDiff: identical sets yield no orphans", () => {
+  const files = [
+    ".swamp/pulled-extensions/@x/y/models/a.ts",
+    ".swamp/bundles/abc/a.js",
+  ];
+  assertEquals(computeOrphanDiff(files, files), []);
+});
+
+Deno.test(
+  "computeOrphanDiff: paths in old but NOT new are orphans",
+  () => {
+    // The canonical case from issue 202: v1 had two files, v2 declares
+    // only one, so the dropped one is the orphan.
+    const oldFiles = [
+      ".swamp/pulled-extensions/@hivemq/harvester/kubeconfig/models/harvester/kubeconfig.ts",
+      ".swamp/pulled-extensions/@hivemq/harvester/kubeconfig/models/harvester/fetch_kubeconfig.ts",
+      ".swamp/bundles/738c72f8/harvester/kubeconfig.js",
+      ".swamp/bundles/738c72f8/harvester/fetch_kubeconfig.js",
+    ];
+    const extractedFiles = [
+      ".swamp/pulled-extensions/@hivemq/harvester/kubeconfig/models/harvester/kubeconfig.ts",
+      ".swamp/bundles/738c72f8/harvester/kubeconfig.js",
+    ];
+    const orphans = computeOrphanDiff(oldFiles, extractedFiles);
+    assertEquals(orphans.length, 2);
+    assertEquals(
+      orphans.includes(
+        ".swamp/pulled-extensions/@hivemq/harvester/kubeconfig/models/harvester/fetch_kubeconfig.ts",
+      ),
+      true,
+    );
+    assertEquals(
+      orphans.includes(".swamp/bundles/738c72f8/harvester/fetch_kubeconfig.js"),
+      true,
+    );
+  },
+);
+
+Deno.test(
+  "computeOrphanDiff: all files dropped — every old path is an orphan",
+  () => {
+    const oldFiles = ["a.ts", "b.ts", "c.ts"];
+    const extractedFiles = ["x.ts"];
+    assertEquals(computeOrphanDiff(oldFiles, extractedFiles), [
+      "a.ts",
+      "b.ts",
+      "c.ts",
+    ]);
+  },
+);
+
+Deno.test(
+  "computeOrphanDiff: order of returned orphans matches old-list order",
+  () => {
+    // Stability: if two callers compute the same diff, they get the
+    // same list. Important for deterministic event output.
+    const oldFiles = ["c.ts", "a.ts", "b.ts"];
+    const extractedFiles = ["a.ts"];
+    assertEquals(computeOrphanDiff(oldFiles, extractedFiles), ["c.ts", "b.ts"]);
+  },
+);

--- a/src/libswamp/extensions/update.ts
+++ b/src/libswamp/extensions/update.ts
@@ -28,6 +28,7 @@ import { readUpstreamExtensions } from "../../infrastructure/persistence/upstrea
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { validationFailed } from "../errors.ts";
+import type { InstallResult } from "./pull.ts";
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
@@ -41,6 +42,13 @@ export type ExtensionUpdateEvent =
   | { kind: "extension_not_installed"; name: string }
   | { kind: "checking"; name: string }
   | { kind: "updating"; name: string; from: string; to: string }
+  | {
+    kind: "orphans-pruned";
+    name: string;
+    from: string;
+    to: string;
+    paths: string[];
+  }
   | { kind: "completed"; data: ExtensionUpdateResult; mode: "check" | "update" }
   | { kind: "error"; error: SwampError };
 
@@ -62,15 +70,26 @@ export interface ExtensionUpdateDeps {
   getExtension: (
     name: string,
   ) => Promise<{ latestVersion: string | null } | null>;
-  /** Install/update a specific extension to a version. */
-  installExtension: (name: string, version: string) => Promise<void>;
+  /**
+   * Install/update a specific extension to a version. Returns the
+   * `InstallResult` so the update path can surface the pruned orphan
+   * list to the user, or `undefined` when the install short-circuited
+   * (alreadyPulled in the same call chain). Errors propagate as throws.
+   */
+  installExtension: (
+    name: string,
+    version: string,
+  ) => Promise<InstallResult | undefined>;
 }
 
 /** Wires real infrastructure into ExtensionUpdateDeps. */
 export function createExtensionUpdateDeps(options: {
   lockfilePath: string;
   serverUrl?: string;
-  installExtension: (name: string, version: string) => Promise<void>;
+  installExtension: (
+    name: string,
+    version: string,
+  ) => Promise<InstallResult | undefined>;
 }): ExtensionUpdateDeps {
   const extensionClient = new ExtensionApiClient(
     options.serverUrl ?? resolveServerUrl(),
@@ -172,7 +191,19 @@ export async function* extensionUpdate(
           };
 
           try {
-            await deps.installExtension(s.name, s.latestVersion);
+            const result = await deps.installExtension(
+              s.name,
+              s.latestVersion,
+            );
+            if (result && result.pruned.length > 0) {
+              yield {
+                kind: "orphans-pruned",
+                name: s.name,
+                from: s.installedVersion,
+                to: s.latestVersion,
+                paths: result.pruned,
+              };
+            }
             finalStatuses.push({
               status: "updated",
               name: s.name,

--- a/src/libswamp/extensions/update_test.ts
+++ b/src/libswamp/extensions/update_test.ts
@@ -33,7 +33,7 @@ function makeDeps(
   return {
     readUpstreamExtensions: () => Promise.resolve({}),
     getExtension: () => Promise.resolve(null),
-    installExtension: () => Promise.resolve(),
+    installExtension: () => Promise.resolve(undefined),
     ...overrides,
   };
 }
@@ -137,7 +137,7 @@ Deno.test("extensionUpdate: update mode successfully updates", async () => {
     getExtension: () => Promise.resolve({ latestVersion: "2026.03.01.1" }),
     installExtension: (name, version) => {
       installed.push(`${name}@${version}`);
-      return Promise.resolve();
+      return Promise.resolve(undefined);
     },
   });
   const input: ExtensionUpdateInput = { checkOnly: false };
@@ -204,3 +204,89 @@ Deno.test("extensionUpdate: registry fetch failure records not_found", async () 
     assertEquals(completed.data.summary.failed, 1);
   }
 });
+
+import type { InstallResult } from "./pull.ts";
+
+function buildInstallResult(
+  name: string,
+  version: string,
+  pruned: string[],
+): InstallResult {
+  return {
+    name,
+    version,
+    description: undefined,
+    extractedFiles: [`.swamp/pulled-extensions/${name}/models/main.ts`],
+    integrityStatus: "verified",
+    repository: undefined,
+    platforms: [],
+    safetyWarnings: [],
+    conflicts: [],
+    missingSourceFiles: [],
+    hasSkills: false,
+    hasSkillScripts: false,
+    skillFiles: [],
+    dependencyResults: [],
+    pruned,
+  };
+}
+
+Deno.test(
+  "extensionUpdate: emits orphans-pruned event when installExtension returns pruned paths",
+  async () => {
+    const deps = makeDeps({
+      readUpstreamExtensions: () =>
+        Promise.resolve({ "@ns/a": { version: "2026.01.01.1" } }),
+      getExtension: () => Promise.resolve({ latestVersion: "2026.03.01.1" }),
+      installExtension: (name, version) =>
+        Promise.resolve(
+          buildInstallResult(name, version, [
+            ".swamp/pulled-extensions/@ns/a/models/old_helper.ts",
+          ]),
+        ),
+    });
+    const input: ExtensionUpdateInput = { checkOnly: false };
+
+    const events = await collect<ExtensionUpdateEvent>(
+      extensionUpdate(makeCtx(), deps, input),
+    );
+
+    const orphansPruned = events.find((e) => e.kind === "orphans-pruned");
+    if (orphansPruned?.kind !== "orphans-pruned") {
+      throw new Error(
+        `expected orphans-pruned event, got: ${
+          events.map((e) => e.kind).join(", ")
+        }`,
+      );
+    }
+    assertEquals(orphansPruned.name, "@ns/a");
+    assertEquals(orphansPruned.from, "2026.01.01.1");
+    assertEquals(orphansPruned.to, "2026.03.01.1");
+    assertEquals(orphansPruned.paths, [
+      ".swamp/pulled-extensions/@ns/a/models/old_helper.ts",
+    ]);
+  },
+);
+
+Deno.test(
+  "extensionUpdate: NO orphans-pruned event when result has empty pruned list",
+  async () => {
+    const deps = makeDeps({
+      readUpstreamExtensions: () =>
+        Promise.resolve({ "@ns/a": { version: "2026.01.01.1" } }),
+      getExtension: () => Promise.resolve({ latestVersion: "2026.03.01.1" }),
+      installExtension: (name, version) =>
+        Promise.resolve(buildInstallResult(name, version, [])),
+    });
+    const input: ExtensionUpdateInput = { checkOnly: false };
+
+    const events = await collect<ExtensionUpdateEvent>(
+      extensionUpdate(makeCtx(), deps, input),
+    );
+
+    assertEquals(
+      events.find((e) => e.kind === "orphans-pruned"),
+      undefined,
+    );
+  },
+);

--- a/src/presentation/renderers/doctor_extensions.ts
+++ b/src/presentation/renderers/doctor_extensions.ts
@@ -84,6 +84,39 @@ class LogDoctorExtensionsRenderer implements DoctorExtensionsRenderer {
       },
       completed: (e) => {
         this.overallStatus = e.report.overallStatus;
+        // Filesystem orphan warnings are independent of pass/fail — if
+        // anything is found, surface it before the summary so users see
+        // both halves of the diagnostic.
+        if (e.report.orphanFiles.length > 0) {
+          writeOutput(
+            `\n${yellow("⚠")} ${
+              bold(
+                `Found ${e.report.orphanFiles.length} orphan file(s) (warnings, not failures):`,
+              )
+            }`,
+          );
+          // Group by extensionName so the user sees which extension
+          // each orphan belongs to.
+          const byExt = new Map<string, string[]>();
+          for (const orphan of e.report.orphanFiles) {
+            const list = byExt.get(orphan.extensionName) ?? [];
+            list.push(orphan.path);
+            byExt.set(orphan.extensionName, list);
+          }
+          for (const [extName, paths] of byExt) {
+            writeOutput(`    ${dim(extName)}`);
+            for (const p of paths) {
+              writeOutput(`      ${yellow("•")} ${p}`);
+            }
+          }
+          writeOutput(
+            dim(
+              "    These will be removed on the next " +
+                "`swamp extension pull <name> --force` or " +
+                "`swamp extension update`.",
+            ),
+          );
+        }
         const passCount = Object.values(e.report.registries)
           .filter((r) => r.status === "pass").length;
         const failCount = Object.values(e.report.registries)
@@ -124,7 +157,11 @@ class JsonDoctorExtensionsRenderer implements DoctorExtensionsRenderer {
         }
         console.log(
           JSON.stringify(
-            { overallStatus: e.report.overallStatus, registries },
+            {
+              overallStatus: e.report.overallStatus,
+              registries,
+              orphanFiles: e.report.orphanFiles,
+            },
             null,
             2,
           ),

--- a/src/presentation/renderers/doctor_extensions_test.ts
+++ b/src/presentation/renderers/doctor_extensions_test.ts
@@ -64,6 +64,7 @@ function buildPassReport(): DoctorExtensionsReport {
       datastore: passResult("datastore"),
       report: passResult("report"),
     },
+    orphanFiles: [],
   };
 }
 
@@ -79,6 +80,7 @@ function buildFailReport(): DoctorExtensionsReport {
       datastore: passResult("datastore"),
       report: passResult("report"),
     },
+    orphanFiles: [],
   };
 }
 
@@ -162,6 +164,7 @@ Deno.test("doctor_extensions json renderer: stable key ordering", async () => {
         vault: passResult("vault"),
         model: passResult("model"),
       },
+      orphanFiles: [],
     };
     await handlers.completed({ kind: "completed", report: reversed });
   });
@@ -205,3 +208,96 @@ Deno.test("doctor_extensions log renderer: no implicit fold — renders every ro
   // overallStatus only updates on `completed`.
   assertEquals(r.overallStatus, "pass");
 });
+
+Deno.test(
+  "doctor_extensions json renderer: orphanFiles surfaces in JSON output",
+  async () => {
+    const out = await captureStdout(async () => {
+      const r = createDoctorExtensionsRenderer("json");
+      const handlers = r.handlers();
+      const report: DoctorExtensionsReport = {
+        overallStatus: "pass",
+        registries: {
+          model: passResult("model"),
+          vault: passResult("vault"),
+          driver: passResult("driver"),
+          datastore: passResult("datastore"),
+          report: passResult("report"),
+        },
+        orphanFiles: [
+          {
+            extensionName: "@hivemq/harvester",
+            path: ".swamp/pulled-extensions/@hivemq/harvester/models/orphan.ts",
+          },
+        ],
+      };
+      await handlers.completed({ kind: "completed", report });
+    });
+
+    const parsed = JSON.parse(out);
+    assertEquals(parsed.overallStatus, "pass");
+    assertEquals(parsed.orphanFiles.length, 1);
+    assertEquals(parsed.orphanFiles[0].extensionName, "@hivemq/harvester");
+    assertEquals(
+      parsed.orphanFiles[0].path,
+      ".swamp/pulled-extensions/@hivemq/harvester/models/orphan.ts",
+    );
+  },
+);
+
+Deno.test(
+  "doctor_extensions log renderer: orphans render as warnings, not failures",
+  async () => {
+    const out = await captureStdout(async () => {
+      const r = createDoctorExtensionsRenderer("log");
+      const handlers = r.handlers();
+      const report: DoctorExtensionsReport = {
+        overallStatus: "pass",
+        registries: {
+          model: passResult("model"),
+          vault: passResult("vault"),
+          driver: passResult("driver"),
+          datastore: passResult("datastore"),
+          report: passResult("report"),
+        },
+        orphanFiles: [
+          {
+            extensionName: "@x/y",
+            path: ".swamp/pulled-extensions/@x/y/models/orphan.ts",
+          },
+        ],
+      };
+      // Drive the kind-completed events first so the registry headers
+      // get rendered, then completed.
+      for (
+        const reg of [
+          "model",
+          "vault",
+          "driver",
+          "datastore",
+          "report",
+        ] as const
+      ) {
+        await handlers["kind-completed"]({
+          kind: "kind-completed",
+          result: passResult(reg),
+        });
+      }
+      await handlers.completed({ kind: "completed", report });
+    });
+
+    // Warnings section appears with the orphan path.
+    if (!out.includes("orphan.ts")) {
+      throw new Error(`expected orphan path in output, got: ${out}`);
+    }
+    if (!out.includes("warnings, not failures")) {
+      throw new Error(
+        `expected 'warnings, not failures' framing in output, got: ${out}`,
+      );
+    }
+    // Overall status remains PASS.
+    if (!out.includes("OVERALL: PASS")) {
+      throw new Error(`expected OVERALL: PASS, got: ${out}`);
+    }
+  },
+);

--- a/src/presentation/renderers/extension_install.ts
+++ b/src/presentation/renderers/extension_install.ts
@@ -49,6 +49,19 @@ class LogExtensionInstallRenderer implements Renderer<ExtensionInstallEvent> {
           },
         );
       },
+      "orphans-pruned": (e) => {
+        logger.info(
+          "Removed {count} file(s) no longer in {name}@{version}:",
+          {
+            count: e.paths.length,
+            name: e.name,
+            version: e.version,
+          },
+        );
+        for (const p of e.paths) {
+          logger.info("  {path}", { path: p });
+        }
+      },
       completed: (e) => {
         const { installed, migrated, upToDate, failed } = e.data;
         if (e.data.entries.length === 0) {
@@ -100,6 +113,18 @@ class JsonExtensionInstallRenderer implements Renderer<ExtensionInstallEvent> {
       resolving: () => {},
       installing: () => {},
       migrating: () => {},
+      "orphans-pruned": (e) => {
+        console.log(JSON.stringify(
+          {
+            status: "orphans_pruned",
+            name: e.name,
+            version: e.version,
+            paths: e.paths,
+          },
+          null,
+          2,
+        ));
+      },
       completed: (e) => {
         console.log(JSON.stringify(e.data, null, 2));
       },

--- a/src/presentation/renderers/extension_pull.ts
+++ b/src/presentation/renderers/extension_pull.ts
@@ -197,6 +197,15 @@ class LogExtensionPullRenderer implements ExtensionPullRenderer {
   handlers(): EventHandlers<ExtensionPullEvent> {
     return {
       installing: () => {},
+      "orphans-pruned": (e) => {
+        this.#logger
+          .info`Removed ${
+          String(e.paths.length)
+        } file(s) no longer in ${e.name}@${e.version}:`;
+        for (const p of e.paths) {
+          this.#logger.info`  ${p}`;
+        }
+      },
       completed: (e) => {
         renderInstallResultLog(e.data);
       },
@@ -219,6 +228,18 @@ class JsonExtensionPullRenderer implements ExtensionPullRenderer {
   handlers(): EventHandlers<ExtensionPullEvent> {
     return {
       installing: () => {},
+      "orphans-pruned": (e) => {
+        console.log(JSON.stringify(
+          {
+            status: "orphans_pruned",
+            name: e.name,
+            version: e.version,
+            paths: e.paths,
+          },
+          null,
+          2,
+        ));
+      },
       completed: (e) => {
         renderInstallResultJson(e.data);
       },

--- a/src/presentation/renderers/extension_update.ts
+++ b/src/presentation/renderers/extension_update.ts
@@ -44,6 +44,20 @@ class LogExtensionUpdateRenderer implements Renderer<ExtensionUpdateEvent> {
       updating: (e) => {
         logger.info`Updating ${e.name}: v${e.from} -> v${e.to}`;
       },
+      "orphans-pruned": (e) => {
+        logger.info(
+          "Removed {count} file(s) no longer in {name} (v{from} -> v{to}):",
+          {
+            count: e.paths.length,
+            name: e.name,
+            from: e.from,
+            to: e.to,
+          },
+        );
+        for (const p of e.paths) {
+          logger.info("  {path}", { path: p });
+        }
+      },
       completed: (e) => {
         if (e.mode === "check") {
           renderCheckLog(e.data, logger);
@@ -80,6 +94,21 @@ class JsonExtensionUpdateRenderer implements Renderer<ExtensionUpdateEvent> {
         console.log(
           JSON.stringify(
             { status: "updating", name: e.name, from: e.from, to: e.to },
+            null,
+            2,
+          ),
+        );
+      },
+      "orphans-pruned": (e) => {
+        console.log(
+          JSON.stringify(
+            {
+              status: "orphans_pruned",
+              name: e.name,
+              from: e.from,
+              to: e.to,
+              paths: e.paths,
+            },
             null,
             2,
           ),


### PR DESCRIPTION
## Summary

`swamp extension install`, `pull --force`, and `update` now remove source files, bundle files, and skill directories declared in a prior version's lockfile entry but absent from the current version. Closes #202 and is the root-cause fix for the apparent catalog issue in #201 — orphan source files were being re-indexed by the catalog rebuild, producing duplicate `bundle_types` rows that resolved non-deterministically.

### How

Single fix point in `installExtension()` (`src/libswamp/extensions/pull.ts`) — all three commands funnel through it:

1. **Snapshot** the prior lockfile entry's `files[]` BEFORE extraction.
2. After extraction completes, **diff** the snapshot against the new `extractedFiles[]` via the new exported `computeOrphanDiff` helper.
3. **Prune** the diff via `pruneOrphanFiles` (recursive remove + empty-parent cleanup, tolerates `NotFound`, returns the actually-removed list — ground truth).
4. **Then** write the new lockfile entry. The prune-then-write ordering means a kill mid-prune leaves the lockfile pointing at the OLD version, so the next install retries the diff.

### User transparency

A new `orphans-pruned` event flows through every command stream (pull/install/update) carrying the **actually removed** paths. Both log and json modes render it. Users always see what was removed:

```
Removed 2 file(s) no longer in @hivemq/harvester/kubeconfig@2026.05.01.39:
  .swamp/pulled-extensions/@hivemq/harvester/kubeconfig/models/harvester/fetch_kubeconfig.ts
  .swamp/bundles/738c72f8/harvester/fetch_kubeconfig.js
```

### Doctor

`swamp doctor extensions` gains filesystem orphan detection across every per-extension root the lockfile references — `pulled-extensions/<name>/` and the bundle namespaces (`bundles/`, `vault-bundles/`, `driver-bundles/`, `datastore-bundles/`, `report-bundles/`). A new `extractTopLevelRoot` helper in `layout.ts` derives the roots from each tracked path. Skills are tracked as directory paths only and skipped from the inner-file walk; legacy paths (gen-1/gen-2) are skipped because the extensionInstall migration handles them.

**Important:** orphans render as **warnings**, NOT failures. `overallStatus` is unchanged by orphan presence so existing CI gates that key on `overallStatus === \"fail\"` keep working through the transition. A future release may promote orphans to failure once routine install/pull/update calls have drained pre-existing dirt.

### Type signature refinements

To make the prune list flow through every command path, two test-seam-style types were tightened:

- `InstallExtensionFn` — `Promise<unknown>` → `Promise<InstallResult | undefined>`.
- `ExtensionUpdateDeps.installExtension` — `Promise<void>` → `Promise<InstallResult | undefined>`.
- `extensionInstall` (`install.ts:152`) now captures the `InstallResult` instead of discarding it.
- The CLI wrapper at `extension_update.ts:127` now returns the awaited result.

The TypeScript compiler caught every dependent change automatically.

### Behavior change

Behavior of `extension install/pull/update` changes from \"additive\" (write new files, leave old in place) to \"sync to manifest\" (write new + remove orphan). If a user has hand-edited files inside `.swamp/pulled-extensions/<name>/` or in skill directories managed by an extension, those files will be removed on the next install/pull/update. The new orphans-pruned event surfaces every removal so the change is visible at every interaction surface.

### Bonus fix

`sweepLegacyPaths` had a latent same-family bug: `Deno.remove` without `{ recursive: true }` would fail on a non-empty directory entry (e.g. legacy skill dirs). Fixed.

## Test Plan

- [x] Unit tests for `pruneOrphanFiles` (file removal, recursive directory removal for skill dirs, NotFound tolerance, empty-parent cleanup, ground-truth return value).
- [x] Unit tests for `computeOrphanDiff` (empty inputs, identical sets, the canonical issue-202 transition, all-files-dropped, order stability).
- [x] Unit tests for `extractTopLevelRoot` (per-extension scoped/flat subtrees, every bundle kind, skill paths return null, gen-1/gen-2 return null).
- [x] `extensionInstall` orphans-pruned event firing/non-firing tests via the existing `InstallExtensionFn` seam.
- [x] `extensionUpdate` orphans-pruned event firing/non-firing tests via the now-typed `installExtension` deps.
- [x] `doctorExtensions` orphan detection across per-extension subtrees AND bundle namespaces, plus skill-dir-skipping and missing-lockfile-as-no-op.
- [x] `doctorExtensions` orphans-do-NOT-flip-overallStatus test.
- [x] Doctor renderer warnings-section test (orphans render as warnings, OVERALL: PASS preserved).
- [x] Doctor JSON renderer surfaces `orphanFiles` field.
- [x] Manual end-to-end verification at `/tmp/swamp-repro-issue-202`:
  - Pull `@hivemq/harvester/kubeconfig@2026.04.21.2` → installs `fetch_kubeconfig.ts` + bundle.
  - Pull `@hivemq/harvester/kubeconfig@2026.05.01.39 --force` → emits the orphans-pruned event listing both old paths; on disk only `kubeconfig.ts` and `kubeconfig.js` remain.
  - `swamp doctor extensions` → 5 passed, 0 orphans, OVERALL: PASS.
  - `_extension_catalog.db.bundle_types` has exactly **one** row for harvester (the duplicate-row state from #201 is gone).
- [x] `deno check`, `deno lint`, `deno fmt`, `deno run test` (5116 passed), `deno run compile`.

## Follow-ups

Tracked separately, not in this PR:

- File an issue against `systeminit/swamp` for a process-level install lock — concurrent installs can now race to remove files another process just wrote (worse than today's duplicate-files race).
- File a UAT gap in `systeminit/swamp-uat` (label `cli`) for the version-bump-drops-a-file scenario.
- File a docs issue in `systeminit/swamp-club` if the existing manual at `content/manual/reference/` covers `extension install/pull/update` semantics.

## Risks & non-mitigations

- **Hand-edited files in `pulled-extensions/<name>/` will disappear** on the next install/pull/update. Mitigated by the always-on `orphans-pruned` event in command output, but a fully-automated install that swallows output won't see it. Documented as residual.
- **Verbose output for large prunes** (extension drops 100 files in a refactor → 100 lines). Acceptable for now; address as follow-up if feedback surfaces noise.
- **Concurrent install race** filed as separate follow-up issue (worse failure mode than today's race, but rare and self-correcting).
- **Narrow window**: prune succeeds, lockfile-write fails → user recovers via `pull --force`. Documented in code comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)