### PR TITLE
fix(persistence): tighten LockfileRepository follow-ups from #1298 review

### DIFF
--- a/src/infrastructure/persistence/lockfile_repository.ts
+++ b/src/infrastructure/persistence/lockfile_repository.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { dirname } from "@std/path";
+import { UserError } from "../../domain/errors.ts";
 import { atomicWriteTextFile } from "./atomic_write.ts";
 import {
   readUpstreamExtensions,
@@ -99,11 +100,14 @@ export class LockfileRepository {
   }
 
   /**
-   * Returns the cached entry map. Callers receive a defensive shallow
-   * copy so external mutation cannot corrupt the cache.
+   * Returns the cached entry map. Callers receive a defensive deep copy
+   * so external mutation — including pushing into nested `files[]` /
+   * `include[]` arrays — cannot corrupt the cache. `structuredClone`
+   * (in scope on Deno via the global) covers every value shape the
+   * lockfile carries today (strings, arrays of strings, booleans).
    */
   getAllEntries(): UpstreamExtensionsMap {
-    return { ...this.cache };
+    return structuredClone(this.cache);
   }
 
   /**
@@ -160,6 +164,13 @@ export class LockfileRepository {
    * the result, releases the lock, and updates this instance's cache.
    */
   async removeEntry(name: string): Promise<void> {
+    // Symmetric with writeEntry — defensive against callers who removed
+    // an extension in this process and the parent dir was cleaned up
+    // between then and now. In practice unreachable today (rm.ts only
+    // calls this after extensionRmPreview confirmed the entry exists,
+    // which read the lockfile successfully) but the asymmetry would
+    // surface as an unhelpful NotFound from acquireLock if it ever did.
+    await Deno.mkdir(dirname(this.lockfilePath), { recursive: true });
     const lockFile = await this.acquireLock();
     try {
       const current = await readUpstreamExtensions(this.lockfilePath);
@@ -189,14 +200,18 @@ export class LockfileRepository {
             await new Promise((r) => setTimeout(r, LOCK_RETRY_DELAY_MS));
             continue;
           }
-          throw new Error(
+          // UserError so the top-level handler renders the clean
+          // message instead of a stack trace — matches the pre-W2-prequel
+          // behavior in pull.ts (rm.ts threw plain Error; this
+          // consolidates on the better UX).
+          throw new UserError(
             "Could not acquire lock on upstream_extensions.json. Another operation may be in progress. Please retry.",
           );
         }
         throw error;
       }
     }
-    throw new Error(
+    throw new UserError(
       "Could not acquire lock on upstream_extensions.json.",
     );
   }

--- a/src/infrastructure/persistence/lockfile_repository_test.ts
+++ b/src/infrastructure/persistence/lockfile_repository_test.ts
@@ -17,10 +17,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertNotEquals } from "@std/assert";
+import { assertEquals, assertNotEquals, assertRejects } from "@std/assert";
 import { join } from "@std/path";
 import { LockfileRepository } from "./lockfile_repository.ts";
 import { atomicWriteTextFile } from "./atomic_write.ts";
+import { UserError } from "../../domain/errors.ts";
 
 async function withTempDir(
   fn: (dir: string) => Promise<void>,
@@ -172,6 +173,23 @@ Deno.test("LockfileRepository.removeEntry: deletes key and persists", async () =
   });
 });
 
+Deno.test("LockfileRepository.removeEntry: creates parent dir (symmetric with writeEntry)", async () => {
+  await withTempDir(async (dir) => {
+    // Construct against a path whose parent dir does NOT exist yet.
+    // removeEntry must create it before acquireLock — otherwise
+    // Deno.open hits NotFound and propagates an unhelpful error.
+    const path = join(dir, "nested", "subdir", "upstream_extensions.json");
+    const repo = new LockfileRepository(path, {});
+
+    // Should not throw.
+    await repo.removeEntry("@scope/never-existed");
+
+    // The empty lockfile is now persisted and the parent dir exists.
+    const onDisk = JSON.parse(await Deno.readTextFile(path));
+    assertEquals(Object.keys(onDisk).length, 0);
+  });
+});
+
 Deno.test("LockfileRepository.removeEntry: missing key is a no-op", async () => {
   await withTempDir(async (dir) => {
     const path = join(dir, "upstream_extensions.json");
@@ -185,17 +203,28 @@ Deno.test("LockfileRepository.removeEntry: missing key is a no-op", async () => 
   });
 });
 
-Deno.test("LockfileRepository: getAllEntries returns a defensive copy", async () => {
+Deno.test("LockfileRepository: getAllEntries returns a defensive deep copy", async () => {
   await withTempDir(async (dir) => {
     const path = join(dir, "upstream_extensions.json");
     const repo = await LockfileRepository.create(path);
-    await repo.writeEntry("@scope/foo", "1.0.0", []);
+    await repo.writeEntry("@scope/foo", "1.0.0", ["models/foo.ts"], {
+      include: ["dep.ts"],
+    });
 
     const map = repo.getAllEntries();
-    delete map["@scope/foo"];
 
-    // Repo's internal cache must not be affected by external mutation.
+    // Top-level key deletion must not affect the cache.
+    delete map["@scope/foo"];
     assertNotEquals(repo.getEntry("@scope/foo"), null);
+
+    // Nested array mutation must not affect the cache either —
+    // deep copy guards against `entries["@x/y"].files!.push(...)`
+    // patterns that a shallow copy would propagate.
+    const fresh = repo.getAllEntries();
+    fresh["@scope/foo"].files!.push("INJECTED");
+    fresh["@scope/foo"].include!.push("INJECTED");
+    assertEquals(repo.getEntry("@scope/foo")?.files, ["models/foo.ts"]);
+    assertEquals(repo.getEntry("@scope/foo")?.include, ["dep.ts"]);
   });
 });
 
@@ -221,6 +250,30 @@ Deno.test("LockfileRepository: concurrent writers all complete via acquireLock r
     for (let i = 0; i < N; i++) {
       assertEquals(onDisk[`@scope/ext${i}`].version, `${i}.0.0`);
     }
+  });
+});
+
+Deno.test("LockfileRepository: lock-acquisition exhaustion throws UserError (clean CLI message, not stack trace)", async () => {
+  await withTempDir(async (dir) => {
+    const path = join(dir, "upstream_extensions.json");
+    const lockPath = `${path}.lock`;
+
+    // Pre-create the lock file so every retry sees AlreadyExists.
+    // 10 retries × 100ms = ~1s before the writer gives up.
+    await Deno.writeTextFile(lockPath, "");
+
+    const repo = await LockfileRepository.create(path);
+    const error = await assertRejects(
+      () => repo.writeEntry("@scope/foo", "1.0.0", []),
+      UserError,
+      "Could not acquire lock on upstream_extensions.json",
+    );
+    // Top-level error_output renderer keys off `instanceof UserError` to
+    // emit a clean message rather than a stack trace; this assertion
+    // pins the contract.
+    assertEquals(error instanceof UserError, true);
+
+    await Deno.remove(lockPath);
   });
 });
 


### PR DESCRIPTION
## Summary

Three follow-up fixes to `LockfileRepository` raised in review of #1298 (the W2 prequel). All small, all tested.

## Changes

### 1. Lock-contention throws `UserError` (clean CLI message), not plain `Error`

Before #1298, `acquireLock` in `pull.ts` threw `UserError`. The top-level error handler at `error_output.ts:64-68` keys off `instanceof UserError` to emit a clean `Error: <message>` line; plain `Error` falls through to a stack trace.

When #1298 consolidated the duplicate `acquireLock` helpers from `pull.ts` and `rm.ts` into the new repository, it picked up `rm.ts`'s plain-`Error` shape. Result: a real lock-exhaustion failure during `swamp extension pull` (two concurrent users, the loser retries 10× and gives up) now shows a stack trace instead of the clean message it used to.

This restores the `pull.ts` UX (the better of the two pre-prequel implementations). New test pins the `instanceof UserError` contract so a future refactor can't quietly break it again.

### 2. `removeEntry` now mkdir's parent dir, symmetric with `writeEntry`

Currently unreachable in practice — `rm.ts` only calls `removeEntry` after `extensionRmPreview` confirmed the entry exists, which implies the lockfile was readable. But the asymmetry would surface as an unhelpful `NotFound` from `Deno.open` if a future caller path ever hit a missing-parent-dir state. Defensive consistency fix; test constructs against a non-existent parent dir and verifies `removeEntry` creates it.

### 3. `getAllEntries` returns a deep copy via `structuredClone`

The previous shallow copy `{ ...this.cache }` only protected against top-level key deletion. A caller doing `entries[\"@x/y\"].files!.push(\"injected\")` could mutate the internal cache through the shared `UpstreamExtensionEntry` reference.

All current callers in this repo are read-only so this was theoretical, but the original regression test only verified top-level deletion — nested array mutation would have slipped through. Test now also verifies `files[]` and `include[]` array mutation cannot reach the cache.

## Test plan

- [x] `deno check` clean
- [x] `deno lint` clean
- [x] `deno fmt` clean
- [x] `deno run test` — **5399 passed, 0 failed** (3 new tests: UserError contract, removeEntry mkdir symmetry, deep-copy nested mutation)

## Out of scope

This is a tightening pass, not a behavioral change. Lockfile JSON format unchanged; no migration; trivial revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)