### PR TITLE
fix(extensions): guard manifest-identity override for pulled rows (swamp-club#283)

### DIFF
--- a/src/infrastructure/persistence/extension_repository.ts
+++ b/src/infrastructure/persistence/extension_repository.ts
@@ -336,13 +336,18 @@ export class ExtensionRepository {
     };
     const groups = new Map<string, Group>();
 
+    const pulledPrefix = this.repoRoot.endsWith("/")
+      ? `${this.repoRoot}.swamp/pulled-extensions/`
+      : `${this.repoRoot}/.swamp/pulled-extensions/`;
+
     for (const row of rows) {
       const identity = this.resolveIdentity(row);
       if (identity === null) continue;
 
       const origin = (
           this.localManifestIdentity &&
-          identity.name === this.localManifestIdentity.name
+          identity.name === this.localManifestIdentity.name &&
+          !row.source_path.startsWith(pulledPrefix)
         )
         ? "local" as ExtensionOrigin
         : inferOrigin(identity.name);

--- a/src/infrastructure/persistence/extension_repository_test.ts
+++ b/src/infrastructure/persistence/extension_repository_test.ts
@@ -24,6 +24,7 @@ import {
   assertStringIncludes,
   assertThrows,
 } from "@std/assert";
+import { assertPathEquals } from "./path_test_helpers.ts";
 import { ensureDirSync } from "@std/fs";
 import { join } from "@std/path";
 import type { ExtensionRepository } from "./extension_repository.ts";
@@ -758,7 +759,7 @@ Deno.test("ExtensionRepository: pulled row retains origin='pulled' when localMan
     const loaded = repo.loadAll();
     assertEquals(loaded.length, 1);
     assertEquals(loaded[0].origin, "pulled");
-    assertEquals(
+    assertPathEquals(
       loaded[0].extensionRoot,
       `${repoRoot}/.swamp/pulled-extensions/@scope/foo`,
     );
@@ -794,6 +795,6 @@ Deno.test("ExtensionRepository: local row gets origin='local' when localManifest
     const loaded = repo.loadAll();
     assertEquals(loaded.length, 1);
     assertEquals(loaded[0].origin, "local");
-    assertEquals(loaded[0].extensionRoot, repoRoot);
+    assertPathEquals(loaded[0].extensionRoot, repoRoot);
   }, { localManifestIdentity: manifest });
 });

--- a/src/infrastructure/persistence/extension_repository_test.ts
+++ b/src/infrastructure/persistence/extension_repository_test.ts
@@ -33,6 +33,7 @@ import {
   fixedLockedVersions,
   makeStubRepository,
 } from "./test_helpers/stub_extension_repository.ts";
+import type { LocalManifestIdentity } from "./local_manifest_reader.ts";
 import type { UpstreamExtensionsMap } from "./upstream_extensions.ts";
 import {
   type Extension,
@@ -68,13 +69,17 @@ function withRepository(
     catalog: ExtensionCatalogStore,
     repoRoot: string,
   ) => void,
-  opts?: { lockedVersions?: UpstreamExtensionsMap },
+  opts?: {
+    lockedVersions?: UpstreamExtensionsMap;
+    localManifestIdentity?: LocalManifestIdentity | null;
+  },
 ): void {
   const { repoRoot, dbPath } = makeTempLayout();
   const { repository, catalog } = makeStubRepository({
     dbPath,
     repoRoot,
     lockedVersions: opts?.lockedVersions,
+    localManifestIdentity: opts?.localManifestIdentity,
   });
   try {
     fn(repository, catalog, repoRoot);
@@ -733,4 +738,62 @@ Deno.test("ExtensionRepository: empty-identity row with neither name nor version
     assertFalse(after[0].extension_name === "");
     assertFalse(after[0].extension_version === "");
   });
+});
+
+// ===== Test: swamp-club#283 — pulled row keeps origin="pulled" when manifest name collides =====
+Deno.test("ExtensionRepository: pulled row retains origin='pulled' when localManifestIdentity name collides (swamp-club#283)", () => {
+  const manifest: LocalManifestIdentity = {
+    name: "@scope/foo",
+    version: "1.0.0",
+  };
+  withRepository((repo, _cat, repoRoot) => {
+    const ext = pulledExtension({
+      repoRoot,
+      name: "@scope/foo",
+      version: "1.0.0",
+      sources: [{ relPath: "models/instance.ts", type: "@scope/foo/instance" }],
+    });
+    repo.save(ext);
+
+    const loaded = repo.loadAll();
+    assertEquals(loaded.length, 1);
+    assertEquals(loaded[0].origin, "pulled");
+    assertEquals(
+      loaded[0].extensionRoot,
+      `${repoRoot}/.swamp/pulled-extensions/@scope/foo`,
+    );
+  }, {
+    lockedVersions: fixedLockedVersions({ "@scope/foo": "1.0.0" }),
+    localManifestIdentity: manifest,
+  });
+});
+
+// ===== Test: local row still gets origin="local" when manifest identity matches =====
+Deno.test("ExtensionRepository: local row gets origin='local' when localManifestIdentity matches (preserves swamp-club#273 fix)", () => {
+  const manifest: LocalManifestIdentity = {
+    name: "@scope/foo",
+    version: "1.0.0",
+  };
+  withRepository((repo, cat, repoRoot) => {
+    const sp = `${repoRoot}/extensions/models/instance.ts`;
+    cat.upsertWithIdentity({
+      source_path: sp,
+      type_normalized: "@scope/foo/instance",
+      kind: "model",
+      bundle_path: `${repoRoot}/.swamp/bundles/instance.js`,
+      version: "1.0.0",
+      description: "",
+      extends_type: "",
+      source_mtime: "",
+      source_fingerprint: "fp",
+      state: "Indexed",
+      extension_name: "@scope/foo",
+      extension_version: "1.0.0",
+    });
+
+    const loaded = repo.loadAll();
+    assertEquals(loaded.length, 1);
+    assertEquals(loaded[0].origin, "local");
+    assertEquals(loaded[0].extensionRoot, repoRoot);
+  }, { localManifestIdentity: manifest });
 });

--- a/src/infrastructure/persistence/extension_repository_test.ts
+++ b/src/infrastructure/persistence/extension_repository_test.ts
@@ -24,6 +24,7 @@ import {
   assertStringIncludes,
   assertThrows,
 } from "@std/assert";
+import { canonicalizePath } from "./canonicalize_path.ts";
 import { assertPathEquals } from "./path_test_helpers.ts";
 import { ensureDirSync } from "@std/fs";
 import { join } from "@std/path";
@@ -761,7 +762,7 @@ Deno.test("ExtensionRepository: pulled row retains origin='pulled' when localMan
     assertEquals(loaded[0].origin, "pulled");
     assertPathEquals(
       loaded[0].extensionRoot,
-      `${repoRoot}/.swamp/pulled-extensions/@scope/foo`,
+      `${canonicalizePath(repoRoot)}/.swamp/pulled-extensions/@scope/foo`,
     );
   }, {
     lockedVersions: fixedLockedVersions({ "@scope/foo": "1.0.0" }),
@@ -795,6 +796,6 @@ Deno.test("ExtensionRepository: local row gets origin='local' when localManifest
     const loaded = repo.loadAll();
     assertEquals(loaded.length, 1);
     assertEquals(loaded[0].origin, "local");
-    assertPathEquals(loaded[0].extensionRoot, repoRoot);
+    assertPathEquals(loaded[0].extensionRoot, canonicalizePath(repoRoot));
   }, { localManifestIdentity: manifest });
 });

--- a/src/infrastructure/persistence/test_helpers/stub_extension_repository.ts
+++ b/src/infrastructure/persistence/test_helpers/stub_extension_repository.ts
@@ -29,6 +29,7 @@
 
 import { ExtensionCatalogStore } from "../extension_catalog_store.ts";
 import { ExtensionRepository } from "../extension_repository.ts";
+import type { LocalManifestIdentity } from "../local_manifest_reader.ts";
 import { LockfileRepository } from "../lockfile_repository.ts";
 import type { UpstreamExtensionsMap } from "../upstream_extensions.ts";
 
@@ -55,6 +56,7 @@ export function makeStubRepository(args: {
   dbPath: string;
   repoRoot?: string;
   lockedVersions?: UpstreamExtensionsMap;
+  localManifestIdentity?: LocalManifestIdentity | null;
 }): { repository: ExtensionRepository; catalog: ExtensionCatalogStore } {
   const catalog = new ExtensionCatalogStore(args.dbPath);
   const lockfileRepository = new LockfileRepository(
@@ -65,6 +67,7 @@ export function makeStubRepository(args: {
     catalog,
     lockfileRepository,
     repoRoot: args.repoRoot ?? "/test/repo",
+    localManifestIdentity: args.localManifestIdentity,
   });
   return { repository, catalog };
 }


### PR DESCRIPTION
## Summary

- Guard the `localManifestIdentity` origin override in `materialiseExtensions` to skip rows whose `source_path` is under the pulled-extensions prefix
- When `manifest.yaml` declares a name matching a pulled extension, the pulled rows were misclassified as `origin: "local"` with `extensionRoot: repoRoot` instead of the correct `.swamp/pulled-extensions/` subdirectory
- Follow-up from swamp-club#273 adversarial review

## Test Plan

- Added regression test: pulled row retains `origin="pulled"` when `localManifestIdentity` name collides (swamp-club#283)
- Added companion test: local row still gets `origin="local"` when `localManifestIdentity` matches (preserves swamp-club#273 fix)
- Full test suite: 5587 passed, 0 failed
- `deno check`, `deno lint`, `deno fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)