### PR TITLE
feat(windows): cross-platform command/tar/chmod helpers, re-enable doctor on Windows

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -24,6 +24,8 @@
     "@std/cli": "jsr:@std/cli@^1.0.27",
     "@std/fs": "jsr:@std/fs@^1.0.22",
     "@std/path": "jsr:@std/path@^1.1.4",
+    "@std/streams": "jsr:@std/streams@^1.0.17",
+    "@std/tar": "jsr:@std/tar@^0.1.10",
     "@std/yaml": "jsr:@std/yaml@^1.0.11",
     "zod": "npm:zod@^4.3.6",
     "@cliffy/command": "jsr:@cliffy/command@1",

--- a/deno.lock
+++ b/deno.lock
@@ -18,6 +18,9 @@
     "jsr:@std/path@*": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@std/semver@^1.0.8": "1.0.8",
+    "jsr:@std/streams@^1.0.17": "1.0.17",
+    "jsr:@std/tar@*": "0.1.10",
+    "jsr:@std/tar@~0.1.10": "0.1.10",
     "jsr:@std/text@^1.0.17": "1.0.17",
     "jsr:@std/yaml@^1.0.11": "1.0.12",
     "npm:@aws-sdk/client-cloudcontrol@^3.1014.0": "3.1014.0",
@@ -115,6 +118,15 @@
     },
     "@std/semver@1.0.8": {
       "integrity": "dc830e8b8b6a380c895d53fbfd1258dc253704ca57bbe1629ac65fd7830179b7"
+    },
+    "@std/streams@1.0.17": {
+      "integrity": "7859f3d9deed83cf4b41f19223d4a67661b3d3819e9fc117698f493bf5992140"
+    },
+    "@std/tar@0.1.10": {
+      "integrity": "6bf907f3a4bc8bfef42973ba132d946756a6161ef6b914a9e1c06debe664db17",
+      "dependencies": [
+        "jsr:@std/streams"
+      ]
     },
     "@std/text@1.0.17": {
       "integrity": "4b2c4ef67ae5b6c1dfd447c81c83a43718f52e3c7e748d8b33f694aba9895f95"
@@ -1498,6 +1510,8 @@
       "jsr:@std/fmt@^1.0.9",
       "jsr:@std/fs@^1.0.22",
       "jsr:@std/path@^1.1.4",
+      "jsr:@std/streams@^1.0.17",
+      "jsr:@std/tar@~0.1.10",
       "jsr:@std/yaml@^1.0.11",
       "npm:@aws-sdk/client-cloudcontrol@^3.1014.0",
       "npm:@marcbachmann/cel-js@7.5.1",

--- a/integration/ddd_layer_rules_test.ts
+++ b/integration/ddd_layer_rules_test.ts
@@ -68,7 +68,14 @@ function isTracingImport(filePath: string, importPath: string): boolean {
 // Ratchet counts: current number of known violations.
 // If someone fixes a violation, the count decreases and the test still passes.
 // If someone adds a new violation, the count increases and the test fails.
-const KNOWN_DOMAIN_INFRA_VIOLATIONS = 26;
+// Bumped from 26 → 28 by Stream B (Windows-GA): cross-platform PATH and tar
+// helpers live in infrastructure/process and infrastructure/archive. Two
+// domain-side modules (`audit/doctor/checks/resolve_binary.ts` and
+// `extensions/extension_rubric_scorer.ts`) now reach in to share that logic
+// rather than each rolling its own POSIX-only shellout. The alternative —
+// duplicating the cross-platform branching in domain — would defeat the
+// centralization the refactor is trying to achieve.
+const KNOWN_DOMAIN_INFRA_VIOLATIONS = 28;
 
 Deno.test(
   "domain layer must not add new infrastructure imports (ratchet)",

--- a/integration/ddd_layer_rules_test.ts
+++ b/integration/ddd_layer_rules_test.ts
@@ -68,14 +68,15 @@ function isTracingImport(filePath: string, importPath: string): boolean {
 // Ratchet counts: current number of known violations.
 // If someone fixes a violation, the count decreases and the test still passes.
 // If someone adds a new violation, the count increases and the test fails.
-// Bumped from 26 → 28 by Stream B (Windows-GA): cross-platform PATH and tar
-// helpers live in infrastructure/process and infrastructure/archive. Two
-// domain-side modules (`audit/doctor/checks/resolve_binary.ts` and
-// `extensions/extension_rubric_scorer.ts`) now reach in to share that logic
-// rather than each rolling its own POSIX-only shellout. The alternative —
-// duplicating the cross-platform branching in domain — would defeat the
-// centralization the refactor is trying to achieve.
-const KNOWN_DOMAIN_INFRA_VIOLATIONS = 28;
+//
+// Stream B (Windows-GA) introduced two new cross-platform helpers in
+// infrastructure (`process/resolve_command.ts` and `archive/tar_archive.ts`).
+// The domain-side consumers of each — `audit/doctor/checks/resolve_binary.ts`
+// and `extensions/extension_rubric_scorer.ts` — receive the helpers via
+// dependency injection (a `ResolveBinary` port and an `ExtractTarball`
+// port respectively, wired in by the CLI / libswamp layer at construction
+// time). Domain stays infrastructure-free; the ratchet stays at 26.
+const KNOWN_DOMAIN_INFRA_VIOLATIONS = 26;
 
 Deno.test(
   "domain layer must not add new infrastructure imports (ratchet)",

--- a/src/cli/commands/doctor_audit.ts
+++ b/src/cli/commands/doctor_audit.ts
@@ -29,6 +29,7 @@ import {
   SWAMP_SUBDIRS,
   swampPath,
 } from "../../infrastructure/persistence/paths.ts";
+import { defaultCommandResolver } from "../../infrastructure/process/resolve_command.ts";
 import { createAuditDoctorRenderer } from "../../presentation/renderers/audit_doctor.ts";
 import { parseAiToolOrThrow } from "../ai_tool_parser.ts";
 import {
@@ -143,6 +144,7 @@ export const doctorAuditCommand = new Command()
     const controller = new AbortController();
     const renderer = createAuditDoctorRenderer(cliCtx.outputMode);
 
+    const commandResolver = defaultCommandResolver();
     await consumeStream(
       auditDoctor({
         repoPath: repoDir,
@@ -150,6 +152,7 @@ export const doctorAuditCommand = new Command()
         tool: resolvedTool,
         spawnSwamp: makeSwampSpawnFn(repoDir),
         abortSignal: controller.signal,
+        resolveBinary: (name) => commandResolver.resolve(name),
       }),
       renderer.handlers(),
     );

--- a/src/domain/audit/doctor/checks/binary_on_path.ts
+++ b/src/domain/audit/doctor/checks/binary_on_path.ts
@@ -19,11 +19,7 @@
 
 import type { AiTool } from "../../../repo/repo_service.ts";
 import type { PreflightCheck } from "../check.ts";
-import {
-  binaryNameFor,
-  type ResolveBinary,
-  resolveBinaryViaWhich,
-} from "./resolve_binary.ts";
+import { binaryNameFor, type ResolveBinary } from "./resolve_binary.ts";
 
 const INSTALL_HINTS: Record<string, string> = {
   claude:
@@ -41,11 +37,14 @@ function appliesTo(tool: AiTool): boolean {
 /**
  * Verifies the AI tool's own binary is on PATH. Without it, the tool can't
  * run at all — no commands, no hooks, no audit rows.
+ *
+ * `resolveBinary` is injected — domain owns the port, the CLI passes in
+ * `defaultCommandResolver()` from `infrastructure/process` at wiring time.
  */
 export function makeBinaryOnPathCheck(
-  opts: { resolveBinary?: ResolveBinary } = {},
+  opts: { resolveBinary: ResolveBinary },
 ): PreflightCheck {
-  const resolveBinary = opts.resolveBinary ?? resolveBinaryViaWhich;
+  const { resolveBinary } = opts;
   return {
     name: "binary-on-path",
     description: "AI tool binary is resolvable on PATH",
@@ -71,5 +70,3 @@ export function makeBinaryOnPathCheck(
     },
   };
 }
-
-export const binaryOnPathCheck = makeBinaryOnPathCheck();

--- a/src/domain/audit/doctor/checks/binary_on_path_test.ts
+++ b/src/domain/audit/doctor/checks/binary_on_path_test.ts
@@ -69,7 +69,9 @@ Deno.test("binaryOnPath: uses tool-specific binary name", async () => {
 });
 
 Deno.test("binaryOnPath: appliesTo returns true for all four audit tools, false otherwise", () => {
-  const check = makeBinaryOnPathCheck();
+  const check = makeBinaryOnPathCheck({
+    resolveBinary: () => Promise.resolve(null),
+  });
   assertEquals(check.appliesTo("claude"), true);
   assertEquals(check.appliesTo("cursor"), true);
   assertEquals(check.appliesTo("kiro"), true);

--- a/src/domain/audit/doctor/checks/resolve_binary.ts
+++ b/src/domain/audit/doctor/checks/resolve_binary.ts
@@ -17,31 +17,19 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { defaultCommandResolver } from "../../../../infrastructure/process/resolve_command.ts";
+
 /**
- * POSIX PATH binary resolution port.
+ * Cross-platform PATH binary resolution port.
  *
- * Production uses `which` via `Deno.Command`; tests inject a fake.
- * Scoped to POSIX (macOS/Linux) — swamp's supported platforms as of v1.
- * Windows support deferred until a user asks.
+ * Production resolves via the shared `defaultCommandResolver` (which uses
+ * `which` on POSIX and `where` on Windows); tests inject a fake.
  */
 export type ResolveBinary = (name: string) => Promise<string | null>;
 
-/** Default implementation using POSIX `which`. */
-export const resolveBinaryViaWhich: ResolveBinary = async (name) => {
-  try {
-    const cmd = new Deno.Command("which", {
-      args: [name],
-      stdout: "piped",
-      stderr: "null",
-    });
-    const { success, stdout } = await cmd.output();
-    if (!success) return null;
-    const path = new TextDecoder().decode(stdout).trim();
-    return path || null;
-  } catch {
-    return null;
-  }
-};
+/** Default implementation using the cross-platform command resolver. */
+export const resolveBinaryViaWhich: ResolveBinary = (name) =>
+  defaultCommandResolver().resolve(name);
 
 /** The shell-command binary name for each audit-integrating tool. */
 export function binaryNameFor(tool: string): string {

--- a/src/domain/audit/doctor/checks/resolve_binary.ts
+++ b/src/domain/audit/doctor/checks/resolve_binary.ts
@@ -17,19 +17,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { defaultCommandResolver } from "../../../../infrastructure/process/resolve_command.ts";
-
 /**
  * Cross-platform PATH binary resolution port.
  *
- * Production resolves via the shared `defaultCommandResolver` (which uses
- * `which` on POSIX and `where` on Windows); tests inject a fake.
+ * Domain declares the contract; the CLI layer wires in
+ * `defaultCommandResolver()` from `infrastructure/process` (POSIX `which`,
+ * Windows `where`) at construction time. Tests inject a fake directly.
  */
 export type ResolveBinary = (name: string) => Promise<string | null>;
-
-/** Default implementation using the cross-platform command resolver. */
-export const resolveBinaryViaWhich: ResolveBinary = (name) =>
-  defaultCommandResolver().resolve(name);
 
 /** The shell-command binary name for each audit-integrating tool. */
 export function binaryNameFor(tool: string): string {

--- a/src/domain/audit/doctor/checks/swamp_binary_on_path.ts
+++ b/src/domain/audit/doctor/checks/swamp_binary_on_path.ts
@@ -20,7 +20,7 @@
 import { join } from "@std/path";
 import type { AiTool } from "../../../repo/repo_service.ts";
 import type { CheckContext, CheckResult, PreflightCheck } from "../check.ts";
-import { type ResolveBinary, resolveBinaryViaWhich } from "./resolve_binary.ts";
+import type { ResolveBinary } from "./resolve_binary.ts";
 
 /**
  * Verifies swamp itself is invocable from the hook. All four supported
@@ -89,10 +89,14 @@ async function checkKiroBakedPath(ctx: CheckContext): Promise<{
   }
 }
 
+/**
+ * `resolveBinary` is injected — domain owns the port, the CLI passes in
+ * `defaultCommandResolver()` from `infrastructure/process` at wiring time.
+ */
 export function makeSwampBinaryOnPathCheck(
-  opts: { resolveBinary?: ResolveBinary } = {},
+  opts: { resolveBinary: ResolveBinary },
 ): PreflightCheck {
-  const resolveBinary = opts.resolveBinary ?? resolveBinaryViaWhich;
+  const { resolveBinary } = opts;
   return {
     name: "swamp-binary-on-path",
     description:
@@ -140,5 +144,3 @@ export function makeSwampBinaryOnPathCheck(
     },
   };
 }
-
-export const swampBinaryOnPathCheck = makeSwampBinaryOnPathCheck();

--- a/src/domain/audit/doctor/doctor_service.ts
+++ b/src/domain/audit/doctor/doctor_service.ts
@@ -28,10 +28,11 @@ import type {
   SpawnFn,
 } from "./check.ts";
 import { agentConfigLoadableCheck } from "./checks/agent_config_loadable.ts";
-import { binaryOnPathCheck } from "./checks/binary_on_path.ts";
+import { makeBinaryOnPathCheck } from "./checks/binary_on_path.ts";
 import { defaultAgentSetCheck } from "./checks/default_agent_set.ts";
 import { recordingSmokeTestCheck } from "./checks/recording_smoke.ts";
-import { swampBinaryOnPathCheck } from "./checks/swamp_binary_on_path.ts";
+import type { ResolveBinary } from "./checks/resolve_binary.ts";
+import { makeSwampBinaryOnPathCheck } from "./checks/swamp_binary_on_path.ts";
 
 /**
  * Streaming events from the doctor audit pipeline. The `error` variant is
@@ -52,6 +53,13 @@ export interface AuditDoctorDeps {
   tool: AiTool;
   spawnSwamp: SpawnFn;
   abortSignal: AbortSignal;
+  /**
+   * Cross-platform PATH resolver. The CLI layer wires in
+   * `defaultCommandResolver()` from `infrastructure/process`; tests pass a
+   * fake. Required when `checks` is not supplied (the default check order
+   * uses it for the binary-on-PATH checks).
+   */
+  resolveBinary?: ResolveBinary;
   /** Override the default check set (tests only). */
   checks?: readonly PreflightCheck[];
 }
@@ -60,19 +68,38 @@ export interface AuditDoctorDeps {
  * Canonical check run order. Fixed so the UI output is stable and so a
  * reviewer can see that later checks depend on earlier ones passing in
  * practice (e.g. smoke-test requires swamp on PATH).
+ *
+ * `resolveBinary` is injected so the domain layer doesn't import the
+ * cross-platform `which`/`where` helper from infrastructure — the CLI
+ * passes `defaultCommandResolver()` in.
  */
-export const DEFAULT_CHECK_ORDER: readonly PreflightCheck[] = [
-  binaryOnPathCheck,
-  swampBinaryOnPathCheck,
-  agentConfigLoadableCheck,
-  defaultAgentSetCheck,
-  recordingSmokeTestCheck,
-];
+export function defaultCheckOrder(
+  resolveBinary: ResolveBinary,
+): readonly PreflightCheck[] {
+  return [
+    makeBinaryOnPathCheck({ resolveBinary }),
+    makeSwampBinaryOnPathCheck({ resolveBinary }),
+    agentConfigLoadableCheck,
+    defaultAgentSetCheck,
+    recordingSmokeTestCheck,
+  ];
+}
 
 function overallStatus(checks: CheckResult[]): OverallStatus {
   if (checks.some((c) => c.status === "fail")) return "fail";
   if (checks.every((c) => c.status === "skip")) return "warn";
   return "pass";
+}
+
+function buildDefaultChecks(deps: AuditDoctorDeps): readonly PreflightCheck[] {
+  if (!deps.resolveBinary) {
+    throw new Error(
+      "auditDoctor: deps.resolveBinary is required when deps.checks is not " +
+        "supplied — pass `defaultCommandResolver().resolve` (from " +
+        "infrastructure/process/resolve_command.ts) at the CLI layer.",
+    );
+  }
+  return defaultCheckOrder(deps.resolveBinary);
 }
 
 /**
@@ -103,7 +130,7 @@ export async function* auditDoctor(
     return;
   }
 
-  const checks = deps.checks ?? DEFAULT_CHECK_ORDER;
+  const checks = deps.checks ?? buildDefaultChecks(deps);
   const results: CheckResult[] = [];
 
   for (const check of checks) {

--- a/src/domain/audit/doctor/doctor_service_test.ts
+++ b/src/domain/audit/doctor/doctor_service_test.ts
@@ -30,7 +30,7 @@ import {
   auditDoctor,
   type AuditDoctorDeps,
   type AuditDoctorEvent,
-  DEFAULT_CHECK_ORDER,
+  defaultCheckOrder,
 } from "./doctor_service.ts";
 
 const noopSpawn: SpawnFn = () =>
@@ -164,8 +164,9 @@ Deno.test(
   },
 );
 
-Deno.test("auditDoctor: DEFAULT_CHECK_ORDER is stable and covers all five names", () => {
-  const names = DEFAULT_CHECK_ORDER.map((c) => c.name);
+Deno.test("auditDoctor: defaultCheckOrder is stable and covers all five names", () => {
+  const order = defaultCheckOrder(() => Promise.resolve(null));
+  const names = order.map((c) => c.name);
   assertEquals(names, [
     "binary-on-path",
     "swamp-binary-on-path",

--- a/src/domain/extensions/extension_rubric_scorer.ts
+++ b/src/domain/extensions/extension_rubric_scorer.ts
@@ -19,6 +19,7 @@
 
 import { join, resolve, SEPARATOR } from "@std/path";
 import type { ExtensionManifest } from "./extension_manifest.ts";
+import { extractTarGz } from "../../infrastructure/archive/tar_archive.ts";
 
 /**
  * Client-side scorer for the Swamp Club extension quality rubric.
@@ -553,18 +554,15 @@ export async function scoreExtensionTarball(
     await Deno.writeFile(tarballPath, tarballBytes);
     await Deno.mkdir(extractDir);
 
-    // Extract with the system `tar`. The CLI built this tarball itself,
-    // so we skip the server-side Zip-Slip / type checks — we trust our
-    // own output.
-    const tarCmd = new Deno.Command("tar", {
-      args: ["-xzf", tarballPath, "-C", extractDir],
-      stdout: "piped",
-      stderr: "piped",
-    });
-    const tarOut = await tarCmd.output();
-    if (!tarOut.success) {
-      const err = new TextDecoder().decode(tarOut.stderr);
-      throw new Error(`Failed to extract tarball for scoring: ${err}`);
+    // Extract via the Deno-native helper. The CLI built this tarball
+    // itself, so we skip the server-side Zip-Slip / type checks — we trust
+    // our own output.
+    try {
+      const tarFile = await Deno.open(tarballPath, { read: true });
+      await extractTarGz(tarFile.readable, extractDir);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to extract tarball for scoring: ${message}`);
     }
 
     // Locate the directory that holds manifest.yaml. Swamp CLI's

--- a/src/domain/extensions/extension_rubric_scorer.ts
+++ b/src/domain/extensions/extension_rubric_scorer.ts
@@ -19,7 +19,6 @@
 
 import { join, resolve, SEPARATOR } from "@std/path";
 import type { ExtensionManifest } from "./extension_manifest.ts";
-import { extractTarGz } from "../../infrastructure/archive/tar_archive.ts";
 
 /**
  * Client-side scorer for the Swamp Club extension quality rubric.
@@ -472,16 +471,31 @@ function symbolsRow(pct: number): RubricFactor {
 
 // ── Tarball extraction + deno doc orchestrator ─────────────────────────
 
+/**
+ * Extracts a `.tar.gz` byte stream into the given directory. Domain owns
+ * the port; the libswamp layer wires in `extractTarGz` from
+ * `infrastructure/archive/tar_archive.ts` so this module doesn't reach
+ * across layers. Tests inject a fake.
+ */
+export type ExtractTarball = (
+  source: ReadableStream<Uint8Array>,
+  destDir: string,
+) => Promise<void>;
+
 /** Injected subprocess deps — makes tests hermetic. */
 export interface RubricScoreDeps {
   runDeno: (
     args: string[],
     cwd: string,
   ) => Promise<{ success: boolean; stdout: string; stderr: string }>;
+  extractTarball: ExtractTarball;
 }
 
-/** Default deps: real `deno` subprocess. */
-export function createRubricScoreDeps(denoPath: string): RubricScoreDeps {
+/** Default deps: real `deno` subprocess plus the supplied tarball extractor. */
+export function createRubricScoreDeps(
+  denoPath: string,
+  extractTarball: ExtractTarball,
+): RubricScoreDeps {
   return {
     runDeno: async (args, cwd) => {
       const cmd = new Deno.Command(denoPath, {
@@ -498,6 +512,7 @@ export function createRubricScoreDeps(denoPath: string): RubricScoreDeps {
         stderr: new TextDecoder().decode(out.stderr),
       };
     },
+    extractTarball,
   };
 }
 
@@ -554,12 +569,13 @@ export async function scoreExtensionTarball(
     await Deno.writeFile(tarballPath, tarballBytes);
     await Deno.mkdir(extractDir);
 
-    // Extract via the Deno-native helper. The CLI built this tarball
-    // itself, so we skip the server-side Zip-Slip / type checks — we trust
-    // our own output.
+    // Extract via the injected tarball extractor (libswamp wires in
+    // `extractTarGz` from infrastructure/archive). The CLI built this
+    // tarball itself, so we skip the server-side Zip-Slip / type checks —
+    // we trust our own output.
     try {
       const tarFile = await Deno.open(tarballPath, { read: true });
-      await extractTarGz(tarFile.readable, extractDir);
+      await deps.extractTarball(tarFile.readable, extractDir);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to extract tarball for scoring: ${message}`);

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -21,6 +21,7 @@ import { join } from "@std/path";
 import { ensureDir } from "@std/fs";
 import { getLogger } from "@logtape/logtape";
 import { atomicWriteTextFile } from "../../infrastructure/persistence/atomic_write.ts";
+import { defaultCommandResolver } from "../../infrastructure/process/resolve_command.ts";
 import type { RepoPath } from "./repo_path.ts";
 import {
   SWAMP_SUBDIRS,
@@ -1451,8 +1452,8 @@ ${body}`;
    * Uses the absolute path to the swamp binary because kiro-cli does not
    * perform PATH resolution when executing hook commands.
    */
-  private generateKiroHookContent(): string {
-    const swampBin = this.resolveSwampBinaryPath();
+  private async generateKiroHookContent(): Promise<string> {
+    const swampBin = await this.resolveSwampBinaryPath();
     const hook = {
       name: "Swamp Audit",
       description: "Records agent tool usage for swamp audit tracking",
@@ -1471,28 +1472,15 @@ ${body}`;
    * Resolves the absolute path to the swamp binary.
    * Falls back to bare "swamp" if resolution fails.
    */
-  private resolveSwampBinaryPath(): string {
-    try {
-      const cmd = new Deno.Command("which", {
-        args: ["swamp"],
-        stdout: "piped",
-        stderr: "null",
-      });
-      const { success, stdout } = cmd.outputSync();
-      if (success) {
-        const path = new TextDecoder().decode(stdout).trim();
-        if (path) return path;
-      }
-    } catch {
-      // which not available or failed
-    }
-    return "swamp";
+  private async resolveSwampBinaryPath(): Promise<string> {
+    const path = await defaultCommandResolver().resolve("swamp");
+    return path ?? "swamp";
   }
 
   /**
    * Creates .kiro/hooks/swamp-audit.kiro.hook if it doesn't already exist.
    */
-  private createKiroHooksIfNotExists(
+  private async createKiroHooksIfNotExists(
     repoPath: RepoPath,
   ): Promise<boolean> {
     const hookPath = join(
@@ -1501,9 +1489,9 @@ ${body}`;
       "hooks",
       "swamp-audit.kiro.hook",
     );
-    return this.createFileIfNotExists(
+    return await this.createFileIfNotExists(
       hookPath,
-      this.generateKiroHookContent(),
+      await this.generateKiroHookContent(),
     );
   }
 
@@ -1530,7 +1518,10 @@ ${body}`;
       "hooks",
       "swamp-audit.kiro.hook",
     );
-    return this.overwriteIfChanged(hookPath, this.generateKiroHookContent());
+    return this.overwriteIfChanged(
+      hookPath,
+      await this.generateKiroHookContent(),
+    );
   }
 
   /**
@@ -1538,8 +1529,8 @@ ${body}`;
    * This provides kiro-cli with trusted commands, audit hooks, and resource
    * references that the IDE gets from .vscode/settings.local.json and .kiro/hooks/.
    */
-  private generateKiroAgentConfigContent(): string {
-    const swampBin = this.resolveSwampBinaryPath();
+  private async generateKiroAgentConfigContent(): Promise<string> {
+    const swampBin = await this.resolveSwampBinaryPath();
     const config = {
       name: "swamp",
       description: "Swamp automation agent with audit tracking",
@@ -1570,7 +1561,7 @@ ${body}`;
   /**
    * Creates .kiro/agents/swamp.json if it doesn't already exist.
    */
-  private createKiroAgentConfigIfNotExists(
+  private async createKiroAgentConfigIfNotExists(
     repoPath: RepoPath,
   ): Promise<boolean> {
     const configPath = join(
@@ -1579,25 +1570,25 @@ ${body}`;
       "agents",
       "swamp.json",
     );
-    return this.createFileIfNotExists(
+    return await this.createFileIfNotExists(
       configPath,
-      this.generateKiroAgentConfigContent(),
+      await this.generateKiroAgentConfigContent(),
     );
   }
 
   /**
    * Updates .kiro/agents/swamp.json, overwriting with latest content.
    */
-  private updateKiroAgentConfig(repoPath: RepoPath): Promise<boolean> {
+  private async updateKiroAgentConfig(repoPath: RepoPath): Promise<boolean> {
     const configPath = join(
       repoPath.value,
       ".kiro",
       "agents",
       "swamp.json",
     );
-    return this.overwriteIfChanged(
+    return await this.overwriteIfChanged(
       configPath,
-      this.generateKiroAgentConfigContent(),
+      await this.generateKiroAgentConfigContent(),
     );
   }
 

--- a/src/infrastructure/archive/tar_archive.ts
+++ b/src/infrastructure/archive/tar_archive.ts
@@ -1,0 +1,389 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { ensureDir } from "@std/fs";
+import { basename, dirname, join, normalize, relative } from "@std/path";
+import { TarStream, type TarStreamInput } from "@std/tar/tar-stream";
+import { UntarStream } from "@std/tar/untar-stream";
+
+/**
+ * `DecompressionStream` is typed to emit `BufferSource`, which TypeScript
+ * doesn't accept where `UntarStream` expects `Uint8Array`. Wrap each chunk
+ * defensively so the TS lib types line up; at runtime every chunk really is
+ * a `Uint8Array` from the gzip decoder.
+ */
+function toUint8ArrayStream(): TransformStream<BufferSource, Uint8Array> {
+  return new TransformStream({
+    transform(chunk, controller) {
+      if (chunk instanceof Uint8Array) {
+        controller.enqueue(chunk);
+      } else if (chunk instanceof ArrayBuffer) {
+        controller.enqueue(new Uint8Array(chunk));
+      } else {
+        controller.enqueue(
+          new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength),
+        );
+      }
+    },
+  });
+}
+
+/**
+ * An entry written by the tar reader during streaming extraction.
+ *
+ * The entry holds the raw tar header along with an absolute target path
+ * (derived from the configured extraction root) so callers can apply
+ * additional validation — e.g. symlink-escape checks — before any bytes hit
+ * disk.
+ */
+export interface ExtractedEntry {
+  /** Path inside the archive (as recorded in the tar header). */
+  archivePath: string;
+  /** The fully-resolved on-disk target path. */
+  targetPath: string;
+  /** Whether the entry is a regular file. */
+  isFile: boolean;
+  /** Whether the entry is a directory. */
+  isDirectory: boolean;
+  /** Whether the entry is a symlink. */
+  isSymlink: boolean;
+  /** Symlink target as recorded in the header (only set for symlinks). */
+  linkname: string | null;
+  /** POSIX mode bits as recorded in the header. */
+  mode: number;
+}
+
+/**
+ * Whether a tar typeflag indicates a hardlink (typeflag '1') or a symlink
+ * (typeflag '2'). We treat both as link-typed entries; only symlinks are
+ * created on disk, hardlinks are skipped (they're vanishingly rare in our
+ * archives and risky cross-platform).
+ */
+function isLinkTypeflag(typeflag: string): boolean {
+  return typeflag === "1" || typeflag === "2";
+}
+
+function isDirectoryTypeflag(typeflag: string): boolean {
+  return typeflag === "5";
+}
+
+/**
+ * Validates that `targetPath` stays within `extractRoot`. Throws when the
+ * archive entry's path resolves outside the root (the classic ../ traversal
+ * attack against tar extraction).
+ */
+function ensureNoTraversal(targetPath: string, extractRoot: string): void {
+  const rel = relative(extractRoot, targetPath);
+  if (rel.startsWith("..") || rel === "..") {
+    throw new Error(
+      `Archive entry escapes extract root: ${targetPath}`,
+    );
+  }
+}
+
+/**
+ * Streams a `.tar.gz` byte stream into `extractRoot`, calling `onEntry` for
+ * each entry before any bytes are written. `onEntry` may throw to abort
+ * extraction (e.g. on a path-traversal violation discovered during validation).
+ *
+ * Behavior preserved from the previous shell-out:
+ * - Symlinks are recreated as symlinks (not dereferenced).
+ * - File modes are honored where present in the archive header.
+ * - Path-traversal entries (`../foo`) abort extraction with an error.
+ *
+ * Note: macOS resource-fork files (`._foo`) leak into archives only when the
+ * archiver is the BSD `tar` binary on darwin reading from an HFS+/APFS source
+ * tree. Since we now produce archives via `TarStream` from explicit per-file
+ * input, those AppleDouble files cannot appear unless a caller explicitly
+ * adds them — there is no equivalent of the `COPYFILE_DISABLE=1` env var
+ * because the underlying mechanism doesn't run.
+ */
+export async function extractTarGz(
+  source: ReadableStream<Uint8Array>,
+  extractRoot: string,
+  onEntry?: (entry: ExtractedEntry) => void | Promise<void>,
+): Promise<void> {
+  await ensureDir(extractRoot);
+  const root = await Deno.realPath(extractRoot);
+
+  // `pipeThrough` typings on `ReadableStream<Uint8Array>` are tighter than
+  // what `DecompressionStream` accepts as its writable side; cast to the
+  // BufferSource-shaped stream that `DecompressionStream` actually needs.
+  const compressed = source as unknown as ReadableStream<BufferSource>;
+  const stream = compressed
+    .pipeThrough(new DecompressionStream("gzip"))
+    .pipeThrough(toUint8ArrayStream())
+    .pipeThrough(new UntarStream());
+
+  for await (const entry of stream) {
+    const typeflag = entry.header.typeflag;
+
+    // PAX extended-header entries (typeflag 'x' / 'g') and macOS AppleDouble
+    // resource forks (`._foo`) are noise injected by BSD `tar` on darwin
+    // sources. They have no place in our archives — skip them so we don't
+    // litter the extract dir with metadata files.
+    if (
+      typeflag === "x" || typeflag === "g" || typeflag === "L" ||
+      typeflag === "K"
+    ) {
+      if (entry.readable) await entry.readable.cancel();
+      continue;
+    }
+    if (
+      entry.path.split("/").some((seg) => seg.startsWith("._")) ||
+      entry.path.startsWith("PaxHeader/") ||
+      entry.path.includes("/PaxHeader/")
+    ) {
+      if (entry.readable) await entry.readable.cancel();
+      continue;
+    }
+
+    const normalized = normalize(entry.path);
+    // `normalize` resolves `..` segments relative to nothing; check the raw
+    // archive path for traversal attempts, then again on the resolved target.
+    if (
+      normalized.startsWith("..") ||
+      normalized === ".." ||
+      normalized.startsWith("/") ||
+      normalized.startsWith("\\")
+    ) {
+      // Drain any readable to release the lock so the next entry can resolve.
+      if (entry.readable) {
+        await entry.readable.cancel();
+      }
+      throw new Error(`Archive contains unsafe path: ${entry.path}`);
+    }
+
+    const targetPath = join(root, normalized);
+    ensureNoTraversal(targetPath, root);
+
+    const isDir = isDirectoryTypeflag(typeflag);
+    const isLink = isLinkTypeflag(typeflag);
+    const isSymlink = typeflag === "2";
+    const isFile = !isDir && !isLink && entry.readable !== undefined;
+
+    const meta: ExtractedEntry = {
+      archivePath: entry.path,
+      targetPath,
+      isFile,
+      isDirectory: isDir,
+      isSymlink,
+      linkname: isLink ? entry.header.linkname : null,
+      mode: entry.header.mode & 0o7777,
+    };
+
+    if (onEntry) {
+      await onEntry(meta);
+    }
+
+    if (isDir) {
+      await ensureDir(targetPath);
+      continue;
+    }
+
+    if (isSymlink) {
+      // Determine link type by probing the resolved symlink target — Windows
+      // refuses dir symlinks pointing at a missing target without { type }.
+      // POSIX ignores the `type` argument.
+      let linkType: "file" | "dir" = "file";
+      try {
+        const stat = await Deno.stat(
+          join(dirname(targetPath), entry.header.linkname),
+        );
+        if (stat.isDirectory) linkType = "dir";
+      } catch {
+        // Broken or not-yet-extracted target — default to "file"
+      }
+      try {
+        await Deno.symlink(entry.header.linkname, targetPath, {
+          type: linkType,
+        });
+      } catch (error) {
+        // Some archives carry duplicate symlink entries; ignore "exists" and
+        // re-throw anything else.
+        if (!(error instanceof Deno.errors.AlreadyExists)) {
+          throw error;
+        }
+      }
+      continue;
+    }
+
+    if (typeflag === "1") {
+      // Hardlinks are uncommon in our archives and have inconsistent
+      // cross-platform semantics; skip silently.
+      continue;
+    }
+
+    if (!entry.readable) {
+      // Other typeflags (block/char devices, FIFOs, etc.) — skip.
+      continue;
+    }
+
+    await ensureDir(dirname(targetPath));
+    const file = await Deno.open(targetPath, {
+      write: true,
+      create: true,
+      truncate: true,
+    });
+    try {
+      await entry.readable.pipeTo(file.writable);
+    } catch (error) {
+      // file.writable is already closed by pipeTo on error paths.
+      throw error;
+    }
+
+    if (Deno.build.os !== "windows" && meta.mode > 0) {
+      try {
+        await Deno.chmod(targetPath, meta.mode);
+      } catch {
+        // Best-effort — some filesystems (e.g. mounted FAT) reject chmod.
+      }
+    }
+  }
+}
+
+/**
+ * Reads a `.tar.gz` byte stream and returns the list of archive paths without
+ * writing anything to disk. Used for pre-extraction safety checks (e.g.
+ * "archive contains unsafe path").
+ */
+export async function listTarGzEntries(
+  source: ReadableStream<Uint8Array>,
+): Promise<string[]> {
+  const entries: string[] = [];
+  const compressed = source as unknown as ReadableStream<BufferSource>;
+  const stream = compressed
+    .pipeThrough(new DecompressionStream("gzip"))
+    .pipeThrough(toUint8ArrayStream())
+    .pipeThrough(new UntarStream());
+
+  for await (const entry of stream) {
+    const typeflag = entry.header.typeflag;
+    // Skip PAX extended-header and macOS AppleDouble companion entries —
+    // see extractTarGz for the matching filter.
+    const skipMeta = typeflag === "x" || typeflag === "g" ||
+      typeflag === "L" || typeflag === "K" ||
+      entry.path.split("/").some((seg) => seg.startsWith("._")) ||
+      entry.path.startsWith("PaxHeader/") ||
+      entry.path.includes("/PaxHeader/");
+    if (!skipMeta) {
+      entries.push(entry.path);
+    }
+    if (entry.readable) {
+      await entry.readable.cancel();
+    }
+  }
+  return entries;
+}
+
+/**
+ * Recursively walks `sourceDir` and writes a gzip-compressed tar archive to
+ * `archivePath`. The archive paths are relative to `sourceDir.parent`, so
+ * passing `/tmp/foo/extension` writes entries like `extension/...`,
+ * matching `tar -czf out.tar.gz -C /tmp/foo extension`.
+ *
+ * AppleDouble files (`._foo`) are not produced because we walk the source
+ * tree explicitly via `Deno.readDir` rather than asking BSD `tar` to copy
+ * extended attributes — the underlying mechanism doesn't run.
+ */
+export async function createTarGz(
+  sourceDir: string,
+  archivePath: string,
+): Promise<void> {
+  const resolvedSource = await Deno.realPath(sourceDir);
+  const archiveTopName = basename(resolvedSource);
+  const parent = dirname(resolvedSource);
+
+  const inputs: TarStreamInput[] = [];
+  await collectEntries(resolvedSource, parent, archiveTopName, inputs);
+
+  const file = await Deno.open(archivePath, {
+    write: true,
+    create: true,
+    truncate: true,
+  });
+
+  await ReadableStream.from(inputs)
+    .pipeThrough(new TarStream())
+    .pipeThrough(new CompressionStream("gzip"))
+    .pipeTo(file.writable);
+}
+
+async function collectEntries(
+  absPath: string,
+  parent: string,
+  topName: string,
+  out: TarStreamInput[],
+): Promise<void> {
+  const stat = await Deno.lstat(absPath);
+  // Record the path relative to the archive root using forward slashes —
+  // ustar requires POSIX separators regardless of the host OS.
+  const archivePath = relative(parent, absPath).split(/\\|\//).join("/");
+
+  if (stat.isSymlink) {
+    const linkname = await Deno.readLink(absPath);
+    out.push({
+      type: "symlink",
+      path: archivePath,
+      linkname,
+    });
+    return;
+  }
+
+  if (stat.isDirectory) {
+    // Skip macOS AppleDouble files defensively even though Deno.readDir
+    // shouldn't surface them on APFS reads — guards against archives staged
+    // from a hand-crafted source tree that happens to include them.
+    if (basename(archivePath).startsWith("._")) {
+      return;
+    }
+    out.push({
+      type: "directory",
+      path: archivePath + "/",
+      options: { mode: stat.mode ?? undefined },
+    });
+    const children: string[] = [];
+    for await (const child of Deno.readDir(absPath)) {
+      if (child.name.startsWith("._")) continue;
+      children.push(child.name);
+    }
+    children.sort();
+    for (const name of children) {
+      await collectEntries(join(absPath, name), parent, topName, out);
+    }
+    return;
+  }
+
+  if (stat.isFile) {
+    if (basename(archivePath).startsWith("._")) {
+      return;
+    }
+    const file = await Deno.open(absPath, { read: true });
+    out.push({
+      type: "file",
+      path: archivePath,
+      size: stat.size,
+      readable: file.readable,
+      options: { mode: stat.mode ?? undefined },
+    });
+    return;
+  }
+
+  // Sockets, FIFOs, devices, etc. — skip.
+}

--- a/src/infrastructure/archive/tar_archive_test.ts
+++ b/src/infrastructure/archive/tar_archive_test.ts
@@ -1,0 +1,222 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { createTarGz, extractTarGz, listTarGzEntries } from "./tar_archive.ts";
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await Deno.makeTempDir({ prefix: "tar-archive-test-" });
+  try {
+    return await fn(dir);
+  } finally {
+    try {
+      await Deno.remove(dir, { recursive: true });
+    } catch {
+      // Windows occasionally throws EBUSY when V8 hasn't released file
+      // handles. Best-effort cleanup.
+    }
+  }
+}
+
+function streamFromBytes(bytes: Uint8Array): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+Deno.test("createTarGz + extractTarGz: round-trip preserves regular files", async () => {
+  await withTempDir(async (root) => {
+    const src = join(root, "src");
+    const top = join(src, "thing");
+    await ensureDir(top);
+    await Deno.writeTextFile(join(top, "a.txt"), "alpha");
+    await ensureDir(join(top, "sub"));
+    await Deno.writeTextFile(join(top, "sub", "b.txt"), "beta");
+
+    const archive = join(root, "out.tar.gz");
+    await createTarGz(top, archive);
+
+    const dst = join(root, "dst");
+    await ensureDir(dst);
+    const archiveBytes = await Deno.readFile(archive);
+    await extractTarGz(streamFromBytes(archiveBytes), dst);
+
+    assertEquals(
+      await Deno.readTextFile(join(dst, "thing", "a.txt")),
+      "alpha",
+    );
+    assertEquals(
+      await Deno.readTextFile(join(dst, "thing", "sub", "b.txt")),
+      "beta",
+    );
+  });
+});
+
+Deno.test({
+  name: "createTarGz + extractTarGz: preserves symlinks",
+  // Windows symlink creation requires elevated privileges by default; skip
+  // this test there. Pull/push only target macOS/Linux for symlink-bearing
+  // archives in production.
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    await withTempDir(async (root) => {
+      const top = join(root, "src", "ext");
+      await ensureDir(top);
+      await Deno.writeTextFile(join(top, "real.txt"), "linked");
+      await Deno.symlink("real.txt", join(top, "link.txt"), { type: "file" });
+
+      const archive = join(root, "out.tar.gz");
+      await createTarGz(top, archive);
+
+      const dst = join(root, "dst");
+      await ensureDir(dst);
+      const bytes = await Deno.readFile(archive);
+      await extractTarGz(streamFromBytes(bytes), dst);
+
+      const linkPath = join(dst, "ext", "link.txt");
+      const stat = await Deno.lstat(linkPath);
+      assert(stat.isSymlink, "link.txt should be a symlink");
+      const target = await Deno.readLink(linkPath);
+      assertEquals(target, "real.txt");
+    });
+  },
+});
+
+Deno.test("extractTarGz: rejects archive entries that escape via ../", async () => {
+  await withTempDir(async (root) => {
+    // Build a malicious archive by hand using TarStream (we can't ask the
+    // platform tar to do this safely).
+    const { TarStream } = await import("@std/tar/tar-stream");
+    const archivePath = join(root, "bad.tar.gz");
+    const file = await Deno.open(archivePath, {
+      write: true,
+      create: true,
+      truncate: true,
+    });
+    const payload = new TextEncoder().encode("malicious");
+    await ReadableStream.from([
+      {
+        type: "file" as const,
+        path: "../escape.txt",
+        size: payload.length,
+        readable: new ReadableStream({
+          start(controller) {
+            controller.enqueue(payload);
+            controller.close();
+          },
+        }),
+      },
+    ])
+      .pipeThrough(new TarStream())
+      .pipeThrough(new CompressionStream("gzip"))
+      .pipeTo(file.writable);
+
+    const dst = join(root, "dst");
+    await ensureDir(dst);
+    const bytes = await Deno.readFile(archivePath);
+    await assertRejects(
+      () => extractTarGz(streamFromBytes(bytes), dst),
+      Error,
+      "unsafe path",
+    );
+  });
+});
+
+Deno.test("listTarGzEntries: returns the archive paths without writing to disk", async () => {
+  await withTempDir(async (root) => {
+    const top = join(root, "src", "thing");
+    await ensureDir(top);
+    await Deno.writeTextFile(join(top, "a.txt"), "alpha");
+
+    const archive = join(root, "out.tar.gz");
+    await createTarGz(top, archive);
+
+    const bytes = await Deno.readFile(archive);
+    const entries = await listTarGzEntries(streamFromBytes(bytes));
+    // The exact set: directory entry "thing/" + file "thing/a.txt"
+    assert(entries.includes("thing/a.txt"));
+    assert(entries.some((e) => e === "thing/" || e === "thing"));
+  });
+});
+
+Deno.test({
+  name:
+    "createTarGz: does not produce AppleDouble (._foo) entries on macOS source trees",
+  // Only meaningful on darwin where BSD tar would otherwise inject them.
+  // Verifies the new code path doesn't introduce any.
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    await withTempDir(async (root) => {
+      const top = join(root, "src", "ext");
+      await ensureDir(top);
+      await Deno.writeTextFile(join(top, "main.txt"), "real content");
+      // Hand-place an AppleDouble companion to confirm we filter it.
+      await Deno.writeTextFile(join(top, "._main.txt"), "fork goo");
+
+      const archive = join(root, "out.tar.gz");
+      await createTarGz(top, archive);
+
+      const bytes = await Deno.readFile(archive);
+      const entries = await listTarGzEntries(streamFromBytes(bytes));
+      for (const entry of entries) {
+        assert(
+          !entry.split("/").some((seg) => seg.startsWith("._")),
+          `archive should not contain AppleDouble entry; saw: ${entry}`,
+        );
+      }
+    });
+  },
+});
+
+Deno.test("extractTarGz: applies file mode bits on POSIX", async () => {
+  await withTempDir(async (root) => {
+    const top = join(root, "src", "ext");
+    await ensureDir(top);
+    const exePath = join(top, "exe.sh");
+    await Deno.writeTextFile(exePath, "#!/bin/sh\necho hi\n");
+    if (Deno.build.os !== "windows") {
+      await Deno.chmod(exePath, 0o755);
+    }
+
+    const archive = join(root, "out.tar.gz");
+    await createTarGz(top, archive);
+
+    const dst = join(root, "dst");
+    await ensureDir(dst);
+    const bytes = await Deno.readFile(archive);
+    await extractTarGz(streamFromBytes(bytes), dst);
+
+    const stat = await Deno.stat(join(dst, "ext", "exe.sh"));
+    if (Deno.build.os !== "windows") {
+      // Executable bits should round-trip on POSIX.
+      assert(
+        (stat.mode! & 0o111) !== 0,
+        `expected exe bits set; got 0o${(stat.mode! & 0o777).toString(8)}`,
+      );
+    } else {
+      // On Windows, chmod is a no-op; just assert file exists with content.
+      assertEquals(stat.isFile, true);
+    }
+  });
+});

--- a/src/infrastructure/editor/editor_service.ts
+++ b/src/infrastructure/editor/editor_service.ts
@@ -17,6 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { defaultCommandResolver } from "../process/resolve_command.ts";
+
 /**
  * Result of opening a file in an editor.
  */
@@ -148,17 +150,8 @@ export class EditorService {
    * Checks if a command is available in the system PATH.
    */
   private async isCommandAvailable(cmd: string): Promise<boolean> {
-    try {
-      const command = new Deno.Command("which", {
-        args: [cmd],
-        stdout: "null",
-        stderr: "null",
-      });
-      const { success } = await command.output();
-      return success;
-    } catch {
-      return false;
-    }
+    const path = await defaultCommandResolver().resolve(cmd);
+    return path !== null;
   }
 
   /**

--- a/src/infrastructure/github/github_issue_service.ts
+++ b/src/infrastructure/github/github_issue_service.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { UserError } from "../../domain/errors.ts";
+import { defaultCommandResolver } from "../process/resolve_command.ts";
 
 /**
  * Result of creating a GitHub issue.
@@ -54,13 +55,8 @@ export class GitHubIssueService {
    * Returns true if available, false otherwise.
    */
   async isAvailable(): Promise<boolean> {
-    const whichCommand = new Deno.Command("which", {
-      args: ["gh"],
-      stdout: "null",
-      stderr: "null",
-    });
-    const { success: ghInstalled } = await whichCommand.output();
-    if (!ghInstalled) {
+    const ghPath = await defaultCommandResolver().resolve("gh");
+    if (!ghPath) {
       return false;
     }
 

--- a/src/infrastructure/process/resolve_command.ts
+++ b/src/infrastructure/process/resolve_command.ts
@@ -1,0 +1,103 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Cross-platform PATH resolver. On POSIX uses `which`; on Windows uses `where`.
+ *
+ * Returns the absolute path of the first match, or `null` when the binary is
+ * not on PATH (or the underlying lookup tool itself is missing). Callers that
+ * want to surface a specific error should wrap the `null` result.
+ */
+export interface CommandResolver {
+  resolve(name: string): Promise<string | null>;
+}
+
+/**
+ * The result of running a PATH-lookup process. The default resolver wraps
+ * `Deno.Command(...).output()`; tests inject a fake to exercise the parser
+ * without spawning a subprocess.
+ */
+export interface CommandLookupResult {
+  /** Whether the lookup process exited with code 0. */
+  success: boolean;
+  /** Captured stdout bytes from the lookup process. */
+  stdout: Uint8Array;
+}
+
+/**
+ * Function shape that runs the platform-native lookup tool (`which` / `where`)
+ * and returns its stdout. Exposed so unit tests can inject deterministic
+ * multi-line output without relying on the host's PATH.
+ */
+export type CommandLookupRunner = (
+  tool: string,
+  name: string,
+) => Promise<CommandLookupResult>;
+
+/** Default runner — actually spawns `which` or `where`. */
+const defaultLookupRunner: CommandLookupRunner = async (tool, name) => {
+  try {
+    const cmd = new Deno.Command(tool, {
+      args: [name],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const output = await cmd.output();
+    return { success: output.success, stdout: output.stdout };
+  } catch {
+    // Underlying lookup tool itself is missing (e.g. `which` not on PATH).
+    return { success: false, stdout: new Uint8Array() };
+  }
+};
+
+/** Picks the platform-appropriate lookup tool name. */
+function lookupTool(): "which" | "where" {
+  return Deno.build.os === "windows" ? "where" : "which";
+}
+
+/**
+ * Parses `which`/`where` stdout: returns the first non-empty trimmed line, or
+ * `null` if there is none. `where` returns multiple matches separated by
+ * newlines on Windows; `which -a` does the same on POSIX. We deliberately take
+ * the first match, mirroring the long-standing one-shot semantics of `which`.
+ */
+function parseFirstLine(stdout: Uint8Array): string | null {
+  const text = new TextDecoder().decode(stdout);
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.length > 0) return trimmed;
+  }
+  return null;
+}
+
+/**
+ * The default cross-platform command resolver. Use this everywhere instead of
+ * spawning `which`/`where` inline.
+ */
+export function defaultCommandResolver(
+  runner: CommandLookupRunner = defaultLookupRunner,
+): CommandResolver {
+  return {
+    async resolve(name: string): Promise<string | null> {
+      const result = await runner(lookupTool(), name);
+      if (!result.success) return null;
+      return parseFirstLine(result.stdout);
+    },
+  };
+}

--- a/src/infrastructure/process/resolve_command_test.ts
+++ b/src/infrastructure/process/resolve_command_test.ts
@@ -1,0 +1,127 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertEquals } from "@std/assert";
+import {
+  type CommandLookupRunner,
+  defaultCommandResolver,
+} from "./resolve_command.ts";
+
+Deno.test("defaultCommandResolver: resolves a binary that exists (deno)", async () => {
+  // `deno` is on PATH on every CI runner — POSIX or Windows.
+  const resolver = defaultCommandResolver();
+  const path = await resolver.resolve("deno");
+  assert(path !== null, "expected deno to resolve to a path");
+  assert(path.length > 0, "expected non-empty path");
+  // Whatever the platform, the resolved path should contain "deno".
+  assert(
+    path.toLowerCase().includes("deno"),
+    `expected resolved path to contain "deno"; got ${path}`,
+  );
+});
+
+Deno.test("defaultCommandResolver: returns null for a binary that does not exist", async () => {
+  const resolver = defaultCommandResolver();
+  const path = await resolver.resolve("some-nonsense-binary-xyz");
+  assertEquals(path, null);
+});
+
+Deno.test("defaultCommandResolver: returns first non-empty line of multi-line output", async () => {
+  // Stream-0 deferred check: when `which`/`where` reports multiple matches
+  // (one per line), only the first line is returned.
+  const fakeRunner: CommandLookupRunner = (_tool, _name) =>
+    Promise.resolve({
+      success: true,
+      stdout: new TextEncoder().encode(
+        "/usr/local/bin/foo\n/opt/homebrew/bin/foo\n/usr/bin/foo\n",
+      ),
+    });
+
+  const resolver = defaultCommandResolver(fakeRunner);
+  const path = await resolver.resolve("foo");
+  assertEquals(path, "/usr/local/bin/foo");
+});
+
+Deno.test("defaultCommandResolver: skips leading blank lines", async () => {
+  const fakeRunner: CommandLookupRunner = (_tool, _name) =>
+    Promise.resolve({
+      success: true,
+      stdout: new TextEncoder().encode(
+        "\n   \n/usr/bin/foo\n/usr/local/bin/foo\n",
+      ),
+    });
+
+  const resolver = defaultCommandResolver(fakeRunner);
+  const path = await resolver.resolve("foo");
+  assertEquals(path, "/usr/bin/foo");
+});
+
+Deno.test("defaultCommandResolver: returns null when lookup process fails", async () => {
+  const fakeRunner: CommandLookupRunner = (_tool, _name) =>
+    Promise.resolve({
+      success: false,
+      stdout: new TextEncoder().encode("/usr/bin/foo\n"),
+    });
+
+  const resolver = defaultCommandResolver(fakeRunner);
+  const path = await resolver.resolve("foo");
+  assertEquals(path, null);
+});
+
+Deno.test("defaultCommandResolver: returns null when stdout is empty", async () => {
+  const fakeRunner: CommandLookupRunner = (_tool, _name) =>
+    Promise.resolve({
+      success: true,
+      stdout: new Uint8Array(),
+    });
+
+  const resolver = defaultCommandResolver(fakeRunner);
+  const path = await resolver.resolve("foo");
+  assertEquals(path, null);
+});
+
+Deno.test("defaultCommandResolver: uses the platform-appropriate lookup tool", async () => {
+  let seenTool = "";
+  const fakeRunner: CommandLookupRunner = (tool, _name) => {
+    seenTool = tool;
+    return Promise.resolve({
+      success: true,
+      stdout: new TextEncoder().encode("/usr/bin/foo\n"),
+    });
+  };
+
+  const resolver = defaultCommandResolver(fakeRunner);
+  await resolver.resolve("foo");
+  assertEquals(seenTool, Deno.build.os === "windows" ? "where" : "which");
+});
+
+Deno.test("defaultCommandResolver: trims trailing CR on Windows-style line endings", async () => {
+  // `where` on Windows emits CRLF line terminators.
+  const fakeRunner: CommandLookupRunner = (_tool, _name) =>
+    Promise.resolve({
+      success: true,
+      stdout: new TextEncoder().encode(
+        "C:\\Tools\\foo.exe\r\nC:\\Other\\foo.exe\r\n",
+      ),
+    });
+
+  const resolver = defaultCommandResolver(fakeRunner);
+  const path = await resolver.resolve("foo");
+  assertEquals(path, "C:\\Tools\\foo.exe");
+});

--- a/src/infrastructure/runtime/embedded_deno_runtime.ts
+++ b/src/infrastructure/runtime/embedded_deno_runtime.ts
@@ -196,11 +196,14 @@ export class EmbeddedDenoRuntime implements DenoRuntime {
    * Searches PATH for a system-installed deno binary.
    * Used as a fallback when the embedded binary fails its health check.
    *
-   * Public so unit tests can exercise the multi-line `which`/`where` parser
-   * via the injected `CommandResolver` without having to drive the full
-   * standalone-mode failure path.
+   * The multi-line `which`/`where` parsing semantics live in
+   * `CommandResolver` and are covered by `resolve_command_test.ts`. The
+   * `commandResolver` constructor argument is the injection seam if tests
+   * ever need to drive this path through a public method (currently
+   * `ensureDeno()` only invokes it when `Deno.build.standalone === true`,
+   * which is not flippable from a test).
    */
-  findSystemDeno(): Promise<string | null> {
+  private findSystemDeno(): Promise<string | null> {
     return this.commandResolver.resolve("deno");
   }
 

--- a/src/infrastructure/runtime/embedded_deno_runtime.ts
+++ b/src/infrastructure/runtime/embedded_deno_runtime.ts
@@ -21,6 +21,10 @@ import { join } from "@std/path";
 import { getLogger } from "@logtape/logtape";
 import type { DenoRuntime } from "../../domain/runtime/deno_runtime.ts";
 import { DenoVersion } from "../../domain/runtime/deno_version.ts";
+import {
+  type CommandResolver,
+  defaultCommandResolver,
+} from "../process/resolve_command.ts";
 
 const logger = getLogger(["swamp", "runtime", "deno"]);
 
@@ -44,6 +48,16 @@ const DENO_BINARY_NAME = Deno.build.os === "windows" ? "deno.exe" : "deno";
 export class EmbeddedDenoRuntime implements DenoRuntime {
   private cachedPath: string | null = null;
   private extractionPromise: Promise<string> | null = null;
+  private readonly commandResolver: CommandResolver;
+
+  /**
+   * @param commandResolver Override the system PATH resolver. Tests inject a
+   *   fake to exercise the standalone-mode fallback path without depending on
+   *   the host's installed `deno`.
+   */
+  constructor(commandResolver: CommandResolver = defaultCommandResolver()) {
+    this.commandResolver = commandResolver;
+  }
 
   async ensureDeno(): Promise<string> {
     if (this.cachedPath) {
@@ -181,25 +195,13 @@ export class EmbeddedDenoRuntime implements DenoRuntime {
   /**
    * Searches PATH for a system-installed deno binary.
    * Used as a fallback when the embedded binary fails its health check.
+   *
+   * Public so unit tests can exercise the multi-line `which`/`where` parser
+   * via the injected `CommandResolver` without having to drive the full
+   * standalone-mode failure path.
    */
-  private async findSystemDeno(): Promise<string | null> {
-    const which = Deno.build.os === "windows" ? "where" : "which";
-    try {
-      const result = await new Deno.Command(which, {
-        args: ["deno"],
-        stdout: "piped",
-        stderr: "null",
-      }).output();
-      if (result.success) {
-        const path = new TextDecoder().decode(result.stdout).trim().split(
-          "\n",
-        )[0].trim();
-        if (path) return path;
-      }
-    } catch {
-      // which/where not available
-    }
-    return null;
+  findSystemDeno(): Promise<string | null> {
+    return this.commandResolver.resolve("deno");
   }
 
   private async readEmbeddedVersion(): Promise<DenoVersion> {

--- a/src/infrastructure/runtime/embedded_deno_runtime_test.ts
+++ b/src/infrastructure/runtime/embedded_deno_runtime_test.ts
@@ -19,6 +19,10 @@
 
 import { assertEquals } from "@std/assert";
 import { EmbeddedDenoRuntime } from "./embedded_deno_runtime.ts";
+import {
+  type CommandLookupRunner,
+  defaultCommandResolver,
+} from "../process/resolve_command.ts";
 
 Deno.test("EmbeddedDenoRuntime returns system deno in dev mode", async () => {
   // When running from source (not compiled), Deno.build.standalone is falsy
@@ -37,4 +41,34 @@ Deno.test("EmbeddedDenoRuntime caches the deno path", async () => {
 
   // Should return the same path both times (cached)
   assertEquals(first, second);
+});
+
+// Stream-0 deferred regression: when the standalone-mode failure path falls
+// back to a system `deno`, the resolver may receive multi-line output (e.g.
+// `which -a deno` or `where deno` listing several entries). The first line
+// must win — we want a single concrete path, not a newline-glued mash.
+Deno.test("EmbeddedDenoRuntime.findSystemDeno: returns first line of multi-line which output", async () => {
+  const fakeRunner: CommandLookupRunner = (_tool, _name) =>
+    Promise.resolve({
+      success: true,
+      stdout: new TextEncoder().encode(
+        "/usr/local/bin/deno\n/opt/homebrew/bin/deno\n/usr/bin/deno\n",
+      ),
+    });
+
+  const runtime = new EmbeddedDenoRuntime(defaultCommandResolver(fakeRunner));
+  const path = await runtime.findSystemDeno();
+  assertEquals(path, "/usr/local/bin/deno");
+});
+
+Deno.test("EmbeddedDenoRuntime.findSystemDeno: returns null when resolver finds nothing", async () => {
+  const fakeRunner: CommandLookupRunner = (_tool, _name) =>
+    Promise.resolve({
+      success: false,
+      stdout: new Uint8Array(),
+    });
+
+  const runtime = new EmbeddedDenoRuntime(defaultCommandResolver(fakeRunner));
+  const path = await runtime.findSystemDeno();
+  assertEquals(path, null);
 });

--- a/src/infrastructure/runtime/embedded_deno_runtime_test.ts
+++ b/src/infrastructure/runtime/embedded_deno_runtime_test.ts
@@ -19,10 +19,13 @@
 
 import { assertEquals } from "@std/assert";
 import { EmbeddedDenoRuntime } from "./embedded_deno_runtime.ts";
-import {
-  type CommandLookupRunner,
-  defaultCommandResolver,
-} from "../process/resolve_command.ts";
+
+// The Stream 0 multi-line `which`/`where` parsing regression is exercised
+// directly against `defaultCommandResolver` in
+// `src/infrastructure/process/resolve_command_test.ts` — that's where the
+// parser lives. `EmbeddedDenoRuntime` only forwards to the resolver, so
+// duplicating the test here would not catch any additional drift; the
+// constructor's `commandResolver` argument is the seam should that change.
 
 Deno.test("EmbeddedDenoRuntime returns system deno in dev mode", async () => {
   // When running from source (not compiled), Deno.build.standalone is falsy
@@ -41,34 +44,4 @@ Deno.test("EmbeddedDenoRuntime caches the deno path", async () => {
 
   // Should return the same path both times (cached)
   assertEquals(first, second);
-});
-
-// Stream-0 deferred regression: when the standalone-mode failure path falls
-// back to a system `deno`, the resolver may receive multi-line output (e.g.
-// `which -a deno` or `where deno` listing several entries). The first line
-// must win — we want a single concrete path, not a newline-glued mash.
-Deno.test("EmbeddedDenoRuntime.findSystemDeno: returns first line of multi-line which output", async () => {
-  const fakeRunner: CommandLookupRunner = (_tool, _name) =>
-    Promise.resolve({
-      success: true,
-      stdout: new TextEncoder().encode(
-        "/usr/local/bin/deno\n/opt/homebrew/bin/deno\n/usr/bin/deno\n",
-      ),
-    });
-
-  const runtime = new EmbeddedDenoRuntime(defaultCommandResolver(fakeRunner));
-  const path = await runtime.findSystemDeno();
-  assertEquals(path, "/usr/local/bin/deno");
-});
-
-Deno.test("EmbeddedDenoRuntime.findSystemDeno: returns null when resolver finds nothing", async () => {
-  const fakeRunner: CommandLookupRunner = (_tool, _name) =>
-    Promise.resolve({
-      success: false,
-      stdout: new Uint8Array(),
-    });
-
-  const runtime = new EmbeddedDenoRuntime(defaultCommandResolver(fakeRunner));
-  const path = await runtime.findSystemDeno();
-  assertEquals(path, null);
 });

--- a/src/infrastructure/source/http_source_downloader.ts
+++ b/src/infrastructure/source/http_source_downloader.ts
@@ -21,6 +21,7 @@ import { ensureDir } from "@std/fs";
 import { dirname, join, resolve, SEPARATOR } from "@std/path";
 import type { SourceDownloader } from "../../domain/source/mod.ts";
 import { UserError } from "../../domain/errors.ts";
+import { extractTarGz } from "../archive/tar_archive.ts";
 
 /**
  * HTTP adapter for downloading swamp source archives from GitHub.
@@ -109,15 +110,12 @@ export class HttpSourceDownloader implements SourceDownloader {
       const extractDir = join(tempDir, "extracted");
       await ensureDir(extractDir);
 
-      const extract = new Deno.Command("tar", {
-        args: ["-xzf", tarballPath, "-C", extractDir],
-        stdout: "piped",
-        stderr: "piped",
-      });
-      const extractResult = await extract.output();
-      if (!extractResult.success) {
-        const stderr = new TextDecoder().decode(extractResult.stderr);
-        throw new UserError(`Failed to extract source archive: ${stderr}`);
+      try {
+        const tarFile = await Deno.open(tarballPath, { read: true });
+        await extractTarGz(tarFile.readable, extractDir);
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new UserError(`Failed to extract source archive: ${message}`);
       }
 
       // GitHub archives have a top-level directory like "swamp-main" or "swamp-v1.2.3"

--- a/src/infrastructure/update/http_update_checker.ts
+++ b/src/infrastructure/update/http_update_checker.ts
@@ -26,13 +26,19 @@ import {
   verifyChecksum,
 } from "../../domain/update/integrity.ts";
 import { computeChecksum } from "../../domain/models/checksum.ts";
+import { extractTarGz } from "../archive/tar_archive.ts";
 
 /**
  * Remove macOS quarantine extended attribute (best-effort).
  * Files downloaded via fetch() get tagged with com.apple.quarantine,
  * and Gatekeeper will SIGKILL unsigned binaries that have it.
+ *
+ * Only meaningful on darwin — `xattr` is not present on Linux or Windows,
+ * and the quarantine attribute is a macOS-specific concept. Calls on other
+ * platforms become a no-op.
  */
 async function removeQuarantine(path: string): Promise<void> {
+  if (Deno.build.os !== "darwin") return;
   try {
     const cmd = new Deno.Command("xattr", {
       args: ["-d", "com.apple.quarantine", path],
@@ -213,15 +219,12 @@ export class HttpUpdateChecker implements UpdateChecker {
       verifyChecksum(expectedChecksum, actualChecksum);
 
       // Extract the tarball
-      const extract = new Deno.Command("tar", {
-        args: ["-xzf", tarballPath, "-C", tempDir],
-        stdout: "piped",
-        stderr: "piped",
-      });
-      const extractResult = await extract.output();
-      if (!extractResult.success) {
-        const stderr = new TextDecoder().decode(extractResult.stderr);
-        throw new UserError(`Failed to extract update: ${stderr}`);
+      try {
+        const tarFile = await Deno.open(tarballPath, { read: true });
+        await extractTarGz(tarFile.readable, tempDir);
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new UserError(`Failed to extract update: ${message}`);
       }
 
       // Find the extracted binary
@@ -243,7 +246,12 @@ export class HttpUpdateChecker implements UpdateChecker {
 
       // Replace the current binary (unlink-then-rename to avoid ETXTBSY on Linux)
       await replaceBinary(extractedBinary, binaryPath);
-      await Deno.chmod(binaryPath, 0o755);
+
+      // chmod is meaningless on Windows (file permissions live in the ACL,
+      // not POSIX mode bits). Only set the executable bit on POSIX hosts.
+      if (Deno.build.os !== "windows") {
+        await Deno.chmod(binaryPath, 0o755);
+      }
 
       // Also clear quarantine on the final path (in case copyFile propagates it)
       if (Deno.build.os === "darwin") {

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -40,6 +40,10 @@ import {
   swampPath,
 } from "../../infrastructure/persistence/paths.ts";
 import { computeChecksum } from "../../domain/models/checksum.ts";
+import {
+  extractTarGz,
+  listTarGzEntries,
+} from "../../infrastructure/archive/tar_archive.ts";
 import { readInstalledExtensionDigest } from "../../infrastructure/persistence/installed_extension_digest_reader.ts";
 import { verifyChecksum } from "../../domain/update/integrity.ts";
 import { resolveLocalImports } from "../../domain/models/local_import_resolver.ts";
@@ -785,20 +789,14 @@ export async function installExtension(
     const archivePath = join(tmpDir, "extension.tar.gz");
     await Deno.writeFile(archivePath, archiveBytes);
 
-    const listCommand = new Deno.Command("tar", {
-      args: ["-tzf", archivePath],
-      stdout: "piped",
-      stderr: "piped",
-    });
-    const listOutput = await listCommand.output();
-    if (!listOutput.success) {
-      const stderr = new TextDecoder().decode(listOutput.stderr);
-      throw new UserError(`Failed to list archive contents: ${stderr}`);
+    let archiveEntries: string[];
+    try {
+      const listFile = await Deno.open(archivePath, { read: true });
+      archiveEntries = await listTarGzEntries(listFile.readable);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new UserError(`Failed to list archive contents: ${message}`);
     }
-    const archiveEntries = new TextDecoder()
-      .decode(listOutput.stdout)
-      .split("\n")
-      .filter((e) => e.length > 0);
     for (const entry of archiveEntries) {
       if (entry.includes("..") || entry.startsWith("/")) {
         throw new UserError(
@@ -807,16 +805,16 @@ export async function installExtension(
       }
     }
 
-    const tarCommand = new Deno.Command("tar", {
-      args: ["-xzf", archivePath, "-C", tmpDir],
-      stdout: "piped",
-      stderr: "piped",
-      env: { COPYFILE_DISABLE: "1" },
-    });
-    const tarOutput = await tarCommand.output();
-    if (!tarOutput.success) {
-      const stderr = new TextDecoder().decode(tarOutput.stderr);
-      throw new UserError(`Failed to extract archive: ${stderr}`);
+    try {
+      const extractFile = await Deno.open(archivePath, { read: true });
+      // The Deno-native extractor doesn't shell out to BSD tar, so the macOS
+      // `COPYFILE_DISABLE=1` env var that suppressed AppleDouble files in
+      // the previous implementation is no longer needed: AppleDouble entries
+      // are filtered out at extraction time as a defensive measure.
+      await extractTarGz(extractFile.readable, tmpDir);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new UserError(`Failed to extract archive: ${message}`);
     }
 
     const extractDir = join(tmpDir, "extension");

--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -19,6 +19,7 @@
 
 import { dirname, join, relative } from "@std/path";
 import { stringify as stringifyYaml } from "@std/yaml";
+import { createTarGz } from "../../infrastructure/archive/tar_archive.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import { validateContentCollectives } from "../../domain/extensions/extension_collective_validator.ts";
 import type {
@@ -1181,18 +1182,16 @@ async function createArchive(
       await Deno.copyFile(absPath, destPath);
     }
 
-    // Create tar.gz
+    // Create tar.gz. The Deno-native archiver walks the staged tree
+    // explicitly, so the previous BSD-tar `COPYFILE_DISABLE=1` env var (which
+    // suppressed macOS resource forks) is no longer needed: AppleDouble
+    // siblings are filtered defensively in the archiver itself.
     const tarPath = join(tmpDir, "extension.tar.gz");
-    const tarCommand = new Deno.Command("tar", {
-      args: ["-czf", tarPath, "-C", tmpDir, "extension"],
-      stdout: "piped",
-      stderr: "piped",
-      env: { GZIP: "-9", COPYFILE_DISABLE: "1" },
-    });
-    const tarOutput = await tarCommand.output();
-    if (!tarOutput.success) {
-      const stderr = new TextDecoder().decode(tarOutput.stderr);
-      throw validationFailed(`Failed to create archive: ${stderr}`);
+    try {
+      await createTarGz(extDir, tarPath);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw validationFailed(`Failed to create archive: ${message}`);
     }
 
     const archiveBytes = await Deno.readFile(tarPath);

--- a/src/libswamp/extensions/quality.ts
+++ b/src/libswamp/extensions/quality.ts
@@ -29,6 +29,7 @@ import {
   type RubricScoreDeps,
   scoreExtensionTarball,
 } from "../../domain/extensions/extension_rubric_scorer.ts";
+import { extractTarGz } from "../../infrastructure/archive/tar_archive.ts";
 import { EmbeddedDenoRuntime } from "../../infrastructure/runtime/embedded_deno_runtime.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 import type { LibSwampContext } from "../context.ts";
@@ -80,7 +81,7 @@ export function createExtensionQualityDeps(
     pushPrepareDeps,
     cache,
     ensureDenoPath: () => denoRuntime.ensureDeno(),
-    makeScoreDeps: (denoPath) => createRubricScoreDeps(denoPath),
+    makeScoreDeps: (denoPath) => createRubricScoreDeps(denoPath, extractTarGz),
   };
 }
 

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -971,8 +971,9 @@ export {
   auditDoctor,
   type AuditDoctorDeps,
   type AuditDoctorEvent,
-  DEFAULT_CHECK_ORDER,
+  defaultCheckOrder,
 } from "../domain/audit/doctor/doctor_service.ts";
+export type { ResolveBinary } from "../domain/audit/doctor/checks/resolve_binary.ts";
 export { todaysAuditFilePath } from "../domain/audit/audit_path.ts";
 
 // Datastore operations


### PR DESCRIPTION
## Summary

Stream B of the Windows-GA push (after Stream 0 #1278). Five work items:

1. **`resolve_command` helper** — new `src/infrastructure/process/resolve_command.ts` with `defaultCommandResolver(runner?)` (POSIX `which` / Windows `where`). Optional runner is the test injection seam. Replaces 5 hand-rolled `which` shellouts: `github_issue_service.ts`, `editor_service.ts`, `repo_service.ts`, `embedded_deno_runtime.ts` (consolidates the existing platform branch), and the doctor binary check via DI.

2. **Tar shellouts → `@std/tar`** — new `src/infrastructure/archive/tar_archive.ts` using `@std/tar` (TarStream / UntarStream) plus Web-standard `DecompressionStream`/`CompressionStream` for gzip. Replaces 5 production sites (4 listed in the audit + 1 the audit missed: `extension_rubric_scorer.ts`). Defensively filters PAX headers and macOS AppleDouble entries — the `COPYFILE_DISABLE=1` env var is no longer needed. Symlinks recreated with `{ type }` resolved via stat (Windows-friendly). Path-traversal rejection covers `..` segments, leading `/`, leading `\`.

3. **`chmod` / `xattr` guards** — `http_update_checker.ts` `removeQuarantine` is darwin-only; line-246 chmod is skipped on Windows. The reference guards in `embedded_deno_runtime.ts` were already correct and unchanged.

4. **`swamp doctor` on Windows** — removed the "Windows support deferred" comment block in `resolve_binary.ts`. Doctor binary check now runs cross-platform via the resolver.

5. **Backfilled Stream 0 deferred test** — multi-line `which`/`where` parsing is now exhaustively covered in `resolve_command_test.ts` (the parser-level tests are hermetic and don't require `Deno.build.standalone`).

## Architectural notes

- **DDD ratchet stays at 26** (no new domain → infrastructure violations). The two domain modules that needed cross-platform helpers (`resolve_binary.ts`, `extension_rubric_scorer.ts`) take their dependencies via injected ports (`ResolveBinary`, `ExtractTarball`). CLI/libswamp wires up `defaultCommandResolver()` and `extractTarGz` at the composition seam. Cost: 99 insertions / 53 deletions across 11 files; no caller signature changes outside the natural composition layer.
- **Internal API surface change** in `libswamp/mod.ts`: `DEFAULT_CHECK_ORDER` (eager const) → `defaultCheckOrder(resolveBinary)` (factory). No external consumers found via grep. Worth a one-line mention in any libswamp release notes.
- **`auditDoctor` deps gain `resolveBinary?: ResolveBinary`** — required when `checks` isn't supplied; clear runtime error otherwise.
- **`createRubricScoreDeps`** is now 2-arg (`denoPath`, `extractTarball`); one internal caller updated.
- **`@std/tar` is `@experimental`**, pinned to `^0.1.10`. Blast radius contained to one infrastructure module (`tar_archive.ts`).
- **`findSystemDeno` stayed `private`** — the redundant test that briefly exposed it was removed; multi-line parsing is covered exhaustively at the resolver level.

## Test Plan

- [x] `deno fmt --check` clean (1288 files)
- [x] `deno lint` clean (1167 files)
- [x] `deno check` clean
- [x] `deno run test` — 5165 passed, 0 failed, 23 ignored
- [x] DDD layer-rule ratchet: 26 (unchanged from pre-Stream-B baseline)
- [x] Stream 0 regression net green throughout (extract→chmod→xattr, source-downloader symlink/traversal, doctor audit)
- [x] All 5 production tar sites use the new library; no leftover `Deno.Command("tar", ...)` in `src/`