### PR TITLE
feat(cli): add 'status' alias for 'swamp auth whoami' (swamp-club#275)

### DIFF
--- a/src/cli/commands/auth_whoami.ts
+++ b/src/cli/commands/auth_whoami.ts
@@ -32,8 +32,10 @@ type AnyOptions = any;
 
 export const authWhoamiCommand = new Command()
   .name("whoami")
+  .alias("status")
   .description("Show current authenticated identity")
   .example("Show current identity", "swamp auth whoami")
+  .example("Show current identity (alias)", "swamp auth status")
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, ["auth", "whoami"]);
     cliCtx.logger.debug("Executing auth whoami command");

--- a/src/cli/commands/auth_whoami_test.ts
+++ b/src/cli/commands/auth_whoami_test.ts
@@ -1,0 +1,32 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Import models barrel to trigger self-registration
+import "../../domain/models/models.ts";
+
+// Initialize logging for tests
+await initializeLogging({});
+
+Deno.test("authWhoamiCommand exposes the status alias", async () => {
+  const { authWhoamiCommand } = await import("./auth_whoami.ts");
+  assertEquals(authWhoamiCommand.getAliases().includes("status"), true);
+});


### PR DESCRIPTION
## Summary

- Adds `status` as a Cliffy alias for the `whoami` subcommand under `swamp auth`, matching the dominant CLI convention (`gh auth status`, `kubectl auth whoami`, etc.)
- Reduces friction for AI coding agents and humans who reach for `swamp auth status` by analogy with other CLIs
- Includes a unit test verifying the alias is registered on the command metadata

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] New alias test passes (`deno run test src/cli/commands/auth_whoami_test.ts`)

Closes swamp-club#275

🤖 Generated with [Claude Code](https://claude.com/claude-code)