### PR TITLE
fix(rubric): collapse platform factors into single 2-point factor

### DIFF
--- a/integration/extension_quality_test.ts
+++ b/integration/extension_quality_test.ts
@@ -257,11 +257,10 @@ Deno.test(
       );
       assertEquals(statusById.get("description"), "missing");
       assertEquals(statusById.get("repository-verified"), "missing");
-      assertEquals(statusById.get("platforms-two"), "missing");
       // Still-earned controls:
       assertEquals(statusById.get("has-readme"), "earned");
       assertEquals(statusById.get("has-license"), "earned");
-      assertEquals(statusById.get("platforms-one"), "earned");
+      assertEquals(statusById.get("platforms"), "earned");
     } finally {
       await Deno.remove(tmpDir, { recursive: true });
     }

--- a/src/domain/extensions/extension_rubric_scorer.ts
+++ b/src/domain/extensions/extension_rubric_scorer.ts
@@ -45,7 +45,7 @@ import type { ExtensionManifest } from "./extension_manifest.ts";
  *   4. Run `deno doc --json` and `deno doc --lint` with CWD at the
  *      extraction root. `--lint` exits 0 regardless of diagnostics;
  *      we parse stdout/stderr for `error[<code>]` patterns.
- *   5. Compute the 5 per-version factors and the 4 per-package
+ *   5. Compute the 5 per-version factors and the 3 per-package
  *      factors + `repository-verified`, then compose a rubric v2
  *      score.
  */
@@ -345,23 +345,14 @@ export function composeScore(
       { remediation: "Fill `description:` in manifest.yaml." },
     ),
     boolRow(
-      "platforms-one",
-      "At least one platform tag (or universal)",
-      1,
+      "platforms",
+      "Platform support declared (or universal)",
+      2,
       manifest.platforms.length === 0 || manifest.platforms.length >= 1,
       {
         remediation:
-          "Leave `platforms:` empty (= universal) or add at least one entry.",
-      },
-    ),
-    boolRow(
-      "platforms-two",
-      "Two or more platform tags (or universal)",
-      1,
-      manifest.platforms.length === 0 || manifest.platforms.length >= 2,
-      {
-        remediation:
-          "Leave `platforms:` empty (= universal) or add ≥2 entries.",
+          "Set `platforms:` in manifest.yaml — list supported platforms " +
+          "or leave it empty to declare universal support.",
       },
     ),
     boolRow(

--- a/src/domain/extensions/extension_rubric_scorer_test.ts
+++ b/src/domain/extensions/extension_rubric_scorer_test.ts
@@ -418,18 +418,17 @@ Deno.test("composeScore: bad manifest fails several factors", () => {
     .map((f) => f.id);
   assert(failed.includes("description"));
   assert(failed.includes("repository-verified"));
-  assert(failed.includes("platforms-two"));
+  assert(!failed.includes("platforms"));
 });
 
-Deno.test("composeScore: empty platforms is universal (both platform factors earned)", () => {
+Deno.test("composeScore: empty platforms is universal (platform factor earned)", () => {
   const score = composeScore(
     factorsAllEarned(),
     makeManifest({ platforms: [] }),
   );
-  const one = score.factors.find((f) => f.id === "platforms-one")!;
-  const two = score.factors.find((f) => f.id === "platforms-two")!;
-  assertEquals(one.status, "earned");
-  assertEquals(two.status, "earned");
+  const factor = score.factors.find((f) => f.id === "platforms")!;
+  assertEquals(factor.status, "earned");
+  assertEquals(factor.earnedPoints, 2);
 });
 
 Deno.test("composeScore: missing LICENSE file misses has-license", () => {
@@ -523,8 +522,7 @@ Deno.test("composeScore: factor IDs and order match server", () => {
     "symbols-docs",
     "fast-check",
     "description",
-    "platforms-one",
-    "platforms-two",
+    "platforms",
     "has-license",
     "repository-verified",
   ]);
@@ -837,14 +835,14 @@ Deno.test("[parity] composeScore: empty everything earns universal-platform only
       platforms: [],
     }),
   );
-  // Universal platforms earns 2 points (platforms-one + platforms-two).
+  // Universal platforms earns 2 points (single platforms factor).
   assertEquals(score.earnedPoints, 2);
   assertEquals(score.percentage, Math.floor((2 * 100) / 12));
   assertEquals(score.rubricVersion, 2);
-  assertEquals(score.factors.length, 10);
+  assertEquals(score.factors.length, 9);
   const byId = new Map(score.factors.map((f) => [f.id, f]));
-  assertEquals(byId.get("platforms-one")?.status, "earned");
-  assertEquals(byId.get("platforms-two")?.status, "earned");
+  assertEquals(byId.get("platforms")?.status, "earned");
+  assertEquals(byId.get("platforms")?.earnedPoints, 2);
   assertEquals(byId.get("repository-verified")?.status, "missing");
   // verified-by-swamp is not a factor in the rubric (badge only)
   assertEquals(byId.get("verified-by-swamp"), undefined);
@@ -869,31 +867,31 @@ Deno.test("[parity] composeScore: percentage floors (11/12 → 91)", () => {
   assertEquals(score.percentage, 91);
 });
 
-Deno.test("[parity] composeScore: platforms thresholds", () => {
-  // 1 platform: platforms-one earned, platforms-two missing
+Deno.test("[parity] composeScore: platforms factor earns 2 for any count", () => {
+  // 1 platform: earned
   const s1 = composeScore(
     factorsAllEarned(),
     makeManifest({ platforms: ["linux"] }),
   );
   const m1 = new Map(s1.factors.map((f) => [f.id, f]));
-  assertEquals(m1.get("platforms-one")?.status, "earned");
-  assertEquals(m1.get("platforms-two")?.status, "missing");
+  assertEquals(m1.get("platforms")?.status, "earned");
+  assertEquals(m1.get("platforms")?.earnedPoints, 2);
 
-  // 2+ platforms: both earned
+  // 2+ platforms: earned
   const s2 = composeScore(
     factorsAllEarned(),
     makeManifest({ platforms: ["linux", "darwin"] }),
   );
   const m2 = new Map(s2.factors.map((f) => [f.id, f]));
-  assertEquals(m2.get("platforms-one")?.status, "earned");
-  assertEquals(m2.get("platforms-two")?.status, "earned");
+  assertEquals(m2.get("platforms")?.status, "earned");
+  assertEquals(m2.get("platforms")?.earnedPoints, 2);
 
-  // Empty (= universal): both earned
+  // Empty (= universal): earned
   const s3 = composeScore(
     factorsAllEarned(),
     makeManifest({ platforms: [] }),
   );
   const m3 = new Map(s3.factors.map((f) => [f.id, f]));
-  assertEquals(m3.get("platforms-one")?.status, "earned");
-  assertEquals(m3.get("platforms-two")?.status, "earned");
+  assertEquals(m3.get("platforms")?.status, "earned");
+  assertEquals(m3.get("platforms")?.earnedPoints, 2);
 });


### PR DESCRIPTION
## Summary

- Mirrors swamp-club#509 — collapse `platforms-one` and `platforms-two` into a single `platforms` factor worth 2 points
- A single-platform manifest now earns full credit — platform breadth is not a quality proxy when the upstream constrains it
- Factor count drops from 10 to 9; max stays at 12
- CLI and registry now produce identical scoring

## Test plan

- [x] All 66 unit tests pass (`deno test src/domain/extensions/extension_rubric_scorer_test.ts`)
- [x] Parity tests updated to match swamp-club server scorer
- [x] Integration test updated (single-platform manifest no longer fails `platforms-two`)
- [ ] Run `integration/extension_quality_test.ts` in a full dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)