### PR TITLE
chore(deps): bump cel-js 7.5.1 → 7.6.1

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -38,7 +38,7 @@
     "react/jsx-runtime": "npm:react@^19.2.5/jsx-runtime",
     "@types/react": "npm:@types/react@^19.2.14",
     "@aws-sdk/client-cloudcontrol": "npm:@aws-sdk/client-cloudcontrol@^3.1042.0",
-    "cel-js": "npm:@marcbachmann/cel-js@7.5.1",
+    "cel-js": "npm:@marcbachmann/cel-js@7.6.1",
     "croner": "npm:croner@^9.1.0",
     "fast-json-patch": "npm:fast-json-patch@^3.1.1",
     "fast-check": "npm:fast-check@^3.23.2",

--- a/deno.lock
+++ b/deno.lock
@@ -25,7 +25,7 @@
     "jsr:@std/text@^1.0.17": "1.0.18",
     "jsr:@std/yaml@^1.1.0": "1.1.0",
     "npm:@aws-sdk/client-cloudcontrol@^3.1042.0": "3.1042.0",
-    "npm:@marcbachmann/cel-js@7.5.1": "7.5.1",
+    "npm:@marcbachmann/cel-js@7.6.1": "7.6.1",
     "npm:@opentelemetry/api@^1.9.1": "1.9.1",
     "npm:@opentelemetry/context-async-hooks@^1.30.1": "1.30.1_@opentelemetry+api@1.9.1",
     "npm:@opentelemetry/core@^1.30.1": "1.30.1_@opentelemetry+api@1.9.1",
@@ -558,8 +558,8 @@
     "@colors/colors@1.5.0": {
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
-    "@marcbachmann/cel-js@7.5.1": {
-      "integrity": "sha512-3X+TKpt/xyPsVSU3R2bVeZQCOW5L29y+EVDOmOp2xnyD7bifNM/UypBaqs2Z6oC075p+tKtjPUT1kUwnyY7cQg==",
+    "@marcbachmann/cel-js@7.6.1": {
+      "integrity": "sha512-YyY8yiDU07ByKb2rJUoNgMAkYeeDvkdrONBREV2MP9siAW7yNft0KfbIoonWTIMY0fGtv8og0EhzKx3Xsi1Nmg==",
       "bin": true
     },
     "@nodable/entities@2.1.0": {
@@ -1565,7 +1565,7 @@
       "jsr:@std/tar@~0.1.10",
       "jsr:@std/yaml@^1.1.0",
       "npm:@aws-sdk/client-cloudcontrol@^3.1042.0",
-      "npm:@marcbachmann/cel-js@7.5.1",
+      "npm:@marcbachmann/cel-js@7.6.1",
       "npm:@opentelemetry/api@^1.9.1",
       "npm:@opentelemetry/context-async-hooks@^1.30.1",
       "npm:@opentelemetry/core@^1.30.1",


### PR DESCRIPTION
## Summary

Bumps `@marcbachmann/cel-js` from 7.5.1 to 7.6.1 (path: 7.5.2 → 7.5.3 → 7.6.0 → 7.6.1).

The notable release on this path is **7.6.0**, which refactored the AST (split stable AST fields from mutable metadata, added stable source ranges, structured diagnostics, eval hot-path rewrite). Per repo memory, CEL is critical to swamp and must never regress, so the bump was verified empirically rather than just trusting changelogs.

### High-risk consumers (verified intact)

- `src/domain/data/query_predicate.ts` — walks the parsed AST by `op`/`args` shape across 12 op codes (`id`, `.`, `.?`, `[]`, `[?]`, `call`, `rcall`, `?:`, `!_`, `-_`, `list`, `map`, `value`).
- `src/domain/data/data_query_service.ts:173` — casts `queryEnv.parse(options.select)` directly to a callable; line 193 invokes `parsed(record)` for filter predicates.
- `src/infrastructure/cel/cel_evaluator.ts` — error catches by class (`InvalidExpressionError`); Promise-leak detection on sync `evaluate()`.

### Unrelated 7.5.x fixes that come along

- 7.5.2: `uint(int)` return type fix; new `string(uint)` (we don't exercise these).
- 7.5.3: faster type-check for variable access (internal perf).
- 7.6.1: regex backtracking fix in signature parsing.

## Test Plan

- [x] `deno check` — pass
- [x] `deno lint` — pass
- [x] `deno fmt --check` — pass
- [x] `deno run test` — 5522 passed, 0 failed
- [x] `deno run compile` — binary built
- [x] swamp-uat `uat:cli` against new binary — 398 passed, 0 failed

The history opt-out path (`isLatest` / `version` triggering implicit `&& isLatest == true` injection) is covered by `data_query_service_test.ts` and exercised in UAT — both green, confirming `collectRootIdentifiers` still extracts root identifiers correctly under the new AST shape.