### PR TITLE
fix(drivers): resolve vault sentinels for out-of-process drivers (swamp-club#263)

### DIFF
--- a/design/execution-drivers.md
+++ b/design/execution-drivers.md
@@ -258,7 +258,8 @@ HOST                                    CONTAINER
 1. Build ExecutionRequest
    ├─ globalArgs, methodArgs
    ├─ definitionMeta
-   └─ bundle (Uint8Array)
+   ├─ bundle (Uint8Array)
+   └─ Resolve vault sentinels in args
 
 2. Create temp dir
    ├─ bundle.js          ──mount──▶  /swamp/bundle.js
@@ -283,6 +284,25 @@ HOST                                    CONTAINER
 8. Host persists outputs
    via DataWriter
 ```
+
+## Vault Secret Resolution
+
+Vault expressions (`${{ vault.get(...) }}`) produce sentinel tokens during
+runtime expression resolution. These sentinels must be replaced with actual
+secret values before execution. Each driver path handles this differently:
+
+- **Raw driver**: The `DefaultMethodExecutionService.execute()` method calls
+  `secretBag.resolveDeep()` on method args and global args before invoking the
+  model's `execute` function. The shell model additionally resolves sentinels
+  via environment variables (`resolveForShell`) to prevent shell injection.
+
+- **Out-of-process drivers** (docker, custom): The method execution service
+  resolves sentinels in `executionRequest.methodArgs` and
+  `executionRequest.globalArgs` before dispatching to the driver. This ensures
+  drivers receive plaintext values without needing vault awareness. The
+  resolution operates on cloned data — the original definition is never mutated,
+  so sentinel tokens remain in the persisted definition while only the in-flight
+  request carries resolved values.
 
 ## Output Parity
 

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -709,6 +709,19 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
           );
         }
 
+        // Resolve vault sentinels for out-of-process drivers. The raw driver
+        // resolves sentinels internally via DefaultMethodExecutionService.execute(),
+        // but out-of-process drivers receive the ExecutionRequest as-is.
+        const secretBag = context.vaultSecrets;
+        if (secretBag && !secretBag.isEmpty) {
+          executionRequest.methodArgs = secretBag.resolveDeep(
+            executionRequest.methodArgs,
+          ) as Record<string, unknown>;
+          executionRequest.globalArgs = secretBag.resolveDeep(
+            executionRequest.globalArgs,
+          ) as Record<string, unknown>;
+        }
+
         // Look up a registered driver type
         await driverTypeRegistry.ensureTypeLoaded(driverType);
         const driverInfo = driverTypeRegistry.get(driverType);

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -36,6 +36,11 @@ import { Data } from "../data/data.ts";
 import { UserError } from "../errors.ts";
 import { getLogger } from "@logtape/logtape";
 import { VaultSecretBag } from "../vaults/vault_secret_bag.ts";
+import type {
+  ExecutionRequest,
+  ExecutionResult,
+} from "../drivers/execution_driver.ts";
+import { driverTypeRegistry } from "../drivers/driver_type_registry.ts";
 
 /**
  * Test model that mimics the echo model's write method.
@@ -2819,3 +2824,69 @@ Deno.test("executeWorkflow - rejects unknown global arg key", async () => {
     "Global arguments validation failed",
   );
 });
+
+Deno.test(
+  "executeWorkflow: out-of-process driver receives resolved vault secrets, not sentinels",
+  async () => {
+    const service = new DefaultMethodExecutionService();
+
+    const driverType = `test-capture-${crypto.randomUUID().slice(0, 8)}`;
+    let capturedRequest: ExecutionRequest | null = null;
+
+    driverTypeRegistry.register({
+      type: driverType,
+      name: "Test capture driver",
+      description: "Captures ExecutionRequest for assertions",
+      isBuiltIn: false,
+      createDriver: () => ({
+        type: driverType,
+        execute: (request: ExecutionRequest): Promise<ExecutionResult> => {
+          capturedRequest = request;
+          return Promise.resolve({
+            status: "success",
+            outputs: [],
+            logs: [],
+            durationMs: 0,
+          });
+        },
+      }),
+    });
+
+    const model: ModelDefinition = {
+      type: ModelType.create("test/driver-vault"),
+      version: "1.0.0",
+      globalArguments: z.object({ apiKey: z.string() }),
+      resources: {},
+      methods: {
+        run: {
+          description: "Test method",
+          arguments: z.object({ token: z.string() }),
+          execute: () => Promise.resolve({ dataHandles: [] }),
+        },
+      },
+    };
+
+    const secretBag = new VaultSecretBag();
+    const apiKeySentinel = secretBag.addSecret("real-api-key-value");
+    const tokenSentinel = secretBag.addSecret("real-token-value");
+
+    const definition = Definition.create({
+      name: "test-driver-vault-def",
+      type: "test/driver-vault",
+      globalArguments: { apiKey: apiKeySentinel },
+      methods: { run: { arguments: { token: tokenSentinel } } },
+    });
+
+    const { context } = createTestContext({
+      modelType: model.type,
+      vaultSecrets: secretBag,
+      driver: driverType,
+    });
+
+    await service.executeWorkflow(definition, model, "run", context);
+
+    assertEquals(capturedRequest !== null, true);
+    assertEquals(capturedRequest!.globalArgs.apiKey, "real-api-key-value");
+    assertEquals(capturedRequest!.methodArgs.token, "real-token-value");
+  },
+);


### PR DESCRIPTION
## Summary

- Resolve vault sentinel tokens (`__SWAMP_VSEC_*__`) in `ExecutionRequest.methodArgs` and `ExecutionRequest.globalArgs` before dispatching to out-of-process drivers (docker, custom extension drivers)
- The raw driver already resolves sentinels internally via `DefaultMethodExecutionService.execute()`, but the non-raw dispatch path sent sentinels through unresolved — models received literal sentinel strings instead of decrypted secret values
- Resolution operates on `structuredClone` data from the definition, so persisted state is never mutated

## Test Plan

- Added unit test: registers a mock capture driver via `DriverTypeRegistry`, dispatches through `executeWorkflow` with a `VaultSecretBag` containing sentinel mappings, and asserts the captured `ExecutionRequest` has resolved plaintext values — not sentinels
- Verified against reproduction scenario: workflow step with `${{ vault.get(...) }}` input under docker driver now resolves correctly (sentinel `__SWAMP_VSEC_8c14a9ea_0__` → redacted `***`)
- All 5528 existing tests pass
- `deno check`, `deno lint`, `deno fmt` clean

Closes swamp-club#263

🤖 Generated with [Claude Code](https://claude.com/claude-code)