### PR TITLE
fix(extensions): scope extractTypeFromSource regex and fix validateSecondaryExport binding

### DIFF
--- a/src/domain/datastore/user_datastore_loader_test.ts
+++ b/src/domain/datastore/user_datastore_loader_test.ts
@@ -711,3 +711,15 @@ export const datastore = {
     }
   },
 );
+
+Deno.test("datastoreKindAdapter.extractTypeFromSource: ignores type in helper objects above the export", () => {
+  const source = `
+const cfg = { type: "wrong/type" };
+export const datastore = {
+  type: "@org/correct-datastore",
+  connect: async () => ({}),
+};`;
+  const result = datastoreKindAdapter.extractTypeFromSource(source);
+  assertNotEquals(result, null);
+  assertEquals(result?.typeNormalized, "@org/correct-datastore");
+});

--- a/src/domain/drivers/user_driver_loader_test.ts
+++ b/src/domain/drivers/user_driver_loader_test.ts
@@ -388,3 +388,15 @@ export const driver = {
     }
   },
 );
+
+Deno.test("driverKindAdapter.extractTypeFromSource: ignores type in helper objects above the export", () => {
+  const source = `
+const cfg = { type: "wrong/type" };
+export const driver = {
+  type: "@org/correct-driver",
+  execute: async () => ({}),
+};`;
+  const result = driverKindAdapter.extractTypeFromSource(source);
+  assertNotEquals(result, null);
+  assertEquals(result?.typeNormalized, "@org/correct-driver");
+});

--- a/src/domain/extensions/datastore_kind_adapter.ts
+++ b/src/domain/extensions/datastore_kind_adapter.ts
@@ -70,7 +70,9 @@ export const datastoreKindAdapter: KindAdapter = {
 
   extractTypeFromSource(source: string) {
     if (!/export\s+const\s+datastore\s*[=:]/.test(source)) return null;
-    const typeMatch = source.match(/type\s*:\s*["']([^"']+)["']/);
+    const typeMatch = source.match(
+      /export\s+const\s+datastore\s*=\s*\{[\s\S]*?type\s*:\s*["']([^"']+)["']/,
+    );
     if (!typeMatch) return null;
     return {
       typeNormalized: typeMatch[1].toLowerCase(),

--- a/src/domain/extensions/driver_kind_adapter.ts
+++ b/src/domain/extensions/driver_kind_adapter.ts
@@ -70,7 +70,9 @@ export const driverKindAdapter: KindAdapter = {
 
   extractTypeFromSource(source: string) {
     if (!/export\s+const\s+driver\s*[=:]/.test(source)) return null;
-    const typeMatch = source.match(/type\s*:\s*["']([^"']+)["']/);
+    const typeMatch = source.match(
+      /export\s+const\s+driver\s*=\s*\{[\s\S]*?type\s*:\s*["']([^"']+)["']/,
+    );
     if (!typeMatch) return null;
     return {
       typeNormalized: typeMatch[1].toLowerCase(),

--- a/src/domain/extensions/extension_loader.ts
+++ b/src/domain/extensions/extension_loader.ts
@@ -431,25 +431,23 @@ export class ExtensionLoader {
 
     if (
       this.adapter.secondaryExportKey &&
-      module[this.adapter.secondaryExportKey]
+      module[this.adapter.secondaryExportKey] &&
+      this.adapter.validateSecondaryExport
     ) {
-      const validate = this.adapter.validateSecondaryExport;
-      if (validate) {
-        const parsed = validate(
-          module[this.adapter.secondaryExportKey],
-        );
-        if (!parsed.success) {
-          throw new Error(parsed.error.message);
-        }
-        const validated = parsed.data as Record<string, unknown>;
-        return {
-          kind: this.adapter.catalogKinds[1] ?? this.adapter.catalogKinds[0],
-          typeNormalized: this.adapter.normalizeType(validated),
-          bundlePath: this.getBundlePath(args.relativePath, args.baseDir),
-          fingerprint,
-          fromCache,
-        };
+      const parsed = this.adapter.validateSecondaryExport(
+        module[this.adapter.secondaryExportKey],
+      );
+      if (!parsed.success) {
+        throw new Error(parsed.error.message);
       }
+      const validated = parsed.data as Record<string, unknown>;
+      return {
+        kind: this.adapter.catalogKinds[1] ?? this.adapter.catalogKinds[0],
+        typeNormalized: this.adapter.normalizeType(validated),
+        bundlePath: this.getBundlePath(args.relativePath, args.baseDir),
+        fingerprint,
+        fromCache,
+      };
     }
 
     return null;
@@ -708,40 +706,38 @@ export class ExtensionLoader {
 
     if (
       this.adapter.secondaryExportKey &&
-      module[this.adapter.secondaryExportKey]
+      module[this.adapter.secondaryExportKey] &&
+      this.adapter.validateSecondaryExport
     ) {
       const bundlePath = this.getBundlePath(relativePath, baseDir);
-      const validate = this.adapter.validateSecondaryExport;
-      if (validate) {
-        const parsed = validate(
-          module[this.adapter.secondaryExportKey],
-        );
-        if (!parsed.success) {
-          markCatalogValidationFailed({
-            catalog,
-            sourcePath: absolutePath,
-            kind: this.adapter.catalogKinds[1] ?? this.adapter.catalogKinds[0],
-            bundlePath,
-            sourceMtime,
-            sourceFingerprint: effectiveFingerprint,
-          });
-          throw new Error(parsed.error.message);
-        }
-        const validated = parsed.data as Record<string, unknown>;
-        const typeNormalized = this.adapter.normalizeType(validated);
-
-        catalog.upsert({
-          type_normalized: typeNormalized,
+      const parsed = this.adapter.validateSecondaryExport(
+        module[this.adapter.secondaryExportKey],
+      );
+      if (!parsed.success) {
+        markCatalogValidationFailed({
+          catalog,
+          sourcePath: absolutePath,
           kind: this.adapter.catalogKinds[1] ?? this.adapter.catalogKinds[0],
-          bundle_path: bundlePath,
-          source_path: absolutePath,
-          version: "",
-          description: "",
-          extends_type: typeNormalized,
-          source_mtime: sourceMtime,
-          source_fingerprint: effectiveFingerprint,
+          bundlePath,
+          sourceMtime,
+          sourceFingerprint: effectiveFingerprint,
         });
+        throw new Error(parsed.error.message);
       }
+      const validated = parsed.data as Record<string, unknown>;
+      const typeNormalized = this.adapter.normalizeType(validated);
+
+      catalog.upsert({
+        type_normalized: typeNormalized,
+        kind: this.adapter.catalogKinds[1] ?? this.adapter.catalogKinds[0],
+        bundle_path: bundlePath,
+        source_path: absolutePath,
+        version: "",
+        description: "",
+        extends_type: typeNormalized,
+        source_mtime: sourceMtime,
+        source_fingerprint: effectiveFingerprint,
+      });
     }
 
     return undefined;

--- a/src/domain/extensions/report_kind_adapter.ts
+++ b/src/domain/extensions/report_kind_adapter.ts
@@ -71,7 +71,9 @@ export const reportKindAdapter: KindAdapter = {
 
   extractTypeFromSource(source: string) {
     if (!/export\s+const\s+report\s*[=:]/.test(source)) return null;
-    const nameMatch = source.match(/name\s*:\s*["']([^"']+)["']/);
+    const nameMatch = source.match(
+      /export\s+const\s+report\s*=\s*\{[\s\S]*?name\s*:\s*["']([^"']+)["']/,
+    );
     if (!nameMatch) return null;
     return {
       typeNormalized: nameMatch[1].toLowerCase(),

--- a/src/domain/extensions/vault_kind_adapter.ts
+++ b/src/domain/extensions/vault_kind_adapter.ts
@@ -70,7 +70,9 @@ export const vaultKindAdapter: KindAdapter = {
 
   extractTypeFromSource(source: string) {
     if (!/export\s+const\s+vault\s*[=:]/.test(source)) return null;
-    const typeMatch = source.match(/type\s*:\s*["']([^"']+)["']/);
+    const typeMatch = source.match(
+      /export\s+const\s+vault\s*=\s*\{[\s\S]*?type\s*:\s*["']([^"']+)["']/,
+    );
     if (!typeMatch) return null;
     return {
       typeNormalized: typeMatch[1].toLowerCase(),

--- a/src/domain/reports/user_report_loader_test.ts
+++ b/src/domain/reports/user_report_loader_test.ts
@@ -389,3 +389,15 @@ export const report = {
     }
   },
 );
+
+Deno.test("reportKindAdapter.extractTypeFromSource: ignores name in helper objects above the export", () => {
+  const source = `
+const cfg = { name: "wrong-report" };
+export const report = {
+  name: "@org/correct-report",
+  render: () => "",
+};`;
+  const result = reportKindAdapter.extractTypeFromSource(source);
+  assertNotEquals(result, null);
+  assertEquals(result?.typeNormalized, "@org/correct-report");
+});

--- a/src/domain/vaults/user_vault_loader_test.ts
+++ b/src/domain/vaults/user_vault_loader_test.ts
@@ -894,3 +894,15 @@ Deno.test(
     }
   },
 );
+
+Deno.test("vaultKindAdapter.extractTypeFromSource: ignores type in helper objects above the export", () => {
+  const source = `
+const cfg = { type: "wrong/type" };
+export const vault = {
+  type: "@org/correct-vault",
+  resolve: async () => "secret",
+};`;
+  const result = vaultKindAdapter.extractTypeFromSource(source);
+  assertNotEquals(result, null);
+  assertEquals(result?.typeNormalized, "@org/correct-vault");
+});


### PR DESCRIPTION
## Summary

Two W4 follow-up fixes:

- **Scope `extractTypeFromSource` regex** in vault/driver/datastore/report adapters to match within the `export const <kind> = {` block, not the first `type:` (or `name:`) occurrence in the file. Previously, a helper object like `const cfg = { type: "wrong/type" }` above the export would pollute the catalog entry, causing unnecessary rebundles on every cold start.
- **Fix `validateSecondaryExport` this-binding loss** in `ExtensionLoader` — called inline instead of extracting to a local variable, preserving the `this` binding for future adapter implementations.

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] 5,697 tests pass, 0 failures
- [x] `deno run compile` succeeds
- [x] Added 4 regression tests (one per non-model adapter) verifying `extractTypeFromSource` ignores `type:`/`name:` in helper objects above the export

🤖 Generated with [Claude Code](https://claude.com/claude-code)