### PR TITLE
fix(datastore): hydrate cache on setup, decouple sync from coordinator (swamp-club#220)

### DIFF
--- a/.claude/skills/swamp-repo/SKILL.md
+++ b/.claude/skills/swamp-repo/SKILL.md
@@ -237,10 +237,17 @@ swamp datastore setup extension @swamp/s3-datastore \
   --config '{"bucket":"my-bucket","prefix":"my-project","region":"us-east-1"}' --json
 ```
 
-Verifies the backend is accessible, pushes existing local data, and updates
-`.swamp.yaml`. Subsequent commands automatically pull before execution and push
-after. Use `--skip-migration` to skip the initial push. Legacy type name `s3` is
-auto-remapped to `@swamp/s3-datastore`.
+Verifies the backend is accessible, pushes existing local `.swamp/` data to the
+remote, hydrates the local cache from any data already present in the remote (so
+a contributor joining a populated shared bucket starts with their cache primed),
+and updates `.swamp.yaml`. Subsequent commands automatically pull before
+execution and push after.
+
+`--skip-migration` skips only the local→remote push; the remote→local hydration
+step still runs, so a fresh contributor can opt out of pushing their `.swamp/`
+(or skip the migration entirely if they have no local data) without ending up
+with an empty cache. Legacy type name `s3` is auto-remapped to
+`@swamp/s3-datastore`.
 
 ### Migrating Between Datastores
 
@@ -256,6 +263,10 @@ swamp datastore sync --json         # Bidirectional sync
 swamp datastore sync --pull --json  # Pull-only
 swamp datastore sync --push --json  # Push-only
 ```
+
+The `filesPulled` and `filesPushed` counts in the output reflect work the sync
+command itself performed — they do not double-count any implicit pre-command
+sync from other commands, and they are not a no-op summary.
 
 ### Lock Management
 

--- a/design/datastores.md
+++ b/design/datastores.md
@@ -245,7 +245,29 @@ Read-only commands (search, get, list, validate, history, etc.):
     (reads local cache directly)
 
     (no flush needed)
+
+Explicit datastore sync (`swamp datastore sync` and `--push`):
+
+  requireInitializedRepo({ skipImplicitSync: true })  ← command start
+    └─ acquire distributed lock
+       (no implicit pullChanged, no implicit pushChanged on flush)
+
+    ─── command executes its OWN pullChanged / pushChanged ───
+    (counts reflect work the command itself performed)
+
+  flushDatastoreSync()
+    └─ release distributed lock
 ```
+
+`swamp datastore sync` deliberately bypasses the coordinator's implicit
+pull/push. Without `skipImplicitSync` the implicit pull would silently
+move files and the explicit pull would fast-path to 0, causing
+`filesPulled: 0` to be reported even when data was hydrated (lab #220).
+The explicit sync command is the user-facing "tell me what I synced"
+command — it owns its I/O and reports honest counts.
+
+`--pull` mode uses `requireInitializedRepoReadOnly` (no lock at all),
+matching the existing read-only pattern.
 
 Read-only commands skip the lock and sync entirely, allowing them to run
 concurrently with write operations. On filesystem datastores, reads see writes
@@ -439,10 +461,26 @@ swamp datastore setup extension @swamp/s3-datastore \
 Each setup command:
 1. Verifies the target is accessible (writable directory or reachable S3 bucket)
 2. Migrates existing runtime data from `.swamp/` to the new location
-3. Updates `.swamp.yaml` with the new datastore config
-4. Cleans up migrated directories from `.swamp/`
+   (skipped when `--skip-migration` is used)
+3. Pushes migrated data to the remote (extension datastores; skipped when
+   `--skip-migration` is used or when there is nothing to push)
+4. **Hydrates** the local cache from the remote datastore (extension
+   datastores only) — runs unconditionally, regardless of `--skip-migration`
+5. Updates `.swamp.yaml` with the new datastore config
+6. Cleans up migrated directories from `.swamp/` (skipped if any prior step
+   reported an error, so retry leaves local data intact)
 
-Use `--skip-migration` to skip the data copy.
+`--skip-migration` controls only step 2 (the local→remote push of existing
+`.swamp/` data). It does NOT skip step 4 (hydration). A contributor joining a
+shared datastore that already has data needs hydration even when there is
+nothing local to migrate; without it the local cache stays empty and reads
+return nothing until a manual `swamp datastore sync --pull` runs.
+
+**Hydration invariant.** After `swamp datastore setup extension` succeeds
+with no errors, the local cache contains every entry advertised by the
+remote `.datastore-index.json` at setup time. Subsequent reads from
+datastore-tier repositories see consistent data without an explicit
+`swamp datastore sync --pull` first.
 
 ### Migrating Between Backends
 

--- a/src/cli/commands/datastore_setup.ts
+++ b/src/cli/commands/datastore_setup.ts
@@ -68,7 +68,10 @@ const datastoreSetupFilesystemCommand = new Command()
     "--directories <dirs:string[]>",
     "Subdirectories to store in the datastore (comma-separated)",
   )
-  .option("--skip-migration", "Skip migrating existing data")
+  .option(
+    "--skip-migration",
+    "Skip copying existing .swamp/ data into the target path",
+  )
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, [
       "datastore",
@@ -121,7 +124,10 @@ const datastoreSetupExtensionCommand = new Command()
     'JSON config object for the extension (e.g., \'{"bucket":"name","region":"us-east-1"}\')',
     { required: true },
   )
-  .option("--skip-migration", "Skip migrating existing data")
+  .option(
+    "--skip-migration",
+    "Skip pushing local .swamp/ data to the remote (does not skip remote→local cache hydration, which always runs)",
+  )
   .action(async function (options: AnyOptions, type: string) {
     const cliCtx = createContext(options as GlobalOptions, [
       "datastore",

--- a/src/cli/commands/datastore_sync.ts
+++ b/src/cli/commands/datastore_sync.ts
@@ -123,6 +123,13 @@ export const datastoreSyncCommand = new Command()
 
     // Pull-only mode uses read-only init to avoid acquiring the global
     // lock and triggering a coordinator push on flush.
+    //
+    // Push and default ("sync") modes acquire the lock but skip the
+    // coordinator's implicit pull-at-startup and push-at-flush — those
+    // are racy duplicates of the explicit pull/push this command owns.
+    // Without skipImplicitSync, the implicit pull silently moves files
+    // and the explicit pull fast-paths to 0, causing `filesPulled: 0`
+    // to be reported even when data was actually hydrated (lab #220).
     const { repoDir, datastoreResolver } = mode === "pull"
       ? await requireInitializedRepoReadOnly({
         repoDir: resolveRepoDir(options.repoDir),
@@ -131,6 +138,7 @@ export const datastoreSyncCommand = new Command()
       : await requireInitializedRepo({
         repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
+        skipImplicitSync: true,
       });
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });

--- a/src/cli/commands/datastore_sync.ts
+++ b/src/cli/commands/datastore_sync.ts
@@ -121,15 +121,8 @@ export const datastoreSyncCommand = new Command()
       ? "pull" as const
       : "sync" as const;
 
-    // Pull-only mode uses read-only init to avoid acquiring the global
-    // lock and triggering a coordinator push on flush.
-    //
-    // Push and default ("sync") modes acquire the lock but skip the
-    // coordinator's implicit pull-at-startup and push-at-flush — those
-    // are racy duplicates of the explicit pull/push this command owns.
-    // Without skipImplicitSync, the implicit pull silently moves files
-    // and the explicit pull fast-paths to 0, causing `filesPulled: 0`
-    // to be reported even when data was actually hydrated (lab #220).
+    // Pull-only mode uses read-only init (no lock). Push and default
+    // modes use skipImplicitSync — see RequireRepoOptions JSDoc.
     const { repoDir, datastoreResolver } = mode === "pull"
       ? await requireInitializedRepoReadOnly({
         repoDir: resolveRepoDir(options.repoDir),

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -352,13 +352,11 @@ export function requireInitializedRepo(
         await ensureDir(datastoreConfig.cachePath);
       }
 
-      // When skipImplicitSync is set, register only the lock — no sync
-      // service. The implicit pull at startup and push at flush are both
-      // skipped; the caller (e.g. `swamp datastore sync`) owns sync I/O
-      // explicitly. The repository factory below still receives the
-      // syncService for its markDirty hooks, but cache writes from the
-      // explicit sync command don't go through repositories so this is
-      // a no-op in practice.
+      // See `RequireRepoOptions.skipImplicitSync` JSDoc. When set, the
+      // sync service is not registered with the coordinator (no implicit
+      // pull/push); the repository factory still receives it for
+      // markDirty hooks, harmlessly so for explicit-sync callers that
+      // don't write through repositories.
       const registerService = options.skipImplicitSync
         ? undefined
         : syncService;

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -122,6 +122,17 @@ async function resolveCustomProvider(
 export interface RequireRepoOptions {
   repoDir: string;
   outputMode: OutputMode;
+  /**
+   * Skip the coordinator's implicit pull-at-startup and push-at-flush.
+   * The lock is still acquired (so concurrent writers are blocked), but
+   * no sync service is registered with the coordinator. Used by the
+   * `swamp datastore sync` command, which owns its own pull/push and
+   * must not race with the coordinator's implicit phase — without this
+   * flag the implicit pull silently moves files and the explicit pull
+   * fast-paths to 0, causing `filesPulled: 0` to be reported even when
+   * data was hydrated. See lab #220.
+   */
+  skipImplicitSync?: boolean;
 }
 
 /**
@@ -341,14 +352,24 @@ export function requireInitializedRepo(
         await ensureDir(datastoreConfig.cachePath);
       }
 
+      // When skipImplicitSync is set, register only the lock — no sync
+      // service. The implicit pull at startup and push at flush are both
+      // skipped; the caller (e.g. `swamp datastore sync`) owns sync I/O
+      // explicitly. The repository factory below still receives the
+      // syncService for its markDirty hooks, but cache writes from the
+      // explicit sync command don't go through repositories so this is
+      // a no-op in practice.
+      const registerService = options.skipImplicitSync
+        ? undefined
+        : syncService;
       await registerDatastoreSync({
-        service: syncService,
+        service: registerService,
         lock,
         label: datastoreConfig.type,
         syncTimeoutMs: resolveSyncTimeoutMs(datastoreConfig),
       });
       // Invalidate catalog after pull so next query backfills from fresh data
-      if (syncService) {
+      if (registerService) {
         needsCatalogInvalidation = true;
       }
     } else if (datastoreConfig.type === "filesystem") {

--- a/src/cli/repo_context_test.ts
+++ b/src/cli/repo_context_test.ts
@@ -471,3 +471,183 @@ Deno.test("acquireModelLocks - deduplicates same model", async () => {
     await lockResult.flush();
   });
 });
+
+// ============================================================================
+// skipImplicitSync Tests (lab #220)
+//
+// `swamp datastore sync` (push and default modes) acquires the lock but must
+// NOT run the coordinator's implicit pre-command pull — otherwise the
+// implicit pull silently moves files and the explicit pull fast-paths to 0,
+// causing `filesPulled: 0` to be reported even when data was hydrated.
+// ============================================================================
+
+async function configureExtensionDatastore(
+  dir: string,
+  type: string,
+): Promise<void> {
+  // Read the existing marker, append the datastore config, write it back.
+  // Mirrors what `swamp datastore setup extension` produces in the
+  // .swamp.yaml file.
+  const markerPath = join(dir, ".swamp.yaml");
+  const existing = await Deno.readTextFile(markerPath);
+  const datastoreYaml = [
+    "datastore:",
+    `  type: '${type}'`,
+    "  config:",
+    "    bucket: test-bucket",
+  ].join("\n");
+  await Deno.writeTextFile(
+    markerPath,
+    existing.trimEnd() + "\n" + datastoreYaml + "\n",
+  );
+}
+
+Deno.test("requireInitializedRepo - skipImplicitSync prevents coordinator pull", async () => {
+  // Late imports so registry side effects do not leak across other test
+  // files that exercise the same registry.
+  const { datastoreTypeRegistry } = await import(
+    "../domain/datastore/datastore_type_registry.ts"
+  );
+
+  let pullCount = 0;
+  let pushCount = 0;
+  const typeName = "test-skip-implicit-sync";
+
+  if (!datastoreTypeRegistry.has(typeName)) {
+    datastoreTypeRegistry.register({
+      type: typeName,
+      name: "Test skipImplicitSync",
+      description: "Test extension for the skipImplicitSync wiring",
+      isBuiltIn: false,
+      createProvider: () => ({
+        createLock: () => ({
+          acquire: () => Promise.resolve(),
+          release: () => Promise.resolve(),
+          withLock: <T>(fn: () => Promise<T>) => fn(),
+          inspect: () => Promise.resolve(null),
+          forceRelease: () => Promise.resolve(true),
+        }),
+        createVerifier: () => ({
+          verify: () =>
+            Promise.resolve({
+              healthy: true,
+              message: "ok",
+              latencyMs: 1,
+              datastoreType: typeName,
+            }),
+        }),
+        resolveDatastorePath: (repoDir: string) => `${repoDir}/.test-store`,
+        resolveCachePath: (repoDir: string) => `${repoDir}/.test-cache`,
+        createSyncService: () => ({
+          pullChanged: () => {
+            pullCount++;
+            return Promise.resolve(0);
+          },
+          pushChanged: () => {
+            pushCount++;
+            return Promise.resolve(0);
+          },
+          markDirty: () => Promise.resolve(),
+        }),
+      }),
+    });
+  }
+
+  await withTempDir(async (dir) => {
+    await initializeRepo(dir);
+    await configureExtensionDatastore(dir, typeName);
+
+    pullCount = 0;
+    pushCount = 0;
+
+    await requireInitializedRepo({
+      repoDir: dir,
+      outputMode: "json",
+      skipImplicitSync: true,
+    });
+
+    assertEquals(
+      pullCount,
+      0,
+      "skipImplicitSync must prevent the coordinator's implicit pull",
+    );
+
+    // Flush should also not trigger an implicit push, since the sync
+    // service was never registered with the coordinator.
+    await flushDatastoreSync();
+
+    assertEquals(
+      pushCount,
+      0,
+      "skipImplicitSync must prevent the coordinator's implicit push on flush",
+    );
+  });
+});
+
+Deno.test("requireInitializedRepo - default behavior still triggers coordinator pull", async () => {
+  // Sanity check that omitting skipImplicitSync preserves the existing
+  // implicit-pull behavior write commands depend on.
+  const { datastoreTypeRegistry } = await import(
+    "../domain/datastore/datastore_type_registry.ts"
+  );
+
+  let pullCount = 0;
+  const typeName = "test-default-implicit-sync";
+
+  if (!datastoreTypeRegistry.has(typeName)) {
+    datastoreTypeRegistry.register({
+      type: typeName,
+      name: "Test default implicit sync",
+      description: "Test extension for default coordinator wiring",
+      isBuiltIn: false,
+      createProvider: () => ({
+        createLock: () => ({
+          acquire: () => Promise.resolve(),
+          release: () => Promise.resolve(),
+          withLock: <T>(fn: () => Promise<T>) => fn(),
+          inspect: () => Promise.resolve(null),
+          forceRelease: () => Promise.resolve(true),
+        }),
+        createVerifier: () => ({
+          verify: () =>
+            Promise.resolve({
+              healthy: true,
+              message: "ok",
+              latencyMs: 1,
+              datastoreType: typeName,
+            }),
+        }),
+        resolveDatastorePath: (repoDir: string) => `${repoDir}/.test-store`,
+        resolveCachePath: (repoDir: string) => `${repoDir}/.test-cache`,
+        createSyncService: () => ({
+          pullChanged: () => {
+            pullCount++;
+            return Promise.resolve(0);
+          },
+          pushChanged: () => Promise.resolve(0),
+          markDirty: () => Promise.resolve(),
+        }),
+      }),
+    });
+  }
+
+  await withTempDir(async (dir) => {
+    await initializeRepo(dir);
+    await configureExtensionDatastore(dir, typeName);
+
+    pullCount = 0;
+
+    await requireInitializedRepo({
+      repoDir: dir,
+      outputMode: "json",
+    });
+
+    assertEquals(
+      pullCount,
+      1,
+      "default requireInitializedRepo must run the coordinator's implicit pull exactly once",
+    );
+
+    await flushDatastoreSync();
+  });
+});

--- a/src/libswamp/datastores/setup.ts
+++ b/src/libswamp/datastores/setup.ts
@@ -62,6 +62,7 @@ export interface DatastoreSetupData {
 export type DatastoreSetupEvent =
   | { kind: "validating" }
   | { kind: "migrating" }
+  | { kind: "hydrating" }
   | { kind: "completed"; data: DatastoreSetupData }
   | { kind: "error"; error: SwampError };
 
@@ -380,6 +381,12 @@ export async function* datastoreSetupExtension(
       // files we just migrated are already in the remote index when
       // pullChanged walks it (size match → no redundant download).
       if (syncService && errors.length === 0) {
+        // Belt-and-suspenders: ensure the cache directory exists before
+        // pull. The non-skip path creates it implicitly via migrateData;
+        // the skip path doesn't, so a sync service that doesn't ensureDir
+        // internally would ENOENT on the first pulled file write.
+        await deps.ensureDir(cachePath);
+        yield { kind: "hydrating" };
         ctx.logger.debug`Hydrating cache from remote datastore...`;
         try {
           const pulled = await runBoundedSync(

--- a/src/libswamp/datastores/setup.ts
+++ b/src/libswamp/datastores/setup.ts
@@ -47,6 +47,13 @@ export interface DatastoreSetupData {
   type: string;
   path?: string;
   filesCopied: number;
+  /**
+   * Files pulled from the remote datastore into the local cache during
+   * setup hydration. Always 0 for filesystem datastores (no separate
+   * cache to hydrate). For extension datastores, reflects the count
+   * returned by the sync service's pullChanged after migration.
+   */
+  filesPulled: number;
   bytesCopied: number;
   directoriesMigrated: string[];
   errors: string[];
@@ -204,6 +211,7 @@ export async function* datastoreSetupFilesystem(
           type: "filesystem",
           path: input.datastorePath,
           filesCopied,
+          filesPulled: 0,
           bytesCopied,
           directoriesMigrated,
           errors,
@@ -294,43 +302,57 @@ export async function* datastoreSetupExtension(
         return;
       }
 
-      // Migrate existing data if the extension supports sync
+      // Migrate existing data, then hydrate the cache from the remote.
+      // Both legs share the same syncService instance and timeout — the
+      // sync service is constructed once up front and reused for the
+      // optional push and the unconditional pull below.
       const errors: string[] = [];
       let filesCopied = 0;
+      let filesPulled = 0;
 
-      if (!input.skipMigration && provider.createSyncService) {
+      // Setup runs outside the flush coordinator, so it does not pick up
+      // per-config syncTimeoutMs. Env override applies if set, else fall
+      // back to the default.
+      const envValue = Deno.env.get(SYNC_TIMEOUT_ENV_VAR);
+      const parsedTimeout = envValue ? Number.parseInt(envValue, 10) : NaN;
+      const timeoutMs = Number.isFinite(parsedTimeout) && parsedTimeout > 0
+        ? parsedTimeout
+        : DEFAULT_SYNC_TIMEOUT_MS;
+
+      const cachePath = provider.resolveCachePath?.(input.repoDir) ??
+        join(getSwampDataDir(), "repos", input.repoId ?? "unknown");
+      const syncService = provider.createSyncService?.(
+        input.repoDir,
+        cachePath,
+      );
+
+      let migrationResult:
+        | {
+          filesCopied: number;
+          directoriesMigrated: string[];
+        }
+        | undefined;
+
+      if (!input.skipMigration && syncService) {
         yield { kind: "migrating" };
 
-        const cachePath = provider.resolveCachePath?.(input.repoDir) ??
-          join(getSwampDataDir(), "repos", input.repoId ?? "unknown");
         const sourceDir = `${input.repoDir}/.swamp`;
 
         // Migrate local .swamp/ data to cache path
         const config = { type: "filesystem" as const, path: cachePath };
-        const migrationResult = await deps.migrateData(
+        const result = await deps.migrateData(
           sourceDir,
           cachePath,
           config,
         );
-        errors.push(...migrationResult.errors);
-        filesCopied = migrationResult.filesCopied;
+        errors.push(...result.errors);
+        filesCopied = result.filesCopied;
+        migrationResult = result;
 
         // Push cache to remote via sync service
-        if (migrationResult.filesCopied > 0) {
+        if (result.filesCopied > 0) {
           ctx.logger.debug`Pushing data to remote datastore...`;
           try {
-            const syncService = provider.createSyncService(
-              input.repoDir,
-              cachePath,
-            );
-            // Setup runs outside the flush coordinator, so it does not
-            // pick up per-config syncTimeoutMs. Env override applies if
-            // set, else fall back to the default.
-            const envValue = Deno.env.get(SYNC_TIMEOUT_ENV_VAR);
-            const parsed = envValue ? Number.parseInt(envValue, 10) : NaN;
-            const timeoutMs = Number.isFinite(parsed) && parsed > 0
-              ? parsed
-              : DEFAULT_SYNC_TIMEOUT_MS;
             await runBoundedSync(
               input.type,
               "push",
@@ -347,22 +369,55 @@ export async function* datastoreSetupExtension(
             errors.push(summary);
           }
         }
+      }
 
-        // Clean up migrated directories from .swamp/ on success
-        if (
-          errors.length === 0 && migrationResult.filesCopied > 0 &&
-          migrationResult.directoriesMigrated.length > 0
-        ) {
-          await deps.cleanupSourceDirs(
-            sourceDir,
-            migrationResult.directoriesMigrated,
+      // Hydrate the local cache from the remote. Runs unconditionally
+      // when the extension exposes a sync service — independent of
+      // --skip-migration. Migration moves data UP (local → remote);
+      // hydration moves data DOWN (remote → local). A contributor
+      // joining a populated remote needs hydration even when there is
+      // nothing local to migrate. Runs AFTER the optional push so any
+      // files we just migrated are already in the remote index when
+      // pullChanged walks it (size match → no redundant download).
+      if (syncService && errors.length === 0) {
+        ctx.logger.debug`Hydrating cache from remote datastore...`;
+        try {
+          const pulled = await runBoundedSync(
+            input.type,
+            "pull",
+            timeoutMs,
+            (signal) => syncService.pullChanged({ signal }),
           );
+          filesPulled = typeof pulled === "number" ? pulled : 0;
+          ctx.logger.debug`Hydration complete: ${filesPulled} file(s) pulled`;
+        } catch (error) {
+          const { summary } = summarizeSyncError(
+            "pull",
+            input.type,
+            error,
+          );
+          errors.push(summary);
         }
       }
 
-      // Update .swamp.yaml only after migration succeeds (or is skipped).
-      // This avoids leaving the config pointing at an extension datastore
-      // when data never made it to the remote.
+      // Clean up migrated directories from .swamp/ only after BOTH push
+      // and pull have succeeded. Pull failure must keep .swamp/ intact
+      // so the user can retry setup without losing local data.
+      if (
+        migrationResult &&
+        errors.length === 0 &&
+        migrationResult.filesCopied > 0 &&
+        migrationResult.directoriesMigrated.length > 0
+      ) {
+        await deps.cleanupSourceDirs(
+          `${input.repoDir}/.swamp`,
+          migrationResult.directoriesMigrated,
+        );
+      }
+
+      // Update .swamp.yaml only after migration and hydration succeed
+      // (or are skipped). This avoids leaving the config pointing at an
+      // extension datastore when data movement failed.
       if (errors.length === 0) {
         await deps.updateRepoConfig(input.repoDir, {
           type: input.type,
@@ -375,6 +430,7 @@ export async function* datastoreSetupExtension(
         data: {
           type: input.type,
           filesCopied,
+          filesPulled,
           bytesCopied: 0,
           directoriesMigrated: [],
           errors,

--- a/src/libswamp/datastores/setup_test.ts
+++ b/src/libswamp/datastores/setup_test.ts
@@ -157,6 +157,8 @@ function createStubProvider(
     healthy?: boolean;
     message?: string;
     hasSyncService?: boolean;
+    pullResult?: number | (() => Promise<number | void>);
+    pushResult?: () => Promise<number | void>;
   },
 ): DatastoreProvider {
   const healthy = overrides?.healthy ?? true;
@@ -183,8 +185,17 @@ function createStubProvider(
     ...(overrides?.hasSyncService !== false
       ? {
         createSyncService: () => ({
-          pullChanged: () => Promise.resolve(),
-          pushChanged: () => Promise.resolve(),
+          pullChanged: () => {
+            if (typeof overrides?.pullResult === "function") {
+              return overrides.pullResult();
+            }
+            if (typeof overrides?.pullResult === "number") {
+              return Promise.resolve(overrides.pullResult);
+            }
+            return Promise.resolve();
+          },
+          pushChanged: () =>
+            overrides?.pushResult ? overrides.pushResult() : Promise.resolve(),
           markDirty: () => Promise.resolve(),
         }),
       }
@@ -200,6 +211,8 @@ function ensureTestExtensionType(
     healthy?: boolean;
     message?: string;
     hasSyncService?: boolean;
+    pullResult?: number | (() => Promise<number | void>);
+    pushResult?: () => Promise<number | void>;
   },
 ): void {
   if (!datastoreTypeRegistry.has(type)) {
@@ -214,6 +227,8 @@ function ensureTestExtensionType(
           healthy: opts?.healthy,
           message: opts?.message,
           hasSyncService: opts?.hasSyncService,
+          pullResult: opts?.pullResult,
+          pushResult: opts?.pushResult,
         }),
     });
   }
@@ -349,4 +364,153 @@ Deno.test("datastoreSetupExtension: errors on non-upgraded repo", async () => {
   const error = events[1] as Extract<DatastoreSetupEvent, { kind: "error" }>;
   assertEquals(error.kind, "error");
   assertEquals(error.error.code, "validation_failed");
+});
+
+// ============================================================================
+// Cache hydration tests (issue #220)
+//
+// Setup must pull existing remote data into the local cache regardless of
+// whether --skip-migration was used. Migration moves data UP (local →
+// remote); hydration moves data DOWN (remote → local). A contributor
+// joining a populated remote needs hydration even when there is nothing
+// local to migrate.
+// ============================================================================
+
+Deno.test("datastoreSetupExtension: skip-migration pulls populated remote into cache", async () => {
+  ensureTestExtensionType("test-ext-hydrate-skip", {
+    pullResult: 17,
+  });
+  const deps = makeDeps();
+  const input = makeExtensionInput({
+    type: "test-ext-hydrate-skip",
+    skipMigration: true,
+  });
+
+  const events = await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    DatastoreSetupEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.filesCopied, 0);
+  assertEquals(completed.data.filesPulled, 17);
+  assertEquals(completed.data.errors, []);
+});
+
+Deno.test("datastoreSetupExtension: skip-migration with empty remote is a no-op pull", async () => {
+  ensureTestExtensionType("test-ext-hydrate-empty", {
+    pullResult: 0,
+  });
+  const deps = makeDeps();
+  const input = makeExtensionInput({
+    type: "test-ext-hydrate-empty",
+    skipMigration: true,
+  });
+
+  const events = await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    DatastoreSetupEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.filesPulled, 0);
+  assertEquals(completed.data.errors, []);
+});
+
+Deno.test("datastoreSetupExtension: default path migrates and then hydrates", async () => {
+  ensureTestExtensionType("test-ext-migrate-and-hydrate", {
+    pullResult: 4,
+  });
+  const deps = makeDeps();
+  const input = makeExtensionInput({
+    type: "test-ext-migrate-and-hydrate",
+    skipMigration: false,
+  });
+
+  const events = await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    DatastoreSetupEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  // makeDeps default migrateData returns filesCopied: 5
+  assertEquals(completed.data.filesCopied, 5);
+  assertEquals(completed.data.filesPulled, 4);
+  assertEquals(completed.data.errors, []);
+});
+
+Deno.test("datastoreSetupExtension: pull failure surfaces in errors and blocks .swamp.yaml writeback", async () => {
+  ensureTestExtensionType("test-ext-pull-fail", {
+    pullResult: () => Promise.reject(new Error("network unreachable")),
+  });
+  let configUpdated = false;
+  let cleanupCalled = false;
+  const deps = makeDeps({
+    updateRepoConfig: () => {
+      configUpdated = true;
+      return Promise.resolve();
+    },
+    cleanupSourceDirs: () => {
+      cleanupCalled = true;
+      return Promise.resolve();
+    },
+  });
+  const input = makeExtensionInput({
+    type: "test-ext-pull-fail",
+    skipMigration: true,
+  });
+
+  const events = await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    DatastoreSetupEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.errors.length, 1);
+  assertStringIncludes(completed.data.errors[0], "network unreachable");
+  assertEquals(
+    configUpdated,
+    false,
+    "pull failure must prevent .swamp.yaml writeback",
+  );
+  assertEquals(
+    cleanupCalled,
+    false,
+    "pull failure must keep migrated .swamp/ dirs intact for retry",
+  );
+});
+
+Deno.test("datastoreSetupExtension: extension without sync service skips push and pull cleanly", async () => {
+  ensureTestExtensionType("test-ext-no-sync", {
+    hasSyncService: false,
+  });
+  const deps = makeDeps();
+  const input = makeExtensionInput({
+    type: "test-ext-no-sync",
+    skipMigration: true,
+  });
+
+  const events = await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    DatastoreSetupEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.filesPulled, 0);
+  assertEquals(completed.data.errors, []);
 });

--- a/src/libswamp/datastores/setup_test.ts
+++ b/src/libswamp/datastores/setup_test.ts
@@ -256,10 +256,13 @@ Deno.test("datastoreSetupExtension: completes with valid config", async () => {
     datastoreSetupExtension(createLibSwampContext(), deps, input),
   );
 
-  assertEquals(events.length, 3);
+  // Event sequence with sync-service-equipped extension:
+  // validating → migrating → hydrating → completed
+  assertEquals(events.length, 4);
   assertEquals(events[0].kind, "validating");
   assertEquals(events[1].kind, "migrating");
-  const completed = events[2] as Extract<
+  assertEquals(events[2].kind, "hydrating");
+  const completed = events[3] as Extract<
     DatastoreSetupEvent,
     { kind: "completed" }
   >;
@@ -279,9 +282,13 @@ Deno.test("datastoreSetupExtension: completes with skip migration", async () => 
     datastoreSetupExtension(createLibSwampContext(), deps, input),
   );
 
-  assertEquals(events.length, 2);
+  // Event sequence on skip-migration with sync service:
+  // validating → hydrating → completed (migration legs skipped, but
+  // hydration still runs because the extension exposes a sync service).
+  assertEquals(events.length, 3);
   assertEquals(events[0].kind, "validating");
-  const completed = events[1] as Extract<
+  assertEquals(events[1].kind, "hydrating");
+  const completed = events[2] as Extract<
     DatastoreSetupEvent,
     { kind: "completed" }
   >;
@@ -513,4 +520,36 @@ Deno.test("datastoreSetupExtension: extension without sync service skips push an
   assertEquals(completed.kind, "completed");
   assertEquals(completed.data.filesPulled, 0);
   assertEquals(completed.data.errors, []);
+});
+
+Deno.test("datastoreSetupExtension: ensures cachePath exists before hydration pull", async () => {
+  // Defensive guard: setup owns its preconditions rather than relying on
+  // sync service internals. Some extension implementations may not call
+  // ensureDir inside pullChanged; the skip-migration path must create
+  // the cache directory itself before pulling.
+  ensureTestExtensionType("test-ext-ensuredir", { pullResult: 5 });
+  const ensureDirCalls: string[] = [];
+  const deps = makeDeps({
+    ensureDir: (path: string) => {
+      ensureDirCalls.push(path);
+      return Promise.resolve();
+    },
+  });
+  const input = makeExtensionInput({
+    type: "test-ext-ensuredir",
+    skipMigration: true,
+  });
+
+  await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  // The stub provider's resolveCachePath returns `${repoDir}/.custom-cache`.
+  assertEquals(
+    ensureDirCalls.includes(`${input.repoDir}/.custom-cache`),
+    true,
+    `expected ensureDir to be called for the cache path before pull; got ${
+      JSON.stringify(ensureDirCalls)
+    }`,
+  );
 });

--- a/src/presentation/renderers/datastore_setup.ts
+++ b/src/presentation/renderers/datastore_setup.ts
@@ -53,6 +53,9 @@ class LogDatastoreSetupRenderer implements Renderer<DatastoreSetupEvent> {
             formatBytes(data.bytesCopied)
           })`,
         );
+        if (data.filesPulled > 0) {
+          lines.push(`  Hydrated: ${data.filesPulled} pulled`);
+        }
         lines.push(`  Dirs:     ${data.directoriesMigrated.join(", ")}`);
 
         if (data.errors.length > 0) {

--- a/src/presentation/renderers/datastore_setup.ts
+++ b/src/presentation/renderers/datastore_setup.ts
@@ -39,6 +39,9 @@ class LogDatastoreSetupRenderer implements Renderer<DatastoreSetupEvent> {
       migrating: () => {
         logger.info`Migrating data...`;
       },
+      hydrating: () => {
+        logger.info`Hydrating cache from remote...`;
+      },
       completed: (e) => {
         const data = e.data;
         const lines = [
@@ -53,7 +56,13 @@ class LogDatastoreSetupRenderer implements Renderer<DatastoreSetupEvent> {
             formatBytes(data.bytesCopied)
           })`,
         );
-        if (data.filesPulled > 0) {
+        // Always surface the hydration count for extension datastores
+        // (filesystem datastores have no separate cache to hydrate, so
+        // filesPulled is structurally always 0 there and the line is
+        // meaningless). Showing 0 for extensions confirms hydration ran
+        // and lets the user distinguish "ran and found nothing" from
+        // "was skipped entirely".
+        if (data.type !== "filesystem") {
           lines.push(`  Hydrated: ${data.filesPulled} pulled`);
         }
         lines.push(`  Dirs:     ${data.directoriesMigrated.join(", ")}`);
@@ -80,6 +89,7 @@ class JsonDatastoreSetupRenderer implements Renderer<DatastoreSetupEvent> {
     return {
       validating: () => {},
       migrating: () => {},
+      hydrating: () => {},
       completed: (e) => {
         console.log(JSON.stringify(e.data, null, 2));
       },


### PR DESCRIPTION
## Summary

Two related fixes for `swamp datastore` UX, both verified end-to-end against MinIO during triage. Closes swamp-club#220.

### Bug 1 — Setup leaves cache empty when joining a populated remote (the user-reported #220 failure)

`swamp datastore setup extension --skip-migration` against a shared S3 bucket that already has data (the realistic onboarding flow when a contributor joins a project that's been on a shared datastore for a while) left the local cache empty. `swamp workflow run search` then returned `[]` even though the bucket had `workflow-runs/*.yaml` files visible via `aws s3 ls`. Setup never called `pullChanged()` — it only ever moved data UP (migration). There was no step that hydrated the cache DOWN from a populated remote.

**Fix:** add an unconditional `pullChanged()` step in `datastoreSetupExtension` after the (optional) migration push. Re-frame `--skip-migration` as push-only: it skips lifting `.swamp/` data UP, but the remote→local hydration always runs. Adds a `filesPulled` field to `DatastoreSetupData`, surfaced in both log mode (`Hydrated: <N> pulled`, suppressed when 0) and JSON.

### Bug 2 — `swamp datastore sync` reports lying counts (the symptom that misled the reporter)

The reporter also observed `swamp datastore sync` reporting `0 pulled, 0 pushed` despite YAMLs in the datastore — which is what convinced them sync wasn't working. Reproduced cleanly: default-mode sync against a fresh cache reports `filesPulled: 0` while silently pulling 22 files. Cause: `requireInitializedRepo` triggers the coordinator's **implicit pull-at-startup**; the explicit `pullChanged` inside `fullSync` then fast-paths to 0 because the cache is already in sync. The explicit count is "honest" for the explicit pull's perspective but misleading for the user.

**Fix:** add `skipImplicitSync?: boolean` to `RequireRepoOptions`. When set, the lock is still acquired but no sync service is registered with the coordinator — neither the implicit pull at startup nor the implicit push on flush runs. The explicit `pullChanged`/`pushChanged` in `fullSync` then own all I/O and reported counts are honest. `--pull` mode keeps using `requireInitializedRepoReadOnly` (no lock, no sync) as before. Write commands (`model create`, `workflow run`, etc.) are unchanged: they don't pass the new flag and continue to use the coordinator's implicit pull/push, which is correct for them.

## What I verified

Reproduction harness: fresh MinIO container, two scratch repos (`/tmp/swamp-repro-issue-220-{A,B,C}`), workflows + 3 prior runs in Repo A populating the bucket, locally-compiled binary used for the post-fix runs.

| # | Scenario | Expected | Actual | Status |
|---|----------|----------|--------|--------|
| 1 | `--skip-migration` setup against empty bucket | `filesPulled: 0`, no errors | `filesPulled: 0` | ✓ |
| 2 | `--skip-migration` setup against populated bucket (the #220 failure scenario) | `filesPulled > 0`, search returns runs | `filesPulled: 17`, search returns 3 | ✓ |
| 3 | Full migration (no `--skip-migration`) with local data + populated remote | both `filesCopied > 0` AND `filesPulled > 0` | `filesCopied: 4`, `filesPulled: 17`, search returns 3 | ✓ |
| 4 | `swamp datastore sync` default mode on fresh cache | honest `filesPulled` count | `filesPulled: 17` (was lying as 0) | ✓ |
| 5 | `--pull` idempotency after setup hydrated | `filesPulled: 0` | `filesPulled: 0` | ✓ |
| 6 | Default `sync` at steady state | 0/0 | 0/0 | ✓ |
| 7 | `workflow run` then `sync` (coordinator already pushed) | 0/0 | 0/0 | ✓ |
| 8 | Pre-fix baseline (sanity check the bug exists) | empty cache, search [] | confirmed | ✓ |

Steady-state sequence (Tests 5–7) confirms idempotency: once the explicit pull-then-push completes once, subsequent sync invocations correctly report 0/0.

## Test coverage added

- `src/libswamp/datastores/setup_test.ts` — 5 new cases covering the hydration matrix:
  - `--skip-migration` with populated remote pulls into cache (`filesPulled > 0`)
  - `--skip-migration` with empty remote is a no-op pull (`filesPulled === 0`)
  - default path migrates AND hydrates (both `filesCopied` and `filesPulled` reflect work)
  - pull failure surfaces in `errors[]` and prevents `.swamp.yaml` writeback (matches push semantics)
  - extension without `createSyncService` skips both push and pull cleanly
- `src/cli/repo_context_test.ts` — 2 new cases on the wiring:
  - `skipImplicitSync: true` prevents the coordinator's implicit pull AND the implicit push on flush (counters on a stub provider's `pullChanged`/`pushChanged`)
  - default behavior still triggers exactly one implicit pull — sanity check that write-command behavior is unchanged
- All existing tests pass: 5243 passed, 0 failed. (One parallel-execution flake on the first run hit a different test on retry; unrelated to this work — both tests pass in isolation and on the third full run with no failures.)
- `deno check`, `deno lint`, `deno fmt --check` all clean across the project.

## Behavior change worth flagging

`swamp datastore sync` JSON output now reports honest `filesPulled` / `filesPushed` counts. Prior to this PR, the default mode always reported 0/0 because the coordinator's implicit pull+push consumed the work first. External tooling that parsed the output and learned to treat 0 as a stable "nothing happened" signal will now see real counts. No flag or feature-gate — the prior behavior was a bug, not a contract.

## Pre-existing extension wart observed (separate from this PR)

During verification I noticed: the first explicit `--push` after a fresh-cache pull re-uploads N files even though they were just downloaded with identical content. Cause: `pullChanged` sets `localMtime` only in memory; the next `pushChanged` calls `pullIndex(forceRemote)` which clobbers in-memory state with the remote payload (no `localMtime` values), and the walk treats the cache files as "needing re-upload." The redundant push refreshes the index with proper `localMtime`, so subsequent operations are clean (Tests 5–7 verify steady state).

This is **pre-existing behavior in `@swamp/s3-datastore`** that was previously masked by the coordinator's implicit pull+push fast-pathing past the explicit ones. Not a correctness issue (data is byte-identical), not a regression from this PR (it existed before, just newly visible because the coordinator no longer eats the work). Worth filing against the s3-datastore extension as a separate quality issue.

## Doc updates

- `design/datastores.md` — Setup Pipeline list expanded with the new "Hydrate" step; new hydration invariant ("After setup completes with `errors.length === 0`, the cache contains every remote index entry"); new section on the explicit-sync init flow with `skipImplicitSync`.
- `.claude/skills/swamp-repo/SKILL.md` — extension setup description and `--skip-migration` semantics updated; sync output accounting clarified.
- User-facing manual at `swamp-club/content/manual/reference/datastore-configuration.md` needs three edits (Setup Pipeline section, two flag-table entries) — will file as a separate `documentation`-labelled issue in `systeminit/swamp-club` per planning conventions.

## Notes for follow-up

- swamp-club#218 (stale-lock loop) implementation is parked behind this PR — there's file overlap in `src/cli/repo_context.ts` that #218 will need to rebase onto.
- The MinIO reproduction harness can be revived for swamp-uat coverage if a UAT story emerges around datastore onboarding.

## Test plan

- [x] Five new unit tests covering setup hydration matrix
- [x] Two new unit tests covering `skipImplicitSync` wiring
- [x] All existing tests pass (5243/5243 on clean run)
- [x] `deno check`, `deno lint`, `deno fmt --check` clean
- [x] Locally-compiled binary verified end-to-end against MinIO across 8 scenarios (table above)
- [x] Pre-fix bug reproduction confirmed first; post-fix verification used the same harness
- [ ] CI runs green