### PR TITLE
feat(extensions): W1a per-extension-aggregate-v3 schema migration (swamp-club#211)

### DIFF
--- a/src/domain/datastore/user_datastore_loader.ts
+++ b/src/domain/datastore/user_datastore_loader.ts
@@ -523,9 +523,10 @@ export class UserDatastoreLoader {
   private registerLazyFromCatalog(catalog: ExtensionCatalogStore): void {
     const entries = catalog.findByKind("datastore");
     for (const entry of entries) {
-      // Skip validation-failed rows (swamp-club#209) — see equivalent
-      // guard in user_model_loader.ts:registerLazyFromCatalog.
-      if (entry.validation_failed) continue;
+      // Skip ValidationFailed rows (swamp-club#209) — see equivalent
+      // guard in user_model_loader.ts:registerLazyFromCatalog. Migrated
+      // to read `state` instead of `validation_failed` per W1a.
+      if (entry.state === "ValidationFailed") continue;
       datastoreTypeRegistry.registerLazy({
         type: entry.type_normalized,
         bundlePath: entry.bundle_path,

--- a/src/domain/drivers/user_driver_loader.ts
+++ b/src/domain/drivers/user_driver_loader.ts
@@ -533,9 +533,10 @@ export class UserDriverLoader {
   private registerLazyFromCatalog(catalog: ExtensionCatalogStore): void {
     const entries = catalog.findByKind("driver");
     for (const entry of entries) {
-      // Skip validation-failed rows (swamp-club#209) — see equivalent
-      // guard in user_model_loader.ts:registerLazyFromCatalog.
-      if (entry.validation_failed) continue;
+      // Skip ValidationFailed rows (swamp-club#209) — see equivalent
+      // guard in user_model_loader.ts:registerLazyFromCatalog. Migrated
+      // to read `state` instead of `validation_failed` per W1a.
+      if (entry.state === "ValidationFailed") continue;
       driverTypeRegistry.registerLazy({
         type: entry.type_normalized,
         bundlePath: entry.bundle_path,

--- a/src/domain/extensions/bundle_freshness.ts
+++ b/src/domain/extensions/bundle_freshness.ts
@@ -52,7 +52,21 @@ export interface FreshnessCatalogRow {
   source_path: string;
   source_fingerprint?: string;
   bundle_path?: string;
+  /**
+   * Vestigial after W1a (issue swamp-club#211) — the row migrated to
+   * the `state` field below. Preserved on the type for back-compat
+   * with tests that still assert on it; production code reads
+   * `state === 'ValidationFailed'` via {@link findStaleFiles}.
+   */
   validation_failed?: boolean;
+  /**
+   * RowState tag (W1a). `findStaleFiles` checks
+   * `state === 'ValidationFailed'` to skip rebundling rows that are
+   * known schema-broken — the swamp-club#209 rebundle-loop guard.
+   * Optional so legacy fixtures that omit it default to 'Indexed'
+   * via {@link mapRow}.
+   */
+  state?: string;
 }
 
 /**
@@ -294,13 +308,17 @@ export async function findStaleFiles(
         // bundle attempt). Without this check the catalog row stays "fresh"
         // and a downstream importBundleByPath ENOENTs (swamp-club#212).
         //
-        // validation_failed rows are skipped: rebundling them is a no-op
+        // ValidationFailed rows are skipped: rebundling them is a no-op
         // cycle — bundle still fails schema validation, markCatalogValidationFailed
         // re-pins the same fingerprint, every command spawns deno bundle.
-        // That is the inverse of the loop swamp-club#209 sealed.
+        // That is the inverse of the loop swamp-club#209 sealed. The W1a
+        // migration absorbed the legacy `validation_failed` boolean into
+        // the `state` column; this reader migrated together with the
+        // writer (markCatalogValidationFailed) so the W1a→W1b window
+        // never has a writer/reader schism on this guard.
         if (
           catalogEntry.bundle_path &&
-          !catalogEntry.validation_failed &&
+          catalogEntry.state !== "ValidationFailed" &&
           !(await bundleExists(catalogEntry.bundle_path))
         ) {
           logger
@@ -343,7 +361,7 @@ export interface ValidationFailureCatalog {
     extends_type: string;
     source_mtime: string;
     source_fingerprint: string;
-    validation_failed: boolean;
+    state?: string;
   }): void;
 }
 
@@ -359,7 +377,7 @@ export interface MarkCatalogValidationFailedParams {
 /**
  * Records the dual of findStaleFiles: when an extension's source bundles
  * and imports cleanly but fails schema validation, write the catalog row
- * with the new fingerprint and validation_failed=true. Without this,
+ * with the new fingerprint and `state: 'ValidationFailed'`. Without this,
  * findStaleFiles keeps marking the file stale on every pass — the
  * `safeParse`-throws-before-upsert pattern in each loader's
  * rebundleAndUpdateCatalog leaves the row's fingerprint pinned at the
@@ -369,9 +387,15 @@ export interface MarkCatalogValidationFailedParams {
  * Storing the new fingerprint terminates the loop: the next
  * findStaleFiles pass compares the computed fingerprint against the
  * stored one, finds them equal, and treats the file as fresh. The row's
- * empty type_normalized + validation_failed=true keeps the broken
+ * empty type_normalized + state='ValidationFailed' keeps the broken
  * extension out of the registry — registration call sites filter on
- * the flag.
+ * the state.
+ *
+ * The W1a migration absorbs the legacy `validation_failed` boolean into
+ * this state column (issue swamp-club#211). Writers (this helper) and
+ * readers (the loaders + findStaleFiles' bundle-missing branch)
+ * migrate together so the column is genuinely vestigial during the
+ * W1a → W1b release window. The column itself drops in W1b.
  *
  * Symmetric to the UNREADABLE_DEP_SENTINEL fix in #208: that one made
  * computeSourceFingerprint total for unreadable transitive deps; this
@@ -403,6 +427,6 @@ export function markCatalogValidationFailed(
     extends_type: "",
     source_mtime: sourceMtime,
     source_fingerprint: sourceFingerprint,
-    validation_failed: true,
+    state: "ValidationFailed",
   });
 }

--- a/src/domain/extensions/bundle_freshness_test.ts
+++ b/src/domain/extensions/bundle_freshness_test.ts
@@ -536,9 +536,11 @@ Deno.test("findStaleFiles: matching fingerprint + missing bundle → stale (#212
   }
 });
 
-Deno.test("findStaleFiles: matching fingerprint + missing bundle + validation_failed → not stale (#212 vs #209)", async () => {
-  // validation_failed rows must skip the bundle-existence check —
+Deno.test("findStaleFiles: matching fingerprint + missing bundle + state=ValidationFailed → not stale (#212 vs #209)", async () => {
+  // ValidationFailed rows must skip the bundle-existence check —
   // rebundling them is the inverse of the loop swamp-club#209 sealed.
+  // The reader migrated from `validation_failed` to `state` per W1a
+  // (issue swamp-club#211); fixture follows.
   const dir = await Deno.makeTempDir({ prefix: "swamp_bf_212_validfail_" });
   try {
     const file = join(dir, "broken.ts");
@@ -556,7 +558,7 @@ Deno.test("findStaleFiles: matching fingerprint + missing bundle + validation_fa
       extends_type: "",
       source_mtime: "",
       source_fingerprint: fp,
-      validation_failed: true,
+      state: "ValidationFailed",
     });
 
     const stale = await findStaleFiles({
@@ -834,7 +836,7 @@ class FakeValidationFailureCatalog implements ValidationFailureCatalog {
     extends_type: string;
     source_mtime: string;
     source_fingerprint: string;
-    validation_failed: boolean;
+    state?: string;
   }): void {
     this.upserts.push({ ...row });
   }
@@ -863,7 +865,7 @@ Deno.test("markCatalogValidationFailed: upserts a row with every field populated
   assertEquals(row.extends_type, "");
   assertEquals(row.source_mtime, "2026-05-01T12:00:00.000Z");
   assertEquals(row.source_fingerprint, "abc123");
-  assertEquals(row.validation_failed, true);
+  assertEquals(row.state, "ValidationFailed");
 });
 
 Deno.test("markCatalogValidationFailed: idempotent — repeated calls produce identical rows", () => {
@@ -1007,6 +1009,6 @@ Deno.test("markCatalogValidationFailed: works for every supported kind", () => {
   assertEquals(catalog.upserts.length, kinds.length);
   for (let i = 0; i < kinds.length; i++) {
     assertEquals(catalog.upserts[i].kind, kinds[i]);
-    assertEquals(catalog.upserts[i].validation_failed, true);
+    assertEquals(catalog.upserts[i].state, "ValidationFailed");
   }
 });

--- a/src/domain/models/user_model_loader.ts
+++ b/src/domain/models/user_model_loader.ts
@@ -79,7 +79,7 @@ const logger = getLogger(["swamp", "models", "loader"]);
  * "per-extension-v2" (each pulled extension owns its own bundle
  * namespace via its per-extension models dir).
  */
-const BUNDLE_LAYOUT_VERSION = "per-extension-v2";
+const BUNDLE_LAYOUT_VERSION = "per-extension-aggregate-v3";
 
 /**
  * Plain object result returned by user methods before conversion.
@@ -940,11 +940,12 @@ export class UserModelLoader {
   private registerLazyFromCatalog(catalog: ExtensionCatalogStore): void {
     const entries = catalog.findByKind("model");
     for (const entry of entries) {
-      // Skip validation-failed rows: their source content is fresh (the
+      // Skip ValidationFailed rows: their source content is fresh (the
       // fingerprint stops findStaleFiles from re-bundling) but the
       // module's schema is invalid, so the type is not safe to register
-      // (swamp-club#209).
-      if (entry.validation_failed) continue;
+      // (swamp-club#209). Migrated to read `state` instead of
+      // `validation_failed` per W1a (issue swamp-club#211).
+      if (entry.state === "ValidationFailed") continue;
       modelRegistry.registerLazy({
         type: ModelType.create(entry.type_normalized),
         bundlePath: entry.bundle_path,

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -3228,13 +3228,16 @@ export const extension = {
   }
 });
 
-Deno.test("UserModelLoader: registerLazyFromCatalog skips validation_failed rows (swamp-club#209)", async () => {
+Deno.test("UserModelLoader: registerLazyFromCatalog skips ValidationFailed rows (swamp-club#209)", async () => {
   // After a schema-invalid extension goes through rebundleAndUpdateCatalog,
-  // the catalog row carries validation_failed=true with empty
+  // the catalog row carries state='ValidationFailed' with empty
   // type_normalized. The fingerprint match terminates the rebundle loop
   // (verified at the catalog/freshness layer), but the registry must
   // not be polluted with the broken row — registerLazyFromCatalog has
-  // to filter on validation_failed.
+  // to filter on state.
+  //
+  // The reader migrated from `validation_failed` to `state` per W1a
+  // (issue swamp-club#211); this test follows.
   //
   // Drives the registration path directly via a seeded catalog rather
   // than going through buildIndex. The buildIndex path bumps into
@@ -3278,7 +3281,7 @@ export const model = {
     const loader1 = new UserModelLoader(testDenoRuntime, repoDir);
     await loader1.buildIndex(modelsDir, catalog1);
 
-    // Inject a validation-failed row to simulate what
+    // Inject a ValidationFailed row to simulate what
     // markCatalogValidationFailed would write after a schema break.
     const ns = bundleNamespace(modelsDir, repoDir);
     const brokenSourcePath = join(modelsDir, "broken.ts");
@@ -3292,7 +3295,7 @@ export const model = {
       extends_type: "",
       source_mtime: "2026-05-01T12:00:00.000Z",
       source_fingerprint: "deadbeef-broken-state",
-      validation_failed: true,
+      state: "ValidationFailed",
     });
     catalog1.close();
 
@@ -3306,12 +3309,12 @@ export const model = {
       r.type_normalized === `@user/issue209-healthy-${ts}`
     );
     assertNotEquals(broken, undefined, "Broken row must be in findByKind");
-    assertEquals(broken?.validation_failed, true);
+    assertEquals(broken?.state, "ValidationFailed");
     assertNotEquals(healthyRow, undefined, "Healthy row must be in findByKind");
-    assertEquals(healthyRow?.validation_failed, false);
+    assertEquals(healthyRow?.state, "Indexed");
 
     // Drive registerLazyFromCatalog. The healthy type registers; the
-    // broken row (empty type_normalized + validation_failed=true) must
+    // broken row (empty type_normalized + state='ValidationFailed') must
     // NOT register. Use a fresh loader so the lazy registration path
     // runs against a clean registry view of the populated catalog.
     const loader2 = new UserModelLoader(testDenoRuntime, repoDir);

--- a/src/domain/reports/user_report_loader.ts
+++ b/src/domain/reports/user_report_loader.ts
@@ -381,9 +381,10 @@ export class UserReportLoader {
   private registerLazyFromCatalog(catalog: ExtensionCatalogStore): void {
     const entries = catalog.findByKind("report");
     for (const entry of entries) {
-      // Skip validation-failed rows (swamp-club#209) — see equivalent
-      // guard in user_model_loader.ts:registerLazyFromCatalog.
-      if (entry.validation_failed) continue;
+      // Skip ValidationFailed rows (swamp-club#209) — see equivalent
+      // guard in user_model_loader.ts:registerLazyFromCatalog. Migrated
+      // to read `state` instead of `validation_failed` per W1a.
+      if (entry.state === "ValidationFailed") continue;
       reportRegistry.registerLazy({
         type: entry.type_normalized,
         bundlePath: entry.bundle_path,

--- a/src/domain/vaults/user_vault_loader.ts
+++ b/src/domain/vaults/user_vault_loader.ts
@@ -534,9 +534,10 @@ export class UserVaultLoader {
   private registerLazyFromCatalog(catalog: ExtensionCatalogStore): void {
     const entries = catalog.findByKind("vault");
     for (const entry of entries) {
-      // Skip validation-failed rows (swamp-club#209) — see equivalent
-      // guard in user_model_loader.ts:registerLazyFromCatalog.
-      if (entry.validation_failed) continue;
+      // Skip ValidationFailed rows (swamp-club#209) — see equivalent
+      // guard in user_model_loader.ts:registerLazyFromCatalog. Migrated
+      // to read `state` instead of `validation_failed` per W1a.
+      if (entry.state === "ValidationFailed") continue;
       vaultTypeRegistry.registerLazy({
         type: entry.type_normalized,
         bundlePath: entry.bundle_path,

--- a/src/infrastructure/persistence/canonicalize_path.ts
+++ b/src/infrastructure/persistence/canonicalize_path.ts
@@ -1,0 +1,57 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Returns a canonical form of a filesystem path suitable for use as the
+ * primary key in the extension catalog. Two paths that refer to the same
+ * file on the host filesystem must produce the same canonical form.
+ *
+ * Rules (issue swamp-club#211, W1 — Repository and RowState):
+ *
+ *   - On Windows: lowercase the entire string and replace every backslash
+ *     with a forward slash. NTFS is case-insensitive, and Node's path APIs
+ *     can produce either separator depending on the call site, so two
+ *     surface forms — `C:\\Users\\Foo\\Bar.ts` and `c:/users/foo/bar.ts` —
+ *     refer to the same file. Without canonicalization the catalog would
+ *     hold two distinct rows for one source.
+ *   - On POSIX (Linux, macOS, *BSD, etc.): return the input unchanged.
+ *     The issue explicitly recommends raw on POSIX to keep the function
+ *     trivially predictable. Note that case-insensitive macOS filesystems
+ *     (HFS+, APFS) can still produce duplicate rows under mixed-case
+ *     access patterns; that is a known limitation accepted for W1.
+ *
+ * The function is intentionally a string transform — it does not stat the
+ * filesystem, normalize `..`/`.` segments, or follow symlinks. Pass-through
+ * for non-existent paths is required so the migration backfill can run
+ * against catalog rows whose source files have already been deleted.
+ */
+export function canonicalizePath(p: string): string {
+  return canonicalizePathFor(p, Deno.build.os === "windows");
+}
+
+/**
+ * OS-parameterised form of {@link canonicalizePath}. Exposed so tests can
+ * exercise both branches without running on different host OSes.
+ */
+export function canonicalizePathFor(p: string, isWindows: boolean): string {
+  if (isWindows) {
+    return p.toLowerCase().replaceAll("\\", "/");
+  }
+  return p;
+}

--- a/src/infrastructure/persistence/canonicalize_path_test.ts
+++ b/src/infrastructure/persistence/canonicalize_path_test.ts
@@ -1,0 +1,110 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { canonicalizePath, canonicalizePathFor } from "./canonicalize_path.ts";
+
+// --- POSIX branch (isWindows = false) -----------------------------------
+
+Deno.test("canonicalizePathFor: POSIX returns input unchanged", () => {
+  assertEquals(
+    canonicalizePathFor("/foo/Bar/Baz.ts", false),
+    "/foo/Bar/Baz.ts",
+  );
+});
+
+Deno.test("canonicalizePathFor: POSIX preserves case", () => {
+  assertEquals(
+    canonicalizePathFor("/Repo/EXTENSIONS/Models/A.ts", false),
+    "/Repo/EXTENSIONS/Models/A.ts",
+  );
+});
+
+Deno.test("canonicalizePathFor: POSIX preserves backslashes (unusual but legal in POSIX file names)", () => {
+  // Backslash is a legal character in POSIX file names. Per the issue's
+  // "raw on POSIX" rule, the canonicalizer must not rewrite it.
+  assertEquals(
+    canonicalizePathFor("/foo\\bar.ts", false),
+    "/foo\\bar.ts",
+  );
+});
+
+Deno.test("canonicalizePathFor: POSIX empty string is unchanged", () => {
+  assertEquals(canonicalizePathFor("", false), "");
+});
+
+// --- Windows branch (isWindows = true) ----------------------------------
+
+Deno.test("canonicalizePathFor: Windows lowercases and uses forward slashes", () => {
+  assertEquals(
+    canonicalizePathFor("C:\\Users\\Foo\\Bar.ts", true),
+    "c:/users/foo/bar.ts",
+  );
+});
+
+Deno.test("canonicalizePathFor: Windows handles mixed slashes", () => {
+  assertEquals(
+    canonicalizePathFor("C:/Users\\Foo/Bar.ts", true),
+    "c:/users/foo/bar.ts",
+  );
+});
+
+Deno.test("canonicalizePathFor: Windows already-canonical input is idempotent", () => {
+  assertEquals(
+    canonicalizePathFor("c:/users/foo/bar.ts", true),
+    "c:/users/foo/bar.ts",
+  );
+});
+
+Deno.test("canonicalizePathFor: Windows two surface forms collapse to one canonical form", () => {
+  // The whole point of the function — `C:\\Users\\Foo\\Bar.ts` and
+  // `c:/users/foo/bar.ts` refer to the same file on NTFS and must produce
+  // the same primary key.
+  assertEquals(
+    canonicalizePathFor("C:\\Users\\Foo\\Bar.ts", true),
+    canonicalizePathFor("c:/users/foo/bar.ts", true),
+  );
+});
+
+Deno.test("canonicalizePathFor: Windows EXTENSIONS/Models/A.ts collapses with extensions/models/a.ts", () => {
+  // The fixture pair the W1 plan calls out explicitly for the SourceLocation
+  // equality test in W1b — pinning it here as well so the contract is
+  // documented at the helper's level.
+  assertEquals(
+    canonicalizePathFor("EXTENSIONS/Models/A.ts", true),
+    canonicalizePathFor("extensions/models/a.ts", true),
+  );
+});
+
+Deno.test("canonicalizePathFor: Windows empty string is unchanged", () => {
+  assertEquals(canonicalizePathFor("", true), "");
+});
+
+// --- Default-OS dispatcher ---------------------------------------------
+
+Deno.test("canonicalizePath: dispatches based on Deno.build.os", () => {
+  // The default canonicalizePath() reads Deno.build.os. On the test
+  // runner's host OS it must match canonicalizePathFor(input, isHostWindows).
+  const input = "/foo/Bar.ts";
+  const isHostWindows = Deno.build.os === "windows";
+  assertEquals(
+    canonicalizePath(input),
+    canonicalizePathFor(input, isHostWindows),
+  );
+});

--- a/src/infrastructure/persistence/derive_extension_identity.ts
+++ b/src/infrastructure/persistence/derive_extension_identity.ts
@@ -1,0 +1,191 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { basename } from "@std/path";
+
+/**
+ * Logical identity of an extension as the catalog records it.
+ *
+ *   - For pulled extensions, `name` is parsed from the on-disk path
+ *     (`.swamp/pulled-extensions/<name>/<kind>/...`); `version` is
+ *     intentionally left empty because the on-disk layout encodes only
+ *     the name. Version is owned by `upstream_extensions.json` (the
+ *     lockfile) and consulted at read time by `ExtensionRepository`'s
+ *     empty-version fallback (W1b). Treating the catalog and the
+ *     lockfile as two systems of record — with the lockfile
+ *     authoritative for version — keeps W1a's schema migration narrow.
+ *
+ *   - For local extensions (rows under `<repo>/extensions/<kind>/`),
+ *     name is the synthetic `@local/<basename(repoRoot)>` and version
+ *     is the literal `"0.0.0"`. Locals have no manifest, no scoped
+ *     name, no version; the design doc (`design/extension-rearchitecture.md`)
+ *     pins `0.0.0` as the only legal value.
+ */
+export interface ExtensionIdentity {
+  readonly name: string;
+  readonly version: string;
+}
+
+/**
+ * Derives the logical extension identity for a catalog row's
+ * `source_path`. Returns `null` when the path matches neither layout —
+ * the W1a migration converts null to "drop the row," and the W1b
+ * `ExtensionRepository` fallback converts null to "skip + DELETE the
+ * orphaned row" with a structured warning.
+ *
+ * The function is a pure string transform. It does not stat the
+ * filesystem, does not read the lockfile, and does not normalize
+ * `..`/`.` segments. Callers must pre-canonicalize `sourcePath` and
+ * `repoRoot` (see {@link canonicalizePath}) so prefix matching is
+ * stable across mixed-case filesystems.
+ *
+ * Layout rules (issue swamp-club#211, W1):
+ *
+ *   - Pulled: `<repoRoot>/.swamp/pulled-extensions/<name>/...`
+ *     Note <name> may contain forward slashes (scoped extension names
+ *     like `@swamp/aws/ec2` are common). The function consumes
+ *     everything between the `pulled-extensions/` prefix and the next
+ *     known kind segment (`models`, `vaults`, `drivers`, `datastores`,
+ *     `reports`, `workflows`, `skills`) as the name.
+ *   - Local or source-mounted: any path containing an
+ *     `/extensions/<kind>/` segment where `<kind>` is one of the known
+ *     kind directory names. Both `<repoRoot>/extensions/<kind>/...`
+ *     (repo-internal locals) and `<externalDir>/extensions/<kind>/...`
+ *     (source-mounted via `swamp extension source add <externalDir>`)
+ *     match this rule. They roll up into the same synthetic
+ *     `@local/<basename(repoRoot)>` aggregate: per the design doc,
+ *     `@local/<repo-name>` covers every Source under every
+ *     `extensions/<kind>/` tree for the repo regardless of whether
+ *     the source dir is inside the repo or mounted from outside.
+ *   - Otherwise: `null`.
+ *
+ * Found-during-implementation correction from issue/v5 spec: the issue
+ * body claimed pulled paths encode `<name>/<version>`. They encode
+ * `<name>` only. Version comes from the lockfile.
+ *
+ * Source-mounted handling note: catalog rows for source-mounted
+ * extensions have absolute paths outside `repoRoot` (e.g.
+ * `/some/external/dir/extensions/models/foo.ts`). An earlier draft of
+ * this helper only matched `<repoRoot>/extensions/` and missed those
+ * rows; the generalised "any `/extensions/<kind>/` segment" rule
+ * catches both layouts.
+ */
+export function deriveExtensionIdentity(
+  sourcePath: string,
+  repoRoot: string,
+): ExtensionIdentity | null {
+  // The migration's sub-step 4 has already canonicalized source_path
+  // (lowercase + forward-slash on Windows; raw on POSIX). We do the
+  // same prefix matching here so a TS-driven backfill loop and the
+  // W1b runtime fallback share the exact same matching semantics.
+  // pulledPrefix always ends in '/', so plain startsWith is correct —
+  // it can't match `/repo/.swamp/pulled-extensions-archive/...` because
+  // the literal `/` after `pulled-extensions` is part of the prefix.
+  const pulledPrefix = joinForward(repoRoot, ".swamp/pulled-extensions/");
+  if (sourcePath.startsWith(pulledPrefix)) {
+    const nameAndRest = sourcePath.slice(pulledPrefix.length);
+    const name = extractPulledExtensionName(nameAndRest);
+    if (name === null) {
+      // Path is under pulled-extensions/ but doesn't have a recognizable
+      // <name>/<kind>/ segment — corrupt or non-standard layout.
+      return null;
+    }
+    return { name, version: "" };
+  }
+
+  // Local or source-mounted: any `/extensions/<kind>/` segment where
+  // <kind> is one of the known kind directory names. Catches both
+  // repo-internal locals (under `<repoRoot>/extensions/<kind>/`) and
+  // source-added external dirs (`/external/dir/extensions/<kind>/`).
+  if (containsKnownExtensionsKindSegment(sourcePath)) {
+    return {
+      name: `@local/${basename(repoRoot)}`,
+      version: "0.0.0",
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Walks the path's `/extensions/<kind>/` segments looking for a known
+ * kind directory after the literal `extensions/` segment. Returns true
+ * if and only if the path contains `**\/extensions/<known-kind>/...`.
+ */
+function containsKnownExtensionsKindSegment(path: string): boolean {
+  const parts = path.split("/");
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (parts[i] === "extensions" && KIND_SEGMENTS.has(parts[i + 1])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Kind subdirectory names that delimit the end of an extension name
+ *  inside the pulled-extensions tree. Matches the directories created
+ *  by `installExtension` at `pull.ts:892` (per-kind subtree under the
+ *  per-extension subtree).
+ */
+const KIND_SEGMENTS = new Set([
+  "models",
+  "vaults",
+  "drivers",
+  "datastores",
+  "reports",
+  "workflows",
+  "skills",
+]);
+
+/**
+ * Walks segment by segment through the trailing portion of a pulled
+ * path until it hits a known kind segment, returning everything
+ * consumed before that as the extension name. Returns null when the
+ * path has no kind segment (corrupt/non-standard layout).
+ *
+ * Examples (sourcePath after `pulledPrefix` is stripped):
+ *   "@scope/foo/models/x.ts"          → "@scope/foo"
+ *   "@hivemq/harvester/kubeconfig/models/harvester/kubeconfig.ts"
+ *                                     → "@hivemq/harvester/kubeconfig"
+ *   "no-kind-segment/file.ts"         → null
+ *   "models/at-the-root.ts"           → null (zero-length name)
+ */
+function extractPulledExtensionName(nameAndRest: string): string | null {
+  const parts = nameAndRest.split("/");
+  for (let i = 0; i < parts.length; i++) {
+    if (KIND_SEGMENTS.has(parts[i])) {
+      if (i === 0) return null; // Empty name — meaningless.
+      return parts.slice(0, i).join("/");
+    }
+  }
+  return null;
+}
+
+/**
+ * Joins a directory and a relative path with forward slashes, matching
+ * the canonical form produced by {@link canonicalizePath} on Windows
+ * and the natural form on POSIX. We deliberately do not use
+ * `@std/path/join` here — `join` produces backslashes on Windows,
+ * which would not match canonicalized source_path values.
+ */
+function joinForward(dir: string, rel: string): string {
+  const trimmedDir = dir.endsWith("/") ? dir.slice(0, -1) : dir;
+  const trimmedRel = rel.startsWith("/") ? rel.slice(1) : rel;
+  return `${trimmedDir}/${trimmedRel}`;
+}

--- a/src/infrastructure/persistence/derive_extension_identity_test.ts
+++ b/src/infrastructure/persistence/derive_extension_identity_test.ts
@@ -1,0 +1,227 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { deriveExtensionIdentity } from "./derive_extension_identity.ts";
+
+// --- Pulled extensions: name only, version intentionally empty -------------
+
+Deno.test("deriveExtensionIdentity: pulled extension at /repo/.swamp/pulled-extensions/<name>/models/...", () => {
+  assertEquals(
+    deriveExtensionIdentity(
+      "/repo/.swamp/pulled-extensions/@scope/foo/models/x.ts",
+      "/repo",
+    ),
+    { name: "@scope/foo", version: "" },
+  );
+});
+
+Deno.test("deriveExtensionIdentity: pulled scoped extension with multi-segment name", () => {
+  // pull.ts joins the per-extension subtree under
+  // `.swamp/pulled-extensions/<ref.name>/<type>/`. ref.name can have
+  // multiple slashes (e.g. `@hivemq/harvester/kubeconfig`); the helper
+  // must consume all segments up to the kind directory.
+  assertEquals(
+    deriveExtensionIdentity(
+      "/repo/.swamp/pulled-extensions/@hivemq/harvester/kubeconfig/models/harvester/fetch_kubeconfig.ts",
+      "/repo",
+    ),
+    { name: "@hivemq/harvester/kubeconfig", version: "" },
+  );
+});
+
+Deno.test("deriveExtensionIdentity: pulled extension with non-models kind", () => {
+  for (
+    const kind of [
+      "vaults",
+      "drivers",
+      "datastores",
+      "reports",
+      "workflows",
+      "skills",
+    ]
+  ) {
+    assertEquals(
+      deriveExtensionIdentity(
+        `/repo/.swamp/pulled-extensions/@scope/foo/${kind}/x.ts`,
+        "/repo",
+      ),
+      { name: "@scope/foo", version: "" },
+      `kind=${kind}`,
+    );
+  }
+});
+
+Deno.test("deriveExtensionIdentity: pulled extension with no kind segment returns null", () => {
+  // .swamp/pulled-extensions/no-kind-segment/file.ts — corrupt layout
+  // (no kind subdir). Migration drops; W1b repository skip-and-DELETEs.
+  assertEquals(
+    deriveExtensionIdentity(
+      "/repo/.swamp/pulled-extensions/no-kind-segment/file.ts",
+      "/repo",
+    ),
+    null,
+  );
+});
+
+Deno.test("deriveExtensionIdentity: pulled extension with kind at root (zero-length name) returns null", () => {
+  assertEquals(
+    deriveExtensionIdentity(
+      "/repo/.swamp/pulled-extensions/models/at-the-root.ts",
+      "/repo",
+    ),
+    null,
+  );
+});
+
+// --- Local extensions: synthetic @local/<repo-name> at version 0.0.0 -------
+
+Deno.test("deriveExtensionIdentity: local extension under extensions/models/", () => {
+  assertEquals(
+    deriveExtensionIdentity(
+      "/repo/extensions/models/echo.ts",
+      "/repo",
+    ),
+    { name: "@local/repo", version: "0.0.0" },
+  );
+});
+
+Deno.test("deriveExtensionIdentity: local extension under extensions/vaults/", () => {
+  // Same synthetic aggregate for every kind under extensions/.
+  assertEquals(
+    deriveExtensionIdentity(
+      "/path/to/myrepo/extensions/vaults/v.ts",
+      "/path/to/myrepo",
+    ),
+    { name: "@local/myrepo", version: "0.0.0" },
+  );
+});
+
+Deno.test("deriveExtensionIdentity: local extension uses basename of repoRoot for synthetic name", () => {
+  // The architect-pinned synthetic name uses basename(repoRoot).
+  // Multi-segment repoRoots collapse to their last segment.
+  assertEquals(
+    deriveExtensionIdentity(
+      "/Users/stack72/code/systeminit/swamp/extensions/models/echo.ts",
+      "/Users/stack72/code/systeminit/swamp",
+    ),
+    { name: "@local/swamp", version: "0.0.0" },
+  );
+});
+
+// --- Source-mounted extensions ---------------------------------------------
+//
+// `swamp extension source add <externalDir>` registers an external
+// directory as an extension source. Catalog rows for those extensions
+// have absolute paths outside `repoRoot`. They roll up into the same
+// `@local/<basename(repoRoot)>` aggregate per the design doc:
+// "@local/<repo-name> covers every Source under every
+// extensions/<kind>/ tree" for the repo, regardless of whether the
+// source dir is inside the repo or mounted from outside.
+
+Deno.test("deriveExtensionIdentity: source-mounted extension outside repoRoot resolves to @local/<repo>", () => {
+  assertEquals(
+    deriveExtensionIdentity(
+      "/some/external/dir/extensions/models/foo.ts",
+      "/repo",
+    ),
+    { name: "@local/repo", version: "0.0.0" },
+  );
+});
+
+Deno.test("deriveExtensionIdentity: source-mounted under /tmp/ resolves to @local/<repo>", () => {
+  // The actual layout produced by swamp-uat's source-mount tests
+  // (Deno.makeTempDir() places the source dir under /var/folders or
+  // /tmp). Pin the contract so a future change can't regress it.
+  assertEquals(
+    deriveExtensionIdentity(
+      "/tmp/swamp-uat-srcmount-srcdir/extensions/models/echo.ts",
+      "/private/tmp/myrepo",
+    ),
+    { name: "@local/myrepo", version: "0.0.0" },
+  );
+});
+
+Deno.test("deriveExtensionIdentity: source-mounted in a sibling repo's tree still resolves to local for our repo", () => {
+  // The catalog opens at /repo/.swamp/_extension_catalog.db; if the
+  // user mounted a source at /repo-fork/extensions/models/, those
+  // rows belong to OUR repo's @local aggregate.
+  assertEquals(
+    deriveExtensionIdentity(
+      "/repo-fork/extensions/models/x.ts",
+      "/repo",
+    ),
+    { name: "@local/repo", version: "0.0.0" },
+  );
+});
+
+// --- Path-prefix safety ---------------------------------------------------
+
+Deno.test("deriveExtensionIdentity: path under `extensions-archive/` does NOT match (not the literal `extensions/` segment)", () => {
+  // The matcher requires the exact path segment `extensions`;
+  // `extensions-archive` is a different segment.
+  assertEquals(
+    deriveExtensionIdentity(
+      "/repo/extensions-archive/old.ts",
+      "/repo",
+    ),
+    null,
+  );
+});
+
+Deno.test("deriveExtensionIdentity: `/extensions/<unknown-kind>/` does NOT match (kind must be a known kind)", () => {
+  // Only the 7 known kind names ('models', 'vaults', 'drivers',
+  // 'datastores', 'reports', 'workflows', 'skills') count. A
+  // hypothetical `extensions/widgets/` would not match.
+  assertEquals(
+    deriveExtensionIdentity(
+      "/repo/extensions/widgets/foo.ts",
+      "/repo",
+    ),
+    null,
+  );
+});
+
+Deno.test("deriveExtensionIdentity: empty source path returns null", () => {
+  assertEquals(deriveExtensionIdentity("", "/repo"), null);
+});
+
+// --- Windows canonical form (lowercase + forward slashes) ------------------
+
+Deno.test("deriveExtensionIdentity: Windows canonical form (lowercase + forward slashes) for pulled", () => {
+  // The migration canonicalizes source_path before backfill (sub-step 4
+  // of W1a step 2); this test pins that we accept the canonical form.
+  assertEquals(
+    deriveExtensionIdentity(
+      "c:/users/foo/repo/.swamp/pulled-extensions/@scope/foo/models/x.ts",
+      "c:/users/foo/repo",
+    ),
+    { name: "@scope/foo", version: "" },
+  );
+});
+
+Deno.test("deriveExtensionIdentity: Windows canonical form for local", () => {
+  assertEquals(
+    deriveExtensionIdentity(
+      "c:/users/foo/myrepo/extensions/models/echo.ts",
+      "c:/users/foo/myrepo",
+    ),
+    { name: "@local/myrepo", version: "0.0.0" },
+  );
+});

--- a/src/infrastructure/persistence/extension_catalog_store.ts
+++ b/src/infrastructure/persistence/extension_catalog_store.ts
@@ -384,7 +384,13 @@ export class ExtensionCatalogStore {
    * row.
    */
   private backfillExtensionIdentity(): void {
-    const repoRoot = inferRepoRootFromDbPath(this.dbPath);
+    // canonicalizePath both sides — sub-step 4 already canonicalized
+    // every row's source_path, but inferRepoRootFromDbPath returns the
+    // raw dbPath form which is native (backslashes, mixed case) on
+    // Windows. deriveExtensionIdentity's docstring requires both inputs
+    // pre-canonicalized so prefix matching is stable across mixed-case
+    // filesystems; running canonicalizePath here makes the contract hold.
+    const repoRoot = canonicalizePath(inferRepoRootFromDbPath(this.dbPath));
     const rows = this.db
       .prepare(
         "SELECT rowid AS rid, source_path FROM bundle_types WHERE extension_name = ''",

--- a/src/infrastructure/persistence/extension_catalog_store.ts
+++ b/src/infrastructure/persistence/extension_catalog_store.ts
@@ -20,7 +20,23 @@
 import { DatabaseSync } from "node:sqlite";
 import { dirname } from "@std/path";
 import { ensureDirSync } from "@std/fs";
+import { getLogger } from "@logtape/logtape";
+import { canonicalizePath } from "./canonicalize_path.ts";
+import { deriveExtensionIdentity } from "./derive_extension_identity.ts";
 import { swampPath } from "./paths.ts";
+
+const logger = getLogger(["swamp", "persistence", "extension-catalog"]);
+
+/**
+ * Marker key in bundle_meta recording that the per-extension-aggregate-v3
+ * data migration has run successfully (or recovered via cold-start rebuild)
+ * on this catalog. Set after the data-migration transaction commits;
+ * checked at the top of the data-migration phase to skip the per-row
+ * UPDATEs after the first successful run. Schema-level changes (ADD COLUMN)
+ * are independently idempotent via pragma_table_info probes.
+ */
+const PER_EXTENSION_AGGREGATE_V3_MIGRATION_KEY =
+  "migration_applied:per-extension-aggregate-v3";
 
 /**
  * The kind of bundle entry — which registry type it belongs to.
@@ -58,15 +74,32 @@ export interface ExtensionTypeRow {
   source_fingerprint?: string;
   /**
    * True when bundle+import succeeded but schema validation failed
-   * (swamp-club#209). The fingerprint and bundle path are still stored
-   * so freshness comparison terminates on a stable broken source —
-   * registration paths filter on this flag to keep broken types out of
-   * the registry. findByKind/findByType deliberately do NOT filter on
-   * this column so freshness (findStaleFiles) can see broken rows.
-   * Defaults to false on upsert; old catalog rows default to false via
-   * the migration.
+   * (swamp-club#209). Vestigial after W1a — preserved on the row by the
+   * ON CONFLICT DO UPDATE SET in {@link ExtensionCatalogStore.upsert}
+   * (the column is intentionally not in the SET list) but no production
+   * code reads or writes it. W1b drops the column entirely via the
+   * SQLite recreate-table pattern. Until then, mapRow continues to
+   * surface the value so legacy tests that introspect it can compile.
    */
   validation_failed?: boolean;
+  /**
+   * RowState tag (issue swamp-club#211, W1). One of `'Indexed'`,
+   * `'Bundled'`, `'BundleBuildFailed'`, `'ValidationFailed'`,
+   * `'EntryPointUnreadable'`, `'OrphanedBundleOnly'`, `'Tombstoned'`.
+   * Optional on upsert: callers that omit it land at the column DEFAULT
+   * `'Indexed'` on INSERT and preserve the prior value on UPDATE
+   * (per-extension-aggregate-v3 schema). markCatalogValidationFailed is
+   * the only writer that sets this to `'ValidationFailed'`; loader
+   * populate paths leave it implicit so newly-bundled rows settle as
+   * `'Indexed'`.
+   *
+   * Reader contract: every row registration site filters on this value
+   * (`if (entry.state === 'ValidationFailed') continue;`). The
+   * `validation_failed` column above is no longer a reader signal —
+   * during the W1a → W1b release window it's a vestigial 0 for every
+   * row.
+   */
+  state?: string;
 }
 
 /**
@@ -84,9 +117,11 @@ export interface ExtensionTypeRow {
  */
 export class ExtensionCatalogStore {
   private readonly db: DatabaseSync;
+  private readonly dbPath: string;
 
   constructor(dbPath: string) {
     ensureDirSync(dirname(dbPath));
+    this.dbPath = dbPath;
     this.db = new DatabaseSync(dbPath);
     this.db.exec("PRAGMA busy_timeout=5000");
     this.initializeWithRetry();
@@ -138,7 +173,10 @@ export class ExtensionCatalogStore {
         extends_type       TEXT NOT NULL DEFAULT '',
         source_mtime       TEXT NOT NULL DEFAULT '',
         source_fingerprint TEXT NOT NULL DEFAULT '',
-        validation_failed  INTEGER NOT NULL DEFAULT 0
+        validation_failed  INTEGER NOT NULL DEFAULT 0,
+        state              TEXT NOT NULL DEFAULT 'Indexed',
+        extension_name     TEXT NOT NULL DEFAULT '',
+        extension_version  TEXT NOT NULL DEFAULT ''
       );
 
       CREATE INDEX IF NOT EXISTS idx_bundle_types_kind
@@ -156,13 +194,47 @@ export class ExtensionCatalogStore {
   }
 
   /**
-   * Adds columns introduced after the initial schema to existing DBs.
-   * Probes via PRAGMA table_info before issuing ALTER TABLE so the
-   * migration runs on SQLite versions without ADD COLUMN IF NOT EXISTS
-   * support, and is idempotent across process restarts. Called from
-   * initializeWithRetry so it inherits the lock-retry + backoff logic.
+   * Adds columns introduced after the initial schema to existing DBs and
+   * runs the data-migration backfill for the per-extension-aggregate-v3
+   * layout (issue swamp-club#211, W1).
+   *
+   * Schema changes (ADD COLUMN) are idempotent via pragma_table_info
+   * probes, applied outside any transaction since SQLite ALTER TABLE has
+   * its own atomicity. The data-migration phase (canonicalize source_path,
+   * backfill state from validation_failed, backfill extension_name via
+   * the path heuristic, drop unmatched rows, post-condition verify)
+   * runs inside ONE transaction with explicit ROLLBACK on any failure;
+   * a marker key in bundle_meta records first-success so subsequent
+   * process restarts skip the per-row UPDATEs.
+   *
+   * On post-condition failure (heuristic gap that the unit tests didn't
+   * catch — typically a legacy on-disk path layout we don't recognize)
+   * the data-migration transaction rolls back, then a separate cold-
+   * start rebuild transaction drops every bundle_types row and clears
+   * the bundle_meta `populated:*` keys so the next loader pass
+   * reconstructs from disk. The loaders are the source of truth for
+   * everything except identity columns; rebuild is non-destructive in
+   * the meaningful sense (the disk state is preserved). Running this
+   * function inherits the lock-retry + backoff logic from
+   * initializeWithRetry.
    */
   private migrateSchema(): void {
+    this.addNewColumnsIfMissing();
+    if (this.isDataMigrationApplied()) {
+      return;
+    }
+    this.runDataMigrationTransaction();
+  }
+
+  /**
+   * Phase 1: idempotent ADD COLUMN via pragma_table_info probes. Includes
+   * the columns added by previous migrations (source_fingerprint from #125,
+   * validation_failed from #1286) plus the per-extension-aggregate-v3
+   * columns (state, extension_name, extension_version). Order matches the
+   * order columns landed historically so probes against existing DBs
+   * produce stable results across migration generations.
+   */
+  private addNewColumnsIfMissing(): void {
     const probe = this.db.prepare(
       "SELECT COUNT(*) AS cnt FROM pragma_table_info('bundle_types') WHERE name = ?",
     );
@@ -180,19 +252,247 @@ export class ExtensionCatalogStore {
         "ALTER TABLE bundle_types ADD COLUMN validation_failed INTEGER NOT NULL DEFAULT 0",
       );
     }
+    if (!hasColumn("state")) {
+      this.db.exec(
+        "ALTER TABLE bundle_types ADD COLUMN state TEXT NOT NULL DEFAULT 'Indexed'",
+      );
+    }
+    if (!hasColumn("extension_name")) {
+      this.db.exec(
+        "ALTER TABLE bundle_types ADD COLUMN extension_name TEXT NOT NULL DEFAULT ''",
+      );
+    }
+    if (!hasColumn("extension_version")) {
+      this.db.exec(
+        "ALTER TABLE bundle_types ADD COLUMN extension_version TEXT NOT NULL DEFAULT ''",
+      );
+    }
   }
 
   /**
-   * Upserts a bundle type entry. Replaces any existing row with
-   * the same source path (primary key).
+   * Returns true if {@link runDataMigrationTransaction} has already
+   * succeeded (or recovered via cold-start rebuild) on this catalog.
+   */
+  private isDataMigrationApplied(): boolean {
+    const stmt = this.db.prepare(
+      "SELECT value FROM bundle_meta WHERE key = ?",
+    );
+    const row = stmt.get(PER_EXTENSION_AGGREGATE_V3_MIGRATION_KEY) as
+      | { value: string }
+      | undefined;
+    return row?.value === "true";
+  }
+
+  private markDataMigrationApplied(): void {
+    const stmt = this.db.prepare(
+      "INSERT OR REPLACE INTO bundle_meta (key, value) VALUES (?, 'true')",
+    );
+    stmt.run(PER_EXTENSION_AGGREGATE_V3_MIGRATION_KEY);
+  }
+
+  /**
+   * Phase 2: data-migration transaction. Inside one BEGIN/COMMIT:
+   * canonicalize source_path, backfill state from validation_failed,
+   * backfill extension_name via deriveExtensionIdentity (also writing
+   * extension_version for local rows; pulled rows leave version empty
+   * for W1b's lockfile-backed fallback to populate at read time), drop
+   * unmatched rows, verify the post-condition (extension_name non-empty
+   * for every remaining row).
+   *
+   * On any throw inside the transaction we ROLLBACK and recover via
+   * a separate cold-start rebuild — drop every row, clear
+   * `populated:*` keys, mark the migration as applied so subsequent
+   * process restarts don't loop. The rebuild path is the only line
+   * of defense against a bad backfill heuristic; we deliberately do
+   * not propagate the throw because the loaders will repopulate the
+   * catalog from disk on the next access.
+   */
+  private runDataMigrationTransaction(): void {
+    this.db.exec("BEGIN");
+    try {
+      this.canonicalizeAllSourcePaths();
+      this.db.exec(
+        "UPDATE bundle_types SET state = 'ValidationFailed' WHERE validation_failed = 1",
+      );
+      this.backfillExtensionIdentity();
+      this.db.exec(
+        "DELETE FROM bundle_types WHERE extension_name = ''",
+      );
+      this.verifyPostMigrationInvariant();
+      this.markDataMigrationApplied();
+      this.db.exec("COMMIT");
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      logger
+        .warn`Catalog migration to per-extension-aggregate-v3 failed (${error}); falling back to cold-start rebuild`;
+      this.runColdStartRebuild();
+    }
+  }
+
+  /**
+   * TS-driven per-row UPDATE. SQLite has no canonicalizePath function;
+   * we iterate, compute canonical form in TypeScript, and UPDATE one
+   * row at a time. Inside the data-migration transaction so the writes
+   * roll back together on any failure. Skips rows whose source_path is
+   * already canonical (the common case on POSIX where canonicalizePath
+   * is the identity).
+   *
+   * If two rows canonicalize to the same string (only possible with
+   * mixed-case access on Windows), the second UPDATE hits a UNIQUE
+   * constraint failure on source_path. We DELETE the duplicate and log
+   * a structured warning rather than aborting the migration.
+   */
+  private canonicalizeAllSourcePaths(): void {
+    const rows = this.db
+      .prepare("SELECT rowid AS rid, source_path FROM bundle_types")
+      .all() as { rid: number; source_path: string }[];
+    const updateStmt = this.db.prepare(
+      "UPDATE bundle_types SET source_path = ? WHERE rowid = ?",
+    );
+    const deleteStmt = this.db.prepare(
+      "DELETE FROM bundle_types WHERE rowid = ?",
+    );
+    for (const row of rows) {
+      const canonical = canonicalizePath(row.source_path);
+      if (canonical === row.source_path) continue;
+      try {
+        updateStmt.run(canonical, row.rid);
+      } catch (error) {
+        const isUniqueViolation = error instanceof Error &&
+          /UNIQUE constraint failed/i.test(error.message);
+        if (!isUniqueViolation) throw error;
+        logger
+          .warn`Migration: dropping duplicate row at ${row.source_path} (canonical form already exists)`;
+        deleteStmt.run(row.rid);
+      }
+    }
+  }
+
+  /**
+   * TS-driven per-row UPDATE that calls deriveExtensionIdentity on each
+   * row's canonical source_path. Backfills extension_name for both
+   * pulled and local rows; backfills extension_version only for local
+   * rows (pulled rows leave extension_version empty for W1b's
+   * lockfile-backed fallback to populate at read time — see Option A
+   * note in plan v6 step 2 sub-step 6 and the helper's docstring).
+   * Rows where the helper returns null (unrecognized path layout) keep
+   * their column DEFAULTs (extension_name='') and are dropped by the
+   * subsequent DELETE in {@link runDataMigrationTransaction}.
+   *
+   * Only updates rows whose extension_name is currently empty — once a
+   * row has an identity, repeat migration runs are a no-op for that
+   * row.
+   */
+  private backfillExtensionIdentity(): void {
+    const repoRoot = inferRepoRootFromDbPath(this.dbPath);
+    const rows = this.db
+      .prepare(
+        "SELECT rowid AS rid, source_path FROM bundle_types WHERE extension_name = ''",
+      )
+      .all() as { rid: number; source_path: string }[];
+    const updateStmt = this.db.prepare(
+      "UPDATE bundle_types SET extension_name = ?, extension_version = ? WHERE rowid = ?",
+    );
+    for (const row of rows) {
+      const identity = deriveExtensionIdentity(row.source_path, repoRoot);
+      if (identity === null) continue;
+      updateStmt.run(identity.name, identity.version, row.rid);
+    }
+  }
+
+  /**
+   * Post-condition for the data-migration transaction: every row must
+   * have a non-empty extension_name. extension_version is intentionally
+   * NOT checked because pulled rows leave it empty for W1b's lockfile
+   * fallback (see plan v6 step 2 sub-step 8 — the architect-pinned
+   * post-condition was narrowed when we discovered the issue body's
+   * "encodes name and version in path" assumption was incorrect).
+   *
+   * If verification fails the throw bubbles up to
+   * {@link runDataMigrationTransaction}'s catch, which runs ROLLBACK
+   * and falls back to cold-start rebuild.
+   */
+  private verifyPostMigrationInvariant(): void {
+    const stmt = this.db.prepare(
+      "SELECT COUNT(*) AS cnt FROM bundle_types WHERE extension_name = ''",
+    );
+    const row = stmt.get() as { cnt: number };
+    if (row.cnt > 0) {
+      throw new Error(
+        `Post-migration invariant violated: ${row.cnt} row(s) with empty extension_name remain`,
+      );
+    }
+  }
+
+  /**
+   * Recovery path when the data-migration transaction rolls back. Drops
+   * every bundle_types row and clears the bundle_meta `populated:*`
+   * flags so the next loader pass reconstructs the catalog from disk.
+   * Marks the migration as applied even though rows are gone — the
+   * marker says "schema is at v3 and we've recovered," not "all rows
+   * have been backfilled." Subsequent restarts skip the data-migration
+   * phase; the loaders' populate paths fill the empty catalog.
+   *
+   * Wrapped in its own transaction so rebuild itself is atomic. If
+   * this fails too the catalog is left in whatever state ROLLBACK
+   * produced; downstream code re-enters migrateSchema on the next
+   * construction, which will retry the whole sequence.
+   */
+  private runColdStartRebuild(): void {
+    this.db.exec("BEGIN");
+    try {
+      this.db.exec("DELETE FROM bundle_types");
+      this.db.exec("DELETE FROM bundle_meta WHERE key LIKE 'populated:%'");
+      this.markDataMigrationApplied();
+      this.db.exec("COMMIT");
+      logger
+        .warn`Catalog cold-start rebuild complete; loaders will repopulate from disk on next access`;
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      logger
+        .error`Catalog cold-start rebuild failed (${error}); next migrateSchema run will retry`;
+    }
+  }
+
+  /**
+   * Upserts a bundle type entry. INSERT path writes every payload
+   * column plus the W1a `state` column; UPDATE path (when a row with
+   * the same source_path already exists) writes the legacy columns +
+   * `state` but DELIBERATELY leaves `extension_name`, `extension_version`,
+   * and the vestigial `validation_failed` untouched.
+   *
+   * The intentional-not-in-SET list resolves ADV-V3-1: under the previous
+   * `INSERT OR REPLACE` pattern, omitted columns reset to DEFAULT on
+   * every UPDATE, which silently undid the migration's
+   * extension_name/extension_version backfill the first time a model-
+   * loader rescan upserted a row. ON CONFLICT DO UPDATE SET preserves
+   * the unwritten columns.
+   *
+   * `state` IS in the SET list because the loader is the source of
+   * truth for state — it transitions a row from `'ValidationFailed'`
+   * back to `'Indexed'` when validation later succeeds, and from
+   * `'Indexed'` to `'ValidationFailed'` via markCatalogValidationFailed.
+   * Callers that don't pass `row.state` get the column DEFAULT
+   * `'Indexed'` on INSERT and `'Indexed'` on UPDATE (since the bind
+   * defaults to `'Indexed'`).
    */
   upsert(row: ExtensionTypeRow): void {
     const stmt = this.db.prepare(`
-      INSERT OR REPLACE INTO bundle_types (
+      INSERT INTO bundle_types (
         source_path, type_normalized, kind, bundle_path,
         version, description, extends_type, source_mtime,
-        source_fingerprint, validation_failed
+        source_fingerprint, state
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(source_path) DO UPDATE SET
+        type_normalized    = excluded.type_normalized,
+        kind               = excluded.kind,
+        bundle_path        = excluded.bundle_path,
+        version            = excluded.version,
+        description        = excluded.description,
+        extends_type       = excluded.extends_type,
+        source_mtime       = excluded.source_mtime,
+        source_fingerprint = excluded.source_fingerprint,
+        state              = excluded.state
     `);
     stmt.run(
       row.source_path,
@@ -204,7 +504,7 @@ export class ExtensionCatalogStore {
       row.extends_type,
       row.source_mtime,
       row.source_fingerprint ?? "",
-      row.validation_failed ? 1 : 0,
+      row.state ?? "Indexed",
     );
   }
 
@@ -233,16 +533,20 @@ export class ExtensionCatalogStore {
 
   /**
    * Coerces a raw SQLite row into a typed ExtensionTypeRow. Maps the
-   * INTEGER 0/1 `validation_failed` column to a boolean — SQLite has no
-   * native boolean type, so the column is stored as INTEGER but consumers
-   * expect a boolean.
+   * INTEGER 0/1 `validation_failed` column to a boolean (SQLite has no
+   * native boolean type) and surfaces the W1a `state` column as a
+   * string with `'Indexed'` as defensive default.
    *
-   * findByKind and findByType deliberately do NOT filter on
-   * validation_failed: findStaleFiles needs to see broken rows so the
+   * findByKind and findByType deliberately do NOT filter on `state` or
+   * `validation_failed`: findStaleFiles needs to see broken rows so the
    * fingerprint match terminates the rebundle loop (swamp-club#209).
-   * Registration call sites filter on the coerced boolean instead.
+   * Registration call sites filter on `state === 'ValidationFailed'`
+   * instead. The legacy `validation_failed` boolean is preserved on
+   * the row through the W1a → W1b release window for backwards
+   * compatibility with tests; W1b drops the column entirely.
    */
   private mapRow(raw: Record<string, unknown>): ExtensionTypeRow {
+    const stateRaw = raw.state;
     return {
       source_path: raw.source_path as string,
       type_normalized: raw.type_normalized as string,
@@ -254,6 +558,9 @@ export class ExtensionCatalogStore {
       source_mtime: raw.source_mtime as string,
       source_fingerprint: raw.source_fingerprint as string,
       validation_failed: raw.validation_failed === 1,
+      state: typeof stateRaw === "string" && stateRaw.length > 0
+        ? stateRaw
+        : "Indexed",
     };
   }
 
@@ -507,4 +814,20 @@ export function forceCatalogRescan(repoDir: string): void {
   } catch {
     // Best-effort — the loader will bootstrap a fresh catalog if this fails.
   }
+}
+
+/**
+ * Recovers the repository root from the catalog's database path.
+ * The catalog opens at `<repoRoot>/.swamp/_extension_catalog.db`, so
+ * `dirname(dirname(dbPath))` gives the repository root. Used by the
+ * data-migration backfill to resolve `<repoRoot>/extensions/<kind>/`
+ * and `<repoRoot>/.swamp/pulled-extensions/` prefixes against catalog
+ * row source_paths without needing a separate constructor parameter.
+ *
+ * The catalog's dbPath is a hard-coded layout assumption (see
+ * `swampPath(repoDir, "_extension_catalog.db")`); if that layout ever
+ * changes, this helper has to change with it.
+ */
+function inferRepoRootFromDbPath(dbPath: string): string {
+  return dirname(dirname(dbPath));
 }

--- a/src/infrastructure/persistence/extension_catalog_store_test.ts
+++ b/src/infrastructure/persistence/extension_catalog_store_test.ts
@@ -26,9 +26,20 @@ import {
   type ExtensionTypeRow,
 } from "./extension_catalog_store.ts";
 
+/**
+ * Returns a dbPath at `<tmpRepo>/.swamp/_extension_catalog.db` so the
+ * catalog's `inferRepoRootFromDbPath()` (which expects a real swamp
+ * layout) produces `<tmpRepo>` — letting tests seed rows whose
+ * source_paths actually match the W1a migration's path heuristic
+ * (`<repoRoot>/extensions/<kind>/...` or
+ * `<repoRoot>/.swamp/pulled-extensions/<name>/<kind>/...`).
+ */
 function makeTempDbPath(): string {
-  const dir = Deno.makeTempDirSync({ prefix: "swamp-ext-catalog-test-" });
-  return join(dir, "_extension_catalog.db");
+  const repoRoot = Deno.makeTempDirSync({
+    prefix: "swamp-ext-catalog-test-",
+  });
+  ensureDirSync(join(repoRoot, ".swamp"));
+  return join(repoRoot, ".swamp", "_extension_catalog.db");
 }
 
 function makeRow(overrides: Partial<ExtensionTypeRow> = {}): ExtensionTypeRow {
@@ -432,6 +443,21 @@ Deno.test("ExtensionCatalogStore: migrates pre-#125 schema by adding source_fing
   ensureDirSync(dirname(dbPath));
 
   // Seed a DB with the pre-#125 schema — no source_fingerprint column.
+  // Source path lives under <repoRoot>/.swamp/pulled-extensions/... so
+  // the W1a data-migration backfills extension_name and the row
+  // survives the post-condition verify. Without a layout-matching path
+  // the row would be dropped (correct W1a behaviour, but defeats this
+  // test's purpose of checking source_fingerprint is added).
+  const repoRoot = dirname(dirname(dbPath));
+  const sourcePath = join(
+    repoRoot,
+    ".swamp",
+    "pulled-extensions",
+    "@legacy",
+    "pre-125",
+    "models",
+    "row.ts",
+  );
   const seed = new DatabaseSync(dbPath);
   seed.exec(`
     CREATE TABLE bundle_types (
@@ -445,14 +471,22 @@ Deno.test("ExtensionCatalogStore: migrates pre-#125 schema by adding source_fing
       source_mtime    TEXT NOT NULL DEFAULT ''
     );
     CREATE TABLE bundle_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
-    INSERT INTO bundle_types (
+  `);
+  seed.prepare(
+    `INSERT INTO bundle_types (
       source_path, type_normalized, kind, bundle_path, version,
       description, extends_type, source_mtime
-    ) VALUES (
-      '/old/row.ts', '@legacy/row', 'model', '/old/bundle.js',
-      '2026.01.01.1', '', '', '2026-01-01T00:00:00.000Z'
-    );
-  `);
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    sourcePath,
+    "@legacy/row",
+    "model",
+    "/old/bundle.js",
+    "2026.01.01.1",
+    "",
+    "",
+    "2026-01-01T00:00:00.000Z",
+  );
   seed.close();
 
   // Opening through ExtensionCatalogStore must run the migration.
@@ -490,6 +524,20 @@ for (
       const dbPath = makeTempDbPath();
       ensureDirSync(dirname(dbPath));
 
+      // Source path under <repoRoot>/.swamp/pulled-extensions/... so the
+      // W1a backfill produces a non-empty extension_name and the row
+      // survives.
+      const repoRoot = dirname(dirname(dbPath));
+      const sourcePath = join(
+        repoRoot,
+        ".swamp",
+        "pulled-extensions",
+        "@legacy",
+        `${kind}-row`,
+        `${kind}s`,
+        `${kind}.ts`,
+      );
+
       // Seed a DB with the pre-#125 schema — no source_fingerprint
       // column — carrying a row of the target kind.
       const seed = new DatabaseSync(dbPath);
@@ -505,14 +553,22 @@ for (
           source_mtime    TEXT NOT NULL DEFAULT ''
         );
         CREATE TABLE bundle_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
-        INSERT INTO bundle_types (
+      `);
+      seed.prepare(
+        `INSERT INTO bundle_types (
           source_path, type_normalized, kind, bundle_path, version,
           description, extends_type, source_mtime
-        ) VALUES (
-          '/old/${kind}.ts', '@legacy/${kind}-row', '${kind}',
-          '/old/${kind}.js', '', '', '', '2026-01-01T00:00:00.000Z'
-        );
-      `);
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        sourcePath,
+        `@legacy/${kind}-row`,
+        kind,
+        `/old/${kind}.js`,
+        "",
+        "",
+        "",
+        "2026-01-01T00:00:00.000Z",
+      );
       seed.close();
 
       // Opening through ExtensionCatalogStore must run the migration.
@@ -536,63 +592,63 @@ for (
   );
 }
 
-// --- validation_failed column tests (swamp-club#209) ---
+// --- RowState column tests (swamp-club#211, W1a) ---
 //
-// The column tracks the third freshness state introduced by
-// markCatalogValidationFailed: bundle+import succeeded, schema
-// validation failed. Storing the new fingerprint terminates the
-// rebundle loop on a stable broken source; registration paths skip
-// validation_failed=true rows.
+// The state column subsumes the legacy validation_failed boolean and
+// will eventually carry the full 7-tag RowState discriminant from W1b.
+// W1a writes 'Indexed' (default for healthy rows) and 'ValidationFailed'
+// (set by markCatalogValidationFailed). Registration paths filter on
+// state === 'ValidationFailed'.
 
-Deno.test("ExtensionCatalogStore: upsert and findByType round-trip validation_failed", () => {
+Deno.test("ExtensionCatalogStore: upsert and findByType round-trip state", () => {
   const dbPath = makeTempDbPath();
   const store = new ExtensionCatalogStore(dbPath);
 
-  store.upsert(makeRow({ validation_failed: true }));
+  store.upsert(makeRow({ state: "ValidationFailed" }));
   const found = store.findByType("@myorg/echo", "model");
-  assertEquals(found?.validation_failed, true);
+  assertEquals(found?.state, "ValidationFailed");
   store.close();
 });
 
-Deno.test("ExtensionCatalogStore: validation_failed defaults to false when omitted from upsert", () => {
+Deno.test("ExtensionCatalogStore: state defaults to 'Indexed' when omitted from upsert", () => {
   const dbPath = makeTempDbPath();
   const store = new ExtensionCatalogStore(dbPath);
 
   store.upsert(makeRow());
   const found = store.findByType("@myorg/echo", "model");
-  assertEquals(found?.validation_failed, false);
+  assertEquals(found?.state, "Indexed");
   store.close();
 });
 
-Deno.test("ExtensionCatalogStore: findByKind returns rows regardless of validation_failed", () => {
+Deno.test("ExtensionCatalogStore: findByKind returns rows regardless of state", () => {
   // ADV-1 invariant guard: findStaleFiles relies on findByKind seeing
-  // broken rows so a stable broken fingerprint terminates the rebundle
-  // loop. Filtering must NOT happen at the store layer — only at
-  // registration call sites.
+  // ValidationFailed rows so the stable broken fingerprint terminates
+  // the rebundle loop (swamp-club#209). Filtering must NOT happen at
+  // the store layer — only at registration call sites.
   const dbPath = makeTempDbPath();
   const store = new ExtensionCatalogStore(dbPath);
 
+  const repoRoot = dirname(dirname(dbPath));
+  const healthyPath = join(repoRoot, "extensions", "models", "healthy.ts");
+  const brokenPath = join(repoRoot, "extensions", "models", "broken.ts");
+
   store.upsert(makeRow({
     type_normalized: "@myorg/healthy",
-    source_path: "/repo/extensions/models/healthy.ts",
-    validation_failed: false,
+    source_path: healthyPath,
+    state: "Indexed",
   }));
   store.upsert(makeRow({
     type_normalized: "",
-    source_path: "/repo/extensions/models/broken.ts",
-    validation_failed: true,
+    source_path: brokenPath,
+    state: "ValidationFailed",
   }));
 
   const rows = store.findByKind("model");
   assertEquals(rows.length, 2);
-  const failed = rows.find((r) =>
-    r.source_path === "/repo/extensions/models/broken.ts"
-  );
-  const healthy = rows.find((r) =>
-    r.source_path === "/repo/extensions/models/healthy.ts"
-  );
-  assertEquals(failed?.validation_failed, true);
-  assertEquals(healthy?.validation_failed, false);
+  const failed = rows.find((r) => r.source_path === brokenPath);
+  const healthy = rows.find((r) => r.source_path === healthyPath);
+  assertEquals(failed?.state, "ValidationFailed");
+  assertEquals(healthy?.state, "Indexed");
   store.close();
 });
 
@@ -600,8 +656,22 @@ Deno.test("ExtensionCatalogStore: migrates pre-#209 schema by adding validation_
   const dbPath = makeTempDbPath();
   ensureDirSync(dirname(dbPath));
 
-  // Seed a DB with the pre-#209 schema — has source_fingerprint but no
-  // validation_failed column.
+  // Source path under <repoRoot>/.swamp/pulled-extensions/... so the
+  // W1a data-migration backfill produces a non-empty extension_name
+  // and the row survives. Pre-#209 schema has source_fingerprint but
+  // no validation_failed column; the migration adds both validation_failed
+  // (vestigial after W1a) and the W1a state/extension_name/extension_version
+  // columns.
+  const repoRoot = dirname(dirname(dbPath));
+  const sourcePath = join(
+    repoRoot,
+    ".swamp",
+    "pulled-extensions",
+    "@legacy",
+    "pre-209",
+    "models",
+    "row.ts",
+  );
   const seed = new DatabaseSync(dbPath);
   seed.exec(`
     CREATE TABLE bundle_types (
@@ -616,27 +686,565 @@ Deno.test("ExtensionCatalogStore: migrates pre-#209 schema by adding validation_
       source_fingerprint TEXT NOT NULL DEFAULT ''
     );
     CREATE TABLE bundle_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
-    INSERT INTO bundle_types (
+  `);
+  seed.prepare(
+    `INSERT INTO bundle_types (
       source_path, type_normalized, kind, bundle_path, version,
       description, extends_type, source_mtime, source_fingerprint
-    ) VALUES (
-      '/old/row.ts', '@legacy/row', 'model', '/old/bundle.js',
-      '2026.01.01.1', '', '', '2026-01-01T00:00:00.000Z', 'deadbeef'
-    );
-  `);
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    sourcePath,
+    "@legacy/row",
+    "model",
+    "/old/bundle.js",
+    "2026.01.01.1",
+    "",
+    "",
+    "2026-01-01T00:00:00.000Z",
+    "deadbeef",
+  );
   seed.close();
 
   // Opening through ExtensionCatalogStore must run the migration.
   const store = new ExtensionCatalogStore(dbPath);
 
   const legacy = store.findByType("@legacy/row", "model");
+  // Pre-#209 row didn't have validation_failed; W1a's ALTER TABLE adds
+  // the column with DEFAULT 0, surfaced as false on the row.
   assertEquals(legacy?.validation_failed, false);
   assertEquals(legacy?.source_fingerprint, "deadbeef");
+  // W1a's state column defaults to 'Indexed' for rows without
+  // validation_failed=1.
+  assertEquals(legacy?.state, "Indexed");
 
   // Re-opening is a no-op — migration is idempotent.
   store.close();
   const store2 = new ExtensionCatalogStore(dbPath);
   const again = store2.findByType("@legacy/row", "model");
   assertEquals(again?.validation_failed, false);
+  assertEquals(again?.state, "Indexed");
   store2.close();
+});
+
+// --- per-extension-aggregate-v3 migration tests (swamp-club#211, W1a) ---
+//
+// Cover the W1a data-migration: state backfill from validation_failed,
+// extension_name backfill via deriveExtensionIdentity, post-condition
+// verify with cold-start rebuild fallback, ON CONFLICT preservation
+// canary (the load-bearing test the architect specified for the v6
+// post-bump rescan story).
+
+Deno.test("ExtensionCatalogStore: migrates post-#1286 schema by backfilling state from validation_failed", () => {
+  const dbPath = makeTempDbPath();
+  ensureDirSync(dirname(dbPath));
+
+  // Source paths under <repoRoot>/.swamp/pulled-extensions/... so the
+  // W1a backfill produces non-empty extension_name and the rows survive.
+  const repoRoot = dirname(dirname(dbPath));
+  const healthyPath = join(
+    repoRoot,
+    ".swamp",
+    "pulled-extensions",
+    "@legacy",
+    "post-1286",
+    "models",
+    "healthy.ts",
+  );
+  const brokenPath = join(
+    repoRoot,
+    ".swamp",
+    "pulled-extensions",
+    "@legacy",
+    "post-1286",
+    "models",
+    "broken.ts",
+  );
+
+  // Seed a DB with the post-#1286 schema (has source_fingerprint AND
+  // validation_failed) carrying one healthy row + one row marked broken
+  // by the legacy markCatalogValidationFailed flow.
+  const seed = new DatabaseSync(dbPath);
+  seed.exec(`
+    CREATE TABLE bundle_types (
+      source_path        TEXT NOT NULL PRIMARY KEY,
+      type_normalized    TEXT NOT NULL,
+      kind               TEXT NOT NULL DEFAULT 'model',
+      bundle_path        TEXT NOT NULL,
+      version            TEXT NOT NULL DEFAULT '',
+      description        TEXT NOT NULL DEFAULT '',
+      extends_type       TEXT NOT NULL DEFAULT '',
+      source_mtime       TEXT NOT NULL DEFAULT '',
+      source_fingerprint TEXT NOT NULL DEFAULT '',
+      validation_failed  INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE bundle_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+  `);
+  const insert = seed.prepare(
+    `INSERT INTO bundle_types (
+      source_path, type_normalized, kind, bundle_path, version,
+      description, extends_type, source_mtime, source_fingerprint,
+      validation_failed
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+  insert.run(
+    healthyPath,
+    "@legacy/healthy",
+    "model",
+    "/old/healthy.js",
+    "2026.01.01.1",
+    "",
+    "",
+    "2026-01-01T00:00:00.000Z",
+    "feedface",
+    0,
+  );
+  insert.run(
+    brokenPath,
+    "",
+    "model",
+    "/old/broken.js",
+    "",
+    "",
+    "",
+    "2026-01-01T00:00:00.000Z",
+    "cafebabe",
+    1,
+  );
+  seed.close();
+
+  const store = new ExtensionCatalogStore(dbPath);
+  const rows = store.findByKind("model");
+  assertEquals(rows.length, 2);
+  const healthy = rows.find((r) => r.source_path === healthyPath);
+  const broken = rows.find((r) => r.source_path === brokenPath);
+  assertEquals(healthy?.state, "Indexed");
+  assertEquals(broken?.state, "ValidationFailed");
+  store.close();
+});
+
+Deno.test("ExtensionCatalogStore: W1a migration backfills extension_name for pulled rows (extension_version intentionally empty per Option A)", () => {
+  const dbPath = makeTempDbPath();
+  ensureDirSync(dirname(dbPath));
+  const repoRoot = dirname(dirname(dbPath));
+  const sourcePath = join(
+    repoRoot,
+    ".swamp",
+    "pulled-extensions",
+    "@scope",
+    "foo",
+    "models",
+    "x.ts",
+  );
+
+  const seed = new DatabaseSync(dbPath);
+  seed.exec(`
+    CREATE TABLE bundle_types (
+      source_path        TEXT NOT NULL PRIMARY KEY,
+      type_normalized    TEXT NOT NULL,
+      kind               TEXT NOT NULL DEFAULT 'model',
+      bundle_path        TEXT NOT NULL,
+      version            TEXT NOT NULL DEFAULT '',
+      description        TEXT NOT NULL DEFAULT '',
+      extends_type       TEXT NOT NULL DEFAULT '',
+      source_mtime       TEXT NOT NULL DEFAULT '',
+      source_fingerprint TEXT NOT NULL DEFAULT '',
+      validation_failed  INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE bundle_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+  `);
+  seed.prepare(
+    `INSERT INTO bundle_types (
+      source_path, type_normalized, kind, bundle_path
+    ) VALUES (?, ?, ?, ?)`,
+  ).run(sourcePath, "@scope/foo/x", "model", "/bundle/x.js");
+  seed.close();
+
+  const store = new ExtensionCatalogStore(dbPath);
+  // Read identity columns directly via SQL — the catalog deliberately
+  // does not surface extension_name/extension_version on
+  // ExtensionTypeRow per W1a Option A; W1b's ExtensionRepository owns
+  // the read path.
+  const probe = (store as unknown as {
+    db: DatabaseSync;
+  }).db.prepare(
+    "SELECT extension_name, extension_version FROM bundle_types WHERE source_path = ?",
+  ).get(sourcePath) as { extension_name: string; extension_version: string };
+  assertEquals(probe.extension_name, "@scope/foo");
+  assertEquals(probe.extension_version, "");
+  store.close();
+});
+
+Deno.test("ExtensionCatalogStore: W1a migration backfills @local/<repo> for rows under extensions/<kind>/ (version 0.0.0)", () => {
+  const dbPath = makeTempDbPath();
+  ensureDirSync(dirname(dbPath));
+  const repoRoot = dirname(dirname(dbPath));
+  const sourcePath = join(repoRoot, "extensions", "models", "echo.ts");
+
+  const seed = new DatabaseSync(dbPath);
+  seed.exec(`
+    CREATE TABLE bundle_types (
+      source_path        TEXT NOT NULL PRIMARY KEY,
+      type_normalized    TEXT NOT NULL,
+      kind               TEXT NOT NULL DEFAULT 'model',
+      bundle_path        TEXT NOT NULL,
+      version            TEXT NOT NULL DEFAULT '',
+      description        TEXT NOT NULL DEFAULT '',
+      extends_type       TEXT NOT NULL DEFAULT '',
+      source_mtime       TEXT NOT NULL DEFAULT '',
+      source_fingerprint TEXT NOT NULL DEFAULT '',
+      validation_failed  INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE bundle_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+  `);
+  seed.prepare(
+    `INSERT INTO bundle_types (
+      source_path, type_normalized, kind, bundle_path
+    ) VALUES (?, ?, ?, ?)`,
+  ).run(sourcePath, "@org/echo", "model", "/bundle/echo.js");
+  seed.close();
+
+  const store = new ExtensionCatalogStore(dbPath);
+  const probe = (store as unknown as {
+    db: DatabaseSync;
+  }).db.prepare(
+    "SELECT extension_name, extension_version FROM bundle_types WHERE source_path = ?",
+  ).get(sourcePath) as { extension_name: string; extension_version: string };
+  // basename(repoRoot) is the temp dir's basename — we only assert the
+  // @local/ prefix and the literal "0.0.0" version since the dir name
+  // varies across runs.
+  assertEquals(probe.extension_name.startsWith("@local/"), true);
+  assertEquals(probe.extension_version, "0.0.0");
+  store.close();
+});
+
+Deno.test("ExtensionCatalogStore: W1a migration drops rows whose path doesn't match the heuristic (and post-condition verify rebuild path)", () => {
+  const dbPath = makeTempDbPath();
+  ensureDirSync(dirname(dbPath));
+
+  const seed = new DatabaseSync(dbPath);
+  seed.exec(`
+    CREATE TABLE bundle_types (
+      source_path        TEXT NOT NULL PRIMARY KEY,
+      type_normalized    TEXT NOT NULL,
+      kind               TEXT NOT NULL DEFAULT 'model',
+      bundle_path        TEXT NOT NULL,
+      version            TEXT NOT NULL DEFAULT '',
+      description        TEXT NOT NULL DEFAULT '',
+      extends_type       TEXT NOT NULL DEFAULT '',
+      source_mtime       TEXT NOT NULL DEFAULT '',
+      source_fingerprint TEXT NOT NULL DEFAULT '',
+      validation_failed  INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE bundle_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    INSERT INTO bundle_meta (key, value) VALUES ('populated:model', 'true');
+  `);
+  // Seed with an unrecognized path layout — neither pulled nor local.
+  seed.prepare(
+    `INSERT INTO bundle_types (
+      source_path, type_normalized, kind, bundle_path
+    ) VALUES (?, ?, ?, ?)`,
+  ).run("/some/random/path/x.ts", "@unknown/x", "model", "/bundle/x.js");
+  seed.close();
+
+  const store = new ExtensionCatalogStore(dbPath);
+  // Migration's data-phase: row had unrecognized layout → backfill
+  // returns null → row left with empty extension_name → DELETE step
+  // drops it → post-condition passes (no rows with empty
+  // extension_name remain). The cold-start rebuild path (which
+  // would also clear bundle_meta `populated:*` keys) does NOT fire
+  // here because the post-condition succeeds.
+  assertEquals(store.count(), 0);
+  // populated:model survives — only the cold-start rebuild path
+  // clears it, and the post-condition succeeded.
+  assertEquals(store.isPopulated("model"), true);
+  store.close();
+});
+
+Deno.test("ExtensionCatalogStore: W1a migration backfills mixed pulled + local + unmatched rows in a single pass", () => {
+  // The whole-pipeline test: a pre-#1286 catalog containing every
+  // origin type the W1a heuristic must classify simultaneously. Pulled
+  // rows get extension_name backfilled with version='' (Option A);
+  // local rows get @local/<repo>/0.0.0; unmatched rows are dropped at
+  // the DELETE step. validation_failed=1 → state='ValidationFailed' on
+  // the broken pulled row. Verifies all branches of
+  // deriveExtensionIdentity compose correctly inside one transaction.
+  const dbPath = makeTempDbPath();
+  ensureDirSync(dirname(dbPath));
+  const repoRoot = dirname(dirname(dbPath));
+
+  const pulledHealthy = join(
+    repoRoot,
+    ".swamp",
+    "pulled-extensions",
+    "@scope",
+    "alpha",
+    "models",
+    "ok.ts",
+  );
+  const pulledBroken = join(
+    repoRoot,
+    ".swamp",
+    "pulled-extensions",
+    "@scope",
+    "alpha",
+    "models",
+    "broken.ts",
+  );
+  const pulledOtherExt = join(
+    repoRoot,
+    ".swamp",
+    "pulled-extensions",
+    "@scope",
+    "beta",
+    "vaults",
+    "secret.ts",
+  );
+  const localPath = join(repoRoot, "extensions", "models", "echo.ts");
+  const sourceMountedPath = "/external/srcdir/extensions/drivers/raw.ts";
+  const unmatchedPath = "/some/legacy/path/orphan.ts";
+
+  const seed = new DatabaseSync(dbPath);
+  seed.exec(`
+    CREATE TABLE bundle_types (
+      source_path        TEXT NOT NULL PRIMARY KEY,
+      type_normalized    TEXT NOT NULL,
+      kind               TEXT NOT NULL DEFAULT 'model',
+      bundle_path        TEXT NOT NULL,
+      version            TEXT NOT NULL DEFAULT '',
+      description        TEXT NOT NULL DEFAULT '',
+      extends_type       TEXT NOT NULL DEFAULT '',
+      source_mtime       TEXT NOT NULL DEFAULT '',
+      source_fingerprint TEXT NOT NULL DEFAULT '',
+      validation_failed  INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE bundle_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+  `);
+  const insert = seed.prepare(
+    `INSERT INTO bundle_types (
+      source_path, type_normalized, kind, bundle_path,
+      validation_failed
+    ) VALUES (?, ?, ?, ?, ?)`,
+  );
+  insert.run(pulledHealthy, "@scope/alpha/ok", "model", "/b/ok.js", 0);
+  insert.run(pulledBroken, "", "model", "/b/broken.js", 1);
+  insert.run(
+    pulledOtherExt,
+    "@scope/beta/secret",
+    "vault",
+    "/b/secret.js",
+    0,
+  );
+  insert.run(localPath, "@org/echo", "model", "/b/echo.js", 0);
+  insert.run(sourceMountedPath, "@org/raw", "driver", "/b/raw.js", 0);
+  insert.run(unmatchedPath, "@legacy/orphan", "model", "/b/orphan.js", 0);
+  seed.close();
+
+  const store = new ExtensionCatalogStore(dbPath);
+  // Read identity columns directly via SQL — ExtensionTypeRow doesn't
+  // surface extension_name/extension_version per W1a Option A.
+  const rows = (store as unknown as { db: DatabaseSync }).db.prepare(
+    `SELECT source_path, extension_name, extension_version, state
+       FROM bundle_types ORDER BY source_path`,
+  ).all() as Array<{
+    source_path: string;
+    extension_name: string;
+    extension_version: string;
+    state: string;
+  }>;
+
+  // Unmatched row was dropped at sub-step 7. Five remain.
+  assertEquals(rows.length, 5);
+  assertEquals(
+    rows.find((r) => r.source_path === unmatchedPath),
+    undefined,
+    "unmatched-path row must be dropped by the DELETE step",
+  );
+
+  const byPath = new Map(rows.map((r) => [r.source_path, r]));
+
+  // Pulled rows: extension_name parsed from path, version intentionally ''.
+  assertEquals(byPath.get(pulledHealthy)?.extension_name, "@scope/alpha");
+  assertEquals(byPath.get(pulledHealthy)?.extension_version, "");
+  assertEquals(byPath.get(pulledHealthy)?.state, "Indexed");
+
+  assertEquals(byPath.get(pulledBroken)?.extension_name, "@scope/alpha");
+  assertEquals(byPath.get(pulledBroken)?.extension_version, "");
+  // validation_failed=1 backfilled to state='ValidationFailed'.
+  assertEquals(byPath.get(pulledBroken)?.state, "ValidationFailed");
+
+  assertEquals(byPath.get(pulledOtherExt)?.extension_name, "@scope/beta");
+  assertEquals(byPath.get(pulledOtherExt)?.extension_version, "");
+  assertEquals(byPath.get(pulledOtherExt)?.state, "Indexed");
+
+  // Local row: @local/<basename(repoRoot)> at 0.0.0.
+  const expectedLocalName = `@local/${
+    repoRoot.split("/").filter((s) => s.length > 0).pop()
+  }`;
+  assertEquals(byPath.get(localPath)?.extension_name, expectedLocalName);
+  assertEquals(byPath.get(localPath)?.extension_version, "0.0.0");
+  assertEquals(byPath.get(localPath)?.state, "Indexed");
+
+  // Source-mounted row: same @local/<repoRoot> aggregate as locals
+  // (per the design doc — "@local/<repo-name> covers every Source
+  // under every extensions/<kind>/ tree" regardless of where the
+  // source dir lives).
+  assertEquals(
+    byPath.get(sourceMountedPath)?.extension_name,
+    expectedLocalName,
+  );
+  assertEquals(byPath.get(sourceMountedPath)?.extension_version, "0.0.0");
+  assertEquals(byPath.get(sourceMountedPath)?.state, "Indexed");
+
+  store.close();
+});
+
+// --- Cold-start rebuild path ---
+//
+// The recovery path that fires when the data-migration's post-condition
+// verify throws (e.g. a backfill heuristic gap that leaves rows with
+// empty extension_name AFTER sub-step 7's DELETE — a bug class the
+// current heuristic doesn't produce, but which a future migration
+// change could). The path is the only line of defense against a silent
+// backfill bug; we test the rebuild's own contract directly via the
+// private-method cast pattern already used elsewhere in this file.
+// The catch-handler in `runDataMigrationTransaction` that triggers the
+// rebuild is three trivial lines (try/catch around verify; log; call
+// runColdStartRebuild) — testing the rebuild itself + reading the
+// catch handler is sufficient.
+
+Deno.test("ExtensionCatalogStore: runColdStartRebuild empties bundle_types, clears populated:* keys, marks migration applied", () => {
+  const dbPath = makeTempDbPath();
+  const store = new ExtensionCatalogStore(dbPath);
+  const repoRoot = dirname(dirname(dbPath));
+
+  // Seed the catalog with rows + populated flags so the rebuild has
+  // something to clear. Use realistic paths so the construction-time
+  // migration accepted them; this is the post-W1a steady state.
+  const sourcePath = join(
+    repoRoot,
+    ".swamp",
+    "pulled-extensions",
+    "@scope",
+    "foo",
+    "models",
+    "x.ts",
+  );
+  store.upsert({
+    source_path: sourcePath,
+    type_normalized: "@scope/foo/x",
+    kind: "model",
+    bundle_path: "/b/x.js",
+    version: "1.0.0",
+    description: "",
+    extends_type: "",
+    source_mtime: "",
+  });
+  store.markPopulated("model");
+  store.markPopulated("vault");
+  assertEquals(store.count(), 1);
+  assertEquals(store.isPopulated("model"), true);
+  assertEquals(store.isPopulated("vault"), true);
+
+  // Drive the rebuild directly. The catch-handler in
+  // runDataMigrationTransaction wraps this in
+  //   try { ... } catch (error) { ROLLBACK; logger.warn; rebuild(); }
+  // — a trivial three-liner. Testing the rebuild's own contract is
+  // what catches a regression in the recovery semantics.
+  (store as unknown as { runColdStartRebuild: () => void })
+    .runColdStartRebuild();
+
+  // Post-rebuild invariants:
+  //   1. bundle_types is empty (DELETE FROM bundle_types).
+  //   2. populated:* keys cleared (so loaders re-discover from disk).
+  //   3. migration_applied marker set (so subsequent restarts skip
+  //      the data-migration phase — the catalog is at v3 even though
+  //      it's empty).
+  assertEquals(store.count(), 0);
+  assertEquals(store.isPopulated("model"), false);
+  assertEquals(store.isPopulated("vault"), false);
+  const markerProbe = (store as unknown as { db: DatabaseSync }).db.prepare(
+    `SELECT value FROM bundle_meta
+         WHERE key = 'migration_applied:per-extension-aggregate-v3'`,
+  ).get() as { value: string } | undefined;
+  assertEquals(markerProbe?.value, "true");
+
+  store.close();
+
+  // Re-opening must be a no-op: marker is set, data-phase is skipped,
+  // catalog stays empty. Loaders re-populate from disk on first access
+  // (out of scope for this unit test).
+  const store2 = new ExtensionCatalogStore(dbPath);
+  assertEquals(store2.count(), 0);
+  assertEquals(store2.isPopulated("model"), false);
+  store2.close();
+});
+
+// --- ON CONFLICT preservation canary (resolves ADV-V3-1) ---
+//
+// The load-bearing test the architect called out: after the W1a
+// migration backfills extension_name/extension_version, the model
+// loader's BUNDLE_LAYOUT_VERSION-bump-triggered rescan upserts every
+// row. Under the previous INSERT OR REPLACE pattern, the upsert reset
+// extension_name/extension_version to DEFAULT '' on every row,
+// silently undoing the migration on first run after deploy. The new
+// ON CONFLICT(source_path) DO UPDATE SET pattern intentionally
+// excludes the identity columns from the SET list. This test fails
+// loudly if a future change reverts to INSERT OR REPLACE or adds the
+// identity columns to the SET list.
+
+Deno.test("ExtensionCatalogStore: upsert preserves migration-backfilled extension_name/extension_version on UPDATE (ADV-V3-1 canary)", () => {
+  const dbPath = makeTempDbPath();
+  const store = new ExtensionCatalogStore(dbPath);
+
+  // Manually INSERT a row with backfilled identity, simulating the
+  // post-W1a-migration state.
+  const sourcePath = "/test/repo/extensions/models/echo.ts";
+  (store as unknown as { db: DatabaseSync }).db.prepare(
+    `INSERT INTO bundle_types (
+      source_path, type_normalized, kind, bundle_path,
+      extension_name, extension_version, state
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    sourcePath,
+    "@myorg/echo",
+    "model",
+    "/bundle/echo-v1.js",
+    "@scope/echo",
+    "1.2.3",
+    "Indexed",
+  );
+
+  // Simulate a loader rescan upserting the same source_path with new
+  // bundle_path, version, etc. (the model loader re-bundles after a
+  // BUNDLE_LAYOUT_VERSION bump and upserts every row).
+  store.upsert(makeRow({
+    source_path: sourcePath,
+    type_normalized: "@myorg/echo",
+    kind: "model",
+    bundle_path: "/bundle/echo-v2.js",
+    version: "2026.05.04.1",
+  }));
+
+  // Identity columns: UNCHANGED. This is the canary — under
+  // INSERT OR REPLACE these would have been reset to ''.
+  const probe = (store as unknown as { db: DatabaseSync }).db.prepare(
+    `SELECT extension_name, extension_version, state, bundle_path, version
+       FROM bundle_types WHERE source_path = ?`,
+  ).get(sourcePath) as {
+    extension_name: string;
+    extension_version: string;
+    state: string;
+    bundle_path: string;
+    version: string;
+  };
+  assertEquals(probe.extension_name, "@scope/echo");
+  assertEquals(probe.extension_version, "1.2.3");
+  // Legacy columns DO change on UPDATE — these are in the SET list.
+  assertEquals(probe.bundle_path, "/bundle/echo-v2.js");
+  assertEquals(probe.version, "2026.05.04.1");
+  // state is in the SET list and defaults to 'Indexed' when callers
+  // omit it (which the loader's upsert always does — only
+  // markCatalogValidationFailed sets state explicitly).
+  assertEquals(probe.state, "Indexed");
+  store.close();
 });

--- a/src/infrastructure/persistence/extension_catalog_store_test.ts
+++ b/src/infrastructure/persistence/extension_catalog_store_test.ts
@@ -21,6 +21,7 @@ import { assertEquals } from "@std/assert";
 import { DatabaseSync } from "node:sqlite";
 import { dirname, join } from "@std/path";
 import { ensureDirSync } from "@std/fs";
+import { canonicalizePath } from "./canonicalize_path.ts";
 import {
   ExtensionCatalogStore,
   type ExtensionTypeRow,
@@ -815,8 +816,16 @@ Deno.test("ExtensionCatalogStore: migrates post-#1286 schema by backfilling stat
   const store = new ExtensionCatalogStore(dbPath);
   const rows = store.findByKind("model");
   assertEquals(rows.length, 2);
-  const healthy = rows.find((r) => r.source_path === healthyPath);
-  const broken = rows.find((r) => r.source_path === brokenPath);
+  // Match against the canonical form — the W1a migration's sub-step 4
+  // canonicalized every row's source_path. On Windows the seeded
+  // healthy/brokenPath are backslash-form; the stored row is
+  // lowercase + forward-slash.
+  const healthy = rows.find((r) =>
+    r.source_path === canonicalizePath(healthyPath)
+  );
+  const broken = rows.find((r) =>
+    r.source_path === canonicalizePath(brokenPath)
+  );
   assertEquals(healthy?.state, "Indexed");
   assertEquals(broken?.state, "ValidationFailed");
   store.close();
@@ -863,12 +872,18 @@ Deno.test("ExtensionCatalogStore: W1a migration backfills extension_name for pul
   // Read identity columns directly via SQL — the catalog deliberately
   // does not surface extension_name/extension_version on
   // ExtensionTypeRow per W1a Option A; W1b's ExtensionRepository owns
-  // the read path.
+  // the read path. Look up by canonical source_path because the W1a
+  // migration's sub-step 4 canonicalized every row's path; on Windows
+  // the seeded `sourcePath` is backslash-form and won't match the
+  // stored canonical (lowercase + forward-slash) form.
   const probe = (store as unknown as {
     db: DatabaseSync;
   }).db.prepare(
     "SELECT extension_name, extension_version FROM bundle_types WHERE source_path = ?",
-  ).get(sourcePath) as { extension_name: string; extension_version: string };
+  ).get(canonicalizePath(sourcePath)) as {
+    extension_name: string;
+    extension_version: string;
+  };
   assertEquals(probe.extension_name, "@scope/foo");
   assertEquals(probe.extension_version, "");
   store.close();
@@ -908,7 +923,10 @@ Deno.test("ExtensionCatalogStore: W1a migration backfills @local/<repo> for rows
     db: DatabaseSync;
   }).db.prepare(
     "SELECT extension_name, extension_version FROM bundle_types WHERE source_path = ?",
-  ).get(sourcePath) as { extension_name: string; extension_version: string };
+  ).get(canonicalizePath(sourcePath)) as {
+    extension_name: string;
+    extension_version: string;
+  };
   // basename(repoRoot) is the temp dir's basename — we only assert the
   // @local/ prefix and the literal "0.0.0" version since the dir name
   // varies across runs.
@@ -1052,10 +1070,21 @@ Deno.test("ExtensionCatalogStore: W1a migration backfills mixed pulled + local +
     state: string;
   }>;
 
+  // The W1a migration's sub-step 4 canonicalized every row's
+  // source_path. On Windows the seeded paths above are backslash-form;
+  // the stored rows are lowercase + forward-slash. Look up against the
+  // canonical form so this test passes on both platforms.
+  const cPulledHealthy = canonicalizePath(pulledHealthy);
+  const cPulledBroken = canonicalizePath(pulledBroken);
+  const cPulledOtherExt = canonicalizePath(pulledOtherExt);
+  const cLocalPath = canonicalizePath(localPath);
+  const cSourceMountedPath = canonicalizePath(sourceMountedPath);
+  const cUnmatchedPath = canonicalizePath(unmatchedPath);
+
   // Unmatched row was dropped at sub-step 7. Five remain.
   assertEquals(rows.length, 5);
   assertEquals(
-    rows.find((r) => r.source_path === unmatchedPath),
+    rows.find((r) => r.source_path === cUnmatchedPath),
     undefined,
     "unmatched-path row must be dropped by the DELETE step",
   );
@@ -1063,37 +1092,40 @@ Deno.test("ExtensionCatalogStore: W1a migration backfills mixed pulled + local +
   const byPath = new Map(rows.map((r) => [r.source_path, r]));
 
   // Pulled rows: extension_name parsed from path, version intentionally ''.
-  assertEquals(byPath.get(pulledHealthy)?.extension_name, "@scope/alpha");
-  assertEquals(byPath.get(pulledHealthy)?.extension_version, "");
-  assertEquals(byPath.get(pulledHealthy)?.state, "Indexed");
+  assertEquals(byPath.get(cPulledHealthy)?.extension_name, "@scope/alpha");
+  assertEquals(byPath.get(cPulledHealthy)?.extension_version, "");
+  assertEquals(byPath.get(cPulledHealthy)?.state, "Indexed");
 
-  assertEquals(byPath.get(pulledBroken)?.extension_name, "@scope/alpha");
-  assertEquals(byPath.get(pulledBroken)?.extension_version, "");
+  assertEquals(byPath.get(cPulledBroken)?.extension_name, "@scope/alpha");
+  assertEquals(byPath.get(cPulledBroken)?.extension_version, "");
   // validation_failed=1 backfilled to state='ValidationFailed'.
-  assertEquals(byPath.get(pulledBroken)?.state, "ValidationFailed");
+  assertEquals(byPath.get(cPulledBroken)?.state, "ValidationFailed");
 
-  assertEquals(byPath.get(pulledOtherExt)?.extension_name, "@scope/beta");
-  assertEquals(byPath.get(pulledOtherExt)?.extension_version, "");
-  assertEquals(byPath.get(pulledOtherExt)?.state, "Indexed");
+  assertEquals(byPath.get(cPulledOtherExt)?.extension_name, "@scope/beta");
+  assertEquals(byPath.get(cPulledOtherExt)?.extension_version, "");
+  assertEquals(byPath.get(cPulledOtherExt)?.state, "Indexed");
 
-  // Local row: @local/<basename(repoRoot)> at 0.0.0.
+  // Local row: @local/<basename(repoRoot)> at 0.0.0. Use @std/path
+  // basename so this works on both POSIX and Windows native repoRoot
+  // values. The migration's deriveExtensionIdentity uses basename on
+  // a canonicalized repoRoot internally — same semantic.
   const expectedLocalName = `@local/${
-    repoRoot.split("/").filter((s) => s.length > 0).pop()
+    canonicalizePath(repoRoot).split("/").filter((s) => s.length > 0).pop()
   }`;
-  assertEquals(byPath.get(localPath)?.extension_name, expectedLocalName);
-  assertEquals(byPath.get(localPath)?.extension_version, "0.0.0");
-  assertEquals(byPath.get(localPath)?.state, "Indexed");
+  assertEquals(byPath.get(cLocalPath)?.extension_name, expectedLocalName);
+  assertEquals(byPath.get(cLocalPath)?.extension_version, "0.0.0");
+  assertEquals(byPath.get(cLocalPath)?.state, "Indexed");
 
   // Source-mounted row: same @local/<repoRoot> aggregate as locals
   // (per the design doc — "@local/<repo-name> covers every Source
   // under every extensions/<kind>/ tree" regardless of where the
   // source dir lives).
   assertEquals(
-    byPath.get(sourceMountedPath)?.extension_name,
+    byPath.get(cSourceMountedPath)?.extension_name,
     expectedLocalName,
   );
-  assertEquals(byPath.get(sourceMountedPath)?.extension_version, "0.0.0");
-  assertEquals(byPath.get(sourceMountedPath)?.state, "Indexed");
+  assertEquals(byPath.get(cSourceMountedPath)?.extension_version, "0.0.0");
+  assertEquals(byPath.get(cSourceMountedPath)?.state, "Indexed");
 
   store.close();
 });


### PR DESCRIPTION
## Summary

Implements W1a of the extension catalog rearchitecture (swamp-club#211). Pure plumbing — no user-visible behaviour change. **Groundwork for #201, not a fix for it.**

## What lands

- Three new `bundle_types` columns: `state`, `extension_name`, `extension_version`. Schema-level changes idempotent via the existing `pragma_table_info` probe pattern.
- **Single-transaction data migration** with explicit `ROLLBACK` on post-condition failure. Ordered TS-driven per-row UPDATEs: canonicalize `source_path` → backfill `state` from `validation_failed` → backfill `extension_name` via `deriveExtensionIdentity` → drop unmatched rows → verify post-condition (`extension_name` non-empty). On failure: cold-start rebuild (DELETE all rows, clear `populated:*` keys, mark migration applied) so loaders repopulate from disk on next access. A `migration_applied:per-extension-aggregate-v3` marker key in `bundle_meta` makes subsequent process restarts skip the data phase.
- Two new helpers under `src/infrastructure/persistence/`: `canonicalizePath` (lowercased + forward-slash on Windows; raw on POSIX) and `deriveExtensionIdentity` (path → `{name, version}` for pulled, local, source-mounted; null for unmatched).
- `BUNDLE_LAYOUT_VERSION` bumped to `per-extension-aggregate-v3`, triggering a one-time model-loader rescan on first run after upgrade. `ExtensionCatalogStore.upsert` SQL changed from `INSERT OR REPLACE` to `INSERT ... ON CONFLICT(source_path) DO UPDATE SET (legacy columns + state)` — `extension_name`/`extension_version` intentionally NOT in the SET list so the migration's identity backfill survives the rescan.
- `markCatalogValidationFailed` migrated from writing `validation_failed=true` to `state='ValidationFailed'`. **All six readers migrated**: five loaders (`model:947`, `driver:538`, `vault:539`, `datastore:528`, `report:386`) plus `bundle_freshness.ts:303` (the rebundle-loop guard from swamp-club#209). `validation_failed` column survives W1a as vestigial — no production code reads or writes it. **W1b drops the column** via SQLite recreate-table pattern.

## What does NOT land

- `extension_name`/`extension_version` are NOT surfaced on `ExtensionTypeRow`. Write-once-by-migration (preserved on UPDATE via the ON CONFLICT SET-list exclusion); read by W1b's `ExtensionRepository` via direct SQL. Loaders' upsert payloads do not include identity columns, so loader rescans cannot clobber them.
- No domain value objects (Extension, Source, RowState, SourceLocation, BundleLocation), no `ExtensionRepository`, no `findRepoRoot` helper, no cold-start guard unification, no `forceCatalogRescan` migration, no `validation_failed` column drop. **All deferred to W1b** per the plan.

## Why this PR is bigger than the issue's literal "schema migration only" scope

The issue's literal W1a/W1b boundary creates a window where `validation_failed` is writable by W1a-vintage helpers but no longer trusted by W1b-vintage readers (or vice versa). The only safe boundary is one where the column is genuinely vestigial during the gap: writers migrate to `state` (this PR), readers migrate to `state` (this PR), and the drop happens after both have shipped (W1b). Coupling all three changes in one PR is larger; decoupling is unsafe; this carve is the smallest safe carve.

## Found-during-implementation corrections from the v5 plan

1. **Pulled-extensions paths do NOT encode version.** The on-disk layout is `.swamp/pulled-extensions/<name>/<kind>/<file>` with no version segment; version is owned by `upstream_extensions.json` (the lockfile) and consulted at read time by W1b's repository fallback (Option A). Migration backfills `extension_name` only for pulled rows; `extension_version` stays empty. Post-condition narrowed to check `extension_name` non-empty only.
2. **Source-mounted extensions** (`swamp extension source add <externalDir>`) have absolute paths OUTSIDE `repoRoot`. The original heuristic only matched `<repoRoot>/extensions/<kind>/` and missed them — would have caused W1b's repository fallback to skip+DELETE every source-mounted row. The generalised matcher recognises any `**/extensions/<known-kind>/` segment and rolls source-mounted into the same `@local/<basename(repoRoot)>` aggregate as repo-internal locals.

## Pre-work contracts pinned

1. Path canonicalization: lowercased + forward-slash on Windows; raw on POSIX.
2. Repo-root identification: nearest ancestor of the source path containing a `.swamp/` directory; first match wins; lexical-only walk (no realpath); innermost wins for nested worktree-in-repo cases. (`findRepoRoot` helper itself lands in W1b.)
3. Unmatched-row backfill: drop the row; cold-start guard repopulates from disk.
4. **Migration ordering: canonicalize `source_path` FIRST, then backfill identity.** Backfill SQL reads `source_path`; canonicalizing after would match against legacy strings.

## Out-of-scope guardrails

- `extension rm` row pruning → W2
- `findStaleFiles` algorithm changes / `bundleWithCache` → W3
- `ReconcileFromDisk` service → W3
- Loader unification (KindAdapter) → W4
- Per-fingerprint import URLs → W5
- `swamp doctor extensions` changes → W6
- Two pulled versions of the same extension coexisting on disk (interrupted upgrade) — would correctly trigger I-Repo-1 in W1b; repair belongs to W3's reconcile.
- **Windows correctness is NOT a W1 merge gate** (parallel workstream).

## Reversibility

- **W1a revert:** rolling back the binary triggers a layout-version mismatch on next start; model loader cold-start guard invalidates `populated:model` and rebuilds from disk. New columns sit unread by old code. Mild loss: rows broken during the W1a window get re-tried on revert (`markCatalogValidationFailed` wrote `state`, not `validation_failed`; old binary reads `validation_failed=0`). Not silent corruption — just re-attempted.
- **W1b revert (future):** forward-only. Reverting the binary after W1b drops `validation_failed` leaves the schema without the column; old loaders that read `validation_failed` see undefined → false → broken rows leak through. Revert path requires deleting `_extension_catalog.db` (manual ops or via `forceCatalogRescan`-equivalent).

## Plan record divergence

The `@swamp/issue-lifecycle` model record has plan v5; this PR ships v6 (Option A + source-mounted handling). The lifecycle model has no `revise_plan` method post-approve, so the canonical record is stale. Documentation chain: issue spec → v5 (approved) → discovered constraint during implementation → v6 (this PR).

## Test plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno check src/` passes
- [x] `deno run test` — **5270 passed, 0 failed, 28 ignored**
- [x] `deno run compile` succeeds
- [x] `swamp-uat uat:cli` against the W1a-compiled binary — **388 passed, 0 failed, 2 ignored** (57s)
- [x] `swamp-uat uat:adversarial` against the W1a-compiled binary — **92 passed, 0 failed, 1 ignored** (3m9s) — covers state corruption, concurrency, resource exhaustion, process lifecycle, security tiers
- [x] Manual smoke test #1: fresh repo + `swamp extension pull @swamp/aws/s3` + `swamp extension pull @swamp/digitalocean` (43 pulled catalog rows). W1a binary migrates cleanly: `bundle_layout` bumps `per-extension-v2` → `per-extension-aggregate-v3`, all 43 rows preserved with `extension_name` correctly grouped (10 + 33), `extension_version` empty per Option A, `state='Indexed'`. Idempotent on second run.
- [x] Manual smoke test #2: fresh repo + `swamp extension source add /tmp/external-srcdir` (source-mounted). W1a binary migrates correctly: source-mounted row resolves to `@local/<repo>/0.0.0`, no rows dropped, no infinite churn.
- [x] **ADV-V3-1 canary test in suite**: explicit assertion that loader rescan after layout-version bump does NOT clobber migration-backfilled `extension_name`/`extension_version`. Catches future regression to `INSERT OR REPLACE`.
- [x] **#209 regression canary in suite**: `findStaleFiles + ValidationFailed → not stale` test passes under new state semantics.
- [x] Cold-start rebuild path test in suite (called via private-method cast).
- [x] Mixed pulled + local + source-mounted + unmatched in single migration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)