### PR TITLE
feat(telemetry): per-method telemetry events for workflow runs (swamp-club#301)

### DIFF
--- a/design/workflow.md
+++ b/design/workflow.md
@@ -307,3 +307,67 @@ The WorkflowRepository and WorkflowRunRepository emit domain events:
 
 The RepoIndexService subscribes to these events (currently a noop
 implementation). See [./repo.md] for details on domain events.
+
+## Per-Method Telemetry
+
+A workflow run emits one parent telemetry entry for the outer
+`swamp workflow run` invocation plus one child entry per workflow YAML step
+that resolves to a model method. Children are linked to the parent through
+`parentInvocationId` and carry a `workflowContext` block:
+
+```yaml
+workflowContext:
+  workflowName: deploy
+  runId: <workflow-run-uuid>
+  jobName: build
+  stepName: validate-config
+  modelType: command/shell
+  driver: local
+```
+
+Children use the same `cli_invocation` event shape as a direct
+`swamp model method run <name> <method>` invocation, with the same
+redactions: `command="model"`, `subcommand="method"`,
+`args=["run", "<REDACTED>", <methodName>]`. Analytics that aggregate by
+command/method roll up direct invocations and workflow-internal
+invocations uniformly; per-driver and per-model-type queries read
+`workflowContext` directly without joining through the parent.
+
+### Failure Semantics
+
+- A step that fails AFTER `method_executing` was yielded records an error
+  child entry with the actual duration.
+- A step that fails BEFORE `method_executing` (model lookup failure, vault
+  expression resolution failure, vary-key validation failure, env-var
+  validation) records a synthesized child entry with `durationMs = 0` —
+  the method was never actually invoked, so duration is honestly zero.
+  Dashboards that filter zero-duration entries will hide
+  failure-by-validation cases by design.
+- A step with `allowFailure: true` records as `error` in the child entry
+  (the method outcome) while the parent records its overall workflow
+  outcome — `success` if all unallowed failures were absent. Joining
+  `child.error_category × parent.success` on `parentInvocationId` surfaces
+  "how many allowed failures" without changing the entry shape.
+
+### V1 Limitations
+
+- **Workflow-step granularity only.** Sub-method follow-up calls inside
+  `DefaultMethodExecutionService.execute` (e.g. one method that internally
+  invokes another method) are NOT captured as separate child entries; the
+  workflow-step boundary is the unit of measurement.
+- **Workflow-task steps** (a step whose task is a nested workflow) emit no
+  child entry of their own. The nested workflow's own model-method steps
+  generate child entries linked to the same parent CLI invocation.
+- **Failures before workflow validation** (e.g. workflow not found, input
+  schema validation) produce no child entry — no method was ever resolved.
+- **Cancellation** during a method invocation (AbortSignal, timeout)
+  records the in-flight method as an error child entry via the bridge's
+  finalize path with a synthetic "workflow run terminated before
+  completion" message.
+
+The bridge lives in `src/libswamp/workflows/telemetry_bridge.ts`. The
+domain `step_failed` event carries optional `modelName`, `methodName`, and
+`driver` fields populated only at the model-method failure site (other
+yield sites — nesting depth, cycle detection, nested-workflow failure —
+leave them undefined so the bridge can distinguish structural failures
+from method failures).

--- a/integration/telemetry_workflow_method_invocations_test.ts
+++ b/integration/telemetry_workflow_method_invocations_test.ts
@@ -153,208 +153,222 @@ interface PersistedEntry {
   durationMs: number;
 }
 
-Deno.test("workflow run persists per-step child telemetry entries with workflowContext", async () => {
-  await withTempDir(async (repoDir) => {
-    // 1. Initialize a single-tool repo
-    const init = await runCli(
-      ["--json", "repo", "init", "--tool", "claude"],
-      repoDir,
-      baseChildEnv(),
-    );
-    assertEquals(init.code, 0, `repo init failed: ${init.stderr}`);
-    await pinTelemetryEndpoint(repoDir);
-
-    // 2. Create two shell models: one that succeeds, one that exits 1
-    await createShellModel(repoDir, "echo-ok", "echo hello");
-    await createShellModel(repoDir, "echo-fail", "exit 1");
-
-    // 3. Create a workflow with three steps:
-    //    (a) success step
-    //    (b) post-method-executing failure (allowFailure so workflow continues)
-    //    (c) forEach with two iterations
-    const workflowData = {
-      id: crypto.randomUUID(),
-      name: "telemetry-test-wf",
-      version: 1,
-      inputs: {
-        properties: {
-          envs: {
-            type: "array",
-            items: { type: "string" },
-            minItems: 1,
-          },
-        },
-        required: ["envs"],
-      },
-      jobs: [
-        {
-          name: "main",
-          steps: [
-            {
-              name: "ok-step",
-              task: {
-                type: "model_method",
-                modelIdOrName: "echo-ok",
-                methodName: "execute",
-              },
-              dependsOn: [],
-              weight: 0,
-            },
-            {
-              name: "fail-step",
-              task: {
-                type: "model_method",
-                modelIdOrName: "echo-fail",
-                methodName: "execute",
-              },
-              allowFailure: true,
-              dependsOn: [],
-              weight: 0,
-            },
-            {
-              name: "fanout-${{self.env}}",
-              forEach: {
-                item: "env",
-                in: "${{ inputs.envs }}",
-              },
-              task: {
-                type: "model_method",
-                modelIdOrName: "echo-ok",
-                methodName: "execute",
-              },
-              dependsOn: [],
-              weight: 0,
-            },
-          ],
-          dependsOn: [],
-          weight: 0,
-        },
-      ],
-    };
-    const workflowDir = join(repoDir, "workflows");
-    await ensureDir(workflowDir);
-    await Deno.writeTextFile(
-      join(workflowDir, `workflow-${workflowData.id}.yaml`),
-      stringifyYaml(workflowData as Record<string, unknown>),
-    );
-
-    // 4. Run the workflow
-    const env = baseChildEnv();
-    const run = await runCli(
-      [
-        "--json",
-        "workflow",
-        "run",
-        "telemetry-test-wf",
-        "--repo-dir",
+Deno.test({
+  name:
+    "workflow run persists per-step child telemetry entries with workflowContext",
+  // Uses the POSIX `echo` / `exit` shell built-ins via the command/shell
+  // model, which exit with code -65536 on Windows. The bridge logic
+  // itself is platform-independent and covered by
+  // src/libswamp/workflows/telemetry_bridge_test.ts which runs on all
+  // platforms.
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    await withTempDir(async (repoDir) => {
+      // 1. Initialize a single-tool repo
+      const init = await runCli(
+        ["--json", "repo", "init", "--tool", "claude"],
         repoDir,
-        "--input",
-        '{"envs": ["a", "b"]}',
-        "--skip-reports",
-        "--skip-checks",
-      ],
-      Deno.cwd(),
-      env,
-    );
-    // Workflow may exit non-zero if a non-allowed failure surfaces; for
-    // this fixture all failures are allowed, so expect success.
-    assertEquals(
-      run.code,
-      0,
-      `workflow run failed: stdout=${run.stdout} stderr=${run.stderr}`,
-    );
-
-    // 5. Read persisted telemetry
-    const persisted = await readPersistedEntries(
-      repoDir,
-    ) as unknown as PersistedEntry[];
-
-    // Find the parent entry for `workflow run`. It carries no
-    // workflowContext (workflowContext is for child entries only).
-    const parents = persisted.filter((entry) =>
-      entry.invocation.command === "workflow" &&
-      entry.invocation.subcommand === "run" &&
-      !entry.workflowContext
-    );
-    assertEquals(parents.length, 1, "expected exactly one workflow run parent");
-    const parentId = parents[0].id;
-
-    // Find child entries linked to this parent
-    const children = persisted.filter((entry) =>
-      entry.parentInvocationId === parentId
-    );
-
-    // Expect: 1 ok-step + 1 fail-step + 2 forEach iterations = 4 children
-    assertEquals(
-      children.length,
-      4,
-      `expected 4 child entries, got ${children.length}: ${
-        JSON.stringify(children.map((c) => c.workflowContext?.stepName))
-      }`,
-    );
-
-    // All children should look like a direct `model method run` invocation
-    for (const child of children) {
-      assertEquals(child.invocation.command, "model");
-      assertEquals(child.invocation.subcommand, "method");
-      assertEquals(child.invocation.args[0], "run");
-      assertEquals(child.invocation.args[1], "<REDACTED>");
-      assertEquals(child.invocation.args[2], "execute");
-      assert(
-        child.workflowContext !== undefined,
-        "child missing workflowContext",
+        baseChildEnv(),
       );
-      assertEquals(child.workflowContext!.workflowName, "telemetry-test-wf");
-      assertEquals(child.workflowContext!.jobName, "main");
-    }
+      assertEquals(init.code, 0, `repo init failed: ${init.stderr}`);
+      await pinTelemetryEndpoint(repoDir);
 
-    // Identify each child by stepName
-    const okChild = children.find((c) =>
-      c.workflowContext!.stepName === "ok-step"
-    );
-    const failChild = children.find((c) =>
-      c.workflowContext!.stepName === "fail-step"
-    );
-    // Match by exact suffix — `includes("a")` would also match "fanout-b"
-    // because the prefix "fanout-" itself contains the letter "a", and
-    // directory iteration order is non-deterministic across platforms.
-    const fanoutA = children.find((c) =>
-      c.workflowContext!.stepName === "fanout-a"
-    );
-    const fanoutB = children.find((c) =>
-      c.workflowContext!.stepName === "fanout-b"
-    );
+      // 2. Create two shell models: one that succeeds, one that exits 1
+      await createShellModel(repoDir, "echo-ok", "echo hello");
+      await createShellModel(repoDir, "echo-fail", "exit 1");
 
-    assert(okChild, "missing ok-step child");
-    assert(failChild, "missing fail-step child");
-    assert(fanoutA, "missing fanout iteration a");
-    assert(fanoutB, "missing fanout iteration b");
+      // 3. Create a workflow with three steps:
+      //    (a) success step
+      //    (b) post-method-executing failure (allowFailure so workflow continues)
+      //    (c) forEach with two iterations
+      const workflowData = {
+        id: crypto.randomUUID(),
+        name: "telemetry-test-wf",
+        version: 1,
+        inputs: {
+          properties: {
+            envs: {
+              type: "array",
+              items: { type: "string" },
+              minItems: 1,
+            },
+          },
+          required: ["envs"],
+        },
+        jobs: [
+          {
+            name: "main",
+            steps: [
+              {
+                name: "ok-step",
+                task: {
+                  type: "model_method",
+                  modelIdOrName: "echo-ok",
+                  methodName: "execute",
+                },
+                dependsOn: [],
+                weight: 0,
+              },
+              {
+                name: "fail-step",
+                task: {
+                  type: "model_method",
+                  modelIdOrName: "echo-fail",
+                  methodName: "execute",
+                },
+                allowFailure: true,
+                dependsOn: [],
+                weight: 0,
+              },
+              {
+                name: "fanout-${{self.env}}",
+                forEach: {
+                  item: "env",
+                  in: "${{ inputs.envs }}",
+                },
+                task: {
+                  type: "model_method",
+                  modelIdOrName: "echo-ok",
+                  methodName: "execute",
+                },
+                dependsOn: [],
+                weight: 0,
+              },
+            ],
+            dependsOn: [],
+            weight: 0,
+          },
+        ],
+      };
+      const workflowDir = join(repoDir, "workflows");
+      await ensureDir(workflowDir);
+      await Deno.writeTextFile(
+        join(workflowDir, `workflow-${workflowData.id}.yaml`),
+        stringifyYaml(workflowData as Record<string, unknown>),
+      );
 
-    assertEquals(okChild!.result.status, "success");
-    // fail-step has allowFailure: true but the child entry records the
-    // method outcome (error). The parent records workflow success.
-    assertEquals(failChild!.result.status, "error");
-    assertEquals(parents[0].result.status, "success");
+      // 4. Run the workflow
+      const env = baseChildEnv();
+      const run = await runCli(
+        [
+          "--json",
+          "workflow",
+          "run",
+          "telemetry-test-wf",
+          "--repo-dir",
+          repoDir,
+          "--input",
+          '{"envs": ["a", "b"]}',
+          "--skip-reports",
+          "--skip-checks",
+        ],
+        Deno.cwd(),
+        env,
+      );
+      // Workflow may exit non-zero if a non-allowed failure surfaces; for
+      // this fixture all failures are allowed, so expect success.
+      assertEquals(
+        run.code,
+        0,
+        `workflow run failed: stdout=${run.stdout} stderr=${run.stderr}`,
+      );
 
-    // forEach iterations have distinct stepNames
-    const stepNames = children.map((c) => c.workflowContext!.stepName);
-    assert(
-      fanoutA!.workflowContext!.stepName !==
-        fanoutB!.workflowContext!.stepName,
-      `forEach iterations should have distinct stepNames; got ${
-        JSON.stringify(stepNames)
-      }`,
-    );
+      // 5. Read persisted telemetry
+      const persisted = await readPersistedEntries(
+        repoDir,
+      ) as unknown as PersistedEntry[];
 
-    // Children carry runId pointing to the same workflow run
-    const runIds = new Set(
-      children.map((c) => c.workflowContext!.runId),
-    );
-    assertEquals(runIds.size, 1, "all children share one workflow run id");
+      // Find the parent entry for `workflow run`. It carries no
+      // workflowContext (workflowContext is for child entries only).
+      const parents = persisted.filter((entry) =>
+        entry.invocation.command === "workflow" &&
+        entry.invocation.subcommand === "run" &&
+        !entry.workflowContext
+      );
+      assertEquals(
+        parents.length,
+        1,
+        "expected exactly one workflow run parent",
+      );
+      const parentId = parents[0].id;
 
-    // Children carry modelType for the shell model
-    for (const child of children) {
-      assertEquals(child.workflowContext!.modelType, "command/shell");
-    }
-  });
+      // Find child entries linked to this parent
+      const children = persisted.filter((entry) =>
+        entry.parentInvocationId === parentId
+      );
+
+      // Expect: 1 ok-step + 1 fail-step + 2 forEach iterations = 4 children
+      assertEquals(
+        children.length,
+        4,
+        `expected 4 child entries, got ${children.length}: ${
+          JSON.stringify(children.map((c) => c.workflowContext?.stepName))
+        }`,
+      );
+
+      // All children should look like a direct `model method run` invocation
+      for (const child of children) {
+        assertEquals(child.invocation.command, "model");
+        assertEquals(child.invocation.subcommand, "method");
+        assertEquals(child.invocation.args[0], "run");
+        assertEquals(child.invocation.args[1], "<REDACTED>");
+        assertEquals(child.invocation.args[2], "execute");
+        assert(
+          child.workflowContext !== undefined,
+          "child missing workflowContext",
+        );
+        assertEquals(child.workflowContext!.workflowName, "telemetry-test-wf");
+        assertEquals(child.workflowContext!.jobName, "main");
+      }
+
+      // Identify each child by stepName
+      const okChild = children.find((c) =>
+        c.workflowContext!.stepName === "ok-step"
+      );
+      const failChild = children.find((c) =>
+        c.workflowContext!.stepName === "fail-step"
+      );
+      // Match by exact suffix — `includes("a")` would also match "fanout-b"
+      // because the prefix "fanout-" itself contains the letter "a", and
+      // directory iteration order is non-deterministic across platforms.
+      const fanoutA = children.find((c) =>
+        c.workflowContext!.stepName === "fanout-a"
+      );
+      const fanoutB = children.find((c) =>
+        c.workflowContext!.stepName === "fanout-b"
+      );
+
+      assert(okChild, "missing ok-step child");
+      assert(failChild, "missing fail-step child");
+      assert(fanoutA, "missing fanout iteration a");
+      assert(fanoutB, "missing fanout iteration b");
+
+      assertEquals(okChild!.result.status, "success");
+      // fail-step has allowFailure: true but the child entry records the
+      // method outcome (error). The parent records workflow success.
+      assertEquals(failChild!.result.status, "error");
+      assertEquals(parents[0].result.status, "success");
+
+      // forEach iterations have distinct stepNames
+      const stepNames = children.map((c) => c.workflowContext!.stepName);
+      assert(
+        fanoutA!.workflowContext!.stepName !==
+          fanoutB!.workflowContext!.stepName,
+        `forEach iterations should have distinct stepNames; got ${
+          JSON.stringify(stepNames)
+        }`,
+      );
+
+      // Children carry runId pointing to the same workflow run
+      const runIds = new Set(
+        children.map((c) => c.workflowContext!.runId),
+      );
+      assertEquals(runIds.size, 1, "all children share one workflow run id");
+
+      // Children carry modelType for the shell model
+      for (const child of children) {
+        assertEquals(child.workflowContext!.modelType, "command/shell");
+      }
+    });
+  },
 });

--- a/integration/telemetry_workflow_method_invocations_test.ts
+++ b/integration/telemetry_workflow_method_invocations_test.ts
@@ -315,13 +315,14 @@ Deno.test("workflow run persists per-step child telemetry entries with workflowC
     const failChild = children.find((c) =>
       c.workflowContext!.stepName === "fail-step"
     );
+    // Match by exact suffix — `includes("a")` would also match "fanout-b"
+    // because the prefix "fanout-" itself contains the letter "a", and
+    // directory iteration order is non-deterministic across platforms.
     const fanoutA = children.find((c) =>
-      c.workflowContext!.stepName.startsWith("fanout-") &&
-      c.workflowContext!.stepName.includes("a")
+      c.workflowContext!.stepName === "fanout-a"
     );
     const fanoutB = children.find((c) =>
-      c.workflowContext!.stepName.startsWith("fanout-") &&
-      c.workflowContext!.stepName.includes("b")
+      c.workflowContext!.stepName === "fanout-b"
     );
 
     assert(okChild, "missing ok-step child");

--- a/integration/telemetry_workflow_method_invocations_test.ts
+++ b/integration/telemetry_workflow_method_invocations_test.ts
@@ -1,0 +1,359 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * End-to-end verification that running a workflow persists per-step
+ * telemetry entries linked to the parent CLI invocation.
+ *
+ * Covers the bridge in src/libswamp/workflows/telemetry_bridge.ts:
+ * one parent entry plus one child entry per workflow YAML step that
+ * resolves to a model method. The shell model is the natural fixture
+ * because it ships in-tree and exit codes drive success vs failure.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+import { stringify as stringifyYaml } from "@std/yaml";
+import { CLI_ARGS } from "./test_helpers.ts";
+
+interface CliRunResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+async function runCli(
+  args: string[],
+  cwd: string,
+  env: Record<string, string>,
+): Promise<CliRunResult> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [...CLI_ARGS, ...args],
+    stdout: "piped",
+    stderr: "piped",
+    cwd,
+    env,
+    clearEnv: true,
+  });
+  const { code, stdout, stderr } = await command.output();
+  return {
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+    code,
+  };
+}
+
+async function readPersistedEntries(
+  repoDir: string,
+): Promise<Record<string, unknown>[]> {
+  const dir = join(repoDir, ".swamp", "telemetry");
+  const entries: Record<string, unknown>[] = [];
+  for await (const file of Deno.readDir(dir)) {
+    if (!file.isFile || !file.name.endsWith(".json")) continue;
+    const text = await Deno.readTextFile(join(dir, file.name));
+    entries.push(JSON.parse(text) as Record<string, unknown>);
+  }
+  return entries;
+}
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-tel-wf-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+function baseChildEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of ["HOME", "PATH", "USER", "TMPDIR", "TMP", "TEMP"]) {
+    const value = Deno.env.get(key);
+    if (value !== undefined) env[key] = value;
+  }
+  return env;
+}
+
+async function pinTelemetryEndpoint(repoDir: string): Promise<void> {
+  // Pin telemetry to a localhost port nothing listens on so the
+  // post-command flush dies fast and entries stay on disk for us to
+  // inspect. keepFlushed: true preserves the file even if a flush did
+  // somehow succeed (renamed to .flushed.json).
+  const markerPath = join(repoDir, ".swamp.yaml");
+  const marker = await Deno.readTextFile(markerPath);
+  await Deno.writeTextFile(
+    markerPath,
+    marker +
+      "\ntelemetryEndpoint: http://127.0.0.1:1\ntelemetryKeepFlushed: true\n",
+  );
+}
+
+async function createShellModel(
+  repoDir: string,
+  name: string,
+  runCommand: string,
+): Promise<void> {
+  const modelData = {
+    type: "command/shell",
+    typeVersion: 1,
+    id: crypto.randomUUID(),
+    name,
+    version: 1,
+    tags: {},
+    globalArguments: {},
+    methods: {
+      execute: {
+        arguments: { run: runCommand },
+      },
+    },
+  };
+
+  const modelDir = join(repoDir, "models/command/shell");
+  await ensureDir(modelDir);
+  await Deno.writeTextFile(
+    join(modelDir, `${modelData.id}.yaml`),
+    stringifyYaml(modelData as Record<string, unknown>),
+  );
+}
+
+interface PersistedEntry {
+  id: string;
+  invocation: { command: string; subcommand?: string; args: string[] };
+  result: { status: string };
+  parentInvocationId?: string;
+  workflowContext?: {
+    workflowName: string;
+    runId: string;
+    jobName: string;
+    stepName: string;
+    modelType?: string;
+    driver?: string;
+  };
+  durationMs: number;
+}
+
+Deno.test("workflow run persists per-step child telemetry entries with workflowContext", async () => {
+  await withTempDir(async (repoDir) => {
+    // 1. Initialize a single-tool repo
+    const init = await runCli(
+      ["--json", "repo", "init", "--tool", "claude"],
+      repoDir,
+      baseChildEnv(),
+    );
+    assertEquals(init.code, 0, `repo init failed: ${init.stderr}`);
+    await pinTelemetryEndpoint(repoDir);
+
+    // 2. Create two shell models: one that succeeds, one that exits 1
+    await createShellModel(repoDir, "echo-ok", "echo hello");
+    await createShellModel(repoDir, "echo-fail", "exit 1");
+
+    // 3. Create a workflow with three steps:
+    //    (a) success step
+    //    (b) post-method-executing failure (allowFailure so workflow continues)
+    //    (c) forEach with two iterations
+    const workflowData = {
+      id: crypto.randomUUID(),
+      name: "telemetry-test-wf",
+      version: 1,
+      inputs: {
+        properties: {
+          envs: {
+            type: "array",
+            items: { type: "string" },
+            minItems: 1,
+          },
+        },
+        required: ["envs"],
+      },
+      jobs: [
+        {
+          name: "main",
+          steps: [
+            {
+              name: "ok-step",
+              task: {
+                type: "model_method",
+                modelIdOrName: "echo-ok",
+                methodName: "execute",
+              },
+              dependsOn: [],
+              weight: 0,
+            },
+            {
+              name: "fail-step",
+              task: {
+                type: "model_method",
+                modelIdOrName: "echo-fail",
+                methodName: "execute",
+              },
+              allowFailure: true,
+              dependsOn: [],
+              weight: 0,
+            },
+            {
+              name: "fanout-${{self.env}}",
+              forEach: {
+                item: "env",
+                in: "${{ inputs.envs }}",
+              },
+              task: {
+                type: "model_method",
+                modelIdOrName: "echo-ok",
+                methodName: "execute",
+              },
+              dependsOn: [],
+              weight: 0,
+            },
+          ],
+          dependsOn: [],
+          weight: 0,
+        },
+      ],
+    };
+    const workflowDir = join(repoDir, "workflows");
+    await ensureDir(workflowDir);
+    await Deno.writeTextFile(
+      join(workflowDir, `workflow-${workflowData.id}.yaml`),
+      stringifyYaml(workflowData as Record<string, unknown>),
+    );
+
+    // 4. Run the workflow
+    const env = baseChildEnv();
+    const run = await runCli(
+      [
+        "--json",
+        "workflow",
+        "run",
+        "telemetry-test-wf",
+        "--repo-dir",
+        repoDir,
+        "--input",
+        '{"envs": ["a", "b"]}',
+        "--skip-reports",
+        "--skip-checks",
+      ],
+      Deno.cwd(),
+      env,
+    );
+    // Workflow may exit non-zero if a non-allowed failure surfaces; for
+    // this fixture all failures are allowed, so expect success.
+    assertEquals(
+      run.code,
+      0,
+      `workflow run failed: stdout=${run.stdout} stderr=${run.stderr}`,
+    );
+
+    // 5. Read persisted telemetry
+    const persisted = await readPersistedEntries(
+      repoDir,
+    ) as unknown as PersistedEntry[];
+
+    // Find the parent entry for `workflow run`. It carries no
+    // workflowContext (workflowContext is for child entries only).
+    const parents = persisted.filter((entry) =>
+      entry.invocation.command === "workflow" &&
+      entry.invocation.subcommand === "run" &&
+      !entry.workflowContext
+    );
+    assertEquals(parents.length, 1, "expected exactly one workflow run parent");
+    const parentId = parents[0].id;
+
+    // Find child entries linked to this parent
+    const children = persisted.filter((entry) =>
+      entry.parentInvocationId === parentId
+    );
+
+    // Expect: 1 ok-step + 1 fail-step + 2 forEach iterations = 4 children
+    assertEquals(
+      children.length,
+      4,
+      `expected 4 child entries, got ${children.length}: ${
+        JSON.stringify(children.map((c) => c.workflowContext?.stepName))
+      }`,
+    );
+
+    // All children should look like a direct `model method run` invocation
+    for (const child of children) {
+      assertEquals(child.invocation.command, "model");
+      assertEquals(child.invocation.subcommand, "method");
+      assertEquals(child.invocation.args[0], "run");
+      assertEquals(child.invocation.args[1], "<REDACTED>");
+      assertEquals(child.invocation.args[2], "execute");
+      assert(
+        child.workflowContext !== undefined,
+        "child missing workflowContext",
+      );
+      assertEquals(child.workflowContext!.workflowName, "telemetry-test-wf");
+      assertEquals(child.workflowContext!.jobName, "main");
+    }
+
+    // Identify each child by stepName
+    const okChild = children.find((c) =>
+      c.workflowContext!.stepName === "ok-step"
+    );
+    const failChild = children.find((c) =>
+      c.workflowContext!.stepName === "fail-step"
+    );
+    const fanoutA = children.find((c) =>
+      c.workflowContext!.stepName.startsWith("fanout-") &&
+      c.workflowContext!.stepName.includes("a")
+    );
+    const fanoutB = children.find((c) =>
+      c.workflowContext!.stepName.startsWith("fanout-") &&
+      c.workflowContext!.stepName.includes("b")
+    );
+
+    assert(okChild, "missing ok-step child");
+    assert(failChild, "missing fail-step child");
+    assert(fanoutA, "missing fanout iteration a");
+    assert(fanoutB, "missing fanout iteration b");
+
+    assertEquals(okChild!.result.status, "success");
+    // fail-step has allowFailure: true but the child entry records the
+    // method outcome (error). The parent records workflow success.
+    assertEquals(failChild!.result.status, "error");
+    assertEquals(parents[0].result.status, "success");
+
+    // forEach iterations have distinct stepNames
+    const stepNames = children.map((c) => c.workflowContext!.stepName);
+    assert(
+      fanoutA!.workflowContext!.stepName !==
+        fanoutB!.workflowContext!.stepName,
+      `forEach iterations should have distinct stepNames; got ${
+        JSON.stringify(stepNames)
+      }`,
+    );
+
+    // Children carry runId pointing to the same workflow run
+    const runIds = new Set(
+      children.map((c) => c.workflowContext!.runId),
+    );
+    assertEquals(runIds.size, 1, "all children share one workflow run id");
+
+    // Children carry modelType for the shell model
+    for (const child of children) {
+      assertEquals(child.workflowContext!.modelType, "command/shell");
+    }
+  });
+});

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -52,8 +52,10 @@ import {
   createLibSwampContext,
   workflowRun,
   type WorkflowRunDeps,
+  type WorkflowTelemetrySink,
 } from "../../libswamp/mod.ts";
 import { createWorkflowRunRenderer } from "../../presentation/renderers/workflow_run.ts";
+import { getActiveTelemetryService } from "../telemetry_integration.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -239,6 +241,20 @@ export const workflowRunCommand = new Command()
         reportRegistry.ensureLoaded(),
       ]);
 
+      // Wire the telemetry sink only when the active service is
+      // available — telemetry is disabled outside a swamp repo or under
+      // --no-telemetry, in which case the bridge inside libswamp
+      // becomes a no-op.
+      const telemetryService = getActiveTelemetryService();
+      const telemetrySink: WorkflowTelemetrySink | undefined = telemetryService
+        ? {
+          parentInvocationId: telemetryService.invocationId,
+          recordChildInvocation: telemetryService.recordChildInvocation.bind(
+            telemetryService,
+          ),
+        }
+        : undefined;
+
       const deps: WorkflowRunDeps = {
         workflowRepo: repoContext.workflowRepo,
         runRepo,
@@ -259,6 +275,7 @@ export const workflowRunCommand = new Command()
         catalogStore: repoContext.catalogStore,
         dataRepo: repoContext.unifiedDataRepo,
         definitionRepo: repoContext.definitionRepo,
+        telemetrySink,
       };
 
       const timeoutMs = options.timeout

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -99,9 +99,11 @@ import { JsonTelemetryRepository } from "../infrastructure/persistence/json_tele
 import { HttpTelemetrySender } from "../infrastructure/telemetry/http_telemetry_sender.ts";
 import {
   buildInvocationContext,
+  clearActiveTelemetryService,
   extractCommandInfo,
   isTelemetryDisabled,
   projectEnvSnapshot,
+  setActiveTelemetryService,
 } from "./telemetry_integration.ts";
 import { UserIdentityRepository } from "../infrastructure/persistence/user_identity_repository.ts";
 import { AuthRepository } from "../infrastructure/persistence/auth_repository.ts";
@@ -990,6 +992,13 @@ export async function runCli(args: string[]): Promise<void> {
     telemetryCtx = await initTelemetryService(repoDir);
   }
 
+  // Surface the active service for command actions that emit child
+  // telemetry (e.g. workflow_run wiring into libswamp). Cleared in the
+  // outer try/finally below regardless of how the invocation ends.
+  if (telemetryCtx) {
+    setActiveTelemetryService(telemetryCtx.service);
+  }
+
   // Read marker once for log level, extension loading, and auto-resolver
   let marker: RepoMarkerData | null = null;
   try {
@@ -1246,5 +1255,10 @@ export async function runCli(args: string[]): Promise<void> {
       });
     }
     throw error;
+  } finally {
+    // Always clear the module-scoped service handle when the CLI
+    // invocation finishes — runCli is the single setter and must be the
+    // single clearer.
+    clearActiveTelemetryService();
   }
 }

--- a/src/cli/telemetry_integration.ts
+++ b/src/cli/telemetry_integration.ts
@@ -25,7 +25,44 @@ import {
   detectAgentHarness,
   RELEVANT_ENV_VARS,
 } from "../domain/telemetry/mod.ts";
+import type { TelemetryService } from "../domain/telemetry/telemetry_service.ts";
 import type { AiTool } from "../infrastructure/persistence/repo_marker_repository.ts";
+
+/**
+ * Module-scoped accessor for the active TelemetryService. Set once at the
+ * top of runCli (before Cliffy parse) and cleared in the surrounding
+ * try/finally. Command actions that need to emit child telemetry (e.g.
+ * workflow_run.ts wiring a sink into libswamp) read it via
+ * `getActiveTelemetryService()`.
+ *
+ * Module-scoped state matches the lifecycle: a single CLI invocation has
+ * a single TelemetryService for its entire duration. Tests that exercise
+ * the bridge inject a stub directly rather than relying on this module.
+ */
+let activeTelemetryService: TelemetryService | null = null;
+
+/**
+ * Sets the active TelemetryService for the current CLI invocation.
+ * Call from runCli only — not from individual commands.
+ */
+export function setActiveTelemetryService(service: TelemetryService): void {
+  activeTelemetryService = service;
+}
+
+/**
+ * Clears the active TelemetryService. Call from runCli's finally block.
+ */
+export function clearActiveTelemetryService(): void {
+  activeTelemetryService = null;
+}
+
+/**
+ * Returns the active TelemetryService, or null if telemetry is disabled
+ * for this invocation (e.g. --no-telemetry, outside a swamp repo).
+ */
+export function getActiveTelemetryService(): TelemetryService | null {
+  return activeTelemetryService;
+}
 
 /**
  * Per-position sensitivity for positional arguments by command.

--- a/src/domain/telemetry/mod.ts
+++ b/src/domain/telemetry/mod.ts
@@ -39,6 +39,14 @@ export {
 } from "./invocation_context.ts";
 
 export {
+  createWorkflowContext,
+  type WorkflowContext,
+  type WorkflowContextData,
+  workflowContextFromData,
+  workflowContextToData,
+} from "./workflow_context.ts";
+
+export {
   type AgentHarnessDetection,
   type DetectableAiTool,
   detectAgentHarness,

--- a/src/domain/telemetry/telemetry_entry.ts
+++ b/src/domain/telemetry/telemetry_entry.ts
@@ -40,6 +40,12 @@ import {
   invocationContextFromData,
   invocationContextToData,
 } from "./invocation_context.ts";
+import {
+  type WorkflowContext,
+  type WorkflowContextData,
+  workflowContextFromData,
+  workflowContextToData,
+} from "./workflow_context.ts";
 
 /**
  * Properties required to create a new TelemetryEntry.
@@ -54,13 +60,16 @@ export interface CreateTelemetryEntryProps {
   denoVersion: string;
   platform: string;
   invocationContext?: InvocationContextData;
+  parentInvocationId?: string;
+  workflowContext?: WorkflowContextData;
 }
 
 /**
  * Data transfer object for TelemetryEntry.
  *
- * `invocationContext` is optional so entries written before the field was
- * introduced still decode without loss.
+ * `invocationContext`, `parentInvocationId`, and `workflowContext` are
+ * optional so entries written before each field was introduced still decode
+ * without loss.
  */
 export interface TelemetryEntryData {
   id: string;
@@ -73,6 +82,8 @@ export interface TelemetryEntryData {
   denoVersion: string;
   platform: string;
   invocationContext?: InvocationContextData;
+  parentInvocationId?: string;
+  workflowContext?: WorkflowContextData;
 }
 
 /**
@@ -90,6 +101,8 @@ export class TelemetryEntry {
     readonly denoVersion: string,
     readonly platform: string,
     readonly invocationContext?: InvocationContext,
+    readonly parentInvocationId?: TelemetryId,
+    readonly workflowContext?: WorkflowContext,
   ) {}
 
   /**
@@ -112,6 +125,12 @@ export class TelemetryEntry {
       props.invocationContext
         ? invocationContextFromData(props.invocationContext)
         : undefined,
+      props.parentInvocationId
+        ? createTelemetryId(props.parentInvocationId)
+        : undefined,
+      props.workflowContext
+        ? workflowContextFromData(props.workflowContext)
+        : undefined,
     );
   }
 
@@ -131,6 +150,12 @@ export class TelemetryEntry {
       data.platform,
       data.invocationContext
         ? invocationContextFromData(data.invocationContext)
+        : undefined,
+      data.parentInvocationId
+        ? createTelemetryId(data.parentInvocationId)
+        : undefined,
+      data.workflowContext
+        ? workflowContextFromData(data.workflowContext)
         : undefined,
     );
   }
@@ -152,6 +177,12 @@ export class TelemetryEntry {
     };
     if (this.invocationContext) {
       data.invocationContext = invocationContextToData(this.invocationContext);
+    }
+    if (this.parentInvocationId) {
+      data.parentInvocationId = this.parentInvocationId;
+    }
+    if (this.workflowContext) {
+      data.workflowContext = workflowContextToData(this.workflowContext);
     }
     return data;
   }

--- a/src/domain/telemetry/telemetry_entry_test.ts
+++ b/src/domain/telemetry/telemetry_entry_test.ts
@@ -241,3 +241,113 @@ Deno.test("TelemetryEntry.fromData decodes legacy entries without invocationCont
   assertEquals(entry.invocationContext, undefined);
   assertEquals("invocationContext" in entry.toData(), false);
 });
+
+Deno.test("TelemetryEntry.create accepts parentInvocationId and workflowContext", () => {
+  const entry = TelemetryEntry.create({
+    invocation: {
+      command: "model",
+      subcommand: "method",
+      args: ["run", "<REDACTED>", "validate"],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    result: { status: "success", exitCode: 0 },
+    startedAt: new Date("2026-02-05T10:00:00Z"),
+    completedAt: new Date("2026-02-05T10:00:00.250Z"),
+    swampVersion: "1.0.0",
+    denoVersion: "2.1.0",
+    platform: "linux",
+    parentInvocationId: "parent-abc",
+    workflowContext: {
+      workflowName: "deploy",
+      runId: "run-123",
+      jobName: "build",
+      stepName: "validate-config",
+      modelType: "@swamp/shell",
+      driver: "local",
+    },
+  });
+
+  assertEquals(entry.parentInvocationId, "parent-abc");
+  assertEquals(entry.workflowContext?.workflowName, "deploy");
+  assertEquals(entry.workflowContext?.runId, "run-123");
+  assertEquals(entry.workflowContext?.jobName, "build");
+  assertEquals(entry.workflowContext?.stepName, "validate-config");
+  assertEquals(entry.workflowContext?.modelType, "@swamp/shell");
+  assertEquals(entry.workflowContext?.driver, "local");
+});
+
+Deno.test("TelemetryEntry round-trips parentInvocationId and workflowContext through toData/fromData", () => {
+  const entry = TelemetryEntry.create({
+    id: "child-1",
+    invocation: {
+      command: "model",
+      subcommand: "method",
+      args: ["run", "<REDACTED>", "transform"],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    result: {
+      status: "error",
+      errorType: "Error",
+      errorMessage: "boom",
+      exitCode: 1,
+    },
+    startedAt: new Date("2026-02-05T10:00:00Z"),
+    completedAt: new Date("2026-02-05T10:00:00.250Z"),
+    swampVersion: "1.0.0",
+    denoVersion: "2.1.0",
+    platform: "linux",
+    parentInvocationId: "parent-xyz",
+    workflowContext: {
+      workflowName: "etl",
+      runId: "run-9",
+      jobName: "extract",
+      stepName: "pull-rows",
+    },
+  });
+
+  const data = entry.toData();
+  assertEquals(data.parentInvocationId, "parent-xyz");
+  assertEquals(data.workflowContext?.workflowName, "etl");
+  assertEquals(data.workflowContext?.runId, "run-9");
+  assertEquals(data.workflowContext?.modelType, undefined);
+  assertEquals(data.workflowContext?.driver, undefined);
+  assertEquals("modelType" in (data.workflowContext ?? {}), false);
+  assertEquals("driver" in (data.workflowContext ?? {}), false);
+
+  const restored = TelemetryEntry.fromData(data);
+  assertEquals(restored.parentInvocationId, "parent-xyz");
+  assertEquals(restored.workflowContext?.workflowName, "etl");
+  assertEquals(restored.workflowContext?.modelType, undefined);
+  assertEquals(restored.workflowContext?.driver, undefined);
+});
+
+Deno.test("TelemetryEntry.fromData decodes legacy entries without parentInvocationId or workflowContext", () => {
+  // Forward-compat contract for the new fields, mirroring the
+  // invocationContext regression above.
+  const legacyData: TelemetryEntryData = {
+    id: "legacy-2",
+    invocation: {
+      command: "workflow",
+      subcommand: "run",
+      args: ["<REDACTED>"],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    result: { status: "success", exitCode: 0 },
+    startedAt: "2026-02-05T12:00:00.000Z",
+    completedAt: "2026-02-05T12:00:05.000Z",
+    durationMs: 5000,
+    swampVersion: "1.0.0",
+    denoVersion: "2.1.0",
+    platform: "linux",
+  };
+
+  const entry = TelemetryEntry.fromData(legacyData);
+  assertEquals(entry.parentInvocationId, undefined);
+  assertEquals(entry.workflowContext, undefined);
+  const roundTripped = entry.toData();
+  assertEquals("parentInvocationId" in roundTripped, false);
+  assertEquals("workflowContext" in roundTripped, false);
+});

--- a/src/domain/telemetry/telemetry_service.ts
+++ b/src/domain/telemetry/telemetry_service.ts
@@ -22,6 +22,8 @@ import type { TelemetrySender } from "./telemetry_sender.ts";
 import { TelemetryEntry } from "./telemetry_entry.ts";
 import type { CommandInvocationData } from "./command_invocation.ts";
 import type { InvocationContextData } from "./invocation_context.ts";
+import { generateTelemetryId, type TelemetryId } from "./telemetry_id.ts";
+import type { WorkflowContextData } from "./workflow_context.ts";
 import {
   createErrorResult,
   createSuccessResult,
@@ -84,13 +86,23 @@ const DEFAULT_RETENTION_DAYS = 2;
  * detected harness, stdin tty state) do not change between recording a
  * success and recording an error, so a single context applies to every
  * entry the service writes.
+ *
+ * The `invocationId` is pre-allocated at construction time so the same id
+ * can be referenced as `parentInvocationId` by child entries written
+ * during the invocation (e.g. workflow-internal method invocations) before
+ * the parent entry itself is recorded at the end of the CLI lifecycle.
  */
 export class TelemetryService {
+  readonly invocationId: TelemetryId;
+
   constructor(
     private readonly repository: TelemetryRepository,
     private readonly swampVersion: string,
     private readonly invocationContext?: InvocationContextData,
-  ) {}
+    invocationId?: TelemetryId,
+  ) {
+    this.invocationId = invocationId ?? generateTelemetryId();
+  }
 
   /**
    * Records a successful CLI invocation.
@@ -103,6 +115,7 @@ export class TelemetryService {
     startedAt: Date,
   ): Promise<void> {
     const entry = TelemetryEntry.create({
+      id: this.invocationId,
       invocation,
       result: createSuccessResult(),
       startedAt,
@@ -134,6 +147,7 @@ export class TelemetryService {
     };
 
     const entry = TelemetryEntry.create({
+      id: this.invocationId,
       invocation,
       result,
       startedAt,
@@ -142,6 +156,61 @@ export class TelemetryService {
       denoVersion: Deno.version.deno,
       platform: Deno.build.os,
       invocationContext: this.invocationContext,
+    });
+
+    await this.repository.save(entry);
+  }
+
+  /**
+   * Records a child invocation that happened inside a workflow run.
+   *
+   * Produces the same wire shape as recordSuccess/recordError plus a
+   * `parentInvocationId` pointer to the outer CLI invocation and a
+   * `workflowContext` block describing the surrounding workflow/job/step.
+   *
+   * The caller supplies `completedAt` rather than letting the service
+   * stamp `new Date()` because workflow-internal invocations finalize via
+   * a bridge that may close them after a deferred event arrives. For
+   * pre-method-executing failures the caller passes the same instant for
+   * `startedAt` and `completedAt`, producing `durationMs = 0` — the
+   * method was never actually invoked.
+   *
+   * @param invocation - The command invocation data shaped like a direct
+   *   `model method run <name> <method>` invocation, with the same
+   *   redactions
+   * @param startedAt - When the method invocation started (or `now` for
+   *   pre-method-executing failures)
+   * @param completedAt - When the method invocation ended (or `now` for
+   *   pre-method-executing failures)
+   * @param error - The error that occurred, or `null` for success. Caller
+   *   classifies UserError vs Error via instanceof — this method mirrors
+   *   recordError's classification.
+   * @param parentInvocationId - Id of the parent CLI invocation
+   * @param workflowContext - Workflow/job/step/driver/modelType context
+   */
+  async recordChildInvocation(
+    invocation: CommandInvocationData,
+    startedAt: Date,
+    completedAt: Date,
+    error: Error | null,
+    parentInvocationId: string,
+    workflowContext: WorkflowContextData,
+  ): Promise<void> {
+    const result: InvocationResultData = error === null
+      ? { ...createSuccessResult() }
+      : { ...createErrorResult(error, error instanceof UserError) };
+
+    const entry = TelemetryEntry.create({
+      invocation,
+      result,
+      startedAt,
+      completedAt,
+      swampVersion: this.swampVersion,
+      denoVersion: Deno.version.deno,
+      platform: Deno.build.os,
+      invocationContext: this.invocationContext,
+      parentInvocationId,
+      workflowContext,
     });
 
     await this.repository.save(entry);

--- a/src/domain/telemetry/telemetry_service_test.ts
+++ b/src/domain/telemetry/telemetry_service_test.ts
@@ -443,3 +443,108 @@ Deno.test("TelemetryService without invocationContext writes entries without the
 
   assertEquals(repo.savedEntries[0].invocationContext, undefined);
 });
+
+Deno.test("TelemetryService.recordChildInvocation writes a success child entry", async () => {
+  const repo = new MockTelemetryRepository();
+  const service = new TelemetryService(repo, "1.0.0");
+
+  const startedAt = new Date("2026-02-05T10:00:00Z");
+  const completedAt = new Date("2026-02-05T10:00:00.500Z");
+
+  await service.recordChildInvocation(
+    {
+      command: "model",
+      subcommand: "method",
+      args: ["run", "<REDACTED>", "validate"],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    startedAt,
+    completedAt,
+    null,
+    "parent-id-1",
+    {
+      workflowName: "deploy",
+      runId: "run-1",
+      jobName: "build",
+      stepName: "step-a",
+      modelType: "@swamp/shell",
+      driver: "local",
+    },
+  );
+
+  assertEquals(repo.savedEntries.length, 1);
+  const saved = repo.savedEntries[0];
+  assertEquals(saved.result.status, "success");
+  assertEquals(saved.parentInvocationId, "parent-id-1");
+  assertEquals(saved.workflowContext?.workflowName, "deploy");
+  assertEquals(saved.workflowContext?.driver, "local");
+  assertEquals(saved.durationMs, 500);
+});
+
+Deno.test("TelemetryService.recordChildInvocation classifies UserError as user_error", async () => {
+  const repo = new MockTelemetryRepository();
+  const service = new TelemetryService(repo, "1.0.0");
+
+  // Reuse the runtime's UserError surface — the service imports it from
+  // ../errors.ts at the top of the file. We construct a UserError-shaped
+  // instance via dynamic import to avoid coupling this test file to the
+  // domain errors module path.
+  const { UserError } = await import("../errors.ts");
+
+  await service.recordChildInvocation(
+    {
+      command: "model",
+      subcommand: "method",
+      args: ["run", "<REDACTED>", "transform"],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    new Date(),
+    new Date(),
+    new UserError("vary key missing"),
+    "parent-id-2",
+    {
+      workflowName: "etl",
+      runId: "run-2",
+      jobName: "extract",
+      stepName: "pull",
+    },
+  );
+
+  assertEquals(repo.savedEntries[0].result.status, "user_error");
+  assertEquals(repo.savedEntries[0].result.errorType, "UserError");
+  assertEquals(repo.savedEntries[0].result.errorMessage, "vary key missing");
+});
+
+Deno.test("TelemetryService.recordChildInvocation supports zero-duration entries (pre-method-executing failure)", async () => {
+  const repo = new MockTelemetryRepository();
+  const service = new TelemetryService(repo, "1.0.0");
+
+  const sameInstant = new Date("2026-02-05T10:00:00Z");
+
+  await service.recordChildInvocation(
+    {
+      command: "model",
+      subcommand: "method",
+      args: ["run", "<REDACTED>", "enrich"],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    sameInstant,
+    sameInstant,
+    new Error("model 'missing' not found"),
+    "parent-id-3",
+    {
+      workflowName: "etl",
+      runId: "run-3",
+      jobName: "lookup",
+      stepName: "fetch",
+    },
+  );
+
+  assertEquals(repo.savedEntries[0].durationMs, 0);
+  assertEquals(repo.savedEntries[0].result.status, "error");
+  assertEquals(repo.savedEntries[0].workflowContext?.modelType, undefined);
+  assertEquals(repo.savedEntries[0].workflowContext?.driver, undefined);
+});

--- a/src/domain/telemetry/workflow_context.ts
+++ b/src/domain/telemetry/workflow_context.ts
@@ -1,0 +1,95 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Captures the workflow context surrounding a method invocation that
+ * happened inside a workflow run. Present only on child telemetry entries
+ * — direct CLI invocations and parent workflow-run entries omit it.
+ *
+ * Fields are individually optional so the bridge can populate what is
+ * known at the failure point. For example, a step that fails before the
+ * model can be resolved leaves `modelType` undefined; a step that fails
+ * before DriverPlan resolution leaves `driver` undefined.
+ */
+export interface WorkflowContext {
+  readonly workflowName: string;
+  readonly runId: string;
+  readonly jobName: string;
+  readonly stepName: string;
+  readonly modelType?: string;
+  readonly driver?: string;
+}
+
+/**
+ * Data transfer object for WorkflowContext.
+ */
+export interface WorkflowContextData {
+  workflowName: string;
+  runId: string;
+  jobName: string;
+  stepName: string;
+  modelType?: string;
+  driver?: string;
+}
+
+/**
+ * Creates a WorkflowContext value object.
+ */
+export function createWorkflowContext(
+  props: WorkflowContextData,
+): WorkflowContext {
+  return {
+    workflowName: props.workflowName,
+    runId: props.runId,
+    jobName: props.jobName,
+    stepName: props.stepName,
+    modelType: props.modelType,
+    driver: props.driver,
+  };
+}
+
+/**
+ * Converts a WorkflowContext to its data representation.
+ */
+export function workflowContextToData(
+  context: WorkflowContext,
+): WorkflowContextData {
+  const data: WorkflowContextData = {
+    workflowName: context.workflowName,
+    runId: context.runId,
+    jobName: context.jobName,
+    stepName: context.stepName,
+  };
+  if (context.modelType !== undefined) {
+    data.modelType = context.modelType;
+  }
+  if (context.driver !== undefined) {
+    data.driver = context.driver;
+  }
+  return data;
+}
+
+/**
+ * Reconstructs a WorkflowContext from data.
+ */
+export function workflowContextFromData(
+  data: WorkflowContextData,
+): WorkflowContext {
+  return createWorkflowContext(data);
+}

--- a/src/domain/workflows/execution_events.ts
+++ b/src/domain/workflows/execution_events.ts
@@ -67,6 +67,17 @@ export type WorkflowExecutionEvent =
     stepId: string;
     error: string;
     allowedFailure?: boolean;
+    /**
+     * Populated only when the failing step represents a model-method task
+     * (the runStep model-method catch site). Workflow-task failures and
+     * structural failures (cycle, max nesting depth) leave these
+     * undefined — the libswamp telemetry bridge keys off their presence
+     * to synthesize a child entry for failures that occur BEFORE the
+     * `method_executing` event was yielded.
+     */
+    modelName?: string;
+    methodName?: string;
+    driver?: string;
   }
   | {
     kind: "model_resolved";
@@ -90,6 +101,12 @@ export type WorkflowExecutionEvent =
     stepId: string;
     modelName: string;
     methodName: string;
+    /**
+     * Resolved driver from the DriverPlan tier resolution (workflow > job
+     * > step > definition > repo). Optional: undefined when no driver is
+     * explicitly configured, allowing the method's default to apply.
+     */
+    driver?: string;
   }
   | {
     kind: "method_output";

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -634,13 +634,6 @@ export class DefaultStepExecutor implements StepExecutor {
     } = args;
 
     runLogger.debug("Executing method {method}", { method: task.methodName });
-    ctx.emitEvent?.({
-      kind: "method_executing",
-      jobId: ctx.jobName,
-      stepId: ctx.stepName,
-      modelName: originalDefinition.name,
-      methodName: task.methodName,
-    });
 
     // Build workflow-specific tag overrides. Use "source" instead of
     // "type" to preserve the original data type (resource/file) while
@@ -690,6 +683,20 @@ export class DefaultStepExecutor implements StepExecutor {
     const resolved = (ctx.driverPlan ?? new DriverPlan({})).withDefinition({
       driver: evaluatedDefinition.driver,
       driverConfig: evaluatedDefinition.driverConfig,
+    });
+
+    // Yield `method_executing` AFTER driver resolution so the resolved
+    // driver can ride along on the event for downstream telemetry. Note:
+    // any failure between the start of runModelMethodTask and this point
+    // (vary-key validation, etc.) becomes a "pre-method-executing"
+    // failure and is reported via step_failed instead — by design.
+    ctx.emitEvent?.({
+      kind: "method_executing",
+      jobId: ctx.jobName,
+      stepId: ctx.stepName,
+      modelName: originalDefinition.name,
+      methodName: task.methodName,
+      driver: resolved.driver,
     });
 
     // Register sensitive argument values with the workflow redactor so they
@@ -1623,6 +1630,12 @@ export class WorkflowExecutionService {
     stepRun.start();
     yield { kind: "step_started", jobId: job.name, stepId: stepName };
 
+    // Declared outside the try so the step_failed yield in the catch
+    // block can populate `driver` when the failure occurred AFTER the
+    // DriverPlan was constructed but BEFORE method_executing was yielded
+    // (e.g. vault expression resolution failure inside the executor).
+    let driverPlan: DriverPlan | undefined;
+
     try {
       // Build the expression context with forEach variable
       let stepExprContext = expressionContext;
@@ -1663,6 +1676,23 @@ export class WorkflowExecutionService {
       // withEventBridge lets the executor push events via callback
       // while we yield them into the parent stream.
       const repoMarker = await this.loadRepoMarker();
+      // Build the DriverPlan; assign to the outer-scoped `driverPlan`
+      // so the catch block can populate `driver` on step_failed events
+      // for failures that occur BEFORE method_executing was yielded
+      // (model lookup, input validation, vault expression resolution).
+      driverPlan = new DriverPlan({
+        cli: { driver: options.driver },
+        step: { driver: step.driver, driverConfig: step.driverConfig },
+        job: { driver: job.driver, driverConfig: job.driverConfig },
+        workflow: {
+          driver: workflow.driver,
+          driverConfig: workflow.driverConfig,
+        },
+        repo: {
+          driver: repoMarker?.defaultDriver,
+          driverConfig: repoMarker?.defaultDriverConfig,
+        },
+      });
       const output = yield* withEventBridge<
         WorkflowExecutionEvent,
         unknown
@@ -1683,19 +1713,7 @@ export class WorkflowExecutionService {
           workflowTags: options.workflowTags,
           runtimeTags: options.runtimeTags,
           secretRedactor: options.secretRedactor,
-          driverPlan: new DriverPlan({
-            cli: { driver: options.driver },
-            step: { driver: step.driver, driverConfig: step.driverConfig },
-            job: { driver: job.driver, driverConfig: job.driverConfig },
-            workflow: {
-              driver: workflow.driver,
-              driverConfig: workflow.driverConfig,
-            },
-            repo: {
-              driver: repoMarker?.defaultDriver,
-              driverConfig: repoMarker?.defaultDriverConfig,
-            },
-          }),
+          driverPlan,
           emitEvent: push,
           reportFilterOptions: options.reportFilterOptions,
           swampSha: options.swampSha,
@@ -1816,12 +1834,37 @@ export class WorkflowExecutionService {
         code: SpanStatusCode.ERROR,
         message: errorMessage,
       });
+      // Populate model/method/driver context on step_failed only for
+      // model-method tasks. The libswamp telemetry bridge keys off these
+      // fields to synthesize a child invocation entry for failures that
+      // occurred before `method_executing` was yielded. Workflow-task
+      // steps (which short-circuit via runWorkflowStep above) and other
+      // structural failures leave them undefined.
+      //
+      // Driver resolution at catch time uses an empty definition tier
+      // because we may not have an evaluated definition yet — for
+      // pre-method-executing failures the driver reflects the upstream
+      // tiers (cli > step > job > workflow > repo) only. This is the
+      // analytically relevant tier for "what driver was the user asking
+      // this step to use".
+      const taskData = step.task.data;
+      const isModelMethodTask = taskData.type === "model_method";
+      const failureDriver = isModelMethodTask && driverPlan
+        ? driverPlan.withDefinition({}).driver
+        : undefined;
       yield {
         kind: "step_failed",
         jobId: job.name,
         stepId: stepName,
         error: errorMessage,
         allowedFailure: isAllowed || undefined,
+        modelName: taskData.type === "model_method"
+          ? taskData.modelIdOrName
+          : undefined,
+        methodName: taskData.type === "model_method"
+          ? taskData.methodName
+          : undefined,
+        driver: failureDriver,
       };
       // Do not re-throw: merge() continues draining all step generators
       // (allSettled semantics). The job generator tracks failure via step_failed events.

--- a/src/infrastructure/persistence/json_telemetry_repository_test.ts
+++ b/src/infrastructure/persistence/json_telemetry_repository_test.ts
@@ -577,3 +577,75 @@ Deno.test("JsonTelemetryRepository round-trips invocationContext (legacy opt-out
     assertEquals(restored[0].invocationContext?.isInteractive, true);
   });
 });
+
+Deno.test("JsonTelemetryRepository round-trips parentInvocationId and workflowContext", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new JsonTelemetryRepository(dir);
+    const entry = TelemetryEntry.create({
+      id: "child-roundtrip",
+      invocation: {
+        command: "model",
+        subcommand: "method",
+        args: ["run", "<REDACTED>", "validate"],
+        optionKeys: [],
+        globalOptions: [],
+      },
+      result: { status: "success", exitCode: 0 },
+      startedAt: new Date("2024-08-01T10:00:00Z"),
+      completedAt: new Date("2024-08-01T10:00:00.500Z"),
+      swampVersion: "1.0.0",
+      denoVersion: "1.40.0",
+      platform: "linux",
+      parentInvocationId: "parent-roundtrip",
+      workflowContext: {
+        workflowName: "deploy",
+        runId: "run-1",
+        jobName: "build",
+        stepName: "validate",
+        modelType: "@swamp/shell",
+        driver: "local",
+      },
+    });
+
+    await repo.save(entry);
+    const restored = await repo.findByDate(new Date("2024-08-01T10:00:00Z"));
+    assertEquals(restored.length, 1);
+    assertEquals(restored[0].parentInvocationId, "parent-roundtrip");
+    assertEquals(restored[0].workflowContext?.workflowName, "deploy");
+    assertEquals(restored[0].workflowContext?.runId, "run-1");
+    assertEquals(restored[0].workflowContext?.modelType, "@swamp/shell");
+    assertEquals(restored[0].workflowContext?.driver, "local");
+  });
+});
+
+Deno.test("JsonTelemetryRepository decodes legacy entries without parentInvocationId or workflowContext", async () => {
+  // Backward-compat: a fixture written before the new fields existed
+  // must round-trip through findByDate without error and surface
+  // undefined for the missing fields.
+  await withTempDir(async (dir) => {
+    const repo = new JsonTelemetryRepository(dir);
+    const entry = TelemetryEntry.create({
+      id: "legacy-roundtrip",
+      invocation: {
+        command: "model",
+        subcommand: "create",
+        args: ["<REDACTED>"],
+        optionKeys: [],
+        globalOptions: [],
+      },
+      result: { status: "success", exitCode: 0 },
+      startedAt: new Date("2024-09-01T10:00:00Z"),
+      completedAt: new Date("2024-09-01T10:00:01Z"),
+      swampVersion: "1.0.0",
+      denoVersion: "1.40.0",
+      platform: "linux",
+      // intentionally no parentInvocationId / workflowContext
+    });
+
+    await repo.save(entry);
+    const restored = await repo.findByDate(new Date("2024-09-01T10:00:00Z"));
+    assertEquals(restored.length, 1);
+    assertEquals(restored[0].parentInvocationId, undefined);
+    assertEquals(restored[0].workflowContext, undefined);
+  });
+});

--- a/src/infrastructure/telemetry/http_telemetry_sender_test.ts
+++ b/src/infrastructure/telemetry/http_telemetry_sender_test.ts
@@ -281,3 +281,85 @@ Deno.test("HttpTelemetrySender.sendBatch lands invocationContext at properties.i
 
   await server.shutdown();
 });
+
+Deno.test("HttpTelemetrySender.sendBatch lands parentInvocationId and workflowContext at properties", async () => {
+  // Same wire-shape contract as invocationContext: TelemetryEntry.toData()
+  // is splatted into properties, so child invocation entries land
+  // properties.parentInvocationId and properties.workflowContext.{...}.
+  let capturedBody: string | undefined;
+
+  const server = Deno.serve({ port: 0 }, async (req: Request) => {
+    capturedBody = await req.text();
+    return new Response(JSON.stringify({ accepted: 1 }), { status: 202 });
+  });
+
+  const port = server.addr.port;
+  const sender = new HttpTelemetrySender(`http://localhost:${port}`);
+  const entry = TelemetryEntry.create({
+    id: "child-wire",
+    invocation: {
+      command: "model",
+      subcommand: "method",
+      args: ["run", "<REDACTED>", "validate"],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    result: { status: "success", exitCode: 0 },
+    startedAt: new Date("2024-03-10T10:00:00Z"),
+    completedAt: new Date("2024-03-10T10:00:00.250Z"),
+    swampVersion: "1.0.0",
+    denoVersion: "2.1.0",
+    platform: "linux",
+    parentInvocationId: "parent-wire",
+    workflowContext: {
+      workflowName: "deploy",
+      runId: "run-1",
+      jobName: "build",
+      stepName: "validate",
+      modelType: "@swamp/shell",
+      driver: "local",
+    },
+  });
+
+  const ok = await sender.sendBatch([entry], "user-uuid");
+  assertEquals(ok, true);
+
+  const parsed = JSON.parse(capturedBody!);
+  assertEquals(parsed.properties.parentInvocationId, "parent-wire");
+  assertEquals(parsed.properties.workflowContext.workflowName, "deploy");
+  assertEquals(parsed.properties.workflowContext.runId, "run-1");
+  assertEquals(parsed.properties.workflowContext.jobName, "build");
+  assertEquals(parsed.properties.workflowContext.stepName, "validate");
+  assertEquals(parsed.properties.workflowContext.modelType, "@swamp/shell");
+  assertEquals(parsed.properties.workflowContext.driver, "local");
+
+  await server.shutdown();
+});
+
+Deno.test("HttpTelemetrySender.sendBatch omits parentInvocationId / workflowContext when absent", async () => {
+  // Backward-compat: parent entries and direct CLI invocations don't
+  // carry these fields. The wire payload must omit them entirely (not
+  // serialize undefined) so older ingest schemas don't break.
+  let capturedBody: string | undefined;
+
+  const server = Deno.serve({ port: 0 }, async (req: Request) => {
+    capturedBody = await req.text();
+    return new Response(JSON.stringify({ accepted: 1 }), { status: 202 });
+  });
+
+  const port = server.addr.port;
+  const sender = new HttpTelemetrySender(`http://localhost:${port}`);
+  const entry = createTestEntry(
+    "no-extras",
+    new Date("2024-03-10T10:00:00Z"),
+  );
+
+  const ok = await sender.sendBatch([entry], "user-uuid");
+  assertEquals(ok, true);
+
+  const parsed = JSON.parse(capturedBody!);
+  assertEquals("parentInvocationId" in parsed.properties, false);
+  assertEquals("workflowContext" in parsed.properties, false);
+
+  await server.shutdown();
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -60,6 +60,7 @@ export {
   type WorkflowRunEvent,
   type WorkflowRunInput,
   type WorkflowRunJobInfo,
+  type WorkflowTelemetrySink,
 } from "./workflows/run.ts";
 export type { MethodExecutionEvent } from "../domain/models/method_events.ts";
 export {

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -66,6 +66,7 @@ import type { DefinitionRepository } from "../../domain/definitions/repositories
 import { YamlEvaluatedDefinitionRepository } from "../../infrastructure/persistence/yaml_evaluated_definition_repository.ts";
 import type { DataHandle } from "../../domain/models/model.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+import { WorkflowTelemetryBridge } from "./telemetry_bridge.ts";
 
 /**
  * Events emitted by the libswamp workflow run generator.
@@ -102,6 +103,14 @@ export type WorkflowRunEvent =
     stepId: string;
     error: string;
     allowedFailure?: boolean;
+    /**
+     * Populated only when the failing step is a model-method task. The
+     * telemetry bridge uses these to synthesize a child entry for
+     * failures that occurred before `method_executing` was yielded.
+     */
+    modelName?: string;
+    methodName?: string;
+    driver?: string;
   }
   | {
     kind: "model_resolved";
@@ -125,6 +134,11 @@ export type WorkflowRunEvent =
     stepId: string;
     modelName: string;
     methodName: string;
+    /**
+     * Resolved driver from the DriverPlan tier resolution. Optional:
+     * undefined when no driver is explicitly configured at any tier.
+     */
+    driver?: string;
   }
   | {
     kind: "method_output";
@@ -171,6 +185,34 @@ export type WorkflowRunEvent =
   | { kind: "error"; error: SwampError };
 
 /**
+ * Narrow callback shape for emitting per-method-invocation telemetry from
+ * inside a workflow run. The CLI binds this to TelemetryService's
+ * recordChildInvocation; non-CLI consumers (UI, tests, scripts) pass
+ * `undefined` for `telemetrySink` to no-op.
+ *
+ * Lives in libswamp (not domain.telemetry) so libswamp can stay free of
+ * direct domain.telemetry imports beyond plain DTO shapes.
+ */
+export interface WorkflowTelemetrySink {
+  recordChildInvocation(
+    invocation:
+      import("../../domain/telemetry/command_invocation.ts").CommandInvocationData,
+    startedAt: Date,
+    completedAt: Date,
+    error: Error | null,
+    parentInvocationId: string,
+    workflowContext:
+      import("../../domain/telemetry/workflow_context.ts").WorkflowContextData,
+  ): Promise<void>;
+  /**
+   * Pre-allocated id of the parent CLI invocation. Children reference
+   * this id via `parentInvocationId` so analytics can join children to
+   * the parent without timestamp guessing.
+   */
+  readonly parentInvocationId: string;
+}
+
+/**
  * Dependencies injected into the workflow run generator.
  */
 export interface WorkflowRunDeps {
@@ -190,6 +232,7 @@ export interface WorkflowRunDeps {
   catalogStore: CatalogStore;
   dataRepo?: UnifiedDataRepository;
   definitionRepo?: DefinitionRepository;
+  telemetrySink?: WorkflowTelemetrySink;
 }
 
 /**
@@ -449,6 +492,14 @@ export async function* workflowRun(
       // Track per-step data handles from step_completed events
       const dataHandlesByStep = new Map<string, DataHandle[]>();
 
+      // Per-method-invocation telemetry bridge. Constructed once per
+      // stream consumption and finalized in the outer try/finally so
+      // any in-flight invocations on cancellation / throw are still
+      // recorded as error child entries.
+      const telemetryBridge = deps.telemetrySink
+        ? new WorkflowTelemetryBridge(deps.telemetrySink)
+        : undefined;
+
       try {
         let completedEvent: WorkflowRunEvent | undefined;
 
@@ -522,6 +573,12 @@ export async function* workflowRun(
 
           const mapped = mapEvent(event, deps, resolvedInput);
 
+          // Per-method telemetry observer — runs alongside existing
+          // event handling. Skipped when telemetry is disabled.
+          if (telemetryBridge) {
+            await telemetryBridge.observe(mapped);
+          }
+
           // Intercept the completed event to run reports first
           if (mapped.kind === "completed") {
             completedEvent = mapped;
@@ -564,6 +621,15 @@ export async function* workflowRun(
           kind: "error",
           error: workflowExecutionFailed(error),
         };
+      } finally {
+        // Drain any in-flight method invocations as error entries. Runs
+        // on every stream termination — normal completion, thrown
+        // errors, and AbortSignal cancellation — so methods that
+        // started but never received a terminal event don't disappear
+        // from telemetry.
+        if (telemetryBridge) {
+          await telemetryBridge.finalize();
+        }
       }
     })(),
   );

--- a/src/libswamp/workflows/run_test.ts
+++ b/src/libswamp/workflows/run_test.ts
@@ -943,3 +943,88 @@ Deno.test("workflowRun yields cancelled error when signal is pre-aborted", async
     assertEquals(last.error.code, "cancelled");
   }
 });
+
+Deno.test("workflowRun bridge finalizes in-flight invocations when execution service throws mid-stream", async () => {
+  // Adversarial case: a method_executing event is yielded, then the
+  // execution service throws BEFORE step_completed/step_failed arrives.
+  // The bridge's try/finally must drain the in-flight invocation as an
+  // error child entry. The parent stream's error event must still
+  // propagate cleanly.
+  const workflow = createTestWorkflow();
+
+  type RecordedCall = {
+    methodName: string;
+    error: Error | null;
+    durationMs: number;
+  };
+  const recorded: RecordedCall[] = [];
+
+  const deps: WorkflowRunDeps = {
+    ...createTestDeps(workflow, []),
+    createExecutionService: (_wr, _rr, _rd, _cs) =>
+      ({
+        async *run(): AsyncGenerator<WorkflowExecutionEvent> {
+          yield {
+            kind: "started",
+            runId: "run-throw",
+            workflowName: "test-workflow",
+            logPath: "/tmp/log",
+            jobs: [],
+          };
+          yield {
+            kind: "method_executing",
+            jobId: "job1",
+            stepId: "step1",
+            modelName: "test-model",
+            methodName: "run",
+            driver: "local",
+          };
+          // Simulate the workflow engine blowing up after starting a
+          // method but before any terminal step event.
+          throw new Error("execution service crashed");
+        },
+        execute(): Promise<WorkflowRun> {
+          throw new Error("not implemented");
+        },
+        // deno-lint-ignore no-explicit-any
+      }) as any,
+    telemetrySink: {
+      parentInvocationId: "parent-throw",
+      recordChildInvocation: (
+        invocation,
+        startedAt,
+        completedAt,
+        error,
+      ) => {
+        recorded.push({
+          methodName: invocation.args[2],
+          error,
+          durationMs: completedAt.getTime() - startedAt.getTime(),
+        });
+        return Promise.resolve();
+      },
+    },
+  };
+
+  const ctx = createLibSwampContext();
+  const events = await collect(workflowRun(ctx, deps, {
+    workflowIdOrName: "test-workflow",
+  }));
+
+  // Parent stream still emits the error event cleanly.
+  const last = events[events.length - 1];
+  assertEquals(last.kind, "error");
+
+  // Bridge drained the in-flight method as an error child entry.
+  assertEquals(recorded.length, 1);
+  assertEquals(recorded[0].methodName, "run");
+  assertEquals(
+    recorded[0].error?.message,
+    "workflow run terminated before completion",
+  );
+  // durationMs is non-negative (start time recorded at method_executing,
+  // end time at finalize) — guard against accidental NaN/negative.
+  if (recorded[0].durationMs < 0 || Number.isNaN(recorded[0].durationMs)) {
+    throw new Error(`unexpected durationMs: ${recorded[0].durationMs}`);
+  }
+});

--- a/src/libswamp/workflows/telemetry_bridge.ts
+++ b/src/libswamp/workflows/telemetry_bridge.ts
@@ -1,0 +1,232 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { CommandInvocationData } from "../../domain/telemetry/command_invocation.ts";
+import type { WorkflowContextData } from "../../domain/telemetry/workflow_context.ts";
+import type { WorkflowRunEvent, WorkflowTelemetrySink } from "./run.ts";
+
+/**
+ * Build the CommandInvocationData for a workflow-internal method
+ * invocation. Shape matches what `extractCommandInfo` would produce for a
+ * direct `swamp model method run <name> <method>` invocation, with the
+ * same redactions per ARG_SCHEMAS["model method"] = ["categorical",
+ * "redact", "categorical"]:
+ *   - args[0] = "run" (categorical, kept verbatim)
+ *   - args[1] = "<REDACTED>" (model name is user-identifiable)
+ *   - args[2] = methodName (categorical, kept verbatim)
+ */
+export function buildChildInvocation(
+  methodName: string,
+): CommandInvocationData {
+  return {
+    command: "model",
+    subcommand: "method",
+    args: ["run", "<REDACTED>", methodName],
+    optionKeys: [],
+    globalOptions: [],
+  };
+}
+
+/**
+ * Internal tracking record for a method invocation that has started but
+ * not yet completed. Held by WorkflowTelemetryBridge while events are
+ * still arriving for the (jobId, stepId) pair.
+ */
+interface InFlightMethodInvocation {
+  startedAt: Date;
+  modelName: string;
+  methodName: string;
+  modelType?: string;
+  driver?: string;
+}
+
+/**
+ * Bridges WorkflowRunEvents to per-method-invocation telemetry. Tracks
+ * in-flight invocations between `method_executing` and the matching
+ * `step_completed`/`step_failed` events; on stream termination,
+ * finalizes any unfinished invocations as errors via {@link finalize}.
+ *
+ * Ownership model: one bridge instance per workflow stream consumption.
+ * Re-using a bridge across runs would leak state. The libswamp
+ * `workflowRun` generator constructs a fresh bridge inside its
+ * try/finally and discards it on exit.
+ */
+export class WorkflowTelemetryBridge {
+  /** Key shape: `${jobId}:${stepId}` */
+  private readonly inFlight = new Map<string, InFlightMethodInvocation>();
+  /** Captured from the `started` event so workflowContext can populate runId/workflowName. */
+  private workflowName = "";
+  private runId = "";
+  /** Captured from `model_resolved` so workflowContext can carry modelType. */
+  private readonly modelTypeByStep = new Map<string, string>();
+  /** Set true after finalize() runs, so observe() becomes a no-op. */
+  private finalized = false;
+
+  constructor(private readonly sink: WorkflowTelemetrySink) {}
+
+  /**
+   * Observe one event from the workflow run stream. Idempotent — calling
+   * with the same event twice would double-record, so callers must invoke
+   * once per event.
+   *
+   * Returns void; awaits internally for `recordChildInvocation` so the
+   * caller's stream loop awaits the write before yielding the next event
+   * (matters for ordering guarantees in tests).
+   */
+  async observe(event: WorkflowRunEvent): Promise<void> {
+    if (this.finalized) return;
+
+    switch (event.kind) {
+      case "started": {
+        this.workflowName = event.workflowName;
+        this.runId = event.runId;
+        return;
+      }
+      case "model_resolved": {
+        const key = stepKey(event.jobId, event.stepId);
+        this.modelTypeByStep.set(key, event.modelType);
+        return;
+      }
+      case "method_executing": {
+        const key = stepKey(event.jobId, event.stepId);
+        this.inFlight.set(key, {
+          startedAt: new Date(),
+          modelName: event.modelName,
+          methodName: event.methodName,
+          modelType: this.modelTypeByStep.get(key),
+          driver: event.driver,
+        });
+        return;
+      }
+      case "step_completed": {
+        const key = stepKey(event.jobId, event.stepId);
+        const tracked = this.inFlight.get(key);
+        if (!tracked) return; // workflow_task step or non-method step
+        this.inFlight.delete(key);
+        await this.sink.recordChildInvocation(
+          buildChildInvocation(tracked.methodName),
+          tracked.startedAt,
+          new Date(),
+          null,
+          this.sink.parentInvocationId,
+          this.buildWorkflowContext(event.jobId, event.stepId, tracked),
+        );
+        return;
+      }
+      case "step_failed": {
+        const key = stepKey(event.jobId, event.stepId);
+        const tracked = this.inFlight.get(key);
+
+        if (tracked) {
+          // Method had started; record an error child entry with the
+          // actual duration from method_executing → step_failed.
+          this.inFlight.delete(key);
+          await this.sink.recordChildInvocation(
+            buildChildInvocation(tracked.methodName),
+            tracked.startedAt,
+            new Date(),
+            new Error(event.error),
+            this.sink.parentInvocationId,
+            this.buildWorkflowContext(event.jobId, event.stepId, tracked),
+          );
+          return;
+        }
+
+        // No method_executing was yielded — this is a pre-method-executing
+        // failure (model lookup, vary-key validation, vault expression
+        // resolution, etc.). The domain layer populates modelName /
+        // methodName / driver on step_failed for model-method tasks; if
+        // those are absent the failure is structural (workflow-task,
+        // nesting-depth, cycle) and we skip emission.
+        if (!event.modelName || !event.methodName) return;
+        const synthesized: InFlightMethodInvocation = {
+          startedAt: new Date(0), // placeholder, overwritten below
+          modelName: event.modelName,
+          methodName: event.methodName,
+          modelType: this.modelTypeByStep.get(key),
+          driver: event.driver,
+        };
+        const sameInstant = new Date();
+        await this.sink.recordChildInvocation(
+          buildChildInvocation(event.methodName),
+          sameInstant,
+          sameInstant,
+          new Error(event.error),
+          this.sink.parentInvocationId,
+          this.buildWorkflowContext(event.jobId, event.stepId, synthesized),
+        );
+        return;
+      }
+    }
+  }
+
+  /**
+   * Drain any in-flight invocations as error entries. Call from the
+   * libswamp generator's `finally` block so cancelled / thrown / aborted
+   * runs don't silently lose telemetry for methods that started but
+   * never received a terminal event.
+   *
+   * Safe to call multiple times; only the first call drains.
+   */
+  async finalize(reason?: string): Promise<void> {
+    if (this.finalized) return;
+    this.finalized = true;
+
+    const now = new Date();
+    const errorMessage = reason ?? "workflow run terminated before completion";
+    const drained = Array.from(this.inFlight.entries());
+    this.inFlight.clear();
+
+    for (const [key, tracked] of drained) {
+      const [jobId, stepId] = key.split(":");
+      await this.sink.recordChildInvocation(
+        buildChildInvocation(tracked.methodName),
+        tracked.startedAt,
+        now,
+        new Error(errorMessage),
+        this.sink.parentInvocationId,
+        this.buildWorkflowContext(jobId, stepId, tracked),
+      );
+    }
+  }
+
+  private buildWorkflowContext(
+    jobId: string,
+    stepId: string,
+    tracked: InFlightMethodInvocation,
+  ): WorkflowContextData {
+    const ctx: WorkflowContextData = {
+      workflowName: this.workflowName,
+      runId: this.runId,
+      jobName: jobId,
+      stepName: stepId,
+    };
+    if (tracked.modelType !== undefined) {
+      ctx.modelType = tracked.modelType;
+    }
+    if (tracked.driver !== undefined) {
+      ctx.driver = tracked.driver;
+    }
+    return ctx;
+  }
+}
+
+function stepKey(jobId: string, stepId: string): string {
+  return `${jobId}:${stepId}`;
+}

--- a/src/libswamp/workflows/telemetry_bridge_test.ts
+++ b/src/libswamp/workflows/telemetry_bridge_test.ts
@@ -1,0 +1,350 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import type { CommandInvocationData } from "../../domain/telemetry/command_invocation.ts";
+import type { WorkflowContextData } from "../../domain/telemetry/workflow_context.ts";
+import type { WorkflowRunEvent, WorkflowTelemetrySink } from "./run.ts";
+import { WorkflowTelemetryBridge } from "./telemetry_bridge.ts";
+
+interface RecordedCall {
+  invocation: CommandInvocationData;
+  startedAt: Date;
+  completedAt: Date;
+  error: Error | null;
+  parentInvocationId: string;
+  workflowContext: WorkflowContextData;
+}
+
+class FakeSink implements WorkflowTelemetrySink {
+  readonly parentInvocationId = "parent-x";
+  readonly calls: RecordedCall[] = [];
+
+  recordChildInvocation(
+    invocation: CommandInvocationData,
+    startedAt: Date,
+    completedAt: Date,
+    error: Error | null,
+    parentInvocationId: string,
+    workflowContext: WorkflowContextData,
+  ): Promise<void> {
+    this.calls.push({
+      invocation,
+      startedAt,
+      completedAt,
+      error,
+      parentInvocationId,
+      workflowContext,
+    });
+    return Promise.resolve();
+  }
+}
+
+const STARTED_EVENT: WorkflowRunEvent = {
+  kind: "started",
+  runId: "run-1",
+  workflowName: "deploy",
+  driver: "local",
+  jobs: [],
+};
+
+Deno.test("bridge records success entry on method_executing → step_completed", async () => {
+  const sink = new FakeSink();
+  const bridge = new WorkflowTelemetryBridge(sink);
+
+  await bridge.observe(STARTED_EVENT);
+  await bridge.observe({
+    kind: "model_resolved",
+    jobId: "build",
+    stepId: "validate",
+    modelName: "shell-step",
+    modelType: "@swamp/shell",
+    methodName: "run",
+  });
+  await bridge.observe({
+    kind: "method_executing",
+    jobId: "build",
+    stepId: "validate",
+    modelName: "shell-step",
+    methodName: "run",
+    driver: "local",
+  });
+  await bridge.observe({
+    kind: "step_completed",
+    jobId: "build",
+    stepId: "validate",
+  });
+  await bridge.finalize();
+
+  assertEquals(sink.calls.length, 1);
+  const call = sink.calls[0];
+  assertEquals(call.invocation.command, "model");
+  assertEquals(call.invocation.subcommand, "method");
+  assertEquals(call.invocation.args, ["run", "<REDACTED>", "run"]);
+  assertEquals(call.error, null);
+  assertEquals(call.parentInvocationId, "parent-x");
+  assertEquals(call.workflowContext.workflowName, "deploy");
+  assertEquals(call.workflowContext.runId, "run-1");
+  assertEquals(call.workflowContext.jobName, "build");
+  assertEquals(call.workflowContext.stepName, "validate");
+  assertEquals(call.workflowContext.modelType, "@swamp/shell");
+  assertEquals(call.workflowContext.driver, "local");
+});
+
+Deno.test("bridge records error entry on method_executing → step_failed (post-method-executing failure)", async () => {
+  const sink = new FakeSink();
+  const bridge = new WorkflowTelemetryBridge(sink);
+
+  await bridge.observe(STARTED_EVENT);
+  await bridge.observe({
+    kind: "model_resolved",
+    jobId: "build",
+    stepId: "transform",
+    modelName: "etl",
+    modelType: "@swamp/python",
+    methodName: "transform",
+  });
+  await bridge.observe({
+    kind: "method_executing",
+    jobId: "build",
+    stepId: "transform",
+    modelName: "etl",
+    methodName: "transform",
+    driver: "docker",
+  });
+  await bridge.observe({
+    kind: "step_failed",
+    jobId: "build",
+    stepId: "transform",
+    error: "transform threw",
+  });
+  await bridge.finalize();
+
+  assertEquals(sink.calls.length, 1);
+  assertEquals(sink.calls[0].error?.message, "transform threw");
+  assertEquals(sink.calls[0].workflowContext.driver, "docker");
+});
+
+Deno.test("bridge synthesizes durationMs=0 entry for pre-method-executing failures", async () => {
+  const sink = new FakeSink();
+  const bridge = new WorkflowTelemetryBridge(sink);
+
+  await bridge.observe(STARTED_EVENT);
+  // No method_executing — domain emits step_failed with modelName/methodName
+  await bridge.observe({
+    kind: "step_failed",
+    jobId: "lookup",
+    stepId: "fetch",
+    error: "model not found: missing",
+    modelName: "missing",
+    methodName: "enrich",
+    driver: "local",
+  });
+  await bridge.finalize();
+
+  assertEquals(sink.calls.length, 1);
+  const call = sink.calls[0];
+  assertEquals(
+    call.completedAt.getTime() - call.startedAt.getTime(),
+    0,
+    "synthesized entries have zero duration",
+  );
+  assertEquals(call.error?.message, "model not found: missing");
+  assertEquals(call.workflowContext.driver, "local");
+  assertEquals(call.invocation.args, ["run", "<REDACTED>", "enrich"]);
+});
+
+Deno.test("bridge skips workflow-task / structural step_failed (no modelName)", async () => {
+  const sink = new FakeSink();
+  const bridge = new WorkflowTelemetryBridge(sink);
+
+  await bridge.observe(STARTED_EVENT);
+  // Structural failure — workflow-task step or cycle/depth — no model context
+  await bridge.observe({
+    kind: "step_failed",
+    jobId: "orchestrate",
+    stepId: "nested",
+    error: "Nested workflow failed",
+  });
+  await bridge.finalize();
+
+  assertEquals(sink.calls.length, 0);
+});
+
+Deno.test("bridge finalize() drains in-flight invocations as error entries", async () => {
+  const sink = new FakeSink();
+  const bridge = new WorkflowTelemetryBridge(sink);
+
+  await bridge.observe(STARTED_EVENT);
+  await bridge.observe({
+    kind: "method_executing",
+    jobId: "build",
+    stepId: "long",
+    modelName: "slow",
+    methodName: "process",
+    driver: "local",
+  });
+  // Stream terminates without step_completed/step_failed
+  await bridge.finalize();
+
+  assertEquals(sink.calls.length, 1);
+  const call = sink.calls[0];
+  assertEquals(
+    call.error?.message,
+    "workflow run terminated before completion",
+  );
+  assertEquals(call.workflowContext.stepName, "long");
+});
+
+Deno.test("bridge finalize() with custom reason propagates to drained entries", async () => {
+  const sink = new FakeSink();
+  const bridge = new WorkflowTelemetryBridge(sink);
+
+  await bridge.observe(STARTED_EVENT);
+  await bridge.observe({
+    kind: "method_executing",
+    jobId: "build",
+    stepId: "long",
+    modelName: "slow",
+    methodName: "process",
+  });
+  await bridge.finalize("aborted by user");
+
+  assertEquals(sink.calls[0].error?.message, "aborted by user");
+});
+
+Deno.test("bridge finalize() is idempotent", async () => {
+  const sink = new FakeSink();
+  const bridge = new WorkflowTelemetryBridge(sink);
+
+  await bridge.observe(STARTED_EVENT);
+  await bridge.observe({
+    kind: "method_executing",
+    jobId: "j",
+    stepId: "s",
+    modelName: "m",
+    methodName: "go",
+  });
+  await bridge.finalize();
+  await bridge.finalize(); // second call should be a no-op
+
+  assertEquals(sink.calls.length, 1);
+});
+
+Deno.test("bridge handles two sequential workflows independently (no state leak)", async () => {
+  // Each workflow stream gets its own bridge. Verify constructing a
+  // fresh bridge after one finalizes does not bleed state.
+  const sink = new FakeSink();
+  const first = new WorkflowTelemetryBridge(sink);
+  await first.observe(STARTED_EVENT);
+  await first.observe({
+    kind: "method_executing",
+    jobId: "j1",
+    stepId: "s1",
+    modelName: "m1",
+    methodName: "do",
+  });
+  await first.observe({
+    kind: "step_completed",
+    jobId: "j1",
+    stepId: "s1",
+  });
+  await first.finalize();
+
+  assertEquals(sink.calls.length, 1);
+
+  const second = new WorkflowTelemetryBridge(sink);
+  await second.observe({
+    kind: "started",
+    runId: "run-2",
+    workflowName: "etl",
+    jobs: [],
+  });
+  await second.observe({
+    kind: "method_executing",
+    jobId: "j2",
+    stepId: "s2",
+    modelName: "m2",
+    methodName: "go",
+  });
+  await second.observe({
+    kind: "step_completed",
+    jobId: "j2",
+    stepId: "s2",
+  });
+  await second.finalize();
+
+  assertEquals(sink.calls.length, 2);
+  assertEquals(sink.calls[0].workflowContext.runId, "run-1");
+  assertEquals(sink.calls[1].workflowContext.runId, "run-2");
+});
+
+Deno.test("bridge emits one entry per forEach iteration (distinct stepNames)", async () => {
+  const sink = new FakeSink();
+  const bridge = new WorkflowTelemetryBridge(sink);
+
+  await bridge.observe(STARTED_EVENT);
+  // forEach expands a step into iterations with derived step names
+  for (const stepId of ["fan-out[0]", "fan-out[1]"]) {
+    await bridge.observe({
+      kind: "method_executing",
+      jobId: "fan",
+      stepId,
+      modelName: "shell",
+      methodName: "run",
+    });
+    await bridge.observe({
+      kind: "step_completed",
+      jobId: "fan",
+      stepId,
+    });
+  }
+  await bridge.finalize();
+
+  assertEquals(sink.calls.length, 2);
+  assertEquals(sink.calls[0].workflowContext.stepName, "fan-out[0]");
+  assertEquals(sink.calls[1].workflowContext.stepName, "fan-out[1]");
+});
+
+Deno.test("bridge does not record allowedFailure: true differently from error", async () => {
+  // Per ADV-3 resolution: allowedFailure records as error (the method
+  // outcome). The workflow's overall success is the parent's concern.
+  const sink = new FakeSink();
+  const bridge = new WorkflowTelemetryBridge(sink);
+
+  await bridge.observe(STARTED_EVENT);
+  await bridge.observe({
+    kind: "method_executing",
+    jobId: "build",
+    stepId: "optional",
+    modelName: "shell",
+    methodName: "run",
+  });
+  await bridge.observe({
+    kind: "step_failed",
+    jobId: "build",
+    stepId: "optional",
+    error: "exit 1",
+    allowedFailure: true,
+  });
+  await bridge.finalize();
+
+  assertEquals(sink.calls.length, 1);
+  assertEquals(sink.calls[0].error?.message, "exit 1");
+});


### PR DESCRIPTION
## Summary

Closes [swamp-club#301](https://swamp-club.com/lab/issues/301).

Workflow runs now emit one `TelemetryEntry` per workflow YAML step that resolves to a model method, alongside the parent CLI invocation entry. Children use the existing `cli_invocation` event shape (same redactions as a direct `swamp model method run`) and link to the parent via a new optional `parentInvocationId` field. A new optional `workflowContext` block carries `workflowName` / `runId` / `jobName` / `stepName` / `modelType` / `driver` so per-driver and per-model-type analytics are first-class without joining through the parent.

The design choice was deliberate: the issue originally proposed a new `workflow_method_invocation` event type. We pushed back during planning and chose additive optional fields on `cli_invocation` instead — the swamp-club ingest side declares `properties: Record<string, unknown>` so additive fields ride across with no consumer-side coordination. Analytics queries that aggregate by `command`/`subcommand`/`duration` immediately see workflow-internal method invocations alongside direct ones.

### What's new on the wire

```jsonc
{
  "event": "cli_invocation",
  "properties": {
    "id": "<child-uuid>",
    "invocation": {
      "command": "model",
      "subcommand": "method",
      "args": ["run", "<REDACTED>", "<methodName>"],
      "optionKeys": [],
      "globalOptions": []
    },
    "result": { "status": "success", "exitCode": 0 },
    "parentInvocationId": "<parent-cli-invocation-uuid>",
    "workflowContext": {
      "workflowName": "deploy",
      "runId": "<workflow-run-uuid>",
      "jobName": "build",
      "stepName": "validate",
      "modelType": "command/shell",
      "driver": "local"
    }
    // ... existing fields (startedAt, completedAt, durationMs, swampVersion,
    //     denoVersion, platform, invocationContext) unchanged
  }
}
```

Older entries continue to decode without `parentInvocationId` / `workflowContext` (forward-compat regression test added).

### Architecture

- **Bridge** (`src/libswamp/workflows/telemetry_bridge.ts`) — tracks in-flight method invocations by `${jobId}:${stepId}`, maps the existing `method_executing` → `step_completed`/`step_failed` event pairs into success/error child entries, synthesizes `durationMs = 0` entries for pre-method-executing failures (model lookup, vault expression resolution, vary-key validation, env-var validation), and finalizes any unfinished invocations on stream termination so cancellation/timeout paths don't silently drop telemetry.
- **Sink** (`WorkflowTelemetrySink` in `src/libswamp/workflows/run.ts`) — narrow callback shape on `WorkflowRunDeps`. CLI binds it to `TelemetryService.recordChildInvocation`; non-CLI consumers pass `undefined` and the bridge becomes a no-op. Keeps libswamp free of direct domain.telemetry imports beyond plain DTOs.
- **Pre-allocated parent id** — `TelemetryService` exposes a stable `invocationId` (constructor pre-allocates a `TelemetryId`) so children can reference it as `parentInvocationId` before the parent entry itself is recorded at the end of the CLI lifecycle. Module-scoped accessor (`getActiveTelemetryService` in `src/cli/telemetry_integration.ts`) is set in `runCli` before parse and cleared in the surrounding `try/finally`.

### Domain event extensions

- `step_failed` gains optional `modelName` / `methodName` / `driver`, populated only at the model-method failure site (line ~1820 in `runStep`'s catch block). Structural failures — max-nesting-depth, cycle detection, nested-workflow throw/failed — leave them undefined so the bridge can distinguish method failures from structural failures.
- `method_executing` gains optional `driver`, captured from the resolved `DriverPlan`. The yield is reordered to fire after DriverPlan resolution; vary-key validation failures (which happen between event start and method_executing) become pre-method-executing failures by design — more accurate categorization since the method was never invoked.

### Failure semantics

| Step outcome | Child entry |
|---|---|
| Success | `status: success`, real duration |
| Failure after `method_executing` | `status: error`, real duration |
| Failure before `method_executing` (model lookup, vault, vary, env var) | `status: error`, `durationMs = 0` (synthesized) |
| `allowFailure: true` step | `status: error` on the child (method outcome); parent records workflow `success` |
| Workflow-task / nested workflow / cycle / depth | No child entry (no method was ever invoked at this step) |
| Cancellation / timeout / mid-stream throw | In-flight invocations drained as `error` via the bridge's `finalize()` |

### V1 limitations (documented in `design/workflow.md`)

- Workflow-step granularity only. Sub-method follow-up calls inside `DefaultMethodExecutionService.execute` are not captured separately.
- Failures before workflow validation (workflow not found, input schema validation) produce no child entry — no method was ever resolved.

## Test Plan

- [x] **Unit tests** — `TelemetryEntry` round-trip with/without new fields (back-compat regression locked in); `TelemetryService.recordChildInvocation` success and error paths with `UserError` classification; `WorkflowTelemetryBridge` for all five branches (success, post-method failure, pre-method failure, structural skip, finalize drain) plus idempotency, sequential workflows, forEach, allowFailure semantics — 23 new test cases.
- [x] **libswamp error-terminal test** — mid-stream `throw` with an in-flight method invocation: bridge's `try/finally` drains it as an error child, parent stream's `error` event still propagates cleanly.
- [x] **Integration test** (`integration/telemetry_workflow_method_invocations_test.ts`) — end-to-end CLI invocation runs a workflow with success step + forEach iterations, asserts one parent + correct number of children with `parentInvocationId` linkage and full `workflowContext` (including `driver`, `modelType`).
- [x] **Wire-shape tests** — `HttpTelemetrySender` includes new fields at `properties.parentInvocationId` / `properties.workflowContext.*`; omitted entirely when absent (no `undefined` serialization).
- [x] **Repository round-trip** — `JsonTelemetryRepository` saves and reads new fields; legacy entries without them decode cleanly.
- [x] **Verification gates** — `deno check`, `deno lint`, `deno fmt --check`, `deno run test` (5723 passed, 0 failed), `deno run compile`.
- [x] **Manual end-to-end** — ran a throwaway workflow in `~/git/swamp-media` and inspected `~/git/swamp-media/.swamp/telemetry/`. Got one parent + three children (ok-step, fanout-a, fanout-b) with all `workflowContext` fields populated and consistent `parentInvocationId` / `runId`. Children share the redacted-args shape with direct `model method run` invocations. forEach iterations have distinct `stepName`s.

## Consumer side

Verified against swamp-club: `services/telemetry/lib/schema.ts` declares `properties: Record<string, unknown>` so the additive fields ride across the wire with zero coordination. Existing rollup metrics in `consumers/metrics.ts` already follow the "read what you need from the opaque bag" pattern. A follow-up workflowContext rollup metric (per-driver / per-model-type / per-step counts) is a separate swamp-club issue, not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)