### PR TITLE
fix(release): install pinned canary Deno via direct download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,27 +28,34 @@ jobs:
         with:
           ref: main
 
-      # CANARY-BRIDGE: pin the host Deno used by `deno compile` to the same
-      # canary SHA that scripts/download_deno.ts embeds as a resource. Without
-      # this, `deno compile` runs under the latest stable v2.x and bakes
-      # `denort-<stable>` into the swamp CLI binary — which is the runtime
+      # CANARY-BRIDGE: install the host Deno used by `deno compile` directly
+      # from the canary SHA pinned in scripts/deno_canary.txt. denoland/setup-deno
+      # only accepts `canary` (latest, non-reproducible) — passing `canary-<sha>`
+      # is parsed as a semver range and fails with "The passed version range is
+      # not valid". We fetch the artifact ourselves to keep the pin reproducible.
+      # Without pinning the host, `deno compile` runs under stable v2.x and
+      # bakes `denort-<stable>` into the swamp CLI binary, which is the runtime
       # that executes workflows (and panics on the tls_wrap.rs unwrap until
       # v2.8.0 ships). See scripts/deno_canary.txt for the back-out checklist.
-      - name: Resolve Deno canary SHA
-        id: canary
+      - name: Install pinned canary Deno
         run: |
           sha=$(grep -v '^[[:space:]]*#' scripts/deno_canary.txt | grep -v '^[[:space:]]*$' | head -n1 | tr -d '[:space:]')
           if [ -z "$sha" ]; then
             echo "scripts/deno_canary.txt has no SHA" >&2
             exit 1
           fi
-          echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "Pinned Deno canary: $sha"
 
-      - name: Setup Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: canary-${{ steps.canary.outputs.sha }}
+          install_dir="$RUNNER_TEMP/deno-canary"
+          mkdir -p "$install_dir"
+          url="https://dl.deno.land/canary/${sha}/deno-x86_64-unknown-linux-gnu.zip"
+          echo "Downloading $url"
+          curl -fsSL "$url" -o "$install_dir/deno.zip"
+          unzip -q "$install_dir/deno.zip" -d "$install_dir"
+          chmod +x "$install_dir/deno"
+
+          echo "$install_dir" >> "$GITHUB_PATH"
+          "$install_dir/deno" --version
 
       - name: Generate version
         id: version


### PR DESCRIPTION
## Summary

Follow-up to #1308. The release job now fails with:

```
Run denoland/setup-deno@v2
  with:
    deno-version: canary-19bd3d8b99d92f15d20692aca02ac059bbc9ada7
Error: The passed version range is not valid.
```

`denoland/setup-deno@v2` only accepts `canary` (latest, non-reproducible) for the canary channel — the `canary-<sha>` form is parsed as a semver range and rejected. My previous PR was wrong about that syntax.

## Change

Replace the Setup Deno step with a direct download of the pinned artifact from `https://dl.deno.land/canary/<sha>/deno-x86_64-unknown-linux-gnu.zip` and prepend the install directory to `GITHUB_PATH` so subsequent `deno run` / `deno compile` invocations pick it up. The SHA is still read from `scripts/deno_canary.txt` (the existing single source of truth), so reproducibility is preserved.

The release runner is `ubuntu-latest`, so we only need the linux x86_64 host artifact — `deno compile` then cross-compiles to the other targets and fetches the matching cross-target `denort` from `dl.deno.land/canary/<sha>/` itself (verified all five `denort-*.zip` artifacts are present at the pinned SHA).

The `CANARY-BRIDGE` marker stays in place; the back-out checklist in `scripts/deno_canary.txt` already references this step.

## Test plan

- [ ] Merge → release runs → confirm log shows `Pinned Deno canary: 19bd3d8b...`, the `unzip` succeeds, and `deno --version` prints the canary build.
- [ ] Subsequent `deno run -A scripts/compile.ts` steps log `Download https://dl.deno.land/canary/19bd3d8b.../denort-...zip` (not `release/v2.7.14/`).
- [ ] Re-run the swamp-club Deploy job on the resulting `stable` swamp; the S3 upload should complete without the `tls_wrap.rs:2018:31` panic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)