### PR TITLE
fix(doctor): kill audit-record child on SIGINT instead of orphaning it

### DIFF
--- a/src/cli/commands/doctor_audit.ts
+++ b/src/cli/commands/doctor_audit.ts
@@ -61,32 +61,49 @@ export function resolveTargetTool(
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
+/** Default grace period before SIGKILL escalation. Exported for tests. */
+export const DEFAULT_SIGKILL_AFTER_MS = 3_000;
+
 /**
- * Builds a SpawnFn that invokes the currently-running swamp binary against
- * the supplied repo directory. Pins `--repo-dir` on every call so the
- * spawned `audit record` writes into the same repo being audited, not
- * whatever repo the CWD happens to point at.
+ * Spawns `cmd`, writes `stdin` to its stdin, and returns the captured
+ * exit code and decoded output. While the child runs, an optional
+ * `signal` aborts by sending SIGTERM to the child — without this, killing
+ * the doctor parent reparents the child to init/launchd instead of
+ * tearing it down. If the child ignores SIGTERM, escalates to SIGKILL
+ * after `sigkillAfterMs` so a hung subprocess can't keep the doctor
+ * alive forever.
+ *
+ * Exported for testing; production callers go through `makeSwampSpawnFn`.
  */
-function makeSwampSpawnFn(repoDir: string): SpawnFn {
-  const execPath = Deno.execPath();
-  // When running from source (`deno run dev ...`), Deno.execPath() returns
-  // the deno binary and Deno.mainModule points at the swamp entrypoint. When
-  // running the compiled binary, Deno.execPath() is the compiled swamp and
-  // we invoke it directly.
-  const runningFromSource = /\/deno(\.exe)?$/.test(execPath);
-  return async (args, stdin, env = {}) => {
-    const argsWithRepo = [...args, "--repo-dir", repoDir];
-    const fullArgs = runningFromSource
-      ? ["run", "-A", Deno.mainModule, ...argsWithRepo]
-      : argsWithRepo;
-    const cmd = new Deno.Command(execPath, {
-      args: fullArgs,
-      stdin: "piped",
-      stdout: "piped",
-      stderr: "piped",
-      env: { ...Deno.env.toObject(), ...env },
-    });
-    const child = cmd.spawn();
+export async function runChildWithAbort(
+  cmd: Deno.Command,
+  stdin: string,
+  signal: AbortSignal | undefined,
+  opts: { sigkillAfterMs?: number } = {},
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  if (signal?.aborted) {
+    throw new DOMException("doctor audit aborted", "AbortError");
+  }
+  const sigkillAfterMs = opts.sigkillAfterMs ?? DEFAULT_SIGKILL_AFTER_MS;
+  const child = cmd.spawn();
+  let escalationTimer: number | undefined;
+  const onAbort = () => {
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      // Child already exited; nothing to escalate.
+      return;
+    }
+    escalationTimer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // Already exited between SIGTERM and the escalation tick.
+      }
+    }, sigkillAfterMs);
+  };
+  signal?.addEventListener("abort", onAbort);
+  try {
     const writer = child.stdin.getWriter();
     try {
       await writer.write(new TextEncoder().encode(stdin));
@@ -100,6 +117,41 @@ function makeSwampSpawnFn(repoDir: string): SpawnFn {
       stdout: decoder.decode(stdout),
       stderr: decoder.decode(stderr),
     };
+  } finally {
+    signal?.removeEventListener("abort", onAbort);
+    if (escalationTimer !== undefined) clearTimeout(escalationTimer);
+  }
+}
+
+/**
+ * Builds a SpawnFn that invokes the currently-running swamp binary against
+ * the supplied repo directory. Pins `--repo-dir` on every call so the
+ * spawned `audit record` writes into the same repo being audited, not
+ * whatever repo the CWD happens to point at.
+ *
+ * Honours the optional `signal` so a SIGINT against the doctor parent
+ * tears down the in-flight child instead of reparenting it to init.
+ */
+export function makeSwampSpawnFn(repoDir: string): SpawnFn {
+  const execPath = Deno.execPath();
+  // When running from source (`deno run dev ...`), Deno.execPath() returns
+  // the deno binary and Deno.mainModule points at the swamp entrypoint. When
+  // running the compiled binary, Deno.execPath() is the compiled swamp and
+  // we invoke it directly.
+  const runningFromSource = /\/deno(\.exe)?$/.test(execPath);
+  return (args, stdin, env = {}, signal) => {
+    const argsWithRepo = [...args, "--repo-dir", repoDir];
+    const fullArgs = runningFromSource
+      ? ["run", "-A", Deno.mainModule, ...argsWithRepo]
+      : argsWithRepo;
+    const cmd = new Deno.Command(execPath, {
+      args: fullArgs,
+      stdin: "piped",
+      stdout: "piped",
+      stderr: "piped",
+      env: { ...Deno.env.toObject(), ...env },
+    });
+    return runChildWithAbort(cmd, stdin, signal);
   };
 }
 
@@ -144,18 +196,41 @@ export const doctorAuditCommand = new Command()
     const controller = new AbortController();
     const renderer = createAuditDoctorRenderer(cliCtx.outputMode);
 
-    const commandResolver = defaultCommandResolver();
-    await consumeStream(
-      auditDoctor({
-        repoPath: repoDir,
-        auditDir,
-        tool: resolvedTool,
-        spawnSwamp: makeSwampSpawnFn(repoDir),
-        abortSignal: controller.signal,
-        resolveBinary: (name) => commandResolver.resolve(name),
-      }),
-      renderer.handlers(),
-    );
+    // Wire SIGINT to the controller so a Ctrl+C tears down any in-flight
+    // smoke-test child instead of leaving it reparented to init. After the
+    // first signal we remove the listener so a second Ctrl+C falls through
+    // to Deno's default exit-130 handler — that gives the user a force-exit
+    // escape hatch if a child hangs and ignores SIGTERM. SIGTERM isn't
+    // listened for here because Deno doesn't support it on Windows.
+    const onSigint = () => {
+      try {
+        Deno.removeSignalListener("SIGINT", onSigint);
+      } catch {
+        // Already removed (e.g. doctor finished before signal arrived).
+      }
+      controller.abort();
+    };
+    Deno.addSignalListener("SIGINT", onSigint);
+    try {
+      const commandResolver = defaultCommandResolver();
+      await consumeStream(
+        auditDoctor({
+          repoPath: repoDir,
+          auditDir,
+          tool: resolvedTool,
+          spawnSwamp: makeSwampSpawnFn(repoDir),
+          abortSignal: controller.signal,
+          resolveBinary: (name) => commandResolver.resolve(name),
+        }),
+        renderer.handlers(),
+      );
+    } finally {
+      try {
+        Deno.removeSignalListener("SIGINT", onSigint);
+      } catch {
+        // Listener may already be detached on a second signal.
+      }
+    }
 
     cliCtx.logger.debug("doctor audit command completed");
 

--- a/src/cli/commands/doctor_audit_test.ts
+++ b/src/cli/commands/doctor_audit_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 import { UserError } from "../../domain/errors.ts";
 import { NoToolConfiguredError } from "../../libswamp/mod.ts";
@@ -108,5 +108,93 @@ Deno.test(
     assertEquals(resolveTargetTool("codex", undefined), "codex");
     assertEquals(resolveTargetTool("copilot", undefined), "copilot");
     assertEquals(resolveTargetTool("none", undefined), "none");
+  },
+);
+
+function makeStdinPipedCommand(args: string[]): Deno.Command {
+  return new Deno.Command(Deno.execPath(), {
+    args,
+    stdin: "piped",
+    stdout: "piped",
+    stderr: "piped",
+  });
+}
+
+Deno.test(
+  "runChildWithAbort: throws AbortError without spawning when signal is already aborted",
+  async () => {
+    const { runChildWithAbort } = await import("./doctor_audit.ts");
+    const controller = new AbortController();
+    controller.abort();
+    // Use deno itself as a stand-in process — but it should never be spawned
+    // because the function must short-circuit on the pre-aborted signal.
+    const cmd = makeStdinPipedCommand([
+      "eval",
+      "console.log('should not run')",
+    ]);
+    await assertRejects(
+      () => runChildWithAbort(cmd, "", controller.signal),
+      DOMException,
+      "doctor audit aborted",
+    );
+  },
+);
+
+Deno.test(
+  "runChildWithAbort: aborting a SIGTERM-respecting child terminates it promptly",
+  // SIGTERM is not a portable kill signal on Windows; the underlying Deno
+  // ChildProcess.kill semantics differ. The bug being fixed is POSIX-only.
+  { ignore: Deno.build.os === "windows" },
+  async () => {
+    const { runChildWithAbort } = await import("./doctor_audit.ts");
+    const controller = new AbortController();
+    // A child that blocks for 30s so we control its lifetime; default
+    // SIGTERM handling exits the child immediately.
+    const cmd = makeStdinPipedCommand([
+      "eval",
+      "await new Promise((r) => setTimeout(r, 30_000));",
+    ]);
+    const start = performance.now();
+    setTimeout(() => controller.abort(), 100);
+    const result = await runChildWithAbort(cmd, "", controller.signal);
+    const elapsed = performance.now() - start;
+    // A well-behaved child dies on SIGTERM in well under a second.
+    if (elapsed > 2_000) {
+      throw new Error(
+        `expected SIGTERM-responding child to exit promptly; took ${elapsed}ms`,
+      );
+    }
+    // SIGTERM exit on POSIX yields code 143 (128 + 15) or similar non-zero.
+    assertEquals(result.exitCode === 0, false);
+  },
+);
+
+Deno.test(
+  "runChildWithAbort: escalates to SIGKILL when child traps SIGTERM",
+  { ignore: Deno.build.os === "windows" },
+  async () => {
+    const { runChildWithAbort } = await import("./doctor_audit.ts");
+    const controller = new AbortController();
+    // Child registers a no-op SIGTERM handler so SIGTERM alone won't
+    // terminate it; only SIGKILL will. Tight escalation window keeps the
+    // test fast.
+    const cmd = makeStdinPipedCommand([
+      "eval",
+      "Deno.addSignalListener('SIGTERM', () => {}); " +
+      "await new Promise((r) => setTimeout(r, 30_000));",
+    ]);
+    const start = performance.now();
+    setTimeout(() => controller.abort(), 100);
+    const result = await runChildWithAbort(cmd, "", controller.signal, {
+      sigkillAfterMs: 200,
+    });
+    const elapsed = performance.now() - start;
+    // SIGTERM lands at ~100ms, SIGKILL ~200ms later, plus reaping slack.
+    if (elapsed > 2_000) {
+      throw new Error(
+        `expected SIGKILL escalation to terminate child; took ${elapsed}ms`,
+      );
+    }
+    assertEquals(result.exitCode === 0, false);
   },
 );

--- a/src/domain/audit/doctor/check.ts
+++ b/src/domain/audit/doctor/check.ts
@@ -69,11 +69,16 @@ export interface CheckResult {
  * The production implementation spawns the swamp binary to run
  * `audit record --from-hook`. Tests inject fakes so unit tests never
  * subprocess-out to a real swamp binary.
+ *
+ * `signal` lets the caller terminate an in-flight child when the doctor
+ * receives SIGINT. Without it, killing the doctor parent reparents the
+ * child to init/launchd instead of terminating it.
  */
 export type SpawnFn = (
   args: string[],
   stdin: string,
   env?: Record<string, string>,
+  signal?: AbortSignal,
 ) => Promise<{ exitCode: number; stdout: string; stderr: string }>;
 
 /** Context passed to every preflight check. */

--- a/src/domain/audit/doctor/checks/recording_smoke.ts
+++ b/src/domain/audit/doctor/checks/recording_smoke.ts
@@ -70,13 +70,28 @@ export const recordingSmokeTestCheck: PreflightCheck = {
       };
     }
 
-    await ensureDir(ctx.auditDir);
+    try {
+      await ensureDir(ctx.auditDir);
+    } catch (error) {
+      if (error instanceof Deno.errors.PermissionDenied) {
+        return {
+          name: "recording-smoke-test",
+          status: "fail",
+          message: `audit directory is not writable: ${ctx.auditDir}`,
+          hint:
+            `The audit directory exists but the current user cannot write to it. Check ownership and permissions (e.g. \`ls -ld ${ctx.auditDir}\`) and \`chmod\`/\`chown\` it so the user running swamp can write to it.`,
+          details: { auditDir: ctx.auditDir, error: String(error) },
+        };
+      }
+      throw error;
+    }
 
     try {
       await ctx.spawnSwamp(
         ["audit", "record", "--from-hook", "--tool", ctx.tool],
         payload.stdin,
         payload.env,
+        ctx.abortSignal,
       );
     } catch (error) {
       return {

--- a/src/domain/audit/doctor/checks/recording_smoke_test.ts
+++ b/src/domain/audit/doctor/checks/recording_smoke_test.ts
@@ -132,3 +132,52 @@ Deno.test("recordingSmokeTest: appliesTo returns true only for audit-hook tools"
   assertEquals(recordingSmokeTestCheck.appliesTo("copilot"), false);
   assertEquals(recordingSmokeTestCheck.appliesTo("none"), false);
 });
+
+Deno.test(
+  "recordingSmokeTest: passes the abort signal through to spawnSwamp",
+  async () => {
+    await withTempAuditDir(async (auditDir) => {
+      const controller = new AbortController();
+      let receivedSignal: AbortSignal | undefined;
+      const captureSpawn: SpawnFn = (_args, stdin, _env, signal) => {
+        receivedSignal = signal;
+        // Simulate a hook that drops the row, so the run still completes.
+        return makeFakeSpawnThatDropsRow()(_args, stdin);
+      };
+      const ctx: CheckContext = {
+        repoPath: auditDir.replace(/\.swamp\/audit$/, ""),
+        auditDir,
+        tool: "claude",
+        abortSignal: controller.signal,
+        spawnSwamp: captureSpawn,
+      };
+      await recordingSmokeTestCheck.run(ctx);
+      assertEquals(receivedSignal, controller.signal);
+    });
+  },
+);
+
+Deno.test(
+  "recordingSmokeTest: returns actionable fail when audit dir is not writable",
+  // Permission semantics differ on Windows; chmod 0500 is not enforced there.
+  { ignore: Deno.build.os === "windows" },
+  async () => {
+    const repo = await Deno.makeTempDir({ prefix: "doctor-smoke-readonly-" });
+    const auditDir = join(repo, ".swamp", "audit-locked");
+    await ensureDir(auditDir);
+    await Deno.chmod(auditDir, 0o500);
+    try {
+      // Force a child path inside the readonly dir so ensureDir must mkdir.
+      const childAuditDir = join(auditDir, "today");
+      const result = await recordingSmokeTestCheck.run(
+        makeCtx(childAuditDir, "claude", makeFakeSpawnThatDropsRow()),
+      );
+      assertEquals(result.status, "fail");
+      assertStringIncludes(result.message, "not writable");
+      assertStringIncludes(result.hint ?? "", "chmod");
+    } finally {
+      await Deno.chmod(auditDir, 0o700).catch(() => {});
+      await Deno.remove(repo, { recursive: true }).catch(() => {});
+    }
+  },
+);


### PR DESCRIPTION
## Summary

`swamp doctor audit` was orphaning its in-flight `swamp audit record` child when the parent received SIGINT during the recording-smoke-test phase. After Ctrl+C the parent died fast (exit 130) but the child got reparented to PID 1 and kept running.

## Reproduction

Spawn `swamp doctor audit` against any kiro/claude/cursor/opencode-initialized repo, send SIGINT 400–600ms in (during the smoke-test window), then check `ps`:

```
PID    PPID  CMD
20939     1  /opt/homebrew/bin/swamp audit record --from-hook --tool kiro --repo-dir .
```

PPID=1 = orphan. Reproduces reliably; goes away below ~200ms (SIGINT lands before the smoke test starts).

## Root Cause

Two cooperating gaps:

1. `src/cli/commands/doctor_audit.ts` allocated an `AbortController` and threaded `controller.signal` into the audit service, but no `Deno.addSignalListener("SIGINT", …)` was wired anywhere. The abort signal was dead wiring.
2. `makeSwampSpawnFn` returned a `SpawnFn` whose `child = cmd.spawn(); await child.output()` never observed any signal, so the child outlived the parent regardless.

## Fix

- Plumb an optional `AbortSignal` through `SpawnFn` (`src/domain/audit/doctor/check.ts`); `recording_smoke` passes `ctx.abortSignal` through.
- Extract `runChildWithAbort` (exported for testing): on abort, send `SIGTERM` to the child and escalate to `SIGKILL` after 3s. This guards against a hung subprocess that ignores SIGTERM.
- Wire SIGINT to the controller in the action handler. The handler removes itself on first fire so a second Ctrl+C falls through to Deno's default exit-130 — escape hatch for an unresponsive child without waiting on the SIGKILL timer. SIGTERM isn't listened for at the parent level because Deno doesn't support it on Windows.

## Bonus: actionable readonly-audit-dir error

`recording_smoke.ts` previously let `Deno.errors.PermissionDenied` from `ensureDir` escape into the service's generic "check threw / file an issue" hint when `.swamp/audit` was chmod 0500. Now returns:

> audit directory is not writable: …
> hint: Check ownership and permissions (e.g. `ls -ld …`) and `chmod`/`chown` it so the user running swamp can write to it.

## Test Plan

- [x] `deno fmt --check`
- [x] `deno lint`
- [x] `deno run test` — 5210 passed, 0 failed (4 new tests: AbortError on pre-aborted signal, prompt termination on SIGTERM, SIGKILL escalation when child traps SIGTERM, signal pass-through in `recording_smoke`, readonly-audit-dir branch)
- [x] `deno run compile`
- [x] e2e repro at 200/400/600ms SIGINT delays — no orphan at any timing
- [x] e2e happy path — `swamp doctor audit` still reports 5/5 PASS, no orphan child
- [x] e2e double-Ctrl+C — second SIGINT escape hatch works (parent exits cleanly from first signal in this case; second has nothing to interrupt, but `Deno.removeSignalListener` proves the listener is gone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)