### PR TITLE
fix(cli): print help when doctor/datastore run with no subcommand

### DIFF
--- a/src/cli/commands/datastore.ts
+++ b/src/cli/commands/datastore.ts
@@ -23,11 +23,11 @@ import { datastoreSetupCommand } from "./datastore_setup.ts";
 import { datastoreSyncCommand } from "./datastore_sync.ts";
 import { datastoreLockCommand } from "./datastore_lock.ts";
 
-/**
- * Parent command group for datastore operations.
- */
 export const datastoreCommand = new Command()
   .description("Manage datastore configuration")
+  .action(function () {
+    this.showHelp();
+  })
   .command("status", datastoreStatusCommand)
   .command("setup", datastoreSetupCommand)
   .command("sync", datastoreSyncCommand)

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -21,14 +21,6 @@ import { Command } from "@cliffy/command";
 import { doctorAuditCommand } from "./doctor_audit.ts";
 import { doctorExtensionsCommand } from "./doctor_extensions.ts";
 
-/**
- * Parent namespace for diagnostic subcommands.
- *
- * `doctor` has no `.action()` — Cliffy falls back to printing help when the
- * user runs `swamp doctor` with no subcommand. Future diagnostics (e.g.
- * `doctor datastore`, `doctor vault`) register as sibling `.command(...)`
- * entries.
- */
 export const doctorCommand = new Command()
   .description(
     "Run diagnostics that verify swamp's integrations are healthy.",
@@ -45,5 +37,8 @@ export const doctorCommand = new Command()
     "Check that user-defined extensions in this repo load cleanly",
     "swamp doctor extensions",
   )
+  .action(function () {
+    this.showHelp();
+  })
   .command("audit", doctorAuditCommand)
   .command("extensions", doctorExtensionsCommand);


### PR DESCRIPTION
## Summary

`swamp doctor` and `swamp datastore` exited 0 with empty output when invoked without a subcommand. The fix adds the canonical default `.action()` pattern already used by every other parent command in the CLI.

- `src/cli/commands/doctor.ts` — added `.action(function () { this.showHelp(); })` and removed a misleading comment that asserted Cliffy auto-prints help (it doesn't, in this version).
- `src/cli/commands/datastore.ts` — same fix.

Found by a UAT agent verifying swamp-uat scenario `tests/cli/doctor/audit_test.ts:448` ("swamp doctor with no subcommand prints help…") which was failing because real swamp returned empty output.

Sibling sweep confirmed only `doctor` and `datastore` had the gap; `data`, `extension`, `vault`, `workflow`, `auth`, `issue`, `source`, `report`, `model method history`, `model output`, `extension source`, `extension trust`, and `vault type` all already use the `.action(function () { this.showHelp(); })` pattern.

## Test Plan

- [x] `deno run dev doctor` — prints full help, exit 0
- [x] `deno run dev datastore` — prints full help, exit 0
- [x] `deno fmt --check`
- [x] `deno lint`
- [x] `deno check` on changed files
- [x] `deno run test` — 5166 passed (one unrelated flake in `user_vault_loader_test.ts` that passes in isolation)
- [x] `deno run compile`
- [ ] After merge, swamp-uat `tests/cli/doctor/audit_test.ts:448` should turn green without test changes