### PR TITLE
feat(data): surface jobTag in data search (swamp-club#245)

### DIFF
--- a/src/libswamp/data/search.ts
+++ b/src/libswamp/data/search.ts
@@ -43,6 +43,7 @@ export interface DataSearchItem {
   createdAt: string;
   tags: Record<string, string>;
   workflowTag?: string;
+  jobTag?: string;
   stepTag?: string;
 }
 
@@ -303,6 +304,7 @@ export async function* dataSearch(
           createdAt: data.createdAt.toISOString(),
           tags: data.tags,
           workflowTag: data.tags.workflow,
+          jobTag: data.tags.job,
           stepTag: data.tags.step,
         });
       }

--- a/src/libswamp/data/search_test.ts
+++ b/src/libswamp/data/search_test.ts
@@ -158,6 +158,45 @@ Deno.test("dataSearch: filters by tags with AND logic", async () => {
   assertEquals(completed.data.results[0].id, "d1");
 });
 
+Deno.test("dataSearch: surfaces workflowTag/jobTag/stepTag from data tags", async () => {
+  const items = [
+    makeDataItem({
+      id: "d1",
+      tags: { workflow: "my-wf", job: "my-job", step: "my-step" },
+    }),
+  ];
+  const deps = makeDeps(items);
+  const events = await collect<DataSearchEvent>(
+    dataSearch(createLibSwampContext(), deps, {}),
+  );
+
+  const completed = events[1] as Extract<
+    DataSearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results.length, 1);
+  assertEquals(completed.data.results[0].workflowTag, "my-wf");
+  assertEquals(completed.data.results[0].jobTag, "my-job");
+  assertEquals(completed.data.results[0].stepTag, "my-step");
+});
+
+Deno.test("dataSearch: jobTag is undefined when data has no job tag", async () => {
+  const items = [
+    makeDataItem({ id: "d1", tags: {} }),
+  ];
+  const deps = makeDeps(items);
+  const events = await collect<DataSearchEvent>(
+    dataSearch(createLibSwampContext(), deps, {}),
+  );
+
+  const completed = events[1] as Extract<
+    DataSearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results.length, 1);
+  assertEquals(completed.data.results[0].jobTag, undefined);
+});
+
 Deno.test("dataSearch: yields error when model not found", async () => {
   const deps = makeDeps([], {
     findDefinitionByIdOrName: () => Promise.resolve(null),

--- a/src/presentation/renderers/data_search.tsx
+++ b/src/presentation/renderers/data_search.tsx
@@ -122,7 +122,7 @@ class InkDataSearchRenderer implements DataSearchRenderer {
           (item) =>
             `${item.name} ${item.modelName} ${item.modelType} ${item.type} ${
               item.workflowTag ?? ""
-            } ${item.stepTag ?? ""} ${
+            } ${item.jobTag ?? ""} ${item.stepTag ?? ""} ${
               Object.entries(item.tags).map(([k, v]) => `${k}=${v}`).join(" ")
             }`,
           renderDataResultLine,
@@ -179,6 +179,7 @@ function buildMetadataMarkdown(item: DataSearchItem): string {
   ];
 
   if (item.workflowTag) lines.push(`**Workflow:** ${item.workflowTag}`);
+  if (item.jobTag) lines.push(`**Job:** ${item.jobTag}`);
   if (item.stepTag) lines.push(`**Step:** ${item.stepTag}`);
 
   if (tagEntries.length > 0) {


### PR DESCRIPTION
## Summary

Follow-up to swamp-club#237. The legacy `swamp data search` surface exposed `workflowTag` and `stepTag` from `data.tags`, but not `jobTag` — leaving the provenance triple incomplete compared to `swamp data query` (which already supports `jobName == \"...\"` after #237 wired `data.tags.job` via `workflowTagOverrides`).

This PR closes the gap:

- `DataSearchItem` gains `jobTag?: string`, ordered between `workflowTag` and `stepTag` to mirror the production tag-write order in `execution_service.ts` (workflow → job → step).
- The `dataSearch` generator populates `jobTag: data.tags.job` in the result mapping.
- The Ink renderer surfaces `jobTag` as a searchable picker token and as a `**Job:**` line in the preview metadata, between Workflow and Step.

Closes swamp-club#245.

## Why no `--job` filter

`data search` already has asymmetric filter coverage — `--workflow` exists, but `--step` does not. Adding `--job` would introduce new asymmetry without solving a real ergonomic gap. Power users wanting filter-by-job should use `swamp data query 'jobName == \"...\"'`, which is the documented modern path.

## Backward compatibility

Pre-#237 data has no `job` tag, so `jobTag` resolves to `undefined` for those records — identical nullable handling to `workflowTag`/`stepTag` on non-workflow data. No migration needed; forward-only.

## Test plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno check` passes
- [x] `deno run test` — full suite (5403 passed, 0 failed)
- [x] Positive regression test: when `data.tags = { workflow, job, step }`, all three `*Tag` fields are populated together
- [x] Negative regression test: when `data.tags = {}`, `jobTag === undefined` (locks in the nullable contract)

## Follow-up

A consolidated swamp-uat issue will be filed alongside this PR covering CLI surfacing of `workflowTag`/`jobTag`/`stepTag` in `data search --json` (none of the three are exercised at the UAT tier today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)