### PR TITLE
fix(extensions): rebundle when cached bundle is missing (swamp-club#212)

### DIFF
--- a/src/domain/extensions/bundle_freshness.ts
+++ b/src/domain/extensions/bundle_freshness.ts
@@ -17,8 +17,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { getLogger } from "@logtape/logtape";
 import { relative, resolve } from "@std/path";
 import { resolveLocalImports } from "../models/local_import_resolver.ts";
+
+const logger = getLogger(["swamp", "extensions", "bundle-freshness"]);
 
 /**
  * The extension-catalog kinds this helper can query. Declared
@@ -48,6 +51,8 @@ export type FreshnessKind =
 export interface FreshnessCatalogRow {
   source_path: string;
   source_fingerprint?: string;
+  bundle_path?: string;
+  validation_failed?: boolean;
 }
 
 /**
@@ -175,6 +180,15 @@ async function hashFile(
   return toHex(digest);
 }
 
+async function bundleExists(bundlePath: string): Promise<boolean> {
+  try {
+    await Deno.stat(bundlePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function toHex(buffer: ArrayBuffer): string {
   const view = new Uint8Array(buffer);
   let out = "";
@@ -271,6 +285,26 @@ export async function findStaleFiles(
           cache,
         );
         if (fingerprint !== catalogEntry.source_fingerprint) {
+          stale.push({ absolutePath, relativePath, baseDir: dir });
+          continue;
+        }
+
+        // Source content is unchanged, but the cached bundle may have been
+        // deleted out from under us (manual rm, partial GC, failed previous
+        // bundle attempt). Without this check the catalog row stays "fresh"
+        // and a downstream importBundleByPath ENOENTs (swamp-club#212).
+        //
+        // validation_failed rows are skipped: rebundling them is a no-op
+        // cycle — bundle still fails schema validation, markCatalogValidationFailed
+        // re-pins the same fingerprint, every command spawns deno bundle.
+        // That is the inverse of the loop swamp-club#209 sealed.
+        if (
+          catalogEntry.bundle_path &&
+          !catalogEntry.validation_failed &&
+          !(await bundleExists(catalogEntry.bundle_path))
+        ) {
+          logger
+            .warn`Rebundling ${relativePath}: cached bundle missing from disk`;
           stale.push({ absolutePath, relativePath, baseDir: dir });
         }
       } catch {

--- a/src/domain/extensions/bundle_freshness_test.ts
+++ b/src/domain/extensions/bundle_freshness_test.ts
@@ -237,7 +237,7 @@ Deno.test("findStaleFiles: matching fingerprint → not stale", async () => {
       source_path: file,
       type_normalized: "@user/a",
       kind: "model",
-      bundle_path: "/ignored",
+      bundle_path: "",
       version: "",
       description: "",
       extends_type: "",
@@ -268,7 +268,7 @@ Deno.test("findStaleFiles: mismatching fingerprint → stale", async () => {
       source_path: file,
       type_normalized: "@user/a",
       kind: "model",
-      bundle_path: "/ignored",
+      bundle_path: "",
       version: "",
       description: "",
       extends_type: "",
@@ -302,7 +302,7 @@ Deno.test("findStaleFiles: catches mtime-preserving content change (#125)", asyn
       source_path: file,
       type_normalized: "@user/a",
       kind: "model",
-      bundle_path: "/ignored",
+      bundle_path: "",
       version: "",
       description: "",
       extends_type: "",
@@ -343,7 +343,7 @@ Deno.test("findStaleFiles: deleted file is removed from catalog", async () => {
       source_path: survivor,
       type_normalized: "@user/s",
       kind: "model",
-      bundle_path: "/ignored",
+      bundle_path: "",
       version: "",
       description: "",
       extends_type: "",
@@ -354,7 +354,7 @@ Deno.test("findStaleFiles: deleted file is removed from catalog", async () => {
       source_path: deletedPath,
       type_normalized: "@user/d",
       kind: "model",
-      bundle_path: "/ignored",
+      bundle_path: "",
       version: "",
       description: "",
       extends_type: "",
@@ -400,7 +400,7 @@ Deno.test("findStaleFiles: kinds filter scopes both the staleness check and dele
       source_path: driverFile,
       type_normalized: "@user/d",
       kind: "driver",
-      bundle_path: "/ignored",
+      bundle_path: "",
       version: "",
       description: "",
       extends_type: "",
@@ -411,7 +411,7 @@ Deno.test("findStaleFiles: kinds filter scopes both the staleness check and dele
       source_path: join(driverDir, "gone.ts"),
       type_normalized: "@user/gone",
       kind: "driver",
-      bundle_path: "/ignored",
+      bundle_path: "",
       version: "",
       description: "",
       extends_type: "",
@@ -422,7 +422,7 @@ Deno.test("findStaleFiles: kinds filter scopes both the staleness check and dele
       source_path: vaultFile,
       type_normalized: "@user/v",
       kind: "vault",
-      bundle_path: "/ignored",
+      bundle_path: "",
       version: "",
       description: "",
       extends_type: "",
@@ -492,6 +492,150 @@ Deno.test("findStaleFiles: missing source dir is silently skipped", async () => 
   } catch (err) {
     // Cleanup already happened — swallow.
     if (!(err instanceof Deno.errors.NotFound)) throw err;
+  }
+});
+
+// -- swamp-club#212: bundle-existence gate -----------------------------
+// findStaleFiles previously decided freshness purely from source content
+// fingerprint. If the cached bundle file at bundle_path was deleted out
+// from under us (manual rm, partial GC, failed previous bundle attempt)
+// while source content stayed unchanged, the catalog row was reported
+// fresh and a downstream importBundleByPath ENOENT'd. The gate now also
+// checks that the bundle file physically exists.
+
+Deno.test("findStaleFiles: matching fingerprint + missing bundle → stale (#212)", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "swamp_bf_212_missing_" });
+  try {
+    const file = join(dir, "a.ts");
+    await Deno.writeTextFile(file, "export const a = 1;");
+    const fp = await computeSourceFingerprint(file, dir);
+
+    const catalog = new FakeCatalog();
+    catalog.add({
+      source_path: file,
+      type_normalized: "@user/a",
+      kind: "model",
+      bundle_path: join(dir, "definitely-not-here.js"),
+      version: "",
+      description: "",
+      extends_type: "",
+      source_mtime: "",
+      source_fingerprint: fp,
+    });
+
+    const stale = await findStaleFiles({
+      modelsDir: dir,
+      catalog,
+      discoverFiles: discoverTsFiles,
+      kinds: ["model"],
+    });
+    assertEquals(stale.length, 1);
+    assertEquals(stale[0].relativePath, "a.ts");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("findStaleFiles: matching fingerprint + missing bundle + validation_failed → not stale (#212 vs #209)", async () => {
+  // validation_failed rows must skip the bundle-existence check —
+  // rebundling them is the inverse of the loop swamp-club#209 sealed.
+  const dir = await Deno.makeTempDir({ prefix: "swamp_bf_212_validfail_" });
+  try {
+    const file = join(dir, "broken.ts");
+    await Deno.writeTextFile(file, "export const broken = 1;");
+    const fp = await computeSourceFingerprint(file, dir);
+
+    const catalog = new FakeCatalog();
+    catalog.add({
+      source_path: file,
+      type_normalized: "",
+      kind: "model",
+      bundle_path: join(dir, "definitely-not-here.js"),
+      version: "",
+      description: "",
+      extends_type: "",
+      source_mtime: "",
+      source_fingerprint: fp,
+      validation_failed: true,
+    });
+
+    const stale = await findStaleFiles({
+      modelsDir: dir,
+      catalog,
+      discoverFiles: discoverTsFiles,
+      kinds: ["model"],
+    });
+    assertEquals(stale.length, 0);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("findStaleFiles: matching fingerprint + bundle exists → not stale (#212)", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "swamp_bf_212_present_" });
+  try {
+    const file = join(dir, "a.ts");
+    const bundle = join(dir, "a.js");
+    await Deno.writeTextFile(file, "export const a = 1;");
+    await Deno.writeTextFile(bundle, "/* fake compiled bundle */");
+    const fp = await computeSourceFingerprint(file, dir);
+
+    const catalog = new FakeCatalog();
+    catalog.add({
+      source_path: file,
+      type_normalized: "@user/a",
+      kind: "model",
+      bundle_path: bundle,
+      version: "",
+      description: "",
+      extends_type: "",
+      source_mtime: "",
+      source_fingerprint: fp,
+    });
+
+    const stale = await findStaleFiles({
+      modelsDir: dir,
+      catalog,
+      discoverFiles: discoverTsFiles,
+      kinds: ["model"],
+    });
+    assertEquals(stale.length, 0);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("findStaleFiles: empty bundle_path → bundle-existence check skipped (#212)", async () => {
+  // Legacy/test rows without a bundle_path must not regress to
+  // permanently-stale just because the new gate has nothing to stat.
+  const dir = await Deno.makeTempDir({ prefix: "swamp_bf_212_empty_path_" });
+  try {
+    const file = join(dir, "a.ts");
+    await Deno.writeTextFile(file, "export const a = 1;");
+    const fp = await computeSourceFingerprint(file, dir);
+
+    const catalog = new FakeCatalog();
+    catalog.add({
+      source_path: file,
+      type_normalized: "@user/a",
+      kind: "model",
+      bundle_path: "",
+      version: "",
+      description: "",
+      extends_type: "",
+      source_mtime: "",
+      source_fingerprint: fp,
+    });
+
+    const stale = await findStaleFiles({
+      modelsDir: dir,
+      catalog,
+      discoverFiles: discoverTsFiles,
+      kinds: ["model"],
+    });
+    assertEquals(stale.length, 0);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
   }
 });
 
@@ -582,7 +726,7 @@ Deno.test("findStaleFiles: broken transitive dep — stale once, then stable (#2
       source_path: entry,
       type_normalized: "@user/entry",
       kind: "model",
-      bundle_path: "/ignored",
+      bundle_path: "",
       version: "",
       description: "",
       extends_type: "",
@@ -618,7 +762,7 @@ Deno.test("findStaleFiles: broken transitive dep — stale once, then stable (#2
       source_path: entry,
       type_normalized: "@user/entry",
       kind: "model",
-      bundle_path: "/ignored",
+      bundle_path: "",
       version: "",
       description: "",
       extends_type: "",

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -731,7 +731,10 @@ export class UserModelLoader {
     if (modelRegistry.get(entry.type_normalized)) return; // Already loaded
 
     // Import directly via file URL for the cached bundle
-    const module = await this.importBundleByPath(entry.bundle_path);
+    const module = await this.importBundleByPath({
+      bundlePath: entry.bundle_path,
+      sourcePath: entry.source_path,
+    });
 
     if (!module.model) {
       throw new Error(`Bundle has no model export: ${entry.bundle_path}`);
@@ -815,7 +818,10 @@ export class UserModelLoader {
   ): Promise<boolean> {
     let module: Record<string, unknown>;
     try {
-      module = await this.importBundleByPath(entry.bundle_path);
+      module = await this.importBundleByPath({
+        bundlePath: entry.bundle_path,
+        sourcePath: entry.source_path,
+      });
     } catch {
       return false;
     }
@@ -852,7 +858,10 @@ export class UserModelLoader {
    * Logs warnings for any failures during extension processing.
    */
   private async importAndExtendBundle(entry: ExtensionTypeRow): Promise<void> {
-    const module = await this.importBundleByPath(entry.bundle_path);
+    const module = await this.importBundleByPath({
+      bundlePath: entry.bundle_path,
+      sourcePath: entry.source_path,
+    });
 
     if (!module.extension) {
       throw new Error(`Bundle has no extension export: ${entry.bundle_path}`);
@@ -870,18 +879,56 @@ export class UserModelLoader {
   /**
    * Imports a cached bundle directly by its file path.
    * Fixes zod imports and CJS/ESM interop before importing.
+   *
+   * Recovers from a missing bundle file (manual rm, partial GC, failed
+   * previous bundle attempt, concurrent rm) by rebundling from source —
+   * defense-in-depth alongside the freshness-gate check in
+   * bundle_freshness.findStaleFiles. This catch covers paths that bypass
+   * freshness, notably attachPendingExtensionsForType (called from
+   * hotLoadModels after `swamp extension pull`) which iterates catalog
+   * rows directly. swamp-club#212.
+   *
+   * Caller contract: this method is called at most once per `bundlePath`
+   * per process. Deno caches imports by URL, so a second call for the same
+   * path in one process would serve a pre-rebundle module from cache.
    */
   private async importBundleByPath(
-    bundlePath: string,
+    paths: { bundlePath: string; sourcePath: string },
   ): Promise<Record<string, unknown>> {
-    // Fix zod imports and CJS/ESM interop in the cached file on disk
-    let js = await Deno.readTextFile(bundlePath);
+    let js: string;
+    try {
+      js = await Deno.readTextFile(paths.bundlePath);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) throw error;
+      js = await this.recoverMissingBundle(paths);
+    }
     const fixed = fixCjsEsmInterop(rewriteZodImports(js));
     if (fixed !== js) {
       js = fixed;
-      await Deno.writeTextFile(bundlePath, js);
+      await Deno.writeTextFile(paths.bundlePath, js);
     }
-    return await import(toFileUrl(bundlePath).href);
+    return await import(toFileUrl(paths.bundlePath).href);
+  }
+
+  /**
+   * Rebundles from source and writes to bundlePath. Used by the
+   * importBundleByPath ENOENT fallback. Errors propagate — if rebundle
+   * itself fails, the caller sees the rebundle failure rather than the
+   * original ENOENT, which is more actionable.
+   */
+  private async recoverMissingBundle(
+    paths: { bundlePath: string; sourcePath: string },
+  ): Promise<string> {
+    const denoPath = await this.denoRuntime.ensureDeno();
+    const denoConfigPath = this.findNearestDenoConfig(paths.sourcePath);
+    const js = await bundleExtension(paths.sourcePath, denoPath, {
+      denoConfigPath,
+    });
+    await Deno.mkdir(dirname(paths.bundlePath), { recursive: true });
+    await Deno.writeTextFile(paths.bundlePath, js);
+    logger
+      .warn`Recovered missing bundle for ${paths.sourcePath} on demand`;
+    return js;
   }
 
   /**

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -3334,3 +3334,96 @@ export const model = {
     await Deno.remove(modelsDir, { recursive: true });
   }
 });
+
+Deno.test("UserModelLoader buildIndex: missing cached bundle is detected and recreated (swamp-club#212)", async () => {
+  // Reproduces the swamp-club#212 user repro end-to-end:
+  //   1. buildIndex populates catalog + writes bundle.
+  //   2. The bundle file is deleted out-of-band (manual rm, partial GC, etc.).
+  //   3. Re-running buildIndex previously failed with `NotFound` at
+  //      importBundleByPath because findStaleFiles only compared source
+  //      content fingerprint and never noticed the bundle was gone.
+  // The freshness gate now stats `bundle_path` for every fingerprint-fresh
+  // row and falls through to rebundleAndUpdateCatalog when the file is
+  // missing. This test asserts no ENOENT and that the bundle is on disk
+  // again after the second buildIndex.
+  //
+  // Note on Deno's per-process import cache: re-importing the same file
+  // URL within a single test process serves the cached module, so this
+  // test can't assert anything about the *contents* of the recovered
+  // module — only that recovery happened (no throw + bundle restored).
+  // Production runs are fresh subprocesses without that cache, which is
+  // why the bug manifests there.
+  const ts = Date.now();
+  const typeId = `@user/missing-bundle-${ts}`;
+  const modelCode = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "${typeId}",
+  version: "2026.05.02.1",
+  methods: {
+    run: {
+      description: "Run",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+  const repoDir = await Deno.makeTempDir({
+    prefix: "swamp_212_repo_",
+  });
+  const modelsDir = await Deno.makeTempDir({
+    prefix: "swamp_212_models_",
+  });
+  const dbPath = join(repoDir, ".swamp", "_extension_catalog.db");
+
+  try {
+    await Deno.writeTextFile(join(modelsDir, "model.ts"), modelCode);
+
+    // Cold-start populates the catalog and writes the bundle.
+    const catalog1 = new ExtensionCatalogStore(dbPath);
+    const loader1 = new UserModelLoader(testDenoRuntime, repoDir);
+    await loader1.buildIndex(modelsDir, catalog1);
+    catalog1.close();
+
+    const ns = bundleNamespace(modelsDir, repoDir);
+    const bundlePath = join(repoDir, ".swamp", "bundles", ns, "model.js");
+    assertEquals(
+      await Deno.stat(bundlePath).then(() => true).catch(() => false),
+      true,
+      "Cold-start must write the bundle to disk",
+    );
+
+    // Simulate the user's rm.
+    await Deno.remove(bundlePath);
+
+    // Second buildIndex must NOT throw NotFound — the freshness gate
+    // detects the missing bundle and triggers rebundleAndUpdateCatalog.
+    const catalog2 = new ExtensionCatalogStore(dbPath);
+    const loader2 = new UserModelLoader(testDenoRuntime, repoDir);
+    const result = await loader2.buildIndex(modelsDir, catalog2);
+    catalog2.close();
+
+    // Bundle is restored on disk and the rebundle landed in `loaded`.
+    assertEquals(
+      await Deno.stat(bundlePath).then(() => true).catch(() => false),
+      true,
+      "Bundle file must be recreated after the missing-bundle recovery",
+    );
+    assertEquals(
+      result.loaded.length > 0,
+      true,
+      "Stale-files loop must report the recovered file as loaded",
+    );
+    assertEquals(
+      result.failed.length,
+      0,
+      "Recovery must complete without surfacing failures",
+    );
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+    await Deno.remove(modelsDir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes [swamp-club#212](https://swamp.club/lab/issues/212) — `swamp model type describe` (and other type-resolving commands) fail with `NotFound: No such file or directory` when the cached bundle at `.swamp/bundles/<hash>/<name>.js` has been deleted but the catalog row at `.swamp/_extension_catalog.db` still references it.

The freshness check previously decided "is this catalog row valid?" purely from the source content fingerprint. The bundle file's physical existence was never verified, so a missing bundle slipped past the gate and the loader's `importBundleByPath` ENOENT'd downstream.

## Fix — two layers

1. **Freshness gate** (`src/domain/extensions/bundle_freshness.ts`). `FreshnessCatalogRow` now exposes `bundle_path` and `validation_failed`. After the fingerprint match check, `findStaleFiles` stats `bundle_path` and marks the row stale if the file is missing. `validation_failed` rows skip this check — rebundling them is the inverse of the loop swamp-club#209 (#1286) sealed (rebundle re-fails validation, `markCatalogValidationFailed` re-pins the same fingerprint, every command spawns `deno bundle`).
2. **Defense-in-depth at the import site** (`src/domain/models/user_model_loader.ts`). `importBundleByPath` now catches `Deno.errors.NotFound` and rebundles from source via a new `recoverMissingBundle` helper. This covers the `attachPendingExtensionsForType` path (called from `hotLoadModels` after `swamp extension pull`) which iterates catalog rows directly and bypasses freshness, plus concurrent-rm races.

A warn log fires at the freshness layer when a row is marked stale specifically because the bundle is missing — distinguishes it from content-change rebundles.

## Notes

- All six catalog-backed loaders (model, extension, vault, driver, datastore, report) inherit the freshness fix automatically since they share `findStaleFiles`. The import-site fallback is only added to the model loader for now (the loader with the `hotLoadModels` attach path); siblings get the same treatment in a follow-up.
- Sibling-loader test fixtures already insert non-existent `bundle_path` rows for the swamp-club#209 regression suite — those are all `validation_failed: true`, which the new gate correctly skips, so no fixture changes are needed.
- `bundle_path: "/ignored"` sentinels in `bundle_freshness_test.ts` were changed to `bundle_path: ""` to match the new "skip when empty" semantics.

## Test Plan

- [x] 4 new unit tests in `bundle_freshness_test.ts` cover all four corners of the new gate (missing bundle = stale, validation_failed + missing bundle = NOT stale, bundle exists = fresh, empty path = fresh).
- [x] 1 new integration test in `user_model_loader_test.ts` mirrors the verbatim scratch-repo reproducer end-to-end (write source → buildIndex → rm bundle → buildIndex again → bundle restored, no ENOENT).
- [x] `deno check`, `deno lint`, `deno fmt` clean.
- [x] `deno run test` passes (5234 passed; one parallel-flake unrelated to this PR passes in isolation).
- [x] `deno run compile` successful.
- [x] Verified end-to-end against `/tmp/swamp-repro-issue-212/` — the previously-fatal `NotFound` becomes a clean rebundle with the warn log: `WRN swamp·extensions·bundle-freshness Rebundling "repro.ts": cached bundle missing from disk`.

## Follow-up

- Port the `importBundleByPath` ENOENT fallback to the four sibling loaders (datastore/driver/vault/report). Same vulnerability class, separate PR.
- File a `swamp-uat` adversarial test under `tests/cli/adversarial/state_corruption_test.ts` for "rm cached bundle with intact catalog → next swamp invocation recovers transparently".

🤖 Generated with [Claude Code](https://claude.com/claude-code)