### PR TITLE
fix(cli): autoupdate review feedback — escaping, tests, UX polish

### DIFF
--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -21,7 +21,7 @@ import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { UpdatePreferencesFileRepository } from "../../infrastructure/update/update_preferences_file_repository.ts";
 import { createScheduler } from "../../infrastructure/update/scheduler_factory.ts";
-import { isValidCadence } from "../../domain/update/update_preferences.ts";
+import type { UpdateCadence } from "../../domain/update/update_preferences.ts";
 import { UserError } from "../../domain/errors.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -91,16 +91,20 @@ const configSetCommand = new Command()
       );
     }
 
+    const meta = CONFIG_KEYS[key];
+    if (meta.values && !meta.values.includes(value)) {
+      throw new UserError(
+        `Invalid value for ${key}: ${value}. Must be ${
+          meta.values.map((v) => `"${v}"`).join(" or ")
+        }.`,
+      );
+    }
+
     const prefsRepo = new UpdatePreferencesFileRepository();
     const prefs = await prefsRepo.read();
 
     switch (key) {
       case "update.auto": {
-        if (value !== "enabled" && value !== "disabled") {
-          throw new UserError(
-            `Invalid value for update.auto: ${value}. Must be "enabled" or "disabled".`,
-          );
-        }
         const enabling = value === "enabled";
 
         const scheduler = await createScheduler();
@@ -124,18 +128,13 @@ const configSetCommand = new Command()
         break;
       }
       case "update.cadence": {
-        if (!isValidCadence(value)) {
-          throw new UserError(
-            `Invalid value for update.cadence: ${value}. Must be "daily" or "weekly".`,
-          );
-        }
-
+        const cadence = value as UpdateCadence;
         if (prefs.enabled) {
           const scheduler = await createScheduler();
-          await scheduler.install(Deno.execPath(), value);
+          await scheduler.install(Deno.execPath(), cadence);
         }
 
-        await prefsRepo.write({ ...prefs, cadence: value });
+        await prefsRepo.write({ ...prefs, cadence });
 
         if (ctx.outputMode === "json") {
           console.log(JSON.stringify({ key, value }));

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -110,8 +110,7 @@ const configSetCommand = new Command()
           await scheduler.remove();
         }
 
-        prefs.enabled = enabling;
-        await prefsRepo.write(prefs);
+        await prefsRepo.write({ ...prefs, enabled: enabling });
 
         if (ctx.outputMode === "json") {
           console.log(JSON.stringify({ key, value }));
@@ -136,8 +135,7 @@ const configSetCommand = new Command()
           await scheduler.install(Deno.execPath(), value);
         }
 
-        prefs.cadence = value;
-        await prefsRepo.write(prefs);
+        await prefsRepo.write({ ...prefs, cadence: value });
 
         if (ctx.outputMode === "json") {
           console.log(JSON.stringify({ key, value }));

--- a/src/cli/commands/config_test.ts
+++ b/src/cli/commands/config_test.ts
@@ -1,0 +1,96 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertStringIncludes } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import "../../domain/models/models.ts";
+
+await initializeLogging({});
+
+Deno.test("config get: rejects unknown key", async () => {
+  const cmd = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--unstable-bundle",
+      "--allow-read",
+      "--allow-write",
+      "--allow-env",
+      "--allow-run",
+      "--allow-sys",
+      "main.ts",
+      "config",
+      "get",
+      "unknown.key",
+    ],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const result = await cmd.output();
+  const stderr = new TextDecoder().decode(result.stderr);
+  assertStringIncludes(stderr, "Unknown config key: unknown.key");
+  assertStringIncludes(stderr, "update.auto");
+});
+
+Deno.test("config set: rejects invalid cadence", async () => {
+  const cmd = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--unstable-bundle",
+      "--allow-read",
+      "--allow-write",
+      "--allow-env",
+      "--allow-run",
+      "--allow-sys",
+      "main.ts",
+      "config",
+      "set",
+      "update.cadence",
+      "hourly",
+    ],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const result = await cmd.output();
+  const stderr = new TextDecoder().decode(result.stderr);
+  assertStringIncludes(stderr, "Invalid value for update.cadence");
+});
+
+Deno.test("config set: rejects unknown key", async () => {
+  const cmd = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--unstable-bundle",
+      "--allow-read",
+      "--allow-write",
+      "--allow-env",
+      "--allow-run",
+      "--allow-sys",
+      "main.ts",
+      "config",
+      "set",
+      "bogus.key",
+      "value",
+    ],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const result = await cmd.output();
+  const stderr = new TextDecoder().decode(result.stderr);
+  assertStringIncludes(stderr, "Unknown config key: bogus.key");
+});

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -96,7 +96,12 @@ function promptCadence(defaultCadence: UpdateCadence): UpdateCadence {
       "How often should swamp check for updates? (daily/weekly)",
       defaultCadence,
     );
-    if (input && isValidCadence(input)) {
+    if (input === null) {
+      throw new UserError(
+        "No input received. Use `swamp config set update.cadence <daily|weekly>` instead.",
+      );
+    }
+    if (isValidCadence(input)) {
       return input;
     }
     console.error(`Invalid cadence: ${input}. Must be "daily" or "weekly".`);

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -46,6 +46,8 @@ import { UserError } from "../../domain/errors.ts";
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
+const BACKGROUND_TIMEOUT_MS = 5 * 60 * 1000;
+
 async function runBackgroundUpdate(
   ctx: { logger: ReturnType<typeof getSwampLogger> },
 ): Promise<void> {
@@ -60,22 +62,24 @@ async function runBackgroundUpdate(
     outcome: "up_to_date",
   };
 
-  const BACKGROUND_TIMEOUT_MS = 5 * 60 * 1000;
+  let timeoutId: number;
   try {
     const timeout = new Promise<never>((_, reject) => {
-      const id = setTimeout(
+      timeoutId = setTimeout(
         () => reject(new Error("Background update timed out")),
         BACKGROUND_TIMEOUT_MS,
       );
-      Deno.unrefTimer(id);
+      Deno.unrefTimer(timeoutId);
     });
     const result = await Promise.race([deps.update(platform), timeout]);
+    clearTimeout(timeoutId!);
 
     if (result.status === "updated") {
       entry.versionAfter = result.newVersion;
       entry.outcome = "updated";
     }
   } catch (error) {
+    clearTimeout(timeoutId!);
     entry.outcome = "error";
     entry.error = error instanceof Error ? error.message : String(error);
   }
@@ -84,6 +88,19 @@ async function runBackgroundUpdate(
   await logRepo.prune(AUTOUPDATE_LOG_RETENTION_DAYS);
 
   ctx.logger.debug`Background update completed: ${entry.outcome}`;
+}
+
+function promptCadence(defaultCadence: UpdateCadence): UpdateCadence {
+  while (true) {
+    const input = prompt(
+      "How often should swamp check for updates? (daily/weekly)",
+      defaultCadence,
+    );
+    if (input && isValidCadence(input)) {
+      return input;
+    }
+    console.error(`Invalid cadence: ${input}. Must be "daily" or "weekly".`);
+  }
 }
 
 async function runSetupAuto(
@@ -99,22 +116,12 @@ async function runSetupAuto(
   const prefs = await prefsRepo.read();
   const logger = ctx.logger;
 
-  const cadenceInput = prompt(
-    "How often should swamp check for updates? (daily/weekly)",
-    prefs.cadence,
-  );
-  if (!cadenceInput || !isValidCadence(cadenceInput)) {
-    throw new UserError(
-      `Invalid cadence: ${cadenceInput}. Must be "daily" or "weekly".`,
-    );
-  }
-
-  const cadence = cadenceInput as UpdateCadence;
+  const cadence = promptCadence(prefs.cadence);
 
   const scheduler = await createScheduler();
   await scheduler.install(Deno.execPath(), cadence);
 
-  await prefsRepo.write({ enabled: true, cadence });
+  await prefsRepo.write({ ...prefs, enabled: true, cadence });
 
   if (ctx.outputMode === "json") {
     console.log(JSON.stringify({ enabled: true, cadence }));
@@ -137,8 +144,7 @@ async function runDisableAuto(
   const scheduler = await createScheduler();
   await scheduler.remove();
 
-  prefs.enabled = false;
-  await prefsRepo.write(prefs);
+  await prefsRepo.write({ ...prefs, enabled: false });
 
   if (ctx.outputMode === "json") {
     console.log(
@@ -231,7 +237,7 @@ export const updateCommand = new Command()
         throw new UserError(
           `Unknown action: ${options.setupAuto}. Valid actions: ${
             validActions.join(", ")
-          }`,
+          } (or omit value for interactive setup)`,
         );
       }
 

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1160,7 +1160,7 @@ export async function runCli(args: string[]): Promise<void> {
           const prefs = await prefsRepo.read();
 
           // Show post-autoupdate notice once after background upgrade
-          if (prefs.notifiedVersion !== VERSION) {
+          if (prefs.enabled && prefs.notifiedVersion !== VERSION) {
             const logRepo = new AutoupdateLogFileRepository();
             const entries = await logRepo.readAll();
             const lastUpdate = entries.findLast((e) =>
@@ -1170,9 +1170,8 @@ export async function runCli(args: string[]): Promise<void> {
               console.error(
                 `\nℹ swamp was auto-updated from ${lastUpdate.versionBefore} → ${lastUpdate.versionAfter}`,
               );
-              prefs.notifiedVersion = VERSION;
-              await prefsRepo.write(prefs);
             }
+            await prefsRepo.write({ ...prefs, notifiedVersion: VERSION });
           }
 
           // Skip the "run swamp update" banner if autoupdate handles it

--- a/src/infrastructure/update/cron_scheduler.ts
+++ b/src/infrastructure/update/cron_scheduler.ts
@@ -25,12 +25,16 @@ import type { UpdateCadence } from "../../domain/update/update_preferences.ts";
 
 const CRON_MARKER = "# swamp-autoupdate";
 
-function cronSchedule(cadence: UpdateCadence): string {
+export function cronSchedule(cadence: UpdateCadence): string {
   return cadence === "daily" ? "0 9 * * *" : "0 9 * * 1";
 }
 
-function cadenceFromSchedule(schedule: string): UpdateCadence {
+export function cadenceFromSchedule(schedule: string): UpdateCadence {
   return schedule.trim().endsWith("* * 1") ? "weekly" : "daily";
+}
+
+export function escapeShellPath(s: string): string {
+  return s.replace(/'/g, "'\\''");
 }
 
 async function readCrontab(): Promise<string> {
@@ -67,8 +71,8 @@ export class CronScheduler implements AutoupdateScheduler {
 
     const existing = await readCrontab();
     const schedule = cronSchedule(cadence);
-    const line =
-      `${schedule} "${binaryPath}" update --background ${CRON_MARKER}`;
+    const escaped = escapeShellPath(binaryPath);
+    const line = `${schedule} '${escaped}' update --background ${CRON_MARKER}`;
     const newContent = existing.trimEnd() + (existing.trim() ? "\n" : "") +
       line + "\n";
     await writeCrontab(newContent);

--- a/src/infrastructure/update/launchd_scheduler.ts
+++ b/src/infrastructure/update/launchd_scheduler.ts
@@ -32,7 +32,7 @@ function plistPath(): string {
   return join(homeDirectory(), "Library", "LaunchAgents", `${LABEL}.plist`);
 }
 
-function escapeXml(s: string): string {
+export function escapeXml(s: string): string {
   return s
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
@@ -41,7 +41,7 @@ function escapeXml(s: string): string {
     .replace(/'/g, "&apos;");
 }
 
-function buildPlist(binaryPath: string, cadence: UpdateCadence): string {
+export function buildPlist(binaryPath: string, cadence: UpdateCadence): string {
   const interval = cadence === "daily" ? 86400 : 604800;
   const escapedPath = escapeXml(binaryPath);
 
@@ -70,7 +70,7 @@ function buildPlist(binaryPath: string, cadence: UpdateCadence): string {
 `;
 }
 
-function cadenceFromInterval(interval: number): UpdateCadence {
+export function cadenceFromInterval(interval: number): UpdateCadence {
   return interval <= 86400 ? "daily" : "weekly";
 }
 

--- a/src/infrastructure/update/scheduler_helpers_test.ts
+++ b/src/infrastructure/update/scheduler_helpers_test.ts
@@ -1,0 +1,125 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  buildPlist,
+  cadenceFromInterval,
+  escapeXml,
+} from "./launchd_scheduler.ts";
+import {
+  buildService,
+  buildTimer,
+  escapeSystemdPath,
+} from "./systemd_scheduler.ts";
+import {
+  cadenceFromSchedule,
+  cronSchedule,
+  escapeShellPath,
+} from "./cron_scheduler.ts";
+
+Deno.test("escapeXml: escapes all five predefined entities", () => {
+  assertEquals(escapeXml("a&b<c>d\"e'f"), "a&amp;b&lt;c&gt;d&quot;e&apos;f");
+});
+
+Deno.test("escapeXml: passes through clean paths", () => {
+  assertEquals(escapeXml("/usr/local/bin/swamp"), "/usr/local/bin/swamp");
+});
+
+Deno.test("buildPlist: contains binary path and daily interval", () => {
+  const plist = buildPlist("/usr/local/bin/swamp", "daily");
+  assertStringIncludes(plist, "<string>/usr/local/bin/swamp</string>");
+  assertStringIncludes(plist, "<integer>86400</integer>");
+});
+
+Deno.test("buildPlist: contains weekly interval", () => {
+  const plist = buildPlist("/usr/local/bin/swamp", "weekly");
+  assertStringIncludes(plist, "<integer>604800</integer>");
+});
+
+Deno.test("buildPlist: escapes special chars in path", () => {
+  const plist = buildPlist('/opt/my "app/swamp', "daily");
+  assertStringIncludes(plist, "&quot;");
+});
+
+Deno.test("cadenceFromInterval: daily for 86400", () => {
+  assertEquals(cadenceFromInterval(86400), "daily");
+});
+
+Deno.test("cadenceFromInterval: weekly for 604800", () => {
+  assertEquals(cadenceFromInterval(604800), "weekly");
+});
+
+Deno.test("escapeSystemdPath: escapes backslashes and quotes", () => {
+  assertEquals(
+    escapeSystemdPath('path with "quotes"'),
+    'path with \\"quotes\\"',
+  );
+  assertEquals(
+    escapeSystemdPath("path\\with\\backslash"),
+    "path\\\\with\\\\backslash",
+  );
+});
+
+Deno.test("buildService: contains quoted binary path", () => {
+  const service = buildService("/usr/local/bin/swamp");
+  assertStringIncludes(
+    service,
+    'ExecStart="/usr/local/bin/swamp" update --background',
+  );
+});
+
+Deno.test("buildService: escapes quotes in path", () => {
+  const service = buildService('/opt/my "app/swamp');
+  assertStringIncludes(service, 'ExecStart="/opt/my \\"app/swamp"');
+});
+
+Deno.test("buildTimer: daily calendar", () => {
+  const timer = buildTimer("daily");
+  assertStringIncludes(timer, "OnCalendar=daily");
+});
+
+Deno.test("buildTimer: weekly calendar", () => {
+  const timer = buildTimer("weekly");
+  assertStringIncludes(timer, "OnCalendar=weekly");
+});
+
+Deno.test("cronSchedule: daily schedule", () => {
+  assertEquals(cronSchedule("daily"), "0 9 * * *");
+});
+
+Deno.test("cronSchedule: weekly schedule", () => {
+  assertEquals(cronSchedule("weekly"), "0 9 * * 1");
+});
+
+Deno.test("cadenceFromSchedule: detects daily", () => {
+  assertEquals(cadenceFromSchedule("0 9 * * *"), "daily");
+});
+
+Deno.test("cadenceFromSchedule: detects weekly", () => {
+  assertEquals(cadenceFromSchedule("0 9 * * 1"), "weekly");
+});
+
+Deno.test("escapeShellPath: escapes single quotes", () => {
+  assertEquals(escapeShellPath("it's a path"), "it'\\''s a path");
+});
+
+Deno.test("escapeShellPath: passes through clean paths", () => {
+  assertEquals(escapeShellPath("/usr/local/bin/swamp"), "/usr/local/bin/swamp");
+});

--- a/src/infrastructure/update/scheduler_helpers_test.ts
+++ b/src/infrastructure/update/scheduler_helpers_test.ts
@@ -66,6 +66,13 @@ Deno.test("cadenceFromInterval: weekly for 604800", () => {
   assertEquals(cadenceFromInterval(604800), "weekly");
 });
 
+Deno.test("escapeSystemdPath: escapes percent specifiers", () => {
+  assertEquals(
+    escapeSystemdPath("/home/user/100%done"),
+    "/home/user/100%%done",
+  );
+});
+
 Deno.test("escapeSystemdPath: escapes backslashes and quotes", () => {
   assertEquals(
     escapeSystemdPath('path with "quotes"'),

--- a/src/infrastructure/update/systemd_scheduler.ts
+++ b/src/infrastructure/update/systemd_scheduler.ts
@@ -46,7 +46,7 @@ function timerPath(): string {
 }
 
 export function escapeSystemdPath(s: string): string {
-  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/%/g, "%%");
 }
 
 export function buildService(binaryPath: string): string {

--- a/src/infrastructure/update/systemd_scheduler.ts
+++ b/src/infrastructure/update/systemd_scheduler.ts
@@ -45,17 +45,22 @@ function timerPath(): string {
   return join(systemdUserDir(), `${UNIT_NAME}.timer`);
 }
 
-function buildService(binaryPath: string): string {
+export function escapeSystemdPath(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+export function buildService(binaryPath: string): string {
+  const escaped = escapeSystemdPath(binaryPath);
   return `[Unit]
 Description=Swamp background autoupdate
 
 [Service]
 Type=oneshot
-ExecStart="${binaryPath}" update --background
+ExecStart="${escaped}" update --background
 `;
 }
 
-function buildTimer(cadence: UpdateCadence): string {
+export function buildTimer(cadence: UpdateCadence): string {
   const onCalendar = cadence === "daily" ? "daily" : "weekly";
   return `[Unit]
 Description=Swamp autoupdate timer


### PR DESCRIPTION
## Summary

Follow-up to #1336 addressing review feedback:

1. Clear orphaned timeout in `runBackgroundUpdate` — no more fire-and-forget promise
2. Set `notifiedVersion` unconditionally after check — prevents repeated log reads after manual upgrades
3. Gate autoupdate log reads on `prefs.enabled` — skip I/O when autoupdate is disabled
4. Add "(or omit value for interactive setup)" hint to `--setup-auto` error message
5. Interactive setup retries on invalid cadence input instead of exiting
6. Add `config_test.ts` — key validation and error message tests (3 tests)
7. Export scheduler pure functions and add 18 unit tests for template generation and escaping
8. Use immutable spread pattern for `UpdatePreferences` writes (DDD alignment)
9. Add `escapeShellPath` for cron and `escapeSystemdPath` for systemd — consistent with launchd's `escapeXml`
10. Cron uses single-quoted paths; systemd escapes quotes in `ExecStart`

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes (1258 files)
- [x] `deno fmt` passes (1382 files)
- [x] 127 update domain/infrastructure tests pass (18 new scheduler helper tests)
- [x] 3 new config CLI tests pass
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)