### PR TITLE
feat(telemetry): record agent harness and tty context per invocation (swamp-club#292)

### DIFF
--- a/integration/telemetry_invocation_context_test.ts
+++ b/integration/telemetry_invocation_context_test.ts
@@ -1,0 +1,150 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { CLI_ARGS } from "./test_helpers.ts";
+
+interface CliRunResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+async function runCliWithEnv(
+  args: string[],
+  cwd: string,
+  env: Record<string, string>,
+): Promise<CliRunResult> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [...CLI_ARGS, ...args],
+    stdout: "piped",
+    stderr: "piped",
+    cwd,
+    env,
+    clearEnv: true,
+  });
+  const { code, stdout, stderr } = await command.output();
+  return {
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+    code,
+  };
+}
+
+async function readPersistedEntries(
+  repoDir: string,
+): Promise<Record<string, unknown>[]> {
+  const dir = join(repoDir, ".swamp", "telemetry");
+  const entries: Record<string, unknown>[] = [];
+  for await (const file of Deno.readDir(dir)) {
+    if (!file.isFile || !file.name.endsWith(".json")) continue;
+    const text = await Deno.readTextFile(join(dir, file.name));
+    entries.push(JSON.parse(text) as Record<string, unknown>);
+  }
+  return entries;
+}
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-tel-ctx-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+/** Subprocess env that the CLI needs to function but with no harness signals
+ * unless the test sets them explicitly. */
+function baseChildEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of ["HOME", "PATH", "USER", "TMPDIR", "TMP", "TEMP"]) {
+    const value = Deno.env.get(key);
+    if (value !== undefined) env[key] = value;
+  }
+  // Pin telemetry to a localhost endpoint that nothing listens on so the
+  // post-command flush dies fast and does not pollute the test's persisted
+  // file. The test reads the still-unflushed local entry directly.
+  env.SWAMP_DEBUG = "0";
+  return env;
+}
+
+Deno.test("CLI bootstrap stamps invocationContext on persisted telemetry", async () => {
+  await withTempDir(async (dir) => {
+    // Initialise a repo enrolled with both claude and cursor. Use --json so
+    // we can parse the result if needed.
+    const init = await runCliWithEnv(
+      ["--json", "repo", "init", "--tool", "claude", "--tool", "cursor"],
+      dir,
+      baseChildEnv(),
+    );
+    assertEquals(init.code, 0, `repo init failed: ${init.stderr}`);
+
+    // Pin a telemetryEndpoint that nothing is listening on so the
+    // post-command flush bails fast and the entry stays on disk for us
+    // to inspect. Append the field to the existing marker.
+    const markerPath = join(dir, ".swamp.yaml");
+    const marker = await Deno.readTextFile(markerPath);
+    await Deno.writeTextFile(
+      markerPath,
+      marker +
+        "\ntelemetryEndpoint: http://127.0.0.1:1\ntelemetryKeepFlushed: true\n",
+    );
+
+    // Run a real command that flows through the full action pipeline
+    // (Cliffy's --version handler exits before recordSuccess runs). repo
+    // upgrade on an already-initialised repo is a cheap no-op and goes
+    // through the full path. Set the claude harness signal in the child
+    // env so detection has something to identify.
+    const childEnv = baseChildEnv();
+    childEnv.CLAUDECODE = "1";
+    const run = await runCliWithEnv(
+      ["--json", "repo", "upgrade"],
+      dir,
+      childEnv,
+    );
+    assertEquals(run.code, 0, `repo upgrade failed: ${run.stderr}`);
+
+    // Read what was persisted under .swamp/telemetry/.
+    const persisted = await readPersistedEntries(dir);
+    assert(persisted.length > 0, "no telemetry entries were written");
+
+    // Find the entry corresponding to the upgrade run.
+    const target = persisted.find((entry) => {
+      const inv = entry.invocation as Record<string, unknown> | undefined;
+      return inv?.command === "repo" && inv?.subcommand === "upgrade";
+    });
+    assert(target, "no entry matched the repo upgrade invocation");
+
+    const ctx = target!.invocationContext as
+      | Record<string, unknown>
+      | undefined;
+    assert(ctx, "entry missing invocationContext");
+    assertEquals(ctx!.configuredAiTools, ["claude", "cursor"]);
+    assertEquals(ctx!.detectedAiTool, "claude");
+    assertEquals(ctx!.agentSessionDetected, true);
+    // The child process inherits no tty by default — isInteractive must be
+    // false in this test.
+    assertEquals(ctx!.isInteractive, false);
+  });
+});

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -96,8 +96,10 @@ import { TelemetryService } from "../domain/telemetry/telemetry_service.ts";
 import { JsonTelemetryRepository } from "../infrastructure/persistence/json_telemetry_repository.ts";
 import { HttpTelemetrySender } from "../infrastructure/telemetry/http_telemetry_sender.ts";
 import {
+  buildInvocationContext,
   extractCommandInfo,
   isTelemetryDisabled,
+  projectEnvSnapshot,
 } from "./telemetry_integration.ts";
 import { UserIdentityRepository } from "../infrastructure/persistence/user_identity_repository.ts";
 import { AuthRepository } from "../infrastructure/persistence/auth_repository.ts";
@@ -923,7 +925,15 @@ async function initTelemetryService(
     }
 
     const repository = new JsonTelemetryRepository(repoDir);
-    const service = new TelemetryService(repository, VERSION);
+    const invocationContext = buildInvocationContext(
+      projectEnvSnapshot(),
+      marker.tools,
+    );
+    const service = new TelemetryService(
+      repository,
+      VERSION,
+      invocationContext,
+    );
     const telemetryEndpoint = resolveTelemetryEndpoint(
       marker.telemetryEndpoint,
       authServerUrl,

--- a/src/cli/telemetry_integration.ts
+++ b/src/cli/telemetry_integration.ts
@@ -17,7 +17,15 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import type { CommandInvocationData } from "../domain/telemetry/mod.ts";
+import type {
+  CommandInvocationData,
+  InvocationContextData,
+} from "../domain/telemetry/mod.ts";
+import {
+  detectAgentHarness,
+  RELEVANT_ENV_VARS,
+} from "../domain/telemetry/mod.ts";
+import type { AiTool } from "../infrastructure/persistence/repo_marker_repository.ts";
 
 /**
  * Per-position sensitivity for positional arguments by command.
@@ -204,4 +212,50 @@ function isKnownFlag(option: string): boolean {
  */
 export function isTelemetryDisabled(args: string[]): boolean {
   return args.includes("--no-telemetry");
+}
+
+/**
+ * Project the live process env down to the whitelist the harness detector
+ * needs. The full env contains secrets (AWS_SECRET_ACCESS_KEY, GITHUB_TOKEN,
+ * vault tokens) — projecting through the whitelist keeps every other key out
+ * of the telemetry pipeline regardless of what future code does with the
+ * snapshot.
+ */
+export function projectEnvSnapshot(): Record<string, string> {
+  const snapshot: Record<string, string> = {};
+  for (const key of RELEVANT_ENV_VARS) {
+    const value = Deno.env.get(key);
+    if (value !== undefined) {
+      snapshot[key] = value;
+    }
+  }
+  return snapshot;
+}
+
+/**
+ * Build the InvocationContext for one CLI invocation. Composes the harness
+ * detector over the env snapshot, captures stdin tty state, and pulls the
+ * configured tool list from the repo marker.
+ *
+ * `configuredAiTools` is undefined when no marker is available (telemetry
+ * recorded outside a swamp repo — forward-compat reserve) and `[]` when the
+ * marker has explicitly opted out via legacy `tool: none`. The two states
+ * carry different meaning downstream and must round-trip distinctly.
+ */
+export function buildInvocationContext(
+  envSnapshot: Record<string, string>,
+  configuredAiTools: AiTool[] | undefined,
+): InvocationContextData {
+  const detection = detectAgentHarness(envSnapshot);
+  const data: InvocationContextData = {
+    agentSessionDetected: detection.agentSessionDetected,
+    isInteractive: Deno.stdin.isTerminal(),
+  };
+  if (configuredAiTools !== undefined) {
+    data.configuredAiTools = configuredAiTools;
+  }
+  if (detection.detectedAiTool !== undefined) {
+    data.detectedAiTool = detection.detectedAiTool;
+  }
+  return data;
 }

--- a/src/cli/telemetry_integration_test.ts
+++ b/src/cli/telemetry_integration_test.ts
@@ -17,10 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import {
+  buildInvocationContext,
   extractCommandInfo,
   isTelemetryDisabled,
+  projectEnvSnapshot,
 } from "./telemetry_integration.ts";
 
 Deno.test("extractCommandInfo extracts simple command", () => {
@@ -276,4 +278,78 @@ Deno.test("extractCommandInfo handles --streaming as boolean flag", () => {
   assertEquals(info.command, "data");
   assertEquals(info.subcommand, "search");
   assertEquals(info.optionKeys, ["--streaming"]);
+});
+
+Deno.test("projectEnvSnapshot picks up whitelist keys present on Deno.env", () => {
+  // Touch one whitelist key in this process so the projection has something
+  // to capture. Restore in a finally so we don't leak into sibling tests.
+  const sentinel = "swamp-test-claude";
+  const previous = Deno.env.get("CLAUDE_CODE_ENTRYPOINT");
+  Deno.env.set("CLAUDE_CODE_ENTRYPOINT", sentinel);
+  try {
+    const snapshot = projectEnvSnapshot();
+    assertEquals(snapshot.CLAUDE_CODE_ENTRYPOINT, sentinel);
+  } finally {
+    if (previous === undefined) {
+      Deno.env.delete("CLAUDE_CODE_ENTRYPOINT");
+    } else {
+      Deno.env.set("CLAUDE_CODE_ENTRYPOINT", previous);
+    }
+  }
+});
+
+Deno.test("projectEnvSnapshot does not include keys outside the whitelist", () => {
+  // Set a non-whitelist key and assert it does not appear in the projection.
+  const previous = Deno.env.get("AWS_SECRET_ACCESS_KEY");
+  Deno.env.set("AWS_SECRET_ACCESS_KEY", "AKIA-test-secret-do-not-leak");
+  try {
+    const snapshot = projectEnvSnapshot();
+    assert(
+      !("AWS_SECRET_ACCESS_KEY" in snapshot),
+      "projectEnvSnapshot leaked a non-whitelist key",
+    );
+  } finally {
+    if (previous === undefined) {
+      Deno.env.delete("AWS_SECRET_ACCESS_KEY");
+    } else {
+      Deno.env.set("AWS_SECRET_ACCESS_KEY", previous);
+    }
+  }
+});
+
+Deno.test("buildInvocationContext: claude detected, tools configured", () => {
+  const ctx = buildInvocationContext(
+    { CLAUDECODE: "1" },
+    ["claude", "cursor"],
+  );
+  assertEquals(ctx.configuredAiTools, ["claude", "cursor"]);
+  assertEquals(ctx.detectedAiTool, "claude");
+  assertEquals(ctx.agentSessionDetected, true);
+});
+
+Deno.test("buildInvocationContext: configuredAiTools=undefined when no marker passed", () => {
+  const ctx = buildInvocationContext({ CLAUDECODE: "1" }, undefined);
+  assertEquals("configuredAiTools" in ctx, false);
+  assertEquals(ctx.detectedAiTool, "claude");
+  assertEquals(ctx.agentSessionDetected, true);
+});
+
+Deno.test("buildInvocationContext: configuredAiTools=[] preserved (legacy opt-out)", () => {
+  const ctx = buildInvocationContext({}, []);
+  assertEquals(ctx.configuredAiTools, []);
+  assertEquals("detectedAiTool" in ctx, false);
+  assertEquals(ctx.agentSessionDetected, false);
+});
+
+Deno.test("buildInvocationContext: generic AGENT fallback flips agentSessionDetected", () => {
+  const ctx = buildInvocationContext({ AGENT: "1" }, ["claude"]);
+  assertEquals(ctx.configuredAiTools, ["claude"]);
+  assertEquals("detectedAiTool" in ctx, false);
+  assertEquals(ctx.agentSessionDetected, true);
+});
+
+Deno.test("buildInvocationContext: empty env yields no detection", () => {
+  const ctx = buildInvocationContext({}, ["claude"]);
+  assertEquals("detectedAiTool" in ctx, false);
+  assertEquals(ctx.agentSessionDetected, false);
 });

--- a/src/domain/repo/ai_tool.ts
+++ b/src/domain/repo/ai_tool.ts
@@ -1,0 +1,37 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * The AI coding tool a swamp repo is enrolled for. Materialised in
+ * .swamp.yaml under `tools` and surfaced to telemetry, audit, skills
+ * resolution, and doctor checks.
+ *
+ * `none` is a marker-file sentinel meaning "explicitly opted out of tool
+ * integration." The legacy single-tool field `tool: none` normalises to the
+ * canonical `tools: []`; the union value is preserved for read-side
+ * compatibility but is never written.
+ */
+export type AiTool =
+  | "claude"
+  | "cursor"
+  | "opencode"
+  | "codex"
+  | "copilot"
+  | "kiro"
+  | "none";

--- a/src/domain/telemetry/agent_harness_detection.ts
+++ b/src/domain/telemetry/agent_harness_detection.ts
@@ -1,0 +1,130 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { AiTool } from "../repo/ai_tool.ts";
+
+/**
+ * Tools that can be identified at runtime from environment variables. The
+ * `none` value of the AiTool union is reserved for the marker file's
+ * "explicitly opted out" sentinel — detection never returns it.
+ */
+export type DetectableAiTool = Exclude<AiTool, "none">;
+
+/**
+ * Result of agent-harness detection over an env snapshot.
+ *
+ * `agentSessionDetected` is a SOFT SIGNAL: it can be flipped on by generic
+ * `AGENT` / `AI_AGENT` / `IS_AGENT` env vars that unrelated tooling (CI
+ * runners, monitoring agents, build orchestrators) also sets. Dashboards or
+ * queries that need precision must cross-reference `detectedAiTool` — when
+ * that field is undefined and `agentSessionDetected` is true, we know an
+ * agent context is present but cannot identify the harness.
+ */
+export interface AgentHarnessDetection {
+  detectedAiTool?: DetectableAiTool;
+  agentSessionDetected: boolean;
+}
+
+interface SpecificSignal {
+  tool: DetectableAiTool;
+  predicate: (env: Record<string, string>) => boolean;
+}
+
+/**
+ * Tier-1 (high-confidence) and tier-2 (best-effort) signals that map a known
+ * env signature to a specific harness. Iteration order is preserved — the
+ * first matching entry wins.
+ */
+const SPECIFIC_HARNESS_SIGNALS: readonly SpecificSignal[] = [
+  // Tier-1: well-attested.
+  {
+    tool: "claude",
+    predicate: (env) =>
+      env.CLAUDECODE === "1" || env.CLAUDE_CODE_ENTRYPOINT !== undefined,
+  },
+  {
+    tool: "cursor",
+    predicate: (env) =>
+      env.TERM_PROGRAM === "cursor" || env.CURSOR_TRACE_ID !== undefined,
+  },
+  // Tier-2: best-effort. Refine these as harness vendors publish stable
+  // markers.
+  // TODO(swamp-club#292): confirm Kiro's published env signature.
+  {
+    tool: "kiro",
+    predicate: (env) => env.TERM_PROGRAM === "kiro" || env.KIRO_AGENT === "1",
+  },
+  // TODO(swamp-club#292): confirm OpenCode's published env signature.
+  {
+    tool: "opencode",
+    predicate: (env) =>
+      env.OPENCODE_VERSION !== undefined || env.TERM_PROGRAM === "opencode",
+  },
+  // TODO(swamp-club#292): confirm Codex's published env signature.
+  {
+    tool: "codex",
+    predicate: (env) => env.CODEX_AGENT_HARNESS === "1",
+  },
+];
+
+const GENERIC_AGENT_SIGNALS = ["AGENT", "AI_AGENT", "IS_AGENT"] as const;
+
+/**
+ * The full set of env keys any signal in this module inspects. Application
+ * callers project Deno.env down to this whitelist before passing a snapshot
+ * to `detectAgentHarness` — keeping the rest of the developer's env
+ * (secrets, tokens, unrelated config) out of the telemetry pipeline.
+ */
+export const RELEVANT_ENV_VARS: readonly string[] = [
+  "CLAUDECODE",
+  "CLAUDE_CODE_ENTRYPOINT",
+  "TERM_PROGRAM",
+  "CURSOR_TRACE_ID",
+  "KIRO_AGENT",
+  "OPENCODE_VERSION",
+  "CODEX_AGENT_HARNESS",
+  ...GENERIC_AGENT_SIGNALS,
+];
+
+function genericAgentDetected(env: Record<string, string>): boolean {
+  for (const key of GENERIC_AGENT_SIGNALS) {
+    const value = env[key];
+    if (value && value !== "0" && value.toLowerCase() !== "false") {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Detect the AI agent harness wrapping the current process from a whitelist
+ * env snapshot. Specific harness signals win over the generic fallback —
+ * when both fire (e.g. CLAUDECODE=1 and AGENT=1) the result names the
+ * specific tool and still reports `agentSessionDetected: true`.
+ */
+export function detectAgentHarness(
+  env: Record<string, string>,
+): AgentHarnessDetection {
+  for (const signal of SPECIFIC_HARNESS_SIGNALS) {
+    if (signal.predicate(env)) {
+      return { detectedAiTool: signal.tool, agentSessionDetected: true };
+    }
+  }
+  return { agentSessionDetected: genericAgentDetected(env) };
+}

--- a/src/domain/telemetry/agent_harness_detection_test.ts
+++ b/src/domain/telemetry/agent_harness_detection_test.ts
@@ -1,0 +1,153 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertEquals } from "@std/assert";
+import {
+  detectAgentHarness,
+  RELEVANT_ENV_VARS,
+} from "./agent_harness_detection.ts";
+
+Deno.test("detectAgentHarness: empty env yields no detection", () => {
+  const result = detectAgentHarness({});
+  assertEquals(result.detectedAiTool, undefined);
+  assertEquals(result.agentSessionDetected, false);
+});
+
+Deno.test("detectAgentHarness: claude via CLAUDECODE=1", () => {
+  const result = detectAgentHarness({ CLAUDECODE: "1" });
+  assertEquals(result.detectedAiTool, "claude");
+  assertEquals(result.agentSessionDetected, true);
+});
+
+Deno.test("detectAgentHarness: claude via CLAUDE_CODE_ENTRYPOINT", () => {
+  const result = detectAgentHarness({ CLAUDE_CODE_ENTRYPOINT: "cli" });
+  assertEquals(result.detectedAiTool, "claude");
+  assertEquals(result.agentSessionDetected, true);
+});
+
+Deno.test("detectAgentHarness: cursor via TERM_PROGRAM=cursor", () => {
+  const result = detectAgentHarness({ TERM_PROGRAM: "cursor" });
+  assertEquals(result.detectedAiTool, "cursor");
+  assertEquals(result.agentSessionDetected, true);
+});
+
+Deno.test("detectAgentHarness: cursor via CURSOR_TRACE_ID", () => {
+  const result = detectAgentHarness({ CURSOR_TRACE_ID: "abc-123" });
+  assertEquals(result.detectedAiTool, "cursor");
+  assertEquals(result.agentSessionDetected, true);
+});
+
+Deno.test("detectAgentHarness: kiro via TERM_PROGRAM=kiro", () => {
+  const result = detectAgentHarness({ TERM_PROGRAM: "kiro" });
+  assertEquals(result.detectedAiTool, "kiro");
+  assertEquals(result.agentSessionDetected, true);
+});
+
+Deno.test("detectAgentHarness: kiro via KIRO_AGENT=1", () => {
+  const result = detectAgentHarness({ KIRO_AGENT: "1" });
+  assertEquals(result.detectedAiTool, "kiro");
+  assertEquals(result.agentSessionDetected, true);
+});
+
+Deno.test("detectAgentHarness: opencode via OPENCODE_VERSION", () => {
+  const result = detectAgentHarness({ OPENCODE_VERSION: "0.1.0" });
+  assertEquals(result.detectedAiTool, "opencode");
+  assertEquals(result.agentSessionDetected, true);
+});
+
+Deno.test("detectAgentHarness: opencode via TERM_PROGRAM=opencode", () => {
+  const result = detectAgentHarness({ TERM_PROGRAM: "opencode" });
+  assertEquals(result.detectedAiTool, "opencode");
+  assertEquals(result.agentSessionDetected, true);
+});
+
+Deno.test("detectAgentHarness: codex via CODEX_AGENT_HARNESS=1", () => {
+  const result = detectAgentHarness({ CODEX_AGENT_HARNESS: "1" });
+  assertEquals(result.detectedAiTool, "codex");
+  assertEquals(result.agentSessionDetected, true);
+});
+
+Deno.test("detectAgentHarness: generic AGENT fallback fires without specific match", () => {
+  const result = detectAgentHarness({ AGENT: "1" });
+  assertEquals(result.detectedAiTool, undefined);
+  assertEquals(result.agentSessionDetected, true);
+});
+
+Deno.test("detectAgentHarness: generic AI_AGENT fallback fires without specific match", () => {
+  const result = detectAgentHarness({ AI_AGENT: "1" });
+  assertEquals(result.detectedAiTool, undefined);
+  assertEquals(result.agentSessionDetected, true);
+});
+
+Deno.test("detectAgentHarness: generic IS_AGENT fallback fires without specific match", () => {
+  const result = detectAgentHarness({ IS_AGENT: "true" });
+  assertEquals(result.detectedAiTool, undefined);
+  assertEquals(result.agentSessionDetected, true);
+});
+
+Deno.test("detectAgentHarness: AGENT=0 does not trip the fallback", () => {
+  const result = detectAgentHarness({ AGENT: "0" });
+  assertEquals(result.agentSessionDetected, false);
+});
+
+Deno.test("detectAgentHarness: AGENT=false does not trip the fallback", () => {
+  const result = detectAgentHarness({ AGENT: "false" });
+  assertEquals(result.agentSessionDetected, false);
+});
+
+Deno.test("detectAgentHarness: specific signal beats generic fallback", () => {
+  const result = detectAgentHarness({ CLAUDECODE: "1", AGENT: "1" });
+  assertEquals(result.detectedAiTool, "claude");
+  assertEquals(result.agentSessionDetected, true);
+});
+
+Deno.test("detectAgentHarness: ignores keys outside the whitelist", () => {
+  const result = detectAgentHarness({
+    AWS_SECRET_ACCESS_KEY: "AKIA...",
+    GITHUB_TOKEN: "ghp_...",
+    HOME: "/home/keeb",
+  });
+  assertEquals(result.detectedAiTool, undefined);
+  assertEquals(result.agentSessionDetected, false);
+});
+
+Deno.test("RELEVANT_ENV_VARS contains every key any signal references", () => {
+  // Cross-checks the contract that callers can trust the export to project
+  // Deno.env safely. If a future PR adds a signal but forgets to update the
+  // whitelist, this test catches the drift.
+  const expected = new Set([
+    "CLAUDECODE",
+    "CLAUDE_CODE_ENTRYPOINT",
+    "TERM_PROGRAM",
+    "CURSOR_TRACE_ID",
+    "KIRO_AGENT",
+    "OPENCODE_VERSION",
+    "CODEX_AGENT_HARNESS",
+    "AGENT",
+    "AI_AGENT",
+    "IS_AGENT",
+  ]);
+  for (const key of expected) {
+    assert(
+      RELEVANT_ENV_VARS.includes(key),
+      `RELEVANT_ENV_VARS missing ${key}`,
+    );
+  }
+  assertEquals(RELEVANT_ENV_VARS.length, expected.size);
+});

--- a/src/domain/telemetry/invocation_context.ts
+++ b/src/domain/telemetry/invocation_context.ts
@@ -1,0 +1,102 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { AiTool } from "../repo/ai_tool.ts";
+import type { DetectableAiTool } from "./agent_harness_detection.ts";
+
+/**
+ * Captures the runtime conditions of a single CLI invocation: which AI
+ * tools the repo is configured for, which agent harness (if any) wraps the
+ * process, and whether stdin is attached to a terminal.
+ *
+ * `agentSessionDetected` is a SOFT SIGNAL — it can flip true on generic
+ * AGENT/AI_AGENT/IS_AGENT env vars that unrelated tooling also sets.
+ * Consumers needing precision (dashboards, leaderboards, billing-relevant
+ * counts) MUST cross-reference `detectedAiTool`. When detectedAiTool is
+ * undefined and agentSessionDetected is true, an agent context is present
+ * but the harness could not be identified.
+ *
+ * `configuredAiTools` distinguishes two states with different downstream
+ * meanings:
+ *  - `undefined` — the entry was recorded outside a swamp repo (forward-
+ *    compat reserve; today initTelemetryService bails before recording in
+ *    this case).
+ *  - `[]` — the repo exists with `tools: []` (legacy `tool: none`
+ *    normalised), an explicit opt-out of tool integration.
+ */
+export interface InvocationContext {
+  readonly configuredAiTools?: AiTool[];
+  readonly detectedAiTool?: DetectableAiTool;
+  readonly agentSessionDetected: boolean;
+  readonly isInteractive: boolean;
+}
+
+/**
+ * Data transfer object for InvocationContext.
+ */
+export interface InvocationContextData {
+  configuredAiTools?: AiTool[];
+  detectedAiTool?: DetectableAiTool;
+  agentSessionDetected: boolean;
+  isInteractive: boolean;
+}
+
+/**
+ * Creates an InvocationContext value object.
+ */
+export function createInvocationContext(
+  props: InvocationContextData,
+): InvocationContext {
+  return {
+    configuredAiTools: props.configuredAiTools
+      ? [...props.configuredAiTools]
+      : undefined,
+    detectedAiTool: props.detectedAiTool,
+    agentSessionDetected: props.agentSessionDetected,
+    isInteractive: props.isInteractive,
+  };
+}
+
+/**
+ * Converts an InvocationContext to its data representation.
+ */
+export function invocationContextToData(
+  context: InvocationContext,
+): InvocationContextData {
+  const data: InvocationContextData = {
+    agentSessionDetected: context.agentSessionDetected,
+    isInteractive: context.isInteractive,
+  };
+  if (context.configuredAiTools !== undefined) {
+    data.configuredAiTools = [...context.configuredAiTools];
+  }
+  if (context.detectedAiTool !== undefined) {
+    data.detectedAiTool = context.detectedAiTool;
+  }
+  return data;
+}
+
+/**
+ * Reconstructs an InvocationContext from data.
+ */
+export function invocationContextFromData(
+  data: InvocationContextData,
+): InvocationContext {
+  return createInvocationContext(data);
+}

--- a/src/domain/telemetry/invocation_context_test.ts
+++ b/src/domain/telemetry/invocation_context_test.ts
@@ -1,0 +1,117 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  createInvocationContext,
+  invocationContextFromData,
+  invocationContextToData,
+} from "./invocation_context.ts";
+import type { AiTool } from "../repo/ai_tool.ts";
+
+Deno.test("createInvocationContext: minimal context with mandatory fields only", () => {
+  const ctx = createInvocationContext({
+    agentSessionDetected: false,
+    isInteractive: true,
+  });
+  assertEquals(ctx.configuredAiTools, undefined);
+  assertEquals(ctx.detectedAiTool, undefined);
+  assertEquals(ctx.agentSessionDetected, false);
+  assertEquals(ctx.isInteractive, true);
+});
+
+Deno.test("createInvocationContext: configuredAiTools=[] preserved (not coerced to undefined)", () => {
+  const ctx = createInvocationContext({
+    configuredAiTools: [],
+    agentSessionDetected: false,
+    isInteractive: false,
+  });
+  assertEquals(ctx.configuredAiTools, []);
+});
+
+Deno.test("createInvocationContext: copies configuredAiTools array (no aliasing)", () => {
+  const tools: AiTool[] = ["claude", "cursor"];
+  const ctx = createInvocationContext({
+    configuredAiTools: tools,
+    agentSessionDetected: true,
+    isInteractive: false,
+  });
+  tools.push("kiro");
+  assertEquals(ctx.configuredAiTools, ["claude", "cursor"]);
+});
+
+Deno.test("invocationContextToData: round-trip with detectedAiTool and tools", () => {
+  const ctx = createInvocationContext({
+    configuredAiTools: ["claude", "cursor"],
+    detectedAiTool: "claude",
+    agentSessionDetected: true,
+    isInteractive: false,
+  });
+  const data = invocationContextToData(ctx);
+  assertEquals(data, {
+    configuredAiTools: ["claude", "cursor"],
+    detectedAiTool: "claude",
+    agentSessionDetected: true,
+    isInteractive: false,
+  });
+});
+
+Deno.test("invocationContextToData: omits absent optional fields", () => {
+  const ctx = createInvocationContext({
+    agentSessionDetected: false,
+    isInteractive: true,
+  });
+  const data = invocationContextToData(ctx);
+  assertEquals("configuredAiTools" in data, false);
+  assertEquals("detectedAiTool" in data, false);
+});
+
+Deno.test("invocationContextToData: empty configuredAiTools array is preserved on the wire", () => {
+  const ctx = createInvocationContext({
+    configuredAiTools: [],
+    agentSessionDetected: false,
+    isInteractive: false,
+  });
+  const data = invocationContextToData(ctx);
+  assertEquals(data.configuredAiTools, []);
+});
+
+Deno.test("invocationContextFromData: round-trip preserves every field", () => {
+  const original = createInvocationContext({
+    configuredAiTools: ["claude"],
+    detectedAiTool: "claude",
+    agentSessionDetected: true,
+    isInteractive: true,
+  });
+  const restored = invocationContextFromData(invocationContextToData(original));
+  assertEquals(restored.configuredAiTools, ["claude"]);
+  assertEquals(restored.detectedAiTool, "claude");
+  assertEquals(restored.agentSessionDetected, true);
+  assertEquals(restored.isInteractive, true);
+});
+
+Deno.test("invocationContextFromData: agent detected without specific tool round-trips", () => {
+  const original = createInvocationContext({
+    agentSessionDetected: true,
+    isInteractive: false,
+  });
+  const restored = invocationContextFromData(invocationContextToData(original));
+  assertEquals(restored.detectedAiTool, undefined);
+  assertEquals(restored.agentSessionDetected, true);
+});

--- a/src/domain/telemetry/mod.ts
+++ b/src/domain/telemetry/mod.ts
@@ -31,6 +31,21 @@ export {
 } from "./command_invocation.ts";
 
 export {
+  createInvocationContext,
+  type InvocationContext,
+  type InvocationContextData,
+  invocationContextFromData,
+  invocationContextToData,
+} from "./invocation_context.ts";
+
+export {
+  type AgentHarnessDetection,
+  type DetectableAiTool,
+  detectAgentHarness,
+  RELEVANT_ENV_VARS,
+} from "./agent_harness_detection.ts";
+
+export {
   createErrorResult,
   createSuccessResult,
   type InvocationResult,

--- a/src/domain/telemetry/telemetry_entry.ts
+++ b/src/domain/telemetry/telemetry_entry.ts
@@ -34,6 +34,12 @@ import {
   invocationResultFromData,
   invocationResultToData,
 } from "./invocation_result.ts";
+import {
+  type InvocationContext,
+  type InvocationContextData,
+  invocationContextFromData,
+  invocationContextToData,
+} from "./invocation_context.ts";
 
 /**
  * Properties required to create a new TelemetryEntry.
@@ -47,10 +53,14 @@ export interface CreateTelemetryEntryProps {
   swampVersion: string;
   denoVersion: string;
   platform: string;
+  invocationContext?: InvocationContextData;
 }
 
 /**
  * Data transfer object for TelemetryEntry.
+ *
+ * `invocationContext` is optional so entries written before the field was
+ * introduced still decode without loss.
  */
 export interface TelemetryEntryData {
   id: string;
@@ -62,6 +72,7 @@ export interface TelemetryEntryData {
   swampVersion: string;
   denoVersion: string;
   platform: string;
+  invocationContext?: InvocationContextData;
 }
 
 /**
@@ -78,6 +89,7 @@ export class TelemetryEntry {
     readonly swampVersion: string,
     readonly denoVersion: string,
     readonly platform: string,
+    readonly invocationContext?: InvocationContext,
   ) {}
 
   /**
@@ -97,6 +109,9 @@ export class TelemetryEntry {
       props.swampVersion,
       props.denoVersion,
       props.platform,
+      props.invocationContext
+        ? invocationContextFromData(props.invocationContext)
+        : undefined,
     );
   }
 
@@ -114,6 +129,9 @@ export class TelemetryEntry {
       data.swampVersion,
       data.denoVersion,
       data.platform,
+      data.invocationContext
+        ? invocationContextFromData(data.invocationContext)
+        : undefined,
     );
   }
 
@@ -121,7 +139,7 @@ export class TelemetryEntry {
    * Converts the TelemetryEntry to a plain data object for persistence.
    */
   toData(): TelemetryEntryData {
-    return {
+    const data: TelemetryEntryData = {
       id: this.id,
       invocation: commandInvocationToData(this.invocation),
       result: invocationResultToData(this.result),
@@ -132,5 +150,9 @@ export class TelemetryEntry {
       denoVersion: this.denoVersion,
       platform: this.platform,
     };
+    if (this.invocationContext) {
+      data.invocationContext = invocationContextToData(this.invocationContext);
+    }
+    return data;
   }
 }

--- a/src/domain/telemetry/telemetry_entry_test.ts
+++ b/src/domain/telemetry/telemetry_entry_test.ts
@@ -150,4 +150,94 @@ Deno.test("TelemetryEntry.fromData reconstructs entry from data", () => {
   assertEquals(entry.durationMs, 1500);
   assertEquals(entry.startedAt.toISOString(), "2026-02-05T12:00:00.000Z");
   assertEquals(entry.completedAt.toISOString(), "2026-02-05T12:00:01.500Z");
+  assertEquals(entry.invocationContext, undefined);
+});
+
+Deno.test("TelemetryEntry.create accepts invocationContext", () => {
+  const entry = TelemetryEntry.create({
+    invocation: {
+      command: "model",
+      args: [],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    result: { status: "success", exitCode: 0 },
+    startedAt: new Date("2026-02-05T10:00:00Z"),
+    completedAt: new Date("2026-02-05T10:00:01Z"),
+    swampVersion: "1.0.0",
+    denoVersion: "2.1.0",
+    platform: "linux",
+    invocationContext: {
+      configuredAiTools: ["claude", "cursor"],
+      detectedAiTool: "claude",
+      agentSessionDetected: true,
+      isInteractive: false,
+    },
+  });
+
+  assertEquals(entry.invocationContext?.configuredAiTools, [
+    "claude",
+    "cursor",
+  ]);
+  assertEquals(entry.invocationContext?.detectedAiTool, "claude");
+  assertEquals(entry.invocationContext?.agentSessionDetected, true);
+  assertEquals(entry.invocationContext?.isInteractive, false);
+});
+
+Deno.test("TelemetryEntry round-trips invocationContext through toData/fromData", () => {
+  const entry = TelemetryEntry.create({
+    id: "ctx-rt-1",
+    invocation: {
+      command: "workflow",
+      args: [],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    result: { status: "success", exitCode: 0 },
+    startedAt: new Date("2026-02-05T10:00:00Z"),
+    completedAt: new Date("2026-02-05T10:00:01Z"),
+    swampVersion: "1.0.0",
+    denoVersion: "2.1.0",
+    platform: "linux",
+    invocationContext: {
+      configuredAiTools: [],
+      agentSessionDetected: true,
+      isInteractive: false,
+    },
+  });
+
+  const data = entry.toData();
+  assertEquals(data.invocationContext?.configuredAiTools, []);
+  assertEquals(data.invocationContext?.agentSessionDetected, true);
+
+  const restored = TelemetryEntry.fromData(data);
+  assertEquals(restored.invocationContext?.configuredAiTools, []);
+  assertEquals(restored.invocationContext?.detectedAiTool, undefined);
+  assertEquals(restored.invocationContext?.agentSessionDetected, true);
+  assertEquals(restored.invocationContext?.isInteractive, false);
+});
+
+Deno.test("TelemetryEntry.fromData decodes legacy entries without invocationContext", () => {
+  // Lock in the back-compat contract: entries written before the field was
+  // introduced must continue to decode without loss.
+  const legacyData: TelemetryEntryData = {
+    id: "legacy-1",
+    invocation: {
+      command: "model",
+      args: [],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    result: { status: "success", exitCode: 0 },
+    startedAt: "2026-02-05T12:00:00.000Z",
+    completedAt: "2026-02-05T12:00:01.000Z",
+    durationMs: 1000,
+    swampVersion: "1.0.0",
+    denoVersion: "2.1.0",
+    platform: "linux",
+  };
+
+  const entry = TelemetryEntry.fromData(legacyData);
+  assertEquals(entry.invocationContext, undefined);
+  assertEquals("invocationContext" in entry.toData(), false);
 });

--- a/src/domain/telemetry/telemetry_service.ts
+++ b/src/domain/telemetry/telemetry_service.ts
@@ -21,6 +21,7 @@ import type { TelemetryRepository } from "./repositories.ts";
 import type { TelemetrySender } from "./telemetry_sender.ts";
 import { TelemetryEntry } from "./telemetry_entry.ts";
 import type { CommandInvocationData } from "./command_invocation.ts";
+import type { InvocationContextData } from "./invocation_context.ts";
 import {
   createErrorResult,
   createSuccessResult,
@@ -77,11 +78,18 @@ const DEFAULT_RETENTION_DAYS = 2;
 
 /**
  * Service for recording and analyzing CLI telemetry.
+ *
+ * The optional `invocationContext` is captured once at construction time —
+ * the runtime conditions of one CLI invocation (configured AI tools,
+ * detected harness, stdin tty state) do not change between recording a
+ * success and recording an error, so a single context applies to every
+ * entry the service writes.
  */
 export class TelemetryService {
   constructor(
     private readonly repository: TelemetryRepository,
     private readonly swampVersion: string,
+    private readonly invocationContext?: InvocationContextData,
   ) {}
 
   /**
@@ -102,6 +110,7 @@ export class TelemetryService {
       swampVersion: this.swampVersion,
       denoVersion: Deno.version.deno,
       platform: Deno.build.os,
+      invocationContext: this.invocationContext,
     });
 
     await this.repository.save(entry);
@@ -132,6 +141,7 @@ export class TelemetryService {
       swampVersion: this.swampVersion,
       denoVersion: Deno.version.deno,
       platform: Deno.build.os,
+      invocationContext: this.invocationContext,
     });
 
     await this.repository.save(entry);

--- a/src/domain/telemetry/telemetry_service_test.ts
+++ b/src/domain/telemetry/telemetry_service_test.ts
@@ -374,3 +374,72 @@ Deno.test("TelemetryService.flushTelemetry passes undefined authToken when not p
   assertEquals(sender.sentBatches.length, 1);
   assertEquals(sender.sentBatches[0].authToken, undefined);
 });
+
+Deno.test("TelemetryService.recordSuccess stamps invocationContext on entries", async () => {
+  const repo = new MockTelemetryRepository();
+  const service = new TelemetryService(repo, "1.0.0", {
+    configuredAiTools: ["claude", "cursor"],
+    detectedAiTool: "claude",
+    agentSessionDetected: true,
+    isInteractive: false,
+  });
+
+  await service.recordSuccess(
+    {
+      command: "model",
+      args: [],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    new Date(),
+  );
+
+  const ctx = repo.savedEntries[0].invocationContext;
+  assertEquals(ctx?.configuredAiTools, ["claude", "cursor"]);
+  assertEquals(ctx?.detectedAiTool, "claude");
+  assertEquals(ctx?.agentSessionDetected, true);
+  assertEquals(ctx?.isInteractive, false);
+});
+
+Deno.test("TelemetryService.recordError stamps invocationContext on entries", async () => {
+  const repo = new MockTelemetryRepository();
+  const service = new TelemetryService(repo, "1.0.0", {
+    configuredAiTools: [],
+    agentSessionDetected: true,
+    isInteractive: false,
+  });
+
+  await service.recordError(
+    {
+      command: "workflow",
+      args: [],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    new Date(),
+    new Error("boom"),
+  );
+
+  const ctx = repo.savedEntries[0].invocationContext;
+  assertEquals(ctx?.configuredAiTools, []);
+  assertEquals(ctx?.detectedAiTool, undefined);
+  assertEquals(ctx?.agentSessionDetected, true);
+  assertEquals(ctx?.isInteractive, false);
+});
+
+Deno.test("TelemetryService without invocationContext writes entries without the field", async () => {
+  const repo = new MockTelemetryRepository();
+  const service = new TelemetryService(repo, "1.0.0");
+
+  await service.recordSuccess(
+    {
+      command: "model",
+      args: [],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    new Date(),
+  );
+
+  assertEquals(repo.savedEntries[0].invocationContext, undefined);
+});

--- a/src/infrastructure/persistence/json_telemetry_repository_test.ts
+++ b/src/infrastructure/persistence/json_telemetry_repository_test.ts
@@ -502,3 +502,78 @@ Deno.test("JsonTelemetryRepository.deleteOlderThan cleans up both flushed and un
     );
   });
 });
+
+Deno.test("JsonTelemetryRepository round-trips invocationContext (with detected harness)", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new JsonTelemetryRepository(dir);
+    const entry = TelemetryEntry.create({
+      id: "ctx-rt-with-tool",
+      invocation: {
+        command: "model",
+        args: [],
+        optionKeys: [],
+        globalOptions: [],
+      },
+      result: { status: "success", exitCode: 0 },
+      startedAt: new Date("2024-07-01T10:00:00Z"),
+      completedAt: new Date("2024-07-01T10:00:01Z"),
+      swampVersion: "1.0.0",
+      denoVersion: "1.40.0",
+      platform: "linux",
+      invocationContext: {
+        configuredAiTools: ["claude", "cursor"],
+        detectedAiTool: "claude",
+        agentSessionDetected: true,
+        isInteractive: false,
+      },
+    });
+
+    await repo.save(entry);
+    const restored = await repo.findByDate(new Date("2024-07-01T10:00:00Z"));
+    assertEquals(restored.length, 1);
+    assertEquals(restored[0].invocationContext?.configuredAiTools, [
+      "claude",
+      "cursor",
+    ]);
+    assertEquals(restored[0].invocationContext?.detectedAiTool, "claude");
+    assertEquals(restored[0].invocationContext?.agentSessionDetected, true);
+    assertEquals(restored[0].invocationContext?.isInteractive, false);
+  });
+});
+
+Deno.test("JsonTelemetryRepository round-trips invocationContext (legacy opt-out)", async () => {
+  // configuredAiTools=[] is distinct from undefined and must survive intact
+  // — the repo previously normalised legacy `tool: none` to an empty tools
+  // array, and the breakdown queries depend on that signal.
+  await withTempDir(async (dir) => {
+    const repo = new JsonTelemetryRepository(dir);
+    const entry = TelemetryEntry.create({
+      id: "ctx-rt-optout",
+      invocation: {
+        command: "model",
+        args: [],
+        optionKeys: [],
+        globalOptions: [],
+      },
+      result: { status: "success", exitCode: 0 },
+      startedAt: new Date("2024-07-02T10:00:00Z"),
+      completedAt: new Date("2024-07-02T10:00:01Z"),
+      swampVersion: "1.0.0",
+      denoVersion: "1.40.0",
+      platform: "linux",
+      invocationContext: {
+        configuredAiTools: [],
+        agentSessionDetected: false,
+        isInteractive: true,
+      },
+    });
+
+    await repo.save(entry);
+    const restored = await repo.findByDate(new Date("2024-07-02T10:00:00Z"));
+    assertEquals(restored.length, 1);
+    assertEquals(restored[0].invocationContext?.configuredAiTools, []);
+    assertEquals(restored[0].invocationContext?.detectedAiTool, undefined);
+    assertEquals(restored[0].invocationContext?.agentSessionDetected, false);
+    assertEquals(restored[0].invocationContext?.isInteractive, true);
+  });
+});

--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -23,18 +23,9 @@ import type { SwampVersion } from "../../domain/repo/swamp_version.ts";
 import type { RepoPath } from "../../domain/repo/repo_path.ts";
 import { swampMarkerPath } from "./paths.ts";
 import type { DatastoreConfigData } from "../../domain/datastore/datastore_config.ts";
+import type { AiTool } from "../../domain/repo/ai_tool.ts";
 
-/**
- * The AI coding tool to configure skills and instructions for.
- */
-export type AiTool =
-  | "claude"
-  | "cursor"
-  | "opencode"
-  | "codex"
-  | "copilot"
-  | "kiro"
-  | "none";
+export type { AiTool };
 
 /**
  * Data structure for the .swamp.yaml marker file.

--- a/src/infrastructure/telemetry/http_telemetry_sender_test.ts
+++ b/src/infrastructure/telemetry/http_telemetry_sender_test.ts
@@ -230,3 +230,54 @@ Deno.test("HttpTelemetrySender.sendBatch omits x-api-key header when authToken n
 
   await server.shutdown();
 });
+
+Deno.test("HttpTelemetrySender.sendBatch lands invocationContext at properties.invocationContext", async () => {
+  // Wire-shape contract: TelemetryEntry.toData() is splatted into properties
+  // verbatim, so the swamp-club consumer side queries
+  // properties.invocationContext.{configuredAiTools, detectedAiTool,
+  // agentSessionDetected, isInteractive}. Lock the shape here.
+  let capturedBody: string | undefined;
+
+  const server = Deno.serve({ port: 0 }, async (req: Request) => {
+    capturedBody = await req.text();
+    return new Response(JSON.stringify({ accepted: 1 }), { status: 202 });
+  });
+
+  const port = server.addr.port;
+  const sender = new HttpTelemetrySender(`http://localhost:${port}`);
+  const entry = TelemetryEntry.create({
+    id: "ctx-wire",
+    invocation: {
+      command: "model",
+      args: [],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    result: { status: "success", exitCode: 0 },
+    startedAt: new Date("2024-03-10T10:00:00Z"),
+    completedAt: new Date("2024-03-10T10:00:01Z"),
+    swampVersion: "1.0.0",
+    denoVersion: "2.1.0",
+    platform: "linux",
+    invocationContext: {
+      configuredAiTools: ["claude", "cursor"],
+      detectedAiTool: "claude",
+      agentSessionDetected: true,
+      isInteractive: false,
+    },
+  });
+
+  const ok = await sender.sendBatch([entry], "user-uuid");
+  assertEquals(ok, true);
+
+  const parsed = JSON.parse(capturedBody!);
+  assertEquals(parsed.properties.invocationContext.configuredAiTools, [
+    "claude",
+    "cursor",
+  ]);
+  assertEquals(parsed.properties.invocationContext.detectedAiTool, "claude");
+  assertEquals(parsed.properties.invocationContext.agentSessionDetected, true);
+  assertEquals(parsed.properties.invocationContext.isInteractive, false);
+
+  await server.shutdown();
+});


### PR DESCRIPTION
## Summary

- Adds an `InvocationContext` value object to every `cli_invocation` telemetry event capturing the configured AI tool list from `.swamp.yaml`, the detected agent harness from a whitelist env snapshot, an `agentSessionDetected` soft signal that catches harnesses without specific signatures, and `isInteractive` from `Deno.stdin.isTerminal()`.
- Lands additively on the swamp-club ingest payload at `properties.invocationContext.*` — receiver accepts `properties` as opaque `Record<string, unknown>` (`services/telemetry/lib/schema.ts`), so no coordinated change.
- Verified end-to-end: a real prod event document (`db.events.findOne(...)`) contains the four new fields populated correctly for a `repoId`-keyed entry.

## What it answers

The original adoption questions are now queryable from the events collection:
- breakdown of configured agent usage → `properties.invocationContext.configuredAiTools`
- breakdown of manual (non-agent) usage → `agentSessionDetected: false`
- breakdown of headless usage → `isInteractive: false`
- multi-agent / configured-vs-detected mismatch → cross-tab `configuredAiTools` against `detectedAiTool`

## Detection coverage

- **Tier-1 (high confidence):** claude (`CLAUDECODE` / `CLAUDE_CODE_ENTRYPOINT`), cursor (`TERM_PROGRAM=cursor` / `CURSOR_TRACE_ID`).
- **Tier-2 (best-effort, refine as harness vendors publish stable markers):** kiro, opencode, codex — each tagged with an inline `TODO(swamp-club#292)`.
- **Generic fallback:** `AGENT` / `AI_AGENT` / `IS_AGENT` flips `agentSessionDetected: true` even when no specific harness can be identified.

## Secret-isolation guarantee

The detection module exports `RELEVANT_ENV_VARS`. The CLI bootstrap projects `Deno.env` down to that whitelist before handing the snapshot to the detector — `AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, etc. never enter the telemetry pipeline. Locked in by `agent_harness_detection_test.ts` ("ignores keys outside the whitelist") and `telemetry_integration_test.ts` ("projectEnvSnapshot does not include keys outside the whitelist").

## Soft-signal contract

`agentSessionDetected` is documented as a soft signal in module JSDoc — generic `AGENT` env vars can be set by unrelated CI runners or monitoring agents. Consumers needing precision must cross-reference `detectedAiTool`. When `detectedAiTool` is undefined and `agentSessionDetected` is true, an agent context is present but the harness could not be identified.

## Architecture note

`AiTool` was promoted from `src/infrastructure/persistence/repo_marker_repository.ts` to `src/domain/repo/ai_tool.ts` to avoid tripping the `KNOWN_DOMAIN_INFRA_VIOLATIONS` ratchet (`integration/ddd_layer_rules_test.ts`). The marker repo re-exports the type so all existing callers are unaffected.

## Test plan

- [x] `deno fmt --check`
- [x] `deno lint`
- [x] `deno run test` (5641 passed, 0 failed)
- [x] `deno run compile`
- [x] End-to-end verification: ran `swamp` from a real Claude Code session, retrieved the resulting MongoDB event doc, confirmed `properties.invocationContext.{configuredAiTools, detectedAiTool, agentSessionDetected, isInteractive}` is populated correctly.

## Followups (out of scope)

- Promote remaining `domain → infrastructure` `AiTool` callers (`primary_tool.ts`, `init.ts`, `ai_tool_parser.ts`, `doctor_audit.ts`) to import from the new domain module — would tighten the ratchet count from 22 toward 0.
- Surface agent-vs-manual breakdowns in `swamp telemetry` output and a swamp-club dashboard now that the data is flowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)