### PR TITLE
fix(extensions): yield terminal completed on empty repo (swamp-club #206)

### DIFF
--- a/src/libswamp/extensions/update.ts
+++ b/src/libswamp/extensions/update.ts
@@ -126,6 +126,11 @@ export async function* extensionUpdate(
 
       if (installedNames.length === 0) {
         yield { kind: "no_extensions" };
+        yield {
+          kind: "completed",
+          data: buildUpdateResult([]),
+          mode: input.checkOnly ? "check" : "update",
+        };
         return;
       }
 

--- a/src/libswamp/extensions/update_test.ts
+++ b/src/libswamp/extensions/update_test.ts
@@ -19,6 +19,7 @@
 
 import { assertEquals } from "@std/assert/equals";
 import { createLibSwampContext } from "../context.ts";
+import { result } from "../stream.ts";
 import { collect } from "../testing.ts";
 import {
   extensionUpdate,
@@ -42,7 +43,7 @@ function makeCtx() {
   return createLibSwampContext();
 }
 
-Deno.test("extensionUpdate: no extensions installed yields no_extensions", async () => {
+Deno.test("extensionUpdate: no extensions installed yields no_extensions then completed", async () => {
   const deps = makeDeps();
   const input: ExtensionUpdateInput = { checkOnly: false };
 
@@ -50,8 +51,23 @@ Deno.test("extensionUpdate: no extensions installed yields no_extensions", async
     extensionUpdate(makeCtx(), deps, input),
   );
 
-  assertEquals(events.length, 1);
+  assertEquals(events.length, 2);
   assertEquals(events[0].kind, "no_extensions");
+  assertEquals(events[1].kind, "completed");
+  if (events[1].kind === "completed") {
+    assertEquals(events[1].mode, "update");
+    assertEquals(events[1].data.extensions.length, 0);
+  }
+});
+
+Deno.test("extensionUpdate: result() resolves on empty installation", async () => {
+  const completed = await result<ExtensionUpdateEvent>(
+    extensionUpdate(makeCtx(), makeDeps(), { checkOnly: true }),
+  );
+
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.mode, "check");
+  assertEquals(completed.data.extensions.length, 0);
 });
 
 Deno.test("extensionUpdate: specific extension not installed yields error", async () => {

--- a/src/presentation/renderers/extension_update.ts
+++ b/src/presentation/renderers/extension_update.ts
@@ -75,11 +75,7 @@ class LogExtensionUpdateRenderer implements Renderer<ExtensionUpdateEvent> {
 class JsonExtensionUpdateRenderer implements Renderer<ExtensionUpdateEvent> {
   handlers(): EventHandlers<ExtensionUpdateEvent> {
     return {
-      no_extensions: () => {
-        console.log(
-          JSON.stringify({ extensions: [], summary: { total: 0 } }, null, 2),
-        );
-      },
+      no_extensions: () => {},
       extension_not_installed: (e) => {
         console.log(
           JSON.stringify(
@@ -128,7 +124,6 @@ import type { Logger } from "@logtape/logtape";
 
 function renderCheckLog(result: ExtensionUpdateResult, logger: Logger): void {
   if (result.extensions.length === 0) {
-    logger.info("No upstream extensions installed.");
     return;
   }
 
@@ -177,6 +172,10 @@ function renderCheckLog(result: ExtensionUpdateResult, logger: Logger): void {
 }
 
 function renderUpdateLog(result: ExtensionUpdateResult, logger: Logger): void {
+  if (result.extensions.length === 0) {
+    return;
+  }
+
   for (const ext of result.extensions) {
     switch (ext.status) {
       case "updated":


### PR DESCRIPTION
## Summary

`swamp extension outdated` crashed with `Stream ended without a completed or error event` on repos with no installed extensions. Fixes swamp-club issue #206.

### Root cause

The `extensionUpdate` generator (`src/libswamp/extensions/update.ts`) yielded a single `no_extensions` event and returned without yielding a terminal `completed` or `error` — a runtime violation of the `HasTerminals<E>` contract documented at `design/libswamp.md:194-214`. The pre-existing `extension update` command consumes via `consumeStream` and tolerated the missing terminal silently. The new `extension outdated` command (shipped in #1276) consumes via `result()`, which strictly requires a terminal and threw.

### Fix

Append a terminal `completed` event with empty data after the existing `no_extensions` yield. Mode propagates from `input.checkOnly`. Renderer changes prevent the new `completed` event from double-emitting alongside the existing `no_extensions` handler in both log and JSON output modes.

### Behavior changes

| Command on empty repo | Before | After |
|---|---|---|
| `swamp extension outdated --log` | FTL crash, exit 1 | `All extensions are up to date.` exit 0 |
| `swamp extension outdated --json` | error JSON, exit 1 | `{"extensions": [], "hasUpdateAvailable": false}` exit 0 |
| `swamp extension update --log` | friendly 2-line message | unchanged (preserved by leaving `no_extensions` handler intact) |
| `swamp extension update --json` | malformed `{"extensions": [], "summary": {"total": 0}}` | canonical full `ExtensionUpdateResult` with all summary fields |

The JSON-mode shape change for `extension update --json` on empty repos is a side-effect of the fix. Practical impact is near zero — the previous payload was malformed (missing `upToDate`/`updated`/`failed` counts) and effectively unusable.

### Notes for reviewers

- The fix preserves the `no_extensions` event variant rather than removing it. The variant is technically redundant now (empty state is already encodable via `completed.data.extensions === []`) but removing it is a wider change that touches the public `ExtensionUpdateEvent` union exported via `libswamp/mod.ts`. That cleanup belongs in a separate PR.
- The original author of #1276 may want to confirm the contract change matches their intent — the user-visible cue is preserved in the renderer, only the event-level escape hatch goes away on the path that used `result()`.

## Test Plan

- [x] `deno check` — passes (1161 files)
- [x] `deno lint` — passes (1161 files)
- [x] `deno fmt --check` — passes (1282 files)
- [x] `deno run test` — 5137 passed, 0 failed
- [x] New regression test `extensionUpdate: result() resolves on empty installation` — fails on the buggy version, passes on the fix
- [x] Existing test `extensionUpdate: no extensions installed yields no_extensions` renamed and updated to assert the new two-event terminal sequence
- [x] Manual reproduction in `/tmp/swamp-repro-issue-206` against recompiled binary:
  - `swamp extension outdated --log --no-color` → exit 0, "All extensions are up to date."
  - `swamp extension outdated --json` → exit 0, `{"extensions": [], "hasUpdateAvailable": false}`
  - `swamp extension update --json` → single canonical `ExtensionUpdateResult`
  - `swamp extension update --log --no-color` → friendly two-line message preserved