### PR TITLE
fix(logging): remove duplicate quotes from log output (swamp-club#230)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,11 @@ authoritative guidelines for structure, frontmatter, and progressive disclosure.
   handled — unhandled promises race with `Deno.exit` and silently lose data. For
   outbound network calls, pass an `AbortSignal` with a timeout so the caller
   controls cancellation.
+- Interpolate values bare in LogTape tagged templates — let the formatter handle
+  quoting. Strings passed as `${value}` render as `"value"` in log output;
+  wrapping them in literal quotes (`"${value}"`) doubles the quotes to
+  `""value""`. Numbers and other primitives render unquoted, so a bare
+  `${count}` is correct in all cases.
 
 Changes should only touch what's necessary — don't refactor adjacent code that
 isn't part of the task. Keep the blast radius small.

--- a/src/cli/commands/vault_migrate.ts
+++ b/src/cli/commands/vault_migrate.ts
@@ -133,7 +133,7 @@ Both the source and target vaults must be different types.`,
 
     if (cliCtx.outputMode === "log") {
       logger
-        .info`Vault "${preview.vaultName}" (${preview.currentType}) has ${preview.secretCount} secret(s).`;
+        .info`Vault ${preview.vaultName} (${preview.currentType}) has ${preview.secretCount} secret(s).`;
       logger
         .info`Target: ${preview.targetTypeName} (${preview.targetType})`;
     }

--- a/src/domain/extensions/extension_auto_resolver.ts
+++ b/src/domain/extensions/extension_auto_resolver.ts
@@ -324,7 +324,7 @@ export class ExtensionAutoResolver {
     }
     searchTerms = searchTerms.replace(/\//g, " ");
 
-    logger.debug`Search fallback: q="${searchTerms}", collective=${collective}`;
+    logger.debug`Search fallback: q=${searchTerms}, collective=${collective}`;
 
     const result = await extensionLookup.searchExtensions({
       q: searchTerms,

--- a/src/infrastructure/cel/cel_evaluator.ts
+++ b/src/infrastructure/cel/cel_evaluator.ts
@@ -475,7 +475,7 @@ export class CelEvaluator {
       if (!this.warnedPatterns.has(expression)) {
         this.warnedPatterns.add(expression);
         getLogger(["expressions"])
-          .warn`Deprecated: expression "${expression}" uses model.*.resource or model.*.file which will be removed in a future release. Use data.latest() or data.version() instead.`;
+          .warn`Deprecated: expression ${expression} uses model.*.resource or model.*.file which will be removed in a future release. Use data.latest() or data.version() instead.`;
       }
     }
   }

--- a/src/infrastructure/persistence/extension_workflow_repository.ts
+++ b/src/infrastructure/persistence/extension_workflow_repository.ts
@@ -86,7 +86,7 @@ export class ExtensionWorkflowRepository implements WorkflowRepository {
               ? parseError.message
               : String(parseError);
             logger
-              .warn`Skipping broken extension workflow "${entry.path}": ${errorMsg}`;
+              .warn`Skipping broken extension workflow ${entry.path}: ${errorMsg}`;
           }
         }
       } catch (error) {

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -640,7 +640,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
       if (version === undefined && data.isRenamed && data.renamedTo) {
         if (depth >= 5) {
           logger
-            .warn`Rename chain depth exceeded for "${dataName}" (model ${modelId}). Data exists but is unreachable — simplify the rename chain.`;
+            .warn`Rename chain depth exceeded for ${dataName} (model ${modelId}). Data exists but is unreachable — simplify the rename chain.`;
           return null;
         }
         return this.findByNameWithDepth(
@@ -1148,7 +1148,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     } catch (tombstoneError) {
       // Roll back: remove the newly created data under the new name
       logger
-        .warn`Tombstone write failed during rename "${oldName}" -> "${newName}". Rolling back new data.`;
+        .warn`Tombstone write failed during rename ${oldName} -> ${newName}. Rolling back new data.`;
       try {
         const newVersionDir = this.getPath(
           type,
@@ -1170,7 +1170,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
         }
       } catch (rollbackError) {
         logger
-          .error`Rollback also failed during rename "${oldName}" -> "${newName}": ${
+          .error`Rollback also failed during rename ${oldName} -> ${newName}: ${
           String(rollbackError)
         }. Manual cleanup may be needed.`;
       }
@@ -1367,7 +1367,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
       if (version === undefined && data.isRenamed && data.renamedTo) {
         if (depth >= 5) {
           logger
-            .warn`Rename chain depth exceeded for "${dataName}" (model ${modelId}). Data exists but is unreachable — simplify the rename chain.`;
+            .warn`Rename chain depth exceeded for ${dataName} (model ${modelId}). Data exists but is unreachable — simplify the rename chain.`;
           return null;
         }
         return this.findByNameSyncWithDepth(

--- a/src/infrastructure/persistence/yaml_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_repository.ts
@@ -100,10 +100,10 @@ export class YamlWorkflowRepository implements WorkflowRepository {
 
             if (errorMsg.includes('type "shell" is no longer supported')) {
               logger
-                .warn`Skipping workflow "${workflowName}": uses deprecated 'shell' task. Delete or update to 'type: model_method' with 'command/shell'. File: ${path}`;
+                .warn`Skipping workflow ${workflowName}: uses deprecated 'shell' task. Delete or update to 'type: model_method' with 'command/shell'. File: ${path}`;
             } else {
               logger
-                .warn`Skipping broken workflow "${workflowName}": ${errorMsg}. File: ${path}`;
+                .warn`Skipping broken workflow ${workflowName}: ${errorMsg}. File: ${path}`;
             }
           }
         }

--- a/src/presentation/renderers/data_delete.ts
+++ b/src/presentation/renderers/data_delete.ts
@@ -32,10 +32,10 @@ class LogDataDeleteRenderer implements Renderer<DataDeleteEvent> {
         const data = e.data;
         if (data.version !== undefined) {
           logger
-            .info`Deleted version ${data.version} of "${data.dataName}" for ${data.modelName} (${data.modelType})`;
+            .info`Deleted version ${data.version} of ${data.dataName} for ${data.modelName} (${data.modelType})`;
         } else {
           logger
-            .info`Deleted ${data.versionsDeleted} version(s) of "${data.dataName}" for ${data.modelName} (${data.modelType})`;
+            .info`Deleted ${data.versionsDeleted} version(s) of ${data.dataName} for ${data.modelName} (${data.modelType})`;
         }
       },
       error: (e) => {

--- a/src/presentation/renderers/data_delete_test.ts
+++ b/src/presentation/renderers/data_delete_test.ts
@@ -17,7 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertThrows } from "@std/assert";
+import {
+  assertEquals,
+  assertFalse,
+  assertStringIncludes,
+  assertThrows,
+} from "@std/assert";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 import {
   createDataDeleteRenderer,
@@ -27,7 +32,11 @@ import type { DataDeleteEvent } from "../../libswamp/mod.ts";
 import { UserError } from "../../domain/errors.ts";
 import { validationFailed } from "../../libswamp/errors.ts";
 
-await initializeLogging({});
+// noColor: true selects LogTape's text formatter, which produces a single
+// pre-rendered string per record — necessary for captureLog to see the
+// formatted output (the default formatter passes %c/%o placeholders that
+// the terminal expands at write time, bypassing console.info mocks).
+await initializeLogging({ noColor: true });
 
 function captureStdout(fn: () => void): string {
   const originalLog = console.log;
@@ -45,37 +54,72 @@ function captureStdout(fn: () => void): string {
   return lines.join("\n");
 }
 
+// LogTape's console sink routes per-level (info → console.info,
+// warning → console.warn, error → console.error, etc.). Capture all
+// of them and strip ANSI for stable cross-terminal assertions.
+function captureLog(fn: () => void): string {
+  const lines: string[] = [];
+  const methods = ["log", "info", "warn", "error", "debug"] as const;
+  const originals = methods.map((m) => [m, console[m]] as const);
+  for (const [m] of originals) {
+    console[m] = (...args: unknown[]) => {
+      lines.push(
+        args.map((a) => typeof a === "string" ? a : String(a)).join(" "),
+      );
+    };
+  }
+  try {
+    fn();
+  } finally {
+    for (const [m, orig] of originals) {
+      console[m] = orig;
+    }
+  }
+  // deno-lint-ignore no-control-regex
+  return lines.join("\n").replace(/\x1b\[[0-9;]*m/g, "");
+}
+
 Deno.test("createDataDeleteRenderer: log mode handles full-artifact delete", () => {
   const renderer = createDataDeleteRenderer("log");
   const handlers = renderer.handlers();
-  // Should not throw — log mode routes through the logger.
-  handlers.completed!({
-    kind: "completed",
-    data: {
-      modelId: "def-1",
-      modelName: "my-model",
-      modelType: "test/example",
-      dataName: "my-data",
-      version: undefined,
-      versionsDeleted: 3,
-    },
-  });
+  const out = captureLog(() =>
+    handlers.completed!({
+      kind: "completed",
+      data: {
+        modelId: "def-1",
+        modelName: "my-model",
+        modelType: "test/example",
+        dataName: "my-data",
+        version: undefined,
+        versionsDeleted: 3,
+      },
+    })
+  );
+  // dataName must render with single-quote style (auto-quoted by LogTape),
+  // matching the modelName/modelType interpolations on the same line. The
+  // doubled-quote artifact (""my-data"") regresses issue swamp-club#230.
+  assertStringIncludes(out, 'of "my-data" for');
+  assertFalse(out.includes('""my-data""'), `regression: ${out}`);
 });
 
 Deno.test("createDataDeleteRenderer: log mode handles single-version delete", () => {
   const renderer = createDataDeleteRenderer("log");
   const handlers = renderer.handlers();
-  handlers.completed!({
-    kind: "completed",
-    data: {
-      modelId: "def-1",
-      modelName: "my-model",
-      modelType: "test/example",
-      dataName: "my-data",
-      version: 2,
-      versionsDeleted: 1,
-    },
-  });
+  const out = captureLog(() =>
+    handlers.completed!({
+      kind: "completed",
+      data: {
+        modelId: "def-1",
+        modelName: "my-model",
+        modelType: "test/example",
+        dataName: "my-data",
+        version: 2,
+        versionsDeleted: 1,
+      },
+    })
+  );
+  assertStringIncludes(out, 'of "my-data" for');
+  assertFalse(out.includes('""my-data""'), `regression: ${out}`);
 });
 
 Deno.test("createDataDeleteRenderer: json mode emits envelope for full delete", () => {

--- a/src/presentation/renderers/data_rename.ts
+++ b/src/presentation/renderers/data_rename.ts
@@ -31,11 +31,11 @@ class LogDataRenameRenderer implements Renderer<DataRenameEvent> {
       completed: (e) => {
         const data = e.data;
         logger
-          .info`Renamed "${data.oldName}" -> "${data.newName}" for ${data.modelName} (${data.modelType})`;
+          .info`Renamed ${data.oldName} -> ${data.newName} for ${data.modelName} (${data.modelType})`;
         logger
           .info`Version ${data.copiedVersion} copied as v${data.newVersion} under new name`;
         logger
-          .info`Old name "${data.oldName}" now forwards to "${data.newName}"`;
+          .info`Old name ${data.oldName} now forwards to ${data.newName}`;
         logger.warn`${data.warning}`;
       },
       error: (e) => {

--- a/src/presentation/renderers/extension_push.ts
+++ b/src/presentation/renderers/extension_push.ts
@@ -180,9 +180,9 @@ class LogExtensionPushRenderer implements ExtensionPushRenderer {
   ): void {
     this.logger.error`Collective errors (push blocked):`;
     this.logger
-      .error`  All content must use collective "${expectedCollective}"`;
+      .error`  All content must use collective ${expectedCollective}`;
     for (const m of mismatches) {
-      this.logger.error`  ${m.kind}: "${m.identifier}" in ${m.fileName}`;
+      this.logger.error`  ${m.kind}: ${m.identifier} in ${m.fileName}`;
     }
   }
 


### PR DESCRIPTION
## Summary

- LogTape's console formatter auto-quotes string interpolations in tagged template literals. Wrapping `${value}` in literal `"..."` doubled the quotes in rendered output (e.g. `""result""` instead of `"result"`). Fixes swamp-club#230.
- The bug was reported against `swamp data delete` but the identical pattern existed across 9 files (16 occurrences). All fixed in one pass — confirmed empirically that `swamp data rename` produced the same `""result"" -> ""outcome""` artifact pre-fix.
- Adds a regression test in `data_delete_test.ts` that captures rendered log output and asserts on the single-quoted form. Verified the test catches a reintroduced bug.
- Adds a `CLAUDE.md` convention note ("interpolate values bare in LogTape tagged templates") to prevent recurrence in future code.

## Files touched

| Layer | File | Lines |
|---|---|---|
| Presentation | `data_delete.ts`, `data_rename.ts`, `extension_push.ts` | 6 occurrences |
| CLI | `vault_migrate.ts` | 1 |
| Infrastructure | `extension_workflow_repository.ts`, `unified_data_repository.ts`, `yaml_workflow_repository.ts`, `cel_evaluator.ts` | 8 |
| Domain | `extension_auto_resolver.ts` | 1 |
| Tests | `data_delete_test.ts` | regression assertions |
| Convention | `CLAUDE.md` | LogTape interpolation note |

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` clean
- [x] `deno run test` passes (5327 tests, 0 failed)
- [x] `deno run compile` succeeds
- [x] Audit grep returns zero matches: `grep -rn '\(\.info\|\.warn\|\.error\|\.debug\|\.fatal\|\.trace\)\`[^\`]*"\${' src --include='*.ts'`
- [x] Regression test verified to fail when bug is reintroduced
- [x] Reproduction repo confirms `swamp data delete` now outputs `Deleted 1 version(s) of "result" for "hello-world" ("command/shell")`
- [x] Reproduction repo confirms `swamp data rename` now outputs `Renamed "result" -> "outcome" for "hello-world" ("command/shell")`

## Follow-ups (out of scope for this PR)

- Consider a `deno lint` rule to block literal-quoted interpolations in LogTape templates so the audit grep becomes CI-enforced rather than convention-only.
- `swamp-uat` has no `tests/cli/data/delete_test.ts` for `swamp data delete` (the feature was just added in #1294); UAT coverage gap pre-dates this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)