### PR TITLE
fix(release): pin host Deno to bundled canary so denort matches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,27 @@ jobs:
         with:
           ref: main
 
+      # CANARY-BRIDGE: pin the host Deno used by `deno compile` to the same
+      # canary SHA that scripts/download_deno.ts embeds as a resource. Without
+      # this, `deno compile` runs under the latest stable v2.x and bakes
+      # `denort-<stable>` into the swamp CLI binary — which is the runtime
+      # that executes workflows (and panics on the tls_wrap.rs unwrap until
+      # v2.8.0 ships). See scripts/deno_canary.txt for the back-out checklist.
+      - name: Resolve Deno canary SHA
+        id: canary
+        run: |
+          sha=$(grep -v '^[[:space:]]*#' scripts/deno_canary.txt | grep -v '^[[:space:]]*$' | head -n1 | tr -d '[:space:]')
+          if [ -z "$sha" ]; then
+            echo "scripts/deno_canary.txt has no SHA" >&2
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "Pinned Deno canary: $sha"
+
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: canary-${{ steps.canary.outputs.sha }}
 
       - name: Generate version
         id: version

--- a/scripts/deno_canary.txt
+++ b/scripts/deno_canary.txt
@@ -18,10 +18,13 @@
 #   1. Delete this file (scripts/deno_canary.txt).
 #   2. In scripts/download_deno.ts, delete the two `CANARY-BRIDGE`
 #      blocks (the helpers near the top and the branch in main()).
-#   3. Delete scripts/download_deno_test.ts (or its canary cases).
-#   4. `grep -rn CANARY-BRIDGE` should return zero matches.
-#   5. Bump the system Deno used by CI / contributors to v2.8.0.
-#   6. Rebuild and republish swamp via the normal release flow.
+#   3. In .github/workflows/release.yml, delete the "Resolve Deno canary
+#      SHA" step (marked CANARY-BRIDGE) and change the Setup Deno step's
+#      `deno-version` back to `v2.x` (or the desired stable line).
+#   4. Delete scripts/download_deno_test.ts (or its canary cases).
+#   5. `grep -rn CANARY-BRIDGE` should return zero matches.
+#   6. Bump the system Deno used by CI / contributors to v2.8.0.
+#   7. Rebuild and republish swamp via the normal release flow.
 #
 # Pinned commit (verified to include the tls_wrap fix df8d21c2):
 19bd3d8b99d92f15d20692aca02ac059bbc9ada7


### PR DESCRIPTION
## Summary

Stop shipping a swamp CLI with the buggy `denort-2.7.14` runtime baked in. Resolve the pinned canary SHA from the existing single source of truth (`scripts/deno_canary.txt`) and use it as the host Deno for `deno compile`, so `denort` is fetched from `dl.deno.land/canary/<sha>/` instead of `release/v2.7.14/`.

## Why the swamp-club deploy still panics on the latest release

The current `stable` swamp tarball was built with this release flow:

1. `denoland/setup-deno@v2` with `deno-version: v2.x` — installs **stable 2.7.14**.
2. `scripts/compile.ts` downloads canary `19bd3d8b` and writes it to `resources/deno/deno` ✅.
3. `deno compile --include resources/deno --output dist/swamp-linux-x86_64 main.ts` — runs **under 2.7.14**, so it pulls `https://dl.deno.land/release/v2.7.14/denort-x86_64-unknown-linux-gnu.zip` and bakes that into the swamp CLI binary.

Result: the shipped swamp binary contains **two runtimes**:

- `denort-2.7.14` — runs `main.ts` (the swamp CLI / workflow runner). Still has the `ext/node/ops/tls_wrap.rs:2018` unwrap.
- `canary-19bd3d8b` (the embedded resource) — extracted to `~/.swamp/deno` and used by spawned children, not by the CLI process.

The TLS panic the swamp-club deploy hits comes from the workflow runner uploading to `giga-swamp.sfo3.digitaloceanspaces.com` — that runs in the swamp CLI process (single PID `2467` throughout the failing log), i.e. in `denort-2.7.14`. So the embedded canary resource doesn't help here.

Verified: `denort-{x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu, x86_64-apple-darwin, aarch64-apple-darwin, x86_64-pc-windows-msvc}.zip` are all present at `dl.deno.land/canary/19bd3d8b99d92f15d20692aca02ac059bbc9ada7/` (HTTP 200 for all five), so `deno compile` will be able to fetch them on every target.

## Change

- `release.yml`: new `Resolve Deno canary SHA` step reads `scripts/deno_canary.txt` (same parsing as `readCanarySha()` in `scripts/download_deno.ts`) and pins `denoland/setup-deno@v2`'s `deno-version` to `canary-<sha>`. Marked `CANARY-BRIDGE` for grep-ability.
- `deno_canary.txt`: back-out checklist now lists the `release.yml` step to remove when v2.8.0 ships.

Other workflows (`publish-testing.yml`, `publish-client.yml`, `ci.yml`) don't run `deno compile`, so they don't bake `denort` and are intentionally left on stable.

## Test plan

- [ ] Merge → release runs → confirm log shows `Pinned Deno canary: 19bd3d8b...` and the subsequent `deno compile` fetches `denort` from `dl.deno.land/canary/19bd3d8b.../denort-...zip` (not `release/v2.7.14/`).
- [ ] Re-run the swamp-club `Deploy swamp-club to DigitalOcean` workflow on the new `stable` swamp; the S3 upload to DigitalOcean Spaces should complete without the `tls_wrap.rs:2018:31` panic.
- [ ] `swamp --version` on the new build still reports the expected swamp version string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)