### PR TITLE
fix(extensions): stop rebundle loop on schema-invalid extensions (swamp-club#209)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -925,6 +925,22 @@ the model registry is wired up initially.
      back to a real hash and triggers a rebundle correctly. This property
      holds uniformly across all five extension kinds (models, drivers,
      vaults, datastores, reports) since they share the freshness service.
+     Symmetrically, when an extension's source bundles and imports cleanly
+     but fails schema validation (e.g. a required field was removed), the
+     catalog row is upserted with the new fingerprint and a
+     `validation_failed = true` marker (#209). Freshness comparison still
+     works via fingerprint equality — the broken row is visible to
+     `findStaleFiles` so a stable broken source produces a stable
+     not-stale state. Registration paths filter on `validation_failed`,
+     so the broken extension is correctly absent from the registry until
+     the source is fixed. Editing the source to a different shape
+     produces a new fingerprint, marks the file stale, triggers a
+     rebundle, and flips the row back to `validation_failed = false`.
+     This fix is scoped to the steady-state `rebundleAndUpdateCatalog`
+     hot path — the cold-start parses (initial `loadModels` Pass 1, the
+     by-name `loadSingleType`, and the extension-attach predicate)
+     retain their existing failure semantics because they are not in
+     the read-only steady-state loop.
    - If not populated (first run or DB deleted): falls back to the existing
      full-import path, then populates the catalog from the loaded registry
 

--- a/src/cli/auto_resolver_adapters.ts
+++ b/src/cli/auto_resolver_adapters.ts
@@ -234,6 +234,9 @@ export function createAutoResolveInstallerAdapter(
       if (catalog && result.loaded.length > 0) {
         const pendingBases = new Set<string>();
         for (const row of catalog.findByKind("extension")) {
+          // Validation-failed rows (swamp-club#209) have empty
+          // extends_type so they fall out of this set naturally — the
+          // explicit emptiness check below already filters them.
           if (row.extends_type) pendingBases.add(row.extends_type);
         }
         for (const type of pendingBases) {

--- a/src/domain/datastore/user_datastore_loader.ts
+++ b/src/domain/datastore/user_datastore_loader.ts
@@ -35,6 +35,7 @@ import {
   createFreshnessCache,
   findStaleFiles as findStaleFilesShared,
   type FreshnessCache,
+  markCatalogValidationFailed,
 } from "../extensions/bundle_freshness.ts";
 import type { DenoRuntime } from "../runtime/deno_runtime.ts";
 import type { DatastoreProvider } from "./datastore_provider.ts";
@@ -522,6 +523,9 @@ export class UserDatastoreLoader {
   private registerLazyFromCatalog(catalog: ExtensionCatalogStore): void {
     const entries = catalog.findByKind("datastore");
     for (const entry of entries) {
+      // Skip validation-failed rows (swamp-club#209) — see equivalent
+      // guard in user_model_loader.ts:registerLazyFromCatalog.
+      if (entry.validation_failed) continue;
       datastoreTypeRegistry.registerLazy({
         type: entry.type_normalized,
         bundlePath: entry.bundle_path,
@@ -686,19 +690,32 @@ export class UserDatastoreLoader {
 
     if (!module.datastore) return;
 
-    const parsed = UserDatastoreSchema.safeParse(module.datastore);
-    if (!parsed.success) {
-      throw new Error(this.formatValidationError(parsed.error));
-    }
-
+    // Compute mtime+fingerprint BEFORE schema validation so we can
+    // record a validation-failed catalog row if the parse throws —
+    // otherwise findStaleFiles re-bundles every pass on a stable
+    // broken source (swamp-club#209).
     const stat = await Deno.stat(absolutePath);
     const sourceMtime = stat.mtime?.toISOString() ?? "";
     const sourceFingerprint = await computeSourceFingerprint(
       absolutePath,
       baseDir,
     );
-    const typeNormalized = parsed.data.type.toLowerCase();
     const bundlePath = this.getDatastoreBundlePath(relativePath, baseDir);
+
+    const parsed = UserDatastoreSchema.safeParse(module.datastore);
+    if (!parsed.success) {
+      markCatalogValidationFailed({
+        catalog,
+        sourcePath: absolutePath,
+        kind: "datastore",
+        bundlePath,
+        sourceMtime,
+        sourceFingerprint,
+      });
+      throw new Error(this.formatValidationError(parsed.error));
+    }
+
+    const typeNormalized = parsed.data.type.toLowerCase();
 
     catalog.upsert({
       type_normalized: typeNormalized,

--- a/src/domain/datastore/user_datastore_loader_test.ts
+++ b/src/domain/datastore/user_datastore_loader_test.ts
@@ -20,7 +20,10 @@
 import { assertEquals, assertNotEquals } from "@std/assert";
 import { join } from "@std/path";
 import { UserDatastoreLoader } from "./user_datastore_loader.ts";
-import { DatastoreTypeRegistry } from "./datastore_type_registry.ts";
+import {
+  DatastoreTypeRegistry,
+  datastoreTypeRegistry,
+} from "./datastore_type_registry.ts";
 import { bundleNamespace } from "../../infrastructure/persistence/paths.ts";
 import { ExtensionCatalogStore } from "../../infrastructure/persistence/extension_catalog_store.ts";
 import type { DenoRuntime } from "../runtime/deno_runtime.ts";
@@ -471,6 +474,67 @@ export const datastore = {
       true,
       "V2 dep marker must be present in the regenerated bundle",
     );
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+    await Deno.remove(datastoresDir, { recursive: true });
+  }
+});
+
+Deno.test("UserDatastoreLoader: registerLazyFromCatalog skips validation_failed rows (swamp-club#209)", async () => {
+  const repoDir = await Deno.makeTempDir({
+    prefix: "swamp_issue209_ds_repo_",
+  });
+  const datastoresDir = await Deno.makeTempDir({
+    prefix: "swamp_issue209_ds_dir_",
+  });
+  const dbPath = join(repoDir, ".swamp", "_extension_catalog.db");
+
+  try {
+    const ts = Date.now();
+    const validDatastore = `
+import { z } from "npm:zod";
+
+export const datastore = {
+  type: "@test/issue209-ds-${ts}",
+  name: "Test Datastore",
+  description: "Healthy datastore",
+  configSchema: z.object({}),
+  createProvider: (_name, _cfg) => ({
+    async write() {},
+    async read() { return null; },
+    async list() { return []; },
+    async delete() {},
+  }),
+};
+`;
+    await Deno.writeTextFile(join(datastoresDir, "valid.ts"), validDatastore);
+
+    const catalog = new ExtensionCatalogStore(dbPath);
+    const loader = new UserDatastoreLoader(new StubDenoRuntime(), repoDir);
+    await loader.buildIndex(datastoresDir, catalog);
+
+    catalog.upsert({
+      source_path: join(datastoresDir, "broken.ts"),
+      type_normalized: "",
+      kind: "datastore",
+      bundle_path: join(repoDir, ".swamp", "datastore-bundles", "broken.js"),
+      version: "",
+      description: "",
+      extends_type: "",
+      source_mtime: "2026-05-01T12:00:00.000Z",
+      source_fingerprint: "deadbeef-broken",
+      validation_failed: true,
+    });
+
+    const loader2 = new UserDatastoreLoader(new StubDenoRuntime(), repoDir);
+    await loader2.buildIndex(datastoresDir, catalog);
+
+    assertEquals(
+      datastoreTypeRegistry.has(`@test/issue209-ds-${ts}`),
+      true,
+    );
+    assertEquals(datastoreTypeRegistry.has(""), false);
+    catalog.close();
   } finally {
     await Deno.remove(repoDir, { recursive: true });
     await Deno.remove(datastoresDir, { recursive: true });

--- a/src/domain/drivers/user_driver_loader.ts
+++ b/src/domain/drivers/user_driver_loader.ts
@@ -35,6 +35,7 @@ import {
   createFreshnessCache,
   findStaleFiles as findStaleFilesShared,
   type FreshnessCache,
+  markCatalogValidationFailed,
 } from "../extensions/bundle_freshness.ts";
 import type { DenoRuntime } from "../runtime/deno_runtime.ts";
 import type { ExecutionDriver } from "./execution_driver.ts";
@@ -532,6 +533,9 @@ export class UserDriverLoader {
   private registerLazyFromCatalog(catalog: ExtensionCatalogStore): void {
     const entries = catalog.findByKind("driver");
     for (const entry of entries) {
+      // Skip validation-failed rows (swamp-club#209) — see equivalent
+      // guard in user_model_loader.ts:registerLazyFromCatalog.
+      if (entry.validation_failed) continue;
       driverTypeRegistry.registerLazy({
         type: entry.type_normalized,
         bundlePath: entry.bundle_path,
@@ -693,19 +697,32 @@ export class UserDriverLoader {
 
     if (!module.driver) return;
 
-    const parsed = UserDriverSchema.safeParse(module.driver);
-    if (!parsed.success) {
-      throw new Error(this.formatValidationError(parsed.error));
-    }
-
+    // Compute mtime+fingerprint BEFORE schema validation so we can
+    // record a validation-failed catalog row if the parse throws —
+    // otherwise findStaleFiles re-bundles every pass on a stable
+    // broken source (swamp-club#209).
     const stat = await Deno.stat(absolutePath);
     const sourceMtime = stat.mtime?.toISOString() ?? "";
     const sourceFingerprint = await computeSourceFingerprint(
       absolutePath,
       baseDir,
     );
-    const typeNormalized = parsed.data.type.toLowerCase();
     const bundlePath = this.getDriverBundlePath(relativePath, baseDir);
+
+    const parsed = UserDriverSchema.safeParse(module.driver);
+    if (!parsed.success) {
+      markCatalogValidationFailed({
+        catalog,
+        sourcePath: absolutePath,
+        kind: "driver",
+        bundlePath,
+        sourceMtime,
+        sourceFingerprint,
+      });
+      throw new Error(this.formatValidationError(parsed.error));
+    }
+
+    const typeNormalized = parsed.data.type.toLowerCase();
 
     catalog.upsert({
       type_normalized: typeNormalized,

--- a/src/domain/drivers/user_driver_loader_test.ts
+++ b/src/domain/drivers/user_driver_loader_test.ts
@@ -20,6 +20,7 @@
 import { assertEquals, assertNotEquals } from "@std/assert";
 import { join } from "@std/path";
 import { UserDriverLoader } from "./user_driver_loader.ts";
+import { driverTypeRegistry } from "./driver_type_registry.ts";
 import { bundleNamespace } from "../../infrastructure/persistence/paths.ts";
 import { ExtensionCatalogStore } from "../../infrastructure/persistence/extension_catalog_store.ts";
 import type { DenoRuntime } from "../runtime/deno_runtime.ts";
@@ -188,6 +189,60 @@ export const driver = {
       true,
       "V2 dep marker must be present in the regenerated bundle",
     );
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+    await Deno.remove(driversDir, { recursive: true });
+  }
+});
+
+Deno.test("UserDriverLoader: registerLazyFromCatalog skips validation_failed rows (swamp-club#209)", async () => {
+  const repoDir = await Deno.makeTempDir({
+    prefix: "swamp_issue209_driver_repo_",
+  });
+  const driversDir = await Deno.makeTempDir({
+    prefix: "swamp_issue209_driver_dir_",
+  });
+  const dbPath = join(repoDir, ".swamp", "_extension_catalog.db");
+
+  try {
+    const ts = Date.now();
+    const validDriver = `
+export const driver = {
+  type: "@test/issue209-driver-${ts}",
+  name: "Test Driver",
+  description: "Healthy driver",
+  createDriver: (_config) => ({
+    async executeMethod() {
+      return { dataHandles: [] };
+    },
+  }),
+};
+`;
+    await Deno.writeTextFile(join(driversDir, "valid.ts"), validDriver);
+
+    const catalog = new ExtensionCatalogStore(dbPath);
+    const loader = new UserDriverLoader(testDenoRuntime, repoDir);
+    await loader.buildIndex(driversDir, catalog);
+
+    catalog.upsert({
+      source_path: join(driversDir, "broken.ts"),
+      type_normalized: "",
+      kind: "driver",
+      bundle_path: join(repoDir, ".swamp", "driver-bundles", "broken.js"),
+      version: "",
+      description: "",
+      extends_type: "",
+      source_mtime: "2026-05-01T12:00:00.000Z",
+      source_fingerprint: "deadbeef-broken",
+      validation_failed: true,
+    });
+
+    const loader2 = new UserDriverLoader(testDenoRuntime, repoDir);
+    await loader2.buildIndex(driversDir, catalog);
+
+    assertEquals(driverTypeRegistry.has(`@test/issue209-driver-${ts}`), true);
+    assertEquals(driverTypeRegistry.has(""), false);
+    catalog.close();
   } finally {
     await Deno.remove(repoDir, { recursive: true });
     await Deno.remove(driversDir, { recursive: true });

--- a/src/domain/extensions/bundle_freshness.ts
+++ b/src/domain/extensions/bundle_freshness.ts
@@ -293,3 +293,82 @@ export async function findStaleFiles(
 
   return stale;
 }
+
+/**
+ * Minimal write-side catalog view the validation-failure helper needs.
+ * Same one-way domain→infrastructure boundary as FreshnessCatalog.
+ */
+export interface ValidationFailureCatalog {
+  upsert(row: {
+    source_path: string;
+    type_normalized: string;
+    kind: FreshnessKind;
+    bundle_path: string;
+    version: string;
+    description: string;
+    extends_type: string;
+    source_mtime: string;
+    source_fingerprint: string;
+    validation_failed: boolean;
+  }): void;
+}
+
+export interface MarkCatalogValidationFailedParams {
+  catalog: ValidationFailureCatalog;
+  sourcePath: string;
+  kind: FreshnessKind;
+  bundlePath: string;
+  sourceMtime: string;
+  sourceFingerprint: string;
+}
+
+/**
+ * Records the dual of findStaleFiles: when an extension's source bundles
+ * and imports cleanly but fails schema validation, write the catalog row
+ * with the new fingerprint and validation_failed=true. Without this,
+ * findStaleFiles keeps marking the file stale on every pass — the
+ * `safeParse`-throws-before-upsert pattern in each loader's
+ * rebundleAndUpdateCatalog leaves the row's fingerprint pinned at the
+ * last-good state, so every command spawns a redundant deno bundle and
+ * emits the same warning (swamp-club#209).
+ *
+ * Storing the new fingerprint terminates the loop: the next
+ * findStaleFiles pass compares the computed fingerprint against the
+ * stored one, finds them equal, and treats the file as fresh. The row's
+ * empty type_normalized + validation_failed=true keeps the broken
+ * extension out of the registry — registration call sites filter on
+ * the flag.
+ *
+ * Symmetric to the UNREADABLE_DEP_SENTINEL fix in #208: that one made
+ * computeSourceFingerprint total for unreadable transitive deps; this
+ * one makes the catalog write total for schema-invalid sources. Both
+ * encode "stable broken state" into the freshness contract.
+ *
+ * Does NOT throw — callers re-throw the original validation error so
+ * the existing per-edit warning behavior is preserved.
+ */
+export function markCatalogValidationFailed(
+  params: MarkCatalogValidationFailedParams,
+): void {
+  const {
+    catalog,
+    sourcePath,
+    kind,
+    bundlePath,
+    sourceMtime,
+    sourceFingerprint,
+  } = params;
+
+  catalog.upsert({
+    source_path: sourcePath,
+    type_normalized: "",
+    kind,
+    bundle_path: bundlePath,
+    version: "",
+    description: "",
+    extends_type: "",
+    source_mtime: sourceMtime,
+    source_fingerprint: sourceFingerprint,
+    validation_failed: true,
+  });
+}

--- a/src/domain/extensions/bundle_freshness_test.ts
+++ b/src/domain/extensions/bundle_freshness_test.ts
@@ -24,16 +24,34 @@ import {
   findStaleFiles,
   type FreshnessCatalog,
   type FreshnessKind,
+  markCatalogValidationFailed,
+  type ValidationFailureCatalog,
 } from "./bundle_freshness.ts";
 import type { ExtensionTypeRow } from "../../infrastructure/persistence/extension_catalog_store.ts";
 
 // -- Test fixture -------------------------------------------------------
 
-class FakeCatalog implements FreshnessCatalog {
+class FakeCatalog implements FreshnessCatalog, ValidationFailureCatalog {
   private rows: ExtensionTypeRow[] = [];
 
   add(row: ExtensionTypeRow): void {
     this.rows.push(row);
+  }
+
+  upsert(row: {
+    source_path: string;
+    type_normalized: string;
+    kind: FreshnessKind;
+    bundle_path: string;
+    version: string;
+    description: string;
+    extends_type: string;
+    source_mtime: string;
+    source_fingerprint: string;
+    validation_failed: boolean;
+  }): void {
+    this.rows = this.rows.filter((r) => r.source_path !== row.source_path);
+    this.rows.push(row as unknown as ExtensionTypeRow);
   }
 
   findByKind(kind: FreshnessKind): ExtensionTypeRow[] {
@@ -654,5 +672,197 @@ Deno.test("computeSourceFingerprint: restoring a broken dep changes the fingerpr
     );
   } finally {
     await Deno.remove(dir, { recursive: true });
+  }
+});
+
+// -- markCatalogValidationFailed (swamp-club#209) -----------------------
+
+class FakeValidationFailureCatalog implements ValidationFailureCatalog {
+  public readonly upserts: Array<Record<string, unknown>> = [];
+
+  upsert(row: {
+    source_path: string;
+    type_normalized: string;
+    kind: FreshnessKind;
+    bundle_path: string;
+    version: string;
+    description: string;
+    extends_type: string;
+    source_mtime: string;
+    source_fingerprint: string;
+    validation_failed: boolean;
+  }): void {
+    this.upserts.push({ ...row });
+  }
+}
+
+Deno.test("markCatalogValidationFailed: upserts a row with every field populated", () => {
+  const catalog = new FakeValidationFailureCatalog();
+
+  markCatalogValidationFailed({
+    catalog,
+    sourcePath: "/repo/extensions/models/echo/echo.ts",
+    kind: "model",
+    bundlePath: "/repo/.swamp/bundles/echo.js",
+    sourceMtime: "2026-05-01T12:00:00.000Z",
+    sourceFingerprint: "abc123",
+  });
+
+  assertEquals(catalog.upserts.length, 1);
+  const row = catalog.upserts[0];
+  assertEquals(row.source_path, "/repo/extensions/models/echo/echo.ts");
+  assertEquals(row.type_normalized, "");
+  assertEquals(row.kind, "model");
+  assertEquals(row.bundle_path, "/repo/.swamp/bundles/echo.js");
+  assertEquals(row.version, "");
+  assertEquals(row.description, "");
+  assertEquals(row.extends_type, "");
+  assertEquals(row.source_mtime, "2026-05-01T12:00:00.000Z");
+  assertEquals(row.source_fingerprint, "abc123");
+  assertEquals(row.validation_failed, true);
+});
+
+Deno.test("markCatalogValidationFailed: idempotent — repeated calls produce identical rows", () => {
+  const catalog = new FakeValidationFailureCatalog();
+
+  const params = {
+    catalog,
+    sourcePath: "/r/v.ts",
+    kind: "vault" as FreshnessKind,
+    bundlePath: "/r/v.js",
+    sourceMtime: "2026-05-01T12:00:00.000Z",
+    sourceFingerprint: "fingerprint-x",
+  };
+
+  markCatalogValidationFailed(params);
+  markCatalogValidationFailed(params);
+
+  assertEquals(catalog.upserts.length, 2);
+  assertEquals(catalog.upserts[0], catalog.upserts[1]);
+});
+
+Deno.test("findStaleFiles + markCatalogValidationFailed: stable broken source converges to not-stale (swamp-club#209)", async () => {
+  // The actual bug-fix invariant. Without markCatalogValidationFailed,
+  // the catalog row's stored fingerprint stays pinned at the last-good
+  // value after a schema break, so findStaleFiles keeps returning the
+  // file as stale on every pass. With it, the new fingerprint is
+  // recorded and findStaleFiles converges to "not stale" — the
+  // rebundle loop terminates on a stable broken source.
+  const dir = await Deno.makeTempDir({ prefix: "swamp_bf_209_converge_" });
+  try {
+    const file = join(dir, "model.ts");
+    const sourceContent = "export const broken = { not: 'a model' };\n";
+    await Deno.writeTextFile(file, sourceContent);
+
+    // Compute the would-be source fingerprint as the loader does.
+    const fingerprint = await computeSourceFingerprint(file, dir);
+
+    // Simulate what rebundleAndUpdateCatalog now does on safeParse
+    // failure: record a validation-failed row with the new fingerprint.
+    const catalog = new FakeCatalog();
+    markCatalogValidationFailed({
+      catalog,
+      sourcePath: file,
+      kind: "model",
+      bundlePath: join(dir, "model.js"),
+      sourceMtime: "2026-05-01T12:00:00.000Z",
+      sourceFingerprint: fingerprint,
+    });
+
+    // findStaleFiles must NOT return this file — its fingerprint
+    // matches the stored value, so it is fresh-but-broken, not stale.
+    const stale = await findStaleFiles({
+      modelsDir: dir,
+      catalog,
+      discoverFiles: discoverTsFiles,
+      kinds: ["model"],
+    });
+    assertEquals(
+      stale.length,
+      0,
+      "Stable broken source must converge to not-stale on the very next " +
+        "findStaleFiles pass",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("findStaleFiles + markCatalogValidationFailed: editing a broken source produces a new fingerprint and re-stales", async () => {
+  // Recovery path. After the broken-state row is in place, editing
+  // the source to ANY different content (broken or valid) produces a
+  // new fingerprint that does not match the stored value, so
+  // findStaleFiles correctly marks the file stale and the loader's
+  // rebundle pass fires.
+  const dir = await Deno.makeTempDir({ prefix: "swamp_bf_209_recover_" });
+  try {
+    const file = join(dir, "model.ts");
+    await Deno.writeTextFile(file, "export const broken = 1;\n");
+    const brokenFp = await computeSourceFingerprint(file, dir);
+
+    const catalog = new FakeCatalog();
+    markCatalogValidationFailed({
+      catalog,
+      sourcePath: file,
+      kind: "model",
+      bundlePath: join(dir, "model.js"),
+      sourceMtime: "2026-05-01T12:00:00.000Z",
+      sourceFingerprint: brokenFp,
+    });
+
+    // Stable broken — not stale.
+    let stale = await findStaleFiles({
+      modelsDir: dir,
+      catalog,
+      discoverFiles: discoverTsFiles,
+      kinds: ["model"],
+    });
+    assertEquals(stale.length, 0);
+
+    // Edit to different content (the recovery path).
+    await Deno.writeTextFile(file, "export const recovered = 42;\n");
+    stale = await findStaleFiles({
+      modelsDir: dir,
+      catalog,
+      discoverFiles: discoverTsFiles,
+      kinds: ["model"],
+    });
+    assertEquals(
+      stale.length,
+      1,
+      "Editing the source after a broken-state row must re-stale the file " +
+        "so the rebundle pass can repair the row",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("markCatalogValidationFailed: works for every supported kind", () => {
+  const catalog = new FakeValidationFailureCatalog();
+  const kinds: FreshnessKind[] = [
+    "model",
+    "extension",
+    "vault",
+    "driver",
+    "datastore",
+    "report",
+  ];
+
+  for (const kind of kinds) {
+    markCatalogValidationFailed({
+      catalog,
+      sourcePath: `/r/${kind}.ts`,
+      kind,
+      bundlePath: `/r/${kind}.js`,
+      sourceMtime: "2026-05-01T12:00:00.000Z",
+      sourceFingerprint: "fp",
+    });
+  }
+
+  assertEquals(catalog.upserts.length, kinds.length);
+  for (let i = 0; i < kinds.length; i++) {
+    assertEquals(catalog.upserts[i].kind, kinds[i]);
+    assertEquals(catalog.upserts[i].validation_failed, true);
   }
 });

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -35,6 +35,7 @@ import {
   createFreshnessCache,
   findStaleFiles as findStaleFilesShared,
   type FreshnessCache,
+  markCatalogValidationFailed,
 } from "../extensions/bundle_freshness.ts";
 import { ModelType } from "./model_type.ts";
 import { CalVer } from "./calver.ts";
@@ -892,6 +893,11 @@ export class UserModelLoader {
   private registerLazyFromCatalog(catalog: ExtensionCatalogStore): void {
     const entries = catalog.findByKind("model");
     for (const entry of entries) {
+      // Skip validation-failed rows: their source content is fresh (the
+      // fingerprint stops findStaleFiles from re-bundling) but the
+      // module's schema is invalid, so the type is not safe to register
+      // (swamp-club#209).
+      if (entry.validation_failed) continue;
       modelRegistry.registerLazy({
         type: ModelType.create(entry.type_normalized),
         bundlePath: entry.bundle_path,
@@ -1095,12 +1101,20 @@ export class UserModelLoader {
     );
 
     if (module.model) {
+      const bundlePath = this.getBundlePath(relativePath, baseDir);
       const parsed = UserModelSchema.safeParse(module.model);
       if (!parsed.success) {
+        markCatalogValidationFailed({
+          catalog,
+          sourcePath: absolutePath,
+          kind: "model",
+          bundlePath,
+          sourceMtime,
+          sourceFingerprint,
+        });
         throw new Error(formatUserModelError(parsed.error));
       }
       const typeNormalized = ModelType.create(parsed.data.type).normalized;
-      const bundlePath = this.getBundlePath(relativePath, baseDir);
 
       catalog.upsert({
         type_normalized: typeNormalized,
@@ -1139,12 +1153,20 @@ export class UserModelLoader {
 
       return typeNormalized;
     } else if (module.extension) {
+      const bundlePath = this.getBundlePath(relativePath, baseDir);
       const parsed = UserExtensionSchema.safeParse(module.extension);
       if (!parsed.success) {
+        markCatalogValidationFailed({
+          catalog,
+          sourcePath: absolutePath,
+          kind: "extension",
+          bundlePath,
+          sourceMtime,
+          sourceFingerprint,
+        });
         throw new Error(parsed.error.message);
       }
       const typeNormalized = ModelType.create(parsed.data.type).normalized;
-      const bundlePath = this.getBundlePath(relativePath, baseDir);
 
       catalog.upsert({
         type_normalized: typeNormalized,

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -3227,3 +3227,110 @@ export const extension = {
     await Deno.remove(modelsDir, { recursive: true });
   }
 });
+
+Deno.test("UserModelLoader: registerLazyFromCatalog skips validation_failed rows (swamp-club#209)", async () => {
+  // After a schema-invalid extension goes through rebundleAndUpdateCatalog,
+  // the catalog row carries validation_failed=true with empty
+  // type_normalized. The fingerprint match terminates the rebundle loop
+  // (verified at the catalog/freshness layer), but the registry must
+  // not be polluted with the broken row — registerLazyFromCatalog has
+  // to filter on validation_failed.
+  //
+  // Drives the registration path directly via a seeded catalog rather
+  // than going through buildIndex. The buildIndex path bumps into
+  // Deno's per-process import cache: rewriting the source file on
+  // disk and re-importing the same bundlePath returns the previously
+  // cached module, masking the parse failure inside a single test
+  // process. Production runs are fresh subprocesses without that cache,
+  // which is why the bug manifests there but not via in-process
+  // integration tests. The fix's actual surface is the catalog row
+  // shape + the registration filter — both unit-testable.
+  const ts = Date.now();
+  const healthy = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "@user/issue209-healthy-${ts}",
+  version: "2026.05.01.1",
+  methods: {
+    run: {
+      description: "Run",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+  const repoDir = await Deno.makeTempDir({
+    prefix: "swamp_issue209_lazy_repo_",
+  });
+  const modelsDir = await Deno.makeTempDir({
+    prefix: "swamp_issue209_lazy_models_",
+  });
+  const dbPath = join(repoDir, ".swamp", "_extension_catalog.db");
+
+  try {
+    await Deno.writeTextFile(join(modelsDir, "healthy.ts"), healthy);
+
+    // Cold-start populates the catalog with the healthy model.
+    const catalog1 = new ExtensionCatalogStore(dbPath);
+    const loader1 = new UserModelLoader(testDenoRuntime, repoDir);
+    await loader1.buildIndex(modelsDir, catalog1);
+
+    // Inject a validation-failed row to simulate what
+    // markCatalogValidationFailed would write after a schema break.
+    const ns = bundleNamespace(modelsDir, repoDir);
+    const brokenSourcePath = join(modelsDir, "broken.ts");
+    catalog1.upsert({
+      source_path: brokenSourcePath,
+      type_normalized: "",
+      kind: "model",
+      bundle_path: join(repoDir, ".swamp", "bundles", ns, "broken.js"),
+      version: "",
+      description: "",
+      extends_type: "",
+      source_mtime: "2026-05-01T12:00:00.000Z",
+      source_fingerprint: "deadbeef-broken-state",
+      validation_failed: true,
+    });
+    catalog1.close();
+
+    // Re-open and find both rows. findByKind must return BOTH —
+    // ADV-1 invariant: findStaleFiles needs to see the broken row to
+    // terminate the rebundle loop on a stable broken source.
+    const catalog2 = new ExtensionCatalogStore(dbPath);
+    const allRows = catalog2.findByKind("model");
+    const broken = allRows.find((r) => r.source_path === brokenSourcePath);
+    const healthyRow = allRows.find((r) =>
+      r.type_normalized === `@user/issue209-healthy-${ts}`
+    );
+    assertNotEquals(broken, undefined, "Broken row must be in findByKind");
+    assertEquals(broken?.validation_failed, true);
+    assertNotEquals(healthyRow, undefined, "Healthy row must be in findByKind");
+    assertEquals(healthyRow?.validation_failed, false);
+
+    // Drive registerLazyFromCatalog. The healthy type registers; the
+    // broken row (empty type_normalized + validation_failed=true) must
+    // NOT register. Use a fresh loader so the lazy registration path
+    // runs against a clean registry view of the populated catalog.
+    const loader2 = new UserModelLoader(testDenoRuntime, repoDir);
+    await loader2.buildIndex(modelsDir, catalog2);
+
+    // After buildIndex, the healthy type is registered. The empty
+    // type_normalized of the broken row never reaches the registry —
+    // ModelType.create("") would throw, but the filter prevents that.
+    const healthyTypeName = `@user/issue209-healthy-${ts}`;
+    assertNotEquals(
+      modelRegistry.has(healthyTypeName)
+        ? modelRegistry.get(healthyTypeName)
+        : undefined,
+      undefined,
+      "Healthy type must be registered",
+    );
+    catalog2.close();
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+    await Deno.remove(modelsDir, { recursive: true });
+  }
+});

--- a/src/domain/reports/user_report_loader.ts
+++ b/src/domain/reports/user_report_loader.ts
@@ -34,6 +34,7 @@ import {
   createFreshnessCache,
   findStaleFiles as findStaleFilesShared,
   type FreshnessCache,
+  markCatalogValidationFailed,
 } from "../extensions/bundle_freshness.ts";
 import type { DenoRuntime } from "../runtime/deno_runtime.ts";
 import type { ReportContext } from "./report_context.ts";
@@ -380,6 +381,9 @@ export class UserReportLoader {
   private registerLazyFromCatalog(catalog: ExtensionCatalogStore): void {
     const entries = catalog.findByKind("report");
     for (const entry of entries) {
+      // Skip validation-failed rows (swamp-club#209) — see equivalent
+      // guard in user_model_loader.ts:registerLazyFromCatalog.
+      if (entry.validation_failed) continue;
       reportRegistry.registerLazy({
         type: entry.type_normalized,
         bundlePath: entry.bundle_path,
@@ -542,19 +546,32 @@ export class UserReportLoader {
 
     if (!module.report) return;
 
-    const parsed = UserReportSchema.safeParse(module.report);
-    if (!parsed.success) {
-      throw new Error(this.formatValidationError(parsed.error));
-    }
-
+    // Compute mtime+fingerprint BEFORE schema validation so we can
+    // record a validation-failed catalog row if the parse throws —
+    // otherwise findStaleFiles re-bundles every pass on a stable
+    // broken source (swamp-club#209).
     const stat = await Deno.stat(absolutePath);
     const sourceMtime = stat.mtime?.toISOString() ?? "";
     const sourceFingerprint = await computeSourceFingerprint(
       absolutePath,
       baseDir,
     );
-    const typeNormalized = parsed.data.name.toLowerCase();
     const bundlePath = this.getReportBundlePath(relativePath, baseDir);
+
+    const parsed = UserReportSchema.safeParse(module.report);
+    if (!parsed.success) {
+      markCatalogValidationFailed({
+        catalog,
+        sourcePath: absolutePath,
+        kind: "report",
+        bundlePath,
+        sourceMtime,
+        sourceFingerprint,
+      });
+      throw new Error(this.formatValidationError(parsed.error));
+    }
+
+    const typeNormalized = parsed.data.name.toLowerCase();
 
     catalog.upsert({
       type_normalized: typeNormalized,

--- a/src/domain/reports/user_report_loader_test.ts
+++ b/src/domain/reports/user_report_loader_test.ts
@@ -20,6 +20,7 @@
 import { assertEquals, assertNotEquals } from "@std/assert";
 import { join } from "@std/path";
 import { UserReportLoader } from "./user_report_loader.ts";
+import { reportRegistry } from "./report_registry.ts";
 import { bundleNamespace } from "../../infrastructure/persistence/paths.ts";
 import { ExtensionCatalogStore } from "../../infrastructure/persistence/extension_catalog_store.ts";
 import type { DenoRuntime } from "../runtime/deno_runtime.ts";
@@ -204,6 +205,59 @@ export const report = {
       true,
       "V2 dep marker must be present in the regenerated bundle",
     );
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+    await Deno.remove(reportsDir, { recursive: true });
+  }
+});
+
+Deno.test("UserReportLoader: registerLazyFromCatalog skips validation_failed rows (swamp-club#209)", async () => {
+  const repoDir = await Deno.makeTempDir({
+    prefix: "swamp_issue209_report_repo_",
+  });
+  const reportsDir = await Deno.makeTempDir({
+    prefix: "swamp_issue209_report_dir_",
+  });
+  const dbPath = join(repoDir, ".swamp", "_extension_catalog.db");
+
+  try {
+    const ts = Date.now();
+    const reportName = `issue209-report-${ts}`;
+    const validReport = `
+export const report = {
+  name: "${reportName}",
+  description: "Healthy report",
+  scope: "model",
+  execute: async (_ctx) => {
+    return { rows: [] };
+  },
+};
+`;
+    await Deno.writeTextFile(join(reportsDir, "valid.ts"), validReport);
+
+    const catalog = new ExtensionCatalogStore(dbPath);
+    const loader = new UserReportLoader(testDenoRuntime, repoDir);
+    await loader.buildIndex(reportsDir, catalog);
+
+    catalog.upsert({
+      source_path: join(reportsDir, "broken.ts"),
+      type_normalized: "",
+      kind: "report",
+      bundle_path: join(repoDir, ".swamp", "report-bundles", "broken.js"),
+      version: "",
+      description: "",
+      extends_type: "",
+      source_mtime: "2026-05-01T12:00:00.000Z",
+      source_fingerprint: "deadbeef-broken",
+      validation_failed: true,
+    });
+
+    const loader2 = new UserReportLoader(testDenoRuntime, repoDir);
+    await loader2.buildIndex(reportsDir, catalog);
+
+    assertEquals(reportRegistry.has(reportName), true);
+    assertEquals(reportRegistry.has(""), false);
+    catalog.close();
   } finally {
     await Deno.remove(repoDir, { recursive: true });
     await Deno.remove(reportsDir, { recursive: true });

--- a/src/domain/vaults/user_vault_loader.ts
+++ b/src/domain/vaults/user_vault_loader.ts
@@ -35,6 +35,7 @@ import {
   createFreshnessCache,
   findStaleFiles as findStaleFilesShared,
   type FreshnessCache,
+  markCatalogValidationFailed,
 } from "../extensions/bundle_freshness.ts";
 import type { DenoRuntime } from "../runtime/deno_runtime.ts";
 import type { VaultProvider } from "./vault_provider.ts";
@@ -533,6 +534,9 @@ export class UserVaultLoader {
   private registerLazyFromCatalog(catalog: ExtensionCatalogStore): void {
     const entries = catalog.findByKind("vault");
     for (const entry of entries) {
+      // Skip validation-failed rows (swamp-club#209) — see equivalent
+      // guard in user_model_loader.ts:registerLazyFromCatalog.
+      if (entry.validation_failed) continue;
       vaultTypeRegistry.registerLazy({
         type: entry.type_normalized,
         bundlePath: entry.bundle_path,
@@ -697,19 +701,32 @@ export class UserVaultLoader {
 
     if (!module.vault) return;
 
-    const parsed = UserVaultSchema.safeParse(module.vault);
-    if (!parsed.success) {
-      throw new Error(this.formatValidationError(parsed.error));
-    }
-
+    // Compute mtime+fingerprint BEFORE schema validation so we can
+    // record a validation-failed catalog row if the parse throws —
+    // otherwise findStaleFiles re-bundles every pass on a stable
+    // broken source (swamp-club#209).
     const stat = await Deno.stat(absolutePath);
     const sourceMtime = stat.mtime?.toISOString() ?? "";
     const sourceFingerprint = await computeSourceFingerprint(
       absolutePath,
       baseDir,
     );
-    const typeNormalized = parsed.data.type.toLowerCase();
     const bundlePath = this.getVaultBundlePath(relativePath, baseDir);
+
+    const parsed = UserVaultSchema.safeParse(module.vault);
+    if (!parsed.success) {
+      markCatalogValidationFailed({
+        catalog,
+        sourcePath: absolutePath,
+        kind: "vault",
+        bundlePath,
+        sourceMtime,
+        sourceFingerprint,
+      });
+      throw new Error(this.formatValidationError(parsed.error));
+    }
+
+    const typeNormalized = parsed.data.type.toLowerCase();
 
     catalog.upsert({
       type_normalized: typeNormalized,

--- a/src/domain/vaults/user_vault_loader_test.ts
+++ b/src/domain/vaults/user_vault_loader_test.ts
@@ -20,7 +20,7 @@
 import { assertEquals, assertNotEquals } from "@std/assert";
 import { join } from "@std/path";
 import { UserVaultLoader } from "./user_vault_loader.ts";
-import { VaultTypeRegistry } from "./vault_type_registry.ts";
+import { VaultTypeRegistry, vaultTypeRegistry } from "./vault_type_registry.ts";
 import { bundleNamespace } from "../../infrastructure/persistence/paths.ts";
 import { ExtensionCatalogStore } from "../../infrastructure/persistence/extension_catalog_store.ts";
 import type { DenoRuntime } from "../runtime/deno_runtime.ts";
@@ -505,6 +505,76 @@ export const vault = {
       true,
       "V2 dep marker must be present in the regenerated bundle",
     );
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+    await Deno.remove(vaultsDir, { recursive: true });
+  }
+});
+
+Deno.test("UserVaultLoader: registerLazyFromCatalog skips validation_failed rows (swamp-club#209)", async () => {
+  // Seed the catalog with a validation-failed sentinel row and verify
+  // it never reaches the registry. The ADV-1 invariant — findByKind
+  // returns the row regardless — is guarded at the catalog-store
+  // level; this test guards the per-loader filter.
+  const repoDir = await Deno.makeTempDir({
+    prefix: "swamp_issue209_vault_repo_",
+  });
+  const vaultsDir = await Deno.makeTempDir({
+    prefix: "swamp_issue209_vault_dir_",
+  });
+  const dbPath = join(repoDir, ".swamp", "_extension_catalog.db");
+
+  try {
+    const ts = Date.now();
+    const validVault = `
+import { z } from "npm:zod";
+
+export const vault = {
+  type: "@test/issue209-vault-${ts}",
+  name: "Test Vault",
+  description: "Healthy vault",
+  configSchema: z.object({}),
+  createProvider: (_name: string, _cfg: Record<string, unknown>) => ({
+    get: async () => "x",
+    put: async () => {},
+    list: async () => [],
+    delete: async () => {},
+  }),
+};
+`;
+    await Deno.writeTextFile(join(vaultsDir, "valid.ts"), validVault);
+
+    // Cold-start populates the catalog with the valid vault.
+    const catalog = new ExtensionCatalogStore(dbPath);
+    const loader = new UserVaultLoader(new StubDenoRuntime(), repoDir);
+    await loader.buildIndex(vaultsDir, catalog);
+
+    // Inject a validation-failed row keyed by a different source path.
+    catalog.upsert({
+      source_path: join(vaultsDir, "broken.ts"),
+      type_normalized: "",
+      kind: "vault",
+      bundle_path: join(repoDir, ".swamp", "vault-bundles", "broken.js"),
+      version: "",
+      description: "",
+      extends_type: "",
+      source_mtime: "2026-05-01T12:00:00.000Z",
+      source_fingerprint: "deadbeef-broken",
+      validation_failed: true,
+    });
+
+    // Re-run buildIndex. registerLazyFromCatalog must skip the broken
+    // row even though findByKind returns it.
+    const loader2 = new UserVaultLoader(new StubDenoRuntime(), repoDir);
+    await loader2.buildIndex(vaultsDir, catalog);
+
+    // Valid type appears; broken sentinel does not. Use the singleton
+    // registry the loader writes into.
+    assertEquals(vaultTypeRegistry.has(`@test/issue209-vault-${ts}`), true);
+    // Empty-string type can never be a real registered name, but
+    // assert anyway to pin the invariant.
+    assertEquals(vaultTypeRegistry.has(""), false);
+    catalog.close();
   } finally {
     await Deno.remove(repoDir, { recursive: true });
     await Deno.remove(vaultsDir, { recursive: true });

--- a/src/infrastructure/persistence/extension_catalog_store.ts
+++ b/src/infrastructure/persistence/extension_catalog_store.ts
@@ -56,6 +56,17 @@ export interface ExtensionTypeRow {
    * coerces to "". Old catalog rows default to "" via the migration.
    */
   source_fingerprint?: string;
+  /**
+   * True when bundle+import succeeded but schema validation failed
+   * (swamp-club#209). The fingerprint and bundle path are still stored
+   * so freshness comparison terminates on a stable broken source —
+   * registration paths filter on this flag to keep broken types out of
+   * the registry. findByKind/findByType deliberately do NOT filter on
+   * this column so freshness (findStaleFiles) can see broken rows.
+   * Defaults to false on upsert; old catalog rows default to false via
+   * the migration.
+   */
+  validation_failed?: boolean;
 }
 
 /**
@@ -126,7 +137,8 @@ export class ExtensionCatalogStore {
         description        TEXT NOT NULL DEFAULT '',
         extends_type       TEXT NOT NULL DEFAULT '',
         source_mtime       TEXT NOT NULL DEFAULT '',
-        source_fingerprint TEXT NOT NULL DEFAULT ''
+        source_fingerprint TEXT NOT NULL DEFAULT '',
+        validation_failed  INTEGER NOT NULL DEFAULT 0
       );
 
       CREATE INDEX IF NOT EXISTS idx_bundle_types_kind
@@ -163,6 +175,11 @@ export class ExtensionCatalogStore {
         "ALTER TABLE bundle_types ADD COLUMN source_fingerprint TEXT NOT NULL DEFAULT ''",
       );
     }
+    if (!hasColumn("validation_failed")) {
+      this.db.exec(
+        "ALTER TABLE bundle_types ADD COLUMN validation_failed INTEGER NOT NULL DEFAULT 0",
+      );
+    }
   }
 
   /**
@@ -174,8 +191,8 @@ export class ExtensionCatalogStore {
       INSERT OR REPLACE INTO bundle_types (
         source_path, type_normalized, kind, bundle_path,
         version, description, extends_type, source_mtime,
-        source_fingerprint
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        source_fingerprint, validation_failed
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     stmt.run(
       row.source_path,
@@ -187,6 +204,7 @@ export class ExtensionCatalogStore {
       row.extends_type,
       row.source_mtime,
       row.source_fingerprint ?? "",
+      row.validation_failed ? 1 : 0,
     );
   }
 
@@ -214,17 +232,55 @@ export class ExtensionCatalogStore {
   }
 
   /**
+   * Coerces a raw SQLite row into a typed ExtensionTypeRow. Maps the
+   * INTEGER 0/1 `validation_failed` column to a boolean — SQLite has no
+   * native boolean type, so the column is stored as INTEGER but consumers
+   * expect a boolean.
+   *
+   * findByKind and findByType deliberately do NOT filter on
+   * validation_failed: findStaleFiles needs to see broken rows so the
+   * fingerprint match terminates the rebundle loop (swamp-club#209).
+   * Registration call sites filter on the coerced boolean instead.
+   */
+  private mapRow(raw: Record<string, unknown>): ExtensionTypeRow {
+    return {
+      source_path: raw.source_path as string,
+      type_normalized: raw.type_normalized as string,
+      kind: raw.kind as ExtensionKind,
+      bundle_path: raw.bundle_path as string,
+      version: raw.version as string,
+      description: raw.description as string,
+      extends_type: raw.extends_type as string,
+      source_mtime: raw.source_mtime as string,
+      source_fingerprint: raw.source_fingerprint as string,
+      validation_failed: raw.validation_failed === 1,
+    };
+  }
+
+  /**
    * Returns all entries for a given kind (e.g. all "model" entries).
+   *
+   * Includes validation-failed rows; consumers that should not register
+   * broken types must filter on `row.validation_failed` themselves.
+   * findStaleFiles relies on this inclusion to terminate the rebundle
+   * loop on schema-invalid sources (swamp-club#209).
    */
   findByKind(kind: ExtensionKind): ExtensionTypeRow[] {
     const stmt = this.db.prepare(
       "SELECT * FROM bundle_types WHERE kind = ? ORDER BY type_normalized",
     );
-    return stmt.all(kind) as unknown as ExtensionTypeRow[];
+    return (stmt.all(kind) as Record<string, unknown>[]).map((r) =>
+      this.mapRow(r)
+    );
   }
 
   /**
    * Returns the entry for a specific type and kind, or undefined.
+   *
+   * Validation-failed rows have empty `type_normalized` so they can
+   * never match a real type lookup here — the protection against
+   * surfacing broken types via this path is structural, not via a
+   * filter clause.
    */
   findByType(
     typeNormalized: string,
@@ -233,21 +289,27 @@ export class ExtensionCatalogStore {
     const stmt = this.db.prepare(
       "SELECT * FROM bundle_types WHERE type_normalized = ? AND kind = ?",
     );
-    return stmt.get(typeNormalized, kind) as unknown as
-      | ExtensionTypeRow
+    const row = stmt.get(typeNormalized, kind) as
+      | Record<string, unknown>
       | undefined;
+    return row ? this.mapRow(row) : undefined;
   }
 
   /**
    * Returns all extension entries that target a given base type.
    * Used by ensureTypeLoaded() to find extensions that add methods
    * to a base model type.
+   *
+   * Validation-failed rows have empty `extends_type` so they fall out
+   * of this query naturally.
    */
   findExtensionsForType(baseType: string): ExtensionTypeRow[] {
     const stmt = this.db.prepare(
       "SELECT * FROM bundle_types WHERE extends_type = ? AND kind = 'extension' ORDER BY type_normalized",
     );
-    return stmt.all(baseType) as unknown as ExtensionTypeRow[];
+    return (stmt.all(baseType) as Record<string, unknown>[]).map((r) =>
+      this.mapRow(r)
+    );
   }
 
   /**

--- a/src/infrastructure/persistence/extension_catalog_store_test.ts
+++ b/src/infrastructure/persistence/extension_catalog_store_test.ts
@@ -535,3 +535,108 @@ for (
     },
   );
 }
+
+// --- validation_failed column tests (swamp-club#209) ---
+//
+// The column tracks the third freshness state introduced by
+// markCatalogValidationFailed: bundle+import succeeded, schema
+// validation failed. Storing the new fingerprint terminates the
+// rebundle loop on a stable broken source; registration paths skip
+// validation_failed=true rows.
+
+Deno.test("ExtensionCatalogStore: upsert and findByType round-trip validation_failed", () => {
+  const dbPath = makeTempDbPath();
+  const store = new ExtensionCatalogStore(dbPath);
+
+  store.upsert(makeRow({ validation_failed: true }));
+  const found = store.findByType("@myorg/echo", "model");
+  assertEquals(found?.validation_failed, true);
+  store.close();
+});
+
+Deno.test("ExtensionCatalogStore: validation_failed defaults to false when omitted from upsert", () => {
+  const dbPath = makeTempDbPath();
+  const store = new ExtensionCatalogStore(dbPath);
+
+  store.upsert(makeRow());
+  const found = store.findByType("@myorg/echo", "model");
+  assertEquals(found?.validation_failed, false);
+  store.close();
+});
+
+Deno.test("ExtensionCatalogStore: findByKind returns rows regardless of validation_failed", () => {
+  // ADV-1 invariant guard: findStaleFiles relies on findByKind seeing
+  // broken rows so a stable broken fingerprint terminates the rebundle
+  // loop. Filtering must NOT happen at the store layer — only at
+  // registration call sites.
+  const dbPath = makeTempDbPath();
+  const store = new ExtensionCatalogStore(dbPath);
+
+  store.upsert(makeRow({
+    type_normalized: "@myorg/healthy",
+    source_path: "/repo/extensions/models/healthy.ts",
+    validation_failed: false,
+  }));
+  store.upsert(makeRow({
+    type_normalized: "",
+    source_path: "/repo/extensions/models/broken.ts",
+    validation_failed: true,
+  }));
+
+  const rows = store.findByKind("model");
+  assertEquals(rows.length, 2);
+  const failed = rows.find((r) =>
+    r.source_path === "/repo/extensions/models/broken.ts"
+  );
+  const healthy = rows.find((r) =>
+    r.source_path === "/repo/extensions/models/healthy.ts"
+  );
+  assertEquals(failed?.validation_failed, true);
+  assertEquals(healthy?.validation_failed, false);
+  store.close();
+});
+
+Deno.test("ExtensionCatalogStore: migrates pre-#209 schema by adding validation_failed column", () => {
+  const dbPath = makeTempDbPath();
+  ensureDirSync(dirname(dbPath));
+
+  // Seed a DB with the pre-#209 schema — has source_fingerprint but no
+  // validation_failed column.
+  const seed = new DatabaseSync(dbPath);
+  seed.exec(`
+    CREATE TABLE bundle_types (
+      source_path        TEXT NOT NULL PRIMARY KEY,
+      type_normalized    TEXT NOT NULL,
+      kind               TEXT NOT NULL DEFAULT 'model',
+      bundle_path        TEXT NOT NULL,
+      version            TEXT NOT NULL DEFAULT '',
+      description        TEXT NOT NULL DEFAULT '',
+      extends_type       TEXT NOT NULL DEFAULT '',
+      source_mtime       TEXT NOT NULL DEFAULT '',
+      source_fingerprint TEXT NOT NULL DEFAULT ''
+    );
+    CREATE TABLE bundle_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    INSERT INTO bundle_types (
+      source_path, type_normalized, kind, bundle_path, version,
+      description, extends_type, source_mtime, source_fingerprint
+    ) VALUES (
+      '/old/row.ts', '@legacy/row', 'model', '/old/bundle.js',
+      '2026.01.01.1', '', '', '2026-01-01T00:00:00.000Z', 'deadbeef'
+    );
+  `);
+  seed.close();
+
+  // Opening through ExtensionCatalogStore must run the migration.
+  const store = new ExtensionCatalogStore(dbPath);
+
+  const legacy = store.findByType("@legacy/row", "model");
+  assertEquals(legacy?.validation_failed, false);
+  assertEquals(legacy?.source_fingerprint, "deadbeef");
+
+  // Re-opening is a no-op — migration is idempotent.
+  store.close();
+  const store2 = new ExtensionCatalogStore(dbPath);
+  const again = store2.findByType("@legacy/row", "model");
+  assertEquals(again?.validation_failed, false);
+  store2.close();
+});


### PR DESCRIPTION
Fixes [swamp-club#209](https://swamp-club.com/lab/issues/209).

## Summary

Schema-invalid extensions previously stayed pinned to their last-good fingerprint forever — every `swamp model type search` (and the analogous read-only commands for the four sibling extension kinds) re-bundled them and re-emitted the schema warning, exhibiting the same wall-time regression shape #208 fixed but via a distinct mechanism.

## Root cause

In each loader's `rebundleAndUpdateCatalog` (models, vaults, drivers, datastores, reports), `UserXSchema.safeParse` threw before `catalog.upsert` ran. The catalog row's stored `source_fingerprint` never advanced past the last-good state, so `findStaleFiles` kept marking the file stale on every `buildIndex` pass.

#208 fixed the throw inside `computeSourceFingerprint` (transitive deps). This one fixes the throw above `catalog.upsert` (schema validation). Both are now encoded as "stable broken state → stable fingerprint → not stuck" in the same freshness model.

## Fix

- Add a `validation_failed` BOOLEAN column (INTEGER 0/1 in SQLite) to `bundle_types` plus an idempotent `migrateSchema` block mirroring the existing `source_fingerprint` migration.
- Add `markCatalogValidationFailed` in `bundle_freshness.ts` next to `findStaleFiles` — the dual operation that records the new fingerprint with `validation_failed=true` and an empty `type_normalized`. Does not throw; callers re-throw the original schema error so the warning still fires once.
- Wire the helper into all five `rebundleAndUpdateCatalog` paths. Vault/driver/datastore/report loaders required a small reorder so mtime+fingerprint are computed before `safeParse` (the model loader already did).
- Filter `validation_failed=true` rows at the 5 `registerLazyFromCatalog` call sites so broken types stay out of the model/vault/driver/datastore/report registries.

`findByKind` / `findByType` deliberately do NOT filter — `findStaleFiles` needs to see broken rows for the fingerprint match to terminate the loop. The catalog-store test pins this invariant explicitly.

## Out of scope

Three other `safeParse` sites in `user_model_loader.ts` (`loadModels` Pass 1 at line 421, `loadSingleType` at line 739, `allExtensionMethodsAttached` at line 823) have the same shape but are not in the steady-state read-only hot path:
- 421 writes to `result.failed` rather than throwing
- 739 fires only via by-name `ensureTypeLoaded`, not `model type search`
- 823 returns false rather than throwing

Documented in `design/extension.md` as a paper trail in case any of those ever moves into a steady-state path.

## Verification

Manual reproduction in `/tmp/swamp-repro-issue-209` (mirrors the issue's steps):

| Run | Action | Warning | Fingerprint | validation_failed |
|---|---|---|---|---|
| Setup | Healthy `@local/echo` | — | `f0728ceb…` | 0 |
| 1 | After schema break | once | `6f868866…` | 1 |
| 2 | Same broken source | none | `6f868866…` (stable) | 1 |
| 3 | Same broken source | none | `6f868866…` (stable) | 1 |
| Recovery | Edit to different valid shape | — | `27604661…` | 0 |

Cross-loader spot-check on the vault loader (`@local/myvault`) matches — runs 2 and 3 silent after the initial warning.

Pre-#209 behavior would have shown the warning and a fresh deno-bundle spawn on every run with the fingerprint stuck at the last-good value.

## Test plan

- [x] `deno fmt --check`, `deno lint`, `deno check` clean
- [x] `deno run test` — 5219 passed, 0 failed
- [x] Catalog store: column round-trip, default-false, ADV-1 invariant guard (`findByKind` returns rows regardless of `validation_failed`), migration on pre-#209 schemas
- [x] Bundle freshness: helper populates every NOT NULL column, idempotent across calls, works for every kind; convergence integration test proves stable broken state is not stale; recovery test proves a different edit re-stales
- [x] Per-loader: `registerLazyFromCatalog` filter test for model + vault + driver + datastore + report
- [x] Manual end-to-end verified for both the model loader and vault loader against `/tmp/swamp-repro-issue-209`

## Caveats

- The integration test originally planned (count `bundleWithCache` invocations across two `buildIndex` passes through the same broken source) couldn't be written in-process — Deno's per-process import cache returns the previously-imported module on the second pass and masks the parse failure inside a single test process. The bug only manifests in production because each `swamp` invocation is a fresh subprocess. Substituted with convergence tests at the freshness layer + per-loader filter tests + end-to-end manual verification. A follow-up `swamp-uat` issue tracking this gap is suggested separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)