### PR TITLE
feat(cli): opt-in background autoupdate for the swamp binary (swamp-club#227)

### DIFF
--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -108,10 +108,18 @@ const configSetCommand = new Command()
         const scheduler = await createScheduler();
         if (enabling) {
           await scheduler.install(Deno.execPath(), prefs.cadence);
-          ctx.logger.info("Autoupdate enabled and scheduler installed");
         } else {
           await scheduler.remove();
-          ctx.logger.info("Autoupdate disabled and scheduler removed");
+        }
+
+        if (ctx.outputMode === "json") {
+          console.log(JSON.stringify({ key, value }));
+        } else {
+          ctx.logger.info(
+            enabling
+              ? "Autoupdate enabled and scheduler installed"
+              : "Autoupdate disabled and scheduler removed",
+          );
         }
         break;
       }
@@ -127,6 +135,11 @@ const configSetCommand = new Command()
         if (prefs.enabled) {
           const scheduler = await createScheduler();
           await scheduler.install(Deno.execPath(), prefs.cadence);
+        }
+
+        if (ctx.outputMode === "json") {
+          console.log(JSON.stringify({ key, value }));
+        } else if (prefs.enabled) {
           ctx.logger
             .info`Cadence updated to ${value} and scheduler reinstalled`;
         } else {

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -1,0 +1,172 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { UpdatePreferencesFileRepository } from "../../infrastructure/update/update_preferences_file_repository.ts";
+import { createScheduler } from "../../infrastructure/update/scheduler_factory.ts";
+import { isValidCadence } from "../../domain/update/update_preferences.ts";
+import { UserError } from "../../domain/errors.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+const CONFIG_KEYS: Record<string, { description: string; values?: string[] }> =
+  {
+    "update.auto": {
+      description: "Enable or disable background autoupdate",
+      values: ["enabled", "disabled"],
+    },
+    "update.cadence": {
+      description: "How often to check for updates",
+      values: ["daily", "weekly"],
+    },
+  };
+
+const configGetCommand = new Command()
+  .description("Get a configuration value")
+  .arguments("<key:string>")
+  .action(async function (options: AnyOptions, key: string) {
+    const ctx = createContext(options as GlobalOptions, ["config", "get"]);
+    ctx.logger.debug`Getting config key: ${key}`;
+
+    if (!(key in CONFIG_KEYS)) {
+      throw new UserError(
+        `Unknown config key: ${key}. Valid keys: ${
+          Object.keys(CONFIG_KEYS).join(", ")
+        }`,
+      );
+    }
+
+    const prefsRepo = new UpdatePreferencesFileRepository();
+    const prefs = await prefsRepo.read();
+
+    let value: string;
+    switch (key) {
+      case "update.auto":
+        value = prefs.enabled ? "enabled" : "disabled";
+        break;
+      case "update.cadence":
+        value = prefs.cadence;
+        break;
+      default:
+        throw new UserError(`Unknown config key: ${key}`);
+    }
+
+    if (ctx.outputMode === "json") {
+      console.log(JSON.stringify({ key, value }));
+    } else {
+      ctx.logger.info`${value}`;
+    }
+  });
+
+const configSetCommand = new Command()
+  .description("Set a configuration value")
+  .arguments("<key:string> <value:string>")
+  .action(async function (options: AnyOptions, key: string, value: string) {
+    const ctx = createContext(options as GlobalOptions, ["config", "set"]);
+    ctx.logger.debug`Setting config key: ${key} = ${value}`;
+
+    if (!(key in CONFIG_KEYS)) {
+      throw new UserError(
+        `Unknown config key: ${key}. Valid keys: ${
+          Object.keys(CONFIG_KEYS).join(", ")
+        }`,
+      );
+    }
+
+    const prefsRepo = new UpdatePreferencesFileRepository();
+    const prefs = await prefsRepo.read();
+
+    switch (key) {
+      case "update.auto": {
+        if (value !== "enabled" && value !== "disabled") {
+          throw new UserError(
+            `Invalid value for update.auto: ${value}. Must be "enabled" or "disabled".`,
+          );
+        }
+        const enabling = value === "enabled";
+        prefs.enabled = enabling;
+        await prefsRepo.write(prefs);
+
+        const scheduler = await createScheduler();
+        if (enabling) {
+          await scheduler.install(Deno.execPath(), prefs.cadence);
+          ctx.logger.info("Autoupdate enabled and scheduler installed");
+        } else {
+          await scheduler.remove();
+          ctx.logger.info("Autoupdate disabled and scheduler removed");
+        }
+        break;
+      }
+      case "update.cadence": {
+        if (!isValidCadence(value)) {
+          throw new UserError(
+            `Invalid value for update.cadence: ${value}. Must be "daily" or "weekly".`,
+          );
+        }
+        prefs.cadence = value;
+        await prefsRepo.write(prefs);
+
+        if (prefs.enabled) {
+          const scheduler = await createScheduler();
+          await scheduler.install(Deno.execPath(), prefs.cadence);
+          ctx.logger
+            .info`Cadence updated to ${value} and scheduler reinstalled`;
+        } else {
+          ctx.logger.info`Cadence updated to ${value}`;
+        }
+        break;
+      }
+    }
+  });
+
+const configListCommand = new Command()
+  .description("List all configuration keys and current values")
+  .action(async function (options: AnyOptions) {
+    const ctx = createContext(options as GlobalOptions, ["config", "list"]);
+
+    const prefsRepo = new UpdatePreferencesFileRepository();
+    const prefs = await prefsRepo.read();
+
+    const values: Record<string, string> = {
+      "update.auto": prefs.enabled ? "enabled" : "disabled",
+      "update.cadence": prefs.cadence,
+    };
+
+    if (ctx.outputMode === "json") {
+      console.log(JSON.stringify(values, null, 2));
+      return;
+    }
+
+    for (const [key, meta] of Object.entries(CONFIG_KEYS)) {
+      const current = values[key];
+      const allowed = meta.values ? `(${meta.values.join("|")})` : "";
+      ctx.logger.info(`${key} = ${current} ${allowed}`);
+    }
+  });
+
+export const configCommand = new Command()
+  .description("Manage swamp configuration")
+  .action(function () {
+    this.showHelp();
+  })
+  .command("get", configGetCommand)
+  .command("set", configSetCommand)
+  .command("list", configListCommand);

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -102,8 +102,6 @@ const configSetCommand = new Command()
           );
         }
         const enabling = value === "enabled";
-        prefs.enabled = enabling;
-        await prefsRepo.write(prefs);
 
         const scheduler = await createScheduler();
         if (enabling) {
@@ -111,6 +109,9 @@ const configSetCommand = new Command()
         } else {
           await scheduler.remove();
         }
+
+        prefs.enabled = enabling;
+        await prefsRepo.write(prefs);
 
         if (ctx.outputMode === "json") {
           console.log(JSON.stringify({ key, value }));
@@ -129,13 +130,14 @@ const configSetCommand = new Command()
             `Invalid value for update.cadence: ${value}. Must be "daily" or "weekly".`,
           );
         }
-        prefs.cadence = value;
-        await prefsRepo.write(prefs);
 
         if (prefs.enabled) {
           const scheduler = await createScheduler();
-          await scheduler.install(Deno.execPath(), prefs.cadence);
+          await scheduler.install(Deno.execPath(), value);
         }
+
+        prefs.cadence = value;
+        await prefsRepo.write(prefs);
 
         if (ctx.outputMode === "json") {
           console.log(JSON.stringify({ key, value }));
@@ -147,6 +149,8 @@ const configSetCommand = new Command()
         }
         break;
       }
+      default:
+        throw new UserError(`Unhandled config key: ${key}`);
     }
   });
 

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -60,8 +60,16 @@ async function runBackgroundUpdate(
     outcome: "up_to_date",
   };
 
+  const BACKGROUND_TIMEOUT_MS = 5 * 60 * 1000;
   try {
-    const result = await deps.update(platform);
+    const timeout = new Promise<never>((_, reject) => {
+      const id = setTimeout(
+        () => reject(new Error("Background update timed out")),
+        BACKGROUND_TIMEOUT_MS,
+      );
+      Deno.unrefTimer(id);
+    });
+    const result = await Promise.race([deps.update(platform), timeout]);
 
     if (result.status === "updated") {
       entry.versionAfter = result.newVersion;

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { createContext, type GlobalOptions } from "../context.ts";
+import { createContext, type GlobalOptions, isStdinTty } from "../context.ts";
 import { VERSION } from "./version.ts";
 import { Platform } from "../../domain/update/platform.ts";
 import {
@@ -29,16 +29,191 @@ import {
 } from "../../libswamp/mod.ts";
 import { createUpdateCheckRenderer } from "../../presentation/renderers/update_check.ts";
 import { Spinner } from "../../presentation/spinner.ts";
+import { UpdatePreferencesFileRepository } from "../../infrastructure/update/update_preferences_file_repository.ts";
+import { AutoupdateLogFileRepository } from "../../infrastructure/update/autoupdate_log_file_repository.ts";
+import { createScheduler } from "../../infrastructure/update/scheduler_factory.ts";
+import {
+  isValidCadence,
+  type UpdateCadence,
+} from "../../domain/update/update_preferences.ts";
+import {
+  AUTOUPDATE_LOG_RETENTION_DAYS,
+  type AutoupdateLogEntry,
+} from "../../domain/update/autoupdate_log.ts";
+import type { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import { UserError } from "../../domain/errors.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
+async function runBackgroundUpdate(
+  ctx: { logger: ReturnType<typeof getSwampLogger> },
+): Promise<void> {
+  const platform = Platform.detect();
+  const logRepo = new AutoupdateLogFileRepository();
+  const deps = createUpdateCheckDeps(VERSION, Deno.execPath());
+
+  const entry: AutoupdateLogEntry = {
+    timestamp: new Date().toISOString(),
+    versionBefore: VERSION,
+    versionAfter: null,
+    outcome: "up_to_date",
+  };
+
+  try {
+    const result = await deps.update(platform);
+
+    if (result.status === "updated") {
+      entry.versionAfter = result.newVersion;
+      entry.outcome = "updated";
+    }
+  } catch (error) {
+    entry.outcome = "error";
+    entry.error = error instanceof Error ? error.message : String(error);
+  }
+
+  await logRepo.append(entry);
+  await logRepo.prune(AUTOUPDATE_LOG_RETENTION_DAYS);
+
+  ctx.logger.debug`Background update completed: ${entry.outcome}`;
+}
+
+async function runSetupAuto(
+  ctx: { logger: ReturnType<typeof getSwampLogger>; outputMode: string },
+): Promise<void> {
+  if (!isStdinTty()) {
+    throw new UserError(
+      "Cannot set up autoupdate in a non-interactive environment. Use `swamp config set` instead.",
+    );
+  }
+
+  const prefsRepo = new UpdatePreferencesFileRepository();
+  const prefs = await prefsRepo.read();
+  const logger = ctx.logger;
+
+  const cadenceInput = prompt(
+    "How often should swamp check for updates? (daily/weekly)",
+    prefs.cadence,
+  );
+  if (!cadenceInput || !isValidCadence(cadenceInput)) {
+    throw new UserError(
+      `Invalid cadence: ${cadenceInput}. Must be "daily" or "weekly".`,
+    );
+  }
+
+  const cadence = cadenceInput as UpdateCadence;
+
+  await prefsRepo.write({ enabled: true, cadence });
+
+  const scheduler = await createScheduler();
+  await scheduler.install(Deno.execPath(), cadence);
+
+  logger.info`Autoupdate enabled with ${cadence} checks`;
+
+  const status = await scheduler.status();
+  if (status.installed) {
+    logger.info("Background scheduler installed successfully");
+  }
+}
+
+async function runDisableAuto(
+  ctx: { logger: ReturnType<typeof getSwampLogger> },
+): Promise<void> {
+  const prefsRepo = new UpdatePreferencesFileRepository();
+  const prefs = await prefsRepo.read();
+
+  const scheduler = await createScheduler();
+  await scheduler.remove();
+
+  prefs.enabled = false;
+  await prefsRepo.write(prefs);
+
+  ctx.logger.info("Autoupdate disabled and scheduler removed");
+}
+
+async function runSetupAutoStatus(
+  ctx: { logger: ReturnType<typeof getSwampLogger>; outputMode: string },
+): Promise<void> {
+  const prefsRepo = new UpdatePreferencesFileRepository();
+  const prefs = await prefsRepo.read();
+
+  if (ctx.outputMode === "json") {
+    const scheduler = await createScheduler();
+    const scheduleStatus = await scheduler.status();
+    const logRepo = new AutoupdateLogFileRepository();
+    const entries = await logRepo.readAll();
+    const lastEntry = entries.length > 0 ? entries[entries.length - 1] : null;
+
+    console.log(JSON.stringify(
+      {
+        enabled: prefs.enabled,
+        cadence: prefs.cadence,
+        schedulerInstalled: scheduleStatus.installed,
+        lastUpdate: lastEntry,
+      },
+      null,
+      2,
+    ));
+    return;
+  }
+
+  const logger = ctx.logger;
+
+  if (!prefs.enabled) {
+    logger.info(
+      "Autoupdate is disabled. Run `swamp update --setup-auto` to enable.",
+    );
+    return;
+  }
+
+  logger.info`Autoupdate: enabled`;
+  logger.info`Cadence: ${prefs.cadence}`;
+
+  const scheduler = await createScheduler();
+  const scheduleStatus = await scheduler.status();
+  logger.info`Scheduler installed: ${scheduleStatus.installed}`;
+
+  const logRepo = new AutoupdateLogFileRepository();
+  const entries = await logRepo.readAll();
+  if (entries.length > 0) {
+    const last = entries[entries.length - 1];
+    logger.info`Last check: ${last.timestamp} (${last.outcome})`;
+    if (last.versionAfter) {
+      logger
+        .info`Last update: ${last.versionBefore} → ${last.versionAfter}`;
+    }
+  } else {
+    logger.info("No autoupdate history yet");
+  }
+}
+
 export const updateCommand = new Command()
   .description("Update swamp to the latest version")
   .option("--check", "Check for updates without installing")
+  .option("--background", "Run update silently (used by autoupdate scheduler)")
+  .option(
+    "--setup-auto [action:string]",
+    "Set up, check, or disable autoupdate (status|disable)",
+  )
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, ["update"]);
     ctx.logger.debug("Executing update command");
+
+    if (options.background) {
+      await runBackgroundUpdate(ctx);
+      return;
+    }
+
+    if (options.setupAuto !== undefined) {
+      if (options.setupAuto === "status") {
+        await runSetupAutoStatus(ctx);
+      } else if (options.setupAuto === "disable") {
+        await runDisableAuto(ctx);
+      } else {
+        await runSetupAuto(ctx);
+      }
+      return;
+    }
 
     const platform = Platform.detect();
     ctx.logger.debug`Detected platform: ${platform}`;

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -108,16 +108,20 @@ async function runSetupAuto(
   const scheduler = await createScheduler();
   await scheduler.install(Deno.execPath(), cadence);
 
-  logger.info`Autoupdate enabled with ${cadence} checks`;
+  if (ctx.outputMode === "json") {
+    console.log(JSON.stringify({ enabled: true, cadence }));
+  } else {
+    logger.info`Autoupdate enabled with ${cadence} checks`;
 
-  const status = await scheduler.status();
-  if (status.installed) {
-    logger.info("Background scheduler installed successfully");
+    const status = await scheduler.status();
+    if (status.installed) {
+      logger.info("Background scheduler installed successfully");
+    }
   }
 }
 
 async function runDisableAuto(
-  ctx: { logger: ReturnType<typeof getSwampLogger> },
+  ctx: { logger: ReturnType<typeof getSwampLogger>; outputMode: string },
 ): Promise<void> {
   const prefsRepo = new UpdatePreferencesFileRepository();
   const prefs = await prefsRepo.read();
@@ -128,7 +132,13 @@ async function runDisableAuto(
   prefs.enabled = false;
   await prefsRepo.write(prefs);
 
-  ctx.logger.info("Autoupdate disabled and scheduler removed");
+  if (ctx.outputMode === "json") {
+    console.log(
+      JSON.stringify({ key: "update.auto", value: "disabled" }),
+    );
+  } else {
+    ctx.logger.info("Autoupdate disabled and scheduler removed");
+  }
 }
 
 async function runSetupAutoStatus(

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -190,10 +190,10 @@ async function runSetupAutoStatus(
 export const updateCommand = new Command()
   .description("Update swamp to the latest version")
   .option("--check", "Check for updates without installing")
-  .option("--background", "Run update silently (used by autoupdate scheduler)")
+  .option("--background", "Run update silently", { hidden: true })
   .option(
     "--setup-auto [action:string]",
-    "Set up, check, or disable autoupdate (status|disable)",
+    "Configure autoupdate interactively; use 'status' to check, 'disable' to turn off",
   )
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, ["update"]);
@@ -205,6 +205,18 @@ export const updateCommand = new Command()
     }
 
     if (options.setupAuto !== undefined) {
+      const validActions = ["status", "disable"];
+      if (
+        typeof options.setupAuto === "string" &&
+        !validActions.includes(options.setupAuto)
+      ) {
+        throw new UserError(
+          `Unknown action: ${options.setupAuto}. Valid actions: ${
+            validActions.join(", ")
+          }`,
+        );
+      }
+
       if (options.setupAuto === "status") {
         await runSetupAutoStatus(ctx);
       } else if (options.setupAuto === "disable") {

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -103,10 +103,10 @@ async function runSetupAuto(
 
   const cadence = cadenceInput as UpdateCadence;
 
-  await prefsRepo.write({ enabled: true, cadence });
-
   const scheduler = await createScheduler();
   await scheduler.install(Deno.execPath(), cadence);
+
+  await prefsRepo.write({ enabled: true, cadence });
 
   if (ctx.outputMode === "json") {
     console.log(JSON.stringify({ enabled: true, cadence }));

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -35,6 +35,7 @@ import { issueCommand } from "./commands/issue.ts";
 import { telemetryCommand } from "./commands/telemetry_stats.ts";
 import { auditCommand } from "./commands/audit.ts";
 import { updateCommand } from "./commands/update.ts";
+import { configCommand } from "./commands/config.ts";
 import { sourceCommand } from "./commands/source.ts";
 import { authCommand } from "./commands/auth.ts";
 import { extensionCommand } from "./commands/extension.ts";
@@ -109,6 +110,8 @@ import { UpdateCheckCacheFileRepository } from "../infrastructure/update/update_
 import { HttpUpdateChecker } from "../infrastructure/update/http_update_checker.ts";
 import { Platform } from "../domain/update/platform.ts";
 import { renderUpdateNotification } from "../presentation/renderers/update_notification.ts";
+import { UpdatePreferencesFileRepository } from "../infrastructure/update/update_preferences_file_repository.ts";
+import { AutoupdateLogFileRepository } from "../infrastructure/update/autoupdate_log_file_repository.ts";
 import { getOutputModeFromArgs, isQuietFromArgs } from "./context.ts";
 import { recordLoadFailures } from "../infrastructure/logging/extension_load_warnings.ts";
 import { flushDatastoreSync } from "../infrastructure/persistence/datastore_sync_coordinator.ts";
@@ -202,6 +205,7 @@ const NON_REPO_COMMANDS = new Set([
   "completions",
   "init",
   "update",
+  "config",
   "auth",
   "telemetry",
   "issue",
@@ -1089,6 +1093,7 @@ export async function runCli(args: string[]): Promise<void> {
     .command("telemetry", telemetryCommand)
     .command("audit", auditCommand.hidden())
     .command("update", updateCommand)
+    .command("config", configCommand)
     .command("source", sourceCommand)
     .command("completions", completionCommand)
     .command("issue", issueCommand)
@@ -1147,21 +1152,39 @@ export async function runCli(args: string[]): Promise<void> {
 
       if (outputMode === "log" && commandName !== "update") {
         try {
-          const cacheRepo = new UpdateCheckCacheFileRepository();
-          const checker = new HttpUpdateChecker();
-          const service = new UpdateNotificationService(
-            VERSION,
-            cacheRepo,
-            checker,
-          );
+          const prefsRepo = new UpdatePreferencesFileRepository();
+          const prefs = await prefsRepo.read();
 
-          const notification = await service.getNotification();
-          if (notification) {
-            renderUpdateNotification(notification);
+          // Show post-autoupdate notice if background upgrade happened
+          const logRepo = new AutoupdateLogFileRepository();
+          const entries = await logRepo.readAll();
+          const lastUpdate = entries.findLast((e) =>
+            e.outcome === "updated" && e.versionAfter
+          );
+          if (lastUpdate && lastUpdate.versionAfter === VERSION) {
+            console.error(
+              `\nℹ swamp was auto-updated from ${lastUpdate.versionBefore} → ${lastUpdate.versionAfter}`,
+            );
           }
 
-          const platform = Platform.detect();
-          service.backgroundCheck(platform);
+          // Skip the "run swamp update" banner if autoupdate handles it
+          if (!prefs.enabled) {
+            const cacheRepo = new UpdateCheckCacheFileRepository();
+            const checker = new HttpUpdateChecker();
+            const service = new UpdateNotificationService(
+              VERSION,
+              cacheRepo,
+              checker,
+            );
+
+            const notification = await service.getNotification();
+            if (notification) {
+              renderUpdateNotification(notification);
+            }
+
+            const platform = Platform.detect();
+            service.backgroundCheck(platform);
+          }
         } catch {
           // Silently ignore — never break the CLI for update checks
         }

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1155,16 +1155,20 @@ export async function runCli(args: string[]): Promise<void> {
           const prefsRepo = new UpdatePreferencesFileRepository();
           const prefs = await prefsRepo.read();
 
-          // Show post-autoupdate notice if background upgrade happened
-          const logRepo = new AutoupdateLogFileRepository();
-          const entries = await logRepo.readAll();
-          const lastUpdate = entries.findLast((e) =>
-            e.outcome === "updated" && e.versionAfter
-          );
-          if (lastUpdate && lastUpdate.versionAfter === VERSION) {
-            console.error(
-              `\nℹ swamp was auto-updated from ${lastUpdate.versionBefore} → ${lastUpdate.versionAfter}`,
+          // Show post-autoupdate notice once after background upgrade
+          if (prefs.notifiedVersion !== VERSION) {
+            const logRepo = new AutoupdateLogFileRepository();
+            const entries = await logRepo.readAll();
+            const lastUpdate = entries.findLast((e) =>
+              e.outcome === "updated" && e.versionAfter
             );
+            if (lastUpdate && lastUpdate.versionAfter === VERSION) {
+              console.error(
+                `\nℹ swamp was auto-updated from ${lastUpdate.versionBefore} → ${lastUpdate.versionAfter}`,
+              );
+              prefs.notifiedVersion = VERSION;
+              await prefsRepo.write(prefs);
+            }
           }
 
           // Skip the "run swamp update" banner if autoupdate handles it

--- a/src/domain/update/autoupdate_log.ts
+++ b/src/domain/update/autoupdate_log.ts
@@ -1,0 +1,36 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+export type AutoupdateOutcome = "updated" | "up_to_date" | "error";
+
+export interface AutoupdateLogEntry {
+  timestamp: string; // ISO 8601
+  versionBefore: string;
+  versionAfter: string | null;
+  outcome: AutoupdateOutcome;
+  error?: string;
+}
+
+export interface AutoupdateLogRepository {
+  append(entry: AutoupdateLogEntry): Promise<void>;
+  readAll(): Promise<AutoupdateLogEntry[]>;
+  prune(maxAgeDays: number): Promise<void>;
+}
+
+export const AUTOUPDATE_LOG_RETENTION_DAYS = 30;

--- a/src/domain/update/autoupdate_scheduler.ts
+++ b/src/domain/update/autoupdate_scheduler.ts
@@ -1,0 +1,36 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { UpdateCadence } from "./update_preferences.ts";
+
+export interface ScheduleStatus {
+  installed: boolean;
+  cadence?: UpdateCadence;
+  nextRun?: string;
+}
+
+export interface AutoupdateScheduler {
+  install(binaryPath: string, cadence: UpdateCadence): Promise<void>;
+  remove(): Promise<void>;
+  status(): Promise<ScheduleStatus>;
+}
+
+// TODO(windows): Implement Windows Task Scheduler support when swamp update
+// ships for Windows. Implement the AutoupdateScheduler interface using
+// schtasks.exe or the Task Scheduler COM API.

--- a/src/domain/update/update_preferences.ts
+++ b/src/domain/update/update_preferences.ts
@@ -1,0 +1,44 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+export type UpdateCadence = "daily" | "weekly";
+
+export const VALID_CADENCES: readonly UpdateCadence[] = [
+  "daily",
+  "weekly",
+] as const;
+
+export interface UpdatePreferences {
+  enabled: boolean;
+  cadence: UpdateCadence;
+}
+
+export const DEFAULT_UPDATE_PREFERENCES: UpdatePreferences = {
+  enabled: false,
+  cadence: "daily",
+};
+
+export function isValidCadence(value: string): value is UpdateCadence {
+  return VALID_CADENCES.includes(value as UpdateCadence);
+}
+
+export interface UpdatePreferencesRepository {
+  read(): Promise<UpdatePreferences>;
+  write(preferences: UpdatePreferences): Promise<void>;
+}

--- a/src/domain/update/update_preferences.ts
+++ b/src/domain/update/update_preferences.ts
@@ -27,6 +27,7 @@ export const VALID_CADENCES: readonly UpdateCadence[] = [
 export interface UpdatePreferences {
   enabled: boolean;
   cadence: UpdateCadence;
+  notifiedVersion?: string;
 }
 
 export const DEFAULT_UPDATE_PREFERENCES: UpdatePreferences = {

--- a/src/domain/update/update_preferences_test.ts
+++ b/src/domain/update/update_preferences_test.ts
@@ -1,0 +1,43 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  DEFAULT_UPDATE_PREFERENCES,
+  isValidCadence,
+} from "./update_preferences.ts";
+
+Deno.test("isValidCadence: accepts daily", () => {
+  assertEquals(isValidCadence("daily"), true);
+});
+
+Deno.test("isValidCadence: accepts weekly", () => {
+  assertEquals(isValidCadence("weekly"), true);
+});
+
+Deno.test("isValidCadence: rejects invalid values", () => {
+  assertEquals(isValidCadence("hourly"), false);
+  assertEquals(isValidCadence(""), false);
+  assertEquals(isValidCadence("monthly"), false);
+});
+
+Deno.test("DEFAULT_UPDATE_PREFERENCES: has safe defaults", () => {
+  assertEquals(DEFAULT_UPDATE_PREFERENCES.enabled, false);
+  assertEquals(DEFAULT_UPDATE_PREFERENCES.cadence, "daily");
+});

--- a/src/infrastructure/update/autoupdate_log_file_repository.ts
+++ b/src/infrastructure/update/autoupdate_log_file_repository.ts
@@ -1,0 +1,80 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { dirname, join } from "@std/path";
+import type {
+  AutoupdateLogEntry,
+  AutoupdateLogRepository,
+} from "../../domain/update/autoupdate_log.ts";
+import { getSwampDataDir } from "../persistence/paths.ts";
+import { atomicWriteTextFile } from "../persistence/atomic_write.ts";
+
+const LOG_FILE_NAME = "autoupdate.log";
+
+function logFilePath(): string {
+  return join(getSwampDataDir(), "log", LOG_FILE_NAME);
+}
+
+export class AutoupdateLogFileRepository implements AutoupdateLogRepository {
+  private readonly filePath: string;
+
+  constructor(filePath?: string) {
+    this.filePath = filePath ?? logFilePath();
+  }
+
+  async append(entry: AutoupdateLogEntry): Promise<void> {
+    const dir = dirname(this.filePath);
+    await Deno.mkdir(dir, { recursive: true });
+    const line = JSON.stringify(entry) + "\n";
+    await Deno.writeTextFile(this.filePath, line, { append: true });
+  }
+
+  async readAll(): Promise<AutoupdateLogEntry[]> {
+    try {
+      const content = await Deno.readTextFile(this.filePath);
+      const entries: AutoupdateLogEntry[] = [];
+      for (const line of content.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          entries.push(JSON.parse(trimmed) as AutoupdateLogEntry);
+        } catch {
+          // Skip malformed lines
+        }
+      }
+      return entries;
+    } catch {
+      return [];
+    }
+  }
+
+  async prune(maxAgeDays: number): Promise<void> {
+    const entries = await this.readAll();
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - maxAgeDays);
+    const cutoffIso = cutoff.toISOString();
+
+    const kept = entries.filter((e) => e.timestamp >= cutoffIso);
+    if (kept.length === entries.length) return;
+
+    const content = kept.map((e) => JSON.stringify(e)).join("\n") +
+      (kept.length > 0 ? "\n" : "");
+    await atomicWriteTextFile(this.filePath, content);
+  }
+}

--- a/src/infrastructure/update/autoupdate_log_file_repository_test.ts
+++ b/src/infrastructure/update/autoupdate_log_file_repository_test.ts
@@ -1,0 +1,146 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { AutoupdateLogFileRepository } from "./autoupdate_log_file_repository.ts";
+import type { AutoupdateLogEntry } from "../../domain/update/autoupdate_log.ts";
+
+async function withTempDir(
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir();
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+function makeEntry(
+  overrides?: Partial<AutoupdateLogEntry>,
+): AutoupdateLogEntry {
+  return {
+    timestamp: new Date().toISOString(),
+    versionBefore: "20260501.120000.0-sha.abc123",
+    versionAfter: null,
+    outcome: "up_to_date",
+    ...overrides,
+  };
+}
+
+Deno.test("AutoupdateLogFileRepository: readAll returns empty for missing file", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new AutoupdateLogFileRepository(
+      join(dir, "nonexistent.log"),
+    );
+    const entries = await repo.readAll();
+    assertEquals(entries, []);
+  });
+});
+
+Deno.test("AutoupdateLogFileRepository: append and readAll round-trip", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "log", "autoupdate.log");
+    const repo = new AutoupdateLogFileRepository(filePath);
+
+    const entry1 = makeEntry({ outcome: "up_to_date" });
+    const entry2 = makeEntry({
+      outcome: "updated",
+      versionAfter: "20260502.120000.0-sha.def456",
+    });
+
+    await repo.append(entry1);
+    await repo.append(entry2);
+
+    const entries = await repo.readAll();
+    assertEquals(entries.length, 2);
+    assertEquals(entries[0].outcome, "up_to_date");
+    assertEquals(entries[1].outcome, "updated");
+    assertEquals(entries[1].versionAfter, "20260502.120000.0-sha.def456");
+  });
+});
+
+Deno.test("AutoupdateLogFileRepository: readAll skips malformed lines", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "autoupdate.log");
+    const validEntry = makeEntry();
+    await Deno.writeTextFile(
+      filePath,
+      `${JSON.stringify(validEntry)}\nnot json\n${
+        JSON.stringify(validEntry)
+      }\n`,
+    );
+
+    const repo = new AutoupdateLogFileRepository(filePath);
+    const entries = await repo.readAll();
+    assertEquals(entries.length, 2);
+  });
+});
+
+Deno.test("AutoupdateLogFileRepository: prune removes old entries", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "autoupdate.log");
+    const repo = new AutoupdateLogFileRepository(filePath);
+
+    const oldDate = new Date();
+    oldDate.setDate(oldDate.getDate() - 60);
+
+    const oldEntry = makeEntry({ timestamp: oldDate.toISOString() });
+    const recentEntry = makeEntry({ timestamp: new Date().toISOString() });
+
+    await repo.append(oldEntry);
+    await repo.append(recentEntry);
+
+    await repo.prune(30);
+
+    const entries = await repo.readAll();
+    assertEquals(entries.length, 1);
+    assertEquals(entries[0].timestamp, recentEntry.timestamp);
+  });
+});
+
+Deno.test("AutoupdateLogFileRepository: prune keeps all entries within retention", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "autoupdate.log");
+    const repo = new AutoupdateLogFileRepository(filePath);
+
+    const entry1 = makeEntry();
+    const entry2 = makeEntry();
+
+    await repo.append(entry1);
+    await repo.append(entry2);
+
+    await repo.prune(30);
+
+    const entries = await repo.readAll();
+    assertEquals(entries.length, 2);
+  });
+});
+
+Deno.test("AutoupdateLogFileRepository: append creates parent directories", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "nested", "dirs", "autoupdate.log");
+    const repo = new AutoupdateLogFileRepository(filePath);
+
+    await repo.append(makeEntry());
+    const entries = await repo.readAll();
+    assertEquals(entries.length, 1);
+  });
+});

--- a/src/infrastructure/update/cron_scheduler.ts
+++ b/src/infrastructure/update/cron_scheduler.ts
@@ -67,7 +67,8 @@ export class CronScheduler implements AutoupdateScheduler {
 
     const existing = await readCrontab();
     const schedule = cronSchedule(cadence);
-    const line = `${schedule} ${binaryPath} update --background ${CRON_MARKER}`;
+    const line =
+      `${schedule} "${binaryPath}" update --background ${CRON_MARKER}`;
     const newContent = existing.trimEnd() + (existing.trim() ? "\n" : "") +
       line + "\n";
     await writeCrontab(newContent);

--- a/src/infrastructure/update/cron_scheduler.ts
+++ b/src/infrastructure/update/cron_scheduler.ts
@@ -1,0 +1,104 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type {
+  AutoupdateScheduler,
+  ScheduleStatus,
+} from "../../domain/update/autoupdate_scheduler.ts";
+import type { UpdateCadence } from "../../domain/update/update_preferences.ts";
+
+const CRON_MARKER = "# swamp-autoupdate";
+
+function cronSchedule(cadence: UpdateCadence): string {
+  return cadence === "daily" ? "0 9 * * *" : "0 9 * * 1";
+}
+
+function cadenceFromSchedule(schedule: string): UpdateCadence {
+  return schedule.trim().endsWith("* * 1") ? "weekly" : "daily";
+}
+
+async function readCrontab(): Promise<string> {
+  const cmd = new Deno.Command("crontab", {
+    args: ["-l"],
+    stdout: "piped",
+    stderr: "null",
+  });
+  const result = await cmd.output();
+  if (!result.success) return "";
+  return new TextDecoder().decode(result.stdout);
+}
+
+async function writeCrontab(content: string): Promise<void> {
+  const cmd = new Deno.Command("crontab", {
+    args: ["-"],
+    stdin: "piped",
+    stdout: "null",
+    stderr: "null",
+  });
+  const process = cmd.spawn();
+  const writer = process.stdin.getWriter();
+  await writer.write(new TextEncoder().encode(content));
+  await writer.close();
+  const status = await process.status;
+  if (!status.success) {
+    throw new Error(`crontab write failed with exit code ${status.code}`);
+  }
+}
+
+export class CronScheduler implements AutoupdateScheduler {
+  async install(binaryPath: string, cadence: UpdateCadence): Promise<void> {
+    await this.remove();
+
+    const existing = await readCrontab();
+    const schedule = cronSchedule(cadence);
+    const line = `${schedule} ${binaryPath} update --background ${CRON_MARKER}`;
+    const newContent = existing.trimEnd() + (existing.trim() ? "\n" : "") +
+      line + "\n";
+    await writeCrontab(newContent);
+  }
+
+  async remove(): Promise<void> {
+    const existing = await readCrontab();
+    if (!existing.includes(CRON_MARKER)) return;
+
+    const filtered = existing
+      .split("\n")
+      .filter((line) => !line.includes(CRON_MARKER))
+      .join("\n");
+    await writeCrontab(filtered);
+  }
+
+  async status(): Promise<ScheduleStatus> {
+    const crontab = await readCrontab();
+    const line = crontab
+      .split("\n")
+      .find((l) => l.includes(CRON_MARKER));
+
+    if (!line) return { installed: false };
+
+    const schedule = line.substring(0, line.indexOf(CRON_MARKER)).trim();
+    const parts = schedule.split(/\s+/);
+    const cronExpr = parts.slice(0, 5).join(" ");
+
+    return {
+      installed: true,
+      cadence: cadenceFromSchedule(cronExpr),
+    };
+  }
+}

--- a/src/infrastructure/update/launchd_scheduler.ts
+++ b/src/infrastructure/update/launchd_scheduler.ts
@@ -1,0 +1,122 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { dirname, join } from "@std/path";
+import type {
+  AutoupdateScheduler,
+  ScheduleStatus,
+} from "../../domain/update/autoupdate_scheduler.ts";
+import type { UpdateCadence } from "../../domain/update/update_preferences.ts";
+import { atomicWriteTextFile } from "../persistence/atomic_write.ts";
+import { homeDirectory } from "../persistence/paths.ts";
+
+const LABEL = "club.swamp.autoupdate";
+
+function plistPath(): string {
+  return join(homeDirectory(), "Library", "LaunchAgents", `${LABEL}.plist`);
+}
+
+function buildPlist(binaryPath: string, cadence: UpdateCadence): string {
+  const interval = cadence === "daily" ? 86400 : 604800;
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${binaryPath}</string>
+    <string>update</string>
+    <string>--background</string>
+  </array>
+  <key>StartInterval</key>
+  <integer>${interval}</integer>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/dev/null</string>
+  <key>StandardErrorPath</key>
+  <string>/dev/null</string>
+</dict>
+</plist>
+`;
+}
+
+function cadenceFromInterval(interval: number): UpdateCadence {
+  return interval <= 86400 ? "daily" : "weekly";
+}
+
+export class LaunchdScheduler implements AutoupdateScheduler {
+  async install(binaryPath: string, cadence: UpdateCadence): Promise<void> {
+    await this.remove();
+
+    const path = plistPath();
+    await Deno.mkdir(dirname(path), { recursive: true });
+    await atomicWriteTextFile(path, buildPlist(binaryPath, cadence));
+
+    const cmd = new Deno.Command("launchctl", {
+      args: ["load", path],
+      stdout: "null",
+      stderr: "null",
+    });
+    const result = await cmd.output();
+    if (!result.success) {
+      throw new Error(
+        `launchctl load failed with exit code ${result.code}`,
+      );
+    }
+  }
+
+  async remove(): Promise<void> {
+    const path = plistPath();
+    try {
+      await Deno.stat(path);
+    } catch {
+      return;
+    }
+
+    const cmd = new Deno.Command("launchctl", {
+      args: ["unload", path],
+      stdout: "null",
+      stderr: "null",
+    });
+    await cmd.output();
+
+    await Deno.remove(path).catch(() => {});
+  }
+
+  async status(): Promise<ScheduleStatus> {
+    const path = plistPath();
+    try {
+      const content = await Deno.readTextFile(path);
+      const intervalMatch = content.match(
+        /<key>StartInterval<\/key>\s*<integer>(\d+)<\/integer>/,
+      );
+      const interval = intervalMatch ? parseInt(intervalMatch[1], 10) : 86400;
+      return {
+        installed: true,
+        cadence: cadenceFromInterval(interval),
+      };
+    } catch {
+      return { installed: false };
+    }
+  }
+}

--- a/src/infrastructure/update/launchd_scheduler.ts
+++ b/src/infrastructure/update/launchd_scheduler.ts
@@ -32,8 +32,13 @@ function plistPath(): string {
   return join(homeDirectory(), "Library", "LaunchAgents", `${LABEL}.plist`);
 }
 
+function escapeXml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
 function buildPlist(binaryPath: string, cadence: UpdateCadence): string {
   const interval = cadence === "daily" ? 86400 : 604800;
+  const escapedPath = escapeXml(binaryPath);
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -43,7 +48,7 @@ function buildPlist(binaryPath: string, cadence: UpdateCadence): string {
   <string>${LABEL}</string>
   <key>ProgramArguments</key>
   <array>
-    <string>${binaryPath}</string>
+    <string>${escapedPath}</string>
     <string>update</string>
     <string>--background</string>
   </array>
@@ -64,6 +69,16 @@ function cadenceFromInterval(interval: number): UpdateCadence {
   return interval <= 86400 ? "daily" : "weekly";
 }
 
+async function getUid(): Promise<string> {
+  const cmd = new Deno.Command("id", {
+    args: ["-u"],
+    stdout: "piped",
+    stderr: "null",
+  });
+  const result = await cmd.output();
+  return new TextDecoder().decode(result.stdout).trim();
+}
+
 export class LaunchdScheduler implements AutoupdateScheduler {
   async install(binaryPath: string, cadence: UpdateCadence): Promise<void> {
     await this.remove();
@@ -72,15 +87,16 @@ export class LaunchdScheduler implements AutoupdateScheduler {
     await Deno.mkdir(dirname(path), { recursive: true });
     await atomicWriteTextFile(path, buildPlist(binaryPath, cadence));
 
+    const uid = await getUid();
     const cmd = new Deno.Command("launchctl", {
-      args: ["load", path],
+      args: ["bootstrap", `gui/${uid}`, path],
       stdout: "null",
       stderr: "null",
     });
     const result = await cmd.output();
     if (!result.success) {
       throw new Error(
-        `launchctl load failed with exit code ${result.code}`,
+        `launchctl bootstrap failed with exit code ${result.code}`,
       );
     }
   }
@@ -93,8 +109,9 @@ export class LaunchdScheduler implements AutoupdateScheduler {
       return;
     }
 
+    const uid = await getUid();
     const cmd = new Deno.Command("launchctl", {
-      args: ["unload", path],
+      args: ["bootout", `gui/${uid}/${LABEL}`],
       stdout: "null",
       stderr: "null",
     });

--- a/src/infrastructure/update/launchd_scheduler.ts
+++ b/src/infrastructure/update/launchd_scheduler.ts
@@ -33,7 +33,12 @@ function plistPath(): string {
 }
 
 function escapeXml(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
 }
 
 function buildPlist(binaryPath: string, cadence: UpdateCadence): string {

--- a/src/infrastructure/update/scheduler_factory.ts
+++ b/src/infrastructure/update/scheduler_factory.ts
@@ -1,0 +1,53 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { AutoupdateScheduler } from "../../domain/update/autoupdate_scheduler.ts";
+import { LaunchdScheduler } from "./launchd_scheduler.ts";
+import { SystemdScheduler } from "./systemd_scheduler.ts";
+import { CronScheduler } from "./cron_scheduler.ts";
+
+async function hasSystemctl(): Promise<boolean> {
+  try {
+    const cmd = new Deno.Command("systemctl", {
+      args: ["--user", "--version"],
+      stdout: "null",
+      stderr: "null",
+    });
+    const result = await cmd.output();
+    return result.success;
+  } catch {
+    return false;
+  }
+}
+
+export async function createScheduler(): Promise<AutoupdateScheduler> {
+  switch (Deno.build.os) {
+    case "darwin":
+      return new LaunchdScheduler();
+    case "linux":
+      if (await hasSystemctl()) {
+        return new SystemdScheduler();
+      }
+      return new CronScheduler();
+    default:
+      throw new Error(
+        `Background autoupdate is not yet supported on ${Deno.build.os}`,
+      );
+  }
+}

--- a/src/infrastructure/update/scheduler_factory.ts
+++ b/src/infrastructure/update/scheduler_factory.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { AutoupdateScheduler } from "../../domain/update/autoupdate_scheduler.ts";
+import { UserError } from "../../domain/errors.ts";
 import { LaunchdScheduler } from "./launchd_scheduler.ts";
 import { SystemdScheduler } from "./systemd_scheduler.ts";
 import { CronScheduler } from "./cron_scheduler.ts";
@@ -46,7 +47,7 @@ export async function createScheduler(): Promise<AutoupdateScheduler> {
       }
       return new CronScheduler();
     default:
-      throw new Error(
+      throw new UserError(
         `Background autoupdate is not yet supported on ${Deno.build.os}`,
       );
   }

--- a/src/infrastructure/update/systemd_scheduler.ts
+++ b/src/infrastructure/update/systemd_scheduler.ts
@@ -1,0 +1,136 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join } from "@std/path";
+import type {
+  AutoupdateScheduler,
+  ScheduleStatus,
+} from "../../domain/update/autoupdate_scheduler.ts";
+import type { UpdateCadence } from "../../domain/update/update_preferences.ts";
+import { atomicWriteTextFile } from "../persistence/atomic_write.ts";
+
+const UNIT_NAME = "swamp-autoupdate";
+
+function systemdUserDir(): string {
+  const xdgConfigHome = Deno.env.get("XDG_CONFIG_HOME");
+  const home = Deno.env.get("HOME");
+  if (!home && !xdgConfigHome) {
+    throw new Error("Cannot determine home directory (HOME not set)");
+  }
+  const base = xdgConfigHome ?? join(home!, ".config");
+  return join(base, "systemd", "user");
+}
+
+function servicePath(): string {
+  return join(systemdUserDir(), `${UNIT_NAME}.service`);
+}
+
+function timerPath(): string {
+  return join(systemdUserDir(), `${UNIT_NAME}.timer`);
+}
+
+function buildService(binaryPath: string): string {
+  return `[Unit]
+Description=Swamp background autoupdate
+
+[Service]
+Type=oneshot
+ExecStart=${binaryPath} update --background
+`;
+}
+
+function buildTimer(cadence: UpdateCadence): string {
+  const onCalendar = cadence === "daily" ? "daily" : "weekly";
+  return `[Unit]
+Description=Swamp autoupdate timer
+
+[Timer]
+OnCalendar=${onCalendar}
+Persistent=true
+RandomizedDelaySec=3600
+
+[Install]
+WantedBy=timers.target
+`;
+}
+
+async function systemctl(...args: string[]): Promise<boolean> {
+  const cmd = new Deno.Command("systemctl", {
+    args: ["--user", ...args],
+    stdout: "null",
+    stderr: "null",
+  });
+  const result = await cmd.output();
+  return result.success;
+}
+
+export class SystemdScheduler implements AutoupdateScheduler {
+  async install(binaryPath: string, cadence: UpdateCadence): Promise<void> {
+    await this.remove();
+
+    const dir = systemdUserDir();
+    await Deno.mkdir(dir, { recursive: true });
+
+    await atomicWriteTextFile(servicePath(), buildService(binaryPath));
+    await atomicWriteTextFile(timerPath(), buildTimer(cadence));
+
+    await systemctl("daemon-reload");
+    const started = await systemctl("enable", "--now", `${UNIT_NAME}.timer`);
+    if (!started) {
+      throw new Error(
+        `Failed to enable systemd timer ${UNIT_NAME}.timer`,
+      );
+    }
+  }
+
+  async remove(): Promise<void> {
+    await systemctl("disable", "--now", `${UNIT_NAME}.timer`);
+    await systemctl("daemon-reload");
+
+    await Deno.remove(timerPath()).catch(() => {});
+    await Deno.remove(servicePath()).catch(() => {});
+  }
+
+  async status(): Promise<ScheduleStatus> {
+    try {
+      const content = await Deno.readTextFile(timerPath());
+      const calendarMatch = content.match(/OnCalendar=(\w+)/);
+      const cadence: UpdateCadence = calendarMatch?.[1] === "weekly"
+        ? "weekly"
+        : "daily";
+
+      const cmd = new Deno.Command("systemctl", {
+        args: ["--user", "is-active", `${UNIT_NAME}.timer`],
+        stdout: "piped",
+        stderr: "null",
+      });
+      const result = await cmd.output();
+      const active = new TextDecoder().decode(result.stdout).trim() ===
+        "active";
+
+      if (!active) {
+        return { installed: false };
+      }
+
+      return { installed: true, cadence };
+    } catch {
+      return { installed: false };
+    }
+  }
+}

--- a/src/infrastructure/update/systemd_scheduler.ts
+++ b/src/infrastructure/update/systemd_scheduler.ts
@@ -51,7 +51,7 @@ Description=Swamp background autoupdate
 
 [Service]
 Type=oneshot
-ExecStart=${binaryPath} update --background
+ExecStart="${binaryPath}" update --background
 `;
 }
 

--- a/src/infrastructure/update/update_preferences_file_repository.ts
+++ b/src/infrastructure/update/update_preferences_file_repository.ts
@@ -56,6 +56,9 @@ export class UpdatePreferencesFileRepository
           typeof data.cadence === "string" && isValidCadence(data.cadence)
             ? data.cadence
             : DEFAULT_UPDATE_PREFERENCES.cadence,
+        notifiedVersion: typeof data.notifiedVersion === "string"
+          ? data.notifiedVersion
+          : undefined,
       };
     } catch {
       return { ...DEFAULT_UPDATE_PREFERENCES };

--- a/src/infrastructure/update/update_preferences_file_repository.ts
+++ b/src/infrastructure/update/update_preferences_file_repository.ts
@@ -1,0 +1,70 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { dirname, join } from "@std/path";
+import { parse, stringify } from "@std/yaml";
+import {
+  DEFAULT_UPDATE_PREFERENCES,
+  isValidCadence,
+  type UpdatePreferences,
+  type UpdatePreferencesRepository,
+} from "../../domain/update/update_preferences.ts";
+import { getSwampConfigDir } from "../persistence/paths.ts";
+import { atomicWriteTextFile } from "../persistence/atomic_write.ts";
+
+const PREFERENCES_FILE_NAME = "update.yaml";
+
+export class UpdatePreferencesFileRepository
+  implements UpdatePreferencesRepository {
+  private readonly filePath: string;
+
+  constructor(filePath?: string) {
+    this.filePath = filePath ??
+      join(getSwampConfigDir(), PREFERENCES_FILE_NAME);
+  }
+
+  async read(): Promise<UpdatePreferences> {
+    try {
+      const content = await Deno.readTextFile(this.filePath);
+      const data = parse(content) as Record<string, unknown>;
+
+      if (!data || typeof data !== "object") {
+        return { ...DEFAULT_UPDATE_PREFERENCES };
+      }
+
+      return {
+        enabled: typeof data.enabled === "boolean"
+          ? data.enabled
+          : DEFAULT_UPDATE_PREFERENCES.enabled,
+        cadence:
+          typeof data.cadence === "string" && isValidCadence(data.cadence)
+            ? data.cadence
+            : DEFAULT_UPDATE_PREFERENCES.cadence,
+      };
+    } catch {
+      return { ...DEFAULT_UPDATE_PREFERENCES };
+    }
+  }
+
+  async write(preferences: UpdatePreferences): Promise<void> {
+    const dir = dirname(this.filePath);
+    await Deno.mkdir(dir, { recursive: true });
+    await atomicWriteTextFile(this.filePath, stringify(preferences));
+  }
+}

--- a/src/infrastructure/update/update_preferences_file_repository_test.ts
+++ b/src/infrastructure/update/update_preferences_file_repository_test.ts
@@ -1,0 +1,105 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { UpdatePreferencesFileRepository } from "./update_preferences_file_repository.ts";
+import { DEFAULT_UPDATE_PREFERENCES } from "../../domain/update/update_preferences.ts";
+
+async function withTempDir(
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir();
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+Deno.test("UpdatePreferencesFileRepository: returns defaults when file missing", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new UpdatePreferencesFileRepository(
+      join(dir, "nonexistent", "update.yaml"),
+    );
+    const prefs = await repo.read();
+    assertEquals(prefs, DEFAULT_UPDATE_PREFERENCES);
+  });
+});
+
+Deno.test("UpdatePreferencesFileRepository: round-trips preferences", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "update.yaml");
+    const repo = new UpdatePreferencesFileRepository(filePath);
+
+    const prefs = {
+      enabled: true,
+      cadence: "weekly" as const,
+    };
+    await repo.write(prefs);
+
+    const result = await repo.read();
+    assertEquals(result, prefs);
+  });
+});
+
+Deno.test("UpdatePreferencesFileRepository: handles corrupt file gracefully", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "update.yaml");
+    await Deno.writeTextFile(filePath, "not: [valid: yaml: {{{");
+
+    const repo = new UpdatePreferencesFileRepository(filePath);
+    const prefs = await repo.read();
+    assertEquals(prefs, DEFAULT_UPDATE_PREFERENCES);
+  });
+});
+
+Deno.test("UpdatePreferencesFileRepository: fills missing fields with defaults", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "update.yaml");
+    await Deno.writeTextFile(filePath, "enabled: true\n");
+
+    const repo = new UpdatePreferencesFileRepository(filePath);
+    const prefs = await repo.read();
+    assertEquals(prefs.enabled, true);
+    assertEquals(prefs.cadence, "daily");
+  });
+});
+
+Deno.test("UpdatePreferencesFileRepository: rejects invalid cadence", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "update.yaml");
+    await Deno.writeTextFile(filePath, "enabled: true\ncadence: hourly\n");
+
+    const repo = new UpdatePreferencesFileRepository(filePath);
+    const prefs = await repo.read();
+    assertEquals(prefs.cadence, "daily");
+  });
+});
+
+Deno.test("UpdatePreferencesFileRepository: creates parent directories", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "nested", "dirs", "update.yaml");
+    const repo = new UpdatePreferencesFileRepository(filePath);
+
+    await repo.write({ enabled: true, cadence: "daily" });
+    const prefs = await repo.read();
+    assertEquals(prefs.enabled, true);
+  });
+});

--- a/src/infrastructure/update/update_preferences_file_repository_test.ts
+++ b/src/infrastructure/update/update_preferences_file_repository_test.ts
@@ -55,7 +55,8 @@ Deno.test("UpdatePreferencesFileRepository: round-trips preferences", async () =
     await repo.write(prefs);
 
     const result = await repo.read();
-    assertEquals(result, prefs);
+    assertEquals(result.enabled, true);
+    assertEquals(result.cadence, "weekly");
   });
 });
 


### PR DESCRIPTION
## Summary

- Add opt-in background autoupdating with platform-native scheduling (launchd on macOS, systemd on Linux with cron fallback for non-systemd distros)
- Add `swamp update --setup-auto` interactive setup, `--setup-auto status`, `--setup-auto disable`, and `--background` silent update entry point
- Add `swamp config get/set/list` command family for non-interactive preference management
- Suppress the "run swamp update" notification banner when autoupdate is enabled; show a one-line post-upgrade notice on next interactive invocation

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes (1252 files)
- [x] `deno fmt` passes (1376 files)
- [x] `deno run test` — 103 update-related tests pass, no regressions
- [x] `deno run compile` succeeds
- [x] macOS: launchd agent installs, fires via RunAtLoad, performs real background update, cleanly removes on disable
- [x] Linux (Debian with systemd path): config commands and background flag work
- [x] Linux (Debian without systemd): detects missing systemctl, falls back to cron, installs/removes crontab entry cleanly
- [ ] CI validation

Closes swamp-club#227
Docs: swamp-club#285
UAT: systeminit/swamp-uat#199

🤖 Generated with [Claude Code](https://claude.com/claude-code)