### PR TITLE
feat(workflows): resolve self.* in modelIdOrName during forEach (swamp-club#279)

### DIFF
--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -430,7 +430,8 @@ swamp workflow evaluate --all --json
 **Key behaviors:**
 
 - CEL expressions (`${{ inputs.X }}`, `${{ model.X.resource... }}`) are resolved
-- forEach steps are expanded into concrete steps with resolved inputs
+- forEach steps are expanded into concrete steps with resolved `modelIdOrName`,
+  `methodName`, inputs, and args
 - Vault expressions (`${{ vault.get(...) }}`) remain raw for runtime resolution
 - Output saved to `.swamp/workflows-evaluated/` for `--last-evaluated` use
 

--- a/.claude/skills/swamp-workflow/references/expressions-and-foreach.md
+++ b/.claude/skills/swamp-workflow/references/expressions-and-foreach.md
@@ -66,6 +66,29 @@ With `--input '{"tags": {"env": "prod", "team": "platform"}}'`, creates steps:
 - `tag-env` (with `self.tag.key="env"`, `self.tag.value="prod"`)
 - `tag-team` (with `self.tag.key="team"`, `self.tag.value="platform"`)
 
+### Dynamic Model Targeting
+
+`self.*` expressions resolve in `modelIdOrName` and `methodName`, enabling
+forEach steps to target different model instances per iteration:
+
+```yaml
+steps:
+  - name: summary-${{ self.region }}
+    forEach:
+      item: region
+      in: ${{ inputs.regions }}
+    task:
+      type: model_method
+      modelIdOrName: aws-alarms-${{ self.region }}
+      methodName: get_summary
+      inputs:
+        historyHours: 24
+```
+
+With `regions: ["us-east-1", "eu-west-1"]`, this creates two steps targeting
+`aws-alarms-us-east-1` and `aws-alarms-eu-west-1` respectively. The resolved
+names appear in `--last-evaluated` output.
+
 ### forEach Variables
 
 | Variable            | Description                    |

--- a/design/expressions.md
+++ b/design/expressions.md
@@ -207,6 +207,23 @@ output.
       uri: ${{ self.ep.magnet }}
 ```
 
+`self.*` expressions also resolve in `modelIdOrName` and `methodName`, enabling
+forEach steps to target different model instances per iteration:
+
+```yaml
+# Fan out across region-specific model instances:
+- name: summary-${{ self.region }}
+  forEach:
+    item: region
+    in: ${{ inputs.regions }}
+  task:
+    type: model_method
+    modelIdOrName: aws-alarms-${{ self.region }}
+    methodName: get_summary
+    inputs:
+      historyHours: 24
+```
+
 Results are **not** run-scoped — `findBySpec` returns every matching record
 in the catalog. Add a `workflowRunId` predicate via `data.query()` when you
 want to scope to the current run.

--- a/src/libswamp/workflows/evaluate.ts
+++ b/src/libswamp/workflows/evaluate.ts
@@ -353,8 +353,8 @@ async function evaluateWorkflowInternal(
 }
 
 /**
- * Resolves forEach self.* expressions in a task's inputs and args.
- * Vault expressions are left raw for runtime resolution.
+ * Resolves forEach self.* expressions in a task's modelIdOrName, methodName,
+ * inputs, and args. Vault expressions are left raw for runtime resolution.
  */
 function resolveForEachTaskExpressions(
   // deno-lint-ignore no-explicit-any
@@ -365,6 +365,23 @@ function resolveForEachTaskExpressions(
   // deno-lint-ignore no-explicit-any
 ): any {
   const expandedTask = JSON.parse(JSON.stringify(taskData));
+
+  // Resolve expressions in modelIdOrName and methodName
+  for (const field of ["modelIdOrName", "methodName"] as const) {
+    if (expandedTask[field] && typeof expandedTask[field] === "string") {
+      expandedTask[field] = (expandedTask[field] as string).replace(
+        /\$\{\{\s*(.+?)\s*\}\}/g,
+        (_match: string, expr: string) => {
+          if (containsRuntimeExpression(expr)) return _match;
+          try {
+            return String(deps.evaluateCel(expr, stepContext));
+          } catch {
+            return _match;
+          }
+        },
+      );
+    }
+  }
 
   // Resolve expressions in task inputs (model and workflow tasks)
   if (expandedTask.inputs) {

--- a/src/libswamp/workflows/evaluate_test.ts
+++ b/src/libswamp/workflows/evaluate_test.ts
@@ -156,6 +156,233 @@ Deno.test("workflowEvaluate workflow without expressions yields hadExpressions=f
   assertEquals(data.hadExpressions, false);
 });
 
+// --- forEach self.* in modelIdOrName / methodName tests ---
+
+function makeForEachWorkflow(overrides: {
+  modelIdOrName: string;
+  methodName: string;
+  forEachIn: string;
+  forEachItem: string;
+  stepName: string;
+  inputs?: Record<string, unknown>;
+}): Workflow {
+  return Workflow.fromData({
+    id: "00000000-0000-4000-8000-000000000002",
+    name: "foreach-workflow",
+    inputs: {},
+    jobs: [{
+      name: "default",
+      steps: [{
+        name: overrides.stepName,
+        forEach: {
+          item: overrides.forEachItem,
+          in: overrides.forEachIn,
+        },
+        task: {
+          type: "model_method",
+          modelIdOrName: overrides.modelIdOrName,
+          methodName: overrides.methodName,
+          ...(overrides.inputs ? { inputs: overrides.inputs } : {}),
+        },
+      }],
+    }],
+  });
+}
+
+// deno-lint-ignore no-explicit-any
+function contextAwareEvaluateCel(expr: string, ctx?: any): unknown {
+  const parts = expr.trim().split(".");
+  // deno-lint-ignore no-explicit-any
+  let value: any = ctx;
+  for (const part of parts) {
+    if (value == null) return expr;
+    value = value[part];
+  }
+  return value ?? expr;
+}
+
+function makeForEachDeps(
+  workflow: Workflow,
+  overrides?: Partial<WorkflowEvaluateDeps>,
+): WorkflowEvaluateDeps {
+  return {
+    findWorkflowById: () => Promise.resolve(workflow),
+    findWorkflowByName: () => Promise.resolve(workflow),
+    findAllWorkflows: () => Promise.resolve([workflow]),
+    buildExpressionContext: () =>
+      Promise.resolve(
+        { model: {}, env: {}, self: {} } as ReturnType<
+          WorkflowEvaluateDeps["buildExpressionContext"]
+        > extends Promise<infer T> ? T : never,
+      ),
+    evaluateCel: contextAwareEvaluateCel,
+    evaluateCelAsync: (expr: string, ctx?: unknown) =>
+      Promise.resolve(contextAwareEvaluateCel(expr, ctx)),
+    saveEvaluatedWorkflow: () => Promise.resolve(),
+    getEvaluatedPath: (id) =>
+      `/tmp/.swamp/workflows-evaluated/workflow-${id}.yaml`,
+    ...overrides,
+  };
+}
+
+async function evaluateForEachWorkflow(
+  workflow: Workflow,
+  overrides?: Partial<WorkflowEvaluateDeps>,
+): Promise<WorkflowEvaluateItemData> {
+  const deps = makeForEachDeps(workflow, overrides);
+  const events = await collect<WorkflowEvaluateEvent>(
+    workflowEvaluate(createLibSwampContext(), deps, {
+      workflowIdOrName: "foreach-workflow",
+      inputs: {},
+    }),
+  );
+  const completed = events[events.length - 1] as Extract<
+    WorkflowEvaluateEvent,
+    { kind: "completed" }
+  >;
+  return completed.data as WorkflowEvaluateItemData;
+}
+
+interface ModelMethodTaskData {
+  type: "model_method";
+  modelIdOrName: string;
+  methodName: string;
+  inputs?: Record<string, unknown>;
+}
+
+function asModelMethodTask(
+  // deno-lint-ignore no-explicit-any
+  task: any,
+): ModelMethodTaskData {
+  return task as ModelMethodTaskData;
+}
+
+Deno.test("forEach: resolves self.* in modelIdOrName", async () => {
+  const workflow = makeForEachWorkflow({
+    modelIdOrName: "${{ self.region }}",
+    methodName: "lookup",
+    forEachIn: "${{ items }}",
+    forEachItem: "region",
+    stepName: "step-${{ self.region }}",
+  });
+
+  const data = await evaluateForEachWorkflow(workflow, {
+    buildExpressionContext: () =>
+      Promise.resolve(
+        { model: {}, env: {}, self: {}, items: ["us-east-1", "eu-west-1"] } as // deno-lint-ignore no-explicit-any
+        any,
+      ),
+  });
+
+  assertEquals(data.forEachExpanded, true);
+  const steps = data.jobs![0].steps;
+  assertEquals(steps.length, 2);
+  assertEquals(asModelMethodTask(steps[0].task).modelIdOrName, "us-east-1");
+  assertEquals(asModelMethodTask(steps[1].task).modelIdOrName, "eu-west-1");
+});
+
+Deno.test("forEach: resolves interpolated self.* in modelIdOrName", async () => {
+  const workflow = makeForEachWorkflow({
+    modelIdOrName: "aws-alarms-${{ self.region }}",
+    methodName: "get_summary",
+    forEachIn: "${{ items }}",
+    forEachItem: "region",
+    stepName: "step-${{ self.region }}",
+  });
+
+  const data = await evaluateForEachWorkflow(workflow, {
+    buildExpressionContext: () =>
+      Promise.resolve(
+        { model: {}, env: {}, self: {}, items: ["us-east-1", "eu-west-1"] } as // deno-lint-ignore no-explicit-any
+        any,
+      ),
+  });
+
+  const steps = data.jobs![0].steps;
+  assertEquals(
+    asModelMethodTask(steps[0].task).modelIdOrName,
+    "aws-alarms-us-east-1",
+  );
+  assertEquals(
+    asModelMethodTask(steps[1].task).modelIdOrName,
+    "aws-alarms-eu-west-1",
+  );
+});
+
+Deno.test("forEach: resolves self.* in methodName", async () => {
+  const workflow = makeForEachWorkflow({
+    modelIdOrName: "my-model",
+    methodName: "${{ self.method }}",
+    forEachIn: "${{ items }}",
+    forEachItem: "method",
+    stepName: "step-${{ self.method }}",
+  });
+
+  const data = await evaluateForEachWorkflow(workflow, {
+    buildExpressionContext: () =>
+      Promise.resolve(
+        { model: {}, env: {}, self: {}, items: ["validate", "transform"] } as // deno-lint-ignore no-explicit-any
+        any,
+      ),
+  });
+
+  const steps = data.jobs![0].steps;
+  assertEquals(asModelMethodTask(steps[0].task).methodName, "validate");
+  assertEquals(asModelMethodTask(steps[1].task).methodName, "transform");
+});
+
+Deno.test("forEach: leaves vault expressions in modelIdOrName unresolved", async () => {
+  const workflow = makeForEachWorkflow({
+    modelIdOrName: "${{ vault.get('model-name') }}",
+    methodName: "lookup",
+    forEachIn: "${{ items }}",
+    forEachItem: "region",
+    stepName: "step-${{ self.region }}",
+  });
+
+  const data = await evaluateForEachWorkflow(workflow, {
+    buildExpressionContext: () =>
+      Promise.resolve(
+        { model: {}, env: {}, self: {}, items: ["us-east-1"] } as // deno-lint-ignore no-explicit-any
+        any,
+      ),
+  });
+
+  const steps = data.jobs![0].steps;
+  assertEquals(
+    asModelMethodTask(steps[0].task).modelIdOrName,
+    "${{ vault.get('model-name') }}",
+  );
+});
+
+Deno.test("forEach: resolves self.* in modelIdOrName with object iteration", async () => {
+  const workflow = makeForEachWorkflow({
+    modelIdOrName: "device-${{ self.entry.key }}",
+    methodName: "scan",
+    forEachIn: "${{ items }}",
+    forEachItem: "entry",
+    stepName: "step-${{ self.entry.key }}",
+  });
+
+  const data = await evaluateForEachWorkflow(workflow, {
+    buildExpressionContext: () =>
+      Promise.resolve(
+        {
+          model: {},
+          env: {},
+          self: {},
+          items: { alpha: "a-config", beta: "b-config" },
+        } as // deno-lint-ignore no-explicit-any
+        any,
+      ),
+  });
+
+  const steps = data.jobs![0].steps;
+  assertEquals(steps.length, 2);
+  assertEquals(asModelMethodTask(steps[0].task).modelIdOrName, "device-alpha");
+  assertEquals(asModelMethodTask(steps[1].task).modelIdOrName, "device-beta");
+});
+
 Deno.test("isWorkflowEvaluateAllData: returns true for AllData, false for ItemData", () => {
   const allData: WorkflowEvaluateAllData = {
     items: [],


### PR DESCRIPTION
## Summary

- Extend `resolveForEachTaskExpressions()` to resolve `self.*` expressions in `task.modelIdOrName` and `task.methodName` during forEach expansion, using the same `.replace()` interpolation pattern already used for `args`
- Vault/env expressions are left unresolved for runtime, matching existing behavior
- Enables forEach steps to dynamically target model instances by name (e.g. `aws-alarms-${{ self.region }}`) without requiring a nested workflow-of-workflows pattern

## Test Plan

- [x] 5 new unit tests in `evaluate_test.ts`: simple expression, interpolated prefix, methodName, vault skip, object iteration
- [x] All 33 workflow integration tests pass
- [x] Full test suite passes (5578 passed)
- [x] `deno check`, `deno lint`, `deno fmt` all clean

Discovery context: https://github.com/webframp/swamp-extensions/issues/58

🤖 Generated with [Claude Code](https://claude.com/claude-code)