### PR TITLE
fix(datastore): make setup migration resumable on partial failure (swamp-club#248)

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -612,6 +612,28 @@ remote `.datastore-index.json` at setup time. Subsequent reads from
 datastore-tier repositories see consistent data without an explicit
 `swamp datastore sync --pull` first.
 
+### Partial Failure and Retry
+
+If `swamp datastore setup extension` fails partway through (network blip,
+timeout, Ctrl-C, transient 5xx), the repo stays in a safe, resumable state:
+
+- `.swamp.yaml` is **not updated** — the repo remains filesystem-typed.
+- `.swamp/` data is **not cleaned up** — local data stays intact for retry.
+- Objects already pushed to the remote are harmless — S3 PutObject is
+  idempotent, so a subsequent push overwrites with identical content.
+
+**To retry:** re-run the exact same `swamp datastore setup extension` command.
+The migration copies files to the cache (overwriting any partial cache from the
+previous attempt), pushes to the remote (idempotent), pulls from the remote,
+and only then updates `.swamp.yaml` and cleans up `.swamp/`.
+
+The same applies to `swamp datastore setup filesystem` — the config update is
+guarded behind a successful migration, so a partial copy leaves `.swamp.yaml`
+unchanged and a retry is safe.
+
+The CLI surfaces a retry hint in the output whenever setup completes with
+errors, so the user knows re-running is safe without consulting documentation.
+
 ### Migrating Between Backends
 
 Run `swamp datastore setup` again with the new backend type. The setup command

--- a/src/libswamp/datastores/setup.ts
+++ b/src/libswamp/datastores/setup.ts
@@ -57,6 +57,7 @@ export interface DatastoreSetupData {
   bytesCopied: number;
   directoriesMigrated: string[];
   errors: string[];
+  retryHint?: string;
 }
 
 export type DatastoreSetupEvent =
@@ -198,13 +199,17 @@ export async function* datastoreSetupFilesystem(
         }
       }
 
-      // Update .swamp.yaml with new datastore config
-      const collapsedPath = deps.collapseEnvVars(input.datastorePath);
-      await deps.updateRepoConfig(input.repoDir, {
-        type: "filesystem",
-        path: collapsedPath,
-        directories: input.directories ?? undefined,
-      });
+      // Update .swamp.yaml only when migration succeeded (or was skipped).
+      // Mirrors the extension path guard — avoids pointing the config at
+      // a destination with incomplete data.
+      if (errors.length === 0) {
+        const collapsedPath = deps.collapseEnvVars(input.datastorePath);
+        await deps.updateRepoConfig(input.repoDir, {
+          type: "filesystem",
+          path: collapsedPath,
+          directories: input.directories ?? undefined,
+        });
+      }
 
       yield {
         kind: "completed",
@@ -216,6 +221,12 @@ export async function* datastoreSetupFilesystem(
           bytesCopied,
           directoriesMigrated,
           errors,
+          ...(errors.length > 0
+            ? {
+              retryHint:
+                "Re-run the same command to retry. Local data is preserved and the retry is safe.",
+            }
+            : {}),
         },
       };
     })(),
@@ -441,6 +452,12 @@ export async function* datastoreSetupExtension(
           bytesCopied: 0,
           directoriesMigrated: [],
           errors,
+          ...(errors.length > 0
+            ? {
+              retryHint:
+                "Re-run the same command to retry. Local data is preserved and the retry is safe.",
+            }
+            : {}),
         },
       };
     })(),

--- a/src/libswamp/datastores/setup_test.ts
+++ b/src/libswamp/datastores/setup_test.ts
@@ -522,6 +522,159 @@ Deno.test("datastoreSetupExtension: extension without sync service skips push an
   assertEquals(completed.data.errors, []);
 });
 
+// ============================================================================
+// Retry and partial-failure tests (issue #248)
+//
+// Verify that failed migrations leave the repo in a resumable state:
+// config not updated, .swamp/ preserved, retryHint populated.
+// ============================================================================
+
+Deno.test("datastoreSetupExtension: push failure blocks config update, preserves .swamp/, and surfaces retryHint", async () => {
+  ensureTestExtensionType("test-ext-push-fail", {
+    pushResult: () => Promise.reject(new Error("connection reset")),
+  });
+  let configUpdated = false;
+  let cleanupCalled = false;
+  const deps = makeDeps({
+    updateRepoConfig: () => {
+      configUpdated = true;
+      return Promise.resolve();
+    },
+    cleanupSourceDirs: () => {
+      cleanupCalled = true;
+      return Promise.resolve();
+    },
+  });
+  const input = makeExtensionInput({
+    type: "test-ext-push-fail",
+    skipMigration: false,
+  });
+
+  const events = await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    DatastoreSetupEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.errors.length, 1);
+  assertStringIncludes(completed.data.errors[0], "connection reset");
+  assertEquals(
+    configUpdated,
+    false,
+    "push failure must prevent .swamp.yaml writeback",
+  );
+  assertEquals(
+    cleanupCalled,
+    false,
+    "push failure must keep migrated .swamp/ dirs intact for retry",
+  );
+  assertEquals(
+    typeof completed.data.retryHint,
+    "string",
+    "push failure must surface a retryHint",
+  );
+});
+
+Deno.test("datastoreSetupExtension: pull failure after successful push surfaces retryHint", async () => {
+  ensureTestExtensionType("test-ext-push-ok-pull-fail", {
+    pullResult: () => Promise.reject(new Error("timeout")),
+  });
+  let configUpdated = false;
+  const deps = makeDeps({
+    updateRepoConfig: () => {
+      configUpdated = true;
+      return Promise.resolve();
+    },
+  });
+  const input = makeExtensionInput({
+    type: "test-ext-push-ok-pull-fail",
+    skipMigration: false,
+  });
+
+  const events = await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    DatastoreSetupEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.errors.length, 1);
+  assertStringIncludes(completed.data.errors[0], "timeout");
+  assertEquals(
+    configUpdated,
+    false,
+    "pull failure must prevent .swamp.yaml writeback even when push succeeded",
+  );
+  assertEquals(
+    typeof completed.data.retryHint,
+    "string",
+    "pull failure must surface a retryHint",
+  );
+});
+
+Deno.test("datastoreSetupFilesystem: migration errors block config update and surface retryHint", async () => {
+  let configUpdated = false;
+  const deps = makeDeps({
+    migrateData: () =>
+      Promise.resolve({
+        filesCopied: 3,
+        bytesCopied: 512,
+        directoriesMigrated: ["data"],
+        errors: ["Failed to migrate outputs: permission denied"],
+      }),
+    updateRepoConfig: () => {
+      configUpdated = true;
+      return Promise.resolve();
+    },
+  });
+  const input = makeFilesystemInput();
+
+  const events = await collect<DatastoreSetupEvent>(
+    datastoreSetupFilesystem(createLibSwampContext(), deps, input),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    DatastoreSetupEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.errors.length, 1);
+  assertStringIncludes(completed.data.errors[0], "permission denied");
+  assertEquals(
+    configUpdated,
+    false,
+    "migration errors must prevent .swamp.yaml writeback",
+  );
+  assertEquals(
+    typeof completed.data.retryHint,
+    "string",
+    "migration errors must surface a retryHint",
+  );
+});
+
+Deno.test("datastoreSetupExtension: successful setup has no retryHint", async () => {
+  ensureTestExtensionType("test-ext-no-hint");
+  const deps = makeDeps();
+  const input = makeExtensionInput({ type: "test-ext-no-hint" });
+
+  const events = await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    DatastoreSetupEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.errors, []);
+  assertEquals(completed.data.retryHint, undefined);
+});
+
 Deno.test("datastoreSetupExtension: ensures cachePath exists before hydration pull", async () => {
   // Defensive guard: setup owns its preconditions rather than relying on
   // sync service internals. Some extension implementations may not call

--- a/src/presentation/renderers/datastore_setup.ts
+++ b/src/presentation/renderers/datastore_setup.ts
@@ -73,6 +73,10 @@ class LogDatastoreSetupRenderer implements Renderer<DatastoreSetupEvent> {
           for (const err of data.errors) {
             lines.push(`  ${yellow("!")} ${err}`);
           }
+          if (data.retryHint) {
+            lines.push("");
+            lines.push(yellow(data.retryHint));
+          }
         }
 
         writeOutput(lines.join("\n"));


### PR DESCRIPTION
## Summary

- Guard `.swamp.yaml` config update behind `errors.length === 0` on both filesystem and extension setup paths, so a failed migration never leaves the config pointing at an incomplete datastore
- Add `retryHint` field to `DatastoreSetupData` and render it in CLI output when setup completes with errors, telling users they can safely re-run
- Document retry/recovery semantics in `design/datastores.md` ("Partial Failure and Retry" subsection)
- Fix consistency bug where `datastoreSetupFilesystem` updated `.swamp.yaml` unconditionally even when migration had errors (the extension path already guarded this correctly)

## Scope note

This intentionally does not add rollback or progress-tracking machinery. Rollback (deleting S3 objects on failure) is fragile — it requires tracking which objects were uploaded in this attempt vs. pre-existing ones, and a rollback failure creates a worse partial state. The migration is already mechanically idempotent (S3 PutObject overwrites are safe, local `.swamp/` preserved on failure). If retry-is-safe messaging proves insufficient, that would be a separate issue.

## Test plan

- [x] New test: push failure blocks config update, preserves `.swamp/`, surfaces retryHint
- [x] New test: pull failure after successful push surfaces retryHint  
- [x] New test: filesystem migration errors block config update and surface retryHint
- [x] New test: successful setup has no retryHint
- [x] All 5574 existing tests pass
- [x] `deno check` / `deno lint` / `deno fmt` clean

Closes swamp-club#248

🤖 Generated with [Claude Code](https://claude.com/claude-code)