### PR TITLE
fix(workflows): resolve self.* in modelIdOrName during runtime forEach execution (swamp-club#294)

### DIFF
--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -64,7 +64,10 @@ import { ModelOutput } from "../models/model_output.ts";
 import type { Definition } from "../definitions/definition.ts";
 import type { ModelType } from "../models/model_type.ts";
 import type { MethodResult, ModelDefinition } from "../models/model.ts";
-import { ExpressionEvaluationService } from "../expressions/expression_evaluation_service.ts";
+import {
+  containsRuntimeExpression,
+  ExpressionEvaluationService,
+} from "../expressions/expression_evaluation_service.ts";
 import {
   buildEnvContext,
   type DataRecord,
@@ -306,6 +309,32 @@ export class DefaultStepExecutor implements StepExecutor {
       vaultService,
       expressionEvaluator,
     } = await this.resolveDeps(ctx);
+
+    // Resolve forEach self.* expressions in modelIdOrName and methodName
+    // before model lookup. The expression context has self populated with
+    // the forEach variable by runStep().
+    if (ctx.expressionContext) {
+      const celEvaluator = new CelEvaluator();
+      const resolve = (value: string): string =>
+        value.replace(
+          /\$\{\{\s*(.+?)\s*\}\}/g,
+          (_match: string, expr: string) => {
+            if (containsRuntimeExpression(expr)) return _match;
+            try {
+              return String(
+                celEvaluator.evaluate(expr, ctx.expressionContext!),
+              );
+            } catch {
+              return _match;
+            }
+          },
+        );
+      task = {
+        ...task,
+        modelIdOrName: resolve(task.modelIdOrName),
+        methodName: resolve(task.methodName),
+      };
+    }
 
     // Look up the model definition by ID or name
     const lookupResult = await findDefinitionByIdOrName(
@@ -1383,9 +1412,11 @@ export class WorkflowExecutionService {
       jobRun.start();
       yield { kind: "job_started", jobId: jobName };
 
-      // Expand forEach steps if we have expression context
+      // Expand forEach steps if we have expression context.
+      // Runs in all modes including --last-evaluated: forEach expansion
+      // is a structural transformation, not expression evaluation.
       let expandedStepsMap: Map<string, ExpandedStep[]> | undefined;
-      if (expressionContext && !options.lastEvaluated) {
+      if (expressionContext) {
         expandedStepsMap = await new ForEachExpansionService(new CelEvaluator())
           .expand(job, expressionContext);
         // Rewrite the jobRun's step list to match the expansion. The

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -2996,3 +2996,104 @@ Deno.test("CONTRACT: dataArtifacts attached to thrown error are preserved on the
     assertEquals(stepRun?.dataArtifacts[0].dataId, partialArtifacts[0].dataId);
   });
 });
+
+// --- forEach self.* in modelIdOrName resolution (Issue #294) ---
+
+Deno.test({
+  name:
+    "DefaultStepExecutor resolves self.* expressions in modelIdOrName before model lookup",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { z } = await import("zod");
+    const { ModelType } = await import("../models/model_type.ts");
+    const { modelRegistry } = await import("../models/model.ts");
+    const { Definition } = await import("../definitions/definition.ts");
+    const { YamlDefinitionRepository } = await import(
+      "../../infrastructure/persistence/yaml_definition_repository.ts"
+    );
+    const { initializeLogging } = await import(
+      "../../infrastructure/logging/logger.ts"
+    );
+    const { buildEnvContext } = await import(
+      "../expressions/model_resolver.ts"
+    );
+    await initializeLogging({});
+
+    await withTempDir(async (tempDir) => {
+      const typeName = `@test-issue294/foreach-${
+        crypto.randomUUID().slice(0, 8)
+      }`;
+      const modelType = ModelType.create(typeName);
+      let methodExecuted = false;
+
+      modelRegistry.register({
+        type: modelType,
+        version: "2026.01.01.1",
+        globalArguments: z.object({}),
+        resources: {},
+        methods: {
+          run: {
+            description: "confirms model was found and method executed",
+            arguments: z.object({}),
+            execute: () => {
+              methodExecuted = true;
+              return Promise.resolve({});
+            },
+          },
+        },
+      });
+
+      const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+      try {
+        const definitionRepo = new YamlDefinitionRepository(tempDir);
+        const instance = Definition.create({
+          name: "test-us-east-1",
+          type: modelType.normalized,
+        });
+        await definitionRepo.save(modelType, instance);
+
+        const step = Step.create({
+          name: "run-us-east-1",
+          task: StepTask.model(
+            "test-${{ self.region }}",
+            "run",
+          ),
+        });
+        const ctx: StepExecutionContext = {
+          workflowId: createWorkflowId(
+            "00000000-0000-0000-0000-000000000000",
+          ),
+          workflowRunId: "00000000-0000-0000-0000-000000000000",
+          workflowName: "foreach-test",
+          jobName: "job1",
+          stepName: "run-us-east-1",
+          repoDir: tempDir,
+          signal: new AbortController().signal,
+          step,
+          expressionContext: {
+            model: {},
+            env: buildEnvContext(),
+            self: {
+              id: "",
+              name: "",
+              version: 1,
+              tags: {},
+              globalArguments: {},
+              region: "us-east-1",
+            },
+          },
+          forEachVariable: { name: "region", value: "us-east-1" },
+          catalogStore,
+        };
+
+        const executor = new DefaultStepExecutor();
+        await executor.execute(step, ctx);
+
+        assertEquals(methodExecuted, true);
+      } finally {
+        catalogStore.close();
+      }
+    });
+  },
+});


### PR DESCRIPTION
## Summary

- Resolve `self.*` expressions in `task.modelIdOrName` and `task.methodName` in `DefaultStepExecutor.executeModelMethod()` before the model lookup, closing the gap between the evaluate display path (which already resolved these) and the runtime execution path
- Remove the `!options.lastEvaluated` guard from `ForEachExpansionService.expand()` in `runJob()` so forEach expansion runs in all modes — it's a structural transformation, not expression evaluation
- Add unit test verifying the executor resolves `self.*` in modelIdOrName via the expression context before model lookup

## Test plan

- [x] Unit test: `DefaultStepExecutor resolves self.* expressions in modelIdOrName before model lookup`
- [x] Full test suite: 5689 passed, 0 failed
- [x] E2E: `swamp workflow run` with forEach + `self.*` in modelIdOrName succeeds
- [x] E2E: `swamp workflow run --last-evaluated --input` with forEach works
- [x] E2E: `swamp workflow evaluate` + `--last-evaluated` with inputs works
- [x] Verified `--last-evaluated` without inputs correctly errors ("No such key") — inputs are required for forEach.in evaluation

Closes swamp-club#294

🤖 Generated with [Claude Code](https://claude.com/claude-code)