### PR TITLE
fix(doctor): write-probe audit dir so readonly state is reported correctly

### DIFF
--- a/src/domain/audit/doctor/checks/recording_smoke.ts
+++ b/src/domain/audit/doctor/checks/recording_smoke.ts
@@ -70,8 +70,17 @@ export const recordingSmokeTestCheck: PreflightCheck = {
       };
     }
 
+    // ensureDir is a no-op when the directory already exists, so it does not
+    // surface a writability problem on its own. Follow it with an active
+    // write-probe so an existing-but-readonly audit dir is caught here rather
+    // than masquerading as hook normalizer drift further down.
     try {
       await ensureDir(ctx.auditDir);
+      const probe = await Deno.makeTempFile({
+        dir: ctx.auditDir,
+        prefix: ".doctor-write-probe-",
+      });
+      await Deno.remove(probe);
     } catch (error) {
       if (error instanceof Deno.errors.PermissionDenied) {
         return {

--- a/src/domain/audit/doctor/checks/recording_smoke_test.ts
+++ b/src/domain/audit/doctor/checks/recording_smoke_test.ts
@@ -181,3 +181,30 @@ Deno.test(
     }
   },
 );
+
+Deno.test(
+  "recordingSmokeTest: returns actionable fail when audit dir already exists but is readonly",
+  // Permission semantics differ on Windows; chmod 0500 is not enforced there.
+  { ignore: Deno.build.os === "windows" },
+  async () => {
+    const repo = await Deno.makeTempDir({
+      prefix: "doctor-smoke-existing-readonly-",
+    });
+    const auditDir = join(repo, ".swamp", "audit");
+    await ensureDir(auditDir);
+    await Deno.chmod(auditDir, 0o500);
+    try {
+      // Repro of swamp-uat#161 scenario 4: audit dir exists, ensureDir is a
+      // silent no-op, write-probe must catch the unwritable state.
+      const result = await recordingSmokeTestCheck.run(
+        makeCtx(auditDir, "claude", makeFakeSpawnThatDropsRow()),
+      );
+      assertEquals(result.status, "fail");
+      assertStringIncludes(result.message, "not writable");
+      assertStringIncludes(result.hint ?? "", "chmod");
+    } finally {
+      await Deno.chmod(auditDir, 0o700).catch(() => {});
+      await Deno.remove(repo, { recursive: true }).catch(() => {});
+    }
+  },
+);


### PR DESCRIPTION
## Summary

PR #1285 wrapped `ensureDir(ctx.auditDir)` in a try/catch for `PermissionDenied`, but `@std/fs`'s `ensureDir` is a silent no-op when the directory already exists. Since `swamp init` creates `.swamp/audit` (mode 0755) before `doctor audit` ever runs, chmod 0500 on the existing dir slips past the catch and `recording-smoke-test` reports a misleading "hook normalizer drift" hint instead of the real problem.

The fix follows `ensureDir` with an active write-probe (`Deno.makeTempFile` + `Deno.remove`). When the dir is unwritable, the probe raises `PermissionDenied`, which falls into the same actionable hint PR #1285 added — pointing the user at `ls -ld` / `chmod` / `chown` rather than internal source files.

Caught during UAT for swamp-uat#161 scenario 4.

## Test Plan

- New unit test in `recording_smoke_test.ts` reproduces the existing-but-readonly scenario (creates `.swamp/audit`, chmod 0500, asserts the "not writable" hint). Without the probe this test gets the drift hint and fails.
- Existing readonly test (parent dir 0500, child path forces mkdir) still passes — same catch covers both branches.
- Manual reproduction against the compiled binary:
  - **Writable baseline:** `recording-smoke-test` → `pass` ("synthetic kiro payload landed in today's audit JSONL").
  - **`chmod 0500 .swamp/audit`:** `recording-smoke-test` → `fail` with message `"audit directory is not writable: .swamp/audit"` and a hint mentioning `chmod`/`chown` — drift hint gone.
- `deno fmt --check`, `deno lint`, `deno run test` (5231 passed) all clean.