### PR TITLE
fix(extensions): stop rebundle loop on broken transitive deps (swamp-club#208)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -901,7 +901,14 @@ the model registry is wired up initially.
      from the catalog (no bundle imports). Fingerprint-based freshness
      replaced mtime-based freshness in issue #125 — mtime was fragile under
      atomic-rename saves, mtime-preserving sync tools, and sub-millisecond
-     edits.
+     edits. The fingerprint is **total**: when a transitive dep is currently
+     unreadable (broken symlink, deleted file, FilesystemLoop), its hash
+     entry is replaced with a stable sentinel rather than throwing — so a
+     stable broken state produces a stable fingerprint and the entry is not
+     marked permanently stale (#208). Repairing the dep flips the sentinel
+     back to a real hash and triggers a rebundle correctly. This property
+     holds uniformly across all five extension kinds (models, drivers,
+     vaults, datastores, reports) since they share the freshness service.
    - If not populated (first run or DB deleted): falls back to the existing
      full-import path, then populates the catalog from the loaded registry
 

--- a/src/domain/extensions/bundle_freshness.ts
+++ b/src/domain/extensions/bundle_freshness.ts
@@ -83,6 +83,17 @@ export interface StaleFile {
 }
 
 /**
+ * Sentinel emitted in place of a real sha-256 hex hash when a transitive
+ * dep cannot be read (broken symlink, deleted file, FilesystemLoop). The
+ * fingerprint then encodes "this dep is currently unreadable" as part of
+ * the source state, so a stable broken state produces a stable
+ * fingerprint instead of marking the entry permanently stale (#208).
+ * Cannot collide with a real hash — "MISSING" contains non-hex
+ * characters.
+ */
+const UNREADABLE_DEP_SENTINEL = "MISSING";
+
+/**
  * Computes a content-based fingerprint covering an entry point and every
  * local .ts file it transitively imports via relative paths.
  *
@@ -93,8 +104,10 @@ export interface StaleFile {
  * resolveLocalImports stops at the boundary dir, matching the bundler's
  * own dependency scope.
  *
- * On any read/hash failure the error surfaces — callers mark the file
- * stale to force a fresh rebundle attempt.
+ * Unreadable deps (broken symlinks, deleted files, FilesystemLoop)
+ * produce an UNREADABLE_DEP_SENTINEL entry instead of throwing — so a
+ * stable broken state yields a stable fingerprint, and repairing the
+ * dep correctly invalidates it (#208).
  */
 export async function computeSourceFingerprint(
   absolutePath: string,
@@ -106,7 +119,12 @@ export async function computeSourceFingerprint(
   const entries: string[] = [];
   for (const file of resolvedFiles) {
     const relPath = relative(boundaryDir, file);
-    const fileHash = await hashFile(file, cache);
+    let fileHash: string;
+    try {
+      fileHash = await hashFile(file, cache);
+    } catch {
+      fileHash = UNREADABLE_DEP_SENTINEL;
+    }
     entries.push(`${relPath}:${fileHash}`);
   }
   entries.sort();
@@ -256,8 +274,12 @@ export async function findStaleFiles(
           stale.push({ absolutePath, relativePath, baseDir: dir });
         }
       } catch {
-        // Unreadable source or disappeared dep — force a rebundle so
-        // the caller either succeeds or surfaces the error to the user.
+        // Defensive backstop only. computeSourceFingerprint is total
+        // since #208 — unreadable transitive deps produce a sentinel
+        // entry rather than throwing. Anything reaching this catch is
+        // an unforeseen failure (Deno API change, crypto.subtle panic,
+        // boundary-dir stat race). Force a rebundle so the error
+        // surfaces to the user.
         stale.push({ absolutePath, relativePath, baseDir: dir });
       }
     }

--- a/src/domain/extensions/bundle_freshness_test.ts
+++ b/src/domain/extensions/bundle_freshness_test.ts
@@ -476,3 +476,183 @@ Deno.test("findStaleFiles: missing source dir is silently skipped", async () => 
     if (!(err instanceof Deno.errors.NotFound)) throw err;
   }
 });
+
+// -- Issue #208: total fingerprint --------------------------------------
+// `swamp model type search` regressed to ~8s because broken transitive
+// deps caused computeSourceFingerprint to throw, which findStaleFiles
+// caught as "permanently stale" and re-attempted bundling on every
+// invocation. The fix makes computeSourceFingerprint total: an
+// unreadable dep produces a stable sentinel entry instead of throwing,
+// so a stable broken state yields a stable fingerprint.
+
+Deno.test("computeSourceFingerprint: broken transitive symlink does not throw", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "swamp_bf_fp_broken_dep_" });
+  try {
+    const entry = join(dir, "entry.ts");
+    const broken = join(dir, "broken.ts");
+    await Deno.writeTextFile(
+      entry,
+      "import { x } from './broken.ts';\nexport const e = x;",
+    );
+    await Deno.symlink("/nonexistent/path/broken.ts", broken, { type: "file" });
+
+    const fp = await computeSourceFingerprint(entry, dir);
+    assertEquals(fp.length, 64);
+    assertEquals(/^[0-9a-f]{64}$/.test(fp), true);
+
+    // Stable across repeated calls.
+    const again = await computeSourceFingerprint(entry, dir);
+    assertEquals(fp, again);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("computeSourceFingerprint: absence of dep is captured in fingerprint", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "swamp_bf_fp_absence_" });
+  try {
+    const entry = join(dir, "entry.ts");
+    const dep = join(dir, "dep.ts");
+    await Deno.writeTextFile(
+      entry,
+      "import { x } from './dep.ts';\nexport const e = x;",
+    );
+    await Deno.writeTextFile(dep, "export const x = 1;");
+    const allPresent = await computeSourceFingerprint(entry, dir);
+
+    // Replace the readable dep with a broken symlink. Same path, same
+    // import — different readability state. Fingerprint must differ.
+    await Deno.remove(dep);
+    await Deno.symlink("/nonexistent/path/dep.ts", dep, { type: "file" });
+    const oneBroken = await computeSourceFingerprint(entry, dir);
+
+    assertNotEquals(
+      allPresent,
+      oneBroken,
+      "Fingerprint must distinguish 'all deps readable' from 'one dep unreadable' — otherwise dep restoration wouldn't trigger a rebundle",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("computeSourceFingerprint: MISSING sentinel cannot collide with a real hash", () => {
+  // The sentinel is substituted for unreadable deps in the
+  // {relPath}:{hash} entry list. A real sha-256 hex hash is exactly 64
+  // hex chars. "MISSING" is 7 chars and contains non-hex letters, so
+  // no real hash can produce the same per-file entry as a sentinel.
+  // Without this invariant a broken-dep file could spoof a healthy
+  // fingerprint.
+  assertEquals(/^[0-9a-f]{64}$/.test("MISSING"), false);
+});
+
+Deno.test("findStaleFiles: broken transitive dep — stale once, then stable (#208 regression)", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "swamp_bf_stale_broken_" });
+  try {
+    const entry = join(dir, "entry.ts");
+    const dep = join(dir, "dep.ts");
+    await Deno.writeTextFile(
+      entry,
+      "import { x } from './dep.ts';\nexport const e = x;",
+    );
+    await Deno.writeTextFile(dep, "export const x = 1;");
+
+    // Step 1: all readable. Compute fingerprint F1, store in catalog.
+    const f1 = await computeSourceFingerprint(entry, dir);
+    const catalog = new FakeCatalog();
+    catalog.add({
+      source_path: entry,
+      type_normalized: "@user/entry",
+      kind: "model",
+      bundle_path: "/ignored",
+      version: "",
+      description: "",
+      extends_type: "",
+      source_mtime: "",
+      source_fingerprint: f1,
+    });
+
+    // Step 2: break the transitive dep. findStaleFiles must mark the
+    // entry stale on this pass — the dep change is a real fingerprint
+    // change and the rebundle path needs to fire to refresh the row.
+    await Deno.remove(dep);
+    await Deno.symlink("/nonexistent/path/dep.ts", dep, { type: "file" });
+
+    const firstPass = await findStaleFiles({
+      modelsDir: dir,
+      catalog,
+      discoverFiles: discoverTsFiles,
+      kinds: ["model"],
+    });
+    assertEquals(
+      firstPass.length,
+      1,
+      "first pass after dep breaks must mark entry stale",
+    );
+    assertEquals(firstPass[0].relativePath, "entry.ts");
+
+    // Step 3: simulate the rebundle path updating the catalog row to
+    // the new sentinel-bearing fingerprint F2.
+    const f2 = await computeSourceFingerprint(entry, dir);
+    assertNotEquals(f1, f2);
+    catalog.removeBySourcePath(entry);
+    catalog.add({
+      source_path: entry,
+      type_normalized: "@user/entry",
+      kind: "model",
+      bundle_path: "/ignored",
+      version: "",
+      description: "",
+      extends_type: "",
+      source_mtime: "",
+      source_fingerprint: f2,
+    });
+
+    // Step 4: subsequent passes — the regression's load-bearing claim.
+    // With the row reflecting the broken state, findStaleFiles must
+    // NOT mark the entry stale. Pre-fix, fingerprint computation threw
+    // and the file was marked stale on every invocation, triggering
+    // bundle spawns and the 8s wall time reported in #208.
+    const secondPass = await findStaleFiles({
+      modelsDir: dir,
+      catalog,
+      discoverFiles: discoverTsFiles,
+      kinds: ["model"],
+    });
+    assertEquals(
+      secondPass.length,
+      0,
+      "subsequent passes must not mark a file with stably-broken transitive dep as stale (#208)",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("computeSourceFingerprint: restoring a broken dep changes the fingerprint", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "swamp_bf_fp_restore_" });
+  try {
+    const entry = join(dir, "entry.ts");
+    const dep = join(dir, "dep.ts");
+    await Deno.writeTextFile(
+      entry,
+      "import { x } from './dep.ts';\nexport const e = x;",
+    );
+    await Deno.symlink("/nonexistent/path/dep.ts", dep, { type: "file" });
+
+    const broken = await computeSourceFingerprint(entry, dir);
+
+    // Restore the dep as a real file with content.
+    await Deno.remove(dep);
+    await Deno.writeTextFile(dep, "export const x = 42;");
+    const restored = await computeSourceFingerprint(entry, dir);
+
+    assertNotEquals(
+      broken,
+      restored,
+      "Repairing a broken dep must change the fingerprint so the rebundle path fires",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes [swamp-club#208](https://swamp-club.com/lab/issues/208).

`swamp model type search` (and the analogous read-only commands for the other four extension kinds) regressed to multi-second wall times on repos with broken transitive imports — emitting a wall of `Rebundle failed` / `FilesystemLoop` warnings and re-attempting `deno bundle` on every invocation.

### Root cause

PR #1063 (lazy per-bundle loading) made `model type search` zero-bundle: it reads type names from the SQLite catalog without spawning `deno bundle`. PR #125 replaced mtime-based freshness with content fingerprinting in `bundle_freshness.ts`. The new fingerprint computation **threw** on any unreadable transitive dep (broken symlink, deleted file, `FilesystemLoop`), and the catch in `findStaleFiles` unconditionally marked the file stale — so every invocation triggered a rebundle attempt that was guaranteed to fail.

### Fix

Make `computeSourceFingerprint` total. Wrap the per-file `hashFile()` call in try/catch and substitute a `${relPath}:MISSING` sentinel when a dep can't be read. The fingerprint now encodes "currently unreadable" as part of the state — a stable broken state produces a stable fingerprint, and repairing the dep flips the sentinel back to a real hash so rebundles fire correctly.

### Cross-loader scope

The fix lives in shared `bundle_freshness.ts` and benefits **all five extension kinds** (models, drivers, vaults, datastores, reports) since PR #1192 ported the freshness check across loaders and `5d711c90` keeps the call sites uniform.

## Benchmarks — `@swamp/aws/ec2` (106 pulled models, shared `_lib/aws.ts` broken)

This mirrors the user's reported scenario in #208 — many extensions sharing a transitive dep that's now broken.

### Pre-fix (system swamp on PATH)

| Run | Wall time | Rebundle / FilesystemLoop warnings |
|-----|-----------|------------------------------------|
| 1   | 5.74s     | **106** |
| 2   | 5.65s     | **106** |
| 3   | 5.99s     | **106** |

Every invocation re-attempts bundling for all 106 affected files. No improvement over time.

### Post-fix (this PR)

| Run | Wall time | Warnings |
|-----|-----------|----------|
| 1 (corrective) | 6.36s | **0** |
| 2   | 0.62s     | **0** |
| 3   | 0.61s     | **0** |

Run 1 absorbs the one-time corrective rebundle pass that updates each catalog row to a sentinel-bearing fingerprint. Subsequent invocations are sub-second and silent.

**Net win on warm runs**: 5.65s → 0.62s (**~9× faster**) and 106 warnings → 0.

## Bootstrap-path behavior shift (call out for review)

`populateCatalogFromDir` previously silently skipped files whose fingerprint computation threw — leaving them rowless in the catalog. After this fix, those files receive a sentinel-bearing row at bootstrap. Net positive (better catalog state, no caller depends on "no row ⇒ unbundlable" semantics that I could find), but worth a focused look during review.

## Out of scope (separate issues)

- **Day-0-broken extensions** (never bundled successfully, no cached bundle, no catalog row) still re-attempt every invocation via the "no row → stale" branch. Different mechanism, different design (negative-cache row with retry-invalidation rules) — to be filed.
- **Schema-validation loop** ([swamp-club#209](https://swamp-club.com/lab/issues/209)) — discovered adjacent during this work. Same loop *shape* as #208 but with a different trigger: when a previously-bundled extension's source becomes schema-invalid, the rebundle path throws before `catalog.upsert` and `findStaleFiles` loops on every invocation. Pre-existing, not introduced by this change.

## Test Plan

- [x] 5 new unit tests in `bundle_freshness_test.ts` covering totality, absence-of-dep capture, sentinel-collision invariant, the precise regression sequence (stale once on dep change, then stable), and recovery on dep restoration
- [x] Full `deno run test` suite passes (5141 / 0)
- [x] `deno check`, `deno lint`, `deno fmt --check` clean
- [x] E2E verified for the model loader: `swamp model type search` — fingerprint cleanly transitions and stabilizes; pre-fix vs post-fix contrast confirmed
- [x] Cross-loader spot-check verified for the vault loader: `swamp vault type search` — exact same behavior; cross-loader uniformity claim is empirical, not just inferred
- [x] Realistic-scale benchmarks captured above with `@swamp/aws/ec2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)