### PR TITLE
fix(datastore): force-release stale global lock to break acquireModelLocks loop (swamp-club#218)

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -391,8 +391,16 @@ interface DistributedLock {
   release(): Promise<void>;   // Release lock, stop heartbeat
   withLock<T>(fn: () => Promise<T>): Promise<T>;
   inspect(): Promise<LockInfo | null>;  // Read without acquiring
+  forceRelease(expectedNonce: string): Promise<boolean>;  // Breakglass delete
 }
 ```
+
+`forceRelease` re-verifies the lock's nonce immediately before deleting and
+returns `false` if the holder has changed, narrowing the TOCTOU window to
+the gap between that final read and the delete itself. It is the
+breakglass primitive used by `swamp datastore lock release --force` and
+by `acquireModelLocks` to clean up stale global locks observed during
+per-model lock acquisition (see "Lock Lifecycle" below).
 
 Lock metadata (`LockInfo`) is stored as JSON:
 
@@ -427,6 +435,14 @@ lifecycle as a global singleton:
 
 - `registerDatastoreSync({ service?, lock? })` — acquire lock, pull if S3
 - `flushDatastoreSync()` — push if S3, release lock
+
+Per-model commands (`model method run`, `workflow run`) acquire only
+per-model locks via `acquireModelLocks`; they do not acquire the global
+lock but do `inspect()` it to wait out any in-flight structural command.
+When a stale global lock is observed during this wait, `acquireModelLocks`
+calls `forceRelease(expectedNonce)` to clear it — without this, the
+post-acquire TOCTOU re-check would re-detect the same stale lock on every
+iteration and recurse indefinitely.
 
 A SIGINT handler ensures best-effort lock release on Ctrl-C. If the process
 crashes without releasing, the lock expires after the TTL (30 seconds by

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -56,6 +56,7 @@ import { summarizeSyncError } from "../infrastructure/persistence/sync_error_dia
 import { FileLock } from "../infrastructure/persistence/file_lock.ts";
 import {
   type DistributedLock,
+  type LockInfo,
   LockTimeoutError,
 } from "../domain/datastore/distributed_lock.ts";
 import {
@@ -675,6 +676,40 @@ export interface ModelLockResult {
   synced: boolean;
 }
 
+/**
+ * Best-effort delete of a stale global lock whose `info` was just observed.
+ *
+ * Without this, the wait loops in `acquireModelLocks` only `break` past a
+ * stale lock — the file remains on disk/in S3 and the post-acquire TOCTOU
+ * re-check immediately re-detects it, triggering an infinite recursive
+ * retry. Using the existing `forceRelease(expectedNonce)` breakglass
+ * primitive (defined on `DistributedLock` for exactly this purpose)
+ * actually clears the stale state so subsequent inspects return null.
+ *
+ * Failure modes are benign and intentionally swallowed:
+ *   - `info.nonce` missing (older lock format) — skip; the surrounding
+ *     wait-loop timeout still bounds the wait.
+ *   - `forceRelease` returns false (nonce changed: the holder
+ *     legitimately re-acquired or another process force-released first)
+ *     — the next inspect will see the new state and we re-loop.
+ *   - Backend transient error — same recovery; one extra loop iteration.
+ */
+async function tryForceReleaseStaleLock(
+  lock: DistributedLock,
+  info: LockInfo,
+): Promise<void> {
+  if (!info.nonce) return;
+  const logger = getSwampLogger(["datastore", "lock"]);
+  try {
+    await lock.forceRelease(info.nonce);
+  } catch (error) {
+    logger.debug(
+      "Best-effort forceRelease of stale global lock failed: {error}",
+      { error: error instanceof Error ? error.message : String(error) },
+    );
+  }
+}
+
 export async function acquireModelLocks(
   config: DatastoreConfig,
   models: Array<{ modelType: string; modelId: string }>,
@@ -733,6 +768,7 @@ export async function acquireModelLocks(
           "Global lock held by {holder} appears stale (exceeded TTL of {ttl}ms) — proceeding",
           { holder: info.holder, ttl: info.ttlMs },
         );
+        await tryForceReleaseStaleLock(globalLock, info);
         break;
       }
       // Hard timeout to prevent indefinite hangs
@@ -804,6 +840,7 @@ export async function acquireModelLocks(
             "Global lock held by {holder} appears stale (exceeded TTL of {ttl}ms) — proceeding",
             { holder: info.holder, ttl: info.ttlMs },
           );
+          await tryForceReleaseStaleLock(globalLock, info);
           break;
         }
         const retryElapsed = Date.now() - retryWaitStart;

--- a/src/cli/repo_context_test.ts
+++ b/src/cli/repo_context_test.ts
@@ -30,6 +30,7 @@ import {
   resolveDatastoreForRepo,
 } from "./repo_context.ts";
 import { flushDatastoreSync } from "../infrastructure/persistence/datastore_sync_coordinator.ts";
+import { isCustomDatastoreConfig } from "../domain/datastore/datastore_config.ts";
 import { RepoPath } from "../domain/repo/repo_path.ts";
 import { RepoService } from "../domain/repo/repo_service.ts";
 import { UserError } from "../domain/errors.ts";
@@ -471,6 +472,76 @@ Deno.test("acquireModelLocks - deduplicates same model", async () => {
     await lockResult.flush();
   });
 });
+
+Deno.test(
+  "acquireModelLocks - force-releases stale global lock instead of infinite-looping",
+  async () => {
+    // Regression test for swamp-club#218. Before the fix, a stale global
+    // lock observed during per-model lock acquisition was bypassed but
+    // never deleted. The post-acquire TOCTOU re-check then re-detected
+    // the same stale lock and recursed forever. With the fix,
+    // acquireModelLocks force-releases the stale lock so subsequent
+    // inspects return null and the per-model loop completes normally.
+    await withTempDir(async (dir) => {
+      await initializeRepo(dir);
+
+      const { datastoreConfig } = await resolveDatastoreForRepo(dir);
+      if (isCustomDatastoreConfig(datastoreConfig)) {
+        throw new Error("expected filesystem datastore for this test");
+      }
+
+      // Plant a stale global lock: acquiredAt 10 minutes ago, ttlMs 30s.
+      // The presence of `nonce` is what enables forceRelease to work.
+      const lockPath = join(datastoreConfig.path, ".datastore.lock");
+      const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000)
+        .toISOString();
+      await Deno.writeTextFile(
+        lockPath,
+        JSON.stringify({
+          holder: "ghost@dead-machine",
+          hostname: "dead-machine",
+          pid: 999999,
+          acquiredAt: tenMinutesAgo,
+          ttlMs: 30_000,
+          nonce: "test-stale-nonce-218",
+        }),
+      );
+
+      // Race acquireModelLocks against a 10s deadline. Without the fix
+      // the call deadlocks (recurses forever) and this throws.
+      const acquirePromise = acquireModelLocks(datastoreConfig, [
+        { modelType: "x", modelId: "y" },
+      ], dir);
+      const timeoutHandle = { id: 0 as number | undefined };
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutHandle.id = setTimeout(
+          () =>
+            reject(
+              new Error(
+                "acquireModelLocks did not return within 10s",
+              ),
+            ),
+          10_000,
+        );
+      });
+      let lockResult;
+      try {
+        lockResult = await Promise.race([acquirePromise, timeoutPromise]);
+      } finally {
+        if (timeoutHandle.id !== undefined) clearTimeout(timeoutHandle.id);
+      }
+
+      // Stale lock file should be gone.
+      await assertRejects(
+        () => Deno.stat(lockPath),
+        Deno.errors.NotFound,
+      );
+
+      // Clean up the per-model lock acquired by the call.
+      await lockResult.flush();
+    });
+  },
+);
 
 // ============================================================================
 // skipImplicitSync Tests (lab #220)


### PR DESCRIPTION
## Summary

Closes swamp-club#218.

When `acquireModelLocks` observed a stale global datastore lock, the
"appears stale — proceeding" branches in both wait loops only `break`
past the lock without deleting it. The post-acquire TOCTOU re-check
then re-detected the same stale lock, logged "Global lock acquired by
... during per-model lock acquisition — releasing and retrying", released
per-model locks, waited it out as stale again, and recursed. The cycle
repeated every ~1s indefinitely until the process eventually crashed
with a top-level await error — exactly the symptom the reporter saw.

## Fix

Wire the existing `DistributedLock.forceRelease(expectedNonce)`
breakglass primitive — already on the interface and implemented by both
`FileLock` and `S3Lock` for this exact purpose — into both wait loops
via a small `tryForceReleaseStaleLock` helper. After the helper runs,
the stale lock is gone, the post-acquire re-check sees `null`, and
per-model acquisition completes normally.

Helper is best-effort: if `info.nonce` is missing (older lock format) or
`forceRelease` returns `false` (nonce changed — someone legitimately
re-acquired), it does nothing and the surrounding wait-loop timeout
still bounds the wait. No risk of deleting a live lock; `forceRelease`
re-verifies the nonce immediately before deleting.

## Verification

| Backend | Pre-fix | Post-fix |
|---|---|---|
| Filesystem unit test | deadlocks (10s timeout fires) | passes in ~1s, lock file gone |
| Filesystem CLI repro (`/tmp/swamp-repro-issue-218`) | infinite loop, ~1s/iter, eventual TLS crash | exits in ~1s, **one** "appears stale" warn line, no recursion |
| S3 / MinIO repro | (assumed identical — same orchestration code) | exits in 1.9s, `.datastore.lock` object deleted from bucket, `lock status` reports "no lock held", model output correct, 14 files synced back |

Full test suite: 5245 passed, 0 failed, no regressions.

## What's not in this PR

Two scoped-extension-type bugs the reporter mentioned in the issue's
"Additional Notes" are out of scope and will be filed separately:
- `swamp datastore lock release --force --model <type/id>` rejects scoped
  types like `@org/name` because the parser splits on `/` and requires
  exactly two parts (`datastore_lock.ts:132–137`).
- `scanModelLocks` requires `parts.length === 4` and skips lock files
  for scoped types (`libswamp/datastores/lock.ts:222`).

## Test Plan

- [x] `deno check` clean
- [x] `deno lint` clean
- [x] `deno fmt --check` clean
- [x] `deno run test` — 5245 passed, 0 failed
- [x] `deno run compile` — verified compiled binary against filesystem repro
- [x] MinIO end-to-end: planted stale lock object in bucket, ran model method, observed clean exit and lock removal
- [x] `design/datastores.md` updated to add `forceRelease` to documented interface and to record the `acquireModelLocks` self-heal behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)