### PR TITLE
docs: strengthen skill-creator prerequisite in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,12 @@ architecture.
 
 ## Skills
 
-Skills live in `.claude/skills/<skill-name>/`. When creating or modifying any
-skill, **always load the `skill-creator` skill first** — it contains the
+Skills live in `.claude/skills/<skill-name>/`.
+
+IMPORTANT: Before creating or modifying ANY skill file, you MUST load the
+`skill-creator` skill first. Do not skip this step — it contains the
 authoritative guidelines for structure, frontmatter, and progressive disclosure.
+This is a hard prerequisite, not a suggestion.
 
 ### Skill structure
 


### PR DESCRIPTION
## Summary
- Promotes the instruction to load `skill-creator` before editing skills from inline text to an `IMPORTANT:` block with `MUST` language
- The previous wording was frequently being skipped; this matches the enforcement level of other critical instructions in CLAUDE.md (e.g., libswamp imports, CLI test patterns)

## Test plan
- [ ] Verify CLAUDE.md renders correctly
- [ ] Confirm no other content was changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)