### PR TITLE
fix(cli): strip undefined values before YAML serialization in config set (swamp-club#289)

### DIFF
--- a/src/infrastructure/update/update_preferences_file_repository.ts
+++ b/src/infrastructure/update/update_preferences_file_repository.ts
@@ -68,6 +68,9 @@ export class UpdatePreferencesFileRepository
   async write(preferences: UpdatePreferences): Promise<void> {
     const dir = dirname(this.filePath);
     await Deno.mkdir(dir, { recursive: true });
-    await atomicWriteTextFile(this.filePath, stringify(preferences));
+    const defined = Object.fromEntries(
+      Object.entries(preferences).filter(([, v]) => v !== undefined),
+    );
+    await atomicWriteTextFile(this.filePath, stringify(defined));
   }
 }

--- a/src/infrastructure/update/update_preferences_file_repository_test.ts
+++ b/src/infrastructure/update/update_preferences_file_repository_test.ts
@@ -94,6 +94,39 @@ Deno.test("UpdatePreferencesFileRepository: rejects invalid cadence", async () =
   });
 });
 
+Deno.test("UpdatePreferencesFileRepository: write succeeds when notifiedVersion is undefined", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "update.yaml");
+    const repo = new UpdatePreferencesFileRepository(filePath);
+
+    const prefs = await repo.read();
+    await repo.write({ ...prefs, enabled: true });
+
+    const result = await repo.read();
+    assertEquals(result.enabled, true);
+    assertEquals(result.cadence, "daily");
+    assertEquals(result.notifiedVersion, undefined);
+  });
+});
+
+Deno.test("UpdatePreferencesFileRepository: write preserves notifiedVersion when present", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "update.yaml");
+    const repo = new UpdatePreferencesFileRepository(filePath);
+
+    await repo.write({
+      enabled: true,
+      cadence: "weekly",
+      notifiedVersion: "1.2.3",
+    });
+
+    const result = await repo.read();
+    assertEquals(result.enabled, true);
+    assertEquals(result.cadence, "weekly");
+    assertEquals(result.notifiedVersion, "1.2.3");
+  });
+});
+
 Deno.test("UpdatePreferencesFileRepository: creates parent directories", async () => {
   await withTempDir(async (dir) => {
     const filePath = join(dir, "nested", "dirs", "update.yaml");


### PR DESCRIPTION
## Summary

- `swamp config set update.auto enabled` (and `update.cadence`) crashed with `TypeError: Cannot stringify undefined` because `UpdatePreferencesFileRepository.read()` explicitly sets `notifiedVersion: undefined` when the field is absent from the YAML file — `@std/yaml`'s `stringify()` cannot serialize `undefined`
- Filter out `undefined` values in `write()` before calling `stringify()`, making it resilient to any optional field

## Test Plan

- [x] Added test: `write()` succeeds when `notifiedVersion` is undefined (the exact crash scenario)
- [x] Added test: `write()` preserves `notifiedVersion` when present
- [x] All 8 repository tests pass
- [x] Reproduced crash in `/tmp/swamp-repro-issue-289`, verified fix with recompiled binary
- [x] `deno check`, `deno lint`, `deno fmt`, `deno run test` all pass

Fixes swamp-club#289