### PR TITLE
feat(cli): add 'list' as alias for 'search' on resource-enumerating commands (swamp-club#276)

### DIFF
--- a/src/cli/commands/model_method_history.ts
+++ b/src/cli/commands/model_method_history.ts
@@ -19,7 +19,10 @@
 
 import { Command } from "@cliffy/command";
 import { modelMethodHistoryGetCommand } from "./model_method_history_get.ts";
-import { modelMethodHistorySearchCommand } from "./model_method_history_search.ts";
+import {
+  modelMethodHistorySearchAction,
+  modelMethodHistorySearchCommand,
+} from "./model_method_history_search.ts";
 import { modelMethodHistoryLogsCommand } from "./model_method_history_logs.ts";
 
 export const modelMethodHistoryCommand = new Command()
@@ -30,4 +33,16 @@ export const modelMethodHistoryCommand = new Command()
   })
   .command("get", modelMethodHistoryGetCommand)
   .command("search", modelMethodHistorySearchCommand)
-  .command("logs", modelMethodHistoryLogsCommand);
+  .command("logs", modelMethodHistoryLogsCommand)
+  .command(
+    "list",
+    new Command()
+      .description("Alias for model method history search")
+      .hidden()
+      .arguments("[query:string]")
+      .option(
+        "--repo-dir <dir:string>",
+        "Repository directory (env: SWAMP_REPO_DIR)",
+      )
+      .action(modelMethodHistorySearchAction),
+  );

--- a/src/cli/commands/model_method_history_search.ts
+++ b/src/cli/commands/model_method_history_search.ts
@@ -41,6 +41,58 @@ import { createDefinitionId } from "../../domain/definitions/definition.ts";
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
+export async function modelMethodHistorySearchAction(
+  options: AnyOptions,
+  query?: string,
+): Promise<void> {
+  const ctx = createContext(options as GlobalOptions, [
+    "model",
+    "method",
+    "history",
+    "search",
+  ]);
+  const effectiveMode = interactiveOutputMode(ctx);
+  const libCtx = createLibSwampContext();
+  ctx.logger.debug`Searching method history with query: ${query ?? "(none)"}`;
+
+  const { repoContext } = await requireInitializedRepoReadOnly({
+    repoDir: resolveRepoDir(options.repoDir),
+    outputMode: effectiveMode,
+  });
+
+  const deps: ModelOutputSearchDeps = {
+    findAllOutputsGlobal: () => repoContext.outputRepo.findAllGlobal(),
+    findDefinitionById: (type, defId) =>
+      repoContext.definitionRepo.findById(
+        ModelType.create(type.normalized),
+        createDefinitionId(defId),
+      ),
+  };
+
+  const renderer = createModelOutputSearchRenderer(effectiveMode);
+  await consumeStream(
+    modelOutputSearch(libCtx, deps, { query }),
+    renderer.handlers(),
+  );
+
+  const selected = renderer.selectedItem();
+  if (selected) {
+    ctx.logger.debug`Selected output: ${selected.id}`;
+    const getRenderer = createModelOutputGetRenderer(effectiveMode);
+    const getDeps = await createModelOutputGetDeps(
+      resolveRepoDir(options.repoDir),
+    );
+    await consumeStream(
+      modelOutputGet(libCtx, getDeps, selected.id),
+      getRenderer.handlers(),
+    );
+  } else {
+    ctx.logger.debug`Search cancelled`;
+  }
+
+  ctx.logger.debug("Model method history search command completed");
+}
+
 export const modelMethodHistorySearchCommand = new Command()
   .name("search")
   .description("Search model method run history")
@@ -51,51 +103,4 @@ export const modelMethodHistorySearchCommand = new Command()
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
-  .action(async function (options: AnyOptions, query?: string) {
-    const ctx = createContext(options as GlobalOptions, [
-      "model",
-      "method",
-      "history",
-      "search",
-    ]);
-    const effectiveMode = interactiveOutputMode(ctx);
-    const libCtx = createLibSwampContext();
-    ctx.logger.debug`Searching method history with query: ${query ?? "(none)"}`;
-
-    const { repoContext } = await requireInitializedRepoReadOnly({
-      repoDir: resolveRepoDir(options.repoDir),
-      outputMode: effectiveMode,
-    });
-
-    const deps: ModelOutputSearchDeps = {
-      findAllOutputsGlobal: () => repoContext.outputRepo.findAllGlobal(),
-      findDefinitionById: (type, defId) =>
-        repoContext.definitionRepo.findById(
-          ModelType.create(type.normalized),
-          createDefinitionId(defId),
-        ),
-    };
-
-    const renderer = createModelOutputSearchRenderer(effectiveMode);
-    await consumeStream(
-      modelOutputSearch(libCtx, deps, { query }),
-      renderer.handlers(),
-    );
-
-    const selected = renderer.selectedItem();
-    if (selected) {
-      ctx.logger.debug`Selected output: ${selected.id}`;
-      const getRenderer = createModelOutputGetRenderer(effectiveMode);
-      const getDeps = await createModelOutputGetDeps(
-        resolveRepoDir(options.repoDir),
-      );
-      await consumeStream(
-        modelOutputGet(libCtx, getDeps, selected.id),
-        getRenderer.handlers(),
-      );
-    } else {
-      ctx.logger.debug`Search cancelled`;
-    }
-
-    ctx.logger.debug("Model method history search command completed");
-  });
+  .action(modelMethodHistorySearchAction);

--- a/src/cli/commands/model_output.ts
+++ b/src/cli/commands/model_output.ts
@@ -19,7 +19,10 @@
 
 import { Command } from "@cliffy/command";
 import { modelOutputGetCommand } from "./model_output_get.ts";
-import { modelOutputSearchCommand } from "./model_output_search.ts";
+import {
+  modelOutputSearchAction,
+  modelOutputSearchCommand,
+} from "./model_output_search.ts";
 import { modelOutputLogsCommand } from "./model_output_logs.ts";
 import { modelOutputDataCommand } from "./model_output_data.ts";
 
@@ -32,4 +35,16 @@ export const modelOutputCommand = new Command()
   .command("get", modelOutputGetCommand)
   .command("search", modelOutputSearchCommand)
   .command("logs", modelOutputLogsCommand)
-  .command("data", modelOutputDataCommand);
+  .command("data", modelOutputDataCommand)
+  .command(
+    "list",
+    new Command()
+      .description("Alias for model output search")
+      .hidden()
+      .arguments("[query:string]")
+      .option(
+        "--repo-dir <dir:string>",
+        "Repository directory (env: SWAMP_REPO_DIR)",
+      )
+      .action(modelOutputSearchAction),
+  );

--- a/src/cli/commands/model_output_search.ts
+++ b/src/cli/commands/model_output_search.ts
@@ -70,6 +70,65 @@ async function createOutputFetchPreview(
   };
 }
 
+export async function modelOutputSearchAction(
+  options: AnyOptions,
+  query?: string,
+): Promise<void> {
+  const ctx = createContext(options as GlobalOptions, [
+    "model",
+    "output",
+    "search",
+  ]);
+  const effectiveMode = interactiveOutputMode(ctx);
+  const libCtx = createLibSwampContext();
+  ctx.logger.debug`Searching outputs with query: ${query ?? "(none)"}`;
+
+  const { repoContext } = await requireInitializedRepoReadOnly({
+    repoDir: resolveRepoDir(options.repoDir),
+    outputMode: effectiveMode,
+  });
+
+  const deps: ModelOutputSearchDeps = {
+    findAllOutputsGlobal: () => repoContext.outputRepo.findAllGlobal(),
+    findDefinitionById: (type, defId) =>
+      repoContext.definitionRepo.findById(
+        ModelType.create(type.normalized),
+        createDefinitionId(defId),
+      ),
+  };
+
+  const repoDir = resolveRepoDir(options.repoDir);
+  const fetchPreview = effectiveMode === "log"
+    ? await createOutputFetchPreview(repoDir)
+    : undefined;
+
+  const renderer = createModelOutputSearchRenderer(
+    effectiveMode,
+    fetchPreview,
+  );
+  await consumeStream(
+    modelOutputSearch(libCtx, deps, { query }),
+    renderer.handlers(),
+  );
+
+  const selected = renderer.selectedItem();
+  if (selected) {
+    ctx.logger.debug`Selected output: ${selected.id}`;
+    if (effectiveMode === "json") {
+      const getRenderer = createModelOutputGetRenderer(effectiveMode);
+      const getDeps = await createModelOutputGetDeps(repoDir);
+      await consumeStream(
+        modelOutputGet(libCtx, getDeps, selected.id),
+        getRenderer.handlers(),
+      );
+    }
+  } else {
+    ctx.logger.debug`Search cancelled`;
+  }
+
+  ctx.logger.debug("Model output search command completed");
+}
+
 export const modelOutputSearchCommand = new Command()
   .name("search")
   .description("Search for model outputs")
@@ -80,61 +139,4 @@ export const modelOutputSearchCommand = new Command()
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
-  .action(async function (options: AnyOptions, query?: string) {
-    const ctx = createContext(options as GlobalOptions, [
-      "model",
-      "output",
-      "search",
-    ]);
-    const effectiveMode = interactiveOutputMode(ctx);
-    const libCtx = createLibSwampContext();
-    ctx.logger.debug`Searching outputs with query: ${query ?? "(none)"}`;
-
-    const { repoContext } = await requireInitializedRepoReadOnly({
-      repoDir: resolveRepoDir(options.repoDir),
-      outputMode: effectiveMode,
-    });
-
-    const deps: ModelOutputSearchDeps = {
-      findAllOutputsGlobal: () => repoContext.outputRepo.findAllGlobal(),
-      findDefinitionById: (type, defId) =>
-        repoContext.definitionRepo.findById(
-          ModelType.create(type.normalized),
-          createDefinitionId(defId),
-        ),
-    };
-
-    const repoDir = resolveRepoDir(options.repoDir);
-    const fetchPreview = effectiveMode === "log"
-      ? await createOutputFetchPreview(repoDir)
-      : undefined;
-
-    const renderer = createModelOutputSearchRenderer(
-      effectiveMode,
-      fetchPreview,
-    );
-    await consumeStream(
-      modelOutputSearch(libCtx, deps, { query }),
-      renderer.handlers(),
-    );
-
-    const selected = renderer.selectedItem();
-    if (selected) {
-      ctx.logger.debug`Selected output: ${selected.id}`;
-      // In JSON mode, still display the full output get after auto-select
-      if (effectiveMode === "json") {
-        const getRenderer = createModelOutputGetRenderer(effectiveMode);
-        const getDeps = await createModelOutputGetDeps(repoDir);
-        await consumeStream(
-          modelOutputGet(libCtx, getDeps, selected.id),
-          getRenderer.handlers(),
-        );
-      }
-      // In interactive mode, the scrollback from the picker already contains
-      // the output detail, so no additional modelOutputGet call is needed.
-    } else {
-      ctx.logger.debug`Search cancelled`;
-    }
-
-    ctx.logger.debug("Model output search command completed");
-  });
+  .action(modelOutputSearchAction);

--- a/src/cli/commands/model_type.ts
+++ b/src/cli/commands/model_type.ts
@@ -19,7 +19,7 @@
 
 import { Command } from "@cliffy/command";
 import { typeDescribeCommand } from "./type_describe.ts";
-import { typeSearchCommand } from "./type_search.ts";
+import { typeSearchAction, typeSearchCommand } from "./type_search.ts";
 
 /**
  * Parent command for model type operations.
@@ -31,4 +31,16 @@ export const modelTypeCommand = new Command()
     this.showHelp();
   })
   .command("describe", typeDescribeCommand)
-  .command("search", typeSearchCommand);
+  .command("search", typeSearchCommand)
+  .command(
+    "list",
+    new Command()
+      .description("Alias for type search")
+      .hidden()
+      .arguments("[query:string]")
+      .option(
+        "--repo-dir <dir:string>",
+        "Repository directory (env: SWAMP_REPO_DIR; not required for type search)",
+      )
+      .action(typeSearchAction),
+  );

--- a/src/cli/commands/report.ts
+++ b/src/cli/commands/report.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { reportSearchCommand } from "./report_search.ts";
+import { reportSearchAction, reportSearchCommand } from "./report_search.ts";
 import { reportGetCommand } from "./report_get.ts";
 import { reportDescribeCommand } from "./report_describe.ts";
 import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
@@ -32,4 +32,16 @@ export const reportCommand = new Command()
   })
   .command("search", reportSearchCommand)
   .command("get", reportGetCommand)
-  .command("describe", reportDescribeCommand);
+  .command("describe", reportDescribeCommand)
+  .command(
+    "list",
+    new Command()
+      .description("Alias for report search")
+      .hidden()
+      .arguments("[query:string]")
+      .option(
+        "--repo-dir <dir:string>",
+        "Repository directory (env: SWAMP_REPO_DIR)",
+      )
+      .action(reportSearchAction),
+  );

--- a/src/cli/commands/report_search.ts
+++ b/src/cli/commands/report_search.ts
@@ -159,6 +159,61 @@ async function displayReportDetail(
   );
 }
 
+export async function reportSearchAction(
+  options: AnyOptions,
+  query?: string,
+): Promise<void> {
+  const ctx = createContext(options as GlobalOptions, [
+    "report",
+    "search",
+  ]);
+  const effectiveMode = interactiveOutputMode(ctx);
+
+  const { repoContext } = await requireInitializedRepoReadOnly({
+    repoDir: resolveRepoDir(options.repoDir),
+    outputMode: effectiveMode,
+  });
+
+  const libCtx = createLibSwampContext({ logger: ctx.logger });
+
+  const fetchPreview = effectiveMode === "log"
+    ? createReportFetchPreview(repoContext)
+    : undefined;
+
+  const searchRenderer = createReportSearchRenderer(
+    effectiveMode,
+    query ?? "",
+    fetchPreview,
+  );
+  await consumeStream(
+    reportSearch(libCtx, await buildSearchDeps(repoContext), {
+      query,
+      model: options.model as string | undefined,
+      workflow: options.workflow as string | undefined,
+      scope: options.scope as string | undefined,
+      labels: options.label as string[] | undefined,
+    }),
+    searchRenderer.handlers(),
+  );
+
+  const selected = searchRenderer.selectedItem();
+  if (selected) {
+    ctx.logger.debug`Selected report: ${selected.reportName}`;
+    if (effectiveMode === "json") {
+      await displayReportDetail(
+        selected,
+        repoContext,
+        libCtx,
+        effectiveMode,
+      );
+    }
+  } else {
+    ctx.logger.debug`Search cancelled`;
+  }
+
+  ctx.logger.debug("Report search command completed");
+}
+
 export const reportSearchCommand = new Command()
   .name("search")
   .description("Search stored report results across all models and workflows")
@@ -180,57 +235,4 @@ export const reportSearchCommand = new Command()
     "Filter by report label (repeatable)",
     { collect: true },
   )
-  .action(async function (options: AnyOptions, query?: string) {
-    const ctx = createContext(options as GlobalOptions, [
-      "report",
-      "search",
-    ]);
-    const effectiveMode = interactiveOutputMode(ctx);
-
-    const { repoContext } = await requireInitializedRepoReadOnly({
-      repoDir: resolveRepoDir(options.repoDir),
-      outputMode: effectiveMode,
-    });
-
-    const libCtx = createLibSwampContext({ logger: ctx.logger });
-
-    const fetchPreview = effectiveMode === "log"
-      ? createReportFetchPreview(repoContext)
-      : undefined;
-
-    const searchRenderer = createReportSearchRenderer(
-      effectiveMode,
-      query ?? "",
-      fetchPreview,
-    );
-    await consumeStream(
-      reportSearch(libCtx, await buildSearchDeps(repoContext), {
-        query,
-        model: options.model as string | undefined,
-        workflow: options.workflow as string | undefined,
-        scope: options.scope as string | undefined,
-        labels: options.label as string[] | undefined,
-      }),
-      searchRenderer.handlers(),
-    );
-
-    const selected = searchRenderer.selectedItem();
-    if (selected) {
-      ctx.logger.debug`Selected report: ${selected.reportName}`;
-      // In JSON mode, still display the full report detail after auto-select
-      if (effectiveMode === "json") {
-        await displayReportDetail(
-          selected,
-          repoContext,
-          libCtx,
-          effectiveMode,
-        );
-      }
-      // In interactive mode, the scrollback from the picker already contains
-      // the report detail, so no additional displayReportDetail call is needed.
-    } else {
-      ctx.logger.debug`Search cancelled`;
-    }
-
-    ctx.logger.debug("Report search command completed");
-  });
+  .action(reportSearchAction);

--- a/src/cli/commands/type_search.ts
+++ b/src/cli/commands/type_search.ts
@@ -71,61 +71,60 @@ function createTypeFetchPreview(): (
   };
 }
 
+export async function typeSearchAction(
+  options: AnyOptions,
+  query?: string,
+): Promise<void> {
+  const ctx = createContext(options as GlobalOptions, ["type", "search"]);
+  const effectiveMode = interactiveOutputMode(ctx);
+  const libCtx = createLibSwampContext();
+  ctx.logger.debug`Searching types with query: ${query ?? "(none)"}`;
+
+  await modelRegistry.ensureLoaded();
+  const deps: TypeSearchDeps = {
+    getRegisteredTypes: () => modelRegistry.types(),
+  };
+
+  const fetchPreview = effectiveMode === "log"
+    ? createTypeFetchPreview()
+    : undefined;
+
+  const renderer = createTypeSearchRenderer(effectiveMode, fetchPreview);
+  await consumeStream(
+    typeSearch(libCtx, deps, { query }),
+    renderer.handlers(),
+  );
+
+  const selected = renderer.selectedItem();
+  if (selected) {
+    ctx.logger.debug`Selected type: ${selected.normalized}`;
+    if (effectiveMode === "json") {
+      const describeRenderer = createTypeDescribeRenderer(effectiveMode);
+      const describeDeps = createTypeDescribeDeps();
+      await consumeStream(
+        typeDescribe(
+          libCtx,
+          describeDeps,
+          ModelType.create(selected.normalized),
+        ),
+        describeRenderer.handlers(),
+      );
+    }
+  } else {
+    ctx.logger.debug`Search cancelled`;
+  }
+
+  ctx.logger.debug("Type search command completed");
+}
+
 export const typeSearchCommand = new Command()
   .name("search")
   .description("Search for model types")
   .example("Browse all types", "swamp type search")
   .example("Search by keyword", "swamp type search aws")
-  // `--repo-dir` is accepted for agentic-flow consistency with other
-  // commands; type search reads only the global extension catalog and
-  // does not require an initialized repo.
   .option(
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR; not required for type search)",
   )
   .arguments("[query:string]")
-  .action(async function (options: AnyOptions, query?: string) {
-    const ctx = createContext(options as GlobalOptions, ["type", "search"]);
-    const effectiveMode = interactiveOutputMode(ctx);
-    const libCtx = createLibSwampContext();
-    ctx.logger.debug`Searching types with query: ${query ?? "(none)"}`;
-
-    await modelRegistry.ensureLoaded();
-    const deps: TypeSearchDeps = {
-      getRegisteredTypes: () => modelRegistry.types(),
-    };
-
-    const fetchPreview = effectiveMode === "log"
-      ? createTypeFetchPreview()
-      : undefined;
-
-    const renderer = createTypeSearchRenderer(effectiveMode, fetchPreview);
-    await consumeStream(
-      typeSearch(libCtx, deps, { query }),
-      renderer.handlers(),
-    );
-
-    const selected = renderer.selectedItem();
-    if (selected) {
-      ctx.logger.debug`Selected type: ${selected.normalized}`;
-      // In JSON mode, still display the full type describe output after auto-select
-      if (effectiveMode === "json") {
-        const describeRenderer = createTypeDescribeRenderer(effectiveMode);
-        const describeDeps = createTypeDescribeDeps();
-        await consumeStream(
-          typeDescribe(
-            libCtx,
-            describeDeps,
-            ModelType.create(selected.normalized),
-          ),
-          describeRenderer.handlers(),
-        );
-      }
-      // In interactive mode, the scrollback from the picker already contains
-      // the type detail, so no additional typeDescribe call is needed.
-    } else {
-      ctx.logger.debug`Search cancelled`;
-    }
-
-    ctx.logger.debug("Type search command completed");
-  });
+  .action(typeSearchAction);

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -25,7 +25,10 @@ import { workflowEvaluateCommand } from "./workflow_evaluate.ts";
 import { workflowGetCommand } from "./workflow_get.ts";
 import { workflowHistoryCommand } from "./workflow_history.ts";
 import { workflowValidateCommand } from "./workflow_validate.ts";
-import { workflowSearchCommand } from "./workflow_search.ts";
+import {
+  workflowSearchAction,
+  workflowSearchCommand,
+} from "./workflow_search.ts";
 import { workflowRunCommand } from "./workflow_run.ts";
 import { workflowSchemaCommand } from "./workflow_schema.ts";
 import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
@@ -46,4 +49,16 @@ export const workflowCommand = new Command()
   .command("validate", workflowValidateCommand)
   .command("search", workflowSearchCommand)
   .command("run", workflowRunCommand)
-  .command("schema", workflowSchemaCommand);
+  .command("schema", workflowSchemaCommand)
+  .command(
+    "list",
+    new Command()
+      .description("Alias for workflow search")
+      .hidden()
+      .arguments("[query:string]")
+      .option(
+        "--repo-dir <dir:string>",
+        "Repository directory (env: SWAMP_REPO_DIR)",
+      )
+      .action(workflowSearchAction),
+  );

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -43,7 +43,10 @@ import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
 import { driverTypeRegistry } from "../../domain/drivers/driver_type_registry.ts";
 import { reportRegistry } from "../../domain/reports/report_registry.ts";
 import { parseTags } from "../../libswamp/mod.ts";
-import { workflowRunSearchCommand } from "./workflow_run_search.ts";
+import {
+  workflowRunSearchAction,
+  workflowRunSearchCommand,
+} from "./workflow_run_search.ts";
 import {
   consumeStream,
   createLibSwampContext,
@@ -317,4 +320,16 @@ export const workflowRunCommand = new Command()
       throw new UserError(`Workflow execution failed: ${message}`);
     }
   })
-  .command("search", workflowRunSearchCommand);
+  .command("search", workflowRunSearchCommand)
+  .command(
+    "list",
+    new Command()
+      .description("Alias for workflow run search")
+      .hidden()
+      .arguments("[query:string]")
+      .option(
+        "--repo-dir <dir:string>",
+        "Repository directory (env: SWAMP_REPO_DIR)",
+      )
+      .action(workflowRunSearchAction),
+  );

--- a/src/cli/commands/workflow_search.ts
+++ b/src/cli/commands/workflow_search.ts
@@ -96,6 +96,64 @@ async function displayWorkflowGet(
   renderWorkflowGet(data, outputMode);
 }
 
+export async function workflowSearchAction(
+  options: AnyOptions,
+  query?: string,
+): Promise<void> {
+  const ctx = createContext(options as GlobalOptions, ["workflow", "search"]);
+  const effectiveMode = interactiveOutputMode(ctx);
+  const libCtx = createLibSwampContext();
+  ctx.logger.debug`Searching workflows with query: ${query ?? "(none)"}`;
+
+  const { repoContext } = await requireInitializedRepoReadOnly({
+    repoDir: resolveRepoDir(options.repoDir),
+    outputMode: effectiveMode,
+  });
+  const repo = repoContext.workflowRepo;
+
+  const deps: WorkflowSearchDeps = {
+    findAllWorkflows: () => repo.findAll(),
+  };
+
+  const fetchPreview = effectiveMode === "log"
+    ? createWorkflowFetchPreview(repo)
+    : undefined;
+
+  const renderer = createWorkflowSearchRenderer(effectiveMode, fetchPreview);
+  await consumeStream(
+    workflowSearch(libCtx, deps, { query }),
+    renderer.handlers(),
+  );
+
+  const selected = renderer.selectedItem();
+
+  if (selected) {
+    ctx.logger.debug`Selected workflow: ${selected.name}`;
+    const action = renderer.selectedAction();
+
+    if (action === "run") {
+      ctx.logger.debug`Running workflow: ${selected.name}`;
+      const repoDir = resolveRepoDir(options.repoDir);
+      const cmd = new Deno.Command(Deno.execPath(), {
+        args: ["workflow", "run", selected.name, "--repo-dir", repoDir],
+        stdin: "inherit",
+        stdout: "inherit",
+        stderr: "inherit",
+      });
+      const status = await cmd.output();
+      if (!status.success) {
+        Deno.exit(status.code);
+      }
+    } else if (effectiveMode === "json") {
+      await displayWorkflowGet(selected.name, repo, effectiveMode);
+    }
+  } else {
+    ctx.logger.debug`Search cancelled`;
+  }
+
+  ctx.logger.debug("Workflow search command completed");
+}
+
 export const workflowSearchCommand = new Command()
   .name("search")
   .description("Search for workflows")
@@ -106,64 +164,4 @@ export const workflowSearchCommand = new Command()
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
-  .action(async function (options: AnyOptions, query?: string) {
-    const ctx = createContext(options as GlobalOptions, ["workflow", "search"]);
-    const effectiveMode = interactiveOutputMode(ctx);
-    const libCtx = createLibSwampContext();
-    ctx.logger.debug`Searching workflows with query: ${query ?? "(none)"}`;
-
-    // Search is always read-only. Execution (if "r" is pressed) happens via
-    // subprocess, so we don't need a write lock.
-    const { repoContext } = await requireInitializedRepoReadOnly({
-      repoDir: resolveRepoDir(options.repoDir),
-      outputMode: effectiveMode,
-    });
-    const repo = repoContext.workflowRepo;
-
-    const deps: WorkflowSearchDeps = {
-      findAllWorkflows: () => repo.findAll(),
-    };
-
-    const fetchPreview = effectiveMode === "log"
-      ? createWorkflowFetchPreview(repo)
-      : undefined;
-
-    const renderer = createWorkflowSearchRenderer(effectiveMode, fetchPreview);
-    await consumeStream(
-      workflowSearch(libCtx, deps, { query }),
-      renderer.handlers(),
-    );
-
-    const selected = renderer.selectedItem();
-
-    if (selected) {
-      ctx.logger.debug`Selected workflow: ${selected.name}`;
-      const action = renderer.selectedAction();
-
-      if (action === "run") {
-        // Shell out to `swamp workflow run <name>`, inheriting stdin/stdout/stderr
-        // so the user gets the full interactive experience (input file selection,
-        // progress tree, etc.)
-        ctx.logger.debug`Running workflow: ${selected.name}`;
-        const repoDir = resolveRepoDir(options.repoDir);
-        const cmd = new Deno.Command(Deno.execPath(), {
-          args: ["workflow", "run", selected.name, "--repo-dir", repoDir],
-          stdin: "inherit",
-          stdout: "inherit",
-          stderr: "inherit",
-        });
-        const status = await cmd.output();
-        if (!status.success) {
-          Deno.exit(status.code);
-        }
-      } else if (effectiveMode === "json") {
-        // JSON mode: display workflow details
-        await displayWorkflowGet(selected.name, repo, effectiveMode);
-      }
-      // Interactive mode without "run": scrollback already has the YAML
-    } else {
-      ctx.logger.debug`Search cancelled`;
-    }
-
-    ctx.logger.debug("Workflow search command completed");
-  });
+  .action(workflowSearchAction);


### PR DESCRIPTION
## Summary

- Add hidden `list` aliases that delegate to the existing `search` action on all resource-enumerating commands: `workflow`, `model type`, `report`, `model output`, `model method history`, and `workflow run`
- Extract inline search actions into named exported functions to enable reuse by the alias commands
- Completes the set — `model`, `vault`, `vault type`, and `workflow history` already had these aliases

Closes swamp-club#276

## Test Plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — no lint errors
- [x] `deno fmt --check` — formatting clean
- [x] `deno run test` — all 5575 tests pass
- [x] Verified the hidden alias pattern matches the 4 existing instances (model, vault, vault type, workflow history)

🤖 Generated with [Claude Code](https://claude.com/claude-code)