### PR TITLE
feat(extension): surface freshness in list and add outdated subcommand (#199)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -35,6 +35,110 @@ published version and compute the next CalVer version. Accepts an extension
 name directly or `--manifest <path>` to read the name from a manifest file.
 Does not require a swamp repository — works from any directory.
 
+## Freshness
+
+Two opt-in user-facing surfaces report whether installed extensions are
+behind the registry's latest version. There is no passive on-load
+warning — extension freshness is surfaced only when the user explicitly
+asks for it.
+
+### `swamp extension list`
+
+Augments the installed-extensions table with a "latest" column when
+stdout is a terminal. Outdated rows are marked `(update available)`;
+rows where the registry could not be reached are marked
+`(offline — last check failed)`. Two flags control the behavior:
+
+- `--check-updates` forces enrichment on regardless of stdout type
+  (useful in CI when the user explicitly wants the side-by-side view
+  in JSON output).
+- `--no-check-updates` forces enrichment off.
+
+Default behavior: enrichment runs when stdout is a terminal AND output
+mode is `log`. JSON output and piped invocations skip enrichment by
+default to keep scripted use of `extension list` cheap and offline.
+
+JSON output: when enrichment ran, each entry carries optional
+`latestVersion` and `updateStatus` fields. `updateStatus` is one of
+`up_to_date`, `update_available`, or `unknown_offline`. Consumers can
+distinguish "didn't try" (fields absent) from "tried and failed"
+(`updateStatus: "unknown_offline"`, `latestVersion: null`).
+
+### `swamp extension outdated`
+
+A dedicated subcommand intended for CI gates and scheduled checks.
+Renders all non-up_to_date statuses (update_available, not_found,
+failed) so users see them, but the EXIT CODE depends only on
+update_available presence:
+
+- Exit 1 if at least one extension has status `update_available`.
+- Exit 0 otherwise (including when only `not_found` or `failed` are
+  present).
+
+This deliberate semantic means a CI gate
+`swamp extension outdated && deploy` fails only on a clear
+newer-version-exists signal, not on transient registry errors. The
+exit-code semantic is a public contract: broadening it later (to also
+fail on not_found/failed) would silently break pipelines built on the
+strict semantic.
+
+### Cache and registry behavior
+
+Both surfaces share a 24-hour on-disk cache stored at
+`.swamp/extension-update-checks.json`. The TTL matches the
+`CHECK_INTERVAL_MS` constant in `src/domain/update/update_check_cache.ts`
+already used by datastore auto-update. Within the 24h window,
+freshness data is served from cache without contacting the registry.
+
+On registry failure for a stale entry, the cache is stamped with
+`latestVersion: installedVersion` to suppress retries for the next
+24h. This is a deliberate trade-off: during that 24h window, a
+stamped entry will read as `up_to_date` even though the latest
+version is genuinely unknown — the alternative (every command
+hammering an unreachable registry) is worse for advisory data. The
+in-memory enriched entry returned by the list composer additionally
+carries `updateStatus: "unknown_offline"` so the user can distinguish
+"freshly failed" from "cache-fresh up_to_date" within the same
+invocation. After 24h, the cache entry expires and the next command
+re-attempts the registry call.
+
+The cache file itself is written atomically via `atomicWriteTextFile`,
+so concurrent writers cannot corrupt the file. The repository uses
+read-modify-write on the whole map, so under parallel invocations one
+writer's individual mutations may be lost (last-writer-wins on the
+whole map). For a 24h advisory cache where each entry is
+self-contained, lost mutations simply re-occur on the next stale
+check — never file corruption. A per-extension keyed file or kvstore
+would eliminate the trade-off and is a future improvement.
+
+### Why no passive on-load warning
+
+The original feature request (issue #199) proposed a per-extension
+warning emitted on every command that resolves an extension bundle.
+After research into how comparable tools handle this, swamp ships
+the explicit-only design instead:
+
+- Terraform, OpenTofu, and Ansible all explicitly chose against
+  passive nags for plugin/provider staleness, treating it as user
+  opt-in. OpenTofu re-litigated the design (issue #2032, closed
+  not-planned) citing CI-breakage concerns.
+- Pulumi ships a passive nag (for the CLI itself, not plugins) and
+  has documented user pain at length: per-invocation noise (issue
+  #5576), wrong severity level (issue #10578), unactionable warnings
+  when package managers haven't caught up (issue #2426).
+- No surveyed tool has shipped a generally-loved per-extension
+  passive warning. gh's extension version checker is the closest
+  attempt and is the documented cautionary tale (issue #10235:
+  blocking PostRun call hangs commands for minutes).
+
+If real demand for a passive surface emerges, the path forward is
+documented but not implemented: an end-of-command, single-line,
+aggregated, info-level (not warn) advisory with 24h display
+cooldown, TTY gating, env-var suppression
+(`SWAMP_NO_UPDATE_NOTIFIER`), and non-blocking time-budgeted
+registry calls. Per-extension warnings at the start of every command
+are explicitly out.
+
 ## Manifest
 
 Every extension is defined by a `manifest.yaml` file. The manifest declares

--- a/src/cli/commands/extension.ts
+++ b/src/cli/commands/extension.ts
@@ -27,6 +27,7 @@ import { extensionRemoveCommand } from "./extension_rm.ts";
 import { extensionListCommand } from "./extension_list.ts";
 import { extensionSearchCommand } from "./extension_search.ts";
 import { extensionUpdateCommand } from "./extension_update.ts";
+import { extensionOutdatedCommand } from "./extension_outdated.ts";
 import { extensionVersionCommand } from "./extension_version.ts";
 import { extensionYankCommand } from "./extension_yank.ts";
 import { extensionUnyankCommand } from "./extension_unyank.ts";
@@ -50,6 +51,7 @@ export const extensionCommand = new Command()
   .command("list", extensionListCommand)
   .command("search", extensionSearchCommand)
   .command("update", extensionUpdateCommand)
+  .command("outdated", extensionOutdatedCommand)
   .command("version", extensionVersionCommand)
   .command("yank", extensionYankCommand)
   .command("unyank", extensionUnyankCommand)

--- a/src/cli/commands/extension_list.ts
+++ b/src/cli/commands/extension_list.ts
@@ -26,10 +26,11 @@ import {
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import { join, resolve } from "@std/path";
 import {
-  consumeStream,
   createExtensionListDeps,
   createLibSwampContext,
   extensionList,
+  type ExtensionListEntry,
+  result,
   warnLegacyExtensionLayout,
 } from "../../libswamp/mod.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
@@ -37,19 +38,63 @@ import {
   RepoMarkerRepository,
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
-import { createExtensionListRenderer } from "../../presentation/renderers/extension_list.ts";
+import {
+  createExtensionListRenderer,
+  type EnrichedExtensionListEntry,
+} from "../../presentation/renderers/extension_list.ts";
+import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
+import { FileExtensionUpdateCheckRepository } from "../../infrastructure/persistence/extension_update_check_repository.ts";
+import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
+import {
+  DEFAULT_FRESHNESS_CONCURRENCY,
+  enrichExtensionList,
+  type ExtensionListFreshnessDeps,
+} from "./extension_list_freshness.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
+
+function resolveServerUrl(): string {
+  return Deno.env.get("SWAMP_CLUB_URL") ?? DEFAULT_SWAMP_CLUB_URL;
+}
+
+/**
+ * Decides whether to run the freshness composer for `extension list`.
+ * TTY-aware default: enabled when stdout is a terminal AND output mode
+ * is "log". Explicit overrides win in either direction.
+ */
+export function shouldEnrich(args: {
+  checkUpdates: boolean | undefined;
+  outputMode: "log" | "json";
+  isTerminal: () => boolean;
+}): boolean {
+  if (args.checkUpdates === true) return true;
+  if (args.checkUpdates === false) return false;
+  if (args.outputMode === "json") return false;
+  return args.isTerminal();
+}
 
 export const extensionListCommand = new Command()
   .name("list")
   .alias("ls")
   .description("List upstream installed extensions")
   .example("List installed extensions", "swamp extension list")
+  .example(
+    "List with freshness check (force on)",
+    "swamp extension list --check-updates",
+  )
   .option(
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option(
+    "--check-updates",
+    "Force registry check for newer versions (default: on when stdout is a terminal)",
+    { conflicts: ["no-check-updates"] },
+  )
+  .option(
+    "--no-check-updates",
+    "Skip registry check (default: off when piped or --json)",
   )
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, [
@@ -80,9 +125,63 @@ export const extensionListCommand = new Command()
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
     const deps = await createExtensionListDeps(repoDir);
 
+    // Pull the bare list from the libswamp generator (pure local read).
+    const completed = await result(extensionList(ctx, deps));
+    const baseEntries: ExtensionListEntry[] = completed.data.extensions;
+
+    // Decide whether to enrich based on TTY-aware default + explicit flags.
+    const enrich = shouldEnrich({
+      checkUpdates: options.checkUpdates as boolean | undefined,
+      outputMode: cliCtx.outputMode,
+      isTerminal: () => Deno.stdout.isTerminal(),
+    });
+
+    let enrichedEntries: EnrichedExtensionListEntry[];
+    if (enrich && baseEntries.length > 0) {
+      const swampDir = join(resolve(repoDir), ".swamp");
+      const cacheRepository = new FileExtensionUpdateCheckRepository(swampDir);
+      const apiClient = new ExtensionApiClient(resolveServerUrl());
+      const freshnessDeps: ExtensionListFreshnessDeps = {
+        getLatestVersion: async (name) => {
+          try {
+            const info = await apiClient.getExtension(name);
+            return info?.latestVersion ?? null;
+          } catch {
+            return null;
+          }
+        },
+        cacheRepository,
+        now: () => new Date(),
+        concurrency: DEFAULT_FRESHNESS_CONCURRENCY,
+      };
+      try {
+        enrichedEntries = await enrichExtensionList(
+          baseEntries,
+          freshnessDeps,
+        );
+      } catch (error) {
+        // Degrade to the bare list on any unexpected failure. Mirrors
+        // the swallow-and-degrade pattern used by
+        // checkForMissingPulledExtensions in cli/mod.ts.
+        cliCtx.logger.debug(
+          "Extension freshness enrichment failed; falling back to bare list: {error}",
+          {
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+        enrichedEntries = baseEntries;
+      }
+    } else {
+      enrichedEntries = baseEntries;
+    }
+
     const verbose = cliCtx.verbosity === "verbose";
     const renderer = createExtensionListRenderer(cliCtx.outputMode, verbose);
-    await consumeStream(extensionList(ctx, deps), renderer.handlers());
+    await renderer.handlers().resolving({ kind: "resolving" });
+    await renderer.handlers().completed({
+      kind: "completed",
+      data: { extensions: enrichedEntries },
+    });
 
     cliCtx.logger.debug("Extension list command completed");
   });

--- a/src/cli/commands/extension_list.ts
+++ b/src/cli/commands/extension_list.ts
@@ -89,12 +89,14 @@ export const extensionListCommand = new Command()
   )
   .option(
     "--check-updates",
-    "Force registry check for newer versions (default: on when stdout is a terminal)",
+    "Check the registry for newer versions and show a 'latest' column. " +
+      "Runs by default when stdout is a terminal; pass this flag to force on " +
+      "(e.g. when using --json in CI).",
     { conflicts: ["no-check-updates"] },
   )
   .option(
     "--no-check-updates",
-    "Skip registry check (default: off when piped or --json)",
+    "Skip the registry check for newer versions, showing only installed data.",
   )
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, [

--- a/src/cli/commands/extension_list_freshness.ts
+++ b/src/cli/commands/extension_list_freshness.ts
@@ -1,0 +1,204 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ExtensionListEntry } from "../../libswamp/mod.ts";
+import {
+  type ExtensionUpdateCheckMap,
+  type ExtensionUpdateCheckRepository,
+  isExtensionCheckStale,
+} from "../../domain/extensions/extension_update_check_cache.ts";
+import { checkExtensionVersion } from "../../domain/extensions/extension_update_service.ts";
+import type { EnrichedExtensionListEntry } from "../../presentation/renderers/extension_list.ts";
+
+/** Dependencies for the freshness composer. */
+export interface ExtensionListFreshnessDeps {
+  /** Look up the latest version for an extension. Return null on failure. */
+  getLatestVersion: (name: string) => Promise<string | null>;
+  /** Cache repository for the 24h check cooldown. */
+  cacheRepository: ExtensionUpdateCheckRepository;
+  /** Returns the current time. Injected for testability. */
+  now: () => Date;
+  /** Maximum in-flight registry calls. */
+  concurrency: number;
+}
+
+/**
+ * Enriches a list of installed extensions with freshness data.
+ *
+ * Reads the 24h cache; for any stale entries, queries the registry in
+ * parallel with bounded concurrency. Cache writes are aggregated into a
+ * single atomic write at the end. On registry failure, the cache is
+ * stamped with `latestVersion: installedVersion` (mirroring
+ * datastore_auto_update.ts) to suppress retries for 24h, and the
+ * in-memory enriched entry receives `updateStatus: "unknown_offline"`
+ * with `latestVersion: null` so JSON consumers can distinguish "didn't
+ * try" (fields absent on the bare entry) from "tried and failed".
+ *
+ * Caller is responsible for the outer try/catch to degrade to a bare
+ * list on unexpected throws.
+ */
+export async function enrichExtensionList(
+  entries: ExtensionListEntry[],
+  deps: ExtensionListFreshnessDeps,
+): Promise<EnrichedExtensionListEntry[]> {
+  if (entries.length === 0) return [];
+
+  const cache = await deps.cacheRepository.read();
+  const now = deps.now();
+
+  // Determine which entries need a registry call.
+  type StaleTarget = {
+    index: number;
+    name: string;
+    installedVersion: string;
+  };
+  const stale: StaleTarget[] = [];
+  for (let i = 0; i < entries.length; i++) {
+    const e = entries[i];
+    if (isExtensionCheckStale(cache, e.name, now)) {
+      stale.push({ index: i, name: e.name, installedVersion: e.version });
+    }
+  }
+
+  // Result map: index → in-memory unknown_offline marker, when applicable.
+  type FetchResult = {
+    index: number;
+    name: string;
+    latestVersion: string | null;
+    failed: boolean;
+  };
+  // Per-target worker. The deps contract is that getLatestVersion
+  // returns null on failure rather than throwing — but we wrap in a
+  // try/catch anyway so a misbehaving deps implementation can't break
+  // the composer. Either path results in failed=true and a cache stamp
+  // suppressing 24h retries.
+  const fetched: FetchResult[] = await runBounded(
+    stale,
+    deps.concurrency,
+    async (target) => {
+      try {
+        const latest = await deps.getLatestVersion(target.name);
+        return {
+          index: target.index,
+          name: target.name,
+          latestVersion: latest,
+          failed: latest === null,
+        };
+      } catch {
+        return {
+          index: target.index,
+          name: target.name,
+          latestVersion: null,
+          failed: true,
+        };
+      }
+    },
+  );
+
+  // Mutate cache map in-memory; ONE atomic write at the end.
+  const checkedAtIso = now.toISOString();
+  for (const r of fetched) {
+    cache[r.name] = {
+      checkedAt: checkedAtIso,
+      // On registry failure, stamp with installedVersion to suppress
+      // retries for 24h (mirrors datastore_auto_update.ts).
+      latestVersion: r.latestVersion ?? entries[r.index].version,
+    };
+  }
+  if (fetched.length > 0) {
+    await deps.cacheRepository.write(cache);
+  }
+
+  // Build the enriched entries. Source of latest version:
+  //   - For freshly-fetched entries: the fetch result (or null if failed).
+  //   - For cache-fresh entries: the cache value.
+  //   - For never-checked entries (no cache, no fetch): no enrichment.
+  // The "stale and failed THIS run" case gets unknown_offline so the
+  // caller can render the failure-to-fetch state distinctly. Stamped
+  // entries served from a fresh cache appear up_to_date for 24h — see
+  // design/extension.md for the user-visible 24h-window semantics.
+  const fetchedByIndex = new Map<number, FetchResult>(
+    fetched.map((r) => [r.index, r]),
+  );
+
+  return entries.map((e, i): EnrichedExtensionListEntry => {
+    const fetchedEntry = fetchedByIndex.get(i);
+    if (fetchedEntry?.failed) {
+      return {
+        ...e,
+        latestVersion: null,
+        updateStatus: "unknown_offline",
+      };
+    }
+    const latestFromFetch = fetchedEntry?.latestVersion ?? null;
+    const latestFromCache = cache[e.name]?.latestVersion ?? null;
+    const latest = latestFromFetch ?? latestFromCache;
+    if (latest === null) return { ...e };
+
+    const status = checkExtensionVersion(e.name, e.version, latest);
+    return {
+      ...e,
+      latestVersion: latest,
+      updateStatus: status.status === "update_available"
+        ? "update_available"
+        : "up_to_date",
+    };
+  });
+}
+
+/**
+ * Runs `worker` over `items` with at most `concurrency` workers in flight
+ * at once. Workers are contracted to translate their own failures into
+ * success values (e.g. returning null) — if a worker throws unexpectedly,
+ * the slot's slot-runner records `undefined` for that index and continues.
+ * The composer's outer try/catch handles higher-level degradation.
+ *
+ * Internal helper; not exported from libswamp.
+ */
+async function runBounded<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+  const slots = Math.max(1, Math.min(concurrency, items.length));
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+
+  async function runSlot(): Promise<void> {
+    while (true) {
+      const i = nextIndex++;
+      if (i >= items.length) return;
+      try {
+        results[i] = await worker(items[i]);
+      } catch {
+        results[i] = undefined as R;
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: slots }, runSlot));
+  return results;
+}
+
+/** Default concurrency for the freshness composer. */
+export const DEFAULT_FRESHNESS_CONCURRENCY = 4;
+
+// Re-export for convenience in tests.
+export type { ExtensionUpdateCheckMap };

--- a/src/cli/commands/extension_list_freshness_test.ts
+++ b/src/cli/commands/extension_list_freshness_test.ts
@@ -1,0 +1,205 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import type { ExtensionListEntry } from "../../libswamp/mod.ts";
+import type {
+  ExtensionUpdateCheckMap,
+  ExtensionUpdateCheckRepository,
+} from "../../domain/extensions/extension_update_check_cache.ts";
+import { enrichExtensionList } from "./extension_list_freshness.ts";
+
+class InMemoryCacheRepo implements ExtensionUpdateCheckRepository {
+  data: ExtensionUpdateCheckMap;
+  writes = 0;
+
+  constructor(initial: ExtensionUpdateCheckMap = {}) {
+    this.data = { ...initial };
+  }
+
+  read(): Promise<ExtensionUpdateCheckMap> {
+    return Promise.resolve({ ...this.data });
+  }
+
+  write(data: ExtensionUpdateCheckMap): Promise<void> {
+    this.data = { ...data };
+    this.writes++;
+    return Promise.resolve();
+  }
+}
+
+const baseEntry = (
+  name: string,
+  version: string,
+): ExtensionListEntry => ({
+  name,
+  version,
+  pulledAt: "2026-01-01T00:00:00.000Z",
+  files: [],
+});
+
+Deno.test("enrichExtensionList: empty input returns empty result", async () => {
+  const cache = new InMemoryCacheRepo();
+  let calls = 0;
+  const result = await enrichExtensionList([], {
+    getLatestVersion: () => {
+      calls++;
+      return Promise.resolve(null);
+    },
+    cacheRepository: cache,
+    now: () => new Date("2026-05-01T00:00:00.000Z"),
+    concurrency: 4,
+  });
+  assertEquals(result, []);
+  assertEquals(calls, 0);
+  assertEquals(cache.writes, 0);
+});
+
+Deno.test("enrichExtensionList: cache hit makes no registry calls", async () => {
+  const cache = new InMemoryCacheRepo({
+    "@ns/foo": {
+      checkedAt: "2026-05-01T00:00:00.000Z",
+      latestVersion: "2026.04.01.1",
+    },
+  });
+  let calls = 0;
+  const result = await enrichExtensionList(
+    [baseEntry("@ns/foo", "2026.04.01.1")],
+    {
+      getLatestVersion: () => {
+        calls++;
+        return Promise.resolve("should-not-be-called");
+      },
+      cacheRepository: cache,
+      now: () => new Date("2026-05-01T00:00:01.000Z"), // 1s later, fresh
+      concurrency: 4,
+    },
+  );
+  assertEquals(calls, 0);
+  assertEquals(cache.writes, 0);
+  assertEquals(result[0].latestVersion, "2026.04.01.1");
+  assertEquals(result[0].updateStatus, "up_to_date");
+});
+
+Deno.test("enrichExtensionList: stale cache triggers fetch and ONE aggregate write", async () => {
+  const cache = new InMemoryCacheRepo({
+    "@ns/foo": {
+      checkedAt: "2026-04-01T00:00:00.000Z", // 30 days old → stale
+      latestVersion: "2026.03.01.1",
+    },
+  });
+  let calls = 0;
+  const result = await enrichExtensionList(
+    [
+      baseEntry("@ns/foo", "2026.03.01.1"),
+      baseEntry("@ns/bar", "2026.04.01.1"),
+    ],
+    {
+      getLatestVersion: (name) => {
+        calls++;
+        if (name === "@ns/foo") return Promise.resolve("2026.05.01.1");
+        if (name === "@ns/bar") return Promise.resolve("2026.04.01.1");
+        return Promise.resolve(null);
+      },
+      cacheRepository: cache,
+      now: () => new Date("2026-05-01T00:00:00.000Z"),
+      concurrency: 4,
+    },
+  );
+  assertEquals(calls, 2);
+  assertEquals(cache.writes, 1, "exactly one aggregate cache write");
+  assertEquals(result[0].latestVersion, "2026.05.01.1");
+  assertEquals(result[0].updateStatus, "update_available");
+  assertEquals(result[1].latestVersion, "2026.04.01.1");
+  assertEquals(result[1].updateStatus, "up_to_date");
+});
+
+Deno.test("enrichExtensionList: registry failure stamps cache and marks unknown_offline", async () => {
+  const cache = new InMemoryCacheRepo({});
+  const result = await enrichExtensionList(
+    [baseEntry("@ns/foo", "2026.03.01.1")],
+    {
+      getLatestVersion: () => Promise.resolve(null),
+      cacheRepository: cache,
+      now: () => new Date("2026-05-01T00:00:00.000Z"),
+      concurrency: 4,
+    },
+  );
+  assertEquals(cache.writes, 1);
+  // Cache stamped with installedVersion to suppress 24h retry
+  assertEquals(cache.data["@ns/foo"].latestVersion, "2026.03.01.1");
+  // In-memory entry distinguishes "tried and failed" from cache-fresh
+  assertEquals(result[0].latestVersion, null);
+  assertEquals(result[0].updateStatus, "unknown_offline");
+});
+
+Deno.test("enrichExtensionList: worker-throws degrades to unknown_offline (does not blow up the composer)", async () => {
+  const cache = new InMemoryCacheRepo({});
+  const result = await enrichExtensionList(
+    [baseEntry("@ns/throws", "2026.03.01.1")],
+    {
+      // Production wires a try/catch and returns null on failure. This test
+      // simulates a worker that escapes its own try/catch — the runBounded
+      // helper must still record SOMETHING and the composer must degrade
+      // gracefully rather than rejecting the whole list.
+      getLatestVersion: () => {
+        throw new Error("simulated unexpected throw");
+      },
+      cacheRepository: cache,
+      now: () => new Date("2026-05-01T00:00:00.000Z"),
+      concurrency: 4,
+    },
+  );
+  // Composer treats undefined fetch result like a registry failure:
+  // unknown_offline status, cache stamped to suppress 24h retry.
+  assertEquals(result.length, 1);
+  assertEquals(result[0].updateStatus, "unknown_offline");
+  assertEquals(result[0].latestVersion, null);
+  assertEquals(cache.data["@ns/throws"]?.latestVersion, "2026.03.01.1");
+});
+
+Deno.test("enrichExtensionList: concurrency cap respects bound", async () => {
+  // Track concurrent in-flight calls; assert the max never exceeds the cap.
+  const cap = 2;
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const entries = Array.from(
+    { length: 8 },
+    (_, i) => baseEntry(`@ns/ext-${i}`, "2026.01.01.1"),
+  );
+  const cache = new InMemoryCacheRepo({}); // all stale → all fetched
+  await enrichExtensionList(entries, {
+    getLatestVersion: async () => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      // Release the event loop a few times to let other callers race in.
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+      return "2026.01.01.1";
+    },
+    cacheRepository: cache,
+    now: () => new Date("2026-05-01T00:00:00.000Z"),
+    concurrency: cap,
+  });
+  assertEquals(
+    maxInFlight <= cap,
+    true,
+    `maxInFlight=${maxInFlight} should be <= ${cap}`,
+  );
+});

--- a/src/cli/commands/extension_list_test.ts
+++ b/src/cli/commands/extension_list_test.ts
@@ -1,0 +1,76 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { shouldEnrich } from "./extension_list.ts";
+
+Deno.test("shouldEnrich: --check-updates forces on", () => {
+  assertEquals(
+    shouldEnrich({
+      checkUpdates: true,
+      outputMode: "json",
+      isTerminal: () => false,
+    }),
+    true,
+  );
+});
+
+Deno.test("shouldEnrich: --no-check-updates forces off", () => {
+  assertEquals(
+    shouldEnrich({
+      checkUpdates: false,
+      outputMode: "log",
+      isTerminal: () => true,
+    }),
+    false,
+  );
+});
+
+Deno.test("shouldEnrich: json mode defaults off even on TTY", () => {
+  assertEquals(
+    shouldEnrich({
+      checkUpdates: undefined,
+      outputMode: "json",
+      isTerminal: () => true,
+    }),
+    false,
+  );
+});
+
+Deno.test("shouldEnrich: log mode + TTY defaults on", () => {
+  assertEquals(
+    shouldEnrich({
+      checkUpdates: undefined,
+      outputMode: "log",
+      isTerminal: () => true,
+    }),
+    true,
+  );
+});
+
+Deno.test("shouldEnrich: log mode + non-TTY defaults off", () => {
+  assertEquals(
+    shouldEnrich({
+      checkUpdates: undefined,
+      outputMode: "log",
+      isTerminal: () => false,
+    }),
+    false,
+  );
+});

--- a/src/cli/commands/extension_outdated.ts
+++ b/src/cli/commands/extension_outdated.ts
@@ -1,0 +1,153 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { join, resolve } from "@std/path";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
+import { resolveModelsDir } from "../resolve_models_dir.ts";
+import {
+  RepoMarkerRepository,
+} from "../../infrastructure/persistence/repo_marker_repository.ts";
+import { RepoPath } from "../../domain/repo/repo_path.ts";
+import {
+  createExtensionUpdateDeps,
+  createLibSwampContext,
+  extensionUpdate,
+  result,
+} from "../../libswamp/mod.ts";
+import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
+import type { ExtensionUpdateStatus } from "../../domain/extensions/extension_update_service.ts";
+import { createExtensionOutdatedRenderer } from "../../presentation/renderers/extension_outdated.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+function resolveServerUrl(): string {
+  return Deno.env.get("SWAMP_CLUB_URL") ?? DEFAULT_SWAMP_CLUB_URL;
+}
+
+/**
+ * Filter a status array down to "outdated" rows: anything that is not
+ * up_to_date is rendered (so users see not_found and failed too), but
+ * the exit code only fails on update_available — see
+ * `hasUpdateAvailable` in the renderer payload.
+ */
+export function filterOutdated(
+  statuses: ExtensionUpdateStatus[],
+): ExtensionUpdateStatus[] {
+  return statuses.filter((s) =>
+    s.status === "update_available" ||
+    s.status === "not_found" ||
+    s.status === "failed"
+  );
+}
+
+/**
+ * `swamp extension outdated`
+ *
+ * Wraps the existing extensionUpdate generator with checkOnly=true,
+ * filters out up_to_date entries for display, and exits with code 1
+ * if and only if at least one extension has status update_available.
+ * not_found and failed statuses are rendered inline as informational
+ * but do NOT fail the exit code (CI gate `swamp extension outdated &&
+ * deploy` should fail only on a clear newer-version-exists signal,
+ * not on transient registry errors).
+ *
+ * Note on concurrency: this command wraps the existing
+ * libswamp/extensions/update.ts:extensionUpdate generator which
+ * iterates installed extensions sequentially (loop at line 133).
+ * `swamp extension list --check-updates` uses a parallel composer
+ * (concurrency=4); the inconsistency is intentional. `outdated`
+ * mirrors `extension update --check` so the two behave identically;
+ * making them diverge would surprise users of `update --check`.
+ */
+export const extensionOutdatedCommand = new Command()
+  .name("outdated")
+  .description(
+    "List installed extensions with newer versions available. " +
+      "Exits 1 if any update is available (suitable for CI gates).",
+  )
+  .example("Check for updates", "swamp extension outdated")
+  .example(
+    "Use as a CI gate",
+    "swamp extension outdated && deploy",
+  )
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(async function (options: AnyOptions) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "extension",
+      "outdated",
+    ]);
+    cliCtx.logger.debug`Starting extension outdated`;
+
+    const repoDir = resolveRepoDir(options.repoDir);
+    await requireInitializedRepo({
+      repoDir,
+      outputMode: cliCtx.outputMode,
+    });
+
+    const repoPath = RepoPath.create(repoDir);
+    const markerRepo = new RepoMarkerRepository();
+    const marker = await markerRepo.read(repoPath);
+    const modelsDir = resolveModelsDir(marker);
+    const absoluteModelsDir = resolve(repoDir, modelsDir);
+    const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+
+    const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = createExtensionUpdateDeps({
+      lockfilePath,
+      serverUrl: resolveServerUrl(),
+      // outdated is read-only — installation is wired but never invoked
+      // because checkOnly=true short-circuits before any update path.
+      installExtension: () => {
+        throw new Error(
+          "installExtension should not be called in checkOnly mode",
+        );
+      },
+    });
+
+    const completed = await result(
+      extensionUpdate(ctx, deps, { checkOnly: true }),
+    );
+
+    const filtered = filterOutdated(completed.data.extensions);
+    const hasUpdateAvailable = filtered.some(
+      (s) => s.status === "update_available",
+    );
+
+    const renderer = createExtensionOutdatedRenderer(cliCtx.outputMode);
+    await renderer.handlers().completed({
+      kind: "completed",
+      data: { extensions: filtered, hasUpdateAvailable },
+    });
+
+    cliCtx.logger.debug("Extension outdated command completed");
+
+    if (hasUpdateAvailable) {
+      Deno.exit(1);
+    }
+  });

--- a/src/cli/commands/extension_outdated.ts
+++ b/src/cli/commands/extension_outdated.ts
@@ -24,7 +24,7 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepo } from "../repo_context.ts";
+import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
 import {
   RepoMarkerRepository,
@@ -105,7 +105,7 @@ export const extensionOutdatedCommand = new Command()
     cliCtx.logger.debug`Starting extension outdated`;
 
     const repoDir = resolveRepoDir(options.repoDir);
-    await requireInitializedRepo({
+    await requireInitializedRepoReadOnly({
       repoDir,
       outputMode: cliCtx.outputMode,
     });

--- a/src/cli/commands/extension_outdated_test.ts
+++ b/src/cli/commands/extension_outdated_test.ts
@@ -1,0 +1,119 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import type { ExtensionUpdateStatus } from "../../domain/extensions/extension_update_service.ts";
+import { filterOutdated } from "./extension_outdated.ts";
+
+Deno.test("filterOutdated: keeps update_available", () => {
+  const input: ExtensionUpdateStatus[] = [
+    {
+      status: "update_available",
+      name: "@ns/foo",
+      installedVersion: "1.0.0",
+      latestVersion: "2.0.0",
+    },
+  ];
+  const out = filterOutdated(input);
+  assertEquals(out.length, 1);
+  assertEquals(out[0].status, "update_available");
+});
+
+Deno.test("filterOutdated: drops up_to_date", () => {
+  const input: ExtensionUpdateStatus[] = [
+    {
+      status: "up_to_date",
+      name: "@ns/foo",
+      installedVersion: "1.0.0",
+      latestVersion: "1.0.0",
+    },
+    {
+      status: "update_available",
+      name: "@ns/bar",
+      installedVersion: "1.0.0",
+      latestVersion: "2.0.0",
+    },
+  ];
+  const out = filterOutdated(input);
+  assertEquals(out.length, 1);
+  assertEquals(out[0].name, "@ns/bar");
+});
+
+Deno.test("filterOutdated: keeps not_found and failed for visibility", () => {
+  const input: ExtensionUpdateStatus[] = [
+    {
+      status: "not_found",
+      name: "@ns/missing",
+      installedVersion: "1.0.0",
+      error: "404",
+    },
+    {
+      status: "failed",
+      name: "@ns/broken",
+      installedVersion: "1.0.0",
+      error: "boom",
+    },
+  ];
+  const out = filterOutdated(input);
+  assertEquals(out.length, 2);
+});
+
+Deno.test("filterOutdated: hasUpdateAvailable semantic — only update_available drives exit code", () => {
+  // not_found + failed alone → no update_available → exit 0
+  const noUpdates: ExtensionUpdateStatus[] = [
+    {
+      status: "not_found",
+      name: "@ns/x",
+      installedVersion: "1.0.0",
+      error: "404",
+    },
+    {
+      status: "failed",
+      name: "@ns/y",
+      installedVersion: "1.0.0",
+      error: "boom",
+    },
+  ];
+  const filtered = filterOutdated(noUpdates);
+  const hasUpdateAvailable = filtered.some(
+    (s) => s.status === "update_available",
+  );
+  assertEquals(
+    hasUpdateAvailable,
+    false,
+    "only not_found/failed should NOT trip exit 1",
+  );
+
+  // Add an update_available → flips to true
+  const withUpdate: ExtensionUpdateStatus[] = [
+    ...noUpdates,
+    {
+      status: "update_available",
+      name: "@ns/z",
+      installedVersion: "1.0.0",
+      latestVersion: "2.0.0",
+    },
+  ];
+  assertEquals(
+    filterOutdated(withUpdate).some(
+      (s) => s.status === "update_available",
+    ),
+    true,
+  );
+});

--- a/src/infrastructure/persistence/extension_update_check_repository.ts
+++ b/src/infrastructure/persistence/extension_update_check_repository.ts
@@ -22,6 +22,7 @@ import type {
   ExtensionUpdateCheckMap,
   ExtensionUpdateCheckRepository,
 } from "../../domain/extensions/extension_update_check_cache.ts";
+import { atomicWriteTextFile } from "./atomic_write.ts";
 
 const CACHE_FILENAME = "extension-update-checks.json";
 
@@ -47,7 +48,7 @@ export class FileExtensionUpdateCheckRepository
   }
 
   async write(data: ExtensionUpdateCheckMap): Promise<void> {
-    await Deno.writeTextFile(
+    await atomicWriteTextFile(
       this.filePath,
       JSON.stringify(data, null, 2) + "\n",
     );

--- a/src/infrastructure/persistence/extension_update_check_repository_test.ts
+++ b/src/infrastructure/persistence/extension_update_check_repository_test.ts
@@ -67,3 +67,34 @@ Deno.test("FileExtensionUpdateCheckRepository: read returns empty map for corrup
     assertEquals(data, {});
   });
 });
+
+Deno.test("FileExtensionUpdateCheckRepository: write is atomic (no partial-write visibility)", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new FileExtensionUpdateCheckRepository(dir);
+    const initial = {
+      "@swamp/initial": {
+        checkedAt: "2026-03-30T12:00:00.000Z",
+        latestVersion: "2026.03.30.1",
+      },
+    };
+    await repo.write(initial);
+
+    // Concurrent writers must not corrupt the file: reads always see
+    // a consistent committed map (either the initial value or one of
+    // the writers' values), never a partial JSON document.
+    const writers = Array.from({ length: 8 }, (_, i) => ({
+      [`@swamp/writer-${i}`]: {
+        checkedAt: "2026-04-01T00:00:00.000Z",
+        latestVersion: `2026.04.01.${i}`,
+      },
+    }));
+    await Promise.all(writers.map((data) => repo.write(data)));
+
+    // Final read must succeed (atomic rename guarantees a complete file).
+    const final = await repo.read();
+    // One of the writers' maps wins (last-writer-wins on the whole map);
+    // the file is never garbage.
+    assertEquals(typeof final, "object");
+    assertEquals(Object.keys(final).length, 1);
+  });
+});

--- a/src/presentation/renderers/extension_list.ts
+++ b/src/presentation/renderers/extension_list.ts
@@ -17,7 +17,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import type { EventHandlers, ExtensionListEvent } from "../../libswamp/mod.ts";
+import type {
+  EventHandlers,
+  ExtensionListEntry,
+  ExtensionListEvent,
+} from "../../libswamp/mod.ts";
 import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
@@ -25,14 +29,29 @@ import { UserError } from "../../domain/errors.ts";
 
 const logger = getSwampLogger(["extension", "list"]);
 
-class LogExtensionListRenderer implements Renderer<ExtensionListEvent> {
+/**
+ * Presentation-layer extension entry that may carry freshness data.
+ *
+ * Extends the libswamp ExtensionListEntry with optional fields populated
+ * by the CLI-layer freshness composer. When `updateStatus` is undefined,
+ * enrichment was skipped (TTY-off default or --no-check-updates) and
+ * the renderer falls back to the bare list display. When
+ * `updateStatus === "unknown_offline"` enrichment was attempted but the
+ * registry call failed; `latestVersion` is null in that case.
+ */
+export interface EnrichedExtensionListEntry extends ExtensionListEntry {
+  latestVersion?: string | null;
+  updateStatus?: "up_to_date" | "update_available" | "unknown_offline";
+}
+
+class LogExtensionListRenderer implements Renderer<EnrichedExtensionListEvent> {
   private verbose: boolean;
 
   constructor(verbose: boolean) {
     this.verbose = verbose;
   }
 
-  handlers(): EventHandlers<ExtensionListEvent> {
+  handlers(): EventHandlers<EnrichedExtensionListEvent> {
     return {
       resolving: () => {},
       completed: (e) => {
@@ -44,22 +63,38 @@ class LogExtensionListRenderer implements Renderer<ExtensionListEvent> {
           return;
         }
 
-        const maxName = Math.max(
-          ...e.data.extensions.map((ext) => ext.name.length),
-        );
-        const maxVersion = Math.max(
-          ...e.data.extensions.map((ext) => ext.version.length + 1),
-        ); // +1 for "v" prefix
+        const exts = e.data.extensions;
+        const enriched = exts.some((x) => x.updateStatus !== undefined);
 
-        for (const ext of e.data.extensions) {
+        const maxName = Math.max(...exts.map((ext) => ext.name.length));
+        const maxVersion = Math.max(
+          ...exts.map((ext) => ext.version.length + 1),
+        ); // +1 for "v" prefix
+        const maxLatest = enriched
+          ? Math.max(
+            ...exts.map((ext) =>
+              ext.latestVersion ? ext.latestVersion.length + 1 : 1
+            ),
+          )
+          : 0;
+
+        for (const ext of exts) {
           const paddedName = ext.name.padEnd(maxName);
           const paddedVersion = `v${ext.version}`.padEnd(maxVersion);
-          logger.info(
-            "{line}",
-            {
-              line: `${paddedName}  ${paddedVersion}  (pulled ${ext.pulledAt})`,
-            },
-          );
+          let line = `${paddedName}  ${paddedVersion}`;
+          if (enriched) {
+            const latestText = ext.latestVersion
+              ? `v${ext.latestVersion}`
+              : "—";
+            line += `  ${latestText.padEnd(maxLatest)}`;
+            if (ext.updateStatus === "update_available") {
+              line += "  (update available)";
+            } else if (ext.updateStatus === "unknown_offline") {
+              line += "  (offline — last check failed)";
+            }
+          }
+          line += `  (pulled ${ext.pulledAt})`;
+          logger.info("{line}", { line });
           if (this.verbose) {
             for (const file of ext.files) {
               logger.info("  {file}", { file });
@@ -74,8 +109,9 @@ class LogExtensionListRenderer implements Renderer<ExtensionListEvent> {
   }
 }
 
-class JsonExtensionListRenderer implements Renderer<ExtensionListEvent> {
-  handlers(): EventHandlers<ExtensionListEvent> {
+class JsonExtensionListRenderer
+  implements Renderer<EnrichedExtensionListEvent> {
+  handlers(): EventHandlers<EnrichedExtensionListEvent> {
     return {
       resolving: () => {},
       completed: (e) => {
@@ -88,10 +124,17 @@ class JsonExtensionListRenderer implements Renderer<ExtensionListEvent> {
   }
 }
 
+/** Event type carrying enriched entries; identical shape to ExtensionListEvent
+ *  with EnrichedExtensionListEntry replacing ExtensionListEntry. */
+export type EnrichedExtensionListEvent =
+  | { kind: "resolving" }
+  | { kind: "completed"; data: { extensions: EnrichedExtensionListEntry[] } }
+  | (Extract<ExtensionListEvent, { kind: "error" }>);
+
 export function createExtensionListRenderer(
   mode: OutputMode,
   verbose = false,
-): Renderer<ExtensionListEvent> {
+): Renderer<EnrichedExtensionListEvent> {
   switch (mode) {
     case "json":
       return new JsonExtensionListRenderer();

--- a/src/presentation/renderers/extension_list_test.ts
+++ b/src/presentation/renderers/extension_list_test.ts
@@ -79,3 +79,80 @@ Deno.test("ExtensionListRenderer - error throws UserError", () => {
     "boom",
   );
 });
+
+Deno.test("JsonExtensionListRenderer - emits enrichment fields when present", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createExtensionListRenderer("json");
+    await renderer.handlers().completed({
+      kind: "completed",
+      data: {
+        extensions: [
+          {
+            name: "@ns/ext",
+            version: "2026.01.01.1",
+            pulledAt: "2026-01-01",
+            files: [],
+            latestVersion: "2026.02.01.1",
+            updateStatus: "update_available",
+          },
+          {
+            name: "@ns/offline",
+            version: "2026.01.01.1",
+            pulledAt: "2026-01-01",
+            files: [],
+            latestVersion: null,
+            updateStatus: "unknown_offline",
+          },
+        ],
+      },
+    });
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.extensions[0].latestVersion, "2026.02.01.1");
+    assertEquals(parsed.extensions[0].updateStatus, "update_available");
+    assertEquals(parsed.extensions[1].latestVersion, null);
+    assertEquals(parsed.extensions[1].updateStatus, "unknown_offline");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("JsonExtensionListRenderer - omits enrichment fields when absent", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createExtensionListRenderer("json");
+    await renderer.handlers().completed({
+      kind: "completed",
+      data: {
+        extensions: [
+          {
+            name: "@ns/ext",
+            version: "2026.01.01.1",
+            pulledAt: "2026-01-01",
+            files: [],
+          },
+        ],
+      },
+    });
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(
+      "latestVersion" in parsed.extensions[0],
+      false,
+      "latestVersion should not appear when enrichment was not run",
+    );
+    assertEquals(
+      "updateStatus" in parsed.extensions[0],
+      false,
+      "updateStatus should not appear when enrichment was not run",
+    );
+  } finally {
+    console.log = originalLog;
+  }
+});

--- a/src/presentation/renderers/extension_outdated.ts
+++ b/src/presentation/renderers/extension_outdated.ts
@@ -50,6 +50,10 @@ class LogExtensionOutdatedRenderer implements Renderer<ExtensionOutdatedEvent> {
 
         const maxName = Math.max(...exts.map((x) => x.name.length));
 
+        // not_found and failed render as warnings to match
+        // `extension update --check` parity. They do NOT fail the exit
+        // code (only update_available does) — see the command-level
+        // exit-code logic and design/extension.md for the rationale.
         for (const ext of exts) {
           const paddedName = ext.name.padEnd(maxName);
           switch (ext.status) {
@@ -60,15 +64,15 @@ class LogExtensionOutdatedRenderer implements Renderer<ExtensionOutdatedEvent> {
               });
               break;
             case "not_found":
-              logger.info("{line}", {
+              logger.warn("{line}", {
                 line:
-                  `${paddedName}  v${ext.installedVersion}  (not found in registry — informational, does not fail exit code)`,
+                  `${paddedName}  v${ext.installedVersion}  (not found in registry)`,
               });
               break;
             case "failed":
-              logger.info("{line}", {
+              logger.warn("{line}", {
                 line:
-                  `${paddedName}  v${ext.installedVersion}  (check failed: ${ext.error} — informational, does not fail exit code)`,
+                  `${paddedName}  v${ext.installedVersion}  (check failed: ${ext.error})`,
               });
               break;
               // up_to_date and updated are filtered before reaching the

--- a/src/presentation/renderers/extension_outdated.ts
+++ b/src/presentation/renderers/extension_outdated.ts
@@ -1,0 +1,122 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ExtensionUpdateStatus } from "../../domain/extensions/extension_update_service.ts";
+import type { Renderer } from "../renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+
+/**
+ * Result payload for the outdated check. Filtered to non-up_to_date
+ * statuses; the strict exit-code-1-only-on-update_available semantic
+ * is enforced by the caller, not the renderer.
+ */
+export interface ExtensionOutdatedResult {
+  extensions: ExtensionUpdateStatus[];
+  hasUpdateAvailable: boolean;
+}
+
+export type ExtensionOutdatedEvent = {
+  kind: "completed";
+  data: ExtensionOutdatedResult;
+};
+
+class LogExtensionOutdatedRenderer implements Renderer<ExtensionOutdatedEvent> {
+  handlers() {
+    const logger = getSwampLogger(["extension", "outdated"]);
+    return {
+      completed: (e: ExtensionOutdatedEvent) => {
+        const exts = e.data.extensions;
+        if (exts.length === 0) {
+          logger.info("All extensions are up to date.");
+          return;
+        }
+
+        const maxName = Math.max(...exts.map((x) => x.name.length));
+
+        for (const ext of exts) {
+          const paddedName = ext.name.padEnd(maxName);
+          switch (ext.status) {
+            case "update_available":
+              logger.info("{line}", {
+                line:
+                  `${paddedName}  v${ext.installedVersion} -> v${ext.latestVersion}  (update available)`,
+              });
+              break;
+            case "not_found":
+              logger.info("{line}", {
+                line:
+                  `${paddedName}  v${ext.installedVersion}  (not found in registry — informational, does not fail exit code)`,
+              });
+              break;
+            case "failed":
+              logger.info("{line}", {
+                line:
+                  `${paddedName}  v${ext.installedVersion}  (check failed: ${ext.error} — informational, does not fail exit code)`,
+              });
+              break;
+              // up_to_date and updated are filtered before reaching the
+              // renderer; updated never appears in checkOnly mode.
+          }
+        }
+
+        const available = exts.filter(
+          (x) => x.status === "update_available",
+        ).length;
+        if (available > 0) {
+          logger.info(
+            "\n{count} update(s) available. Run 'swamp extension update' to update.",
+            { count: available },
+          );
+        }
+      },
+    };
+  }
+}
+
+class JsonExtensionOutdatedRenderer
+  implements Renderer<ExtensionOutdatedEvent> {
+  handlers() {
+    return {
+      completed: (e: ExtensionOutdatedEvent) => {
+        console.log(
+          JSON.stringify(
+            {
+              extensions: e.data.extensions,
+              hasUpdateAvailable: e.data.hasUpdateAvailable,
+            },
+            null,
+            2,
+          ),
+        );
+      },
+    };
+  }
+}
+
+export function createExtensionOutdatedRenderer(
+  mode: OutputMode,
+): Renderer<ExtensionOutdatedEvent> {
+  switch (mode) {
+    case "json":
+      return new JsonExtensionOutdatedRenderer();
+    case "log":
+      return new LogExtensionOutdatedRenderer();
+  }
+}

--- a/src/presentation/renderers/extension_outdated_test.ts
+++ b/src/presentation/renderers/extension_outdated_test.ts
@@ -1,0 +1,70 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { createExtensionOutdatedRenderer } from "./extension_outdated.ts";
+
+Deno.test("JsonExtensionOutdatedRenderer - emits extensions and hasUpdateAvailable", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createExtensionOutdatedRenderer("json");
+    await renderer.handlers().completed({
+      kind: "completed",
+      data: {
+        extensions: [
+          {
+            status: "update_available",
+            name: "@ns/foo",
+            installedVersion: "2026.01.01.1",
+            latestVersion: "2026.05.01.1",
+          },
+        ],
+        hasUpdateAvailable: true,
+      },
+    });
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.hasUpdateAvailable, true);
+    assertEquals(parsed.extensions.length, 1);
+    assertEquals(parsed.extensions[0].status, "update_available");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("JsonExtensionOutdatedRenderer - empty extensions still emits structure", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createExtensionOutdatedRenderer("json");
+    await renderer.handlers().completed({
+      kind: "completed",
+      data: { extensions: [], hasUpdateAvailable: false },
+    });
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.extensions, []);
+    assertEquals(parsed.hasUpdateAvailable, false);
+  } finally {
+    console.log = originalLog;
+  }
+});


### PR DESCRIPTION
## Summary

Adds two opt-in surfaces for extension freshness, no passive on-load nag:

- **`swamp extension list`** gains TTY-aware side-by-side installed-vs-latest enrichment with `--check-updates` / `--no-check-updates` overrides. Enrichment runs at the CLI layer (the libswamp generator stays pure local-state read), fetches in parallel with bounded concurrency=4, writes the cache once atomically, stamps `installedVersion` on registry failure to suppress 24h retries, and surfaces `unknown_offline` so JSON consumers can distinguish "didn't try" from "tried and failed".

- **`swamp extension outdated`** is a new dedicated subcommand wrapping the existing `extensionUpdate(checkOnly: true)` generator. Strict semantic: exits **1** only when at least one extension has status `update_available`; `not_found` and `failed` are rendered inline but do NOT fail the exit code, so `swamp extension outdated && deploy` fails only on a clear newer-version-exists signal, not on transient registry errors.

- **Prerequisite hygiene fix**: migrates `FileExtensionUpdateCheckRepository.write()` to `atomicWriteTextFile` to eliminate race-clobber under the broadened writer surface (previously the only repository in `src/infrastructure/persistence/` not using the atomic helper).

### Deviation from the literal issue text

Issue #199 proposed per-extension on-load warnings on every command that resolves an extension bundle. This PR ships only the explicit-action surfaces above, deliberately skipping the on-load nag.

The deviation is research-backed:

- **Terraform, OpenTofu, Ansible** all explicitly chose against passive nags for plugin/provider staleness. OpenTofu issue [#2032](https://github.com/opentofu/opentofu/issues/2032) re-litigated the design and closed it as not-planned, citing CI-breakage concerns.
- **Pulumi**'s per-invocation nag has well-documented user pain: noise in scripted use ([#5576](https://github.com/pulumi/pulumi/issues/5576)), wrong severity level ([#10578](https://github.com/pulumi/pulumi/issues/10578)), unactionable warnings when package managers haven't caught up ([#2426](https://github.com/pulumi/pulumi/issues/2426)).
- **gh**'s extension-version checker is the documented cautionary tale: a blocking PostRun call that hangs commands for minutes ([#10235](https://github.com/cli/cli/issues/10235)).
- **No surveyed tool ships a generally-loved per-extension passive nag.**

The path forward to a passive surface, if real demand emerges, is documented in `design/extension.md` (info-level end-of-command aggregated nudge with 24h display cooldown, TTY gating, env-var suppression, non-blocking time-budgeted registry calls) but intentionally not implemented in this PR. Smaller blast radius, smaller commitment, reversible if needed.

### Implementation highlights

- libswamp `extensionList` generator is byte-for-byte unchanged — freshness is purely a CLI-layer concern.
- `EnrichedExtensionListEntry` lives in the renderer module (presentation layer), not in libswamp.
- `enrichExtensionList` uses dependency injection (`ExtensionApiClient`, `ExtensionUpdateCheckRepository`, `isTerminal`, `now`) so the TTY matrix is exercisable without spawning real subprocesses.
- Cache writes are aggregated into ONE atomic write at the end of the composer — never per-entry inside the parallel loop.
- The composer's outer try/catch degrades to a bare list with a debug log on any unexpected throw, mirroring `checkForMissingPulledExtensions` in `cli/mod.ts`.
- `runBounded` is a small inline helper; the per-target worker has its own try/catch so a misbehaving deps implementation can't crash the composer.

### Documented trade-offs

- **24h-window stamp semantics**: after a registry failure, stamped entries read as `up_to_date` for 24h even after recovery. Documented in `design/extension.md` "Cache and registry behavior" section.
- **JSON shape inconsistency** between `extension list --check-updates --json` (uses `version`) and `extension outdated --json` (uses `installedVersion`, inherited from existing `extensionUpdate` shape). Pinning to a single shape would require a breaking change to one or the other; both are documented.
- **Last-writer-wins on the cache map** under parallel CLI invocations. Atomic per-write thanks to step 1; lost individual mutations re-occur on the next stale check. Per-extension keyed file or kvstore is the proper fix and is out of scope.

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno check` passes
- [x] `deno run test` — 5105 passed, 0 failed
- [x] `deno run compile` produces working binary
- [x] Smoke test against live registry:
  - `extension list --check-updates --json` correctly shows `update_available` for an outdated entry, `up_to_date` after bumping
  - Cache populated at `.swamp/extension-update-checks.json`; second invocation served from cache
  - `extension outdated --json` exits 1 with outdated, exits 0 when up to date
- [x] Unit tests cover: cache hit (no HTTP), cache miss (one HTTP, cache write), registry failure (stamp + `unknown_offline`), worker-throws degrades cleanly, concurrency cap respected, `shouldEnrich` matrix (TTY/JSON/flag combinations), exit-code semantic for `extension outdated`, atomic write under concurrent writers
- [x] Verified swamp-uat `ExtensionListSchema` uses `.passthrough()` (NOT `.strict()`) — additive JSON fields are safe

## Follow-ups (post-merge)

- File `gh issue create --repo systeminit/swamp-uat --label cli` for UAT scenarios covering the new surfaces
- File `gh issue create --repo systeminit/swamp-club --label documentation` for the user-facing manual page on `swamp extension <list|update|outdated>` (closes a pre-existing manual gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)