### PR TITLE
fix(extensions): preserve skill dirs through layout migration (swamp-club#207)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -855,6 +855,22 @@ usable during a partial upgrade. The migration is **resumable**:
 aborts the upgrade before any further mutations, leaving the lockfile
 intact so retry starts from a consistent state.
 
+Skill directory entries (tracked as a single dir path in `entry.files[]`,
+e.g. `.claude/skills/<name>`, `.cursor/skills/<name>`, or
+`.swamp/pulled-extensions/skills/<name>` for the `tool=none` fallback)
+are **always** treated as current-layout regardless of physical location.
+The install flow filters them via the skillsDir wired through
+`ExtensionInstallDeps` before classification runs, so they neither
+trigger migration on their own nor get touched by the post-migration
+sweep — without that filter, the `tool=none` fallback shape would be
+indistinguishable from a gen-2 path and the freshly-restored skill dir
+would be destructively removed. The path-only `classifyExtensionFile`
+helper on its own only flags paths matching the documented gen-1 shape
+(`extensions/<known-type>/...` where `<known-type>` is in
+`PULLED_TYPE_DIRS`); arbitrary non-`.swamp/` paths and any path the
+classifier doesn't recognise fall through to current-layout and are
+ignored by migration rather than swept.
+
 ## Removal
 
 Installed extensions can be removed with `extension rm`. Removal deletes all

--- a/src/cli/create_extension_install_deps.ts
+++ b/src/cli/create_extension_install_deps.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { join, resolve } from "@std/path";
+import { join, relative, resolve } from "@std/path";
 import type { Logger } from "@logtape/logtape";
 import { RepoPath } from "../domain/repo/repo_path.ts";
 import { resolveSkillsDir } from "../domain/repo/skill_dirs.ts";
@@ -55,7 +55,15 @@ export async function createExtensionInstallDeps(
   const absoluteModelsDir = resolve(absoluteRepoDir, modelsDir);
   const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
   const tool = resolvePrimaryTool(marker);
-  const skillsDir = resolveSkillsDir(absoluteRepoDir, tool);
+  const absoluteSkillsDir = resolveSkillsDir(absoluteRepoDir, tool);
+  // `entry.files[]` paths in the lockfile are relative to the repo
+  // root, so the skill-dir filter in needsInstallOrMigration /
+  // sweepLegacyPaths must compare against a repo-relative skillsDir.
+  // The InstallContext's `skillsDir` stays absolute — pull.ts joins it
+  // with the destination dir and that path is independent of the
+  // lockfile's relative-path convention. Two fields with the same
+  // logical role but different conventions; keep them named distinctly.
+  const skillsDirRelative = relative(absoluteRepoDir, absoluteSkillsDir);
 
   const serverUrl = resolveServerUrl();
   const client = new ExtensionApiClient(serverUrl);
@@ -63,13 +71,14 @@ export async function createExtensionInstallDeps(
   return {
     lockfilePath,
     repoDir: absoluteRepoDir,
+    skillsDirRelative,
     createInstallContext: (_name, _version) => ({
       getExtension: (n) => client.getExtension(n),
       downloadArchive: (n, v) => client.downloadArchive(n, v),
       getChecksum: (n, v) => client.getChecksum(n, v),
       logger,
       lockfilePath,
-      skillsDir,
+      skillsDir: absoluteSkillsDir,
       repoDir: absoluteRepoDir,
       force: true,
       alreadyPulled: new Set(),

--- a/src/libswamp/extensions/install.ts
+++ b/src/libswamp/extensions/install.ts
@@ -30,7 +30,7 @@ import {
   type InstallResult,
   parseExtensionRef,
 } from "./pull.ts";
-import { classifyExtensionFile } from "./layout.ts";
+import { classifyExtensionFile, isSkillDirEntry } from "./layout.ts";
 
 /**
  * Test seam for `extensionInstall`. Production always uses
@@ -83,6 +83,26 @@ export type ExtensionInstallEvent =
 export interface ExtensionInstallDeps {
   lockfilePath: string;
   repoDir: string;
+  /**
+   * Tool-aware skills destination as a **repo-relative** path (e.g.
+   * `.claude/skills`, `.cursor/skills`, or
+   * `.swamp/pulled-extensions/skills` for `tool=none`). Repo-relative
+   * is load-bearing: `entry.files[]` paths in the lockfile are
+   * repo-relative, and `isSkillDirEntry` compares them directly. Note
+   * the deliberate asymmetry with `InstallContext.skillsDir`, which is
+   * **absolute** because `pull.ts` joins it with destination dirs to
+   * write skill files. Don't conflate the two.
+   *
+   * Optional for source-compat with direct libswamp consumers that
+   * hand-build the deps; production callers should always provide it
+   * (`createExtensionInstallDeps` does). When provided, skill dir
+   * entries are filtered out of legacy classification and the
+   * post-migration sweep so the freshly-installed skills survive —
+   * without it, the `tool=none` fallback path is structurally
+   * indistinguishable from a gen-2 path and would be destructively
+   * removed.
+   */
+  skillsDirRelative?: string;
   createInstallContext: (
     name: string,
     version: string,
@@ -138,6 +158,7 @@ export async function* extensionInstall(
         const needs = await needsInstallOrMigration(
           originalFiles,
           deps.repoDir,
+          deps.skillsDirRelative,
         );
 
         if (needs === "up_to_date") {
@@ -170,7 +191,11 @@ export async function* extensionInstall(
           // locations, so the legacy paths are "orphaned" and safe to
           // remove.
           if (needs === "migrate") {
-            await sweepLegacyPaths(originalFiles, deps.repoDir);
+            await sweepLegacyPaths(
+              originalFiles,
+              deps.repoDir,
+              deps.skillsDirRelative,
+            );
             entries.push({ name, version, status: "migrated" });
             migrated++;
           } else {
@@ -223,10 +248,18 @@ export async function* extensionInstall(
  *
  * Missing beats legacy: a missing file cannot be migrated without a
  * re-pull, so the flow is the same either way.
+ *
+ * `skillsDirRelative` (when provided, repo-relative) filters skill
+ * directory entries out of legacy classification — they are always
+ * considered current-layout regardless of physical location. Their
+ * on-disk presence is still checked so a skill dir deleted by a prior
+ * buggy migration triggers `"install"` and self-heals on the next
+ * run.
  */
 export async function needsInstallOrMigration(
   files: string[],
   repoDir: string,
+  skillsDirRelative?: string,
 ): Promise<"install" | "migrate" | "up_to_date"> {
   let hasLegacy = false;
   for (const file of files) {
@@ -238,6 +271,9 @@ export async function needsInstallOrMigration(
         return "install";
       }
       throw error;
+    }
+    if (isSkillDirEntry(file, skillsDirRelative)) {
+      continue;
     }
     const generation = classifyExtensionFile(file);
     if (generation !== "current") {
@@ -258,14 +294,26 @@ export async function needsInstallOrMigration(
  * tracked by their root, with nested files inside) are handled — a plain
  * Deno.remove fails on non-empty directories.
  *
+ * `skillsDirRelative` (when provided, repo-relative) excludes skill
+ * directory entries from the sweep — skill paths are current-layout
+ * regardless of physical location and the freshly-restored skill dir
+ * must survive the post-install cleanup. Without this filter, the
+ * `tool=none` fallback at `.swamp/pulled-extensions/skills/<name>` is
+ * structurally identical to a gen-2 path and would be destructively
+ * removed.
+ *
  * Exported for direct unit testing; production callers invoke it
  * indirectly through `extensionInstall`.
  */
 export async function sweepLegacyPaths(
   originalFiles: string[],
   repoDir: string,
+  skillsDirRelative?: string,
 ): Promise<void> {
   for (const file of originalFiles) {
+    if (isSkillDirEntry(file, skillsDirRelative)) {
+      continue;
+    }
     if (classifyExtensionFile(file) === "current") {
       continue;
     }

--- a/src/libswamp/extensions/install_test.ts
+++ b/src/libswamp/extensions/install_test.ts
@@ -469,6 +469,137 @@ Deno.test("needsInstallOrMigration: missing file beats legacy classification", a
 });
 
 Deno.test(
+  "needsInstallOrMigration: skill dir under tool-specific skillsDir does not trigger migrate",
+  async () => {
+    // Pre-fix bug: skill paths classified as gen-1 (any non-`.swamp/`
+    // path was gen-1) made every skill-bearing extension trigger migrate
+    // → re-pull → sweep destroyed the skill. Post-fix: skill paths are
+    // filtered before classification.
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+    try {
+      const currentPath = join(
+        tmpDir,
+        ".swamp/pulled-extensions/@me/ext/models/main.ts",
+      );
+      await ensureDir(
+        join(tmpDir, ".swamp/pulled-extensions/@me/ext/models"),
+      );
+      await Deno.writeTextFile(currentPath, "// current");
+
+      const skillDir = join(tmpDir, ".claude/skills/foo");
+      await ensureDir(skillDir);
+      await Deno.writeTextFile(join(skillDir, "SKILL.md"), "# foo");
+
+      const result = await needsInstallOrMigration(
+        [
+          ".swamp/pulled-extensions/@me/ext/models/main.ts",
+          ".claude/skills/foo",
+        ],
+        tmpDir,
+        ".claude/skills",
+      );
+      assertEquals(result, "up_to_date");
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "needsInstallOrMigration: skill dir at tool=none fallback does not trigger migrate",
+  async () => {
+    // Without skillsDir filtering, the path
+    // `.swamp/pulled-extensions/skills/<name>` is structurally
+    // indistinguishable from a gen-2 model file path and would be
+    // misclassified. The skillsDir filter pins it down as a skill.
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+    try {
+      const currentPath = join(
+        tmpDir,
+        ".swamp/pulled-extensions/@me/ext/models/main.ts",
+      );
+      await ensureDir(
+        join(tmpDir, ".swamp/pulled-extensions/@me/ext/models"),
+      );
+      await Deno.writeTextFile(currentPath, "// current");
+
+      const skillDir = join(tmpDir, ".swamp/pulled-extensions/skills/foo");
+      await ensureDir(skillDir);
+      await Deno.writeTextFile(join(skillDir, "SKILL.md"), "# foo");
+
+      const result = await needsInstallOrMigration(
+        [
+          ".swamp/pulled-extensions/@me/ext/models/main.ts",
+          ".swamp/pulled-extensions/skills/foo",
+        ],
+        tmpDir,
+        ".swamp/pulled-extensions/skills",
+      );
+      assertEquals(result, "up_to_date");
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "needsInstallOrMigration: missing skill dir still triggers install (auto-recovery)",
+  async () => {
+    // Users who lost their skill dir to a prior buggy migration must
+    // self-heal on the next install/upgrade. The skill path stat-check
+    // runs BEFORE the skillsDir filter — a missing skill returns
+    // "install" so the next pass re-pulls.
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+    try {
+      const currentPath = join(
+        tmpDir,
+        ".swamp/pulled-extensions/@me/ext/models/main.ts",
+      );
+      await ensureDir(
+        join(tmpDir, ".swamp/pulled-extensions/@me/ext/models"),
+      );
+      await Deno.writeTextFile(currentPath, "// current");
+
+      // Skill dir intentionally NOT created on disk.
+      const result = await needsInstallOrMigration(
+        [
+          ".swamp/pulled-extensions/@me/ext/models/main.ts",
+          ".claude/skills/foo",
+        ],
+        tmpDir,
+        ".claude/skills",
+      );
+      assertEquals(result, "install");
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "needsInstallOrMigration: no skillsDir param still catches gen-1 paths (back-compat)",
+  async () => {
+    // ADV-6 guard: optional skillsDir must default to "no filter" so
+    // direct libswamp consumers without skillsDir wired keep their
+    // current legacy-detection behaviour.
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+    try {
+      const path = join(tmpDir, "extensions/models/legacy.ts");
+      await ensureDir(join(tmpDir, "extensions/models"));
+      await Deno.writeTextFile(path, "// legacy");
+
+      const result = await needsInstallOrMigration(
+        ["extensions/models/legacy.ts"],
+        tmpDir,
+      );
+      assertEquals(result, "migrate");
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
   "extensionInstall: gen-1 entry migrates, sweeps legacy files, sets status=migrated",
   async () => {
     const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
@@ -673,6 +804,218 @@ Deno.test(
   },
 );
 
+/**
+ * Stub `installExtensionFn` that simulates a real install with both
+ * per-extension model files AND a skill directory. Writes the model
+ * file under the per-extension subtree, writes the skill dir at the
+ * caller-provided `skillsDirAbs`, and rewrites the lockfile entry's
+ * files[] to include both. Used by the issue-#207 migration regression
+ * tests to verify the freshly-restored skill dir survives the
+ * post-migration sweep.
+ */
+function makeSuccessfulInstallWithSkill(
+  tmpDir: string,
+  lockfilePath: string,
+  skillsDirRelative: string,
+): InstallExtensionFn {
+  return async (ref) => {
+    const extRoot = join(
+      tmpDir,
+      ".swamp",
+      "pulled-extensions",
+      ref.name,
+      "models",
+    );
+    await ensureDir(extRoot);
+    await Deno.writeTextFile(join(extRoot, "main.ts"), "// reinstalled");
+
+    const skillDirAbs = join(tmpDir, skillsDirRelative, "good-planning");
+    await ensureDir(skillDirAbs);
+    await Deno.writeTextFile(
+      join(skillDirAbs, "SKILL.md"),
+      "# good-planning",
+    );
+
+    const upstream = await readUpstreamExtensions(lockfilePath);
+    upstream[ref.name] = {
+      ...upstream[ref.name],
+      files: [
+        `.swamp/pulled-extensions/${ref.name}/models/main.ts`,
+        `${skillsDirRelative}/good-planning`,
+      ],
+      filesChecksum: "fake-anchor",
+    };
+    await Deno.writeTextFile(
+      lockfilePath,
+      JSON.stringify(upstream, null, 2),
+    );
+    return undefined;
+  };
+}
+
+Deno.test(
+  "extensionInstall: tool=claude migration preserves the skill dir (issue #207)",
+  async () => {
+    // Issue #207 reproduction at the integration boundary. Lockfile
+    // mixes a gen-2 model path (forces migrate) with a `.claude/skills/`
+    // skill dir entry. Pre-fix: sweepLegacyPaths recursively deleted
+    // the freshly-restored skill dir. Post-fix: the skillsDir filter
+    // excludes the skill from both the migrate trigger and the sweep,
+    // so it survives.
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+    try {
+      // Seed the gen-2 path on disk so needsInstallOrMigration sees it
+      // present (otherwise it would short-circuit to "install").
+      const gen2Path = join(
+        tmpDir,
+        ".swamp/pulled-extensions/models/legacy.ts",
+      );
+      await ensureDir(join(tmpDir, ".swamp/pulled-extensions/models"));
+      await Deno.writeTextFile(gen2Path, "// legacy");
+
+      // Skill dir already on disk from a prior pull; the entry tracks
+      // it. The migration must not destroy it.
+      const skillDir = join(tmpDir, ".claude/skills/good-planning");
+      await ensureDir(skillDir);
+      await Deno.writeTextFile(join(skillDir, "SKILL.md"), "# original");
+
+      const lockfilePath = join(tmpDir, "upstream_extensions.json");
+      await Deno.writeTextFile(
+        lockfilePath,
+        JSON.stringify({
+          "@magistr/good-planning": {
+            version: "2026.05.01.1",
+            pulledAt: "2026-05-01T00:00:00Z",
+            files: [
+              ".swamp/pulled-extensions/models/legacy.ts",
+              ".claude/skills/good-planning",
+            ],
+          },
+        }),
+      );
+
+      const ctx = createLibSwampContext({});
+      const events = await collectEvents(
+        extensionInstall(ctx, {
+          lockfilePath,
+          repoDir: tmpDir,
+          skillsDirRelative: ".claude/skills",
+          createInstallContext: () =>
+            makeStubInstallContext(tmpDir, lockfilePath),
+          installExtensionFn: makeSuccessfulInstallWithSkill(
+            tmpDir,
+            lockfilePath,
+            ".claude/skills",
+          ),
+        }),
+      );
+
+      // Migration ran (gen-2 path forced it).
+      const completed = events.find((e) => e.kind === "completed");
+      assertEquals(completed?.kind, "completed");
+      if (completed?.kind === "completed") {
+        assertEquals(completed.data.migrated, 1);
+        assertEquals(completed.data.entries[0].status, "migrated");
+      }
+
+      // gen-2 path swept.
+      let gen2Exists = true;
+      try {
+        await Deno.stat(gen2Path);
+      } catch (e) {
+        if (e instanceof Deno.errors.NotFound) gen2Exists = false;
+      }
+      assertEquals(gen2Exists, false, "gen-2 path should be swept");
+
+      // Skill dir survives — the load-bearing assertion for #207.
+      const stat = await Deno.stat(skillDir);
+      assertEquals(
+        stat.isDirectory,
+        true,
+        "skill dir must survive migration",
+      );
+      const skillFile = await Deno.stat(join(skillDir, "SKILL.md"));
+      assertEquals(skillFile.isFile, true, "SKILL.md must survive migration");
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "extensionInstall: tool=none fallback migration preserves the skill dir (issue #207)",
+  async () => {
+    // The `tool=none` fallback puts skills at
+    // `.swamp/pulled-extensions/skills/<name>` — structurally identical
+    // to a gen-2 path. Without skillsDir threaded into the deps, the
+    // skill would be classified gen-2 and recursively swept after
+    // re-install. The skillsDir filter pins it down.
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+    try {
+      const gen2Path = join(
+        tmpDir,
+        ".swamp/pulled-extensions/models/legacy.ts",
+      );
+      await ensureDir(join(tmpDir, ".swamp/pulled-extensions/models"));
+      await Deno.writeTextFile(gen2Path, "// legacy");
+
+      const skillDir = join(
+        tmpDir,
+        ".swamp/pulled-extensions/skills/good-planning",
+      );
+      await ensureDir(skillDir);
+      await Deno.writeTextFile(join(skillDir, "SKILL.md"), "# original");
+
+      const lockfilePath = join(tmpDir, "upstream_extensions.json");
+      await Deno.writeTextFile(
+        lockfilePath,
+        JSON.stringify({
+          "@magistr/good-planning": {
+            version: "2026.05.01.1",
+            pulledAt: "2026-05-01T00:00:00Z",
+            files: [
+              ".swamp/pulled-extensions/models/legacy.ts",
+              ".swamp/pulled-extensions/skills/good-planning",
+            ],
+          },
+        }),
+      );
+
+      const ctx = createLibSwampContext({});
+      const events = await collectEvents(
+        extensionInstall(ctx, {
+          lockfilePath,
+          repoDir: tmpDir,
+          skillsDirRelative: ".swamp/pulled-extensions/skills",
+          createInstallContext: () =>
+            makeStubInstallContext(tmpDir, lockfilePath),
+          installExtensionFn: makeSuccessfulInstallWithSkill(
+            tmpDir,
+            lockfilePath,
+            ".swamp/pulled-extensions/skills",
+          ),
+        }),
+      );
+
+      const completed = events.find((e) => e.kind === "completed");
+      assertEquals(completed?.kind, "completed");
+      if (completed?.kind === "completed") {
+        assertEquals(completed.data.migrated, 1);
+        assertEquals(completed.data.entries[0].status, "migrated");
+      }
+
+      const stat = await Deno.stat(skillDir);
+      assertEquals(
+        stat.isDirectory,
+        true,
+        "tool=none skill dir must survive migration",
+      );
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
 Deno.test(
   "sweepLegacyPaths: removes gen-1 and gen-2 paths, leaves current-layout paths",
   async () => {
@@ -804,6 +1147,117 @@ Deno.test(
         if (e instanceof Deno.errors.NotFound) exists = false;
       }
       assertEquals(exists, false, "skills/foo should be removed recursively");
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "sweepLegacyPaths: leaves tool-specific skill dir intact when skillsDir is provided",
+  async () => {
+    // Regression guard for issue #207: with skillsDir threaded through,
+    // the freshly-installed `.claude/skills/<name>` dir survives the
+    // post-migration sweep even though the original lockfile entry
+    // tracked it.
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+    try {
+      const skillDir = join(tmpDir, ".claude/skills/good-planning");
+      await ensureDir(skillDir);
+      await Deno.writeTextFile(join(skillDir, "SKILL.md"), "# good-planning");
+
+      const gen1 = join(tmpDir, "extensions/models/legacy.ts");
+      await ensureDir(join(tmpDir, "extensions/models"));
+      await Deno.writeTextFile(gen1, "// legacy");
+
+      await sweepLegacyPaths(
+        ["extensions/models/legacy.ts", ".claude/skills/good-planning"],
+        tmpDir,
+        ".claude/skills",
+      );
+
+      // gen-1 path swept.
+      let gen1Exists = true;
+      try {
+        await Deno.stat(gen1);
+      } catch (e) {
+        if (e instanceof Deno.errors.NotFound) gen1Exists = false;
+      }
+      assertEquals(gen1Exists, false, "gen-1 path should be swept");
+
+      // Skill dir intact.
+      const stat = await Deno.stat(skillDir);
+      assertEquals(stat.isDirectory, true, "skill dir should survive sweep");
+      const skillFile = await Deno.stat(join(skillDir, "SKILL.md"));
+      assertEquals(skillFile.isFile, true, "SKILL.md should survive sweep");
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "sweepLegacyPaths: leaves tool=none skill dir intact when skillsDir is provided",
+  async () => {
+    // The `tool=none` fallback puts skills at
+    // `.swamp/pulled-extensions/skills/<name>`, structurally identical to
+    // a gen-2 path. Without skillsDir filtering they would be swept.
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+    try {
+      const skillDir = join(
+        tmpDir,
+        ".swamp/pulled-extensions/skills/good-planning",
+      );
+      await ensureDir(skillDir);
+      await Deno.writeTextFile(join(skillDir, "SKILL.md"), "# good-planning");
+
+      await sweepLegacyPaths(
+        [".swamp/pulled-extensions/skills/good-planning"],
+        tmpDir,
+        ".swamp/pulled-extensions/skills",
+      );
+
+      const stat = await Deno.stat(skillDir);
+      assertEquals(
+        stat.isDirectory,
+        true,
+        "tool=none skill dir should survive sweep",
+      );
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "sweepLegacyPaths: no skillsDir param still sweeps gen-2 dir entries (back-compat)",
+  async () => {
+    // ADV-6 guard: optional skillsDir defaults to "no filter" so the
+    // pre-existing recursive-remove behaviour for legacy skill-style
+    // directory entries continues to work for callers that don't wire
+    // skillsDir.
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+    try {
+      const dirPath = join(tmpDir, ".swamp/pulled-extensions/skills/foo");
+      await ensureDir(dirPath);
+      await Deno.writeTextFile(join(dirPath, "nested.ts"), "// nested");
+
+      await sweepLegacyPaths(
+        [".swamp/pulled-extensions/skills/foo"],
+        tmpDir,
+      );
+
+      let exists = true;
+      try {
+        await Deno.stat(dirPath);
+      } catch (e) {
+        if (e instanceof Deno.errors.NotFound) exists = false;
+      }
+      assertEquals(
+        exists,
+        false,
+        "skills/foo should still be removed when skillsDir is omitted",
+      );
     } finally {
       await Deno.remove(tmpDir, { recursive: true });
     }

--- a/src/libswamp/extensions/layout.ts
+++ b/src/libswamp/extensions/layout.ts
@@ -57,23 +57,39 @@ export const PULLED_TYPE_DIRS: ReadonlySet<string> = new Set([
 ]);
 
 const PULLED_PREFIX = `${SWAMP_DATA_DIR}/pulled-extensions/`;
+const GEN1_PREFIX = "extensions/";
 
 /**
  * Classifies a single lockfile file path.
  *
- * - Returns `"gen-1"` when the path lives outside `.swamp/` (pre-`.swamp/`
- *   layout, e.g. `extensions/models/foo.ts`).
+ * - Returns `"gen-1"` when the path matches the published gen-1 shape:
+ *   `extensions/<known-type>/...` where `<known-type>` is in
+ *   `PULLED_TYPE_DIRS`. Tightened from "any path outside `.swamp/`" so
+ *   tool-specific skill dirs (`.claude/skills/<name>`,
+ *   `.cursor/skills/<name>`, etc.) and other non-`.swamp/` paths are not
+ *   misclassified as legacy and routed through migration's destructive
+ *   sweep.
  * - Returns `"gen-2"` when the path lives under
  *   `.swamp/pulled-extensions/<type>/...` where `<type>` is a known
  *   pulled-type dir — the "flat" layout where filenames collide across
  *   extensions.
  * - Returns `"current"` for the per-extension subtree
- *   (`.swamp/pulled-extensions/@<scope>/...`) and for paths outside
- *   `pulled-extensions/` entirely (bundles, etc.).
+ *   (`.swamp/pulled-extensions/@<scope>/...`), for paths outside
+ *   `pulled-extensions/` entirely (bundles, etc.), and for any
+ *   non-`.swamp/` path that does not match the gen-1 shape.
+ *
+ * Note: this classifier is path-only and cannot tell a `tool=none` skill
+ * directory entry (`.swamp/pulled-extensions/skills/<name>`) apart from a
+ * gen-2 model file path. The install flow filters skill dir entries via
+ * `isSkillDirEntry` before reaching the classifier — see
+ * `needsInstallOrMigration` and `sweepLegacyPaths` in `install.ts`.
  */
 export function classifyExtensionFile(file: string): ExtensionLayoutGeneration {
-  if (!file.startsWith(`${SWAMP_DATA_DIR}/`)) {
-    return "gen-1";
+  if (file.startsWith(GEN1_PREFIX)) {
+    const firstSegment = file.slice(GEN1_PREFIX.length).split("/")[0];
+    if (PULLED_TYPE_DIRS.has(firstSegment)) {
+      return "gen-1";
+    }
   }
   if (!file.startsWith(PULLED_PREFIX)) {
     return "current";
@@ -83,6 +99,39 @@ export function classifyExtensionFile(file: string): ExtensionLayoutGeneration {
     return "gen-2";
   }
   return "current";
+}
+
+/**
+ * Returns true when a tracked file path is a skill directory entry —
+ * either the skillsDir root itself or a path under it.
+ *
+ * Skills are tracked in `entry.files[]` as a single directory path (set
+ * by `installExtension` in `pull.ts`), so this check compares against
+ * the directory boundary. The skillsDir is repo-and-tool-specific
+ * (`.claude/skills`, `.cursor/skills`, `.swamp/pulled-extensions/skills`
+ * for `tool=none`, etc.) and must be repo-relative — `entry.files[]`
+ * paths are repo-relative; the caller passes it in.
+ *
+ * Both sides are normalised to forward slashes before comparison so
+ * the check works on Windows (where `@std/path` `relative()` returns
+ * backslash-separated paths) without requiring callers to normalise.
+ *
+ * Used by the install flow to short-circuit skill paths before legacy
+ * classification — without this filter, the `tool=none` fallback at
+ * `.swamp/pulled-extensions/skills/<name>` is structurally identical to
+ * a gen-2 path and would otherwise be swept destructively after
+ * migration.
+ */
+export function isSkillDirEntry(
+  file: string,
+  skillsDir: string | undefined,
+): boolean {
+  if (!skillsDir) return false;
+  const trimmed = skillsDir.replaceAll("\\", "/").replace(/\/$/, "");
+  if (trimmed.length === 0) return false;
+  const normalizedFile = file.replaceAll("\\", "/");
+  return normalizedFile === trimmed ||
+    normalizedFile.startsWith(`${trimmed}/`);
 }
 
 /**
@@ -127,13 +176,7 @@ export function extractTopLevelRoot(
   // Skills are tracked as directory paths (the dir root, not its
   // contents). We can't detect orphan files within a skill dir
   // because the inner files aren't in entry.files[].
-  const normalizedSkillsDir = skillsDir.endsWith("/")
-    ? skillsDir
-    : `${skillsDir}/`;
-  if (
-    filePath === skillsDir.replace(/\/$/, "") ||
-    filePath.startsWith(normalizedSkillsDir)
-  ) {
+  if (isSkillDirEntry(filePath, skillsDir)) {
     return null;
   }
 

--- a/src/libswamp/extensions/layout_test.ts
+++ b/src/libswamp/extensions/layout_test.ts
@@ -23,6 +23,7 @@ import {
   classifyExtensionFile,
   detectLegacyExtensionLayout,
   extractTopLevelRoot,
+  isSkillDirEntry,
   requireCurrentExtensionLayout,
   summariseLegacyLayout,
   warnLegacyExtensionLayout,
@@ -79,6 +80,91 @@ Deno.test("classifyExtensionFile: .swamp paths outside pulled-extensions are cur
     classifyExtensionFile(".swamp/bundles/abc123/@scope/name/foo.js"),
     "current",
   );
+});
+
+Deno.test("classifyExtensionFile: tool-specific skill dir paths are current", () => {
+  // Pre-fix bug: any non-`.swamp/` path classified as gen-1 → migration's
+  // sweep recursively deleted skill dirs after re-install.
+  assertEquals(
+    classifyExtensionFile(".claude/skills/good-planning"),
+    "current",
+  );
+  assertEquals(
+    classifyExtensionFile(".claude/skills/good-planning/SKILL.md"),
+    "current",
+  );
+  assertEquals(
+    classifyExtensionFile(".cursor/skills/foo"),
+    "current",
+  );
+  assertEquals(
+    classifyExtensionFile(".kiro/skills/foo"),
+    "current",
+  );
+  assertEquals(
+    classifyExtensionFile(".agents/skills/foo"),
+    "current",
+  );
+});
+
+Deno.test("classifyExtensionFile: arbitrary non-extensions/ paths are current", () => {
+  // Tightened classifier no longer flags hand-rolled or unknown paths as
+  // gen-1; only the documented gen-1 shape (extensions/<known-type>/...)
+  // counts.
+  assertEquals(
+    classifyExtensionFile("random/path/file.ts"),
+    "current",
+  );
+  assertEquals(
+    classifyExtensionFile("extensions/unknown-type/foo.ts"),
+    "current",
+  );
+});
+
+Deno.test("classifyExtensionFile: extensions/<known-type>/ paths still gen-1", () => {
+  for (
+    const type of ["models", "workflows", "vaults", "drivers", "datastores"]
+  ) {
+    assertEquals(
+      classifyExtensionFile(`extensions/${type}/foo.ts`),
+      "gen-1",
+      `${type} should still classify as gen-1`,
+    );
+  }
+});
+
+Deno.test("isSkillDirEntry: matches the dir root and contents", () => {
+  assertEquals(isSkillDirEntry(".claude/skills/foo", ".claude/skills"), true);
+  assertEquals(
+    isSkillDirEntry(".claude/skills/foo/SKILL.md", ".claude/skills"),
+    true,
+  );
+  assertEquals(
+    isSkillDirEntry(".claude/skills/foo", ".claude/skills/"),
+    true,
+  );
+  assertEquals(
+    isSkillDirEntry(
+      ".swamp/pulled-extensions/skills/foo",
+      ".swamp/pulled-extensions/skills",
+    ),
+    true,
+  );
+});
+
+Deno.test("isSkillDirEntry: returns false for non-skill paths", () => {
+  assertEquals(
+    isSkillDirEntry("extensions/models/foo.ts", ".claude/skills"),
+    false,
+  );
+  assertEquals(
+    isSkillDirEntry(".claude/skillsfoo", ".claude/skills"),
+    false,
+  );
+});
+
+Deno.test("isSkillDirEntry: returns false when skillsDir is undefined", () => {
+  assertEquals(isSkillDirEntry(".claude/skills/foo", undefined), false);
 });
 
 Deno.test("detectLegacyExtensionLayout: returns empty for current layout", async () => {
@@ -430,3 +516,22 @@ Deno.test("extractTopLevelRoot: handles trailing-slash skillsDir", () => {
     null,
   );
 });
+
+Deno.test(
+  "extractTopLevelRoot: hand-rolled non-extensions path returns null",
+  () => {
+    // Regression guard: after the classifier was tightened so non-`.swamp/`
+    // non-`extensions/<type>/...` paths classify as `current`, the early
+    // return inside extractTopLevelRoot no longer fires for them. Confirm
+    // they still bottom out at the trailing `return null` rather than
+    // leaking into a misidentified per-extension or bundle root.
+    assertEquals(
+      extractTopLevelRoot("random/file.ts", SKILLS_DIR),
+      null,
+    );
+    assertEquals(
+      extractTopLevelRoot("extensions/unknown-type/foo.ts", SKILLS_DIR),
+      null,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Closes [swamp-club#207](https://swamp.club/lab/issues/207).

`swamp self-update` (and any `extension install`/`repo upgrade` thereafter) was silently deleting Claude/Cursor/etc. skill directories from already-pulled extensions. The user's repro: pull `@magistr/good-planning@2026.05.01.1`, run `self-update` across the PR-#1275 boundary — migration logs `Migrating "@magistr/good-planning" to per-extension layout...`, the skill at `.claude/skills/good-planning` is gone afterward.

### Root cause

Skill dir entries in `entry.files[]` (e.g. `.claude/skills/<name>`, written as a single dir path by `installExtension` in `pull.ts`) were classified as `gen-1` by `classifyExtensionFile` — the rule was "any path outside `.swamp/`". `needsInstallOrMigration` flagged the entry as `migrate`; the re-pull correctly restored the skill; then `sweepLegacyPaths` recursively deleted everything in `originalFiles` that wasn't `current`, including the freshly-restored skill.

The misclassification existed since per-extension layout shipped in #1186, but only became destructive in #1275 — that PR's "bonus fix" added `{ recursive: true }` to the sweep's `Deno.remove`. Pre-#1275, the recursive-less remove threw on the non-empty skill dir and the migration surfaced as `status: failed` (noisy but non-destructive).

### Fix

Two layers, both narrowing — neither triggers migration where the old code wouldn't:

1. **Tighten `classifyExtensionFile`** (`src/libswamp/extensions/layout.ts`) so only paths matching the documented gen-1 shape (`extensions/<known-type>/...` where `<known-type>` is in `PULLED_TYPE_DIRS`) classify as `gen-1`. All other non-`.swamp/` paths fall through to `current`. Handles all tool-specific skill dirs (`.claude/skills/`, `.cursor/skills/`, `.kiro/skills/`, `.agents/skills/`).

2. **Plumb `skillsDirRelative` through `ExtensionInstallDeps`** so `needsInstallOrMigration` and `sweepLegacyPaths` filter skill paths before classification. Handles the `tool=none` fallback at `.swamp/pulled-extensions/skills/<name>`, structurally identical to a gen-2 path — the path-only classifier can't distinguish them. Named `skillsDirRelative` to mark the deliberate asymmetry with `InstallContext.skillsDir` (absolute, used by `pull.ts` to write skills).

A small refactor extracts `isSkillDirEntry` so `extractTopLevelRoot` shares the helper. Both sides are normalised to forward slashes so the comparison works on Windows where `@std/path` `relative()` returns backslash-separated paths.

### Recovery for users in the broken state

No manual recovery needed. `needsInstallOrMigration` stat-checks every entry path; a missing skill dir returns `"install"`, the re-pull restores the skill, and the new filter prevents the sweep from deleting it again. The next `swamp extension install` or `swamp repo upgrade` self-heals.

## Test plan

- [x] **layout_test.ts** (7 added): classifier covers `.claude/skills/`, `.cursor/skills/`, `.kiro/skills/`, `.agents/skills/`, arbitrary non-`.swamp/` paths, `extensions/<unknown>/`; `extensions/<known-type>/` still gen-1; `isSkillDirEntry` positive/negative/undefined cases; `extractTopLevelRoot` regression for skill paths and hand-rolled paths.
- [x] **install_test.ts** `needsInstallOrMigration` (4 added): tool-specific skillsDir → up_to_date; tool=none skillsDir → up_to_date; missing skill dir → install (auto-recovery); no-skillsDir param still catches gen-1 (back-compat).
- [x] **install_test.ts** `sweepLegacyPaths` (3 added): tool-specific skill preserved with skillsDir; tool=none skill preserved with skillsDir; no-skillsDir param still sweeps gen-2 dir entries (back-compat).
- [x] **install_test.ts** integration (2 added): full `extensionInstall` migration through both skill-storage modes via the existing `installExtensionFn` test seam — load-bearing assertions are that the skill dir survives and the entry is marked `migrated`.
- [x] `deno check`, `deno lint`, `deno fmt --check`: clean.
- [x] `deno run test`: 5152 passed, 0 failed (16 added).
- [x] `deno run compile`: built.
- [x] **E2E scratch repo** at `/tmp/swamp-repro-issue-207-{claude,none}`: `swamp extension install` reports `up_to_date` and the skill dir is intact post-run, in both modes.

## Cross-platform notes

- `isSkillDirEntry` normalises both sides to forward slashes; unit tests cover the helper.
- Full Windows E2E for migration+skill preservation tracked in [systeminit/swamp-uat#176](https://github.com/systeminit/swamp-uat/issues/176).

## Follow-ups (filed separately)

- UAT gap: [systeminit/swamp-uat#176](https://github.com/systeminit/swamp-uat/issues/176) — E2E coverage for migration + skill preservation, both modes, including Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)